### PR TITLE
fix(renovate): use fix for Docker renovations

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,6 +143,9 @@
       ":label(ready)",
       ":assignee(rarkins)"
     ],
+    "docker": {
+      "semanticCommitType": "fix"
+    },
     "semanticCommitScope": null
   },
   "publishConfig": {


### PR DESCRIPTION
This will mean that any update to our Docker base image causes semantic-release to release a patch, which in turn will ensure Docker Hub autobuilds it.