### PR TITLE
Allow --renovate-fork Cli flag for onboarding.

### DIFF
--- a/lib/workers/repository/onboarding/branch/index.js
+++ b/lib/workers/repository/onboarding/branch/index.js
@@ -11,7 +11,7 @@ async function checkOnboardingBranch(config) {
     logger.debug('Repo is onboarded');
     return { ...config, repoIsOnboarded };
   }
-  if (config.isFork) {
+  if (config.isFork && !config.renovateFork) {
     throw new Error('fork');
   }
   logger.info('Repo is not onboarded');


### PR DESCRIPTION
Fixes https://github.com/renovateapp/renovate/issues/1371.