### PR TITLE
feat: Block automerging if negative reviews exist (github)

### DIFF
--- a/lib/platform/github/index.js
+++ b/lib/platform/github/index.js
@@ -1052,6 +1052,11 @@ async function getOpenPrs() {
                 }
               }
               body
+              reviews(first: 1, states:[CHANGES_REQUESTED]){
+                nodes{
+                  state
+                }
+              }
             }
           }
         }
@@ -1077,11 +1082,10 @@ async function getOpenPrs() {
         delete pr.headRefName;
         // https://developer.github.com/v4/enum/mergeablestate
         const canMergeStates = ['BEHIND', 'CLEAN'];
-        if (canMergeStates.includes(pr.mergeStateStatus)) {
-          pr.canMerge = true;
-        } else {
-          pr.canMerge = false;
-        }
+        const hasNegativeReview =
+          pr.reviews && pr.reviews.nodes && pr.reviews.nodes.length > 0;
+        pr.canMerge =
+          canMergeStates.includes(pr.mergeStateStatus) && !hasNegativeReview;
         // https://developer.github.com/v4/enum/mergestatestatus
         if (pr.mergeStateStatus === 'DIRTY') {
           pr.isConflicted = true;

--- a/website/docs/configuration-options.md
+++ b/website/docs/configuration-options.md
@@ -42,6 +42,8 @@ Also note that this option can be combined with other nested settings, such as d
 
 Warning: GitHub currently has a bug where automerge won't work if a GitHub Organization has protected their master branch, and there is no way to configure around this. Hence, automerging will try and fail in such situations. This doc will be updated once that bug/limitation is fixed by GitHub.
 
+Warning: GitHub won't do automerge if the PR has a negative feedback.
+
 ## automergeComment
 
 Example use:


### PR DESCRIPTION
…canMerge to false.

<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate
-->

If an automerging PR has negative/disapproving reviews, then do not automerge it until they are approved or dismissed.

Closes #2949 
