### PR TITLE
fix: skip branch creation if the updated dependency fails to lock

### DIFF
--- a/lib/workers/branch/index.js
+++ b/lib/workers/branch/index.js
@@ -177,7 +177,10 @@ async function processBranch(branchConfig) {
       logger.debug('Passing repository-changed error up');
       throw err;
     }
-    logger.error({ err }, `Error updating branch: ${err.message}`);
+    // istanbul ignore if
+    if (err.message !== 'registry-failure') {
+      logger.error({ err }, `Error updating branch: ${err.message}`);
+    }
     // Don't throw here - we don't want to stop the other renovations
     return 'error';
   }

--- a/lib/workers/branch/lock-files.js
+++ b/lib/workers/branch/lock-files.js
@@ -402,6 +402,22 @@ async function getUpdatedLockFiles(config) {
       'package-lock.json'
     );
     if (res.error) {
+      // istanbul ignore if
+      if (res.stderr && res.stderr.includes('No matching version found for')) {
+        for (const upgrade of config.upgrades) {
+          if (
+            res.stderr.includes(
+              `No matching version found for ${upgrade.depName}`
+            )
+          ) {
+            logger.info(
+              { dependency: upgrade.depName },
+              'npm install failed for the dependency being updated - skipping branch creation'
+            );
+            throw new Error('registry-failure');
+          }
+        }
+      }
       lockFileErrors.push({
         lockFile: lockFileName,
         stderr: res.stderr,
@@ -433,6 +449,22 @@ async function getUpdatedLockFiles(config) {
       'npm-shrinkwrap.json'
     );
     if (res.error) {
+      // istanbul ignore if
+      if (res.stderr && res.stderr.includes('No matching version found for')) {
+        for (const upgrade of config.upgrades) {
+          if (
+            res.stderr.includes(
+              `No matching version found for ${upgrade.depName}`
+            )
+          ) {
+            logger.info(
+              { dependency: upgrade.depName },
+              'npm install failed for the dependency being updated - skipping branch creation'
+            );
+            throw new Error('registry-failure');
+          }
+        }
+      }
       lockFileErrors.push({
         lockFile: lockFileName,
         stderr: res.stderr,
@@ -462,6 +494,24 @@ async function getUpdatedLockFiles(config) {
       env
     );
     if (res.error) {
+      // istanbul ignore if
+      if (res.stderr && res.stderr.includes(`Couldn't find any versions for`)) {
+        for (const upgrade of config.upgrades) {
+          /* eslint-disable no-useless-escape */
+          if (
+            res.stderr.includes(
+              `Couldn't find any versions for \\\"${upgrade.depName}\\\"`
+            )
+          ) {
+            logger.warn(
+              { dependency: upgrade.depName },
+              'yarn install failed for the dependency being updated - skipping branch creation'
+            );
+            throw new Error('registry-failure');
+          }
+          /* eslint-enable no-useless-escape */
+        }
+      }
       lockFileErrors.push({
         lockFile: lockFileName,
         stderr: res.stderr,
@@ -491,6 +541,22 @@ async function getUpdatedLockFiles(config) {
       env
     );
     if (res.error) {
+      // istanbul ignore if
+      if (res.stdout && res.stdout.includes(`No compatible version found:`)) {
+        for (const upgrade of config.upgrades) {
+          if (
+            res.stdout.includes(
+              `No compatible version found: ${upgrade.depName}`
+            )
+          ) {
+            logger.warn(
+              { dependency: upgrade.depName },
+              'pnpm install failed for the dependency being updated - skipping branch creation'
+            );
+            throw new Error('registry-failure');
+          }
+        }
+      }
       lockFileErrors.push({
         lockFile: lockFileName,
         stderr: res.stderr,

--- a/lib/workers/branch/npm.js
+++ b/lib/workers/branch/npm.js
@@ -70,7 +70,7 @@ async function generateLockFile(tmpDir, env, filename) {
       'Generated lockfile'
     );
   } catch (err) /* istanbul ignore next */ {
-    logger.warn(
+    logger.info(
       {
         err,
         stdout,

--- a/lib/workers/branch/pnpm.js
+++ b/lib/workers/branch/pnpm.js
@@ -79,7 +79,7 @@ async function generateLockFile(tmpDir, env) {
       },
       'pnpm install error'
     );
-    return { error: true, stderr: err.stderr };
+    return { error: true, stderr: err.stderr, stdout: err.stdout };
   }
   return { lockFile };
 }

--- a/lib/workers/branch/yarn.js
+++ b/lib/workers/branch/yarn.js
@@ -81,6 +81,8 @@ async function generateLockFile(tmpDir, env) {
     logger.info(
       {
         err,
+        stdout,
+        stderr,
       },
       'yarn install error'
     );


### PR DESCRIPTION
There are times when an npm dependency has an update available yet the “npm/yarn/pnpm install” fails to find it, and the lock file can’t be generated. We check for this any time there’s a lock file error and abort the branch creation, hoping it fixes itself on the next run.

Closes #1666