### PR TITLE
feat: skip onboarding if renovate config detected in root package.json

### DIFF
--- a/lib/workers/repository/onboarding/branch/check.js
+++ b/lib/workers/repository/onboarding/branch/check.js
@@ -1,14 +1,25 @@
-const findFile = async (config, fileName) => {
-  logger.debug('findFile()');
-  logger.trace({ config });
+const findFile = async fileName => {
+  logger.debug(`findFile(${fileName})`);
   const fileList = await platform.getFileList();
   return fileList.includes(fileName);
 };
 
-const renovateJsonExists = async config =>
-  (await findFile(config, 'renovate.json')) ||
-  (await findFile(config, '.renovaterc')) ||
-  findFile(config, '.renovaterc.json');
+const renovateJsonExists = async () =>
+  (await findFile('renovate.json')) ||
+  (await findFile('.renovaterc')) ||
+  findFile('.renovaterc.json');
+
+const packageJsonRenovateExists = async () => {
+  try {
+    const pJson = JSON.parse(await platform.getFile('package.json'));
+    if (pJson.renovate) {
+      return true;
+    }
+  } catch (err) {
+    // Do nothing
+  }
+  return false;
+};
 
 const closedPrExists = config =>
   platform.findPr(
@@ -23,11 +34,15 @@ const isOnboarded = async config => {
   if (config.onboarding === false) {
     return true;
   }
-  if (await renovateJsonExists(config)) {
+  if (await renovateJsonExists()) {
     logger.debug('renovate.json exists');
     return true;
   }
   logger.debug('renovate.json not found');
+  if (await packageJsonRenovateExists()) {
+    logger.debug('package.json contains renovate config');
+    return true;
+  }
   if (await closedPrExists(config)) {
     logger.debug('Found closed onboarding PR');
     return true;

--- a/test/workers/repository/onboarding/branch/index.spec.js
+++ b/test/workers/repository/onboarding/branch/index.spec.js
@@ -44,6 +44,12 @@ describe('workers/repository/onboarding/branch', () => {
       const res = await checkOnboardingBranch(config);
       expect(res.repoIsOnboarded).toBe(true);
     });
+    it('detects repo is onboarded via package.json config', async () => {
+      platform.getFileList.mockReturnValueOnce(['package.json']);
+      platform.getFile.mockReturnValueOnce('{"renovate":{}}');
+      const res = await checkOnboardingBranch(config);
+      expect(res.repoIsOnboarded).toBe(true);
+    });
     it('detects repo is onboarded via PR', async () => {
       platform.findPr.mockReturnValue(true);
       const res = await checkOnboardingBranch(config);


### PR DESCRIPTION
Renovate will now detect if renovate config already exists within the project’s ‘package.json’ root, and skip onboarding if so.

Closes #1159