### PR TITLE
fix(tests): sort setup.py dependencies by lineNumber

### DIFF
--- a/lib/manager/pip_setup/extract.js
+++ b/lib/manager/pip_setup/extract.js
@@ -103,7 +103,12 @@ async function extractPackageFile(content, packageFile, config) {
       };
       return dep;
     })
-    .filter(Boolean);
+    .filter(Boolean)
+    .sort((a, b) =>
+      a.lineNumber === b.lineNumber
+        ? (a.depName > b.depName) - (a.depName < b.depName)
+        : a.lineNumber - b.lineNumber
+    );
   if (!deps.length) {
     return null;
   }

--- a/test/manager/pip_setup/__snapshots__/extract.spec.js.snap
+++ b/test/manager/pip_setup/__snapshots__/extract.spec.js.snap
@@ -4,6 +4,54 @@ exports[`lib/manager/pip_setup/extract extractPackageFile() returns found deps 1
 Object {
   "deps": Array [
     Object {
+      "currentValue": ">=3.1.13.0,<5.0",
+      "depName": "celery",
+      "lineNumber": 36,
+      "purl": "pkg:pypi/celery",
+    },
+    Object {
+      "currentValue": ">=1.7",
+      "depName": "logging_tree",
+      "lineNumber": 39,
+      "purl": "pkg:pypi/logging_tree",
+    },
+    Object {
+      "currentValue": ">=2.2",
+      "depName": "pygments",
+      "lineNumber": 40,
+      "purl": "pkg:pypi/pygments",
+    },
+    Object {
+      "currentValue": ">=5.0",
+      "depName": "psutil",
+      "lineNumber": 41,
+      "purl": "pkg:pypi/psutil",
+    },
+    Object {
+      "currentValue": ">=3.0",
+      "depName": "objgraph",
+      "lineNumber": 42,
+      "purl": "pkg:pypi/objgraph",
+    },
+    Object {
+      "currentValue": ">=1.10,<2.0",
+      "depName": "django",
+      "lineNumber": 45,
+      "purl": "pkg:pypi/django",
+    },
+    Object {
+      "currentValue": ">=0.11,<2.0",
+      "depName": "flask",
+      "lineNumber": 48,
+      "purl": "pkg:pypi/flask",
+    },
+    Object {
+      "currentValue": ">=1.4,<2.0",
+      "depName": "blinker",
+      "lineNumber": 49,
+      "purl": "pkg:pypi/blinker",
+    },
+    Object {
       "currentValue": ">=19.7.0,<20.0",
       "depName": "gunicorn",
       "lineNumber": 61,
@@ -45,54 +93,6 @@ Object {
       "depName": "ipaddress",
       "lineNumber": 67,
       "purl": "pkg:pypi/ipaddress",
-    },
-    Object {
-      "currentValue": ">=3.1.13.0,<5.0",
-      "depName": "celery",
-      "lineNumber": 36,
-      "purl": "pkg:pypi/celery",
-    },
-    Object {
-      "currentValue": ">=0.11,<2.0",
-      "depName": "flask",
-      "lineNumber": 48,
-      "purl": "pkg:pypi/flask",
-    },
-    Object {
-      "currentValue": ">=1.4,<2.0",
-      "depName": "blinker",
-      "lineNumber": 49,
-      "purl": "pkg:pypi/blinker",
-    },
-    Object {
-      "currentValue": ">=1.7",
-      "depName": "logging_tree",
-      "lineNumber": 39,
-      "purl": "pkg:pypi/logging_tree",
-    },
-    Object {
-      "currentValue": ">=2.2",
-      "depName": "pygments",
-      "lineNumber": 40,
-      "purl": "pkg:pypi/pygments",
-    },
-    Object {
-      "currentValue": ">=5.0",
-      "depName": "psutil",
-      "lineNumber": 41,
-      "purl": "pkg:pypi/psutil",
-    },
-    Object {
-      "currentValue": ">=3.0",
-      "depName": "objgraph",
-      "lineNumber": 42,
-      "purl": "pkg:pypi/objgraph",
-    },
-    Object {
-      "currentValue": ">=1.10,<2.0",
-      "depName": "django",
-      "lineNumber": 45,
-      "purl": "pkg:pypi/django",
     },
   ],
 }


### PR DESCRIPTION
If dependencies were installed in a different order, snapshot tests would fail. This PR solves that by sorting them.

Closes #3131