### PR TITLE
fix: basBranch typo in gitlab api

### DIFF
--- a/lib/platform/gitlab/index.js
+++ b/lib/platform/gitlab/index.js
@@ -459,7 +459,7 @@ async function commitFilesToBranch(
       const opts = {
         body: {
           branch: branchName,
-          ref: config.basBranch,
+          ref: config.baseBranch,
         },
       };
       await get.post(`projects/${config.repoName}/repository/branches`, opts);


### PR DESCRIPTION
As per #1075 