### PR TITLE
fix: throw error if yarn out of disk space

### DIFF
--- a/lib/workers/branch/yarn.js
+++ b/lib/workers/branch/yarn.js
@@ -84,6 +84,9 @@ async function generateLockFile(tmpDir, env) {
       },
       'yarn install error'
     );
+    if (err.stderr && err.stderr.includes('ENOSPC: no space left on device')) {
+      throw new Error('Out of disk space when generating yarn.lock');
+    }
     return { error: true, stderr: err.stderr };
   }
   return { lockFile };


### PR DESCRIPTION
Throw error instead of raising PR with error log attached.

Closes #1548