### PR TITLE
feat(onboarding): Recreate renovate.json if it’s not modified

### DIFF
--- a/lib/workers/repository/onboarding.js
+++ b/lib/workers/repository/onboarding.js
@@ -176,6 +176,7 @@ async function getOnboardingStatus(config) {
     'Configure Renovate'
   );
   if (pr) {
+    config.logger.debug(`Found existing onboarding PR#${pr.number}`);
     if (pr.isClosed) {
       config.logger.debug('Found closed Configure Renovate PR');
       return true;
@@ -184,8 +185,13 @@ async function getOnboardingStatus(config) {
     config.logger.debug(
       `PR #${pr.displayNumber} needs to be closed to enable renovate to continue`
     );
-    return false;
+    const prDetails = await config.api.getPr(pr.number);
+    if (!prDetails.canRebase) {
+      // Cannot update files if rebasing not possible
+      return false;
+    }
   }
+  // Create or update files, then return
   await module.exports.createBranch(config);
   return false;
 }

--- a/test/workers/repository/__snapshots__/onboarding.spec.js.snap
+++ b/test/workers/repository/__snapshots__/onboarding.spec.js.snap
@@ -201,6 +201,43 @@ Alternatively, you can add the same configuration settings into a \\"renovate\\"
 ]
 `;
 
+exports[`lib/workers/repository/onboarding getOnboardingStatus(config) commits files and returns false if no pr 1`] = `
+Array [
+  "renovate/configure",
+  Array [
+    Object {
+      "contents": "{
+  \\"enabled\\": true,
+  \\"timezone\\": null,
+  \\"schedule\\": [],
+  \\"packageFiles\\": [],
+  \\"depTypes\\": [
+    {\\"depType\\": \\"dependencies\\", \\"semanticPrefix\\": \\"fix(deps): \\"},
+    \\"devDependencies\\",
+    \\"optionalDependencies\\"
+  ],
+  \\"ignoreDeps\\": [],
+  \\"pinVersions\\": true,
+  \\"separateMajorReleases\\": true,
+  \\"semanticCommits\\": false,
+  \\"semanticPrefix\\": \\"chore(deps): \\",
+  \\"rebaseStalePrs\\": false,
+  \\"prCreation\\": \\"immediate\\",
+  \\"automerge\\": \\"none\\",
+  \\"branchName\\": \\"renovate/{{depName}}-{{newVersionMajor}}.x\\",
+  \\"commitMessage\\": \\"{{semanticPrefix}}Update dependency {{depName}} to version {{newVersion}}\\",
+  \\"labels\\": [],
+  \\"assignees\\": [],
+  \\"reviewers\\": []
+}
+",
+      "name": "renovate.json",
+    },
+  ],
+  "Add renovate.json",
+]
+`;
+
 exports[`lib/workers/repository/onboarding getOnboardingStatus(config) enables semantic commits 1`] = `
 Array [
   "renovate/configure",
@@ -220,43 +257,6 @@ Array [
   \\"pinVersions\\": true,
   \\"separateMajorReleases\\": true,
   \\"semanticCommits\\": true,
-  \\"semanticPrefix\\": \\"chore(deps): \\",
-  \\"rebaseStalePrs\\": false,
-  \\"prCreation\\": \\"immediate\\",
-  \\"automerge\\": \\"none\\",
-  \\"branchName\\": \\"renovate/{{depName}}-{{newVersionMajor}}.x\\",
-  \\"commitMessage\\": \\"{{semanticPrefix}}Update dependency {{depName}} to version {{newVersion}}\\",
-  \\"labels\\": [],
-  \\"assignees\\": [],
-  \\"reviewers\\": []
-}
-",
-      "name": "renovate.json",
-    },
-  ],
-  "Add renovate.json",
-]
-`;
-
-exports[`lib/workers/repository/onboarding getOnboardingStatus(config) returns false if no pr 1`] = `
-Array [
-  "renovate/configure",
-  Array [
-    Object {
-      "contents": "{
-  \\"enabled\\": true,
-  \\"timezone\\": null,
-  \\"schedule\\": [],
-  \\"packageFiles\\": [],
-  \\"depTypes\\": [
-    {\\"depType\\": \\"dependencies\\", \\"semanticPrefix\\": \\"fix(deps): \\"},
-    \\"devDependencies\\",
-    \\"optionalDependencies\\"
-  ],
-  \\"ignoreDeps\\": [],
-  \\"pinVersions\\": true,
-  \\"separateMajorReleases\\": true,
-  \\"semanticCommits\\": false,
   \\"semanticPrefix\\": \\"chore(deps): \\",
   \\"rebaseStalePrs\\": false,
   \\"prCreation\\": \\"immediate\\",


### PR DESCRIPTION
This allows for improvements to renovate’s default renovate.json to be passed on to users who haven’t merged or modified their Configure Renovate PR.

Closes #465