### PR TITLE
Add support for v4 of Gitlab API

### DIFF
--- a/lib/api/gitlab.js
+++ b/lib/api/gitlab.js
@@ -64,6 +64,15 @@ async function initRepo(repoName, token, endpoint) {
   if (endpoint) {
     process.env.GITLAB_ENDPOINT = endpoint;
   }
+  try {
+    logger.debug(`Determining Gitlab API version`);
+    // projects/visible route deprecated in v4
+    await glGot(`projects/visible`);
+    config.apiVersion = 'v3';
+  } catch (err) {
+    config.apiVersion = 'v4';
+  }
+  logger.debug(`Detected Gitlab API ${config.apiVersion}`);
   config.repoName = repoName.replace('/', '%2F');
   try {
     const res = await glGot(`projects/${config.repoName}`);
@@ -275,9 +284,14 @@ async function mergePr(pr) {
 // Generic File operations
 
 async function getFile(filePath, branchName = config.defaultBranch) {
-  const res = await glGot(
-    `projects/${config.repoName}/repository/files?file_path=${filePath}&ref=${branchName}`
-  );
+  // Gitlab API v3 support
+  let url;
+  if (config.apiVersion === 'v3') {
+    url = `projects/${config.repoName}/repository/files?file_path=${filePath}&ref=${branchName}`;
+  } else {
+    url = `projects/${config.repoName}/repository/files/${filePath}?ref=${branchName}`;
+  }
+  const res = await glGot(url);
   return res.body.content;
 }
 
@@ -310,27 +324,53 @@ async function getFileJson(filePath, branchName) {
 }
 
 async function createFile(branchName, filePath, fileContents, message) {
-  await glGot.post(`projects/${config.repoName}/repository/files`, {
-    body: {
+  // Gitlab API v3 support
+  let url;
+  const opts = {};
+  if (config.apiVersion === 'v3') {
+    url = `projects/${config.repoName}/repository/files`;
+    opts.body = {
       file_path: filePath,
       branch_name: branchName,
       commit_message: message,
       encoding: 'base64',
       content: new Buffer(fileContents).toString('base64'),
-    },
-  });
+    };
+  } else {
+    url = `projects/${config.repoName}/repository/files/${filePath}`;
+    opts.body = {
+      branch: branchName,
+      commit_message: message,
+      encoding: 'base64',
+      content: new Buffer(fileContents).toString('base64'),
+    };
+  }
+  await glGot.post(url, opts);
 }
 
 async function updateFile(branchName, filePath, fileContents, message) {
-  await glGot.put(`projects/${config.repoName}/repository/files`, {
-    body: {
+  // Gitlab API v3 support
+  let url;
+  const opts = {};
+  if (config.apiVersion === 'v3') {
+    url = `projects/${config.repoName}/repository/files`;
+    opts.body = {
       file_path: filePath,
       branch_name: branchName,
       commit_message: message,
       encoding: 'base64',
       content: new Buffer(fileContents).toString('base64'),
-    },
-  });
+    };
+  } else {
+    url = `projects/${config.repoName}/repository/files/${filePath}`;
+    opts.body = {
+      branch: branchName,
+      commit_message: message,
+      encoding: 'base64',
+      content: new Buffer(fileContents).toString('base64'),
+    };
+  }
+  await glGot.put(url, opts);
 }
 
 // Add a new commit, create branch if not existing
@@ -368,10 +408,18 @@ async function commitFilesToBranch(
 
 // Creates a new branch with provided commit
 async function createBranch(branchName, ref = config.defaultBranch) {
-  await glGot.post(`projects/${config.repoName}/repository/branches`, {
-    body: {
+  // Gitlab API v3 support
+  const opts = {};
+  if (config.apiVersion === 'v3') {
+    opts.body = {
       branch_name: branchName,
       ref,
-    },
-  });
+    };
+  } else {
+    opts.body = {
+      branch: branchName,
+      ref,
+    };
+  }
+  await glGot.post(`projects/${config.repoName}/repository/branches`, opts);
 }

--- a/lib/api/gitlab.js
+++ b/lib/api/gitlab.js
@@ -66,8 +66,8 @@ async function initRepo(repoName, token, endpoint) {
   }
   try {
     logger.debug(`Determining Gitlab API version`);
-    // projects/visible route deprecated in v4
-    await glGot(`projects/visible`);
+    // projects/owned route deprecated in v4
+    await glGot(`projects/owned`);
     config.apiVersion = 'v3';
   } catch (err) {
     config.apiVersion = 'v4';


### PR DESCRIPTION
A full list of changes from API V3 to V4 is available here: https://docs.gitlab.com/ce/api/v3_to_v4.html

After looking over those docs it seemed the easiest way to determine the API version was to pull the `projects/visible` route which was deprecated in v4 in favor of making all projects visible immediately.

Only a small number of tweaks needed to be made to support v4, these included renaming `branch_name` to `branch` in the request body, and getting/posting repo files with the `filePath` included in the URL instead of as `file_path` in the request body. These tweaks are done in if..else statements and will be easy to remove once you decide to deprecate v3.

(Closes #220)