### PR TITLE
Decouple npm and github logic in changelog.

### DIFF
--- a/lib/workers/pr/changelog/index.js
+++ b/lib/workers/pr/changelog/index.js
@@ -3,26 +3,30 @@ const { addReleaseNotes } = require('../release-notes');
 const sourceCache = require('./source-cache');
 const sourceGithub = require('./source-github');
 
+const managerNpm = require('./manager-npm');
+
 module.exports = {
   getChangeLogJSON,
 };
 
-async function getChangeLogJSON(depName, fromVersion, newVersion) {
-  logger.debug(`getChangeLogJSON(${depName}, ${fromVersion}, ${newVersion})`);
+async function getChangeLogJSON(args) {
+  const { manager, fromVersion, newVersion } = args;
+  logger.debug({ args }, `getChangeLogJSON(args)`);
   if (!fromVersion || fromVersion === newVersion) {
     return null;
   }
-
-  const args = [depName, fromVersion, newVersion];
-
   // Return from cache if present
-  let res = await sourceCache.getChangeLogJSON(...args);
+  let res = await sourceCache.getChangeLogJSON(args);
   if (res) {
     return addReleaseNotes(res);
   }
+  let pkg = null;
+  if (['npm', 'meteor'].includes(manager)) {
+    pkg = await managerNpm.getPackage(args);
+  }
 
-  res = await sourceGithub.getChangeLogJSON(...args);
+  res = await sourceGithub.getChangeLogJSON({ ...args, ...pkg });
 
-  await sourceCache.setChangeLogJSON(...args, res);
+  await sourceCache.setChangeLogJSON(args, res);
   return addReleaseNotes(res);
 }

--- a/lib/workers/pr/changelog/manager-npm.js
+++ b/lib/workers/pr/changelog/manager-npm.js
@@ -1,0 +1,27 @@
+const npmRegistry = require('../../../datasource/npm');
+const { semverSort } = require('../../../util/semver');
+
+module.exports = {
+  getPackage,
+};
+
+async function getPackage({ depName, depType }) {
+  if (depType === 'engines') {
+    return null;
+  }
+  const dep = await npmRegistry.getDependency(depName);
+  if (!dep) {
+    return null;
+  }
+  const releases = Object.keys(dep.versions);
+  releases.sort(semverSort);
+  const versions = releases.map(release => ({
+    version: release,
+    date: dep.versions[release].time,
+    gitHead: dep.versions[release].gitHead,
+  }));
+  return {
+    repositoryUrl: dep.repositoryUrl,
+    versions,
+  };
+}

--- a/lib/workers/pr/changelog/source-cache.js
+++ b/lib/workers/pr/changelog/source-cache.js
@@ -7,15 +7,16 @@ module.exports = {
   rmAllCache,
 };
 
-function getCache(depName, fromVersion, newVersion) {
+function getCache({ depName, fromVersion, newVersion }) {
   const tmpdir = process.env.RENOVATE_TMPDIR || os.tmpdir();
   const cachePath = tmpdir + '/renovate-commits-cache';
   const cacheKey = `${depName}-${fromVersion}-${newVersion}`;
   return [cachePath, cacheKey];
 }
 
-async function getChangeLogJSON(depName, fromVersion, newVersion) {
-  const cache = getCache(depName, fromVersion, newVersion);
+async function getChangeLogJSON(args) {
+  const cache = getCache(args);
+  const { depName } = args;
   try {
     const cacheVal = await cacache.get(...cache);
     logger.trace(`Returning cached version of ${depName}`);
@@ -27,12 +28,12 @@ async function getChangeLogJSON(depName, fromVersion, newVersion) {
   }
 }
 
-async function setChangeLogJSON(depName, fromVersion, newVersion, res) {
-  const cache = getCache(depName, fromVersion, newVersion);
+async function setChangeLogJSON(args, res) {
+  const cache = getCache(args);
   await cacache.put(...cache, JSON.stringify(res));
 }
 
 async function rmAllCache() {
-  const cache = getCache();
+  const cache = getCache({});
   await cacache.rm.all(cache[0]);
 }

--- a/lib/workers/pr/changelog/source-github.js
+++ b/lib/workers/pr/changelog/source-github.js
@@ -1,9 +1,4 @@
-const npmRegistry = require('../../../datasource/npm');
-const {
-  matchesSemver,
-  isPinnedVersion,
-  semverSort,
-} = require('../../../util/semver');
+const { matchesSemver, isPinnedVersion } = require('../../../util/semver');
 const ghGot = require('../../../platform/github/gh-got-wrapper');
 
 module.exports = {
@@ -47,39 +42,37 @@ async function getRepositoryHead(repository, version) {
   if (version.gitHead) {
     return version.gitHead;
   }
-  if (!version.time) {
+  if (!version.date) {
     return null;
   }
-  logger.info({ repository, version }, 'Looking for commit SHA by time');
+  logger.info({ repository, version }, 'Looking for commit SHA by date');
   try {
     const res = await ghGot(
-      `https://api.github.com/repos/${repository}/commits/@{${version.time}}`
+      `https://api.github.com/repos/${repository}/commits/@{${version.date}}`
     );
     const commit = res && res.body;
     return commit && commit.sha;
   } catch (err) {
-    logger.debug({ err, repository }, 'Failed to fetch Github commit by time');
+    logger.debug({ err, repository }, 'Failed to fetch Github commit by date');
     return null;
   }
 }
 
-async function getChangeLogJSON(depName, fromVersion, newVersion) {
+async function getChangeLogJSON({
+  repositoryUrl,
+  fromVersion,
+  newVersion,
+  versions,
+}) {
   logger.debug('Checking for github source URL manually');
   const semverString = `>${fromVersion} <=${newVersion}`;
   logger.trace(`semverString: ${semverString}`);
-  const dep = await npmRegistry.getDependency(depName);
-  if (
-    !(
-      dep &&
-      dep.repositoryUrl &&
-      dep.repositoryUrl.startsWith('https://github.com/')
-    )
-  ) {
+  if (!(repositoryUrl && repositoryUrl.startsWith('https://github.com/'))) {
     logger.debug('No repo found manually');
     return null;
   }
-  logger.info({ url: dep.repositoryUrl }, 'Found github URL manually');
-  const repository = dep.repositoryUrl
+  logger.info({ url: repositoryUrl }, 'Found github URL manually');
+  const repository = repositoryUrl
     .replace('https://github.com/', '')
     .replace(/#.*/, '');
   if (repository.split('/').length !== 2) {
@@ -88,25 +81,24 @@ async function getChangeLogJSON(depName, fromVersion, newVersion) {
   }
 
   const tags = await getTags(repository);
-  const releases = Object.keys(dep.versions);
-  releases.sort(semverSort);
 
-  function getHead(name) {
+  function getHead(version) {
     return getRepositoryHead(repository, {
-      ...dep.versions[name],
-      ...tags[name],
+      ...version,
+      ...tags[version.version],
     });
   }
 
-  const versions = [];
+  const releases = [];
+
   // compare versions
-  for (let i = 1; i < releases.length; i += 1) {
-    const prev = releases[i - 1];
-    const next = releases[i];
-    if (matchesSemver(next, semverString)) {
-      const version = {
-        version: next,
-        date: dep.versions[next].time,
+  for (let i = 1; i < versions.length; i += 1) {
+    const prev = versions[i - 1];
+    const next = versions[i];
+    if (matchesSemver(next.version, semverString)) {
+      const release = {
+        version: next.version,
+        date: next.date,
         // put empty changes so that existing templates won't break
         changes: [],
         compare: {},
@@ -114,18 +106,18 @@ async function getChangeLogJSON(depName, fromVersion, newVersion) {
       const prevHead = await getHead(prev);
       const nextHead = await getHead(next);
       if (prevHead && nextHead) {
-        version.compare.url = `https://github.com/${repository}/compare/${prevHead}...${nextHead}`;
+        release.compare.url = `https://github.com/${repository}/compare/${prevHead}...${nextHead}`;
       }
-      versions.unshift(version);
+      releases.unshift(release);
     }
   }
 
   const res = {
     project: {
       github: repository,
-      repository: dep.repositoryUrl,
+      repository: repositoryUrl,
     },
-    versions,
+    versions: releases,
   };
 
   logger.debug({ res }, 'Manual res');

--- a/lib/workers/pr/changelog/source-github.js
+++ b/lib/workers/pr/changelog/source-github.js
@@ -45,7 +45,7 @@ async function getRepositoryHead(repository, version) {
   if (!version.date) {
     return null;
   }
-  logger.info({ repository, version }, 'Looking for commit SHA by date');
+  logger.trace({ repository, version }, 'Looking for commit SHA by date');
   try {
     const res = await ghGot(
       `https://api.github.com/repos/${repository}/commits/@{${version.date}}`
@@ -71,7 +71,7 @@ async function getChangeLogJSON({
     logger.debug('No repo found manually');
     return null;
   }
-  logger.info({ url: repositoryUrl }, 'Found github URL manually');
+  logger.debug({ url: repositoryUrl }, 'Found github URL manually');
   const repository = repositoryUrl
     .replace('https://github.com/', '')
     .replace(/#.*/, '');

--- a/lib/workers/pr/index.js
+++ b/lib/workers/pr/index.js
@@ -123,19 +123,14 @@ async function ensurePr(prConfig) {
     }
     processedUpgrades.push(upgradeKey);
 
-    let logJSON;
-    if (
-      upgrade.manager !== 'travis' &&
-      upgrade.manager !== 'nvm' &&
-      upgrade.manager !== 'circleci' &&
-      upgrade.depType !== 'engines'
-    ) {
-      logJSON = await changelogHelper.getChangeLogJSON(
-        upgrade.depName,
-        upgrade.changeLogFromVersion,
-        upgrade.changeLogToVersion
-      );
-    }
+    const logJSON = await changelogHelper.getChangeLogJSON({
+      manager: upgrade.manager,
+      depType: upgrade.depType,
+      depName: upgrade.depName,
+      fromVersion: upgrade.changeLogFromVersion,
+      newVersion: upgrade.changeLogToVersion,
+    });
+
     if (logJSON) {
       upgrade.githubName = logJSON.project.github;
       upgrade.hasReleaseNotes = logJSON.hasReleaseNotes;


### PR DESCRIPTION
This PR splits the logic behind changelog into manager (npm) and source (github)
the manager provides the repo url + versions
the source consumes the manager info and generates changelog info

Closes #1911 

