### PR TITLE
feat: rename open prs before autoclosing

### DIFF
--- a/lib/api/github.js
+++ b/lib/api/github.js
@@ -621,8 +621,13 @@ async function getPr(prNo) {
 }
 
 async function updatePr(prNo, title, body) {
+  logger.debug(`updatePr(${prNo}, ${title}, body)`);
+  const patchBody = { title };
+  if (body) {
+    patchBody.body = body;
+  }
   await get.patch(`repos/${config.repoName}/pulls/${prNo}`, {
-    body: { title, body },
+    body: patchBody,
   });
 }
 

--- a/lib/workers/repository/cleanup.js
+++ b/lib/workers/repository/cleanup.js
@@ -58,6 +58,7 @@ async function pruneStaleBranches(config, branchList) {
     logger.debug({ branch: branchName }, `Deleting orphan branch`);
     const pr = await config.api.findPr(branchName, null, 'open');
     if (pr) {
+      logger.info({ prNo: pr.number, prTitle: pr.title }, 'Autoclosing PR');
       await config.api.updatePr(pr.number, `${pr.title} - autoclosed`);
     }
     await config.api.deleteBranch(branchName);

--- a/lib/workers/repository/cleanup.js
+++ b/lib/workers/repository/cleanup.js
@@ -56,6 +56,10 @@ async function pruneStaleBranches(config, branchList) {
   }
   for (const branchName of remainingBranches) {
     logger.debug({ branch: branchName }, `Deleting orphan branch`);
+    const pr = await config.api.findPr(branchName, null, 'open');
+    if (pr) {
+      await config.api.updatePr(pr.number, `${pr.title} - autoclosed`);
+    }
     await config.api.deleteBranch(branchName);
   }
 }

--- a/test/workers/repository/cleanup.spec.js
+++ b/test/workers/repository/cleanup.spec.js
@@ -13,6 +13,8 @@ describe('workers/repository/cleanup', () => {
         getAllRenovateBranches: jest.fn(),
         getPr: jest.fn(),
         deleteBranch: jest.fn(),
+        findPr: jest.fn(),
+        updatePr: jest.fn(),
       };
       config.logger = logger;
     });
@@ -27,14 +29,16 @@ describe('workers/repository/cleanup', () => {
       await cleanup.pruneStaleBranches(config, branchNames);
       expect(config.api.getAllRenovateBranches.mock.calls).toHaveLength(1);
     });
-    it('deletes remaining branch', async () => {
+    it('renames deletes remaining branch', async () => {
       branchNames = ['renovate/a', 'renovate/b'];
       config.api.getAllRenovateBranches.mockReturnValueOnce(
         branchNames.concat(['renovate/c'])
       );
+      config.api.findPr.mockReturnValueOnce({});
       await cleanup.pruneStaleBranches(config, branchNames);
       expect(config.api.getAllRenovateBranches.mock.calls).toHaveLength(1);
       expect(config.api.deleteBranch.mock.calls).toHaveLength(1);
+      expect(config.api.updatePr.mock.calls).toHaveLength(1);
     });
     it('deletes lock file maintenance if pr is closed', async () => {
       branchNames = ['renovate/lock-file-maintenance'];


### PR DESCRIPTION
This is a failsafe against Renovate bugs and potentially also mistakes on the user’s part. Before deleting/pruning any branches, Renovate will rename the PR’s title so that it should not block future PRs.

Closes #989