### PR TITLE
Add npm caching

### DIFF
--- a/lib/api/npm.js
+++ b/lib/api/npm.js
@@ -8,7 +8,14 @@ const logger = require('winston');
 
 module.exports = {
   getDependency,
+  resetCache,
 };
+
+let npmCache = {};
+
+function resetCache() {
+  npmCache = {};
+}
 
 async function getDependency(name) {
   logger.debug(`getDependency(${name})`);
@@ -28,12 +35,30 @@ async function getDependency(name) {
     headers.authorization = `${authInfo.type} ${authInfo.token}`;
   }
 
+  // Cache based on combinatino of package URL and headers
+  const cacheKey = pkgUrl + JSON.stringify(headers);
+
+  // Return from cache if present
+  if (npmCache[cacheKey]) {
+    logger.debug(`Returning cached version of ${name}`);
+    return npmCache[cacheKey];
+  }
+
+  // Retrieve from API if not cached
   try {
     const res = await got(pkgUrl, {
       json: true,
       headers,
     });
-    return res.body;
+    // Simpilfy response before caching and returning
+    const dep = Object.assign({}, res.body);
+    Object.keys(dep.versions).forEach(version => {
+      // We don't use any of the version payload currently
+      dep.versions[version] = {};
+    });
+    npmCache[cacheKey] = dep;
+    logger.debug(JSON.stringify(dep));
+    return dep;
   } catch (err) {
     logger.warn(`Dependency not found: ${name}`);
     logger.debug(`err: ${JSON.stringify(err)}`);

--- a/test/api/__snapshots__/npm.spec.js.snap
+++ b/test/api/__snapshots__/npm.spec.js.snap
@@ -2,7 +2,9 @@
 
 exports[`api/npm should fetch package info from npm 1`] = `
 Object {
-  "some": "data",
+  "versions": Object {
+    "0.0.1": Object {},
+  },
 }
 `;
 
@@ -20,7 +22,9 @@ Array [
 
 exports[`api/npm should send an authorization header if provided 1`] = `
 Object {
-  "some": "data",
+  "versions": Object {
+    "0.0.1": Object {},
+  },
 }
 `;
 

--- a/test/api/__snapshots__/npm.spec.js.snap
+++ b/test/api/__snapshots__/npm.spec.js.snap
@@ -1,6 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`api/npm should fetch package info from npm 1`] = `
+Object {
+  "some": "data",
+}
+`;
+
+exports[`api/npm should fetch package info from npm 2`] = `
 Array [
   "https://npm.mycustomregistry.com/foobar",
   Object {
@@ -13,6 +19,12 @@ Array [
 `;
 
 exports[`api/npm should send an authorization header if provided 1`] = `
+Object {
+  "some": "data",
+}
+`;
+
+exports[`api/npm should send an authorization header if provided 2`] = `
 Array [
   "https://npm.mycustomregistry.com/foobar",
   Object {

--- a/test/api/npm.spec.js
+++ b/test/api/npm.spec.js
@@ -15,7 +15,7 @@ describe('api/npm', () => {
     registryUrl.mockImplementation(() => 'https://npm.mycustomregistry.com/');
     got.mockImplementation(() => Promise.resolve({ body: { some: 'data' } }));
     const res = await npm.getDependency('foobar');
-    expect(res).toMatchObject({ some: 'data' });
+    expect(res).toMatchSnapshot();
     const call = got.mock.calls[0];
     expect(call).toMatchSnapshot();
   });
@@ -35,7 +35,7 @@ describe('api/npm', () => {
     }));
     got.mockImplementation(() => Promise.resolve({ body: { some: 'data' } }));
     const res = await npm.getDependency('foobar');
-    expect(res).toMatchObject({ some: 'data' });
+    expect(res).toMatchSnapshot();
     const call = got.mock.calls[0];
     expect(call).toMatchSnapshot();
   });

--- a/test/api/npm.spec.js
+++ b/test/api/npm.spec.js
@@ -30,6 +30,14 @@ describe('api/npm', () => {
     const call = got.mock.calls[0];
     expect(call).toMatchSnapshot();
   });
+  it('should cache package info from npm', async () => {
+    registryUrl.mockImplementation(() => 'https://npm.mycustomregistry.com/');
+    got.mockImplementation(() => Promise.resolve(npmResponse));
+    const res1 = await npm.getDependency('foobar');
+    const res2 = await npm.getDependency('foobar');
+    expect(res1).toEqual(res2);
+    expect(got.mock.calls.length).toEqual(1);
+  });
   it('should return null if lookup fails', async () => {
     registryUrl.mockImplementation(() => 'https://npm.mycustomregistry.com/');
     got.mockImplementation(() => {

--- a/test/api/npm.spec.js
+++ b/test/api/npm.spec.js
@@ -7,13 +7,24 @@ jest.mock('registry-url');
 jest.mock('registry-auth-token');
 jest.mock('got');
 
+const npmResponse = {
+  body: {
+    versions: {
+      '0.0.1': {
+        foo: 1,
+      },
+    },
+  },
+};
+
 describe('api/npm', () => {
   beforeEach(() => {
     jest.resetAllMocks();
+    npm.resetCache();
   });
   it('should fetch package info from npm', async () => {
     registryUrl.mockImplementation(() => 'https://npm.mycustomregistry.com/');
-    got.mockImplementation(() => Promise.resolve({ body: { some: 'data' } }));
+    got.mockImplementation(() => Promise.resolve(npmResponse));
     const res = await npm.getDependency('foobar');
     expect(res).toMatchSnapshot();
     const call = got.mock.calls[0];
@@ -33,7 +44,7 @@ describe('api/npm', () => {
       type: 'Basic',
       token: '1234',
     }));
-    got.mockImplementation(() => Promise.resolve({ body: { some: 'data' } }));
+    got.mockImplementation(() => Promise.resolve(npmResponse));
     const res = await npm.getDependency('foobar');
     expect(res).toMatchSnapshot();
     const call = got.mock.calls[0];


### PR DESCRIPTION
This PR adds caching for `npm` requests.

- Caching is in-memory
- Caching currently *does not* expire
- Caching key is based on combination of package url + headers combination
- Version details have been stripped from cache to reduce memory usage

Closes #246 