### PR TITLE
perf(gitlab): Use gitlab's API to find renovate branches

### DIFF
--- a/lib/platform/gitlab/storage.js
+++ b/lib/platform/gitlab/storage.js
@@ -71,15 +71,14 @@ class Storage {
 
     async function getAllRenovateBranches(branchPrefix) {
       logger.debug(`getAllRenovateBranches(${branchPrefix})`);
+
+      const search = urlEscape(`^${branchPrefix}`);
+
       const allBranches = await get(
-        `projects/${config.repository}/repository/branches`
+        `projects/${config.repository}/repository/branches?search=${search}`,
+        { paginate: true }
       );
-      return allBranches.body.reduce((arr, branch) => {
-        if (branch.name.startsWith(branchPrefix)) {
-          arr.push(branch.name);
-        }
-        return arr;
-      }, []);
+      return allBranches.body.map(branch => branch.name);
     }
 
     async function isBranchStale(branchName) {

--- a/test/platform/gitlab/index.spec.js
+++ b/test/platform/gitlab/index.spec.js
@@ -257,20 +257,24 @@ describe('platform/gitlab', () => {
   });
   describe('getAllRenovateBranches()', () => {
     it('should return all renovate branches', async () => {
-      get.mockImplementationOnce(() => ({
-        body: [
-          {
-            name: 'renovate/a',
-          },
-          {
-            name: 'master',
-          },
-          {
-            name: 'renovate/b',
-          },
-        ],
-      }));
-      const res = await gitlab.getAllRenovateBranches('renovate/');
+      const search = 'renovate/';
+      get.mockImplementationOnce(path => {
+        expect(path).toBe(
+          'projects/undefined/repository/branches?search=^renovate%2F'
+        );
+
+        return {
+          body: [
+            {
+              name: 'renovate/a',
+            },
+            {
+              name: 'renovate/b',
+            },
+          ],
+        };
+      });
+      const res = await gitlab.getAllRenovateBranches(search);
       expect(res).toMatchSnapshot();
     });
   });


### PR DESCRIPTION
Instead of retrieving all branches and filtering later on, we make use
of GitLab's search: https://docs.gitlab.com/ee/api/branches.html
