### PR TITLE
fix: filter out “Update branch” commits when determining canRebase

### DIFF
--- a/lib/platform/github/index.js
+++ b/lib/platform/github/index.js
@@ -719,37 +719,28 @@ async function getPr(prNo) {
       const prCommits = (await get(
         `repos/${config.parentRepo || config.repoName}/pulls/${prNo}/commits`
       )).body;
-      const authors = prCommits.reduce((arr, commit) => {
-        logger.trace({ commit }, `Checking commit`);
-        let author = 'unknown';
-        if (commit.author) {
-          author = commit.author.login || commit.author.email;
-        } else if (commit.committer && commit.committer.login) {
-          author = commit.committer.login || commit.committer.email;
-        } else if (commit.commit && commit.commit.author) {
-          author = commit.commit.author.login || commit.commit.author.email;
-        } else {
-          logger.debug('Could not determine commit author');
+      // Remove first commit - it should be Renovate
+      prCommits.shift();
+      // Filter out "Update branch" presses
+      const remainingCommits = prCommits.filter(commit => {
+        const isWebflow =
+          commit.committer && commit.committer.login === 'web-flow';
+        if (!isWebflow) {
+          // Not a web UI commit, so keep it
+          return true;
         }
-        logger.debug(`Commit author is: ${author}`);
-        const message = commit.commit ? commit.commit.message : '';
-        const parents = commit.parents || [];
-        let ignoreWebFlow = false;
-        if (
-          author === 'web-flow' &&
-          message.startsWith("Merge branch '") &&
-          parents.length === 2
-        ) {
-          ignoreWebFlow = true;
+        const isUpdateBranch =
+          commit.commit &&
+          commit.commit.message &&
+          commit.commit.message.startsWith("Merge branch 'master' into");
+        if (isUpdateBranch) {
+          // They just clicked the button
+          return false;
         }
-        // Ignore GitHub "web-flow"
-        if (!ignoreWebFlow && arr.indexOf(author) === -1) {
-          arr.push(author);
-        }
-        return arr;
-      }, []);
-      logger.debug(`Author list: ${authors}`);
-      if (authors.length === 1) {
+        // They must have done some other edit through the web UI
+        return true;
+      });
+      if (remainingCommits.length === 0) {
         pr.canRebase = true;
       }
     }

--- a/test/platform/github/index.spec.js
+++ b/test/platform/github/index.spec.js
@@ -1142,15 +1142,15 @@ describe('platform/github', () => {
       get.mockImplementationOnce(() => ({
         body: [
           {
-            committer: {
-              login: 'web-flow',
-            },
-          },
-          {
             commit: {
               author: {
                 email: 'bar',
               },
+            },
+          },
+          {
+            committer: {
+              login: 'web-flow',
             },
           },
           {},


### PR DESCRIPTION
Closes #1405