### PR TITLE
fix check on empty/missing yarn.lock file. closes #110

### DIFF
--- a/lib/workers/branch.js
+++ b/lib/workers/branch.js
@@ -54,7 +54,7 @@ async function getParentBranch(branchName, config) {
 async function getYarnLockFile(packageJson, config) {
   // Detect if a yarn.lock file is in use
   const yarnLockFileName = path.join(path.dirname(config.packageFile), 'yarn.lock');
-  if (await config.api.getFileContent(yarnLockFileName) === false) {
+  if (await !config.api.getFileContent(yarnLockFileName)) {
     return null;
   }
   // Copy over custom config files


### PR DESCRIPTION
`getFileContent` returns  `null` and not `false` on missing files from repos. This closes #110  