### PR TITLE
fix: use author first and then committer when checking pr

### DIFF
--- a/lib/platform/github/index.js
+++ b/lib/platform/github/index.js
@@ -707,12 +707,12 @@ async function getPr(prNo) {
       const authors = prCommits.reduce((arr, commit) => {
         logger.trace({ commit }, `Checking commit`);
         let author = 'unknown';
-        if (commit.committer && commit.committer.login) {
-          author = commit.committer.login;
-        } else if (commit.author) {
-          author = commit.author.login;
+        if (commit.author) {
+          author = commit.author.login || commit.author.email;
+        } else if (commit.committer && commit.committer.login) {
+          author = commit.committer.login || commit.committer.email;
         } else if (commit.commit && commit.commit.author) {
-          author = commit.commit.author.email;
+          author = commit.commit.author.login || commit.commit.author.email;
         } else {
           logger.debug('Could not determine commit author');
         }


### PR DESCRIPTION
Lets author take precedence over committer, in case users edit PRs and commit Renovate’s commit back themselves.

Fixes #1364