### PR TITLE
fix(gitlab): gracefully handle PR merge rejections

### DIFF
--- a/lib/platform/gitlab/index.js
+++ b/lib/platform/gitlab/index.js
@@ -750,12 +750,22 @@ async function updatePr(iid, title, description) {
 }
 
 async function mergePr(iid) {
-  await get.put(`projects/${config.repository}/merge_requests/${iid}/merge`, {
-    body: {
-      should_remove_source_branch: true,
-    },
-  });
-  return true;
+  try {
+    await get.put(`projects/${config.repository}/merge_requests/${iid}/merge`, {
+      body: {
+        should_remove_source_branch: true,
+      },
+    });
+    return true;
+  } catch (err) /* istanbul ignore next */ {
+    if (err.statusCode === 401) {
+      logger.info('No permissions to merge PR');
+      return false;
+    }
+    logger.debug({ err }, 'merge PR error');
+    logger.warn('PR merge failed');
+    return false;
+  }
 }
 
 function getPrBody(input) {


### PR DESCRIPTION
Currently any GitLab PR merge rejection results in a Renovate ERROR being thrown. This includes 401 which is due to permissions:
![image](https://user-images.githubusercontent.com/6311784/47613176-25d72980-da8a-11e8-84cf-7441a50312ef.png)

Although it's unideal for someone to configure automerge but not grant Renovate adequate permissions to merge to master, it definitely should be gracefully handled and not throwing errors to logs.