### PR TITLE
fix(docker): resolve relative URLs from registry

### DIFF
--- a/lib/datasource/docker.js
+++ b/lib/datasource/docker.js
@@ -187,7 +187,10 @@ async function getPkgReleases(purl) {
       const res = await got(url, { json: true, headers, timeout: 10000 });
       tags = tags.concat(res.body.tags);
       const linkHeader = parseLinkHeader(res.headers.link);
-      url = linkHeader && linkHeader.next ? linkHeader.next.url : null;
+      url =
+        linkHeader && linkHeader.next
+          ? URL.resolve(url, linkHeader.next.url)
+          : null;
       page += 1;
     } while (url && page < 20);
     logger.debug({ length: tags.length }, 'Got docker tags');


### PR DESCRIPTION
The Link header from quay.io containts a relative URL that Renovate did not resolve

Closes #2338