### PR TITLE
Use .npmrc from repository for registry lookups

### DIFF
--- a/lib/api/npm.js
+++ b/lib/api/npm.js
@@ -7,25 +7,31 @@ const registryAuthToken = require('registry-auth-token');
 const logger = require('winston');
 
 module.exports = {
+  setNpmrc,
   getDependency,
   resetCache,
 };
 
 let npmCache = {};
+let npmrc = null;
 
 function resetCache() {
   npmCache = {};
 }
 
+async function setNpmrc(input) {
+  npmrc = input;
+}
+
 async function getDependency(name) {
   logger.debug(`getDependency(${name})`);
   const scope = name.split('/')[0];
-  const regUrl = registryUrl(scope);
+  const regUrl = registryUrl(scope, npmrc);
   const pkgUrl = url.resolve(
     regUrl,
     encodeURIComponent(name).replace(/^%40/, '@')
   );
-  const authInfo = registryAuthToken(regUrl);
+  const authInfo = registryAuthToken(regUrl, npmrc);
   const headers = {};
 
   // Reduce metadata https://github.com/npm/registry/blob/master/docs/responses/package-metadata.md

--- a/lib/api/npm.js
+++ b/lib/api/npm.js
@@ -26,12 +26,12 @@ async function setNpmrc(input) {
 async function getDependency(name) {
   logger.debug(`getDependency(${name})`);
   const scope = name.split('/')[0];
-  const regUrl = registryUrl(scope, npmrc);
+  const regUrl = registryUrl(scope, { npmrc });
   const pkgUrl = url.resolve(
     regUrl,
     encodeURIComponent(name).replace(/^%40/, '@')
   );
-  const authInfo = registryAuthToken(regUrl, npmrc);
+  const authInfo = registryAuthToken(regUrl, { npmrc });
   const headers = {};
 
   // Reduce metadata https://github.com/npm/registry/blob/master/docs/responses/package-metadata.md

--- a/lib/index.js
+++ b/lib/index.js
@@ -69,7 +69,7 @@ async function processRepo(repo) {
 async function setNpmrc() {
   try {
     let npmrc = null;
-    const npmrcContent = await api.getFileJson('.npmrc');
+    const npmrcContent = await api.getFileContent('.npmrc');
     if (npmrcContent) {
       logger.debug('Found .npmrc file in repository');
       npmrc = ini.parse(npmrcContent);

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,9 @@ const logger = require('./logger');
 const configParser = require('./config');
 const githubApi = require('./api/github');
 const gitlabApi = require('./api/gitlab');
+const npmApi = require('./api/npm');
 const defaultsParser = require('./config/defaults');
+const ini = require('ini');
 
 // Require main source
 const worker = require('./worker');
@@ -11,6 +13,7 @@ const worker = require('./worker');
 module.exports = {
   start,
   processRepo,
+  setNpmrc,
 };
 
 // This will be github or others
@@ -53,11 +56,27 @@ async function processRepo(repo) {
     if (isConfigured === false) {
       return;
     }
+    await setNpmrc();
     await findPackageFiles(config);
     const upgrades = await getAllRepoUpgrades(config);
     await worker.processUpgrades(upgrades);
   } catch (error) {
     throw error;
+  }
+}
+
+// Check for config in `renovate.json`
+async function setNpmrc() {
+  try {
+    let npmrc = null;
+    const npmrcContent = await api.getFileJson('.npmrc');
+    if (npmrcContent) {
+      logger.debug('Found .npmrc file in repository');
+      npmrc = ini.parse(npmrcContent);
+    }
+    npmApi.setNpmrc(npmrc);
+  } catch (err) {
+    logger.error('Failed to set .npmrc');
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "gl-got": "6.0.2",
     "got": "7.0.0",
     "handlebars": "4.0.10",
+    "ini": "1.3.4",
     "json-stringify-pretty-compact": "1.0.4",
     "jsonwebtoken": "7.4.1",
     "lodash": "4.17.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1586,7 +1586,7 @@ inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
-ini@~1.3.0:
+ini@1.3.4, ini@~1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
 


### PR DESCRIPTION
The goal of this PR is to allow `renovate` to use any credentials that are checked into an `.npmrc` file within the current registry. i.e. instead of searching the filesystem of the machine running `renovate` for its npm credentials, the contents of the repository's `.npmrc` would be used instead.

Important to note: if an `.npmrc` file is found in the target repository, any file system `.npmrc` credentials will be *ignored*.

Also note: Not looking up `.yarnrc` as it does not seem relevant to this

Closes #291 