### PR TITLE
feat: compare depTypes to depType (WIP)

### DIFF
--- a/lib/util/package-rules.js
+++ b/lib/util/package-rules.js
@@ -33,6 +33,7 @@ function applyPackageRules(inputConfig) {
       languages,
       managers,
       depTypeList,
+      depTypes,
       packageNames,
       packagePatterns,
       excludePackageNames,
@@ -45,6 +46,7 @@ function applyPackageRules(inputConfig) {
     paths = paths || [];
     languages = languages || [];
     managers = managers || [];
+    depTypes = depTypes || [];
     depTypeList = depTypeList || [];
     packageNames = packageNames || [];
     packagePatterns = packagePatterns || [];
@@ -67,6 +69,11 @@ function applyPackageRules(inputConfig) {
         rulePath =>
           packageFile.includes(rulePath) || minimatch(packageFile, rulePath)
       );
+      positiveMatch = positiveMatch || isMatch;
+      negativeMatch = negativeMatch || !isMatch;
+    }
+    if (depTypes.length) {
+      const isMatch = depTypes.includes(depType);
       positiveMatch = positiveMatch || isMatch;
       negativeMatch = negativeMatch || !isMatch;
     }


### PR DESCRIPTION
Currently packageRules evaluation (inside lib/util) will compare depTypeList to depType. We need to also compare it against the depTypes array if one is present.

<!-- Replace this text with a description of what this PR fixes or adds -->

Closes #3076 
