### PR TITLE
feat: import existing greenkeeper config when onboarding 

### DIFF
--- a/lib/workers/repository/onboarding/branch/create.js
+++ b/lib/workers/repository/onboarding/branch/create.js
@@ -1,8 +1,30 @@
 async function createOnboardingBranch() {
-  logger.debug('Creating onboarding branch');
+  logger.debug('createOnboardingBranch()');
   const renovateJson = {
     extends: ['config:base'],
   };
+  try {
+    logger.debug('Checking for greenkeeper config');
+    const { label, branchName, ignore } = JSON.parse(
+      await platform.getFile('package.json')
+    ).greenkeeper;
+    if (label) {
+      logger.info({ label }, 'Migrating Greenkeeper label');
+      renovateJson.labels = [String(label).replace('greenkeeper', 'renovate')];
+    }
+    if (branchName) {
+      logger.info({ branchName }, 'Migrating Greenkeeper branchName');
+      renovateJson.branchName = [
+        String(branchName).replace('greenkeeper', 'renovate'),
+      ];
+    }
+    if (ignore) {
+      logger.info({ ignore }, 'Migrating Greenkeeper ignore');
+      renovateJson.ignoreDeps = ignore;
+    }
+  } catch (err) {
+    logger.debug('No greenkeeper config migration');
+  }
   logger.info({ renovateJson }, 'Creating onboarding branch');
   await platform.commitFilesToBranch(
     `renovate/configure`,

--- a/lib/workers/repository/onboarding/branch/create.js
+++ b/lib/workers/repository/onboarding/branch/create.js
@@ -18,9 +18,9 @@ async function createOnboardingBranch() {
         String(branchName).replace('greenkeeper', 'renovate'),
       ];
     }
-    if (ignore) {
+    if (Array.isArray(ignore) && ignore.length) {
       logger.info({ ignore }, 'Migrating Greenkeeper ignore');
-      renovateJson.ignoreDeps = ignore;
+      renovateJson.ignoreDeps = ignore.map(String);
     }
   } catch (err) {
     logger.debug('No greenkeeper config migration');

--- a/lib/workers/repository/onboarding/branch/index.js
+++ b/lib/workers/repository/onboarding/branch/index.js
@@ -24,7 +24,7 @@ async function checkOnboardingBranch(config) {
       throw new Error('no-package-files');
     }
     logger.info('Need to create onboarding PR');
-    await createOnboardingBranch(config);
+    await createOnboardingBranch();
   }
   await platform.setBaseBranch(`renovate/configure`);
   const branchList = [`renovate/configure`];

--- a/test/workers/repository/onboarding/branch/__snapshots__/index.spec.js.snap
+++ b/test/workers/repository/onboarding/branch/__snapshots__/index.spec.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`workers/repository/onboarding/branch checkOnboardingBranch creates onboarding branch with greenkeeper migration 1`] = `
+"{
+  \\"extends\\": [
+    \\"config:base\\"
+  ],
+  \\"labels\\": [
+    \\"renovate\\"
+  ],
+  \\"branchName\\": [
+    \\"renovate--\\"
+  ],
+  \\"ignoreDeps\\": [
+    \\"foo\\",
+    \\"bar\\"
+  ]
+}
+"
+`;

--- a/test/workers/repository/onboarding/branch/index.spec.js
+++ b/test/workers/repository/onboarding/branch/index.spec.js
@@ -62,6 +62,23 @@ describe('workers/repository/onboarding/branch', () => {
       expect(res.branchList).toEqual(['renovate/configure']);
       expect(platform.setBaseBranch.mock.calls).toHaveLength(1);
     });
+    it('creates onboarding branch with greenkeeper migration', async () => {
+      platform.getFileList.mockReturnValue(['package.json']);
+      const pJsonContent = JSON.stringify({
+        name: 'some-name',
+        version: '0.0.1',
+        greenkeeper: {
+          label: 'greenkeeper',
+          branchName: 'greenkeeper--',
+          ignore: ['foo', 'bar'],
+        },
+      });
+      platform.getFile.mockReturnValue(pJsonContent);
+      await checkOnboardingBranch(config);
+      expect(
+        platform.commitFilesToBranch.mock.calls[0][1][0].contents
+      ).toMatchSnapshot();
+    });
     it('updates onboarding branch', async () => {
       platform.getFileList.mockReturnValue(['package.json']);
       platform.findPr.mockReturnValueOnce(null);


### PR DESCRIPTION
Detects any existing greenkeeper configuration fields in `package.json` and migrates them to Renovate’s config during onboarding.

Closes #1429