### PR TITLE
fix: do not automerge pr if it has been modified

### DIFF
--- a/lib/workers/pr/index.js
+++ b/lib/workers/pr/index.js
@@ -197,6 +197,11 @@ async function checkAutoMerge(pr, config, logger) {
       logger.info('Branch status is not "success"');
       return;
     }
+    // Check if it's been touched
+    if (!pr.canRebase) {
+      logger.info('PR is ready for automerge but has been modified');
+      return;
+    }
     // Let's merge this
     logger.info(`Automerging #${pr.number}`);
     await config.api.mergePr(pr);

--- a/test/workers/pr/index.spec.js
+++ b/test/workers/pr/index.spec.js
@@ -50,10 +50,19 @@ describe('workers/pr', () => {
     });
     it('should automerge if enabled and pr is mergeable', async () => {
       config.automergeEnabled = true;
+      pr.canRebase = true;
       pr.mergeable = true;
       config.api.getBranchStatus.mockReturnValueOnce('success');
       await prWorker.checkAutoMerge(pr, config, logger);
       expect(config.api.mergePr.mock.calls.length).toBe(1);
+    });
+    it('should not automerge if enabled and pr is mergeable but cannot rebase', async () => {
+      config.automergeEnabled = true;
+      pr.canRebase = false;
+      pr.mergeable = true;
+      config.api.getBranchStatus.mockReturnValueOnce('success');
+      await prWorker.checkAutoMerge(pr, config, logger);
+      expect(config.api.mergePr.mock.calls.length).toBe(0);
     });
     it('should not automerge if enabled and pr is mergeable but branch status is not success', async () => {
       config.automergeEnabled = true;


### PR DESCRIPTION
Add check for pr.canRebase. This will be false if the PR has been modified.

Fixes #709 