### PR TITLE
fix(gitAuthor): add support for GitLab

### DIFF
--- a/lib/platform/gitlab/index.js
+++ b/lib/platform/gitlab/index.js
@@ -1,4 +1,5 @@
 const get = require('./gl-got-wrapper');
+const addrs = require('email-addresses');
 
 let config = {};
 
@@ -516,7 +517,8 @@ async function commitFilesToBranch(
   branchName,
   files,
   message,
-  parentBranch = config.baseBranch
+  parentBranch = config.baseBranch,
+  gitAuthor
 ) {
   logger.debug(
     `commitFilesToBranch('${branchName}', files, message, '${parentBranch})'`
@@ -529,6 +531,20 @@ async function commitFilesToBranch(
       actions: [],
     },
   };
+
+  try {
+    if (gitAuthor) {
+      logger.debug({ gitAuthor }, 'Found gitAuthor');
+      const { name, address } = addrs.parseOneAddress(gitAuthor);
+      if (name && address) {
+        opts.body.author_name = name;
+        opts.body.author_email = address;
+      }
+    }
+  } catch (err) {
+    logger.warn({ gitAuthor }, 'Error parsing gitAuthor');
+  }
+
   for (const file of files) {
     const action = {
       file_path: file.name,

--- a/test/platform/gitlab/index.spec.js
+++ b/test/platform/gitlab/index.spec.js
@@ -691,6 +691,58 @@ describe('platform/gitlab', () => {
       expect(get.post.mock.calls).toMatchSnapshot();
       expect(get.post.mock.calls).toHaveLength(1);
     });
+
+    it('should parse valid gitAuthor', async () => {
+      get.mockImplementationOnce(() => Promise.reject({ statusCode: 404 })); // file exists
+      get.mockImplementationOnce(() =>
+        Promise.reject({
+          statusCode: 404,
+        })
+      ); // branch exists
+      const file = {
+        name: 'some-new-file',
+        contents: 'some new-contents',
+      };
+
+      await gitlab.commitFilesToBranch(
+        'renovate/something',
+        [file],
+        'Update something',
+        undefined,
+        'Renovate Bot <bot@renovateapp.com>'
+      );
+
+      expect(get.post.mock.calls[0][1].body.author_name).toEqual(
+        'Renovate Bot'
+      );
+      expect(get.post.mock.calls[0][1].body.author_email).toEqual(
+        'bot@renovateapp.com'
+      );
+    });
+
+    it('should skip invalid gitAuthor', async () => {
+      get.mockImplementationOnce(() => Promise.reject({ statusCode: 404 })); // file exists
+      get.mockImplementationOnce(() =>
+        Promise.reject({
+          statusCode: 404,
+        })
+      ); // branch exists
+      const file = {
+        name: 'some-new-file',
+        contents: 'some new-contents',
+      };
+
+      await gitlab.commitFilesToBranch(
+        'renovate/something',
+        [file],
+        'Update something',
+        undefined,
+        'Renovate Bot bot@renovateapp.com'
+      );
+
+      expect(get.post.mock.calls[0][1].body.author_name).toBeUndefined();
+      expect(get.post.mock.calls[0][1].body.author_email).toBeUndefined();
+    });
   });
   describe('getCommitMessages()', () => {
     it('returns commits messages', async () => {


### PR DESCRIPTION
Allow the `gitAuthor` configuration option to override the committer
property when creating or updating a file within GitLab.  Port of #1280
which introduced the same capability for GitHub.

(I still need to add tests for this but I'm not able to get the existing test suite running locally.  Happy to take any comments/guidance)