### PR TITLE
fix: skip newlines at start of Dockerfile

### DIFF
--- a/lib/manager/docker/detect.js
+++ b/lib/manager/docker/detect.js
@@ -10,7 +10,7 @@ async function detectPackageFiles(config, fileList) {
       if (file === 'Dockerfile' || file.endsWith('/Dockerfile')) {
         const content = await platform.getFile(file);
         if (content) {
-          const strippedComment = content.replace(/^(#.*?\n)+/, '');
+          const strippedComment = content.replace(/^((#.*?|\s*)\n)+/, '');
           // This means we skip ones with ARG for now
           const fromMatch = strippedComment.startsWith('FROM ');
           if (fromMatch) {

--- a/lib/manager/docker/resolve.js
+++ b/lib/manager/docker/resolve.js
@@ -14,7 +14,7 @@ async function resolvePackageFile(config, inputFile) {
     logger.debug('No packageFile content');
     return null;
   }
-  const strippedComment = packageFile.content.replace(/^(#.*?\n)+/, '');
+  const strippedComment = packageFile.content.replace(/^((#.*?|\s*)\n)+/, '');
   const fromMatch = strippedComment.match(/^[Ff][Rr][Oo][Mm] (.*)\n/);
   if (!fromMatch) {
     logger.debug(

--- a/lib/workers/repository/updates/determine.js
+++ b/lib/workers/repository/updates/determine.js
@@ -9,7 +9,12 @@ async function determineRepoUpgrades(config) {
   logger.debug(`Found ${config.packageFiles.length} package files`);
   // Iterate through repositories sequentially
   for (const packageFile of config.packageFiles) {
-    logger.trace({ packageFile }, 'Getting packageFile config');
+    logger.setMeta({
+      repository: config.repository,
+      packageFile: packageFile.packageFile,
+    });
+    logger.debug('Getting packageFile config');
+    logger.trace({ fullPackageFile: packageFile });
     let packageFileConfig = mergeChildConfig(config, packageFile);
     packageFileConfig = filterConfig(packageFileConfig, 'packageFile');
     if (packageFileConfig.packageFile.endsWith('package.json')) {

--- a/test/manager/index.spec.js
+++ b/test/manager/index.spec.js
@@ -55,7 +55,7 @@ describe('manager', () => {
         'other/Dockerfile',
       ]);
       platform.getFile.mockReturnValueOnce(
-        '### comment\nFROM something\nRUN something'
+        '### comment\n\n \nFROM something\nRUN something'
       );
       platform.getFile.mockReturnValueOnce(
         'ARG foo\nFROM something\nRUN something'


### PR DESCRIPTION
Ignore both comment lines and empty lines before looking for a FROM