### PR TITLE
fix: escape gitlab branch name forward slash

### DIFF
--- a/lib/api/gitlab.js
+++ b/lib/api/gitlab.js
@@ -135,7 +135,10 @@ async function findFilePaths() {
 async function branchExists(branchName) {
   logger.debug(`Checking if branch exists: ${branchName}`);
   try {
-    const url = `projects/${config.repoName}/repository/branches/${branchName}`;
+    const url = `projects/${config.repoName}/repository/branches/${branchName.replace(
+      '/',
+      '%2F'
+    )}`;
     const res = await glGot(url);
     if (res.statusCode === 200) {
       logger.debug('Branch exists');
@@ -158,7 +161,10 @@ async function branchExists(branchName) {
 // Returns branch object
 async function getBranch(branchName) {
   logger.debug(`getBranch(${branchName})`);
-  const url = `projects/${config.repoName}/repository/branches/${branchName}`;
+  const url = `projects/${config.repoName}/repository/branches/${branchName.replace(
+    '/',
+    '%2F'
+  )}`;
   try {
     return (await glGot(url)).body;
   } catch (err) {
@@ -198,7 +204,10 @@ async function getBranchStatus(branchName, requiredStatusChecks) {
     return 'failed';
   }
   // First, get the branch to find the commit SHA
-  let url = `projects/${config.repoName}/repository/branches/${branchName}`;
+  let url = `projects/${config.repoName}/repository/branches/${branchName.replace(
+    '/',
+    '%2F'
+  )}`;
   let res = await glGot(url);
   const branchSha = res.body.commit.id;
   // Now, check the statuses for that commit
@@ -226,7 +235,10 @@ async function getBranchStatus(branchName, requiredStatusChecks) {
 
 async function getBranchStatusCheck(branchName, context) {
   // First, get the branch to find the commit SHA
-  let url = `projects/${config.repoName}/repository/branches/${branchName}`;
+  let url = `projects/${config.repoName}/repository/branches/${branchName.replace(
+    '/',
+    '%2F'
+  )}`;
   let res = await glGot(url);
   const branchSha = res.body.commit.id;
   // Now, check the statuses for that commit
@@ -249,7 +261,10 @@ async function setBranchStatus(
   targetUrl
 ) {
   // First, get the branch to find the commit SHA
-  let url = `projects/${config.repoName}/repository/branches/${branchName}`;
+  let url = `projects/${config.repoName}/repository/branches/${branchName.replace(
+    '/',
+    '%2F'
+  )}`;
   const res = await glGot(url);
   const branchSha = res.body.commit.id;
   // Now, check the statuses for that commit
@@ -267,7 +282,10 @@ async function setBranchStatus(
 
 async function deleteBranch(branchName) {
   await glGot.delete(
-    `projects/${config.repoName}/repository/branches/${branchName}`
+    `projects/${config.repoName}/repository/branches/${branchName.replace(
+      '/',
+      '%2F'
+    )}`
   );
 }
 

--- a/test/api/__snapshots__/gitlab.spec.js.snap
+++ b/test/api/__snapshots__/gitlab.spec.js.snap
@@ -232,7 +232,7 @@ Array [
     "projects/some%2Frepo/merge_requests/undefined",
   ],
   Array [
-    "projects/some%2Frepo/repository/branches/undefined",
+    "projects/some%2Frepo/repository/branches/some-branch",
   ],
 ]
 `;
@@ -246,8 +246,10 @@ Object {
   "body": undefined,
   "commits": 1,
   "deletions": 1,
-  "displayNumber": "Merge Request #undefined",
+  "displayNumber": "Merge Request #91",
+  "iid": 91,
   "number": undefined,
+  "source_branch": "some-branch",
 }
 `;
 
@@ -284,6 +286,7 @@ Object {
   "isUnmergeable": true,
   "merge_status": "cannot_be_merged",
   "number": 12345,
+  "source_branch": "some-branch",
   "state": "merged",
 }
 `;

--- a/test/api/gitlab.spec.js
+++ b/test/api/gitlab.spec.js
@@ -263,10 +263,11 @@ describe('api/gitlab', () => {
       }));
       glGot.mockImplementationOnce(() => ({
         body: {
-          number: 91,
+          iid: 91,
           additions: 1,
           deletions: 1,
           commits: 1,
+          source_branch: 'some-branch',
           base: {
             sha: '1234',
           },
@@ -574,6 +575,7 @@ describe('api/gitlab', () => {
           description: 'a merge request',
           state: 'merged',
           merge_status: 'cannot_be_merged',
+          source_branch: 'some-branch',
         },
       });
       glGot.mockReturnValueOnce({


### PR DESCRIPTION
Forward slash is replaced with %2F. It is assumed that this is backwards compatible with api v3 too.

Closes #749