### PR TITLE
feat: force, forceCli

### DIFF
--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -60,7 +60,7 @@ const options = [
       'Whether CLI configuration options should be moved to the `force` config section',
     stage: 'global',
     type: 'boolean',
-    default: true,
+    default: false,
   },
   // Log options
   {

--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -44,6 +44,24 @@ const options = [
     cli: false,
     env: false,
   },
+  {
+    name: 'force',
+    description:
+      'Any configuration defined within this object will force override existing settings',
+    stage: 'repository',
+    admin: true,
+    type: 'json',
+    cli: false,
+    env: false,
+  },
+  {
+    name: 'forceCli',
+    description:
+      'Whether CLI configuration options should be moved to the `force` config section',
+    stage: 'global',
+    type: 'boolean',
+    default: true,
+  },
   // Log options
   {
     name: 'logLevel',

--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -165,7 +165,7 @@ const options = [
     description: 'Times of day/week to renovate',
     type: 'list',
     allowString: true,
-    cli: false,
+    cli: true,
     env: false,
   },
   {

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -45,6 +45,9 @@ async function parseConfigs(env, argv) {
   config = mergeChildConfig(config, envConfig);
   config = mergeChildConfig(config, cliConfig);
 
+  if (config.forceCli) {
+    config = mergeChildConfig(config, { force: { ...cliConfig } });
+  }
 
   // Set log level
   logger.levels('stdout', config.logLevel);

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -36,17 +36,15 @@ async function parseConfigs(env, argv) {
   logger.debug('Parsing configs');
 
   // Get configs
-  const defaultConfig = defaultsParser.getConfig();
-  const fileConfig = fileParser.getConfig(env);
-  const cliConfig = cliParser.getConfig(argv);
-  const envConfig = envParser.getConfig(env);
+  const defaultConfig = await resolveConfigPresets(defaultsParser.getConfig());
+  const fileConfig = await resolveConfigPresets(fileParser.getConfig(env));
+  const cliConfig = await resolveConfigPresets(cliParser.getConfig(argv));
+  const envConfig = await resolveConfigPresets(envParser.getConfig(env));
 
-  let config = mergeChildConfig(
-    await resolveConfigPresets(defaultConfig),
-    await resolveConfigPresets(fileConfig)
-  );
-  config = mergeChildConfig(config, await resolveConfigPresets(envConfig));
-  config = mergeChildConfig(config, await resolveConfigPresets(cliConfig));
+  let config = mergeChildConfig(defaultConfig, fileConfig);
+  config = mergeChildConfig(config, envConfig);
+  config = mergeChildConfig(config, cliConfig);
+
 
   // Set log level
   logger.levels('stdout', config.logLevel);

--- a/lib/workers/repository/init/force.js
+++ b/lib/workers/repository/init/force.js
@@ -5,6 +5,7 @@ function applyForceConfig(input) {
   if (config.force && Object.keys(config.force).length) {
     logger.debug('Applying forced config');
     config = mergeChildConfig(config, config.force);
+    config.packageRules = config.packageRules || [];
     config.packageRules.push({
       ...config.force,
       packagePatterns: ['.*'],

--- a/lib/workers/repository/init/force.js
+++ b/lib/workers/repository/init/force.js
@@ -1,0 +1,19 @@
+const { mergeChildConfig } = require('../../../config');
+
+function applyForceConfig(input) {
+  let config = { ...input };
+  if (config.force && Object.keys(config.force).length) {
+    logger.debug('Applying forced config');
+    config = mergeChildConfig(config, config.force);
+    config.packageRules.push({
+      ...config.force,
+      packagePatterns: ['.*'],
+    });
+    delete config.force;
+  }
+  return config;
+}
+
+module.exports = {
+  applyForceConfig,
+};

--- a/lib/workers/repository/init/index.js
+++ b/lib/workers/repository/init/index.js
@@ -4,6 +4,7 @@ const { initApis } = require('../init/apis');
 const { checkBaseBranch } = require('./base');
 const { mergeRenovateConfig } = require('./config');
 const { detectSemanticCommits } = require('./semantic');
+const { applyForceConfig } = require('./force');
 
 async function initRepo(input) {
   let config = {
@@ -16,6 +17,7 @@ async function initRepo(input) {
   config = await initApis(config);
   config = await checkOnboardingBranch(config);
   config = await mergeRenovateConfig(config);
+  config = await applyForceConfig(config);
   checkIfConfigured(config);
   config = await checkBaseBranch(config);
   config.semanticCommits = await detectSemanticCommits(config);

--- a/test/config/index.spec.js
+++ b/test/config/index.spec.js
@@ -83,6 +83,11 @@ describe('config/index', () => {
       const env = {};
       await configParser.parseConfigs(env, defaultArgv);
     });
+    it('supports forceCli', async () => {
+      defaultArgv = defaultArgv.concat(['--force-cli=true']);
+      const env = { GITHUB_TOKEN: 'abc' };
+      await configParser.parseConfigs(env, defaultArgv);
+    });
     it('autodiscovers github platform', async () => {
       const env = {};
       defaultArgv = defaultArgv.concat(['--autodiscover', '--token=abc']);

--- a/test/workers/repository/init/__snapshots__/force.spec.js.snap
+++ b/test/workers/repository/init/__snapshots__/force.spec.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`workers/repository/init/flatten flattenPackageRules() forces 1`] = `
+Object {
+  "a": 2,
+  "b": 2,
+  "packageRules": Array [
+    Object {
+      "a": 2,
+      "b": 2,
+      "packagePatterns": Array [
+        ".*",
+      ],
+    },
+  ],
+}
+`;

--- a/test/workers/repository/init/force.spec.js
+++ b/test/workers/repository/init/force.spec.js
@@ -1,0 +1,18 @@
+const {
+  applyForceConfig,
+} = require('../../../../lib/workers/repository/init/force');
+
+describe('workers/repository/init/flatten', () => {
+  describe('flattenPackageRules()', () => {
+    it('returns empty', () => {
+      expect(applyForceConfig({})).toEqual({});
+    });
+    it('forces', () => {
+      const res = applyForceConfig({ a: 1, force: { a: 2, b: 2 } });
+      expect(res).toMatchSnapshot();
+      expect(res.a).toEqual(2);
+      expect(res.b).toEqual(2);
+      expect(res.force).toBeUndefined();
+    });
+  });
+});

--- a/website/docs/self-hosted-configuration.md
+++ b/website/docs/self-hosted-configuration.md
@@ -15,6 +15,16 @@ Be cautious when using this option - it will run Renovate over _every_ repositor
 
 ## exposeEnv
 
+## force
+
+This object is used as a "force override" when you need to make sure certain configuration overrides whatever is configured in the repository. For example, forcing a null (no) schedule to make sure Renovate raises PRs on a run even if the repository itself or its preset defines a schedule that's currently in active.
+
+In practice, it is implemented by converting the `force` configuration into a `packageRule` that matches all packages.
+
+## forceCli
+
+This is set to true by default, meaning that any settings (such as `schedule`) take maximum priority even against custom settings existing inside individual repositories.
+
 ## forkMode
 
 You probably have no need for this option - it is an experimental setting for the Renovate hosted GitHub App.


### PR DESCRIPTION
Adds config options force and forceCli. These cover the use case where a certain setting is desired to be forced by the bot admin, regardless of repository config, for example removing all configured schedules in order to force PR creation.

Closes #1731 