### PR TITLE
feat: don’t autodetect js type during onboarding

### DIFF
--- a/lib/workers/package-file/index.js
+++ b/lib/workers/package-file/index.js
@@ -5,10 +5,26 @@ const npmApi = require('../../manager/npm/registry');
 let logger = require('../../logger');
 
 module.exports = {
+  mightBeABrowserLibrary,
   renovatePackageFile,
   renovateMeteorPackageFile,
   renovateDockerfile,
 };
+
+function mightBeABrowserLibrary(packageJson) {
+  // return true unless we're sure it's not a browser library
+  if (packageJson.private === true) {
+    // it's not published
+    return false;
+  }
+  if (packageJson.main === undefined) {
+    // it can't be required
+    return false;
+  }
+  // TODO: how can we know if it's a node.js library only, and not browser?
+  // Otherwise play it safe and return true
+  return true;
+}
 
 async function renovatePackageFile(packageFileConfig) {
   const config = { ...packageFileConfig };
@@ -41,7 +57,17 @@ async function renovatePackageFile(packageFileConfig) {
       packageFile: depTypeConfig.packageFile,
       depType: depTypeConfig.depType,
     });
-    logger.trace({ config: depTypeConfig }, 'depTypeConfig');
+    // Always pin devDependencies
+    // Pin dependencies if we're pretty sure it's not a browser library
+    if (
+      depTypeConfig.pinVersions === null &&
+      (depType === 'devDependencies' ||
+        (depType === 'dependencies' && !mightBeABrowserLibrary(config.content)))
+    ) {
+      depTypeConfig.logger.debug('Autodetecting pinVersions = true');
+      depTypeConfig.pinVersions = true;
+    }
+    depTypeConfig.logger.trace({ config: depTypeConfig }, 'depTypeConfig');
     return configParser.filterConfig(depTypeConfig, 'depType');
   });
   logger.trace({ config: depTypeConfigs }, `depTypeConfigs`);

--- a/lib/workers/repository/onboarding.js
+++ b/lib/workers/repository/onboarding.js
@@ -4,24 +4,10 @@ const manager = require('../../manager');
 const onboardPrTitle = 'Configure Renovate';
 
 module.exports = {
-  isRepoPrivate,
   createOnboardingBranch,
   ensurePr,
   getOnboardingStatus,
 };
