### PR TITLE
fix: use 'maven' version scheme for Maven

### DIFF
--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -1388,6 +1388,7 @@ const options = [
     default: {
       enabled: false,
       fileMatch: ['\\.pom.xml$', '(^|/)pom.xml$'],
+      versionScheme: 'maven',
     },
     mergeable: true,
     cli: false,


### PR DESCRIPTION
Use the correct version scheme for Maven.

See #2986 