### PR TITLE
fix(github): Use more specific URI when checking branch protection

### DIFF
--- a/lib/api/github.js
+++ b/lib/api/github.js
@@ -163,10 +163,7 @@ async function initRepo(repoName, token, endpoint, repoLogger) {
     config.repoForceRebase = false;
     try {
       const branchProtection = await getBranchProtection(config.baseBranch);
-      if (
-        branchProtection.required_status_checks &&
-        branchProtection.required_status_checks.strict
-      ) {
+      if (branchProtection.strict) {
         logger.debug('Repo has branch protection and needs PRs up-to-date');
         config.repoForceRebase = true;
       } else {
@@ -196,7 +193,7 @@ async function initRepo(repoName, token, endpoint, repoLogger) {
 
 async function getBranchProtection(branchName) {
   const res = await ghGot(
-    `repos/${config.repoName}/branches/${branchName}/protection`,
+    `repos/${config.repoName}/branches/${branchName}/protection/required_status_checks`,
     {
       headers: {
         accept: 'application/vnd.github.loki-preview+json',

--- a/lib/api/github.js
+++ b/lib/api/github.js
@@ -177,6 +177,8 @@ async function initRepo(repoName, token, endpoint, repoLogger) {
     } catch (err) {
       if (err.statusCode === 404) {
         logger.debug('Repo has no branch protection');
+      } else if (err.statusCode === 403) {
+        logger.debug('Do not have permissions to detect branch protection');
       } else {
         throw err;
       }

--- a/test/api/__snapshots__/github.spec.js.snap
+++ b/test/api/__snapshots__/github.spec.js.snap
@@ -920,6 +920,18 @@ Object {
 }
 `;
 
+exports[`api/github initRepo should ignore repoForceRebase 403 1`] = `
+Object {
+  "baseBranch": "master",
+  "baseCommitSHA": "1234",
+  "defaultBranch": "master",
+  "owner": "theowner",
+  "privateRepo": false,
+  "repoForceRebase": false,
+  "repoName": "some/repo",
+}
+`;
+
 exports[`api/github initRepo should ignore repoForceRebase 404 1`] = `
 Object {
   "baseBranch": "master",

--- a/test/api/__snapshots__/github.spec.js.snap
+++ b/test/api/__snapshots__/github.spec.js.snap
@@ -58,7 +58,7 @@ Array [
     "repos/some/repo/git/refs/heads/master",
   ],
   Array [
-    "repos/some/repo/branches/master/protection",
+    "repos/some/repo/branches/master/protection/required_status_checks",
     Object {
       "headers": Object {
         "accept": "application/vnd.github.loki-preview+json",
@@ -80,7 +80,7 @@ Array [
     "repos/some/repo/git/refs/heads/master",
   ],
   Array [
-    "repos/some/repo/branches/master/protection",
+    "repos/some/repo/branches/master/protection/required_status_checks",
     Object {
       "headers": Object {
         "accept": "application/vnd.github.loki-preview+json",
@@ -102,7 +102,7 @@ Array [
     "repos/some/repo/git/refs/heads/master",
   ],
   Array [
-    "repos/some/repo/branches/master/protection",
+    "repos/some/repo/branches/master/protection/required_status_checks",
     Object {
       "headers": Object {
         "accept": "application/vnd.github.loki-preview+json",
@@ -124,7 +124,7 @@ Array [
     "repos/some/repo/git/refs/heads/master",
   ],
   Array [
-    "repos/some/repo/branches/master/protection",
+    "repos/some/repo/branches/master/protection/required_status_checks",
     Object {
       "headers": Object {
         "accept": "application/vnd.github.loki-preview+json",
@@ -146,7 +146,7 @@ Array [
     "repos/some/repo/git/refs/heads/master",
   ],
   Array [
-    "repos/some/repo/branches/master/protection",
+    "repos/some/repo/branches/master/protection/required_status_checks",
     Object {
       "headers": Object {
         "accept": "application/vnd.github.loki-preview+json",
@@ -168,7 +168,7 @@ Array [
     "repos/some/repo/git/refs/heads/master",
   ],
   Array [
-    "repos/some/repo/branches/master/protection",
+    "repos/some/repo/branches/master/protection/required_status_checks",
     Object {
       "headers": Object {
         "accept": "application/vnd.github.loki-preview+json",
@@ -190,7 +190,7 @@ Array [
     "repos/some/repo/git/refs/heads/master",
   ],
   Array [
-    "repos/some/repo/branches/master/protection",
+    "repos/some/repo/branches/master/protection/required_status_checks",
     Object {
       "headers": Object {
         "accept": "application/vnd.github.loki-preview+json",
@@ -212,7 +212,7 @@ Array [
     "repos/some/repo/git/refs/heads/master",
   ],
   Array [
-    "repos/some/repo/branches/master/protection",
+    "repos/some/repo/branches/master/protection/required_status_checks",
     Object {
       "headers": Object {
         "accept": "application/vnd.github.loki-preview+json",
@@ -293,7 +293,7 @@ Array [
     "repos/some/repo/git/refs/heads/master",
   ],
   Array [
-    "repos/some/repo/branches/master/protection",
+    "repos/some/repo/branches/master/protection/required_status_checks",
     Object {
       "headers": Object {
         "accept": "application/vnd.github.loki-preview+json",
@@ -423,7 +423,7 @@ Array [
     "repos/some/repo/git/refs/heads/master",
   ],
   Array [
-    "repos/some/repo/branches/master/protection",
+    "repos/some/repo/branches/master/protection/required_status_checks",
     Object {
       "headers": Object {
         "accept": "application/vnd.github.loki-preview+json",
@@ -445,7 +445,7 @@ Array [
     "repos/some/repo/git/refs/heads/master",
   ],
   Array [
-    "repos/some/repo/branches/master/protection",
+    "repos/some/repo/branches/master/protection/required_status_checks",
     Object {
       "headers": Object {
         "accept": "application/vnd.github.loki-preview+json",
@@ -475,7 +475,7 @@ Array [
     "repos/some/repo/git/refs/heads/master",
   ],
   Array [
-    "repos/some/repo/branches/master/protection",
+    "repos/some/repo/branches/master/protection/required_status_checks",
     Object {
       "headers": Object {
         "accept": "application/vnd.github.loki-preview+json",
@@ -506,7 +506,7 @@ Array [
     "repos/some/repo/git/refs/heads/master",
   ],
   Array [
-    "repos/some/repo/branches/master/protection",
+    "repos/some/repo/branches/master/protection/required_status_checks",
     Object {
       "headers": Object {
         "accept": "application/vnd.github.loki-preview+json",
@@ -528,7 +528,7 @@ Array [
     "repos/some/repo/git/refs/heads/master",
   ],
   Array [
-    "repos/some/repo/branches/master/protection",
+    "repos/some/repo/branches/master/protection/required_status_checks",
     Object {
       "headers": Object {
         "accept": "application/vnd.github.loki-preview+json",
@@ -584,7 +584,7 @@ Array [
     "repos/some/repo/git/refs/heads/master",
   ],
   Array [
-    "repos/some/repo/branches/master/protection",
+    "repos/some/repo/branches/master/protection/required_status_checks",
     Object {
       "headers": Object {
         "accept": "application/vnd.github.loki-preview+json",
@@ -606,7 +606,7 @@ Array [
     "repos/some/repo/git/refs/heads/master",
   ],
   Array [
-    "repos/some/repo/branches/master/protection",
+    "repos/some/repo/branches/master/protection/required_status_checks",
     Object {
       "headers": Object {
         "accept": "application/vnd.github.loki-preview+json",
@@ -652,7 +652,7 @@ Array [
     "repos/some/repo/git/refs/heads/master",
   ],
   Array [
-    "repos/some/repo/branches/master/protection",
+    "repos/some/repo/branches/master/protection/required_status_checks",
     Object {
       "headers": Object {
         "accept": "application/vnd.github.loki-preview+json",
@@ -674,7 +674,7 @@ Array [
     "repos/some/repo/git/refs/heads/master",
   ],
   Array [
-    "repos/some/repo/branches/master/protection",
+    "repos/some/repo/branches/master/protection/required_status_checks",
     Object {
       "headers": Object {
         "accept": "application/vnd.github.loki-preview+json",
@@ -696,7 +696,7 @@ Array [
     "repos/some/repo/git/refs/heads/master",
   ],
   Array [
-    "repos/some/repo/branches/master/protection",
+    "repos/some/repo/branches/master/protection/required_status_checks",
     Object {
       "headers": Object {
         "accept": "application/vnd.github.loki-preview+json",
@@ -718,7 +718,7 @@ Array [
     "repos/some/repo/git/refs/heads/master",
   ],
   Array [
-    "repos/some/repo/branches/master/protection",
+    "repos/some/repo/branches/master/protection/required_status_checks",
     Object {
       "headers": Object {
         "accept": "application/vnd.github.loki-preview+json",
@@ -740,7 +740,7 @@ Array [
     "repos/some/repo/git/refs/heads/master",
   ],
   Array [
-    "repos/some/repo/branches/master/protection",
+    "repos/some/repo/branches/master/protection/required_status_checks",
     Object {
       "headers": Object {
         "accept": "application/vnd.github.loki-preview+json",
@@ -953,7 +953,7 @@ Array [
     "repos/some/repo/git/refs/heads/master",
   ],
   Array [
-    "repos/some/repo/branches/master/protection",
+    "repos/some/repo/branches/master/protection/required_status_checks",
     Object {
       "headers": Object {
         "accept": "application/vnd.github.loki-preview+json",
@@ -985,7 +985,7 @@ Array [
     "repos/some/repo/git/refs/heads/master",
   ],
   Array [
-    "repos/some/repo/branches/master/protection",
+    "repos/some/repo/branches/master/protection/required_status_checks",
     Object {
       "headers": Object {
         "accept": "application/vnd.github.loki-preview+json",
@@ -1017,7 +1017,7 @@ Array [
     "repos/some/repo/git/refs/heads/master",
   ],
   Array [
-    "repos/some/repo/branches/master/protection",
+    "repos/some/repo/branches/master/protection/required_status_checks",
     Object {
       "headers": Object {
         "accept": "application/vnd.github.loki-preview+json",
@@ -1100,7 +1100,7 @@ Array [
     "repos/some/repo/git/refs/heads/master",
   ],
   Array [
-    "repos/some/repo/branches/master/protection",
+    "repos/some/repo/branches/master/protection/required_status_checks",
     Object {
       "headers": Object {
         "accept": "application/vnd.github.loki-preview+json",
@@ -1148,7 +1148,7 @@ Array [
     "repos/some/repo/git/refs/heads/master",
   ],
   Array [
-    "repos/some/repo/branches/master/protection",
+    "repos/some/repo/branches/master/protection/required_status_checks",
     Object {
       "headers": Object {
         "accept": "application/vnd.github.loki-preview+json",
@@ -1200,7 +1200,7 @@ Array [
     "repos/some/repo/git/refs/heads/master",
   ],
   Array [
-    "repos/some/repo/branches/master/protection",
+    "repos/some/repo/branches/master/protection/required_status_checks",
     Object {
       "headers": Object {
         "accept": "application/vnd.github.loki-preview+json",
@@ -1241,7 +1241,7 @@ Array [
     "repos/some/repo/git/refs/heads/master",
   ],
   Array [
-    "repos/some/repo/branches/master/protection",
+    "repos/some/repo/branches/master/protection/required_status_checks",
     Object {
       "headers": Object {
         "accept": "application/vnd.github.loki-preview+json",
@@ -1284,7 +1284,7 @@ Array [
     "repos/some/repo/git/refs/heads/master",
   ],
   Array [
-    "repos/some/repo/branches/master/protection",
+    "repos/some/repo/branches/master/protection/required_status_checks",
     Object {
       "headers": Object {
         "accept": "application/vnd.github.loki-preview+json",
@@ -1311,7 +1311,7 @@ Array [
     "repos/some/repo/git/refs/heads/master",
   ],
   Array [
-    "repos/some/repo/branches/master/protection",
+    "repos/some/repo/branches/master/protection/required_status_checks",
     Object {
       "headers": Object {
         "accept": "application/vnd.github.loki-preview+json",

--- a/test/api/github.spec.js
+++ b/test/api/github.spec.js
@@ -155,9 +155,7 @@ describe('api/github', () => {
     // getBranchProtection
     ghGot.mockImplementationOnce(() => ({
       body: {
-        required_status_checks: {
-          strict: false,
-        },
+        strict: false,
       },
     }));
     return github.initRepo(...args);
@@ -224,9 +222,7 @@ describe('api/github', () => {
         // getBranchProtection
         ghGot.mockImplementationOnce(() => ({
           body: {
-            required_status_checks: {
-              strict: false,
-            },
+            strict: false,
           },
         }));
         return github.initRepo(...args);
@@ -259,9 +255,7 @@ describe('api/github', () => {
         // getBranchProtection
         ghGot.mockImplementationOnce(() => ({
           body: {
-            required_status_checks: {
-              strict: false,
-            },
+            strict: false,
           },
         }));
         return github.initRepo(...args);
@@ -294,9 +288,7 @@ describe('api/github', () => {
         // getBranchProtection
         ghGot.mockImplementationOnce(() => ({
           body: {
-            required_status_checks: {
-              strict: false,
-            },
+            strict: false,
           },
         }));
         return github.initRepo(...args);
@@ -326,9 +318,7 @@ describe('api/github', () => {
         // getBranchProtection
         ghGot.mockImplementationOnce(() => ({
           body: {
-            required_status_checks: {
-              strict: false,
-            },
+            strict: false,
           },
         }));
         return github.initRepo(...args);
@@ -358,9 +348,7 @@ describe('api/github', () => {
         // getBranchProtection
         ghGot.mockImplementationOnce(() => ({
           body: {
-            required_status_checks: {
-              strict: true,
-            },
+            strict: true,
           },
         }));
         return github.initRepo(...args);

--- a/test/api/github.spec.js
+++ b/test/api/github.spec.js
@@ -402,6 +402,40 @@ describe('api/github', () => {
       const config = await mergeInitRepo('some/repo', 'token');
       expect(config).toMatchSnapshot();
     });
+    it('should ignore repoForceRebase 403', async () => {
+      async function mergeInitRepo(...args) {
+        // repo info
+        ghGot.mockImplementationOnce(() => ({
+          body: {
+            owner: {
+              login: 'theowner',
+            },
+            default_branch: 'master',
+          },
+        }));
+        // getBranchCommit
+        ghGot.mockImplementationOnce(() => ({
+          body: {
+            object: {
+              sha: '1234',
+            },
+          },
+        }));
+        // getBranchProtection
+        ghGot.mockImplementationOnce(() => {
+          // Create a new object, that prototypically inherits from the Error constructor
+          function MyError() {
+            this.statusCode = 403;
+          }
+          MyError.prototype = Object.create(Error.prototype);
+          MyError.prototype.constructor = MyError;
+          throw new MyError();
+        });
+        return github.initRepo(...args);
+      }
+      const config = await mergeInitRepo('some/repo', 'token');
+      expect(config).toMatchSnapshot();
+    });
     it('should throw repoForceRebase non-404', async () => {
       async function mergeInitRepo(...args) {
         // repo info


### PR DESCRIPTION
This is necessary to avoid 403 errors when in GitHub App mode.