### PR TITLE
feat(onboarding): Allow branch cleanup after onboarding

### DIFF
--- a/lib/workers/repository/index.js
+++ b/lib/workers/repository/index.js
@@ -77,6 +77,7 @@ async function renovateRepository(packageFileConfig) {
     const branchUpgrades = res.upgrades;
     config.logger.debug(`Updating ${branchUpgrades.length} branch(es)`);
     config.logger.trace({ config: branchUpgrades }, 'branchUpgrades');
+    let branchList;
     if (config.repoIsOnboarded) {
       for (const branchUpgrade of branchUpgrades) {
         await branchWorker.processBranchUpgrades(
@@ -85,13 +86,15 @@ async function renovateRepository(packageFileConfig) {
           config.warnings
         );
       }
-      const branchList = branchUpgrades.map(upgrade => upgrade.branchName);
+      branchList = branchUpgrades.map(upgrade => upgrade.branchName);
       config.logger.debug(`branchList=${branchList}`);
       await cleanup.pruneStaleBranches(config, branchList);
     } else {
       await onboarding.ensurePr(config, branchUpgrades);
       config.logger.info('"Configure Renovate" PR needs to be closed first');
+      branchList = ['renovate/configure'];
     }
+    await cleanup.pruneStaleBranches(config, branchList);
   } catch (error) {
     // Swallow this error so that other repositories can be processed
     config.logger.error(`Failed to process repository: ${error.message}`);


### PR DESCRIPTION
Refactored location of branch cleanup so that it can be run even if onboarding is enabled.
This means someone can “undo” a closed Configure Renovate and all other PRs would get cleaned up.