### PR TITLE
feat: depTypeList in packageRules

### DIFF
--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -372,6 +372,17 @@ const options = [
     env: false,
   },
   {
+    name: 'depTypeList',
+    description:
+      'List of depTypes to match (e.g. [`peerDependencies`]). Valid only within `packageRules` object',
+    type: 'list',
+    allowString: true,
+    stage: 'depType',
+    mergeable: true,
+    cli: false,
+    env: false,
+  },
+  {
     name: 'packageNames',
     description:
       'Package names to match. Valid only within `packageRules` object',

--- a/lib/config/validation.js
+++ b/lib/config/validation.js
@@ -125,6 +125,7 @@ async function validateConfig(config) {
             }
             if (key === 'packageRules') {
               const selectors = [
+                'depTypeList',
                 'packageNames',
                 'packagePatterns',
                 'excludePackageNames',

--- a/lib/workers/dep-type/index.js
+++ b/lib/workers/dep-type/index.js
@@ -57,12 +57,13 @@ function getDepConfig(depTypeConfig, dep) {
     );
     depConfig.packageRules.forEach(packageRule => {
       const {
+        depTypeList,
         excludePackageNames,
         excludePackagePatterns,
         packageNames,
         packagePatterns,
       } = packageRule;
-      let applyRule = false;
+      let applyRule;
       if (
         (excludePackageNames || excludePackagePatterns) &&
         !(packageNames || packagePatterns)
@@ -102,6 +103,9 @@ function getDepConfig(depTypeConfig, dep) {
             applyRule = false;
           }
         }
+      }
+      if (applyRule !== false && depTypeList && depTypeList.length) {
+        applyRule = depTypeList.includes(dep.depType);
       }
       if (applyRule) {
         // Package rule config overrides any existing config

--- a/test/config/__snapshots__/index.spec.js.snap
+++ b/test/config/__snapshots__/index.spec.js.snap
@@ -23,6 +23,7 @@ Object {
   "commitBody": null,
   "commitMessage": "Update dependency {{{depName}}} to {{#unless isRange}}v{{/unless}}{{{newVersion}}}",
   "copyLocalLibs": false,
+  "depTypeList": Array [],
   "dependencies": Object {},
   "description": Array [
     "Do not renovate <code>peerDependencies</code> versions/ranges",

--- a/test/config/__snapshots__/validation.spec.js.snap
+++ b/test/config/__snapshots__/validation.spec.js.snap
@@ -48,7 +48,7 @@ Array [
   },
   Object {
     "depName": "Configuration Error",
-    "message": "Each packageRule must contain at least one selector (packageNames, packagePatterns, excludePackageNames, excludePackagePatterns). If you wish for configuration to apply to all packages, it is not necessary to place it inside a packageRule at all.",
+    "message": "Each packageRule must contain at least one selector (depTypeList, packageNames, packagePatterns, excludePackageNames, excludePackagePatterns). If you wish for configuration to apply to all packages, it is not necessary to place it inside a packageRule at all.",
   },
   Object {
     "depName": "Configuration Error",

--- a/test/workers/dep-type/index.spec.js
+++ b/test/workers/dep-type/index.spec.js
@@ -207,5 +207,58 @@ describe('lib/workers/dep-type/index', () => {
       expect(res.y).toBeUndefined();
       expect(res.packageRules).toBeUndefined();
     });
+    it('filters depType', () => {
+      const config = {
+        packageRules: [
+          {
+            depTypeList: ['dependencies', 'peerDependencies'],
+            packageNames: ['a'],
+            x: 1,
+          },
+        ],
+      };
+      const dep = {
+        depType: 'dependencies',
+        depName: 'a',
+      };
+      const res = depTypeWorker.getDepConfig(config, dep);
+      expect(res.x).toBe(1);
+      expect(res.packageRules).toBeUndefined();
+    });
+    it('filters naked depType', () => {
+      const config = {
+        packageRules: [
+          {
+            depTypeList: ['dependencies', 'peerDependencies'],
+            x: 1,
+          },
+        ],
+      };
+      const dep = {
+        depType: 'dependencies',
+        depName: 'a',
+      };
+      const res = depTypeWorker.getDepConfig(config, dep);
+      expect(res.x).toBe(1);
+      expect(res.packageRules).toBeUndefined();
+    });
+    it('filters depType', () => {
+      const config = {
+        packageRules: [
+          {
+            depTypeList: ['dependencies', 'peerDependencies'],
+            packageNames: ['a'],
+            x: 1,
+          },
+        ],
+      };
+      const dep = {
+        depType: 'devDependencies',
+        depName: 'a',
+      };
+      const res = depTypeWorker.getDepConfig(config, dep);
+      expect(res.x).toBeUndefined();
+      expect(res.packageRules).toBeUndefined();
+    });
   });
 });

--- a/website/docs/_posts/2017-10-05-configuration-options.md
+++ b/website/docs/_posts/2017-10-05-configuration-options.md
@@ -196,6 +196,17 @@ Example commit message: "chore(deps): Update dependency eslint to version 4.0.1"
 
 Set to true if repository package.json files contain any local (file) dependencies + lock files. The `package.json` files from each will be copied to disk before lock file generation, even if they are within ignored directories.
 
+## depTypeList
+
+A list of depType names inside a package rule to filter on. Matches all depTypes if empty.
+
+| name    | value            |
+| ------- | ---------------- |
+| type    | array of strings |
+| default | []               |
+
+Use this field if you want to limit a `packageRule` to certain `depType` values. Invalid if used outside of a `packageRule`.
+
 ## dependencies
 
 Configuration specific for `package.json > dependencies`.


### PR DESCRIPTION
Adds a field `depTypeList` to `packageRules`, enabling rules for packages to be applied for any `depType`. Config objects `dependencies`, `devDependencies` and `peerDependencies` will be deprecated in favour of this new approach.
