### PR TITLE
fix: Config validation ignore null and massage schedule to array

### DIFF
--- a/lib/config/validation.js
+++ b/lib/config/validation.js
@@ -27,7 +27,7 @@ function validateConfig(config) {
   }
 
   for (const key of Object.keys(config)) {
-    const val = config[key];
+    let val = config[key];
     if (
       !isIgnored(key) && // We need to ignore some reserved keys
       !isAFunction(val) // Ignore all functions
@@ -37,7 +37,7 @@ function validateConfig(config) {
           depName: 'Configuration Error',
           message: `Invalid configuration option: \`${key}\``,
         });
-      } else {
+      } else if (val != null) {
         const type = optionTypes[key].toString();
         if (type === 'boolean') {
           if (val !== true && val !== false) {
@@ -47,6 +47,9 @@ function validateConfig(config) {
             });
           }
         } else if (type === 'list') {
+          if (key === 'schedule' && typeof val === 'string') {
+            val = [val];
+          }
           if (!Array.isArray(val)) {
             errors.push({
               depName: 'Configuration Error',

--- a/test/config/validation.spec.js
+++ b/test/config/validation.spec.js
@@ -5,6 +5,7 @@ describe('config/validation', () => {
     it('returns nested errors', () => {
       const config = {
         foo: 1,
+        schedule: 'after 5pm',
         prBody: 'some-body',
         lockFileMaintenance: {
           bar: 2,
@@ -17,7 +18,7 @@ describe('config/validation', () => {
     it('errors for all types', () => {
       const config = {
         enabled: 1,
-        schedule: 'after 5pm',
+        schedule: 5,
         semanticPrefix: 7,
         githubAppId: 'none',
         lockFileMaintenance: false,


### PR DESCRIPTION
Don't perform type checking if value is null or undefined. Allow string schedule.