### PR TITLE
fix: loosen docker digest replace regex

### DIFF
--- a/lib/manager/docker/update.js
+++ b/lib/manager/docker/update.js
@@ -11,7 +11,7 @@ function setNewValue(
 ) {
   try {
     logger.debug(`setNewValue: ${depName} = ${newVersion}`);
-    const regexReplace = new RegExp(`(^|\n)FROM ${currentVersion}\n`);
+    const regexReplace = new RegExp(`(^|\n)FROM ${depName}.*?\n`);
     const newFileContent = currentFileContent.replace(
       regexReplace,
       `$1FROM ${newVersion}\n`


### PR DESCRIPTION
By searching for the *original* value, this caused problems if a tag gets updated multiple times in the same PR.

Closes #1050 hopefully for the last time