### PR TITLE
feat: hyphen range support

### DIFF
--- a/lib/workers/package/versions.js
+++ b/lib/workers/package/versions.js
@@ -179,6 +179,11 @@ function determineUpgrades(npmDep, config) {
       logger.debug('Found less than range');
     } else if (secondLastSemver.operator === '||') {
       logger.debug('Found an OR range');
+    } else if (secondLastSemver.operator === '-') {
+      logger.info(
+        { currentVersion, upgrades, semverParsed },
+        'Found a hyphen range'
+      );
     } else {
       // We don't know how to support complex semver ranges, so don't upgrade
       result.message = `Complex semver ranges such as "${currentVersion}" are not yet supported so will be skipped`;
@@ -289,14 +294,36 @@ function determineUpgrades(npmDep, config) {
         return { ...upgrade, newVersion };
       } else if (lastSemver.minor === undefined) {
         // Example: 1
-        return { ...upgrade, ...{ newVersion: `${major}` } };
+        const newRange = [...semverParsed];
+        logger.debug('Found a standalone major');
+        newRange[newRange.length - 1].major = String(upgrade.newVersionMajor);
+        let newVersion;
+        if (secondLastSemver && secondLastSemver.operator === '||') {
+          newVersion = `${currentVersion} || ${upgrade.newVersionMajor}`;
+        } else {
+          newVersion = semverUtils.stringifyRange(newRange);
+          // Fixes a bug with semver-utils
+          newVersion = newVersion.replace(/\.0/g, '');
+        }
+        return { ...upgrade, newVersion };
       } else if (lastSemver.minor === 'x') {
         // Example: 1.x
-        return { ...upgrade, ...{ newVersion: `${major}.x` } };
+        const newRange = [...semverParsed];
+        logger.debug('Found a .x');
+        newRange[newRange.length - 1].major = String(upgrade.newVersionMajor);
+        let newVersion;
+        if (secondLastSemver && secondLastSemver.operator === '||') {
+          newVersion = `${currentVersion} || ${upgrade.newVersionMajor}.x`;
+        } else {
+          newVersion = semverUtils.stringifyRange(newRange);
+          // Fixes a bug with semver-utils
+          newVersion = newVersion.replace(/\.0/g, '');
+        }
+        return { ...upgrade, newVersion };
       } else if (lastSemver.patch === undefined) {
         // Example: 1.2
         return { ...upgrade, ...{ newVersion: `${major}.${minor}` } };
-      } else if (lastSemver.patch === 'x') {
+      } else if (lastSemver.patch === 'x' && semverParsed.length === 1) {
         // Example: 1.2.x
         return { ...upgrade, ...{ newVersion: `${major}.${minor}.x` } };
       }

--- a/test/workers/package/__snapshots__/versions.spec.js.snap
+++ b/test/workers/package/__snapshots__/versions.spec.js.snap
@@ -347,6 +347,22 @@ Array [
 ]
 `;
 
+exports[`workers/package/versions .determineUpgrades(npmDep, config) supports complex major hyphen ranges 1`] = `
+Array [
+  Object {
+    "changeLogFromVersion": "2.7.0",
+    "changeLogToVersion": "3.8.1",
+    "isMajor": true,
+    "isRange": true,
+    "newVersion": "1.x - 3.x",
+    "newVersionMajor": 3,
+    "newVersionMinor": 8,
+    "type": "major",
+    "unpublishable": false,
+  },
+]
+`;
+
 exports[`workers/package/versions .determineUpgrades(npmDep, config) supports complex major ranges 1`] = `
 Array [
   Object {
@@ -820,6 +836,38 @@ Array [
     "newVersionMajor": 1,
     "newVersionMinor": 4,
     "type": "minor",
+    "unpublishable": false,
+  },
+]
+`;
+
+exports[`workers/package/versions .determineUpgrades(npmDep, config) widens .x OR ranges 1`] = `
+Array [
+  Object {
+    "changeLogFromVersion": "2.7.0",
+    "changeLogToVersion": "3.8.1",
+    "isMajor": true,
+    "isRange": true,
+    "newVersion": "1.x || 2.x || 3.x",
+    "newVersionMajor": 3,
+    "newVersionMinor": 8,
+    "type": "major",
+    "unpublishable": false,
+  },
+]
+`;
+
+exports[`workers/package/versions .determineUpgrades(npmDep, config) widens stanndalone major OR ranges 1`] = `
+Array [
+  Object {
+    "changeLogFromVersion": "2.7.0",
+    "changeLogToVersion": "3.8.1",
+    "isMajor": true,
+    "isRange": true,
+    "newVersion": "1 || 2 || 3",
+    "newVersionMajor": 3,
+    "newVersionMinor": 8,
+    "type": "major",
     "unpublishable": false,
   },
 ]

--- a/test/workers/package/versions.spec.js
+++ b/test/workers/package/versions.spec.js
@@ -169,6 +169,24 @@ describe('workers/package/versions', () => {
       const res = versions.determineUpgrades(webpackJson, config);
       expect(res).toMatchSnapshot();
     });
+    it('supports complex major hyphen ranges', () => {
+      config.pinVersions = false;
+      config.currentVersion = '1.x - 2.x';
+      const res = versions.determineUpgrades(webpackJson, config);
+      expect(res).toMatchSnapshot();
+    });
+    it('widens .x OR ranges', () => {
+      config.pinVersions = false;
+      config.currentVersion = '1.x || 2.x';
+      const res = versions.determineUpgrades(webpackJson, config);
+      expect(res).toMatchSnapshot();
+    });
+    it('widens stanndalone major OR ranges', () => {
+      config.pinVersions = false;
+      config.currentVersion = '1 || 2';
+      const res = versions.determineUpgrades(webpackJson, config);
+      expect(res).toMatchSnapshot();
+    });
     it('supports complex tilde ranges', () => {
       config.pinVersions = false;
       config.currentVersion = '~1.2.0 || ~1.3.0';


### PR DESCRIPTION
Adds support for ranges, such as `”1.x - 2.x”`. Adds support for widening .x ranges, e.g. `”1.x || 2.x”` becomes updated to `”1.x || 2.x || 3.x”`.

Closes #687