### PR TITLE
refactor: pass gitAuthor to platform during init

### DIFF
--- a/lib/platform/github/index.js
+++ b/lib/platform/github/index.js
@@ -96,6 +96,8 @@ async function initRepo({
   forkMode,
   forkToken,
   mirrorMode,
+  gitAuthor,
+  gitPrivateKey,
 }) {
   logger.debug(`initRepo("${repository}")`);
   if (token) {
@@ -112,6 +114,18 @@ async function initRepo({
   // config is used by the platform api itself, not necessary for the app layer to know
   cleanRepo();
   config.repository = repository;
+  if (gitAuthor) {
+    try {
+      config.gitAuthor = addrs.parseOneAddress(gitAuthor);
+    } catch (err) /* istanbul ignore next */ {
+      logger.error(
+        { gitAuthor, err, message: err.message },
+        'Invalid gitAuthor'
+      );
+      throw new Error('Invalid gitAuthor');
+    }
+  }
+  config.gitPrivateKey = gitPrivateKey;
   // platformConfig is passed back to the app layer and contains info about the platform they require
   const platformConfig = {};
   let res;
@@ -1138,9 +1152,7 @@ async function commitFilesToBranch(
   branchName,
   files,
   message,
-  parentBranch = config.baseBranch,
-  gitAuthor,
-  gitPrivateKey
+  parentBranch = config.baseBranch
 ) {
   logger.debug(
     `commitFilesToBranch('${branchName}', files, message, '${parentBranch})'`
@@ -1158,13 +1170,7 @@ async function commitFilesToBranch(
   }
   // Create tree
   const tree = await createTree(parentTree, fileBlobs);
-  const commit = await createCommit(
-    parentCommit,
-    tree,
-    message,
-    gitAuthor,
-    gitPrivateKey
-  );
+  const commit = await createCommit(parentCommit, tree, message);
   const isBranchExisting = await branchExists(branchName);
   try {
     if (isBranchExisting) {
@@ -1330,22 +1336,18 @@ async function createTree(baseTree, files) {
 }
 
 // Create a commit and return commit SHA
-async function createCommit(parent, tree, message, gitAuthor, gitPrivateKey) {
-  logger.debug(`createCommit(${parent}, ${tree}, ${message}, ${gitAuthor})`);
+async function createCommit(parent, tree, message) {
+  logger.debug(`createCommit(${parent}, ${tree}, ${message})`);
+  const { gitAuthor, gitPrivateKey } = config;
   const now = moment();
   let author;
-  try {
-    if (gitAuthor) {
-      logger.debug({ gitAuthor }, 'Found gitAuthor');
-      const { name, address: email } = addrs.parseOneAddress(gitAuthor);
-      author = {
-        name,
-        email,
-        date: now.format(),
-      };
-    }
-  } catch (err) {
-    logger.warn({ gitAuthor }, 'Error parsing gitAuthor');
+  if (gitAuthor) {
+    logger.trace('Setting gitAuthor');
+    author = {
+      name: gitAuthor.name,
+      email: gitAuthor.address,
+      date: now.format(),
+    };
   }
   const body = {
     message,

--- a/lib/platform/gitlab/index.js
+++ b/lib/platform/gitlab/index.js
@@ -74,7 +74,7 @@ function urlEscape(str) {
 }
 
 // Initialize GitLab by getting base branch
-async function initRepo({ repository, token, endpoint }) {
+async function initRepo({ repository, token, endpoint, gitAuthor }) {
   if (token) {
     process.env.GITLAB_TOKEN = token;
   } else if (!process.env.GITLAB_TOKEN) {
@@ -89,6 +89,17 @@ async function initRepo({ repository, token, endpoint }) {
   config = {};
   get.reset();
   config.repository = urlEscape(repository);
+  if (gitAuthor) {
+    try {
+      config.gitAuthor = addrs.parseOneAddress(gitAuthor);
+    } catch (err) /* istanbul ignore next */ {
+      logger.error(
+        { gitAuthor, err, message: err.message },
+        'Invalid gitAuthor'
+      );
+      throw new Error('Invalid gitAuthor');
+    }
+  }
   try {
     const res = await get(`projects/${config.repository}`);
     config.defaultBranch = res.body.default_branch;
@@ -705,8 +716,7 @@ async function commitFilesToBranch(
   branchName,
   files,
   message,
-  parentBranch = config.baseBranch,
-  gitAuthor
+  parentBranch = config.baseBranch
 ) {
   logger.debug(
     `commitFilesToBranch('${branchName}', files, message, '${parentBranch})'`
@@ -719,20 +729,11 @@ async function commitFilesToBranch(
       actions: [],
     },
   };
-
-  try {
-    if (gitAuthor) {
-      logger.debug({ gitAuthor }, 'Found gitAuthor');
-      const { name, address } = addrs.parseOneAddress(gitAuthor);
-      if (name && address) {
-        opts.body.author_name = name;
-        opts.body.author_email = address;
-      }
-    }
-  } catch (err) {
-    logger.warn({ gitAuthor }, 'Error parsing gitAuthor');
+  // istanbul ignore if
+  if (config.gitAuthor) {
+    opts.body.author_name = config.gitAuthor.name;
+    opts.body.author_email = config.gitAuthor.address;
   }
-
   for (const file of files) {
     const action = {
       file_path: file.name,

--- a/lib/workers/branch/commit.js
+++ b/lib/workers/branch/commit.js
@@ -16,9 +16,7 @@ async function commitFilesToBranch(config) {
       config.branchName,
       updatedFiles,
       config.commitMessage,
-      config.parentBranch || config.baseBranch || undefined,
-      config.gitAuthor,
-      config.gitPrivateKey
+      config.parentBranch || config.baseBranch || undefined
     );
   } else {
     logger.debug(`No files to commit`);

--- a/lib/workers/repository/onboarding/branch/create.js
+++ b/lib/workers/repository/onboarding/branch/create.js
@@ -24,10 +24,7 @@ async function createOnboardingBranch(config) {
         contents,
       },
     ],
-    commitMessage,
-    undefined,
-    config.gitAuthor,
-    config.gitPrivateKey
+    commitMessage
   );
 }
 

--- a/lib/workers/repository/onboarding/branch/rebase.js
+++ b/lib/workers/repository/onboarding/branch/rebase.js
@@ -38,10 +38,7 @@ async function rebaseOnboardingBranch(config) {
         contents: existingContents || contents,
       },
     ],
-    commitMessage,
-    undefined,
-    config.gitAuthor,
-    config.gitPrivateKey
+    commitMessage
   );
 }
 

--- a/test/platform/github/__snapshots__/index.spec.js.snap
+++ b/test/platform/github/__snapshots__/index.spec.js.snap
@@ -61,59 +61,6 @@ Array [
 ]
 `;
 
-exports[`platform/github commitFilesToBranch(branchName, files, message, parentBranch) should add a commit to a new branch if the branch does not already exist 2`] = `
-Array [
-  Array [
-    "repos/some/repo/git/blobs",
-    Object {
-      "body": Object {
-        "content": "aGVsbG8gd29ybGQ=",
-        "encoding": "base64",
-      },
-    },
-  ],
-  Array [
-    "repos/some/repo/git/trees",
-    Object {
-      "body": Object {
-        "base_tree": "2222",
-        "tree": Array [
-          Object {
-            "mode": "100644",
-            "path": "package.json",
-            "sha": "3333",
-            "type": "blob",
-          },
-        ],
-      },
-    },
-  ],
-  Array [
-    "repos/some/repo/git/commits",
-    Object {
-      "body": Object {
-        "message": "my other commit message",
-        "parents": Array [
-          "1111",
-        ],
-        "tree": "4444",
-      },
-    },
-  ],
-  Array [
-    "repos/some/repo/git/refs",
-    Object {
-      "body": Object {
-        "ref": "refs/heads/the-branch",
-        "sha": "5555",
-      },
-    },
-  ],
-]
-`;
-
-exports[`platform/github commitFilesToBranch(branchName, files, message, parentBranch) should add a commit to a new branch if the branch does not already exist 3`] = `Array []`;
-
 exports[`platform/github commitFilesToBranch(branchName, files, message, parentBranch) should add a new commit to the branch 1`] = `
 Array [
   Array [
@@ -138,62 +85,6 @@ Array [
     "repos/some/repo/branches?per_page=100",
     Object {
       "paginate": true,
-    },
-  ],
-]
-`;
-
-exports[`platform/github commitFilesToBranch(branchName, files, message, parentBranch) should add a new commit to the branch 2`] = `
-Array [
-  Array [
-    "repos/some/repo/git/blobs",
-    Object {
-      "body": Object {
-        "content": "aGVsbG8gd29ybGQ=",
-        "encoding": "base64",
-      },
-    },
-  ],
-  Array [
-    "repos/some/repo/git/trees",
-    Object {
-      "body": Object {
-        "base_tree": "2222",
-        "tree": Array [
-          Object {
-            "mode": "100644",
-            "path": "package.json",
-            "sha": "3333",
-            "type": "blob",
-          },
-        ],
-      },
-    },
-  ],
-  Array [
-    "repos/some/repo/git/commits",
-    Object {
-      "body": Object {
-        "message": "my commit message",
-        "parents": Array [
-          "1111",
-        ],
-        "tree": "4444",
-      },
-    },
-  ],
-]
-`;
-
-exports[`platform/github commitFilesToBranch(branchName, files, message, parentBranch) should add a new commit to the branch 3`] = `
-Array [
-  Array [
-    "repos/some/repo/git/refs/heads/the-branch",
-    Object {
-      "body": Object {
-        "force": true,
-        "sha": "5555",
-      },
     },
   ],
 ]

--- a/test/platform/github/index.spec.js
+++ b/test/platform/github/index.spec.js
@@ -1625,7 +1625,11 @@ describe('platform/github', () => {
   });
   describe('commitFilesToBranch(branchName, files, message, parentBranch)', () => {
     beforeEach(async () => {
-      await initRepo({ repository: 'some/repo', token: 'token' });
+      await initRepo({
+        repository: 'some/repo',
+        token: 'token',
+        gitAuthor: 'Renovate Bot <bot@renovatebot.com>',
+      });
 
       // getBranchCommit
       get.mockImplementationOnce(() => ({
@@ -1690,8 +1694,8 @@ describe('platform/github', () => {
         'my commit message'
       );
       expect(get.mock.calls).toMatchSnapshot();
-      expect(get.post.mock.calls).toMatchSnapshot();
-      expect(get.patch.mock.calls).toMatchSnapshot();
+      expect(get.post.mock.calls).toHaveLength(3);
+      expect(get.patch.mock.calls).toHaveLength(1);
     });
     it('should add a commit to a new branch if the branch does not already exist', async () => {
       // branchExists
@@ -1714,8 +1718,8 @@ describe('platform/github', () => {
         'my other commit message'
       );
       expect(get.mock.calls).toMatchSnapshot();
-      expect(get.post.mock.calls).toMatchSnapshot();
-      expect(get.patch.mock.calls).toMatchSnapshot();
+      expect(get.post.mock.calls).toHaveLength(4);
+      expect(get.patch.mock.calls).toHaveLength(0);
     });
     it('should parse valid gitAuthor', async () => {
       // branchExists
@@ -1735,9 +1739,7 @@ describe('platform/github', () => {
       await github.commitFilesToBranch(
         'the-branch',
         files,
-        'my other commit message',
-        undefined,
-        'Renovate Bot <bot@renovatebot.com>'
+        'my other commit message'
       );
       expect(get.post.mock.calls[2][1].body.author.name).toEqual(
         'Renovate Bot'
@@ -1745,30 +1747,6 @@ describe('platform/github', () => {
       expect(get.post.mock.calls[2][1].body.author.email).toEqual(
         'bot@renovatebot.com'
       );
-    });
-    it('should skip invalid gitAuthor', async () => {
-      // branchExists
-      get.mockImplementationOnce(() => ({
-        body: [
-          {
-            name: 'master',
-          },
-        ],
-      }));
-      const files = [
-        {
-          name: 'package.json',
-          contents: 'hello world',
-        },
-      ];
-      await github.commitFilesToBranch(
-        'the-branch',
-        files,
-        'my other commit message',
-        undefined,
-        'Renovate Bot bot@renovatebot.com'
-      );
-      expect(get.post.mock.calls[2][1].body.author).toBeUndefined();
     });
   });
   describe('getCommitMessages()', () => {

--- a/test/platform/gitlab/__snapshots__/index.spec.js.snap
+++ b/test/platform/gitlab/__snapshots__/index.spec.js.snap
@@ -383,6 +383,31 @@ Array [
 
 exports[`platform/gitlab initRepo should initialise the config for the repo - 2 2`] = `Object {}`;
 
+exports[`platform/gitlab initRepo should initialise the config for the repo - 3 1`] = `
+Array [
+  Array [
+    "projects/some%2Frepo",
+  ],
+  Array [
+    "user",
+  ],
+  Array [
+    "projects/some%2Frepo/merge_requests?per_page=100",
+    Object {
+      "paginate": true,
+    },
+  ],
+  Array [
+    "projects/some%2Frepo/repository/tree?ref=undefined&per_page=100&recursive=true",
+    Object {
+      "paginate": true,
+    },
+  ],
+]
+`;
+
+exports[`platform/gitlab initRepo should initialise the config for the repo - 3 2`] = `Object {}`;
+
 exports[`platform/gitlab setBaseBranch(branchName) sets the base branch 1`] = `
 Array [
   Array [

--- a/test/platform/gitlab/index.spec.js
+++ b/test/platform/gitlab/index.spec.js
@@ -96,7 +96,8 @@ describe('platform/gitlab', () => {
       [undefined, 'mytoken', undefined],
       [undefined, 'mytoken', 'https://my.custom.endpoint/'],
       ['myenvtoken', 'myenvtoken', undefined],
-    ].forEach(([envToken, token, endpoint], i) => {
+      [undefined, 'mytoken', undefined, 'Renovate Bot <bot@renovatebot.com>'],
+    ].forEach(([envToken, token, endpoint, gitAuthor], i) => {
       it(`should initialise the config for the repo - ${i}`, async () => {
         if (envToken !== undefined) {
           process.env.GITLAB_TOKEN = envToken;
@@ -106,6 +107,7 @@ describe('platform/gitlab', () => {
           repository: 'some/repo',
           token,
           endpoint,
+          gitAuthor,
         });
         expect(get.mock.calls).toMatchSnapshot();
         expect(config).toMatchSnapshot();
@@ -903,66 +905,6 @@ describe('platform/gitlab', () => {
       );
       expect(get.post.mock.calls).toMatchSnapshot();
       expect(get.post.mock.calls).toHaveLength(1);
-    });
-    it('should parse valid gitAuthor', async () => {
-      get.mockImplementationOnce(() => Promise.reject({ statusCode: 404 })); // file exists
-      get.mockImplementationOnce(() =>
-        Promise.reject({
-          statusCode: 404,
-        })
-      ); // branch exists
-      get.mockImplementationOnce(() =>
-        Promise.reject({
-          statusCode: 404,
-        })
-      ); // branch exists
-      const file = {
-        name: 'some-new-file',
-        contents: 'some new-contents',
-      };
-
-      await gitlab.commitFilesToBranch(
-        'renovate/something',
-        [file],
-        'Update something',
-        undefined,
-        'Renovate Bot <bot@renovatebot.com>'
-      );
-
-      expect(get.post.mock.calls[0][1].body.author_name).toEqual(
-        'Renovate Bot'
-      );
-      expect(get.post.mock.calls[0][1].body.author_email).toEqual(
-        'bot@renovatebot.com'
-      );
-    });
-    it('should skip invalid gitAuthor', async () => {
-      get.mockImplementationOnce(() => Promise.reject({ statusCode: 404 })); // file exists
-      get.mockImplementationOnce(() =>
-        Promise.reject({
-          statusCode: 404,
-        })
-      ); // branch exists
-      get.mockImplementationOnce(() =>
-        Promise.reject({
-          statusCode: 404,
-        })
-      ); // branch exists
-      const file = {
-        name: 'some-new-file',
-        contents: 'some new-contents',
-      };
-
-      await gitlab.commitFilesToBranch(
-        'renovate/something',
-        [file],
-        'Update something',
-        undefined,
-        'Renovate Bot bot@renovatebot.com'
-      );
-
-      expect(get.post.mock.calls[0][1].body.author_name).toBeUndefined();
-      expect(get.post.mock.calls[0][1].body.author_email).toBeUndefined();
     });
   });
   describe('getCommitMessages()', () => {

--- a/test/workers/branch/__snapshots__/commit.spec.js.snap
+++ b/test/workers/branch/__snapshots__/commit.spec.js.snap
@@ -12,8 +12,6 @@ Array [
     ],
     "some commit message",
     undefined,
-    null,
-    null,
   ],
 ]
 `;


### PR DESCRIPTION
Refactors platforms to take the admin-only gitAuthor and gitPrivateKey values during repository initialisation instead of during file commits.