### PR TITLE
fix: Remove yarn version from package.json

### DIFF
--- a/bin/install-yarn.sh
+++ b/bin/install-yarn.sh
@@ -1,2 +1,0 @@
-YARN_VERSION_REQUIRED=$(grep '"yarn"' package.json | sed 's/    "yarn": "//' | sed 's/"//')
-curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version $YARN_VERSION_REQUIRED

--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ machine:
 
 dependencies:
   pre:
-    - bash bin/install-yarn.sh
+    - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 0.27.5
     - yarn --version
   override:
     - yarn install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
   "homepage": "https://github.com/singapore/renovate#readme",
   "engines": {
     "node": ">=6.9.0",
-    "npm": "5",
-    "yarn": "0.24.6"
+    "npm": "5"
   },
   "dependencies": {
     "bunyan": "1.8.10",


### PR DESCRIPTION
This pinned yarn version prevents newer or older versions of yarn from installing renovate.