### PR TITLE
fix: reopen MR after branch deletion (GitLab)

### DIFF
--- a/lib/platform/gitlab/index.js
+++ b/lib/platform/gitlab/index.js
@@ -489,6 +489,15 @@ function getPrFiles() {
   return [];
 }
 
+// istanbul ignore next
+async function reopenPr(iid) {
+  await get.put(`projects/${config.repository}/merge_requests/${iid}`, {
+    body: {
+      state_event: 'reopen',
+    },
+  });
+}
+
 async function updatePr(iid, title, description) {
   await get.put(`projects/${config.repository}/merge_requests/${iid}`, {
     body: {
@@ -575,9 +584,18 @@ async function commitFilesToBranch(
     opts.body.actions.push(action);
   }
   if (await branchExists(branchName)) {
+    logger.debug('Deleting existing branch');
     await deleteBranch(branchName);
   }
+  logger.debug('Adding commits');
   await get.post(`projects/${config.repository}/repository/commits`, opts);
+  // Reopen PR if it previousluy existed and was closed by GitLab when we deleted branch
+  const pr = await getBranchPr(branchName);
+  // istanbul ignore if
+  if (pr) {
+    logger.debug('Reopening PR');
+    await reopenPr(pr.number);
+  }
 }
 
 // GET /projects/:id/repository/commits

--- a/test/platform/gitlab/index.spec.js
+++ b/test/platform/gitlab/index.spec.js
@@ -686,6 +686,11 @@ describe('platform/gitlab', () => {
           statusCode: 404,
         })
       ); // branch exists
+      get.mockImplementationOnce(() =>
+        Promise.reject({
+          statusCode: 404,
+        })
+      ); // branch exists
       const file = {
         name: 'some-new-file',
         contents: 'some new-contents',
@@ -712,6 +717,11 @@ describe('platform/gitlab', () => {
       });
       // branch exists
       get.mockImplementationOnce(() => ({ statusCode: 200 }));
+      get.mockImplementationOnce(() =>
+        Promise.reject({
+          statusCode: 404,
+        })
+      ); // branch exists
       const files = [
         {
           name: 'some-existing-file',
@@ -730,9 +740,13 @@ describe('platform/gitlab', () => {
       expect(get.post.mock.calls).toMatchSnapshot();
       expect(get.post.mock.calls).toHaveLength(1);
     });
-
     it('should parse valid gitAuthor', async () => {
       get.mockImplementationOnce(() => Promise.reject({ statusCode: 404 })); // file exists
+      get.mockImplementationOnce(() =>
+        Promise.reject({
+          statusCode: 404,
+        })
+      ); // branch exists
       get.mockImplementationOnce(() =>
         Promise.reject({
           statusCode: 404,
@@ -758,9 +772,13 @@ describe('platform/gitlab', () => {
         'bot@renovateapp.com'
       );
     });
-
     it('should skip invalid gitAuthor', async () => {
       get.mockImplementationOnce(() => Promise.reject({ statusCode: 404 })); // file exists
+      get.mockImplementationOnce(() =>
+        Promise.reject({
+          statusCode: 404,
+        })
+      ); // branch exists
       get.mockImplementationOnce(() =>
         Promise.reject({
           statusCode: 404,


### PR DESCRIPTION
GitLab modified behaviour we depended on and now MRs are unfortunately closed automatically by GitLab whenever we delete the source branch. We need to delete the branch and recreate in order to rebase, such as for when a newer version than what's in a PR exists.

Ref: https://gitlab.com/gitlab-org/gitlab-ce/merge_requests/16690

Closes #1657 