### PR TITLE
fix: got needs url parsed for basic-auth in url

### DIFF
--- a/lib/datasource/pypi.js
+++ b/lib/datasource/pypi.js
@@ -51,7 +51,7 @@ async function getDependency(depName, hostUrl, compatibility) {
   const lookupUrl = url.resolve(hostUrl, `${depName}/json`);
   try {
     const dependency = {};
-    const rep = await got(lookupUrl, {
+    const rep = await got(url.parse(lookupUrl), {
       json: true,
     });
     const dep = rep && rep.body;

--- a/test/datasource/__snapshots__/pypi.spec.js.snap
+++ b/test/datasource/__snapshots__/pypi.spec.js.snap
@@ -125,7 +125,20 @@ Object {
 exports[`datasource/pypi getPkgReleases supports custom datasource url 1`] = `
 Array [
   Array [
-    "https://custom.pypi.net/azure-cli-monitor/json",
+    Url {
+      "auth": null,
+      "hash": null,
+      "host": "custom.pypi.net",
+      "hostname": "custom.pypi.net",
+      "href": "https://custom.pypi.net/azure-cli-monitor/json",
+      "path": "/azure-cli-monitor/json",
+      "pathname": "/azure-cli-monitor/json",
+      "port": null,
+      "protocol": "https:",
+      "query": null,
+      "search": null,
+      "slashes": true,
+    },
     Object {
       "json": true,
     },
@@ -136,7 +149,20 @@ Array [
 exports[`datasource/pypi getPkgReleases supports custom datasource url from environmental variable 1`] = `
 Array [
   Array [
-    "https://my.pypi.python/pypi/azure-cli-monitor/json",
+    Url {
+      "auth": null,
+      "hash": null,
+      "host": "my.pypi.python",
+      "hostname": "my.pypi.python",
+      "href": "https://my.pypi.python/pypi/azure-cli-monitor/json",
+      "path": "/pypi/azure-cli-monitor/json",
+      "pathname": "/pypi/azure-cli-monitor/json",
+      "port": null,
+      "protocol": "https:",
+      "query": null,
+      "search": null,
+      "slashes": true,
+    },
     Object {
       "json": true,
     },
@@ -147,13 +173,39 @@ Array [
 exports[`datasource/pypi getPkgReleases supports multiple custom datasource urls 1`] = `
 Array [
   Array [
-    "https://custom.pypi.net/azure-cli-monitor/json",
+    Url {
+      "auth": null,
+      "hash": null,
+      "host": "custom.pypi.net",
+      "hostname": "custom.pypi.net",
+      "href": "https://custom.pypi.net/azure-cli-monitor/json",
+      "path": "/azure-cli-monitor/json",
+      "pathname": "/azure-cli-monitor/json",
+      "port": null,
+      "protocol": "https:",
+      "query": null,
+      "search": null,
+      "slashes": true,
+    },
     Object {
       "json": true,
     },
   ],
   Array [
-    "https://second-index/azure-cli-monitor/json",
+    Url {
+      "auth": null,
+      "hash": null,
+      "host": "second-index",
+      "hostname": "second-index",
+      "href": "https://second-index/azure-cli-monitor/json",
+      "path": "/azure-cli-monitor/json",
+      "pathname": "/azure-cli-monitor/json",
+      "port": null,
+      "protocol": "https:",
+      "query": null,
+      "search": null,
+      "slashes": true,
+    },
     Object {
       "json": true,
     },


### PR DESCRIPTION
When including basic-auth information in the URL, such as
`https://user:pass@my.pypi.repo.xx/repo`, `got` needs this url-parsed to
not throw an error. Since this is common with requirement.txts and
Pipfiles, let’s support this.

Closes #2971
