### PR TITLE
feat: support lock file maintenance automerge

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -98,7 +98,7 @@ $ node renovate --help
     --rebase-stale-prs [boolean]         Rebase stale PRs (GitHub only)
     --unpublish-safe [boolean]           Set a status check for unpublish-safe upgrades
     --pr-creation <string>               When to create the PR for a branch. Values: immediate, not-pending, status-success.
-    --automerge <string>                 What types of upgrades to merge to base branch automatically. Values: none, patch, minor or any
+    --automerge [boolean]                Whether to automerge branches/PRs automatically, without human intervention
     --automerge-type <string>            How to automerge - "branch-merge-commit", "branch-push" or "pr". Branch support is GitHub-only
     --lazy-grouping [boolean]            Use group names only when multiple dependencies upgraded
     --group-name <string>                Human understandable name for the dependency group
@@ -144,6 +144,22 @@ Obviously, you can't set repository or package file location with this method.
   <th>Default value</th>
   <th>Environment</th>
   <th>CLI</th>
+</tr>
+<tr>
+  <td>`extends`</td>
+  <td>Configuration presets to use/extend</td>
+  <td>list</td>
+  <td><pre>[]</pre></td>
+  <td>`RENOVATE_EXTENDS`</td>
+  <td><td>
+</tr>
+<tr>
+  <td>`description`</td>
+  <td>Plain text description for a config or preset</td>
+  <td>list</td>
+  <td><pre>[]</pre></td>
+  <td></td>
+  <td><td>
 </tr>
 <tr>
   <td>`enabled`</td>
@@ -293,7 +309,7 @@ Obviously, you can't set repository or package file location with this method.
   <td>`dependencies`</td>
   <td>Configuration specifically for `package.json`>`dependencies`</td>
   <td>json</td>
-  <td><pre>{}</pre></td>
+  <td><pre>{"semanticPrefix": "fix(deps):"}</pre></td>
   <td>`RENOVATE_DEPENDENCIES`</td>
   <td><td>
 </tr>
@@ -455,7 +471,7 @@ Obviously, you can't set repository or package file location with this method.
   <td>`semanticCommits`</td>
   <td>Enable semantic commit prefixes for commits and PR titles</td>
   <td>boolean</td>
-  <td><pre>false</pre></td>
+  <td><pre>null</pre></td>
   <td>`RENOVATE_SEMANTIC_COMMITS`</td>
   <td>`--semantic-commits`<td>
 </tr>
@@ -487,7 +503,7 @@ Obviously, you can't set repository or package file location with this method.
   <td>`unpublishSafe`</td>
   <td>Set a status check for unpublish-safe upgrades</td>
   <td>boolean</td>
-  <td><pre>true</pre></td>
+  <td><pre>false</pre></td>
   <td>`RENOVATE_UNPUBLISH_SAFE`</td>
   <td>`--unpublish-safe`<td>
 </tr>
@@ -501,9 +517,9 @@ Obviously, you can't set repository or package file location with this method.
 </tr>
 <tr>
   <td>`automerge`</td>
-  <td>What types of upgrades to merge to base branch automatically. Values: none, patch, minor or any</td>
-  <td>string</td>
-  <td><pre>"none"</pre></td>
+  <td>Whether to automerge branches/PRs automatically, without human intervention</td>
+  <td>boolean</td>
+  <td><pre>false</pre></td>
   <td>`RENOVATE_AUTOMERGE`</td>
   <td>`--automerge`<td>
 </tr>

