### PR TITLE
fix: use `iid` for gitlab api v4 in findPr

### DIFF
--- a/lib/api/gitlab.js
+++ b/lib/api/gitlab.js
@@ -319,7 +319,7 @@ async function findPr(branchName, prTitle, state = 'all') {
     ) {
       pr = result;
       // GitHub uses number, GitLab uses iid
-      pr.number = pr.id;
+      pr.number = config.apiVersion === 'v3' ? pr.id : pr.iid;
       pr.body = pr.description;
       pr.displayNumber = `Merge Request #${pr.iid}`;
       if (pr.state !== 'opened') {

--- a/test/api/gitlab.spec.js
+++ b/test/api/gitlab.spec.js
@@ -482,11 +482,11 @@ describe('api/gitlab', () => {
         body: [
           {
             source_branch: 'some-branch',
-            id: 1,
+            iid: 1,
           },
           {
             source_branch: 'some-branch',
-            id: 2,
+            iid: 2,
             title: 'foo',
           },
         ],

--- a/test/api/gitlab.spec.js
+++ b/test/api/gitlab.spec.js
@@ -499,11 +499,11 @@ describe('api/gitlab', () => {
         body: [
           {
             source_branch: 'some-branch',
-            id: 1,
+            iid: 1,
           },
           {
             source_branch: 'some-branch',
-            id: 2,
+            iid: 2,
           },
         ],
       });


### PR DESCRIPTION
Encountered a Gitlab API v4 error when re-running renovate for an existing onboarding merge reqest.

Error message is:

```
DEBUG: Found existing onboarding PR#1675 (repository=184)
DEBUG: PR #Merge Request #193 needs to be closed to enable renovate to continue (repository=184)
DEBUG: getPr(1675) (repository=184)
ERROR: Failed to process repository: 404 Not found (404) (repository=184)
DEBUG: 404 Not found (404) (repository=184)
```

Wonder whether `createPr()` would cause similar errors, see [line 360](https://github.com/singapore/renovate/blob/master/lib/api/gitlab.js#L360)

