### PR TITLE
fix(docker): don't send manifest header when fetching tag list

### DIFF
--- a/lib/datasource/docker/index.js
+++ b/lib/datasource/docker/index.js
@@ -266,7 +266,9 @@ async function getTags(registry, repository) {
       'docker.getTags() error'
     );
     if (err.statusCode === 404 && !repository.includes('/')) {
-      logger.info(`Retrying Tags for ${registry}/${repository} using library/ prefix`);
+      logger.info(
+        `Retrying Tags for ${registry}/${repository} using library/ prefix`
+      );
       return getTags(registry, 'library/' + repository);
     }
     if (err.statusCode === 401) {

--- a/lib/datasource/docker/index.js
+++ b/lib/datasource/docker/index.js
@@ -67,7 +67,6 @@ async function getAuthHeaders(registry, repository) {
     }
     return {
       Authorization: `Bearer ${token}`,
-      Accept: 'application/vnd.docker.distribution.manifest.v2+json',
     };
   } catch (err) /* istanbul ignore next */ {
     if (err.statusCode === 401) {
@@ -266,8 +265,17 @@ async function getTags(registry, repository) {
       },
       'docker.getTags() error'
     );
-    if (err.statusCode === 406 && !repository.includes('/')) {
-      logger.info('Retrying docker repository using library/ prefix');
+    if (err.statusCode === 404 && !repository.includes('/')) {
+      logger.info(
+        'Retrying getting Tags for ' +
+          registry +
+          '/' +
+          repository +
+          ' using library/ prefix  -> ' +
+          registry +
+          '/library/' +
+          repository
+      );
       return getTags(registry, 'library/' + repository);
     }
     if (err.statusCode === 401) {

--- a/lib/datasource/docker/index.js
+++ b/lib/datasource/docker/index.js
@@ -266,16 +266,7 @@ async function getTags(registry, repository) {
       'docker.getTags() error'
     );
     if (err.statusCode === 404 && !repository.includes('/')) {
-      logger.info(
-        'Retrying getting Tags for ' +
-          registry +
-          '/' +
-          repository +
-          ' using library/ prefix  -> ' +
-          registry +
-          '/library/' +
-          repository
-      );
+      logger.info(`Retrying Tags for ${registry}/${repository} using library/ prefix`);
       return getTags(registry, 'library/' + repository);
     }
     if (err.statusCode === 401) {

--- a/test/datasource/__snapshots__/docker.spec.js.snap
+++ b/test/datasource/__snapshots__/docker.spec.js.snap
@@ -23,7 +23,6 @@ exports[`api/docker getPkgReleases adds library/ prefix for Docker Hub (explicit
       "https://index.docker.io/v2/library/node/tags/list?n=10000",
       Object {
         "headers": Object {
-          "Accept": "application/vnd.docker.distribution.manifest.v2+json",
           "Authorization": "Bearer some-token ",
         },
         "json": true,
@@ -87,7 +86,6 @@ exports[`api/docker getPkgReleases adds library/ prefix for Docker Hub (implicit
       "https://index.docker.io/v2/library/node/tags/list?n=10000",
       Object {
         "headers": Object {
-          "Accept": "application/vnd.docker.distribution.manifest.v2+json",
           "Authorization": "Bearer some-token ",
         },
         "json": true,
@@ -151,7 +149,6 @@ exports[`api/docker getPkgReleases adds no library/ prefix for other registries 
       "https://k8s.gcr.io/v2/kubernetes-dashboard-amd64/tags/list?n=10000",
       Object {
         "headers": Object {
-          "Accept": "application/vnd.docker.distribution.manifest.v2+json",
           "Authorization": "Bearer some-token ",
         },
         "json": true,


### PR DESCRIPTION
Artifactory 406 Error when fetching tags

fixes access headers when listing tags
fix for strange behavior when listing tags from artifactory

Closes #3078
