### PR TITLE
chore(deps): Loosen engines to be v10 at first LTS

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   },
   "homepage": "https://renovatebot.com",
   "engines": {
-    "node": ">= 10.14.0"
+    "node": ">= 10.13.0"
   },
   "dependencies": {
     "@renovate/pep440": "0.4.1",


### PR DESCRIPTION
Closes #3104 

This slightly loosens the engine check to be `>=10.13` which is when Node 10 first went into LTS. 
