### PR TITLE
feat: conventional commits detection

### DIFF
--- a/lib/api/github.js
+++ b/lib/api/github.js
@@ -39,6 +39,8 @@ module.exports = {
   getFile,
   getFileContent,
   getFileJson,
+  // Commits
+  getCommitMessages,
 };
 
 // Get all installations for a GitHub app
@@ -689,4 +691,15 @@ async function createCommit(parent, tree, message) {
       tree,
     },
   })).body.sha;
+}
+
+async function getCommitMessages() {
+  logger.debug('getCommitMessages');
+  try {
+    const res = await ghGot(`repos/${config.repoName}/commits`);
+    return res.body.map(commit => commit.commit.message);
+  } catch (err) {
+    logger.error(`getCommitMessages error: ${JSON.stringify(err)}`);
+    return [];
+  }
 }

--- a/lib/api/gitlab.js
+++ b/lib/api/gitlab.js
@@ -34,6 +34,8 @@ module.exports = {
   getFileJson,
   createFile,
   updateFile,
+  // commits
+  getCommitMessages,
 };
 
 // Get all repositories that the user has access to
@@ -467,6 +469,18 @@ async function commitFilesToBranch(
       logger.debug(`Creating file ${file.name}`);
       await createFile(branchName, file.name, file.contents, message);
     }
+  }
+}
+
+// GET /projects/:id/repository/commits
+async function getCommitMessages() {
+  logger.debug('getCommitMessages');
+  try {
+    const res = await glGot(`projects/${config.repoName}/repository/commits`);
+    return res.body.map(commit => commit.title);
+  } catch (err) {
+    logger.error(`getCommitMessages error: ${JSON.stringify(err)}`);
+    return [];
   }
 }
 

--- a/lib/workers/repository/onboarding.js
+++ b/lib/workers/repository/onboarding.js
@@ -1,3 +1,4 @@
+const conventionalCommitsDetector = require('conventional-commits-detector');
 const stringify = require('json-stringify-pretty-compact');
 
 const configParser = require('../../config');
@@ -6,13 +7,31 @@ const onboardBranchName = 'renovate/configure';
 const onboardPrTitle = 'Configure Renovate';
 
 module.exports = {
+  determineSemanticCommits,
   createBranch,
   ensurePr,
   getOnboardingStatus,
 };
 
+async function determineSemanticCommits(config) {
+  const commitMessages = await config.api.getCommitMessages();
+  config.logger.trace(`commitMessages=${JSON.stringify(commitMessages)}`);
+  const type = conventionalCommitsDetector(commitMessages);
+  if (type === 'unknown') {
+    config.logger.debug('No semantic commit type found');
+    return false;
+  }
+  config.logger.debug(
+    `Found semantic commit type ${type} - enabling semantic commits`
+  );
+  return true;
+}
+
 async function createBranch(config) {
   const onboardingConfig = configParser.getOnboardingConfig(config);
+  onboardingConfig.semanticCommits = await module.exports.determineSemanticCommits(
+    config
+  );
   const onboardingConfigString = `${stringify(onboardingConfig)}\n`;
   await config.api.commitFilesToBranch(
     onboardBranchName,

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "chalk": "2.0.1",
     "changelog": "1.3.0",
     "commander": "2.11.0",
+    "conventional-commits-detector": "0.1.1",
     "gh-got": "6.0.0",
     "github-url-from-git": "1.5.0",
     "gl-got": "7.0.0",

--- a/test/api/__snapshots__/github.spec.js.snap
+++ b/test/api/__snapshots__/github.spec.js.snap
@@ -508,6 +508,13 @@ Object {
 }
 `;
 
+exports[`api/github getCommitMessages() returns commits messages 1`] = `
+Array [
+  "foo",
+  "bar",
+]
+`;
+
 exports[`api/github getFile(filePatch, branchName) should return the encoded file content 1`] = `
 Array [
   Array [

--- a/test/api/__snapshots__/gitlab.spec.js.snap
+++ b/test/api/__snapshots__/gitlab.spec.js.snap
@@ -226,6 +226,13 @@ Object {
 }
 `;
 
+exports[`api/gitlab getCommitMessages() returns commits messages 1`] = `
+Array [
+  "foo",
+  "bar",
+]
+`;
+
 exports[`api/gitlab getFile(filePath, branchName) gets the file with v3 1`] = `
 Object {
   "apiVersion": "v3",

--- a/test/api/github.spec.js
+++ b/test/api/github.spec.js
@@ -1211,4 +1211,27 @@ describe('api/github', () => {
       expect(ghGot.patch.mock.calls).toMatchSnapshot();
     });
   });
+  describe('getCommitMessages()', () => {
+    it('returns commits messages', async () => {
+      ghGot.mockReturnValueOnce({
+        body: [
+          {
+            commit: { message: 'foo' },
+          },
+          {
+            commit: { message: 'bar' },
+          },
+        ],
+      });
+      const res = await github.getCommitMessages();
+      expect(res).toMatchSnapshot();
+    });
+    it('swallows errors', async () => {
+      ghGot.mockImplementationOnce(() => {
+        throw new Error('some-error');
+      });
+      const res = await github.getCommitMessages();
+      expect(res).toHaveLength(0);
+    });
+  });
 });

--- a/test/api/gitlab.spec.js
+++ b/test/api/gitlab.spec.js
@@ -678,4 +678,27 @@ describe('api/gitlab', () => {
       });
     });
   });
