### PR TITLE
feat: automatically group @types companion packages

### DIFF
--- a/lib/config/templates/default/pr-body.hbs
+++ b/lib/config/templates/default/pr-body.hbs
@@ -1,4 +1,8 @@
 This Pull Request {{#if isRollback}}rolls back{{else}}updates{{/if}} dependency {{#if repositoryUrl}}[{{depName}}]({{repositoryUrl}}){{else}}{{depName}}{{/if}} from `{{#unless isRange}}{{#unless isPin}}v{{/unless}}{{/unless}}{{currentVersion}}` to `{{#unless isRange}}v{{/unless}}{{newVersion}}`{{#if isRollback}}. This is necessary and important because `v{{currentVersion}}` cannot be found in the npm registry - probably because of it being unpublished.{{/if}}
+{{#if hasTypes}}
+
+This PR also includes an upgrade to the corresponding [@types/{{depName}}](https://npmjs.com/package/@types/{{depName}}) package.
+{{/if}}
 {{#if releases.length}}
 
 {{#if schedule}}

--- a/lib/workers/repository/updates/branchify.js
+++ b/lib/workers/repository/updates/branchify.js
@@ -41,11 +41,17 @@ function branchifyUpgrades(config) {
   }
   logger.debug(`Returning ${Object.keys(branchUpgrades).length} branch(es)`);
   for (const branchName of Object.keys(branchUpgrades)) {
-    logger.debug('loop');
+    logger.setMeta({
+      repository: config.repository,
+      branch: branchName,
+    });
     const branch = generateBranchConfig(branchUpgrades[branchName]);
     branch.branchName = branchName;
     branches.push(branch);
   }
+  logger.setMeta({
+    repository: config.repository,
+  });
   logger.debug(`config.repoIsOnboarded=${config.repoIsOnboarded}`);
   const branchList = config.repoIsOnboarded
     ? branches.map(upgrade => upgrade.branchName)

--- a/lib/workers/repository/updates/determine.js
+++ b/lib/workers/repository/updates/determine.js
@@ -52,6 +52,7 @@ async function determineRepoUpgrades(config) {
     semanticCommits,
     depNameSanitized: upgrade.depName
       ? upgrade.depName
+          .replace('@types/', '')
           .replace('@', '')
           .replace('/', '-')
           .replace(/\s+/g, '-')

--- a/lib/workers/repository/updates/generate.js
+++ b/lib/workers/repository/updates/generate.js
@@ -1,6 +1,8 @@
 const handlebars = require('handlebars');
 
 function generateBranchConfig(branchUpgrades) {
+  logger.debug(`generateBranchConfig()`);
+  logger.trace({ config: branchUpgrades });
   const config = {
     upgrades: [],
   };
@@ -55,6 +57,17 @@ function generateBranchConfig(branchUpgrades) {
     }
     logger.debug(`${upgrade.branchName}, ${upgrade.prTitle}`);
     config.upgrades.push(upgrade);
+  }
+  if (
+    depNames.length === 2 &&
+    !hasGroupName &&
+    config.upgrades[0].depName.startsWith('@types/') &&
+    config.upgrades[0].depName.endsWith(config.upgrades[1].depName)
+  ) {
+    logger.debug('Found @types - reversing upgrades to use depName in PR');
+    config.upgrades.reverse();
+    config.upgrades[0].recreateClosed = false;
+    config.hasTypes = true;
   }
   // Now assign first upgrade's config as branch config
   return { ...config, ...config.upgrades[0] };

--- a/test/workers/repository/updates/generate.spec.js
+++ b/test/workers/repository/updates/generate.spec.js
@@ -158,5 +158,30 @@ describe('workers/repository/updates/generate', () => {
       const res = generateBranchConfig(branch);
       expect(res.prTitle).toEqual('chore(package): some-title');
     });
+    it('handles @types specially', () => {
+      const branch = [
+        {
+          depName: '@types/some-dep',
+          groupName: null,
+          branchName: 'some-branch',
+          prTitle: 'some-title',
+          lazyGrouping: true,
+          newVersion: '0.5.7',
+          group: {},
+        },
+        {
+          depName: 'some-dep',
+          groupName: null,
+          branchName: 'some-branch',
+          prTitle: 'some-title',
+          lazyGrouping: true,
+          newVersion: '0.6.0',
+          group: {},
+        },
+      ];
+      const res = generateBranchConfig(branch);
+      expect(res.recreateClosed).toBe(false);
+      expect(res.groupName).toBeUndefined();
+    });
   });
 });


### PR DESCRIPTION
By stripping `types` from the branch name, package `x` and `@types/x` then become automatically combined in the same PR. We then massage it a little to ensure the decription for the non-types package is used, and a note added saying that types is included.

Closes #1365