### PR TITLE
Add separateMajorReleases config option

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -69,26 +69,27 @@ $ node renovate --help
 
   Options:
 
-    -h, --help                      output usage information
-    --enabled [boolean]             Enable or disable renovate
-    --onboarding [boolean]          Require a Configuration PR first
-    --platform <string>             Platform type of repository
-    --endpoint <string>             Custom endpoint to use
-    --token <string>                Repository Auth Token
-    --package-files <list>          Package file paths
-    --dep-types <list>              Dependency types
-    --ignore-deps <list>            Dependencies to ignore
-    --ignore-future [boolean]       Ignore versions tagged as "future"
-    --ignore-unstable [boolean]     Ignore versions with unstable semver
-    --respect-latest [boolean]      Ignore versions newer than npm "latest" version
-    --recreate-closed [boolean]     Recreate PRs even if same ones were closed previously
-    --rebase-stale-prs [boolean]    Rebase stale PRs (GitHub only)
-    --maintain-yarn-lock [boolean]  Keep yarn.lock updated in base branch (no monorepo support)
-    --labels <list>                 Labels to add to Pull Request
-    --assignees <list>              Assignees for Pull Request
-    --reviewers <list>              Requested reviewers for Pull Requests (GitHub only)
-    --pin-versions [boolean]        Convert ranged versions in package.json to pinned versions
-    --log-level <string>            Logging level
+    -h, --help                           output usage information
+    --enabled [boolean]                  Enable or disable renovate
+    --onboarding [boolean]               Require a Configuration PR first
+    --platform <string>                  Platform type of repository
+    --endpoint <string>                  Custom endpoint to use
+    --token <string>                     Repository Auth Token
+    --package-files <list>               Package file paths
+    --dep-types <list>                   Dependency types
+    --separate-major-releases [boolean]  If set to false, it will upgrade dependencies to latest release only, and not separate major/minor branches
+    --ignore-deps <list>                 Dependencies to ignore
+    --ignore-future [boolean]            Ignore versions tagged as "future"
+    --ignore-unstable [boolean]          Ignore versions with unstable semver
+    --respect-latest [boolean]           Ignore versions newer than npm "latest" version
+    --recreate-closed [boolean]          Recreate PRs even if same ones were closed previously
+    --rebase-stale-prs [boolean]         Rebase stale PRs (GitHub only)
+    --maintain-yarn-lock [boolean]       Keep yarn.lock updated in base branch (no monorepo support)
+    --labels <list>                      Labels to add to Pull Request
+    --assignees <list>                   Assignees for Pull Request
+    --reviewers <list>                   Requested reviewers for Pull Requests (GitHub only)
+    --pin-versions [boolean]             Convert ranged versions in package.json to pinned versions
+    --log-level <string>                 Logging level
 
   Examples:
 
@@ -128,6 +129,7 @@ Obviously, you can't set repository or package file location with this method.
 | `repositories` | List of Repositories | list | `[]` | `RENOVATE_REPOSITORIES` |  |
 | `packageFiles` | Package file paths | list | `[]` | `RENOVATE_PACKAGE_FILES` | `--package-files` |
 | `depTypes` | Dependency types | list | `["dependencies", "devDependencies", "optionalDependencies"]` | `RENOVATE_DEP_TYPES` | `--dep-types` |
+| `separateMajorReleases` | If set to false, it will upgrade dependencies to latest release only, and not separate major/minor branches | boolean | `true` | `RENOVATE_SEPARATE_MAJOR_RELEASES` | `--separate-major-releases` |
 | `ignoreDeps` | Dependencies to ignore | list | `[]` | `RENOVATE_IGNORE_DEPS` | `--ignore-deps` |
 | `ignoreFuture` | Ignore versions tagged as "future" | boolean | `true` | `RENOVATE_IGNORE_FUTURE` | `--ignore-future` |
 | `ignoreUnstable` | Ignore versions with unstable semver | boolean | `true` | `RENOVATE_IGNORE_UNSTABLE` | `--ignore-unstable` |

