### PR TITLE
fix: resolve all presets before merge

### DIFF
--- a/lib/workers/repository/apis.js
+++ b/lib/workers/repository/apis.js
@@ -6,6 +6,7 @@ const configParser = require('../../config');
 const configMigration = require('../../config/migration');
 const configMassage = require('../../config/massage');
 const configValidation = require('../../config/validation');
+const presets = require('../../config/presets');
 // API
 const githubApi = require('../../api/github');
 const gitlabApi = require('../../api/gitlab');
@@ -180,7 +181,19 @@ async function mergeRenovateJson(config, branchName) {
     renovateJson = JSON.parse(renovateJsonContent);
     config.logger.debug({ config: renovateJson }, 'renovate.json config');
     const migratedConfig = migrateAndValidate(config, renovateJson);
-    returnConfig = configParser.mergeChildConfig(returnConfig, migratedConfig);
+    config.logger.debug(
+      { config: migratedConfig },
+      'renovate.json migrated config'
+    );
+    const resolvedConfig = await presets.resolveConfigPresets(
+      migratedConfig,
+      config.logger
+    );
+    config.logger.debug(
+      { config: resolvedConfig },
+      'renovate.json resolved config'
+    );
+    returnConfig = configParser.mergeChildConfig(returnConfig, resolvedConfig);
     returnConfig.renovateJsonPresent = true;
   } catch (err) {
     // Add to config.errors
@@ -247,14 +260,29 @@ async function resolvePackageFiles(inputConfig) {
       // hoist renovate config if exists
       if (packageFile.content.renovate) {
         config.logger.debug(
-          { packageFile: packageFile.packageFile },
-          `Found renovate config`
+          {
+            packageFile: packageFile.packageFile,
+            config: packageFile.content.renovate,
+          },
+          `Found package.json renovate config`
         );
-        config.hasPackageJsonRenovateConfig = true;
-        Object.assign(
-          packageFile,
-          migrateAndValidate(config, packageFile.content.renovate)
+        const migratedConfig = migrateAndValidate(
+          config,
+          packageFile.content.renovate
         );
+        config.logger.debug(
+          { config: migratedConfig },
+          'package.json migrated config'
+        );
+        const resolvedConfig = await presets.resolveConfigPresets(
+          migratedConfig,
+          config.logger
+        );
+        config.logger.debug(
+          { config: resolvedConfig },
+          'package.json resolved config'
+        );
+        Object.assign(packageFile, resolvedConfig);
         delete packageFile.content.renovate;
       } else {
         config.logger.debug(
@@ -287,7 +315,7 @@ async function resolvePackageFiles(inputConfig) {
       ) {
         config.logger.debug(
           { packageFile: packageFile.packageFile },
-          'Found yarn.lock'
+          'Found package-lock.json'
         );
         packageFile.hasPackageLock = true;
       } else {

--- a/lib/workers/repository/index.js
+++ b/lib/workers/repository/index.js
@@ -60,9 +60,6 @@ async function renovateRepository(repoConfig, token) {
     logger.debug('Resolving package files and content');
     config = await apis.resolvePackageFiles(config);
     logger.trace({ config }, 'post-packageFiles config');
-    logger.debug('Resolving config presets');
-    config = await presets.resolveConfigPresets(config);
-    logger.trace({ config }, 'post-presets config');
     // TODO: why is this fix needed?!
     config.logger = logger;
     config.repoIsOnboarded = await onboarding.getOnboardingStatus(config);


### PR DESCRIPTION
Previously, preset resolution was being done last, after merges of renoate.json or package.json config. This caused wrong ordering of config in cases where both presets + regular config was in use. Instead, resolving of presets is now done at each stage before merging.

Fixes #708