### PR TITLE
fix: Allow ‘@user’ format for assignees and reviewers

### DIFF
--- a/lib/workers/pr/index.js
+++ b/lib/workers/pr/index.js
@@ -143,10 +143,22 @@ async function ensurePr(inputConfig, logger, errors, warnings) {
       );
     } else {
       if (config.assignees.length > 0) {
-        await config.api.addAssignees(pr.number, config.assignees);
+        const assignees = config.assignees.map(
+          assignee =>
+            assignee.length && assignee[0] === '@'
+              ? assignee.slice(1)
+              : assignee
+        );
+        await config.api.addAssignees(pr.number, assignees);
       }
       if (config.reviewers.length > 0) {
-        await config.api.addReviewers(pr.number, config.reviewers);
+        const reviewers = config.reviewers.map(
+          reviewer =>
+            reviewer.length && reviewer[0] === '@'
+              ? reviewer.slice(1)
+              : reviewer
+        );
+        await config.api.addReviewers(pr.number, reviewers);
       }
     }
     logger.info(`Created ${pr.displayNumber}`);

--- a/test/workers/pr/__snapshots__/index.spec.js.snap
+++ b/test/workers/pr/__snapshots__/index.spec.js.snap
@@ -1,3 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`workers/pr ensurePr(upgrades, logger) should add assignees and reviewers to new PR 1`] = `
+Array [
+  Array [
+    undefined,
+    Array [
+      "foo",
+      "bar",
+    ],
+  ],
+]
+`;
+
+exports[`workers/pr ensurePr(upgrades, logger) should add assignees and reviewers to new PR 2`] = `
+Array [
+  Array [
+    undefined,
+    Array [
+      "baz",
+      "boo",
+    ],
+  ],
+]
+`;
+
 exports[`workers/pr ensurePr(upgrades, logger) should return unmodified existing PR 1`] = `Array []`;

--- a/test/workers/pr/index.spec.js
+++ b/test/workers/pr/index.spec.js
@@ -166,12 +166,14 @@ describe('workers/pr', () => {
       config.api.getBranchPr = jest.fn();
       config.api.addAssignees = jest.fn();
       config.api.addReviewers = jest.fn();
-      config.assignees = ['bar'];
-      config.reviewers = ['baz'];
+      config.assignees = ['@foo', 'bar'];
+      config.reviewers = ['baz', '@boo'];
       const pr = await prWorker.ensurePr(config, logger);
       expect(pr).toMatchObject({ displayNumber: 'New Pull Request' });
       expect(config.api.addAssignees.mock.calls.length).toBe(1);
+      expect(config.api.addAssignees.mock.calls).toMatchSnapshot();
       expect(config.api.addReviewers.mock.calls.length).toBe(1);
+      expect(config.api.addReviewers.mock.calls).toMatchSnapshot();
     });
     it('should display errors and warnings', async () => {
       config.api.getBranchPr = jest.fn();


### PR DESCRIPTION
Usernames can now be expressed as like either ‘rarkins’ or ‘@rarkins’