### PR TITLE
fix(kubernetes): support image line in a YAML array

### DIFF
--- a/lib/manager/kubernetes/extract.js
+++ b/lib/manager/kubernetes/extract.js
@@ -16,7 +16,7 @@ function extractDependencies(content) {
   }
 
   for (const line of content.split('\n')) {
-    const match = line.match(/^\s*image:\s*'?"?([^\s'"]+)'?"?\s*$/);
+    const match = line.match(/^\s*-?\s*image:\s*'?"?([^\s'"]+)'?"?\s*$/);
     if (match) {
       const currentFrom = match[1];
       const dep = getDep(currentFrom);

--- a/test/_fixtures/kubernetes/array-syntax.yaml
+++ b/test/_fixtures/kubernetes/array-syntax.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: local-volume-provisioner
+  namespace: kube-system
+  labels:
+    app: local-volume-provisioner
+spec:
+  selector:
+    matchLabels:
+      app: local-volume-provisioner
+  template:
+    spec:
+      containers:
+      - image: "quay.io/external_storage/local-volume-provisioner:v2.1.0"
+        name: provisioner

--- a/test/manager/kubernetes/__snapshots__/extract.spec.js.snap
+++ b/test/manager/kubernetes/__snapshots__/extract.spec.js.snap
@@ -1,5 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`lib/manager/kubernetes/extract extractDependencies() extracts image line in a YAML array 1`] = `
+Array [
+  Object {
+    "currentDepTag": "external_storage/local-volume-provisioner:v2.1.0",
+    "currentDepTagDigest": "external_storage/local-volume-provisioner:v2.1.0",
+    "currentDigest": undefined,
+    "currentFrom": "quay.io/external_storage/local-volume-provisioner:v2.1.0",
+    "currentTag": "v2.1.0",
+    "currentValue": "v2.1.0",
+    "depName": "external_storage/local-volume-provisioner",
+    "dockerRegistry": "quay.io",
+    "lineNumber": 14,
+    "purl": "pkg:docker/external_storage/local-volume-provisioner?registry=quay.io",
+    "tagSuffix": undefined,
+    "versionScheme": "docker",
+  },
+]
+`;
+
 exports[`lib/manager/kubernetes/extract extractDependencies() extracts multiple image lines 1`] = `
 Array [
   Object {

--- a/test/manager/kubernetes/extract.spec.js
+++ b/test/manager/kubernetes/extract.spec.js
@@ -13,6 +13,11 @@ const kubernetesConfigMapFile = fs.readFileSync(
   'utf8'
 );
 
+const kubernetesArraySyntaxFile = fs.readFileSync(
+  'test/_fixtures/kubernetes/array-syntax.yaml',
+  'utf8'
+);
+
 const otherYamlFile = fs.readFileSync(
   'test/_fixtures/kubernetes/gitlab-ci.yaml',
   'utf8'
@@ -33,6 +38,11 @@ describe('lib/manager/kubernetes/extract', () => {
       const res = extractDependencies(kubernetesImagesFile, config);
       expect(res.deps).toMatchSnapshot();
       expect(res.deps).toHaveLength(2);
+    });
+    it('extracts image line in a YAML array', () => {
+      const res = extractDependencies(kubernetesArraySyntaxFile, config);
+      expect(res.deps).toMatchSnapshot();
+      expect(res.deps).toHaveLength(1);
     });
     it('ignores non-Kubernetes YAML files', () => {
       expect(extractDependencies(otherYamlFile, config)).toBe(null);


### PR DESCRIPTION
Renovate did not recognize images where "image" was the first key in the YAML mapping inside the YAMl container list/array