### PR TITLE
fix: delete pr list before first get

### DIFF
--- a/lib/platform/github/index.js
+++ b/lib/platform/github/index.js
@@ -105,6 +105,8 @@ async function initRepo(repoName, token, endpoint) {
     logger.info({ err, res }, 'Unknown GitHub initRepo error');
     throw err;
   }
+  delete config.prList;
+  delete config.fileList;
   await Promise.all([getPrList(), getFileList()]);
   return platformConfig;
 }


### PR DESCRIPTION
This shouldn’t be necessary because we already `config = {};` during the init. But somehow `if (!config.prList)` is returning false sometimes.