### PR TITLE
feat: workaround gitlab hyperlinking bug

### DIFF
--- a/lib/api/gitlab.js
+++ b/lib/api/gitlab.js
@@ -372,6 +372,7 @@ async function createPr(branchName, title, body, useDefaultBranch) {
     : config.baseBranch;
   logger.debug(`Creating Merge Request: ${title}`);
   const description = body
+    .replace('</h4>', ' </h4>') // See #954
     .replace(/Pull Request/g, 'Merge Request')
     .replace(/PR/g, 'MR');
   const res = await get.post(`projects/${config.repoName}/merge_requests`, {
@@ -416,6 +417,7 @@ async function getPr(prNo) {
 
 async function updatePr(prNo, title, body) {
   const description = body
+    .replace('</h4>', ' </h4>') // See #954
     .replace(/Pull Request/g, 'Merge Request')
     .replace(/PR/g, 'MR');
   await get.put(`projects/${config.repoName}/merge_requests/${prNo}`, {


### PR DESCRIPTION
Add space before closing `</h4>` to prevent unintential hyperlinking on GitLab.

Closes #954