### PR TITLE
feat(composer): enable composer by default

### DIFF
--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -1087,7 +1087,6 @@ const options = [
     stage: 'package',
     type: 'json',
     default: {
-      enabled: false,
       fileMatch: ['(^|\\/)([\\w-]*)composer.json$'],
     },
     mergeable: true,


### PR DESCRIPTION
After merging this PR, composer will be enabled by default for anyone running Renovate, without requiring it to be opted-into. i.e. like other package managers we support.