--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -50,6 +50,11 @@ const options = [
   },
   // Version behaviour
   {
+    name: 'separateMajorReleases',
+    description: 'If set to false, it will upgrade dependencies to latest release only, and not separate major/minor branches',
+    type: 'boolean',
+  },
+  {
     name: 'ignoreDeps',
     description: 'Dependencies to ignore',
     type: 'list',

--- a/lib/helpers/versions.js
+++ b/lib/helpers/versions.js
@@ -56,12 +56,13 @@ function determineUpgrades(dep, currentVersion, config) {
     .forEach((newVersion) => {
       // Group by major versions
       const newVersionMajor = semver.major(newVersion);
+      const upgradeKey = config.separateMajorReleases ? newVersionMajor : 'latest';
       // Save this, if it's a new major version or greater than the previous greatest
-      if (!allUpgrades[newVersionMajor] ||
-          semver.gt(newVersion, allUpgrades[newVersionMajor].newVersion)) {
+      if (!allUpgrades[upgradeKey] ||
+          semver.gt(newVersion, allUpgrades[upgradeKey].newVersion)) {
         const upgradeType = newVersionMajor > semver.major(changeLogFromVersion) ? 'major' : 'minor';
         const changeLogToVersion = newVersion;
-        allUpgrades[newVersionMajor] = {
+        allUpgrades[upgradeKey] = {
           upgradeType,
           newVersion,
           newVersionMajor,

--- a/readme.md
+++ b/readme.md
@@ -38,26 +38,27 @@ $ node renovate --help
 
   Options:
 
-    -h, --help                      output usage information
-    --enabled [boolean]             Enable or disable renovate
-    --onboarding [boolean]          Require a Configuration PR first
-    --platform <string>             Platform type of repository
-    --endpoint <string>             Custom endpoint to use
-    --token <string>                Repository Auth Token
-    --package-files <list>          Package file paths
-    --dep-types <list>              Dependency types
-    --ignore-deps <list>            Dependencies to ignore
-    --ignore-future [boolean]       Ignore versions tagged as "future"
-    --ignore-unstable [boolean]     Ignore versions with unstable semver
-    --respect-latest [boolean]      Ignore versions newer than npm "latest" version
-    --recreate-closed [boolean]     Recreate PRs even if same ones were closed previously
-    --rebase-stale-prs [boolean]    Rebase stale PRs (GitHub only)
-    --maintain-yarn-lock [boolean]  Keep yarn.lock updated in base branch (no monorepo support)
-    --labels <list>                 Labels to add to Pull Request
-    --assignees <list>              Assignees for Pull Request
-    --reviewers <list>              Requested reviewers for Pull Requests (GitHub only)
-    --pin-versions [boolean]        Convert ranged versions in package.json to pinned versions
-    --log-level <string>            Logging level
+    -h, --help                           output usage information
+    --enabled [boolean]                  Enable or disable renovate
+    --onboarding [boolean]               Require a Configuration PR first
+    --platform <string>                  Platform type of repository
+    --endpoint <string>                  Custom endpoint to use
+    --token <string>                     Repository Auth Token
+    --package-files <list>               Package file paths
+    --dep-types <list>                   Dependency types
+    --separate-major-releases [boolean]  If set to false, it will upgrade dependencies to latest release only, and not separate major/minor branches
+    --ignore-deps <list>                 Dependencies to ignore
+    --ignore-future [boolean]            Ignore versions tagged as "future"
+    --ignore-unstable [boolean]          Ignore versions with unstable semver
+    --respect-latest [boolean]           Ignore versions newer than npm "latest" version
+    --recreate-closed [boolean]          Recreate PRs even if same ones were closed previously
+    --rebase-stale-prs [boolean]         Rebase stale PRs (GitHub only)
+    --maintain-yarn-lock [boolean]       Keep yarn.lock updated in base branch (no monorepo support)
+    --labels <list>                      Labels to add to Pull Request
+    --assignees <list>                   Assignees for Pull Request
+    --reviewers <list>                   Requested reviewers for Pull Requests (GitHub only)
+    --pin-versions [boolean]             Convert ranged versions in package.json to pinned versions
+    --log-level <string>                 Logging level
 
   Examples:
 

--- a/test/helpers/versions.spec.js
+++ b/test/helpers/versions.spec.js
@@ -39,6 +39,32 @@ describe('helpers/versions', () => {
       ];
       versionsHelper.determineUpgrades(qJson, '^0.4.0', defaultConfig).should.eql(upgradeVersions);
     });
+    it('disables major release separation (major)', () => {
+      const config = Object.assign({}, defaultConfig, { separateMajorReleases: false });
+      const upgradeVersions = [
+        {
+          newVersion: '1.4.1',
+          newVersionMajor: 1,
+          upgradeType: 'major',
+          changeLogFromVersion: '0.4.4',
+          changeLogToVersion: '1.4.1',
+        },
+      ];
+      versionsHelper.determineUpgrades(qJson, '^0.4.0', config).should.eql(upgradeVersions);
+    });
+    it('disables major release separation (minor)', () => {
+      const config = Object.assign({}, defaultConfig, { separateMajorReleases: false });
+      const upgradeVersions = [
+        {
+          newVersion: '1.4.1',
+          newVersionMajor: 1,
+          upgradeType: 'minor',
+          changeLogFromVersion: '1.0.0',
+          changeLogToVersion: '1.4.1',
+        },
+      ];
+      versionsHelper.determineUpgrades(qJson, '1.0.0', config).should.eql(upgradeVersions);
+    });
     it('supports minor and major upgrades for ranged versions', () => {
       const pinVersions = [
         {


### PR DESCRIPTION
This PR adds the `separateMajorReleases` config option, which defaults to true (existing behaviour). If set to false, it means that each dependency is upgraded to the very latest and we don't separate by major/minor.