### PR TITLE
feat: yarn workspaces lock file support

### DIFF
--- a/lib/workers/branch/lock-files.js
+++ b/lib/workers/branch/lock-files.js
@@ -67,6 +67,11 @@ function determineLockFileDirs(config) {
     }
   }
 
+  // If yarn workspaces are in use, then we need to generate yarn.lock from root dir
+  if (config.updatedPackageFiles.length && config.hasYarnWorkspaces) {
+    yarnLockFileDirs.push(path.dirname('package.json'));
+  }
+
   return { yarnLockFileDirs, packageLockFileDirs };
 }
 

--- a/lib/workers/package-file/index.js
+++ b/lib/workers/package-file/index.js
@@ -23,17 +23,6 @@ async function renovatePackageFile(packageFileConfig) {
     return upgrades;
   }
 
-  // Warn if workspaces found
-  if (config.content.workspaces) {
-    logger.warn('Found workspaces');
-    const warn = { ...config };
-    warn.depName = 'workspaces';
-    warn.type = 'warning';
-    warn.message =
-      'workspaces configuration detected in `package.json` but this is currently unsupported. Please see https://github.com/singapore/renovate/issues/473 for details.';
-    upgrades.push(warn);
-  }
-
   const depTypes = [
     'dependencies',
     'devDependencies',

--- a/lib/workers/repository/apis.js
+++ b/lib/workers/repository/apis.js
@@ -206,30 +206,42 @@ async function mergeRenovateJson(config, branchName) {
 
 async function detectPackageFiles(input) {
   const config = { ...input };
-  config.logger.trace({ config }, 'detectPackageFiles');
+  const { logger } = config;
+  logger.trace({ config }, 'detectPackageFiles');
   config.packageFiles = await config.api.findFilePaths('package.json');
-  config.logger.debug(
+  logger.debug(
     { packageFiles: config.packageFiles },
     `Found ${config.packageFiles.length} package file(s)`
   );
   if (Array.isArray(config.ignorePaths)) {
+    logger.debug('Checking ignorePaths');
     const skippedPackageFiles = [];
     config.packageFiles = config.packageFiles.filter(packageFile => {
+      logger.trace(`Checking ${packageFile}`);
       if (
-        config.ignorePaths.some(ignorePath => packageFile.includes(ignorePath))
+        config.ignorePaths.some(ignorePath => {
+          logger.trace(` ..against ${ignorePath}`);
+          return packageFile.includes(ignorePath);
+        })
       ) {
+        logger.trace('Filtered out');
         skippedPackageFiles.push(packageFile);
         return false;
       }
+      logger.trace('Included');
       return true;
     });
     if (skippedPackageFiles.length) {
+      logger.debug(
+        { skippedPackageFiles },
+        `Skipped ${skippedPackageFiles.length} file(s)`
+      );
       config.foundIgnoredPaths = true;
       config.warnings.push({
         depName: 'packageFiles',
         message: `Skipped package.json files found within ignored paths: \`${skippedPackageFiles}\``,
       });
-      config.logger.debug(
+      logger.debug(
         `Now have ${config.packageFiles.length} package file(s) after filtering`
       );
     }
@@ -264,6 +276,14 @@ async function resolvePackageFiles(inputConfig) {
       config.baseBranch
     );
     if (packageFile.content) {
+      // check for workspaces
+      if (
+        packageFile.packageFile === 'package.json' &&
+        packageFile.content.workspaces
+      ) {
+        config.logger.info('Found yarn workspaces configuration');
+        config.hasYarnWorkspaces = true;
+      }
       // hoist renovate config if exists
       if (packageFile.content.renovate) {
         config.hasPackageJsonRenovateConfig = true;

--- a/test/workers/branch/__snapshots__/lock-files.spec.js.snap
+++ b/test/workers/branch/__snapshots__/lock-files.spec.js.snap
@@ -22,6 +22,15 @@ Object {
 }
 `;
 
+exports[`workers/branch/lock-files determineLockFileDirs returns root directory if using yarn workspaces 1`] = `
+Object {
+  "packageLockFileDirs": Array [],
+  "yarnLockFileDirs": Array [
+    ".",
+  ],
+}
+`;
+
 exports[`workers/branch/lock-files getUpdatedLockFiles adds multiple lock files 1`] = `
 Object {
   "lockFileError": false,

--- a/test/workers/branch/lock-files.spec.js
+++ b/test/workers/branch/lock-files.spec.js
@@ -149,6 +149,30 @@ describe('workers/branch/lock-files', () => {
       const res = determineLockFileDirs(config);
       expect(res).toMatchSnapshot();
     });
+    it('returns root directory if using yarn workspaces', () => {
+      config.hasYarnWorkspaces = true;
+      config.upgrades = [{}];
+      config.packageFiles = [
+        {
+          packageFile: 'package.json',
+          hasYarnLock: true,
+        },
+        {
+          packageFile: 'backend/package.json',
+        },
+      ];
+      config.updatedPackageFiles = [
+        {
+          name: 'backend/package.json',
+          contents: 'some contents',
+        },
+      ];
+      const res = determineLockFileDirs(config);
+      expect(res).toMatchSnapshot();
+      expect(res.packageLockFileDirs).toHaveLength(0);
+      expect(res.yarnLockFileDirs).toHaveLength(1);
+      expect(res.yarnLockFileDirs[0]).toEqual('.');
+    });
   });
   describe('writeExistingFiles', () => {
     let config;

--- a/test/workers/package-file/index.spec.js
+++ b/test/workers/package-file/index.spec.js
@@ -26,12 +26,6 @@ describe('packageFileWorker', () => {
       const res = await packageFileWorker.renovatePackageFile(config);
       expect(res).toEqual([]);
     });
-    it('warns if using workspaces', async () => {
-      config.content.workspaces = {};
-      const res = await packageFileWorker.renovatePackageFile(config);
-      expect(res).toHaveLength(1);
-      expect(res[0].type).toEqual('warning');
-    });
     it('returns upgrades', async () => {
       depTypeWorker.renovateDepType.mockReturnValueOnce([{}]);
       depTypeWorker.renovateDepType.mockReturnValueOnce([{}, {}]);

--- a/test/workers/repository/__snapshots__/apis.spec.js.snap
+++ b/test/workers/repository/__snapshots__/apis.spec.js.snap
@@ -93,7 +93,9 @@ exports[`workers/repository/apis mergeRenovateJson(config) returns warning + err
 exports[`workers/repository/apis resolvePackageFiles includes files with content 1`] = `
 Array [
   Object {
-    "content": Object {},
+    "content": Object {
+      "workspaces": Array [],
+    },
     "errors": Array [],
     "hasPackageLock": true,
     "hasYarnLock": true,

--- a/test/workers/repository/apis.spec.js
+++ b/test/workers/repository/apis.spec.js
@@ -285,7 +285,10 @@ describe('workers/repository/apis', () => {
       expect(res.packageFiles).toEqual([]);
     });
     it('includes files with content', async () => {
-      config.api.getFileJson.mockReturnValueOnce({ renovate: {} });
+      config.api.getFileJson.mockReturnValueOnce({
+        renovate: {},
+        workspaces: [],
+      });
       config.api.getFileJson.mockReturnValueOnce({});
       config.api.getFileContent.mockReturnValueOnce(null);
       config.api.getFileContent.mockReturnValueOnce(null);


### PR DESCRIPTION
This feature adds explicit support for correctly generating the yarn.lock file for workspaces. Specifically, it means that the yarn.lock in the root directory is regenerated whenever *any* package.json is modified. Previously lock files were only every updated if its corresponding package.json changes, but that is not the way yarn workspaces works.

Closes #473