### PR TITLE
add release notes babel-preset-react-app

### DIFF
--- a/lib/datasource/metadata.js
+++ b/lib/datasource/metadata.js
@@ -8,6 +8,8 @@ module.exports = {
 // Only necessary when the changelog data cannot be found in the package's source repository
 const manualChangelogUrls = {
   npm: {
+    'babel-preset-react-app':
+      'https://github.com/facebook/create-react-app/releases',
     firebase: 'https://firebase.google.com/support/release-notes/js',
     'flow-bin': 'https://github.com/facebook/flow/blob/master/Changelog.md',
     'react-native':


### PR DESCRIPTION
the preset package notes are written in the create-react-app github releases
https://github.com/facebook/create-react-app/releases

<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate
-->

<!-- Replace this text with a description of what this PR fixes or adds -->

Closes # <!-- Ideally each PR should be closing an open issue -->
