### PR TITLE
refactor: synchronous extractAllFiles

### DIFF
--- a/lib/manager/gradle/index.js
+++ b/lib/manager/gradle/index.js
@@ -9,7 +9,7 @@ const GRADLE_DEPENDENCY_REPORT_COMMAND =
 const GRADLE_DEPENDENCY_REPORT_FILENAME = 'build/dependencyUpdates/report.json';
 const TIMEOUT_CODE = 143;
 
-async function extractAllFiles(config, packageFiles) {
+async function extractAllPackageFiles(config, packageFiles) {
   if (!packageFiles.some(packageFile => packageFile === 'build.gradle')) {
     logger.warn('No root build.gradle found - skipping');
   }
@@ -185,7 +185,7 @@ function getDockerRenovateGradleCommandLine(localDir) {
 }
 
 module.exports = {
-  extractAllFiles,
+  extractAllPackageFiles,
   getPackageUpdates,
   updateDependency,
   language: 'java',

--- a/lib/manager/gradle/index.js
+++ b/lib/manager/gradle/index.js
@@ -12,6 +12,7 @@ const TIMEOUT_CODE = 143;
 async function extractAllPackageFiles(config, packageFiles) {
   if (!packageFiles.some(packageFile => packageFile === 'build.gradle')) {
     logger.warn('No root build.gradle found - skipping');
+    return null;
   }
   logger.info('Extracting dependencies from all gradle files');
   // Gradle needs all files to be written to disk before we parse any as some files may reference others
@@ -27,7 +28,7 @@ async function extractAllPackageFiles(config, packageFiles) {
   for (const packageFile of packageFiles) {
     const content = await platform.getFile(packageFile);
     if (content) {
-      const deps = await extractDependencies(content, packageFile, config);
+      const deps = await extractPackageFile(content, packageFile, config);
       if (deps) {
         gradleFiles.push({
           packageFile,
@@ -186,6 +187,7 @@ function getDockerRenovateGradleCommandLine(localDir) {
 
 module.exports = {
   extractAllPackageFiles,
+  extractPackageFile,
   getPackageUpdates,
   updateDependency,
   language: 'java',

--- a/lib/manager/gradle/index.js
+++ b/lib/manager/gradle/index.js
@@ -9,14 +9,37 @@ const GRADLE_DEPENDENCY_REPORT_COMMAND =
 const GRADLE_DEPENDENCY_REPORT_FILENAME = 'build/dependencyUpdates/report.json';
 const TIMEOUT_CODE = 143;
 
-async function preExtract(config, packageFiles) {
-  // eslint-disable-next-line guard-for-in
-  for (const fileName in packageFiles) {
-    await mkdirp(config.localDir, fileName);
-    const gradleFile = path.join(config.localDir, fileName);
-    logger.debug(`preExtract=${fileName}`);
-    await fs.writeFile(gradleFile, packageFiles[fileName]);
+async function extractAllFiles(config, packageFiles) {
+  if (!packageFiles.some(packageFile => packageFile === 'build.gradle')) {
+    logger.warn('No root build.gradle found - skipping');
   }
+  logger.info('Extracting dependencies from all gradle files');
+  // Gradle needs all files to be written to disk before we parse any as some files may reference others
+  // But if we're using gitFs then it's not necessary because they're already there
+  if (!config.gitFs) {
+    for (const packageFile of packageFiles) {
+      const localFileName = path.join(config.localDir, packageFile);
+      const content = await platform.getFile(packageFile);
+      await fs.outputFile(localFileName, content);
+    }
+  }
+  const gradleFiles = [];
+  for (const packageFile of packageFiles) {
+    const content = await platform.getFile(packageFile);
+    if (content) {
+      const deps = await extractDependencies(content, packageFile, config);
+      if (deps) {
+        gradleFiles.push({
+          packageFile,
+          manager: 'gradle',
+          ...deps,
+        });
+      }
+    } else {
+      logger.info({ packageFile }, 'packageFile has no content');
+    }
+  }
+  return gradleFiles;
 }
 
 async function extractDependencies(content, fileName, config) {
@@ -153,20 +176,6 @@ async function executeGradle(config) {
   return true;
 }
 
-async function mkdirp(localDir, dir) {
-  const parts = path.dirname(dir).split('/');
-
-  for (let i = 1; i <= parts.length; i += 1) {
-    const pathToCreate = path.join.apply(
-      null,
-      [localDir].concat(parts.slice(0, i))
-    );
-    if (!(await fs.pathExists(pathToCreate))) {
-      await fs.mkdir(pathToCreate);
-    }
-  }
-}
-
 function isProjectRootGradle(fileName) {
   return fileName === 'build.gradle';
 }
@@ -176,9 +185,8 @@ function getDockerRenovateGradleCommandLine(localDir) {
 }
 
 module.exports = {
-  extractDependencies,
+  extractAllFiles,
   getPackageUpdates,
-  preExtract,
   updateDependency,
   language: 'java',
 };

--- a/lib/manager/index.js
+++ b/lib/manager/index.js
@@ -36,9 +36,9 @@ module.exports = {
 };
 
 const managerFunctions = [
+  'extractAllFiles',
   'extractDependencies',
   'postExtract',
-  'preExtract',
   'getPackageUpdates',
   'updateDependency',
   'supportsLockFileMaintenance',

--- a/lib/manager/index.js
+++ b/lib/manager/index.js
@@ -36,7 +36,7 @@ module.exports = {
 };
 
 const managerFunctions = [
-  'extractAllFiles',
+  'extractAllPackageFiles',
   'extractPackageFile',
   'getPackageUpdates',
   'updateDependency',

--- a/lib/manager/index.js
+++ b/lib/manager/index.js
@@ -38,7 +38,6 @@ module.exports = {
 const managerFunctions = [
   'extractAllFiles',
   'extractDependencies',
-  'postExtract',
   'getPackageUpdates',
   'updateDependency',
   'supportsLockFileMaintenance',

--- a/lib/manager/npm/extract/index.js
+++ b/lib/manager/npm/extract/index.js
@@ -8,9 +8,29 @@ const versioning = require('../../../versioning');
 const semver = versioning('semver');
 
 module.exports = {
-  extractDependencies,
-  postExtract,
+  extractAllFiles,
 };
+
+async function extractAllFiles(config, packageFiles) {
+  const npmFiles = [];
+  for (const packageFile of packageFiles) {
+    const content = await platform.getFile(packageFile);
+    if (content) {
+      const deps = await extractDependencies(content, packageFile, config);
+      if (deps) {
+        npmFiles.push({
+          packageFile,
+          manager: 'npm',
+          ...deps,
+        });
+      }
+    } else {
+      logger.info({ packageFile }, 'packageFile has no content');
+    }
+  }
+  await postExtract(npmFiles);
+  return npmFiles;
+}
 
 async function extractDependencies(content, fileName, config) {
   logger.debug(`npm.extractDependencies(${fileName})`);

--- a/lib/manager/npm/extract/index.js
+++ b/lib/manager/npm/extract/index.js
@@ -8,10 +8,10 @@ const versioning = require('../../../versioning');
 const semver = versioning('semver');
 
 module.exports = {
-  extractAllFiles,
+  extractAllPackageFiles,
 };
 
-async function extractAllFiles(config, packageFiles) {
+async function extractAllPackageFiles(config, packageFiles) {
   const npmFiles = [];
   for (const packageFile of packageFiles) {
     const content = await platform.getFile(packageFile);

--- a/lib/manager/npm/extract/index.js
+++ b/lib/manager/npm/extract/index.js
@@ -9,6 +9,8 @@ const semver = versioning('semver');
 
 module.exports = {
   extractAllPackageFiles,
+  extractPackageFile,
+  postExtract,
 };
 
 async function extractAllPackageFiles(config, packageFiles) {

--- a/lib/manager/npm/index.js
+++ b/lib/manager/npm/index.js
@@ -1,9 +1,9 @@
-const { extractAllFiles } = require('./extract');
+const { extractAllPackageFiles } = require('./extract');
 const { updateDependency } = require('./update');
 const { getRangeStrategy } = require('./range');
 
 module.exports = {
-  extractAllFiles,
+  extractAllPackageFiles,
   language: 'js',
   getRangeStrategy,
   updateDependency,

--- a/lib/manager/npm/index.js
+++ b/lib/manager/npm/index.js
@@ -1,11 +1,10 @@
-const { extractDependencies, postExtract } = require('./extract');
+const { extractAllFiles } = require('./extract');
 const { updateDependency } = require('./update');
 const { getRangeStrategy } = require('./range');
 
 module.exports = {
-  extractDependencies,
+  extractAllFiles,
   language: 'js',
-  postExtract,
   getRangeStrategy,
   updateDependency,
   supportsLockFileMaintenance: true,

--- a/lib/workers/repository/extract/manager-files.js
+++ b/lib/workers/repository/extract/manager-files.js
@@ -65,6 +65,7 @@ async function getManagerPackageFiles(config, managerConfig) {
         });
       }
     } else {
+      // istanbul ignore next
       logger.info({ packageFile }, 'packageFile has no content');
     }
   }

--- a/lib/workers/repository/extract/manager-files.js
+++ b/lib/workers/repository/extract/manager-files.js
@@ -6,7 +6,6 @@ const {
   extractAllFiles,
   extractDependencies,
   get,
-  postExtract,
 } = require('../../../manager');
 
 const {
@@ -69,7 +68,6 @@ async function getManagerPackageFiles(config, managerConfig) {
       logger.info({ packageFile }, 'packageFile has no content');
     }
   }
-  await postExtract(manager, packageFiles);
   return packageFiles;
 }
 

--- a/lib/workers/repository/extract/manager-files.js
+++ b/lib/workers/repository/extract/manager-files.js
@@ -3,7 +3,7 @@ module.exports = {
 };
 
 const {
-  extractAllFiles,
+  extractAllPackageFiles,
   extractPackageFile,
   get,
 } = require('../../../manager');
@@ -43,8 +43,8 @@ async function getManagerPackageFiles(config, managerConfig) {
       } file(s) for manager ${manager}: ${matchedFiles.join(', ')}`
     );
   }
-  if (get(manager, 'extractAllFiles')) {
-    return extractAllFiles(manager, config, matchedFiles);
+  if (get(manager, 'extractAllPackageFiles')) {
+    return extractAllPackageFiles(manager, config, matchedFiles);
   }
   const packageFiles = [];
   const matchedFilesContent = await extractMatchedFilesContent(matchedFiles);

--- a/lib/workers/repository/extract/manager-files.js
+++ b/lib/workers/repository/extract/manager-files.js
@@ -3,9 +3,10 @@ module.exports = {
 };
 
 const {
+  extractAllFiles,
   extractDependencies,
+  get,
   postExtract,
-  preExtract,
 } = require('../../../manager');
 
 const {
@@ -43,10 +44,11 @@ async function getManagerPackageFiles(config, managerConfig) {
       } file(s) for manager ${manager}: ${matchedFiles.join(', ')}`
     );
   }
+  if (get(manager, 'extractAllFiles')) {
+    return extractAllFiles(manager, config, matchedFiles);
+  }
   const packageFiles = [];
   const matchedFilesContent = await extractMatchedFilesContent(matchedFiles);
-  await preExtract(manager, config, matchedFilesContent);
-
   for (const packageFile of matchedFiles) {
     const content = matchedFilesContent[packageFile];
     if (content) {

--- a/lib/workers/repository/extract/manager-files.js
+++ b/lib/workers/repository/extract/manager-files.js
@@ -43,13 +43,13 @@ async function getManagerPackageFiles(config, managerConfig) {
       } file(s) for manager ${manager}: ${matchedFiles.join(', ')}`
     );
   }
+  // Extract package files synchronously if manager requires it
   if (get(manager, 'extractAllPackageFiles')) {
     return extractAllPackageFiles(manager, config, matchedFiles);
   }
   const packageFiles = [];
-  const matchedFilesContent = await extractMatchedFilesContent(matchedFiles);
   for (const packageFile of matchedFiles) {
-    const content = matchedFilesContent[packageFile];
+    const content = await platform.getFile(packageFile);
     if (content) {
       const res = await extractPackageFile(
         manager,
@@ -69,12 +69,4 @@ async function getManagerPackageFiles(config, managerConfig) {
     }
   }
   return packageFiles;
-}
-
-async function extractMatchedFilesContent(matchedFiles) {
-  const matchedFilesContent = {};
-  for (const packageFile of matchedFiles) {
-    matchedFilesContent[packageFile] = await platform.getFile(packageFile);
-  }
-  return matchedFilesContent;
 }

--- a/test/manager/gradle/index.spec.js
+++ b/test/manager/gradle/index.spec.js
@@ -97,27 +97,24 @@ describe('manager/gradle', () => {
       });
     });
 
-    it('should write the gradle config file in the tmp dir', async () => {
-      await manager.preExtract(config, {
-        'build.gradle': 'content root file',
-        'subproject1/build.gradle': 'content subproject1',
-        'subproject1/subproject2/build.gradle': 'content subproject2',
-      });
+    it('should return null if no build.gradle', async () => {
+      const packageFiles = ['foo/build.gradle'];
+      expect(
+        await manager.extractAllPackageFiles(config, packageFiles)
+      ).toBeNull();
+    });
 
-      expect(toUnix(fs.writeFile.mock.calls[0][0])).toBe(
-        'localDir/build.gradle'
-      );
-      expect(fs.writeFile.mock.calls[0][1]).toBe('content root file');
+    it('should return empty if not content', async () => {
+      const packageFiles = ['build.gradle'];
+      const res = await manager.extractAllPackageFiles(config, packageFiles);
+      expect(res).toEqual([]);
+    });
 
-      expect(toUnix(fs.writeFile.mock.calls[1][0])).toBe(
-        'localDir/subproject1/build.gradle'
-      );
-      expect(fs.writeFile.mock.calls[1][1]).toBe('content subproject1');
-
-      expect(toUnix(fs.writeFile.mock.calls[2][0])).toBe(
-        'localDir/subproject1/subproject2/build.gradle'
-      );
-      expect(fs.writeFile.mock.calls[2][1]).toBe('content subproject2');
+    it('should write files before extracting', async () => {
+      const packageFiles = ['build.gradle'];
+      platform.getFile.mockReturnValue('some content');
+      const res = await manager.extractAllPackageFiles(config, packageFiles);
+      expect(res).not.toBeNull();
     });
 
     it('should configure the useLatestVersion plugin', async () => {

--- a/test/manager/index.spec.js
+++ b/test/manager/index.spec.js
@@ -16,12 +16,12 @@ describe('manager', () => {
       expect(manager.getManagerList()).not.toBe(null);
     });
   });
-  describe('postExtract()', () => {
+  describe('extractAllPackageFiles()', () => {
     it('returns null', () => {
-      expect(manager.postExtract('dockerfile', [])).toBe(null);
+      expect(manager.extractAllPackageFiles('dockerfile', [])).toBe(null);
     });
-    it('returns postExtract', () => {
-      expect(manager.postExtract('npm', [])).not.toBe(null);
+    it('returns non-null', () => {
+      expect(manager.extractAllPackageFiles('npm', [])).not.toBe(null);
     });
   });
 });

--- a/test/workers/repository/extract/__snapshots__/manager-files.spec.js.snap
+++ b/test/workers/repository/extract/__snapshots__/manager-files.spec.js.snap
@@ -1,10 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`workers/repository/extract/manager-files getManagerPackageFiles() returns files 1`] = `
+exports[`workers/repository/extract/manager-files getManagerPackageFiles() returns files with extractAllPackageFiles 1`] = `
 Array [
   Object {
+    "deps": Array [],
+    "lernaClient": "npm",
+    "lernaDir": ".",
+    "lernaPackages": undefined,
     "manager": "npm",
+    "npmLock": "package-lock.json",
+    "npmrc": "{}",
     "packageFile": "package.json",
+    "packageJsonName": undefined,
+    "packageJsonType": "app",
+    "packageJsonVersion": undefined,
+    "pnpmShrinkwrap": "shrinkwrap.yaml",
+    "skipInstalls": true,
+    "yarnLock": "yarn.lock",
+    "yarnWorkspacesPackages": undefined,
+    "yarnrc": "{}",
+  },
+]
+`;
+
+exports[`workers/repository/extract/manager-files getManagerPackageFiles() returns files with extractPackageFile 1`] = `
+Array [
+  Object {
+    "manager": "dockerfile",
+    "packageFile": "Dockerfile",
     "some": "result",
   },
 ]

--- a/test/workers/repository/extract/manager-files.spec.js
+++ b/test/workers/repository/extract/manager-files.spec.js
@@ -3,6 +3,7 @@ const {
 } = require('../../../../lib/workers/repository/extract/manager-files');
 const fileMatch = require('../../../../lib/workers/repository/extract/file-match');
 const npm = require('../../../../lib/manager/npm');
+const dockerfile = require('../../../../lib/manager/dockerfile');
 
 jest.mock('../../../../lib/workers/repository/extract/file-match');
 
@@ -30,7 +31,15 @@ describe('workers/repository/extract/manager-files', () => {
       const res = await getManagerPackageFiles(config, managerConfig);
       expect(res).toHaveLength(0);
     });
-    it('returns files', async () => {
+    it('returns files with extractPackageFile', async () => {
+      const managerConfig = { manager: 'dockerfile', enabled: true };
+      fileMatch.getMatchingFiles.mockReturnValue(['Dockerfile']);
+      platform.getFile.mockReturnValue('some content');
+      dockerfile.extractPackageFile = jest.fn(() => ({ some: 'result' }));
+      const res = await getManagerPackageFiles(config, managerConfig);
+      expect(res).toMatchSnapshot();
+    });
+    it('returns files with extractAllPackageFiles', async () => {
       const managerConfig = { manager: 'npm', enabled: true };
       fileMatch.getMatchingFiles.mockReturnValue(['package.json']);
       platform.getFile.mockReturnValue('{}');


### PR DESCRIPTION
This internalises the existing `preExtract` and `postExtract` functions to be replaced with a new `extractAllFiles` function. Most package managers can parse/extract multiple files in parallel, but some require processing them all synchronously. Using this single function instead of preExtract + extract or extract + postExtract makes more logical sense.

Closes #2694