### PR TITLE
changelogUrls in pypi.js

### DIFF
--- a/lib/datasource/pypi.js
+++ b/lib/datasource/pypi.js
@@ -11,6 +11,11 @@ function normalizeName(input) {
   return input.toLowerCase().replace(/(-|\.)/g, '_');
 }
 
+// This is a manual list of changelog URLs for dependencies that don't publish to repositoryUrl
+const changelogUrls = {
+  'pytest-django': 'https://pytest-django.readthedocs.io/en/latest/changelog.html#changelog',
+};
+
 async function getPkgReleases(purl, config = {}) {
   const { fullname: depName } = purl;
   let hostUrl = 'https://pypi.org/pypi/';
@@ -61,6 +66,10 @@ async function getPkgReleases(purl, config = {}) {
         version,
         releaseTimestamp: (dep.releases[version][0] || {}).upload_time,
       }));
+    }
+    // istanbul ignore if
+    if (changelogUrls[purl.fullname]) {
+      dependency.changelogUrl = changelogUrls[purl.fullname] || dependency.changelogUrl;
     }
     return dependency;
   } catch (err) {


### PR DESCRIPTION
Following  58d548, I introduced changelogUrls in the pypi.js file with pytest-django as first mapped changelog.

<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate
-->

<!-- Replace this text with a description of what this PR fixes or adds -->

Closes #2520 <!-- Ideally each PR should be closing an open issue -->
