### PR TITLE
adds a gitlab config option to remove source branch after PR is merged

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,24 +56,25 @@ $ node renovate --help
 
   Options:
 
-    -h, --help                    output usage information
-    --enabled [boolean]           Enable or disable renovate
-    --onboarding [boolean]        Require a Configuration PR first
-    --platform <string>           Platform type of repository
-    --endpoint <string>           Custom endpoint to use
-    --token <string>              Repository Auth Token
-    --package-files <list>        Package file paths
-    --dep-types <list>            Dependency types
-    --ignore-deps <list>          Dependencies to ignore
-    --ignore-future [boolean]     Ignore versions tagged as "future"
-    --ignore-unstable [boolean]   Ignore versions with unstable semver
-    --respect-latest [boolean]    Ignore versions newer than npm "latest" version
-    --recreate-closed [boolean]   Recreate PRs even if same ones were closed previously
-    --rebase-stale-prs [boolean]  Rebase stale PRs
-    --labels <list>               Labels to add to Pull Request
-    --assignees <list>            Assignees for Pull Request
-    --reviewers <list>            Requested reviewers for Pull Requests
-    --log-level <string>          Logging level
+    -h, --help                               output usage information
+    --enabled [boolean]                      Enable or disable renovate
+    --onboarding [boolean]                   Require a Configuration PR first
+    --platform <string>                      Platform type of repository
+    --endpoint <string>                      Custom endpoint to use
+    --token <string>                         Repository Auth Token
+    --package-files <list>                   Package file paths
+    --dep-types <list>                       Dependency types
+    --ignore-deps <list>                     Dependencies to ignore
+    --ignore-future [boolean]                Ignore versions tagged as "future"
+    --ignore-unstable [boolean]              Ignore versions with unstable semver
+    --respect-latest [boolean]               Ignore versions newer than npm "latest" version
+    --recreate-closed [boolean]              Recreate PRs even if same ones were closed previously
+    --rebase-stale-prs [boolean]             Rebase stale PRs
+    --labels <list>                          Labels to add to Pull Request
+    --assignees <list>                       Assignees for Pull Request
+    --reviewers <list>                       Requested reviewers for Pull Requests
+    --gitlab-remove-source-branch [boolean]  Remove source branch on merge
+    --log-level <string>                     Logging level
 
   Examples:
 
@@ -126,4 +127,5 @@ Obviously, you can't set repository or package file location with this method.
 | `labels` | Labels to add to Pull Request | list | `[]` | `RENOVATE_LABELS` | `--labels` |
 | `assignees` | Assignees for Pull Request | list | `[]` | `RENOVATE_ASSIGNEES` | `--assignees` |
 | `reviewers` | Requested reviewers for Pull Requests | list | `[]` | `RENOVATE_REVIEWERS` | `--reviewers` |
+| `gitlabRemoveSourceBranch` | Remove source branch on merge | boolean | `true` | `RENOVATE_GITLAB_REMOVE_SOURCE_BRANCH` | `--gitlab-remove-source-branch` |
 | `logLevel` | Logging level | string | `"info"` | `LOG_LEVEL` | `--log-level` |

--- a/lib/api/gitlab.js
+++ b/lib/api/gitlab.js
@@ -158,12 +158,13 @@ async function checkForClosedPr(branchName, prTitle) {
   return false;
 }
 
-async function createPr(branchName, title, body) {
+async function createPr(branchName, title, body, upgradeConfig) {
   logger.debug(`Creating Merge Request: ${title}`);
   const res = await glGot.post(`projects/${config.repoName}/merge_requests`, {
     body: {
       source_branch: branchName,
       target_branch: config.defaultBranch,
+      remove_source_branch: upgradeConfig.gitlabRemoveSourceBranch,
       title,
       description: body,
     },

--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -131,6 +131,12 @@ const options = [
     description: 'Requested reviewers for Pull Requests',
     type: 'list',
   },
+  {
+    name: 'gitlabRemoveSourceBranch',
+    description: 'Remove source branch on merge',
+    type: 'boolean',
+    default: true,
+  },
   // Debug options
   {
     name: 'logLevel',

--- a/lib/workers/pr.js
+++ b/lib/workers/pr.js
@@ -32,7 +32,7 @@ async function ensurePr(upgradeConfig) {
       return existingPr;
     }
     logger.debug(`Creating PR for branch ${branchName}`);
-    const pr = await config.api.createPr(branchName, prTitle, prBody);
+    const pr = await config.api.createPr(branchName, prTitle, prBody, config);
     if (config.labels.length > 0) {
       await config.api.addLabels(pr.number, config.labels);
     }

--- a/readme.md
+++ b/readme.md
@@ -38,24 +38,25 @@ $ node renovate --help
 
   Options:
 
-    -h, --help                    output usage information
-    --enabled [boolean]           Enable or disable renovate
-    --onboarding [boolean]        Require a Configuration PR first
-    --platform <string>           Platform type of repository
-    --endpoint <string>           Custom endpoint to use
-    --token <string>              Repository Auth Token
-    --package-files <list>        Package file paths
-    --dep-types <list>            Dependency types
-    --ignore-deps <list>          Dependencies to ignore
-    --ignore-future [boolean]     Ignore versions tagged as "future"
-    --ignore-unstable [boolean]   Ignore versions with unstable semver
-    --respect-latest [boolean]    Ignore versions newer than npm "latest" version
-    --recreate-closed [boolean]   Recreate PRs even if same ones were closed previously
-    --rebase-stale-prs [boolean]  Rebase stale PRs
-    --labels <list>               Labels to add to Pull Request
-    --assignees <list>            Assignees for Pull Request
-    --reviewers <list>            Requested reviewers for Pull Requests
-    --log-level <string>          Logging level
+    -h, --help                               output usage information
+    --enabled [boolean]                      Enable or disable renovate
+    --onboarding [boolean]                   Require a Configuration PR first
+    --platform <string>                      Platform type of repository
+    --endpoint <string>                      Custom endpoint to use
+    --token <string>                         Repository Auth Token
+    --package-files <list>                   Package file paths
+    --dep-types <list>                       Dependency types
+    --ignore-deps <list>                     Dependencies to ignore
+    --ignore-future [boolean]                Ignore versions tagged as "future"
+    --ignore-unstable [boolean]              Ignore versions with unstable semver
+    --respect-latest [boolean]               Ignore versions newer than npm "latest" version
+    --recreate-closed [boolean]              Recreate PRs even if same ones were closed previously
+    --rebase-stale-prs [boolean]             Rebase stale PRs
+    --labels <list>                          Labels to add to Pull Request
+    --assignees <list>                       Assignees for Pull Request
+    --reviewers <list>                       Requested reviewers for Pull Requests
+    --gitlab-remove-source-branch [boolean]  Remove source branch on merge
+    --log-level <string>                     Logging level
 
   Examples:
 


### PR DESCRIPTION
Gitlab have a nice feature to remove source branches automatically after a PR is merged. This code enables `renovate` to setup that option on GitLab PRs.

 I've tested it with all the different formats, in config file as `gitlabRemoveSourceBranch`, as a CLI option `--gitlab-remove-source-branch=true` and as an env var `RENOVATE_GITLAB_REMOVE_SOURCE_BRANCH` and all works fine. 

I've put it under the `gitlab` prefix because the same feature is not present on GitHub.