### PR TITLE
fix: unset ghe token before calling changelog

### DIFF
--- a/lib/workers/pr/changelog.js
+++ b/lib/workers/pr/changelog.js
@@ -27,14 +27,20 @@ async function getChangeLogJSON(depName, fromVersion, newVersion) {
   }
   const semverString = `>${fromVersion} <=${newVersion}`;
   logger.debug(`semverString: ${semverString}`);
+  let token;
   try {
+    // istanbul ignore if
+    if (process.env.GITHUB_ENDPOINT) {
+      logger.debug('Removing GitHub Token before calling changelog');
+      token = process.env.GITHUB_TOKEN;
+      delete process.env.GITHUB_TOKEN;
+    }
     const res = await changelog.generate(depName, semverString);
     if (!res) {
       logger.info({ depName, fromVersion, newVersion }, 'No changelog found');
       return null;
     }
     // Sort from oldest to newest
-    logger.debug({ res });
     if (Array.isArray(res.versions)) {
       res.versions.reverse();
       res.versions.forEach(version => {
@@ -48,5 +54,7 @@ async function getChangeLogJSON(depName, fromVersion, newVersion) {
   } catch (err) {
     logger.debug({ err }, `getChangeLogJSON error`);
     return null;
+  } finally {
+    process.env.GITHUB_TOKEN = process.env.GITHUB_TOKEN || token;
   }
 }


### PR DESCRIPTION
Saves then unsets process.env.GITHUB_TOKEN before calling `changelog`, only if process.env.GITHUB_ENDPOINT is set, then restores it afterwards.