### PR TITLE
fix: escape #issueNumber and backticks in prBody

### DIFF
--- a/lib/workers/pr/index.js
+++ b/lib/workers/pr/index.js
@@ -52,6 +52,8 @@ async function ensurePr(inputConfig, logger, errors, warnings) {
 
   const processedUpgrades = [];
 
+  const issueRe = /([\s(])#(\d+)([)\s]?)/g;
+
   // Get changelog and then generate template strings
   for (const upgrade of upgrades) {
     const upgradeKey = `${upgrade.depName}-${upgrade.changeLogFromVersion}-${upgrade.changeLogToVersion}`;
@@ -82,15 +84,11 @@ async function ensurePr(inputConfig, logger, errors, warnings) {
             commit.url = `${logJSON.project.repository}/commit/${change.sha}`;
             if (change.message) {
               commit.message = change.message.split('\n')[0];
-              const re = /([\s(])#(\d+)([)\s]?)/g;
               if (!config.isGitHub || config.privateRepo === true) {
                 commit.message = commit.message.replace(
-                  re,
+                  issueRe,
                   `$1[#$2](${upgrade.repositoryUrl}/issues/$2)$3`
                 );
-              } else {
-                // Public GitHub repos need links prevented - see #489
-                commit.message = commit.message.replace(re, '$1`#$2`$3');
               }
             }
             release.commits.push(commit);
@@ -117,7 +115,11 @@ async function ensurePr(inputConfig, logger, errors, warnings) {
   let prBodyMarkdown = handlebars.compile(config.prBody)(config);
   const atUserRe = /[^`]@([a-z]+\/[a-z]+)/g;
   prBodyMarkdown = prBodyMarkdown.replace(atUserRe, '@&#8203;$1');
-  const prBody = converter.makeHtml(prBodyMarkdown);
+  let prBody = converter.makeHtml(prBodyMarkdown);
+  // Public GitHub repos need links prevented - see #489
+  prBody = prBody.replace(issueRe, '$1#&#8203;$2$3');
+  const backTickRe = /&#x60;([^/]*?)&#x60;/g;
+  prBody = prBody.replace(backTickRe, '<code>$1</code>');
 
   try {
     // Check if existing PR exists


### PR DESCRIPTION
Adds a zero width space between the # and first digit in issue numbers to prevent GitHub autolinking, also replaces escaped backticks with `<code></code>`

Closes #595