### PR TITLE
feat: deprecate platform env

### DIFF
--- a/lib/config/env.js
+++ b/lib/config/env.js
@@ -39,51 +39,11 @@ function getConfig(env) {
     }
   });
 
-  if (env.GITHUB_TOKEN) {
-    config.hostRules.push({
-      platform: 'github',
-      endpoint: env.GITHUB_ENDPOINT,
-      token: env.GITHUB_TOKEN,
-      default: true,
-    });
-  }
-
   if (env.GITHUB_COM_TOKEN) {
     config.hostRules.push({
       endpoint: 'https://api.github.com/',
       platform: 'github',
       token: env.GITHUB_COM_TOKEN,
-    });
-  }
-
-  if (env.GITLAB_TOKEN) {
-    config.hostRules.push({
-      platform: 'gitlab',
-      endpoint: env.GITLAB_ENDPOINT,
-      token: env.GITLAB_TOKEN,
-    });
-  }
-
-  if (env.BITBUCKET_TOKEN) {
-    config.hostRules.push({
-      platform: 'bitbucket',
-      endpoint: env.BITBUCKET_ENDPOINT,
-      token: env.BITBUCKET_TOKEN,
-    });
-  } else if (env.BITBUCKET_USERNAME && env.BITBUCKET_PASSWORD) {
-    const base64 = str => Buffer.from(str, 'binary').toString('base64');
-    config.hostRules.push({
-      platform: 'bitbucket',
-      endpoint: env.BITBUCKET_ENDPOINT,
-      token: base64(`${env.BITBUCKET_USERNAME}:${env.BITBUCKET_PASSWORD}`),
-    });
-  }
-
-  if (env.VSTS_ENDPOINT || env.VSTS_TOKEN) {
-    config.hostRules.push({
-      platform: 'vsts',
-      endpoint: env.VSTS_ENDPOINT,
-      token: env.VSTS_TOKEN,
     });
   }
 
@@ -95,23 +55,20 @@ function getConfig(env) {
     });
   }
 
-  if (config.platform === 'gitlab') {
-    config.endpoint = env.GITLAB_ENDPOINT;
-  } else if (config.platform === 'vsts') {
-    config.endpoint = env.VSTS_ENDPOINT;
-  } else if (env.GITHUB_ENDPOINT) {
-    // GitHub is default
-    config.endpoint = env.GITHUB_ENDPOINT;
-  }
-
-  /* eslint-disable no-param-reassign */
-  delete env.GITHUB_TOKEN;
-  delete env.GITHUB_ENDPOINT;
-  delete env.GITHUB_COM_TOKEN;
-  delete env.GITLAB_TOKEN;
-  delete env.GITLAB_ENDPOINT;
-  delete env.VSTS_TOKEN;
-  delete env.VSTS_ENDPOINT;
+  // These env vars are deprecated and deleted to make sure they're not used
+  const unsupportedEnv = [
+    'BITBUCKET_TOKEN',
+    'BITBUCKET_USERNAME',
+    'BITBUCKET_PASSWORD',
+    'GITHUB_ENDPOINT',
+    'GITHUB_TOKEN',
+    'GITLAB_ENDPOINT',
+    'GITLAB_TOKEN',
+    'VSTS_ENDPOINT',
+    'VSTS_TOKEN',
+  ];
+  // eslint-disable-next-line no-param-reassign
+  unsupportedEnv.forEach(val => delete env[val]);
 
   return config;
 }

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -96,10 +96,9 @@ async function parseConfigs(env, argv) {
       const base64 = str => Buffer.from(str, 'binary').toString('base64');
       token = base64(`${username}:${password}`);
     } else {
-      logger.error(
+      throw new Error(
         `No authentication found for platform ${endpoint} (${platform})`
       );
-      process.exit();
     }
   }
   config.hostRules.push({

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -83,12 +83,32 @@ async function parseConfigs(env, argv) {
   // Get global config
   logger.trace({ config }, 'Full config');
 
-  // Check platforms and tokens
-  const { platform, endpoint, username, password, token } = config;
+  // Check platform and authentication
+  const { platform, username, password } = config;
   const platformInfo = hostRules.defaults[platform];
   if (!platformInfo) {
     throw new Error(`Unsupported platform: ${config.platform}.`);
   }
+  const endpoint = config.endpoint || platformInfo.endpoint;
+  let token = config.token;
+  if (!token) {
+    if (username && password) {
+      const base64 = str => Buffer.from(str, 'binary').toString('base64');
+      token = base64(`${username}:${password}`);
+    } else {
+      logger.error(
+        `No authentication found for platform ${endpoint} (${platform})`
+      );
+      process.exit();
+    }
+  }
+  config.hostRules.push({
+    platform,
+    endpoint,
+    username,
+    password,
+    token,
+  });
   config.hostRules.forEach(hostRules.update);
   delete config.hostRules;
   delete config.token;


### PR DESCRIPTION
Deprecate use of “special” env var like `GITHUB_TOKEN` and instead standardize on `RENOVATE_*` environment variables instead.

Closes #2834

BREAKING CHANGE: For GitHub, GitLab, Bitbucket and VSTS you need to migrate `*_ENDPOINT` to `RENOVATE_ENDPOINT`, `*_TOKEN` to `RENOVATE_TOKEN`, and same for `BITBUCKET_USERNAME` and `BITBUCKET_PASSWORD`.