### PR TITLE
Add repository autodiscovery

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,11 +39,24 @@ module.exports = {
     },
     {
       repository: 'singapore/repo2',
-      depTypes: ['dependencies', 'devDependencies', 'optionalDependencies'],
+      depTypes: [
+        'dependencies',
+        'devDependencies',
+        {
+          depType: 'optionalDependencies',
+          labels: ['renovate', 'optional'],
+        },
+      ],
       labels: ['renovate'],
     },
     'singapore/repo3',
-  ]
+  ],
+  packages: [
+    {
+      package: 'jquery',
+      labels: ['jquery', 'uhoh'],
+    },
+  ],
 }
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,6 +62,7 @@ $ node renovate --help
     --platform <string>             Platform type of repository
     --endpoint <string>             Custom endpoint to use
     --token <string>                Repository Auth Token
+    --autodiscover [boolean]        Autodiscover all repositories
     --package-files <list>          Package file paths
     --dep-types <list>              Dependency types
     --ignore-deps <list>            Dependencies to ignore
@@ -112,6 +113,7 @@ Obviously, you can't set repository or package file location with this method.
 | `platform` | Platform type of repository | string | `"github"` | `RENOVATE_PLATFORM` | `--platform` |
 | `endpoint` | Custom endpoint to use | string | `null` | `RENOVATE_ENDPOINT` | `--endpoint` |
 | `token` | Repository Auth Token | string | `null` | `RENOVATE_TOKEN` | `--token` |
+| `autodiscover` | Autodiscover all repositories | boolean | `false` | `RENOVATE_AUTODISCOVER` | `--autodiscover` |
 | `repositories` | List of Repositories | list | `[]` | `RENOVATE_REPOSITORIES` |  |
 | `packageFiles` | Package file paths | list | `[]` | `RENOVATE_PACKAGE_FILES` | `--package-files` |
 | `depTypes` | Dependency types | list | `["dependencies", "devDependencies", "optionalDependencies"]` | `RENOVATE_DEP_TYPES` | `--dep-types` |

--- a/lib/api/github.js
+++ b/lib/api/github.js
@@ -43,7 +43,7 @@ async function getRepos(token, endpoint) {
     const res = await ghGot('user/repos');
     return res.body.map(repo => repo.full_name);
   } catch (err) {
-    logger.error(`GitHub init error: ${JSON.stringify(err)}`);
+    logger.error(`GitHub getRepos error: ${JSON.stringify(err)}`);
     throw err;
   }
 }

