### PR TITLE
feat: lerna bootstrap support

### DIFF
--- a/lib/manager/npm/monorepos.js
+++ b/lib/manager/npm/monorepos.js
@@ -11,12 +11,14 @@ async function checkMonorepos(config) {
   logger.debug('checkMonorepos()');
   logger.trace({ config });
   // yarn workspaces
+  let foundWorkspaces = false;
   for (const packageFile of config.packageFiles) {
     if (
       packageFile.packageFile &&
       packageFile.packageFile.endsWith('package.json') &&
       packageFile.content.workspaces
     ) {
+      foundWorkspaces = true;
       packageFile.workspaces = true;
       const workspaceDir = path.dirname(packageFile.packageFile);
       const { workspaces } = packageFile.content;
@@ -42,12 +44,27 @@ async function checkMonorepos(config) {
       }
     }
   }
+  if (foundWorkspaces) {
+    logger.debug('Ignoring any lerna and returning workspaces');
+    return { ...config, workspaces: true, monorepoPackages };
+  }
   // lerna
   let lernaJson;
   try {
+    logger.debug('Checking for lerna.json');
     lernaJson = JSON.parse(await platform.getFile('lerna.json'));
   } catch (err) {
-    // do nothing
+    logger.debug('No lerna.json found');
+    return { ...config, monorepoPackages };
+  }
+  let lernaLockFile;
+  // istanbul ignore else
+  if (await platform.getFile('package-lock.json')) {
+    logger.debug('lerna has a package-lock.json');
+    lernaLockFile = 'npm';
+  } else if (await platform.getFile('yarn.lock')) {
+    logger.debug('lerna has non-workspaces yarn');
+    lernaLockFile = 'yarn';
   }
   if (lernaJson && lernaJson.packages) {
     logger.debug({ lernaJson }, 'Found lerna config');
@@ -63,5 +80,5 @@ async function checkMonorepos(config) {
       }
     }
   }
-  return { ...config, monorepoPackages };
+  return { ...config, lernaLockFile, monorepoPackages };
 }

--- a/lib/workers/branch/lerna.js
+++ b/lib/workers/branch/lerna.js
@@ -1,0 +1,48 @@
+const { exec } = require('child-process-promise');
+
+module.exports = {
+  generateLockFiles,
+};
+
+async function generateLockFiles(manager, tmpDir, env) {
+  logger.debug(`Spawning lerna to create lock files`);
+  let stdout;
+  let stderr;
+  try {
+    const startTime = process.hrtime();
+    let lernaVersion = 'latest';
+    try {
+      lernaVersion = JSON.parse(await platform.getFile('package.json'))
+        .devDependencies.lerna;
+    } catch (err) {
+      logger.warn('Could not detect lerna in devDependencies');
+    }
+    logger.debug('Using lerna version ' + lernaVersion);
+    const params =
+      manager === 'npm' ? '--package-lock-only' : '--ignore-scripts';
+    const cmd = `${manager} install ${params} && npx lerna@${lernaVersion} bootstrap -- ${params}`;
+    logger.debug({ cmd });
+    // TODO: Switch to native util.promisify once using only node 8
+    ({ stdout, stderr } = await exec(cmd, {
+      cwd: tmpDir,
+      shell: true,
+      env,
+    }));
+    logger.debug(`npm stdout:\n${stdout}`);
+    logger.debug(`npm stderr:\n${stderr}`);
+    const duration = process.hrtime(startTime);
+    const seconds = Math.round(duration[0] + duration[1] / 1e9);
+    logger.info({ seconds, manager, stdout, stderr }, 'Generated lockfile');
+  } catch (err) /* istanbul ignore next */ {
+    logger.warn(
+      {
+        err,
+        stdout,
+        stderr,
+      },
+      'lerna bootstrap error'
+    );
+    return { error: true, stderr: stderr || err.stderr };
+  }
+  return { error: false };
+}

--- a/lib/workers/branch/lock-files.js
+++ b/lib/workers/branch/lock-files.js
@@ -2,6 +2,7 @@ const fs = require('fs-extra');
 const path = require('path');
 const upath = require('upath');
 const npm = require('./npm');
+const lerna = require('./lerna');
 const yarn = require('./yarn');
 const pnpm = require('./pnpm');
 
