### PR TITLE
docs: Fix pinDigests documentation to match option default

### DIFF
--- a/website/docs/configuration-options.md
+++ b/website/docs/configuration-options.md
@@ -625,7 +625,7 @@ Add to this object if you wish to define rules that apply only to PRs that pin d
 
 ## pinDigests
 
-By default, Renovate will add sha256 digests to Docker source images so that they are then "immutable". Set this to false to continue using only tags to identify source images.
+If enabled Renovate will pin docker images by means of their sha256 digest and not only by tag so that they are immutable.
 
 ## pip_requirements
 


### PR DESCRIPTION
Default was changed to false but text was not adjusted.

* https://renovatebot.com/docs/configuration-options/#pindigests
* https://github.com/renovatebot/renovate/blame/master/lib/config/definitions.js#L542

<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate
-->

<!-- Replace this text with a description of what this PR fixes or adds -->

Closes # <!-- Ideally each PR should be closing an open issue -->
