### PR TITLE
feat: support commit prefix in onboarding commit

### DIFF
--- a/lib/workers/repository/onboarding/branch/create.js
+++ b/lib/workers/repository/onboarding/branch/create.js
@@ -4,6 +4,18 @@ async function createOnboardingBranch(config) {
   logger.debug('createOnboardingBranch()');
   const contents = await getOnboardingConfig(config);
   logger.info('Creating onboarding branch');
+  let commitMessage;
+  // istanbul ignore if
+  if (config.semanticCommits) {
+    commitMessage = config.semanticCommitType;
+    if (config.semanticCommitScope) {
+      commitMessage += `(${config.semanticCommitScope})`;
+    }
+    commitMessage += ': ';
+    commitMessage += 'add renovate.json';
+  } else {
+    commitMessage = 'Add renovate.json';
+  }
   await platform.commitFilesToBranch(
     `renovate/configure`,
     [
@@ -12,7 +24,7 @@ async function createOnboardingBranch(config) {
         contents,
       },
     ],
-    'Add renovate.json',
+    commitMessage,
     undefined,
     config.gitAuthor,
     config.gitPrivateKey

--- a/lib/workers/repository/onboarding/branch/rebase.js
+++ b/lib/workers/repository/onboarding/branch/rebase.js
@@ -18,6 +18,18 @@ async function rebaseOnboardingBranch(config) {
     return;
   }
   logger.info('Rebasing onboarding branch');
+  let commitMessage;
+  // istanbul ignore if
+  if (config.semanticCommits) {
+    commitMessage = config.semanticCommitType;
+    if (config.semanticCommitScope) {
+      commitMessage += `(${config.semanticCommitScope})`;
+    }
+    commitMessage += ': ';
+    commitMessage += 'add renovate.json';
+  } else {
+    commitMessage = 'Add renovate.json';
+  }
   await platform.commitFilesToBranch(
     onboardingBranch,
     [
@@ -26,7 +38,7 @@ async function rebaseOnboardingBranch(config) {
         contents,
       },
     ],
-    'Add renovate.json',
+    commitMessage,
     undefined,
     config.gitAuthor,
     config.gitPrivateKey


### PR DESCRIPTION
This PR adds the capability so that the onboarding commit message (“Add renovate.json”) will have a prefix if semanticCommits is explicitly set to true by the bot administrator.

e.g. “renovate a/b —semantic-commits=true —semantic-commit-type=foo” will result in the onboarding commit being “foobar: add renovate.json”.

Closes #1867
