### PR TITLE
feat: support globs in ignorePaths 

### DIFF
--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -203,10 +203,11 @@ const options = [
   },
   {
     name: 'ignorePaths',
-    description: 'Skip any package.json whose path matches one of these.',
+    description:
+      'Skip any package.json whose path matches one of these. Can be string or glob pattern',
     type: 'list',
     stage: 'repository',
-    default: ['node_modules/'],
+    default: ['**/node_modules/**'],
   },
   {
     name: 'dependencies',

--- a/lib/manager/index.js
+++ b/lib/manager/index.js
@@ -1,3 +1,5 @@
+const minimatch = require('minimatch');
+
 const docker = require('./docker/package');
 const npm = require('./npm/package');
 
@@ -19,7 +21,10 @@ async function detectPackageFiles(input) {
   const config = { ...input };
   const { logger } = config;
   const fileList = (await config.api.getFileList()).filter(
-    file => !config.ignorePaths.some(ignorePath => file.includes(ignorePath))
+    file =>
+      !config.ignorePaths.some(
+        ignorePath => file.includes(ignorePath) || minimatch(file, ignorePath)
+      )
   );
   logger.debug({ config }, 'detectPackageFiles');
   config.types = {};

--- a/test/manager/__snapshots__/index.spec.js.snap
+++ b/test/manager/__snapshots__/index.spec.js.snap
@@ -22,6 +22,7 @@ Array [
 exports[`manager detectPackageFiles(config) ignores node modules 1`] = `
 Array [
   "package.json",
+  "not_node_mldules/backend/package.json",
 ]
 `;
 

--- a/test/manager/index.spec.js
+++ b/test/manager/index.spec.js
@@ -70,10 +70,11 @@ describe('manager', () => {
       config.api.getFileList.mockReturnValueOnce([
         'package.json',
         'node_modules/backend/package.json',
+        'not_node_mldules/backend/package.json',
       ]);
       const res = await manager.detectPackageFiles(config);
       expect(res.packageFiles).toMatchSnapshot();
-      expect(res.packageFiles).toHaveLength(1);
+      expect(res.packageFiles).toHaveLength(2);
       expect(res.foundIgnoredPaths).toMatchSnapshot();
       expect(res.warnings).toMatchSnapshot();
     });


### PR DESCRIPTION
Renovate will now check ignorePaths values for either (a) a string match, or (b) glob pattern. e.g. a string of `'node_modules/'` will ignore `node_modules/foo/package.json` and `backend/node_modules/foo/package.json` but it will also mistakenly ignore `not_node_modules/foo/package.json` too. Therefore a glob pattern of `'**/node_modules/**'` is superior.

Closes #1054

BREAKING CHANGE: ignorePaths now supports globs and may match more than before, but that’s probably a good thing.