--- a/lib/api/github.js
+++ b/lib/api/github.js
@@ -4,6 +4,7 @@ const ghGot = require('gh-got');
 const config = {};
 
 module.exports = {
+  getRepos,
   initRepo,
   // Search
   findFilePaths,
@@ -26,6 +27,26 @@ module.exports = {
   getFileContent,
   getFileJson,
 };
+
+// Get all repositories that the user has access to
+async function getRepos(token, endpoint) {
+  logger.debug('getRepos(token, endpoint)');
+  if (token) {
+    process.env.GITHUB_TOKEN = token;
+  } else if (!process.env.GITHUB_TOKEN) {
+    throw new Error('No token found for getRepos');
+  }
+  if (endpoint) {
+    process.env.GITHUB_ENDPOINT = endpoint;
+  }
+  try {
+    const res = await ghGot('user/repos');
+    return res.map(repo => repo.full_name);
+  } catch (err) {
+    logger.error(`GitHub init error: ${JSON.stringify(err)}`);
+    throw err;
+  }
+}
 
 // Initialize GitHub by getting base branch and SHA
 async function initRepo(repoName, token, endpoint) {

--- a/lib/api/github.js
+++ b/lib/api/github.js
@@ -44,7 +44,7 @@ async function getRepos(token, endpoint) {
   try {
     const res = await ghGot('user/repos');
     return res.body.map(repo => repo.full_name);
-  } catch (err) {
+  } catch (err) /* istanbul ignore next */ {
     logger.error(`GitHub getRepos error: ${JSON.stringify(err)}`);
     throw err;
   }

--- a/lib/api/github.js
+++ b/lib/api/github.js
@@ -41,7 +41,7 @@ async function getRepos(token, endpoint) {
   }
   try {
     const res = await ghGot('user/repos');
-    return res.map(repo => repo.full_name);
+    return res.body.map(repo => repo.full_name);
   } catch (err) {
     logger.error(`GitHub init error: ${JSON.stringify(err)}`);
     throw err;

--- a/lib/api/gitlab.js
+++ b/lib/api/gitlab.js
@@ -4,6 +4,7 @@ const glGot = require('gl-got');
 const config = {};
 
 module.exports = {
+  getRepos,
   initRepo,
   // Search
   findFilePaths,
@@ -26,6 +27,26 @@ module.exports = {
   getFileContent,
   getFileJson,
 };
+
+// Get all repositories that the user has access to
+async function getRepos(token, endpoint) {
+  logger.debug('getRepos(token, endpoint)');
+  if (token) {
+    process.env.GITLAB_TOKEN = token;
+  } else if (!process.env.GITLAB_TOKEN) {
+    throw new Error('No token found for getRepos');
+  }
+  if (endpoint) {
+    process.env.GITLAB_ENDPOINT = endpoint;
+  }
+  try {
+    const res = await glGot('projects');
+    return res.body.map(repo => repo.path_with_namespace);
+  } catch (err) {
+    logger.error(`GitLab getRepos error: ${JSON.stringify(err)}`);
+    throw err;
+  }
+}
 
 // Initialize GitLab by getting base branch
 async function initRepo(repoName, token, endpoint) {

--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -32,6 +32,12 @@ const options = [
     type: 'string',
   },
   {
+    name: 'autodiscover',
+    description: 'Autodiscover all repositories',
+    type: 'boolean',
+    default: false,
+  },
+  {
     name: 'repositories',
     description: 'List of Repositories',
     type: 'list',

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -38,20 +38,22 @@ async function parseConfigs(env, argv) {
   // Get global config
   logger.debug(`raw config=${redact(config)}`);
 
-  // Check platform
-  if (config.platform !== 'github' && config.platform !== 'gitlab') {
+  // Check platforms and tokens
+  if (config.platform === 'github') {
+    if (!config.token && !env.GITHUB_TOKEN) {
+      throw new Error('You need to supply a GitHub token.');
+    }
+    config.api = githubApi;
+  } else if (config.platform === 'gitlab') {
+    if (!config.token && !env.GITLAB_TOKEN) {
+      throw new Error('You need to supply a GitLab token.');
+    }
+    config.api = gitlabApi;
+  } else {
     throw new Error(`Unsupported platform: ${config.platform}.`);
   }
 
-  // Check for token
-  if (!config.token) {
-    if (config.platform === 'github' && !env.GITHUB_TOKEN) {
-      throw new Error('You need to supply a GitHub token.');
-    } else if (config.platform === 'gitlab' && !env.GITLAB_TOKEN) {
-      throw new Error('You need to supply a GitLab token.');
-    }
-  }
-
+  // Autodiscover
   if (config.autodiscover) {
     if (config.platform === 'github') {
       logger.info('Autodiscovering GitHub repositories');
@@ -64,10 +66,7 @@ async function parseConfigs(env, argv) {
       logger.info('The account associated with your token does not have access to any repos');
       return;
     }
-  }
-
-  // We need at least one repository defined
-  if (!config.repositories || config.repositories.length === 0) {
+  } else if (!config.repositories || config.repositories.length === 0) {
     throw new Error('At least one repository must be configured, or use --autodiscover');
   }
 

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -63,11 +63,15 @@ async function parseConfigs(env, argv) {
       config.repositories = await gitlabApi.getRepos(config.token, config.endpoint);
     }
     if (!config.repositories || config.repositories.length === 0) {
+      // Soft fail (no error thrown) if no accessible repositories
       logger.info('The account associated with your token does not have access to any repos');
       return;
     }
-  } else if (!config.repositories || config.repositories.length === 0) {
-    throw new Error('At least one repository must be configured, or use --autodiscover');
+  }
+
+  // We need at least one repository defined
+  if (!config.repositories || config.repositories.length === 0) {
+    throw new Error('At least one repository must be configured');
   }
 
   // Configure each repository

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -1,5 +1,7 @@
 const logger = require('winston');
 const stringify = require('json-stringify-pretty-compact');
+const githubApi = require('../api/github');
+const gitlabApi = require('../api/gitlab');
 
 const defaultsParser = require('./defaults');
 const fileParser = require('./file');
@@ -14,7 +16,7 @@ module.exports = {
   getRepositories,
 };
 
-function parseConfigs(env, argv) {
+async function parseConfigs(env, argv) {
   logger.debug('Parsing configs');
 
   // Get configs
@@ -35,6 +37,20 @@ function parseConfigs(env, argv) {
 
   // Get global config
   logger.debug(`raw config=${redact(config)}`);
+
+  if (config.autodiscover) {
+    logger.info('Autodiscovering repositories...');
+    let api;
+    if (config.platform === 'github') {
+      api = githubApi;
+    } else if (config.platform === 'gitlab') {
+      api = gitlabApi;
+    } else {
+      logger.error(`Unknown platform ${config.platform}`);
+      return;
+    }
+    config.repositories = await api.getRepos(config.token, config.endpoint);
+  }
 
   // We need at least one repository defined
   if (!config.repositories || config.repositories.length === 0) {

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -39,18 +39,18 @@ async function parseConfigs(env, argv) {
   logger.debug(`raw config=${redact(config)}`);
 
   if (config.autodiscover) {
-    logger.info('Autodiscovering repositories...');
-    let api;
     if (config.platform === 'github') {
-      api = githubApi;
+      logger.info('Autodiscovering GitHub repositories');
+      config.repositories = await githubApi.getRepos(config.token, config.endpoint);
     } else if (config.platform === 'gitlab') {
-      api = gitlabApi;
+      logger.info('Autodiscovering GitLab repositories');
+      config.repositories = await gitlabApi.getRepos(config.token, config.endpoint);
     } else {
       logger.error(`Unknown platform ${config.platform}`);
       return;
     }
-    config.repositories = await api.getRepos(config.token, config.endpoint);
   }
+
 
   // We need at least one repository defined
   if (!config.repositories || config.repositories.length === 0) {

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -38,6 +38,20 @@ async function parseConfigs(env, argv) {
   // Get global config
   logger.debug(`raw config=${redact(config)}`);
 
+  // Check platform
+  if (config.platform !== 'github' && config.platform !== 'gitlab') {
+    throw new Error(`Unsupported platform: ${config.platform}.`);
+  }
+
+  // Check for token
+  if (!config.token) {
+    if (config.platform === 'github' && !env.GITHUB_TOKEN) {
+      throw new Error('You need to supply a GitHub token.');
+    } else if (config.platform === 'gitlab' && !env.GITLAB_TOKEN) {
+      throw new Error('You need to supply a GitLab token.');
+    }
+  }
+
   if (config.autodiscover) {
     if (config.platform === 'github') {
       logger.info('Autodiscovering GitHub repositories');
@@ -45,9 +59,6 @@ async function parseConfigs(env, argv) {
     } else if (config.platform === 'gitlab') {
       logger.info('Autodiscovering GitLab repositories');
       config.repositories = await gitlabApi.getRepos(config.token, config.endpoint);
-    } else {
-      logger.error(`Unsupported platform: ${config.platform}`);
-      return;
     }
     if (!config.repositories || config.repositories.length === 0) {
       logger.info('The account associated with your token does not have access to any repos');

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -46,7 +46,7 @@ async function parseConfigs(env, argv) {
       logger.info('Autodiscovering GitLab repositories');
       config.repositories = await gitlabApi.getRepos(config.token, config.endpoint);
     } else {
-      logger.error(`Unknown platform ${config.platform}`);
+      logger.error(`Unsupported platform: ${config.platform}`);
       return;
     }
   }

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -67,11 +67,9 @@ async function parseConfigs(env, argv) {
       logger.info('The account associated with your token does not have access to any repos');
       return;
     }
-  }
-
-  // We need at least one repository defined
-  if (!config.repositories || config.repositories.length === 0) {
-    throw new Error('At least one repository must be configured');
+  } else if (!config.repositories || config.repositories.length === 0) {
+    // We need at least one repository defined
+    throw new Error('At least one repository must be configured, or use --autodiscover');
   }
 
   // Configure each repository

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -49,12 +49,15 @@ async function parseConfigs(env, argv) {
       logger.error(`Unsupported platform: ${config.platform}`);
       return;
     }
+    if (!config.repositories || config.repositories.length === 0) {
+      logger.info('The account associated with your token does not have access to any repos');
+      return;
+    }
   }
-
 
   // We need at least one repository defined
   if (!config.repositories || config.repositories.length === 0) {
-    throw new Error('At least one repository must be configured');
+    throw new Error('At least one repository must be configured, or use --autodiscover');
   }
 
   // Configure each repository

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,7 @@ let api;
 async function start() {
   // Parse config
   try {
-    configParser.parseConfigs(process.env, process.argv);
+    await configParser.parseConfigs(process.env, process.argv);
     // Iterate through repositories sequentially
     for (const repo of configParser.getRepositories()) {
       await processRepo(repo);

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -1,7 +1,5 @@
 const logger = require('winston');
 const stringify = require('json-stringify-pretty-compact');
-const githubApi = require('./api/github');
-const gitlabApi = require('./api/gitlab');
 const handlebars = require('handlebars');
 const versionsHelper = require('./helpers/versions');
 const packageJson = require('./helpers/package-json');
@@ -25,14 +23,6 @@ async function processPackageFile(repoName, packageFile, packageConfig) {
   // Initialize globals
   config = Object.assign({}, packageConfig);
   config.packageFile = packageFile;
-
-  // Set API
-  if (packageConfig.platform === 'github') {
-    config.api = githubApi;
-  }
-  if (packageConfig.platform === 'gitlab') {
-    config.api = gitlabApi;
-  }
 
   logger.info(`Processing ${repoName} ${packageFile}`);
 

--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,7 @@ $ node renovate --help
     --platform <string>             Platform type of repository
     --endpoint <string>             Custom endpoint to use
     --token <string>                Repository Auth Token
+    --autodiscover [boolean]        Autodiscover all repositories
     --package-files <list>          Package file paths
     --dep-types <list>              Dependency types
     --ignore-deps <list>            Dependencies to ignore

--- a/test/api/__snapshots__/github.spec.js.snap
+++ b/test/api/__snapshots__/github.spec.js.snap
@@ -648,6 +648,21 @@ Array [
 ]
 `;
 
+exports[`api/github getRepos should support a custom endpoint 1`] = `
+Array [
+  Array [
+    "user/repos",
+  ],
+]
+`;
+
+exports[`api/github getRepos should support a custom endpoint 2`] = `
+Array [
+  "a/b",
+  "c/d",
+]
+`;
+
 exports[`api/github initRepo should initialise the config for the repo - 0 1`] = `
 Array [
   Array [

--- a/test/api/__snapshots__/github.spec.js.snap
+++ b/test/api/__snapshots__/github.spec.js.snap
@@ -582,6 +582,21 @@ Object {
 }
 `;
 
+exports[`api/github getRepos should return an array of repos 1`] = `
+Array [
+  Array [
+    "user/repos",
+  ],
+]
+`;
+
+exports[`api/github getRepos should return an array of repos 2`] = `
+Array [
+  "a/b",
+  "c/d",
+]
+`;
+
 exports[`api/github initRepo should initialise the config for the repo - 0 1`] = `
 Array [
   Array [

--- a/test/api/github.spec.js
+++ b/test/api/github.spec.js
@@ -13,6 +13,38 @@ describe('api/github', () => {
     ghGot = require('gh-got');
   });
 
+  async function getRepos(...args) {
+    // repo info
+    ghGot.mockImplementationOnce(() => ({
+      body: [
+        {
+          full_name: 'a/b',
+        },
+        {
+          full_name: 'c/d',
+        },
+      ],
+    }));
+    return github.getRepos(...args);
+  }
+
+  describe('getRepos', () => {
+    it('should throw an error if no token is provided', async () => {
+      let err;
+      try {
+        await github.getRepos();
+      } catch (e) {
+        err = e;
+      }
+      expect(err.message).toBe('No token found for getRepos');
+    });
+    it('should return an array of repos', async () => {
+      const repos = await getRepos('sometoken');
+      expect(ghGot.mock.calls).toMatchSnapshot();
+      expect(repos).toMatchSnapshot();
+    });
+  });
+
   async function initRepo(...args) {
     // repo info
     ghGot.mockImplementationOnce(() => ({

--- a/test/api/github.spec.js
+++ b/test/api/github.spec.js
@@ -43,6 +43,11 @@ describe('api/github', () => {
       expect(ghGot.mock.calls).toMatchSnapshot();
       expect(repos).toMatchSnapshot();
     });
+    it('should support a custom endpoint', async () => {
+      const repos = await getRepos('sometoken', 'someendpoint');
+      expect(ghGot.mock.calls).toMatchSnapshot();
+      expect(repos).toMatchSnapshot();
+    });
   });
 
   async function initRepo(...args) {

--- a/test/config/index.spec.js
+++ b/test/config/index.spec.js
@@ -1,5 +1,10 @@
 const argv = require('../_fixtures/config/argv');
 const should = require('chai').should();
+const githubApi = require('../../lib/api/github');
+const gitlabApi = require('../../lib/api/gitlab');
+
+githubApi.getRepos = jest.fn();
+gitlabApi.getRepos = jest.fn();
 
 describe('config/index', () => {
   describe('.parseConfigs(env, defaultArgv)', () => {
@@ -9,6 +14,21 @@ describe('config/index', () => {
       jest.resetModules();
       configParser = require('../../lib/config/index.js');
       defaultArgv = argv();
+    });
+    it('autodiscovers github repos', async () => {
+      const env = {};
+      defaultArgv = defaultArgv.concat(['--autodiscover']);
+      await configParser.parseConfigs(env, defaultArgv);
+    });
+    it('autodiscovers gitlab repos', async () => {
+      const env = {};
+      defaultArgv = defaultArgv.concat(['--autodiscover', '--platform=gitlab']);
+      await configParser.parseConfigs(env, defaultArgv);
+    });
+    it('errors for unknown platform', async () => {
+      const env = {};
+      defaultArgv = defaultArgv.concat(['--autodiscover', '--platform=foo']);
+      await configParser.parseConfigs(env, defaultArgv);
     });
     it('throws for no token', async () => {
       const env = {};

--- a/test/config/index.spec.js
+++ b/test/config/index.spec.js
@@ -1,10 +1,5 @@
 const argv = require('../_fixtures/config/argv');
 const should = require('chai').should();
-const githubApi = require('../../lib/api/github');
-const gitlabApi = require('../../lib/api/gitlab');
-
-githubApi.getRepos = jest.fn();
-gitlabApi.getRepos = jest.fn();
 
 describe('config/index', () => {
   describe('.parseConfigs(env, defaultArgv)', () => {
@@ -45,16 +40,6 @@ describe('config/index', () => {
         err = e;
       }
       expect(err.message).toBe('At least one repository must be configured');
-    });
-    it('autodiscovers github repos', async () => {
-      const env = { GITHUB_TOKEN: 'abc' };
-      defaultArgv = defaultArgv.concat(['--autodiscover']);
-      await configParser.parseConfigs(env, defaultArgv);
-    });
-    it('autodiscovers gitlab repos', async () => {
-      const env = { GITLAB_TOKEN: 'abc' };
-      defaultArgv = defaultArgv.concat(['--autodiscover', '--platform=gitlab']);
-      await configParser.parseConfigs(env, defaultArgv);
     });
     it('errors for unknown platform', async () => {
       const env = { GITHUB_TOKEN: 'abc' };

--- a/test/config/index.spec.js
+++ b/test/config/index.spec.js
@@ -24,7 +24,7 @@ describe('config/index', () => {
       } catch (e) {
         err = e;
       }
-      expect(err.message).toBe('At least one repository must be configured');
+      expect(err.message).toBe('At least one repository must be configured, or use --autodiscover');
     });
     it('supports token in env', async () => {
       const env = { GITHUB_TOKEN: 'abc' };
@@ -34,7 +34,7 @@ describe('config/index', () => {
       } catch (e) {
         err = e;
       }
-      expect(err.message).toBe('At least one repository must be configured');
+      expect(err.message).toBe('At least one repository must be configured, or use --autodiscover');
     });
     it('supports token in CLI options', async () => {
       defaultArgv = defaultArgv.concat(['--token=abc']);
@@ -45,7 +45,7 @@ describe('config/index', () => {
       } catch (e) {
         err = e;
       }
-      expect(err.message).toBe('At least one repository must be configured');
+      expect(err.message).toBe('At least one repository must be configured, or use --autodiscover');
     });
     it('autodiscovers github platform', async () => {
       const env = { GITHUB_TOKEN: 'abc' };

--- a/test/config/index.spec.js
+++ b/test/config/index.spec.js
@@ -52,7 +52,7 @@ describe('config/index', () => {
       await configParser.parseConfigs(env, defaultArgv);
     });
     it('autodiscovers gitlab repos', async () => {
-      const env = { GITHUB_TOKEN: 'abc' };
+      const env = { GITLAB_TOKEN: 'abc' };
       defaultArgv = defaultArgv.concat(['--autodiscover', '--platform=gitlab']);
       await configParser.parseConfigs(env, defaultArgv);
     });

--- a/test/config/index.spec.js
+++ b/test/config/index.spec.js
@@ -49,7 +49,7 @@ describe('config/index', () => {
     });
     it('autodiscovers github platform', async () => {
       const env = { GITHUB_TOKEN: 'abc' };
-      defaultArgv = defaultArgv.concat(['--autodiscover']);
+      defaultArgv = defaultArgv.concat(['--autodiscover', '--token=abc']);
       ghGot.mockImplementationOnce(() => ({
         body: [
           {
@@ -66,7 +66,7 @@ describe('config/index', () => {
     });
     it('autodiscovers gitlab platform', async () => {
       const env = { GITLAB_TOKEN: 'abc' };
-      defaultArgv = defaultArgv.concat(['--autodiscover', '--platform=gitlab']);
+      defaultArgv = defaultArgv.concat(['--autodiscover', '--platform=gitlab', '--token=abc']);
       glGot.mockImplementationOnce(() => ({
         body: [
           {

--- a/test/config/index.spec.js
+++ b/test/config/index.spec.js
@@ -15,21 +15,6 @@ describe('config/index', () => {
       configParser = require('../../lib/config/index.js');
       defaultArgv = argv();
     });
-    it('autodiscovers github repos', async () => {
-      const env = {};
-      defaultArgv = defaultArgv.concat(['--autodiscover']);
-      await configParser.parseConfigs(env, defaultArgv);
-    });
-    it('autodiscovers gitlab repos', async () => {
-      const env = {};
-      defaultArgv = defaultArgv.concat(['--autodiscover', '--platform=gitlab']);
-      await configParser.parseConfigs(env, defaultArgv);
-    });
-    it('errors for unknown platform', async () => {
-      const env = {};
-      defaultArgv = defaultArgv.concat(['--autodiscover', '--platform=foo']);
-      await configParser.parseConfigs(env, defaultArgv);
-    });
     it('throws for no token', async () => {
       const env = {};
       let err;
@@ -60,6 +45,21 @@ describe('config/index', () => {
         err = e;
       }
       expect(err.message).toBe('At least one repository must be configured');
+    });
+    it('autodiscovers github repos', async () => {
+      const env = { GITHUB_TOKEN: 'abc' };
+      defaultArgv = defaultArgv.concat(['--autodiscover']);
+      await configParser.parseConfigs(env, defaultArgv);
+    });
+    it('autodiscovers gitlab repos', async () => {
+      const env = { GITHUB_TOKEN: 'abc' };
+      defaultArgv = defaultArgv.concat(['--autodiscover', '--platform=gitlab']);
+      await configParser.parseConfigs(env, defaultArgv);
+    });
+    it('errors for unknown platform', async () => {
+      const env = { GITHUB_TOKEN: 'abc' };
+      defaultArgv = defaultArgv.concat(['--autodiscover', '--platform=foo']);
+      await configParser.parseConfigs(env, defaultArgv);
     });
     it('supports repositories in CLI', async () => {
       const env = {};

--- a/test/config/index.spec.js
+++ b/test/config/index.spec.js
@@ -10,31 +10,49 @@ describe('config/index', () => {
       configParser = require('../../lib/config/index.js');
       defaultArgv = argv();
     });
-    it('throws for no token', () => {
+    it('throws for no token', async () => {
       const env = {};
-      configParser.parseConfigs.bind(configParser, env, defaultArgv).should.throw('At least one repository must be configured');
+      let err;
+      try {
+        await configParser.parseConfigs(env, defaultArgv);
+      } catch (e) {
+        err = e;
+      }
+      expect(err.message).toBe('At least one repository must be configured');
     });
-    it('supports token in env', () => {
+    it('supports token in env', async () => {
       const env = { GITHUB_TOKEN: 'abc' };
-      configParser.parseConfigs.bind(configParser, env, defaultArgv).should.throw('At least one repository must be configured');
+      let err;
+      try {
+        await configParser.parseConfigs(env, defaultArgv);
+      } catch (e) {
+        err = e;
+      }
+      expect(err.message).toBe('At least one repository must be configured');
     });
-    it('supports token in CLI options', () => {
-      const env = {};
+    it('supports token in CLI options', async () => {
       defaultArgv = defaultArgv.concat(['--token=abc']);
-      configParser.parseConfigs.bind(configParser, env, defaultArgv).should.throw('At least one repository must be configured');
+      const env = { GITHUB_TOKEN: 'abc' };
+      let err;
+      try {
+        await configParser.parseConfigs(env, defaultArgv);
+      } catch (e) {
+        err = e;
+      }
+      expect(err.message).toBe('At least one repository must be configured');
     });
-    it('supports repositories in CLI', () => {
+    it('supports repositories in CLI', async () => {
       const env = {};
       defaultArgv = defaultArgv.concat(['--token=abc', 'foo']);
-      configParser.parseConfigs(env, defaultArgv);
+      await configParser.parseConfigs(env, defaultArgv);
       const repos = configParser.getRepositories();
       should.exist(repos);
       repos.should.have.length(1);
       repos[0].repository.should.eql('foo');
     });
-    it('gets cascaded config', () => {
+    it('gets cascaded config', async () => {
       const env = { RENOVATE_CONFIG_FILE: 'test/_fixtures/config/file.js' };
-      configParser.parseConfigs(env, defaultArgv);
+      await configParser.parseConfigs(env, defaultArgv);
       const repo = configParser.getRepositories().pop();
       should.exist(repo);
       const cascadedConfig = configParser.getCascadedConfig(repo, null);


### PR DESCRIPTION
This adds the opt-in config option `autodiscover`, which results in the supplied `token` being used to discover all accessible repositories and iterate through them.

I've decided to leave this disabled by default as it could be "dangerous" to perform this behaviour any time `renovate` is run with no repository arguments.

Closes #146 