### PR TITLE
docs: Fix logging example

### DIFF
--- a/lib/config/cli.js
+++ b/lib/config/cli.js
@@ -64,7 +64,7 @@ function getConfig(input) {
     console.log('');
     console.log('    $ renovate --token abc123 singapore/lint-condo');
     console.log(
-      '    $ renovate --labels=renovate,dependency --ignore-unstable=false --log-level verbose singapore/lint-condo'
+      '    $ renovate --labels=renovate,dependency --ignore-unstable=false --log-level debug singapore/lint-condo'
     );
     console.log('    $ renovate singapore/lint-condo singapore/package-test');
     /* eslint-enable no-console */


### PR DESCRIPTION
`verbose` is not a valid level.