### PR TITLE
fix: disable reusing existing package-lock.json when upgrading

### DIFF
--- a/lib/workers/branch/lock-files.js
+++ b/lib/workers/branch/lock-files.js
@@ -237,6 +237,8 @@ async function writeExistingFiles(config) {
         packageFile.yarnrc.replace('--install.pure-lockfile true', '')
       );
     }
+    /*
+    // TODO: restore this functionality when https://github.com/npm/npm/issues/19852 is fixed
     if (packageFile.packageLock && config.type !== 'lockFileMaintenance') {
       logger.debug(`Writing package-lock.json to ${basedir}`);
       const existingPackageLock =
@@ -253,6 +255,7 @@ async function writeExistingFiles(config) {
       logger.debug(`Removing ${basedir}/package-lock.json`);
       await fs.remove(upath.join(basedir, 'package-lock.json'));
     }
+    */
     if (packageFile.yarnLock && config.type !== 'lockFileMaintenance') {
       logger.debug(`Writing yarn.lock to ${basedir}`);
       const existingYarnLock =

--- a/test/workers/branch/lock-files.spec.js
+++ b/test/workers/branch/lock-files.spec.js
@@ -291,7 +291,7 @@ describe('workers/branch/lock-files', () => {
       ];
       await writeExistingFiles(config);
       expect(fs.outputFile.mock.calls).toHaveLength(6);
-      expect(fs.remove.mock.calls).toHaveLength(6);
+      expect(fs.remove.mock.calls).toHaveLength(4);
     });
     it('writes package.json of local lib', async () => {
       const renoPath = upath.join(__dirname, '../../../');
@@ -313,7 +313,7 @@ describe('workers/branch/lock-files', () => {
       ];
       platform.getFile.mockReturnValue('some lock file contents');
       await writeExistingFiles(config);
-      expect(fs.outputFile.mock.calls).toHaveLength(5);
+      expect(fs.outputFile.mock.calls).toHaveLength(4);
       expect(fs.remove.mock.calls).toHaveLength(1);
     });
     it('Try to write package.json of local lib, but file not found', async () => {
@@ -336,7 +336,7 @@ describe('workers/branch/lock-files', () => {
       ];
       platform.getFile.mockReturnValue(null);
       await writeExistingFiles(config);
-      expect(fs.outputFile.mock.calls).toHaveLength(3);
+      expect(fs.outputFile.mock.calls).toHaveLength(2);
       expect(fs.remove.mock.calls).toHaveLength(1);
     });
     it('detect malicious intent (error config in package.json) local lib is not in the repo', async () => {
@@ -359,7 +359,7 @@ describe('workers/branch/lock-files', () => {
       ];
       platform.getFile.mockReturnValue(null);
       await writeExistingFiles(config);
-      expect(fs.outputFile.mock.calls).toHaveLength(3);
+      expect(fs.outputFile.mock.calls).toHaveLength(2);
       expect(fs.remove.mock.calls).toHaveLength(1);
     });
   });


### PR DESCRIPTION
Skip writing package-lock.json locally before `npm install —package-lock-only` to work around https://github.com/npm/npm/issues/19852

Workaround to fix #1528