### PR TITLE
Fix: filepath encoding for gitlab createFile and updateFile

### DIFF
--- a/lib/api/gitlab.js
+++ b/lib/api/gitlab.js
@@ -498,7 +498,10 @@ async function createFile(branchName, filePath, fileContents, message) {
       content: Buffer.from(fileContents).toString('base64'),
     };
   } else {
-    url = `projects/${config.repoName}/repository/files/${filePath.replace(/\//g, '%2F')}`;
+    url = `projects/${config.repoName}/repository/files/${filePath.replace(
+      /\//g,
+      '%2F'
+    )}`;
     opts.body = {
       branch: branchName,
       commit_message: message,
@@ -523,7 +526,10 @@ async function updateFile(branchName, filePath, fileContents, message) {
       content: Buffer.from(fileContents).toString('base64'),
     };
   } else {
-    url = `projects/${config.repoName}/repository/files/${filePath.replace(/\//g, '%2F')}`;
+    url = `projects/${config.repoName}/repository/files/${filePath.replace(
+      /\//g,
+      '%2F'
+    )}`;
     opts.body = {
       branch: branchName,
       commit_message: message,

--- a/lib/api/gitlab.js
+++ b/lib/api/gitlab.js
@@ -498,7 +498,7 @@ async function createFile(branchName, filePath, fileContents, message) {
       content: Buffer.from(fileContents).toString('base64'),
     };
   } else {
-    url = `projects/${config.repoName}/repository/files/${filePath}`;
+    url = `projects/${config.repoName}/repository/files/${filePath.replace(/\//g, '%2F')}`;
     opts.body = {
       branch: branchName,
       commit_message: message,
@@ -523,7 +523,7 @@ async function updateFile(branchName, filePath, fileContents, message) {
       content: Buffer.from(fileContents).toString('base64'),
     };
   } else {
-    url = `projects/${config.repoName}/repository/files/${filePath}`;
+    url = `projects/${config.repoName}/repository/files/${filePath.replace(/\//g, '%2F')}`;
     opts.body = {
       branch: branchName,
       commit_message: message,


### PR DESCRIPTION
Relates to #962 and #968 

Auto detected file names are not encoded correctly so here's a fix for that.