### PR TITLE
fix: digest pinning of latest version

### DIFF
--- a/lib/workers/repository/process/lookup/index.js
+++ b/lib/workers/repository/process/lookup/index.js
@@ -108,9 +108,6 @@ async function lookupUpdates(config) {
       allVersions,
       releases
     );
-    if (!filteredVersions.length) {
-      return res;
-    }
     const buckets = {};
     for (const toVersion of filteredVersions) {
       const update = { fromVersion, toVersion };

--- a/test/workers/repository/process/lookup/__snapshots__/index.spec.js.snap
+++ b/test/workers/repository/process/lookup/__snapshots__/index.spec.js.snap
@@ -127,6 +127,26 @@ Object {
 }
 `;
 
+exports[`manager/npm/lookup .lookupUpdates() handles digest pin for up to date version 1`] = `
+Object {
+  "releases": Array [
+    Object {
+      "version": "8.1.0",
+    },
+  ],
+  "repositoryUrl": null,
+  "updates": Array [
+    Object {
+      "newDigest": "sha256:aaaaaaaaaaaaaaaa",
+      "newDigestShort": "aaaaaa",
+      "newValue": "8.1.0",
+      "updateType": "pin",
+    },
+  ],
+  "warnings": Array [],
+}
+`;
+
 exports[`manager/npm/lookup .lookupUpdates() handles digest update 1`] = `
 Object {
   "releases": Array [

--- a/test/workers/repository/process/lookup/index.spec.js
+++ b/test/workers/repository/process/lookup/index.spec.js
@@ -919,6 +919,25 @@ describe('manager/npm/lookup', () => {
       const res = await lookup.lookupUpdates(config);
       expect(res).toMatchSnapshot();
     });
+    it('handles digest pin for up to date version', async () => {
+      config.currentValue = '8.1.0';
+      config.depName = 'node';
+      config.purl = 'pkg:docker/node';
+      config.pinDigests = true;
+      docker.getPkgReleases.mockReturnValueOnce({
+        releases: [
+          {
+            version: '8.0.0',
+          },
+          {
+            version: '8.1.0',
+          },
+        ],
+      });
+      docker.getDigest.mockReturnValueOnce('sha256:aaaaaaaaaaaaaaaa');
+      const res = await lookup.lookupUpdates(config);
+      expect(res).toMatchSnapshot();
+    });
     it('handles digest pin for non-version', async () => {
       config.currentValue = 'alpine';
       config.depName = 'node';


### PR DESCRIPTION
If the dependency already is the latest version, filteredVersions is empty here, and then the early exit skips over the pinning code
