### PR TITLE
fix: drop preformatted changelog

### DIFF
--- a/lib/workers/pr/index.js
+++ b/lib/workers/pr/index.js
@@ -65,8 +65,6 @@ async function ensurePr(upgrades, logger) {
     );
     // Store changelog markdown for backwards compatibility
     if (logJSON) {
-      config.changelog =
-        config.changelog || changelogHelper.getMarkdown(logJSON);
       upgrade.githubName = logJSON.project.github;
       upgrade.releases = [];
       logJSON.versions.forEach(version => {


### PR DESCRIPTION
This PR drops support for the preformatted (markdown) `{{changelog}}` element. Changelogs should use the embedded JSON objects for changelogs.

BREAKING CHANGE: {{changelog}} no longer supported in templates.