### PR TITLE
fix: docker: Only add library/ for Docker Hub images

### DIFF
--- a/lib/datasource/docker.js
+++ b/lib/datasource/docker.js
@@ -22,8 +22,13 @@ function massageRegistry(input) {
   return registry;
 }
 
-function getRepository(pkgName) {
-  return pkgName.includes('/') ? pkgName : `library/${pkgName}`;
+function getRepository(pkgName, registry) {
+  // The implicit prefix only applies to Docker Hub, not other registries
+  if (!registry || registry === 'docker.io') {
+    return pkgName.includes('/') ? pkgName : `library/${pkgName}`;
+  }
+
+  return pkgName;
 }
 
 async function getAuthHeaders(registry, repository) {
@@ -91,7 +96,7 @@ async function getDigest(config, newValue) {
   const { dockerRegistry, depName, tagSuffix } = config;
   logger.debug(`getDigest(${dockerRegistry}, ${depName}, ${newValue})`);
   const massagedRegistry = massageRegistry(dockerRegistry);
-  const repository = getRepository(depName);
+  const repository = getRepository(depName, dockerRegistry);
   let newTag = newValue;
   if (tagSuffix) {
     newTag += `-${tagSuffix}`;
@@ -174,7 +179,7 @@ async function getPkgReleases(purl) {
   const { registry, suffix } = qualifiers;
   logger.debug({ fullname, registry, suffix }, 'docker.getDependencies()');
   const massagedRegistry = massageRegistry(registry);
-  const repository = getRepository(fullname);
+  const repository = getRepository(fullname, registry);
   try {
     let url = `${massagedRegistry}/v2/${repository}/tags/list?n=10000`;
     const headers = await getAuthHeaders(massagedRegistry, repository);

--- a/test/datasource/__snapshots__/docker.spec.js.snap
+++ b/test/datasource/__snapshots__/docker.spec.js.snap
@@ -1,5 +1,197 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`api/docker getPkgReleases adds library/ prefix for Docker Hub (explicit) 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "https://index.docker.io/v2/",
+      Object {
+        "throwHttpErrors": false,
+      },
+    ],
+    Array [
+      "https://auth.docker.io/token?service=registry.docker.io&scope=repository:library/node:pull",
+      Object {
+        "headers": Object {
+          "Authorization": "Basic c29tZS11c2VybmFtZTpzb21lLXBhc3N3b3Jk",
+        },
+        "password": "some-password",
+        "username": "some-username",
+      },
+    ],
+    Array [
+      "https://index.docker.io/v2/library/node/tags/list?n=10000",
+      Object {
+        "headers": Object {
+          "Accept": "application/vnd.docker.distribution.manifest.v2+json",
+          "Authorization": "Bearer some-token ",
+        },
+        "json": true,
+        "timeout": 10000,
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Object {
+        "headers": Object {
+          "www-authenticate": "Bearer realm=\\"https://auth.docker.io/token\\",service=\\"registry.docker.io\\",scope=\\"repository:library/node:pull  \\"",
+        },
+      },
+    },
+    Object {
+      "isThrow": false,
+      "value": Object {
+        "body": Object {
+          "token": "some-token ",
+        },
+        "headers": Object {},
+      },
+    },
+    Object {
+      "isThrow": false,
+      "value": Object {
+        "body": Object {
+          "tags": Array [
+            "1.0.0",
+          ],
+        },
+        "headers": Object {},
+      },
+    },
+  ],
+}
+`;
+
+exports[`api/docker getPkgReleases adds library/ prefix for Docker Hub (implicit) 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "https://index.docker.io/v2/",
+      Object {
+        "throwHttpErrors": false,
+      },
+    ],
+    Array [
+      "https://auth.docker.io/token?service=registry.docker.io&scope=repository:library/node:pull",
+      Object {
+        "headers": Object {
+          "Authorization": "Basic c29tZS11c2VybmFtZTpzb21lLXBhc3N3b3Jk",
+        },
+        "password": "some-password",
+        "username": "some-username",
+      },
+    ],
+    Array [
+      "https://index.docker.io/v2/library/node/tags/list?n=10000",
+      Object {
+        "headers": Object {
+          "Accept": "application/vnd.docker.distribution.manifest.v2+json",
+          "Authorization": "Bearer some-token ",
+        },
+        "json": true,
+        "timeout": 10000,
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Object {
+        "headers": Object {
+          "www-authenticate": "Bearer realm=\\"https://auth.docker.io/token\\",service=\\"registry.docker.io\\",scope=\\"repository:library/node:pull  \\"",
+        },
+      },
+    },
+    Object {
+      "isThrow": false,
+      "value": Object {
+        "body": Object {
+          "token": "some-token ",
+        },
+        "headers": Object {},
+      },
+    },
+    Object {
+      "isThrow": false,
+      "value": Object {
+        "body": Object {
+          "tags": Array [
+            "1.0.0",
+          ],
+        },
+        "headers": Object {},
+      },
+    },
+  ],
+}
+`;
+
+exports[`api/docker getPkgReleases adds no library/ prefix for other registries 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "https://k8s.gcr.io/v2/",
+      Object {
+        "throwHttpErrors": false,
+      },
+    ],
+    Array [
+      "https://k8s.gcr.io/v2/token?service=k8s.gcr.io&scope=repository:kubernetes-dashboard-amd64:pull",
+      Object {
+        "headers": Object {
+          "Authorization": "Basic c29tZS11c2VybmFtZTpzb21lLXBhc3N3b3Jk",
+        },
+        "password": "some-password",
+        "username": "some-username",
+      },
+    ],
+    Array [
+      "https://k8s.gcr.io/v2/kubernetes-dashboard-amd64/tags/list?n=10000",
+      Object {
+        "headers": Object {
+          "Accept": "application/vnd.docker.distribution.manifest.v2+json",
+          "Authorization": "Bearer some-token ",
+        },
+        "json": true,
+        "timeout": 10000,
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Object {
+        "headers": Object {
+          "www-authenticate": "Bearer realm=\\"https://k8s.gcr.io/v2/token\\",service=\\"k8s.gcr.io\\"",
+        },
+      },
+    },
+    Object {
+      "isThrow": false,
+      "value": Object {
+        "body": Object {
+          "token": "some-token ",
+        },
+        "headers": Object {},
+      },
+    },
+    Object {
+      "isThrow": false,
+      "value": Object {
+        "body": Object {
+          "tags": Array [
+            "1.0.0",
+          ],
+        },
+        "headers": Object {},
+      },
+    },
+  ],
+}
+`;
+
 exports[`api/docker getPkgReleases returns tags with no suffix 1`] = `
 Object {
   "releases": Array [


### PR DESCRIPTION
Renovate adds library/ to every image that does not contain a /. That breaks images like `k8s.gcr.io/kubernetes-dashboard-amd64:v1.8.3`.

I changed it to only add the library prefix if the image is from Docker Hub and not another registry. 