### PR TITLE
fix link to default definitions

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,7 +14,7 @@ i.e. `package.json` settings will override `renovate.json` settings, CLI, which 
 
 ### Default Configuration
 
-Default configuration can be found in [lib/config/default.js](../lib/config/default.js)
+Default configuration can be found in [lib/config/definitions.js](../lib/config/definitions.js)
 
 ### Configuration File
 


### PR DESCRIPTION
Small update to fix default definitions link on the doc page.