### PR TITLE
fix: match current version

### DIFF
--- a/lib/util/package-rules.js
+++ b/lib/util/package-rules.js
@@ -9,7 +9,14 @@ module.exports = {
 
 function applyPackageRules(inputConfig) {
   let config = { ...inputConfig };
-  const { versionScheme, packageFile, depType, depName, fromVersion } = config;
+  const {
+    versionScheme,
+    packageFile,
+    depType,
+    depName,
+    currentValue,
+    fromVersion,
+  } = config;
   const packageRules = config.packageRules || [];
   logger.trace(
     { depName, packageRules },
@@ -94,9 +101,12 @@ function applyPackageRules(inputConfig) {
       positiveMatch = positiveMatch || !isMatch;
     }
     if (matchCurrentVersion) {
-      if (fromVersion) {
-        const { matches } = versioning(versionScheme);
-        const isMatch = matches(fromVersion, matchCurrentVersion);
+      const { matches, isVersion } = versioning(versionScheme);
+      const compareVersion = isVersion(currentValue)
+        ? currentValue // it's a version so we can match against it
+        : fromVersion; // need to match against this fromVersion, if available
+      if (compareVersion) {
+        const isMatch = matches(compareVersion, matchCurrentVersion);
         positiveMatch = positiveMatch || isMatch;
         negativeMatch = negativeMatch || !isMatch;
       } else {

--- a/lib/workers/repository/updates/flatten.js
+++ b/lib/workers/repository/updates/flatten.js
@@ -18,12 +18,12 @@ function flattenUpdates(config, packageFiles) {
       const packageFileConfig = mergeChildConfig(managerConfig, packageFile);
       for (const dep of packageFile.deps) {
         if (dep.updates.length) {
-          let depConfig = mergeChildConfig(packageFileConfig, dep);
+          const depConfig = mergeChildConfig(packageFileConfig, dep);
           delete depConfig.deps;
-          depConfig = applyPackageRules(depConfig);
           for (const update of dep.updates) {
             let updateConfig = mergeChildConfig(depConfig, update);
             delete updateConfig.updates;
+            updateConfig = applyPackageRules(updateConfig);
             // apply major/minor/patch/pin/digest
             updateConfig = mergeChildConfig(
               updateConfig,


### PR DESCRIPTION
Use `currentValue` first if it's a valid version, otherwise wait until a `fromVersion` and use it instead.

Closes #2129 