### PR TITLE
Fix some small bugs

### DIFF
--- a/lib/api/github.js
+++ b/lib/api/github.js
@@ -59,8 +59,10 @@ async function initRepo(repoName, token, endpoint) {
 async function findFilePaths(fileName) {
   const res = await ghGot(`search/code?q=repo:${config.repoName}+filename:${fileName}`);
   const exactMatches = res.body.items.filter(item => item.name === fileName);
-  const filePaths = exactMatches.map(item => item.path);
-  return filePaths;
+
+  // GitHub seems to return files in the root with a leading `/`
+  // which then breaks things later on down the line
+  return exactMatches.map(item => item.path.replace(/^\//, ''));
 }
 
 // Branch
@@ -164,6 +166,7 @@ async function createPr(branchName, title, body) {
     body: { title, head: branchName, base: config.defaultBranch, body },
   })).body.number;
   pr.displayNumber = `Pull Request #${pr.number}`;
+  return pr;
 }
 
 // Gets details for a PR

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -23,49 +23,51 @@ function parseConfigs(env, argv) {
   const cliConfig = cliParser.getConfig(argv);
   const envConfig = envParser.getConfig(env);
 
+  config = Object.assign({}, defaultConfig, fileConfig, envConfig, cliConfig);
+
+  // Set log level
+  logger.level = config.logLevel;
+
   logger.debug(`Default config = ${redact(defaultConfig)}`);
   logger.debug(`File config = ${redact(fileConfig)}`);
   logger.debug(`CLI config: ${redact(cliConfig)}`);
   logger.debug(`Env config: ${redact(envConfig)}`);
 
   // Get global config
-  config = Object.assign({}, defaultConfig, fileConfig, envConfig, cliConfig);
   logger.debug(`raw config=${redact(config)}`);
-
-  // Set log level
-  logger.level = config.logLevel;
 
   // We need at least one repository defined
   if (!config.repositories || config.repositories.length === 0) {
     throw new Error('At least one repository must be configured');
   }
-  // Convert any repository strings to objects
-  config.repositories.forEach((repo, index) => {
-    if (typeof repo === 'string') {
-      config.repositories[index] = { repository: repo };
-    }
-  });
-  // Copy token, platform and onboarding settings if not present
-  config.repositories.forEach((repo, index) => {
-    config.repositories[index].token = repo.token || config.token;
-    config.repositories[index].platform = repo.platform || config.platform;
-    config.repositories[index].onboarding = repo.onboarding || config.onboarding;
-  });
-  // Set default packageFiles
-  config.repositories.forEach((repo, index) => {
+
+  // Configure each repository
+  config.repositories = config.repositories.map((item) => {
+    // Convert any repository strings to objects
+    const repo = typeof item === 'string' ? { repository: item } : item;
+
+    // copy across some fields from the base config if not present
+    repo.token = repo.token || config.token;
+    repo.platform = repo.platform || config.platform;
+    repo.onboarding = repo.onboarding || config.onboarding;
+    repo.endpoint = repo.endpoint || config.endpoint;
+
+    // Set default packageFiles
     if (!repo.packageFiles || !repo.packageFiles.length) {
-      config.repositories[index].packageFiles = config.packageFiles;
+      repo.packageFiles = config.packageFiles;
     }
-  });
-  // Expand packageFile format
-  config.repositories.forEach((repo, index) => {
-    config.repositories[index].packageFiles = repo.packageFiles.map((packageFile) => {
+
+    // Expand packageFile format
+    repo.packageFiles = repo.packageFiles.map((packageFile) => {
       if (typeof packageFile === 'string') {
         return { fileName: packageFile };
       }
       return packageFile;
     });
+
+    return repo;
   });
+
   // Print config
   logger.verbose(`config=${redact(config)}`);
 }

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -226,7 +226,7 @@ async function updateDependency(upgrade) {
       const pr = await api.getBranchPr(branchName);
       await processExistingPr(pr);
     } catch (error) {
-      logger.error(`${depName} failed to ensure PR: ${JSON.stringify(error)}`);
+      logger.error(`${depName} failed to ensure PR:`, error);
     }
 
     // Update PR based on current state


### PR DESCRIPTION
First of all - thanks for making this 😄  The stateless design is perfect for our use case at Lyst.

In trying to get the service set up I can across a few bugs:

**Remove leading `/` from file paths returned from GitHub API search**
For example it was returning `/package.json` which then seemed to break the `createTree` function. Not 100% sure about this though.

**Return PR object from `createPr` function in api/github**
Pretty self-explanatory!

**Set the logging level as soon as it's known**
There were a couple of logs that I couldn't get in the output due to being logged before setting the logging level. Minor but useful.

**Make sure endpoint is set at the repository level**
If setting the endpoint via the CLI options `--endpoint` it wasn't being applied to the repository.

**Failed to ensure PR error message**
By `JSON.stringify`-ing the error I was not seeing any detail e.g. stack trace. Fixing was how I found the `createPR` bug.