### PR TITLE
fix: do not delete branches if PR creation fails

### DIFF
--- a/lib/workers/pr/index.js
+++ b/lib/workers/pr/index.js
@@ -177,8 +177,7 @@ async function ensurePr(prConfig) {
     try {
       pr = await platform.createPr(branchName, prTitle, prBody, config.labels);
     } catch (err) {
-      logger.warn({ err }, `Failed to create PR - deleting branch`);
-      await platform.deleteBranch(branchName);
+      logger.warn({ err }, `Failed to create PR`);
       return null;
     }
     // Skip assign and review if automerging PR

--- a/test/workers/pr/index.spec.js
+++ b/test/workers/pr/index.spec.js
@@ -147,7 +147,7 @@ describe('workers/pr', () => {
       expect(platform.createPr.mock.calls[0]).toMatchSnapshot();
       expect(platform.createPr.mock.calls[0][2].indexOf('<details>')).toBe(-1);
     });
-    it('should delete branch and return null if creating PR fails', async () => {
+    it('should return null if creating PR fails', async () => {
       platform.getBranchStatus.mockReturnValueOnce('success');
       platform.createPr = jest.fn();
       platform.createPr.mockImplementationOnce(() => {
@@ -155,7 +155,6 @@ describe('workers/pr', () => {
       });
       config.prCreation = 'status-success';
       const pr = await prWorker.ensurePr(config);
-      expect(platform.deleteBranch.mock.calls).toHaveLength(1);
       expect(pr).toBe(null);
     });
     it('should return null if waiting for not pending', async () => {


### PR DESCRIPTION
GitHub’s API is behaving too flakily and this can end up with closing PRs by accident, which then block future PRs. See https://github.com/ikatyang/emoji-cheat-sheet/pull/110 for example problem