### PR TITLE
refactor: replace fast-xml-parser dependency to xmldoc

### DIFF
--- a/lib/datasource/maven.js
+++ b/lib/datasource/maven.js
@@ -1,8 +1,7 @@
-const _ = require('lodash');
 const got = require('got');
 const url = require('url');
 const fs = require('fs-extra');
-const xmlParser = require('fast-xml-parser');
+const { XmlDocument } = require('xmldoc');
 
 module.exports = {
   getPkgReleases,
@@ -96,10 +95,11 @@ async function downloadMavenMetadata(dependency, repoUrl) {
 }
 
 function extractVersions(mavenMetadata) {
-  const doc = xmlParser.parse(mavenMetadata);
-  return _.get(doc, 'metadata.versioning.versions.version', []).map(v =>
-    String(v)
-  );
+  const doc = new XmlDocument(mavenMetadata);
+  const versions = doc.descendantWithPath('versioning.versions');
+  const elements = versions && versions.childrenNamed('version');
+  if (!elements) return [];
+  return elements.map(el => el.val);
 }
 
 async function downloadFileProtocol(pkgUrl) {

--- a/lib/datasource/nuget/index.js
+++ b/lib/datasource/nuget/index.js
@@ -1,6 +1,6 @@
 const parse = require('github-url-from-git');
 const got = require('got');
-const xmlParser = require('fast-xml-parser');
+const { XmlDocument } = require('xmldoc');
 
 module.exports = {
   getPkgReleases,
@@ -23,9 +23,11 @@ async function getPkgReleases(purl) {
     const url = `https://api.nuget.org/v3-flatcontainer/${name.toLowerCase()}/${res.versions.pop()}/${name.toLowerCase()}.nuspec`;
     try {
       const result = await got(url);
-      const nuspec = xmlParser.parse(result.body, { ignoreAttributes: false });
+      const nuspec = new XmlDocument(result.body);
       if (nuspec) {
-        const sourceUrl = parse(nuspec.package.metadata.repository['@_url']);
+        const sourceUrl = parse(
+          nuspec.valueWithPath('metadata.repository@url')
+        );
         if (sourceUrl) {
           dep.sourceUrl = sourceUrl;
         }

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "upath": "1.1.0",
     "validator": "10.9.0",
     "www-authenticate": "0.6.2",
-    "xmldoc": "^1.1.2",
+    "xmldoc": "1.1.2",
     "yarn": "1.9.4",
     "@snyk/ruby-semver": "2.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
     "detect-indent": "5.0.0",
     "email-addresses": "3.0.3",
     "fast-clone": "1.5.3",
-    "fast-xml-parser": "3.12.12",
     "form-data": "2.3.3",
     "fs-extra": "7.0.1",
     "get-installed-path": "4.0.8",
@@ -137,6 +136,7 @@
     "upath": "1.1.0",
     "validator": "10.9.0",
     "www-authenticate": "0.6.2",
+    "xmldoc": "^1.1.2",
     "yarn": "1.9.4",
     "@snyk/ruby-semver": "2.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9200,7 +9200,7 @@ xml-name-validator@^3.0.0:
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
 
-xmldoc@^1.1.2:
+xmldoc@1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/xmldoc/-/xmldoc-1.1.2.tgz#6666e029fe25470d599cd30e23ff0d1ed50466d7"
   integrity sha512-ruPC/fyPNck2BD1dpz0AZZyrEwMOrWTO5lDdIXS91rs3wtm4j+T8Rp2o+zoOYkkAxJTZRPOSnOGei1egoRmKMQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2693,13 +2693,6 @@ fast-safe-stringify@^1.1.3:
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-1.2.3.tgz#9fe22c37fb2f7f86f06b8f004377dbf8f1ee7bc1"
   integrity sha512-QJYT/i0QYoiZBQ71ivxdyTqkwKkQ0oxACXHYxH2zYHJEgzi2LsbjgvtzTbLi1SZcF190Db2YP7I7eTsU2egOlw==
 
-fast-xml-parser@3.12.12:
-  version "3.12.12"
-  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-3.12.12.tgz#f45b738f8283e42ecd193a8621de87108b4764b4"
-  integrity sha512-8fZ3+lyB36Yqxr5q4LT5T/0e9EU9IipstotFLin6EUsC1kN8iEy9wgBvie/hULX3p3YYjJxKQCf1J0UaB5jZPg==
-  dependencies:
-    nimnjs "^1.3.2"
-
 fb-watchman@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-2.0.0.tgz#54e9abf7dfa2f26cd9b1636c588c1afc05de5d58"
@@ -5702,24 +5695,6 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.4.tgz#d93962f6c52f2c1558c0fbda6d512819f1efe1c4"
   integrity sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA==
 
-nimn-date-parser@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/nimn-date-parser/-/nimn-date-parser-1.0.0.tgz#4ce55d1fd5ea206bbe82b76276f7b7c582139351"
-  integrity sha512-1Nf+x3EeMvHUiHsVuEhiZnwA8RMeOBVTQWfB1S2n9+i6PYCofHd2HRMD+WOHIHYshy4T4Gk8wQoCol7Hq3av8Q==
-
-nimn_schema_builder@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/nimn_schema_builder/-/nimn_schema_builder-1.1.0.tgz#b370ccf5b647d66e50b2dcfb20d0aa12468cd247"
-  integrity sha512-DK5/B8CM4qwzG2URy130avcwPev4uO0ev836FbQyKo1ms6I9z/i6EJyiZ+d9xtgloxUri0W+5gfR8YbPq7SheA==
-
-nimnjs@^1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/nimnjs/-/nimnjs-1.3.2.tgz#a6a877968d87fad836375a4f616525e55079a5ba"
-  integrity sha512-TIOtI4iqkQrUM1tiM76AtTQem0c7e56SkDZ7sj1d1MfUsqRcq2ZWQvej/O+HBTZV7u/VKnwlKTDugK/75IRPPw==
-  dependencies:
-    nimn-date-parser "^1.0.0"
-    nimn_schema_builder "^1.0.0"
-
 nock@10.0.4:
   version "10.0.4"
   resolved "https://registry.yarnpkg.com/nock/-/nock-10.0.4.tgz#44f5dcfe0a6b09f95d541f6b3f057cfabbbd2a3a"
@@ -7774,7 +7749,7 @@ sane@^2.0.0:
   optionalDependencies:
     fsevents "^1.2.3"
 
-sax@^1.2.4:
+sax@^1.2.1, sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -9224,6 +9199,13 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+
+xmldoc@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/xmldoc/-/xmldoc-1.1.2.tgz#6666e029fe25470d599cd30e23ff0d1ed50466d7"
+  integrity sha512-ruPC/fyPNck2BD1dpz0AZZyrEwMOrWTO5lDdIXS91rs3wtm4j+T8Rp2o+zoOYkkAxJTZRPOSnOGei1egoRmKMQ==
+  dependencies:
+    sax "^1.2.1"
 
 xregexp@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Xmldoc is better when position of tag in original file is needed, so we'll be able to replace versions easily.
