### PR TITLE
fix: docker separateMajorReleases and groupName

### DIFF
--- a/lib/manager/docker/package.js
+++ b/lib/manager/docker/package.js
@@ -84,17 +84,32 @@ async function getPackageUpdates(config) {
     const versionUpgrades = {};
     for (const version of versionList) {
       const paddedVersion = padRange(version);
-      const major = semver.major(paddedVersion);
+      const newVersionMajor = semver.major(paddedVersion);
+      let upgradeKey;
       if (
-        !versionUpgrades[major] ||
-        compareVersions(version, versionUpgrades[major]) > 0
+        !config.separateMajorReleases ||
+        config.groupName ||
+        config.major.automerge === true
       ) {
-        versionUpgrades[major] = version;
+        // If we're not separating releases then we use a common lookup key
+        upgradeKey = 'latest';
+      } else {
+        // Use major version as lookup key
+        upgradeKey = newVersionMajor;
+      }
+      if (
+        !versionUpgrades[upgradeKey] ||
+        compareVersions(version, versionUpgrades[upgradeKey]) > 0
+      ) {
+        versionUpgrades[upgradeKey] = version;
       }
     }
     logger.debug({ versionUpgrades }, 'Docker versionUpgrades');
-    for (const newVersionMajor of Object.keys(versionUpgrades)) {
-      let newTag = versionUpgrades[newVersionMajor];
+    for (const upgradeKey of Object.keys(versionUpgrades)) {
+      let newTag = versionUpgrades[upgradeKey];
+      const newVersionMajor = `${semver.major(
+        padRange(versionUpgrades[upgradeKey])
+      )}`;
       if (tagSuffix) {
         newTag += `-${tagSuffix}`;
       }

--- a/test/manager/docker/__snapshots__/package.spec.js.snap
+++ b/test/manager/docker/__snapshots__/package.spec.js.snap
@@ -72,6 +72,21 @@ Array [
 ]
 `;
 
+exports[`lib/workers/package/docker getPackageUpdates returns only one upgrade if automerging major 1`] = `
+Array [
+  Object {
+    "isMajor": true,
+    "newDepTag": "some-dep:3.0.0",
+    "newDigest": "sha256:one",
+    "newFrom": "some-dep:3.0.0@sha256:one",
+    "newTag": "3.0.0",
+    "newVersion": "3.0.0",
+    "newVersionMajor": "3",
+    "type": "major",
+  },
+]
+`;
+
 exports[`lib/workers/package/docker getPackageUpdates upgrades from unstable to stable 1`] = `
 Array [
   Object {

--- a/test/manager/docker/package.spec.js
+++ b/test/manager/docker/package.spec.js
@@ -66,6 +66,22 @@ describe('lib/workers/package/docker', () => {
       dockerApi.getDigest.mockReturnValueOnce(config.currentDigest);
       expect(await docker.getPackageUpdates(config)).toEqual([]);
     });
+    it('returns only one upgrade if automerging major', async () => {
+      dockerApi.getDigest.mockReturnValueOnce(config.currentDigest);
+      dockerApi.getDigest.mockReturnValueOnce('sha256:one');
+      dockerApi.getTags.mockReturnValueOnce([
+        '1.1.0',
+        '1.2.0',
+        '2.0.0',
+        '3.0.0',
+      ]);
+      config.major.automerge = true;
+      const res = await docker.getPackageUpdates(config);
+      expect(res).toMatchSnapshot();
+      expect(res).toHaveLength(1);
+      expect(res[0].newVersionMajor).toEqual('3');
+      config.major.automerge = false;
+    });
     it('returns major and minor upgrades', async () => {
       dockerApi.getDigest.mockReturnValueOnce(config.currentDigest);
       dockerApi.getDigest.mockReturnValueOnce('sha256:one');


### PR DESCRIPTION
Bring docker config support up to npm support.