### PR TITLE
fix: don’t group lockFileMaintenance update

### DIFF
--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -507,6 +507,7 @@ const options = [
       prTitle: template('prTitle', 'lock-file-maintenance'),
       prBody: template('prBody', 'lock-file-maintenance'),
       schedule: ['before 5am on monday'],
+      groupName: null,
     },
     cli: false,
     mergeable: true,

--- a/test/config/__snapshots__/index.spec.js.snap
+++ b/test/config/__snapshots__/index.spec.js.snap
@@ -5,6 +5,7 @@ Object {
   "branchName": "{{branchPrefix}}lock-file-maintenance",
   "commitMessage": "Update lock file",
   "enabled": true,
+  "groupName": null,
   "prBody": "This {{#if isGitHub}}Pull{{else}}Merge{{/if}} Request updates \`package.json\` lock files to use the latest dependency versions.
 
 {{#if schedule}}


### PR DESCRIPTION
Setting lockFileMaintenance.groupName =  null will prevent the case where the user configures a repository groupName like “all” and then that group inherits the schedule of lock file maintenance. Instead, there will be renovate/all and renovate/lock-file-maintenance.

Fixes #885