### PR TITLE
fix: return shrinkwrapdir to avoid crash

### DIFF
--- a/lib/workers/branch/lock-files.js
+++ b/lib/workers/branch/lock-files.js
@@ -106,7 +106,7 @@ function determineLockFileDirs(config) {
           shrinkwrapYamlDirs.push(dirname);
         }
       }
-      return { packageLockFileDirs, yarnLockFileDirs, shrinkwrapYamlDirs };
+      return { packageLockFileDirs, npmShrinkwrapDirs, yarnLockFileDirs, shrinkwrapYamlDirs };
     }
   }
 

--- a/lib/workers/branch/lock-files.js
+++ b/lib/workers/branch/lock-files.js
@@ -106,7 +106,12 @@ function determineLockFileDirs(config) {
           shrinkwrapYamlDirs.push(dirname);
         }
       }
-      return { packageLockFileDirs, npmShrinkwrapDirs, yarnLockFileDirs, shrinkwrapYamlDirs };
+      return {
+        packageLockFileDirs,
+        npmShrinkwrapDirs,
+        yarnLockFileDirs,
+        shrinkwrapYamlDirs,
+      };
     }
   }
 

--- a/test/workers/branch/__snapshots__/lock-files.spec.js.snap
+++ b/test/workers/branch/__snapshots__/lock-files.spec.js.snap
@@ -2,6 +2,9 @@
 
 exports[`workers/branch/lock-files determineLockFileDirs returns all directories if lock file maintenance 1`] = `
 Object {
+  "npmShrinkwrapDirs": Array [
+    "leftend",
+  ],
   "packageLockFileDirs": Array [
     "backend",
   ],


### PR DESCRIPTION
# What
Hi, 
i tried to run renovate on one of my projet but i kept having an error : 
```
 INFO: Branch has 0 upgrade(s) (repository=bmaron/repo, dependencies=, branch=renovate/lock-file-maintenance)
 INFO: Branch needs creating (repository=bmaron/repo, dependencies=, branch=renovate/lock-file-maintenance)
ERROR: Error updating branch: dirs.npmShrinkwrapDirs is not iterable (repository=bmaron/repo, dependencies=, branch=renovate/lock-file-maintenance)
       "err": {}
 INFO: Finished repository (repository=bmaron/repo)
```

i looked and in fact the npmShrinkwrapDirs was not returned ... so here is  little fix.
After that everything seems to work well :) 