### PR TITLE
feat: convet ignoreNodeModules to ignorePaths

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,7 +83,7 @@ $ node renovate --help
     --github-app-id <integer>            GitHub App ID (enables GitHub App functionality if set)
     --github-app-key <string>            GitHub App Private Key (.pem file contents)
     --package-files <list>               Package file paths
-    --ignore-node-modules [boolean]      Skip any package.json files found within node_modules folders
+    --ignore-paths <list>                Skip any package.json whose path matches one of these.
     --ignore-deps <list>                 Dependencies to ignore
     --pin-versions [boolean]             Convert ranged versions in package.json to pinned versions
     --separate-major-releases [boolean]  If set to false, it will upgrade dependencies to latest release only, and not separate major/minor branches
@@ -298,12 +298,12 @@ Obviously, you can't set repository or package file location with this method.
   <td>`--package-files`<td>
 </tr>
 <tr>
-  <td>`ignoreNodeModules`</td>
-  <td>Skip any package.json files found within node_modules folders</td>
-  <td>boolean</td>
-  <td><pre>true</pre></td>
-  <td>`RENOVATE_IGNORE_NODE_MODULES`</td>
-  <td>`--ignore-node-modules`<td>
+  <td>`ignorePaths`</td>
+  <td>Skip any package.json whose path matches one of these.</td>
+  <td>list</td>
+  <td><pre>["node_modules/"]</pre></td>
+  <td>`RENOVATE_IGNORE_PATHS`</td>
+  <td>`--ignore-paths`<td>
 </tr>
 <tr>
   <td>`dependencies`</td>
@@ -577,7 +577,6 @@ Obviously, you can't set repository or package file location with this method.
   <td>json</td>
   <td><pre>{
   "enabled": true,
-  "groupName": "Lock File Maintenance",
   "recreateClosed": true,
   "branchName": "{{branchPrefix}}lock-file-maintenance",
   "commitMessage": "Update lock file",

--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -153,11 +153,11 @@ const options = [
     stage: 'branch',
   },
   {
-    name: 'ignoreNodeModules',
-    description:
-      'Skip any package.json files found within node_modules folders',
-    type: 'boolean',
+    name: 'ignorePaths',
+    description: 'Skip any package.json whose path matches one of these.',
+    type: 'list',
     stage: 'repository',
+    default: ['node_modules/'],
   },
   {
     name: 'dependencies',

--- a/lib/config/migration.js
+++ b/lib/config/migration.js
@@ -32,6 +32,10 @@ function migrateConfig(config, parentConfig) {
     if (removedOptions.includes(key)) {
       isMigrated = true;
       delete migratedConfig[key];
+    } else if (key === 'ignoreNodeModules') {
+      isMigrated = true;
+      delete migratedConfig.ignoreNodeModules;
+      migratedConfig.ignorePaths = val ? ['node_modules/'] : [];
     } else if (key === 'semanticCommits') {
       if (parentConfig && parentConfig[key] === val) {
         isMigrated = true;

--- a/lib/workers/repository/apis.js
+++ b/lib/workers/repository/apis.js
@@ -1,5 +1,4 @@
 const conventionalCommitsDetector = require('conventional-commits-detector');
-const ini = require('ini');
 const path = require('path');
 const jsonValidator = require('json-dup-key-validator');
 const configParser = require('../../config');
@@ -213,20 +212,22 @@ async function detectPackageFiles(input) {
     { packageFiles: config.packageFiles },
     `Found ${config.packageFiles.length} package file(s)`
   );
-  if (config.ignoreNodeModules) {
+  if (Array.isArray(config.ignorePaths)) {
     const skippedPackageFiles = [];
     config.packageFiles = config.packageFiles.filter(packageFile => {
-      if (packageFile.indexOf('node_modules/') === -1) {
-        return true;
+      if (
+        config.ignorePaths.some(ignorePath => packageFile.includes(ignorePath))
+      ) {
+        skippedPackageFiles.push(packageFile);
+        return false;
       }
-      skippedPackageFiles.push(packageFile);
-      return false;
+      return true;
     });
     if (skippedPackageFiles.length) {
-      config.foundNodeModules = true;
+      config.foundIgnoredPaths = true;
       config.warnings.push({
         depName: 'packageFiles',
-        message: `Skipped package.json files found within node_modules subfolders: \`${skippedPackageFiles}\``,
+        message: `Skipped package.json files found within ignored paths: \`${skippedPackageFiles}\``,
       });
       config.logger.debug(
         `Now have ${config.packageFiles.length} package file(s) after filtering`

--- a/test/config/__snapshots__/migration.spec.js.snap
+++ b/test/config/__snapshots__/migration.spec.js.snap
@@ -20,6 +20,9 @@ Object {
     },
   },
   "enabled": true,
+  "ignorePaths": Array [
+    "node_modules/",
+  ],
   "lockFileConfig": Object {
     "automerge": true,
   },

--- a/test/config/migration.spec.js
+++ b/test/config/migration.spec.js
@@ -9,6 +9,7 @@ describe('config/migration', () => {
         maintainYarnLock: true,
         onboarding: 'false',
         automerge: 'none',
+        ignoreNodeModules: true,
         autodiscover: 'true',
         schedule: 'on the last day of the month',
         commitMessage: '{{semanticPrefix}}some commit message',

--- a/test/workers/repository/__snapshots__/apis.spec.js.snap
+++ b/test/workers/repository/__snapshots__/apis.spec.js.snap
@@ -54,7 +54,7 @@ exports[`workers/repository/apis detectPackageFiles(config) ignores node modules
 Array [
   Object {
     "depName": "packageFiles",
-    "message": "Skipped package.json files found within node_modules subfolders: \`node_modules/backend/package.json\`",
+    "message": "Skipped package.json files found within ignored paths: \`node_modules/backend/package.json\`",
   },
 ]
 `;

--- a/test/workers/repository/apis.spec.js
+++ b/test/workers/repository/apis.spec.js
@@ -229,7 +229,7 @@ describe('workers/repository/apis', () => {
     });
     it('ignores node modules', async () => {
       const config = {
-        ignoreNodeModules: true,
+        ignorePaths: ['node_modules/'],
         api: {
           findFilePaths: jest.fn(() => [
             'package.json',
@@ -241,7 +241,7 @@ describe('workers/repository/apis', () => {
       };
       const res = await apis.detectPackageFiles(config);
       expect(res.packageFiles).toMatchSnapshot();
-      expect(res.foundNodeModules).toMatchSnapshot();
+      expect(res.foundIgnoredPaths).toMatchSnapshot();
       expect(res.warnings).toMatchSnapshot();
     });
     it('defaults to package.json if found', async () => {

--- a/test/workers/repository/onboarding.spec.js
+++ b/test/workers/repository/onboarding.spec.js
@@ -230,7 +230,7 @@ describe('lib/workers/repository/onboarding', () => {
         getPr: jest.fn(() => {}),
         getCommitMessages: jest.fn(),
       };
-      config.foundNodeModules = true;
+      config.foundIgnoredPaths = true;
       config.logger = logger;
       config.detectedPackageFiles = true;
       onboarding.isRepoPrivate = jest.fn();


### PR DESCRIPTION
The ignoreNodeModules feature is replaced with a generic ignorePaths one and allows any array of strings to be defined and package.json file matching them will be skipped/ignored. Also migrates any existing config/presets.