### PR TITLE
fix: remove duplicate 'onboarding' config definition

### DIFF
--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -125,12 +125,6 @@ const options = [
     type: 'boolean',
   },
   {
-    name: 'onboarding',
-    description: 'Require a Configuration PR first',
-    stage: 'repository',
-    type: 'boolean',
-  },
-  {
     name: 'platform',
     description: 'Platform type of repository',
     stage: 'repository',


### PR DESCRIPTION
Since it's already defined higher up in the file:
https://github.com/renovateapp/renovate/blob/48a2d2de8e2389b2b58c36d1dc510c6ecc488046/lib/config/definitions.js#L67-L73