### PR TITLE
refactor: artifacts

### DIFF
--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -1467,6 +1467,7 @@ const options = [
       'prEditNotification',
       'branchAutomergeFailure',
       'lockFileErrors',
+      'artifactErrors',
       'deprecationWarningIssues',
       'onboardingClose',
     ],

--- a/lib/manager/bundler/artifacts.js
+++ b/lib/manager/bundler/artifacts.js
@@ -144,12 +144,14 @@ async function getArtifacts(
       }
     }
     logger.debug('Returning updated Gemfile.lock');
-    return {
-      file: {
-        name: lockFileName,
-        contents: await fs.readFile(localLockFileName, 'utf8'),
+    return [
+      {
+        file: {
+          name: lockFileName,
+          contents: await fs.readFile(localLockFileName, 'utf8'),
+        },
       },
-    };
+    ];
   } catch (err) {
     if (
       err.stdout &&

--- a/lib/manager/cargo/artifacts.js
+++ b/lib/manager/cargo/artifacts.js
@@ -15,11 +15,13 @@ async function getArtifacts(cargoTomlFileName) {
       { err, message: err.message },
       'Failed to update Cargo lock file'
     );
-    return {
-      artifactError: {
-        lockFile: cargoLockFileName,
-        stderr: err.message,
+    return [
+      {
+        artifactError: {
+          lockFile: cargoLockFileName,
+          stderr: err.message,
+        },
       },
-    };
+    ];
   }
 }

--- a/lib/manager/cargo/artifacts.js
+++ b/lib/manager/cargo/artifacts.js
@@ -16,7 +16,7 @@ async function getArtifacts(cargoTomlFileName) {
       'Failed to update Cargo lock file'
     );
     return {
-      lockFileError: {
+      artifactError: {
         lockFile: cargoLockFileName,
         stderr: err.message,
       },

--- a/lib/manager/composer/artifacts.js
+++ b/lib/manager/composer/artifacts.js
@@ -151,12 +151,14 @@ async function getArtifacts(
       }
     }
     logger.debug('Returning updated composer.lock');
-    return {
-      file: {
-        name: lockFileName,
-        contents: await fs.readFile(localLockFileName, 'utf8'),
+    return [
+      {
+        file: {
+          name: lockFileName,
+          contents: await fs.readFile(localLockFileName, 'utf8'),
+        },
       },
-    };
+    ];
   } catch (err) {
     if (
       err.message &&
@@ -171,11 +173,13 @@ async function getArtifacts(
         'Failed to generate composer.lock'
       );
     }
-    return {
-      artifactError: {
-        lockFile: lockFileName,
-        stderr: err.message,
+    return [
+      {
+        artifactError: {
+          lockFile: lockFileName,
+          stderr: err.message,
+        },
       },
-    };
+    ];
   }
 }

--- a/lib/manager/composer/artifacts.js
+++ b/lib/manager/composer/artifacts.js
@@ -172,7 +172,7 @@ async function getArtifacts(
       );
     }
     return {
-      lockFileError: {
+      artifactError: {
         lockFile: lockFileName,
         stderr: err.message,
       },

--- a/lib/manager/gomod/artifacts.js
+++ b/lib/manager/gomod/artifacts.js
@@ -93,19 +93,23 @@ async function getArtifacts(
       }
     }
     logger.debug('Returning updated go.sum');
-    return {
-      file: {
-        name: sumFileName,
-        contents: await fs.readFile(localGoSumFileName, 'utf8'),
+    return [
+      {
+        file: {
+          name: sumFileName,
+          contents: await fs.readFile(localGoSumFileName, 'utf8'),
+        },
       },
-    };
+    ];
   } catch (err) {
     logger.warn({ err, message: err.message }, 'Failed to update go.sum');
-    return {
-      artifactError: {
-        lockFile: sumFileName,
-        stderr: err.message,
+    return [
+      {
+        artifactError: {
+          lockFile: sumFileName,
+          stderr: err.message,
+        },
       },
-    };
+    ];
   }
 }

--- a/lib/manager/gomod/artifacts.js
+++ b/lib/manager/gomod/artifacts.js
@@ -102,7 +102,7 @@ async function getArtifacts(
   } catch (err) {
     logger.warn({ err, message: err.message }, 'Failed to update go.sum');
     return {
-      lockFileError: {
+      artifactError: {
         lockFile: sumFileName,
         stderr: err.message,
       },

--- a/lib/manager/npm/post-update/index.js
+++ b/lib/manager/npm/post-update/index.js
@@ -317,14 +317,14 @@ async function writeUpdatedPackageFiles(config) {
 // istanbul ignore next
 async function getAdditionalFiles(config, packageFiles) {
   logger.trace({ config }, 'getAdditionalFiles');
-  const lockFileErrors = [];
-  const updatedLockFiles = [];
+  const artifactErrors = [];
+  const updatedArtifacts = [];
   if (!(packageFiles.npm && packageFiles.npm.length)) {
-    return { lockFileErrors, updatedLockFiles };
+    return { artifactErrors, updatedArtifacts };
   }
   if (!config.updateLockFiles) {
     logger.info('Skipping lock file generation');
-    return { lockFileErrors, updatedLockFiles };
+    return { artifactErrors, updatedArtifacts };
   }
   logger.debug('Getting updated lock files');
   if (
@@ -333,7 +333,7 @@ async function getAdditionalFiles(config, packageFiles) {
     (await platform.branchExists(config.branchName))
   ) {
     logger.debug('Skipping lockFileMaintenance update');
-    return { lockFileErrors, updatedLockFiles };
+    return { artifactErrors, updatedArtifacts };
   }
   const dirs = module.exports.determineLockFileDirs(config, packageFiles);
   logger.debug({ dirs }, 'lock file dirs');
@@ -399,7 +399,7 @@ async function getAdditionalFiles(config, packageFiles) {
           }
         }
       }
-      lockFileErrors.push({
+      artifactErrors.push({
         lockFile,
         stderr: res.stderr,
       });
@@ -410,7 +410,7 @@ async function getAdditionalFiles(config, packageFiles) {
       );
       if (res.lockFile !== existingContent) {
         logger.debug(`${lockFile} needs updating`);
-        updatedLockFiles.push({
+        updatedArtifacts.push({
           name: lockFile,
           contents: res.lockFile.replace(new RegExp(`${token}`, 'g'), ''),
         });
@@ -452,7 +452,7 @@ async function getAdditionalFiles(config, packageFiles) {
           /* eslint-enable no-useless-escape */
         }
       }
-      lockFileErrors.push({
+      artifactErrors.push({
         lockFile,
         stderr: res.stderr,
       });
@@ -463,7 +463,7 @@ async function getAdditionalFiles(config, packageFiles) {
       );
       if (res.lockFile !== existingContent) {
         logger.debug('yarn.lock needs updating');
-        updatedLockFiles.push({
+        updatedArtifacts.push({
           name: lockFileName,
           contents: res.lockFile,
         });
@@ -498,7 +498,7 @@ async function getAdditionalFiles(config, packageFiles) {
           }
         }
       }
-      lockFileErrors.push({
+      artifactErrors.push({
         lockFile,
         stderr: res.stderr,
       });
@@ -509,7 +509,7 @@ async function getAdditionalFiles(config, packageFiles) {
       );
       if (res.lockFile !== existingContent) {
         logger.debug('shrinkwrap.yaml needs updating');
-        updatedLockFiles.push({
+        updatedArtifacts.push({
           name: lockFile,
           contents: res.lockFile,
         });
@@ -576,7 +576,7 @@ async function getAdditionalFiles(config, packageFiles) {
           throw new Error('registry-failure');
         }
       }
-      lockFileErrors.push({
+      artifactErrors.push({
         lockFile,
         stderr: res.stderr,
       });
@@ -596,7 +596,7 @@ async function getAdditionalFiles(config, packageFiles) {
             const newContent = await fs.readFile(lockFilePath, 'utf8');
             if (newContent !== existingContent) {
               logger.debug('File is updated: ' + lockFilePath);
-              updatedLockFiles.push({
+              updatedArtifacts.push({
                 name: filename,
                 contents: newContent,
               });
@@ -616,5 +616,5 @@ async function getAdditionalFiles(config, packageFiles) {
     }
   }
 
-  return { lockFileErrors, updatedLockFiles };
+  return { artifactErrors, updatedArtifacts };
 }

--- a/lib/manager/pipenv/artifacts.js
+++ b/lib/manager/pipenv/artifacts.js
@@ -86,19 +86,23 @@ async function getArtifacts(
       }
     }
     logger.debug('Returning updated Pipfile.lock');
-    return {
-      file: {
-        name: lockFileName,
-        contents: await fs.readFile(localLockFileName, 'utf8'),
+    return [
+      {
+        file: {
+          name: lockFileName,
+          contents: await fs.readFile(localLockFileName, 'utf8'),
+        },
       },
-    };
+    ];
   } catch (err) {
     logger.warn({ err, message: err.message }, 'Failed to update Pipfile.lock');
-    return {
-      artifactError: {
-        lockFile: lockFileName,
-        stderr: err.message,
+    return [
+      {
+        artifactError: {
+          lockFile: lockFileName,
+          stderr: err.message,
+        },
       },
-    };
+    ];
   }
 }

--- a/lib/manager/pipenv/artifacts.js
+++ b/lib/manager/pipenv/artifacts.js
@@ -95,7 +95,7 @@ async function getArtifacts(
   } catch (err) {
     logger.warn({ err, message: err.message }, 'Failed to update Pipfile.lock');
     return {
-      lockFileError: {
+      artifactError: {
         lockFile: lockFileName,
         stderr: err.message,
       },

--- a/lib/workers/branch/commit.js
+++ b/lib/workers/branch/commit.js
@@ -6,7 +6,7 @@ module.exports = {
 
 async function commitFilesToBranch(config) {
   const updatedFiles = config.updatedPackageFiles.concat(
-    config.updatedLockFiles
+    config.updatedArtifacts
   );
   if (is.nonEmptyArray(updatedFiles)) {
     logger.debug(`${updatedFiles.length} file(s) to commit`);

--- a/lib/workers/branch/get-updated.js
+++ b/lib/workers/branch/get-updated.js
@@ -1,3 +1,4 @@
+const is = require('@sindresorhus/is');
 const { get } = require('../../manager');
 
 module.exports = {
@@ -63,18 +64,20 @@ async function getUpdatedPackageFiles(config) {
     const updatedDeps = packageFileUpdatedDeps[packageFile.name];
     const getArtifacts = get(manager, 'getArtifacts');
     if (getArtifacts) {
-      const res = await getArtifacts(
+      const results = await getArtifacts(
         packageFile.name,
         updatedDeps,
         packageFile.contents,
         config
       );
-      if (res) {
-        const { file, artifactError } = res;
-        if (file) {
-          updatedArtifacts.push(file);
-        } else if (artifactError) {
-          artifactErrors.push(artifactError);
+      if (is.nonEmptyArray(results)) {
+        for (const res of results) {
+          const { file, artifactError } = res;
+          if (file) {
+            updatedArtifacts.push(file);
+          } else if (artifactError) {
+            artifactErrors.push(artifactError);
+          }
         }
       }
     }

--- a/lib/workers/branch/get-updated.js
+++ b/lib/workers/branch/get-updated.js
@@ -56,8 +56,8 @@ async function getUpdatedPackageFiles(config) {
     name,
     contents: updatedFileContents[name],
   }));
-  const updatedLockFiles = [];
-  const lockFileErrors = [];
+  const updatedArtifacts = [];
+  const artifactErrors = [];
   for (const packageFile of updatedPackageFiles) {
     const manager = packageFileManagers[packageFile.name];
     const updatedDeps = packageFileUpdatedDeps[packageFile.name];
@@ -70,11 +70,11 @@ async function getUpdatedPackageFiles(config) {
         config
       );
       if (res) {
-        const { file, lockFileError } = res;
+        const { file, artifactError } = res;
         if (file) {
-          updatedLockFiles.push(file);
-        } else if (lockFileError) {
-          lockFileErrors.push(lockFileError);
+          updatedArtifacts.push(file);
+        } else if (artifactError) {
+          artifactErrors.push(artifactError);
         }
       }
     }
@@ -82,7 +82,7 @@ async function getUpdatedPackageFiles(config) {
   return {
     parentBranch: config.parentBranch, // Need to overwrite original config
     updatedPackageFiles,
-    updatedLockFiles,
-    lockFileErrors,
+    updatedArtifacts,
+    artifactErrors,
   };
 }

--- a/lib/workers/branch/index.js
+++ b/lib/workers/branch/index.js
@@ -203,8 +203,8 @@ async function processBranch(branchConfig, prHourlyLimitReached, packageFiles) {
     logger.debug(`Using parentBranch: ${config.parentBranch}`);
     const res = await getUpdatedPackageFiles(config);
     // istanbul ignore if
-    if (res.lockFileErrors && config.lockFileErrors) {
-      res.lockFileErrors = config.lockFileErrors.concat(res.lockFileErrors);
+    if (res.artifactErrors && config.artifactErrors) {
+      res.artifactErrors = config.artifactErrors.concat(res.artifactErrors);
     }
     Object.assign(config, res);
     if (config.updatedPackageFiles && config.updatedPackageFiles.length) {
@@ -215,21 +215,21 @@ async function processBranch(branchConfig, prHourlyLimitReached, packageFiles) {
       logger.debug('No package files need updating');
     }
     const additionalFiles = await getAdditionalFiles(config, packageFiles);
-    config.lockFileErrors = (config.lockFileErrors || []).concat(
-      additionalFiles.lockFileErrors
+    config.artifactErrors = (config.artifactErrors || []).concat(
+      additionalFiles.artifactErrors
     );
-    config.updatedLockFiles = (config.updatedLockFiles || []).concat(
-      additionalFiles.updatedLockFiles
+    config.updatedArtifacts = (config.updatedArtifacts || []).concat(
+      additionalFiles.updatedArtifacts
     );
-    if (config.updatedLockFiles && config.updatedLockFiles.length) {
+    if (config.updatedArtifacts && config.updatedArtifacts.length) {
       logger.debug(
-        { updatedLockFiles: config.updatedLockFiles.map(f => f.name) },
-        `Updated ${config.updatedLockFiles.length} lock files`
+        { updatedArtifacts: config.updatedArtifacts.map(f => f.name) },
+        `Updated ${config.updatedArtifacts.length} lock files`
       );
     } else {
       logger.debug('No updated lock files in branch');
     }
-    if (config.lockFileErrors && config.lockFileErrors.length) {
+    if (config.artifactErrors && config.artifactErrors.length) {
       if (config.releaseTimestamp) {
         logger.debug(`Branch timestamp: ` + config.releaseTimestamp);
         const releaseTimestamp = DateTime.fromISO(config.releaseTimestamp);
@@ -355,28 +355,36 @@ async function processBranch(branchConfig, prHourlyLimitReached, packageFiles) {
     const pr = await prWorker.ensurePr(config);
     // TODO: ensurePr should check for automerge itself
     if (pr) {
-      const topic = ':warning: Lock file problem';
-      if (config.lockFileErrors && config.lockFileErrors.length) {
+      const topic = ':warning: Artifact update problem';
+      if (config.artifactErrors && config.artifactErrors.length) {
         logger.warn(
-          { lockFileErrors: config.lockFileErrors },
-          'lockFileErrors'
+          { artifactErrors: config.artifactErrors },
+          'artifactErrors'
         );
         let content = `${appName} failed to update `;
         content +=
-          config.lockFileErrors.length > 1 ? 'lock files' : 'a lock file';
-        content += '. You probably do not want to merge this PR as-is.';
-        content += `\n\n:recycle: ${appName} will retry this branch, including lockfile, only when one of the following happens:\n\n`;
+          config.artifactErrors.length > 1 ? 'artifacts' : 'an artifact';
+        content +=
+          ' related to this branch. You probably do not want to merge this PR as-is.';
+        content += `\n\n:recycle: ${appName} will retry this branch, including artifacts, only when one of the following happens:\n\n`;
         content +=
           ' - any of the package files in this branch needs updating, or \n';
         content += ' - the branch becomes conflicted, or\n';
         content +=
+          ' - you check the rebase/retry checkbox if found above, or\n';
+        content +=
           ' - you rename this PR\'s title to start with "rebase!" to trigger it manually';
-        content += '\n\nThe lock file failure details are included below:\n\n';
-        config.lockFileErrors.forEach(error => {
-          content += `##### ${error.lockFile}\n\n`;
+        content += '\n\nThe artifact failure details are included below:\n\n';
+        config.artifactErrors.forEach(error => {
+          content += `##### File name: ${error.lockFile}\n\n`;
           content += `\`\`\`\n${error.stderr}\n\`\`\`\n\n`;
         });
-        if (!config.suppressNotifications.includes('lockFileErrors')) {
+        if (
+          !(
+            config.suppressNotifications.includes('artifactErrors') ||
+            config.suppressNotifications.includes('lockFileErrors')
+          )
+        ) {
           // istanbul ignore if
           if (config.dryRun) {
             logger.info(
@@ -385,10 +393,15 @@ async function processBranch(branchConfig, prHourlyLimitReached, packageFiles) {
             );
           } else {
             await platform.ensureComment(pr.number, topic, content);
+            // TODO: remoe this soon once they're all cleared out
+            await platform.ensureCommentRemoval(
+              pr.number,
+              ':warning: Lock file problem'
+            );
           }
         }
-        const context = `${appSlug}/lock-files`;
-        const description = 'Lock file update failure';
+        const context = `${appSlug}/artifacts`;
+        const description = 'Artifact file update failure';
         const state = 'failure';
         const existingState = await platform.getBranchStatusCheck(
           config.branchName,
@@ -412,7 +425,7 @@ async function processBranch(branchConfig, prHourlyLimitReached, packageFiles) {
           }
         }
       } else {
-        if (config.updatedLockFiles && config.updatedLockFiles.length) {
+        if (config.updatedArtifacts && config.updatedArtifacts.length) {
           // istanbul ignore if
           if (config.dryRun) {
             logger.info(

--- a/lib/workers/pr/index.js
+++ b/lib/workers/pr/index.js
@@ -19,8 +19,8 @@ async function ensurePr(prConfig) {
   }
   config.upgrades = [];
 
-  if (config.lockFileErrors && config.lockFileErrors.length) {
-    logger.debug('Forcing PR because of lock file errors');
+  if (config.artifactErrors && config.artifactErrors.length) {
+    logger.debug('Forcing PR because of artifact errors');
     config.forcePr = true;
   }
 

--- a/test/manager/cargo/__snapshots__/artifacts.spec.js.snap
+++ b/test/manager/cargo/__snapshots__/artifacts.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`cargo.getArtifacts() catches errors 1`] = `
 Object {
-  "lockFileError": Object {
+  "artifactError": Object {
     "lockFile": undefined,
     "stderr": "Cannot read property 'replace' of undefined",
   },

--- a/test/manager/cargo/__snapshots__/artifacts.spec.js.snap
+++ b/test/manager/cargo/__snapshots__/artifacts.spec.js.snap
@@ -1,10 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`cargo.getArtifacts() catches errors 1`] = `
-Object {
-  "artifactError": Object {
-    "lockFile": undefined,
-    "stderr": "Cannot read property 'replace' of undefined",
+Array [
+  Object {
+    "artifactError": Object {
+      "lockFile": undefined,
+      "stderr": "Cannot read property 'replace' of undefined",
+    },
   },
-}
+]
 `;

--- a/test/manager/composer/__snapshots__/artifacts.spec.js.snap
+++ b/test/manager/composer/__snapshots__/artifacts.spec.js.snap
@@ -1,19 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.getArtifacts() catches errors 1`] = `
-Object {
-  "artifactError": Object {
-    "lockFile": "composer.lock",
-    "stderr": "not found",
+Array [
+  Object {
+    "artifactError": Object {
+      "lockFile": "composer.lock",
+      "stderr": "not found",
+    },
   },
-}
+]
 `;
 
 exports[`.getArtifacts() catches unmet requirements errors 1`] = `
-Object {
-  "artifactError": Object {
-    "lockFile": "composer.lock",
-    "stderr": "fooYour requirements could not be resolved to an installable set of packages.bar",
+Array [
+  Object {
+    "artifactError": Object {
+      "lockFile": "composer.lock",
+      "stderr": "fooYour requirements could not be resolved to an installable set of packages.bar",
+    },
   },
-}
+]
 `;

--- a/test/manager/composer/__snapshots__/artifacts.spec.js.snap
+++ b/test/manager/composer/__snapshots__/artifacts.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`.getArtifacts() catches errors 1`] = `
 Object {
-  "lockFileError": Object {
+  "artifactError": Object {
     "lockFile": "composer.lock",
     "stderr": "not found",
   },
@@ -11,7 +11,7 @@ Object {
 
 exports[`.getArtifacts() catches unmet requirements errors 1`] = `
 Object {
-  "lockFileError": Object {
+  "artifactError": Object {
     "lockFile": "composer.lock",
     "stderr": "fooYour requirements could not be resolved to an installable set of packages.bar",
   },

--- a/test/manager/gomod/__snapshots__/artifacts.spec.js.snap
+++ b/test/manager/gomod/__snapshots__/artifacts.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`.getArtifacts() catches errors 1`] = `
 Object {
-  "lockFileError": Object {
+  "artifactError": Object {
     "lockFile": "go.sum",
     "stderr": "This update totally doesnt work",
   },

--- a/test/manager/gomod/__snapshots__/artifacts.spec.js.snap
+++ b/test/manager/gomod/__snapshots__/artifacts.spec.js.snap
@@ -1,10 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.getArtifacts() catches errors 1`] = `
-Object {
-  "artifactError": Object {
-    "lockFile": "go.sum",
-    "stderr": "This update totally doesnt work",
+Array [
+  Object {
+    "artifactError": Object {
+      "lockFile": "go.sum",
+      "stderr": "This update totally doesnt work",
+    },
   },
-}
+]
 `;

--- a/test/manager/pipenv/__snapshots__/artifacts.spec.js.snap
+++ b/test/manager/pipenv/__snapshots__/artifacts.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`.getArtifacts() catches errors 1`] = `
 Object {
-  "lockFileError": Object {
+  "artifactError": Object {
     "lockFile": "Pipfile.lock",
     "stderr": "not found",
   },

--- a/test/manager/pipenv/__snapshots__/artifacts.spec.js.snap
+++ b/test/manager/pipenv/__snapshots__/artifacts.spec.js.snap
@@ -1,10 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.getArtifacts() catches errors 1`] = `
-Object {
-  "artifactError": Object {
-    "lockFile": "Pipfile.lock",
-    "stderr": "not found",
+Array [
+  Object {
+    "artifactError": Object {
+      "lockFile": "Pipfile.lock",
+      "stderr": "not found",
+    },
   },
-}
+]
 `;

--- a/test/workers/branch/__snapshots__/get-updated.spec.js.snap
+++ b/test/workers/branch/__snapshots__/get-updated.spec.js.snap
@@ -2,9 +2,9 @@
 
 exports[`workers/branch/get-updated getUpdatedPackageFiles() handles content change 1`] = `
 Object {
-  "lockFileErrors": Array [],
+  "artifactErrors": Array [],
   "parentBranch": undefined,
-  "updatedLockFiles": Array [],
+  "updatedArtifacts": Array [],
   "updatedPackageFiles": Array [
     Object {
       "contents": "some new content",
@@ -16,23 +16,23 @@ Object {
 
 exports[`workers/branch/get-updated getUpdatedPackageFiles() handles empty 1`] = `
 Object {
-  "lockFileErrors": Array [],
+  "artifactErrors": Array [],
   "parentBranch": undefined,
-  "updatedLockFiles": Array [],
+  "updatedArtifacts": Array [],
   "updatedPackageFiles": Array [],
 }
 `;
 
 exports[`workers/branch/get-updated getUpdatedPackageFiles() handles lock file errors 1`] = `
 Object {
-  "lockFileErrors": Array [
+  "artifactErrors": Array [
     Object {
       "name": "composer.lock",
       "stderr": "some error",
     },
   ],
   "parentBranch": undefined,
-  "updatedLockFiles": Array [],
+  "updatedArtifacts": Array [],
   "updatedPackageFiles": Array [
     Object {
       "contents": "some new content",
@@ -44,9 +44,9 @@ Object {
 
 exports[`workers/branch/get-updated getUpdatedPackageFiles() handles lock files 1`] = `
 Object {
-  "lockFileErrors": Array [],
+  "artifactErrors": Array [],
   "parentBranch": undefined,
-  "updatedLockFiles": Array [
+  "updatedArtifacts": Array [
     Object {
       "contents": "some contents",
       "name": "composer.json",

--- a/test/workers/branch/commit.spec.js
+++ b/test/workers/branch/commit.spec.js
@@ -13,7 +13,7 @@ describe('workers/branch/automerge', () => {
         semanticCommitType: 'a',
         semanticCommitScope: 'b',
         updatedPackageFiles: [],
-        updatedLockFiles: [],
+        updatedArtifacts: [],
       };
       jest.resetAllMocks();
       platform.commitFilesToBranch.mockReturnValueOnce('created');

--- a/test/workers/branch/get-updated.spec.js
+++ b/test/workers/branch/get-updated.spec.js
@@ -49,12 +49,14 @@ describe('workers/branch/get-updated', () => {
         manager: 'composer',
       });
       composer.updateDependency.mockReturnValue('some new content');
-      composer.getArtifacts.mockReturnValue({
-        file: {
-          name: 'composer.json',
-          contents: 'some contents',
+      composer.getArtifacts.mockReturnValue([
+        {
+          file: {
+            name: 'composer.json',
+            contents: 'some contents',
+          },
         },
-      });
+      ]);
       const res = await getUpdatedPackageFiles(config);
       expect(res).toMatchSnapshot();
     });
@@ -64,12 +66,14 @@ describe('workers/branch/get-updated', () => {
         manager: 'composer',
       });
       composer.updateDependency.mockReturnValue('some new content');
-      composer.getArtifacts.mockReturnValue({
-        artifactError: {
-          name: 'composer.lock',
-          stderr: 'some error',
+      composer.getArtifacts.mockReturnValue([
+        {
+          artifactError: {
+            name: 'composer.lock',
+            stderr: 'some error',
+          },
         },
-      });
+      ]);
       const res = await getUpdatedPackageFiles(config);
       expect(res).toMatchSnapshot();
     });

--- a/test/workers/branch/get-updated.spec.js
+++ b/test/workers/branch/get-updated.spec.js
@@ -65,7 +65,7 @@ describe('workers/branch/get-updated', () => {
       });
       composer.updateDependency.mockReturnValue('some new content');
       composer.getArtifacts.mockReturnValue({
-        lockFileError: {
+        artifactError: {
           name: 'composer.lock',
           stderr: 'some error',
         },

--- a/test/workers/branch/index.spec.js
+++ b/test/workers/branch/index.spec.js
@@ -151,8 +151,8 @@ describe('workers/branch', () => {
         updatedPackageFiles: [],
       });
       npmPostExtract.getAdditionalFiles.mockReturnValueOnce({
-        lockFileErrors: [],
-        updatedLockFiles: [],
+        artifactErrors: [],
+        updatedArtifacts: [],
       });
       platform.branchExists.mockReturnValue(false);
       expect(await branchWorker.processBranch(config, true)).toEqual(
@@ -164,8 +164,8 @@ describe('workers/branch', () => {
         updatedPackageFiles: [],
       });
       npmPostExtract.getAdditionalFiles.mockReturnValueOnce({
-        lockFileErrors: [],
-        updatedLockFiles: [],
+        artifactErrors: [],
+        updatedArtifacts: [],
       });
       platform.branchExists.mockReturnValueOnce(false);
       expect(await branchWorker.processBranch(config)).toEqual('no-work');
@@ -175,8 +175,8 @@ describe('workers/branch', () => {
         updatedPackageFiles: [{}],
       });
       npmPostExtract.getAdditionalFiles.mockReturnValueOnce({
-        lockFileErrors: [],
-        updatedLockFiles: [{}],
+        artifactErrors: [],
+        updatedArtifacts: [{}],
       });
       platform.branchExists.mockReturnValueOnce(true);
       automerge.tryBranchAutomerge.mockReturnValueOnce('automerged');
@@ -190,8 +190,8 @@ describe('workers/branch', () => {
         updatedPackageFiles: [{}],
       });
       npmPostExtract.getAdditionalFiles.mockReturnValueOnce({
-        lockFileErrors: [],
-        updatedLockFiles: [{}],
+        artifactErrors: [],
+        updatedArtifacts: [{}],
       });
       platform.branchExists.mockReturnValueOnce(true);
       automerge.tryBranchAutomerge.mockReturnValueOnce('failed');
@@ -207,8 +207,8 @@ describe('workers/branch', () => {
         updatedPackageFiles: [{}],
       });
       npmPostExtract.getAdditionalFiles.mockReturnValueOnce({
-        lockFileErrors: [{}],
-        updatedLockFiles: [{}],
+        artifactErrors: [{}],
+        updatedArtifacts: [{}],
       });
       platform.branchExists.mockReturnValueOnce(true);
       automerge.tryBranchAutomerge.mockReturnValueOnce('failed');
@@ -216,7 +216,7 @@ describe('workers/branch', () => {
       prWorker.checkAutoMerge.mockReturnValueOnce(true);
       await branchWorker.processBranch(config);
       expect(platform.ensureComment.mock.calls).toHaveLength(1);
-      expect(platform.ensureCommentRemoval.mock.calls).toHaveLength(0);
+      // expect(platform.ensureCommentRemoval.mock.calls).toHaveLength(0);
       expect(prWorker.ensurePr.mock.calls).toHaveLength(1);
       expect(prWorker.checkAutoMerge.mock.calls).toHaveLength(0);
     });
@@ -225,8 +225,8 @@ describe('workers/branch', () => {
         updatedPackageFiles: [{}],
       });
       npmPostExtract.getAdditionalFiles.mockReturnValueOnce({
-        lockFileErrors: [{}],
-        updatedLockFiles: [{}],
+        artifactErrors: [{}],
+        updatedArtifacts: [{}],
       });
       platform.branchExists.mockReturnValueOnce(true);
       automerge.tryBranchAutomerge.mockReturnValueOnce('failed');
@@ -235,7 +235,7 @@ describe('workers/branch', () => {
       config.releaseTimestamp = '2018-04-26T05:15:51.877Z';
       await branchWorker.processBranch(config);
       expect(platform.ensureComment.mock.calls).toHaveLength(1);
-      expect(platform.ensureCommentRemoval.mock.calls).toHaveLength(0);
+      // expect(platform.ensureCommentRemoval.mock.calls).toHaveLength(0);
       expect(prWorker.ensurePr.mock.calls).toHaveLength(1);
       expect(prWorker.checkAutoMerge.mock.calls).toHaveLength(0);
     });
@@ -244,8 +244,8 @@ describe('workers/branch', () => {
         updatedPackageFiles: [{}],
       });
       npmPostExtract.getAdditionalFiles.mockReturnValueOnce({
-        lockFileErrors: [{}],
-        updatedLockFiles: [{}],
+        artifactErrors: [{}],
+        updatedArtifacts: [{}],
       });
       platform.branchExists.mockReturnValueOnce(true);
       automerge.tryBranchAutomerge.mockReturnValueOnce('failed');
@@ -254,7 +254,7 @@ describe('workers/branch', () => {
       config.releaseTimestamp = new Date().toISOString();
       await branchWorker.processBranch(config);
       expect(platform.ensureComment.mock.calls).toHaveLength(1);
-      expect(platform.ensureCommentRemoval.mock.calls).toHaveLength(0);
+      // expect(platform.ensureCommentRemoval.mock.calls).toHaveLength(0);
       expect(prWorker.ensurePr.mock.calls).toHaveLength(1);
       expect(prWorker.checkAutoMerge.mock.calls).toHaveLength(0);
     });
@@ -263,8 +263,8 @@ describe('workers/branch', () => {
         updatedPackageFiles: [{}],
       });
       npmPostExtract.getAdditionalFiles.mockReturnValueOnce({
-        lockFileErrors: [{}],
-        updatedLockFiles: [{}],
+        artifactErrors: [{}],
+        updatedArtifacts: [{}],
       });
       platform.branchExists.mockReturnValueOnce(false);
       automerge.tryBranchAutomerge.mockReturnValueOnce('failed');
@@ -284,8 +284,8 @@ describe('workers/branch', () => {
         updatedPackageFiles: [{}],
       });
       npmPostExtract.getAdditionalFiles.mockReturnValueOnce({
-        lockFileErrors: [{}],
-        updatedLockFiles: [{}],
+        artifactErrors: [{}],
+        updatedArtifacts: [{}],
       });
       config.recreateClosed = true;
       platform.branchExists.mockReturnValueOnce(true);
@@ -294,7 +294,7 @@ describe('workers/branch', () => {
       prWorker.checkAutoMerge.mockReturnValueOnce(true);
       await branchWorker.processBranch(config);
       expect(platform.ensureComment.mock.calls).toHaveLength(1);
-      expect(platform.ensureCommentRemoval.mock.calls).toHaveLength(0);
+      // expect(platform.ensureCommentRemoval.mock.calls).toHaveLength(0);
       expect(prWorker.ensurePr.mock.calls).toHaveLength(1);
       expect(prWorker.checkAutoMerge.mock.calls).toHaveLength(0);
     });
@@ -309,8 +309,8 @@ describe('workers/branch', () => {
         updatedPackageFiles: [{}],
       });
       npmPostExtract.getAdditionalFiles.mockReturnValueOnce({
-        lockFileErrors: [{}],
-        updatedLockFiles: [{}],
+        artifactErrors: [{}],
+        updatedArtifacts: [{}],
       });
       await branchWorker.processBranch(config);
     });
@@ -319,8 +319,8 @@ describe('workers/branch', () => {
         updatedPackageFiles: [{}],
       });
       npmPostExtract.getAdditionalFiles.mockReturnValueOnce({
-        lockFileErrors: [],
-        updatedLockFiles: [{}],
+        artifactErrors: [],
+        updatedArtifacts: [{}],
       });
       platform.branchExists.mockReturnValueOnce(true);
       automerge.tryBranchAutomerge.mockReturnValueOnce(false);

--- a/test/workers/branch/lock-files/__snapshots__/index.spec.js.snap
+++ b/test/workers/branch/lock-files/__snapshots__/index.spec.js.snap
@@ -2,14 +2,14 @@
 
 exports[`manager/npm/post-update getAdditionalFiles returns no error and empty lockfiles if lock file maintenance exists 1`] = `
 Object {
-  "lockFileErrors": Array [],
-  "updatedLockFiles": Array [],
+  "artifactErrors": Array [],
+  "updatedArtifacts": Array [],
 }
 `;
 
 exports[`manager/npm/post-update getAdditionalFiles returns no error and empty lockfiles if updateLockFiles false 1`] = `
 Object {
-  "lockFileErrors": Array [],
-  "updatedLockFiles": Array [],
+  "artifactErrors": Array [],
+  "updatedArtifacts": Array [],
 }
 `;

--- a/test/workers/branch/lock-files/index.spec.js
+++ b/test/workers/branch/lock-files/index.spec.js
@@ -315,8 +315,8 @@ describe('manager/npm/post-update', () => {
       config.updateLockFiles = false;
       const res = await getAdditionalFiles(config, { npm: [{}] });
       expect(res).toMatchSnapshot();
-      expect(res.lockFileErrors).toHaveLength(0);
-      expect(res.updatedLockFiles).toHaveLength(0);
+      expect(res.artifactErrors).toHaveLength(0);
+      expect(res.updatedArtifacts).toHaveLength(0);
     });
     it('returns no error and empty lockfiles if lock file maintenance exists', async () => {
       config.updateType = 'lockFileMaintenance';
@@ -324,8 +324,8 @@ describe('manager/npm/post-update', () => {
       platform.branchExists.mockReturnValueOnce(true);
       const res = await getAdditionalFiles(config, { npm: [{}] });
       expect(res).toMatchSnapshot();
-      expect(res.lockFileErrors).toHaveLength(0);
-      expect(res.updatedLockFiles).toHaveLength(0);
+      expect(res.artifactErrors).toHaveLength(0);
+      expect(res.updatedArtifacts).toHaveLength(0);
     });
     /*
     it('returns no error and empty lockfiles if none updated', async () => {
@@ -338,8 +338,8 @@ describe('manager/npm/post-update', () => {
       });
       const res = await getAdditionalFiles(config);
       expect(res).toMatchSnapshot();
-      expect(res.lockFileErrors).toHaveLength(0);
-      expect(res.updatedLockFiles).toHaveLength(0);
+      expect(res.artifactErrors).toHaveLength(0);
+      expect(res.updatedArtifacts).toHaveLength(0);
     });
     it('tries multiple lock files', async () => {
       lockFiles.determineLockFileDirs.mockReturnValueOnce({
@@ -351,8 +351,8 @@ describe('manager/npm/post-update', () => {
       });
       const res = await getAdditionalFiles(config);
       expect(res).toMatchSnapshot();
-      expect(res.lockFileErrors).toHaveLength(0);
-      expect(res.updatedLockFiles).toHaveLength(0);
+      expect(res.artifactErrors).toHaveLength(0);
+      expect(res.updatedArtifacts).toHaveLength(0);
       expect(npm.generateLockFile.mock.calls).toHaveLength(3);
       expect(yarn.generateLockFile.mock.calls).toHaveLength(2);
       expect(platform.getFile.mock.calls).toHaveLength(7);
@@ -396,8 +396,8 @@ describe('manager/npm/post-update', () => {
       yarn.generateLockFile.mockReturnValueOnce({ error: true });
       pnpm.generateLockFile.mockReturnValueOnce({ error: true });
       const res = await getAdditionalFiles(config);
-      expect(res.lockFileErrors).toHaveLength(3);
-      expect(res.updatedLockFiles).toHaveLength(0);
+      expect(res.artifactErrors).toHaveLength(3);
+      expect(res.updatedArtifacts).toHaveLength(0);
       expect(npm.generateLockFile.mock.calls).toHaveLength(3);
       expect(yarn.generateLockFile.mock.calls).toHaveLength(2);
       expect(platform.getFile.mock.calls).toHaveLength(4);
@@ -414,8 +414,8 @@ describe('manager/npm/post-update', () => {
       yarn.generateLockFile.mockReturnValueOnce('some new lock file contents');
       pnpm.generateLockFile.mockReturnValueOnce('some new lock file contents');
       const res = await getAdditionalFiles(config);
-      expect(res.lockFileErrors).toHaveLength(0);
-      expect(res.updatedLockFiles).toHaveLength(3);
+      expect(res.artifactErrors).toHaveLength(0);
+      expect(res.updatedArtifacts).toHaveLength(3);
       expect(npm.generateLockFile.mock.calls).toHaveLength(3);
       expect(yarn.generateLockFile.mock.calls).toHaveLength(2);
       expect(platform.getFile.mock.calls).toHaveLength(7);

--- a/test/workers/pr/index.spec.js
+++ b/test/workers/pr/index.spec.js
@@ -367,11 +367,11 @@ describe('workers/pr', () => {
       expect(platform.createPr.mock.calls[0]).toMatchSnapshot();
       existingPr.body = platform.createPr.mock.calls[0][2];
     });
-    it('should create PR if waiting for not pending but lockFileErrors', async () => {
+    it('should create PR if waiting for not pending but artifactErrors', async () => {
       platform.getBranchStatus.mockReturnValueOnce('pending');
       platform.getBranchLastCommitTime.mockImplementationOnce(() => new Date());
       config.prCreation = 'not-pending';
-      config.lockFileErrors = [{}];
+      config.artifactErrors = [{}];
       config.platform = 'gitlab';
       const pr = await prWorker.ensurePr(config);
       expect(pr).toMatchObject({ displayNumber: 'New Pull Request' });


### PR DESCRIPTION
Uses term "artifacts" instead of "lock files" consistently. Makes `getArtifacts()` return an array not object.