### PR TITLE
fix: check commit message before ignoring web-flow commits

### DIFF
--- a/lib/platform/github/index.js
+++ b/lib/platform/github/index.js
@@ -551,8 +551,18 @@ async function getPr(prNo) {
           logger.debug('Could not determine commit author');
         }
         logger.debug(`Commit author is: ${author}`);
+        const message = commit.commit ? commit.commit.message : '';
+        const parents = commit.parents || [];
+        let ignoreWebFlow = false;
+        if (
+          author === 'web-flow' &&
+          message.startsWith("Merge branch '") &&
+          parents.length === 2
+        ) {
+          ignoreWebFlow = true;
+        }
         // Ignore GitHub "web-flow"
-        if (author !== 'web-flow' && arr.indexOf(author) === -1) {
+        if (!ignoreWebFlow && arr.indexOf(author) === -1) {
           arr.push(author);
         }
         return arr;

--- a/test/platform/github/index.spec.js
+++ b/test/platform/github/index.spec.js
@@ -1066,8 +1066,8 @@ describe('platform/github', () => {
       get.mockImplementationOnce(() => ({
         body: [
           {
-            author: {
-              login: 'foo',
+            committer: {
+              login: 'web-flow',
             },
           },
           {
@@ -1105,6 +1105,10 @@ describe('platform/github', () => {
             committer: {
               login: 'web-flow',
             },
+            commit: {
+              message: "Merge branch 'master' into renovate/foo",
+            },
+            parents: [1, 2],
           },
         ],
       }));


### PR DESCRIPTION
We need to check the message + number of commit parents to be confident that the user was just keeping the branch up-to-date. Otherwise it might be other edits via the web interface.