### PR TITLE
fix(kubernetes): Fix updating of image in YAML array

### DIFF
--- a/lib/manager/kubernetes/update.js
+++ b/lib/manager/kubernetes/update.js
@@ -10,7 +10,7 @@ function updateDependency(fileContent, upgrade) {
     logger.debug(`kubernetes.updateDependency(): ${newFrom}`);
     const lines = fileContent.split('\n');
     const lineToChange = lines[upgrade.lineNumber];
-    const imageLine = new RegExp(/^(\s*image:\s*'?"?)[^\s'"]+('?"?\s*)$/);
+    const imageLine = new RegExp(/^(\s*-?\s*image:\s*'?"?)[^\s'"]+('?"?\s*)$/);
     if (!lineToChange.match(imageLine)) {
       logger.debug('No image line found');
       return null;

--- a/test/manager/kubernetes/__snapshots__/update.spec.js.snap
+++ b/test/manager/kubernetes/__snapshots__/update.spec.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`manager/kubernetes/update updateDependency replaces image inside YAML array 1`] = `
+"apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: local-volume-provisioner
+  namespace: kube-system
+  labels:
+    app: local-volume-provisioner
+spec:
+  selector:
+    matchLabels:
+      app: local-volume-provisioner
+  template:
+    spec:
+      containers:
+      - image: \\"quay.io/external_storage/local-volume-provisioner:v2.2.0\\"
+        name: provisioner
+"
+`;

--- a/test/manager/kubernetes/update.spec.js
+++ b/test/manager/kubernetes/update.spec.js
@@ -6,6 +6,11 @@ const yamlFile = fs.readFileSync(
   'utf8'
 );
 
+const arraySyntaxFile = fs.readFileSync(
+  'test/_fixtures/kubernetes/array-syntax.yaml',
+  'utf8'
+);
+
 describe('manager/kubernetes/update', () => {
   describe('updateDependency', () => {
     it('replaces existing value', () => {
@@ -40,6 +45,17 @@ describe('manager/kubernetes/update', () => {
     it('returns null if error', () => {
       const res = dcUpdate.updateDependency(null, null);
       expect(res).toBe(null);
+    });
+    it('replaces image inside YAML array', () => {
+      const upgrade = {
+        lineNumber: 14,
+        dockerRegistry: 'quay.io',
+        depName: 'external_storage/local-volume-provisioner',
+        newValue: 'v2.2.0',
+      };
+      const res = dcUpdate.updateDependency(arraySyntaxFile, upgrade);
+      expect(res).not.toEqual(arraySyntaxFile);
+      expect(res).toMatchSnapshot();
     });
   });
 });


### PR DESCRIPTION
Follow up to #2434, this lets Renovate actually update those image lines