### PR TITLE
feat: Add `go mod tidy` to gomod if configured

### DIFF
--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -1065,6 +1065,12 @@ const options = [
     mergeable: true,
   },
   {
+    name: 'gomodTidy',
+    description: 'Enable to run `go mod tidy` after Go module updates',
+    type: 'boolean',
+    default: false,
+  },
+  {
     name: 'ruby',
     releaseStatus: 'alpha',
     description: 'Configuration object for ruby language',

--- a/lib/manager/gomod/artifacts.js
+++ b/lib/manager/gomod/artifacts.js
@@ -78,6 +78,21 @@ async function getArtifacts(
       { seconds, type: 'go.sum', stdout, stderr },
       'Generated lockfile'
     );
+    if (config.goModTidy) {
+      args = 'mod tidy';
+      logger.debug({ cmd, args }, 'go mod tidy command');
+      ({ stdout, stderr } = await exec(`${cmd} ${args}`, {
+        cwd,
+        shell: true,
+        env,
+      }));
+      duration = process.hrtime(startTime);
+      seconds = Math.round(duration[0] + duration[1] / 1e9);
+      logger.info(
+        { seconds, type: 'go.sum', stdout, stderr },
+        'Tidied lockfile'
+      );
+    }
     const res = [];
     // istanbul ignore if
     if (config.gitFs) {

--- a/lib/manager/gomod/artifacts.js
+++ b/lib/manager/gomod/artifacts.js
@@ -78,20 +78,27 @@ async function getArtifacts(
       { seconds, type: 'go.sum', stdout, stderr },
       'Generated lockfile'
     );
-    if (config.goModTidy) {
-      args = 'mod tidy';
-      logger.debug({ cmd, args }, 'go mod tidy command');
-      ({ stdout, stderr } = await exec(`${cmd} ${args}`, {
-        cwd,
-        shell: true,
-        env,
-      }));
-      duration = process.hrtime(startTime);
-      seconds = Math.round(duration[0] + duration[1] / 1e9);
-      logger.info(
-        { seconds, type: 'go.sum', stdout, stderr },
-        'Tidied lockfile'
-      );
+    // istanbul ignore if
+    if (config.gomodTidy) {
+      if (config.gitFs) {
+        args = 'mod tidy';
+        logger.debug({ cmd, args }, 'go mod tidy command');
+        ({ stdout, stderr } = await exec(`${cmd} ${args}`, {
+          cwd,
+          shell: true,
+          env,
+        }));
+        duration = process.hrtime(startTime);
+        seconds = Math.round(duration[0] + duration[1] / 1e9);
+        logger.info(
+          { seconds, type: 'go.sum', stdout, stderr },
+          'Tidied lockfile'
+        );
+      } else {
+        logger.warn(
+          'Renovate administrator should enable gitFs in order to support tidying go modules'
+        );
+      }
     }
     const res = [];
     // istanbul ignore if

--- a/test/workers/repository/updates/__snapshots__/flatten.spec.js.snap
+++ b/test/workers/repository/updates/__snapshots__/flatten.spec.js.snap
@@ -27,6 +27,7 @@ Array [
     "gitAuthor": null,
     "gitFs": null,
     "gitPrivateKey": null,
+    "gomodTidy": false,
     "group": Object {
       "branchTopic": "{{{groupSlug}}}",
       "commitMessageTopic": "{{{groupName}}}",
@@ -124,6 +125,7 @@ Array [
     "gitAuthor": null,
     "gitFs": null,
     "gitPrivateKey": null,
+    "gomodTidy": false,
     "group": Object {
       "branchTopic": "{{{groupSlug}}}",
       "commitMessageTopic": "{{{groupName}}}",
@@ -219,6 +221,7 @@ Array [
     "gitAuthor": null,
     "gitFs": null,
     "gitPrivateKey": null,
+    "gomodTidy": false,
     "group": Object {
       "branchTopic": "{{{groupSlug}}}",
       "commitMessageTopic": "{{{groupName}}}",
@@ -318,6 +321,7 @@ Array [
     "gitAuthor": null,
     "gitFs": null,
     "gitPrivateKey": null,
+    "gomodTidy": false,
     "group": Object {
       "branchTopic": "{{{groupSlug}}}",
       "commitMessageTopic": "{{{groupName}}}",
@@ -413,6 +417,7 @@ Array [
     "gitAuthor": null,
     "gitFs": null,
     "gitPrivateKey": null,
+    "gomodTidy": false,
     "group": Object {
       "branchTopic": "{{{groupSlug}}}",
       "commitMessageTopic": "{{{groupName}}}",
@@ -512,6 +517,7 @@ Array [
     "gitAuthor": null,
     "gitFs": null,
     "gitPrivateKey": null,
+    "gomodTidy": false,
     "group": Object {
       "branchTopic": "{{{groupSlug}}}",
       "commitMessageTopic": "{{{groupName}}}",
@@ -609,6 +615,7 @@ Array [
     "gitAuthor": null,
     "gitFs": null,
     "gitPrivateKey": null,
+    "gomodTidy": false,
     "group": Object {
       "branchTopic": "{{{groupSlug}}}",
       "commitMessageTopic": "{{{groupName}}} Docker tags",
@@ -706,6 +713,7 @@ Array [
     "gitAuthor": null,
     "gitFs": null,
     "gitPrivateKey": null,
+    "gomodTidy": false,
     "group": Object {
       "branchTopic": "{{{groupSlug}}}",
       "commitMessageTopic": "{{{groupName}}} Docker tags",

--- a/website/docs/configuration-options.md
+++ b/website/docs/configuration-options.md
@@ -247,6 +247,8 @@ Configuration added here applies for all Go-related updates, however currently t
 
 Configuration for Go Modules (`go mod`). Supersedes anything in the `go` config object.
 
+## gomodTidy
+
 ## gradle
 
 Configuration for Java gradle projects


### PR DESCRIPTION
<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate
-->

Adds a configurable option to run `go mod tidy` on a repo between the `go get...` and the `go mod vendor`.

Not sure if I've coded this entirely correctly, but maybe its a good start?

Closes #2594