### PR TITLE
fix(gitlab): use correct API for closing issues

### DIFF
--- a/lib/platform/gitlab/index.js
+++ b/lib/platform/gitlab/index.js
@@ -445,8 +445,8 @@ async function ensureIssueClosing(title) {
   for (const issue of issueList) {
     if (issue.title === title) {
       logger.info({ issue }, 'Closing issue');
-      await get.delete(`projects/${config.repository}/issues/${issue.iid}`, {
-        body: { state: 'closed' },
+      await get.put(`projects/${config.repository}/issues/${issue.iid}`, {
+        body: { state_event: 'close' },
       });
     }
   }


### PR DESCRIPTION
GitLab's API for closing issue is to send a PUT request with `state_event` set to `close`.

Reference: https://docs.gitlab.com/ce/api/issues.html#edit-issue

<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate
-->

<!-- Replace this text with a description of what this PR fixes or adds -->

Closes N/A <!-- Ideally each PR should be closing an open issue -->
