### PR TITLE
fix(gitlab): close and reopen MR while rebasing to prevent errorneous GitLab CI message

### DIFF
--- a/lib/platform/gitlab/index.js
+++ b/lib/platform/gitlab/index.js
@@ -264,6 +264,9 @@ async function commitFilesToBranch(
   if (pr) {
     logger.debug('Reopening PR');
     await reopenPr(pr.number);
+    // Close and repoen MR again due to known GitLab bug https://gitlab.com/gitlab-org/gitlab-ce/issues/41545
+    await closePr(pr.number);
+    await reopenPr(pr.number);
   }
   return res;
 }
@@ -272,20 +275,13 @@ function getFile(filePath, branchName) {
   return config.storage.getFile(filePath, branchName);
 }
 
-async function deleteBranch(branchName, closePr = false) {
-  if (closePr) {
+async function deleteBranch(branchName, shouldClosePr = false) {
+  if (shouldClosePr) {
     logger.debug('Closing PR');
     const pr = await getBranchPr(branchName);
     // istanbul ignore if
     if (pr) {
-      await get.put(
-        `projects/${config.repository}/merge_requests/${pr.number}`,
-        {
-          body: {
-            state_event: 'close',
-          },
-        }
-      );
+      await closePr(pr.number);
     }
   }
   return config.storage.deleteBranch(branchName);
@@ -741,6 +737,15 @@ async function reopenPr(iid) {
   await get.put(`projects/${config.repository}/merge_requests/${iid}`, {
     body: {
       state_event: 'reopen',
+    },
+  });
+}
+
+// istanbul ignore next
+async function closePr(iid) {
+  await get.put(`projects/${config.repository}/merge_requests/${iid}`, {
+    body: {
+      state_event: 'close',
     },
   });
 }

--- a/lib/platform/gitlab/index.js
+++ b/lib/platform/gitlab/index.js
@@ -258,15 +258,17 @@ async function commitFilesToBranch(
     message,
     parentBranch
   );
-  // Reopen PR if it previousluy existed and was closed by GitLab when we deleted branch
-  const pr = await getBranchPr(branchName);
-  // istanbul ignore if
-  if (pr) {
-    logger.debug('Reopening PR');
-    await reopenPr(pr.number);
-    // Close and repoen MR again due to known GitLab bug https://gitlab.com/gitlab-org/gitlab-ce/issues/41545
-    await closePr(pr.number);
-    await reopenPr(pr.number);
+  if (config.gitFs !== 'ssh') {
+    // Reopen PR if it previousluy existed and was closed by GitLab when we deleted branch
+    const pr = await getBranchPr(branchName);
+    // istanbul ignore if
+    if (pr) {
+      logger.debug('Reopening PR');
+      await reopenPr(pr.number);
+      // Close and repoen MR again due to known GitLab bug https://gitlab.com/gitlab-org/gitlab-ce/issues/41545
+      await closePr(pr.number);
+      await reopenPr(pr.number);
+    }
   }
   return res;
 }


### PR DESCRIPTION
Currently, using Renovate with GitLab makes GitLab CI to show the error message "Could not connect to the CI server. Please check your settings and try again". This issue is [a known bug of GitLab](https://gitlab.com/gitlab-org/gitlab-ce/issues/41545) and the current workaround is to close and reopen the merge request.

This PR implements the aforementioned workaround.

<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate
-->

<!-- Replace this text with a description of what this PR fixes or adds -->

Closes # N/A
