### PR TITLE
feat: allow rebase after github web branch update

### DIFF
--- a/lib/api/github.js
+++ b/lib/api/github.js
@@ -599,7 +599,9 @@ async function getPr(prNo) {
       const authors = prCommits.reduce((arr, commit) => {
         logger.trace({ commit }, `Checking commit`);
         let author = 'unknown';
-        if (commit.author) {
+        if (commit.committer && commit.committer.login) {
+          author = commit.committer.login;
+        } else if (commit.author) {
           author = commit.author.login;
         } else if (commit.commit && commit.commit.author) {
           author = commit.commit.author.email;
@@ -607,7 +609,8 @@ async function getPr(prNo) {
           logger.debug('Could not determine commit author');
         }
         logger.debug(`Commit author is: ${author}`);
-        if (arr.indexOf(author) === -1) {
+        // Ignore GitHub "web-flow"
+        if (author !== 'web-flow' && arr.indexOf(author) === -1) {
           arr.push(author);
         }
         return arr;

--- a/test/api/__snapshots__/github.spec.js.snap
+++ b/test/api/__snapshots__/github.spec.js.snap
@@ -849,6 +849,21 @@ Object {
 }
 `;
 
+exports[`api/github getPr(prNo) should return a rebaseable PR if web-flow is second author 1`] = `
+Object {
+  "base": Object {
+    "sha": "1234",
+  },
+  "canRebase": true,
+  "commits": 2,
+  "displayNumber": "Pull Request #1",
+  "isUnmergeable": true,
+  "mergeable_state": "dirty",
+  "number": 1,
+  "state": "open",
+}
+`;
+
 exports[`api/github getPr(prNo) should return an unrebaseable PR if multiple authors 1`] = `
 Object {
   "base": Object {

--- a/test/api/github.spec.js
+++ b/test/api/github.spec.js
@@ -1167,6 +1167,35 @@ describe('api/github', () => {
       const pr = await github.getPr(1234);
       expect(pr).toMatchSnapshot();
     });
+    it('should return a rebaseable PR if web-flow is second author', async () => {
+      await initRepo('some/repo', 'token');
+      get.mockImplementationOnce(() => ({
+        body: {
+          number: 1,
+          state: 'open',
+          mergeable_state: 'dirty',
+          base: { sha: '1234' },
+          commits: 2,
+        },
+      }));
+      get.mockImplementationOnce(() => ({
+        body: [
+          {
+            author: {
+              login: 'foo',
+            },
+          },
+          {
+            committer: {
+              login: 'web-flow',
+            },
+          },
+        ],
+      }));
+      const pr = await github.getPr(1234);
+      expect(pr.canRebase).toBe(true);
+      expect(pr).toMatchSnapshot();
+    });
   });
   describe('getAllPrs()', () => {
     it('maps results to simple array', async () => {


### PR DESCRIPTION
GitHub provides a tempting “Update branch” button whenever a branch is out of date with master, but the problem was that this then made us flag the branch as modified and hence unrebaseable, so the user would be stuck with keeping it update themselves from then on. With this feature, we ignore the “web-flow” committer when calculcating if there has been only one author.