### PR TITLE
feat: yarn integrity switching

### DIFF
--- a/lib/manager/npm/extract/locked-versions.js
+++ b/lib/manager/npm/extract/locked-versions.js
@@ -21,6 +21,10 @@ async function getLockedVersions(packageFiles) {
         dep.lockedVersion =
           lockFileCache[yarnLock][`${dep.depName}@${dep.currentValue}`];
       }
+      // istanbul ignore if
+      if (lockFileCache[yarnLock]['@renovate_yarn_integrity']) {
+        packageFile.yarnIntegrity = true;
+      }
     } else if (npmLock) {
       logger.debug({ npmLock }, 'npm lockfile');
       if (!lockFileCache[npmLock]) {

--- a/lib/manager/npm/extract/yarn.js
+++ b/lib/manager/npm/extract/yarn.js
@@ -20,6 +20,10 @@ async function getYarnLock(filePath) {
     for (const [entry, val] of Object.entries(yarnLockParsed.object)) {
       logger.trace({ entry, version: val.version });
       lockFile[entry] = val.version;
+      // istanbul ignore if
+      if (val.integrity) {
+        lockFile['@renovate_yarn_integrity'] = true;
+      }
     }
     return lockFile;
   } catch (err) {

--- a/lib/manager/npm/post-update/index.js
+++ b/lib/manager/npm/post-update/index.js
@@ -419,7 +419,7 @@ async function getAdditionalFiles(config, packageFiles) {
     const res = await yarn.generateLockFile(
       upath.join(config.localDir, lockFileDir),
       env,
-      config.binarysource
+      config
     );
     if (res.error) {
       // istanbul ignore if

--- a/lib/manager/npm/post-update/yarn.js
+++ b/lib/manager/npm/post-update/yarn.js
@@ -7,7 +7,8 @@ module.exports = {
   generateLockFile,
 };
 
-async function generateLockFile(cwd, env, binarySource) {
+async function generateLockFile(cwd, env, config = {}) {
+  const { binarySource, yarnIntegrity } = config;
   logger.debug(`Spawning yarn install to create ${cwd}/yarn.lock`);
   let lockFile = null;
   let stdout;
@@ -24,6 +25,11 @@ async function generateLockFile(cwd, env, binarySource) {
         'bin/yarn.js'
       );
       cmd = `node ${installedPath}`;
+      // istanbul ignore if
+      if (yarnIntegrity) {
+        logger.info('Using yarn@1.10 for install');
+        cmd = cmd.replace('node_modules/yarn/', 'node_modules/yarn110/');
+      }
     } catch (localerr) {
       logger.debug('No locally installed yarn found');
       // Look inside globally installed renovate

--- a/package.json
+++ b/package.json
@@ -120,7 +120,8 @@
     "validator": "10.8.0",
     "vso-node-api": "6.5.0",
     "www-authenticate": "0.6.2",
-    "yarn": "1.9.4"
+    "yarn": "1.9.4",
+    "yarn110": "npm:yarn@1.10.1"
   },
   "devDependencies": {
     "babel-plugin-transform-object-rest-spread": "6.26.0",

--- a/test/workers/branch/lock-files/yarn.spec.js
+++ b/test/workers/branch/lock-files/yarn.spec.js
@@ -87,11 +87,9 @@ describe('generateLockFile', () => {
       stderror: '',
     });
     fs.readFile = jest.fn(() => 'package-lock-contents');
-    const res = await yarnHelper.generateLockFile(
-      'some-dir',
-      undefined,
-      'global'
-    );
+    const res = await yarnHelper.generateLockFile('some-dir', undefined, {
+      binarySource: 'global',
+    });
     expect(fs.readFile.mock.calls.length).toEqual(1);
     expect(res.lockFile).toEqual('package-lock-contents');
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -9206,6 +9206,11 @@ yargs@~3.10.0:
     decamelize "^1.0.0"
     window-size "0.1.0"
 
+"yarn110@npm:yarn@1.10.1":
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.10.1.tgz#b792ba28f050ae94cd7e719dbca80639d70da76f"
+  integrity sha512-EH0H1fyfFxkE4UpG4b+VCaVY4I488I2EyQNmGjGGKmvsSIb0G3b+1IcfGYPI2gqa1du43g4ZA3jH8fXlq6oVxg==
+
 yarn@1.9.4:
   version "1.9.4"
   resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.9.4.tgz#3b82d8446b652775723900b470d966861976924b"


### PR DESCRIPTION
Detects if `yarn.lock` contains `integrity` fields already and if so then runs `yarn` using v1.10.1 instead of the default v1.9.4.

Closes #2566