### PR TITLE
refactor: make gitAuthor admin-only

### DIFF
--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -271,6 +271,7 @@ const options = [
     name: 'gitAuthor',
     description: 'Author to use for git commits. RFC5322',
     type: 'string',
+    admin: true,
   },
   {
     name: 'gitPrivateKey',

--- a/website/docs/configuration-options.md
+++ b/website/docs/configuration-options.md
@@ -197,10 +197,6 @@ See https://renovateapp.com/docs/configuration-reference/config-presets for deta
 
 ## fileMatch
 
-## gitAuthor
-
-RFC5322-compliant string if you wish to customise the git author for commits.
-
 ## group
 
 The default configuration for groups are essentially internal to Renovate and you normally shouldn't need to modify them. However, you may choose to _add_ settings to any group by defining your own `group` configuration object.

--- a/website/docs/self-hosted-configuration.md
+++ b/website/docs/self-hosted-configuration.md
@@ -29,6 +29,10 @@ This is set to true by default, meaning that any settings (such as `schedule`) t
 
 You probably have no need for this option - it is an experimental setting for the Renovate hosted GitHub App.
 
+## gitAuthor
+
+RFC5322-compliant string if you wish to customise the git author for commits.
+
 ## gitPrivateKey
 
 ## logFile


### PR DESCRIPTION
Changes gitAuthor to be an admin-only setting, i.e. configurable by bot admin and not by repo admin.

BREAKING CHANGE: gitAuthor can no longer be configured in repository config and can be set by bot admin only.
