### PR TITLE
fix(gitlab-reviewer): change from error to warning

### DIFF
--- a/lib/platform/gitlab/index.js
+++ b/lib/platform/gitlab/index.js
@@ -370,7 +370,7 @@ async function addAssignees(iid, assignees) {
 
 function addReviewers(iid, reviewers) {
   logger.debug(`addReviewers('${iid}, '${reviewers})`);
-  logger.error('No reviewer functionality in GitLab');
+  logger.warn('Unimplemented in GitLab: approvals');
 }
 
 async function ensureComment() {


### PR DESCRIPTION
GitLab as of v10.6 has a API end point for Merge Request Approvals
which equates to the Reviewer functionality in GitHub.  This is available
to both GitLab.com and EES or above on-prem users.

See https://docs.gitlab.com/ee/api/merge_request_approvals.html#merge-request-level-approvals

If this is implemented in future it may be appropriate to issue an _error_ for GitLab CE installs where the functionality is definitely not available.