### PR TITLE
fix: Detect npm & yarn when globally installed

### DIFF
--- a/lib/workers/branch/npm.js
+++ b/lib/workers/branch/npm.js
@@ -1,6 +1,7 @@
 const fs = require('fs-extra');
 const cp = require('child_process');
 const path = require('path');
+const getInstalledPath = require('get-installed-path');
 
 module.exports = {
   generateLockFile,
@@ -12,9 +13,49 @@ async function generateLockFile(tmpDir, logger) {
   let result = {};
   try {
     const startTime = process.hrtime();
-    const npmBin = path.resolve('./node_modules/.bin/npm');
-    const npmOptions = [npmBin, 'install', '--ignore-scripts'];
-    result = cp.spawnSync('node', npmOptions, {
+    let npmCmd = 'node';
+    const npmOptions = [];
+    try {
+      // See if renovate is installed locally
+      npmOptions.push(
+        path.join(
+          await getInstalledPath('npm', {
+            local: true,
+          }),
+          'bin/npm-cli.js'
+        )
+      );
+    } catch (localerr) {
+      logger.debug('No locally installed npm found');
+      // Look inside globally installed renovate
+      try {
+        const renovateLocation = await getInstalledPath('renovate');
+        npmOptions.push(
+          path.join(
+            await getInstalledPath('npm', {
+              local: true,
+              cwd: renovateLocation,
+            }),
+            'bin/npm-cli.js'
+          )
+        );
+      } catch (nestederr) {
+        logger.debug('Could not find globally nested npm');
+        // look for global npm
+        try {
+          npmOptions.push(
+            path.join(await getInstalledPath('npm'), 'bin/npm-cli.js')
+          );
+        } catch (globalerr) {
+          logger.warn('Could not find globally installed npm');
+          npmCmd = 'npm';
+        }
+      }
+    }
+    logger.debug(`Using npm: ${npmOptions[0] || npmCmd}`);
+    npmOptions.push('install');
+    npmOptions.push('--ignore-scripts');
+    result = cp.spawnSync(npmCmd, npmOptions, {
       cwd: tmpDir,
       shell: true,
       env: { NODE_ENV: 'dev', PATH: process.env.PATH },

--- a/lib/workers/branch/npm.js
+++ b/lib/workers/branch/npm.js
@@ -13,11 +13,11 @@ async function generateLockFile(tmpDir, logger) {
   let result = {};
   try {
     const startTime = process.hrtime();
-    let npmCmd = 'node';
-    const npmOptions = [];
+    let cmd = 'node';
+    const options = [];
     try {
       // See if renovate is installed locally
-      npmOptions.push(
+      options.push(
         path.join(
           await getInstalledPath('npm', {
             local: true,
@@ -30,7 +30,7 @@ async function generateLockFile(tmpDir, logger) {
       // Look inside globally installed renovate
       try {
         const renovateLocation = await getInstalledPath('renovate');
-        npmOptions.push(
+        options.push(
           path.join(
             await getInstalledPath('npm', {
               local: true,
@@ -43,19 +43,19 @@ async function generateLockFile(tmpDir, logger) {
         logger.debug('Could not find globally nested npm');
         // look for global npm
         try {
-          npmOptions.push(
+          options.push(
             path.join(await getInstalledPath('npm'), 'bin/npm-cli.js')
           );
         } catch (globalerr) {
           logger.warn('Could not find globally installed npm');
-          npmCmd = 'npm';
+          cmd = 'npm';
         }
       }
     }
-    logger.debug(`Using npm: ${npmOptions[0] || npmCmd}`);
-    npmOptions.push('install');
-    npmOptions.push('--ignore-scripts');
-    result = cp.spawnSync(npmCmd, npmOptions, {
+    logger.debug(`Using npm: ${options[0] || cmd}`);
+    options.push('install');
+    options.push('--ignore-scripts');
+    result = cp.spawnSync(cmd, options, {
       cwd: tmpDir,
       shell: true,
       env: { NODE_ENV: 'dev', PATH: process.env.PATH },

--- a/lib/workers/branch/yarn.js
+++ b/lib/workers/branch/yarn.js
@@ -13,11 +13,11 @@ async function generateLockFile(tmpDir, logger) {
   let result = {};
   try {
     const startTime = process.hrtime();
-    let yarnCmd = 'node';
-    const yarnOptions = [];
+    let cmd = 'node';
+    const options = [];
     try {
       // See if renovate is installed locally
-      yarnOptions.push(
+      options.push(
         path.join(
           await getInstalledPath('yarn', {
             local: true,
@@ -30,7 +30,7 @@ async function generateLockFile(tmpDir, logger) {
       // Look inside globally installed renovate
       try {
         const renovateLocation = await getInstalledPath('renovate');
-        yarnOptions.push(
+        options.push(
           path.join(
             await getInstalledPath('yarn', {
               local: true,
@@ -43,19 +43,19 @@ async function generateLockFile(tmpDir, logger) {
         logger.debug('Could not find globally nested yarn');
         // look for global yarn
         try {
-          yarnOptions.push(
+          options.push(
             path.join(await getInstalledPath('yarn'), 'bin/yarn.js')
           );
         } catch (globalerr) {
           logger.warn('Could not find globally installed yarn');
-          yarnCmd = 'npm';
+          cmd = 'yarn';
         }
       }
     }
-    logger.debug(`Using yarn: ${yarnOptions[0] || yarnCmd}`);
-    yarnOptions.push('install');
-    yarnOptions.push('--ignore-scripts');
-    result = cp.spawnSync(yarnCmd, yarnOptions, {
+    logger.debug(`Using yarn: ${options[0] || cmd}`);
+    options.push('install');
+    options.push('--ignore-scripts');
+    result = cp.spawnSync(cmd, options, {
       cwd: tmpDir,
       shell: true,
       env: { NODE_ENV: 'dev', PATH: process.env.PATH },

--- a/lib/workers/branch/yarn.js
+++ b/lib/workers/branch/yarn.js
@@ -1,22 +1,61 @@
 const fs = require('fs-extra');
 const cp = require('child_process');
 const path = require('path');
+const getInstalledPath = require('get-installed-path');
 
 module.exports = {
   generateLockFile,
 };
 
 async function generateLockFile(tmpDir, logger) {
-  logger.debug('Generating new yarn.lock file');
+  logger.debug(`Spawning yarn install to create ${tmpDir}/yarn.lock`);
   let lockFile = null;
   let result = {};
   try {
     const startTime = process.hrtime();
-    logger.debug(`Spawning yarn install to create ${tmpDir}/yarn.lock`);
-    // Use an embedded yarn
-    const yarnBin = path.resolve('./node_modules/.bin/yarn');
-    const yarnOptions = [yarnBin, 'install', '--ignore-scripts'];
-    result = cp.spawnSync('node', yarnOptions, {
+    let yarnCmd = 'node';
+    const yarnOptions = [];
+    try {
+      // See if renovate is installed locally
+      yarnOptions.push(
+        path.join(
+          await getInstalledPath('yarn', {
+            local: true,
+          }),
+          'bin/yarn.js'
+        )
+      );
+    } catch (localerr) {
+      logger.debug('No locally installed yarn found');
+      // Look inside globally installed renovate
+      try {
+        const renovateLocation = await getInstalledPath('renovate');
+        yarnOptions.push(
+          path.join(
+            await getInstalledPath('yarn', {
+              local: true,
+              cwd: renovateLocation,
+            }),
+            'bin/yarn.js'
+          )
+        );
+      } catch (nestederr) {
+        logger.debug('Could not find globally nested yarn');
+        // look for global yarn
+        try {
+          yarnOptions.push(
+            path.join(await getInstalledPath('yarn'), 'bin/yarn.js')
+          );
+        } catch (globalerr) {
+          logger.warn('Could not find globally installed yarn');
+          yarnCmd = 'npm';
+        }
+      }
+    }
+    logger.debug(`Using yarn: ${yarnOptions[0] || yarnCmd}`);
+    yarnOptions.push('install');
+    yarnOptions.push('--ignore-scripts');
+    result = cp.spawnSync(yarnCmd, yarnOptions, {
       cwd: tmpDir,
       shell: true,
       env: { NODE_ENV: 'dev', PATH: process.env.PATH },

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "commander": "2.11.0",
     "conventional-commits-detector": "0.1.1",
     "fs-extra": "4.0.2",
+    "get-installed-path": "3.0.1",
     "gh-got": "6.0.0",
     "github-url-from-git": "1.5.0",
     "gl-got": "7.0.0",

--- a/test/workers/branch/npm.spec.js
+++ b/test/workers/branch/npm.spec.js
@@ -6,6 +6,8 @@ jest.mock('fs-extra');
 jest.mock('child_process');
 jest.mock('get-installed-path');
 
+getInstalledPath.mockImplementation(() => null);
+
 const fs = require('fs-extra');
 const cp = require('child_process');
 

--- a/test/workers/branch/npm.spec.js
+++ b/test/workers/branch/npm.spec.js
@@ -1,8 +1,10 @@
 const npmHelper = require('../../../lib/workers/branch/npm');
 const logger = require('../../_fixtures/logger');
+const getInstalledPath = require('get-installed-path');
 
 jest.mock('fs-extra');
 jest.mock('child_process');
+jest.mock('get-installed-path');
 
 const fs = require('fs-extra');
 const cp = require('child_process');

--- a/test/workers/branch/yarn.spec.js
+++ b/test/workers/branch/yarn.spec.js
@@ -6,6 +6,8 @@ jest.mock('fs-extra');
 jest.mock('child_process');
 jest.mock('get-installed-path');
 
+getInstalledPath.mockImplementation(() => null);
+
 const fs = require('fs-extra');
 const cp = require('child_process');
 

--- a/test/workers/branch/yarn.spec.js
+++ b/test/workers/branch/yarn.spec.js
@@ -1,8 +1,10 @@
 const yarnHelper = require('../../../lib/workers/branch/yarn');
 const logger = require('../../_fixtures/logger');
+const getInstalledPath = require('get-installed-path');
 
 jest.mock('fs-extra');
 jest.mock('child_process');
+jest.mock('get-installed-path');
 
 const fs = require('fs-extra');
 const cp = require('child_process');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1171,7 +1171,7 @@ debug@^3.0.1:
   dependencies:
     ms "2.0.0"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
 
@@ -1595,6 +1595,12 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
+expand-tilde@^2.0.0, expand-tilde@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/expand-tilde/-/expand-tilde-2.0.2.tgz#97e801aa052df02454de46b02bf621642cdc8502"
+  dependencies:
+    homedir-polyfill "^1.0.1"
+
 extend@3, extend@~3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
@@ -1883,6 +1889,12 @@ get-func-name@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
 
+get-installed-path@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/get-installed-path/-/get-installed-path-3.0.1.tgz#aa9daf1f1f10c7dcce755e6bc52cfeaa02534060"
+  dependencies:
+    global-modules "1.0.0"
+
 get-pkg-repo@^1.0.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/get-pkg-repo/-/get-pkg-repo-1.4.0.tgz#c73b489c06d80cc5536c2c853f9e05232056972d"
@@ -2034,6 +2046,24 @@ glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@~7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+global-modules@1.0.0, global-modules@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-1.0.0.tgz#6d770f0eb523ac78164d72b5e71a8877265cc3ea"
+  dependencies:
+    global-prefix "^1.0.1"
+    is-windows "^1.0.1"
+    resolve-dir "^1.0.0"
+
+global-prefix@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-1.0.2.tgz#dbf743c6c14992593c655568cb66ed32c0122ebe"
+  dependencies:
+    expand-tilde "^2.0.2"
+    homedir-polyfill "^1.0.1"
+    ini "^1.3.4"
+    is-windows "^1.0.1"
+    which "^1.2.14"
+
 globals@^9.17.0, globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
@@ -2180,6 +2210,12 @@ home-or-tmp@^2.0.0:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.1"
 
+homedir-polyfill@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz#4c2bbc8a758998feebf5ed68580f76d46768b4bc"
+  dependencies:
+    parse-passwd "^1.0.0"
+
 hosted-git-info@^2.1.4, hosted-git-info@^2.1.5, hosted-git-info@^2.4.2, hosted-git-info@~2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
@@ -2256,7 +2292,7 @@ import-lazy@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
 
@@ -2519,6 +2555,10 @@ is-typedarray@~1.0.0:
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
+
+is-windows@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.1.tgz#310db70f742d259a16a369202b51af84233310d9"
 
 isarray@0.0.1:
   version "0.0.1"
@@ -3070,10 +3110,6 @@ lodash._basecopy@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz#8da0e6a876cf344c0ad8a54882111dd3c5c7ca36"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-
 lodash._basetostring@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz#d1861d877f824a52f669832dcaf3ee15566a07d5"
@@ -3089,13 +3125,9 @@ lodash._basevalues@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz#5b775762802bde3d3297503e26300820fdf661b7"
 
-lodash._bindcallback@*, lodash._bindcallback@^3.0.0:
+lodash._bindcallback@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
 
 lodash._createassigner@^3.0.0:
   version "3.1.1"
@@ -3105,17 +3137,11 @@ lodash._createassigner@^3.0.0:
     lodash._isiterateecall "^3.0.0"
     lodash.restparam "^3.0.0"
 
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
 
-lodash._getnative@*, lodash._getnative@^3.0.0:
+lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
 
@@ -3209,7 +3235,7 @@ lodash.padstart@^4.1.0:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.padstart/-/lodash.padstart-4.6.1.tgz#d2e3eebff0d9d39ad50f5cbd1b52a7bce6bb611b"
 
-lodash.restparam@*, lodash.restparam@^3.0.0:
+lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
 
@@ -4045,6 +4071,10 @@ parse-json@^2.2.0:
   dependencies:
     error-ex "^1.2.0"
 
+parse-passwd@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
+
 parse5@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
@@ -4371,7 +4401,7 @@ readable-stream@~2.0.5:
     string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
 
-readdir-scoped-modules@*, readdir-scoped-modules@^1.0.0:
+readdir-scoped-modules@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz#9fafa37d286be5d92cbaebdee030dc9b5f406747"
   dependencies:
@@ -4552,6 +4582,13 @@ require-uncached@^1.0.3:
   dependencies:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
+
+resolve-dir@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-1.0.1.tgz#79a40644c362be82f26effe739c9bb5382046f43"
+  dependencies:
+    expand-tilde "^2.0.0"
+    global-modules "^1.0.0"
 
 resolve-from@^1.0.0:
   version "1.0.1"
@@ -5330,7 +5367,7 @@ v8flags@^2.1.1:
   dependencies:
     user-home "^1.1.1"
 
-validate-npm-package-license@*, validate-npm-package-license@^3.0.1:
+validate-npm-package-license@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz#2804babe712ad3379459acfbe24746ab2c303fbc"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1889,7 +1889,7 @@ get-func-name@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
 
-get-installed-path@^3.0.1:
+get-installed-path@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/get-installed-path/-/get-installed-path-3.0.1.tgz#aa9daf1f1f10c7dcce755e6bc52cfeaa02534060"
   dependencies:


### PR DESCRIPTION
This fix improves the way Renovate detects embedded/installed npm and yarn. It tries:
- locally installed npm or yarn
- npm or yarn embedded inside globally installed renovate
- globally installed npm or yarn
- global `yarn` or `npm` commands as fallback

Fixes #824 