### PR TITLE
Update configuration-options URL in document

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -88,6 +88,6 @@ any other settings above.
 
 ## Configuration Options
 
-Please see [https://renovateapp.com/docs/configuration-reference/configuration-options](https://renovateapp.com/docs/configuration-reference/configuration-options) for a list of user-facing configuration options.
+Please see [https://renovatebot.com/docs/configuration-options/](https://renovatebot.com/docs/configuration-options/) for a list of user-facing configuration options.
 
 For further options when running your own instance of Renovate, please see the full config definitions file at `lib/config/definitions.js`.


### PR DESCRIPTION
- It is changed from https://renovateapp.com/docs/configuration-reference/configuration-options to https://renovatebot.com/docs/configuration-options/

<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate
-->

<!-- Replace this text with a description of what this PR fixes or adds -->

Closes #1929
