### PR TITLE
fix: Prefer /usr/src/app workdir so no need for chown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,15 +3,14 @@ FROM node:8.11.0-alpine@sha256:fa3766ad0159e71ccb8970b00c1f2bfc354e22e2c26aa7a14
 LABEL maintainer="Rhys Arkins <rhys@arkins.net>"
 LABEL name="renovate"
 
-WORKDIR /src
+WORKDIR /usr/src/app/
 
 RUN apk add --quiet --no-cache git openssh-client
 COPY package.json .
 COPY yarn.lock .
 RUN yarn install --production && yarn cache clean
-COPY lib ./lib
-RUN chown -R node:node /src
+COPY lib lib
 USER node
 
-ENTRYPOINT ["node", "/src/lib/renovate.js"]
+ENTRYPOINT ["node", "/usr/src/app/lib/renovate.js"]
 CMD ["--help"]


### PR DESCRIPTION
In alpine linux, the `/usr/src` dir is already configured to allow system users read access. Keeping the ownership to root, but permitting the `node` user read access.

**Note**: Maybe a breaking change if users are mounting to `/src` path on docker run.