### PR TITLE
refactor: remove label and assignees description from onboarding pr

### DIFF
--- a/lib/workers/repository/onboarding/pr/config-description.js
+++ b/lib/workers/repository/onboarding/pr/config-description.js
@@ -1,33 +1,3 @@
-function getAssigneesDesc(config) {
-  logger.debug('getAssigneesDesc()');
-  logger.trace({ config });
-  if (!(config.assignees && config.assignees.length)) {
-    logger.debug('No assignees configuration');
-    return [];
-  }
-  logger.debug('Found assignees config');
-  let desc = `Assign PRs to `;
-  desc += config.assignees
-    .map(assignee => (assignee[0] === '@' ? assignee : `@${assignee}`))
-    .join(' and ');
-  return [desc];
-}
-
-function getLabelsDesc(config) {
-  logger.debug('getLabelsDesc()');
-  logger.trace({ config });
-  if (!(config.labels && config.labels.length)) {
-    logger.debug('No labels configuration');
-    return [];
-  }
-  let desc = 'Apply label';
-  if (config.labels.length > 1) {
-    desc += 's';
-  }
-  desc += ` ${config.labels.map(label => `\`${label}\``).join(' and ')} to PRs`;
-  return [desc];
-}
-
 function getScheduleDesc(config) {
   logger.debug('getScheduleDesc()');
   logger.trace({ config });
@@ -42,10 +12,7 @@ function getScheduleDesc(config) {
 function getDescriptionArray(config) {
   logger.debug('getDescriptionArray()');
   logger.trace({ config });
-  return (config.description || [])
-    .concat(getAssigneesDesc(config))
-    .concat(getLabelsDesc(config))
-    .concat(getScheduleDesc(config));
+  return (config.description || []).concat(getScheduleDesc(config));
 }
 
 function getConfigDesc(config) {
@@ -71,8 +38,6 @@ function getConfigDesc(config) {
 }
 
 module.exports = {
-  getAssigneesDesc,
-  getLabelsDesc,
   getScheduleDesc,
   getConfigDesc,
 };

--- a/test/workers/repository/onboarding/pr/__snapshots__/config-description.spec.js.snap
+++ b/test/workers/repository/onboarding/pr/__snapshots__/config-description.spec.js.snap
@@ -7,8 +7,6 @@ exports[`workers/repository/onboarding/pr/config-description getConfigDesc() ass
 Based on the currently configured presets, Renovate will:
 
   - Start dependency updates once this Configure Renovate PR is merged or closed
-  - Assign PRs to @someone and @someone-else
-  - Apply labels \`renovate\` and \`deps\` to PRs
   - Run Renovate on following schedule: before 5am
 
 Would you like to change the way Renovate is upgrading your dependencies? Simply edit the \`renovate.json\` in this branch and this Pull Request description will be updated the next time Renovate runs. 


### PR DESCRIPTION
These can now be described via presets instead