### PR TITLE
fix: expand automerge string to fill all upgrade types

### DIFF
--- a/lib/config/migration.js
+++ b/lib/config/migration.js
@@ -42,15 +42,23 @@ function migrateConfig(config, parentConfig) {
       if (val === 'none') {
         migratedConfig.automerge = false;
       }
-      if (val === 'patch' || val === 'minor') {
+      if (val === 'patch') {
         delete migratedConfig.automerge;
         migratedConfig.patch = migratedConfig.patch || {};
         migratedConfig.patch.automerge = true;
+        migratedConfig.minor = migratedConfig.minor || {};
+        migratedConfig.minor.automerge = false;
+        migratedConfig.major = migratedConfig.major || {};
+        migratedConfig.major.automerge = false;
       }
       if (val === 'minor') {
         delete migratedConfig.automerge;
+        migratedConfig.patch = migratedConfig.patch || {};
+        migratedConfig.patch.automerge = true;
         migratedConfig.minor = migratedConfig.minor || {};
         migratedConfig.minor.automerge = true;
+        migratedConfig.major = migratedConfig.major || {};
+        migratedConfig.major.automerge = false;
       }
       if (val === 'any') {
         migratedConfig.automerge = true;

--- a/test/config/__snapshots__/migration.spec.js.snap
+++ b/test/config/__snapshots__/migration.spec.js.snap
@@ -6,6 +6,9 @@ Object {
   "automerge": false,
   "commitMessage": "some commit message",
   "devDependencies": Object {
+    "major": Object {
+      "automerge": false,
+    },
     "minor": Object {
       "automerge": true,
     },
@@ -67,6 +70,34 @@ Object {
     "optionalDependencies": Object {
       "respectLatest": false,
     },
+  },
+}
+`;
+
+exports[`config/migration migrateConfig(config, parentConfig) it overrides existing automerge setting 1`] = `
+Object {
+  "major": Object {
+    "automerge": false,
+  },
+  "minor": Object {
+    "automerge": true,
+  },
+  "packageRules": Array [
+    Object {
+      "major": Object {
+        "automerge": false,
+      },
+      "minor": Object {
+        "automerge": false,
+      },
+      "packagePatterns": "^(@angular|typescript)",
+      "patch": Object {
+        "automerge": true,
+      },
+    },
+  ],
+  "patch": Object {
+    "automerge": true,
   },
 }
 `;

--- a/test/config/migration.spec.js
+++ b/test/config/migration.spec.js
@@ -72,6 +72,25 @@ describe('config/migration', () => {
       expect(isMigrated).toBe(true);
       expect(migratedConfig).toMatchSnapshot();
     });
+    it('it overrides existing automerge setting', () => {
+      const config = {
+        automerge: 'minor',
+        packages: [
+          {
+            packagePatterns: '^(@angular|typescript)',
+            automerge: 'patch',
+          },
+        ],
+      };
+      const parentConfig = { ...defaultConfig };
+      const { isMigrated, migratedConfig } = configMigration.migrateConfig(
+        config,
+        parentConfig
+      );
+      expect(isMigrated).toBe(true);
+      expect(migratedConfig).toMatchSnapshot();
+      expect(migratedConfig.packageRules[0].minor.automerge).toBe(false);
+    });
     it('it does not migrate config', () => {
       const config = {
         enabled: true,


### PR DESCRIPTION
This makes for an uglier migration and potentially some redundancy, but is the only easy way to ensure that the migrated behaviour is definitely correct.

Fixes #713