### PR TITLE
feat: support package rule merging

### DIFF
--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -192,6 +192,7 @@ const options = [
     description: 'Rules for matching package names',
     type: 'list',
     stage: 'depType',
+    mergeable: true,
     cli: false,
     env: false,
   },

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -118,10 +118,17 @@ function mergeChildConfig(parentConfig, childConfig) {
   for (const option of definitions.getOptions()) {
     if (option.mergeable && childConfig[option.name]) {
       logger.debug(`mergeable option: ${option.name}`);
-      config[option.name] = {
-        ...parentConfig[option.name],
-        ...childConfig[option.name],
-      };
+      if (option.type === 'list') {
+        // Place parent values *after* child
+        config[option.name] = config[option.name].concat(
+          parentConfig[option.name]
+        );
+      } else {
+        config[option.name] = {
+          ...parentConfig[option.name],
+          ...childConfig[option.name],
+        };
+      }
       logger.debug({ option: config[option.name] }, `config.${option.name}`);
     }
   }

--- a/test/config/index.spec.js
+++ b/test/config/index.spec.js
@@ -173,5 +173,22 @@ describe('config/index', () => {
       const config = configParser.mergeChildConfig(parentConfig, childConfig);
       expect(config.depTypes).toMatchSnapshot();
     });
+    it('merges packageRules', () => {
+      const parentConfig = { ...defaultConfig };
+      Object.assign(parentConfig, {
+        packageRules: [{ a: 1 }, { a: 2 }],
+      });
+      const childConfig = {
+        packageRules: [{ a: 3 }, { a: 4 }],
+      };
+      const configParser = require('../../lib/config/index.js');
+      const config = configParser.mergeChildConfig(parentConfig, childConfig);
+      expect(config.packageRules.map(rule => rule.a)).toMatchObject([
+        3,
+        4,
+        1,
+        2,
+      ]);
+    });
   });
 });


### PR DESCRIPTION
packageRules are now mergeable between parent and child. Child rules will be placed before parent rules.

Closes #591