### PR TITLE
fix: don’t check for branch existing when rebasing (gitlab)

### DIFF
--- a/lib/platform/gitlab/index.js
+++ b/lib/platform/gitlab/index.js
@@ -498,10 +498,7 @@ async function commitFilesToBranch(
     `commitFilesToBranch('${branchName}', files, message, '${parentBranch})'`
   );
   if (branchName !== parentBranch) {
-    const isBranchExisting = await branchExists(branchName);
-    if (isBranchExisting) {
-      logger.debug(`Branch ${branchName} already exists`);
-    } else {
+    try {
       logger.debug(`Creating branch ${branchName}`);
       const opts = {
         body: {
@@ -510,6 +507,8 @@ async function commitFilesToBranch(
         },
       };
       await get.post(`projects/${config.repository}/repository/branches`, opts);
+    } catch (err) {
+      logger.info({ err }, 'Branch could not be created - already exists?');
     }
   }
   for (const file of files) {

--- a/lib/platform/gitlab/index.js
+++ b/lib/platform/gitlab/index.js
@@ -512,9 +512,7 @@ async function commitFilesToBranch(
     }
   }
   for (const file of files) {
-    const existingFile = await getFile(file.name, branchName);
-    if (existingFile) {
-      logger.debug(`${file.name} exists - updating it`);
+    try {
       await updateFile(
         config.repository,
         branchName,
@@ -522,8 +520,8 @@ async function commitFilesToBranch(
         file.contents,
         message
       );
-    } else {
-      logger.debug(`Creating file ${file.name}`);
+    } catch (err) {
+      logger.debug({ err }, 'Cannot update file - trying to create it');
       await createFile(
         config.repository,
         branchName,


### PR DESCRIPTION
Previously, our GitLab API library was checking if a a branch existed first before trying to create it. But due to caching, a branch we'd deleted ourselves still showed up as existing, so then there was no branch to update the files in. Skip this check and use try/catch for creating branch instead.

Fixes #1468 