### PR TITLE
feat: updateLockFiles

### DIFF
--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -214,6 +214,11 @@ const options = [
     default: false,
   },
   {
+    name: 'updateLockFiles',
+    description: 'Set to false to disable lock file updating',
+    type: 'boolean',
+  },
+  {
     name: 'ignoreNpmrcFile',
     description: 'Whether to ignore any .npmrc file found in repository',
     stage: 'packageFile',

--- a/lib/manager/npm/package.js
+++ b/lib/manager/npm/package.js
@@ -50,7 +50,10 @@ async function getPackageUpdates(config) {
       type: 'warning',
       message: 'Failed to look up dependency',
     };
-    if (config.yarnLock || config.packageLock || config.npmShrinkwrap) {
+    if (
+      config.updateLockFiles &&
+      (config.yarnLock || config.packageLock || config.npmShrinkwrap)
+    ) {
       result.message +=
         '. This will block *all* dependencies from being updated due to presence of lock file.';
     }

--- a/lib/workers/branch/lock-files.js
+++ b/lib/workers/branch/lock-files.js
@@ -374,6 +374,10 @@ async function getUpdatedLockFiles(config) {
   logger.debug('Getting updated lock files');
   const lockFileErrors = [];
   const updatedLockFiles = [];
+  if (!config.updateLockFiles) {
+    logger.info('Skipping lock file generation');
+    return { lockFileErrors, updatedLockFiles };
+  }
   if (
     config.type === 'lockFileMaintenance' &&
     config.parentBranch &&

--- a/test/workers/branch/__snapshots__/lock-files.spec.js.snap
+++ b/test/workers/branch/__snapshots__/lock-files.spec.js.snap
@@ -73,6 +73,13 @@ Object {
 }
 `;
 
+exports[`workers/branch/lock-files getUpdatedLockFiles returns no error and empty lockfiles if updateLockFiles false 1`] = `
+Object {
+  "lockFileErrors": Array [],
+  "updatedLockFiles": Array [],
+}
+`;
+
 exports[`workers/branch/lock-files getUpdatedLockFiles tries lerna npm 1`] = `
 Object {
   "lockFileErrors": Array [],

--- a/test/workers/branch/lock-files.spec.js
+++ b/test/workers/branch/lock-files.spec.js
@@ -491,6 +491,13 @@ describe('workers/branch/lock-files', () => {
     afterEach(() => {
       jest.resetAllMocks();
     });
+    it('returns no error and empty lockfiles if updateLockFiles false', async () => {
+      config.updateLockFiles = false;
+      const res = await getUpdatedLockFiles(config);
+      expect(res).toMatchSnapshot();
+      expect(res.lockFileErrors).toHaveLength(0);
+      expect(res.updatedLockFiles).toHaveLength(0);
+    });
     it('returns no error and empty lockfiles if lock file maintenance exists', async () => {
       config.type = 'lockFileMaintenance';
       config.parentBranch = 'renovate/lock-file-maintenance';

--- a/website/docs/_posts/2017-10-05-configuration-options.md
+++ b/website/docs/_posts/2017-10-05-configuration-options.md
@@ -1069,6 +1069,15 @@ Because Docker uses tags instead of semver, there is no fixed convention for how
 
 This field is currently used by some config prefixes.
 
+## updateLockFiles
+
+Set to false to disable lock file updating.
+
+| name    | value   |
+| ------- | ------- |
+| type    | boolean |
+| default | true    |
+
 ## updateNotScheduled
 
 Whether to update (but not create) branches when not scheduled.


### PR DESCRIPTION
Adds an option “updateLockFiles” which defaults to true. Setting to false means that updating lock files (e.g. package-lock.json, yarn.lock and shrinkwrap.yaml) will be skipped. The main reason for doing this is for repositories that use a dependency we can’t resolve, so that they can keep updating the package.json without lock file.