### PR TITLE
Normalize Gitlab findPr with Github structure and add PR cache

### DIFF
--- a/lib/platform/gitlab/index.js
+++ b/lib/platform/gitlab/index.js
@@ -323,29 +323,39 @@ async function ensureCommentRemoval() {
   // Todo: implement. See GitHub API for example
 }
 
+async function getPrList() {
+  if (!config.prList) {
+    const urlString = `projects/${config.repoName}/merge_requests?per_page=100`;
+    const res = await get(urlString, { paginate: true });
+    config.prList = res.body.map(pr => ({
+      number: pr.iid,
+      branchName: pr.source_branch,
+      title: pr.title,
+      state: pr.state,
+    }));
+  }
+  return config.prList;
+}
+
 async function findPr(branchName, prTitle, state = 'all') {
   logger.debug(`findPr(${branchName}, ${prTitle}, ${state})`);
-  const urlString = `projects/${config.repoName}/merge_requests?state=${
-    state
-  }&per_page=100`;
-  const res = await get(urlString, { paginated: true });
-  let pr = null;
-  res.body.forEach(result => {
-    if (
-      (!prTitle || result.title === prTitle) &&
-      result.source_branch === branchName
-    ) {
-      pr = result;
-      // GitHub uses number, GitLab uses iid
-      pr.number = pr.iid;
-      pr.body = pr.description;
-      pr.displayNumber = `Merge Request #${pr.iid}`;
-      if (pr.state !== 'opened') {
-        pr.isClosed = true;
+  const prList = await getPrList();
+  const pr = prList
+    .reverse()
+    .find(
+      p =>
+        p.branchName === branchName &&
+        (!prTitle || p.title === prTitle) &&
+        (state === 'all' || p.state === state)
+    );
+  return pr
+    ? {
+        ...pr,
+        isClosed: pr.state === 'merged',
+        body: pr.description,
+        displayNumber: `Merge Request #${pr.iid}`,
       }
-    }
-  });
-  return pr;
+    : null;
 }
 
 // Pull Request

--- a/lib/platform/gitlab/index.js
+++ b/lib/platform/gitlab/index.js
@@ -332,7 +332,7 @@ async function getPrList() {
       branchName: pr.source_branch,
       title: pr.title,
       state: pr.state === 'opened' ? 'open' : 'closed',
-      isClosed: pr.state !== 'opened',t
+      isClosed: pr.state !== 'opened',
     }));
   }
   return config.prList;

--- a/lib/platform/gitlab/index.js
+++ b/lib/platform/gitlab/index.js
@@ -332,6 +332,7 @@ async function getPrList() {
       branchName: pr.source_branch,
       title: pr.title,
       state: pr.state === 'opened' ? 'open' : 'closed',
+      isClosed: pr.state !== 'opened',t
     }));
   }
   return config.prList;
@@ -340,7 +341,7 @@ async function getPrList() {
 async function findPr(branchName, prTitle, state = 'all') {
   logger.debug(`findPr(${branchName}, ${prTitle}, ${state})`);
   const prList = await getPrList();
-  const pr = prList
+  return prList
     .reverse()
     .find(
       p =>
@@ -348,14 +349,6 @@ async function findPr(branchName, prTitle, state = 'all') {
         (!prTitle || p.title === prTitle) &&
         (state === 'all' || p.state === state)
     );
-  return pr
-    ? {
-        ...pr,
-        isClosed: pr.state !== 'open',
-        body: pr.description,
-        displayNumber: `Merge Request #${pr.iid}`,
-      }
-    : null;
 }
 
 // Pull Request

--- a/lib/platform/gitlab/index.js
+++ b/lib/platform/gitlab/index.js
@@ -331,7 +331,7 @@ async function getPrList() {
       number: pr.iid,
       branchName: pr.source_branch,
       title: pr.title,
-      state: pr.state,
+      state: pr.state === 'opened' ? 'open' : 'closed',
     }));
   }
   return config.prList;

