### PR TITLE
fix(semanticCommitScope): compile with handlebars

### DIFF
--- a/lib/workers/branch/commit.js
+++ b/lib/workers/branch/commit.js
@@ -16,7 +16,9 @@ async function commitFilesToBranch(config) {
       splitMessage[0] = splitMessage[0].toLowerCase();
       let semanticPrefix = config.semanticCommitType;
       if (config.semanticCommitScope) {
-        semanticPrefix += `(${config.semanticCommitScope})`;
+        semanticPrefix += `(${handlebars.compile(config.semanticCommitScope)(
+          config
+        )})`;
       }
       commitMessage = `${semanticPrefix}: ${splitMessage.join('\n')}`;
     }


### PR DESCRIPTION
Compile the semanticCommitScope with handlebars to ensure any
substitions such as {{depName}} are correctly parsed and replaced.

(I think this is correct - I'm having trouble getting the tests to run locally)