### PR TITLE
feat: Nuget documentation

### DIFF
--- a/website/docs/nuget.md
+++ b/website/docs/nuget.md
@@ -5,33 +5,24 @@ description: Nuget (.NET) dependencies support in Renovate
 
 # Nuget
 
-Renovate supports upgrading dependencies in `csproj` files.
+Renovate supports upgrading dependencies in `.csproj` files.
 
 ## Version Support
 
-Only SDK-style .csproj files are currently supported. By default, this includes:
+Only SDK-style `.csproj` files are currently supported. By default, this includes:
 
 - .NET Core 1.0 and above
 - .NET Standard class libraries
-- Any .csproj in the SDK-style syntax
+- Any `.csproj` in the SDK-style syntax
 
 To convert your .NET Framework .csproj into an SDK-style project, one can follow the [following guide](https://natemcmaster.com/blog/2017/03/09/vs2015-to-vs2017-upgrade/).
 
 ## How It Works
 
-1.  Nuget support is currently not enabled automatically, meaning you have to enable it in the `renovate.json` configuration file, like this:
-
-```json
-{
-  "nuget": {
-    "enabled": true
-  }
-}
-```
-
-2.  Renovate will search each repository for any files with a `.csproj` extension.
-3.  Existing dependencies will be extracted from `<PackageReference>` tags
-4.  Renovate will look up the latest version on [nuget.org](https://nuget.org) to determine if any upgrades are available
+1.  Renovate will search each repository for any files with a `.csproj` extension.
+2.  Existing dependencies will be extracted from `<PackageReference>` tags
+3.  Renovate will look up the latest version on [nuget.org](https://nuget.org) to determine if any upgrades are available
+4.  If the source package includes a GitHub URL as its source, and has either a "changelog" file or uses GitHub releases, then Release Notes for each version will be embedded in the generated PR.
 
 ## Future work
 

--- a/website/docs/nuget.md
+++ b/website/docs/nuget.md
@@ -10,6 +10,7 @@ Renovate supports upgrading dependencies in `csproj` files.
 ## Version Support
 
 Only SDK-style .csproj files are currently supported. By default, this includes:
+
 - .NET Core 1.0 and above
 - .NET Standard class libraries
 - Any .csproj in the SDK-style syntax
@@ -18,7 +19,8 @@ To convert your .NET Framework .csproj into an SDK-style project, one can follow
 
 ## How It Works
 
-1. Nuget support is currently not enabled automatically, meaning you have to enable it in the `renovate.json` configuration file, like this:
+1.  Nuget support is currently not enabled automatically, meaning you have to enable it in the `renovate.json` configuration file, like this:
+
 ```json
 {
   "nuget": {
@@ -27,9 +29,9 @@ To convert your .NET Framework .csproj into an SDK-style project, one can follow
 }
 ```
 
-2. Renovate will search each repository for any files with a `.csproj` extension.
-3. Existing dependencies will be extracted from `<PackageReference>` tags
-4. Renovate will look up the latest version on [nuget.org](https://nuget.org) to determine if any upgrades are available
+2.  Renovate will search each repository for any files with a `.csproj` extension.
+3.  Existing dependencies will be extracted from `<PackageReference>` tags
+4.  Renovate will look up the latest version on [nuget.org](https://nuget.org) to determine if any upgrades are available
 
 ## Future work
 

--- a/website/docs/nuget.md
+++ b/website/docs/nuget.md
@@ -1,0 +1,36 @@
+---
+title: Nuget
+description: Nuget (.NET) dependencies support in Renovate
+---
+
+# Nuget
+
+Renovate supports upgrading dependencies in `csproj` files.
+
+## Version Support
+
+Only SDK-style .csproj files are currently supported. By default, this includes:
+- .NET Core 1.0 and above
+- .NET Standard class libraries
+- Any .csproj in the SDK-style syntax
+
+To convert your .NET Framework .csproj into an SDK-style project, one can follow the [following guide](https://natemcmaster.com/blog/2017/03/09/vs2015-to-vs2017-upgrade/).
+
+## How It Works
+
+1. Nuget support is currently not enabled automatically, meaning you have to enable it in the `renovate.json` configuration file, like this:
+```json
+{
+  "nuget": {
+    "enabled": true
+  }
+}
+```
+
+2. Renovate will search each repository for any files with a `.csproj` extension.
+3. Existing dependencies will be extracted from `<PackageReference>` tags
+4. Renovate will look up the latest version on [nuget.org](https://nuget.org) to determine if any upgrades are available
+
+## Future work
+
+Contributions and/or feature requests are welcome to support more patterns or additional use cases.

--- a/website/docs/nuget.md
+++ b/website/docs/nuget.md
@@ -1,5 +1,5 @@
 ---
-title: Nuget
+title: Nuget (.NET)
 description: Nuget (.NET) dependencies support in Renovate
 ---
 


### PR DESCRIPTION
Adds initial documentation on how .NET support works, and how Renovate knows which packages to update via nuget.org.

This addresses #2156 