### PR TITLE
fix: strip yarn-path option from yarnrc

### DIFF
--- a/lib/manager/npm/post-update/index.js
+++ b/lib/manager/npm/post-update/index.js
@@ -176,7 +176,9 @@ async function writeExistingFiles(config, packageFiles) {
       logger.debug(`Writing .yarnrc to ${basedir}`);
       await fs.outputFile(
         upath.join(basedir, '.yarnrc'),
-        packageFile.yarnrc.replace('--install.pure-lockfile true', '')
+        packageFile.yarnrc
+          .replace('--install.pure-lockfile true', '')
+          .replace(/^yarn-path.*$/m, '')
       );
     }
     const { npmLock } = packageFile;


### PR DESCRIPTION
Removing the `yarn-path` option from `yarnrc` makes sure that renovate always uses its bundled version of `yarn`.

Closes #2310
