### PR TITLE
fix: add bin to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -99,6 +99,7 @@ COPY package.json .
 COPY yarn.lock .
 RUN yarn install --production && yarn cache clean
 COPY lib lib
+COPY bin bin
 
 ENTRYPOINT ["node", "/usr/src/app/lib/renovate.js"]
 CMD ["--help"]


### PR DESCRIPTION
forgotten in 8796b6123cdbc9bef99069184fd54cc719d87b49

fixes `Error: Cannot find module '/usr/src/app/bin/yarn-1.10.1.js'`