### PR TITLE
feat: custom docker registries

### DIFF
--- a/lib/datasource/docker.js
+++ b/lib/datasource/docker.js
@@ -11,7 +11,7 @@ function getRepository(pkgName) {
   return pkgName.includes('/') ? pkgName : `library/${pkgName}`;
 }
 
-async function getHeaders(repository) {
+async function getDockerIoHeaders(repository) {
   try {
     const authUrl = `https://auth.docker.io/token?service=registry.docker.io&scope=repository:${repository}:pull`;
     logger.debug(`Obtaining docker registry token for ${repository}`);
@@ -38,8 +38,8 @@ async function getHeaders(repository) {
 async function getDigest(name, tag = 'latest') {
   try {
     const repository = getRepository(name);
-    const headers = await getHeaders(repository);
     const url = `${registry}/${repository}/manifests/${tag}`;
+    const headers = await getDockerIoHeaders(repository);
     const digest = (await got(url, { json: true, headers })).headers[
       'docker-content-digest'
     ];
@@ -82,7 +82,7 @@ async function getTags(name) {
   try {
     const repository = getRepository(name);
     const url = `${registry}/${repository}/tags/list?n=10000`;
-    const headers = await getHeaders(repository);
+    const headers = await getDockerIoHeaders(repository);
     const { tags } = (await got(url, { json: true, headers })).body;
     logger.debug({ tags }, 'Got docker tags');
     return tags;

--- a/lib/datasource/docker.js
+++ b/lib/datasource/docker.js
@@ -5,7 +5,16 @@ module.exports = {
   getTags,
 };
 
-const registry = 'https://index.docker.io/v2';
+function massageRegistry(input) {
+  let registry = input;
+  if (!registry || registry === 'docker.io') {
+    registry = 'index.docker.io'; // eslint-disable-line no-param-reassign
+  }
+  if (!registry.match('$https?://')) {
+    registry = `https://${registry}`; // eslint-disable-line no-param-reassign
+  }
+  return registry;
+}
 
 function getRepository(pkgName) {
   return pkgName.includes('/') ? pkgName : `library/${pkgName}`;
@@ -35,10 +44,12 @@ async function getDockerIoHeaders(repository) {
   }
 }
 
-async function getDigest(name, tag = 'latest') {
+async function getDigest(registry, name, tag = 'latest') {
+  logger.debug(`getDigest(${registry}, ${name}, ${tag})`);
   try {
+    const massagedRegistry = massageRegistry(registry);
     const repository = getRepository(name);
-    const url = `${registry}/${repository}/manifests/${tag}`;
+    const url = `${massagedRegistry}/v2/${repository}/manifests/${tag}`;
     const headers = await getDockerIoHeaders(repository);
     const digest = (await got(url, { json: true, headers })).headers[
       'docker-content-digest'
@@ -78,13 +89,16 @@ async function getDigest(name, tag = 'latest') {
   }
 }
 
-async function getTags(name) {
+async function getTags(registry, name) {
+  logger.debug(`getTags(${registry}, ${name})`);
   try {
+    const massagedRegistry = massageRegistry(registry);
     const repository = getRepository(name);
-    const url = `${registry}/${repository}/tags/list?n=10000`;
+    const url = `${massagedRegistry}/v2/${repository}/tags/list?n=10000`;
     const headers = await getDockerIoHeaders(repository);
     const { tags } = (await got(url, { json: true, headers })).body;
-    logger.debug({ tags }, 'Got docker tags');
+    logger.debug({ length: tags.length }, 'Got docker tags');
+    logger.trace({ tags });
     return tags;
   } catch (err) {
     // istanbul ignore if

--- a/lib/datasource/docker.js
+++ b/lib/datasource/docker.js
@@ -20,7 +20,11 @@ function getRepository(pkgName) {
   return pkgName.includes('/') ? pkgName : `library/${pkgName}`;
 }
 
-async function getDockerIoHeaders(repository) {
+async function getAuthHeaders(registry, repository) {
+  // istanbul ignore if
+  if (registry !== 'https://index.docker.io') {
+    return {};
+  }
   try {
     const authUrl = `https://auth.docker.io/token?service=registry.docker.io&scope=repository:${repository}:pull`;
     logger.debug(`Obtaining docker registry token for ${repository}`);
@@ -50,7 +54,7 @@ async function getDigest(registry, name, tag = 'latest') {
     const massagedRegistry = massageRegistry(registry);
     const repository = getRepository(name);
     const url = `${massagedRegistry}/v2/${repository}/manifests/${tag}`;
-    const headers = await getDockerIoHeaders(repository);
+    const headers = await getAuthHeaders(massagedRegistry, repository);
     const digest = (await got(url, { json: true, headers })).headers[
       'docker-content-digest'
     ];
@@ -95,7 +99,7 @@ async function getTags(registry, name) {
     const massagedRegistry = massageRegistry(registry);
     const repository = getRepository(name);
     const url = `${massagedRegistry}/v2/${repository}/tags/list?n=10000`;
-    const headers = await getDockerIoHeaders(repository);
+    const headers = await getAuthHeaders(massagedRegistry, repository);
     const { tags } = (await got(url, { json: true, headers })).body;
     logger.debug({ length: tags.length }, 'Got docker tags');
     logger.trace({ tags });

--- a/lib/datasource/docker.js
+++ b/lib/datasource/docker.js
@@ -112,12 +112,8 @@ async function getTags(registry, name) {
       const res = await got(url, { json: true, headers, timeout: 10000 });
       tags = tags.concat(res.body.tags);
       const linkHeader = parseLinkHeader(res.headers.link);
-      if (linkHeader && linkHeader.next) {
-        url = `${massagedRegistry}${linkHeader.next.url}`;
-        page += 1;
-      } else {
-        url = null;
-      }
+      url = linkHeader && linkHeader.next ? linkHeader.next.url : null;
+      page += 1;
     } while (url && page < 20);
     logger.debug({ length: tags.length }, 'Got docker tags');
     logger.trace({ tags });

--- a/lib/datasource/docker.js
+++ b/lib/datasource/docker.js
@@ -1,4 +1,5 @@
 const got = require('got');
+const parseLinkHeader = require('parse-link-header');
 
 module.exports = {
   getDigest,
@@ -50,18 +51,17 @@ async function getAuthHeaders(registry, repository) {
 
 async function getDigest(registry, name, tag = 'latest') {
   logger.debug(`getDigest(${registry}, ${name}, ${tag})`);
+  const massagedRegistry = massageRegistry(registry);
+  const repository = getRepository(name);
   try {
-    const massagedRegistry = massageRegistry(registry);
-    const repository = getRepository(name);
     const url = `${massagedRegistry}/v2/${repository}/manifests/${tag}`;
     const headers = await getAuthHeaders(massagedRegistry, repository);
-    const digest = (await got(url, { json: true, headers })).headers[
-      'docker-content-digest'
-    ];
+    headers.accept = 'application/vnd.docker.distribution.manifest.v2+json';
+    const digest = (await got(url, { json: true, headers, timeout: 10000 }))
+      .headers['docker-content-digest'];
     logger.debug({ digest }, 'Got docker digest');
     return digest;
-  } catch (err) {
-    // istanbul ignore if
+  } catch (err) /* istanbul ignore next */ {
     if (err.statusCode === 401) {
       logger.info(
         { err, body: err.response ? err.response.body : undefined, name, tag },
@@ -69,7 +69,6 @@ async function getDigest(registry, name, tag = 'latest') {
       );
       return null;
     }
-    // istanbul ignore if
     if (err.statusCode === 404) {
       logger.info(
         { err, body: err.response ? err.response.body : undefined, name, tag },
@@ -77,13 +76,20 @@ async function getDigest(registry, name, tag = 'latest') {
       );
       return null;
     }
-    // istanbul ignore if
     if (err.statusCode >= 500 && err.statusCode < 600) {
       logger.warn(
         { err, body: err.response ? err.response.body : undefined, name, tag },
         'docker registry failure: internal error'
       );
       throw new Error('registry-failure');
+    }
+    if (err.code === 'ETIMEDOUT') {
+      logger.info(
+        { massagedRegistry },
+        'Timeout when attempting to connect to docker registry'
+      );
+      logger.debug({ err });
+      return null;
     }
     logger.info(
       { err, body: err.response ? err.response.body : undefined, name, tag },
@@ -95,20 +101,39 @@ async function getDigest(registry, name, tag = 'latest') {
 
 async function getTags(registry, name) {
   logger.debug(`getTags(${registry}, ${name})`);
+  const massagedRegistry = massageRegistry(registry);
+  const repository = getRepository(name);
   try {
-    const massagedRegistry = massageRegistry(registry);
-    const repository = getRepository(name);
-    const url = `${massagedRegistry}/v2/${repository}/tags/list?n=10000`;
+    let url = `${massagedRegistry}/v2/${repository}/tags/list?n=10000`;
     const headers = await getAuthHeaders(massagedRegistry, repository);
-    const { tags } = (await got(url, { json: true, headers })).body;
+    let tags = [];
+    let page = 1;
+    do {
+      const res = await got(url, { json: true, headers, timeout: 10000 });
+      tags = tags.concat(res.body.tags);
+      const linkHeader = parseLinkHeader(res.headers.link);
+      if (linkHeader && linkHeader.next) {
+        url = `${massagedRegistry}${linkHeader.next.url}`;
+        page += 1;
+      } else {
+        url = null;
+      }
+    } while (url && page < 20);
     logger.debug({ length: tags.length }, 'Got docker tags');
     logger.trace({ tags });
     return tags;
-  } catch (err) {
-    // istanbul ignore if
+  } catch (err) /* istanbul ignore next */ {
     if (err.statusCode >= 500 && err.statusCode < 600) {
       logger.warn({ err }, 'docker registry failure: internal error');
       throw new Error('registry-failure');
+    }
+    if (err.code === 'ETIMEDOUT') {
+      logger.info(
+        { massagedRegistry },
+        'Timeout when attempting to connect to docker registry'
+      );
+      logger.debug({ err });
+      return null;
     }
     logger.warn({ err, name }, 'Error getting docker image tags');
     return null;

--- a/lib/manager/docker/package.js
+++ b/lib/manager/docker/package.js
@@ -19,7 +19,7 @@ async function getPackageUpdates(config) {
     unstablePattern,
     ignoreUnstable,
   } = config;
-  if (dockerRegistry) {
+  if (dockerRegistry && dockerRegistry !== 'docker.io') {
     logger.info(
       { currentFrom, dockerRegistry },
       'Skipping Dockerfile image with custom host'
@@ -29,7 +29,11 @@ async function getPackageUpdates(config) {
   const upgrades = [];
   if (currentDigest || config.pinDigests) {
     logger.debug('Checking docker pinDigests');
-    const newDigest = await dockerApi.getDigest(depName, currentTag);
+    const newDigest = await dockerApi.getDigest(
+      dockerRegistry,
+      depName,
+      currentTag
+    );
     if (!newDigest) {
       logger.debug({ content: config.content }, 'Dockerfile no digest');
     }
@@ -38,7 +42,13 @@ async function getPackageUpdates(config) {
       upgrade.newTag = currentTag || 'latest';
       upgrade.newDigest = newDigest;
       upgrade.newDigestShort = newDigest.slice(7, 13);
-      upgrade.newFrom = `${depName}:${upgrade.newTag}@${newDigest}`;
+      if (dockerRegistry) {
+        upgrade.newFrom = `${dockerRegistry}/`;
+      } else {
+        upgrade.newFrom = '';
+      }
+      upgrade.newFrom += `${depName}:${upgrade.newTag}@${newDigest}`;
+
       if (currentDigest) {
         upgrade.type = 'digest';
         upgrade.isDigest = true;
@@ -62,7 +72,7 @@ async function getPackageUpdates(config) {
     const currentMajor = semver.major(padRange(tagVersion));
     const currentlyStable = isStable(tagVersion, unstablePattern);
     let versionList = [];
-    const allTags = await dockerApi.getTags(config.depName);
+    const allTags = await dockerApi.getTags(dockerRegistry, config.depName);
     if (allTags) {
       versionList = allTags
         .filter(tag => getSuffix(tag) === tagSuffix)
@@ -130,15 +140,20 @@ async function getPackageUpdates(config) {
       };
       upgrade.newVersion = newTag;
       upgrade.newDepTag = `${config.depName}:${upgrade.newTag}`;
-      let newFrom = upgrade.newDepTag;
+      if (dockerRegistry) {
+        upgrade.newFrom = `${dockerRegistry}/`;
+      } else {
+        upgrade.newFrom = '';
+      }
+      upgrade.newFrom += `${depName}:${upgrade.newTag}`;
       if (config.currentDigest || config.pinDigests) {
         upgrade.newDigest = await dockerApi.getDigest(
+          dockerRegistry,
           config.depName,
           upgrade.newTag
         );
-        newFrom = `${newFrom}@${upgrade.newDigest}`;
+        upgrade.newFrom += `@${upgrade.newDigest}`;
       }
-      upgrade.newFrom = newFrom;
       if (newVersionMajor > currentMajor) {
         upgrade.type = 'major';
         upgrade.isMajor = true;

--- a/lib/manager/docker/package.js
+++ b/lib/manager/docker/package.js
@@ -11,7 +11,6 @@ module.exports = {
 async function getPackageUpdates(config) {
   const {
     dockerRegistry,
-    currentFrom,
     depName,
     currentDepTag,
     currentTag,
@@ -19,13 +18,6 @@ async function getPackageUpdates(config) {
     unstablePattern,
     ignoreUnstable,
   } = config;
-  if (dockerRegistry && dockerRegistry !== 'docker.io') {
-    logger.info(
-      { currentFrom, dockerRegistry },
-      'Skipping Dockerfile image with custom host'
-    );
-    return [];
-  }
   const upgrades = [];
   if (currentDigest || config.pinDigests) {
     logger.debug('Checking docker pinDigests');

--- a/lib/manager/docker/update.js
+++ b/lib/manager/docker/update.js
@@ -6,9 +6,9 @@ function setNewValue(currentFileContent, upgrade) {
   try {
     logger.debug(`setNewValue: ${upgrade.newFrom}`);
     const oldLine = new RegExp(
-      `(^|\\n)${upgrade.fromPrefix}(\\s+)${upgrade.depName}[^\\s]*(\\s?)${
-        upgrade.fromSuffix
-      }\\n`
+      `(^|\\n)${upgrade.fromPrefix}(\\s+)${
+        upgrade.dockerRegistry ? upgrade.dockerRegistry + '/' : ''
+      }${upgrade.depName}[^\\s]*(\\s?)${upgrade.fromSuffix}\\n`
     );
     const newLine = `$1${upgrade.fromPrefix}$2${upgrade.newFrom}$3${
       upgrade.fromSuffix

--- a/test/datasource/docker.spec.js
+++ b/test/datasource/docker.spec.js
@@ -10,12 +10,12 @@ describe('api/docker', () => {
     });
     it('returns null if no token', async () => {
       got.mockReturnValueOnce({ body: {} });
-      const res = await docker.getDigest('some-name', undefined);
+      const res = await docker.getDigest(undefined, 'some-name', undefined);
       expect(res).toBe(null);
     });
     it('returns null if errored', async () => {
       got.mockReturnValueOnce({ body: { token: 'some-token' } });
-      const res = await docker.getDigest('some-name', undefined);
+      const res = await docker.getDigest(undefined, 'some-name', undefined);
       expect(res).toBe(null);
     });
     it('returns digest', async () => {
@@ -23,7 +23,7 @@ describe('api/docker', () => {
       got.mockReturnValueOnce({
         headers: { 'docker-content-digest': 'some-digest' },
       });
-      const res = await docker.getDigest('some-name', undefined);
+      const res = await docker.getDigest(undefined, 'some-name', undefined);
       expect(res).toBe('some-digest');
     });
     it('supports scoped names', async () => {
@@ -31,26 +31,26 @@ describe('api/docker', () => {
       got.mockReturnValueOnce({
         headers: { 'docker-content-digest': 'some-digest' },
       });
-      const res = await docker.getDigest('some/name', undefined);
+      const res = await docker.getDigest(undefined, 'some/name', undefined);
       expect(res).toBe('some-digest');
     });
   });
   describe('getTags', () => {
     it('returns null if no token', async () => {
       got.mockReturnValueOnce({ body: {} });
-      const res = await docker.getTags('node');
+      const res = await docker.getTags(undefined, 'node');
       expect(res).toBe(null);
     });
     it('returns tags', async () => {
       const tags = ['a', 'b'];
       got.mockReturnValueOnce({ body: { token: 'some-token ' } });
       got.mockReturnValueOnce({ body: { tags } });
-      const res = await docker.getTags('my/node');
+      const res = await docker.getTags(undefined, 'my/node');
       expect(res).toBe(tags);
     });
     it('returns null on error', async () => {
       got.mockReturnValueOnce({});
-      const res = await docker.getTags('node');
+      const res = await docker.getTags(undefined, 'node');
       expect(res).toBe(null);
     });
   });

--- a/test/datasource/docker.spec.js
+++ b/test/datasource/docker.spec.js
@@ -43,10 +43,10 @@ describe('api/docker', () => {
     });
     it('returns tags', async () => {
       const tags = ['a', 'b'];
-      got.mockReturnValueOnce({ body: { token: 'some-token ' } });
-      got.mockReturnValueOnce({ body: { tags } });
+      got.mockReturnValueOnce({ headers: {}, body: { token: 'some-token ' } });
+      got.mockReturnValueOnce({ headers: {}, body: { tags } });
       const res = await docker.getTags(undefined, 'my/node');
-      expect(res).toBe(tags);
+      expect(res).toEqual(tags);
     });
     it('returns null on error', async () => {
       got.mockReturnValueOnce({});

--- a/test/manager/docker/__snapshots__/package.spec.js.snap
+++ b/test/manager/docker/__snapshots__/package.spec.js.snap
@@ -37,6 +37,19 @@ Array [
 ]
 `;
 
+exports[`lib/workers/package/docker getPackageUpdates returns a digest when registry is present 1`] = `
+Array [
+  Object {
+    "isDigest": true,
+    "newDigest": "sha256:1234567890",
+    "newDigestShort": "123456",
+    "newFrom": "docker.io/some-dep:1.0.0@sha256:1234567890",
+    "newTag": "1.0.0",
+    "type": "digest",
+  },
+]
+`;
+
 exports[`lib/workers/package/docker getPackageUpdates returns major and minor upgrades 1`] = `
 Array [
   Object {
@@ -118,7 +131,7 @@ Array [
     "isMajor": true,
     "newDepTag": "some-dep:3.0.0",
     "newDigest": "sha256:one",
-    "newFrom": "some-dep:3.0.0@sha256:one",
+    "newFrom": "docker.io/some-dep:3.0.0@sha256:one",
     "newTag": "3.0.0",
     "newVersion": "3.0.0",
     "newVersionMajor": "3",

--- a/test/manager/docker/package.spec.js
+++ b/test/manager/docker/package.spec.js
@@ -47,6 +47,15 @@ describe('lib/workers/package/docker', () => {
       expect(res).toHaveLength(1);
       expect(res[0].type).toEqual('digest');
     });
+    it('returns a digest when registry is present', async () => {
+      config.dockerRegistry = 'docker.io';
+      config.currentFrom = 'docker.io/some-dep:1.0.0@sha256:abcdefghijklmnop';
+      dockerApi.getDigest.mockReturnValueOnce('sha256:1234567890');
+      const res = await docker.getPackageUpdates(config);
+      expect(res).toMatchSnapshot();
+      expect(res).toHaveLength(1);
+      expect(res[0].type).toEqual('digest');
+    });
     it('adds latest tag', async () => {
       delete config.currentTag;
       dockerApi.getDigest.mockReturnValueOnce('sha256:1234567890');
@@ -67,6 +76,7 @@ describe('lib/workers/package/docker', () => {
       expect(await docker.getPackageUpdates(config)).toEqual([]);
     });
     it('returns only one upgrade if automerging major', async () => {
+      config.dockerRegistry = 'docker.io';
       dockerApi.getDigest.mockReturnValueOnce(config.currentDigest);
       dockerApi.getDigest.mockReturnValueOnce('sha256:one');
       dockerApi.getTags.mockReturnValueOnce([


### PR DESCRIPTION
Adds support for custom docker registries. To work (for now), registries must support anonymous public access to their v2 API. Tested against quay.io and gcr.io, including tags pagination for quay. Also needed to add a 10s timeout for registry queries to catch private/firewalled registries that we can't access.

Closes #797 