+  describe('getCommitMessages()', () => {
+    it('returns commits messages', async () => {
+      glGot.mockReturnValueOnce({
+        body: [
+          {
+            title: 'foo',
+          },
+          {
+            title: 'bar',
+          },
+        ],
+      });
+      const res = await gitlab.getCommitMessages();
+      expect(res).toMatchSnapshot();
+    });
+    it('swallows errors', async () => {
+      glGot.mockImplementationOnce(() => {
+        throw new Error('some-error');
+      });
+      const res = await gitlab.getCommitMessages();
+      expect(res).toHaveLength(0);
+    });
+  });
 });

--- a/test/workers/repository/__snapshots__/onboarding.spec.js.snap
+++ b/test/workers/repository/__snapshots__/onboarding.spec.js.snap
@@ -206,6 +206,43 @@ If the default settings are all suitable for you, simply close this Pull Request
 ]
 `;
 
+exports[`lib/workers/repository/onboarding getOnboardingStatus(config) enables semantic commits 1`] = `
+Array [
+  "renovate/configure",
+  Array [
+    Object {
+      "contents": "{
+  \\"enabled\\": true,
+  \\"timezone\\": null,
+  \\"schedule\\": [],
+  \\"packageFiles\\": [],
+  \\"depTypes\\": [
+    {\\"depType\\": \\"dependencies\\", \\"semanticPrefix\\": \\"fix(deps): \\"},
+    \\"devDependencies\\",
+    \\"optionalDependencies\\"
+  ],
+  \\"ignoreDeps\\": [],
+  \\"pinVersions\\": true,
+  \\"separateMajorReleases\\": true,
+  \\"semanticCommits\\": true,
+  \\"semanticPrefix\\": \\"chore(deps): \\",
+  \\"rebaseStalePrs\\": false,
+  \\"prCreation\\": \\"immediate\\",
+  \\"automerge\\": \\"none\\",
+  \\"branchName\\": \\"renovate/{{depName}}-{{newVersionMajor}}.x\\",
+  \\"commitMessage\\": \\"{{semanticPrefix}}Update dependency {{depName}} to version {{newVersion}}\\",
+  \\"labels\\": [],
+  \\"assignees\\": [],
+  \\"reviewers\\": []
+}
+",
+      "name": "renovate.json",
+    },
+  ],
+  "Add renovate.json",
+]
+`;
+
 exports[`lib/workers/repository/onboarding getOnboardingStatus(config) returns false if no pr 1`] = `
 Array [
   "renovate/configure",

--- a/test/workers/repository/onboarding.spec.js
+++ b/test/workers/repository/onboarding.spec.js
@@ -198,6 +198,7 @@ If the default settings are all suitable for you, simply close this Pull Request
         commitFilesToBranch: jest.fn(),
         createPr: jest.fn(() => ({ displayNumber: 1 })),
         findPr: jest.fn(),
+        getCommitMessages: jest.fn(),
       };
       config.logger = logger;
       config.detectedPackageFiles = true;
