### PR TITLE
fix: return non-zero exit code if any errors

### DIFF
--- a/lib/logger/index.js
+++ b/lib/logger/index.js
@@ -40,6 +40,9 @@ function initLogger() {
   ];
   logFunctions.forEach(x => {
     global.logger[x] = (p1, p2) => {
+      if (x === 'error') {
+        global.renovateError = true;
+      }
       if (p2) {
         // meta and msg provided
         return bunyanLogger[x]({ ...meta, ...p1 }, p2);

--- a/lib/renovate.js
+++ b/lib/renovate.js
@@ -2,4 +2,10 @@
 
 const globalWorker = require('./workers/global');
 
-globalWorker.start();
+(async () => {
+  await globalWorker.start();
+  // istanbul ignore if
+  if (global.renovateError) {
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
renovate now returns a non-zero edit code if logger.error() has been called any times during the run.

Closes #1338