### PR TITLE
fix(gitlab): s/PATCH/PUT on MR note modification API call.

### DIFF
--- a/lib/platform/gitlab/index.js
+++ b/lib/platform/gitlab/index.js
@@ -535,8 +535,8 @@ async function addComment(issueNo, body) {
 }
 
 async function editComment(issueNo, commentId, body) {
-  // PATCH projects/:owner/:repo/merge_requests/:number/notes/:id
-  await get.patch(
+  // PUT projects/:owner/:repo/merge_requests/:number/notes/:id
+  await get.put(
     `projects/${
       config.repository
     }/merge_requests/${issueNo}/notes/${commentId}`,

--- a/test/platform/gitlab/index.spec.js
+++ b/test/platform/gitlab/index.spec.js
@@ -706,8 +706,8 @@ describe('platform/gitlab', () => {
       });
       await gitlab.ensureComment(42, 'some-subject', 'some\ncontent');
       expect(get.post.mock.calls).toHaveLength(0);
-      expect(get.patch.mock.calls).toHaveLength(1);
-      expect(get.patch.mock.calls).toMatchSnapshot();
+      expect(get.put.mock.calls).toHaveLength(1);
+      expect(get.put.mock.calls).toMatchSnapshot();
     });
     it('skips comment', async () => {
       await initRepo({ repository: 'some/repo', token: 'token' });
@@ -716,14 +716,14 @@ describe('platform/gitlab', () => {
       });
       await gitlab.ensureComment(42, 'some-subject', 'some\ncontent');
       expect(get.post.mock.calls).toHaveLength(0);
-      expect(get.patch.mock.calls).toHaveLength(0);
+      expect(get.put.mock.calls).toHaveLength(0);
     });
     it('handles comment with no description', async () => {
       await initRepo({ repository: 'some/repo', token: 'token' });
       get.mockReturnValueOnce({ body: [{ id: 1234, body: '!merge' }] });
       await gitlab.ensureComment(42, null, '!merge');
       expect(get.post.mock.calls).toHaveLength(0);
-      expect(get.patch.mock.calls).toHaveLength(0);
+      expect(get.put.mock.calls).toHaveLength(0);
     });
   });
   describe('ensureCommentRemoval', () => {


### PR DESCRIPTION
When trying to modifying an existing note for a merge request,
RenovateBot ended up with an `Error updating branch`, the API call
returning a `404 Not Found`.
After taking a look at the GitLab API documentation
(https://docs.gitlab.com/ee/api/notes.html#modify-existing-merge-request-note),
the right call for modifying a MR notes should be perform using the
`PUT` HTTP Method.

This has been discovered because I observed errors after commit
6577651f745e936599cb462472ab8a4dfa0a9e5c that modify all occurences of
`Pull request` (or `PR`) to `Merge Request` (or `MR`) of notes bodies
before updated it.
