### PR TITLE
fix: improve compatibility with nexus private npm repo

### DIFF
--- a/lib/datasource/npm.js
+++ b/lib/datasource/npm.js
@@ -141,8 +141,14 @@ async function getDependency(name, retries = 5) {
       await delay(5000 / retries);
       return getDependency(name, 0);
     }
+
+    const latestVersion = res.versions[res['dist-tags'].latest];
+    res.repository = res.repository || latestVersion.repository;
+    res.homepage = res.homepage || latestVersion.homepage;
+
     // Determine repository URL
     let repositoryUrl;
+
     if (res.repository) {
       repositoryUrl = parse(res.repository.url);
     }
@@ -156,8 +162,7 @@ async function getDependency(name, retries = 5) {
       repositoryUrl,
       versions: res.versions,
       'dist-tags': res['dist-tags'],
-      'renovate-config':
-        res.versions[res['dist-tags'].latest]['renovate-config'],
+      'renovate-config': latestVersion['renovate-config'],
     };
     Object.keys(dep.versions).forEach(version => {
       // We don't use any of the version payload currently


### PR DESCRIPTION
as nexus hosted npm repository does not automatically extracts any value from the published versions we have to manually pick repository and namepage fields from the latest version if not defined in the response root