### PR TITLE
docs: specify supported binarySource modes

### DIFF
--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -68,7 +68,8 @@ const options = [
   },
   {
     name: 'binarySource',
-    description: 'Where to source binaries like `npm` and `yarn` from',
+    description:
+      'Where to source binaries like `npm` and `yarn` from, choices are `bundled`, `global` and `docker`',
     admin: true,
     type: 'string',
     default: 'bundled',

--- a/website/docs/self-hosted-configuration.md
+++ b/website/docs/self-hosted-configuration.md
@@ -14,6 +14,7 @@ Be cautious when using this option - it will run Renovate over _every_ repositor
 ## binarySource
 
 Set this to 'global' if you wish Renovate to use globally-installed binaries (`npm`, `yarn`, etc) instead of using its bundled versions.
+Set this to 'docker' instead to use docker-based binaries.
 
 ## dryRun
 


### PR DESCRIPTION
<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate
-->

<!-- Replace this text with a description of what this PR fixes or adds -->
Relative to #3135, I was advised to look at `binarySource` option to specify from where binaries should come from. But I wanted to know possible options and I had to dug the sourcecode to see possible values.
