### PR TITLE
Support configuring per dependency-type

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -18,6 +18,7 @@ module.exports = {
   processUpgradesSequentially,
   updateDependency,
   assignDepConfigs,
+  getDepTypeConfig,
 };
 
 // This function manages the queue per-package file
@@ -85,6 +86,16 @@ function assignDepConfigs(inputConfig, deps) {
     delete returnDep.config.yarnMaintenancePrBody;
     return returnDep;
   });
+}
+
+function getDepTypeConfig(depTypes, depTypeName) {
+  let depTypeConfig = {};
+  depTypes.forEach((depType) => {
+    if (typeof depType !== 'string' && depType.depType === depTypeName) {
+      depTypeConfig = depType;
+    }
+  });
+  return depTypeConfig;
 }
 
 async function maintainYarnLock(inputConfig) {

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -49,8 +49,15 @@ async function processPackageFile(repoName, packageFile, packageConfig) {
     return;
   }
 
+  const depTypes = config.depTypes.map((depType) => {
+    if (typeof depType === 'string') {
+      return depType;
+    }
+    return depType.depType;
+  });
+
   // Extract all dependencies from the package.json
-  let dependencies = await packageJson.extractDependencies(packageContent, config.depTypes);
+  let dependencies = await packageJson.extractDependencies(packageContent, depTypes);
   // Filter out ignored dependencies
   dependencies =
     dependencies.filter(dependency => config.ignoreDeps.indexOf(dependency.depName) === -1);

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -70,7 +70,7 @@ function assignDepConfigs(inputConfig, deps) {
   return deps.map((dep) => {
     const returnDep = Object.assign({}, dep);
     returnDep.config =
-      Object.assign({}, inputConfig);
+      Object.assign({}, inputConfig, getDepTypeConfig(inputConfig.depTypes, dep.depType));
     delete returnDep.config.depTypes;
     delete returnDep.config.enabled;
     delete returnDep.config.onboarding;
@@ -90,11 +90,13 @@ function assignDepConfigs(inputConfig, deps) {
 
 function getDepTypeConfig(depTypes, depTypeName) {
   let depTypeConfig = {};
-  depTypes.forEach((depType) => {
-    if (typeof depType !== 'string' && depType.depType === depTypeName) {
-      depTypeConfig = depType;
-    }
-  });
+  if (depTypes) {
+    depTypes.forEach((depType) => {
+      if (typeof depType !== 'string' && depType.depType === depTypeName) {
+        depTypeConfig = depType;
+      }
+    });
+  }
   return depTypeConfig;
 }
 

--- a/test/__snapshots__/worker.spec.js.snap
+++ b/test/__snapshots__/worker.spec.js.snap
@@ -1,5 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`worker assignDepConfigs(inputConfig, deps) handles depType config with override 1`] = `
+Array [
+  Object {
+    "config": Object {
+      "depType": "dependencies",
+      "foo": "beta",
+    },
+    "depName": "a",
+    "depType": "dependencies",
+  },
+]
+`;
+
+exports[`worker assignDepConfigs(inputConfig, deps) handles depType config without override 1`] = `
+Array [
+  Object {
+    "config": Object {
+      "alpha": "beta",
+      "depType": "dependencies",
+      "foo": "bar",
+    },
+    "depName": "a",
+    "depType": "dependencies",
+  },
+]
+`;
+
 exports[`worker assignDepConfigs(inputConfig, deps) handles multiple deps 1`] = `
 Array [
   Object {

--- a/test/worker.spec.js
+++ b/test/worker.spec.js
@@ -135,4 +135,40 @@ describe('worker', () => {
       expect(updatedDeps).toMatchSnapshot();
     });
   });
+  describe('getDepTypeConfig(depTypes, depTypeName)', () => {
+    it('handles empty depTypes', () => {
+      const depTypeConfig = worker.getDepTypeConfig([], 'dependencies');
+      expect(depTypeConfig).toMatchObject({});
+    });
+    it('handles all strings', () => {
+      const depTypes = ['dependencies', 'devDependencies'];
+      const depTypeConfig = worker.getDepTypeConfig(depTypes, 'dependencies');
+      expect(depTypeConfig).toMatchObject({});
+    });
+    it('handles missed object', () => {
+      const depTypes = [
+        'dependencies',
+        {
+          depType: 'devDependencies',
+          foo: 'bar',
+        },
+      ];
+      const depTypeConfig = worker.getDepTypeConfig(depTypes, 'dependencies');
+      expect(depTypeConfig).toMatchObject({});
+    });
+    it('handles hit object', () => {
+      const depTypes = [
+        {
+          depType: 'dependencies',
+          foo: 'bar',
+        },
+        'devDependencies',
+      ];
+      const depTypeConfig = worker.getDepTypeConfig(depTypes, 'dependencies');
+      const expectedResult = {
+        foo: 'bar',
+      };
+      expect(depTypeConfig).toMatchObject(expectedResult);
+    });
+  });
 });

--- a/test/worker.spec.js
+++ b/test/worker.spec.js
@@ -134,6 +134,32 @@ describe('worker', () => {
       const updatedDeps = worker.assignDepConfigs(config, deps);
       expect(updatedDeps).toMatchSnapshot();
     });
+    it('handles depType config without override', () => {
+      config.foo = 'bar';
+      config.depTypes = [{
+        depType: 'dependencies',
+        alpha: 'beta',
+      }];
+      deps.push({
+        depName: 'a',
+        depType: 'dependencies',
+      });
+      const updatedDeps = worker.assignDepConfigs(config, deps);
+      expect(updatedDeps).toMatchSnapshot();
+    });
+    it('handles depType config with override', () => {
+      config.foo = 'bar';
+      config.depTypes = [{
+        depType: 'dependencies',
+        foo: 'beta',
+      }];
+      deps.push({
+        depName: 'a',
+        depType: 'dependencies',
+      });
+      const updatedDeps = worker.assignDepConfigs(config, deps);
+      expect(updatedDeps).toMatchSnapshot();
+    });
   });
   describe('getDepTypeConfig(depTypes, depTypeName)', () => {
     it('handles empty depTypes', () => {


### PR DESCRIPTION
This PR adds support for configuring down to a dependency type level (e.g. applying different labels for `dependencies` and `devDependencies`).

Example config in a `package.json`:

```json
  "renovate": {
    "labels": ["renovate"],
    "depTypes": [
      "dependencies",
      "devDependencies",
      {
        "depType": "optionalDependencies",
        "labels": ["renovate", "optional"]
      }
    ]
  },
```

Supports #133 