### PR TITLE
feat(golang): support major version updates

### DIFF
--- a/lib/manager/gomod/update.js
+++ b/lib/manager/gomod/update.js
@@ -7,10 +7,6 @@ module.exports = {
 function updateDependency(currentFileContent, upgrade) {
   try {
     logger.debug(`gomod.updateDependency: ${upgrade.newValue}`);
-    if (upgrade.updateType === 'major' && upgrade.newMajor > 1) {
-      logger.warn('Skipping major gomod upgrade');
-      return currentFileContent;
-    }
     const lines = currentFileContent.split('\n');
     const lineToChange = lines[upgrade.lineNumber];
     if (!lineToChange.includes(upgrade.depName)) {
@@ -18,9 +14,9 @@ function updateDependency(currentFileContent, upgrade) {
     }
     let requireLine;
     if (upgrade.multiLine) {
-      requireLine = new RegExp(/^(\s+[^\s]+\s+)[^\s]+/);
+      requireLine = new RegExp(/^(\s+[^\s]+)(\s+)([^\s]+)/);
     } else {
-      requireLine = new RegExp(/^(require\s+[^\s]+\s+)[^\s]+/);
+      requireLine = new RegExp(/^(require\s+[^\s]+)(\s+)([^\s]+)/);
     }
     if (!lineToChange.match(requireLine)) {
       logger.debug('No image line found');
@@ -37,9 +33,27 @@ function updateDependency(currentFileContent, upgrade) {
       }
       const currentDateTime = DateTime.local().toFormat('yyyyMMddHHmmss');
       const newValue = `v0.0.0-${currentDateTime}-${newDigestRightSized}`;
-      newLine = lineToChange.replace(requireLine, `$1${newValue}`);
+      newLine = lineToChange.replace(requireLine, `$1$2${newValue}`);
     } else {
-      newLine = lineToChange.replace(requireLine, `$1${upgrade.newValue}`);
+      newLine = lineToChange.replace(requireLine, `$1$2${upgrade.newValue}`);
+    }
+    if (upgrade.updateType === 'major') {
+      if (upgrade.depName.startsWith('gopkg.in/')) {
+        const oldV = upgrade.depName.split('.').pop();
+        newLine = newLine.replace(`.${oldV}`, `.v${upgrade.newMajor}`);
+      } else if (upgrade.newMajor > 1) {
+        if (upgrade.currentValue.match(/^v(0|1)\./)) {
+          // Add version
+          newLine = newLine.replace(requireLine, `$1/v${upgrade.newMajor}$2$3`);
+        } else {
+          // Replace version
+          const [oldV] = upgrade.currentValue.split('.');
+          newLine = newLine.replace(
+            new RegExp(`/${oldV}(\\s+)`),
+            `/v${upgrade.newMajor}$1`
+          );
+        }
+      }
     }
     if (newLine === lineToChange) {
       logger.debug('No changes necessary');

--- a/test/_fixtures/go/1/go.mod
+++ b/test/_fixtures/go/1/go.mod
@@ -5,3 +5,4 @@ require github.com/aws/aws-sdk-go v1.15.21
 require github.com/davecgh/go-spew v1.0.0
 require golang.org/x/foo v1.0.0
 require github.com/rarkins/foo abcdef1
+require gopkg.in/russross/blackfriday.v1 v1.0.0

--- a/test/_fixtures/go/2/go.mod
+++ b/test/_fixtures/go/2/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/spf13/pflag v1.0.2
 	github.com/spf13/viper v1.1.0
 	github.com/spkg/bom v0.0.0-20160624110644-59b7046e48ad
-	github.com/src-d/gcfg v1.3.0
+	github.com/src-d/gcfg/v2 v2.3.0
 	github.com/stretchr/testify v1.2.2
 	github.com/stvp/roll v0.0.0-20170522205222-3627a5cbeaea
 	github.com/tcnksm/go-gitconfig v0.1.2

--- a/test/manager/gomod/__snapshots__/extract.spec.js.snap
+++ b/test/manager/gomod/__snapshots__/extract.spec.js.snap
@@ -465,13 +465,13 @@ Array [
     "versionScheme": "semver",
   },
   Object {
-    "currentValue": "v1.3.0",
-    "depName": "github.com/src-d/gcfg",
-    "depNameShort": "src-d/gcfg",
+    "currentValue": "v2.3.0",
+    "depName": "github.com/src-d/gcfg/v2",
+    "depNameShort": "src-d/gcfg/v2",
     "depType": "require",
     "lineNumber": 47,
     "multiLine": true,
-    "purl": "pkg:github/src-d/gcfg",
+    "purl": "pkg:github/src-d/gcfg/v2",
     "versionScheme": "semver",
   },
   Object {
@@ -655,6 +655,15 @@ Array [
     "depType": "require",
     "lineNumber": 6,
     "skipReason": "unsupported-version",
+    "versionScheme": "semver",
+  },
+  Object {
+    "currentValue": "v1.0.0",
+    "depName": "gopkg.in/russross/blackfriday.v1",
+    "depNameShort": "russross/blackfriday",
+    "depType": "require",
+    "lineNumber": 7,
+    "purl": "pkg:github/russross/blackfriday",
     "versionScheme": "semver",
   },
 ]

--- a/test/manager/gomod/__snapshots__/update.spec.js.snap
+++ b/test/manager/gomod/__snapshots__/update.spec.js.snap
@@ -1,5 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`manager/gomod/update updateDependency replaces major gopkg.in updates 1`] = `
+"module github.com/renovate-tests/gomod1
+
+require github.com/pkg/errors v0.7.0
+require github.com/aws/aws-sdk-go v1.15.21
+require github.com/davecgh/go-spew v1.0.0
+require golang.org/x/foo v1.0.0
+require github.com/rarkins/foo abcdef1
+require gopkg.in/russross/blackfriday.v2 v2.0.0
+"
+`;
+
 exports[`manager/gomod/update updateDependency replaces two values in one file 1`] = `
 "module github.com/renovate-tests/gomod1
 
@@ -8,5 +20,6 @@ require github.com/aws/aws-sdk-go v1.15.36
 require github.com/davecgh/go-spew v1.0.0
 require golang.org/x/foo v1.0.0
 require github.com/rarkins/foo abcdef1
+require gopkg.in/russross/blackfriday.v1 v1.0.0
 "
 `;

--- a/test/manager/gomod/extract.spec.js
+++ b/test/manager/gomod/extract.spec.js
@@ -16,7 +16,7 @@ describe('lib/manager/gomod/extract', () => {
     it('extracts single-line requires', () => {
       const res = extractDependencies(gomod1, config).deps;
       expect(res).toMatchSnapshot();
-      expect(res).toHaveLength(5);
+      expect(res).toHaveLength(6);
       expect(res.filter(e => e.skipReason).length).toBe(1);
     });
     it('extracts multi-line requires', () => {

--- a/test/manager/gomod/update.spec.js
+++ b/test/manager/gomod/update.spec.js
@@ -43,16 +43,35 @@ describe('manager/gomod/update', () => {
       const res = goUpdate.updateDependency(gomod1, upgrade);
       expect(res).toEqual(gomod1);
     });
-    it('skips major updates > 1', () => {
+    it('replaces major updates > 1', () => {
       const upgrade = {
         depName: 'github.com/pkg/errors',
         lineNumber: 2,
         newMajor: 2,
         updateType: 'major',
+        currentValue: 'v0.7.0',
         newValue: 'v2.0.0',
       };
       const res = goUpdate.updateDependency(gomod1, upgrade);
-      expect(res).toEqual(gomod1);
+      expect(res).not.toEqual(gomod2);
+      expect(res.includes(upgrade.newValue)).toBe(true);
+      expect(res.includes('github.com/pkg/errors/v2')).toBe(true);
+    });
+    it('replaces major gopkg.in updates', () => {
+      const upgrade = {
+        depName: 'gopkg.in/russross/blackfriday.v1',
+        lineNumber: 7,
+        newMajor: 2,
+        updateType: 'major',
+        currentValue: 'v1.0.0',
+        newValue: 'v2.0.0',
+      };
+      const res = goUpdate.updateDependency(gomod1, upgrade);
+      expect(res).toMatchSnapshot();
+      expect(res).not.toEqual(gomod2);
+      expect(res.includes('gopkg.in/russross/blackfriday.v2 v2.0.0')).toBe(
+        true
+      );
     });
     it('returns null if mismatch', () => {
       const upgrade = {
@@ -77,6 +96,36 @@ describe('manager/gomod/update', () => {
       const res = goUpdate.updateDependency(gomod2, upgrade);
       expect(res).not.toEqual(gomod2);
       expect(res.includes(upgrade.newValue)).toBe(true);
+    });
+    it('replaces major multiline', () => {
+      const upgrade = {
+        depName: 'github.com/emirpasic/gods',
+        lineNumber: 7,
+        multiLine: true,
+        currentValue: 'v1.9.0',
+        newValue: 'v2.0.0',
+        newMajor: 2,
+        updateType: 'major',
+      };
+      const res = goUpdate.updateDependency(gomod2, upgrade);
+      expect(res).not.toEqual(gomod2);
+      expect(res.includes(upgrade.newValue)).toBe(true);
+      expect(res.includes('github.com/emirpasic/gods/v2')).toBe(true);
+    });
+    it('bumps major multiline', () => {
+      const upgrade = {
+        depName: 'github.com/src-d/gcfg',
+        lineNumber: 47,
+        multiLine: true,
+        currentValue: 'v2.3.0',
+        newValue: 'v3.0.0',
+        newMajor: 3,
+        updateType: 'major',
+      };
+      const res = goUpdate.updateDependency(gomod2, upgrade);
+      expect(res).not.toEqual(gomod2);
+      expect(res.includes(upgrade.newValue)).toBe(true);
+      expect(res.includes('github.com/src-d/gcfg/v3')).toBe(true);
     });
     it('update multiline digest', () => {
       const upgrade = {


### PR DESCRIPTION
Adds capability to upgrade major versions of Go Modules. Includes special handling for gopkg.in modules.

Closes #2583