### PR TITLE
feat: massage package.json files before lock file generation

### DIFF
--- a/lib/workers/branch/lock-files.js
+++ b/lib/workers/branch/lock-files.js
@@ -100,9 +100,16 @@ async function writeExistingFiles(config) {
     );
     if (packageFile.packageFile.endsWith('package.json')) {
       logger.debug(`Writing package.json to ${basedir}`);
+      // Massage the file to eliminate yarn errors
+      const massagedFile = { ...packageFile.content };
+      if (!massagedFile.name.match(/^[0-9a-z-_]+$/)) {
+        massagedFile.name = 'dummy';
+      }
+      delete massagedFile.engines;
+      delete massagedFile.scripts;
       await fs.outputFile(
         path.join(basedir, 'package.json'),
-        JSON.stringify(packageFile.content)
+        JSON.stringify(massagedFile)
       );
     }
     if (packageFile.npmrc) {
@@ -131,9 +138,15 @@ async function writeUpdatedPackageFiles(config) {
   }
   for (const packageFile of config.updatedPackageFiles) {
     logger.debug(`Writing ${packageFile.name}`);
+    const massagedFile = JSON.parse(packageFile.contents);
+    if (!massagedFile.name.match(/^[0-9a-z-_]+$/)) {
+      massagedFile.name = 'dummy';
+    }
+    delete massagedFile.engines;
+    delete massagedFile.scripts;
     await fs.outputFile(
       path.join(config.tmpDir.name, packageFile.name),
-      packageFile.contents
+      JSON.stringify(massagedFile)
     );
   }
 }

--- a/test/workers/branch/__snapshots__/lock-files.spec.js.snap
+++ b/test/workers/branch/__snapshots__/lock-files.spec.js.snap
@@ -86,7 +86,7 @@ exports[`workers/branch/lock-files writeExistingFiles writes files and removes f
 Array [
   Array [
     "some-tmp-dir/package.json",
-    "{\\"name\\":\\"package 1\\"}",
+    "{\\"name\\":\\"dummy\\"}",
   ],
   Array [
     "some-tmp-dir/.npmrc",
@@ -94,7 +94,7 @@ Array [
   ],
   Array [
     "some-tmp-dir/backend/package.json",
-    "{\\"name\\":\\"package 2\\"}",
+    "{\\"name\\":\\"package-2\\"}",
   ],
   Array [
     "some-tmp-dir/backend/.yarnrc",
@@ -107,11 +107,11 @@ exports[`workers/branch/lock-files writeUpdatedPackageFiles writes updated packa
 Array [
   Array [
     "some-tmp-dir/package.json",
-    "raw contents",
+    "{\\"name\\":\\"dummy\\"}",
   ],
   Array [
     "some-tmp-dir/backend/package.json",
-    "more raw contents",
+    "{\\"name\\":\\"some-other-name\\"}",
   ],
 ]
 `;

--- a/test/workers/branch/lock-files.spec.js
+++ b/test/workers/branch/lock-files.spec.js
@@ -201,7 +201,7 @@ describe('workers/branch/lock-files', () => {
         },
         {
           packageFile: 'backend/package.json',
-          content: { name: 'package 2' },
+          content: { name: 'package-2', engines: { yarn: '^0.27.5' } },
           yarnrc: 'some yarnrc',
         },
       ];
@@ -230,16 +230,19 @@ describe('workers/branch/lock-files', () => {
       config.updatedPackageFiles = [
         {
           name: 'package.json',
-          contents: 'raw contents',
+          contents: '{ "name": "{{some-template}}" }',
         },
         {
           name: 'backend/package.json',
-          contents: 'more raw contents',
+          contents:
+            '{ "name": "some-other-name", "engines": { "node": "^6.0.0" }}',
         },
       ];
       await writeUpdatedPackageFiles(config);
       expect(fs.outputFile.mock.calls).toMatchSnapshot();
       expect(fs.outputFile.mock.calls).toHaveLength(2);
+      expect(fs.outputFile.mock.calls[0][1].includes('"dummy"')).toBe(true);
+      expect(fs.outputFile.mock.calls[1][1].includes('"engines"')).toBe(false);
     });
   });
   describe('getUpdatedLockFiles', () => {


### PR DESCRIPTION
- Any package names not matching valid pattern will be rewritten to “dummy”
- “engines” and “scripts” fields will be completely removed

Closes #801, Closes #784