### PR TITLE
Add gitlab api v4 support to getPr

### DIFF
--- a/lib/api/gitlab.js
+++ b/lib/api/gitlab.js
@@ -134,7 +134,7 @@ async function getBranchPr(branchName) {
   if (!pr) {
     return null;
   }
-  return getPr(pr.id);
+  return getPr(config.apiVersion === 'v3' ? pr.id : pr.iid);
 }
 
 // Returns the combined status for a branch.


### PR DESCRIPTION
This is a quick patch to fix the `getPr` method. Turns out v4 api uses the `iid` field to get the merge request instead of the `id` field. This wasn't spelled out super clearly in the documentation and therefore ended up being overlooked.