### PR TITLE
fix(proxy): remove setting proxy-agent as globalAgent - #2966

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -15,7 +15,6 @@ if (envKeys.includes('HTTP_PROXY') || envKeys.includes('HTTPS_PROXY')) {
 
 function patch(httpOrHttps, protocol, proxy) {
   const originalRequest = httpOrHttps.request;
-  httpOrHttps.globalAgent = proxy;
   httpOrHttps.request = function request(options, callback) {
     let opts;
     if (typeof opts === 'string') {


### PR DESCRIPTION
Fixes NO_PROXY support by removing `proxy-agent` as global instance of `Agent` which is used as the default for all HTTP client requests.

Closes #2966 
