### PR TITLE
fix: find config path in cwd when installed globally

### DIFF
--- a/lib/config/file.js
+++ b/lib/config/file.js
@@ -7,7 +7,7 @@ module.exports = {
 function getConfig(env) {
   let configFile = env.RENOVATE_CONFIG_FILE || 'config';
   if (!path.isAbsolute(configFile)) {
-    configFile = `../../${configFile}`;
+    configFile = `${process.cwd()}/${configFile}`;
   }
   let config = {};
   try {


### PR DESCRIPTION
Before I update tests, is this how this is expected to work? I don't understand when or how the existing behavior would be useful.