### PR TITLE
fix(branch): Add check before rebasing stale PRs

### DIFF
--- a/lib/workers/branch/index.js
+++ b/lib/workers/branch/index.js
@@ -7,42 +7,56 @@ const prWorker = require('../pr');
 let logger = require('../../logger');
 
 module.exports = {
+  checkStale,
   getParentBranch,
   ensureBranch,
   processBranchUpgrades,
 };
 
+function checkStale(config) {
+  // Manually configured
+  if (config.rebaseStalePrs) {
+    return true;
+  }
+  // Commits can't be pushed to a branch unless they are up-to-date
+  if (config.automergeEnabled && config.automergeType === 'branch-push') {
+    return true;
+  }
+  return false;
+}
+
 async function getParentBranch(branchName, config) {
   // Check if branch exists
-  if ((await config.api.branchExists(branchName)) === false) {
+  const branchExists = await config.api.branchExists(branchName);
+  if (!branchExists) {
     logger.info(`Branch needs creating`);
     return undefined;
   }
   logger.info(`Branch already exists`);
-  // Check if needs rebasing
-  if (
-    config.rebaseStalePrs ||
-    (config.automergeEnabled && config.automergeType === 'branch-push')
-  ) {
-    const isBranchStale = await config.api.isBranchStale(branchName);
-    if (isBranchStale) {
-      logger.info(`Branch is stale and needs rebasing`);
-      return undefined;
-    }
-  }
 
   // Check for existing PR
   const pr = await config.api.getBranchPr(branchName);
-  // Decide if we need to rebase
-  if (!pr) {
-    logger.debug(`No PR found`);
-    // We can't tell if this branch can be rebased so better not
-    return branchName;
+
+  if (checkStale(config)) {
+    const isBranchStale = await config.api.isBranchStale(branchName);
+    if (isBranchStale) {
+      logger.info(`Branch is stale and needs rebasing`);
+      // We can rebase the branch only if no PR or PR can be rebased
+      if (!pr || pr.canRebase) {
+        return undefined;
+      }
+      // TODO: Warn here so that it appears in PR body
+      logger.info('Cannot rebase branch');
+      return branchName;
+    }
   }
-  if (pr.isUnmergeable) {
+
+  // Now check if PR is unmergeable. If so then we also rebase
+  if (pr && pr.isUnmergeable) {
     logger.debug('PR is unmergeable');
     if (pr.canRebase) {
       logger.info(`Branch is not mergeable and needs rebasing`);
+      // TODO: Move this down to api library
       if (config.isGitLab) {
         logger.info(`Deleting unmergeable branch in order to recreate/rebase`);
         await config.api.deleteBranch(branchName);
@@ -51,6 +65,7 @@ async function getParentBranch(branchName, config) {
       return undefined;
     }
     // Don't do anything different, but warn
+    // TODO: Add warning to PR
     logger.warn(`Branch is not mergeable but can't be rebased`);
   }
   logger.debug(`Branch does not need rebasing`);

--- a/test/workers/branch/index.spec.js
+++ b/test/workers/branch/index.spec.js
@@ -91,6 +91,17 @@ describe('workers/branch', () => {
         undefined
       );
     });
+    it('returns branch if rebaseStalePrs enabled but cannot rebase', async () => {
+      config.rebaseStalePrs = true;
+      config.api.isBranchStale.mockReturnValueOnce(true);
+      config.api.getBranchPr.mockReturnValue({
+        isUnmergeable: true,
+        canRebase: false,
+      });
+      expect(await branchWorker.getParentBranch(branchName, config)).not.toBe(
+        undefined
+      );
+    });
   });
   describe('ensureBranch(config)', () => {
     let config;


### PR DESCRIPTION
We should not rebase stale PRs if they have been edited any anyone. This adds a check from the PR to see if it can be rebased. If no PR then we assume we can - nobody should be editing our branches directly without PR.

Closes #525