### PR TITLE
fix: advanced schedules migration

### DIFF
--- a/lib/config/migration.js
+++ b/lib/config/migration.js
@@ -76,13 +76,35 @@ function migrateConfig(config, parentConfig) {
       migratedConfig.packagePatterns = [val];
       delete migratedConfig.packagePattern;
     } else if (key === 'schedule') {
-      for (let i = 0; i < val.length; i += 1) {
-        if (val[i].indexOf('on the last day of the month') !== -1) {
+      // massage to array first
+      let schedules = typeof val === 'string' ? [val] : val;
+      // split 'and'
+      for (let i = 0; i < schedules.length; i += 1) {
+        if (schedules[i].indexOf(' and ') !== -1) {
           isMigrated = true;
-          migratedConfig.schedule[i] = val[i].replace(
+          const split = schedules[i].split(' and ');
+          schedules[i] = split[0];
+          schedules = schedules.concat(split.slice(1));
+        }
+      }
+      for (let i = 0; i < schedules.length; i += 1) {
+        if (schedules[i].indexOf('on the last day of the month') !== -1) {
+          isMigrated = true;
+          schedules[i] = schedules[i].replace(
             'on the last day of the month',
             'on the first day of the month'
           );
+        }
+        if (schedules[i].endsWith('days')) {
+          isMigrated = true;
+          schedules[i] = schedules[i].replace('days', 'day');
+        }
+      }
+      if (isMigrated) {
+        if (typeof val === 'string' && schedules.length === 1) {
+          migratedConfig.schedule = schedules[0];
+        } else {
+          migratedConfig.schedule = schedules;
         }
       }
     } else if (

--- a/lib/workers/branch/schedule.js
+++ b/lib/workers/branch/schedule.js
@@ -91,8 +91,11 @@ function isScheduledNow(config) {
   config.logger.debug(`Checking ${configSchedule.length} schedule(s)`);
   // We run if any schedule matches
   const isWithinSchedule = configSchedule.some(scheduleText => {
-    config.logger.debug(`Checking schedule "${scheduleText}"`);
     const parsedSchedule = later.parse.text(fixShortHours(scheduleText));
+    config.logger.debug(
+      { parsedSchedule },
+      `Checking schedule "${scheduleText}"`
+    );
     // Later library returns array of schedules
     return parsedSchedule.schedules.some(schedule => {
       // Check if days are defined

--- a/test/config/__snapshots__/migration.spec.js.snap
+++ b/test/config/__snapshots__/migration.spec.js.snap
@@ -26,6 +26,7 @@ Object {
       "automerge": true,
     },
     "respectLatest": false,
+    "schedule": "before 5am on Monday",
   },
   "packageRules": Array [
     Object {
@@ -49,9 +50,7 @@ Object {
     },
   ],
   "prTitle": "some pr title",
-  "schedule": Array [
-    "on the first day of the month",
-  ],
+  "schedule": "on the first day of the month",
   "semanticPrefix": "fix(deps):",
 }
 `;
@@ -98,6 +97,15 @@ Object {
         "automerge": true,
       },
     },
+  ],
+}
+`;
+
+exports[`config/migration migrateConfig(config, parentConfig) migrates schedules with and 1`] = `
+Object {
+  "schedule": Array [
+    "after 10pm",
+    "before 7am",
   ],
 }
 `;

--- a/test/config/migration.spec.js
+++ b/test/config/migration.spec.js
@@ -10,7 +10,7 @@ describe('config/migration', () => {
         onboarding: 'false',
         automerge: 'none',
         autodiscover: 'true',
-        schedule: ['on the last day of the month'],
+        schedule: 'on the last day of the month',
         commitMessage: '{{semanticPrefix}}some commit message',
         prTitle: '{{semanticPrefix}}some pr title',
         semanticPrefix: 'fix(deps): ',
@@ -42,6 +42,7 @@ describe('config/migration', () => {
             depType: 'optionalDependencies',
             respectLatest: false,
             automerge: 'minor',
+            schedule: 'before 5am on Mondays',
           },
         ],
       };
@@ -55,6 +56,21 @@ describe('config/migration', () => {
       expect(migratedConfig.optionalDependencies.respectLatest).toBe(false);
       expect(migratedConfig.automerge).toEqual(false);
       expect(migratedConfig).toMatchSnapshot();
+    });
+    it('migrates schedules with and', () => {
+      const config = {
+        schedule: 'after 10pm and before 7am',
+      };
+      const parentConfig = { ...defaultConfig };
+      const { isMigrated, migratedConfig } = configMigration.migrateConfig(
+        config,
+        parentConfig
+      );
+      expect(migratedConfig).toMatchSnapshot();
+      expect(isMigrated).toBe(true);
+      expect(migratedConfig.schedule.length).toBe(2);
+      expect(migratedConfig.schedule[0]).toEqual('after 10pm');
+      expect(migratedConfig.schedule[1]).toEqual('before 7am');
     });
     it('it migrates packages', () => {
       const config = {


### PR DESCRIPTION
- Split ‘x and y’ schedule into [x, y]
- Replace schedules like ’on mondays’ with ‘on monday’