### PR TITLE
feat: GitFs for GitLab

### DIFF
--- a/lib/platform/gitlab/index.js
+++ b/lib/platform/gitlab/index.js
@@ -6,7 +6,9 @@ const hostRules = require('../../util/host-rules');
 const GitStorage = require('../git/storage');
 const Storage = require('./storage');
 
-let config = {};
+let config = {
+  storage: new Storage()
+};
 
 module.exports = {
   getRepos,
@@ -180,8 +182,7 @@ async function setBaseBranch(branchName) {
   if (branchName) {
     logger.debug(`Setting baseBranch to ${branchName}`);
     config.baseBranch = branchName;
-    config.storage.setBaseBranch(branchName);
-    await getFileList(branchName);
+    await config.storage.setBaseBranch(branchName);
   }
 }
 

--- a/lib/platform/gitlab/index.js
+++ b/lib/platform/gitlab/index.js
@@ -1,3 +1,4 @@
+const URL = require('url');
 const is = require('@sindresorhus/is');
 const addrs = require('email-addresses');
 
@@ -100,6 +101,7 @@ async function initRepo({
   endpoint,
   gitAuthor,
   gitFs,
+  localDir,
 }) {
   const opts = hostRules.find(
     { platform: 'gitlab' },
@@ -112,6 +114,8 @@ async function initRepo({
   config = {};
   get.reset();
   config.repository = urlEscape(repository);
+  config.gitFs = gitFs;
+  config.localDir = localDir;
   if (gitAuthor) {
     try {
       config.gitAuthor = addrs.parseOneAddress(gitAuthor);
@@ -139,12 +143,9 @@ async function initRepo({
     config.email = (await get(`user`)).body.email;
     delete config.prList;
     // istanbul ignore if
-    if (gitFs) {
+    if (config.gitFs) {
       logger.debug('Enabling Git FS');
       let { protocol, host } = URL.parse(opts.endpoint);
-      if (host === 'api.gitlab.com') {
-        host = null;
-      }
       host = host || 'gitlab.com';
       protocol = protocol || 'https:';
       const url = URL.format({
@@ -160,8 +161,8 @@ async function initRepo({
       });
     } else {
       config.storage = new Storage();
+      await config.storage.initRepo(config);
     }
-    await config.storage.initRepo(config);
     await Promise.all([getPrList(), getFileList()]);
   } catch (err) {
     logger.debug('Caught initRepo error');
@@ -237,7 +238,14 @@ async function commitFilesToBranch(
   message,
   parentBranch = config.baseBranch
 ) {
-  const res = await config.storage.commitFilesToBranch(
+  // GitLab does not support push with GitFs
+  let storage = config.storage;
+  // istanbul ignore if
+  if (config.gitFs) {
+    storage = new Storage();
+    storage.initRepo(config);
+  }
+  const res = await storage.commitFilesToBranch(
     branchName,
     files,
     message,

--- a/lib/platform/gitlab/index.js
+++ b/lib/platform/gitlab/index.js
@@ -3,6 +3,8 @@ const addrs = require('email-addresses');
 
 const get = require('./gl-got-wrapper');
 const hostRules = require('../../util/host-rules');
+const GitStorage = require('../git/storage');
+const Storage = require('./storage');
 
 let config = {};
 
@@ -10,7 +12,7 @@ module.exports = {
   getRepos,
   cleanRepo,
   initRepo,
-  getRepoStatus: () => ({}),
+  getRepoStatus,
   getRepoForceRebase,
   setBaseBranch,
   // Search
@@ -79,13 +81,24 @@ function urlEscape(str) {
 }
 
 function cleanRepo() {
+  // istanbul ignore if
+  if (config.storage) {
+    config.storage.cleanRepo();
+  }
   // In theory most of this isn't necessary. In practice..
   get.reset();
   config = {};
 }
 
 // Initialize GitLab by getting base branch
-async function initRepo({ repository, token, oauth, endpoint, gitAuthor }) {
+async function initRepo({
+  repository,
+  token,
+  oauth,
+  endpoint,
+  gitAuthor,
+  gitFs,
+}) {
   const opts = hostRules.find(
     { platform: 'gitlab' },
     { token, endpoint, oauth }
@@ -123,7 +136,30 @@ async function initRepo({ repository, token, oauth, endpoint, gitAuthor }) {
     // Discover our user email
     config.email = (await get(`user`)).body.email;
     delete config.prList;
-    delete config.fileList;
+    // istanbul ignore if
+    if (gitFs) {
+      logger.debug('Enabling Git FS');
+      let { protocol, host } = URL.parse(opts.endpoint);
+      if (host === 'api.gitlab.com') {
+        host = null;
+      }
+      host = host || 'gitlab.com';
+      protocol = protocol || 'https:';
+      const url = URL.format({
+        protocol,
+        auth: config.forkToken || opts.token,
+        hostname: host,
+        pathname: repository + '.git',
+      });
+      config.storage = new GitStorage();
+      await config.storage.initRepo({
+        ...config,
+        url,
+      });
+    } else {
+      config.storage = new Storage();
+    }
+    await config.storage.initRepo(config);
     await Promise.all([getPrList(), getFileList()]);
   } catch (err) {
     logger.debug('Caught initRepo error');
@@ -144,7 +180,7 @@ async function setBaseBranch(branchName) {
   if (branchName) {
     logger.debug(`Setting baseBranch to ${branchName}`);
     config.baseBranch = branchName;
-    delete config.fileList;
+    config.storage.setBaseBranch(branchName);
     await getFileList(branchName);
   }
 }
@@ -152,81 +188,15 @@ async function setBaseBranch(branchName) {
 // Search
 
 // Get full file list
-async function getFileList(branchName = config.baseBranch) {
-  if (config.fileList) {
-    return config.fileList;
-  }
-  try {
-    let url = `projects/${
-      config.repository
-    }/repository/tree?ref=${branchName}&per_page=100`;
-    if (!(process.env.RENOVATE_DISABLE_FILE_RECURSION === 'true')) {
-      url += '&recursive=true';
-    }
-    const res = await get(url, { paginate: true });
-    config.fileList = res.body
-      .filter(item => item.type === 'blob' && item.mode !== '120000')
-      .map(item => item.path)
-      .sort();
-    logger.debug(`Retrieved fileList with length ${config.fileList.length}`);
-  } catch (err) {
-    logger.info('Error retrieving git tree - no files detected');
-    config.fileList = [];
-  }
-  return config.fileList;
+function getFileList(branchName = config.baseBranch) {
+  return config.storage.getFileList(branchName);
 }
 
 // Branch
 
 // Returns true if branch exists, otherwise false
-async function branchExists(branchName) {
-  logger.debug(`Checking if branch exists: ${branchName}`);
-  try {
-    const url = `projects/${config.repository}/repository/branches/${urlEscape(
-      branchName
-    )}`;
-    const res = await get(url);
-    if (res.statusCode === 200) {
-      logger.debug('Branch exists');
-      return true;
-    }
-    // This probably shouldn't happen
-    logger.debug("Branch doesn't exist");
-    return false;
-  } catch (error) {
-    if (error.statusCode === 404) {
-      // If file not found, then return false
-      logger.debug("Branch doesn't exist");
-      return false;
-    }
-    // Propagate if it's any other error
-    throw error;
-  }
-}
-
-async function getAllRenovateBranches(branchPrefix) {
-  logger.debug(`getAllRenovateBranches(${branchPrefix})`);
-  const allBranches = await get(
-    `projects/${config.repository}/repository/branches`
-  );
-  return allBranches.body.reduce((arr, branch) => {
-    if (branch.name.startsWith(branchPrefix)) {
-      arr.push(branch.name);
-    }
-    return arr;
-  }, []);
-}
-
-async function isBranchStale(branchName) {
-  logger.debug(`isBranchStale(${branchName})`);
-  const branchDetails = await getBranchDetails(branchName);
-  logger.trace({ branchDetails }, 'branchDetails');
-  const parentSha = branchDetails.body.commit.parent_ids[0];
-  logger.debug(`parentSha=${parentSha}`);
-  const baseCommitSHA = await getBaseCommitSHA();
-  logger.debug(`baseCommitSHA=${baseCommitSHA}`);
-  // Return true if the SHAs don't match
-  return parentSha !== baseCommitSHA;
+function branchExists(branchName) {
+  return config.storage.branchExists(branchName);
 }
 
 // Returns the Pull Request for a branch. Null if not exists.
@@ -250,6 +220,72 @@ async function getBranchPr(branchName) {
     return null;
   }
   return getPr(pr.iid);
+}
+
+function getAllRenovateBranches(branchPrefix) {
+  return config.storage.getAllRenovateBranches(branchPrefix);
+}
+
+function isBranchStale(branchName) {
+  return config.storage.isBranchStale(branchName);
+}
+
+async function commitFilesToBranch(
+  branchName,
+  files,
+  message,
+  parentBranch = config.baseBranch
+) {
+  const res = await config.storage.commitFilesToBranch(
+    branchName,
+    files,
+    message,
+    parentBranch
+  );
+  // Reopen PR if it previousluy existed and was closed by GitLab when we deleted branch
+  const pr = await getBranchPr(branchName);
+  // istanbul ignore if
+  if (pr) {
+    logger.debug('Reopening PR');
+    await reopenPr(pr.number);
+  }
+  return res;
+}
+
+function getFile(filePath, branchName) {
+  return config.storage.getFile(filePath, branchName);
+}
+
+async function deleteBranch(branchName, closePr = false) {
+  if (closePr) {
+    logger.debug('Closing PR');
+    const pr = await getBranchPr(branchName);
+    // istanbul ignore if
+    if (pr) {
+      await get.put(
+        `projects/${config.repository}/merge_requests/${pr.number}`,
+        {
+          body: {
+            state_event: 'close',
+          },
+        }
+      );
+    }
+  }
+  return config.storage.deleteBranch(branchName);
+}
+
+function mergeBranch(branchName) {
+  return config.storage.mergeBranch(branchName);
+}
+
+function getBranchLastCommitTime(branchName) {
+  return config.storage.getBranchLastCommitTime(branchName);
+}
+
+// istanbul ignore next
+function getRepoStatus() {
+  return config.storage.getRepoStatus();
 }
 
 // Returns the combined status for a branch.
@@ -342,60 +378,6 @@ async function setBranchStatus(
     options.target_url = targetUrl;
   }
   await get.post(url, { body: options });
-}
-
-async function deleteBranch(branchName, closePr = false) {
-  if (closePr) {
-    logger.debug('Closing PR');
-    const pr = await getBranchPr(branchName);
-    // istanbul ignore if
-    if (pr) {
-      await get.put(
-        `projects/${config.repository}/merge_requests/${pr.number}`,
-        {
-          body: {
-            state_event: 'close',
-          },
-        }
-      );
-    }
-  }
-  await get.delete(
-    `projects/${config.repository}/repository/branches/${urlEscape(branchName)}`
-  );
-}
-
-async function mergeBranch(branchName) {
-  logger.debug(`mergeBranch(${branchName}`);
-  const branchURI = encodeURIComponent(branchName);
-  try {
-    await get.post(
-      `projects/${
-        config.repository
-      }/repository/commits/${branchURI}/cherry_pick?branch=${config.baseBranch}`
-    );
-  } catch (err) {
-    logger.info({ err }, `Error pushing branch merge for ${branchName}`);
-    throw new Error('Branch automerge failed');
-  }
-  // Update base commit
-  config.baseCommitSHA = null;
-  // Delete branch
-  await deleteBranch(branchName);
-}
-
-async function getBranchLastCommitTime(branchName) {
-  try {
-    const res = await get(
-      `projects/${config.repository}/repository/commits?ref_name=${urlEscape(
-        branchName
-      )}`
-    );
-    return new Date(res.body[0].committed_date);
-  } catch (err) {
-    logger.error({ err }, `getBranchLastCommitTime error`);
-    return new Date();
-  }
 }
 
 // Issue
@@ -765,106 +747,8 @@ function getPrBody(input) {
     .replace(/\]\(\.\.\/pull\//g, '](../merge_requests/');
 }
 
-// Generic File operations
-
-async function getFile(filePath, branchName) {
-  logger.debug(`getFile(filePath=${filePath}, branchName=${branchName})`);
-  if (!branchName || branchName === config.baseBranch) {
-    if (config.fileList && !config.fileList.includes(filePath)) {
-      return null;
-    }
-  }
-  try {
-    const url = `projects/${config.repository}/repository/files/${urlEscape(
-      filePath
-    )}?ref=${branchName || config.baseBranch}`;
-    const res = await get(url);
-    return Buffer.from(res.body.content, 'base64').toString();
-  } catch (error) {
-    if (error.statusCode === 404) {
-      // If file not found, then return null JSON
-      return null;
-    }
-    // Propagate if it's any other error
-    throw error;
-  }
-}
-
-// Add a new commit, create branch if not existing
-async function commitFilesToBranch(
-  branchName,
-  files,
-  message,
-  parentBranch = config.baseBranch
-) {
-  logger.debug(
-    `commitFilesToBranch('${branchName}', files, message, '${parentBranch})'`
-  );
-  const opts = {
-    body: {
-      branch: branchName,
-      commit_message: message,
-      start_branch: parentBranch,
-      actions: [],
-    },
-  };
-  // istanbul ignore if
-  if (config.gitAuthor) {
-    opts.body.author_name = config.gitAuthor.name;
-    opts.body.author_email = config.gitAuthor.address;
-  }
-  for (const file of files) {
-    const action = {
-      file_path: file.name,
-      content: Buffer.from(file.contents).toString('base64'),
-      encoding: 'base64',
-    };
-    action.action = (await getFile(file.name)) ? 'update' : 'create';
-    opts.body.actions.push(action);
-  }
-  let res = 'created';
-  try {
-    if (await branchExists(branchName)) {
-      logger.debug('Deleting existing branch');
-      await deleteBranch(branchName);
-      res = 'updated';
-    }
-  } catch (err) {
-    // istanbul ignore next
-    logger.info(`Ignoring branch deletion failure`);
-  }
-  logger.debug('Adding commits');
-  await get.post(`projects/${config.repository}/repository/commits`, opts);
-  // Reopen PR if it previousluy existed and was closed by GitLab when we deleted branch
-  const pr = await getBranchPr(branchName);
-  // istanbul ignore if
-  if (pr) {
-    logger.debug('Reopening PR');
-    await reopenPr(pr.number);
-  }
-  return res;
-}
-
-// GET /projects/:id/repository/commits
-async function getCommitMessages() {
-  logger.debug('getCommitMessages');
-  const res = await get(`projects/${config.repository}/repository/commits`);
-  return res.body.map(commit => commit.title);
-}
-
-function getBranchDetails(branchName) {
-  const url = `/projects/${config.repository}/repository/branches/${urlEscape(
-    branchName
-  )}`;
-  return get(url);
-}
-
-async function getBaseCommitSHA() {
-  if (!config.baseCommitSHA) {
-    const branchDetails = await getBranchDetails(config.baseBranch);
-    config.baseCommitSHA = branchDetails.body.commit.id;
-  }
-  return config.baseCommitSHA;
+function getCommitMessages() {
+  return config.storage.getCommitMessages();
 }
 
 function getVulnerabilityAlerts() {

--- a/lib/platform/gitlab/index.js
+++ b/lib/platform/gitlab/index.js
@@ -150,7 +150,7 @@ async function initRepo({
       protocol = protocol || 'https:';
       const url = URL.format({
         protocol,
-        auth: config.forkToken || opts.token,
+        auth: 'oauth2:' + (config.forkToken || opts.token),
         hostname: host,
         pathname: repository + '.git',
       });

--- a/lib/platform/gitlab/index.js
+++ b/lib/platform/gitlab/index.js
@@ -7,7 +7,7 @@ const GitStorage = require('../git/storage');
 const Storage = require('./storage');
 
 let config = {
-  storage: new Storage()
+  storage: new Storage(),
 };
 
 module.exports = {
@@ -301,17 +301,13 @@ async function getBranchStatus(branchName, requiredStatusChecks) {
     logger.warn({ requiredStatusChecks }, `Unsupported requiredStatusChecks`);
     return 'failed';
   }
-  // First, get the branch to find the commit SHA
-  let url = `projects/${config.repository}/repository/branches/${urlEscape(
-    branchName
-  )}`;
-  let res = await get(url);
-  const branchSha = res.body.commit.id;
+  // First, get the branch commit SHA
+  const branchSha = await config.storage.getBranchCommit(branchName);
   // Now, check the statuses for that commit
-  url = `projects/${
+  const url = `projects/${
     config.repository
   }/repository/commits/${branchSha}/statuses`;
-  res = await get(url);
+  const res = await get(url);
   logger.debug(`Got res with ${res.body.length} results`);
   if (res.body.length === 0) {
     // Return 'pending' if we have no status checks
@@ -335,17 +331,13 @@ async function getBranchStatus(branchName, requiredStatusChecks) {
 }
 
 async function getBranchStatusCheck(branchName, context) {
-  // First, get the branch to find the commit SHA
-  let url = `projects/${config.repository}/repository/branches/${urlEscape(
-    branchName
-  )}`;
-  let res = await get(url);
-  const branchSha = res.body.commit.id;
+  // First, get the branch commit SHA
+  const branchSha = await config.storage.getBranchCommit(branchName);
   // Now, check the statuses for that commit
-  url = `projects/${
+  const url = `projects/${
     config.repository
   }/repository/commits/${branchSha}/statuses`;
-  res = await get(url);
+  const res = await get(url);
   logger.debug(`Got res with ${res.body.length} results`);
   for (const check of res.body) {
     if (check.name === context) {
@@ -362,14 +354,10 @@ async function setBranchStatus(
   state,
   targetUrl
 ) {
-  // First, get the branch to find the commit SHA
-  let url = `projects/${config.repository}/repository/branches/${urlEscape(
-    branchName
-  )}`;
-  const res = await get(url);
-  const branchSha = res.body.commit.id;
+  // First, get the branch commit SHA
+  const branchSha = await config.storage.getBranchCommit(branchName);
   // Now, check the statuses for that commit
-  url = `projects/${config.repository}/statuses/${branchSha}`;
+  const url = `projects/${config.repository}/statuses/${branchSha}`;
   const options = {
     state,
     description,

--- a/lib/platform/gitlab/storage.js
+++ b/lib/platform/gitlab/storage.js
@@ -177,7 +177,9 @@ class Storage {
           .filter(item => item.type === 'blob' && item.mode !== '120000')
           .map(item => item.path)
           .sort();
-        logger.debug(`Retrieved fileList with length ${branchFiles[branchName].length}`);
+        logger.debug(
+          `Retrieved fileList with length ${branchFiles[branchName].length}`
+        );
       } catch (err) {
         logger.info('Error retrieving git tree - no files detected');
         branchFiles[branchName] = [];
@@ -190,7 +192,10 @@ class Storage {
     async function getFile(filePath, branchName) {
       logger.debug(`getFile(filePath=${filePath}, branchName=${branchName})`);
       if (!branchName || branchName === config.baseBranch) {
-        if (branchFiles[branchName] && !branchFiles[branchName].includes(filePath)) {
+        if (
+          branchFiles[branchName] &&
+          !branchFiles[branchName].includes(filePath)
+        ) {
           return null;
         }
       }
@@ -263,8 +268,10 @@ class Storage {
           return branch.commit.id;
         }
       } catch (err) {
+        // istanbul ignore next
         logger.error({ err }, `getBranchCommit error`);
       }
+      // istanbul ignore next
       return null;
     }
 
@@ -286,7 +293,7 @@ class Storage {
       if (branchName) {
         logger.debug(`Setting baseBranch to ${branchName}`);
         config.baseBranch = branchName;
-        branchFiles= {};
+        branchFiles = {};
         await getFileList(branchName);
       }
     }

--- a/lib/platform/gitlab/storage.js
+++ b/lib/platform/gitlab/storage.js
@@ -1,0 +1,296 @@
+const get = require('./gl-got-wrapper');
+
+function urlEscape(str) {
+  return str ? str.replace(/\//g, '%2F') : str;
+}
+
+class Storage {
+  constructor() {
+    // config
+    let config = {};
+    // cache
+    let baseCommitSHA = null;
+    let fileList = null;
+
+    Object.assign(this, {
+      initRepo,
+      cleanRepo,
+      getRepoStatus: () => ({}),
+      branchExists,
+      commitFilesToBranch,
+      createBranch,
+      deleteBranch,
+      getAllRenovateBranches,
+      getBranchCommit,
+      getBranchLastCommitTime,
+      getCommitMessages,
+      getFile,
+      getFileList,
+      isBranchStale,
+      mergeBranch,
+      setBaseBranch,
+    });
+
+    function initRepo(args) {
+      cleanRepo();
+      config = { ...args };
+    }
+
+    function cleanRepo() {
+      baseCommitSHA = null;
+      fileList = null;
+    }
+
+    // Branch
+
+    // Returns true if branch exists, otherwise false
+    async function branchExists(branchName) {
+      logger.debug(`Checking if branch exists: ${branchName}`);
+      try {
+        const url = `projects/${
+          config.repository
+        }/repository/branches/${urlEscape(branchName)}`;
+        const res = await get(url);
+        if (res.statusCode === 200) {
+          logger.debug('Branch exists');
+          return true;
+        }
+        // This probably shouldn't happen
+        logger.debug("Branch doesn't exist");
+        return false;
+      } catch (error) {
+        if (error.statusCode === 404) {
+          // If file not found, then return false
+          logger.debug("Branch doesn't exist");
+          return false;
+        }
+        // Propagate if it's any other error
+        throw error;
+      }
+    }
+
+    async function getAllRenovateBranches(branchPrefix) {
+      logger.debug(`getAllRenovateBranches(${branchPrefix})`);
+      const allBranches = await get(
+        `projects/${config.repository}/repository/branches`
+      );
+      return allBranches.body.reduce((arr, branch) => {
+        if (branch.name.startsWith(branchPrefix)) {
+          arr.push(branch.name);
+        }
+        return arr;
+      }, []);
+    }
+
+    async function isBranchStale(branchName) {
+      logger.debug(`isBranchStale(${branchName})`);
+      const branchDetails = await getBranchDetails(branchName);
+      logger.trace({ branchDetails }, 'branchDetails');
+      const parentSha = branchDetails.body.commit.parent_ids[0];
+      logger.debug(`parentSha=${parentSha}`);
+      const baseSHA = await getBaseCommitSHA();
+      logger.debug(`baseSHA=${baseSHA}`);
+      // Return true if the SHAs don't match
+      return parentSha !== baseSHA;
+    }
+
+    // Add a new commit, create branch if not existing
+    async function commitFilesToBranch(
+      branchName,
+      files,
+      message,
+      parentBranch = config.baseBranch
+    ) {
+      logger.debug(
+        `commitFilesToBranch('${branchName}', files, message, '${parentBranch})'`
+      );
+      const opts = {
+        body: {
+          branch: branchName,
+          commit_message: message,
+          start_branch: parentBranch,
+          actions: [],
+        },
+      };
+      // istanbul ignore if
+      if (config.gitAuthor) {
+        opts.body.author_name = config.gitAuthor.name;
+        opts.body.author_email = config.gitAuthor.address;
+      }
+      for (const file of files) {
+        const action = {
+          file_path: file.name,
+          content: Buffer.from(file.contents).toString('base64'),
+          encoding: 'base64',
+        };
+        action.action = (await getFile(file.name)) ? 'update' : 'create';
+        opts.body.actions.push(action);
+      }
+      let res = 'created';
+      try {
+        if (await branchExists(branchName)) {
+          logger.debug('Deleting existing branch');
+          await deleteBranch(branchName);
+          res = 'updated';
+        }
+      } catch (err) {
+        // istanbul ignore next
+        logger.info(`Ignoring branch deletion failure`);
+      }
+      logger.debug('Adding commits');
+      await get.post(`projects/${config.repository}/repository/commits`, opts);
+      return res;
+    }
+
+    async function createBranch(branchName, sha) {
+      await get.post(
+        `projects/${config.repository}/repository/branches?branch=${urlEscape(
+          branchName
+        )}&ref=${sha}`
+      );
+    }
+
+    async function deleteBranch(branchName) {
+      await get.delete(
+        `projects/${config.repository}/repository/branches/${urlEscape(
+          branchName
+        )}`
+      );
+    }
+
+    // Search
+
+    // Get full file list
+    async function getFileList(branchName = config.baseBranch) {
+      if (fileList) {
+        return fileList;
+      }
+      try {
+        let url = `projects/${
+          config.repository
+        }/repository/tree?ref=${branchName}&per_page=100`;
+        if (!(process.env.RENOVATE_DISABLE_FILE_RECURSION === 'true')) {
+          url += '&recursive=true';
+        }
+        const res = await get(url, { paginate: true });
+        fileList = res.body
+          .filter(item => item.type === 'blob' && item.mode !== '120000')
+          .map(item => item.path)
+          .sort();
+        logger.debug(`Retrieved fileList with length ${fileList.length}`);
+      } catch (err) {
+        logger.info('Error retrieving git tree - no files detected');
+        fileList = [];
+      }
+      return fileList;
+    }
+
+    // Generic File operations
+
+    async function getFile(filePath, branchName) {
+      logger.debug(`getFile(filePath=${filePath}, branchName=${branchName})`);
+      if (!branchName || branchName === config.baseBranch) {
+        if (fileList && !fileList.includes(filePath)) {
+          return null;
+        }
+      }
+      try {
+        const url = `projects/${config.repository}/repository/files/${urlEscape(
+          filePath
+        )}?ref=${branchName || config.baseBranch}`;
+        const res = await get(url);
+        return Buffer.from(res.body.content, 'base64').toString();
+      } catch (error) {
+        if (error.statusCode === 404) {
+          // If file not found, then return null JSON
+          return null;
+        }
+        // Propagate if it's any other error
+        throw error;
+      }
+    }
+
+    // GET /projects/:id/repository/commits
+    async function getCommitMessages() {
+      logger.debug('getCommitMessages');
+      const res = await get(`projects/${config.repository}/repository/commits`);
+      return res.body.map(commit => commit.title);
+    }
+
+    function getBranchDetails(branchName) {
+      const url = `/projects/${
+        config.repository
+      }/repository/branches/${urlEscape(branchName)}`;
+      return get(url);
+    }
+
+    async function getBaseCommitSHA() {
+      if (!baseCommitSHA) {
+        const branchDetails = await getBranchDetails(config.baseBranch);
+        baseCommitSHA = branchDetails.body.commit.id;
+      }
+      return baseCommitSHA;
+    }
+
+    async function mergeBranch(branchName) {
+      logger.debug(`mergeBranch(${branchName}`);
+      const branchURI = encodeURIComponent(branchName);
+      try {
+        await get.post(
+          `projects/${
+            config.repository
+          }/repository/commits/${branchURI}/cherry_pick?branch=${
+            config.baseBranch
+          }`
+        );
+      } catch (err) {
+        logger.info({ err }, `Error pushing branch merge for ${branchName}`);
+        throw new Error('Branch automerge failed');
+      }
+      // Update base commit
+      baseCommitSHA = null;
+      // Delete branch
+      await deleteBranch(branchName);
+    }
+
+    async function getBranchCommit(branchName) {
+      const branchUrl = `projects/${
+        config.repository
+      }/repository/branches/${urlEscape(branchName)}`;
+      try {
+        const branch = (await get(branchUrl)).body;
+        if (branch && branch.commit) {
+          return branch.commit.id;
+        }
+      } catch (err) {
+        logger.error({ err }, `getBranchCommit error`);
+      }
+      return null;
+    }
+
+    async function getBranchLastCommitTime(branchName) {
+      try {
+        const res = await get(
+          `projects/${
+            config.repository
+          }/repository/commits?ref_name=${urlEscape(branchName)}`
+        );
+        return new Date(res.body[0].committed_date);
+      } catch (err) {
+        logger.error({ err }, `getBranchLastCommitTime error`);
+        return new Date();
+      }
+    }
+
+    async function setBaseBranch(branchName) {
+      if (branchName) {
+        logger.debug(`Setting baseBranch to ${branchName}`);
+        config.baseBranch = branchName;
+        fileList = null;
+        await getFileList(branchName);
+      }
+    }
+  }
+}
+
+module.exports = Storage;

--- a/lib/platform/gitlab/storage.js
+++ b/lib/platform/gitlab/storage.js
@@ -10,7 +10,7 @@ class Storage {
     let config = {};
     // cache
     let baseCommitSHA = null;
-    let fileList = null;
+    let branchFiles = {};
 
     Object.assign(this, {
       initRepo,
@@ -38,7 +38,7 @@ class Storage {
 
     function cleanRepo() {
       baseCommitSHA = null;
-      fileList = null;
+      branchFiles = {};
     }
 
     // Branch
@@ -162,8 +162,8 @@ class Storage {
 
     // Get full file list
     async function getFileList(branchName = config.baseBranch) {
-      if (fileList) {
-        return fileList;
+      if (branchFiles[branchName]) {
+        return branchFiles[branchName];
       }
       try {
         let url = `projects/${
@@ -173,16 +173,16 @@ class Storage {
           url += '&recursive=true';
         }
         const res = await get(url, { paginate: true });
-        fileList = res.body
+        branchFiles[branchName] = res.body
           .filter(item => item.type === 'blob' && item.mode !== '120000')
           .map(item => item.path)
           .sort();
-        logger.debug(`Retrieved fileList with length ${fileList.length}`);
+        logger.debug(`Retrieved fileList with length ${branchFiles[branchName].length}`);
       } catch (err) {
         logger.info('Error retrieving git tree - no files detected');
-        fileList = [];
+        branchFiles[branchName] = [];
       }
-      return fileList;
+      return branchFiles[branchName];
     }
 
     // Generic File operations
@@ -190,7 +190,7 @@ class Storage {
     async function getFile(filePath, branchName) {
       logger.debug(`getFile(filePath=${filePath}, branchName=${branchName})`);
       if (!branchName || branchName === config.baseBranch) {
-        if (fileList && !fileList.includes(filePath)) {
+        if (branchFiles[branchName] && !branchFiles[branchName].includes(filePath)) {
           return null;
         }
       }
@@ -286,7 +286,7 @@ class Storage {
       if (branchName) {
         logger.debug(`Setting baseBranch to ${branchName}`);
         config.baseBranch = branchName;
-        fileList = null;
+        branchFiles= {};
         await getFileList(branchName);
       }
     }

--- a/test/platform/gitlab/__snapshots__/storage.spec.js.snap
+++ b/test/platform/gitlab/__snapshots__/storage.spec.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`platform/gitlab/storage createBranch() creates the branch 1`] = `
+Array [
+  Array [
+    "projects/undefined/repository/branches?branch=renovate%2Fsome-branch&ref=commit",
+  ],
+]
+`;

--- a/test/platform/gitlab/storage.spec.js
+++ b/test/platform/gitlab/storage.spec.js
@@ -1,6 +1,8 @@
 describe('platform/gitlab/storage', () => {
+  jest.mock('../../../lib/platform/gitlab/gl-got-wrapper');
   const GitlabStorage = require('../../../lib/platform/gitlab/storage');
   const GitStorage = require('../../../lib/platform/git/storage');
+  const get = require('../../../lib/platform/gitlab/gl-got-wrapper');
   it('has same API for git storage', () => {
     const gitlabMethods = Object.keys(new GitlabStorage()).sort();
     const gitMethods = Object.keys(new GitStorage()).sort();
@@ -8,5 +10,13 @@ describe('platform/gitlab/storage', () => {
   });
   it('getRepoStatus exists', async () => {
     expect((await new GitlabStorage()).getRepoStatus()).toEqual({});
+  });
+  describe('createBranch()', () => {
+    it('creates the branch', async () => {
+      get.post.mockReturnValue({});
+      const storage = new GitlabStorage();
+      await storage.createBranch('renovate/some-branch', 'commit');
+      expect(get.post.mock.calls).toMatchSnapshot();
+    });
   });
 });

--- a/test/platform/gitlab/storage.spec.js
+++ b/test/platform/gitlab/storage.spec.js
@@ -1,0 +1,12 @@
+describe('platform/gitlab/storage', () => {
+  const GitlabStorage = require('../../../lib/platform/gitlab/storage');
+  const GitStorage = require('../../../lib/platform/git/storage');
+  it('has same API for git storage', () => {
+    const gitlabMethods = Object.keys(new GitlabStorage()).sort();
+    const gitMethods = Object.keys(new GitStorage()).sort();
+    expect(gitlabMethods).toMatchObject(gitMethods);
+  });
+  it('getRepoStatus exists', async () => {
+    expect((await new GitlabStorage()).getRepoStatus()).toEqual({});
+  });
+});


### PR DESCRIPTION
<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate
-->

<!-- Replace this text with a description of what this PR fixes or adds -->

Since Gitlab does not support using tokens to write to repo, `commitFilesToBranch` will always use the API. This could be changed once GitFS over SSH is implemented. 

Closes #2549