### PR TITLE
fix: GitLab issues API is `description` not `body`

### DIFF
--- a/lib/platform/gitlab/index.js
+++ b/lib/platform/gitlab/index.js
@@ -444,7 +444,7 @@ async function ensureIssue(title, body) {
     if (issue) {
       const issueBody = (await get(
         `projects/${config.repository}/issues/${issue.iid}`
-      )).body.body;
+      )).body.description;
       if (issueBody !== body) {
         logger.debug('Updating issue body');
         await get.put(`projects/${config.repository}/issues/${issue.iid}`, {

--- a/lib/platform/gitlab/index.js
+++ b/lib/platform/gitlab/index.js
@@ -425,7 +425,7 @@ async function findIssue(title) {
     }
     const issueBody = (await get(
       `projects/${config.repository}/issues/${issue.iid}`
-    )).body.body;
+    )).body.description;
     return {
       number: issue.iid,
       body: issueBody,

--- a/test/platform/gitlab/index.spec.js
+++ b/test/platform/gitlab/index.spec.js
@@ -591,7 +591,7 @@ describe('platform/gitlab', () => {
           },
         ],
       });
-      get.mockReturnValueOnce({ body: { body: 'new-content' } });
+      get.mockReturnValueOnce({ body: { description: 'new-content' } });
       const res = await gitlab.findIssue('title-2');
       expect(res).not.toBeNull();
     });
@@ -626,7 +626,7 @@ describe('platform/gitlab', () => {
           },
         ],
       });
-      get.mockReturnValueOnce({ body: { body: 'new-content' } });
+      get.mockReturnValueOnce({ body: { description: 'new-content' } });
       const res = await gitlab.ensureIssue('title-2', 'newer-content');
       expect(res).toEqual('updated');
     });
@@ -643,7 +643,7 @@ describe('platform/gitlab', () => {
           },
         ],
       });
-      get.mockReturnValueOnce({ body: { body: 'newer-content' } });
+      get.mockReturnValueOnce({ body: { description: 'newer-content' } });
       const res = await gitlab.ensureIssue('title-2', 'newer-content');
       expect(res).toBe(null);
     });


### PR DESCRIPTION
Fixes a crash with GitLab due to the API Issue body being called `description` and not `body`:

https://docs.gitlab.com/ee/api/issues.html#single-issue

Not sure how to actually test this, please test before merge.

Closes #2619 
