### PR TITLE
fix: composer global hanging due to script / autoloader errors

### DIFF
--- a/lib/manager/composer/artifacts.js
+++ b/lib/manager/composer/artifacts.js
@@ -76,7 +76,7 @@ async function getArtifacts(
     }
     const args =
       ('update ' + updatedDeps.join(' ')).trim() +
-      ' --ignore-platform-reqs --no-ansi';
+      ' --ignore-platform-reqs --no-ansi --no-interaction --no-scripts --no-autoloader';
     logger.debug({ cmd, args }, 'composer update command');
     ({ stdout, stderr } = await exec(`${cmd} ${args}`, {
       cwd,


### PR DESCRIPTION
Make sure no scripts or autoloader or interactivity is set when updating composer dependencies to stop issues with PHP frameworks.

Closes #2625 
