### PR TITLE
Make renovate compatible with Artifactory Docker Registries

### DIFF
--- a/lib/datasource/docker.js
+++ b/lib/datasource/docker.js
@@ -1,6 +1,6 @@
 const got = require('got');
 const parseLinkHeader = require('parse-link-header');
-const parsers = require('www-authenticate').parsers;
+const wwwAuthenticate = require('www-authenticate');
 const { isVersion, sortVersions } = require('../versioning/docker');
 
 module.exports = {
@@ -26,12 +26,18 @@ function getRepository(pkgName) {
 async function getAuthHeaders(registry, repository) {
   // istanbul ignore if
   try {
-    const apiCheckUrl = `${registry}/v2/`
-    const apiCheckResponse = (await got(apiCheckUrl, {throwHttpErrors: false}))
-    const authenticateHeader = new parsers.WWW_Authenticate(apiCheckResponse.headers['www-authenticate'])
+    const apiCheckUrl = `${registry}/v2/`;
+    const apiCheckResponse = await got(apiCheckUrl, { throwHttpErrors: false });
+    const authenticateHeader = new wwwAuthenticate.parsers.WWW_Authenticate(
+      apiCheckResponse.headers['www-authenticate']
+    );
 
-    const authUrl = `${authenticateHeader.parms.realm}?service=${authenticateHeader.parms.service}&scope=repository:${repository}:pull`;
-    logger.debug(`Obtaining docker registry token for ${repository} using url ${authUrl}`);
+    const authUrl = `${authenticateHeader.parms.realm}?service=${
+      authenticateHeader.parms.service
+    }&scope=repository:${repository}:pull`;
+    logger.debug(
+      `Obtaining docker registry token for ${repository} using url ${authUrl}`
+    );
     const { token } = (await got(authUrl, { json: true })).body;
     if (!token) {
       logger.warn('Failed to obtain docker registry token');

--- a/lib/datasource/docker.js
+++ b/lib/datasource/docker.js
@@ -32,6 +32,7 @@ async function getAuthHeaders(registry, repository) {
       apiCheckResponse.headers['www-authenticate']
     );
 
+    // prettier-ignore
     const authUrl = `${authenticateHeader.parms.realm}?service=${authenticateHeader.parms.service}&scope=repository:${repository}:pull`;
     logger.debug(
       `Obtaining docker registry token for ${repository} using url ${authUrl}`

--- a/lib/datasource/docker.js
+++ b/lib/datasource/docker.js
@@ -1,5 +1,6 @@
 const got = require('got');
 const parseLinkHeader = require('parse-link-header');
+const parsers = require('www-authenticate').parsers;
 const { isVersion, sortVersions } = require('../versioning/docker');
 
 module.exports = {
@@ -24,12 +25,13 @@ function getRepository(pkgName) {
 
 async function getAuthHeaders(registry, repository) {
   // istanbul ignore if
-  if (registry !== 'https://index.docker.io') {
-    return {};
-  }
   try {
-    const authUrl = `https://auth.docker.io/token?service=registry.docker.io&scope=repository:${repository}:pull`;
-    logger.debug(`Obtaining docker registry token for ${repository}`);
+    const apiCheckUrl = `${registry}/v2/`
+    const apiCheckResponse = (await got(apiCheckUrl, {throwHttpErrors: false}))
+    const authenticateHeader = new parsers.WWW_Authenticate(apiCheckResponse.headers['www-authenticate'])
+
+    const authUrl = `${authenticateHeader.parms.realm}?service=${authenticateHeader.parms.service}&scope=repository:${repository}:pull`;
+    logger.debug(`Obtaining docker registry token for ${repository} using url ${authUrl}`);
     const { token } = (await got(authUrl, { json: true })).body;
     if (!token) {
       logger.warn('Failed to obtain docker registry token');

--- a/lib/datasource/docker.js
+++ b/lib/datasource/docker.js
@@ -32,9 +32,7 @@ async function getAuthHeaders(registry, repository) {
       apiCheckResponse.headers['www-authenticate']
     );
 
-    const authUrl = `${authenticateHeader.parms.realm}?service=${
-      authenticateHeader.parms.service
-    }&scope=repository:${repository}:pull`;
+    const authUrl = `${authenticateHeader.parms.realm}?service=${authenticateHeader.parms.service}&scope=repository:${repository}:pull`;
     logger.debug(
       `Obtaining docker registry token for ${repository} using url ${authUrl}`
     );

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "upath": "1.1.0",
     "validator": "10.4.0",
     "vso-node-api": "6.5.0",
+    "www-authenticate": "^0.6.2",
     "yarn": "1.7.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "upath": "1.1.0",
     "validator": "10.4.0",
     "vso-node-api": "6.5.0",
-    "www-authenticate": "^0.6.2",
+    "www-authenticate": "0.6.2",
     "yarn": "1.7.0"
   },
   "devDependencies": {

--- a/test/datasource/docker.spec.js
+++ b/test/datasource/docker.spec.js
@@ -25,6 +25,9 @@ describe('api/docker', () => {
       expect(res).toBe(null);
     });
     it('returns digest', async () => {
+      got.mockReturnValueOnce({ 
+        headers: { 'www-authenticate': 'Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:samalba/my-app:pull  "' } 
+      });
       got.mockReturnValueOnce({ body: { token: 'some-token' } });
       got.mockReturnValueOnce({
         headers: { 'docker-content-digest': 'some-digest' },
@@ -36,6 +39,9 @@ describe('api/docker', () => {
       expect(res).toBe('some-digest');
     });
     it('supports scoped names', async () => {
+      got.mockReturnValueOnce({ 
+        headers: { 'www-authenticate': 'Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:samalba/my-app:pull  "' } 
+      });
       got.mockReturnValueOnce({ body: { token: 'some-token' } });
       got.mockReturnValueOnce({
         headers: { 'docker-content-digest': 'some-digest' },
@@ -58,6 +64,9 @@ describe('api/docker', () => {
     });
     it('returns tags with no suffix', async () => {
       const tags = ['a', 'b', '1.0.0', '1.1.0', '1.1.0-alpine'];
+      got.mockReturnValueOnce({ 
+        headers: { 'www-authenticate': 'Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:samalba/my-app:pull  "' } 
+      });
       got.mockReturnValueOnce({ headers: {}, body: { token: 'some-token ' } });
       got.mockReturnValueOnce({ headers: {}, body: { tags } });
       const res = await docker.getDependency({
@@ -69,6 +78,9 @@ describe('api/docker', () => {
     });
     it('returns tags with suffix', async () => {
       const tags = ['a', 'b', '1.0.0', '1.1.0-alpine'];
+      got.mockReturnValueOnce({ 
+        headers: { 'www-authenticate': 'Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:samalba/my-app:pull  "' } 
+      });
       got.mockReturnValueOnce({ headers: {}, body: { token: 'some-token ' } });
       got.mockReturnValueOnce({ headers: {}, body: { tags } });
       const res = await docker.getDependency({

--- a/test/datasource/docker.spec.js
+++ b/test/datasource/docker.spec.js
@@ -25,8 +25,11 @@ describe('api/docker', () => {
       expect(res).toBe(null);
     });
     it('returns digest', async () => {
-      got.mockReturnValueOnce({ 
-        headers: { 'www-authenticate': 'Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:samalba/my-app:pull  "' } 
+      got.mockReturnValueOnce({
+        headers: {
+          'www-authenticate':
+            'Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:samalba/my-app:pull  "',
+        },
       });
       got.mockReturnValueOnce({ body: { token: 'some-token' } });
       got.mockReturnValueOnce({
@@ -39,8 +42,11 @@ describe('api/docker', () => {
       expect(res).toBe('some-digest');
     });
     it('supports scoped names', async () => {
-      got.mockReturnValueOnce({ 
-        headers: { 'www-authenticate': 'Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:samalba/my-app:pull  "' } 
+      got.mockReturnValueOnce({
+        headers: {
+          'www-authenticate':
+            'Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:samalba/my-app:pull  "',
+        },
       });
       got.mockReturnValueOnce({ body: { token: 'some-token' } });
       got.mockReturnValueOnce({
@@ -64,8 +70,11 @@ describe('api/docker', () => {
     });
     it('returns tags with no suffix', async () => {
       const tags = ['a', 'b', '1.0.0', '1.1.0', '1.1.0-alpine'];
-      got.mockReturnValueOnce({ 
-        headers: { 'www-authenticate': 'Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:samalba/my-app:pull  "' } 
+      got.mockReturnValueOnce({
+        headers: {
+          'www-authenticate':
+            'Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:samalba/my-app:pull  "',
+        },
       });
       got.mockReturnValueOnce({ headers: {}, body: { token: 'some-token ' } });
       got.mockReturnValueOnce({ headers: {}, body: { tags } });
@@ -78,8 +87,11 @@ describe('api/docker', () => {
     });
     it('returns tags with suffix', async () => {
       const tags = ['a', 'b', '1.0.0', '1.1.0-alpine'];
-      got.mockReturnValueOnce({ 
-        headers: { 'www-authenticate': 'Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:samalba/my-app:pull  "' } 
+      got.mockReturnValueOnce({
+        headers: {
+          'www-authenticate':
+            'Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:samalba/my-app:pull  "',
+        },
       });
       got.mockReturnValueOnce({ headers: {}, body: { token: 'some-token ' } });
       got.mockReturnValueOnce({ headers: {}, body: { tags } });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1334,7 +1334,7 @@ debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
 
@@ -2691,7 +2691,7 @@ import-local@^1.0.0:
     pkg-dir "^2.0.0"
     resolve-cwd "^2.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
 
@@ -3777,10 +3777,6 @@ lodash._basecopy@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz#8da0e6a876cf344c0ad8a54882111dd3c5c7ca36"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-
 lodash._basetostring@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz#d1861d877f824a52f669832dcaf3ee15566a07d5"
@@ -3796,25 +3792,11 @@ lodash._basevalues@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz#5b775762802bde3d3297503e26300820fdf661b7"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
 
-lodash._getnative@*, lodash._getnative@^3.0.0:
+lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
 
@@ -3876,7 +3858,7 @@ lodash.keys@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
-lodash.restparam@*, lodash.restparam@^3.0.0:
+lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
 
@@ -5493,7 +5475,7 @@ readable-stream@~1.1.10:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readdir-scoped-modules@*, readdir-scoped-modules@^1.0.0:
+readdir-scoped-modules@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz#9fafa37d286be5d92cbaebdee030dc9b5f406747"
   dependencies:
@@ -6840,7 +6822,7 @@ ws@^4.0.0:
     async-limiter "~1.0.0"
     safe-buffer "~5.1.0"
 
-www-authenticate@^0.6.2:
+www-authenticate@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/www-authenticate/-/www-authenticate-0.6.2.tgz#b7a7d487bdc5a8b423a4d8fd5f9c661adde50ebf"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4650,7 +4650,6 @@ npm@6.2.0:
     cmd-shim "~2.0.2"
     columnify "~1.5.4"
     config-chain "~1.1.11"
-    debuglog "*"
     detect-indent "~5.0.0"
     detect-newline "^2.1.0"
     dezalgo "~1.0.3"
@@ -4665,7 +4664,6 @@ npm@6.2.0:
     has-unicode "~2.0.1"
     hosted-git-info "^2.6.0"
     iferr "^1.0.0"
-    imurmurhash "*"
     inflight "~1.0.6"
     inherits "~2.0.3"
     ini "^1.3.5"
@@ -4678,14 +4676,8 @@ npm@6.2.0:
     libnpx "^10.2.0"
     lock-verify "^2.0.2"
     lockfile "^1.0.4"
-    lodash._baseindexof "*"
     lodash._baseuniq "~4.6.0"
-    lodash._bindcallback "*"
-    lodash._cacheindexof "*"
-    lodash._createcache "*"
-    lodash._getnative "*"
     lodash.clonedeep "~4.5.0"
-    lodash.restparam "*"
     lodash.union "~4.6.0"
     lodash.uniq "~4.5.0"
     lodash.without "~4.4.0"
@@ -4724,7 +4716,6 @@ npm@6.2.0:
     read-package-json "^2.0.13"
     read-package-tree "^5.2.1"
     readable-stream "^2.3.6"
-    readdir-scoped-modules "*"
     request "^2.81.0"
     retry "^0.12.0"
     rimraf "~2.6.2"
@@ -6848,6 +6839,10 @@ ws@^4.0.0:
   dependencies:
     async-limiter "~1.0.0"
     safe-buffer "~5.1.0"
+
+www-authenticate@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/www-authenticate/-/www-authenticate-0.6.2.tgz#b7a7d487bdc5a8b423a4d8fd5f9c661adde50ebf"
 
 xdg-basedir@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Currently Renovate supports only Docker registries which obtain their token through auth.docker.io. We have an Artifactory Server for this locally. This implements the original Token Authentication Specification. To use renovate with this registry, I added the processing of the www-authenticate Header to obtain a token from the artifactory server.

This backwards-compatible to Docker Hub which issues this header with the current hard-coded URLs.

This is a duplicate of #2313 which was closed by accident.