### PR TITLE
fix: ignore symlink package files

### DIFF
--- a/lib/api/github.js
+++ b/lib/api/github.js
@@ -251,7 +251,7 @@ async function getFileList(branchName) {
       );
     }
     config.fileList = res.body.tree
-      .filter(item => item.type === 'blob')
+      .filter(item => item.type === 'blob' && item.mode !== '12000')
       .map(item => item.path)
       .sort();
   } catch (err) {

--- a/lib/api/gitlab.js
+++ b/lib/api/gitlab.js
@@ -127,7 +127,7 @@ async function getFileList(branchName) {
       { paginate: true }
     );
     config.fileList = res.body
-      .filter(item => item.type === 'blob')
+      .filter(item => item.type === 'blob' && item.mode !== '12000')
       .map(item => item.path)
       .sort();
   } catch (err) {

--- a/test/api/github.spec.js
+++ b/test/api/github.spec.js
@@ -509,6 +509,7 @@ describe('api/github', () => {
       get.mockImplementationOnce(() => ({
         body: {
           tree: [
+            { type: 'blob', path: 'symlinks/package.json', mode: '12000' },
             { type: 'blob', path: 'package.json' },
             {
               type: 'blob',

--- a/test/api/gitlab.spec.js
+++ b/test/api/gitlab.spec.js
@@ -202,6 +202,7 @@ describe('api/gitlab', () => {
       await initRepo('some/repo', 'token');
       get.mockImplementationOnce(() => ({
         body: [
+          { type: 'blob', path: 'symlinks/package.json', mode: '12000' },
           { type: 'blob', path: 'package.json' },
           {
             type: 'blob',


### PR DESCRIPTION
Ignore files in git tree with mode "12000" as that indicates a symlink and not real file. As reported here: https://github.com/Urigo/angular-meteor/commit/ebeb89df5e5ee59f315e29ffba24adb9ff38cf82 by @Urigo