### PR TITLE
feat: rename node config object to travis

### DIFF
--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -762,8 +762,8 @@ const options = [
     allowString: true,
   },
   {
-    name: 'node',
-    description: 'Configuration object for node version renovation',
+    name: 'travis',
+    description: 'Configuration object for .travis.yml renovation',
     stage: 'repository',
     type: 'json',
     default: {

--- a/lib/manager/travis/detect.js
+++ b/lib/manager/travis/detect.js
@@ -4,7 +4,7 @@ module.exports = {
 
 function detectPackageFiles(config, fileList) {
   logger.debug('node.detectPackageFiles()');
-  if (config.node.enabled) {
+  if (config.travis.enabled) {
     if (fileList.includes('.travis.yml')) {
       return ['.travis.yml'];
     }

--- a/lib/manager/travis/resolve.js
+++ b/lib/manager/travis/resolve.js
@@ -5,7 +5,7 @@ module.exports = {
 };
 
 async function resolvePackageFile(config, inputFile) {
-  const packageFile = configParser.mergeChildConfig(config.node, inputFile);
+  const packageFile = configParser.mergeChildConfig(config.travis, inputFile);
   logger.debug(
     `Resolving packageFile ${JSON.stringify(packageFile.packageFile)}`
   );

--- a/test/manager/index.spec.js
+++ b/test/manager/index.spec.js
@@ -69,7 +69,7 @@ describe('manager', () => {
       expect(res).toHaveLength(2);
     });
     it('finds .travis.yml files', async () => {
-      config.node.enabled = true;
+      config.travis.enabled = true;
       platform.getFileList.mockReturnValueOnce([
         '.travis.yml',
         'other/.travis.yml',

--- a/website/docs/_posts/2017-10-05-configuration-options.md
+++ b/website/docs/_posts/2017-10-05-configuration-options.md
@@ -509,17 +509,6 @@ Add to this object if you wish to define rules that apply only to minor updates.
 
 Set this to true if you wish to receive one PR for every separate major version upgrade of a dependency. e.g. if you are on webpack@v1 currently then default behaviour is a PR for upgrading to webpack@v3 and not for webpack@v2. If this setting is true then you would get one PR for webpack@v2 and one for webpack@v3.
 
-## node
-
-Configuration specific for node.js version updates (e.g. `.travis.yml`).
-
-| name    | value                                      |
-| ------- | ------------------------------------------ |
-| type    | object                                     |
-| default | { enabled: false, supportPolicy: ['lts'] } |
-
-It's set to false by default as we cannot 100% besure what supportPolicy you would want.
-
 ## npm
 
 Configuration specific for npm dependency updates (`package.json`).
@@ -1014,6 +1003,17 @@ Dependency support policy, e.g. used for LTS vs non-LTS etc (node-only)
 | default | `Etc/UTC` |
 
 It is only recommended to set this field if you wish to use the `schedules` feature and want to write them in your local timezone. Please see the above link for valid timezone names.
+
+## travis
+
+Configuration specific for .travis.yml node.js version updates.
+
+| name    | value                                      |
+| ------- | ------------------------------------------ |
+| type    | object                                     |
+| default | { enabled: false, supportPolicy: ['lts'] } |
+
+It's set to false by default as we cannot 100% be sure what supportPolicy you would want.
 
 ## unpublishSafe
 


### PR DESCRIPTION
The previous “node” object is now renamed to “travis”. A new “node” object will soon take its place, so we cannot migrate this automatically.

BREAKING CHANGE: Rename any existing “node” config object to “travis”