### PR TITLE
feat: github semver tag support for npm

### DIFF
--- a/lib/manager/npm/extract/index.js
+++ b/lib/manager/npm/extract/index.js
@@ -148,7 +148,28 @@ async function extractDependencies(content, fileName, config) {
               dep.skipReason = 'empty';
             }
           } else {
-            dep.skipReason = 'unknown-version';
+            const hashSplit = dep.currentValue.split('#');
+            if (hashSplit.length !== 2) {
+              dep.skipReason = 'unknown-version';
+            } else {
+              const [depNamePart, depRefPart] = hashSplit;
+              if (!semver.isVersion(depRefPart)) {
+                dep.skipReason = 'unversioned-reference';
+              } else {
+                const depNamePartSplit = depNamePart.split(':');
+                if (
+                  depNamePartSplit.length === 1 ||
+                  depNamePartSplit[0] === 'github'
+                ) {
+                  const githubRepo = depNamePartSplit[1] || depNamePartSplit[0];
+                  dep.currentRawValue = dep.currentValue;
+                  dep.currentValue = depRefPart;
+                  dep.purl = `pkg:github/${githubRepo}?ref=tags`;
+                } else {
+                  dep.skipReason = 'unknown-version';
+                }
+              }
+            }
           }
           if (depName === 'node') {
             // This is a special case for Node.js to group it together with other managers

--- a/lib/manager/npm/update.js
+++ b/lib/manager/npm/update.js
@@ -7,7 +7,15 @@ module.exports = {
 };
 
 function updateDependency(fileContent, upgrade) {
-  const { depType, depName, newValue } = upgrade;
+  const { depType, depName } = upgrade;
+  let { newValue } = upgrade;
+  if (upgrade.currentRawValue) {
+    logger.info('Replacing package.json git reference');
+    newValue = upgrade.currentRawValue.replace(
+      upgrade.currentValue,
+      upgrade.newValue
+    );
+  }
   logger.debug(`npm.updateDependency(): ${depType}.${depName} = ${newValue}`);
   try {
     const parsedContents = JSON.parse(fileContent);

--- a/test/manager/npm/__snapshots__/update.spec.js.snap
+++ b/test/manager/npm/__snapshots__/update.spec.js.snap
@@ -3,3 +3,5 @@
 exports[`workers/branch/package-json .bumpPackageVersion() increments 1`] = `"{\\"name\\":\\"some-package\\",\\"version\\":\\"0.0.3\\"}"`;
 
 exports[`workers/branch/package-json .bumpPackageVersion() updates 1`] = `"{\\"name\\":\\"some-package\\",\\"version\\":\\"0.1.0\\"}"`;
+
+exports[`workers/branch/package-json .updateDependency(fileContent, depType, depName, newValue) replaces a github dependency value 1`] = `"{\\"dependencies\\":{\\"gulp\\":\\"gulpjs/gulp#v4.0.0\\"}}"`;

--- a/test/manager/npm/extract/__snapshots__/index.spec.js.snap
+++ b/test/manager/npm/extract/__snapshots__/index.spec.js.snap
@@ -109,6 +109,84 @@ Object {
 }
 `;
 
+exports[`manager/npm/extract .extractDependencies() extracts non-npmjs 1`] = `
+Object {
+  "deps": Array [
+    Object {
+      "currentValue": "github:owner/a",
+      "depName": "a",
+      "depType": "dependencies",
+      "prettyDepType": "dependency",
+      "skipReason": "unknown-version",
+      "versionScheme": "semver",
+    },
+    Object {
+      "currentValue": "github:owner/b#master",
+      "depName": "b",
+      "depType": "dependencies",
+      "prettyDepType": "dependency",
+      "skipReason": "unversioned-reference",
+      "versionScheme": "semver",
+    },
+    Object {
+      "currentRawValue": "github:owner/c#v1.1.0",
+      "currentValue": "v1.1.0",
+      "depName": "c",
+      "depType": "dependencies",
+      "prettyDepType": "dependency",
+      "purl": "pkg:github/owner/c?ref=tags",
+      "versionScheme": "semver",
+    },
+    Object {
+      "currentValue": "github:owner/d#a7g3eaf",
+      "depName": "d",
+      "depType": "dependencies",
+      "prettyDepType": "dependency",
+      "skipReason": "unversioned-reference",
+      "versionScheme": "semver",
+    },
+    Object {
+      "currentValue": "github:owner/e#49b5aca613b33c5b626ae68c03a385f25c142f55",
+      "depName": "e",
+      "depType": "dependencies",
+      "prettyDepType": "dependency",
+      "skipReason": "unversioned-reference",
+      "versionScheme": "semver",
+    },
+    Object {
+      "currentRawValue": "owner/f#v2.0.0",
+      "currentValue": "v2.0.0",
+      "depName": "f",
+      "depType": "dependencies",
+      "prettyDepType": "dependency",
+      "purl": "pkg:github/owner/f?ref=tags",
+      "versionScheme": "semver",
+    },
+    Object {
+      "currentValue": "gitlab:owner/g#v1.0.0",
+      "depName": "g",
+      "depType": "dependencies",
+      "prettyDepType": "dependency",
+      "skipReason": "unknown-version",
+      "versionScheme": "semver",
+    },
+  ],
+  "lernaClient": undefined,
+  "lernaDir": undefined,
+  "lernaPackages": undefined,
+  "npmLock": undefined,
+  "npmrc": undefined,
+  "packageJsonName": undefined,
+  "packageJsonType": "app",
+  "packageJsonVersion": undefined,
+  "pnpmShrinkwrap": undefined,
+  "skipInstalls": true,
+  "yarnLock": undefined,
+  "yarnWorkspacesPackages": undefined,
+  "yarnrc": undefined,
+}
+`;
+
 exports[`manager/npm/extract .extractDependencies() finds a lock file 1`] = `
 Object {
   "deps": Array [

--- a/test/manager/npm/extract/index.spec.js
+++ b/test/manager/npm/extract/index.spec.js
@@ -169,6 +169,26 @@ describe('manager/npm/extract', () => {
       );
       expect(res).toMatchSnapshot();
     });
+    it('extracts non-npmjs', async () => {
+      const pJson = {
+        dependencies: {
+          a: 'github:owner/a',
+          b: 'github:owner/b#master',
+          c: 'github:owner/c#v1.1.0',
+          d: 'github:owner/d#a7g3eaf',
+          e: 'github:owner/e#49b5aca613b33c5b626ae68c03a385f25c142f55',
+          f: 'owner/f#v2.0.0',
+          g: 'gitlab:owner/g#v1.0.0',
+        },
+      };
+      const pJsonStr = JSON.stringify(pJson);
+      const res = await npmExtract.extractDependencies(
+        pJsonStr,
+        'package.json',
+        {}
+      );
+      expect(res).toMatchSnapshot();
+    });
   });
   describe('.postExtract()', () => {
     it('runs', async () => {

--- a/test/manager/npm/update.spec.js
+++ b/test/manager/npm/update.spec.js
@@ -24,6 +24,22 @@ describe('workers/branch/package-json', () => {
       const testContent = npmUpdater.updateDependency(input01Content, upgrade);
       testContent.should.equal(outputContent);
     });
+    it('replaces a github dependency value', () => {
+      const upgrade = {
+        depType: 'dependencies',
+        depName: 'gulp',
+        currentValue: 'v4.0.0-alpha.2',
+        currentRawValue: 'gulpjs/gulp#v4.0.0-alpha.2',
+        newValue: 'v4.0.0',
+      };
+      const input = JSON.stringify({
+        dependencies: {
+          gulp: 'gulpjs/gulp#v4.0.0-alpha.2',
+        },
+      });
+      const res = npmUpdater.updateDependency(input, upgrade);
+      expect(res).toMatchSnapshot();
+    });
     it('updates resolutions too', () => {
       const upgrade = {
         depType: 'dependencies',


### PR DESCRIPTION
Detects github repos in package.json and keeps them up to date if they are using semver tags, e.g. `”github:gulpjs/gulp#v4.0.0-alpha.2”` will get updated to `”github:gulpjs/gulp#v4.0.0”`.

Part of #415 but not closing it yet.
