### PR TITLE
Added runnable Dockerfile for renovate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:8-alpine as dependencies
+WORKDIR /usr/src/app/
+RUN yarn add renovate --production --no-lockfile
+
+FROM alpine:3.7
+RUN addgroup -g 1000 node && adduser -H -u 1000 -G node -s /bin/sh -D node
+WORKDIR /usr/src/app/
+COPY --from=dependencies /usr/local/bin/node /usr/local/bin/
+COPY --from=dependencies /usr/lib/libgcc* /usr/lib/libstdc* /usr/lib/
+COPY --from=dependencies /usr/src/app/node_modules ./node_modules
+
+USER node
+CMD ["./node_modules/.bin/renovate"]


### PR DESCRIPTION
Example usage (once published):
```
docker run -it --rm -v "$PWD":"/usr/src/app/" -E GITHUB_TOKEN="xyz" renovateapp/renovate 
```