### PR TITLE
fix: use baseBranch when branchName is null

### DIFF
--- a/lib/api/github.js
+++ b/lib/api/github.js
@@ -636,14 +636,16 @@ async function mergePr(pr) {
 
 // Generic File operations
 
-async function getFile(filePath, branchName = config.baseBranch) {
+async function getFile(filePath, branchName) {
+  logger.trace(`getFile(filePath=${filePath}, branchName=${branchName})`);
   const res = await ghGotRetry(
-    `repos/${config.repoName}/contents/${filePath}?ref=${branchName}`
+    `repos/${config.repoName}/contents/${filePath}?ref=${branchName ||
+      config.baseBranch}`
   );
   return res.body.content;
 }
 
-async function getFileContent(filePath, branchName = config.baseBranch) {
+async function getFileContent(filePath, branchName) {
   logger.trace(
     `getFileContent(filePath=${filePath}, branchName=${branchName})`
   );

--- a/lib/api/gitlab.js
+++ b/lib/api/gitlab.js
@@ -381,13 +381,15 @@ async function mergePr(pr) {
 
 // Generic File operations
 
-async function getFile(filePath, branchName = config.baseBranch) {
+async function getFile(filePath, branchName) {
   // Gitlab API v3 support
   let url;
   if (config.apiVersion === 'v3') {
-    url = `projects/${config.repoName}/repository/files?file_path=${filePath}&ref=${branchName}`;
+    url = `projects/${config.repoName}/repository/files?file_path=${filePath}&ref=${branchName ||
+      config.baseBranch}`;
   } else {
-    url = `projects/${config.repoName}/repository/files/${filePath}?ref=${branchName}`;
+    url = `projects/${config.repoName}/repository/files/${filePath}?ref=${branchName ||
+      config.baseBranch}`;
   }
   const res = await glGot(url);
   return res.body.content;

--- a/test/api/gitlab.spec.js
+++ b/test/api/gitlab.spec.js
@@ -516,7 +516,7 @@ describe('api/gitlab', () => {
           content: 'foo',
         },
       });
-      const res = await gitlab.getFile('some-path', 'some-branch');
+      const res = await gitlab.getFile('some-path');
       expect(res).toMatchSnapshot();
       expect(glGot.mock.calls[0][0].indexOf('file_path')).toBe(-1);
     });
@@ -537,7 +537,7 @@ describe('api/gitlab', () => {
       });
       const config = await gitlab.initRepo('some-repo', 'some-token');
       expect(config).toMatchSnapshot();
-      const res = await gitlab.getFile('some-path', 'some-branch');
+      const res = await gitlab.getFile('some-path');
       expect(res).toMatchSnapshot();
       expect(glGot.mock.calls[3][0].indexOf('file_path')).not.toBe(-1);
     });


### PR DESCRIPTION
Using fallback in function params only replaces if `branchName` is `undefined` but we also need to handle when it is `null`.