### PR TITLE
fix(npm): Log correct package name when 404

### DIFF
--- a/lib/workers/package/index.js
+++ b/lib/workers/package/index.js
@@ -2,7 +2,7 @@ const npmApi = require('../../api/npm');
 const versions = require('./versions');
 const configParser = require('../../config');
 
-let logger = require('../../logger');
+const pLogger = require('../../logger');
 
 module.exports = {
   renovatePackage,
@@ -10,7 +10,7 @@ module.exports = {
 
 // Returns all results for a given dependency config
 async function renovatePackage(config) {
-  logger = config.logger || logger;
+  const logger = config.logger || pLogger;
   if (config.enabled === false) {
     logger.debug('package is disabled');
     return [];


### PR DESCRIPTION
Because we are running Promise.all on package lookups, we were getting some incorrect package names in our log messages.