### PR TITLE
fix(gitlab): getPrFiles throw `TypeError: files.map is not a function`.

### DIFF
--- a/lib/platform/gitlab/index.js
+++ b/lib/platform/gitlab/index.js
@@ -715,8 +715,8 @@ async function getPrFiles(mrNo) {
   }
   const files = (await get(
     `projects/${config.repository}/merge_requests/${mrNo}/changes`
-  )).body;
-  return files.map(f => f.filename);
+  )).body.changes;
+  return files.map(f => f.new_path);
 }
 
 // istanbul ignore next

--- a/test/platform/gitlab/index.spec.js
+++ b/test/platform/gitlab/index.spec.js
@@ -870,10 +870,12 @@ describe('platform/gitlab', () => {
     });
     it('returns files', async () => {
       get.mockReturnValueOnce({
-        body: [
-          { filename: 'renovate.json' },
-          { filename: 'not renovate.json' },
-        ],
+        body: {
+          changes: [
+            { new_path: 'renovate.json' },
+            { new_path: 'not renovate.json' },
+          ],
+        },
       });
       const prFiles = await gitlab.getPrFiles(123);
       expect(prFiles).toMatchSnapshot();


### PR DESCRIPTION
In `getPrFiles` function, when requesting MR changes to GitLab API
(in order to return files modified by the MR), we should iterate over
`changes` property in the HTTP body response, and return `new_path` as
the filename.
See: https://docs.gitlab.com/ee/api/merge_requests.html#get-single-mr-changes
