### PR TITLE
Use iid when setting up harmonized github PR object in getPr

### DIFF
--- a/lib/api/gitlab.js
+++ b/lib/api/gitlab.js
@@ -245,7 +245,7 @@ async function getPr(prNo) {
   const url = `projects/${config.repoName}/merge_requests/${prNo}`;
   const pr = (await glGot(url)).body;
   // Harmonize fields with GitHub
-  pr.number = pr.id;
+  pr.number = config.apiVersion === 'v3' ? pr.id : pr.iid;
   pr.displayNumber = `Merge Request #${pr.iid}`;
   pr.body = pr.description;
   if (pr.state === 'closed' || pr.state === 'merged') {


### PR DESCRIPTION
I've returned with the latest and greatest tweak for gitlab v4 support!

This tweak is essentially the same as https://github.com/singapore/renovate/pull/295.

We're ensuring that when we pass the pr object to other libraries we won't get errors on v4. (Ensure PR was throwing some errors in certain edge case scenarios)