### PR TITLE
feat: set github app preview header when in app mode

### DIFF
--- a/lib/api/gh-got-retry.js
+++ b/lib/api/gh-got-retry.js
@@ -9,6 +9,18 @@ function sleep(ms) {
 
 async function ghGotRetry(path, opts, retries = 5) {
   try {
+    if (appMode) {
+      // eslint-disable-next-line no-param-reassign
+      opts = opts || {};
+      // eslint-disable-next-line no-param-reassign
+      opts.headers = Object.assign(
+        {
+          accept: 'application/vnd.github.machine-man-preview+json',
+          'user-agent': 'https://github.com/singapore/renovate',
+        },
+        opts.headers
+      );
+    }
     const res = await ghGot(path, opts);
     return res;
   } catch (err) {
@@ -77,5 +89,10 @@ for (const x of helpers) {
     }
   };
 }
+
+let appMode = false;
+ghGotRetry.setAppMode = function setAppMode(val) {
+  appMode = val;
+};
 
 module.exports = ghGotRetry;

--- a/test/api/__snapshots__/github.spec.js.snap
+++ b/test/api/__snapshots__/github.spec.js.snap
@@ -1063,6 +1063,7 @@ Array [
       "headers": Object {
         "accept": "application/vnd.github.machine-man-preview+json",
         "authorization": "Bearer sometoken",
+        "user-agent": "https://github.com/singapore/renovate",
       },
     },
   ],

--- a/test/api/github.spec.js
+++ b/test/api/github.spec.js
@@ -3,6 +3,7 @@ const logger = require('../_fixtures/logger');
 describe('api/github', () => {
   let github;
   let ghGot;
+  let ghGotRetry;
   beforeEach(() => {
     // clean up env
     delete process.env.GITHUB_TOKEN;
@@ -11,6 +12,7 @@ describe('api/github', () => {
     // reset module
     jest.resetModules();
     jest.mock('gh-got');
+    ghGotRetry = require('../../lib/api/gh-got-retry');
     github = require('../../lib/api/github');
     ghGot = require('gh-got');
   });
@@ -20,6 +22,7 @@ describe('api/github', () => {
       ghGot.mockImplementationOnce(() => ({
         body: ['a', 'b'],
       }));
+      ghGotRetry.setAppMode(true);
       const installations = await github.getInstallations('sometoken');
       expect(ghGot.mock.calls).toMatchSnapshot();
       expect(installations).toMatchSnapshot();


### PR DESCRIPTION
From https://developer.github.com/v3/apps/available-endpoints/:
> In order to access the API with your GitHub App, you must provide a custom media type in the `Accept` Header for your requests.
```
application/vnd.github.machine-man-preview+json
```