### PR TITLE
fix(pr): Prevent accidental hyperlinks in PR body

### DIFF
--- a/lib/workers/pr/index.js
+++ b/lib/workers/pr/index.js
@@ -82,12 +82,15 @@ async function ensurePr(inputConfig, logger, errors, warnings) {
             commit.url = `${logJSON.project.repository}/commit/${change.sha}`;
             if (change.message) {
               commit.message = change.message.split('\n')[0];
-              if (config.isGitHub && config.privateRepo === true) {
-                const re = /([\s(])#(\d+)([)\s]?)/g;
+              const re = /([\s(])#(\d+)([)\s]?)/g;
+              if (!config.isGitHub || config.privateRepo === true) {
                 commit.message = commit.message.replace(
                   re,
                   `$1[#$2](${upgrade.repositoryUrl}/issues/$2)$3`
                 );
+              } else {
+                // Public GitHub repos need links prevented - see #489
+                commit.message = commit.message.replace(re, '$1`#$2`$3');
               }
             }
             release.commits.push(commit);

--- a/test/workers/pr/index.spec.js
+++ b/test/workers/pr/index.spec.js
@@ -215,6 +215,7 @@ describe('workers/pr', () => {
       config.depName = 'dummy';
       config.currentVersion = '1.0.0';
       config.newVersion = '1.2.0';
+      config.isGitHub = true;
       config.api.getBranchPr = jest.fn(() => existingPr);
       config.api.updatePr = jest.fn();
       const pr = await prWorker.ensurePr(config, logger);


### PR DESCRIPTION
GitHub incorrect assumes these #12345 issue numbers refer to the *local* repo, not the source. Adding ` ` should prevent that auto-hyperlinking.

Closes #489