### PR TITLE
VSTS - RepoName & ProjectName

### DIFF
--- a/lib/platform/vsts/index.js
+++ b/lib/platform/vsts/index.js
@@ -59,7 +59,9 @@ async function initRepo(repoName, token, endpoint) {
   const repos = await gitApi().getRepositories();
   const names = vstsHelper.getProjectAndRepo(repoName);
   const repo = repos.filter(
-    c => c.name === names.repo && c.project.name === names.project
+    c =>
+      c.name.toLowerCase() === names.repo.toLowerCase() &&
+      c.project.name.toLowerCase() === names.project.toLowerCase()
   )[0];
   logger.debug({ repositoryDetails: repo }, 'Repository details');
   config.repoId = repo.id;

--- a/lib/platform/vsts/index.js
+++ b/lib/platform/vsts/index.js
@@ -243,14 +243,21 @@ async function commitFilesToBranch(
     );
   }
 
-  let changes = await vstsHelper.getChanges(files, config.repoId, config.name, parentBranch);
+  const changesInCommit = await vstsHelper.getChanges(
+    files,
+    config.repoId,
+    config.name,
+    parentBranch
+  );
 
   await gitApi().createPush(
     {
-      commits: [{
-        comment: message,
-        changes: changes
-      }],
+      commits: [
+        {
+          comment: message,
+          changes: changesInCommit,
+        },
+      ],
       refUpdates: [branchRef],
     },
     config.repoId
@@ -440,7 +447,7 @@ async function getBranchLastCommitTime(branchName) {
 function setBranchStatus(branchName, context, description, state, targetUrl) {
   logger.debug(
     `setBranchStatus(${branchName}, ${context}, ${description}, ${state}, ${
-    targetUrl
+      targetUrl
     }) - Not supported by VSTS (yet!)`
   );
 }
@@ -448,7 +455,7 @@ function setBranchStatus(branchName, context, description, state, targetUrl) {
 async function mergeBranch(branchName, mergeType) {
   logger.info(
     `mergeBranch(branchName, mergeType)(${branchName}, ${
-    mergeType
+      mergeType
     }) - Not supported by VSTS (yet!)`
   );
   await null;
@@ -462,7 +469,7 @@ async function mergePr(pr) {
 async function addAssignees(issueNo, assignees) {
   logger.info(
     `addAssignees(issueNo, assignees)(${issueNo}, ${
-    assignees
+      assignees
     }) - Not supported by VSTS (yet!)`
   );
   await null;
@@ -471,7 +478,7 @@ async function addAssignees(issueNo, assignees) {
 async function addReviewers(issueNo, reviewers) {
   logger.info(
     `addReviewers(issueNo, reviewers)(${issueNo}, ${
-    reviewers
+      reviewers
     }) - Not supported by VSTS (yet!)`
   );
   await null;

--- a/lib/platform/vsts/index.js
+++ b/lib/platform/vsts/index.js
@@ -234,34 +234,27 @@ async function commitFilesToBranch(
     parentBranch
   );
 
-  // create commits
-  for (const file of files) {
-    const isBranchExisting = await branchExists(`refs/heads/${branchName}`);
-    if (isBranchExisting) {
-      branchRef = await vstsHelper.getVSTSBranchObj(
-        config.repoId,
-        branchName,
-        branchName
-      );
-    }
-
-    const commit = await vstsHelper.getVSTSCommitObj(
-      message,
-      file.name,
-      file.contents,
+  const isBranchExisting = await branchExists(`refs/heads/${branchName}`);
+  if (isBranchExisting) {
+    branchRef = await vstsHelper.getVSTSBranchObj(
       config.repoId,
-      config.name,
-      parentBranch
-    );
-    await gitApi().createPush(
-      // @ts-ignore
-      {
-        commits: [commit],
-        refUpdates: [branchRef],
-      },
-      config.repoId
+      branchName,
+      branchName
     );
   }
+
+  let changes = await vstsHelper.getChanges(files, config.repoId, config.name, parentBranch);
+
+  await gitApi().createPush(
+    {
+      commits: [{
+        comment: message,
+        changes: changes
+      }],
+      refUpdates: [branchRef],
+    },
+    config.repoId
+  );
 }
 
 async function branchExists(branchName) {
@@ -447,7 +440,7 @@ async function getBranchLastCommitTime(branchName) {
 function setBranchStatus(branchName, context, description, state, targetUrl) {
   logger.debug(
     `setBranchStatus(${branchName}, ${context}, ${description}, ${state}, ${
-      targetUrl
+    targetUrl
     }) - Not supported by VSTS (yet!)`
   );
 }
@@ -455,7 +448,7 @@ function setBranchStatus(branchName, context, description, state, targetUrl) {
 async function mergeBranch(branchName, mergeType) {
   logger.info(
     `mergeBranch(branchName, mergeType)(${branchName}, ${
-      mergeType
+    mergeType
     }) - Not supported by VSTS (yet!)`
   );
   await null;
@@ -469,7 +462,7 @@ async function mergePr(pr) {
 async function addAssignees(issueNo, assignees) {
   logger.info(
     `addAssignees(issueNo, assignees)(${issueNo}, ${
-      assignees
+    assignees
     }) - Not supported by VSTS (yet!)`
   );
   await null;
@@ -478,7 +471,7 @@ async function addAssignees(issueNo, assignees) {
 async function addReviewers(issueNo, reviewers) {
   logger.info(
     `addReviewers(issueNo, reviewers)(${issueNo}, ${
-      reviewers
+    reviewers
     }) - Not supported by VSTS (yet!)`
   );
   await null;

--- a/lib/platform/vsts/index.js
+++ b/lib/platform/vsts/index.js
@@ -47,7 +47,7 @@ async function getRepos(token, endpoint) {
   logger.debug('getRepos(token, endpoint)');
   vstsHelper.setTokenAndEndpoint(token, endpoint);
   const repos = await gitApi().getRepositories();
-  return repos.map(repo => repo.name);
+  return repos.map(repo => `${repo.project.name}/${repo.name}`);
 }
 
 async function initRepo(repoName, token, endpoint) {
@@ -57,7 +57,10 @@ async function initRepo(repoName, token, endpoint) {
   config.fileList = null;
   config.prList = null;
   const repos = await gitApi().getRepositories();
-  const repo = repos.filter(c => c.name === repoName)[0];
+  const names = vstsHelper.getProjectAndRepo(repoName);
+  const repo = repos.filter(
+    c => c.name === names.repo && c.project.name === names.project
+  )[0];
   logger.debug({ repositoryDetails: repo }, 'Repository details');
   config.repoId = repo.id;
   config.privateRepo = true;

--- a/lib/platform/vsts/vsts-helper.js
+++ b/lib/platform/vsts/vsts-helper.js
@@ -13,6 +13,7 @@ module.exports = {
   max4000Chars,
   getRenovatePRFormat,
   getCommitDetails,
+  getProjectAndRepo,
 };
 
 /**
@@ -260,4 +261,29 @@ async function getCommitDetails(commit, repoId) {
   logger.debug(`getCommitDetails(${commit}, ${repoId})`);
   const results = await gitApi().getCommit(commit, repoId);
   return results;
+}
+
+/**
+ *
+ * @param {string} str
+ */
+function getProjectAndRepo(str) {
+  logger.trace(`getProjectAndRepo(${str})`);
+  const strSplited = str.split(`/`);
+  if (strSplited.length === 1) {
+    return {
+      project: str,
+      repo: str,
+    };
+  } else if (strSplited.length === 2) {
+    return {
+      project: strSplited[0],
+      repo: strSplited[1],
+    };
+  }
+  const msg = `${
+    str
+  } can be only structured this way : 'repoName' or 'projectName/repoName'!`;
+  logger.error(msg);
+  throw new Error(msg);
 }

--- a/lib/platform/vsts/vsts-helper.js
+++ b/lib/platform/vsts/vsts-helper.js
@@ -7,7 +7,7 @@ module.exports = {
   getBranchNameWithoutRefsheadsPrefix,
   getRefs,
   getVSTSBranchObj,
-  getVSTSCommitObj,
+  getChanges,
   getNewBranchName,
   getFile,
   max4000Chars,
@@ -58,7 +58,7 @@ function getBranchNameWithoutRefsheadsPrefix(branchPath) {
   if (!branchPath.startsWith('refs/heads/')) {
     logger.trace(
       `The refs/heads/ name should have started with 'refs/heads/' but it didn't. (${
-        branchPath
+      branchPath
       })`
     );
     return branchPath;
@@ -78,7 +78,7 @@ function getBranchNameWithoutRefsPrefix(branchPath) {
   if (!branchPath.startsWith('refs/')) {
     logger.trace(
       `The ref name should have started with 'refs/' but it didn't. (${
-        branchPath
+      branchPath
       })`
     );
     return branchPath;
@@ -130,47 +130,29 @@ async function getVSTSBranchObj(repoId, branchName, from) {
  * @param {string} repoName
  * @param {string} branchName
  */
-async function getVSTSCommitObj(
-  msg,
-  filePath,
-  fileContent,
-  repoId,
-  repoName,
-  branchName
-) {
-  // Add or update
-  let changeType = 1;
-  const fileAlreadyThere = await getFile(
-    repoId,
-    repoName,
-    filePath,
-    branchName
-  );
-  if (fileAlreadyThere) {
-    changeType = 2;
+async function getChanges(files, repoId, repoName, branchName) {
+  let changes = [];
+  for (const file of files) {
+    // Add or update
+    let changeType = 1;
+    const fileAlreadyThere = await getFile(repoId, repoName, file.name, branchName);
+    if (fileAlreadyThere) {
+      changeType = 2;
+    }
+
+    changes.push({
+      changeType,
+      item: {
+        path: file.name,
+      },
+      newContent: {
+        Content: file.contents,
+        ContentType: 0, // RawText
+      }
+    });
   }
 
-  return {
-    comment: msg,
-    author: {
-      name: 'VSTS Renovate', // Todo... this is not working
-    },
-    committer: {
-      name: 'VSTS Renovate', // Todo... this is not working
-    },
-    changes: [
-      {
-        changeType,
-        item: {
-          path: filePath,
-        },
-        newContent: {
-          Content: fileContent,
-          ContentType: 0, // RawText
-        },
-      },
-    ],
-  };
+  return changes;
 }
 
 /**

--- a/lib/platform/vsts/vsts-helper.js
+++ b/lib/platform/vsts/vsts-helper.js
@@ -236,15 +236,35 @@ function getRenovatePRFormat(vstsPr) {
   pr.displayNumber = `Pull Request #${vstsPr.pullRequestId}`;
   pr.number = vstsPr.pullRequestId;
 
+  // status
+  // export declare enum PullRequestStatus {
+  //   NotSet = 0,
+  //   Active = 1,
+  //   Abandoned = 2,
+  //   Completed = 3,
+  //   All = 4,
+  // }
+
   if (vstsPr.status === 2 || vstsPr.status === 3) {
     pr.isClosed = true;
   } else {
     pr.isClosed = false;
   }
 
+  // mergeStatus
+  // export declare enum PullRequestAsyncStatus {
+  //   NotSet = 0,
+  //   Queued = 1,
+  //   Conflicts = 2,
+  //   Succeeded = 3,
+  //   RejectedByPolicy = 4,
+  //   Failure = 5,
+  // }
   if (vstsPr.mergeStatus === 2) {
     pr.isUnmergeable = true;
   }
+
+  pr.canRebase = true;
 
   return pr;
 }

--- a/lib/platform/vsts/vsts-helper.js
+++ b/lib/platform/vsts/vsts-helper.js
@@ -58,7 +58,7 @@ function getBranchNameWithoutRefsheadsPrefix(branchPath) {
   if (!branchPath.startsWith('refs/heads/')) {
     logger.trace(
       `The refs/heads/ name should have started with 'refs/heads/' but it didn't. (${
-      branchPath
+        branchPath
       })`
     );
     return branchPath;
@@ -78,7 +78,7 @@ function getBranchNameWithoutRefsPrefix(branchPath) {
   if (!branchPath.startsWith('refs/')) {
     logger.trace(
       `The ref name should have started with 'refs/' but it didn't. (${
-      branchPath
+        branchPath
       })`
     );
     return branchPath;
@@ -131,11 +131,16 @@ async function getVSTSBranchObj(repoId, branchName, from) {
  * @param {string} branchName
  */
 async function getChanges(files, repoId, repoName, branchName) {
-  let changes = [];
+  const changes = [];
   for (const file of files) {
     // Add or update
     let changeType = 1;
-    const fileAlreadyThere = await getFile(repoId, repoName, file.name, branchName);
+    const fileAlreadyThere = await getFile(
+      repoId,
+      repoName,
+      file.name,
+      branchName
+    );
     if (fileAlreadyThere) {
       changeType = 2;
     }
@@ -148,7 +153,7 @@ async function getChanges(files, repoId, repoName, branchName) {
       newContent: {
         Content: file.contents,
         ContentType: 0, // RawText
-      }
+      },
     });
   }
 

--- a/lib/workers/branch/parent.js
+++ b/lib/workers/branch/parent.js
@@ -39,7 +39,7 @@ async function getParentBranch(config) {
     if (pr.canRebase) {
       logger.info(`Branch is not mergeable and needs rebasing`);
       // TODO: Move this down to api library
-      if (config.isGitLab) {
+      if (config.isGitLab || config.isVsts) {
         logger.info(`Deleting unmergeable branch in order to recreate/rebase`);
         await platform.deleteBranch(branchName);
       }

--- a/test/config/index.spec.js
+++ b/test/config/index.spec.js
@@ -119,12 +119,22 @@ describe('config/index', () => {
       gitApi.mockImplementationOnce(() => ({
         getRepositories: jest.fn(() => [
           {
-            name: 'a/b',
+            name: 'repo1',
+            project: {
+              name: 'prj1',
+            },
           },
           {
-            name: 'c/d',
+            name: 'repo2',
+            project: {
+              name: 'prj1',
+            },
           },
         ]),
+      }));
+      vstsHelper.getProjectAndRepo.mockImplementationOnce(() => ({
+        project: 'prj1',
+        repo: 'repo1',
       }));
       await configParser.parseConfigs(env, defaultArgv);
       expect(ghGot.mock.calls.length).toBe(0);

--- a/test/platform/vsts/__snapshots__/index.spec.js.snap
+++ b/test/platform/vsts/__snapshots__/index.spec.js.snap
@@ -132,8 +132,8 @@ Array [
 
 exports[`platform/vsts getRepos should return an array of repos 2`] = `
 Array [
-  "a/b",
-  "c/d",
+  "prj1/repo1",
+  "prj1/repo2",
 ]
 `;
 
@@ -157,7 +157,7 @@ Object {
   "privateRepo": true,
   "repoForceRebase": false,
   "repoId": "1",
-  "repoName": "some/repo",
+  "repoName": "some-repo",
 }
 `;
 

--- a/test/platform/vsts/__snapshots__/vsts-helper.spec.js.snap
+++ b/test/platform/vsts/__snapshots__/vsts-helper.spec.js.snap
@@ -40,6 +40,20 @@ Object {
 
 exports[`platform/vsts/helpers getFile should return the file content because it is not a json 1`] = `"{\\"hello\\"= \\"test\\"}"`;
 
+exports[`platform/vsts/helpers getProjectAndRepo should return the object with project and repo 1`] = `
+Object {
+  "project": "prjName",
+  "repo": "myRepoName",
+}
+`;
+
+exports[`platform/vsts/helpers getProjectAndRepo should return the object with same strings 1`] = `
+Object {
+  "project": "myRepoName",
+  "repo": "myRepoName",
+}
+`;
+
 exports[`platform/vsts/helpers getRef should get the ref 1`] = `
 Array [
   Object {

--- a/test/platform/vsts/__snapshots__/vsts-helper.spec.js.snap
+++ b/test/platform/vsts/__snapshots__/vsts-helper.spec.js.snap
@@ -1,5 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`platform/vsts/helpers getChanges should be get the commit obj formated (file to create) 1`] = `
+Array [
+  Object {
+    "changeType": 1,
+    "item": Object {
+      "path": "./myFilePath/test",
+    },
+    "newContent": Object {
+      "Content": "Hello world!",
+      "ContentType": 0,
+    },
+  },
+]
+`;
+
+exports[`platform/vsts/helpers getChanges should be get the commit obj formated (file to update) 1`] = `
+Array [
+  Object {
+    "changeType": 2,
+    "item": Object {
+      "path": "./myFilePath/test",
+    },
+    "newContent": Object {
+      "Content": "Hello world!",
+      "ContentType": 0,
+    },
+  },
+]
+`;
+
 exports[`platform/vsts/helpers getCommitDetails should get commit details 1`] = `
 Object {
   "parents": Array [
@@ -78,54 +108,6 @@ exports[`platform/vsts/helpers getVSTSBranchObj should be the branch object form
 Object {
   "name": "refs/heads/branchName",
   "oldObjectId": "0000000000000000000000000000000000000000",
-}
-`;
-
-exports[`platform/vsts/helpers getVSTSCommitObj should be get the commit obj formated (file to create) 1`] = `
-Object {
-  "author": Object {
-    "name": "VSTS Renovate",
-  },
-  "changes": Array [
-    Object {
-      "changeType": 1,
-      "item": Object {
-        "path": "./myFilePath/test",
-      },
-      "newContent": Object {
-        "Content": "Hello world!",
-        "ContentType": 0,
-      },
-    },
-  ],
-  "comment": "Commit msg",
-  "committer": Object {
-    "name": "VSTS Renovate",
-  },
-}
-`;
-
-exports[`platform/vsts/helpers getVSTSCommitObj should be get the commit obj formated (file to update) 1`] = `
-Object {
-  "author": Object {
-    "name": "VSTS Renovate",
-  },
-  "changes": Array [
-    Object {
-      "changeType": 2,
-      "item": Object {
-        "path": "./myFilePath/test",
-      },
-      "newContent": Object {
-        "Content": "Hello world!",
-        "ContentType": 0,
-      },
-    },
-  ],
-  "comment": "Commit msg",
-  "committer": Object {
-    "name": "VSTS Renovate",
-  },
 }
 `;
 

--- a/test/platform/vsts/__snapshots__/vsts-helper.spec.js.snap
+++ b/test/platform/vsts/__snapshots__/vsts-helper.spec.js.snap
@@ -28,6 +28,7 @@ Array [
 
 exports[`platform/vsts/helpers getRenovatePRFormat should be formated (closed v2) 1`] = `
 Object {
+  "canRebase": true,
   "displayNumber": "Pull Request #undefined",
   "isClosed": true,
   "number": undefined,
@@ -37,6 +38,7 @@ Object {
 
 exports[`platform/vsts/helpers getRenovatePRFormat should be formated (closed) 1`] = `
 Object {
+  "canRebase": true,
   "displayNumber": "Pull Request #undefined",
   "isClosed": true,
   "number": undefined,
@@ -46,6 +48,7 @@ Object {
 
 exports[`platform/vsts/helpers getRenovatePRFormat should be formated (isUnmergeable) 1`] = `
 Object {
+  "canRebase": true,
   "displayNumber": "Pull Request #undefined",
   "isClosed": false,
   "isUnmergeable": true,
@@ -56,6 +59,7 @@ Object {
 
 exports[`platform/vsts/helpers getRenovatePRFormat should be formated (not closed) 1`] = `
 Object {
+  "canRebase": true,
   "displayNumber": "Pull Request #undefined",
   "isClosed": false,
   "number": undefined,

--- a/test/platform/vsts/vsts-helper.spec.js
+++ b/test/platform/vsts/vsts-helper.spec.js
@@ -127,7 +127,7 @@ describe('platform/vsts/helpers', () => {
     });
   });
 
-  describe('getVSTSCommitObj', () => {
+  describe('getChanges', () => {
     it('should be get the commit obj formated (file to update)', async () => {
       gitApi.mockImplementationOnce(() => ({
         getItemText: jest.fn(() => ({
@@ -138,10 +138,13 @@ describe('platform/vsts/helpers', () => {
         })),
       }));
 
-      const res = await vstsHelper.getVSTSCommitObj(
-        'Commit msg',
-        './myFilePath/test',
-        'Hello world!',
+      const res = await vstsHelper.getChanges(
+        [
+          {
+            name: './myFilePath/test',
+            contents: 'Hello world!',
+          },
+        ],
         '123',
         'repoName',
         'branchName'
@@ -153,10 +156,13 @@ describe('platform/vsts/helpers', () => {
         getItemText: jest.fn(() => null),
       }));
 
-      const res = await vstsHelper.getVSTSCommitObj(
-        'Commit msg',
-        './myFilePath/test',
-        'Hello world!',
+      const res = await vstsHelper.getChanges(
+        [
+          {
+            name: './myFilePath/test',
+            contents: 'Hello world!',
+          },
+        ],
         '123',
         'repoName',
         'branchName'

--- a/test/platform/vsts/vsts-helper.spec.js
+++ b/test/platform/vsts/vsts-helper.spec.js
@@ -298,4 +298,26 @@ describe('platform/vsts/helpers', () => {
       expect(res).toMatchSnapshot();
     });
   });
+
+  describe('getProjectAndRepo', () => {
+    it('should return the object with same strings', async () => {
+      const res = await vstsHelper.getProjectAndRepo('myRepoName');
+      expect(res).toMatchSnapshot();
+    });
+    it('should return the object with project and repo', async () => {
+      const res = await vstsHelper.getProjectAndRepo('prjName/myRepoName');
+      expect(res).toMatchSnapshot();
+    });
+    it('should return an error', async () => {
+      let err;
+      try {
+        await vstsHelper.getProjectAndRepo('prjName/myRepoName/blalba');
+      } catch (error) {
+        err = error;
+      }
+      expect(err.message).toBe(
+        `prjName/myRepoName/blalba can be only structured this way : 'repoName' or 'projectName/repoName'!`
+      );
+    });
+  });
 });


### PR DESCRIPTION
VSTS has 3 level:
- endpoint
- project 
- repo

By default, repo and project has the same name.
In my VSTS implementation I didn't take care of project level! :(

Here is the issue link to RenovateMe (VSTS task based on renovate)
https://github.com/jycouet/VSTSExtensions/issues/7

With this PR, the project level will be handle! :)