### PR TITLE
fix: Revert "feat: docker registry cache (#1210)"

### DIFF
--- a/lib/manager/docker/registry.js
+++ b/lib/manager/docker/registry.js
@@ -5,8 +5,6 @@ module.exports = {
   getTags,
 };
 
-const map = new Map();
-
 async function getDigest(name, tag = 'latest') {
   const repository = name.includes('/') ? name : `library/${name}`;
   try {
@@ -14,7 +12,7 @@ async function getDigest(name, tag = 'latest') {
       repository
     }:pull`;
     logger.debug(`Obtaining docker registry token for ${repository}`);
-    const { token } = (await got(authUrl, { cache: map, json: true })).body;
+    const { token } = (await got(authUrl, { json: true })).body;
     if (!token) {
       logger.warn('Failed to obtain docker registry token');
       return null;
@@ -25,8 +23,9 @@ async function getDigest(name, tag = 'latest') {
       Authorization: `Bearer ${token}`,
       Accept: 'application/vnd.docker.distribution.manifest.v2+json',
     };
-    const digest = (await got(url, { cache: map, json: true, headers }))
-      .headers['docker-content-digest'];
+    const digest = (await got(url, { json: true, headers })).headers[
+      'docker-content-digest'
+    ];
     logger.debug({ digest }, 'Got docker digest');
     return digest;
   } catch (err) {
@@ -42,7 +41,7 @@ async function getTags(name) {
       repository
     }:pull`;
     logger.debug(`Obtaining docker registry token for ${repository}`);
-    const { token } = (await got(authUrl, { cache: map, json: true })).body;
+    const { token } = (await got(authUrl, { json: true })).body;
     if (!token) {
       logger.warn('Failed to obtain docker registry token');
       return null;
@@ -53,7 +52,7 @@ async function getTags(name) {
       Authorization: `Bearer ${token}`,
       Accept: 'application/vnd.docker.distribution.manifest.v2+json',
     };
-    const res = await got(url, { cache: map, json: true, headers });
+    const res = await got(url, { json: true, headers });
     logger.debug({ tags: res.body.tags }, 'Got docker tags');
     return res.body.tags;
   } catch (err) {


### PR DESCRIPTION
This reverts commit 371f1cbf3ddb9ad2499c2564f60301d2c91d2a9f. Caching caused 401 Docker registry errors.