### PR TITLE
fix: don't use --package-lock-only for npm install

### DIFF
--- a/lib/workers/branch/lerna.js
+++ b/lib/workers/branch/lerna.js
@@ -23,7 +23,7 @@ async function generateLockFiles(manager, tmpDir, env) {
     logger.debug('Using lerna version ' + lernaVersion);
     const params =
       manager === 'npm'
-        ? '--package-lock-only'
+        ? '--ignore-scripts'
         : '--ignore-scripts --ignore-engines --ignore-platform --mutex network:31879';
     const cmd = `${manager} install ${params} && npx lerna@${lernaVersion} bootstrap -- ${params}`;
     logger.debug({ cmd });

--- a/lib/workers/branch/lock-files.js
+++ b/lib/workers/branch/lock-files.js
@@ -237,8 +237,6 @@ async function writeExistingFiles(config) {
         packageFile.yarnrc.replace('--install.pure-lockfile true', '')
       );
     }
-    /*
-    // TODO: restore this functionality when https://github.com/npm/npm/issues/19852 is fixed
     if (packageFile.packageLock && config.type !== 'lockFileMaintenance') {
       logger.debug(`Writing package-lock.json to ${basedir}`);
       const existingPackageLock =
@@ -255,7 +253,6 @@ async function writeExistingFiles(config) {
       logger.debug(`Removing ${basedir}/package-lock.json`);
       await fs.remove(upath.join(basedir, 'package-lock.json'));
     }
-    */
     if (packageFile.yarnLock && config.type !== 'lockFileMaintenance') {
       logger.debug(`Writing yarn.lock to ${basedir}`);
       const yarnLock = await platform.getFile(packageFile.yarnLock);

--- a/lib/workers/branch/npm.js
+++ b/lib/workers/branch/npm.js
@@ -53,7 +53,7 @@ async function generateLockFile(tmpDir, env) {
       }
     }
     logger.debug(`Using npm: ${cmd}`);
-    cmd = `ls -l && ${cmd} --version && ${cmd} install --package-lock-only`;
+    cmd = `ls -l && ${cmd} --version && ${cmd} install --ignore-scripts`;
     // TODO: Switch to native util.promisify once using only node 8
     ({ stdout, stderr } = await exec(cmd, {
       cwd: tmpDir,

--- a/test/workers/branch/lock-files.spec.js
+++ b/test/workers/branch/lock-files.spec.js
@@ -291,7 +291,7 @@ describe('workers/branch/lock-files', () => {
       ];
       await writeExistingFiles(config);
       expect(fs.outputFile.mock.calls).toHaveLength(6);
-      expect(fs.remove.mock.calls).toHaveLength(4);
+      expect(fs.remove.mock.calls).toHaveLength(6);
     });
     it('writes package.json of local lib', async () => {
       const renoPath = upath.join(__dirname, '../../../');
@@ -313,7 +313,7 @@ describe('workers/branch/lock-files', () => {
       ];
       platform.getFile.mockReturnValue('some lock file contents');
       await writeExistingFiles(config);
-      expect(fs.outputFile.mock.calls).toHaveLength(4);
+      expect(fs.outputFile.mock.calls).toHaveLength(5);
       expect(fs.remove.mock.calls).toHaveLength(1);
     });
     it('Try to write package.json of local lib, but file not found', async () => {
@@ -336,7 +336,7 @@ describe('workers/branch/lock-files', () => {
       ];
       platform.getFile.mockReturnValue(null);
       await writeExistingFiles(config);
-      expect(fs.outputFile.mock.calls).toHaveLength(2);
+      expect(fs.outputFile.mock.calls).toHaveLength(3);
       expect(fs.remove.mock.calls).toHaveLength(1);
     });
     it('detect malicious intent (error config in package.json) local lib is not in the repo', async () => {
@@ -359,7 +359,7 @@ describe('workers/branch/lock-files', () => {
       ];
       platform.getFile.mockReturnValue(null);
       await writeExistingFiles(config);
-      expect(fs.outputFile.mock.calls).toHaveLength(2);
+      expect(fs.outputFile.mock.calls).toHaveLength(3);
       expect(fs.remove.mock.calls).toHaveLength(1);
     });
   });


### PR DESCRIPTION
Removing `--package-lock-only` option from npm installs due to https://github.com/npm/npm/issues/19852

Pretty sure this fixes #1495