@@ -231,6 +232,14 @@ If the default settings are all suitable for you, simply close this Pull Request
       expect(config.api.commitFilesToBranch.mock.calls.length).toBe(0);
     });
     it('returns false if no pr', async () => {
+      const res = await onboarding.getOnboardingStatus(config);
+      expect(res).toEqual(false);
+      expect(config.api.findPr.mock.calls.length).toBe(1);
+      expect(config.api.commitFilesToBranch.mock.calls.length).toBe(1);
+      expect(config.api.commitFilesToBranch.mock.calls[0]).toMatchSnapshot();
+    });
+    it('enables semantic commits', async () => {
+      config.api.getCommitMessages.mockReturnValueOnce(['fix: something']);
       const res = await onboarding.getOnboardingStatus(config);
       expect(res).toEqual(false);
       expect(config.api.findPr.mock.calls.length).toBe(1);

--- a/yarn.lock
+++ b/yarn.lock
@@ -776,6 +776,15 @@ conventional-changelog@0.0.17:
     lodash "^3.6.0"
     normalize-package-data "^1.0.3"
 
+conventional-commits-detector@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/conventional-commits-detector/-/conventional-commits-detector-0.1.1.tgz#7cd66a3628326c366dd0f315d88a7d42b2c9229b"
+  dependencies:
+    arrify "^1.0.0"
+    git-raw-commits "^0.1.2"
+    meow "^3.3.0"
+    through2-concurrent "^1.1.0"
+
 convert-source-map@^1.1.0, convert-source-map@^1.4.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.0.tgz#9acd70851c6d5dfdd93d9282e5edf94a03ff46b5"
@@ -829,6 +838,12 @@ d@1:
   resolved "https://registry.yarnpkg.com/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
   dependencies:
     es5-ext "^0.10.9"
+
+dargs@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/dargs/-/dargs-4.1.0.tgz#03a9dbb4b5c2f139bf14ae53f0b8a2a6a86f4e17"
+  dependencies:
+    number-is-nan "^1.0.0"
 
 dashdash@^1.12.0:
   version "1.14.1"
@@ -1494,6 +1509,16 @@ git-head@^1.2.1:
   resolved "https://registry.yarnpkg.com/git-head/-/git-head-1.20.1.tgz#036d16a4b374949e4e3daf15827903686d3ccd52"
   dependencies:
     git-refs "^1.1.3"
+
+git-raw-commits@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/git-raw-commits/-/git-raw-commits-0.1.2.tgz#2becbdcd3f96ef0b19f16863f7a2f6d9d8ab8369"
+  dependencies:
+    dargs "^4.0.1"
+    lodash.template "^3.6.1"
+    meow "^3.1.0"
+    split2 "^1.0.0"
+    through2 "^2.0.0"
 
 git-refs@^1.1.3:
   version "1.1.3"
@@ -2432,6 +2457,14 @@ lodash._basecopy@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz#8da0e6a876cf344c0ad8a54882111dd3c5c7ca36"
 
+lodash._basetostring@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz#d1861d877f824a52f669832dcaf3ee15566a07d5"
+
+lodash._basevalues@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz#5b775762802bde3d3297503e26300820fdf661b7"
+
 lodash._bindcallback@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
@@ -2452,6 +2485,14 @@ lodash._isiterateecall@^3.0.0:
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz#5203ad7ba425fae842460e696db9cf3e6aac057c"
 
+lodash._reinterpolate@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
+
+lodash._root@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/lodash._root/-/lodash._root-3.0.1.tgz#fba1c4524c19ee9a5f8136b4609f017cf4ded692"
+
 lodash.assign@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-3.2.0.tgz#3ce9f0234b4b2223e296b8fa0ac1fee8ebca64fa"
@@ -2463,6 +2504,12 @@ lodash.assign@^3.0.0:
 lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
+
+lodash.escape@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.escape/-/lodash.escape-3.2.0.tgz#995ee0dc18c1b48cc92effae71a10aab5b487698"
+  dependencies:
+    lodash._root "^3.0.0"
 
 lodash.isarguments@^3.0.0:
   version "3.1.0"
@@ -2499,6 +2546,27 @@ lodash.padstart@^4.1.0:
 lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
+
+lodash.template@^3.6.1:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-3.6.2.tgz#f8cdecc6169a255be9098ae8b0c53d378931d14f"
+  dependencies:
+    lodash._basecopy "^3.0.0"
+    lodash._basetostring "^3.0.0"
+    lodash._basevalues "^3.0.0"
+    lodash._isiterateecall "^3.0.0"
+    lodash._reinterpolate "^3.0.0"
+    lodash.escape "^3.0.0"
+    lodash.keys "^3.0.0"
+    lodash.restparam "^3.0.0"
+    lodash.templatesettings "^3.0.0"
+
+lodash.templatesettings@^3.0.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz#fb307844753b66b9f1afa54e262c745307dba8e5"
+  dependencies:
+    lodash._reinterpolate "^3.0.0"
+    lodash.escape "^3.0.0"
 
 lodash@4.17.4, lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
@@ -2560,7 +2628,7 @@ mem@^1.1.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-meow@^3.3.0:
+meow@^3.1.0, meow@^3.3.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"
   dependencies:
@@ -3179,7 +3247,7 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
-"readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.2.2:
+"readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
   dependencies:
@@ -3614,6 +3682,12 @@ spdx-license-ids@^1.0.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
 
+split2@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/split2/-/split2-1.1.1.tgz#162d9b18865f02ab2f2ad9585522db9b54c481f9"
+  dependencies:
+    through2 "~2.0.0"
+
 split@0.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/split/-/split-0.3.3.tgz#cd0eea5e63a211dfff7eb0f091c4133e2d0dd28f"
@@ -3792,6 +3866,19 @@ text-table@~0.2.0:
 throat@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-3.2.0.tgz#50cb0670edbc40237b9e347d7e1f88e4620af836"
+
+through2-concurrent@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/through2-concurrent/-/through2-concurrent-1.1.1.tgz#11cb4ea4c9e31bca6e4c1e6dba48d1c728c3524b"
+  dependencies:
+    through2 "^2.0.0"
+
+through2@^2.0.0, through2@~2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be"
+  dependencies:
+    readable-stream "^2.1.5"
+    xtend "~4.0.1"
 
 through@2, through@^2.3.6, through@~2.3, through@~2.3.1:
   version "2.3.8"
@@ -4071,7 +4158,7 @@ xml-name-validator@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
 
-xtend@^4.0.0, xtend@^4.0.1:
+xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 


### PR DESCRIPTION
When onboarding, retrieve the most recent commits from the repository and use https://github.com/conventional-changelog/conventional-commits-detector to parse the commit messages to detect if any conventional commit approach is being used.

Closes #462 
