### PR TITLE
feat: add api caching to gitlab

### DIFF
--- a/lib/platform/gitlab/gl-got-wrapper.js
+++ b/lib/platform/gitlab/gl-got-wrapper.js
@@ -1,16 +1,31 @@
 const glGot = require('gl-got');
 const parseLinkHeader = require('parse-link-header');
 
+let cache = {};
+
 async function get(path, opts, retries = 5) {
+  const method = opts && opts.method ? opts.method : 'get';
+  if (method === 'get' && cache[path]) {
+    logger.debug({ path }, 'Returning cached result');
+    return cache[path];
+  }
+  logger.debug({ path }, method.toUpperCase());
   const res = await glGot(path, opts);
   if (opts && opts.paginate) {
     // Check if result is paginated
-    const linkHeader = parseLinkHeader(res.headers.link);
-    if (linkHeader && linkHeader.next) {
-      res.body = res.body.concat(
-        (await get(linkHeader.next.url, opts, retries)).body
-      );
+    try {
+      const linkHeader = parseLinkHeader(res.headers.link);
+      if (linkHeader && linkHeader.next) {
+        res.body = res.body.concat(
+          (await get(linkHeader.next.url, opts, retries)).body
+        );
+      }
+    } catch (err) {
+      logger.warn({ err }, 'Pagination error');
     }
+  }
+  if (method === 'get' && path.startsWith('projects/')) {
+    cache[path] = res;
   }
   return res;
 }
@@ -21,5 +36,9 @@ for (const x of helpers) {
   get[x] = (url, opts) =>
     get(url, Object.assign({}, opts, { method: x.toUpperCase() }));
 }
+
+get.reset = function reset() {
+  cache = {};
+};
 
 module.exports = get;

--- a/lib/platform/gitlab/index.js
+++ b/lib/platform/gitlab/index.js
@@ -2,7 +2,7 @@ const get = require('./gl-got-wrapper');
 
 const { createFile, updateFile } = require('./helpers');
 
-const config = {};
+let config = {};
 
 module.exports = {
   getRepos,
@@ -84,9 +84,9 @@ async function initRepo(repoName, token, endpoint) {
   if (endpoint) {
     process.env.GITLAB_ENDPOINT = endpoint;
   }
+  config = {};
+  get.reset();
   config.repoName = urlEscape(repoName);
-  config.fileList = null;
-  config.prList = null;
   try {
     const res = await get(`projects/${config.repoName}`);
     config.defaultBranch = res.body.default_branch;
@@ -94,6 +94,9 @@ async function initRepo(repoName, token, endpoint) {
     logger.debug(`${repoName} default branch = ${config.baseBranch}`);
     // Discover our user email
     config.email = (await get(`user`)).body.email;
+    delete config.prList;
+    delete config.fileList;
+    await Promise.all([getPrList(), getFileList()]);
   } catch (err) {
     logger.error({ err }, `GitLab init error`);
     throw err;
@@ -455,6 +458,12 @@ async function mergePr(iid) {
 // Generic File operations
 
 async function getFile(filePath, branchName) {
+  logger.debug(`getFile(filePath=${filePath}, branchName=${branchName})`);
+  if (!branchName || branchName === config.baseBranch) {
+    if (config.fileList && !config.fileList.includes(filePath)) {
+      return null;
+    }
+  }
   try {
     const url = `projects/${config.repoName}/repository/files/${urlEscape(
       filePath

--- a/test/platform/gitlab/__snapshots__/index.spec.js.snap
+++ b/test/platform/gitlab/__snapshots__/index.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`platform/gitlab addAssignees(issueNo, assignees) should add the given assignees to the issue 1`] = `
 Array [
   Array [
-    "projects/some%2Frepo/merge_requests/42?assignee_id=123",
+    "projects/undefined/merge_requests/42?assignee_id=123",
   ],
 ]
 `;
@@ -11,7 +11,7 @@ Array [
 exports[`platform/gitlab addAssignees(issueNo, assignees) should warn if more than one assignee 1`] = `
 Array [
   Array [
-    "projects/some%2Frepo/merge_requests/42?assignee_id=123",
+    "projects/undefined/merge_requests/42?assignee_id=123",
   ],
 ]
 `;
@@ -75,13 +75,7 @@ exports[`platform/gitlab getBranchLastCommitTime should return a Date 1`] = `201
 exports[`platform/gitlab getBranchPr(branchName) should return null if no PR exists 1`] = `
 Array [
   Array [
-    "projects/some%2Frepo",
-  ],
-  Array [
-    "user",
-  ],
-  Array [
-    "projects/some%2Frepo/merge_requests?state=opened&per_page=100",
+    "projects/undefined/merge_requests?state=opened&per_page=100",
     Object {
       "paginate": true,
     },
@@ -92,22 +86,16 @@ Array [
 exports[`platform/gitlab getBranchPr(branchName) should return the PR object 1`] = `
 Array [
   Array [
-    "projects/some%2Frepo",
-  ],
-  Array [
-    "user",
-  ],
-  Array [
-    "projects/some%2Frepo/merge_requests?state=opened&per_page=100",
+    "projects/undefined/merge_requests?state=opened&per_page=100",
     Object {
       "paginate": true,
     },
   ],
   Array [
-    "projects/some%2Frepo/merge_requests/undefined",
+    "projects/undefined/merge_requests/undefined",
   ],
   Array [
-    "projects/some%2Frepo/repository/branches/some-branch",
+    "projects/undefined/repository/branches/some-branch",
   ],
 ]
 `;
@@ -212,10 +200,20 @@ Array [
   Array [
     "user",
   ],
+  Array [
+    "projects/some%2Frepo%2Fproject/merge_requests?per_page=100",
+    Object {
+      "paginate": true,
+    },
+  ],
+  Array [
+    "projects/some%2Frepo%2Fproject/repository/tree?ref=undefined&recursive=true&per_page=100",
+    Object {
+      "paginate": true,
+    },
+  ],
 ]
 `;
-
-exports[`platform/gitlab initRepo should escape all forward slashes in project names 2`] = `Object {}`;
 
 exports[`platform/gitlab initRepo should initialise the config for the repo - 0 1`] = `
 Array [
@@ -224,6 +222,18 @@ Array [
   ],
   Array [
     "user",
+  ],
+  Array [
+    "projects/some%2Frepo/merge_requests?per_page=100",
+    Object {
+      "paginate": true,
+    },
+  ],
+  Array [
+    "projects/some%2Frepo/repository/tree?ref=undefined&recursive=true&per_page=100",
+    Object {
+      "paginate": true,
+    },
   ],
 ]
 `;
@@ -238,6 +248,18 @@ Array [
   Array [
     "user",
   ],
+  Array [
+    "projects/some%2Frepo/merge_requests?per_page=100",
+    Object {
+      "paginate": true,
+    },
+  ],
+  Array [
+    "projects/some%2Frepo/repository/tree?ref=undefined&recursive=true&per_page=100",
+    Object {
+      "paginate": true,
+    },
+  ],
 ]
 `;
 
@@ -251,18 +273,21 @@ Array [
   Array [
     "user",
   ],
+  Array [
+    "projects/some%2Frepo/merge_requests?per_page=100",
+    Object {
+      "paginate": true,
+    },
+  ],
+  Array [
+    "projects/some%2Frepo/repository/tree?ref=undefined&recursive=true&per_page=100",
+    Object {
+      "paginate": true,
+    },
+  ],
 ]
 `;
 
 exports[`platform/gitlab initRepo should initialise the config for the repo - 2 2`] = `Object {}`;
 
-exports[`platform/gitlab setBaseBranch(branchName) sets the base branch 1`] = `
-Array [
-  Array [
-    "projects/some%2Frepo",
-  ],
-  Array [
-    "user",
-  ],
-]
-`;
+exports[`platform/gitlab setBaseBranch(branchName) sets the base branch 1`] = `Array []`;

--- a/test/platform/gitlab/gl-got-wrapper.spec.js
+++ b/test/platform/gitlab/gl-got-wrapper.spec.js
@@ -52,4 +52,13 @@ describe('platform/gl-got-wrapper', () => {
     const res = await get.post('some-url');
     expect(res.body).toEqual(body);
   });
+  it('returns cached', async () => {
+    get.reset();
+    glGot.mockReturnValueOnce({
+      body: {},
+    });
+    const res1 = await get('projects/foo');
+    const res2 = await get('projects/foo');
+    expect(res1).toEqual(res2);
+  });
 });

--- a/test/workers/repository/init/apis.spec.js
+++ b/test/workers/repository/init/apis.spec.js
@@ -20,7 +20,8 @@ describe('workers/repository/init/apis', () => {
       config.repository = 'some/name';
       glGot.mockReturnValueOnce({ body: {} });
       glGot.mockReturnValueOnce({ body: {} });
-      glGot.mockReturnValueOnce({ body: {} });
+      glGot.mockReturnValueOnce({ body: [] });
+      glGot.mockReturnValueOnce({ body: [] });
       await initApis(config, 'some-token');
     });
     it('runs vsts', async () => {


### PR DESCRIPTION
This PR ports across GitHub’s caching approach to the GitLab platform API.