### PR TITLE
feat: use pip environmental variables for repository urls

### DIFF
--- a/lib/datasource/pypi.js
+++ b/lib/datasource/pypi.js
@@ -18,7 +18,7 @@ async function getDependency(purl, config = {}) {
     [hostUrl] = config.registryUrls;
   }
   if (process.env.PIP_INDEX_URL) {
-    [hostUrl] = [process.env.PIP_INDEX_URL]
+    [hostUrl] = [process.env.PIP_INDEX_URL];
   }
   const lookupUrl = url.resolve(hostUrl, `${depName}/json`);
   try {

--- a/lib/datasource/pypi.js
+++ b/lib/datasource/pypi.js
@@ -17,6 +17,9 @@ async function getDependency(purl, config = {}) {
   if (!is.empty(config.registryUrls)) {
     [hostUrl] = config.registryUrls;
   }
+  if (process.env.PIP_INDEX_URL) {
+    [hostUrl] = [process.env.PIP_INDEX_URL]
+  }
   const lookupUrl = url.resolve(hostUrl, `${depName}/json`);
   try {
     const dependency = {};

--- a/test/datasource/__snapshots__/pypi.spec.js.snap
+++ b/test/datasource/__snapshots__/pypi.spec.js.snap
@@ -113,3 +113,14 @@ Array [
   ],
 ]
 `;
+
+exports[`datasource/pypi getDependency supports custom datasource url from environmental variable 1`] = `
+Array [
+  Array [
+    "https://my.pypi.python/pypi/azure-cli-monitor/json",
+    Object {
+      "json": true,
+    },
+  ],
+]
+`;

--- a/test/datasource/pypi.spec.js
+++ b/test/datasource/pypi.spec.js
@@ -43,11 +43,11 @@ describe('datasource/pypi', () => {
       got.mockReturnValueOnce({
         body: JSON.parse(res1),
       });
-      const pipIndexUrl = process.env.PIP_INDEX_URL
-      process.env.PIP_INDEX_URL = 'https://my.pypi.python/pypi/'
+      const pipIndexUrl = process.env.PIP_INDEX_URL;
+      process.env.PIP_INDEX_URL = 'https://my.pypi.python/pypi/';
       await datasource.getDependency('pkg:pypi/azure-cli-monitor');
       expect(got.mock.calls).toMatchSnapshot();
-      process.env.PIP_INDEX_URL = pipIndexUrl
+      process.env.PIP_INDEX_URL = pipIndexUrl;
     });
     it('returns non-github home_page', async () => {
       got.mockReturnValueOnce({

--- a/test/datasource/pypi.spec.js
+++ b/test/datasource/pypi.spec.js
@@ -43,9 +43,11 @@ describe('datasource/pypi', () => {
       got.mockReturnValueOnce({
         body: JSON.parse(res1),
       });
+      const pipIndexUrl = process.env.PIP_INDEX_URL
       process.env.PIP_INDEX_URL = 'https://my.pypi.python/pypi/'
       await datasource.getDependency('pkg:pypi/azure-cli-monitor');
       expect(got.mock.calls).toMatchSnapshot();
+      process.env.PIP_INDEX_URL = pipIndexUrl
     });
     it('returns non-github home_page', async () => {
       got.mockReturnValueOnce({

--- a/test/datasource/pypi.spec.js
+++ b/test/datasource/pypi.spec.js
@@ -39,6 +39,14 @@ describe('datasource/pypi', () => {
       await datasource.getDependency('pkg:pypi/azure-cli-monitor', config);
       expect(got.mock.calls).toMatchSnapshot();
     });
+    it('supports custom datasource url from environmental variable', async () => {
+      got.mockReturnValueOnce({
+        body: JSON.parse(res1),
+      });
+      process.env.PIP_INDEX_URL = 'https://my.pypi.python/pypi/'
+      await datasource.getDependency('pkg:pypi/azure-cli-monitor');
+      expect(got.mock.calls).toMatchSnapshot();
+    });
     it('returns non-github home_page', async () => {
       got.mockReturnValueOnce({
         body: {


### PR DESCRIPTION
Adds support for PIP_INDEX_URL from environmental variables for self
hosted version. This is used instead of any urls set in the config.

<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate
-->

<!-- Replace this text with a description of what this PR fixes or adds -->

Closes #2181 <!-- Ideally each PR should be closing an open issue -->
