### PR TITLE
feat: ignoreNpmrcFile

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,6 +83,7 @@ $ node renovate --help
     --token <string>                     Repository Auth Token
     --npmrc <string>                     String copy of npmrc file. Use \n instead of line breaks
     --yarnrc <string>                    String copy of yarnrc file. Use \n instead of line breaks
+    --ignore-npmrc-file [boolean]        Whether to ignore any .npmrc file found in repository
     --autodiscover [boolean]             Autodiscover all repositories
     --autodiscover [boolean]             Autodiscover all repositories
     --github-app-id <integer>            GitHub App ID (enables GitHub App functionality if set)
@@ -287,6 +288,14 @@ Obviously, you can't set repository or package file location with this method.
   <td><pre>null</pre></td>
   <td>`RENOVATE_YARNRC`</td>
   <td>`--yarnrc`<td>
+</tr>
+<tr>
+  <td>`ignoreNpmrcFile`</td>
+  <td>Whether to ignore any .npmrc file found in repository</td>
+  <td>boolean</td>
+  <td><pre>false</pre></td>
+  <td>`RENOVATE_IGNORE_NPMRC_FILE`</td>
+  <td>`--ignore-npmrc-file`<td>
 </tr>
 <tr>
   <td>`autodiscover`</td>

--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -140,6 +140,13 @@ const options = [
     type: 'string',
   },
   {
+    name: 'ignoreNpmrcFile',
+    description: 'Whether to ignore any .npmrc file found in repository',
+    stage: 'packageFile',
+    type: 'boolean',
+    default: false,
+  },
+  {
     name: 'autodiscover',
     description: 'Autodiscover all repositories',
     stage: 'repository',

--- a/lib/workers/repository/apis.js
+++ b/lib/workers/repository/apis.js
@@ -83,6 +83,9 @@ async function checkMonorepos(input) {
 
 // Check for .npmrc in repository and pass it to npm api if found
 async function getNpmrc(config) {
+  if (config.ignoreNpmrcFile) {
+    return config;
+  }
   const { logger } = config;
   let npmrc;
   try {
@@ -300,10 +303,12 @@ async function resolvePackageFiles(inputConfig) {
         packageFile.packageFile,
         config.baseBranch
       );
-      packageFile.npmrc = await config.api.getFileContent(
-        path.join(path.dirname(packageFile.packageFile), '.npmrc'),
-        config.baseBranch
-      );
+      if (!inputConfig.ignoreNpmrcFile) {
+        packageFile.npmrc = await config.api.getFileContent(
+          path.join(path.dirname(packageFile.packageFile), '.npmrc'),
+          config.baseBranch
+        );
+      }
       if (!packageFile.npmrc) {
         delete packageFile.npmrc;
       }

--- a/test/workers/repository/apis.spec.js
+++ b/test/workers/repository/apis.spec.js
@@ -15,6 +15,13 @@ jest.mock('../../../lib/api/npm');
 
 describe('workers/repository/apis', () => {
   describe('getNpmrc', () => {
+    it('Skips if ignoring npmrc', async () => {
+      const config = {
+        foo: 1,
+        ignoreNpmrcFile: true,
+      };
+      expect(await apis.getNpmrc(config)).toMatchObject(config);
+    });
     it('Skips if npmrc not found', async () => {
       const config = {
         api: {


### PR DESCRIPTION
This feature adds support for ignoring .npmrc files in a repository. Set config option to true if you wish to enable ignoring.

Closes #851