### PR TITLE
feat: support semver equals (=)

### DIFF
--- a/lib/manager/npm/extract/index.js
+++ b/lib/manager/npm/extract/index.js
@@ -111,8 +111,7 @@ async function extractDependencies(content, packageFile, config) {
             depName,
             versionScheme: 'semver',
           };
-          // TODO: do we need to remove the equals?
-          dep.currentVersion = version.trim().replace(/^=/, '');
+          dep.currentVersion = version.trim();
           if (depType === 'engines') {
             if (depName === 'node') {
               dep.purl = 'pkg:github/nodejs/node?clean=true';

--- a/lib/versioning/semver/range.js
+++ b/lib/versioning/semver/range.js
@@ -49,6 +49,9 @@ function rangify(config, currentVersion, fromVersion, toVersion) {
       if (element.operator === '~') {
         return `~${toVersion}`;
       }
+      if (element.operator === '=') {
+        return `=${toVersion}`;
+      }
       if (element.operator === '>=') {
         return currentVersion.includes('>= ')
           ? `>= ${toVersion}`
@@ -74,6 +77,9 @@ function rangify(config, currentVersion, fromVersion, toVersion) {
       return `^${toVersion}`;
     }
     return `^${major(toVersion)}.0.0`;
+  }
+  if (element.operator === '=') {
+    return `=${toVersion}`;
   }
   if (element.operator === '~') {
     return `~${major(toVersion)}.${minor(toVersion)}.0`;

--- a/test/manager/npm/extract/__snapshots__/index.spec.js.snap
+++ b/test/manager/npm/extract/__snapshots__/index.spec.js.snap
@@ -122,7 +122,7 @@ Object {
       "versionScheme": "semver",
     },
     Object {
-      "currentVersion": "0.22.0",
+      "currentVersion": "=0.22.0",
       "depName": "cheerio",
       "depType": "dependencies",
       "purl": "pkg:npm/cheerio",
@@ -231,7 +231,7 @@ Object {
       "versionScheme": "semver",
     },
     Object {
-      "currentVersion": "0.22.0",
+      "currentVersion": "=0.22.0",
       "depName": "cheerio",
       "depType": "dependencies",
       "purl": "pkg:npm/cheerio",
@@ -320,7 +320,7 @@ Object {
       "versionScheme": "semver",
     },
     Object {
-      "currentVersion": "0.22.0",
+      "currentVersion": "=0.22.0",
       "depName": "cheerio",
       "depType": "dependencies",
       "purl": "pkg:npm/cheerio",

--- a/test/versioning/semver.spec.js
+++ b/test/versioning/semver.spec.js
@@ -37,3 +37,15 @@ describe('semver.isRange(input)', () => {
     expect(!!semver.isRange('^1.2.3')).toBe(true);
   });
 });
+describe('semver.rangify()', () => {
+  it('bumps equals', () => {
+    expect(
+      semver.rangify({ rangeStrategy: 'bump' }, '=1.0.0', '1.0.0', '1.1.0')
+    ).toEqual('=1.1.0');
+  });
+  it('replaces equals', () => {
+    expect(
+      semver.rangify({ rangeStrategy: 'replace' }, '=1.0.0', '1.0.0', '1.1.0')
+    ).toEqual('=1.1.0');
+  });
+});


### PR DESCRIPTION
Adds support for upgrading equals values, e.g. from `=1.0.0` to `=1.0.1`. Previously these would be stripped (e.g. from `=1.0.0` to `1.0.0`)
