### PR TITLE
fix: remove a useless param from renovateRepository()

### DIFF
--- a/lib/workers/global/index.js
+++ b/lib/workers/global/index.js
@@ -26,7 +26,7 @@ async function start() {
     // Iterate through repositories sequentially
     for (const repository of config.repositories) {
       const repoConfig = getRepositoryConfig(config, repository);
-      await repositoryWorker.renovateRepository(repoConfig, repoConfig.token);
+      await repositoryWorker.renovateRepository(repoConfig);
     }
     logger.setMeta({});
     logger.info('Renovate finished');


### PR DESCRIPTION
It was removed in eb3c55b125ebb17f3df696e5f518b234e491d099