### PR TITLE
feat: default pinVersions to null (autodetect)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -93,7 +93,7 @@ $ node renovate --help
     --ignore-paths <list>                Skip any package.json whose path matches one of these.
     --ignore-deps <list>                 Dependencies to ignore
     --pin-digests [boolean]              Whether to add digests to Dockerfile source images
-    --pin-versions [boolean]             Convert ranged versions in package.json to pinned versions
+    --pin-versions [boolean]             Convert ranged versions to pinned versions
     --separate-major-releases [boolean]  If set to false, it will upgrade dependencies to latest release only, and not separate major/minor branches
     --separate-patch-releases [boolean]  If set to true, it will separate minor and patch updates into separate branches
     --ignore-future [boolean]            Ignore versions tagged as "future"
@@ -469,9 +469,9 @@ Obviously, you can't set repository or package file location with this method.
 </tr>
 <tr>
   <td>`pinVersions`</td>
-  <td>Convert ranged versions in package.json to pinned versions</td>
+  <td>Convert ranged versions to pinned versions</td>
   <td>boolean</td>
-  <td><pre>true</pre></td>
+  <td><pre>null</pre></td>
   <td>`RENOVATE_PIN_VERSIONS`</td>
   <td>`--pin-versions`<td>
 </tr>

--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -323,9 +323,10 @@ const options = [
   },
   {
     name: 'pinVersions',
-    description: 'Convert ranged versions in package.json to pinned versions',
+    description: 'Convert ranged versions to pinned versions',
     stage: 'package',
     type: 'boolean',
+    default: null,
   },
   {
     name: 'separateMajorReleases',

--- a/test/workers/package/versions.spec.js
+++ b/test/workers/package/versions.spec.js
@@ -8,6 +8,7 @@ let config;
 describe('workers/package/versions', () => {
   beforeEach(() => {
     config = require('../../../lib/config/defaults').getConfig();
+    config.pinVersions = true;
   });
 
   describe('.determineUpgrades(npmDep, config)', () => {


### PR DESCRIPTION
By defaulting pinVersions to null, this allows Renover to autodetect on a per-package file basis. Users may still manually configure (override autodetection) pinning enabled or disabled via config.

Closes #589

BREAKING CHANGE: Renovate will no longer default to pinning versions - instead it will autodetect whether to pin, unless overrided.