### PR TITLE
feat: validate renovate config PRs

### DIFF
--- a/lib/workers/repository/index.js
+++ b/lib/workers/repository/index.js
@@ -5,6 +5,7 @@ const { ensureOnboardingPr } = require('./onboarding/pr');
 const { writeUpdates } = require('./write');
 const { handleError } = require('./error');
 const { pruneStaleBranches } = require('./cleanup');
+const { validatePrs } = require('./validate');
 
 const { resolvePackageFiles } = require('../../manager');
 
@@ -82,6 +83,7 @@ async function renovateRepository(repoConfig, token, loop = 1) {
       logger.info(`Restarting repo renovation after ${res}`);
       return renovateRepository(repoConfig, token, loop + 1);
     }
+    await validatePrs(commonConfig || config);
     return res;
   } catch (err) {
     return handleError(config, err);

--- a/lib/workers/repository/validate.js
+++ b/lib/workers/repository/validate.js
@@ -1,0 +1,92 @@
+const { migrateAndValidate } = require('../../config/migrate-validate');
+
+async function getRenovatePrs(branchPrefix) {
+  return (await platform.getPrList())
+    .filter(pr => pr.state === 'open')
+    .filter(pr => pr.branchName && !pr.branchName.startsWith(branchPrefix))
+    .filter(pr => pr.title && pr.title.match(/renovate/i));
+}
+
+async function getRenovateFiles(prNo) {
+  const configFileNames = [
+    'package.json',
+    'renovate.json',
+    '.renovaterc',
+    '.renovaterc.json',
+  ];
+  return (await platform.getPrFiles(prNo)).filter(file =>
+    configFileNames.includes(file)
+  );
+}
+
+async function validatePrs(config) {
+  const renovatePrs = await getRenovatePrs(config.branchName);
+  let validations = [];
+  for (const pr of renovatePrs) {
+    try {
+      const renovateFiles = await getRenovateFiles(pr.number);
+      if (!renovateFiles.length) {
+        continue; // eslint-disable-line no-continue
+      }
+      logger.info(
+        { prNo: pr.number, title: pr.title, renovateFiles },
+        'PR has renovate files'
+      );
+      for (const file of renovateFiles) {
+        const content = await platform.getFile(file, pr.branchName);
+        let parsed;
+        try {
+          parsed = JSON.parse(content);
+        } catch (err) {
+          validations.push('Cannot parse ' + file);
+        }
+        if (parsed) {
+          const { errors } = migrateAndValidate(
+            config,
+            file === 'package.json'
+              ? parsed.renovate || parsed['renovate-config']
+              : parsed
+          );
+          if (errors && errors.length) {
+            validations = validations.concat(
+              errors.map(error => error.message)
+            );
+          }
+        }
+      }
+      // if the PR has renovate files then we set a status no matter what
+      let status;
+      let description;
+      if (validations.length) {
+        description = validations.join(', ').substring(0, 140); // GitHub limit
+        status = 'failure';
+      } else {
+        description = 'Renovate config is valid';
+        status = 'success';
+      }
+      logger.info({ status, description }, 'Setting PR validation status');
+      const context = 'renovate/validate';
+      await platform.setBranchStatus(
+        pr.branchName,
+        context,
+        description,
+        status
+      );
+    } catch (err) {
+      logger.warn(
+        {
+          err,
+          message: err.message,
+          body: err.response ? err.response.body : undefined,
+          prNo: pr.number,
+          branchName: pr.branchName,
+        },
+        'Error checking PR'
+      );
+    }
+  }
+}
+
+module.exports = {
+  validatePrs,
+};

--- a/test/workers/repository/index.spec.js
+++ b/test/workers/repository/index.spec.js
@@ -12,6 +12,7 @@ jest.mock('../../../lib/workers/repository/updates');
 jest.mock('../../../lib/workers/repository/onboarding/pr');
 jest.mock('../../../lib/workers/repository/write');
 jest.mock('../../../lib/workers/repository/cleanup');
+jest.mock('../../../lib/workers/repository/validate');
 jest.mock('../../../lib/manager');
 
 let config;

--- a/test/workers/repository/validate.spec.js
+++ b/test/workers/repository/validate.spec.js
@@ -1,0 +1,75 @@
+const validate = require('../../../lib/workers/repository/validate');
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('workers/repository/validate', () => {
+  describe('validatePrs()', () => {
+    it('catches error', async () => {
+      platform.getPrList.mockReturnValueOnce([
+        {
+          state: 'open',
+          branchName: 'some/branch',
+          title: 'Update Renovate',
+        },
+      ]);
+      await validate.validatePrs({});
+      expect(platform.setBranchStatus.mock.calls).toHaveLength(0);
+    });
+    it('returns if no matching files', async () => {
+      platform.getPrList.mockReturnValueOnce([
+        {
+          state: 'open',
+          branchName: 'some/branch',
+          title: 'Update Renovate',
+        },
+      ]);
+      platform.getPrFiles.mockReturnValueOnce(['readme.md']);
+      await validate.validatePrs({});
+      expect(platform.setBranchStatus.mock.calls).toHaveLength(0);
+    });
+    it('validates failures if cannot parse', async () => {
+      platform.getPrList.mockReturnValueOnce([
+        {
+          state: 'open',
+          branchName: 'some/branch',
+          title: 'Update Renovate',
+        },
+      ]);
+      platform.getPrFiles.mockReturnValueOnce(['renovate.json']);
+      platform.getFile.mockReturnValue('not JSON');
+      await validate.validatePrs({});
+      expect(platform.setBranchStatus.mock.calls).toHaveLength(1);
+      expect(platform.setBranchStatus.mock.calls[0][3]).toEqual('failure');
+    });
+    it('validates failures if config validation fails', async () => {
+      platform.getPrList.mockReturnValueOnce([
+        {
+          state: 'open',
+          branchName: 'some/branch',
+          title: 'Update Renovate',
+        },
+      ]);
+      platform.getPrFiles.mockReturnValueOnce(['renovate.json']);
+      platform.getFile.mockReturnValue('{"foo":1}');
+      await validate.validatePrs({});
+      expect(platform.setBranchStatus.mock.calls).toHaveLength(1);
+      expect(platform.setBranchStatus.mock.calls[0][3]).toEqual('failure');
+    });
+    it('validates successfully', async () => {
+      platform.getPrList.mockReturnValueOnce([
+        {
+          state: 'open',
+          branchName: 'some/branch',
+          title: 'Update Renovate',
+        },
+      ]);
+      platform.getPrFiles.mockReturnValueOnce(['renovate.json']);
+      platform.getFile.mockReturnValue('{}');
+      await validate.validatePrs({});
+      expect(platform.setBranchStatus.mock.calls).toHaveLength(1);
+      expect(platform.setBranchStatus.mock.calls[0][3]).toEqual('success');
+    });
+  });
+});


### PR DESCRIPTION
Checks for PRs mentioning renovate in the title and containing one or more renovate config files. Sets status check ‘renovate/validate’ to success or failure depending on whether any errors are found.

GitHub-only for now due to missing getPrFiles() method in gitlab and vsts.

Closes #1454