### PR TITLE
feat: node version 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,14 @@ notifications:
 language: node_js
 
 node_js:
-  - "8.11.1"
+  - '10.15.0'
 
 sudo: false
 
 branches:
   only:
-  - master
-  - stable
+    - master
+    - stable
 
 if: tag IS blank
 
@@ -27,9 +27,9 @@ install:
 cache:
   yarn: true
   directories:
-    - ".cache"
-    - ".eslintcache"
-    - "node_modules"
+    - '.cache'
+    - '.eslintcache'
+    - 'node_modules'
 
 script:
   - yarn prettier --list-different

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   },
   "homepage": "https://renovatebot.com",
   "engines": {
-    "node": ">= 8.11.0"
+    "node": ">= 10.14.0"
   },
   "dependencies": {
     "@renovate/pep440": "0.4.1",


### PR DESCRIPTION
Updates required Node.js versions in package.json>engines and Travis.

BREAKING CHANGE: Renovate now requires Node.js 10 or greater