@@ -67,6 +68,7 @@ function determineLockFileDirs(config) {
   const packageLockFileDirs = [];
   const yarnLockFileDirs = [];
   const shrinkwrapYamlDirs = [];
+  const lernaDirs = [];
 
   for (const upgrade of config.upgrades) {
     if (upgrade.type === 'lockFileMaintenance') {
@@ -88,15 +90,25 @@ function determineLockFileDirs(config) {
   }
 
   for (const packageFile of config.updatedPackageFiles) {
-    if (module.exports.hasYarnLock(config, packageFile.name)) {
+    if (
+      module.exports.hasYarnLock(config, packageFile.name) &&
+      !config.lernaLockFile
+    ) {
       yarnLockFileDirs.push(path.dirname(packageFile.name));
     }
-    if (module.exports.hasPackageLock(config, packageFile.name)) {
+    if (
+      module.exports.hasPackageLock(config, packageFile.name) &&
+      !config.lernaLockFile
+    ) {
       packageLockFileDirs.push(path.dirname(packageFile.name));
     }
     if (module.exports.hasShrinkwrapYaml(config, packageFile.name)) {
       shrinkwrapYamlDirs.push(path.dirname(packageFile.name));
     }
+  }
+
+  if (config.updatedPackageFiles.length && config.lernaLockFile) {
+    lernaDirs.push('.');
   }
 
   // If yarn workspaces are in use, then we need to generate yarn.lock from the workspaces dir
@@ -112,10 +124,23 @@ function determineLockFileDirs(config) {
     }
   }
 
-  return { yarnLockFileDirs, packageLockFileDirs, shrinkwrapYamlDirs };
+  return {
+    yarnLockFileDirs,
+    packageLockFileDirs,
+    shrinkwrapYamlDirs,
+    lernaDirs,
+  };
 }
 
 async function writeExistingFiles(config) {
+  const lernaJson = await platform.getFile('lerna.json');
+  if (lernaJson) {
+    logger.debug({ path: config.tmpDir.path }, 'Writing repo lerna.json');
+    await fs.outputFile(
+      upath.join(config.tmpDir.path, 'lerna.json'),
+      lernaJson
+    );
+  }
   if (config.npmrc) {
     logger.debug({ path: config.tmpDir.path }, 'Writing repo .npmrc');
     await fs.outputFile(upath.join(config.tmpDir.path, '.npmrc'), config.npmrc);
@@ -302,7 +327,7 @@ async function getUpdatedLockFiles(config) {
   const env =
     config.global && config.global.exposeEnv
       ? process.env
-      : { PATH: process.env.PATH };
+      : { HOME: process.env.HOME, PATH: process.env.PATH };
   env.NODE_ENV = 'dev';
 
   for (const lockFileDir of dirs.packageLockFileDirs) {
@@ -388,6 +413,54 @@ async function getUpdatedLockFiles(config) {
         });
       } else {
         logger.debug("shrinkwrap.yaml hasn't changed");
+      }
+    }
+  }
+
+  if (dirs.lernaDirs.length) {
+    let manager;
+    let lockFile;
+    if (config.lernaLockFile === 'npm') {
+      manager = 'npm';
+      lockFile = 'package-lock.json';
+    } else {
+      manager = 'yarn';
+      lockFile = 'yarn.lock';
+    }
+    logger.debug({ manager, lockFile }, 'Generating lock files using lerna');
+    const res = await lerna.generateLockFiles(manager, config.tmpDir.path, env);
+    // istanbul ignore else
+    if (res.error) {
+      lockFileErrors.push({
+        lockFile,
+        stderr: res.stderr,
+      });
+    } else {
+      for (const packageFile of config.packageFiles) {
+        const baseDir = path.dirname(packageFile.packageFile);
+        const filename = upath.join(baseDir, lockFile);
+        logger.debug('Checking for ' + filename);
+        const existingContent = await platform.getFile(
+          filename,
+          config.parentBranch
+        );
+        if (existingContent) {
+          logger.debug('Found lock file');
+          const lockFilePath = upath.join(config.tmpDir.path, filename);
+          logger.debug('Checking against ' + lockFilePath);
+          const newContent = await fs.readFile(lockFilePath, 'utf8');
+          if (newContent !== existingContent) {
+            logger.debug('File is updated');
+            updatedLockFiles.push({
+              name: filename,
+              contents: newContent,
+            });
+          } else {
+            logger.debug('File is unchanged');
+          }
+        } else {
+          logger.debug('No lock file found');
+        }
       }
     }
   }

--- a/test/workers/branch/__snapshots__/lock-files.spec.js.snap
+++ b/test/workers/branch/__snapshots__/lock-files.spec.js.snap
@@ -16,6 +16,7 @@ Object {
 
 exports[`workers/branch/lock-files determineLockFileDirs returns directories from updated package files 1`] = `
 Object {
+  "lernaDirs": Array [],
   "packageLockFileDirs": Array [
     "backend",
   ],
@@ -28,8 +29,20 @@ Object {
 }
 `;
 
+exports[`workers/branch/lock-files determineLockFileDirs returns root directory if using lerna package lock 1`] = `
+Object {
+  "lernaDirs": Array [
+    ".",
+  ],
+  "packageLockFileDirs": Array [],
+  "shrinkwrapYamlDirs": Array [],
+  "yarnLockFileDirs": Array [],
+}
+`;
+
 exports[`workers/branch/lock-files determineLockFileDirs returns root directory if using yarn workspaces 1`] = `
 Object {
+  "lernaDirs": Array [],
   "packageLockFileDirs": Array [],
   "shrinkwrapYamlDirs": Array [],
   "yarnLockFileDirs": Array [
@@ -48,6 +61,25 @@ Object {
 exports[`workers/branch/lock-files getUpdatedLockFiles returns no error and empty lockfiles if none updated 1`] = `
 Object {
   "lockFileErrors": Array [],
+  "updatedLockFiles": Array [],
+}
+`;
+
+exports[`workers/branch/lock-files getUpdatedLockFiles tries lerna npm 1`] = `
+Object {
+  "lockFileErrors": Array [],
+  "updatedLockFiles": Array [],
+}
+`;
+
+exports[`workers/branch/lock-files getUpdatedLockFiles tries lerna yarn 1`] = `
+Object {
+  "lockFileErrors": Array [
+    Object {
+      "lockFile": "yarn.lock",
+      "stderr": undefined,
+    },
+  ],
   "updatedLockFiles": Array [],
 }
 `;

--- a/test/workers/branch/lerna.spec.js
+++ b/test/workers/branch/lerna.spec.js
@@ -1,0 +1,18 @@
+const lernaHelper = require('../../../lib/workers/branch/lerna');
+
+jest.mock('child-process-promise');
+
+const { exec } = require('child-process-promise');
+
+describe('generateLockFiles()', () => {
+  it('generates package-lock.json files', async () => {
+    exec.mockReturnValueOnce({});
+    const res = await lernaHelper.generateLockFiles('npm', 'some-dir', {});
+    expect(res.error).toBe(false);
+  });
+  it('generates yarn.lock files', async () => {
+    exec.mockReturnValueOnce({});
+    const res = await lernaHelper.generateLockFiles('yarn', 'some-dir', {});
+    expect(res.error).toBe(false);
+  });
+});

--- a/test/workers/branch/lock-files.spec.js
+++ b/test/workers/branch/lock-files.spec.js
@@ -6,6 +6,7 @@ const upath = require('upath');
 const npm = require('../../../lib/workers/branch/npm');
 const yarn = require('../../../lib/workers/branch/yarn');
 const pnpm = require('../../../lib/workers/branch/pnpm');
+const lerna = require('../../../lib/workers/branch/lerna');
 
 const {
   hasPackageLock,
@@ -229,6 +230,32 @@ describe('workers/branch/lock-files', () => {
       expect(res.yarnLockFileDirs).toHaveLength(1);
       expect(res.yarnLockFileDirs[0]).toEqual('.');
     });
+    it('returns root directory if using lerna package lock', () => {
+      config.lernaLockFile = 'yarn';
+      config.upgrades = [{}];
+      config.packageFiles = [
+        {
+          packageFile: 'package.json',
+          yarnLock: '# some yarn lock',
+        },
+        {
+          packageFile: 'backend/package.json',
+          workspaceDir: '.',
+        },
+      ];
+      config.updatedPackageFiles = [
+        {
+          name: 'backend/package.json',
+          contents: 'some contents',
+        },
+      ];
+      const res = determineLockFileDirs(config);
+      expect(res).toMatchSnapshot();
+      expect(res.packageLockFileDirs).toHaveLength(0);
+      expect(res.yarnLockFileDirs).toHaveLength(0);
+      expect(res.lernaDirs).toHaveLength(1);
+      expect(res.lernaDirs[0]).toEqual('.');
+    });
   });
   describe('writeExistingFiles', () => {
     let config;
@@ -286,7 +313,7 @@ describe('workers/branch/lock-files', () => {
       ];
       platform.getFile.mockReturnValue('some lock file contents');
       await writeExistingFiles(config);
-      expect(fs.outputFile.mock.calls).toHaveLength(4);
+      expect(fs.outputFile.mock.calls).toHaveLength(5);
       expect(fs.remove.mock.calls).toHaveLength(1);
     });
     it('Try to write package.json of local lib, but file not found', async () => {
@@ -397,6 +424,7 @@ describe('workers/branch/lock-files', () => {
       pnpm.generateLockFile.mockReturnValue({
         lockFile: 'some lock file contents',
       });
+      lerna.generateLockFiles = jest.fn();
       lockFiles.determineLockFileDirs = jest.fn();
     });
     afterEach(() => {
@@ -415,6 +443,7 @@ describe('workers/branch/lock-files', () => {
         packageLockFileDirs: [],
         yarnLockFileDirs: [],
         shrinkwrapYamlDirs: [],
+        lernaDirs: [],
       });
       const res = await getUpdatedLockFiles(config);
       expect(res).toMatchSnapshot();
@@ -426,6 +455,7 @@ describe('workers/branch/lock-files', () => {
         packageLockFileDirs: ['a', 'b'],
         yarnLockFileDirs: ['c', 'd'],
         shrinkwrapYamlDirs: ['e'],
+        lernaDirs: [],
       });
       const res = await getUpdatedLockFiles(config);
       expect(res).toMatchSnapshot();
@@ -433,13 +463,38 @@ describe('workers/branch/lock-files', () => {
       expect(res.updatedLockFiles).toHaveLength(0);
       expect(npm.generateLockFile.mock.calls).toHaveLength(2);
       expect(yarn.generateLockFile.mock.calls).toHaveLength(2);
-      expect(platform.getFile.mock.calls).toHaveLength(5);
+      expect(platform.getFile.mock.calls).toHaveLength(6);
+    });
+    it('tries lerna npm', async () => {
+      lockFiles.determineLockFileDirs.mockReturnValueOnce({
+        packageLockFileDirs: ['a', 'b'],
+        yarnLockFileDirs: [],
+        shrinkwrapYamlDirs: [],
+        lernaDirs: ['.'],
+      });
+      config.lernaLockFile = 'npm';
+      lerna.generateLockFiles.mockReturnValueOnce({ error: false });
+      const res = await getUpdatedLockFiles(config);
+      expect(res).toMatchSnapshot();
+    });
+    it('tries lerna yarn', async () => {
+      lockFiles.determineLockFileDirs.mockReturnValueOnce({
+        packageLockFileDirs: [],
+        yarnLockFileDirs: ['c', 'd'],
+        shrinkwrapYamlDirs: [],
+        lernaDirs: ['.'],
+      });
+      config.lernaLockFile = 'yarn';
+      lerna.generateLockFiles.mockReturnValueOnce({ error: true });
+      const res = await getUpdatedLockFiles(config);
+      expect(res).toMatchSnapshot();
     });
     it('sets error if receiving null', async () => {
       lockFiles.determineLockFileDirs.mockReturnValueOnce({
         packageLockFileDirs: ['a', 'b'],
         yarnLockFileDirs: ['c', 'd'],
         shrinkwrapYamlDirs: ['e'],
+        lernaDirs: [],
       });
       npm.generateLockFile.mockReturnValueOnce({ error: true });
       yarn.generateLockFile.mockReturnValueOnce({ error: true });
@@ -449,13 +504,14 @@ describe('workers/branch/lock-files', () => {
       expect(res.updatedLockFiles).toHaveLength(0);
       expect(npm.generateLockFile.mock.calls).toHaveLength(2);
       expect(yarn.generateLockFile.mock.calls).toHaveLength(2);
-      expect(platform.getFile.mock.calls).toHaveLength(2);
+      expect(platform.getFile.mock.calls).toHaveLength(3);
     });
     it('adds multiple lock files', async () => {
       lockFiles.determineLockFileDirs.mockReturnValueOnce({
         packageLockFileDirs: ['a', 'b'],
         yarnLockFileDirs: ['c', 'd'],
         shrinkwrapYamlDirs: ['e'],
+        lernaDirs: [],
       });
       npm.generateLockFile.mockReturnValueOnce('some new lock file contents');
       yarn.generateLockFile.mockReturnValueOnce('some new lock file contents');
@@ -465,7 +521,7 @@ describe('workers/branch/lock-files', () => {
       expect(res.updatedLockFiles).toHaveLength(3);
       expect(npm.generateLockFile.mock.calls).toHaveLength(2);
       expect(yarn.generateLockFile.mock.calls).toHaveLength(2);
-      expect(platform.getFile.mock.calls).toHaveLength(5);
+      expect(platform.getFile.mock.calls).toHaveLength(6);
     });
   });
 });


### PR DESCRIPTION
Adds support for running `lerna bootstrap` instead of `npm install` or `yarn install` (without Workspaces), hence allowing support of internally-linked dependencies.

Closes #1441, Closes #1443