### PR TITLE
feat: docker registry cache

### DIFF
--- a/lib/manager/docker/registry.js
+++ b/lib/manager/docker/registry.js
@@ -5,6 +5,8 @@ module.exports = {
   getTags,
 };
 
+const map = new Map();
+
 async function getDigest(name, tag = 'latest') {
   const repository = name.includes('/') ? name : `library/${name}`;
   try {
@@ -12,7 +14,7 @@ async function getDigest(name, tag = 'latest') {
       repository
     }:pull`;
     logger.debug(`Obtaining docker registry token for ${repository}`);
-    const { token } = (await got(authUrl, { json: true })).body;
+    const { token } = (await got(authUrl, { cache: map, json: true })).body;
     if (!token) {
       logger.warn('Failed to obtain docker registry token');
       return null;
@@ -23,9 +25,8 @@ async function getDigest(name, tag = 'latest') {
       Authorization: `Bearer ${token}`,
       Accept: 'application/vnd.docker.distribution.manifest.v2+json',
     };
-    const digest = (await got(url, { json: true, headers })).headers[
-      'docker-content-digest'
-    ];
+    const digest = (await got(url, { cache: map, json: true, headers }))
+      .headers['docker-content-digest'];
     logger.debug({ digest }, 'Got docker digest');
     return digest;
   } catch (err) {
@@ -41,7 +42,7 @@ async function getTags(name) {
       repository
     }:pull`;
     logger.debug(`Obtaining docker registry token for ${repository}`);
-    const { token } = (await got(authUrl, { json: true })).body;
+    const { token } = (await got(authUrl, { cache: map, json: true })).body;
     if (!token) {
       logger.warn('Failed to obtain docker registry token');
       return null;
@@ -52,7 +53,7 @@ async function getTags(name) {
       Authorization: `Bearer ${token}`,
       Accept: 'application/vnd.docker.distribution.manifest.v2+json',
     };
-    const res = await got(url, { json: true, headers });
+    const res = await got(url, { cache: map, json: true, headers });
     logger.debug({ tags: res.body.tags }, 'Got docker tags');
     return res.body.tags;
   } catch (err) {


### PR DESCRIPTION
Use got’s built-in caching with in-memory map.

Closes #1028