### PR TITLE
fix: improve pr merged detection logic

### DIFF
--- a/lib/platform/github/index.js
+++ b/lib/platform/github/index.js
@@ -471,10 +471,14 @@ async function getPrList() {
       number: pr.number,
       branchName: pr.head.ref,
       title: pr.title,
-      state: pr.merged_at ? 'merged' : pr.state,
+      state:
+        pr.state === 'closed' && pr.merged_at && pr.merged_at.length
+          ? 'merged'
+          : pr.state,
       closed_at: pr.closed_at,
     }));
   }
+  logger.debug({ length: config.prList.length }, 'Returning prList');
   return config.prList;
 }
 


### PR DESCRIPTION
Make sure PR is closed and merged_at is a non-zero length string.

Helps #1247