--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -380,9 +380,9 @@ const options = [
   {
     name: 'automerge',
     description:
-      'What types of upgrades to merge to base branch automatically. Values: none, patch, minor or any',
-    type: 'string',
-    default: 'none',
+      'Whether to automerge branches/PRs automatically, without human intervention',
+    type: 'boolean',
+    default: false,
   },
   {
     name: 'automergeType',

--- a/lib/config/migration.js
+++ b/lib/config/migration.js
@@ -37,9 +37,24 @@ function migrateConfig(config, parentConfig) {
         isMigrated = true;
         delete migratedConfig[key];
       }
-    } else if (key === 'automerge' && val === false) {
+    } else if (key === 'automerge' && typeof val === 'string') {
       isMigrated = true;
-      migratedConfig.automerge = 'none';
+      if (val === 'none') {
+        migratedConfig.automerge = false;
+      }
+      if (val === 'patch' || val === 'minor') {
+        delete migratedConfig.automerge;
+        migratedConfig.patch = migratedConfig.patch || {};
+        migratedConfig.patch.automerge = true;
+      }
+      if (val === 'minor') {
+        delete migratedConfig.automerge;
+        migratedConfig.minor = migratedConfig.minor || {};
+        migratedConfig.minor.automerge = true;
+      }
+      if (val === 'any') {
+        migratedConfig.automerge = true;
+      }
     } else if (key === 'packages') {
       isMigrated = true;
       migratedConfig.packageRules = migratedConfig.packages.map(

--- a/lib/workers/branch/index.js
+++ b/lib/workers/branch/index.js
@@ -19,7 +19,7 @@ function checkStale(config) {
     return true;
   }
   // Commits can't be pushed to a branch unless they are up-to-date
-  if (config.automergeEnabled && config.automergeType === 'branch-push') {
+  if (config.automerge && config.automergeType === 'branch-push') {
     return true;
   }
   return false;
@@ -225,7 +225,7 @@ async function ensureBranch(config) {
       );
     }
   }
-  if (config.automergeEnabled === false || config.automergeType === 'pr') {
+  if (config.automerge === false || config.automergeType === 'pr') {
     // No branch automerge
     return true;
   }

--- a/lib/workers/package/versions.js
+++ b/lib/workers/package/versions.js
@@ -11,7 +11,6 @@ module.exports = {
   isValidVersion,
   isFuture,
   isPastLatest,
-  isAutomergeEnabled,
 };
 
 function determineUpgrades(npmDep, config) {
@@ -36,7 +35,7 @@ function determineUpgrades(npmDep, config) {
     allUpgrades.pin = {
       type: 'pin',
       isPin: true,
-      automergeEnabled: true,
+      automerge: true,
       unpublishSafe: false,
       newVersion: maxSatisfying,
       newVersionMajor: semver.major(maxSatisfying),
@@ -90,12 +89,13 @@ function determineUpgrades(npmDep, config) {
       // Group by major versions
       const newVersionMajor = semver.major(newVersion);
       const newVersionMinor = semver.minor(newVersion);
+      const hasPatchAutomerge = config.patch && config.patch.automerge === true;
       let type;
       if (newVersionMajor > semver.major(changeLogFromVersion)) {
         type = 'major';
       } else if (
         newVersionMinor === semver.minor(changeLogFromVersion) &&
-        (config.separatePatchReleases || config.automerge === 'patch')
+        (config.separatePatchReleases || hasPatchAutomerge)
       ) {
         // Only use patch if configured to
         type = 'patch';
@@ -122,7 +122,6 @@ function determineUpgrades(npmDep, config) {
         semver.gt(newVersion, allUpgrades[upgradeKey].newVersion)
       ) {
         const changeLogToVersion = newVersion;
-        const automergeEnabled = isAutomergeEnabled(config.automerge, type);
         allUpgrades[upgradeKey] = {
           type,
           newVersion,
@@ -130,7 +129,6 @@ function determineUpgrades(npmDep, config) {
           newVersionMinor,
           changeLogFromVersion,
           changeLogToVersion,
-          automergeEnabled,
         };
         if (type === 'major') {
           allUpgrades[upgradeKey].isMajor = true;
@@ -250,18 +248,5 @@ function isPastLatest(npmDep, version) {
     return semver.gt(version, npmDep['dist-tags'].latest);
   }
   logger.warn(`No dist-tags.latest for ${npmDep.name}`);
-  return false;
-}
-
-function isAutomergeEnabled(automerge, type) {
-  if (automerge === 'any') {
-    return true;
-  }
-  if (automerge === 'minor' && type !== 'major') {
-    return true;
-  }
-  if (automerge === 'patch' && type === 'patch') {
-    return true;
-  }
   return false;
 }

--- a/lib/workers/pr/index.js
+++ b/lib/workers/pr/index.js
@@ -24,7 +24,7 @@ async function ensurePr(inputConfig, logger, errors, warnings) {
   );
 
   // Only create a PR if a branch automerge has failed
-  if (config.automergeEnabled && config.automergeType.startsWith('branch')) {
+  if (config.automerge && config.automergeType.startsWith('branch')) {
     logger.debug(
       `Branch is configured for branch automerge, branchStatus is: ${branchStatus}`
     );
@@ -141,7 +141,7 @@ async function ensurePr(inputConfig, logger, errors, warnings) {
       await config.api.addLabels(pr.number, config.labels);
     }
     // Skip assign and review if automerging PR
-    if (config.automergeEnabled && config.automergeType === 'pr') {
+    if (config.automerge && config.automergeType === 'pr') {
       logger.debug(
         `Skipping assignees and reviewers as automerge=${config.automerge}`
       );
@@ -176,7 +176,7 @@ async function ensurePr(inputConfig, logger, errors, warnings) {
 async function checkAutoMerge(pr, config, logger) {
   logger.trace({ config }, 'checkAutoMerge');
   logger.debug(`Checking #${pr.number} for automerge`);
-  if (config.automergeEnabled && config.automergeType === 'pr') {
+  if (config.automerge && config.automergeType === 'pr') {
     logger.info('PR is configured for automerge');
     // Return if PR not ready for automerge
     if (pr.mergeable !== true) {

--- a/lib/workers/repository/apis.js
+++ b/lib/workers/repository/apis.js
@@ -259,6 +259,7 @@ async function resolvePackageFiles(inputConfig) {
     if (packageFile.content) {
       // hoist renovate config if exists
       if (packageFile.content.renovate) {
+        config.hasPackageJsonRenovateConfig = true;
         config.logger.debug(
           {
             packageFile: packageFile.packageFile,

--- a/test/config/__snapshots__/migration.spec.js.snap
+++ b/test/config/__snapshots__/migration.spec.js.snap
@@ -3,9 +3,20 @@
 exports[`config/migration migrateConfig(config, parentConfig) it migrates config 1`] = `
 Object {
   "autodiscover": true,
-  "automerge": "none",
+  "automerge": false,
   "commitMessage": "some commit message",
+  "devDependencies": Object {
+    "minor": Object {
+      "automerge": true,
+    },
+    "patch": Object {
+      "automerge": true,
+    },
+  },
   "enabled": true,
+  "lockFileConfig": Object {
+    "automerge": true,
+  },
   "onboarding": false,
   "optionalDependencies": Object {
     "respectLatest": false,

--- a/test/config/migration.spec.js
+++ b/test/config/migration.spec.js
@@ -8,7 +8,7 @@ describe('config/migration', () => {
         enabled: true,
         maintainYarnLock: true,
         onboarding: 'false',
-        automerge: false,
+        automerge: 'none',
         autodiscover: 'true',
         schedule: ['on the last day of the month'],
         commitMessage: '{{semanticPrefix}}some commit message',
@@ -30,6 +30,12 @@ describe('config/migration', () => {
             enabled: false,
           },
         ],
+        lockFileConfig: {
+          automerge: 'any',
+        },
+        devDependencies: {
+          automerge: 'minor',
+        },
         depTypes: [
           'dependencies',
           {
@@ -46,7 +52,7 @@ describe('config/migration', () => {
       expect(isMigrated).toBe(true);
       expect(migratedConfig.depTypes).not.toBeDefined();
       expect(migratedConfig.optionalDependencies.respectLatest).toBe(false);
-      expect(migratedConfig.automerge).toEqual('none');
+      expect(migratedConfig.automerge).toEqual(false);
       expect(migratedConfig).toMatchSnapshot();
     });
     it('it migrates packages', () => {

--- a/test/workers/branch/index.spec.js
+++ b/test/workers/branch/index.spec.js
@@ -77,14 +77,14 @@ describe('workers/branch', () => {
       expect(config.api.deleteBranch.mock.calls.length).toBe(1);
     });
     it('returns branchName if automerge branch-push and not stale', async () => {
-      config.automergeEnabled = true;
+      config.automerge = true;
       config.automergeType = 'branch-push';
       expect(await branchWorker.getParentBranch(branchName, config)).toBe(
         branchName
       );
     });
     it('returns undefined if automerge branch-push and stale', async () => {
-      config.automergeEnabled = true;
+      config.automerge = true;
       config.automergeType = 'branch-push';
       config.api.isBranchStale.mockReturnValueOnce(true);
       expect(await branchWorker.getParentBranch(branchName, config)).toBe(
@@ -154,7 +154,7 @@ describe('workers/branch', () => {
       branchWorker.getParentBranch.mockReturnValueOnce('dummy branch');
       packageJsonHelper.setNewValue.mockReturnValueOnce('new content');
       config.api.branchExists.mockReturnValueOnce(true);
-      config.automergeEnabled = true;
+      config.automerge = true;
       config.automergeType = 'pr';
       expect(await branchWorker.ensureBranch(config)).toBe(true);
       expect(branchWorker.getParentBranch.mock.calls.length).toBe(1);
@@ -202,7 +202,7 @@ describe('workers/branch', () => {
       config.api.branchExists.mockReturnValueOnce(true);
       config.api.getBranchStatus.mockReturnValueOnce('success');
       config.api.mergeBranch = jest.fn();
-      config.automergeEnabled = true;
+      config.automerge = true;
       config.automergeType = 'branch-push';
       expect(await branchWorker.ensureBranch(config)).toBe(false);
       expect(branchWorker.getParentBranch.mock.calls.length).toBe(1);
@@ -219,7 +219,7 @@ describe('workers/branch', () => {
       config.api.branchExists.mockReturnValueOnce(true);
       config.api.getBranchStatus.mockReturnValueOnce('pending');
       config.api.mergeBranch = jest.fn();
-      config.automergeEnabled = true;
+      config.automerge = true;
       config.automergeType = 'branch-push';
       expect(await branchWorker.ensureBranch(config)).toBe(true);
       expect(branchWorker.getParentBranch.mock.calls.length).toBe(1);
@@ -235,7 +235,7 @@ describe('workers/branch', () => {
       packageJsonHelper.setNewValue.mockReturnValueOnce('new content');
       config.api.branchExists.mockReturnValueOnce(true);
       config.api.getBranchStatus.mockReturnValueOnce('success');
-      config.automergeEnabled = true;
+      config.automerge = true;
       config.automergeType = 'branch-push';
       config.api.mergeBranch = jest.fn(() => {
         throw new Error('automerge failed');

--- a/test/workers/package/__snapshots__/index.spec.js.snap
+++ b/test/workers/package/__snapshots__/index.spec.js.snap
@@ -69,7 +69,7 @@ exports[`lib/workers/package/index renovatePackage(config) returns error if no n
 Array [
   Object {
     "assignees": Array [],
-    "automerge": "none",
+    "automerge": false,
     "automergeType": "pr",
     "branchName": "{{branchPrefix}}{{depName}}-{{newVersionMajor}}.x",
     "branchPrefix": "renovate/",
@@ -221,7 +221,7 @@ exports[`lib/workers/package/index renovatePackage(config) returns error if no n
 Array [
   Object {
     "assignees": Array [],
-    "automerge": "none",
+    "automerge": false,
     "automergeType": "pr",
     "branchName": "{{branchPrefix}}{{depName}}-{{newVersionMajor}}.x",
     "branchPrefix": "renovate/",

--- a/test/workers/package/__snapshots__/versions.spec.js.snap
+++ b/test/workers/package/__snapshots__/versions.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`workers/package/versions .determineUpgrades(npmDep, config) disables major release separation (major) 1`] = `
 Array [
   Object {
-    "automergeEnabled": true,
+    "automerge": true,
     "group": Object {
       "prTitle": "{{groupName}}",
       "semanticPrefix": "refactor(deps):",
@@ -17,7 +17,6 @@ Array [
     "unpublishable": false,
   },
   Object {
-    "automergeEnabled": false,
     "changeLogFromVersion": "0.4.4",
     "changeLogToVersion": "1.4.1",
     "isMajor": true,
@@ -33,7 +32,6 @@ Array [
 exports[`workers/package/versions .determineUpgrades(npmDep, config) disables major release separation (minor) 1`] = `
 Array [
   Object {
-    "automergeEnabled": false,
     "changeLogFromVersion": "1.0.0",
     "changeLogToVersion": "1.4.1",
     "isMinor": true,
@@ -56,7 +54,6 @@ Object {
 exports[`workers/package/versions .determineUpgrades(npmDep, config) ignores pinning for ranges when other upgrade exists 1`] = `
 Array [
   Object {
-    "automergeEnabled": false,
     "changeLogFromVersion": "0.9.7",
     "changeLogToVersion": "1.4.1",
     "isMajor": true,
@@ -67,7 +64,7 @@ Array [
     "unpublishable": false,
   },
   Object {
-    "automergeEnabled": true,
+    "automerge": true,
     "group": Object {
       "prTitle": "{{groupName}}",
       "semanticPrefix": "refactor(deps):",
@@ -86,7 +83,7 @@ Array [
 exports[`workers/package/versions .determineUpgrades(npmDep, config) pins minor ranged versions 1`] = `
 Array [
   Object {
-    "automergeEnabled": true,
+    "automerge": true,
     "group": Object {
       "prTitle": "{{groupName}}",
       "semanticPrefix": "refactor(deps):",
@@ -128,7 +125,6 @@ Object {
 exports[`workers/package/versions .determineUpgrades(npmDep, config) returns both updates if automerging minor 1`] = `
 Array [
   Object {
-    "automergeEnabled": true,
     "changeLogFromVersion": "0.4.4",
     "changeLogToVersion": "0.9.7",
     "isMinor": true,
@@ -139,7 +135,6 @@ Array [
     "unpublishable": false,
   },
   Object {
-    "automergeEnabled": false,
     "changeLogFromVersion": "0.4.4",
     "changeLogToVersion": "1.4.1",
     "isMajor": true,
@@ -150,7 +145,7 @@ Array [
     "unpublishable": false,
   },
   Object {
-    "automergeEnabled": true,
+    "automerge": true,
     "group": Object {
       "prTitle": "{{groupName}}",
       "semanticPrefix": "refactor(deps):",
@@ -169,7 +164,6 @@ Array [
 exports[`workers/package/versions .determineUpgrades(npmDep, config) returns minor update if separate patches not configured 1`] = `
 Array [
   Object {
-    "automergeEnabled": false,
     "changeLogFromVersion": "0.9.0",
     "changeLogToVersion": "0.9.7",
     "isMinor": true,
@@ -180,7 +174,6 @@ Array [
     "unpublishable": false,
   },
   Object {
-    "automergeEnabled": false,
     "changeLogFromVersion": "0.9.0",
     "changeLogToVersion": "1.4.1",
     "isMajor": true,
@@ -196,7 +189,7 @@ Array [
 exports[`workers/package/versions .determineUpgrades(npmDep, config) returns only one update if automerging any 1`] = `
 Array [
   Object {
-    "automergeEnabled": true,
+    "automerge": true,
     "group": Object {
       "prTitle": "{{groupName}}",
       "semanticPrefix": "refactor(deps):",
@@ -210,7 +203,6 @@ Array [
     "unpublishable": false,
   },
   Object {
-    "automergeEnabled": true,
     "changeLogFromVersion": "0.4.4",
     "changeLogToVersion": "1.4.1",
     "isMajor": true,
@@ -226,7 +218,7 @@ Array [
 exports[`workers/package/versions .determineUpgrades(npmDep, config) returns only one update if grouping 1`] = `
 Array [
   Object {
-    "automergeEnabled": true,
+    "automerge": true,
     "group": Object {
       "prTitle": "{{groupName}}",
       "semanticPrefix": "refactor(deps):",
@@ -240,7 +232,6 @@ Array [
     "unpublishable": false,
   },
   Object {
-    "automergeEnabled": false,
     "changeLogFromVersion": "0.4.4",
     "changeLogToVersion": "1.4.1",
     "isMajor": true,
@@ -256,7 +247,6 @@ Array [
 exports[`workers/package/versions .determineUpgrades(npmDep, config) returns patch minor and major 1`] = `
 Array [
   Object {
-    "automergeEnabled": false,
     "changeLogFromVersion": "0.8.0",
     "changeLogToVersion": "0.9.7",
     "isMinor": true,
@@ -267,7 +257,6 @@ Array [
     "unpublishable": false,
   },
   Object {
-    "automergeEnabled": false,
     "changeLogFromVersion": "0.8.0",
     "changeLogToVersion": "1.4.1",
     "isMajor": true,
@@ -278,7 +267,6 @@ Array [
     "unpublishable": false,
   },
   Object {
-    "automergeEnabled": false,
     "changeLogFromVersion": "0.8.0",
     "changeLogToVersion": "0.8.12",
     "isPatch": true,
@@ -294,7 +282,6 @@ Array [
 exports[`workers/package/versions .determineUpgrades(npmDep, config) returns patch update if automerging patch 1`] = `
 Array [
   Object {
-    "automergeEnabled": false,
     "changeLogFromVersion": "0.9.0",
     "changeLogToVersion": "1.4.1",
     "isMajor": true,
@@ -305,7 +292,6 @@ Array [
     "unpublishable": false,
   },
   Object {
-    "automergeEnabled": true,
     "changeLogFromVersion": "0.9.0",
     "changeLogToVersion": "0.9.7",
     "isPatch": true,
@@ -321,7 +307,6 @@ Array [
 exports[`workers/package/versions .determineUpgrades(npmDep, config) returns patch update if separatePatchReleases 1`] = `
 Array [
   Object {
-    "automergeEnabled": false,
     "changeLogFromVersion": "0.9.0",
     "changeLogToVersion": "1.4.1",
     "isMajor": true,
@@ -332,7 +317,6 @@ Array [
     "unpublishable": false,
   },
   Object {
-    "automergeEnabled": false,
     "changeLogFromVersion": "0.9.0",
     "changeLogToVersion": "0.9.7",
     "isPatch": true,
@@ -348,7 +332,6 @@ Array [
 exports[`workers/package/versions .determineUpgrades(npmDep, config) should allow unstable versions if the current version is unstable 1`] = `
 Array [
   Object {
-    "automergeEnabled": false,
     "changeLogFromVersion": "1.0.0-beta",
     "changeLogToVersion": "1.1.0-beta",
     "isMinor": true,
@@ -376,7 +359,6 @@ Object {
 exports[`workers/package/versions .determineUpgrades(npmDep, config) should treat zero zero caret ranges as pinned 1`] = `
 Array [
   Object {
-    "automergeEnabled": false,
     "changeLogFromVersion": "0.0.34",
     "changeLogToVersion": "0.0.35",
     "isMinor": true,
@@ -393,7 +375,6 @@ Array [
 exports[`workers/package/versions .determineUpgrades(npmDep, config) supports > latest versions if configured 1`] = `
 Array [
   Object {
-    "automergeEnabled": false,
     "changeLogFromVersion": "1.4.1",
     "changeLogToVersion": "2.0.1",
     "isMajor": true,
@@ -409,7 +390,7 @@ Array [
 exports[`workers/package/versions .determineUpgrades(npmDep, config) supports future versions if already future 1`] = `
 Array [
   Object {
-    "automergeEnabled": true,
+    "automerge": true,
     "group": Object {
       "prTitle": "{{groupName}}",
       "semanticPrefix": "refactor(deps):",
@@ -428,7 +409,6 @@ Array [
 exports[`workers/package/versions .determineUpgrades(npmDep, config) supports future versions if configured 1`] = `
 Array [
   Object {
-    "automergeEnabled": false,
     "changeLogFromVersion": "1.4.1",
     "changeLogToVersion": "2.0.3",
     "isMajor": true,
@@ -444,7 +424,6 @@ Array [
 exports[`workers/package/versions .determineUpgrades(npmDep, config) supports minor and major upgrades for ranged versions 1`] = `
 Array [
   Object {
-    "automergeEnabled": false,
     "changeLogFromVersion": "0.4.4",
     "changeLogToVersion": "0.9.7",
     "isMinor": true,
@@ -455,7 +434,6 @@ Array [
     "unpublishable": false,
   },
   Object {
-    "automergeEnabled": false,
     "changeLogFromVersion": "0.4.4",
     "changeLogToVersion": "1.4.1",
     "isMajor": true,
@@ -466,7 +444,7 @@ Array [
     "unpublishable": false,
   },
   Object {
-    "automergeEnabled": true,
+    "automerge": true,
     "group": Object {
       "prTitle": "{{groupName}}",
       "semanticPrefix": "refactor(deps):",
@@ -485,7 +463,6 @@ Array [
 exports[`workers/package/versions .determineUpgrades(npmDep, config) supports minor and major upgrades for tilde ranges 1`] = `
 Array [
   Object {
-    "automergeEnabled": false,
     "changeLogFromVersion": "0.4.4",
     "changeLogToVersion": "0.9.7",
     "isMinor": true,
@@ -496,7 +473,6 @@ Array [
     "unpublishable": false,
   },
   Object {
-    "automergeEnabled": false,
     "changeLogFromVersion": "0.4.4",
     "changeLogToVersion": "1.4.1",
     "isMajor": true,
@@ -507,7 +483,7 @@ Array [
     "unpublishable": false,
   },
   Object {
-    "automergeEnabled": true,
+    "automerge": true,
     "group": Object {
       "prTitle": "{{groupName}}",
       "semanticPrefix": "refactor(deps):",
@@ -526,7 +502,6 @@ Array [
 exports[`workers/package/versions .determineUpgrades(npmDep, config) upgrades .x major ranges without pinning 1`] = `
 Array [
   Object {
-    "automergeEnabled": false,
     "changeLogFromVersion": "0.9.7",
     "changeLogToVersion": "1.4.1",
     "isMajor": true,
@@ -543,7 +518,6 @@ Array [
 exports[`workers/package/versions .determineUpgrades(npmDep, config) upgrades .x minor ranges 1`] = `
 Array [
   Object {
-    "automergeEnabled": false,
     "changeLogFromVersion": "1.3.0",
     "changeLogToVersion": "1.4.1",
     "isMinor": true,
@@ -554,7 +528,7 @@ Array [
     "unpublishable": false,
   },
   Object {
-    "automergeEnabled": true,
+    "automerge": true,
     "group": Object {
       "prTitle": "{{groupName}}",
       "semanticPrefix": "refactor(deps):",
@@ -573,7 +547,6 @@ Array [
 exports[`workers/package/versions .determineUpgrades(npmDep, config) upgrades .x minor ranges without pinning 1`] = `
 Array [
   Object {
-    "automergeEnabled": false,
     "changeLogFromVersion": "1.3.0",
     "changeLogToVersion": "1.4.1",
     "isMinor": true,
@@ -590,7 +563,6 @@ Array [
 exports[`workers/package/versions .determineUpgrades(npmDep, config) upgrades less than equal ranges without pinning 1`] = `
 Array [
   Object {
-    "automergeEnabled": false,
     "changeLogFromVersion": "0.7.2",
     "changeLogToVersion": "0.9.7",
     "isMinor": true,
@@ -602,7 +574,6 @@ Array [
     "unpublishable": false,
   },
   Object {
-    "automergeEnabled": false,
     "changeLogFromVersion": "0.7.2",
     "changeLogToVersion": "1.4.1",
     "isMajor": true,
@@ -619,7 +590,6 @@ Array [
 exports[`workers/package/versions .determineUpgrades(npmDep, config) upgrades minor ranged versions 1`] = `
 Array [
   Object {
-    "automergeEnabled": false,
     "changeLogFromVersion": "1.0.1",
     "changeLogToVersion": "1.4.1",
     "isMinor": true,
@@ -630,7 +600,7 @@ Array [
     "unpublishable": false,
   },
   Object {
-    "automergeEnabled": true,
+    "automerge": true,
     "group": Object {
       "prTitle": "{{groupName}}",
       "semanticPrefix": "refactor(deps):",
@@ -649,7 +619,6 @@ Array [
 exports[`workers/package/versions .determineUpgrades(npmDep, config) upgrades multiple caret ranges without pinning 1`] = `
 Array [
   Object {
-    "automergeEnabled": false,
     "changeLogFromVersion": "0.7.2",
     "changeLogToVersion": "0.9.7",
     "isMinor": true,
@@ -661,7 +630,6 @@ Array [
     "unpublishable": false,
   },
   Object {
-    "automergeEnabled": false,
     "changeLogFromVersion": "0.7.2",
     "changeLogToVersion": "1.4.1",
     "isMajor": true,
@@ -678,7 +646,6 @@ Array [
 exports[`workers/package/versions .determineUpgrades(npmDep, config) upgrades multiple tilde ranges without pinning 1`] = `
 Array [
   Object {
-    "automergeEnabled": false,
     "changeLogFromVersion": "0.7.2",
     "changeLogToVersion": "0.9.7",
     "isMinor": true,
@@ -690,7 +657,6 @@ Array [
     "unpublishable": false,
   },
   Object {
-    "automergeEnabled": false,
     "changeLogFromVersion": "0.7.2",
     "changeLogToVersion": "1.4.1",
     "isMajor": true,
@@ -707,7 +673,6 @@ Array [
 exports[`workers/package/versions .determineUpgrades(npmDep, config) upgrades shorthand major ranges without pinning 1`] = `
 Array [
   Object {
-    "automergeEnabled": false,
     "changeLogFromVersion": "0.9.7",
     "changeLogToVersion": "1.4.1",
     "isMajor": true,
@@ -724,7 +689,6 @@ Array [
 exports[`workers/package/versions .determineUpgrades(npmDep, config) upgrades shorthand minor ranges without pinning 1`] = `
 Array [
   Object {
-    "automergeEnabled": false,
     "changeLogFromVersion": "1.3.0",
     "changeLogToVersion": "1.4.1",
     "isMinor": true,
@@ -741,7 +705,6 @@ Array [
 exports[`workers/package/versions .determineUpgrades(npmDep, config) upgrades tilde ranges 1`] = `
 Array [
   Object {
-    "automergeEnabled": false,
     "changeLogFromVersion": "1.3.0",
     "changeLogToVersion": "1.4.1",
     "isMinor": true,
@@ -752,7 +715,7 @@ Array [
     "unpublishable": false,
   },
   Object {
-    "automergeEnabled": true,
+    "automerge": true,
     "group": Object {
       "prTitle": "{{groupName}}",
       "semanticPrefix": "refactor(deps):",
@@ -771,7 +734,6 @@ Array [
 exports[`workers/package/versions .determineUpgrades(npmDep, config) upgrades tilde ranges without pinning 1`] = `
 Array [
   Object {
-    "automergeEnabled": false,
     "changeLogFromVersion": "1.3.0",
     "changeLogToVersion": "1.4.1",
     "isMinor": true,

--- a/test/workers/package/versions.spec.js
+++ b/test/workers/package/versions.spec.js
@@ -51,10 +51,16 @@ describe('workers/package/versions', () => {
     });
     it('returns minor update if separate patches not configured', () => {
       config.currentVersion = '0.9.0';
-      expect(versions.determineUpgrades(qJson, config)).toMatchSnapshot();
+      const res = versions.determineUpgrades(qJson, config);
+      expect(res).toMatchSnapshot();
+      expect(res.length).toBe(2);
+      expect(res[0].type).not.toEqual('patch');
+      expect(res[1].type).not.toEqual('patch');
     });
     it('returns patch update if automerging patch', () => {
-      config.automerge = 'patch';
+      config.patch = {
+        automerge: true,
+      };
       config.currentVersion = '0.9.0';
       expect(versions.determineUpgrades(qJson, config)).toMatchSnapshot();
     });
@@ -271,32 +277,6 @@ describe('workers/package/versions', () => {
     });
     it('should return true for greater than', () => {
       versions.isPastLatest(qJson, '2.0.3').should.eql(true);
-    });
-  });
-  describe('.isAutomergeEnabled(automerge, type)', () => {
-    it('should return true for automerge = any', () => {
-      versions.isAutomergeEnabled('any', 'whatever').should.eql(true);
-    });
-    it('should return true for automerge = minor and type = minor', () => {
-      versions.isAutomergeEnabled('minor', 'minor').should.eql(true);
-    });
-    it('should return true for automerge = minor and type = patch', () => {
-      versions.isAutomergeEnabled('minor', 'patch').should.eql(true);
-    });
-    it('should return true for automerge = patch and type = patch', () => {
-      versions.isAutomergeEnabled('patch', 'patch').should.eql(true);
-    });
-    it('should return false for automerge = minor and type = major', () => {
-      versions.isAutomergeEnabled('minor', 'major').should.eql(false);
-    });
-    it('should return false for automerge = patch and type = minor', () => {
-      versions.isAutomergeEnabled('patch', 'minor').should.eql(false);
-    });
-    it('should return false for automerge = patch and type = major', () => {
-      versions.isAutomergeEnabled('patch', 'major').should.eql(false);
-    });
-    it('should return false for automerge = none', () => {
-      versions.isAutomergeEnabled('none', 'whatever').should.eql(false);
     });
   });
 });

--- a/test/workers/pr/index.spec.js
+++ b/test/workers/pr/index.spec.js
@@ -49,7 +49,7 @@ describe('workers/pr', () => {
       expect(config.api.mergePr.mock.calls.length).toBe(0);
     });
     it('should automerge if enabled and pr is mergeable', async () => {
-      config.automergeEnabled = true;
+      config.automerge = true;
       pr.canRebase = true;
       pr.mergeable = true;
       config.api.getBranchStatus.mockReturnValueOnce('success');
@@ -57,7 +57,7 @@ describe('workers/pr', () => {
       expect(config.api.mergePr.mock.calls.length).toBe(1);
     });
     it('should not automerge if enabled and pr is mergeable but cannot rebase', async () => {
-      config.automergeEnabled = true;
+      config.automerge = true;
       pr.canRebase = false;
       pr.mergeable = true;
       config.api.getBranchStatus.mockReturnValueOnce('success');
@@ -65,21 +65,21 @@ describe('workers/pr', () => {
       expect(config.api.mergePr.mock.calls.length).toBe(0);
     });
     it('should not automerge if enabled and pr is mergeable but branch status is not success', async () => {
-      config.automergeEnabled = true;
+      config.automerge = true;
       pr.mergeable = true;
       config.api.getBranchStatus.mockReturnValueOnce('pending');
       await prWorker.checkAutoMerge(pr, config, logger);
       expect(config.api.mergePr.mock.calls.length).toBe(0);
     });
     it('should not automerge if enabled and pr is mergeable but unstable', async () => {
-      config.automergeEnabled = true;
+      config.automerge = true;
       pr.mergeable = true;
       pr.mergeable_state = 'unstable';
       await prWorker.checkAutoMerge(pr, config, logger);
       expect(config.api.mergePr.mock.calls.length).toBe(0);
     });
     it('should not automerge if enabled and pr is unmergeable', async () => {
-      config.automergeEnabled = true;
+      config.automerge = true;
       pr.mergeable = false;
       await prWorker.checkAutoMerge(pr, config, logger);
       expect(config.api.mergePr.mock.calls.length).toBe(0);
@@ -201,7 +201,7 @@ describe('workers/pr', () => {
       config.api.addReviewers = jest.fn();
       config.assignees = ['bar'];
       config.reviewers = ['baz'];
-      config.automergeEnabled = true;
+      config.automerge = true;
       const pr = await prWorker.ensurePr(config, logger);
       expect(pr).toMatchObject({ displayNumber: 'New Pull Request' });
       expect(config.api.addAssignees.mock.calls.length).toBe(0);
@@ -233,7 +233,7 @@ describe('workers/pr', () => {
       expect(pr).toMatchSnapshot();
     });
     it('should create PR if branch automerging failed', async () => {
-      config.automergeEnabled = true;
+      config.automerge = true;
       config.automergeType = 'branch-push';
       config.api.getBranchStatus.mockReturnValueOnce('failure');
       config.api.getBranchPr = jest.fn();
@@ -241,7 +241,7 @@ describe('workers/pr', () => {
       expect(pr).toMatchObject({ displayNumber: 'New Pull Request' });
     });
     it('should return null if branch automerging not failed', async () => {
-      config.automergeEnabled = true;
+      config.automerge = true;
       config.automergeType = 'branch-push';
       config.api.getBranchStatus.mockReturnValueOnce('pending');
       const pr = await prWorker.ensurePr(config, logger);


### PR DESCRIPTION
Refactored the `automerge` field to change it to boolean. Existing string will be migrated to new config. Automerging lock files is now possible by adding `”lockFileMaintenance”: { ”automerge”: true}` to config.

Closes #706