### PR TITLE
fix: exit gracefully if no files to commit

### DIFF
--- a/lib/workers/branch/commit.js
+++ b/lib/workers/branch/commit.js
@@ -29,5 +29,7 @@ async function commitFilesToBranch(config) {
     );
   } else {
     logger.debug(`No files to commit`);
+    return false;
   }
+  return true;
 }

--- a/lib/workers/branch/index.js
+++ b/lib/workers/branch/index.js
@@ -100,7 +100,10 @@ async function processBranch(branchConfig) {
     } else {
       logger.debug('No updated lock files in branch');
     }
-    await commitFilesToBranch(config);
+    const committedFiles = await commitFilesToBranch(config);
+    if (!committedFiles) {
+      return 'no-work';
+    }
 
     // Set branch statuses
     await setUnpublishable(config);


### PR DESCRIPTION
This handles case where checking for lock file maintenance but lock file is up-to-date.