### PR TITLE
fix(docker): use library/ prefix instead of amd64/

### DIFF
--- a/lib/datasource/docker.js
+++ b/lib/datasource/docker.js
@@ -23,7 +23,7 @@ function massageRegistry(input) {
 }
 
 function getRepository(pkgName) {
-  return pkgName.includes('/') ? pkgName : `amd64/${pkgName}`;
+  return pkgName.includes('/') ? pkgName : `library/${pkgName}`;
 }
 
 async function getAuthHeaders(registry, repository) {


### PR DESCRIPTION
The default prefix is library/. Using amd64/ as the prefix created weird
issues with pinning to digests that matched no images.
