### PR TITLE
feat: deprecate gitlab api v3

### DIFF
--- a/lib/platform/gitlab.js
+++ b/lib/platform/gitlab.js
@@ -83,15 +83,6 @@ async function initRepo(repoName, token, endpoint, repoLogger) {
   if (endpoint) {
     process.env.GITLAB_ENDPOINT = endpoint;
   }
-  try {
-    logger.debug(`Determining Gitlab API version`);
-    // projects/owned route deprecated in v4
-    await get(`projects/owned`);
-    config.apiVersion = 'v3';
-  } catch (err) {
-    config.apiVersion = 'v4';
-  }
-  logger.debug(`Detected Gitlab API ${config.apiVersion}`);
   config.repoName = repoName.replace('/', '%2F');
   config.fileList = null;
   try {
@@ -196,7 +187,7 @@ async function getBranchPr(branchName) {
   if (!pr) {
     return null;
   }
-  return getPr(config.apiVersion === 'v3' ? pr.id : pr.iid);
+  return getPr(pr.iid);
 }
 
 // Returns the combined status for a branch.
@@ -353,7 +344,7 @@ async function findPr(branchName, prTitle, state = 'all') {
     ) {
       pr = result;
       // GitHub uses number, GitLab uses iid
-      pr.number = config.apiVersion === 'v3' ? pr.id : pr.iid;
+      pr.number = pr.iid;
       pr.body = pr.description;
       pr.displayNumber = `Merge Request #${pr.iid}`;
       if (pr.state !== 'opened') {
@@ -395,7 +386,7 @@ async function getPr(prNo) {
   const url = `projects/${config.repoName}/merge_requests/${prNo}`;
   const pr = (await get(url)).body;
   // Harmonize fields with GitHub
-  pr.number = config.apiVersion === 'v3' ? pr.id : pr.iid;
+  pr.number = pr.iid;
   pr.displayNumber = `Merge Request #${pr.iid}`;
   pr.body = pr.description;
   if (pr.state === 'closed' || pr.state === 'merged') {
@@ -442,18 +433,11 @@ async function mergePr(pr) {
 
 // Generic File operations
 
-async function getFile(filePath, branchName) {
-  // Gitlab API v3 support
-  let url;
-  if (config.apiVersion === 'v3') {
-    url = `projects/${config.repoName}/repository/files?file_path=${filePath}&ref=${branchName ||
-      config.baseBranch}`;
-  } else {
-    url = `projects/${config.repoName}/repository/files/${filePath.replace(
-      /\//g,
-      '%2F'
-    )}?ref=${branchName || config.baseBranch}`;
-  }
+async function getFile(filePath, branchName = config.baseBranch) {
+  const url = `projects/${config.repoName}/repository/files/${filePath.replace(
+    /\//g,
+    '%2F'
+  )}?ref=${branchName}`;
   const res = await get(url);
   return res.body.content;
 }
@@ -478,58 +462,33 @@ async function getFileJson(filePath, branchName) {
 }
 
 async function createFile(branchName, filePath, fileContents, message) {
-  // Gitlab API v3 support
-  let url;
   const opts = {};
-  if (config.apiVersion === 'v3') {
-    url = `projects/${config.repoName}/repository/files`;
-    opts.body = {
-      file_path: filePath,
-      branch_name: branchName,
-      commit_message: message,
-      encoding: 'base64',
-      content: Buffer.from(fileContents).toString('base64'),
-    };
-  } else {
-    url = `projects/${config.repoName}/repository/files/${filePath.replace(
-      /\//g,
-      '%2F'
-    )}`;
-    opts.body = {
-      branch: branchName,
-      commit_message: message,
-      encoding: 'base64',
-      content: Buffer.from(fileContents).toString('base64'),
-    };
-  }
+  const url = `projects/${config.repoName}/repository/files/${filePath.replace(
+    /\//g,
+    '%2F'
+  )}`;
+  opts.body = {
+    branch: branchName,
+    commit_message: message,
+    encoding: 'base64',
+    content: Buffer.from(fileContents).toString('base64'),
+  };
   await get.post(url, opts);
 }
 
 async function updateFile(branchName, filePath, fileContents, message) {
-  // Gitlab API v3 support
-  let url;
   const opts = {};
-  if (config.apiVersion === 'v3') {
-    url = `projects/${config.repoName}/repository/files`;
-    opts.body = {
-      file_path: filePath,
-      branch_name: branchName,
-      commit_message: message,
-      encoding: 'base64',
-      content: Buffer.from(fileContents).toString('base64'),
-    };
-  } else {
-    url = `projects/${config.repoName}/repository/files/${filePath.replace(
-      /\//g,
-      '%2F'
-    )}`;
-    opts.body = {
-      branch: branchName,
-      commit_message: message,
-      encoding: 'base64',
-      content: Buffer.from(fileContents).toString('base64'),
-    };
-  }
+  const url = `projects/${config.repoName}/repository/files/${filePath.replace(
+    /\//g,
+    '%2F'
+  )}`;
+  opts.body = {
+    branch: branchName,
+    commit_message: message,
+    encoding: 'base64',
+    content: Buffer.from(fileContents).toString('base64'),
+  };
+
   await get.put(url, opts);
 }
 
@@ -594,18 +553,11 @@ async function getCommitMessages() {
 
 // Creates a new branch with provided commit
 async function createBranch(branchName, ref = config.baseBranch) {
-  // Gitlab API v3 support
-  const opts = {};
-  if (config.apiVersion === 'v3') {
-    opts.body = {
-      branch_name: branchName,
-      ref,
-    };
-  } else {
-    opts.body = {
+  const opts = {
+    body: {
       branch: branchName,
       ref,
-    };
-  }
+    },
+  };
   await get.post(`projects/${config.repoName}/repository/branches`, opts);
 }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "get-installed-path": "4.0.8",
     "gh-got": "6.0.0",
     "github-url-from-git": "1.5.0",
-    "gl-got": "7.0.0",
+    "gl-got": "8.0.0",
     "got": "7.1.0",
     "handlebars": "4.0.11",
     "ini": "1.3.4",

--- a/test/platform/__snapshots__/gitlab.spec.js.snap
+++ b/test/platform/__snapshots__/gitlab.spec.js.snap
@@ -24,21 +24,7 @@ Array [
 ]
 `;
 
-exports[`platform/gitlab createFile(branchName, filePath, fileContents, message) createBranch(branchName) creates file with v3 1`] = `
-Array [
-  Array [
-    "projects/some-repo/repository/branches",
-    Object {
-      "body": Object {
-        "branch_name": "some-branch",
-        "ref": undefined,
-      },
-    },
-  ],
-]
-`;
-
-exports[`platform/gitlab createFile(branchName, filePath, fileContents, message) createBranch(branchName) creates file with v4 1`] = `
+exports[`platform/gitlab createFile(branchName, filePath, fileContents, message) createBranch(branchName) creates branch 1`] = `
 Array [
   Array [
     "projects/undefined/repository/branches",
@@ -52,24 +38,7 @@ Array [
 ]
 `;
 
-exports[`platform/gitlab createFile(branchName, filePath, fileContents, message) creates file with v3 1`] = `
-Array [
-  Array [
-    "projects/some-repo/repository/files",
-    Object {
-      "body": Object {
-        "branch_name": "some-branch",
-        "commit_message": "some-message",
-        "content": "c29tZS1jb250ZW50cw==",
-        "encoding": "base64",
-        "file_path": "some-path",
-      },
-    },
-  ],
-]
-`;
-
-exports[`platform/gitlab createFile(branchName, filePath, fileContents, message) creates file with v4 1`] = `
+exports[`platform/gitlab createFile(branchName, filePath, fileContents, message) creates file 1`] = `
 Array [
   Array [
     "projects/undefined/repository/files/some-path",
@@ -88,9 +57,6 @@ Array [
 exports[`platform/gitlab createFile(branchName, filePath, fileContents, message) getSubDirectories(path) should return subdirectories 1`] = `
 Array [
   Array [
-    "projects/owned",
-  ],
-  Array [
     "projects/some%2Frepo",
   ],
   Array [
@@ -108,24 +74,7 @@ Array [
 ]
 `;
 
-exports[`platform/gitlab createFile(branchName, filePath, fileContents, message) updateFile(branchName, filePath, fileContents, message) creates file with v3 1`] = `
-Array [
-  Array [
-    "projects/some-repo/repository/files",
-    Object {
-      "body": Object {
-        "branch_name": "some-branch",
-        "commit_message": "some-message",
-        "content": "c29tZS1jb250ZW50cw==",
-        "encoding": "base64",
-        "file_path": "some-path",
-      },
-    },
-  ],
-]
-`;
-
-exports[`platform/gitlab createFile(branchName, filePath, fileContents, message) updateFile(branchName, filePath, fileContents, message) creates file with v4 1`] = `
+exports[`platform/gitlab createFile(branchName, filePath, fileContents, message) updateFile(branchName, filePath, fileContents, message) updates file 1`] = `
 Array [
   Array [
     "projects/undefined/repository/files/some-path",
@@ -200,9 +149,6 @@ exports[`platform/gitlab getBranchLastCommitTime should return a Date 1`] = `201
 exports[`platform/gitlab getBranchPr(branchName) should return null if no PR exists 1`] = `
 Array [
   Array [
-    "projects/owned",
-  ],
-  Array [
     "projects/some%2Frepo",
   ],
   Array [
@@ -219,9 +165,6 @@ Array [
 
 exports[`platform/gitlab getBranchPr(branchName) should return the PR object 1`] = `
 Array [
-  Array [
-    "projects/owned",
-  ],
   Array [
     "projects/some%2Frepo",
   ],
@@ -254,7 +197,7 @@ Object {
   "deletions": 1,
   "displayNumber": "Merge Request #91",
   "iid": 91,
-  "number": undefined,
+  "number": 91,
   "source_branch": "some-branch",
 }
 `;
@@ -266,11 +209,7 @@ Array [
 ]
 `;
 
-exports[`platform/gitlab getFile(filePath, branchName) gets the file with v3 1`] = `Object {}`;
-
-exports[`platform/gitlab getFile(filePath, branchName) gets the file with v3 2`] = `"foo"`;
-
-exports[`platform/gitlab getFile(filePath, branchName) gets the file with v4 by default 1`] = `"foo"`;
+exports[`platform/gitlab getFile(filePath, branchName) gets the file 1`] = `"foo"`;
 
 exports[`platform/gitlab getFileContent(filePath, branchName) gets the file 1`] = `"~�"`;
 
@@ -345,9 +284,6 @@ Array [
 exports[`platform/gitlab initRepo should initialise the config for the repo - 0 1`] = `
 Array [
   Array [
-    "projects/owned",
-  ],
-  Array [
     "projects/some%2Frepo",
   ],
   Array [
@@ -360,9 +296,6 @@ exports[`platform/gitlab initRepo should initialise the config for the repo - 0 
 
 exports[`platform/gitlab initRepo should initialise the config for the repo - 1 1`] = `
 Array [
-  Array [
-    "projects/owned",
-  ],
   Array [
     "projects/some%2Frepo",
   ],
@@ -377,9 +310,6 @@ exports[`platform/gitlab initRepo should initialise the config for the repo - 1 
 exports[`platform/gitlab initRepo should initialise the config for the repo - 2 1`] = `
 Array [
   Array [
-    "projects/owned",
-  ],
-  Array [
     "projects/some%2Frepo",
   ],
   Array [
@@ -390,15 +320,10 @@ Array [
 
 exports[`platform/gitlab initRepo should initialise the config for the repo - 2 2`] = `Object {}`;
 
-exports[`platform/gitlab initRepo should use api v4 1`] = `Object {}`;
-
 exports[`platform/gitlab initRepo uses provided logger 1`] = `Object {}`;
 
 exports[`platform/gitlab setBaseBranch(branchName) sets the base branch 1`] = `
 Array [
-  Array [
-    "projects/owned",
-  ],
   Array [
     "projects/some%2Frepo",
   ],

--- a/test/platform/gitlab.spec.js
+++ b/test/platform/gitlab.spec.js
@@ -64,8 +64,6 @@ describe('platform/gitlab', () => {
   });
 
   async function initRepo(...args) {
-    // projects/owned
-    get.mockImplementationOnce();
     // projects/${config.repoName
     get.mockImplementationOnce(() => ({
       body: {
@@ -134,26 +132,6 @@ describe('platform/gitlab', () => {
         err = e;
       }
       expect(err.message).toBe('always error');
-    });
-    it('should use api v4', async () => {
-      // projects/owned
-      get.mockImplementationOnce(() => {
-        throw new Error('any error');
-      });
-      // projects/${config.repoName
-      get.mockImplementationOnce(() => ({
-        body: {
-          default_branch: 'master',
-        },
-      }));
-      // user
-      get.mockImplementationOnce(() => ({
-        body: {
-          email: 'a@b.com',
-        },
-      }));
-      const config = await initRepo('some/repo', 'some_token');
-      expect(config).toMatchSnapshot();
     });
   });
   describe('setBaseBranch(branchName)', () => {
@@ -606,7 +584,7 @@ describe('platform/gitlab', () => {
     });
   });
   describe('getFile(filePath, branchName)', () => {
-    it('gets the file with v4 by default', async () => {
+    it('gets the file', async () => {
       get.mockReturnValueOnce({
         body: {
           content: 'foo',
@@ -615,27 +593,6 @@ describe('platform/gitlab', () => {
       const res = await gitlab.getFile('some/path');
       expect(res).toMatchSnapshot();
       expect(get.mock.calls[0][0].indexOf('some%2Fpath')).not.toBe(-1);
-    });
-    it('gets the file with v3', async () => {
-      get.mockReturnValueOnce({
-        body: {},
-      });
-      get.mockReturnValueOnce({
-        body: {},
-      });
-      get.mockReturnValueOnce({
-        body: {},
-      });
-      get.mockReturnValueOnce({
-        body: {
-          content: 'foo',
-        },
-      });
-      const config = await gitlab.initRepo('some-repo', 'some-token');
-      expect(config).toMatchSnapshot();
-      const res = await gitlab.getFile('some-path');
-      expect(res).toMatchSnapshot();
-      expect(get.mock.calls[3][0].indexOf('file_path')).not.toBe(-1);
     });
   });
   describe('getFileContent(filePath, branchName)', () => {
@@ -672,7 +629,7 @@ describe('platform/gitlab', () => {
     });
   });
   describe('createFile(branchName, filePath, fileContents, message)', () => {
-    it('creates file with v4', async () => {
+    it('creates file', async () => {
       await gitlab.createFile(
         'some-branch',
         'some-path',
@@ -682,28 +639,8 @@ describe('platform/gitlab', () => {
       expect(get.post.mock.calls).toMatchSnapshot();
       expect(get.post.mock.calls[0][1].body.file_path).not.toBeDefined();
     });
-    it('creates file with v3', async () => {
-      get.mockReturnValueOnce({
-        body: {},
-      });
-      get.mockReturnValueOnce({
-        body: {},
-      });
-      get.mockReturnValueOnce({
-        body: {},
-      });
-      await gitlab.initRepo('some-repo', 'some-token');
-      await gitlab.createFile(
-        'some-branch',
-        'some-path',
-        'some-contents',
-        'some-message'
-      );
-      expect(get.post.mock.calls).toMatchSnapshot();
-      expect(get.post.mock.calls[0][1].body.file_path).toBeDefined();
-    });
     describe('updateFile(branchName, filePath, fileContents, message)', () => {
-      it('creates file with v4', async () => {
+      it('updates file', async () => {
         await gitlab.updateFile(
           'some-branch',
           'some-path',
@@ -713,47 +650,12 @@ describe('platform/gitlab', () => {
         expect(get.put.mock.calls).toMatchSnapshot();
         expect(get.put.mock.calls[0][1].body.file_path).not.toBeDefined();
       });
-      it('creates file with v3', async () => {
-        get.mockReturnValueOnce({
-          body: {},
-        });
-        get.mockReturnValueOnce({
-          body: {},
-        });
-        get.mockReturnValueOnce({
-          body: {},
-        });
-        await gitlab.initRepo('some-repo', 'some-token');
-        await gitlab.updateFile(
-          'some-branch',
-          'some-path',
-          'some-contents',
-          'some-message'
-        );
-        expect(get.put.mock.calls).toMatchSnapshot();
-        expect(get.put.mock.calls[0][1].body.file_path).toBeDefined();
-      });
     });
     describe('createBranch(branchName)', () => {
-      it('creates file with v4', async () => {
+      it('creates branch', async () => {
         await gitlab.createBranch('some-branch');
         expect(get.post.mock.calls).toMatchSnapshot();
         expect(get.post.mock.calls[0][1].body.branch_name).not.toBeDefined();
-      });
-      it('creates file with v3', async () => {
-        get.mockReturnValueOnce({
-          body: {},
-        });
-        get.mockReturnValueOnce({
-          body: {},
-        });
-        get.mockReturnValueOnce({
-          body: {},
-        });
-        await gitlab.initRepo('some-repo', 'some-token');
-        await gitlab.createBranch('some-branch');
-        expect(get.post.mock.calls).toMatchSnapshot();
-        expect(get.post.mock.calls[0][1].body.branch_name).toBeDefined();
       });
     });
     describe('getSubDirectories(path)', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1942,9 +1942,9 @@ github@~0.1.10:
   version "0.1.16"
   resolved "https://registry.yarnpkg.com/github/-/github-0.1.16.tgz#895d2a85b0feb7980d89ac0ce4f44dcaa03f17b5"
 
-gl-got@7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/gl-got/-/gl-got-7.0.0.tgz#f0183d81aace8c3b77dcea13812837b6506cb0bb"
+gl-got@8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/gl-got/-/gl-got-8.0.0.tgz#aebf93387af0ed2066f8f296f9ff324a82138a9c"
   dependencies:
     got "^7.0.0"
     is-plain-obj "^1.1.0"


### PR DESCRIPTION
Out GitHub platform api code is now hardcoded to apiv4 with no detection performed.

BREAKING CHANGE: GitLab API v3 is no longer supported