### PR TITLE
docs: update to match latest docker tag

### DIFF
--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -21,9 +21,9 @@ Renovate is available for Docker via an automated build [renovate/renovate](http
 
 ```
 $ docker run renovate/renovate
-$ docker run renovate/renovate:12.1.1
-$ docker run renovate/renovate:12.1
-$ docker run renovate/renovate:12
+$ docker run renovate/renovate:13.1.1
+$ docker run renovate/renovate:13.1
+$ docker run renovate/renovate:13
 ```
 
 If you wish to configure Renovate using a `config.js` file then map it to `/usr/src/app/config.js` using Docker volumes.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -26,6 +26,8 @@ $ docker run renovate/renovate:13.1
 $ docker run renovate/renovate:13
 ```
 
+(Please look up what the latest actual tags are though, do not use the above literally).
+
 If you wish to configure Renovate using a `config.js` file then map it to `/usr/src/app/config.js` using Docker volumes.
 
 ## Authentication


### PR DESCRIPTION
Update the documentation of self-hosting to match the latest docker tag. I accidentally assumed that version 12 was the latest and therefore encountered and issue, which was already fixed. 