### PR TITLE
fix(file): use path.isAbsolute for Windows compatibility

### DIFF
--- a/lib/config/file.js
+++ b/lib/config/file.js
@@ -1,13 +1,13 @@
 const logger = require('winston');
+const path = require('path');
 
 module.exports = {
   getConfig,
-  isPathAbsolute,
 };
 
 function getConfig(env) {
   let configFile = env.RENOVATE_CONFIG_FILE || 'config';
-  if (!isPathAbsolute(configFile)) {
+  if (!path.isAbsolute(configFile)) {
     configFile = `../../${configFile}`;
   }
   let config = {};
@@ -19,8 +19,4 @@ function getConfig(env) {
     logger.verbose('Could not locate config file');
   }
   return config;
-}
-
-function isPathAbsolute(path) {
-  return /^(?:\/|[a-z]+:\/\/)/.test(path);
 }


### PR DESCRIPTION
Use Node's built-in `path.isAbsolute` for compatibility with
Window's file paths.