### PR TITLE
refactor: use prettier instead of eslint-plugin-prettier

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,13 +9,11 @@ module.exports = {
     'plugins': [
       'import',
       'promise',
-      'prettier',
     ],
     'rules': {
       'no-use-before-define': 0,
       'no-restricted-syntax': 0,
       'no-await-in-loop': 0,
-      'prettier/prettier': ['error', { 'trailingComma': 'es5', 'singleQuote': true }],
       'promise/always-return': 'error',
       'promise/no-return-wrap': 'error',
       'promise/param-names': 'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,27 +1,21 @@
 module.exports = {
-    'env': {
-      'node': true,
-    },
-    'extends': [
-      'airbnb-base',
-      'prettier',
-    ],
-    'plugins': [
-      'import',
-      'promise',
-    ],
-    'rules': {
-      'no-use-before-define': 0,
-      'no-restricted-syntax': 0,
-      'no-await-in-loop': 0,
-      'promise/always-return': 'error',
-      'promise/no-return-wrap': 'error',
-      'promise/param-names': 'error',
-      'promise/catch-or-return': 'error',
-      'promise/no-native': 'off',
-      'promise/no-nesting': 'warn',
-      'promise/no-promise-in-callback': 'warn',
-      'promise/no-callback-in-promise': 'warn',
-      'promise/avoid-new': 'warn'
-    }
+  env: {
+    node: true,
+  },
+  extends: ['airbnb-base', 'prettier'],
+  plugins: ['import', 'promise'],
+  rules: {
+    'no-use-before-define': 0,
+    'no-restricted-syntax': 0,
+    'no-await-in-loop': 0,
+    'promise/always-return': 'error',
+    'promise/no-return-wrap': 'error',
+    'promise/param-names': 'error',
+    'promise/catch-or-return': 'error',
+    'promise/no-native': 'off',
+    'promise/no-nesting': 'warn',
+    'promise/no-promise-in-callback': 'warn',
+    'promise/no-callback-in-promise': 'warn',
+    'promise/avoid-new': 'warn',
+  },
 };

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,9 @@
+/node_modules
+/config.js
+/coverage
+/dist
+/tmp
+.DS_Store
+.cache
+/*.log
+test/_fixtures/

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,4 +6,5 @@
 .DS_Store
 .cache
 /*.log
+package.json
 test/_fixtures/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,5 @@
+# It would be nice to remove this file and use .gitignore instead however we need to add package.json and _fixtures
+
 /node_modules
 /config.js
 /coverage

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "version": "0.0.0-semantic-release",
   "bin": "dist/renovate.js",
   "scripts": {
-    "build":
-      "yarn && npm run transpile && cp -R lib/config/templates dist/config",
+    "build": "yarn && npm run transpile && cp -R lib/config/templates dist/config",
     "heroku-push": "git push heroku master",
     "heroku-scheduler": "heroku addons:open scheduler",
     "jest": "NODE_ENV=test LOG_LEVEL=fatal jest",
@@ -17,18 +16,20 @@
     "start-babel": "babel-node lib/renovate",
     "start-raw": "node lib/renovate",
     "test-dirty": "git diff --exit-code",
-    "test":
-      "npm run prettier -- --list-different && npm run lint && npm run jest",
+    "test": "npm run prettier -- --list-different && npm run lint && npm run jest",
     "transpile": "rimraf dist && mkdirp dist && babel lib --out-dir dist",
     "update-docs": "npm run build && bash bin/update-docs.sh",
-    "semantic-release":
-      "semantic-release pre && npm publish && semantic-release post"
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/singapore/renovate.git"
   },
-  "keywords": ["npm", "outdated", "update"],
+  "keywords": [
+    "npm",
+    "outdated",
+    "update"
+  ],
   "author": "Rhys Arkins <rhys@arkins.net>",
   "license": "MIT",
   "bugs": {
@@ -94,14 +95,23 @@
     "semantic-release": "7.0.2"
   },
   "babel": {
-    "plugins": ["transform-async-to-generator", "transform-object-rest-spread"]
+    "plugins": [
+      "transform-async-to-generator",
+      "transform-object-rest-spread"
+    ]
   },
   "jest": {
     "cacheDirectory": ".cache/jest",
     "coverageDirectory": "./coverage",
     "collectCoverage": true,
-    "collectCoverageFrom": ["lib/**/*.js"],
-    "coverageReporters": ["json", "lcov", "text-summary"],
+    "collectCoverageFrom": [
+      "lib/**/*.js"
+    ],
+    "coverageReporters": [
+      "json",
+      "lcov",
+      "text-summary"
+    ],
     "setupTestFrameworkScriptFile": "./test/chai.js"
   },
   "prettier": {
@@ -116,8 +126,12 @@
       "group:monorepos",
       ":automergeLinters"
     ],
-    "labels": ["ready"],
-    "assignees": ["rarkins"]
+    "labels": [
+      "ready"
+    ],
+    "assignees": [
+      "rarkins"
+    ]
   },
   "release": {
     "verifyConditions": "condition-circle"

--- a/package.json
+++ b/package.json
@@ -4,31 +4,31 @@
   "version": "0.0.0-semantic-release",
   "bin": "dist/renovate.js",
   "scripts": {
-    "build": "yarn && npm run transpile && cp -R lib/config/templates dist/config",
+    "build":
+      "yarn && npm run transpile && cp -R lib/config/templates dist/config",
     "heroku-push": "git push heroku master",
     "heroku-scheduler": "heroku addons:open scheduler",
     "jest": "NODE_ENV=test LOG_LEVEL=fatal jest",
     "lint-fix": "eslint --fix lib test",
     "lint": "eslint lib test",
     "prepublishOnly": "npm run build",
+    "prettier": "prettier '**/*.{js,json}' --write",
     "start": "node dist/renovate",
     "start-babel": "babel-node lib/renovate",
     "start-raw": "node lib/renovate",
     "test-dirty": "git diff --exit-code",
-    "test": "npm run lint && npm run jest",
+    "test":
+      "npm run prettier -- --list-different && npm run lint && npm run jest",
     "transpile": "rimraf dist && mkdirp dist && babel lib --out-dir dist",
     "update-docs": "npm run build && bash bin/update-docs.sh",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "semantic-release":
+      "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/singapore/renovate.git"
   },
-  "keywords": [
-    "npm",
-    "outdated",
-    "update"
-  ],
+  "keywords": ["npm", "outdated", "update"],
   "author": "Rhys Arkins <rhys@arkins.net>",
   "license": "MIT",
   "bugs": {
@@ -94,24 +94,19 @@
     "semantic-release": "7.0.2"
   },
   "babel": {
-    "plugins": [
-      "transform-async-to-generator",
-      "transform-object-rest-spread"
-    ]
+    "plugins": ["transform-async-to-generator", "transform-object-rest-spread"]
   },
   "jest": {
     "cacheDirectory": ".cache/jest",
     "coverageDirectory": "./coverage",
     "collectCoverage": true,
-    "collectCoverageFrom": [
-      "lib/**/*.js"
-    ],
-    "coverageReporters": [
-      "json",
-      "lcov",
-      "text-summary"
-    ],
+    "collectCoverageFrom": ["lib/**/*.js"],
+    "coverageReporters": ["json", "lcov", "text-summary"],
     "setupTestFrameworkScriptFile": "./test/chai.js"
+  },
+  "prettier": {
+    "singleQuote": true,
+    "trailingComma": "es5"
   },
   "renovate": {
     "extends": [
@@ -121,12 +116,8 @@
       "group:monorepos",
       ":automergeLinters"
     ],
-    "labels": [
-      "ready"
-    ],
-    "assignees": [
-      "rarkins"
-    ]
+    "labels": ["ready"],
+    "assignees": ["rarkins"]
   },
   "release": {
     "verifyConditions": "condition-circle"

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "eslint-config-airbnb-base": "12.0.1",
     "eslint-config-prettier": "2.6.0",
     "eslint-plugin-import": "2.7.0",
-    "eslint-plugin-prettier": "2.3.1",
     "eslint-plugin-promise": "3.5.0",
     "jest": "20.0.4",
     "mkdirp": "0.5.1",

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -1,10 +1,10 @@
 module.exports = {
   env: {
-    jest: true
+    jest: true,
   },
   rules: {
-    "prefer-promise-reject-errors": 0,
-    "import/no-extraneous-dependencies": 0,
-    "global-require": 0
-  }
+    'prefer-promise-reject-errors': 0,
+    'import/no-extraneous-dependencies': 0,
+    'global-require': 0,
+  },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1216,7 +1216,7 @@ debug@^3.0.1:
   dependencies:
     ms "2.0.0"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
 
@@ -1461,13 +1461,6 @@ eslint-plugin-import@2.7.0:
     minimatch "^3.0.3"
     read-pkg-up "^2.0.0"
 
-eslint-plugin-prettier@2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.3.1.tgz#e7a746c67e716f335274b88295a9ead9f544e44d"
-  dependencies:
-    fast-diff "^1.1.1"
-    jest-docblock "^21.0.0"
-
 eslint-plugin-promise@3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-3.5.0.tgz#78fbb6ffe047201627569e85a6c5373af2a68fca"
@@ -1638,10 +1631,6 @@ extsprintf@1.3.0, extsprintf@^1.2.0:
 fast-deep-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
-
-fast-diff@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.1.2.tgz#4b62c42b8e03de3f848460b639079920695d0154"
 
 fast-levenshtein@~2.0.4:
   version "2.0.6"
@@ -2334,7 +2323,7 @@ import-lazy@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
 
@@ -2739,10 +2728,6 @@ jest-docblock@^20.0.3:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-20.0.3.tgz#17bea984342cc33d83c50fbe1545ea0efaa44712"
 
-jest-docblock@^21.0.0:
-  version "21.2.0"
-  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-21.2.0.tgz#51529c3b30d5fd159da60c27ceedc195faf8d414"
-
 jest-environment-jsdom@^20.0.3:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-20.0.3.tgz#048a8ac12ee225f7190417713834bb999787de99"
@@ -3130,10 +3115,6 @@ lodash._basecopy@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz#8da0e6a876cf344c0ad8a54882111dd3c5c7ca36"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-
 lodash._basetostring@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz#d1861d877f824a52f669832dcaf3ee15566a07d5"
@@ -3149,13 +3130,9 @@ lodash._basevalues@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz#5b775762802bde3d3297503e26300820fdf661b7"
 
-lodash._bindcallback@*, lodash._bindcallback@^3.0.0:
+lodash._bindcallback@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
 
 lodash._createassigner@^3.0.0:
   version "3.1.1"
@@ -3165,17 +3142,11 @@ lodash._createassigner@^3.0.0:
     lodash._isiterateecall "^3.0.0"
     lodash.restparam "^3.0.0"
 
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
 
-lodash._getnative@*, lodash._getnative@^3.0.0:
+lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
 
@@ -3269,7 +3240,7 @@ lodash.padstart@^4.1.0:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.padstart/-/lodash.padstart-4.6.1.tgz#d2e3eebff0d9d39ad50f5cbd1b52a7bce6bb611b"
 
-lodash.restparam@*, lodash.restparam@^3.0.0:
+lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
 
@@ -4443,7 +4414,7 @@ readable-stream@~2.0.5:
     string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
 
-readdir-scoped-modules@*, readdir-scoped-modules@^1.0.0:
+readdir-scoped-modules@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz#9fafa37d286be5d92cbaebdee030dc9b5f406747"
   dependencies:
@@ -5406,7 +5377,7 @@ v8flags@^2.1.1:
   dependencies:
     user-home "^1.1.1"
 
-validate-npm-package-license@*, validate-npm-package-license@^3.0.1:
+validate-npm-package-license@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz#2804babe712ad3379459acfbe24746ab2c303fbc"
   dependencies:


### PR DESCRIPTION
Having eslint flag prettier "errors" in editors can be rather painful. Also chose against linting staged files for prettier because I like to stage partials. Instead:
- Recommended to use plugins for editors to format on save, e.g. `prettier-atom`
- Prettier will be run as part of `npm test`