### PR TITLE
feat: includePaths

### DIFF
--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -273,6 +273,13 @@ const options = [
     stage: 'branch',
   },
   {
+    name: 'includePaths',
+    description: 'Include package files only within these defined paths',
+    type: 'list',
+    stage: 'repository',
+    default: [],
+  },
+  {
     name: 'ignorePaths',
     description:
       'Skip any package.json whose path matches one of these. Can be string or glob pattern',

--- a/lib/manager/index.js
+++ b/lib/manager/index.js
@@ -34,7 +34,15 @@ async function detectPackageFiles(config) {
   logger.debug('detectPackageFiles()');
   logger.trace({ config });
   let packageFiles = [];
-  const fileList = (await platform.getFileList()).filter(
+  let fileList = await platform.getFileList();
+  if (config.includePaths.length) {
+    fileList = fileList.filter(file =>
+      config.includePaths.some(
+        includePath => file === includePath || minimatch(file, includePath)
+      )
+    );
+  }
+  fileList = fileList.filter(
     file =>
       !config.ignorePaths.some(
         ignorePath => file.includes(ignorePath) || minimatch(file, ignorePath)

--- a/test/config/__snapshots__/index.spec.js.snap
+++ b/test/config/__snapshots__/index.spec.js.snap
@@ -118,6 +118,7 @@ Object {
     "**/bower_components/**",
   ],
   "ignoreUnstable": true,
+  "includePaths": Array [],
   "labels": Array [],
   "lazyGrouping": true,
   "lockFileMaintenance": Object {

--- a/test/manager/__snapshots__/index.spec.js.snap
+++ b/test/manager/__snapshots__/index.spec.js.snap
@@ -80,3 +80,12 @@ exports[`manager detectPackageFiles(config) ignores node modules 2`] = `undefine
 exports[`manager detectPackageFiles(config) ignores node modules 3`] = `undefined`;
 
 exports[`manager detectPackageFiles(config) skips meteor package files with no json 1`] = `Array []`;
+
+exports[`manager detectPackageFiles(config) uses includePaths 1`] = `
+Array [
+  Object {
+    "manager": "npm",
+    "packageFile": "package.json",
+  },
+]
+`;

--- a/test/manager/index.spec.js
+++ b/test/manager/index.spec.js
@@ -140,6 +140,16 @@ describe('manager', () => {
       expect(res.foundIgnoredPaths).toMatchSnapshot();
       expect(res.warnings).toMatchSnapshot();
     });
+    it('uses includePaths', async () => {
+      platform.getFileList.mockReturnValueOnce([
+        'package.json',
+        'backend/package.json',
+      ]);
+      config.includePaths = ['package.json'];
+      const res = await manager.detectPackageFiles(config);
+      expect(res).toMatchSnapshot();
+      expect(res).toHaveLength(1);
+    });
   });
   describe('getManager', () => {
     it('rejects unknown files', () => {

--- a/website/docs/_posts/2017-10-05-configuration-options.md
+++ b/website/docs/_posts/2017-10-05-configuration-options.md
@@ -547,6 +547,19 @@ Ignore versions with unstable semver.
 
 By default, Renovate won't update any packages to unstable versions (e.g. `4.0.0-rc3`) unless the package version was _already_ unstable (e.g. it was already on `4.0.0-rc2`). If for some reason you wish to _force_ unstable updates on Renovate, you can set `ignoreUnstable` to `false`, but this is not recommended for most situations.
 
+## includePaths
+
+Include package files only within these defined paths.
+
+| name    | value            |
+| ------- | ---------------- |
+| type    | array of strings |
+| default | []               |
+
+If you wish for Renovate to process only select paths in the repository, use `includePaths`.
+If instead you need to just exclude/ignore certain paths then consider `ignorePaths` instead.
+If you are more interested in including only certain package managers (e.g. `npm`), then consider `enabledManagers` instead.
+
 ## labels
 
 Labels to add to Pull Requests


### PR DESCRIPTION
Adds a config option `includePaths` that allows the user to specify one or more paths to include in renovation and the rest will be excluded.