### PR TITLE
refactor: check for RENOVATE_SKIP_CACHE in npm registry

### DIFF
--- a/lib/manager/npm/registry.js
+++ b/lib/manager/npm/registry.js
@@ -67,7 +67,7 @@ async function getDependency(name) {
   // Retrieve from API if not cached
   try {
     const res = (await got(pkgUrl, {
-      cache: map,
+      cache: process.env.RENOVATE_SKIP_CACHE ? undefined : map,
       json: true,
       headers,
     })).body;


### PR DESCRIPTION
Adds an undocumented env option RENOVATE_SKIP_CACHE to disable `got` caching if set.

Closes #1335