--- a/lib/platform/gitlab/index.js
+++ b/lib/platform/gitlab/index.js
@@ -342,7 +342,6 @@ async function findPr(branchName, prTitle, state = 'all') {
   logger.debug(`findPr(${branchName}, ${prTitle}, ${state})`);
   const prList = await getPrList();
   return prList
-    .reverse()
     .find(
       p =>
         p.branchName === branchName &&

--- a/lib/platform/gitlab/index.js
+++ b/lib/platform/gitlab/index.js
@@ -79,6 +79,7 @@ async function initRepo(repoName, token, endpoint) {
   }
   config.repoName = repoName.replace('/', '%2F');
   config.fileList = null;
+  config.prList = null;
   try {
     const res = await get(`projects/${config.repoName}`);
     config.defaultBranch = res.body.default_branch;
@@ -340,13 +341,12 @@ async function getPrList() {
 async function findPr(branchName, prTitle, state = 'all') {
   logger.debug(`findPr(${branchName}, ${prTitle}, ${state})`);
   const prList = await getPrList();
-  return prList
-    .find(
-      p =>
-        p.branchName === branchName &&
-        (!prTitle || p.title === prTitle) &&
-        (state === 'all' || p.state === state)
-    );
+  return prList.find(
+    p =>
+      p.branchName === branchName &&
+      (!prTitle || p.title === prTitle) &&
+      (state === 'all' || p.state === state)
+  );
 }
 
 // Pull Request

--- a/lib/platform/gitlab/index.js
+++ b/lib/platform/gitlab/index.js
@@ -351,7 +351,7 @@ async function findPr(branchName, prTitle, state = 'all') {
   return pr
     ? {
         ...pr,
-        isClosed: pr.state === 'merged',
+        isClosed: pr.state !== 'open',
         body: pr.description,
         displayNumber: `Merge Request #${pr.iid}`,
       }

--- a/lib/workers/repository/onboarding/branch/check.js
+++ b/lib/workers/repository/onboarding/branch/check.js
@@ -32,13 +32,12 @@ const isOnboarded = async config => {
   return false;
 };
 
-const onboardingPrExists = async config => {
-  const pullRequest = await platform.findPr(
+const onboardingPrExists = config =>
+  platform.findPr(
     `${config.branchPrefix}configure`,
-    'Configure Renovate'
+    'Configure Renovate',
+    'open'
   );
-  return pullRequest && !pullRequest.isClosed ? pullRequest : null;
-};
 
 module.exports = {
   isOnboarded,

--- a/lib/workers/repository/onboarding/branch/check.js
+++ b/lib/workers/repository/onboarding/branch/check.js
@@ -32,12 +32,13 @@ const isOnboarded = async config => {
   return false;
 };
 
-const onboardingPrExists = config =>
-  platform.findPr(
+const onboardingPrExists = async config => {
+  const pullRequest = await platform.findPr(
     `${config.branchPrefix}configure`,
-    'Configure Renovate',
-    'open'
+    'Configure Renovate'
   );
+  return pullRequest && !pullRequest.isClosed ? pullRequest : null;
+};
 
 module.exports = {
   isOnboarded,

--- a/test/platform/gitlab/index.spec.js
+++ b/test/platform/gitlab/index.spec.js
@@ -475,45 +475,39 @@ describe('platform/gitlab', () => {
     });
   });
   describe('findPr(branchName, prTitle, state)', () => {
-    it('returns null if no results', async () => {
-      get.mockReturnValueOnce({
-        body: [],
-      });
-      const pr = await gitlab.findPr('some-branch');
-      expect(pr).toBe(null);
-    });
-    it('returns null if no matching titles', async () => {
+    it('returns true if no title and all state', async () => {
       get.mockReturnValueOnce({
         body: [
           {
-            source_branch: 'some-branch',
-            iid: 1,
-          },
-          {
-            source_branch: 'some-branch',
-            iid: 2,
-            title: 'foo',
+            number: 1,
+            source_branch: 'branch-a',
+            title: 'branch a pr',
+            state: 'opened',
           },
         ],
       });
-      const pr = await gitlab.findPr('some-branch', 'some-title');
-      expect(pr).toBe(null);
+      const res = await gitlab.findPr('branch-a', null);
+      expect(res).toBeDefined();
     });
-    it('returns last result if multiple match', async () => {
+    it('caches pr list', async () => {
       get.mockReturnValueOnce({
         body: [
           {
-            source_branch: 'some-branch',
-            iid: 1,
-          },
-          {
-            source_branch: 'some-branch',
-            iid: 2,
+            number: 1,
+            source_branch: 'branch-a',
+            title: 'branch a pr',
+            state: 'opened',
           },
         ],
       });
-      const pr = await gitlab.findPr('some-branch');
-      expect(pr.number).toBe(2);
+      let res = await gitlab.findPr('branch-a', null);
+      expect(res).toBeDefined();
+      res = await gitlab.findPr('branch-a', 'branch a pr');
+      expect(res).toBeDefined();
+      res = await gitlab.findPr('branch-a', 'branch a pr', 'open');
+      expect(res).toBeDefined();
+      res = await gitlab.findPr('branch-b');
+      expect(res).not.toBeDefined();
     });
   });
   describe('createPr(branchName, title, body)', () => {


### PR DESCRIPTION
Uses the same method structure with Github and Gitlab, fixed #1164 and also adds PR list cache to gitlab too.