### PR TITLE
Fix call to gitlab api

### DIFF
--- a/lib/platform/gitlab/index.js
+++ b/lib/platform/gitlab/index.js
@@ -650,7 +650,7 @@ async function getPrFiles(mrNo) {
     return [];
   }
   const files = (await get(
-    `/api/v4/projects/${config.repository}/merge_requests/${mrNo}/changes`
+    `projects/${config.repository}/merge_requests/${mrNo}/changes`
   )).body;
   return files.map(f => f.filename);
 }


### PR DESCRIPTION
Fixes call to Gitlab API.
Settings require direct path to API, the fixed string doubled it