### PR TITLE
refactor: move config globals inside functions

### DIFF
--- a/lib/config/massage.js
+++ b/lib/config/massage.js
@@ -1,12 +1,7 @@
 const deepcopy = require('deepcopy');
 const options = require('./definitions').getOptions();
 
-const allowedStrings = [];
-options.forEach(option => {
-  if (option.allowString) {
-    allowedStrings.push(option.name);
-  }
-});
+let allowedStrings;
 
 module.exports = {
   massageConfig,
@@ -14,6 +9,14 @@ module.exports = {
 
 // Returns a massaged config
 function massageConfig(config) {
+  if (!allowedStrings) {
+    allowedStrings = [];
+    options.forEach(option => {
+      if (option.allowString) {
+        allowedStrings.push(option.name);
+      }
+    });
+  }
   const massagedConfig = deepcopy(config);
   for (const key of Object.keys(config)) {
     const val = config[key];

--- a/lib/config/migration.js
+++ b/lib/config/migration.js
@@ -2,10 +2,7 @@ const later = require('later');
 const deepcopy = require('deepcopy');
 const options = require('./definitions').getOptions();
 
-const optionTypes = {};
-options.forEach(option => {
-  optionTypes[option.name] = option.type;
-});
+let optionTypes;
 
 module.exports = {
   migrateConfig,
@@ -27,6 +24,12 @@ const removedOptions = [
 
 // Returns a migrated config
 function migrateConfig(config) {
+  if (!optionTypes) {
+    optionTypes = {};
+    options.forEach(option => {
+      optionTypes[option.name] = option.type;
+    });
+  }
   let isMigrated = false;
   const migratedConfig = deepcopy(config);
   for (const key of Object.keys(config)) {

--- a/lib/config/presets.js
+++ b/lib/config/presets.js
@@ -161,7 +161,8 @@ async function getPreset(preset, logger) {
     logger.warn(`Cannot find preset ${preset}`);
     return {};
   }
-  logger.debug({ presetConfig }, `Found preset ${preset}`);
+  logger.debug(`Found preset ${preset}`);
+  logger.trace({ presetConfig });
   if (params) {
     const argMapping = {};
     for (const [index, value] of params.entries()) {

--- a/lib/config/validation.js
+++ b/lib/config/validation.js
@@ -1,16 +1,19 @@
 const options = require('./definitions').getOptions();
 const { hasValidSchedule } = require('../workers/branch/schedule');
 
-const optionTypes = {};
-options.forEach(option => {
-  optionTypes[option.name] = option.type;
-});
+let optionTypes;
 
 module.exports = {
   validateConfig,
 };
 
 function validateConfig(config) {
+  if (!optionTypes) {
+    optionTypes = {};
+    options.forEach(option => {
+      optionTypes[option.name] = option.type;
+    });
+  }
   let errors = [];
   let warnings = [];
 


### PR DESCRIPTION
This was necessary when attempting to use jest mock all