### PR TITLE
feat: re-use node_modules per package file

### DIFF
--- a/lib/workers/branch/index.js
+++ b/lib/workers/branch/index.js
@@ -153,6 +153,7 @@ async function ensureBranch(config) {
       });
       try {
         const yarnLockFile = await yarn.getLockFile(
+          config.tmpDir,
           packageFile,
           packageFiles[packageFile],
           api,
@@ -164,6 +165,7 @@ async function ensureBranch(config) {
           commitFiles.push(yarnLockFile);
         }
         const packageLockFile = await npm.getLockFile(
+          config.tmpDir,
           packageFile,
           packageFiles[packageFile],
           api,

--- a/lib/workers/branch/index.js
+++ b/lib/workers/branch/index.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const handlebars = require('handlebars');
 const packageJsonHelper = require('./package-json');
 const npm = require('./npm');
@@ -153,7 +154,7 @@ async function ensureBranch(config) {
       });
       try {
         const yarnLockFile = await yarn.getLockFile(
-          config.tmpDir.name,
+          path.join(config.tmpDir.name, path.dirname(packageFile)),
           packageFile,
           packageFiles[packageFile],
           api,
@@ -165,7 +166,7 @@ async function ensureBranch(config) {
           commitFiles.push(yarnLockFile);
         }
         const packageLockFile = await npm.getLockFile(
-          config.tmpDir.name,
+          path.join(config.tmpDir.name, path.dirname(packageFile)),
           packageFile,
           packageFiles[packageFile],
           api,

--- a/lib/workers/branch/index.js
+++ b/lib/workers/branch/index.js
@@ -153,7 +153,7 @@ async function ensureBranch(config) {
       });
       try {
         const yarnLockFile = await yarn.getLockFile(
-          config.tmpDir,
+          config.tmpDir.name,
           packageFile,
           packageFiles[packageFile],
           api,
@@ -165,7 +165,7 @@ async function ensureBranch(config) {
           commitFiles.push(yarnLockFile);
         }
         const packageLockFile = await npm.getLockFile(
-          config.tmpDir,
+          config.tmpDir.name,
           packageFile,
           packageFiles[packageFile],
           api,

--- a/lib/workers/branch/npm.js
+++ b/lib/workers/branch/npm.js
@@ -1,4 +1,4 @@
-const fs = require('fs');
+const fs = require('fs-extra');
 const cp = require('child_process');
 const path = require('path');
 
@@ -13,11 +13,14 @@ async function generateLockFile(tmpDir, newPackageJson, npmrcContent, logger) {
   let packageLock;
   let result = {};
   try {
-    fs.writeFileSync(path.join(tmpDir, 'package.json'), newPackageJson);
+    await fs.outputFile(path.join(tmpDir, 'package.json'), newPackageJson);
     if (npmrcContent) {
-      fs.writeFileSync(path.join(tmpDir, '.npmrc'), npmrcContent);
+      await fs.outputFile(path.join(tmpDir, '.npmrc'), npmrcContent);
     }
-    logger.debug('Spawning npm install');
+    await fs.remove(path.join(tmpDir, 'package-lock.json'));
+    logger.debug(
+      `Spawning npm install to generate ${tmpDir}/package-lock.json`
+    );
     result = cp.spawnSync('npm', ['install', '--ignore-scripts'], {
       cwd: tmpDir,
       shell: true,
@@ -39,17 +42,7 @@ async function generateLockFile(tmpDir, newPackageJson, npmrcContent, logger) {
       },
       'Error generating package-lock.json'
     );
-    try {
-      tmpDir.removeCallback();
-    } catch (err2) {
-      logger.warn(`Failed to remove tmpDir ${tmpDir}`);
-    }
     throw Error('Error generating lock file');
-  }
-  try {
-    tmpDir.removeCallback();
-  } catch (err2) {
-    logger.warn(`Failed to remove tmpDir ${tmpDir}`);
   }
   return packageLock;
 }
@@ -117,7 +110,7 @@ async function maintainLockFile(inputConfig) {
   }
   logger.debug('Found existing package-lock.json file');
   const newPackageLock = await module.exports.getLockFile(
-    inputConfig.tmpDir.name,
+    path.join(inputConfig.tmpDir.name, path.dirname(inputConfig.packageFile)),
     inputConfig.packageFile,
     packageContent,
     inputConfig.api,

--- a/lib/workers/branch/npm.js
+++ b/lib/workers/branch/npm.js
@@ -13,13 +13,13 @@ async function generateLockFile(tmpDir, newPackageJson, npmrcContent, logger) {
   let packageLock;
   let result = {};
   try {
-    fs.writeFileSync(path.join(tmpDir.name, 'package.json'), newPackageJson);
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), newPackageJson);
     if (npmrcContent) {
-      fs.writeFileSync(path.join(tmpDir.name, '.npmrc'), npmrcContent);
+      fs.writeFileSync(path.join(tmpDir, '.npmrc'), npmrcContent);
     }
     logger.debug('Spawning npm install');
     result = cp.spawnSync('npm', ['install', '--ignore-scripts'], {
-      cwd: tmpDir.name,
+      cwd: tmpDir,
       shell: true,
       env: { ...process.env, ...{ NODE_ENV: 'dev' } },
     });
@@ -27,7 +27,7 @@ async function generateLockFile(tmpDir, newPackageJson, npmrcContent, logger) {
       { stdout: String(result.stdout), stderr: String(result.stderr) },
       'npm install complete'
     );
-    packageLock = fs.readFileSync(path.join(tmpDir.name, 'package-lock.json'));
+    packageLock = fs.readFileSync(path.join(tmpDir, 'package-lock.json'));
   } catch (err) /* istanbul ignore next */ {
     logger.warn(
       {
@@ -42,14 +42,14 @@ async function generateLockFile(tmpDir, newPackageJson, npmrcContent, logger) {
     try {
       tmpDir.removeCallback();
     } catch (err2) {
-      logger.warn(`Failed to remove tmpDir ${tmpDir.name}`);
+      logger.warn(`Failed to remove tmpDir ${tmpDir}`);
     }
     throw Error('Error generating lock file');
   }
   try {
     tmpDir.removeCallback();
   } catch (err2) {
-    logger.warn(`Failed to remove tmpDir ${tmpDir.name}`);
+    logger.warn(`Failed to remove tmpDir ${tmpDir}`);
   }
   return packageLock;
 }
@@ -117,7 +117,7 @@ async function maintainLockFile(inputConfig) {
   }
   logger.debug('Found existing package-lock.json file');
   const newPackageLock = await module.exports.getLockFile(
-    inputConfig.tmpDir,
+    inputConfig.tmpDir.name,
     inputConfig.packageFile,
     packageContent,
     inputConfig.api,

--- a/lib/workers/branch/npm.js
+++ b/lib/workers/branch/npm.js
@@ -1,6 +1,5 @@
 const fs = require('fs');
 const cp = require('child_process');
-const tmp = require('tmp');
 const path = require('path');
 
 module.exports = {
@@ -9,9 +8,8 @@ module.exports = {
   maintainLockFile,
 };
 
-async function generateLockFile(newPackageJson, npmrcContent, logger) {
+async function generateLockFile(tmpDir, newPackageJson, npmrcContent, logger) {
   logger.debug('Generating new package-lock.json file');
-  const tmpDir = tmp.dirSync({ unsafeCleanup: true });
   let packageLock;
   let result = {};
   try {
@@ -57,6 +55,7 @@ async function generateLockFile(newPackageJson, npmrcContent, logger) {
 }
 
 async function getLockFile(
+  tmpDir,
   packageFile,
   packageContent,
   api,
@@ -86,6 +85,7 @@ async function getLockFile(
   const npmrcContent = await api.getFileContent('.npmrc');
   // Generate package-lock.json using shell command
   const newPackageLockContent = await module.exports.generateLockFile(
+    tmpDir,
     packageContent,
     npmrcContent,
     logger
@@ -117,6 +117,7 @@ async function maintainLockFile(inputConfig) {
   }
   logger.debug('Found existing package-lock.json file');
   const newPackageLock = await module.exports.getLockFile(
+    inputConfig.tmpDir,
     inputConfig.packageFile,
     packageContent,
     inputConfig.api,

--- a/lib/workers/branch/yarn.js
+++ b/lib/workers/branch/yarn.js
@@ -21,16 +21,16 @@ async function generateLockFile(
   let yarnLock;
   let result = {};
   try {
-    fs.writeFileSync(path.join(tmpDir.name, 'package.json'), newPackageJson);
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), newPackageJson);
     if (npmrcContent) {
-      fs.writeFileSync(path.join(tmpDir.name, '.npmrc'), npmrcContent);
+      fs.writeFileSync(path.join(tmpDir, '.npmrc'), npmrcContent);
     }
     if (yarnrcContent) {
       const filteredYarnrc = yarnrcContent.replace(
         '--install.pure-lockfile true',
         ''
       );
-      fs.writeFileSync(path.join(tmpDir.name, '.yarnrc'), filteredYarnrc);
+      fs.writeFileSync(path.join(tmpDir, '.yarnrc'), filteredYarnrc);
     }
     logger.debug('Spawning yarn install');
     // Use an embedded yarn
@@ -41,13 +41,13 @@ async function generateLockFile(
     );
     const yarnOptions = [yarnBin, 'install', '--ignore-scripts'];
     result = cp.spawnSync('node', yarnOptions, {
-      cwd: tmpDir.name,
+      cwd: tmpDir,
       shell: true,
       env: { ...process.env, ...{ NODE_ENV: 'dev' } },
     });
     logger.debug(String(result.stdout));
     logger.debug(String(result.stderr));
-    yarnLock = fs.readFileSync(path.join(tmpDir.name, 'yarn.lock'));
+    yarnLock = fs.readFileSync(path.join(tmpDir, 'yarn.lock'));
   } catch (err) /* istanbul ignore next */ {
     logger.warn(
       {
@@ -113,7 +113,7 @@ async function maintainLockFile(inputConfig) {
   }
   logger.debug('Found existing yarn.lock file');
   const newYarnLock = await module.exports.getLockFile(
-    inputConfig.tmpDir,
+    inputConfig.tmpDir.name,
     inputConfig.packageFile,
     packageContent,
     inputConfig.api,

--- a/lib/workers/branch/yarn.js
+++ b/lib/workers/branch/yarn.js
@@ -1,4 +1,4 @@
-const fs = require('fs');
+const fs = require('fs-extra');
 const cp = require('child_process');
 const path = require('path');
 
@@ -21,18 +21,19 @@ async function generateLockFile(
   let yarnLock;
   let result = {};
   try {
-    fs.writeFileSync(path.join(tmpDir, 'package.json'), newPackageJson);
+    await fs.outputFile(path.join(tmpDir, 'package.json'), newPackageJson);
     if (npmrcContent) {
-      fs.writeFileSync(path.join(tmpDir, '.npmrc'), npmrcContent);
+      await fs.outputFile(path.join(tmpDir, '.npmrc'), npmrcContent);
     }
     if (yarnrcContent) {
       const filteredYarnrc = yarnrcContent.replace(
         '--install.pure-lockfile true',
         ''
       );
-      fs.writeFileSync(path.join(tmpDir, '.yarnrc'), filteredYarnrc);
+      await fs.outputFile(path.join(tmpDir, '.yarnrc'), filteredYarnrc);
     }
-    logger.debug('Spawning yarn install');
+    await fs.remove(path.join(tmpDir, 'yarn.lock'));
+    logger.debug(`Spawning yarn install to create ${tmpDir}/yarn.lock`);
     // Use an embedded yarn
     const yarnBin = path.join(
       __dirname,
@@ -113,7 +114,7 @@ async function maintainLockFile(inputConfig) {
   }
   logger.debug('Found existing yarn.lock file');
   const newYarnLock = await module.exports.getLockFile(
-    inputConfig.tmpDir.name,
+    path.join(inputConfig.tmpDir.name, path.dirname(inputConfig.packageFile)),
     inputConfig.packageFile,
     packageContent,
     inputConfig.api,

--- a/lib/workers/branch/yarn.js
+++ b/lib/workers/branch/yarn.js
@@ -1,6 +1,5 @@
 const fs = require('fs');
 const cp = require('child_process');
-const tmp = require('tmp');
 const path = require('path');
 
 module.exports = {
@@ -12,13 +11,13 @@ module.exports = {
 const yarnVersion = '0.27.5';
 
 async function generateLockFile(
+  tmpDir,
   newPackageJson,
   npmrcContent,
   yarnrcContent,
   logger
 ) {
   logger.debug('Generating new yarn.lock file');
-  const tmpDir = tmp.dirSync({ unsafeCleanup: true });
   let yarnLock;
   let result = {};
   try {
@@ -61,22 +60,12 @@ async function generateLockFile(
       },
       'Error generating yarn.lock'
     );
-    try {
-      tmpDir.removeCallback();
-    } catch (err2) {
-      logger.warn(`Failed to remove tmpDir ${tmpDir.name}`);
-    }
     throw Error('Error generating lock file');
-  }
-  try {
-    tmpDir.removeCallback();
-  } catch (err2) {
-    logger.warn(`Failed to remove tmpDir ${tmpDir.name}`);
   }
   return yarnLock;
 }
 
-async function getLockFile(packageFile, packageContent, api, logger) {
+async function getLockFile(tmpDir, packageFile, packageContent, api, logger) {
   // Detect if a yarn.lock file is in use
   const yarnLockFileName = path.join(path.dirname(packageFile), 'yarn.lock');
   if (!await api.getFileContent(yarnLockFileName)) {
@@ -87,6 +76,7 @@ async function getLockFile(packageFile, packageContent, api, logger) {
   const yarnrcContent = await api.getFileContent('.yarnrc');
   // Generate yarn.lock using shell command
   const newYarnLockContent = await module.exports.generateLockFile(
+    tmpDir,
     packageContent,
     npmrcContent,
     yarnrcContent,
@@ -123,6 +113,7 @@ async function maintainLockFile(inputConfig) {
   }
   logger.debug('Found existing yarn.lock file');
   const newYarnLock = await module.exports.getLockFile(
+    inputConfig.tmpDir,
     inputConfig.packageFile,
     packageContent,
     inputConfig.api,

--- a/lib/workers/repository/index.js
+++ b/lib/workers/repository/index.js
@@ -1,3 +1,4 @@
+const tmp = require('tmp');
 const presets = require('../../config/presets');
 // Workers
 const branchWorker = require('../branch');
@@ -14,6 +15,7 @@ module.exports = {
 async function renovateRepository(repoConfig, token) {
   let config = { ...repoConfig };
   const { logger } = config;
+  config.tmpDir = tmp.dirSync({ unsafeCleanup: true });
   config.errors = [];
   config.warnings = [];
   logger.trace({ config }, 'renovateRepository');
@@ -128,4 +130,5 @@ async function renovateRepository(repoConfig, token) {
       logger.debug({ err });
     }
   }
+  config.tmpDir.removeCallback();
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "changelog": "1.4.0",
     "commander": "2.11.0",
     "conventional-commits-detector": "0.1.1",
+    "fs-extra": "4.0.1",
     "gh-got": "6.0.0",
     "github-url-from-git": "1.5.0",
     "gl-got": "7.0.0",
@@ -115,8 +116,12 @@
       ":automergeBranchPush",
       "group:monorepos"
     ],
-    "labels": ["ready"],
-    "assignees": ["rarkins"]
+    "labels": [
+      "ready"
+    ],
+    "assignees": [
+      "rarkins"
+    ]
   },
   "release": {
     "verifyConditions": "condition-circle"

--- a/test/workers/branch/__snapshots__/npm.spec.js.snap
+++ b/test/workers/branch/__snapshots__/npm.spec.js.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`getLockFile(packageFile, packageContent, api, npmVersion) throws if no npm 1`] = `[Error: Need to generate package-lock.json but npm is not installed]`;
+exports[`getLockFile throws if no npm 1`] = `[Error: Need to generate package-lock.json but npm is not installed]`;
 
-exports[`getLockFile(packageFile, packageContent, api, npmVersion) throws if wrong npm version 1`] = `[Error: Need to generate package-lock.json but npm version is "4.0.0"]`;
+exports[`getLockFile throws if wrong npm version 1`] = `[Error: Need to generate package-lock.json but npm version is "4.0.0"]`;

--- a/test/workers/branch/index.spec.js
+++ b/test/workers/branch/index.spec.js
@@ -121,6 +121,7 @@ describe('workers/branch', () => {
       config.api.getBranchStatus = jest.fn();
       config.api.getBranchStatusCheck = jest.fn();
       config.api.setBranchStatus = jest.fn();
+      config.tmpDir = { name: 'some-dir' };
       config.depName = 'dummy';
       config.currentVersion = '1.0.0';
       config.newVersion = '1.1.0';

--- a/test/workers/branch/npm.spec.js
+++ b/test/workers/branch/npm.spec.js
@@ -7,9 +7,7 @@ jest.mock('child_process');
 const fs = require('fs');
 const cp = require('child_process');
 
-const tmpDir = {
-  name: 'some-dir',
-};
+const tmpDir = 'some-dir';
 
 describe('generateLockFile', () => {
   fs.writeFileSync = jest.fn();

--- a/test/workers/branch/npm.spec.js
+++ b/test/workers/branch/npm.spec.js
@@ -1,16 +1,16 @@
 const npmHelper = require('../../../lib/workers/branch/npm');
 const logger = require('../../_fixtures/logger');
 
-jest.mock('fs');
+jest.mock('fs-extra');
 jest.mock('child_process');
 
-const fs = require('fs');
+const fs = require('fs-extra');
 const cp = require('child_process');
 
-const tmpDir = 'some-dir';
+const tmpDir = { name: 'some-dir' };
 
 describe('generateLockFile', () => {
-  fs.writeFileSync = jest.fn();
+  fs.outputFile = jest.fn();
   fs.readFileSync = jest.fn(() => 'package-lock-contents');
   cp.spawnSync = jest.fn(() => ({
     stdout: '',
@@ -18,12 +18,12 @@ describe('generateLockFile', () => {
   }));
   it('generates lock files', async () => {
     const packageLock = await npmHelper.generateLockFile(
-      tmpDir,
-      'package-json-contents',
+      tmpDir.name,
+      {},
       'npmrc-contents',
       logger
     );
-    expect(fs.writeFileSync.mock.calls.length).toEqual(2);
+    expect(fs.outputFile.mock.calls.length).toEqual(2);
     expect(fs.readFileSync.mock.calls.length).toEqual(1);
     expect(packageLock).toEqual('package-lock-contents');
   });

--- a/test/workers/branch/yarn.spec.js
+++ b/test/workers/branch/yarn.spec.js
@@ -1,16 +1,16 @@
 const yarnHelper = require('../../../lib/workers/branch/yarn');
 const logger = require('../../_fixtures/logger');
 
-jest.mock('fs');
+jest.mock('fs-extra');
 jest.mock('child_process');
 
-const fs = require('fs');
+const fs = require('fs-extra');
 const cp = require('child_process');
 
-const tmpDir = 'some-dir';
+const tmpDir = { name: 'some-dir' };
 
 describe('generateLockFile', () => {
-  fs.writeFileSync = jest.fn();
+  fs.outputFile = jest.fn();
   fs.readFileSync = jest.fn(() => 'yarn-lock-contents');
   cp.spawnSync = jest.fn(() => ({
     stdout: '',
@@ -18,13 +18,13 @@ describe('generateLockFile', () => {
   }));
   it('generates lock files', async () => {
     const yarnLock = await yarnHelper.generateLockFile(
-      tmpDir,
-      'package-json-contents',
+      tmpDir.name,
+      {},
       'npmrc-contents',
       'yarnrc-contents',
       logger
     );
-    expect(fs.writeFileSync.mock.calls.length).toEqual(3);
+    expect(fs.outputFile.mock.calls.length).toEqual(3);
     expect(fs.readFileSync.mock.calls.length).toEqual(1);
     expect(yarnLock).toEqual('yarn-lock-contents');
   });

--- a/test/workers/branch/yarn.spec.js
+++ b/test/workers/branch/yarn.spec.js
@@ -7,9 +7,7 @@ jest.mock('child_process');
 const fs = require('fs');
 const cp = require('child_process');
 
-const tmpDir = {
-  name: 'some-dir',
-};
+const tmpDir = 'some-dir';
 
 describe('generateLockFile', () => {
   fs.writeFileSync = jest.fn();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1362,6 +1362,14 @@ from@~0:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe"
 
+fs-extra@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.1.tgz#7fc0c6c8957f983f57f306a24e5b9ddd8d0dd880"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^3.0.0"
+    universalify "^0.1.0"
+
 fs-readdir-recursive@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz#8cd1745c8b4f8a29c8caec392476921ba195f560"
@@ -2315,6 +2323,12 @@ json-stringify-safe@~5.0.1:
 json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
+
+jsonfile@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-3.0.1.tgz#a5ecc6f65f53f662c4415c7675a0331d0992ec66"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
 
 jsonify@~0.0.0:
   version "0.0.0"
@@ -3996,6 +4010,10 @@ uid-number@^0.0.6:
 underscore.string@~2.2.0rc:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/underscore.string/-/underscore.string-2.2.1.tgz#d7c0fa2af5d5a1a67f4253daee98132e733f0f19"
+
+universalify@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.1.tgz#fa71badd4437af4c148841e3b3b165f9e9e590b7"
 
 url-parse-lax@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
tmpDir is now created once per-repository and package.json files are written and lockfiles generated based on the repo's directory structure. This way node_modules can be reused between branches in same run.

Closes #501 