### PR TITLE
fix: return false after successful branch automerge

### DIFF
--- a/lib/workers/branch/index.js
+++ b/lib/workers/branch/index.js
@@ -202,6 +202,7 @@ async function ensureBranch(config) {
     logger.info(`Automerging branch`);
     try {
       await api.mergeBranch(branchName, config.automergeType);
+      return false; // Branch no longer exists
     } catch (err) {
       logger.error({ err }, `Failed to automerge branch`);
       throw err;

--- a/test/workers/branch/index.spec.js
+++ b/test/workers/branch/index.spec.js
@@ -169,7 +169,7 @@ describe('workers/branch', () => {
       config.api.mergeBranch = jest.fn();
       config.automergeEnabled = true;
       config.automergeType = 'branch-push';
-      expect(await branchWorker.ensureBranch(config)).toBe(true);
+      expect(await branchWorker.ensureBranch(config)).toBe(false);
       expect(branchWorker.getParentBranch.mock.calls.length).toBe(1);
       expect(config.api.getBranchStatus.mock.calls.length).toBe(1);
       expect(config.api.mergeBranch.mock).toMatchSnapshot();


### PR DESCRIPTION
This prevents attempts to view the PR or check branch status again.

Fixes #499 