### PR TITLE
fix: allow json for endpoints argument

### DIFF
--- a/lib/config/cli.js
+++ b/lib/config/cli.js
@@ -26,6 +26,7 @@ function getConfig(argv) {
       val === '[]' || val === '' ? [] : val.split(',').map(el => el.trim()),
     string: val => val,
     integer: parseInt,
+    json: JSON.parse,
   };
 
   let program = new commander.Command().arguments('[repositories...]');

--- a/lib/config/cli.js
+++ b/lib/config/cli.js
@@ -22,11 +22,18 @@ function getConfig(argv) {
 
   const coersions = {
     boolean: val => val === 'true',
-    list: val =>
-      val === '[]' || val === '' ? [] : val.split(',').map(el => el.trim()),
+    list: val => {
+      if (val === '[]' || val === '') {
+        return [];
+      }
+      try {
+        return JSON.parse(val);
+      } catch (err) {
+        return val.split(',').map(el => el.trim());
+      }
+    },
     string: val => val,
     integer: parseInt,
-    json: JSON.parse,
   };
 
   let program = new commander.Command().arguments('[repositories...]');

--- a/lib/config/cli.js
+++ b/lib/config/cli.js
@@ -23,7 +23,7 @@ function getConfig(argv) {
   const coersions = {
     boolean: val => val === 'true',
     list: val => {
-      if (val === '[]' || val === '') {
+      if (val === '') {
         return [];
       }
       try {

--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -1159,7 +1159,7 @@ const options = [
   {
     name: 'endpoints',
     description: 'Endpoint configuration for credentials',
-    type: 'json',
+    type: 'list',
     stage: 'repository',
     cli: true,
     mergeable: true,

--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -1159,8 +1159,9 @@ const options = [
   {
     name: 'endpoints',
     description: 'Endpoint configuration for credentials',
-    type: 'list',
+    type: 'json',
     stage: 'repository',
+    cli: true,
     mergeable: true,
   },
 ];

--- a/test/config/cli.spec.js
+++ b/test/config/cli.spec.js
@@ -80,5 +80,17 @@ describe('config/cli', () => {
         ],
       });
     });
+    it('parses [] correctly as empty list of endpoints', () => {
+      argv.push(`--endpoints=[]`);
+      cli.getConfig(argv).should.eql({
+        endpoints: [],
+      });
+    });
+    it('parses an empty string correctly as empty list of endpoints', () => {
+      argv.push(`--endpoints=`);
+      cli.getConfig(argv).should.eql({
+        endpoints: [],
+      });
+    });
   });
 });

--- a/test/config/cli.spec.js
+++ b/test/config/cli.spec.js
@@ -65,7 +65,7 @@ describe('config/cli', () => {
       argv.push('bar');
       cli.getConfig(argv).should.eql({ repositories: ['foo', 'bar'] });
     });
-    it('parses --endpoints json correctly', () => {
+    it('parses json lists correctly', () => {
       argv.push(
         `--endpoints=[{"host":"docker.io","platform":"docker","username":"user","password":"password"}]`
       );

--- a/test/config/cli.spec.js
+++ b/test/config/cli.spec.js
@@ -65,5 +65,20 @@ describe('config/cli', () => {
       argv.push('bar');
       cli.getConfig(argv).should.eql({ repositories: ['foo', 'bar'] });
     });
+    it('parses --endpoints json correctly', () => {
+      argv.push(
+        `--endpoints=[{"host":"docker.io","platform":"docker","username":"user","password":"password"}]`
+      );
+      cli.getConfig(argv).should.deep.equal({
+        endpoints: [
+          {
+            host: 'docker.io',
+            platform: 'docker',
+            username: 'user',
+            password: 'password',
+          },
+        ],
+      });
+    });
   });
 });


### PR DESCRIPTION
Actually, just adding `cli: true` does not fix this problem as the parsing is still missing and it's interpreted as a string. This technically introduces a breaking change as it changes the way this command is interpreted. *BUT* this is only changing for the cli argument `--endpoints` and does not have any effect on the other ways to configure renovate. So, as it was impossible to use the `--endpoints` arg before, I would say it should be a fix and not a breaking change. Let me know what you think @rarkins 🙂 This would really be appreciated as it allows to globally configure access to internal docker registries for self deployed renovate bots!

Closes #2455 