### PR TITLE
fix: don’t upgrade docker from unstable to new major unstable

### DIFF
--- a/lib/manager/docker/package.js
+++ b/lib/manager/docker/package.js
@@ -17,6 +17,7 @@ async function getPackageUpdates(config) {
     currentTag,
     currentDigest,
     unstablePattern,
+    ignoreUnstable,
   } = config;
   if (dockerRegistry) {
     logger.info({ currentFrom }, 'Skipping Dockerfile image with custom host');
@@ -56,6 +57,7 @@ async function getPackageUpdates(config) {
       return upgrades;
     }
     const currentlyStable = isStable(tagVersion, unstablePattern);
+    const currentMajor = semver.major(padRange(tagVersion));
     let versionList = [];
     const allTags = await dockerApi.getTags(config.depName);
     if (allTags) {
@@ -65,9 +67,13 @@ async function getPackageUpdates(config) {
         .filter(versions.isValidVersion)
         .filter(
           version =>
+            // All stable are allowed
             isStable(version, unstablePattern) ||
-            !currentlyStable ||
-            !config.ignoreUnstable
+            // All unstable are allowed if we aren't ignoring them
+            !ignoreUnstable ||
+            // Allow unstable of same major version
+            (!currentlyStable &&
+              semver.major(padRange(version)) === currentMajor)
         )
         .filter(
           prefix => prefix.split('.').length === tagVersion.split('.').length
@@ -87,7 +93,6 @@ async function getPackageUpdates(config) {
       }
     }
     logger.debug({ versionUpgrades }, 'Docker versionUpgrades');
-    const currentMajor = semver.major(padRange(tagVersion));
     for (const newVersionMajor of Object.keys(versionUpgrades)) {
       let newTag = versionUpgrades[newVersionMajor];
       if (tagSuffix) {

--- a/test/manager/docker/__snapshots__/package.spec.js.snap
+++ b/test/manager/docker/__snapshots__/package.spec.js.snap
@@ -71,3 +71,40 @@ Array [
   },
 ]
 `;
+
+exports[`lib/workers/package/docker getPackageUpdates upgrades from unstable to stable 1`] = `
+Array [
+  Object {
+    "isMajor": true,
+    "newDepTag": "node:8",
+    "newFrom": "node:8",
+    "newTag": "8",
+    "newVersion": "8",
+    "newVersionMajor": "8",
+    "type": "major",
+  },
+]
+`;
+
+exports[`lib/workers/package/docker getPackageUpdates upgrades from unstable to unstable if not ignoring 1`] = `
+Array [
+  Object {
+    "isMajor": true,
+    "newDepTag": "node:8",
+    "newFrom": "node:8",
+    "newTag": "8",
+    "newVersion": "8",
+    "newVersionMajor": "8",
+    "type": "major",
+  },
+  Object {
+    "isMajor": true,
+    "newDepTag": "node:9",
+    "newFrom": "node:9",
+    "newTag": "9",
+    "newVersion": "9",
+    "newVersionMajor": "9",
+    "type": "major",
+  },
+]
+`;

--- a/test/manager/docker/package.spec.js
+++ b/test/manager/docker/package.spec.js
@@ -103,6 +103,41 @@ describe('lib/workers/package/docker', () => {
       expect(res[0].type).toEqual('major');
       expect(res[0].newVersion).toEqual('8');
     });
+    it('upgrades from unstable to stable', async () => {
+      config = {
+        ...defaultConfig,
+        depName: 'node',
+        currentFrom: 'node:7',
+        currentDepTag: 'node:7',
+        currentTag: '7',
+        currentDigest: undefined,
+        pinDigests: false,
+        unstablePattern: '^\\d*[13579]($|.)',
+      };
+      dockerApi.getTags.mockReturnValueOnce(['4', '6', '6.1', '7', '8', '9']);
+      const res = await docker.getPackageUpdates(config);
+      expect(res).toMatchSnapshot();
+      expect(res).toHaveLength(1);
+      expect(res[0].type).toEqual('major');
+      expect(res[0].newVersion).toEqual('8');
+    });
+    it('upgrades from unstable to unstable if not ignoring', async () => {
+      config = {
+        ...defaultConfig,
+        depName: 'node',
+        currentFrom: 'node:7',
+        currentDepTag: 'node:7',
+        currentTag: '7',
+        currentDigest: undefined,
+        pinDigests: false,
+        unstablePattern: '^\\d*[13579]($|.)',
+        ignoreUnstable: false,
+      };
+      dockerApi.getTags.mockReturnValueOnce(['4', '6', '6.1', '7', '8', '9']);
+      const res = await docker.getPackageUpdates(config);
+      expect(res).toMatchSnapshot();
+      expect(res).toHaveLength(2);
+    });
     it('adds digest', async () => {
       delete config.currentDigest;
       config.currentTag = '1.0.0-something';


### PR DESCRIPTION
Before, if current node version was 7 then Renovate would propose upgrades to versions 8 and 9. However, like with npm we should allow upgrades to unstable only if it’s the same major version or if ignoreUnstable is explicitly set to false.