### PR TITLE
feat: sanitize branch names

### DIFF
--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -374,7 +374,7 @@ const options = [
     type: 'json',
     default: {
       branchName:
-        '{{branchPrefix}}{{depName}}-{{newVersionMajor}}.{{newVersionMinor}}.x',
+        '{{branchPrefix}}{{depNameSanitized}}-{{newVersionMajor}}.{{newVersionMinor}}.x',
     },
     cli: false,
     mergeable: true,

--- a/lib/config/templates/default/branch-name.hbs
+++ b/lib/config/templates/default/branch-name.hbs
@@ -1,1 +1,1 @@
-{{branchPrefix}}{{depName}}-{{newVersionMajor}}.x
+{{branchPrefix}}{{depNameSanitized}}-{{newVersionMajor}}.x

--- a/lib/config/templates/docker/branch-name.hbs
+++ b/lib/config/templates/docker/branch-name.hbs
@@ -1,1 +1,1 @@
-{{branchPrefix}}docker-{{depName}}-{{currentTag}}
+{{branchPrefix}}docker-{{depNameSanitized}}-{{currentTag}}

--- a/lib/workers/package/versions.js
+++ b/lib/workers/package/versions.js
@@ -50,7 +50,8 @@ function determineUpgrades(npmDep, config) {
       newVersion: rollbackVersion,
       newVersionMajor: semver.major(rollbackVersion),
       semanticPrefix: 'fix(deps):',
-      branchName: '{{branchPrefix}}rollback-{{depName}}-{{newVersionMajor}}.x',
+      branchName:
+        '{{branchPrefix}}rollback-{{depNameSanitized}}-{{newVersionMajor}}.x',
     };
   }
   _(versionList)

--- a/lib/workers/repository/upgrades.js
+++ b/lib/workers/repository/upgrades.js
@@ -123,6 +123,10 @@ function groupByBranch(upgrades) {
         branchName = handlebars.compile(upgrade.group.branchName)(upgrade);
       } else {
         // Use regular branchName template
+        upgrade.depNameSanitized = upgrade.depName
+          .replace('@', '')
+          .replace('/', '-')
+          .toLowerCase();
         branchName = handlebars.compile(upgrade.branchName)(upgrade);
       }
       result.branchUpgrades[branchName] =

