### PR TITLE
chore: add -v parameter to cli

### DIFF
--- a/lib/config/cli.js
+++ b/lib/config/cli.js
@@ -1,5 +1,6 @@
 const commander = require('commander');
 const configDefinitions = require('./definitions');
+const version = require('../../package.json).version;
 
 module.exports = {
   getCliName,
@@ -53,6 +54,7 @@ function getConfig(argv) {
   }
 
   program = program
+    .version(version, '-v, --version')
     .on('--help', helpConsole)
     .action(repositories => {
       config.repositories = repositories;

--- a/lib/config/cli.js
+++ b/lib/config/cli.js
@@ -1,6 +1,6 @@
 const commander = require('commander');
 const configDefinitions = require('./definitions');
-const version = require('../../package.json).version;
+const version = require('../../package.json').version;
 
 module.exports = {
   getCliName,

--- a/lib/config/cli.js
+++ b/lib/config/cli.js
@@ -1,6 +1,6 @@
 const commander = require('commander');
 const configDefinitions = require('./definitions');
-const version = require('../../package.json').version;
+const { version } = require('../../package.json');
 
 module.exports = {
   getCliName,


### PR DESCRIPTION
Not tested, just a quick Github edit. Should work though.

NOTE: 
I followed this doc as from what I've seen in the discussion the desired arguments would be `--version` and `-v`, while `commander` uses `-V` as default. This is their suggested way of overwriting it.

https://github.com/tj/commander.js#version-option

Fixes #1469 

PS. Feel free to squash and merge this, as I made some useless commit for not testing it before pushing