### PR TITLE
fix: add zero width space after every @ sign in prBody

### DIFF
--- a/lib/workers/pr/index.js
+++ b/lib/workers/pr/index.js
@@ -129,8 +129,7 @@ async function ensurePr(prConfig) {
   let prBody;
   async function trimPrBody() {
     let prBodyMarkdown = handlebars.compile(config.prBody)(config);
-    const atUserRe = /[^`]@([a-z]+\/[a-z]+)/g;
-    prBodyMarkdown = prBodyMarkdown.replace(atUserRe, '@&#8203;$1');
+    prBodyMarkdown = prBodyMarkdown.replace('@', '@&#8203;');
     prBody = converter.makeHtml(prBodyMarkdown);
     // Public GitHub repos need links prevented - see #489
     prBody = prBody.replace(issueRe, '$1#&#8203;$2$3');


### PR DESCRIPTION
Aggressive search/replace to avoid unnecessary @ mentions. 
Reference: https://twitter.com/ljharb/status/926137291902300160
Hopefully this will be the last time @ljharb gets notified by Renovate