### PR TITLE
fix: escape filename %2F (GitLab)

### DIFF
--- a/lib/api/gitlab.js
+++ b/lib/api/gitlab.js
@@ -438,8 +438,10 @@ async function getFile(filePath, branchName) {
     url = `projects/${config.repoName}/repository/files?file_path=${filePath}&ref=${branchName ||
       config.baseBranch}`;
   } else {
-    url = `projects/${config.repoName}/repository/files/${filePath}?ref=${branchName ||
-      config.baseBranch}`;
+    url = `projects/${config.repoName}/repository/files/${filePath.replace(
+      /\//g,
+      '%2F'
+    )}?ref=${branchName || config.baseBranch}`;
   }
   const res = await glGot(url);
   return res.body.content;

--- a/test/api/gitlab.spec.js
+++ b/test/api/gitlab.spec.js
@@ -608,9 +608,9 @@ describe('api/gitlab', () => {
           content: 'foo',
         },
       });
-      const res = await gitlab.getFile('some-path');
+      const res = await gitlab.getFile('some/path');
       expect(res).toMatchSnapshot();
-      expect(glGot.mock.calls[0][0].indexOf('file_path')).toBe(-1);
+      expect(glGot.mock.calls[0][0].indexOf('some%2Fpath')).not.toBe(-1);
     });
     it('gets the file with v3', async () => {
       glGot.mockReturnValueOnce({


### PR DESCRIPTION
Fixes #849