### PR TITLE
feat: Ignore forked repositories unless already configured

### DIFF
--- a/lib/api/github.js
+++ b/lib/api/github.js
@@ -173,7 +173,8 @@ async function initRepo(repoName, token, endpoint, repoLogger) {
   const platformConfig = {};
   try {
     const res = await ghGotRetry(`repos/${repoName}`);
-    config.privateRepo = res.body.private === true;
+    platformConfig.privateRepo = res.body.private === true;
+    platformConfig.isFork = res.body.fork === true;
     config.owner = res.body.owner.login;
     logger.debug(`${repoName} owner = ${config.owner}`);
     // Use default branch as PR target unless later overridden

--- a/lib/workers/repository/index.js
+++ b/lib/workers/repository/index.js
@@ -20,6 +20,12 @@ async function renovateRepository(repoConfig, token) {
     config = await apis.mergeRenovateJson(config);
     if (config.enabled === false) {
       config.logger.debug('repository is disabled');
+      await cleanup.pruneStaleBranches(config, []);
+      return;
+    }
+    if (config.isFork && !config.renovateJsonPresent) {
+      config.logger.debug('repository is a fork and not manually configured');
+      await cleanup.pruneStaleBranches(config, []);
       return;
     }
     if (config.baseBranch) {

--- a/test/api/__snapshots__/github.spec.js.snap
+++ b/test/api/__snapshots__/github.spec.js.snap
@@ -1059,18 +1059,24 @@ Array [
 
 exports[`api/github initRepo should detect repoForceRebase 1`] = `
 Object {
+  "isFork": false,
+  "privateRepo": false,
   "repoForceRebase": true,
 }
 `;
 
 exports[`api/github initRepo should ignore repoForceRebase 403 1`] = `
 Object {
+  "isFork": false,
+  "privateRepo": false,
   "repoForceRebase": false,
 }
 `;
 
 exports[`api/github initRepo should ignore repoForceRebase 404 1`] = `
 Object {
+  "isFork": false,
+  "privateRepo": false,
   "repoForceRebase": false,
 }
 `;
@@ -1098,6 +1104,8 @@ Array [
 
 exports[`api/github initRepo should initialise the config for the repo - 0 2`] = `
 Object {
+  "isFork": false,
+  "privateRepo": false,
   "repoForceRebase": false,
 }
 `;
@@ -1125,6 +1133,8 @@ Array [
 
 exports[`api/github initRepo should initialise the config for the repo - 1 2`] = `
 Object {
+  "isFork": false,
+  "privateRepo": false,
   "repoForceRebase": false,
 }
 `;
@@ -1152,30 +1162,40 @@ Array [
 
 exports[`api/github initRepo should initialise the config for the repo - 2 2`] = `
 Object {
+  "isFork": false,
+  "privateRepo": false,
   "repoForceRebase": false,
 }
 `;
 
 exports[`api/github initRepo should merge 1`] = `
 Object {
+  "isFork": false,
+  "privateRepo": false,
   "repoForceRebase": false,
 }
 `;
 
 exports[`api/github initRepo should not guess at merge 1`] = `
 Object {
+  "isFork": false,
+  "privateRepo": false,
   "repoForceRebase": false,
 }
 `;
 
 exports[`api/github initRepo should rebase 1`] = `
 Object {
+  "isFork": false,
+  "privateRepo": false,
   "repoForceRebase": false,
 }
 `;
 
 exports[`api/github initRepo should squash 1`] = `
 Object {
+  "isFork": false,
+  "privateRepo": false,
   "repoForceRebase": false,
 }
 `;

--- a/test/workers/repository/index.spec.js
+++ b/test/workers/repository/index.spec.js
@@ -35,6 +35,12 @@ describe('workers/repository', () => {
       await repositoryWorker.renovateRepository(config);
       expect(apis.detectPackageFiles.mock.calls.length).toBe(0);
     });
+    it('skips repository if its unconfigured fork', async () => {
+      config.isFork = true;
+      config.renovateJsonPresent = false;
+      await repositoryWorker.renovateRepository(config);
+      expect(apis.detectPackageFiles.mock.calls.length).toBe(0);
+    });
     it('sets custom base branch', async () => {
       config.baseBranch = 'some-branch';
       config.api.branchExists.mockReturnValueOnce(true);


### PR DESCRIPTION
This feature is particularly useful in the case that renovate is enabled on all repositories a user/account has. Many of those might be forks, and it makes no sense to renovate those by default. Instead, Renovate will skip over forked repositories unless a renovate.json has been added to their root.
Also, Renovate will now prune branches after deciding to skip a repository, whether because of a fork or disablement.

Closes #541