### PR TITLE
fix: use assignee_id when adding assignees in gitlab

### DIFF
--- a/lib/platform/gitlab/index.js
+++ b/lib/platform/gitlab/index.js
@@ -297,11 +297,16 @@ async function getBranchLastCommitTime(branchName) {
 async function addAssignees(iid, assignees) {
   logger.debug(`Adding assignees ${assignees} to #${iid}`);
   if (assignees.length > 1) {
-    logger.error('Cannot assign more than one assignee to Merge Requests');
+    logger.warn('Cannot assign more than one assignee to Merge Requests');
   }
-  let url = `projects/${config.repoName}/merge_requests/${iid}`;
-  url = `${url}?assignee_id=${assignees[0]}`;
-  await get.put(url);
+  try {
+    const assigneeId = (await get(`users?username=${assignees[0]}`)).body[0].id;
+    let url = `projects/${config.repoName}/merge_requests/${iid}`;
+    url += `?assignee_id=${assigneeId}`;
+    await get.put(url);
+  } catch (err) {
+    logger.error({ iid, assignees }, 'Failed to add assignees');
+  }
 }
 
 function addReviewers(iid, reviewers) {

--- a/test/platform/gitlab/__snapshots__/index.spec.js.snap
+++ b/test/platform/gitlab/__snapshots__/index.spec.js.snap
@@ -3,15 +3,15 @@
 exports[`platform/gitlab addAssignees(issueNo, assignees) should add the given assignees to the issue 1`] = `
 Array [
   Array [
-    "projects/some%2Frepo/merge_requests/42?assignee_id=someuser",
+    "projects/some%2Frepo/merge_requests/42?assignee_id=123",
   ],
 ]
 `;
 
-exports[`platform/gitlab addAssignees(issueNo, assignees) should log error if more than one assignee 1`] = `
+exports[`platform/gitlab addAssignees(issueNo, assignees) should warn if more than one assignee 1`] = `
 Array [
   Array [
-    "projects/some%2Frepo/merge_requests/42?assignee_id=someuser",
+    "projects/some%2Frepo/merge_requests/42?assignee_id=123",
   ],
 ]
 `;

--- a/test/platform/gitlab/index.spec.js
+++ b/test/platform/gitlab/index.spec.js
@@ -438,7 +438,7 @@ describe('platform/gitlab', () => {
     it('should add the given assignees to the issue', async () => {
       await initRepo('some/repo', 'token');
       get.mockReturnValueOnce({
-        body: [{ id: 123 }]
+        body: [{ id: 123 }],
       });
       await gitlab.addAssignees(42, ['someuser']);
       expect(get.put.mock.calls).toMatchSnapshot();
@@ -446,7 +446,7 @@ describe('platform/gitlab', () => {
     it('should warn if more than one assignee', async () => {
       await initRepo('some/repo', 'token');
       get.mockReturnValueOnce({
-        body: [{ id: 123 }]
+        body: [{ id: 123 }],
       });
       await gitlab.addAssignees(42, ['someuser', 'someotheruser']);
       expect(get.put.mock.calls).toMatchSnapshot();

--- a/test/platform/gitlab/index.spec.js
+++ b/test/platform/gitlab/index.spec.js
@@ -437,13 +437,25 @@ describe('platform/gitlab', () => {
   describe('addAssignees(issueNo, assignees)', () => {
     it('should add the given assignees to the issue', async () => {
       await initRepo('some/repo', 'token');
+      get.mockReturnValueOnce({
+        body: [{ id: 123 }]
+      });
       await gitlab.addAssignees(42, ['someuser']);
       expect(get.put.mock.calls).toMatchSnapshot();
     });
-    it('should log error if more than one assignee', async () => {
+    it('should warn if more than one assignee', async () => {
       await initRepo('some/repo', 'token');
+      get.mockReturnValueOnce({
+        body: [{ id: 123 }]
+      });
       await gitlab.addAssignees(42, ['someuser', 'someotheruser']);
       expect(get.put.mock.calls).toMatchSnapshot();
+    });
+    it('should swallow error', async () => {
+      await initRepo('some/repo', 'token');
+      get.mockImplementationOnce({});
+      await gitlab.addAssignees(42, ['someuser', 'someotheruser']);
+      expect(get.put.mock.calls).toHaveLength(0);
     });
   });
   describe('addReviewers(issueNo, reviewers)', () => {


### PR DESCRIPTION
GitLab’s API requires assignee *id* and not *username* when adding assignees to a merge request. Now, we allow Renovate users to still configure usernames and we will look up the ID and use it in the request instead.

Closes #1131