### PR TITLE
fix: add uniqueness to docker-digest pr title

### DIFF
--- a/lib/config/templates/docker-digest/pr-title.hbs
+++ b/lib/config/templates/docker-digest/pr-title.hbs
@@ -1,1 +1,1 @@
-Update Dockerfile {{depName}} image {{currentTag}} digest
+Update Dockerfile {{depName}} image {{currentTag}} digest ({{newDigestShort}})

--- a/lib/manager/docker/package.js
+++ b/lib/manager/docker/package.js
@@ -21,6 +21,7 @@ async function getPackageUpdates(config) {
       const upgrade = {};
       upgrade.newTag = currentTag;
       upgrade.newDigest = newDigest;
+      upgrade.newDigestShort = newDigest.slice(7, 13);
       upgrade.newVersion = newDigest;
       upgrade.newFrom = config.depName;
       if (upgrade.newTag) {

--- a/test/manager/docker/__snapshots__/package.spec.js.snap
+++ b/test/manager/docker/__snapshots__/package.spec.js.snap
@@ -5,6 +5,7 @@ Array [
   Object {
     "isPin": true,
     "newDigest": "sha256:one",
+    "newDigestShort": "one",
     "newFrom": "some-dep:1.0.0-something@sha256:one",
     "newTag": "1.0.0-something",
     "newVersion": "sha256:one",


### PR DESCRIPTION
Use first 6 chars of sha256 digest in PR title to ensure uniqueness and not block future digest updates.

Closes #1050