### PR TITLE
docs: bundler readme

### DIFF
--- a/lib/manager/bundler/readme.md
+++ b/lib/manager/bundler/readme.md
@@ -4,61 +4,98 @@
 
 #### Name of package manager
 
-Bundler
+[Bundler](https://bundler.io/)
+
+---
 
 #### What language does this support?
 
 Ruby
 
+---
+
 #### Does that language have other (competing?) package managers?
 
 No
+
 
 ## Package File Detection
 
 #### What type of package files and names does it use?
 
-Package - gem. Name - Gemfile or gemspec
+Gemfile or gemspec
+
+---
 
 #### What [fileMatch](https://renovatebot.com/docs/configuration-options/#filematch) pattern(s) should be used?
 
-`/Gemfile|.gemspec/`
+['(^|/)(Gemfile|.gemspec)$']
+
+---
 
 #### Is it likely that many users would need to extend this pattern for custom file names?
 
-No
+Not likely
+
+---
 
 #### Is the fileMatch pattern likely to get many "false hits" for files that have nothing to do with package management?
 
 No
 
+---
+
 ## Parsing and Extraction
 
 #### Can package files have "local" links to each other that need to be resolved?
 
-No
+No local/file references - only to hosted sources like RubyGems
+
+---
 
 #### Is there reason why package files need to be parsed together (in serial) instead of independently?
 
-No
+No, if a project has more than one Bundler file then they can be parsed and processed independently.
+
+---
 
 #### What format/syntax is the package file in? e.g. JSON, TOML, custom?
 
 Ruby syntax
 
+---
+
 #### How do you suggest parsing the file? Using an off-the-shelf parser, using regex, or can it be custom-parsed line by line?
 
-I'm thinking about to use something that can transform ruby code to abstract syntax tree
+It would be quite challenging to parse all the allowable Ruby syntax without using Ruby itself, unless you decide to support only a subset of allowable syntax.
+
+---
 
 #### Does the package file structure distinguish between different "types" of dependencies? e.g. production dependencies, dev dependencies, etc?
 
-Yes, but not sure that it's relevant to Renovate purposes
+Yes, Bundler allows "groups" but these are only for the convenience of users and should not affect the results that Renovate produces.
+
+---
 
 #### List all the sources/syntaxes of dependencies that can be extracted:
 
-Bundler can use multiple gem sources
+Most are regular gem sources. 
+
+> Git repositories are also valid gem sources, as long as the repo contains one or more valid gems. Specify what to check out with `:tag`, `:branch`, or `:ref`. The default is the `master` branch.
+
+Example:
+
+```
+gem 'nokogiri', :git => 'https://github.com/tenderlove/nokogiri.git', :branch => '1.4'
+```
+
+More information: https://bundler.io/v1.5/gemfile.html
+
+---
 
 #### Describe which types of dependencies above are supported and which will be implemented in future:
+
+Skip git dependencies initially. Then support git tags, and then add a github branch datasource and support git branch-based after.
 
 ## Versioning
 
@@ -66,31 +103,43 @@ Bundler can use multiple gem sources
 
 Semantic version scheme
 
-#### Does this versioning scheme support range constraints, e.g. ^1.0.0 or 1.x?
+---
 
-Yes
+#### Does this versioning scheme support range constraints, e.g. `^1.0.0` or `1.x`?
+
+Yes, but different syntax to npm's semver.
+
+---
 
 #### Is this package manager used for applications, libraries, or both? If both, is there a way to tell which is which?
 
-Yes
+Used for both.
+
+---
 
 #### If ranges are supported, are there any cases when Renovate should pin ranges to exact versions if rangeStrategy=auto?
 
-No
+Application pinning to be determined later.
 
 ## Lookup
 
 #### Is a new datasource required? Provide details
 
-No
+Yes, a RubyGems datasource is required to be added.
+
+---
 
 #### Will users need the capability to specify a custom host/registry to look up? Can it be found within the package files, or within other files inside the repository, or would it require Renovate configuration?
 
-Yes, I think it can be achived in both ways.
+Yes, to be specified from within Gemfile (there are multiple ways to define source, e.g. file-wide or per-dependency).
+
+---
 
 #### Do the package files contain any "constraints" on the parent language (e.g. supports only v3.x of Python) or platform (Linux, Windows, etc) that should be used in the lookup procedure?
 
-No
+Yes, Ruby version.
+
+---
 
 #### Will users need the ability to configure language or other constraints using Renovate config?
 
@@ -102,17 +151,23 @@ No
 
 File - Gemfile.lock. Mandatory - Yes
 
+---
+
 #### If so, what tool and exact commands should be used if updating 1 or more package versions in a dependency file?
 
 bundle update
 
+---
+
 #### If applicable, describe how the tool maintains a cache and if it can be controlled via CLI or env? Do you recommend the cache be kept or disabled/ignored?
 
-Bundler has own cache wich can be specified via --local or --no-cache flags
+Bundler has own cache wich can be specified via --local or --no-cache flags. To be determined which works best for Renovate.
+
+---
 
 #### If applicable, what command should be used to generate a lock file from scratch if you already have a package file? This will be used for "lock file maintenance".
 
-If Gemfile.lock missing than bundle check can be used, ff preset then bundle check.
+If Gemfile.lock missing than bundle check can be used.
 
 ## Other
 

--- a/lib/manager/bundler/readme.md
+++ b/lib/manager/bundler/readme.md
@@ -4,39 +4,29 @@
 
 #### Name of package manager
 
-[Bundler](https://bundler.io/)
-
----
+Bundler
 
 #### What language does this support?
 
 Ruby
 
----
-
 #### Does that language have other (competing?) package managers?
 
-No mainstream
+No
 
 ## Package File Detection
 
 #### What type of package files and names does it use?
 
-"Gemfiles", usually named `Gemfile`.
-
----
+Package - gem. Name - Gemfile or gemspec
 
 #### What [fileMatch](https://renovatebot.com/docs/configuration-options/#filematch) pattern(s) should be used?
 
-`["(^|/)Gemfile$]`
-
----
+`/Gemfile|.gemspec/`
 
 #### Is it likely that many users would need to extend this pattern for custom file names?
 
-It's possible, but not a common case.
-
----
+No
 
 #### Is the fileMatch pattern likely to get many "false hits" for files that have nothing to do with package management?
 
@@ -46,27 +36,27 @@ No
 
 #### Can package files have "local" links to each other that need to be resolved?
 
+No
+
 #### Is there reason why package files need to be parsed together (in serial) instead of independently?
-
----
-
-#### What format/syntax is the package file in? e.g. JSON, TOML, custom?
-
----
-
-#### How do you suggest parsing the file? Using an off-the-shelf parser, using regex, or can it be custom-parsed line by line?
-
----
-
-#### Does the package file structure distinguish between different "types" of dependencies? e.g. production dependencies, dev dependencies, etc?
 
 No
 
----
+#### What format/syntax is the package file in? e.g. JSON, TOML, custom?
+
+Ruby syntax
+
+#### How do you suggest parsing the file? Using an off-the-shelf parser, using regex, or can it be custom-parsed line by line?
+
+I'm thinking about to use something that can transform ruby code to abstract syntax tree
+
+#### Does the package file structure distinguish between different "types" of dependencies? e.g. production dependencies, dev dependencies, etc?
+
+Yes, but not sure that it's relevant to Renovate purposes
 
 #### List all the sources/syntaxes of dependencies that can be extracted:
 
----
+Bundler can use multiple gem sources
 
 #### Describe which types of dependencies above are supported and which will be implemented in future:
 
@@ -74,50 +64,58 @@ No
 
 #### What versioning scheme do the package files use?
 
----
+Semantic version scheme
 
-#### Does this versioning scheme support range constraints, e.g. `^1.0.0` or `1.x`?
+#### Does this versioning scheme support range constraints, e.g. ^1.0.0 or 1.x?
 
----
+Yes
 
 #### Is this package manager used for applications, libraries, or both? If both, is there a way to tell which is which?
 
----
+Yes
 
 #### If ranges are supported, are there any cases when Renovate should pin ranges to exact versions if rangeStrategy=auto?
+
+No
 
 ## Lookup
 
 #### Is a new datasource required? Provide details
 
----
+No
 
 #### Will users need the capability to specify a custom host/registry to look up? Can it be found within the package files, or within other files inside the repository, or would it require Renovate configuration?
 
----
+Yes, I think it can be achived in both ways.
 
 #### Do the package files contain any "constraints" on the parent language (e.g. supports only v3.x of Python) or platform (Linux, Windows, etc) that should be used in the lookup procedure?
 
----
+No
 
 #### Will users need the ability to configure language or other constraints using Renovate config?
+
+No
 
 ## Artifacts
 
 #### Are lock files or checksum files used? Mandatory?
 
----
+File - Gemfile.lock. Mandatory - Yes
 
 #### If so, what tool and exact commands should be used if updating 1 or more package versions in a dependency file?
 
----
+bundle update
 
 #### If applicable, describe how the tool maintains a cache and if it can be controlled via CLI or env? Do you recommend the cache be kept or disabled/ignored?
 
----
+Bundler has own cache wich can be specified via --local or --no-cache flags
 
 #### If applicable, what command should be used to generate a lock file from scratch if you already have a package file? This will be used for "lock file maintenance".
+
+If Gemfile.lock missing than bundle check can be used, ff preset then bundle check.
 
 ## Other
 
 #### Is there anything else to know about this package manager?
+
+No

--- a/lib/manager/bundler/readme.md
+++ b/lib/manager/bundler/readme.md
@@ -40,8 +40,6 @@ Not likely
 
 No
 
----
-
 ## Parsing and Extraction
 
 #### Can package files have "local" links to each other that need to be resolved?

--- a/lib/manager/bundler/readme.md
+++ b/lib/manager/bundler/readme.md
@@ -1,5 +1,3 @@
-# Work in Progress
-
 ## Overview
 
 #### Name of package manager
@@ -17,7 +15,6 @@ Ruby
 #### Does that language have other (competing?) package managers?
 
 No
-
 
 ## Package File Detection
 
@@ -79,7 +76,7 @@ Yes, Bundler allows "groups" but these are only for the convenience of users and
 
 #### List all the sources/syntaxes of dependencies that can be extracted:
 
-Most are regular gem sources. 
+Most are regular gem sources.
 
 > Git repositories are also valid gem sources, as long as the repo contains one or more valid gems. Specify what to check out with `:tag`, `:branch`, or `:ref`. The default is the `master` branch.
 


### PR DESCRIPTION
Add documentation for bundler package manager. [Rendered version here](https://github.com/sleekybadger/renovate/blob/53b6ef0ff4824998ef83f9824aac8a986bd7babd/lib/manager/bundler/readme.md).
