### PR TITLE
feat: prConcurrentLimit

### DIFF
--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -561,6 +561,13 @@ const options = [
     type: 'integer',
     default: 0, // no limit
   },
+  {
+    name: 'prConcurrentLimit',
+    description:
+      'Limit to a maximum of x concurrent branches/PRs. 0 (default) means no limit.',
+    type: 'integer',
+    default: 0, // no limit
+  },
   // Automatic merging
   {
     name: 'automerge',

--- a/lib/workers/repository/write.js
+++ b/lib/workers/repository/write.js
@@ -29,10 +29,24 @@ async function writeUpdates(config) {
             pr.branchName !== 'renovate/configure' &&
             moment(pr.createdAt).isAfter(currentHourStart)
         ).length;
-      logger.info(`PR creations remaining this hour: ${prsRemaining}`);
+      logger.info(`PR hourly limit remaining: ${prsRemaining}`);
     } catch (err) {
       logger.error('Error checking PRs created per hour');
     }
+  }
+  if (config.prConcurrentLimit) {
+    logger.debug(`Enforcing prConcurrentLimit (${config.prConcurrentLimit})`);
+    let currentlyOpen = 0;
+    for (const branch of branches) {
+      if (await platform.branchExists(branch.branchName)) {
+        currentlyOpen += 1;
+      }
+    }
+    logger.debug(`${currentlyOpen} PRs are currently open`);
+    const concurrentRemaining = config.prConcurrentLimit - currentlyOpen;
+    logger.info(`PR concurrent limit remaining: ${concurrentRemaining}`);
+    prsRemaining =
+      prsRemaining < concurrentRemaining ? prsRemaining : concurrentRemaining;
   }
   try {
     for (const branch of branches) {

--- a/test/workers/repository/write.spec.js
+++ b/test/workers/repository/write.spec.js
@@ -21,6 +21,16 @@ describe('workers/repository/write', () => {
       const res = await writeUpdates(config);
       expect(res).toEqual('done');
     });
+    it('calculates concurrent limit remaining', async () => {
+      config.branches = ['renovate/chalk-2.x'];
+      config.prConcurrentLimit = 1;
+      platform.getPrList.mockReturnValueOnce([
+        { created_at: moment().format() },
+      ]);
+      platform.branchExists.mockReturnValueOnce(true);
+      const res = await writeUpdates(config);
+      expect(res).toEqual('done');
+    });
     it('handles error in calculation', async () => {
       config.branches = [];
       config.prHourlyLimit = 1;

--- a/website/docs/_posts/2017-10-05-configuration-options.md
+++ b/website/docs/_posts/2017-10-05-configuration-options.md
@@ -713,6 +713,17 @@ Pull Request body template.
 
 Although the PR body can be customised by you, it might be quite challenging. If you think the Pull Request should include different information or could be formatted better, perhaps try raising an [Issue](https://github.com/renovateapp/renovate/issues) and let us solve it for you and for everyone else too.
 
+## prConcurrentLimit
+
+Limit to a maximum of x concurrent branches/PRs. 0 (default) means no limit.
+
+| name    | value   |
+| ------- | ------- |
+| type    | integer |
+| default | 0       |
+
+This setting - if enabled - limits Renovate to a maximum of x concurrent PRs open at any time.
+
 ## prCreation
 
 When to create the PR for a branch.


### PR DESCRIPTION
Adds a new feature to limit the number of concurrent branches/PRs to have open at any one time. Defaults to 0 (disabled), set it to a positive integer to enforce that limit.