### PR TITLE
fix: restore allowedVersions filter

### DIFF
--- a/lib/manager/npm/lookup/filter.js
+++ b/lib/manager/npm/lookup/filter.js
@@ -2,6 +2,8 @@ const {
   getMajor,
   isGreaterThan,
   isStable,
+  isValid,
+  matches,
 } = require('../../../versioning/semver');
 
 module.exports = {
@@ -10,7 +12,7 @@ module.exports = {
 };
 
 function filterVersions(config, fromVersion, latestVersion, versions) {
-  const { ignoreUnstable, respectLatest } = config;
+  const { ignoreUnstable, respectLatest, allowedVersions } = config;
   if (!fromVersion) {
     return [];
   }
@@ -19,6 +21,16 @@ function filterVersions(config, fromVersion, latestVersion, versions) {
   let filteredVersions = versions.filter(version =>
     isGreaterThan(version, fromVersion)
   );
+
+  if (allowedVersions) {
+    if (isValid(allowedVersions)) {
+      filteredVersions = filteredVersions.filter(version =>
+        matches(version, allowedVersions)
+      );
+    } else {
+      logger.warn(`Invalid allowedVersions: "${allowedVersions}"`);
+    }
+  }
 
   // Return all versions if we aren't ignore unstable. Also ignore latest
   if (ignoreUnstable === false) {

--- a/test/manager/npm/lookup.spec.js
+++ b/test/manager/npm/lookup.spec.js
@@ -89,6 +89,24 @@ describe('manager/npm/lookup', () => {
         .reply(200, qJson);
       expect(await lookup.lookupUpdates(config)).toMatchSnapshot();
     });
+    it('enforces allowedVersions', async () => {
+      config.currentVersion = '0.4.0';
+      config.allowedVersions = '<1';
+      config.depName = 'q';
+      nock('https://registry.npmjs.org')
+        .get('/q')
+        .reply(200, qJson);
+      expect(await lookup.lookupUpdates(config)).toHaveLength(1);
+    });
+    it('skips invalid allowedVersions', async () => {
+      config.currentVersion = '0.4.0';
+      config.allowedVersions = 'less than 1';
+      config.depName = 'q';
+      nock('https://registry.npmjs.org')
+        .get('/q')
+        .reply(200, qJson);
+      expect(await lookup.lookupUpdates(config)).toHaveLength(2);
+    });
     it('returns minor update if separate patches not configured', async () => {
       config.currentVersion = '0.9.0';
       config.rangeStrategy = 'pin';


### PR DESCRIPTION
Also adds tests to make sure it’s never lost again.

Fixes https://github.com/renovatebot/config-help/issues/49