### PR TITLE
feat: rename mistakenly closed PRs

### DIFF
--- a/lib/workers/branch/check-existing.js
+++ b/lib/workers/branch/check-existing.js
@@ -25,8 +25,9 @@ async function prAlreadyExisted(config) {
     if (problemStart.isBefore(closedAt) && closedAt.isBefore(problemStopped)) {
       logger.info(
         { closedAt, problemStart, problemStopped },
-        'Ignoring mistakenly closed PR'
+        'Renaming mistakenly closed PR'
       );
+      await config.api.updatePr(pr.number, `${pr.title} - autoclosed`);
       return null;
     }
     return pr;

--- a/test/workers/branch/check-existing.spec.js
+++ b/test/workers/branch/check-existing.spec.js
@@ -10,7 +10,7 @@ describe('workers/branch/check-existing', () => {
     beforeEach(() => {
       config = {
         ...defaultConfig,
-        api: { findPr: jest.fn() },
+        api: { findPr: jest.fn(), updatePr: jest.fn() },
         logger,
         branchName: 'some-branch',
         prTitle: 'some-title',
@@ -39,9 +39,11 @@ describe('workers/branch/check-existing', () => {
     });
     it('returns false if mistaken', async () => {
       config.api.findPr.mockReturnValueOnce({
+        title: 'some title',
         closed_at: '2017-10-15T21:28:07.000Z',
       });
       expect(await prAlreadyExisted(config)).toBe(null);
+      expect(config.api.updatePr.mock.calls).toHaveLength(1);
     });
   });
 });


### PR DESCRIPTION
Renovate already detects PRs mistakenly closed during a certain time period when a bug was present. Now, it will rename those so that they are no longer detected and the ignore code does not have to remain indefinitely.