### PR TITLE
fix(github): Hyperlink issues on GitHub only if private repo

### DIFF
--- a/lib/api/github.js
+++ b/lib/api/github.js
@@ -145,6 +145,7 @@ async function initRepo(repoName, token, endpoint, repoLogger) {
   config.repoName = repoName;
   try {
     const res = await ghGot(`repos/${repoName}`);
+    config.privateRepo = res.body.private === true;
     config.owner = res.body.owner.login;
     logger.debug(`${repoName} owner = ${config.owner}`);
     // Use default branch as PR target unless later overridden

--- a/lib/workers/pr/index.js
+++ b/lib/workers/pr/index.js
@@ -82,11 +82,13 @@ async function ensurePr(inputConfig, logger, errors, warnings) {
             commit.url = `${logJSON.project.repository}/commit/${change.sha}`;
             if (change.message) {
               commit.message = change.message.split('\n')[0];
-              const re = /([\s(])#(\d+)([)\s]?)/g;
-              commit.message = commit.message.replace(
-                re,
-                `$1[#$2](${upgrade.repositoryUrl}/issues/$2)$3`
-              );
+              if (config.isGitHub && config.privateRepo === true) {
+                const re = /([\s(])#(\d+)([)\s]?)/g;
+                commit.message = commit.message.replace(
+                  re,
+                  `$1[#$2](${upgrade.repositoryUrl}/issues/$2)$3`
+                );
+              }
             }
             release.commits.push(commit);
           });

--- a/test/api/__snapshots__/github.spec.js.snap
+++ b/test/api/__snapshots__/github.spec.js.snap
@@ -758,6 +758,7 @@ Object {
   "defaultBranch": "master",
   "mergeMethod": "rebase",
   "owner": "theowner",
+  "privateRepo": false,
   "repoName": "some/repo",
 }
 `;
@@ -780,6 +781,7 @@ Object {
   "defaultBranch": "master",
   "mergeMethod": "rebase",
   "owner": "theowner",
+  "privateRepo": false,
   "repoName": "some/repo",
 }
 `;
@@ -802,6 +804,7 @@ Object {
   "defaultBranch": "master",
   "mergeMethod": "rebase",
   "owner": "theowner",
+  "privateRepo": false,
   "repoName": "some/repo",
 }
 `;
@@ -813,6 +816,7 @@ Object {
   "defaultBranch": "master",
   "mergeMethod": "merge",
   "owner": "theowner",
+  "privateRepo": false,
   "repoName": "some/repo",
 }
 `;
@@ -823,6 +827,7 @@ Object {
   "baseCommitSHA": "1234",
   "defaultBranch": "master",
   "owner": "theowner",
+  "privateRepo": false,
   "repoName": "some/repo",
 }
 `;
@@ -834,6 +839,7 @@ Object {
   "defaultBranch": "master",
   "mergeMethod": "rebase",
   "owner": "theowner",
+  "privateRepo": false,
   "repoName": "some/repo",
 }
 `;
@@ -845,6 +851,7 @@ Object {
   "defaultBranch": "master",
   "mergeMethod": "squash",
   "owner": "theowner",
+  "privateRepo": false,
   "repoName": "some/repo",
 }
 `;

--- a/test/workers/pr/index.spec.js
+++ b/test/workers/pr/index.spec.js
@@ -199,6 +199,7 @@ describe('workers/pr', () => {
     it('should return unmodified existing PR', async () => {
       config.depName = 'dummy';
       config.isGitHub = true;
+      config.privateRepo = true;
       config.currentVersion = '1.0.0';
       config.newVersion = '1.1.0';
       config.repositoryUrl = 'https://github.com/renovateapp/dummy';


### PR DESCRIPTION
When we add hyperlinks to all #12345 issues/PRs in changelogs it causes undesirable noise for maintainers of those upstream repositories.
Now, such hyperlinking is done only for private repos as that won’t result in the same GitHub annotations.

Closes #478