### PR TITLE
fix: add missing await to getBranchPr call

### DIFF
--- a/lib/workers/branch/automerge.js
+++ b/lib/workers/branch/automerge.js
@@ -8,7 +8,7 @@ async function tryBranchAutomerge(config) {
   if (!config.automerge || config.automergeType === 'pr') {
     return 'no automerge';
   }
-  const existingPr = config.api.getBranchPr(config.branchName);
+  const existingPr = await config.api.getBranchPr(config.branchName);
   if (existingPr) {
     return 'automerge aborted - PR exists';
   }


### PR DESCRIPTION
This bug was preventing branch automerge from working.

Closes #983