### PR TITLE
feat: use persistent cache for npm registry queries

### DIFF
--- a/lib/manager/npm/registry.js
+++ b/lib/manager/npm/registry.js
@@ -1,26 +1,21 @@
-// Most of this borrowed from https://github.com/sindresorhus/package-json/blob/master/index.js
+// Much of this borrowed from https://github.com/sindresorhus/package-json/blob/master/index.js
 
-const got = require('got');
 const url = require('url');
 const ini = require('ini');
-const Keyv = require('keyv');
 const getRegistryUrl = require('registry-auth-token/registry-url');
 const registryAuthToken = require('registry-auth-token');
 const parse = require('github-url-from-git');
-
-const cache = new Keyv({ namespace: 'npm' });
+const os = require('os');
+const fetch = require('make-fetch-happen').defaults({
+  cacheManager: os.tmpdir() + '/renovate-npm-cache',
+});
 
 module.exports = {
   setNpmrc,
   getDependency,
-  resetCache,
 };
 
 let npmrc = null;
-
-function resetCache() {
-  cache.clear();
-}
 
 function setNpmrc(input) {
   npmrc = ini.parse(input);
@@ -48,51 +43,36 @@ async function getDependency(name) {
     headers.authorization = `Bearer ${process.env.NPM_TOKEN}`;
   }
 
-  // Cache based on combinatino of package URL and headers
-  const cacheKey = pkgUrl + JSON.stringify(headers);
-
-  // Return from cache if present
-  const cacheVal = await cache.get(cacheKey);
-  if (cacheVal) {
-    logger.trace(`Returning cached version of ${name}`);
-    return cacheVal;
-  }
-
   // Retrieve from API if not cached
   try {
-    const res = await got(pkgUrl, {
-      json: true,
+    const res = await fetch(pkgUrl, {
       headers,
-    });
+    }).then(r => r.json());
     // Determine repository URL
     let repositoryUrl;
-    if (res.body.repository) {
-      repositoryUrl = parse(res.body.repository.url);
+    if (res.repository) {
+      repositoryUrl = parse(res.repository.url);
     }
     if (!repositoryUrl) {
-      repositoryUrl = res.body.homepage;
+      repositoryUrl = res.homepage;
     }
     // Simplify response before caching and returning
     const dep = {
-      name: res.body.name,
-      homepage: res.body.homepage,
+      name: res.name,
+      homepage: res.homepage,
       repositoryUrl,
-      versions: res.body.versions,
-      'dist-tags': res.body['dist-tags'],
+      versions: res.versions,
+      'dist-tags': res['dist-tags'],
       'renovate-config':
-        res.body.versions[res.body['dist-tags'].latest]['renovate-config'],
+        res.versions[res['dist-tags'].latest]['renovate-config'],
     };
     Object.keys(dep.versions).forEach(version => {
       // We don't use any of the version payload currently
       dep.versions[version] = {
         // fall back to arbitrary time for old npm servers
-        time: res.body.time
-          ? res.body.time[version]
-          : '2017-01-01T12:00:00.000Z',
+        time: res.time ? res.time[version] : '2017-01-01T12:00:00.000Z',
       };
     });
-    const expiryMs = 5 * 60 * 1000;
-    await cache.set(cacheKey, dep, expiryMs);
     logger.trace({ dependency: dep }, 'dependency');
     return dep;
   } catch (err) {

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "jest": "21.2.1",
     "mkdirp": "0.5.1",
     "mockdate": "2.0.2",
+    "nock": "9.1.0",
     "prettier": "1.8.2",
     "rimraf": "2.6.2",
     "semantic-release": "8.2.0"

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "keyv": "3.0.0",
     "later": "1.2.0",
     "lodash": "4.17.4",
+    "make-fetch-happen": "2.5.0",
     "minimatch": "3.0.4",
     "moment": "2.19.2",
     "moment-timezone": "0.5.14",

--- a/test/manager/npm/__snapshots__/registry.spec.js.snap
+++ b/test/manager/npm/__snapshots__/registry.spec.js.snap
@@ -5,26 +5,16 @@ Object {
   "dist-tags": Object {
     "latest": "0.0.1",
   },
-  "homepage": "https://google.com",
+  "homepage": undefined,
   "name": undefined,
   "renovate-config": undefined,
-  "repositoryUrl": "https://google.com",
+  "repositoryUrl": undefined,
   "versions": Object {
     "0.0.1": Object {
       "time": "",
     },
   },
 }
-`;
-
-exports[`api/npm should fetch package info from custom registry 2`] = `
-Array [
-  "https://npm.mycustomregistry.com/foobar",
-  Object {
-    "headers": Object {},
-    "json": true,
-  },
-]
 `;
 
 exports[`api/npm should fetch package info from npm 1`] = `
@@ -44,43 +34,21 @@ Object {
 }
 `;
 
-exports[`api/npm should fetch package info from npm 2`] = `
-Array [
-  "https://registry.npmjs.org/foobar",
-  Object {
-    "headers": Object {},
-    "json": true,
-  },
-]
-`;
-
 exports[`api/npm should send an authorization header if provided 1`] = `
 Object {
   "dist-tags": Object {
     "latest": "0.0.1",
   },
-  "homepage": "https://google.com",
+  "homepage": undefined,
   "name": undefined,
   "renovate-config": undefined,
-  "repositoryUrl": "https://google.com",
+  "repositoryUrl": undefined,
   "versions": Object {
     "0.0.1": Object {
       "time": "",
     },
   },
 }
-`;
-
-exports[`api/npm should send an authorization header if provided 2`] = `
-Array [
-  "https://registry.npmjs.org/foobar",
-  Object {
-    "headers": Object {
-      "authorization": "Basic 1234",
-    },
-    "json": true,
-  },
-]
 `;
 
 exports[`api/npm should use NPM_TOKEN if provided 1`] = `
@@ -88,28 +56,16 @@ Object {
   "dist-tags": Object {
     "latest": "0.0.1",
   },
-  "homepage": "https://google.com",
+  "homepage": undefined,
   "name": undefined,
   "renovate-config": undefined,
-  "repositoryUrl": "https://google.com",
+  "repositoryUrl": undefined,
   "versions": Object {
     "0.0.1": Object {
       "time": "",
     },
   },
 }
-`;
-
-exports[`api/npm should use NPM_TOKEN if provided 2`] = `
-Array [
-  "https://registry.npmjs.org/foobar",
-  Object {
-    "headers": Object {
-      "authorization": "Bearer some-token",
-    },
-    "json": true,
-  },
-]
 `;
 
 exports[`api/npm should use default registry if missing from npmrc 1`] = `
@@ -117,10 +73,10 @@ Object {
   "dist-tags": Object {
     "latest": "0.0.1",
   },
-  "homepage": "https://google.com",
+  "homepage": undefined,
   "name": undefined,
   "renovate-config": undefined,
-  "repositoryUrl": "https://google.com",
+  "repositoryUrl": undefined,
   "versions": Object {
     "0.0.1": Object {
       "time": "",
@@ -129,41 +85,21 @@ Object {
 }
 `;
 
-exports[`api/npm should use default registry if missing from npmrc 2`] = `
-Array [
-  "https://registry.npmjs.org/foobar",
-  Object {
-    "headers": Object {},
-    "json": true,
-  },
-]
-`;
-
 exports[`api/npm should use dummy time if missing 1`] = `
 Object {
   "dist-tags": Object {
     "latest": "0.0.1",
   },
-  "homepage": "https://google.com",
+  "homepage": undefined,
   "name": undefined,
   "renovate-config": undefined,
-  "repositoryUrl": "https://google.com",
+  "repositoryUrl": undefined,
   "versions": Object {
     "0.0.1": Object {
       "time": "2017-01-01T12:00:00.000Z",
     },
   },
 }
-`;
-
-exports[`api/npm should use dummy time if missing 2`] = `
-Array [
-  "https://registry.npmjs.org/foobar",
-  Object {
-    "headers": Object {},
-    "json": true,
-  },
-]
 `;
 
 exports[`api/npm should use homepage 1`] = `
@@ -181,14 +117,4 @@ Object {
     },
   },
 }
-`;
-
-exports[`api/npm should use homepage 2`] = `
-Array [
-  "https://registry.npmjs.org/foobarhome",
-  Object {
-    "headers": Object {},
-    "json": true,
-  },
-]
 `;

--- a/test/manager/npm/registry.spec.js
+++ b/test/manager/npm/registry.spec.js
@@ -1,27 +1,25 @@
 const npm = require('../../../lib/manager/npm/registry');
 const got = require('got');
 const registryAuthToken = require('registry-auth-token');
+const nock = require('nock');
 
 jest.mock('registry-auth-token');
-jest.mock('got');
 
 const npmResponse = {
-  body: {
-    versions: {
-      '0.0.1': {
-        foo: 1,
-      },
+  versions: {
+    '0.0.1': {
+      foo: 1,
     },
-    repository: {
-      type: 'git',
-      url: 'git://github.com/renovateapp/dummy.git',
-    },
-    'dist-tags': {
-      latest: '0.0.1',
-    },
-    time: {
-      '0.0.1': '',
-    },
+  },
+  repository: {
+    type: 'git',
+    url: 'git://github.com/renovateapp/dummy.git',
+  },
+  'dist-tags': {
+    latest: '0.0.1',
+  },
+  time: {
+    '0.0.1': '',
   },
 };
 
@@ -32,33 +30,34 @@ describe('api/npm', () => {
     npm.resetCache();
   });
   it('should fetch package info from npm', async () => {
-    got.mockImplementation(() => Promise.resolve(npmResponse));
+    nock('https://registry.npmjs.org')
+      .get('/foobar')
+      .reply(200, npmResponse);
     const res = await npm.getDependency('foobar');
     expect(res).toMatchSnapshot();
-    const call = got.mock.calls[0];
-    expect(call).toMatchSnapshot();
   });
   it('should use homepage', async () => {
     const npmResponseHomepage = { ...npmResponse };
-    npmResponseHomepage.body.repository.url = '';
-    npmResponseHomepage.body.homepage = 'https://google.com';
-    got.mockImplementationOnce(() => Promise.resolve(npmResponseHomepage));
+    npmResponseHomepage.repository.url = '';
+    npmResponseHomepage.homepage = 'https://google.com';
+    nock('https://registry.npmjs.org')
+      .get('/foobarhome')
+      .reply(200, npmResponseHomepage);
     const res = await npm.getDependency('foobarhome');
     expect(res).toMatchSnapshot();
-    const call = got.mock.calls[0];
-    expect(call).toMatchSnapshot();
   });
   it('should cache package info from npm', async () => {
-    got.mockImplementation(() => Promise.resolve(npmResponse));
+    nock('https://registry.npmjs.org')
+      .get('/foobar')
+      .reply(200, npmResponse);
     const res1 = await npm.getDependency('foobar');
     const res2 = await npm.getDependency('foobar');
     expect(res1).toEqual(res2);
-    expect(got.mock.calls.length).toEqual(1);
   });
   it('should return null if lookup fails', async () => {
-    got.mockImplementation(() => {
-      throw new Error('not found');
-    });
+    nock('https://registry.npmjs.org')
+      .get('/foobar')
+      .reply(404);
     const res = await npm.getDependency('foobar');
     expect(res).toBeNull();
   });
@@ -67,45 +66,47 @@ describe('api/npm', () => {
       type: 'Basic',
       token: '1234',
     }));
-    got.mockImplementation(() => Promise.resolve(npmResponse));
+    nock('https://registry.npmjs.org')
+      .matchHeader('authorization', 'Basic 1234')
+      .get('/foobar')
+      .reply(200, npmResponse);
     const res = await npm.getDependency('foobar');
     expect(res).toMatchSnapshot();
-    const call = got.mock.calls[0];
-    expect(call).toMatchSnapshot();
   });
   it('should use NPM_TOKEN if provided', async () => {
-    got.mockImplementation(() => Promise.resolve(npmResponse));
+    nock('https://registry.npmjs.org')
+      .matchHeader('authorization', 'Bearer some-token')
+      .get('/foobar')
+      .reply(200, npmResponse);
     const oldToken = process.env.NPM_TOKEN;
     process.env.NPM_TOKEN = 'some-token';
     const res = await npm.getDependency('foobar');
     process.env.NPM_TOKEN = oldToken;
     expect(res).toMatchSnapshot();
-    const call = got.mock.calls[0];
-    expect(call).toMatchSnapshot();
   });
   it('should fetch package info from custom registry', async () => {
-    got.mockImplementation(() => Promise.resolve(npmResponse));
+    nock('https://npm.mycustomregistry.com')
+      .get('/foobar')
+      .reply(200, npmResponse);
     npm.setNpmrc('registry=https://npm.mycustomregistry.com/');
     const res = await npm.getDependency('foobar');
     expect(res).toMatchSnapshot();
-    const call = got.mock.calls[0];
-    expect(call).toMatchSnapshot();
   });
   it('should use default registry if missing from npmrc', async () => {
-    got.mockImplementation(() => Promise.resolve(npmResponse));
+    nock('https://registry.npmjs.org')
+      .get('/foobar')
+      .reply(200, npmResponse);
     npm.setNpmrc('foo=bar');
     const res = await npm.getDependency('foobar');
     expect(res).toMatchSnapshot();
-    const call = got.mock.calls[0];
-    expect(call).toMatchSnapshot();
   });
   it('should use dummy time if missing', async () => {
     const noTimeResponse = { ...npmResponse };
-    delete noTimeResponse.body.time;
-    got.mockImplementation(() => Promise.resolve(noTimeResponse));
+    delete noTimeResponse.time;
+    nock('https://registry.npmjs.org')
+      .get('/foobar')
+      .reply(200, noTimeResponse);
     const res = await npm.getDependency('foobar');
     expect(res).toMatchSnapshot();
-    const call = got.mock.calls[0];
-    expect(call).toMatchSnapshot();
   });
 });

--- a/test/manager/npm/registry.spec.js
+++ b/test/manager/npm/registry.spec.js
@@ -27,7 +27,6 @@ describe('api/npm', () => {
   delete process.env.NPM_TOKEN;
   beforeEach(() => {
     jest.resetAllMocks();
-    npm.resetCache();
   });
   it('should fetch package info from npm', async () => {
     nock('https://registry.npmjs.org')

--- a/test/manager/npm/registry.spec.js
+++ b/test/manager/npm/registry.spec.js
@@ -1,5 +1,4 @@
 const npm = require('../../../lib/manager/npm/registry');
-const got = require('got');
 const registryAuthToken = require('registry-auth-token');
 const nock = require('nock');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3282,7 +3282,7 @@ make-dir@^1.0.0:
   dependencies:
     pify "^3.0.0"
 
-make-fetch-happen@^2.4.13, make-fetch-happen@^2.5.0:
+make-fetch-happen@2.5.0, make-fetch-happen@^2.4.13, make-fetch-happen@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/make-fetch-happen/-/make-fetch-happen-2.5.0.tgz#08c22d499f4f30111addba79fe87c98cf01b6bc8"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -672,6 +672,14 @@ chai@4.1.2:
     pathval "^1.0.0"
     type-detect "^4.0.0"
 
+"chai@>=1.9.2 <4.0.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-3.5.0.tgz#4d02637b067fe958bdbfdd3a40ec56fef7373247"
+  dependencies:
+    assertion-error "^1.0.1"
+    deep-eql "^0.1.3"
+    type-detect "^1.0.0"
+
 chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -1111,11 +1119,21 @@ decompress-response@^3.2.0:
   dependencies:
     mimic-response "^1.0.0"
 
+deep-eql@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-0.1.3.tgz#ef558acab8de25206cd713906d74e56930eb69f2"
+  dependencies:
+    type-detect "0.1.1"
+
 deep-eql@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
   dependencies:
     type-detect "^4.0.0"
+
+deep-equal@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
 
 deep-extend@~0.4.0:
   version "0.4.2"
@@ -3218,7 +3236,7 @@ lodash.without@~4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.without/-/lodash.without-4.4.0.tgz#3cd4574a00b67bae373a94b748772640507b7aac"
 
-lodash@4.17.4, lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.3.0:
+lodash@4.17.4, lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.3.0, lodash@~4.17.2:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -3490,6 +3508,20 @@ nerf-dart@^1.0.0:
 netrc@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/netrc/-/netrc-0.1.4.tgz#6be94fcaca8d77ade0a9670dc460914c94472444"
+
+nock@9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-9.1.0.tgz#b6fd783abc1e774cb028058ea81207369a735747"
+  dependencies:
+    chai ">=1.9.2 <4.0.0"
+    debug "^2.2.0"
+    deep-equal "^1.0.0"
+    json-stringify-safe "^5.0.1"
+    lodash "~4.17.2"
+    mkdirp "^0.5.0"
+    propagate "0.4.0"
+    qs "^6.0.2"
+    semver "^5.3.0"
 
 node-fetch-npm@^2.0.1:
   version "2.0.2"
@@ -4134,6 +4166,10 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
+propagate@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/propagate/-/propagate-0.4.0.tgz#f3fcca0a6fe06736a7ba572966069617c130b481"
+
 proto-list@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
@@ -4183,6 +4219,10 @@ qrcode-terminal@~0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/qrcode-terminal/-/qrcode-terminal-0.11.0.tgz#ffc6c28a2fc0bfb47052b47e23f4f446a5fbdb9e"
 
+qs@^6.0.2, qs@~6.5.1:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
+
 qs@~6.2.0:
   version "6.2.3"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.2.3.tgz#1cfcb25c10a9b2b483053ff39f5dfc9233908cfe"
@@ -4194,10 +4234,6 @@ qs@~6.3.0:
 qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
-
-qs@~6.5.1:
-  version "6.5.1"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
 
 query-string@~5.0.0:
   version "5.0.1"
@@ -5153,6 +5189,14 @@ type-check@~0.3.2:
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
   dependencies:
     prelude-ls "~1.1.2"
+
+type-detect@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-0.1.1.tgz#0ba5ec2a885640e470ea4e8505971900dac58822"
+
+type-detect@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-1.0.0.tgz#762217cc06db258ec48908a1298e8b95121e8ea2"
 
 type-detect@^4.0.0:
   version "4.0.3"


### PR DESCRIPTION
This PR refactors the npm registry code to use `make-fetch-happen` instead of got. Additionally, it will use `cacache` for a disk-based caching solution.