### PR TITLE
test: Fix gradle tests in Windows

### DIFF
--- a/test/manager/gradle/index.spec.js
+++ b/test/manager/gradle/index.spec.js
@@ -1,6 +1,7 @@
 jest.mock('fs-extra');
 jest.mock('child-process-promise');
 
+const { toUnix } = require('upath');
 const fs = require('fs-extra');
 const fsReal = require('fs');
 const { exec } = require('child-process-promise');
@@ -103,15 +104,17 @@ describe('manager/gradle', () => {
         'subproject1/subproject2/build.gradle': 'content subproject2',
       });
 
-      expect(fs.writeFile.mock.calls[0][0]).toBe('localDir/build.gradle');
+      expect(toUnix(fs.writeFile.mock.calls[0][0])).toBe(
+        'localDir/build.gradle'
+      );
       expect(fs.writeFile.mock.calls[0][1]).toBe('content root file');
 
-      expect(fs.writeFile.mock.calls[1][0]).toBe(
+      expect(toUnix(fs.writeFile.mock.calls[1][0])).toBe(
         'localDir/subproject1/build.gradle'
       );
       expect(fs.writeFile.mock.calls[1][1]).toBe('content subproject1');
 
-      expect(fs.writeFile.mock.calls[2][0]).toBe(
+      expect(toUnix(fs.writeFile.mock.calls[2][0])).toBe(
         'localDir/subproject1/subproject2/build.gradle'
       );
       expect(fs.writeFile.mock.calls[2][1]).toBe('content subproject2');
@@ -120,7 +123,9 @@ describe('manager/gradle', () => {
     it('should configure the useLatestVersion plugin', async () => {
       await manager.extractDependencies('content', 'build.gradle', config);
 
-      expect(fs.writeFile.mock.calls[0][0]).toBe('localDir/init.gradle');
+      expect(toUnix(fs.writeFile.mock.calls[0][0])).toBe(
+        'localDir/init.gradle'
+      );
     });
 
     it('should use docker if required', async () => {


### PR DESCRIPTION
<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate
-->
Some gradle tests are failing in windows due to path delimiter difference
```
  ● manager/gradle › extractDependencies › should write the gradle config file in the tmp dir

    expect(received).toBe(expected) // Object.is equality

    Expected: "localDir/build.gradle"
    Received: "localDir\\build.gradle"
```

<!-- Replace this text with a description of what this PR fixes or adds -->

<!-- Ideally each PR should be closing an open issue -->
