### PR TITLE
feat: Skip schedules when onboarding

### DIFF
--- a/lib/workers/package/index.js
+++ b/lib/workers/package/index.js
@@ -18,6 +18,7 @@ async function findUpgrades(config) {
   }
   // Check schedule
   if (
+    config.repoIsOnboarded &&
     config.schedule &&
     config.schedule.length &&
     schedule.isScheduledNow(config) === false

--- a/test/workers/package/index.spec.js
+++ b/test/workers/package/index.spec.js
@@ -22,6 +22,7 @@ describe('lib/workers/package/index', () => {
       expect(res).toMatchObject([]);
     });
     it('returns empty if package is not scheduled', async () => {
+      config.repoIsOnboarded = true;
       config.schedule = 'some schedule';
       schedule.isScheduledNow.mockReturnValueOnce(false);
       const res = await pkgWorker.findUpgrades(config);
@@ -29,6 +30,7 @@ describe('lib/workers/package/index', () => {
       expect(npmApi.getDependency.mock.calls.length).toBe(0);
     });
     it('returns error if no npm dep found', async () => {
+      config.repoIsOnboarded = true;
       config.schedule = 'some schedule';
       schedule.isScheduledNow.mockReturnValueOnce(true);
       const res = await pkgWorker.findUpgrades(config);


### PR DESCRIPTION
This way, all PRs/branches will be shown in onboarding even if they have been scheduled for another day.

Closes #429