### PR TITLE
Support simple range upgrades

### DIFF
--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -131,6 +131,11 @@ const options = [
     description: 'Requested reviewers for Pull Requests (GitHub only)',
     type: 'list',
   },
+  {
+    name: 'pinVersions',
+    description: 'Convert ranged versions in package.json to pinned versions',
+    type: 'boolean',
+  },
   // Debug options
   {
     name: 'logLevel',

--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -103,7 +103,7 @@ const options = [
     name: 'prTitle',
     description: 'Pull Request title template',
     type: 'string',
-    default: '{{#if isPin}}Pin{{else}}Update{{/if}} dependency {{depName}} to version {{#if isMajor}}{{newVersionMajor}}.x{{else}}{{newVersion}}{{/if}}',
+    default: '{{#if isPin}}Pin{{else}}Update{{/if}} dependency {{depName}} to version {{#if isRange}}{{newVersion}}{{else}}{{#if isMajor}}{{newVersionMajor}}.x{{else}}{{newVersion}}{{/if}}{{/if}}',
     cli: false,
     env: false,
   },

--- a/lib/helpers/versions.js
+++ b/lib/helpers/versions.js
@@ -2,6 +2,7 @@ const logger = require('winston');
 const semver = require('semver');
 const stable = require('semver-stable');
 const _ = require('lodash');
+const semverUtils = require('semver-utils');
 
 module.exports = {
   determineUpgrades,
@@ -28,7 +29,6 @@ function determineUpgrades(dep, currentVersion, config) {
   if (isRange(currentVersion)) {
     // Pin ranges to their maximum satisfying version
     const maxSatisfying = semver.maxSatisfying(versionList, currentVersion);
-    console.log('currentVersion is ' + currentVersion + ', maxSatisfying is ' + maxSatisfying); // eslint-disable-line
     if (config.pinVersions) {
       allUpgrades.pin = {
         upgradeType: 'pin',
@@ -75,7 +75,30 @@ function determineUpgrades(dep, currentVersion, config) {
     delete allUpgrades.pin;
   }
   // Return only the values - we don't need the keys anymore
-  return Object.keys(allUpgrades).map(key => allUpgrades[key]);
+  const reducedUpgrades = Object.keys(allUpgrades).map(key => allUpgrades[key]);
+
+  // Check for ranges
+  if (!config.pinVersions && isRange(currentVersion)) {
+    const semverParsed = semverUtils.parseRange(currentVersion);
+    if (semverParsed.length > 1) {
+      logger.warn(`Can't support upgrading complex range ${currentVersion}`);
+      return [];
+    }
+    const newUpgrades = [];
+    if (semverParsed[0].operator === '~') {
+      reducedUpgrades.forEach((upgrade) => {
+        const upgradeMajor = semver.major(upgrade.newVersion);
+        const upgradeMinor = semver.minor(upgrade.newVersion);
+        const newRange = `${upgradeMajor}.${upgradeMinor}`;
+        const minSatisfying = semver.minSatisfying(versionList, newRange);
+        const newUpgrade = Object.assign({}, upgrade);
+        newUpgrade.newVersion = `~${minSatisfying}`;
+        newUpgrades.push(newUpgrade);
+      });
+    }
+    return newUpgrades;
+  }
+  return reducedUpgrades;
 }
 
 function isRange(input) {

--- a/lib/helpers/versions.js
+++ b/lib/helpers/versions.js
@@ -102,18 +102,17 @@ function determineUpgrades(dep, currentVersion, config) {
     let upgrade = Object.assign({}, pinnedUpgrade);
     // Set this flag to assist with templating
     upgrade.isRange = true;
-    const upgradeMajor = semver.major(upgrade.newVersion);
-    const upgradeMinor = semver.minor(upgrade.newVersion);
+    const { major, minor } = semverUtils.parse(upgrade.newVersion);
     if (currentSemver.operator === '~') {
       // Utilise that a.b is the same as ~a.b.0
-      const minSatisfying = semver.minSatisfying(versionList, `${upgradeMajor}.${upgradeMinor}`);
+      const minSatisfying = semver.minSatisfying(versionList, `${major}.${minor}`);
       // Add a tilde before that version number
       upgrade.newVersion = `~${minSatisfying}`;
     } else if (currentSemver.operator === '^') {
-      let newRange = `${upgradeMajor}`;
+      let newRange = `${major}`;
       // If version is < 1, then semver treats ^ same as ~
-      if (upgradeMajor === 0) {
-        newRange = `${upgradeMajor}.${upgradeMinor}`;
+      if (major === 0) {
+        newRange = `${major}.${minor}`;
       }
       const minSatisfying = semver.minSatisfying(versionList, newRange);
       // Add in the caret
@@ -123,16 +122,16 @@ function determineUpgrades(dep, currentVersion, config) {
       upgrade.newVersion = `<= ${upgrade.newVersion}`;
     } else if (currentSemver.minor === undefined) {
       // Example: 1
-      upgrade.newVersion = `${upgradeMajor}`;
+      upgrade.newVersion = `${major}`;
     } else if (currentSemver.minor === 'x') {
       // Example: 1.x
-      upgrade.newVersion = `${upgradeMajor}.x`;
+      upgrade.newVersion = `${major}.x`;
     } else if (currentSemver.patch === undefined) {
       // Example: 1.2
-      upgrade.newVersion = `${upgradeMajor}.${upgradeMinor}`;
+      upgrade.newVersion = `${major}.${minor}`;
     } else if (currentSemver.patch === 'x') {
       // Example: 1.2.x
-      upgrade.newVersion = `${upgradeMajor}.${upgradeMinor}.x`;
+      upgrade.newVersion = `${major}.${minor}.x`;
     } else {
       logger.warn(`Unsupported semver type: ${currentSemver}`);
       upgrade = null;

--- a/lib/helpers/versions.js
+++ b/lib/helpers/versions.js
@@ -85,7 +85,8 @@ function determineUpgrades(dep, currentVersion, config) {
       return [];
     }
     const rangeUpgrades = [];
-    if (semverParsed[0].operator === '~') {
+    const semverOperator = semverParsed[0].operator;
+    if (semverOperator === '~') {
       pinnedUpgrades.forEach((upgrade) => {
         const upgradeMajor = semver.major(upgrade.newVersion);
         const upgradeMinor = semver.minor(upgrade.newVersion);
@@ -95,8 +96,7 @@ function determineUpgrades(dep, currentVersion, config) {
         newUpgrade.newVersion = `~${minSatisfying}`;
         rangeUpgrades.push(newUpgrade);
       });
-    }
-    if (semverParsed[0].operator === '^') {
+    } else if (semverOperator === '^') {
       pinnedUpgrades.forEach((upgrade) => {
         const upgradeMajor = semver.major(upgrade.newVersion);
         const upgradeMinor = semver.minor(upgrade.newVersion);
@@ -109,6 +109,14 @@ function determineUpgrades(dep, currentVersion, config) {
         newUpgrade.newVersion = `^${minSatisfying}`;
         rangeUpgrades.push(newUpgrade);
       });
+    } else if (semverOperator === '<=') {
+      pinnedUpgrades.forEach((upgrade) => {
+        const newUpgrade = Object.assign({}, upgrade);
+        newUpgrade.newVersion = `<= ${upgrade.newVersion}`;
+        rangeUpgrades.push(newUpgrade);
+      });
+    } else {
+      logger.warn(`Unsupported semver operator '${semverOperator}'`);
     }
     return rangeUpgrades;
   }

--- a/lib/helpers/versions.js
+++ b/lib/helpers/versions.js
@@ -94,47 +94,45 @@ function determineUpgrades(dep, currentVersion, config) {
   // We know we have a simple semver, now check which operator it is
   const currentSemver = semverParsed[0];
   // Loop through all upgrades and convert to ranges
-  pinnedUpgrades.forEach((pinnedUpgrade) => {
-    if (pinnedUpgrade.upgradeType === 'pin') {
-      // Skip these completely
-      return;
-    }
-    let upgrade = Object.assign({}, pinnedUpgrade, { isRange: true });
-    const { major, minor } = semverUtils.parse(upgrade.newVersion);
-    if (currentSemver.operator === '~') {
-      // Utilise that a.b is the same as ~a.b.0
-      const minSatisfying = semver.minSatisfying(versionList, `${major}.${minor}`);
-      // Add a tilde before that version number
-      upgrade.newVersion = `~${minSatisfying}`;
-    } else if (currentSemver.operator === '^') {
-      // If version is < 1, then semver treats ^ same as ~
-      const newRange = major === 0 ? `${major}.${minor}` : `${major}`;
-      const minSatisfying = semver.minSatisfying(versionList, newRange);
-      // Add in the caret
-      upgrade.newVersion = `^${minSatisfying}`;
-    } else if (currentSemver.operator === '<=') {
-      // Example: <= 1.2.0
-      upgrade.newVersion = `<= ${upgrade.newVersion}`;
-    } else if (currentSemver.minor === undefined) {
-      // Example: 1
-      upgrade.newVersion = `${major}`;
-    } else if (currentSemver.minor === 'x') {
-      // Example: 1.x
-      upgrade.newVersion = `${major}.x`;
-    } else if (currentSemver.patch === undefined) {
-      // Example: 1.2
-      upgrade.newVersion = `${major}.${minor}`;
-    } else if (currentSemver.patch === 'x') {
-      // Example: 1.2.x
-      upgrade.newVersion = `${major}.${minor}.x`;
-    } else {
-      logger.warn(`Unsupported semver type: ${currentSemver}`);
-      upgrade = null;
-    }
-    if (upgrade) {
-      rangeUpgrades.push(upgrade);
-    }
-  });
+  _(pinnedUpgrades)
+    .reject(upgrade => upgrade.upgradeType === 'pin')
+    .forEach((pinnedUpgrade) => {
+      let upgrade = Object.assign({}, pinnedUpgrade, { isRange: true });
+      const { major, minor } = semverUtils.parse(upgrade.newVersion);
+      if (currentSemver.operator === '~') {
+        // Utilise that a.b is the same as ~a.b.0
+        const minSatisfying = semver.minSatisfying(versionList, `${major}.${minor}`);
+        // Add a tilde before that version number
+        upgrade.newVersion = `~${minSatisfying}`;
+      } else if (currentSemver.operator === '^') {
+        // If version is < 1, then semver treats ^ same as ~
+        const newRange = major === '0' ? `${major}.${minor}` : `${major}`;
+        const minSatisfying = semver.minSatisfying(versionList, newRange);
+        // Add in the caret
+        upgrade.newVersion = `^${minSatisfying}`;
+      } else if (currentSemver.operator === '<=') {
+        // Example: <= 1.2.0
+        upgrade.newVersion = `<= ${upgrade.newVersion}`;
+      } else if (currentSemver.minor === undefined) {
+        // Example: 1
+        upgrade.newVersion = `${major}`;
+      } else if (currentSemver.minor === 'x') {
+        // Example: 1.x
+        upgrade.newVersion = `${major}.x`;
+      } else if (currentSemver.patch === undefined) {
+        // Example: 1.2
+        upgrade.newVersion = `${major}.${minor}`;
+      } else if (currentSemver.patch === 'x') {
+        // Example: 1.2.x
+        upgrade.newVersion = `${major}.${minor}.x`;
+      } else {
+        logger.warn(`Unsupported semver type: ${currentSemver}`);
+        upgrade = null;
+      }
+      if (upgrade) {
+        rangeUpgrades.push(upgrade);
+      }
+    });
   return rangeUpgrades;
 }
 

--- a/lib/helpers/versions.js
+++ b/lib/helpers/versions.js
@@ -89,15 +89,13 @@ function determineUpgrades(dep, currentVersion, config) {
     logger.warn(`Can't support upgrading complex range ${currentVersion}`);
     return [];
   }
-  // Start with empty set of range upgrades
-  const rangeUpgrades = [];
   // We know we have a simple semver, now check which operator it is
   const currentSemver = semverParsed[0];
   // Loop through all upgrades and convert to ranges
-  _(pinnedUpgrades)
+  return _(pinnedUpgrades)
   .reject(pinnedUpgrade => pinnedUpgrade.upgradeType === 'pin')
-  .forEach((pinnedUpgrade) => {
-    let upgrade = Object.assign({}, pinnedUpgrade, { isRange: true });
+  .map((pinnedUpgrade) => {
+    const upgrade = Object.assign({}, pinnedUpgrade, { isRange: true });
     const { major, minor } = semverUtils.parse(upgrade.newVersion);
     if (currentSemver.operator === '~') {
       // Utilise that a.b is the same as ~a.b.0
@@ -127,13 +125,12 @@ function determineUpgrades(dep, currentVersion, config) {
       upgrade.newVersion = `${major}.${minor}.x`;
     } else {
       logger.warn(`Unsupported semver type: ${currentSemver}`);
-      upgrade = null;
+      return null;
     }
-    if (upgrade) {
-      rangeUpgrades.push(upgrade);
-    }
-  });
-  return rangeUpgrades;
+    return upgrade;
+  })
+  .compact()
+  .value();
 }
 
 function isRange(input) {

--- a/lib/helpers/versions.js
+++ b/lib/helpers/versions.js
@@ -108,7 +108,7 @@ function determineUpgrades(dep, currentVersion, config) {
       upgrade.newVersion = `~${minSatisfying}`;
     } else if (currentSemver.operator === '^') {
       // If version is < 1, then semver treats ^ same as ~
-      const newRange = major === 0 ? `${major}.${minor}` : `${major}`;
+      const newRange = major === '0' ? `${major}.${minor}` : `${major}`;
       const minSatisfying = semver.minSatisfying(versionList, newRange);
       // Add in the caret
       upgrade.newVersion = `^${minSatisfying}`;

--- a/lib/helpers/versions.js
+++ b/lib/helpers/versions.js
@@ -79,7 +79,7 @@ function determineUpgrades(dep, currentVersion, config) {
   // Return only the values - we don't need the keys anymore
   const pinnedUpgrades = Object.keys(allUpgrades).map(key => allUpgrades[key]);
 
-  if (isRange(currentVersion) && !config.pinVersions) {
+  if (pinnedUpgrades.length && isRange(currentVersion) && !config.pinVersions) {
     // The user prefers to maintain ranges, so we need to unpin our upgrades
     const semverParsed = semverUtils.parseRange(currentVersion);
     if (semverParsed.length > 1) {
@@ -126,7 +126,42 @@ function determineUpgrades(dep, currentVersion, config) {
         newUpgrade.newVersion = `<= ${upgrade.newVersion}`;
         rangeUpgrades.push(newUpgrade);
       });
+    } else if (semverParsed[0].minor === 'x') {
+      pinnedUpgrades.forEach((upgrade) => {
+        const upgradeMajor = semver.major(upgrade.newVersion);
+        const newUpgrade = Object.assign({}, upgrade);
+        // Add a tilde before that version number
+        newUpgrade.newVersion = `${upgradeMajor}.x`;
+        rangeUpgrades.push(newUpgrade);
+      });
+    } else if (semverParsed[0].minor === undefined) {
+      pinnedUpgrades.forEach((upgrade) => {
+        const upgradeMajor = semver.major(upgrade.newVersion);
+        const newUpgrade = Object.assign({}, upgrade);
+        // Add a tilde before that version number
+        newUpgrade.newVersion = `${upgradeMajor}`;
+        rangeUpgrades.push(newUpgrade);
+      });
+    } else if (semverParsed[0].patch === undefined) {
+      pinnedUpgrades.forEach((upgrade) => {
+        const upgradeMajor = semver.major(upgrade.newVersion);
+        const upgradeMinor = semver.minor(upgrade.newVersion);
+        const newUpgrade = Object.assign({}, upgrade);
+        // Add a tilde before that version number
+        newUpgrade.newVersion = `${upgradeMajor}.${upgradeMinor}`;
+        rangeUpgrades.push(newUpgrade);
+      });
+    } else if (semverParsed[0].patch === 'x') {
+      pinnedUpgrades.forEach((upgrade) => {
+        const upgradeMajor = semver.major(upgrade.newVersion);
+        const upgradeMinor = semver.minor(upgrade.newVersion);
+        const newUpgrade = Object.assign({}, upgrade);
+        // Add a tilde before that version number
+        newUpgrade.newVersion = `${upgradeMajor}.${upgradeMinor}.x`;
+        rangeUpgrades.push(newUpgrade);
+      });
     } else {
+      console.log(semverParsed);
       // We don't support these operators yet
       logger.warn(`Unsupported semver operator '${semverOperator}'`);
     }

--- a/lib/helpers/versions.js
+++ b/lib/helpers/versions.js
@@ -99,9 +99,7 @@ function determineUpgrades(dep, currentVersion, config) {
       // Skip these completely
       return;
     }
-    let upgrade = Object.assign({}, pinnedUpgrade);
-    // Set this flag to assist with templating
-    upgrade.isRange = true;
+    let upgrade = Object.assign({}, pinnedUpgrade, { isRange: true });
     const { major, minor } = semverUtils.parse(upgrade.newVersion);
     if (currentSemver.operator === '~') {
       // Utilise that a.b is the same as ~a.b.0

--- a/lib/helpers/versions.js
+++ b/lib/helpers/versions.js
@@ -79,95 +79,64 @@ function determineUpgrades(dep, currentVersion, config) {
   // Return only the values - we don't need the keys anymore
   const pinnedUpgrades = Object.keys(allUpgrades).map(key => allUpgrades[key]);
 
-  if (pinnedUpgrades.length && isRange(currentVersion) && !config.pinVersions) {
-    // The user prefers to maintain ranges, so we need to unpin our upgrades
-    const semverParsed = semverUtils.parseRange(currentVersion);
-    if (semverParsed.length > 1) {
-      // We don't know how to support complex semver ranges, so don't upgrade
-      logger.warn(`Can't support upgrading complex range ${currentVersion}`);
-      return [];
-    }
-    // Start with empty set of range upgrades
-    const rangeUpgrades = [];
-    // We know we have a simple semver, now check which operator it is
-    const semverOperator = semverParsed[0].operator;
-    if (semverOperator === '~') {
-      pinnedUpgrades.forEach((upgrade) => {
-        const upgradeMajor = semver.major(upgrade.newVersion);
-        const upgradeMinor = semver.minor(upgrade.newVersion);
-        // Utilise that a.b is the same as ~a.b.0
-        const newRange = `${upgradeMajor}.${upgradeMinor}`;
-        // Now find the minimum upgrade that satisfies the range
-        const minSatisfying = semver.minSatisfying(versionList, newRange);
-        const newUpgrade = Object.assign({}, upgrade);
-        // Add a tilde before that version number
-        newUpgrade.newVersion = `~${minSatisfying}`;
-        rangeUpgrades.push(newUpgrade);
-      });
-    } else if (semverOperator === '^') {
-      pinnedUpgrades.forEach((upgrade) => {
-        const upgradeMajor = semver.major(upgrade.newVersion);
-        const upgradeMinor = semver.minor(upgrade.newVersion);
-        let newRange = `${upgradeMajor}`;
-        // If version is < 1, then semver treats ^ same as ~
-        if (upgradeMajor === 0) {
-          newRange = `${upgradeMajor}.${upgradeMinor}`;
-        }
-        const minSatisfying = semver.minSatisfying(versionList, newRange);
-        const newUpgrade = Object.assign({}, upgrade);
-        // Add in the caret
-        newUpgrade.newVersion = `^${minSatisfying}`;
-        rangeUpgrades.push(newUpgrade);
-      });
-    } else if (semverOperator === '<=') {
-      pinnedUpgrades.forEach((upgrade) => {
-        const newUpgrade = Object.assign({}, upgrade);
-        // Add the operator to the front of the pinned upgrade version
-        newUpgrade.newVersion = `<= ${upgrade.newVersion}`;
-        rangeUpgrades.push(newUpgrade);
-      });
-    } else if (semverParsed[0].minor === 'x') {
-      pinnedUpgrades.forEach((upgrade) => {
-        const upgradeMajor = semver.major(upgrade.newVersion);
-        const newUpgrade = Object.assign({}, upgrade);
-        // Add a tilde before that version number
-        newUpgrade.newVersion = `${upgradeMajor}.x`;
-        rangeUpgrades.push(newUpgrade);
-      });
-    } else if (semverParsed[0].minor === undefined) {
-      pinnedUpgrades.forEach((upgrade) => {
-        const upgradeMajor = semver.major(upgrade.newVersion);
-        const newUpgrade = Object.assign({}, upgrade);
-        // Add a tilde before that version number
-        newUpgrade.newVersion = `${upgradeMajor}`;
-        rangeUpgrades.push(newUpgrade);
-      });
-    } else if (semverParsed[0].patch === undefined) {
-      pinnedUpgrades.forEach((upgrade) => {
-        const upgradeMajor = semver.major(upgrade.newVersion);
-        const upgradeMinor = semver.minor(upgrade.newVersion);
-        const newUpgrade = Object.assign({}, upgrade);
-        // Add a tilde before that version number
-        newUpgrade.newVersion = `${upgradeMajor}.${upgradeMinor}`;
-        rangeUpgrades.push(newUpgrade);
-      });
-    } else if (semverParsed[0].patch === 'x') {
-      pinnedUpgrades.forEach((upgrade) => {
-        const upgradeMajor = semver.major(upgrade.newVersion);
-        const upgradeMinor = semver.minor(upgrade.newVersion);
-        const newUpgrade = Object.assign({}, upgrade);
-        // Add a tilde before that version number
-        newUpgrade.newVersion = `${upgradeMajor}.${upgradeMinor}.x`;
-        rangeUpgrades.push(newUpgrade);
-      });
-    } else {
-      console.log(semverParsed);
-      // We don't support these operators yet
-      logger.warn(`Unsupported semver operator '${semverOperator}'`);
-    }
-    return rangeUpgrades;
+  if (pinnedUpgrades.length === 0 || config.pinVersions || !isRange(currentVersion)) {
+    return pinnedUpgrades;
   }
-  return pinnedUpgrades;
+
+  // The user prefers to maintain ranges, so we need to unpin our upgrades
+  const semverParsed = semverUtils.parseRange(currentVersion);
+  if (semverParsed.length > 1) {
+    // We don't know how to support complex semver ranges, so don't upgrade
+    logger.warn(`Can't support upgrading complex range ${currentVersion}`);
+    return [];
+  }
+  // Start with empty set of range upgrades
+  const rangeUpgrades = [];
+  // We know we have a simple semver, now check which operator it is
+  const currentSemver = semverParsed[0];
+  // Loop through all upgrades and convert to ranges
+  pinnedUpgrades.forEach((pinnedUpgrade) => {
+    let upgrade = Object.assign({}, pinnedUpgrade);
+    const upgradeMajor = semver.major(upgrade.newVersion);
+    const upgradeMinor = semver.minor(upgrade.newVersion);
+    if (currentSemver.operator === '~') {
+      // Utilise that a.b is the same as ~a.b.0
+      const minSatisfying = semver.minSatisfying(versionList, `${upgradeMajor}.${upgradeMinor}`);
+      // Add a tilde before that version number
+      upgrade.newVersion = `~${minSatisfying}`;
+    } else if (currentSemver.operator === '^') {
+      let newRange = `${upgradeMajor}`;
+      // If version is < 1, then semver treats ^ same as ~
+      if (upgradeMajor === 0) {
+        newRange = `${upgradeMajor}.${upgradeMinor}`;
+      }
+      const minSatisfying = semver.minSatisfying(versionList, newRange);
+      // Add in the caret
+      upgrade.newVersion = `^${minSatisfying}`;
+    } else if (currentSemver.operator === '<=') {
+      // Example: <= 1.2.0
+      upgrade.newVersion = `<= ${upgrade.newVersion}`;
+    } else if (currentSemver.minor === undefined) {
+      // Example: 1
+      upgrade.newVersion = `${upgradeMajor}`;
+    } else if (currentSemver.minor === 'x') {
+      // Example: 1.x
+      upgrade.newVersion = `${upgradeMajor}.x`;
+    } else if (currentSemver.patch === undefined) {
+      // Example: 1.2
+      upgrade.newVersion = `${upgradeMajor}.${upgradeMinor}`;
+    } else if (currentSemver.patch === 'x') {
+      // Example: 1.2.x
+      upgrade.newVersion = `${upgradeMajor}.${upgradeMinor}.x`;
+    } else {
+      logger.warn(`Unsupported semver type: ${currentSemver}`);
+      upgrade = null;
+    }
+    if (upgrade) {
+      rangeUpgrades.push(upgrade);
+    }
+  });
+  return rangeUpgrades;
 }
 
 function isRange(input) {

--- a/lib/helpers/versions.js
+++ b/lib/helpers/versions.js
@@ -94,45 +94,47 @@ function determineUpgrades(dep, currentVersion, config) {
   // We know we have a simple semver, now check which operator it is
   const currentSemver = semverParsed[0];
   // Loop through all upgrades and convert to ranges
-  _(pinnedUpgrades)
-    .reject(upgrade => upgrade.upgradeType === 'pin')
-    .forEach((pinnedUpgrade) => {
-      let upgrade = Object.assign({}, pinnedUpgrade, { isRange: true });
-      const { major, minor } = semverUtils.parse(upgrade.newVersion);
-      if (currentSemver.operator === '~') {
-        // Utilise that a.b is the same as ~a.b.0
-        const minSatisfying = semver.minSatisfying(versionList, `${major}.${minor}`);
-        // Add a tilde before that version number
-        upgrade.newVersion = `~${minSatisfying}`;
-      } else if (currentSemver.operator === '^') {
-        // If version is < 1, then semver treats ^ same as ~
-        const newRange = major === '0' ? `${major}.${minor}` : `${major}`;
-        const minSatisfying = semver.minSatisfying(versionList, newRange);
-        // Add in the caret
-        upgrade.newVersion = `^${minSatisfying}`;
-      } else if (currentSemver.operator === '<=') {
-        // Example: <= 1.2.0
-        upgrade.newVersion = `<= ${upgrade.newVersion}`;
-      } else if (currentSemver.minor === undefined) {
-        // Example: 1
-        upgrade.newVersion = `${major}`;
-      } else if (currentSemver.minor === 'x') {
-        // Example: 1.x
-        upgrade.newVersion = `${major}.x`;
-      } else if (currentSemver.patch === undefined) {
-        // Example: 1.2
-        upgrade.newVersion = `${major}.${minor}`;
-      } else if (currentSemver.patch === 'x') {
-        // Example: 1.2.x
-        upgrade.newVersion = `${major}.${minor}.x`;
-      } else {
-        logger.warn(`Unsupported semver type: ${currentSemver}`);
-        upgrade = null;
-      }
-      if (upgrade) {
-        rangeUpgrades.push(upgrade);
-      }
-    });
+  pinnedUpgrades.forEach((pinnedUpgrade) => {
+    if (pinnedUpgrade.upgradeType === 'pin') {
+      // Skip these completely
+      return;
+    }
+    let upgrade = Object.assign({}, pinnedUpgrade, { isRange: true });
+    const { major, minor } = semverUtils.parse(upgrade.newVersion);
+    if (currentSemver.operator === '~') {
+      // Utilise that a.b is the same as ~a.b.0
+      const minSatisfying = semver.minSatisfying(versionList, `${major}.${minor}`);
+      // Add a tilde before that version number
+      upgrade.newVersion = `~${minSatisfying}`;
+    } else if (currentSemver.operator === '^') {
+      // If version is < 1, then semver treats ^ same as ~
+      const newRange = major === 0 ? `${major}.${minor}` : `${major}`;
+      const minSatisfying = semver.minSatisfying(versionList, newRange);
+      // Add in the caret
+      upgrade.newVersion = `^${minSatisfying}`;
+    } else if (currentSemver.operator === '<=') {
+      // Example: <= 1.2.0
+      upgrade.newVersion = `<= ${upgrade.newVersion}`;
+    } else if (currentSemver.minor === undefined) {
+      // Example: 1
+      upgrade.newVersion = `${major}`;
+    } else if (currentSemver.minor === 'x') {
+      // Example: 1.x
+      upgrade.newVersion = `${major}.x`;
+    } else if (currentSemver.patch === undefined) {
+      // Example: 1.2
+      upgrade.newVersion = `${major}.${minor}`;
+    } else if (currentSemver.patch === 'x') {
+      // Example: 1.2.x
+      upgrade.newVersion = `${major}.${minor}.x`;
+    } else {
+      logger.warn(`Unsupported semver type: ${currentSemver}`);
+      upgrade = null;
+    }
+    if (upgrade) {
+      rangeUpgrades.push(upgrade);
+    }
+  });
   return rangeUpgrades;
 }
 

--- a/lib/helpers/versions.js
+++ b/lib/helpers/versions.js
@@ -75,7 +75,7 @@ function determineUpgrades(dep, currentVersion, config) {
     delete allUpgrades.pin;
   }
   // Return only the values - we don't need the keys anymore
-  const reducedUpgrades = Object.keys(allUpgrades).map(key => allUpgrades[key]);
+  const pinnedUpgrades = Object.keys(allUpgrades).map(key => allUpgrades[key]);
 
   // Check for ranges
   if (!config.pinVersions && isRange(currentVersion)) {
@@ -84,21 +84,35 @@ function determineUpgrades(dep, currentVersion, config) {
       logger.warn(`Can't support upgrading complex range ${currentVersion}`);
       return [];
     }
-    const newUpgrades = [];
+    const rangeUpgrades = [];
     if (semverParsed[0].operator === '~') {
-      reducedUpgrades.forEach((upgrade) => {
+      pinnedUpgrades.forEach((upgrade) => {
         const upgradeMajor = semver.major(upgrade.newVersion);
         const upgradeMinor = semver.minor(upgrade.newVersion);
         const newRange = `${upgradeMajor}.${upgradeMinor}`;
         const minSatisfying = semver.minSatisfying(versionList, newRange);
         const newUpgrade = Object.assign({}, upgrade);
         newUpgrade.newVersion = `~${minSatisfying}`;
-        newUpgrades.push(newUpgrade);
+        rangeUpgrades.push(newUpgrade);
       });
     }
-    return newUpgrades;
+    if (semverParsed[0].operator === '^') {
+      pinnedUpgrades.forEach((upgrade) => {
+        const upgradeMajor = semver.major(upgrade.newVersion);
+        const upgradeMinor = semver.minor(upgrade.newVersion);
+        let newRange = `${upgradeMajor}`;
+        if (upgradeMajor === 0) {
+          newRange = `${upgradeMajor}.${upgradeMinor}`;
+        }
+        const minSatisfying = semver.minSatisfying(versionList, newRange);
+        const newUpgrade = Object.assign({}, upgrade);
+        newUpgrade.newVersion = `^${minSatisfying}`;
+        rangeUpgrades.push(newUpgrade);
+      });
+    }
+    return rangeUpgrades;
   }
-  return reducedUpgrades;
+  return pinnedUpgrades;
 }
 
 function isRange(input) {

--- a/lib/helpers/versions.js
+++ b/lib/helpers/versions.js
@@ -25,14 +25,17 @@ function determineUpgrades(dep, currentVersion, config) {
   const allUpgrades = {};
   let workingVersion = currentVersion;
   // Check for a current range and pin it
-  if (config.pinVersions && isRange(currentVersion)) {
+  if (isRange(currentVersion)) {
     // Pin ranges to their maximum satisfying version
     const maxSatisfying = semver.maxSatisfying(versionList, currentVersion);
-    allUpgrades.pin = {
-      upgradeType: 'pin',
-      newVersion: maxSatisfying,
-      newVersionMajor: semver.major(maxSatisfying),
-    };
+    console.log('currentVersion is ' + currentVersion + ', maxSatisfying is ' + maxSatisfying); // eslint-disable-line
+    if (config.pinVersions) {
+      allUpgrades.pin = {
+        upgradeType: 'pin',
+        newVersion: maxSatisfying,
+        newVersionMajor: semver.major(maxSatisfying),
+      };
+    }
     workingVersion = maxSatisfying;
   }
   _(versionList)

--- a/lib/helpers/versions.js
+++ b/lib/helpers/versions.js
@@ -79,22 +79,28 @@ function determineUpgrades(dep, currentVersion, config) {
   // Return only the values - we don't need the keys anymore
   const pinnedUpgrades = Object.keys(allUpgrades).map(key => allUpgrades[key]);
 
-  // Check for ranges
-  if (!config.pinVersions && isRange(currentVersion)) {
+  if (isRange(currentVersion) && !config.pinVersions) {
+    // The user prefers to maintain ranges, so we need to unpin our upgrades
     const semverParsed = semverUtils.parseRange(currentVersion);
     if (semverParsed.length > 1) {
+      // We don't know how to support complex semver ranges, so don't upgrade
       logger.warn(`Can't support upgrading complex range ${currentVersion}`);
       return [];
     }
+    // Start with empty set of range upgrades
     const rangeUpgrades = [];
+    // We know we have a simple semver, now check which operator it is
     const semverOperator = semverParsed[0].operator;
     if (semverOperator === '~') {
       pinnedUpgrades.forEach((upgrade) => {
         const upgradeMajor = semver.major(upgrade.newVersion);
         const upgradeMinor = semver.minor(upgrade.newVersion);
+        // Utilise that a.b is the same as ~a.b.0
         const newRange = `${upgradeMajor}.${upgradeMinor}`;
+        // Now find the minimum upgrade that satisfies the range
         const minSatisfying = semver.minSatisfying(versionList, newRange);
         const newUpgrade = Object.assign({}, upgrade);
+        // Add a tilde before that version number
         newUpgrade.newVersion = `~${minSatisfying}`;
         rangeUpgrades.push(newUpgrade);
       });
@@ -103,21 +109,25 @@ function determineUpgrades(dep, currentVersion, config) {
         const upgradeMajor = semver.major(upgrade.newVersion);
         const upgradeMinor = semver.minor(upgrade.newVersion);
         let newRange = `${upgradeMajor}`;
+        // If version is < 1, then semver treats ^ same as ~
         if (upgradeMajor === 0) {
           newRange = `${upgradeMajor}.${upgradeMinor}`;
         }
         const minSatisfying = semver.minSatisfying(versionList, newRange);
         const newUpgrade = Object.assign({}, upgrade);
+        // Add in the caret
         newUpgrade.newVersion = `^${minSatisfying}`;
         rangeUpgrades.push(newUpgrade);
       });
     } else if (semverOperator === '<=') {
       pinnedUpgrades.forEach((upgrade) => {
         const newUpgrade = Object.assign({}, upgrade);
+        // Add the operator to the front of the pinned upgrade version
         newUpgrade.newVersion = `<= ${upgrade.newVersion}`;
         rangeUpgrades.push(newUpgrade);
       });
     } else {
+      // We don't support these operators yet
       logger.warn(`Unsupported semver operator '${semverOperator}'`);
     }
     return rangeUpgrades;

--- a/lib/helpers/versions.js
+++ b/lib/helpers/versions.js
@@ -77,6 +77,7 @@ function determineUpgrades(dep, currentVersion, config) {
   // Return only the values - we don't need the keys anymore
   const pinnedUpgrades = Object.keys(allUpgrades).map(key => allUpgrades[key]);
 
+  // Return now if array is empty, or we can keep pinned version upgrades
   if (pinnedUpgrades.length === 0 || config.pinVersions || !isRange(currentVersion)) {
     return pinnedUpgrades;
   }

--- a/lib/helpers/versions.js
+++ b/lib/helpers/versions.js
@@ -107,11 +107,8 @@ function determineUpgrades(dep, currentVersion, config) {
       // Add a tilde before that version number
       upgrade.newVersion = `~${minSatisfying}`;
     } else if (currentSemver.operator === '^') {
-      let newRange = `${major}`;
       // If version is < 1, then semver treats ^ same as ~
-      if (major === 0) {
-        newRange = `${major}.${minor}`;
-      }
+      const newRange = major === 0 ? `${major}.${minor}` : `${major}`;
       const minSatisfying = semver.minSatisfying(versionList, newRange);
       // Add in the caret
       upgrade.newVersion = `^${minSatisfying}`;

--- a/lib/helpers/versions.js
+++ b/lib/helpers/versions.js
@@ -25,7 +25,7 @@ function determineUpgrades(dep, currentVersion, config) {
   const allUpgrades = {};
   let workingVersion = currentVersion;
   // Check for a current range and pin it
-  if (isRange(currentVersion)) {
+  if (config.pinVersions && isRange(currentVersion)) {
     // Pin ranges to their maximum satisfying version
     const maxSatisfying = semver.maxSatisfying(versionList, currentVersion);
     allUpgrades.pin = {

--- a/lib/helpers/versions.js
+++ b/lib/helpers/versions.js
@@ -75,11 +75,11 @@ function determineUpgrades(dep, currentVersion, config) {
     delete allUpgrades.pin;
   }
   // Return only the values - we don't need the keys anymore
-  const pinnedUpgrades = Object.keys(allUpgrades).map(key => allUpgrades[key]);
+  const upgrades = Object.keys(allUpgrades).map(key => allUpgrades[key]);
 
   // Return now if array is empty, or we can keep pinned version upgrades
-  if (pinnedUpgrades.length === 0 || config.pinVersions || !isRange(currentVersion)) {
-    return pinnedUpgrades;
+  if (upgrades.length === 0 || config.pinVersions || !isRange(currentVersion)) {
+    return upgrades;
   }
 
   // The user prefers to maintain ranges, so we need to unpin our upgrades
@@ -92,42 +92,42 @@ function determineUpgrades(dep, currentVersion, config) {
   // We know we have a simple semver, now check which operator it is
   const currentSemver = semverParsed[0];
   // Loop through all upgrades and convert to ranges
-  return _(pinnedUpgrades)
-  .reject(pinnedUpgrade => pinnedUpgrade.upgradeType === 'pin')
-  .map((pinnedUpgrade) => {
-    const upgrade = Object.assign({}, pinnedUpgrade, { isRange: true });
+  return _(upgrades)
+  .reject(upgrade => upgrade.upgradeType === 'pin')
+  .map((upgrade) => {
+    const rangeUpgrade = Object.assign({}, upgrade, { isRange: true });
     const { major, minor } = semverUtils.parse(upgrade.newVersion);
     if (currentSemver.operator === '~') {
       // Utilise that a.b is the same as ~a.b.0
       const minSatisfying = semver.minSatisfying(versionList, `${major}.${minor}`);
       // Add a tilde before that version number
-      upgrade.newVersion = `~${minSatisfying}`;
+      rangeUpgrade.newVersion = `~${minSatisfying}`;
     } else if (currentSemver.operator === '^') {
       // If version is < 1, then semver treats ^ same as ~
       const newRange = major === '0' ? `${major}.${minor}` : `${major}`;
       const minSatisfying = semver.minSatisfying(versionList, newRange);
       // Add in the caret
-      upgrade.newVersion = `^${minSatisfying}`;
+      rangeUpgrade.newVersion = `^${minSatisfying}`;
     } else if (currentSemver.operator === '<=') {
       // Example: <= 1.2.0
-      upgrade.newVersion = `<= ${upgrade.newVersion}`;
+      rangeUpgrade.newVersion = `<= ${rangeUpgrade.newVersion}`;
     } else if (currentSemver.minor === undefined) {
       // Example: 1
-      upgrade.newVersion = `${major}`;
+      rangeUpgrade.newVersion = `${major}`;
     } else if (currentSemver.minor === 'x') {
       // Example: 1.x
-      upgrade.newVersion = `${major}.x`;
+      rangeUpgrade.newVersion = `${major}.x`;
     } else if (currentSemver.patch === undefined) {
       // Example: 1.2
-      upgrade.newVersion = `${major}.${minor}`;
+      rangeUpgrade.newVersion = `${major}.${minor}`;
     } else if (currentSemver.patch === 'x') {
       // Example: 1.2.x
-      upgrade.newVersion = `${major}.${minor}.x`;
+      rangeUpgrade.newVersion = `${major}.${minor}.x`;
     } else {
       logger.warn(`Unsupported semver type: ${currentSemver}`);
       return null;
     }
-    return upgrade;
+    return rangeUpgrade;
   })
   .compact()
   .value();

--- a/lib/helpers/versions.js
+++ b/lib/helpers/versions.js
@@ -94,40 +94,38 @@ function determineUpgrades(dep, currentVersion, config) {
   // Loop through all upgrades and convert to ranges
   return _(upgrades)
   .reject(upgrade => upgrade.upgradeType === 'pin')
+  .map(upgrade => Object.assign(upgrade, { isRange: true }))
   .map((upgrade) => {
-    const rangeUpgrade = Object.assign({}, upgrade, { isRange: true });
     const { major, minor } = semverUtils.parse(upgrade.newVersion);
     if (currentSemver.operator === '~') {
       // Utilise that a.b is the same as ~a.b.0
       const minSatisfying = semver.minSatisfying(versionList, `${major}.${minor}`);
       // Add a tilde before that version number
-      rangeUpgrade.newVersion = `~${minSatisfying}`;
+      return Object.assign(upgrade, { newVersion: `~${minSatisfying}` });
     } else if (currentSemver.operator === '^') {
       // If version is < 1, then semver treats ^ same as ~
       const newRange = major === '0' ? `${major}.${minor}` : `${major}`;
       const minSatisfying = semver.minSatisfying(versionList, newRange);
       // Add in the caret
-      rangeUpgrade.newVersion = `^${minSatisfying}`;
+      return Object.assign(upgrade, { newVersion: `^${minSatisfying}` });
     } else if (currentSemver.operator === '<=') {
       // Example: <= 1.2.0
-      rangeUpgrade.newVersion = `<= ${rangeUpgrade.newVersion}`;
+      return Object.assign(upgrade, { newVersion: `<= ${upgrade.newVersion}` });
     } else if (currentSemver.minor === undefined) {
       // Example: 1
-      rangeUpgrade.newVersion = `${major}`;
+      return Object.assign(upgrade, { newVersion: `${major}` });
     } else if (currentSemver.minor === 'x') {
       // Example: 1.x
-      rangeUpgrade.newVersion = `${major}.x`;
+      return Object.assign(upgrade, { newVersion: `${major}.x` });
     } else if (currentSemver.patch === undefined) {
       // Example: 1.2
-      rangeUpgrade.newVersion = `${major}.${minor}`;
+      return Object.assign(upgrade, { newVersion: `${major}.${minor}` });
     } else if (currentSemver.patch === 'x') {
       // Example: 1.2.x
-      rangeUpgrade.newVersion = `${major}.${minor}.x`;
-    } else {
-      logger.warn(`Unsupported semver type: ${currentSemver}`);
-      return null;
+      return Object.assign(upgrade, { newVersion: `${major}.${minor}.x` });
     }
-    return rangeUpgrade;
+    logger.warn(`Unsupported semver type: ${currentSemver}`);
+    return null;
   })
   .compact()
   .value();

--- a/lib/helpers/versions.js
+++ b/lib/helpers/versions.js
@@ -29,13 +29,11 @@ function determineUpgrades(dep, currentVersion, config) {
   if (isRange(currentVersion)) {
     // Pin ranges to their maximum satisfying version
     const maxSatisfying = semver.maxSatisfying(versionList, currentVersion);
-    if (config.pinVersions) {
-      allUpgrades.pin = {
-        upgradeType: 'pin',
-        newVersion: maxSatisfying,
-        newVersionMajor: semver.major(maxSatisfying),
-      };
-    }
+    allUpgrades.pin = {
+      upgradeType: 'pin',
+      newVersion: maxSatisfying,
+      newVersionMajor: semver.major(maxSatisfying),
+    };
     changeLogFromVersion = maxSatisfying;
   }
   _(versionList)
@@ -96,6 +94,10 @@ function determineUpgrades(dep, currentVersion, config) {
   const currentSemver = semverParsed[0];
   // Loop through all upgrades and convert to ranges
   pinnedUpgrades.forEach((pinnedUpgrade) => {
+    if (pinnedUpgrade.upgradeType === 'pin') {
+      // Skip these completely
+      return;
+    }
     let upgrade = Object.assign({}, pinnedUpgrade);
     const upgradeMajor = semver.major(upgrade.newVersion);
     const upgradeMinor = semver.minor(upgrade.newVersion);

--- a/lib/helpers/versions.js
+++ b/lib/helpers/versions.js
@@ -94,11 +94,9 @@ function determineUpgrades(dep, currentVersion, config) {
   // We know we have a simple semver, now check which operator it is
   const currentSemver = semverParsed[0];
   // Loop through all upgrades and convert to ranges
-  pinnedUpgrades.forEach((pinnedUpgrade) => {
-    if (pinnedUpgrade.upgradeType === 'pin') {
-      // Skip these completely
-      return;
-    }
+  _(pinnedUpgrades)
+  .reject(pinnedUpgrade => pinnedUpgrade.upgradeType === 'pin')
+  .forEach((pinnedUpgrade) => {
     let upgrade = Object.assign({}, pinnedUpgrade, { isRange: true });
     const { major, minor } = semverUtils.parse(upgrade.newVersion);
     if (currentSemver.operator === '~') {

--- a/lib/helpers/versions.js
+++ b/lib/helpers/versions.js
@@ -100,6 +100,8 @@ function determineUpgrades(dep, currentVersion, config) {
       return;
     }
     let upgrade = Object.assign({}, pinnedUpgrade);
+    // Set this flag to assist with templating
+    upgrade.isRange = true;
     const upgradeMajor = semver.major(upgrade.newVersion);
     const upgradeMinor = semver.minor(upgrade.newVersion);
     if (currentSemver.operator === '~') {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "registry-url": "3.1.0",
     "semver": "5.3.0",
     "semver-stable": "2.0.4",
+    "semver-utils": "1.1.1",
     "tmp": "0.0.31",
     "winston": "2.3.1"
   },

--- a/test/helpers/versions.spec.js
+++ b/test/helpers/versions.spec.js
@@ -102,6 +102,19 @@ describe('helpers/versions', () => {
       ];
       expect(versionsHelper.determineUpgrades(qJson, '~1.3.0', defaultConfig)).toEqual(upgradeVersions);
     });
+    it('upgrades tilde ranges without pinning', () => {
+      const upgradeVersions = [
+        {
+          newVersion: '~1.4.0',
+          newVersionMajor: 1,
+          upgradeType: 'minor',
+          workingVersion: '1.3.0',
+        },
+      ];
+      const config = Object.assign({}, defaultConfig);
+      config.pinVersions = false;
+      expect(versionsHelper.determineUpgrades(qJson, '~1.3.0', config)).toEqual(upgradeVersions);
+    });
     it('supports > latest versions if configured', () => {
       const config = Object.assign({}, defaultConfig);
       config.respectLatest = false;

--- a/test/helpers/versions.spec.js
+++ b/test/helpers/versions.spec.js
@@ -115,6 +115,25 @@ describe('helpers/versions', () => {
       config.pinVersions = false;
       expect(versionsHelper.determineUpgrades(qJson, '~1.3.0', config)).toEqual(upgradeVersions);
     });
+    it('upgrades multiple tilde ranges without pinning', () => {
+      const upgradeVersions = [
+        {
+          newVersion: '~0.9.0',
+          newVersionMajor: 0,
+          upgradeType: 'minor',
+          workingVersion: '0.7.2',
+        },
+        {
+          newVersion: '~1.4.0',
+          newVersionMajor: 1,
+          upgradeType: 'major',
+          workingVersion: '0.7.2',
+        },
+      ];
+      const config = Object.assign({}, defaultConfig);
+      config.pinVersions = false;
+      expect(versionsHelper.determineUpgrades(qJson, '~0.7.0', config)).toEqual(upgradeVersions);
+    });
     it('supports > latest versions if configured', () => {
       const config = Object.assign({}, defaultConfig);
       config.respectLatest = false;

--- a/test/helpers/versions.spec.js
+++ b/test/helpers/versions.spec.js
@@ -129,6 +129,7 @@ describe('helpers/versions', () => {
           upgradeType: 'minor',
           changeLogFromVersion: '1.3.0',
           changeLogToVersion: '1.4.1',
+          isRange: true,
         },
       ];
       const config = Object.assign({}, defaultConfig);
@@ -143,6 +144,7 @@ describe('helpers/versions', () => {
           upgradeType: 'major',
           changeLogFromVersion: '0.9.7',
           changeLogToVersion: '1.4.1',
+          isRange: true,
         },
       ];
       const config = Object.assign({}, defaultConfig);
@@ -157,6 +159,7 @@ describe('helpers/versions', () => {
           upgradeType: 'minor',
           changeLogFromVersion: '1.3.0',
           changeLogToVersion: '1.4.1',
+          isRange: true,
         },
       ];
       const config = Object.assign({}, defaultConfig);
@@ -171,6 +174,7 @@ describe('helpers/versions', () => {
           upgradeType: 'major',
           changeLogFromVersion: '0.9.7',
           changeLogToVersion: '1.4.1',
+          isRange: true,
         },
       ];
       const config = Object.assign({}, defaultConfig);
@@ -185,6 +189,7 @@ describe('helpers/versions', () => {
           upgradeType: 'minor',
           changeLogFromVersion: '1.3.0',
           changeLogToVersion: '1.4.1',
+          isRange: true,
         },
       ];
       const config = Object.assign({}, defaultConfig);
@@ -199,6 +204,7 @@ describe('helpers/versions', () => {
           upgradeType: 'minor',
           changeLogFromVersion: '0.7.2',
           changeLogToVersion: '0.9.7',
+          isRange: true,
         },
         {
           newVersion: '~1.4.0',
@@ -206,6 +212,7 @@ describe('helpers/versions', () => {
           upgradeType: 'major',
           changeLogFromVersion: '0.7.2',
           changeLogToVersion: '1.4.1',
+          isRange: true,
         },
       ];
       const config = Object.assign({}, defaultConfig);
@@ -220,6 +227,7 @@ describe('helpers/versions', () => {
           upgradeType: 'minor',
           changeLogFromVersion: '0.7.2',
           changeLogToVersion: '0.9.7',
+          isRange: true,
         },
         {
           newVersion: '^1.0.0',
@@ -227,6 +235,7 @@ describe('helpers/versions', () => {
           upgradeType: 'major',
           changeLogFromVersion: '0.7.2',
           changeLogToVersion: '1.4.1',
+          isRange: true,
         },
       ];
       const config = Object.assign({}, defaultConfig);
@@ -251,6 +260,7 @@ describe('helpers/versions', () => {
           upgradeType: 'minor',
           changeLogFromVersion: '0.7.2',
           changeLogToVersion: '0.9.7',
+          isRange: true,
         },
         {
           newVersion: '<= 1.4.1',
@@ -258,6 +268,7 @@ describe('helpers/versions', () => {
           upgradeType: 'major',
           changeLogFromVersion: '0.7.2',
           changeLogToVersion: '1.4.1',
+          isRange: true,
         },
       ];
       const config = Object.assign({}, defaultConfig);

--- a/test/helpers/versions.spec.js
+++ b/test/helpers/versions.spec.js
@@ -134,6 +134,30 @@ describe('helpers/versions', () => {
       config.pinVersions = false;
       expect(versionsHelper.determineUpgrades(qJson, '~0.7.0', config)).toEqual(upgradeVersions);
     });
+    it('upgrades multiple tilde ranges without pinning', () => {
+      const upgradeVersions = [
+        {
+          newVersion: '^0.9.0',
+          newVersionMajor: 0,
+          upgradeType: 'minor',
+          workingVersion: '0.7.2',
+        },
+        {
+          newVersion: '^1.0.0',
+          newVersionMajor: 1,
+          upgradeType: 'major',
+          workingVersion: '0.7.2',
+        },
+      ];
+      const config = Object.assign({}, defaultConfig);
+      config.pinVersions = false;
+      expect(versionsHelper.determineUpgrades(qJson, '^0.7.0', config)).toEqual(upgradeVersions);
+    });
+    it('ignores complex ranges when not pinning', () => {
+      const config = Object.assign({}, defaultConfig);
+      config.pinVersions = false;
+      expect(versionsHelper.determineUpgrades(qJson, '^0.7.0 || ^0.8.0', config)).toHaveLength(0);
+    });
     it('supports > latest versions if configured', () => {
       const config = Object.assign({}, defaultConfig);
       config.respectLatest = false;

--- a/test/helpers/versions.spec.js
+++ b/test/helpers/versions.spec.js
@@ -26,16 +26,16 @@ describe('helpers/versions', () => {
           newVersion: '0.9.7',
           newVersionMajor: 0,
           upgradeType: 'minor',
-          workingVersion: '0.4.4',
+          workingVersion: '0.4.0',
         },
         {
           newVersion: '1.4.1',
           newVersionMajor: 1,
           upgradeType: 'major',
-          workingVersion: '0.4.4',
+          workingVersion: '0.4.0',
         },
       ];
-      versionsHelper.determineUpgrades(qJson, '^0.4.0', defaultConfig).should.eql(upgradeVersions);
+      expect(versionsHelper.determineUpgrades(qJson, '0.4.0', defaultConfig)).toEqual(upgradeVersions);
     });
     it('supports minor and major upgrades for ranged versions', () => {
       const pinVersions = [
@@ -53,6 +53,54 @@ describe('helpers/versions', () => {
         },
       ];
       versionsHelper.determineUpgrades(qJson, '~0.4.0', defaultConfig).should.eql(pinVersions);
+    });
+    it('ignores pinning for ranges when other upgrade exists', () => {
+      const pinVersions = [
+        {
+          newVersion: '1.4.1',
+          newVersionMajor: 1,
+          upgradeType: 'major',
+          workingVersion: '0.9.7',
+        },
+      ];
+      expect(versionsHelper.determineUpgrades(qJson, '~0.9.0', defaultConfig)).toEqual(pinVersions);
+    });
+    it('upgrades minor ranged versions', () => {
+      const upgradeVersions = [
+        {
+          newVersion: '1.4.1',
+          newVersionMajor: 1,
+          upgradeType: 'minor',
+          workingVersion: '1.0.1',
+        },
+      ];
+      expect(versionsHelper.determineUpgrades(qJson, '~1.0.0', defaultConfig)).toEqual(upgradeVersions);
+    });
+    it('pins minor ranged versions', () => {
+      const upgradeVersions = [
+        {
+          newVersion: '1.4.1',
+          newVersionMajor: 1,
+          upgradeType: 'pin',
+        },
+      ];
+      expect(versionsHelper.determineUpgrades(qJson, '^1.0.0', defaultConfig)).toEqual(upgradeVersions);
+    });
+    it('ignores minor ranged versions when not pinning', () => {
+      const noPinConfig = Object.assign({}, defaultConfig);
+      noPinConfig.pinVersions = false;
+      expect(versionsHelper.determineUpgrades(qJson, '^1.0.0', noPinConfig)).toHaveLength(0);
+    });
+    it('upgrades tilde ranges', () => {
+      const upgradeVersions = [
+        {
+          newVersion: '1.4.1',
+          newVersionMajor: 1,
+          upgradeType: 'minor',
+          workingVersion: '1.3.0',
+        },
+      ];
+      expect(versionsHelper.determineUpgrades(qJson, '~1.3.0', defaultConfig)).toEqual(upgradeVersions);
     });
     it('supports > latest versions if configured', () => {
       const config = Object.assign({}, defaultConfig);

--- a/test/helpers/versions.spec.js
+++ b/test/helpers/versions.spec.js
@@ -20,24 +20,24 @@ describe('helpers/versions', () => {
       };
       versionsHelper.determineUpgrades(testDep, '1.0.0', defaultConfig).should.have.length(0);
     });
-    it('supports minor and major upgrades for pinned versions', () => {
+    it('supports minor and major upgrades for tilde ranges', () => {
       const upgradeVersions = [
         {
           newVersion: '0.9.7',
           newVersionMajor: 0,
           upgradeType: 'minor',
-          changeLogFromVersion: '0.4.0',
+          changeLogFromVersion: '0.4.4',
           changeLogToVersion: '0.9.7',
         },
         {
           newVersion: '1.4.1',
           newVersionMajor: 1,
           upgradeType: 'major',
-          changeLogFromVersion: '0.4.0',
+          changeLogFromVersion: '0.4.4',
           changeLogToVersion: '1.4.1',
         },
       ];
-      expect(versionsHelper.determineUpgrades(qJson, '0.4.0', defaultConfig)).toEqual(upgradeVersions);
+      versionsHelper.determineUpgrades(qJson, '^0.4.0', defaultConfig).should.eql(upgradeVersions);
     });
     it('supports minor and major upgrades for ranged versions', () => {
       const pinVersions = [

--- a/test/helpers/versions.spec.js
+++ b/test/helpers/versions.spec.js
@@ -93,9 +93,8 @@ describe('helpers/versions', () => {
       expect(versionsHelper.determineUpgrades(qJson, '^1.0.0', defaultConfig)).toEqual(upgradeVersions);
     });
     it('ignores minor ranged versions when not pinning', () => {
-      const noPinConfig = Object.assign({}, defaultConfig);
-      noPinConfig.pinVersions = false;
-      expect(versionsHelper.determineUpgrades(qJson, '^1.0.0', noPinConfig)).toHaveLength(0);
+      const config = Object.assign({}, defaultConfig, { pinVersions: false });
+      expect(versionsHelper.determineUpgrades(qJson, '^1.0.0', config)).toHaveLength(0);
     });
     it('upgrades tilde ranges', () => {
       const upgradeVersions = [
@@ -132,8 +131,7 @@ describe('helpers/versions', () => {
           isRange: true,
         },
       ];
-      const config = Object.assign({}, defaultConfig);
-      config.pinVersions = false;
+      const config = Object.assign({}, defaultConfig, { pinVersions: false });
       expect(versionsHelper.determineUpgrades(qJson, '~1.3.0', config)).toEqual(upgradeVersions);
     });
     it('upgrades .x major ranges without pinning', () => {
@@ -147,8 +145,7 @@ describe('helpers/versions', () => {
           isRange: true,
         },
       ];
-      const config = Object.assign({}, defaultConfig);
-      config.pinVersions = false;
+      const config = Object.assign({}, defaultConfig, { pinVersions: false });
       expect(versionsHelper.determineUpgrades(qJson, '0.x', config)).toEqual(upgradeVersions);
     });
     it('upgrades .x minor ranges without pinning', () => {
@@ -162,8 +159,7 @@ describe('helpers/versions', () => {
           isRange: true,
         },
       ];
-      const config = Object.assign({}, defaultConfig);
-      config.pinVersions = false;
+      const config = Object.assign({}, defaultConfig, { pinVersions: false });
       expect(versionsHelper.determineUpgrades(qJson, '1.3.x', config)).toEqual(upgradeVersions);
     });
     it('upgrades shorthand major ranges without pinning', () => {
@@ -177,8 +173,7 @@ describe('helpers/versions', () => {
           isRange: true,
         },
       ];
-      const config = Object.assign({}, defaultConfig);
-      config.pinVersions = false;
+      const config = Object.assign({}, defaultConfig, { pinVersions: false });
       expect(versionsHelper.determineUpgrades(qJson, '0', config)).toEqual(upgradeVersions);
     });
     it('upgrades shorthand minor ranges without pinning', () => {
@@ -192,8 +187,7 @@ describe('helpers/versions', () => {
           isRange: true,
         },
       ];
-      const config = Object.assign({}, defaultConfig);
-      config.pinVersions = false;
+      const config = Object.assign({}, defaultConfig, { pinVersions: false });
       expect(versionsHelper.determineUpgrades(qJson, '1.3', config)).toEqual(upgradeVersions);
     });
     it('upgrades multiple tilde ranges without pinning', () => {
@@ -215,8 +209,7 @@ describe('helpers/versions', () => {
           isRange: true,
         },
       ];
-      const config = Object.assign({}, defaultConfig);
-      config.pinVersions = false;
+      const config = Object.assign({}, defaultConfig, { pinVersions: false });
       expect(versionsHelper.determineUpgrades(qJson, '~0.7.0', config)).toEqual(upgradeVersions);
     });
     it('upgrades multiple caret ranges without pinning', () => {
@@ -238,18 +231,15 @@ describe('helpers/versions', () => {
           isRange: true,
         },
       ];
-      const config = Object.assign({}, defaultConfig);
-      config.pinVersions = false;
+      const config = Object.assign({}, defaultConfig, { pinVersions: false });
       expect(versionsHelper.determineUpgrades(qJson, '^0.7.0', config)).toEqual(upgradeVersions);
     });
     it('ignores complex ranges when not pinning', () => {
-      const config = Object.assign({}, defaultConfig);
-      config.pinVersions = false;
+      const config = Object.assign({}, defaultConfig, { pinVersions: false });
       expect(versionsHelper.determineUpgrades(qJson, '^0.7.0 || ^0.8.0', config)).toHaveLength(0);
     });
     it('returns nothing for greater than ranges', () => {
-      const config = Object.assign({}, defaultConfig);
-      config.pinVersions = false;
+      const config = Object.assign({}, defaultConfig, { pinVersions: false });
       expect(versionsHelper.determineUpgrades(qJson, '>= 0.7.0', config)).toHaveLength(0);
     });
     it('upgrades less than equal ranges without pinning', () => {
@@ -271,8 +261,7 @@ describe('helpers/versions', () => {
           isRange: true,
         },
       ];
-      const config = Object.assign({}, defaultConfig);
-      config.pinVersions = false;
+      const config = Object.assign({}, defaultConfig, { pinVersions: false });
       expect(versionsHelper.determineUpgrades(qJson, '<= 0.7.2', config)).toEqual(upgradeVersions);
     });
     it('supports > latest versions if configured', () => {

--- a/test/helpers/versions.spec.js
+++ b/test/helpers/versions.spec.js
@@ -109,6 +109,18 @@ describe('helpers/versions', () => {
       ];
       expect(versionsHelper.determineUpgrades(qJson, '~1.3.0', defaultConfig)).toEqual(upgradeVersions);
     });
+    it('upgrades .x minor ranges', () => {
+      const upgradeVersions = [
+        {
+          newVersion: '1.4.1',
+          newVersionMajor: 1,
+          upgradeType: 'minor',
+          changeLogFromVersion: '1.3.0',
+          changeLogToVersion: '1.4.1',
+        },
+      ];
+      expect(versionsHelper.determineUpgrades(qJson, '1.3.x', defaultConfig)).toEqual(upgradeVersions);
+    });
     it('upgrades tilde ranges without pinning', () => {
       const upgradeVersions = [
         {
@@ -122,6 +134,62 @@ describe('helpers/versions', () => {
       const config = Object.assign({}, defaultConfig);
       config.pinVersions = false;
       expect(versionsHelper.determineUpgrades(qJson, '~1.3.0', config)).toEqual(upgradeVersions);
+    });
+    it('upgrades .x major ranges without pinning', () => {
+      const upgradeVersions = [
+        {
+          newVersion: '1.x',
+          newVersionMajor: 1,
+          upgradeType: 'major',
+          changeLogFromVersion: '0.9.7',
+          changeLogToVersion: '1.4.1',
+        },
+      ];
+      const config = Object.assign({}, defaultConfig);
+      config.pinVersions = false;
+      expect(versionsHelper.determineUpgrades(qJson, '0.x', config)).toEqual(upgradeVersions);
+    });
+    it('upgrades .x minor ranges without pinning', () => {
+      const upgradeVersions = [
+        {
+          newVersion: '1.4.x',
+          newVersionMajor: 1,
+          upgradeType: 'minor',
+          changeLogFromVersion: '1.3.0',
+          changeLogToVersion: '1.4.1',
+        },
+      ];
+      const config = Object.assign({}, defaultConfig);
+      config.pinVersions = false;
+      expect(versionsHelper.determineUpgrades(qJson, '1.3.x', config)).toEqual(upgradeVersions);
+    });
+    it('upgrades shorthand major ranges without pinning', () => {
+      const upgradeVersions = [
+        {
+          newVersion: '1',
+          newVersionMajor: 1,
+          upgradeType: 'major',
+          changeLogFromVersion: '0.9.7',
+          changeLogToVersion: '1.4.1',
+        },
+      ];
+      const config = Object.assign({}, defaultConfig);
+      config.pinVersions = false;
+      expect(versionsHelper.determineUpgrades(qJson, '0', config)).toEqual(upgradeVersions);
+    });
+    it('upgrades shorthand minor ranges without pinning', () => {
+      const upgradeVersions = [
+        {
+          newVersion: '1.4',
+          newVersionMajor: 1,
+          upgradeType: 'minor',
+          changeLogFromVersion: '1.3.0',
+          changeLogToVersion: '1.4.1',
+        },
+      ];
+      const config = Object.assign({}, defaultConfig);
+      config.pinVersions = false;
+      expect(versionsHelper.determineUpgrades(qJson, '1.3', config)).toEqual(upgradeVersions);
     });
     it('upgrades multiple tilde ranges without pinning', () => {
       const upgradeVersions = [

--- a/test/helpers/versions.spec.js
+++ b/test/helpers/versions.spec.js
@@ -158,6 +158,30 @@ describe('helpers/versions', () => {
       config.pinVersions = false;
       expect(versionsHelper.determineUpgrades(qJson, '^0.7.0 || ^0.8.0', config)).toHaveLength(0);
     });
+    it('returns nothing for greater than ranges', () => {
+      const config = Object.assign({}, defaultConfig);
+      config.pinVersions = false;
+      expect(versionsHelper.determineUpgrades(qJson, '>= 0.7.0', config)).toHaveLength(0);
+    });
+    it('upgrades multiple tilde ranges without pinning', () => {
+      const upgradeVersions = [
+        {
+          newVersion: '<= 0.9.7',
+          newVersionMajor: 0,
+          upgradeType: 'minor',
+          workingVersion: '0.7.2',
+        },
+        {
+          newVersion: '<= 1.4.1',
+          newVersionMajor: 1,
+          upgradeType: 'major',
+          workingVersion: '0.7.2',
+        },
+      ];
+      const config = Object.assign({}, defaultConfig);
+      config.pinVersions = false;
+      expect(versionsHelper.determineUpgrades(qJson, '<= 0.7.2', config)).toEqual(upgradeVersions);
+    });
     it('supports > latest versions if configured', () => {
       const config = Object.assign({}, defaultConfig);
       config.respectLatest = false;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3082,6 +3082,10 @@ semver-stable@2.0.4:
   dependencies:
     semver "^5.0.1"
 
+semver-utils@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/semver-utils/-/semver-utils-1.1.1.tgz#27d92fec34d27cfa42707d3b40d025ae9855f2df"
+
 "semver@2 || 3 || 4 || 5", semver@5.3.0, semver@^5.0.1, semver@^5.0.3, semver@^5.1.0, semver@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"


### PR DESCRIPTION
This Pull Request adds support for maintaining simple semver ranges (`~1.0.0`, `^1.0.0`, `<= 1.0.0`, `1.x`, `1.0.x`, `1`, `1.0`). It is configured by setting the new `pinVersions` config option to false (default is true, i.e. existing behaviour which pins).

Great thanks to @hbetts for the work in #139 and other related discussions.

Closes #31