### PR TITLE
fix: Don’t stringify options body for PR labels

### DIFF
--- a/lib/api/github.js
+++ b/lib/api/github.js
@@ -360,7 +360,7 @@ async function addReviewers(issueNo, reviewers) {
 async function addLabels(issueNo, labels) {
   logger.debug(`Adding labels ${labels} to #${issueNo}`);
   await ghGot.post(`repos/${config.repoName}/issues/${issueNo}/labels`, {
-    body: JSON.stringify(labels),
+    body: labels,
   });
 }
 

--- a/test/api/__snapshots__/github.spec.js.snap
+++ b/test/api/__snapshots__/github.spec.js.snap
@@ -21,7 +21,10 @@ Array [
   Array [
     "repos/some/repo/issues/42/labels",
     Object {
-      "body": "[\\"foo\\",\\"bar\\"]",
+      "body": Array [
+        "foo",
+        "bar",
+      ],
     },
   ],
 ]


### PR DESCRIPTION
This has been required since the last major got update

Closes #456