--- a/test/workers/package/__snapshots__/index.spec.js.snap
+++ b/test/workers/package/__snapshots__/index.spec.js.snap
@@ -5,7 +5,7 @@ Object {
   "assignees": Array [],
   "automerge": true,
   "automergeType": "pr",
-  "branchName": "{{branchPrefix}}{{depName}}-{{newVersionMajor}}.x",
+  "branchName": "{{branchPrefix}}{{depNameSanitized}}-{{newVersionMajor}}.x",
   "branchPrefix": "renovate/",
   "commitMessage": "Update dependency {{depName}} to v{{newVersion}}",
   "currentVersion": "1.0.0",

--- a/test/workers/package/__snapshots__/versions.spec.js.snap
+++ b/test/workers/package/__snapshots__/versions.spec.js.snap
@@ -304,7 +304,7 @@ Array [
 
 exports[`workers/package/versions .determineUpgrades(npmDep, config) should downgrade from missing versions 1`] = `
 Object {
-  "branchName": "{{branchPrefix}}rollback-{{depName}}-{{newVersionMajor}}.x",
+  "branchName": "{{branchPrefix}}rollback-{{depNameSanitized}}-{{newVersionMajor}}.x",
   "isRollback": true,
   "newVersion": "1.16.0",
   "newVersionMajor": 1,

--- a/test/workers/repository/__snapshots__/upgrades.spec.js.snap
+++ b/test/workers/repository/__snapshots__/upgrades.spec.js.snap
@@ -72,6 +72,8 @@ Object {
     "bar-1.1.0": Array [
       Object {
         "branchName": "bar-{{version}}",
+        "depName": "bar",
+        "depNameSanitized": "bar",
         "prTitle": "some-title",
         "version": "1.1.0",
       },
@@ -79,6 +81,8 @@ Object {
     "foo-1.1.0": Array [
       Object {
         "branchName": "foo-{{version}}",
+        "depName": "foo",
+        "depNameSanitized": "foo",
         "prTitle": "some-title",
         "version": "1.1.0",
       },
@@ -86,6 +90,8 @@ Object {
     "foo-2.0.0": Array [
       Object {
         "branchName": "foo-{{version}}",
+        "depName": "foo",
+        "depNameSanitized": "foo",
         "prTitle": "some-title",
         "version": "2.0.0",
       },
@@ -102,6 +108,8 @@ Object {
     "bar-1.1.0": Array [
       Object {
         "branchName": "bar-{{version}}",
+        "depName": "bar",
+        "depNameSanitized": "bar",
         "prTitle": "some-title",
         "version": "1.1.0",
       },
@@ -109,11 +117,15 @@ Object {
     "foo": Array [
       Object {
         "branchName": "foo",
+        "depName": "foo",
+        "depNameSanitized": "foo",
         "prTitle": "some-title",
         "version": "2.0.0",
       },
       Object {
         "branchName": "foo",
+        "depName": "foo",
+        "depNameSanitized": "foo",
         "prTitle": "some-title",
         "version": "1.1.0",
       },
@@ -130,6 +142,8 @@ Object {
     "foo": Array [
       Object {
         "branchName": "foo",
+        "depName": "foo",
+        "depNameSanitized": "foo",
         "prTitle": "some-title",
         "version": "2.0.0",
       },
@@ -137,6 +151,7 @@ Object {
     "renovate/my-group": Array [
       Object {
         "branchName": "bar-{{version}}",
+        "depName": "bar",
         "group": Object {
           "branchName": "renovate/my-group",
         },
@@ -147,6 +162,7 @@ Object {
       },
       Object {
         "branchName": "foo",
+        "depName": "foo",
         "group": Object {
           "branchName": "renovate/{{groupSlug}}",
         },
@@ -168,6 +184,8 @@ Object {
     "bar-1.1.0": Array [
       Object {
         "branchName": "bar-{{version}}",
+        "depName": "bar",
+        "depNameSanitized": "bar",
         "prTitle": "some-title",
         "version": "1.1.0",
       },
@@ -175,6 +193,8 @@ Object {
     "foo-1.1.0": Array [
       Object {
         "branchName": "foo-{{version}}",
+        "depName": "foo",
+        "depNameSanitized": "foo",
         "prTitle": "some-title",
         "version": "1.1.0",
       },
@@ -188,6 +208,7 @@ Object {
   "warnings": Array [
     Object {
       "branchName": "foo-{{version}}",
+      "depName": "foo",
       "prTitle": "some-title",
       "type": "warning",
       "version": "2.0.0",
@@ -210,6 +231,8 @@ Object {
     "foo-1.1.0": Array [
       Object {
         "branchName": "foo-{{version}}",
+        "depName": "foo",
+        "depNameSanitized": "foo",
         "prTitle": "some-title",
         "version": "1.1.0",
       },

--- a/test/workers/repository/upgrades.spec.js
+++ b/test/workers/repository/upgrades.spec.js
@@ -125,6 +125,7 @@ describe('workers/repository/upgrades', () => {
     it('returns one branch if one input', async () => {
       const input = [
         {
+          depName: 'foo',
           branchName: 'foo-{{version}}',
           version: '1.1.0',
           prTitle: 'some-title',
@@ -137,16 +138,19 @@ describe('workers/repository/upgrades', () => {
     it('does not group if different compiled branch names', async () => {
       const input = [
         {
+          depName: 'foo',
           branchName: 'foo-{{version}}',
           version: '1.1.0',
           prTitle: 'some-title',
         },
         {
+          depName: 'foo',
           branchName: 'foo-{{version}}',
           version: '2.0.0',
           prTitle: 'some-title',
         },
         {
+          depName: 'bar',
           branchName: 'bar-{{version}}',
           version: '1.1.0',
           prTitle: 'some-title',
@@ -159,16 +163,19 @@ describe('workers/repository/upgrades', () => {
     it('groups if same compiled branch names', async () => {
       const input = [
         {
+          depName: 'foo',
           branchName: 'foo',
           version: '1.1.0',
           prTitle: 'some-title',
         },
         {
+          depName: 'foo',
           branchName: 'foo',
           version: '2.0.0',
           prTitle: 'some-title',
         },
         {
+          depName: 'bar',
           branchName: 'bar-{{version}}',
           version: '1.1.0',
           prTitle: 'some-title',
@@ -181,6 +188,7 @@ describe('workers/repository/upgrades', () => {
     it('groups if same compiled group name', async () => {
       const input = [
         {
+          depName: 'foo',
           branchName: 'foo',
           prTitle: 'some-title',
           version: '1.1.0',
@@ -188,11 +196,13 @@ describe('workers/repository/upgrades', () => {
           group: { branchName: 'renovate/{{groupSlug}}' },
         },
         {
+          depName: 'foo',
           branchName: 'foo',
           prTitle: 'some-title',
           version: '2.0.0',
         },
         {
+          depName: 'bar',
           branchName: 'bar-{{version}}',
           prTitle: 'some-title',
           version: '1.1.0',
@@ -210,17 +220,20 @@ describe('workers/repository/upgrades', () => {
           type: 'error',
         },
         {
+          depName: 'foo',
           branchName: 'foo-{{version}}',
           prTitle: 'some-title',
           version: '1.1.0',
         },
         {
+          depName: 'foo',
           type: 'warning',
           branchName: 'foo-{{version}}',
           prTitle: 'some-title',
           version: '2.0.0',
         },
         {
+          depName: 'bar',
           branchName: 'bar-{{version}}',
           prTitle: 'some-title',
           version: '1.1.0',


### PR DESCRIPTION
Previously, you might see branch names like `renovate/@types/jquery-3.x`. Now, such branches will instead be like `renovate/types-jquery-3.x`.