### PR TITLE
fix: raise PR immediately if there are lock file errors

### DIFF
--- a/lib/workers/pr/index.js
+++ b/lib/workers/pr/index.js
@@ -28,8 +28,17 @@ async function ensurePr(prConfig) {
     config.requiredStatusChecks
   );
 
+  if (config.lockFileErrors && config.lockFileErrors.length) {
+    logger.debug('Forcing PR because of lock file errors');
+    config.forcePr = true;
+  }
+
   // Only create a PR if a branch automerge has failed
-  if (config.automerge === true && config.automergeType.startsWith('branch')) {
+  if (
+    config.automerge === true &&
+    config.automergeType.startsWith('branch') &&
+    !config.forcePr
+  ) {
     logger.debug(
       `Branch is configured for branch automerge, branchStatus is: ${branchStatus}`
     );
@@ -59,7 +68,11 @@ async function ensurePr(prConfig) {
       return null;
     }
     logger.debug('Branch status success');
-  } else if (config.prCreation === 'not-pending' && !existingPr) {
+  } else if (
+    config.prCreation === 'not-pending' &&
+    !existingPr &&
+    !config.forcePr
+  ) {
     logger.debug('Checking branch combined status');
     if (branchStatus === 'pending' || branchStatus === 'running') {
       logger.debug(`Branch status is "${branchStatus}" - checking timeout`);

--- a/test/workers/pr/index.spec.js
+++ b/test/workers/pr/index.spec.js
@@ -325,5 +325,13 @@ describe('workers/pr', () => {
       expect(platform.createPr.mock.calls[0]).toMatchSnapshot();
       existingPr.body = platform.createPr.mock.calls[0][2];
     });
+    it('should create PR if waiting for not pending but lockFileErrors', async () => {
+      platform.getBranchStatus.mockReturnValueOnce('pending');
+      platform.getBranchLastCommitTime.mockImplementationOnce(() => new Date());
+      config.prCreation = 'not-pending';
+      config.lockFileErrors = [{}];
+      const pr = await prWorker.ensurePr(config);
+      expect(pr).toMatchObject({ displayNumber: 'New Pull Request' });
+    });
   });
 });


### PR DESCRIPTION
Ignore any branch automerge or not-pending settings and raise the PR immediately so that the lock file error can be logged and included.

Closes #1654