### PR TITLE
feat: implement isBranchStale for GitLab

### DIFF
--- a/lib/platform/gitlab/index.js
+++ b/lib/platform/gitlab/index.js
@@ -185,9 +185,16 @@ async function getAllRenovateBranches(branchPrefix) {
   }, []);
 }
 
-function isBranchStale() {
-  logger.warn('Unimplemented in GitLab: isBranchStale');
-  return false;
+async function isBranchStale(branchName) {
+  logger.debug(`isBranchStale(${branchName})`);
+  const branchDetails = await getBranchDetails(branchName);
+  logger.trace({ branchDetails }, 'branchDetails');
+  const parentSha = branchDetails.body.commit.parent_ids[0];
+  logger.debug(`parentSha=${parentSha}`);
+  const baseCommitSHA = await getBaseCommitSHA();
+  logger.debug(`baseCommitSHA=${baseCommitSHA}`);
+  // Return true if the SHAs don't match
+  return parentSha !== baseCommitSHA;
 }
 
 // Returns the Pull Request for a branch. Null if not exists.
@@ -611,4 +618,19 @@ async function getCommitMessages() {
     logger.error({ err }, `getCommitMessages error`);
     return [];
   }
+}
+
+function getBranchDetails(branchName) {
+  const url = `/projects/${config.repository}/repository/branches/${urlEscape(
+    branchName
+  )}`;
+  return get(url);
+}
+
+async function getBaseCommitSHA() {
+  if (!config.baseCommitSHA) {
+    const branchDetails = await getBranchDetails(config.baseBranch);
+    config.baseCommitSHA = branchDetails.body.commit.id;
+  }
+  return config.baseCommitSHA;
 }

--- a/test/platform/gitlab/index.spec.js
+++ b/test/platform/gitlab/index.spec.js
@@ -239,8 +239,43 @@ describe('platform/gitlab', () => {
     });
   });
   describe('isBranchStale()', () => {
-    it('exists', () => {
-      gitlab.isBranchStale();
+    it('should return false if same SHA as master', async () => {
+      // getBranchDetails - same as master
+      get.mockImplementationOnce(() => ({
+        body: {
+          commit: {
+            parent_ids: ['1234'],
+          },
+        },
+      }));
+      // getBranchDetails - master
+      get.mockImplementationOnce(() => ({
+        body: {
+          commit: {
+            id: '1234',
+          },
+        },
+      }));
+      expect(await gitlab.isBranchStale('thebranchname')).toBe(false);
+    });
+    it('should return true if SHA different from master', async () => {
+      // getBranchDetails - different from master
+      get.mockImplementationOnce(() => ({
+        body: {
+          commit: {
+            parent_ids: ['12345678'],
+          },
+        },
+      }));
+      // getBranchDetails - master
+      get.mockImplementationOnce(() => ({
+        body: {
+          commit: {
+            id: '1234',
+          },
+        },
+      }));
+      expect(await gitlab.isBranchStale('thebranchname')).toBe(true);
     });
   });
   describe('getBranchPr(branchName)', () => {


### PR DESCRIPTION
<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate
-->

<!-- Replace this text with a description of what this PR fixes or adds -->
This PR implements the `isBranchStale` method of GitLab platform, which will enable `rebaseStalePrs` option for GitLab.

Closes #1626