### PR TITLE
fix: remove black-cat header from github reviewers api

### DIFF
--- a/lib/api/github.js
+++ b/lib/api/github.js
@@ -445,9 +445,6 @@ async function addReviewers(issueNo, reviewers) {
   await ghGotRetry.post(
     `repos/${config.repoName}/pulls/${issueNo}/requested_reviewers`,
     {
-      headers: {
-        accept: 'application/vnd.github.black-cat-preview+json',
-      },
       body: {
         reviewers,
       },

--- a/test/api/__snapshots__/github.spec.js.snap
+++ b/test/api/__snapshots__/github.spec.js.snap
@@ -41,9 +41,6 @@ Array [
           "someotheruser",
         ],
       },
-      "headers": Object {
-        "accept": "application/vnd.github.black-cat-preview+json",
-      },
     },
   ],
 ]


### PR DESCRIPTION
Maybe closes #782