### PR TITLE
feat: optimise lerna reuse

### DIFF
--- a/lib/manager/npm/post-update/lerna.js
+++ b/lib/manager/npm/post-update/lerna.js
@@ -30,7 +30,7 @@ async function generateLockFiles(lernaClient, tmpDir, env) {
       lernaClient === 'npm'
         ? '--package-lock-only --no-audit'
         : '--ignore-scripts --ignore-engines --ignore-platform --mutex network:31879';
-    cmd = `find . && ${lernaClient} install ${params} && npx lerna@${lernaVersion} bootstrap -- ${params}`;
+    cmd = `npm i -g -C ~/.npm/lerna@${lernaVersion} lerna@${lernaVersion} && ${lernaClient} install ${params} && ~/.npm/lerna@${lernaVersion}/bin/lerna bootstrap -- ${params}`;
     logger.debug({ cmd });
     // TODO: Switch to native util.promisify once using only node 8
     ({ stdout, stderr } = await exec(cmd, {


### PR DESCRIPTION
Removes `npx` approach and instead installs each version globally.

Closes #1801