### PR TITLE
fix: detect custom registry from repo npmrc

### DIFF
--- a/lib/api/npm.js
+++ b/lib/api/npm.js
@@ -3,7 +3,7 @@
 const got = require('got');
 const url = require('url');
 const ini = require('ini');
-const registryUrl = require('registry-url');
+const getRegistryUrl = require('registry-auth-token/registry-url');
 const registryAuthToken = require('registry-auth-token');
 const parse = require('github-url-from-git');
 
@@ -27,7 +27,7 @@ async function setNpmrc(input) {
 async function getDependency(name, logger) {
   logger.debug(`getDependency(${name})`);
   const scope = name.split('/')[0];
-  const regUrl = registryUrl(scope, { npmrc });
+  const regUrl = getRegistryUrl(scope, npmrc);
   const pkgUrl = url.resolve(
     regUrl,
     encodeURIComponent(name).replace(/^%40/, '@')

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "moment": "2.18.1",
     "moment-timezone": "0.5.13",
     "registry-auth-token": "3.3.1",
-    "registry-url": "3.1.0",
     "root-require": "0.3.1",
     "semver": "5.4.1",
     "semver-stable": "2.0.4",

--- a/test/api/__snapshots__/npm.spec.js.snap
+++ b/test/api/__snapshots__/npm.spec.js.snap
@@ -1,5 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`api/npm should fetch package info from custom registry 1`] = `
+Object {
+  "dist-tags": Object {
+    "latest": "0.0.1",
+  },
+  "homepage": "https://google.com",
+  "name": undefined,
+  "renovate-config": undefined,
+  "repositoryUrl": "https://google.com",
+  "versions": Object {
+    "0.0.1": Object {
+      "time": "",
+    },
+  },
+}
+`;
+
+exports[`api/npm should fetch package info from custom registry 2`] = `
+Array [
+  "https://npm.mycustomregistry.com/foobar",
+  Object {
+    "headers": Object {
+      "authorization": "Bearer undefined",
+    },
+    "json": true,
+  },
+]
+`;
+
 exports[`api/npm should fetch package info from npm 1`] = `
 Object {
   "dist-tags": Object {
@@ -19,7 +48,7 @@ Object {
 
 exports[`api/npm should fetch package info from npm 2`] = `
 Array [
-  "https://npm.mycustomregistry.com/foobar",
+  "https://registry.npmjs.org/foobar",
   Object {
     "headers": Object {},
     "json": true,
@@ -46,7 +75,7 @@ Object {
 
 exports[`api/npm should send an authorization header if provided 2`] = `
 Array [
-  "https://npm.mycustomregistry.com/foobar",
+  "https://registry.npmjs.org/foobar",
   Object {
     "headers": Object {
       "authorization": "Basic 1234",
@@ -75,7 +104,7 @@ Object {
 
 exports[`api/npm should use NPM_TOKEN if provided 2`] = `
 Array [
-  "https://npm.mycustomregistry.com/foobar",
+  "https://registry.npmjs.org/foobar",
   Object {
     "headers": Object {
       "authorization": "Bearer some-token",
@@ -104,7 +133,7 @@ Object {
 
 exports[`api/npm should use homepage 2`] = `
 Array [
-  "https://npm.mycustomregistry.com/foobarhome",
+  "https://registry.npmjs.org/foobarhome",
   Object {
     "headers": Object {},
     "json": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -810,13 +810,11 @@ content-type-parser@^1.0.1:
   resolved "https://registry.yarnpkg.com/content-type-parser/-/content-type-parser-1.0.1.tgz#c3e56988c53c65127fb46d4032a3a900246fdc94"
 
 conventional-changelog-angular@^1.3.4:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-angular/-/conventional-changelog-angular-1.4.0.tgz#118b9f7d41a3d99500bfb6bea1f3525e055e8b9b"
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-angular/-/conventional-changelog-angular-1.5.0.tgz#50b2d45008448455fdf67e06ea01972fbd08182a"
   dependencies:
     compare-func "^1.3.1"
-    github-url-from-git "^1.4.0"
     q "^1.4.1"
-    read-pkg-up "^2.0.0"
 
 conventional-changelog-atom@^0.1.0:
   version "0.1.1"
@@ -831,16 +829,16 @@ conventional-changelog-codemirror@^0.1.0:
     q "^1.4.1"
 
 conventional-changelog-core@^1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-core/-/conventional-changelog-core-1.9.0.tgz#de5dfbc091847656508d4a389e35c9a1bc49e7f4"
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-core/-/conventional-changelog-core-1.9.1.tgz#ddf767c405850dfc8df31726c80fa1a6a10bdc7b"
   dependencies:
-    conventional-changelog-writer "^1.1.0"
-    conventional-commits-parser "^1.0.0"
+    conventional-changelog-writer "^2.0.1"
+    conventional-commits-parser "^2.0.0"
     dateformat "^1.0.12"
     get-pkg-repo "^1.0.0"
     git-raw-commits "^1.2.0"
     git-remote-origin-url "^2.0.0"
-    git-semver-tags "^1.2.0"
+    git-semver-tags "^1.2.1"
     lodash "^4.0.0"
     normalize-package-data "^2.3.5"
     q "^1.4.1"
@@ -849,8 +847,8 @@ conventional-changelog-core@^1.9.0:
     through2 "^2.0.0"
 
 conventional-changelog-ember@^0.2.6:
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-ember/-/conventional-changelog-ember-0.2.6.tgz#8b7355419f5127493c4c562473ab2fc792f1c2b6"
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-ember/-/conventional-changelog-ember-0.2.7.tgz#c6aff35976284e7222649f81c62bd96ff3217bd2"
   dependencies:
     q "^1.4.1"
 
@@ -885,9 +883,9 @@ conventional-changelog-jshint@^0.1.0:
     compare-func "^1.3.1"
     q "^1.4.1"
 
-conventional-changelog-writer@^1.1.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-writer/-/conventional-changelog-writer-1.4.1.tgz#3f4cb4d003ebb56989d30d345893b52a43639c8e"
+conventional-changelog-writer@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-writer/-/conventional-changelog-writer-2.0.1.tgz#47c10d0faba526b78d194389d1e931d09ee62372"
   dependencies:
     compare-func "^1.3.1"
     conventional-commits-filter "^1.0.0"
@@ -941,9 +939,9 @@ conventional-commits-filter@^1.0.0:
     is-subset "^0.1.1"
     modify-values "^1.0.0"
 
-conventional-commits-parser@^1.0.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/conventional-commits-parser/-/conventional-commits-parser-1.3.0.tgz#e327b53194e1a7ad5dc63479ee9099a52b024865"
+conventional-commits-parser@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/conventional-commits-parser/-/conventional-commits-parser-2.0.0.tgz#71d01910cb0a99aeb20c144e50f81f4df3178447"
   dependencies:
     JSONStream "^1.0.4"
     is-text-path "^1.0.0"
@@ -1677,7 +1675,7 @@ git-remote-origin-url@^2.0.0:
     gitconfiglocal "^1.0.0"
     pify "^2.3.0"
 
-git-semver-tags@^1.2.0:
+git-semver-tags@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/git-semver-tags/-/git-semver-tags-1.2.1.tgz#6ccd2a52e735b736748dc762444fcd9588e27490"
   dependencies:
@@ -3430,7 +3428,7 @@ randomatic@^1.1.3:
     is-number "^3.0.0"
     kind-of "^4.0.0"
 
-rc@^1.0.1, rc@^1.1.6, rc@^1.1.7:
+rc@^1.1.6, rc@^1.1.7:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.1.tgz#2e03e8e42ee450b8cb3dce65be1bf8974e1dfd95"
   dependencies:
@@ -3529,12 +3527,6 @@ registry-auth-token@3.3.1:
   dependencies:
     rc "^1.1.6"
     safe-buffer "^5.0.1"
-
-registry-url@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/registry-url/-/registry-url-3.1.0.tgz#3d4ef870f73dde1d77f0cf9a381432444e174942"
-  dependencies:
-    rc "^1.0.1"
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"


### PR DESCRIPTION
Replaced registry-url with registry-auth-token/registry-url, which contains npmrc logic.

Fixes #793