### PR TITLE
refactor: check blocked PR before checking schedule

### DIFF
--- a/lib/workers/branch/index.js
+++ b/lib/workers/branch/index.js
@@ -30,24 +30,9 @@ async function processBranch(branchConfig) {
   });
   logger.trace({ config }, 'processBranch');
   try {
-    // Check schedule
-    config.isScheduledNow = isScheduledNow(config);
-    if (!config.isScheduledNow) {
-      if (!await platform.branchExists(config.branchName)) {
-        logger.info('Skipping branch creation as not within schedule');
-        return 'not-scheduled';
-      }
-      if (config.updateNotScheduled === false) {
-        logger.debug('Skipping branch update as not within schedule');
-        return 'not-scheduled';
-      }
-      logger.debug(
-        'Branch exists but is not scheduled -- will update if necessary'
-      );
-    }
-
     logger.info(`Branch has ${dependencies.length} upgrade(s)`);
 
+    // Check if branch already existed
     const pr = await prAlreadyExisted(config);
     if (pr) {
       logger.info(
@@ -78,6 +63,23 @@ async function processBranch(branchConfig) {
       await platform.ensureComment(pr.number, subject, content);
       return 'already-existed';
     }
+
+    // Check schedule
+    config.isScheduledNow = isScheduledNow(config);
+    if (!config.isScheduledNow) {
+      if (!await platform.branchExists(config.branchName)) {
+        logger.info('Skipping branch creation as not within schedule');
+        return 'not-scheduled';
+      }
+      if (config.updateNotScheduled === false) {
+        logger.debug('Skipping branch update as not within schedule');
+        return 'not-scheduled';
+      }
+      logger.debug(
+        'Branch exists but is not scheduled -- will update if necessary'
+      );
+    }
+
     Object.assign(config, await getParentBranch(config));
     logger.debug(`Using parentBranch: ${config.parentBranch}`);
     Object.assign(config, await getUpdatedPackageFiles(config));

--- a/test/workers/branch/index.spec.js
+++ b/test/workers/branch/index.spec.js
@@ -38,18 +38,25 @@ describe('workers/branch', () => {
     afterEach(() => {
       platform.ensureComment.mockClear();
       platform.ensureCommentRemoval.mockClear();
+      jest.resetAllMocks();
     });
     it('skips branch if not scheduled and branch does not exist', async () => {
       schedule.isScheduledNow.mockReturnValueOnce(false);
-      await branchWorker.processBranch(config);
-      expect(checkExisting.prAlreadyExisted.mock.calls).toHaveLength(0);
+      const res = await branchWorker.processBranch(config);
+      expect(res).toEqual('not-scheduled');
     });
     it('skips branch if not scheduled and not updating out of schedule', async () => {
       schedule.isScheduledNow.mockReturnValueOnce(false);
       config.updateNotScheduled = false;
       platform.branchExists.mockReturnValueOnce(true);
+      const res = await branchWorker.processBranch(config);
+      expect(res).toEqual('not-scheduled');
+    });
+    it('processes branch if not scheduled but updating out of schedule', async () => {
+      schedule.isScheduledNow.mockReturnValueOnce(false);
+      config.updateNotScheduled = true;
+      platform.branchExists.mockReturnValueOnce(true);
       await branchWorker.processBranch(config);
-      expect(checkExisting.prAlreadyExisted.mock.calls).toHaveLength(0);
     });
     it('skips branch if closed major PR found', async () => {
       schedule.isScheduledNow.mockReturnValueOnce(false);


### PR DESCRIPTION
Instead of checking schedule first, now we check first if the PR is blocked by a closed PR. This provides more consistent feedback.

Closes #1100