### PR TITLE
res.branchUpgrades was renamed to res.upgrades

### DIFF
--- a/lib/workers/repository/index.js
+++ b/lib/workers/repository/index.js
@@ -61,7 +61,7 @@ async function renovateRepository(packageFileConfig) {
     const res = await upgrades.branchifyUpgrades(allUpgrades, config.logger);
     config.errors = config.errors.concat(res.errors);
     config.warnings = config.warnings.concat(res.warnings);
-    const branchUpgrades = res.branchUpgrades;
+    const branchUpgrades = res.upgrades;
     config.logger.debug(`Updating ${branchUpgrades.length} branch(es)`);
     config.logger.trace({ config: branchUpgrades }, 'branchUpgrades');
     if (config.repoIsOnboarded) {


### PR DESCRIPTION
`upgrades.branchifyUpgrade` returns an object that has `upgrades` but no `branchUpgrades`.  
this was likely renamed and breaks `renovate`.

After local testing this fixes the problem.