### PR TITLE
fix: Shortened the URLs in the GitLab wrapper

### DIFF
--- a/lib/platform/gitlab/index.js
+++ b/lib/platform/gitlab/index.js
@@ -440,7 +440,7 @@ function addReviewers(iid, reviewers) {
 }
 
 async function getComments(issueNo) {
-  // GET /api/v4/projects/:owner/:repo/merge_requests/:number/notes
+  // GET projects/:owner/:repo/merge_requests/:number/notes
   logger.debug(`Getting comments for #${issueNo}`);
   const url = `projects/${
     config.repository
@@ -451,9 +451,9 @@ async function getComments(issueNo) {
 }
 
 async function addComment(issueNo, body) {
-  // POST /api/v4/projects/:owner/:repo/merge_requests/:number/notes
+  // POST projects/:owner/:repo/merge_requests/:number/notes
   await get.post(
-    `/api/v4/projects/${config.repository}/merge_requests/${issueNo}/notes`,
+    `projects/${config.repository}/merge_requests/${issueNo}/notes`,
     {
       body: { body },
     }
@@ -461,9 +461,9 @@ async function addComment(issueNo, body) {
 }
 
 async function editComment(issueNo, commentId, body) {
-  // PATCH /api/v4/projects/:owner/:repo/merge_requests/:number/notes/:id
+  // PATCH projects/:owner/:repo/merge_requests/:number/notes/:id
   await get.patch(
-    `/api/v4/projects/${
+    `projects/${
       config.repository
     }/merge_requests/${issueNo}/notes/${commentId}`,
     {
@@ -473,9 +473,9 @@ async function editComment(issueNo, commentId, body) {
 }
 
 async function deleteComment(issueNo, commentId) {
-  // DELETE /api/v4/projects/:owner/:repo/merge_requests/:number/notes/:id
+  // DELETE projects/:owner/:repo/merge_requests/:number/notes/:id
   await get.delete(
-    `/api/v4/projects/${
+    `projects/${
       config.repository
     }/merge_requests/${issueNo}/notes/${commentId}`
   );

--- a/lib/platform/gitlab/index.js
+++ b/lib/platform/gitlab/index.js
@@ -442,7 +442,7 @@ function addReviewers(iid, reviewers) {
 async function getComments(issueNo) {
   // GET /api/v4/projects/:owner/:repo/merge_requests/:number/notes
   logger.debug(`Getting comments for #${issueNo}`);
-  const url = `/api/v4/projects/${
+  const url = `projects/${
     config.repository
   }/merge_requests/${issueNo}/notes`;
   const comments = (await get(url, { paginate: true })).body;


### PR DESCRIPTION
This PR shortens the URLs for the comment handling function in the GitLab wrapper 
