### PR TITLE
chore: set maxWorkers=4 for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ cache:
 script:
   - yarn run prettier -- --list-different
   - yarn run lint
-  - yarn run jest
+  - yarn run jest --maxWorkers=4
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
As recommended in http://facebook.github.io/jest/docs/en/troubleshooting.html#tests-are-extremely-slow-on-docker-and-or-continuous-integration-ci-server