### PR TITLE
Make package pattern use explicit

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -84,11 +84,13 @@ function assignDepConfigs(inputConfig, deps) {
       // Exit after first match
       returnDep.config.packages.forEach((packageConfig) => {
         if (!packageRuleApplied) {
-          const packageRegex = new RegExp(packageConfig.packageName);
+          const pattern = packageConfig.packagePattern || `^${packageConfig.packageName}$`;
+          const packageRegex = new RegExp(pattern);
           if (dep.depName.match(packageRegex)) {
             packageRuleApplied = true;
             Object.assign(returnDep.config, packageConfig);
             delete returnDep.config.packageName;
+            delete returnDep.config.packagePattern;
           }
         }
       });

--- a/test/__snapshots__/worker.spec.js.snap
+++ b/test/__snapshots__/worker.spec.js.snap
@@ -42,6 +42,38 @@ Array [
 ]
 `;
 
+exports[`worker assignDepConfigs(inputConfig, deps) handles non-regex package name 1`] = `
+Array [
+  Object {
+    "config": Object {
+      "foo": "bar",
+      "labels": Array [
+        "eslint",
+      ],
+    },
+    "depName": "eslint",
+  },
+  Object {
+    "config": Object {
+      "foo": "bar",
+    },
+    "depName": "eslint-foo",
+  },
+  Object {
+    "config": Object {
+      "foo": "bar",
+    },
+    "depName": "a",
+  },
+  Object {
+    "config": Object {
+      "foo": "bar",
+    },
+    "depName": "also-eslint",
+  },
+]
+`;
+
 exports[`worker assignDepConfigs(inputConfig, deps) handles package config 1`] = `
 Array [
   Object {
@@ -56,7 +88,7 @@ Array [
 ]
 `;
 
-exports[`worker assignDepConfigs(inputConfig, deps) handles regex package config 1`] = `
+exports[`worker assignDepConfigs(inputConfig, deps) handles regex package pattern 1`] = `
 Array [
   Object {
     "config": Object {
@@ -88,6 +120,41 @@ Array [
       "labels": Array [
         "eslint",
       ],
+    },
+    "depName": "also-eslint",
+  },
+]
+`;
+
+exports[`worker assignDepConfigs(inputConfig, deps) handles regex wildcard package pattern 1`] = `
+Array [
+  Object {
+    "config": Object {
+      "foo": "bar",
+      "labels": Array [
+        "eslint",
+      ],
+    },
+    "depName": "eslint",
+  },
+  Object {
+    "config": Object {
+      "foo": "bar",
+      "labels": Array [
+        "eslint",
+      ],
+    },
+    "depName": "eslint-foo",
+  },
+  Object {
+    "config": Object {
+      "foo": "bar",
+    },
+    "depName": "a",
+  },
+  Object {
+    "config": Object {
+      "foo": "bar",
     },
     "depName": "also-eslint",
   },

--- a/test/worker.spec.js
+++ b/test/worker.spec.js
@@ -206,10 +206,52 @@ describe('worker', () => {
       const updatedDeps = worker.assignDepConfigs(config, deps);
       expect(updatedDeps).toMatchSnapshot();
     });
-    it('handles regex package config', () => {
+    it('handles regex package pattern', () => {
       config.foo = 'bar';
       config.packages = [{
-        packageName: 'eslint.*',
+        packagePattern: 'eslint',
+        labels: ['eslint'],
+      }];
+      deps.push({
+        depName: 'eslint',
+      });
+      deps.push({
+        depName: 'eslint-foo',
+      });
+      deps.push({
+        depName: 'a',
+      });
+      deps.push({
+        depName: 'also-eslint',
+      });
+      const updatedDeps = worker.assignDepConfigs(config, deps);
+      expect(updatedDeps).toMatchSnapshot();
+    });
+    it('handles regex wildcard package pattern', () => {
+      config.foo = 'bar';
+      config.packages = [{
+        packagePattern: '^eslint',
+        labels: ['eslint'],
+      }];
+      deps.push({
+        depName: 'eslint',
+      });
+      deps.push({
+        depName: 'eslint-foo',
+      });
+      deps.push({
+        depName: 'a',
+      });
+      deps.push({
+        depName: 'also-eslint',
+      });
+      const updatedDeps = worker.assignDepConfigs(config, deps);
+      expect(updatedDeps).toMatchSnapshot();
+    });
+    it('handles non-regex package name', () => {
+      config.foo = 'bar';
+      config.packages = [{
+        packageName: 'eslint',
         labels: ['eslint'],
       }];
       deps.push({


### PR DESCRIPTION
This PR refactors how package name patterns are used, so they won't be used "accidentally" by people intending to use a package name instead.