### PR TITLE
feat: suppressNotifications onboardingClose

### DIFF
--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -1359,7 +1359,7 @@ const options = [
       'prEditNotification',
       'branchAutomergeFailure',
       'lockFileErrors',
-      'onboardingClose'
+      'onboardingClose',
     ],
     cli: false,
     env: false,

--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -1359,6 +1359,7 @@ const options = [
       'prEditNotification',
       'branchAutomergeFailure',
       'lockFileErrors',
+      'onboardingClose'
     ],
     cli: false,
     env: false,

--- a/lib/workers/repository/onboarding/branch/check.js
+++ b/lib/workers/repository/onboarding/branch/check.js
@@ -60,12 +60,14 @@ const isOnboarded = async config => {
     return true;
   }
   logger.info('Repo is not onboarded and no merged PRs exist');
-  // ensure PR comment
-  await platform.ensureComment(
-    pr.number,
-    'Renovate is disabled',
-    'Renovate is disabled due to lack of config. If you wish to reenable it, you can either (a) commit a Renovate config to your base branch, or (b) rename this closed PR to trigger a replacement onboarding PR.'
-  );
+  if (!config.suppressNotifications.includes('onboardingClose')) {
+    // ensure PR comment
+    await platform.ensureComment(
+      pr.number,
+      'Renovate is disabled',
+      'Renovate is disabled due to lack of config. If you wish to reenable it, you can either (a) commit a Renovate config to your base branch, or (b) rename this closed PR to trigger a replacement onboarding PR.'
+    );
+  }
   throw new Error('disabled');
 };
 


### PR DESCRIPTION
<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate
-->

New suppressNotifications option "onboardingClose" to skip this comment: 'Renovate is disabled',

Closes #2913 
