### PR TITLE
Refactor per-dependency configs

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -17,6 +17,7 @@ module.exports = {
   findUpgrades,
   processUpgradesSequentially,
   updateDependency,
+  assignDepConfigs,
 };
 
 // This function manages the queue per-package file
@@ -52,14 +53,26 @@ async function processPackageFile(repoName, packageFile, packageConfig) {
   // Filter out ignored dependencies
   dependencies =
     dependencies.filter(dependency => config.ignoreDeps.indexOf(dependency.depName) === -1);
+  dependencies = assignDepConfigs(config, dependencies);
   // Find all upgrades for remaining dependencies
-  const upgrades = await findUpgrades(dependencies, config);
+  const upgrades = await findUpgrades(dependencies);
   // Process all upgrades sequentially
   if (config.maintainYarnLock) {
     await maintainYarnLock(config);
   }
   await processUpgradesSequentially(config, upgrades);
   logger.info(`${repoName} ${packageFile} done`);
+}
+
+// Add custom config for each dep
+function assignDepConfigs(inputConfig, deps) {
+  return deps.map((dep) => {
+    const returnDep = Object.assign({}, dep);
+    returnDep.config =
+      Object.assign({}, inputConfig);
+    delete returnDep.config.depTypes;
+    return returnDep;
+  });
 }
 
 async function maintainYarnLock(inputConfig) {
@@ -87,13 +100,13 @@ async function maintainYarnLock(inputConfig) {
   prWorker.ensurePr(params);
 }
 
-async function findUpgrades(dependencies, inputConfig) {
+async function findUpgrades(dependencies) {
   const allUpgrades = [];
   // findDepUpgrades can add more than one upgrade to allUpgrades
   async function findDepUpgrades(dep) {
     const npmDependency = await npmApi.getDependency(dep.depName);
     const upgrades =
-      await versionsHelper.determineUpgrades(npmDependency, dep.currentVersion, inputConfig);
+      await versionsHelper.determineUpgrades(npmDependency, dep.currentVersion, dep.config);
     if (upgrades.length > 0) {
       logger.verbose(`${dep.depName}: Upgrades = ${JSON.stringify(upgrades)}`);
       upgrades.forEach((upgrade) => {
@@ -110,7 +123,7 @@ async function findUpgrades(dependencies, inputConfig) {
   return allUpgrades;
 }
 
-async function processUpgradesSequentially(baseConfig, upgrades) {
+async function processUpgradesSequentially(upgrades) {
   if (Object.keys(upgrades).length) {
     logger.verbose('Processing upgrades');
   } else {
@@ -121,7 +134,9 @@ async function processUpgradesSequentially(baseConfig, upgrades) {
   // 1. Reduce chances of GitHub API rate limiting
   // 2. Edge case collision of branch name, e.g. dependency also listed as dev dependency
   for (const upgrade of upgrades) {
-    await module.exports.updateDependency(Object.assign({}, baseConfig, upgrade));
+    const flattened = Object.assign({}, upgrade.config, upgrade);
+    delete flattened.config;
+    await module.exports.updateDependency(flattened);
   }
 }
 

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -71,6 +71,18 @@ function assignDepConfigs(inputConfig, deps) {
     returnDep.config =
       Object.assign({}, inputConfig);
     delete returnDep.config.depTypes;
+    delete returnDep.config.enabled;
+    delete returnDep.config.onboarding;
+    delete returnDep.config.token;
+    delete returnDep.config.packageFiles;
+    delete returnDep.config.logLevel;
+    delete returnDep.config.repoConfigured;
+    delete returnDep.config.ignoreDeps;
+    delete returnDep.config.maintainYarnLock;
+    delete returnDep.config.yarnMaintenanceBranchName;
+    delete returnDep.config.yarnMaintenanceCommitMessage;
+    delete returnDep.config.yarnMaintenancePrTitle;
+    delete returnDep.config.yarnMaintenancePrBody;
     return returnDep;
   });
 }

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -60,7 +60,7 @@ async function processPackageFile(repoName, packageFile, packageConfig) {
   if (config.maintainYarnLock) {
     await maintainYarnLock(config);
   }
-  await processUpgradesSequentially(config, upgrades);
+  await processUpgradesSequentially(upgrades);
   logger.info(`${repoName} ${packageFile} done`);
 }
 

--- a/test/__snapshots__/worker.spec.js.snap
+++ b/test/__snapshots__/worker.spec.js.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`worker assignDepConfigs(inputConfig, deps) handles multiple deps 1`] = `
+Array [
+  Object {
+    "config": Object {
+      "foo": "bar",
+    },
+    "depName": "a",
+  },
+  Object {
+    "config": Object {
+      "foo": "bar",
+    },
+    "depName": "b",
+  },
+]
+`;
+
+exports[`worker assignDepConfigs(inputConfig, deps) handles string deps 1`] = `
+Array [
+  Object {
+    "config": Object {
+      "foo": "bar",
+    },
+    "depName": "a",
+  },
+]
+`;

--- a/test/worker.spec.js
+++ b/test/worker.spec.js
@@ -59,17 +59,15 @@ describe('worker', () => {
     });
   });
   describe('processUpgradesSequentially(baseConfig, upgrades)', () => {
-    let config;
     beforeEach(() => {
-      config = {};
       worker.updateDependency = jest.fn();
     });
     it('handles zero upgrades', async () => {
-      await worker.processUpgradesSequentially(config, []);
+      await worker.processUpgradesSequentially([]);
       expect(worker.updateDependency.mock.calls.length).toBe(0);
     });
     it('handles non-zero upgrades', async () => {
-      await worker.processUpgradesSequentially(config, [{}, {}]);
+      await worker.processUpgradesSequentially([{}, {}]);
       expect(worker.updateDependency.mock.calls.length).toBe(2);
     });
   });
@@ -103,6 +101,38 @@ describe('worker', () => {
       versionsHelper.determineUpgrades = jest.fn(() => []);
       const allUpgrades = await worker.findUpgrades([dep], config);
       expect(allUpgrades).toMatchObject([]);
+    });
+  });
+  describe('assignDepConfigs(inputConfig, deps)', () => {
+    let config;
+    let deps;
+    beforeEach(() => {
+      config = {};
+      deps = [];
+    });
+    it('handles empty deps', () => {
+      const updatedDeps = worker.assignDepConfigs(config, deps);
+      expect(updatedDeps).toMatchObject([]);
+    });
+    it('handles string deps', () => {
+      config.foo = 'bar';
+      config.depTypes = ['dependencies', 'devDependencies'];
+      deps.push({
+        depName: 'a',
+      });
+      const updatedDeps = worker.assignDepConfigs(config, deps);
+      expect(updatedDeps).toMatchSnapshot();
+    });
+    it('handles multiple deps', () => {
+      config.foo = 'bar';
+      deps.push({
+        depName: 'a',
+      });
+      deps.push({
+        depName: 'b',
+      });
+      const updatedDeps = worker.assignDepConfigs(config, deps);
+      expect(updatedDeps).toMatchSnapshot();
     });
   });
 });


### PR DESCRIPTION
This commit refactors the code to attach one copy of the config per-dependency, rather than using a shared dependency. Currently the config will be identical for all dependencies, but this change will simplify the implementation of #133 