-
-async function isRepoPrivate(config) {
-  let repoIsPrivate = true;
-  for (const packageFile of config.packageFiles) {
-    const fileName =
-      typeof packageFile === 'string' ? packageFile : packageFile.packageFile;
-    if (fileName.endsWith('package.json')) {
-      const packageContent = await config.api.getFileJson(fileName);
-      repoIsPrivate = repoIsPrivate && packageContent && packageContent.private;
-    }
-  }
-  return repoIsPrivate === true;
-}
 
 async function createOnboardingBranch(inputConfig) {
   let config = { ...inputConfig };
@@ -31,21 +17,9 @@ async function createOnboardingBranch(inputConfig) {
   if (config.packageFiles.length === 0) {
     throw new Error('no package files');
   }
-  const repoIsPrivate = await module.exports.isRepoPrivate(config);
   const renovateJson = {
-    extends: [],
+    extends: ['config:base'],
   };
-  if (config.types.npm) {
-    if (repoIsPrivate) {
-      logger.debug('Repo is private - setting to app type');
-      renovateJson.extends.push('config:js-app');
-    } else {
-      logger.debug('Repo is not private - setting to library');
-      renovateJson.extends.push('config:js-lib');
-    }
-  } else {
-    renovateJson.extends.push('config:base');
-  }
   logger.info({ renovateJson }, 'Creating onboarding branch');
   await config.api.commitFilesToBranch(
     config.onboardingBranch,

--- a/test/workers/package-file/index.spec.js
+++ b/test/workers/package-file/index.spec.js
@@ -34,6 +34,23 @@ describe('packageFileWorker', () => {
       const res = await packageFileWorker.renovatePackageFile(config);
       expect(res).toHaveLength(3);
     });
+    it('autodetects dependency pinning true if private', async () => {
+      config.pinVersions = null;
+      config.content.private = true;
+      const res = await packageFileWorker.renovatePackageFile(config);
+      expect(res).toHaveLength(0);
+    });
+    it('autodetects dependency pinning true if no main', async () => {
+      config.pinVersions = null;
+      const res = await packageFileWorker.renovatePackageFile(config);
+      expect(res).toHaveLength(0);
+    });
+    it('autodetects dependency pinning true', async () => {
+      config.pinVersions = null;
+      config.content.main = 'something';
+      const res = await packageFileWorker.renovatePackageFile(config);
+      expect(res).toHaveLength(0);
+    });
     it('maintains lock files', async () => {
       config.yarnLock = '# some yarn lock';
       const res = await packageFileWorker.renovatePackageFile(config);

--- a/test/workers/repository/__snapshots__/onboarding.spec.js.snap
+++ b/test/workers/repository/__snapshots__/onboarding.spec.js.snap
@@ -375,25 +375,7 @@ Array [
     Object {
       "contents": "{
   \\"extends\\": [
-    \\"config:js-lib\\"
-  ]
-}
-",
-      "name": "renovate.json",
-    },
-  ],
-  "Add renovate.json",
-]
-`;
-
-exports[`lib/workers/repository/onboarding getOnboardingStatus(config) pins private repos 1`] = `
-Array [
-  "renovate/configure",
-  Array [
-    Object {
-      "contents": "{
-  \\"extends\\": [
-    \\"config:js-app\\"
+    \\"config:base\\"
   ]
 }
 ",
@@ -405,21 +387,3 @@ Array [
 `;
 
 exports[`lib/workers/repository/onboarding getOnboardingStatus(config) throws if no packageFiles 1`] = `[Error: no package files]`;
-
-exports[`lib/workers/repository/onboarding getOnboardingStatus(config) uses base + docker 1`] = `
-Array [
-  "renovate/configure",
-  Array [
-    Object {
-      "contents": "{
-  \\"extends\\": [
-    \\"config:base\\"
-  ]
-}
-",
-      "name": "renovate.json",
-    },
-  ],
-  "Add renovate.json",
-]
-`;

--- a/test/workers/repository/onboarding.spec.js
+++ b/test/workers/repository/onboarding.spec.js
@@ -4,32 +4,6 @@ const logger = require('../../_fixtures/logger');
 const defaultConfig = require('../../../lib/config/defaults').getConfig();
 
 describe('lib/workers/repository/onboarding', () => {
-  describe('isRepoPrivate(config)', () => {
-    let config;
-    beforeEach(() => {
-      config = {
-        api: {
-          getFileJson: jest.fn(),
-        },
-        packageFiles: [
-          'package.json',
-          {
-            packageFile: 'a/package.json',
-          },
-        ],
-      };
-    });
-    it('returns true if all are private', async () => {
-      config.api.getFileJson.mockReturnValueOnce({ private: true });
-      config.api.getFileJson.mockReturnValueOnce({ private: true });
-      expect(await onboarding.isRepoPrivate(config)).toBe(true);
-    });
-    it('returns false if some are not private', async () => {
-      config.api.getFileJson.mockReturnValueOnce({ private: true });
-      config.api.getFileJson.mockReturnValueOnce({});
-      expect(await onboarding.isRepoPrivate(config)).toBe(false);
-    });
-  });
   describe('ensurePr(config, branchUpgrades)', () => {
     let config;
     let branchUpgrades;
@@ -236,7 +210,6 @@ describe('lib/workers/repository/onboarding', () => {
       config.foundIgnoredPaths = true;
       config.logger = logger;
       config.detectedPackageFiles = true;
-      onboarding.isRepoPrivate = jest.fn();
     });
     it('returns true if onboarding is false', async () => {
       config.onboarding = false;
@@ -268,29 +241,6 @@ describe('lib/workers/repository/onboarding', () => {
     });
     it('commits files and returns false if no pr', async () => {
       config.api.getFileList.mockReturnValueOnce(['package.json']);
-      const res = await onboarding.getOnboardingStatus(config);
-      expect(res.repoIsOnboarded).toEqual(false);
-      expect(config.api.findPr.mock.calls.length).toBe(1);
-      expect(config.api.commitFilesToBranch.mock.calls.length).toBe(1);
-      expect(config.api.commitFilesToBranch.mock.calls[0]).toMatchSnapshot();
-    });
-    it('pins private repos', async () => {
-      config.api.getFileList.mockReturnValueOnce(['package.json']);
-      onboarding.isRepoPrivate.mockReturnValueOnce(true);
-      const res = await onboarding.getOnboardingStatus(config);
-      expect(res.repoIsOnboarded).toEqual(false);
-      expect(config.api.findPr.mock.calls.length).toBe(1);
-      expect(config.api.commitFilesToBranch.mock.calls.length).toBe(1);
-      expect(config.api.commitFilesToBranch.mock.calls[0]).toMatchSnapshot();
-    });
-    it('uses base + docker', async () => {
-      manager.detectPackageFiles = jest.fn(input => ({
-        ...input,
-        packageFiles: [{}, {}],
-        types: {
-          docker: true,
-        },
-      }));
       const res = await onboarding.getOnboardingStatus(config);
       expect(res.repoIsOnboarded).toEqual(false);
       expect(config.api.findPr.mock.calls.length).toBe(1);


### PR DESCRIPTION
.. instead, autodetect it for every file at runtime. This means some might be all pinned while others in the same monorepo can be not. This also simplifies the onboarding logic as all repos will now extend `"config:base"` by default.