### PR TITLE
fix: set contentBranch to undefined instead of null

### DIFF
--- a/lib/workers/repository/apis.js
+++ b/lib/workers/repository/apis.js
@@ -233,7 +233,7 @@ async function resolvePackageFiles(inputConfig) {
   logger.trace({ config }, 'resolvePackageFiles()');
   const packageFiles = [];
   const contentBranch = config.repoIsOnboarded
-    ? config.baseBranch
+    ? config.baseBranch || undefined
     : config.onboardingBranch;
   config.contentBranch = contentBranch;
   for (let packageFile of config.packageFiles) {


### PR DESCRIPTION
This allows parameter substitution to work correctly (undefined is replace, null is not).

Closes #1076