### PR TITLE
feat: skip group name if all depNames are the same

### DIFF
--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -223,7 +223,14 @@ const options = [
       'Configuration specifically for `package.json`>`devDependencies`',
     stage: 'packageFile',
     type: 'json',
-    default: {},
+    default: {
+      pin: {
+        group: {
+          commitMessage: 'Pin devDependencies',
+          prTitle: 'Pin devDependencies',
+        },
+      },
+    },
     mergeable: true,
     cli: false,
   },

--- a/lib/workers/repository/upgrades.js
+++ b/lib/workers/repository/upgrades.js
@@ -63,8 +63,14 @@ function generateConfig(branchUpgrades) {
   const hasGroupName = branchUpgrades[0].groupName !== null;
   logger.debug(`hasGroupName: ${hasGroupName}`);
   // Use group settings only if multiple upgrades or lazy grouping is disabled
+  const depNames = [];
+  branchUpgrades.forEach(upg => {
+    if (!depNames.includes(upg.depName)) {
+      depNames.push(upg.depName);
+    }
+  });
   const groupEligible =
-    branchUpgrades.length > 1 || branchUpgrades[0].lazyGrouping === false;
+    depNames.length > 1 || branchUpgrades[0].lazyGrouping === false;
   logger.debug(`groupEligible: ${groupEligible}`);
   const useGroupSettings = hasGroupName && groupEligible;
   logger.debug(`useGroupSettings: ${useGroupSettings}`);

--- a/test/workers/repository/upgrades.spec.js
+++ b/test/workers/repository/upgrades.spec.js
@@ -86,6 +86,35 @@ describe('workers/repository/upgrades', () => {
       expect(res.groupName).toBeDefined();
       expect(res).toMatchSnapshot();
     });
+    it('does not group same upgrades', () => {
+      const branchUpgrades = [
+        {
+          depName: 'some-dep',
+          groupName: 'some-group',
+          branchName: 'some-branch',
+          prTitle: 'some-title',
+          lazyGrouping: true,
+          foo: 1,
+          group: {
+            foo: 2,
+          },
+        },
+        {
+          depName: 'some-dep',
+          groupName: 'some-group',
+          branchName: 'some-branch',
+          prTitle: 'some-title',
+          lazyGrouping: true,
+          foo: 1,
+          group: {
+            foo: 2,
+          },
+        },
+      ];
+      const res = upgrades.generateConfig(branchUpgrades);
+      expect(res.foo).toBe(1);
+      expect(res.groupName).toBeUndefined();
+    });
     it('groups multiple upgrades', () => {
       const branchUpgrades = [
         {


### PR DESCRIPTION
This commonly applies to monorepos where the same dependency may be present in multiple.json files. Instead of using the group name to describe the PR, it uses the dependency name.

Closes #848