### PR TITLE
Renamed "user name" to "username" in definitions.js

### DIFF
--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -774,13 +774,13 @@ const options = [
   {
     name: 'assignees',
     description:
-      'Assignees for Pull Request (user name in GitHub/GitLab, email address in VSTS)',
+      'Assignees for Pull Request (username in GitHub/GitLab, email address in VSTS)',
     type: 'list',
   },
   {
     name: 'reviewers',
     description:
-      'Requested reviewers for Pull Requests (user name in GitHub/GitLab, email or user name in VSTS)',
+      'Requested reviewers for Pull Requests (username in GitHub/GitLab, email or username in VSTS)',
     type: 'list',
   },
   {


### PR DESCRIPTION
Changed `user name` to `username` in description to clarify we want a login name and not the user's actual name.