### PR TITLE
fix: error and exit if cannot parse renovate.json

### DIFF
--- a/lib/workers/repository/apis.js
+++ b/lib/workers/repository/apis.js
@@ -224,13 +224,8 @@ async function mergeRenovateJson(config, branchName) {
     returnConfig = configParser.mergeChildConfig(returnConfig, resolvedConfig);
     returnConfig.renovateJsonPresent = true;
   } catch (err) {
-    // Add to config.errors
-    const error = {
-      depName: 'renovate.json',
-      message: `Could not parse repository's renovate.json file`,
-    };
-    logger.warn({ err }, error.message);
-    returnConfig.errors.push(error);
+    logger.info({ err, renovateJsonContent }, 'Could not parse renovate.json');
+    throw err;
   }
   return returnConfig;
 }

--- a/test/workers/repository/__snapshots__/apis.spec.js.snap
+++ b/test/workers/repository/__snapshots__/apis.spec.js.snap
@@ -70,15 +70,6 @@ exports[`workers/repository/apis detectPackageFiles(config) skips meteor package
 
 exports[`workers/repository/apis initApis(config) throws if unknown platform 1`] = `"Unknown platform: foo"`;
 
-exports[`workers/repository/apis mergeRenovateJson(config) returns error in JSON.parse 1`] = `
-Array [
-  Object {
-    "depName": "renovate.json",
-    "message": "Could not parse repository's renovate.json file",
-  },
-]
-`;
-
 exports[`workers/repository/apis mergeRenovateJson(config) returns error in config if renovate.json cannot be parsed 1`] = `
 Array [
   Object {

--- a/test/workers/repository/apis.spec.js
+++ b/test/workers/repository/apis.spec.js
@@ -243,10 +243,13 @@ describe('workers/repository/apis', () => {
       jsonValidator.validate = jest.fn();
       jsonValidator.validate.mockReturnValueOnce(false);
       jsonValidator.validate.mockReturnValueOnce(false);
-      const returnConfig = await apis.mergeRenovateJson(config);
-      expect(returnConfig.foo).toBeUndefined();
-      expect(returnConfig.renovateJsonPresent).toBeUndefined();
-      expect(returnConfig.errors).toMatchSnapshot();
+      let e;
+      try {
+        await apis.mergeRenovateJson(config);
+      } catch (err) {
+        e = err;
+      }
+      expect(e).toBeDefined();
     });
   });
   describe('detectPackageFiles(config)', () => {


### PR DESCRIPTION
It's safest to stop processing the repository than to process it without the `renovate.json`, otherwise one typo could lead to a complete change in behaviour (reverting to defaults). Later, we will raise a "Fix Renovate Config" issue to alert the user, but for now the administrator can check logs.