### PR TITLE
fix(bitbucket-server): use relative endpoint path

### DIFF
--- a/lib/platform/bitbucket-server/index.js
+++ b/lib/platform/bitbucket-server/index.js
@@ -69,11 +69,11 @@ async function getRepos(token, endpoint) {
   }
   hostRules.update({ ...opts, platform, default: true });
   try {
-    const projects = await utils.accumulateValues('/rest/api/1.0/projects');
+    const projects = await utils.accumulateValues('./rest/api/1.0/projects');
     const repos = await Promise.all(
       projects.map(({ key }) =>
         // TODO: can we filter this by permission=REPO_WRITE?
-        utils.accumulateValues(`/rest/api/1.0/projects/${key}/repos`)
+        utils.accumulateValues(`./rest/api/1.0/projects/${key}/repos`)
       )
     );
     const result = _.flatten(repos).map(
@@ -142,7 +142,7 @@ async function initRepo({ repository, endpoint, gitFs, localDir }) {
 
   try {
     const info = (await api.get(
-      `/rest/api/1.0/projects/${config.projectKey}/repos/${
+      `./rest/api/1.0/projects/${config.projectKey}/repos/${
         config.repositorySlug
       }`
     )).body;
@@ -152,7 +152,7 @@ async function initRepo({ repository, endpoint, gitFs, localDir }) {
     config.owner = info.project.key;
     logger.debug(`${repository} owner = ${config.owner}`);
     config.defaultBranch = (await api.get(
-      `/rest/api/1.0/projects/${config.projectKey}/repos/${
+      `./rest/api/1.0/projects/${config.projectKey}/repos/${
         config.repositorySlug
       }/branches/default`
     )).body.displayId;
@@ -259,7 +259,7 @@ async function deleteBranch(branchName, closePr = false) {
     const pr = await getBranchPr(branchName);
     if (pr) {
       await api.post(
-        `/rest/api/1.0/projects/${config.projectKey}/repos/${
+        `./rest/api/1.0/projects/${config.projectKey}/repos/${
           config.repositorySlug
         }/pull-requests/${pr.number}/decline?version=${pr.version + 1}`
       );
@@ -303,7 +303,7 @@ async function getBranchStatus(branchName, requiredStatusChecks) {
   logger.debug({ prForBranch }, 'PRFORBRANCH');
 
   const res = await api.get(
-    `/rest/api/1.0/projects/${config.projectKey}/repos/${
+    `./rest/api/1.0/projects/${config.projectKey}/repos/${
       config.repositorySlug
     }/pull-requests/${prForBranch.number}/merge`
   );
@@ -325,7 +325,7 @@ async function getBranchStatusCheck(branchName, context) {
     return null;
   }
   const res = await api.get(
-    `/rest/api/1.0/projects/${config.projectKey}/repos/${
+    `./rest/api/1.0/projects/${config.projectKey}/repos/${
       config.repositorySlug
     }/pull-requests/${prForBranch.number}/merge`
   );
@@ -391,7 +391,7 @@ async function addReviewers(iid, reviewers) {
   logger.debug(`Adding reviewers ${reviewers} to #${iid}`);
   for (const name of reviewers) {
     await api.post(
-      `/rest/api/1.0/projects/${config.projectKey}/repos/${
+      `./rest/api/1.0/projects/${config.projectKey}/repos/${
         config.repositorySlug
       }/pull-requests/${iid}/participants`,
       { body: { user: { name }, role: 'REVIEWER' } }
@@ -426,7 +426,7 @@ async function getPrList() {
   logger.debug(`getPrList()`);
   if (!config.prList) {
     const values = await utils.accumulateValues(
-      `/rest/api/1.0/projects/${config.projectKey}/repos/${
+      `./rest/api/1.0/projects/${config.projectKey}/repos/${
         config.repositorySlug
       }/pull-requests?state=OPEN`
     );
@@ -498,7 +498,7 @@ async function createPr(
   let prInfoRes;
   try {
     prInfoRes = await api.post(
-      `/rest/api/1.0/projects/${config.projectKey}/repos/${
+      `./rest/api/1.0/projects/${config.projectKey}/repos/${
         config.repositorySlug
       }/pull-requests`,
       { body }
@@ -541,7 +541,7 @@ async function getPr(prNo) {
     return null;
   }
   const res = await api.get(
-    `/rest/api/1.0/projects/${config.projectKey}/repos/${
+    `./rest/api/1.0/projects/${config.projectKey}/repos/${
       config.repositorySlug
     }/pull-requests/${prNo}`
   );
@@ -553,7 +553,7 @@ async function getPr(prNo) {
 
   if (pr.state === 'open') {
     const mergeRes = await api.get(
-      `/rest/api/1.0/projects/${config.projectKey}/repos/${
+      `./rest/api/1.0/projects/${config.projectKey}/repos/${
         config.repositorySlug
       }/pull-requests/${prNo}/merge`
     );
@@ -577,13 +577,13 @@ async function updatePr(prNo, title, description) {
   logger.debug(`updatePr(${prNo}, title=${title})`);
 
   const { version } = (await api.get(
-    `/rest/api/1.0/projects/${config.projectKey}/repos/${
+    `./rest/api/1.0/projects/${config.projectKey}/repos/${
       config.repositorySlug
     }/pull-requests/${prNo}`
   )).body;
 
   await api.put(
-    `/rest/api/1.0/projects/${config.projectKey}/repos/${
+    `./rest/api/1.0/projects/${config.projectKey}/repos/${
       config.repositorySlug
     }/pull-requests/${prNo}`,
     { body: { title, description, version } }
@@ -595,12 +595,12 @@ async function mergePr(prNo) {
   // TODO: Needs implementation
   // Used for "automerge" feature
   const { version } = (await api.get(
-    `/rest/api/1.0/projects/${config.projectKey}/repos/${
+    `./rest/api/1.0/projects/${config.projectKey}/repos/${
       config.repositorySlug
     }/pull-requests/${prNo}`
   )).body;
   await api.post(
-    `/rest/api/1.0/projects/${config.projectKey}/repos/${
+    `./rest/api/1.0/projects/${config.projectKey}/repos/${
       config.repositorySlug
     }/pull-requests/${prNo}/merge?version=${version}`
   );

--- a/lib/platform/bitbucket-server/index.js
+++ b/lib/platform/bitbucket-server/index.js
@@ -594,10 +594,15 @@ async function mergePr(prNo) {
   logger.debug(`mergePr(${prNo})`);
   // TODO: Needs implementation
   // Used for "automerge" feature
+  const { version } = (await api.get(
+    `/rest/api/1.0/projects/${config.projectKey}/repos/${
+      config.repositorySlug
+    }/pull-requests/${prNo}`
+  )).body;
   await api.post(
     `/rest/api/1.0/projects/${config.projectKey}/repos/${
       config.repositorySlug
-    }/pull-requests/${prNo}/merge`
+    }/pull-requests/${prNo}/merge?version=${version}`
   );
 }
 

--- a/test/_fixtures/bitbucket-server/responses.js
+++ b/test/_fixtures/bitbucket-server/responses.js
@@ -464,4 +464,5 @@ function generateServerResponses(endpoint) {
 
 module.exports = {
   'endpoint with no path': generateServerResponses('https://stash.renovatebot.com'),
+  'endpoint with path': generateServerResponses('https://stash.renovatebot.com/vcs'),
 };

--- a/test/_fixtures/bitbucket-server/responses.js
+++ b/test/_fixtures/bitbucket-server/responses.js
@@ -1,4 +1,6 @@
-function generateRepo(projectKey, repositorySlug) {
+const { URL } = require('url');
+
+function generateRepo(endpoint, projectKey, repositorySlug) {
   let projectKeyLower = projectKey.toLowerCase();
   return {
     slug: repositorySlug,
@@ -24,7 +26,7 @@ function generateRepo(projectKey, repositorySlug) {
     links: {
       clone: [
         {
-          href: `https://stash.renovatebot.com/scm/${projectKeyLower}/${repositorySlug}.git`,
+          href: `${endpoint}/scm/${projectKeyLower}/${repositorySlug}.git`,
           name: 'http',
         },
         {
@@ -34,14 +36,14 @@ function generateRepo(projectKey, repositorySlug) {
       ],
       self: [
         {
-          href: `https://stash.renovatebot.com/projects/${projectKey}/repos/${repositorySlug}/browse`,
+          href: `${endpoint}/projects/${projectKey}/repos/${repositorySlug}/browse`,
         },
       ],
     },
   };
 }
 
-function generatePR(projectKey, repositorySlug) {
+function generatePR(endpoint, projectKey, repositorySlug) {
   return {
     id: 5,
     version: 1,
@@ -77,7 +79,7 @@ function generatePR(projectKey, repositorySlug) {
         slug: 'userName1',
         type: 'NORMAL',
         links: {
-          self: [{ href: 'https://stash.renovatebot.com/users/userName1' }],
+          self: [{ href: `${endpoint}/users/userName1` }],
         },
       },
       role: 'AUTHOR',
@@ -95,7 +97,7 @@ function generatePR(projectKey, repositorySlug) {
           slug: 'userName2',
           type: 'NORMAL',
           links: {
-            self: [{ href: 'https://stash.renovatebot.com/users/userName2' }],
+            self: [{ href: `${endpoint}/users/userName2` }],
           },
         },
         role: 'REVIEWER',
@@ -107,289 +109,359 @@ function generatePR(projectKey, repositorySlug) {
     links: {
       self: [
         {
-          href: `https://stash.renovatebot.com/projects/${projectKey}/repos/${repositorySlug}/pull-requests/5`,
+          href: `${endpoint}/projects/${projectKey}/repos/${repositorySlug}/pull-requests/5`,
         },
       ],
     },
   };
 }
 
-module.exports = {
-  baseURL: "https://stash.renovatebot.com/",
-  '/rest/api/1.0/projects': {
-    size: 1,
-    limit: 100,
-    isLastPage: true,
-    values: [
-      {
-        key: 'SOME',
-        id: 1964,
-        name: 'Some',
-        public: false,
-        type: 'NORMAL',
-        links: {
-          self: [{ href: 'https://stash.renovatebot.com/projects/SOME' }],
-        },
-      },
-    ],
-    start: 0,
-  },
-  '/rest/api/1.0/projects/some/repos': {
-    size: 1,
-    limit: 25,
-    isLastPage: true,
-    values: [generateRepo('SOME', 'repo')],
-    start: 0,
-  },
-  '/rest/api/1.0/projects/some/repos/repo': generateRepo('SOME', 'repo'),
-  '/rest/api/1.0/projects/some/repos/repo/branches/default': {
-    displayId: 'master',
-  },
-  '/rest/api/1.0/projects/some/repos/repo/issues': {
-    // TODO - I'm not sure there is an issues link to provide
-    values: [],
-  },
-  '/rest/api/1.0/projects/some/repos/repo/pullrequests': {
-    values: [generatePR()],
-  },
-  '/rest/api/1.0/projects/some/repos/repo/pullrequests/5': generatePR(),
-  '/rest/api/1.0/projects/some/repos/repo/pullrequests/5/diff': {
-    fromHash: 'afdcf5e55dfce85055a146783434b0e2a81722c1',
-    toHash: '590e661bb8c189b5a4bee115b475c9f14bf112bd',
-    contextLines: 10,
-    whitespace: 'SHOW',
-    diffs: [
-      {
-        source: {
-          components: ['package.json'],
-          parent: '',
-          name: 'package.json',
-          extension: 'json',
-          toString: 'package.json',
-        },
-        destination: {
-          components: ['package.json'],
-          parent: '',
-          name: 'package.json',
-          extension: 'json',
-          toString: 'package.json',
-        },
-        hunks: [
-          {
-            sourceLine: 47,
-            sourceSpan: 18,
-            destinationLine: 47,
-            destinationSpan: 18,
-            segments: [
-              {
-                type: 'CONTEXT',
-                lines: [
-                  {
-                    source: 47,
-                    destination: 47,
-                    line: '    "webpack": "4.28.0"',
-                    truncated: false,
-                  },
-                  {
-                    source: 48,
-                    destination: 48,
-                    line: '  },',
-                    truncated: false,
-                  },
-                  {
-                    source: 49,
-                    destination: 49,
-                    line: '  "license": "MIT",',
-                    truncated: false,
-                  },
-                  {
-                    source: 50,
-                    destination: 50,
-                    line: '  "main": "dist/index.js",',
-                    truncated: false,
-                  },
-                  {
-                    source: 51,
-                    destination: 51,
-                    line: '  "module": "dist/index.es.js",',
-                    truncated: false,
-                  },
-                  {
-                    source: 52,
-                    destination: 52,
-                    line: '  "name": "removed-for-privacy",',
-                    truncated: false,
-                  },
-                  {
-                    source: 53,
-                    destination: 53,
-                    line: '  "publishConfig": {',
-                    truncated: false,
-                  },
-                  {
-                    source: 54,
-                    destination: 54,
-                    line: '    "registry": "https://npm.renovatebot.com/"',
-                    truncated: false,
-                  },
-                  {
-                    source: 55,
-                    destination: 55,
-                    line: '  },',
-                    truncated: false,
-                  },
-                  {
-                    source: 56,
-                    destination: 56,
-                    line: '  "scripts": {',
-                    truncated: false,
-                  },
-                ],
-                truncated: false,
-              },
-              {
-                type: 'REMOVED',
-                lines: [
-                  {
-                    source: 57,
-                    destination: 57,
-                    line:
-                      '    "build": "TS_NODE_PROJECT=\\"tsconfig.webpack.json\\" webpack --config=webpack.config.prod.ts",',
-                    truncated: false,
-                  },
-                ],
-                truncated: false,
-              },
-              {
-                type: 'ADDED',
-                lines: [
-                  {
-                    source: 58,
-                    destination: 57,
-                    line:
-                      '    "build": "npm run env TS_NODE_PROJECT=\\"tsconfig.webpack.json\\" -- && webpack --config=webpack.config.prod.ts",',
-                    truncated: false,
-                  },
-                ],
-                truncated: false,
-              },
-              {
-                type: 'CONTEXT',
-                lines: [
-                  {
-                    source: 58,
-                    destination: 58,
-                    line: '    "clean": "rimraf dist",',
-                    truncated: false,
-                  },
-                ],
-                truncated: false,
-              },
-              {
-                type: 'REMOVED',
-                lines: [
-                  {
-                    source: 59,
-                    destination: 59,
-                    line:
-                      '    "dev": "TS_NODE_PROJECT=\\"tsconfig.webpack.json\\" webpack --config=webpack.config.ts",',
-                    truncated: false,
-                  },
-                ],
-                truncated: false,
-              },
-              {
-                type: 'ADDED',
-                lines: [
-                  {
-                    source: 60,
-                    destination: 59,
-                    line:
-                      '    "dev": "npm run env TS_NODE_PROJECT=\\"tsconfig.webpack.json\\" -- && webpack --config=webpack.config.ts",',
-                    truncated: false,
-                  },
-                ],
-                truncated: false,
-              },
-              {
-                type: 'CONTEXT',
-                lines: [
-                  {
-                    source: 60,
-                    destination: 60,
-                    line: '    "prepare": "npm run clean && npm run build",',
-                    truncated: false,
-                  },
-                ],
-                truncated: false,
-              },
-              {
-                type: 'REMOVED',
-                lines: [
-                  {
-                    source: 61,
-                    destination: 61,
-                    line:
-                      '    "start": "TS_NODE_PROJECT=\\"tsconfig.webpack.json\\" webpack-dev-server --env.NODE_ENV=development --env.buildenv=stage"',
-                    truncated: false,
-                  },
-                ],
-                truncated: false,
-              },
-              {
-                type: 'ADDED',
-                lines: [
-                  {
-                    source: 62,
-                    destination: 61,
-                    line:
-                      '    "start": "npm run env TS_NODE_PROJECT=\\"tsconfig.webpack.json\\" -- && webpack-dev-server --env.NODE_ENV=development --env.buildenv=stage"',
-                    truncated: false,
-                  },
-                ],
-                truncated: false,
-              },
-              {
-                type: 'CONTEXT',
-                lines: [
-                  {
-                    source: 62,
-                    destination: 62,
-                    line: '  },',
-                    truncated: false,
-                  },
-                  {
-                    source: 63,
-                    destination: 63,
-                    line: '  "version": "0.0.1"',
-                    truncated: false,
-                  },
-                  { source: 64, destination: 64, line: '}', truncated: false },
-                ],
-                truncated: false,
-              },
-            ],
-            truncated: false,
+function generateServerResponses(endpoint) {
+  return {
+    baseURL: endpoint,
+    [`${endpoint}/rest/api/1.0/projects?limit=100`]: {
+      'GET': {
+      size: 1,
+      limit: 100,
+      isLastPage: true,
+      values: [
+        {
+          key: 'SOME',
+          id: 1964,
+          name: 'Some',
+          public: false,
+          type: 'NORMAL',
+          links: {
+            self: [{ href: `${endpoint}/projects/SOME` }],
           },
-        ],
-        truncated: false,
+        },
+      ],
+      start: 0,
+    },
+    },
+    [`${endpoint}/rest/api/1.0/projects/SOME/repos?limit=100`]: {
+      'GET': {
+      size: 1,
+      limit: 25,
+      isLastPage: true,
+      values: [generateRepo(endpoint, 'SOME', 'repo')],
+      start: 0,
+    },
+    },
+    [`${endpoint}/rest/api/1.0/projects/SOME/repos/repo`]: {
+      'GET': generateRepo(endpoint, 'SOME', 'repo'),
+    },
+    [`${endpoint}/rest/api/1.0/projects/SOME/repos/repo/branches/default`]: {
+      'GET': {
+      displayId: 'master',
+    },
+    },
+    // // TODO - I'm not sure there is an issues link to provide
+    // [`${endpoint}/rest/api/1.0/projects/SOME/repos/repo/issues`]: {
+    //   'GET': {
+    //     values: [],
+    //   },
+    // },
+    [`${endpoint}/rest/api/1.0/projects/SOME/repos/repo/pull-requests`]: {
+      'GET': {
+        values: [generatePR(endpoint, 'SOME', 'repo')],
       },
-    ],
-    truncated: false,
-  },
-  '/rest/api/1.0/projects/some/repos/repo/pullrequests/5/commits': {
-    values: [{}],
-  },
-  '/rest/api/1.0/projects/some/repos/branches': {
-    isLastPage: true,
-    limit: 25,
-    size: 2,
-    start: 0,
-    values: [
-      { displayId: 'master', id: 'refs/heads/master' },
-      { displayId: 'branch', id: 'refs/heads/branch' },
-      { displayId: 'renovate/branch', id: 'refs/heads/renovate/branch' },
-      { displayId: 'renovate/upgrade', id: 'refs/heads/renovate/upgrade' },
-    ],
-  },
+      'POST': generatePR(endpoint, 'SOME', 'repo'),
+    },
+    [`${endpoint}/rest/api/1.0/projects/SOME/repos/repo/pull-requests/5`]: {
+      'GET': generatePR(endpoint, 'SOME', 'repo'),
+      'PUT': generatePR(endpoint, 'SOME', 'repo'),
+    },
+    [`${endpoint}/rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/participants`]: {
+      'POST': {
+        "user": {
+          "name": "jcitizen",
+          "emailAddress": "jane@example.com",
+          "id": 101,
+          "displayName": "Jane Citizen",
+          "active": true,
+          "slug": "jcitizen",
+          "type": "NORMAL"
+        },
+        "lastReviewedCommit": "7549846524f8aed2bd1c0249993ae1bf9d3c9998",
+        "role": "REVIEWER",
+        "approved": false,
+        "status": "UNAPPROVED"
+      },
+    },
+    [`${endpoint}/rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/diff`]: {
+      'GET': {
+      fromHash: 'afdcf5e55dfce85055a146783434b0e2a81722c1',
+      toHash: '590e661bb8c189b5a4bee115b475c9f14bf112bd',
+      contextLines: 10,
+      whitespace: 'SHOW',
+      diffs: [
+        {
+          source: {
+            components: ['package.json'],
+            parent: '',
+            name: 'package.json',
+            extension: 'json',
+            toString: 'package.json',
+          },
+          destination: {
+            components: ['package.json'],
+            parent: '',
+            name: 'package.json',
+            extension: 'json',
+            toString: 'package.json',
+          },
+          hunks: [
+            {
+              sourceLine: 47,
+              sourceSpan: 18,
+              destinationLine: 47,
+              destinationSpan: 18,
+              segments: [
+                {
+                  type: 'CONTEXT',
+                  lines: [
+                    {
+                      source: 47,
+                      destination: 47,
+                      line: '    "webpack": "4.28.0"',
+                      truncated: false,
+                    },
+                    {
+                      source: 48,
+                      destination: 48,
+                      line: '  },',
+                      truncated: false,
+                    },
+                    {
+                      source: 49,
+                      destination: 49,
+                      line: '  "license": "MIT",',
+                      truncated: false,
+                    },
+                    {
+                      source: 50,
+                      destination: 50,
+                      line: '  "main": "dist/index.js",',
+                      truncated: false,
+                    },
+                    {
+                      source: 51,
+                      destination: 51,
+                      line: '  "module": "dist/index.es.js",',
+                      truncated: false,
+                    },
+                    {
+                      source: 52,
+                      destination: 52,
+                      line: '  "name": "removed-for-privacy",',
+                      truncated: false,
+                    },
+                    {
+                      source: 53,
+                      destination: 53,
+                      line: '  "publishConfig": {',
+                      truncated: false,
+                    },
+                    {
+                      source: 54,
+                      destination: 54,
+                      line: '    "registry": "https://npm.renovatebot.com/"',
+                      truncated: false,
+                    },
+                    {
+                      source: 55,
+                      destination: 55,
+                      line: '  },',
+                      truncated: false,
+                    },
+                    {
+                      source: 56,
+                      destination: 56,
+                      line: '  "scripts": {',
+                      truncated: false,
+                    },
+                  ],
+                  truncated: false,
+                },
+                {
+                  type: 'REMOVED',
+                  lines: [
+                    {
+                      source: 57,
+                      destination: 57,
+                      line:
+                        '    "build": "TS_NODE_PROJECT=\\"tsconfig.webpack.json\\" webpack --config=webpack.config.prod.ts",',
+                      truncated: false,
+                    },
+                  ],
+                  truncated: false,
+                },
+                {
+                  type: 'ADDED',
+                  lines: [
+                    {
+                      source: 58,
+                      destination: 57,
+                      line:
+                        '    "build": "npm run env TS_NODE_PROJECT=\\"tsconfig.webpack.json\\" -- && webpack --config=webpack.config.prod.ts",',
+                      truncated: false,
+                    },
+                  ],
+                  truncated: false,
+                },
+                {
+                  type: 'CONTEXT',
+                  lines: [
+                    {
+                      source: 58,
+                      destination: 58,
+                      line: '    "clean": "rimraf dist",',
+                      truncated: false,
+                    },
+                  ],
+                  truncated: false,
+                },
+                {
+                  type: 'REMOVED',
+                  lines: [
+                    {
+                      source: 59,
+                      destination: 59,
+                      line:
+                        '    "dev": "TS_NODE_PROJECT=\\"tsconfig.webpack.json\\" webpack --config=webpack.config.ts",',
+                      truncated: false,
+                    },
+                  ],
+                  truncated: false,
+                },
+                {
+                  type: 'ADDED',
+                  lines: [
+                    {
+                      source: 60,
+                      destination: 59,
+                      line:
+                        '    "dev": "npm run env TS_NODE_PROJECT=\\"tsconfig.webpack.json\\" -- && webpack --config=webpack.config.ts",',
+                      truncated: false,
+                    },
+                  ],
+                  truncated: false,
+                },
+                {
+                  type: 'CONTEXT',
+                  lines: [
+                    {
+                      source: 60,
+                      destination: 60,
+                      line: '    "prepare": "npm run clean && npm run build",',
+                      truncated: false,
+                    },
+                  ],
+                  truncated: false,
+                },
+                {
+                  type: 'REMOVED',
+                  lines: [
+                    {
+                      source: 61,
+                      destination: 61,
+                      line:
+                        '    "start": "TS_NODE_PROJECT=\\"tsconfig.webpack.json\\" webpack-dev-server --env.NODE_ENV=development --env.buildenv=stage"',
+                      truncated: false,
+                    },
+                  ],
+                  truncated: false,
+                },
+                {
+                  type: 'ADDED',
+                  lines: [
+                    {
+                      source: 62,
+                      destination: 61,
+                      line:
+                        '    "start": "npm run env TS_NODE_PROJECT=\\"tsconfig.webpack.json\\" -- && webpack-dev-server --env.NODE_ENV=development --env.buildenv=stage"',
+                      truncated: false,
+                    },
+                  ],
+                  truncated: false,
+                },
+                {
+                  type: 'CONTEXT',
+                  lines: [
+                    {
+                      source: 62,
+                      destination: 62,
+                      line: '  },',
+                      truncated: false,
+                    },
+                    {
+                      source: 63,
+                      destination: 63,
+                      line: '  "version": "0.0.1"',
+                      truncated: false,
+                    },
+                    { source: 64, destination: 64, line: '}', truncated: false },
+                  ],
+                  truncated: false,
+                },
+              ],
+              truncated: false,
+            },
+          ],
+          truncated: false,
+        },
+      ],
+      truncated: false,
+    },
+    },
+    [`${endpoint}/rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits`]: {
+      'GET': {
+      values: [{}],
+    },
+    },
+    [`${endpoint}/rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge`]: {
+      'GET': { conflicted: false },
+      'POST': Promise.reject({
+    "errors": [
+        {
+            "context": null,
+            "message": "A detailed error message.",
+            "exceptionName": null
+        }
+    ]
+}),
+    },
+    [`${endpoint}/rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge?version=1`]: {
+      'POST': {
+        ...generatePR(endpoint, 'SOME', 'repo'),
+        ...{
+          "state": "MERGED",
+          "open": false,
+          "closed": true,
+          "createdDate": 1547853840016,
+          "updatedDate": 1547853840016,
+          "closedDate": 1547853840017,
+        },
+      },
+    },
+    [`${endpoint}/rest/api/1.0/projects/SOME/repos/branches`]: {
+      'GET': {
+      isLastPage: true,
+      limit: 25,
+      size: 2,
+      start: 0,
+      values: [
+        { displayId: 'master', id: 'refs/heads/master' },
+        { displayId: 'branch', id: 'refs/heads/branch' },
+        { displayId: 'renovate/branch', id: 'refs/heads/renovate/branch' },
+        { displayId: 'renovate/upgrade', id: 'refs/heads/renovate/upgrade' },
+      ],
+    },
+    },
+  }
+}
+
+module.exports = {
+  'endpoint with no path': generateServerResponses('https://stash.renovatebot.com'),
 };

--- a/test/platform/bitbucket-server/__snapshots__/index.spec.js.snap
+++ b/test/platform/bitbucket-server/__snapshots__/index.spec.js.snap
@@ -1,9 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`platform/bitbucket-server createPr() posts PR 1`] = `
+exports[`platform/bitbucket-server endpoint with no path addReviewers sends the reviewer name as a reviewer 1`] = `
 Array [
   Array [
-    "/rest/api/1.0/projects/some/repos/repo/pull-requests",
+    "/rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/participants",
+    Object {
+      "body": Object {
+        "role": "REVIEWER",
+        "user": Object {
+          "name": "name",
+        },
+      },
+    },
+  ],
+]
+`;
+
+exports[`platform/bitbucket-server endpoint with no path createPr() posts PR 1`] = `
+Array [
+  Array [
+    "/rest/api/1.0/projects/SOME/repos/repo/pull-requests",
     Object {
       "body": Object {
         "description": "body",
@@ -20,7 +36,7 @@ Array [
 ]
 `;
 
-exports[`platform/bitbucket-server getPr() gets a PR 1`] = `
+exports[`platform/bitbucket-server endpoint with no path getPr() gets a PR 1`] = `
 Object {
   "body": "* Line 1
 * Line 2",
@@ -37,9 +53,9 @@ Object {
 }
 `;
 
-exports[`platform/bitbucket-server getPrBody() returns diff files 1`] = `"**foo**bartext"`;
+exports[`platform/bitbucket-server endpoint with no path getPrBody() returns diff files 1`] = `"**foo**bartext"`;
 
-exports[`platform/bitbucket-server initRepo() works 1`] = `
+exports[`platform/bitbucket-server endpoint with no path initRepo() works 1`] = `
 Object {
   "isFork": false,
   "privateRepo": undefined,
@@ -47,29 +63,29 @@ Object {
 }
 `;
 
-exports[`platform/bitbucket-server mergePr() posts Merge 1`] = `
+exports[`platform/bitbucket-server endpoint with no path mergePr() posts Merge 1`] = `
 Array [
   Array [
-    "/rest/api/1.0/projects/some/repos/repo/pull-requests/5/merge",
+    "/rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge?version=1",
   ],
 ]
 `;
 
-exports[`platform/bitbucket-server setBaseBranch() updates file list 1`] = `
+exports[`platform/bitbucket-server endpoint with no path setBaseBranch() updates file list 1`] = `
 Array [
   Array [
-    "/rest/api/1.0/projects/some/repos/repo",
+    "/rest/api/1.0/projects/SOME/repos/repo",
   ],
   Array [
-    "/rest/api/1.0/projects/some/repos/repo/branches/default",
+    "/rest/api/1.0/projects/SOME/repos/repo/branches/default",
   ],
 ]
 `;
 
-exports[`platform/bitbucket-server updatePr() puts PR 1`] = `
+exports[`platform/bitbucket-server endpoint with no path updatePr() puts PR 1`] = `
 Array [
   Array [
-    "/rest/api/1.0/projects/some/repos/repo/pull-requests/5",
+    "/rest/api/1.0/projects/SOME/repos/repo/pull-requests/5",
     Object {
       "body": Object {
         "description": "body",

--- a/test/platform/bitbucket-server/__snapshots__/index.spec.js.snap
+++ b/test/platform/bitbucket-server/__snapshots__/index.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`platform/bitbucket-server endpoint with no path addReviewers sends the reviewer name as a reviewer 1`] = `
 Array [
   Array [
-    "/rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/participants",
+    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/participants",
     Object {
       "body": Object {
         "role": "REVIEWER",
@@ -19,7 +19,7 @@ Array [
 exports[`platform/bitbucket-server endpoint with no path createPr() posts PR 1`] = `
 Array [
   Array [
-    "/rest/api/1.0/projects/SOME/repos/repo/pull-requests",
+    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests",
     Object {
       "body": Object {
         "description": "body",
@@ -66,7 +66,7 @@ Object {
 exports[`platform/bitbucket-server endpoint with no path mergePr() posts Merge 1`] = `
 Array [
   Array [
-    "/rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge?version=1",
+    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge?version=1",
   ],
 ]
 `;
@@ -74,10 +74,10 @@ Array [
 exports[`platform/bitbucket-server endpoint with no path setBaseBranch() updates file list 1`] = `
 Array [
   Array [
-    "/rest/api/1.0/projects/SOME/repos/repo",
+    "./rest/api/1.0/projects/SOME/repos/repo",
   ],
   Array [
-    "/rest/api/1.0/projects/SOME/repos/repo/branches/default",
+    "./rest/api/1.0/projects/SOME/repos/repo/branches/default",
   ],
 ]
 `;
@@ -85,7 +85,104 @@ Array [
 exports[`platform/bitbucket-server endpoint with no path updatePr() puts PR 1`] = `
 Array [
   Array [
-    "/rest/api/1.0/projects/SOME/repos/repo/pull-requests/5",
+    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5",
+    Object {
+      "body": Object {
+        "description": "body",
+        "title": "title",
+        "version": 1,
+      },
+    },
+  ],
+]
+`;
+
+exports[`platform/bitbucket-server endpoint with path addReviewers sends the reviewer name as a reviewer 1`] = `
+Array [
+  Array [
+    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/participants",
+    Object {
+      "body": Object {
+        "role": "REVIEWER",
+        "user": Object {
+          "name": "name",
+        },
+      },
+    },
+  ],
+]
+`;
+
+exports[`platform/bitbucket-server endpoint with path createPr() posts PR 1`] = `
+Array [
+  Array [
+    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests",
+    Object {
+      "body": Object {
+        "description": "body",
+        "fromRef": Object {
+          "id": "refs/heads/branch",
+        },
+        "title": "title",
+        "toRef": Object {
+          "id": "refs/heads/master",
+        },
+      },
+    },
+  ],
+]
+`;
+
+exports[`platform/bitbucket-server endpoint with path getPr() gets a PR 1`] = `
+Object {
+  "body": "* Line 1
+* Line 2",
+  "branchName": "userName1/pullRequest5",
+  "canMerge": false,
+  "canRebase": true,
+  "createdAt": undefined,
+  "displayNumber": "Pull Request #5",
+  "isConflicted": false,
+  "number": 5,
+  "state": "open",
+  "title": "title",
+  "version": 1,
+}
+`;
+
+exports[`platform/bitbucket-server endpoint with path getPrBody() returns diff files 1`] = `"**foo**bartext"`;
+
+exports[`platform/bitbucket-server endpoint with path initRepo() works 1`] = `
+Object {
+  "isFork": false,
+  "privateRepo": undefined,
+  "repoFullName": "repo",
+}
+`;
+
+exports[`platform/bitbucket-server endpoint with path mergePr() posts Merge 1`] = `
+Array [
+  Array [
+    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge?version=1",
+  ],
+]
+`;
+
+exports[`platform/bitbucket-server endpoint with path setBaseBranch() updates file list 1`] = `
+Array [
+  Array [
+    "./rest/api/1.0/projects/SOME/repos/repo",
+  ],
+  Array [
+    "./rest/api/1.0/projects/SOME/repos/repo/branches/default",
+  ],
+]
+`;
+
+exports[`platform/bitbucket-server endpoint with path updatePr() puts PR 1`] = `
+Array [
+  Array [
+    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5",
     Object {
       "body": Object {
         "description": "body",

--- a/test/platform/bitbucket-server/index.spec.js
+++ b/test/platform/bitbucket-server/index.spec.js
@@ -4,285 +4,278 @@ const URL = require('url');
 const responses = require('../../_fixtures/bitbucket-server/responses');
 
 describe('platform/bitbucket-server', () => {
-  let bitbucket;
-  let api;
-  let hostRules;
-  let GitStorage;
-  beforeEach(() => {
-    // reset module
-    jest.resetModules();
-    jest.mock('../../../lib/platform/bitbucket-server/bb-got-wrapper');
-    jest.mock('../../../lib/platform/git/storage');
-    hostRules = require('../../../lib/util/host-rules');
-    api = require('../../../lib/platform/bitbucket-server/bb-got-wrapper');
-    bitbucket = require('../../../lib/platform/bitbucket-server');
-    GitStorage = require('../../../lib/platform/git/storage');
-    GitStorage.mockImplementation(() => ({
-      initRepo: jest.fn(),
-      cleanRepo: jest.fn(),
-      getFileList: jest.fn(),
-      branchExists: jest.fn(() => true),
-      isBranchStale: jest.fn(() => false),
-      setBaseBranch: jest.fn(),
-      getBranchLastCommitTime: jest.fn(),
-      getAllRenovateBranches: jest.fn(),
-      getCommitMessages: jest.fn(),
-      getFile: jest.fn(),
-      commitFilesToBranch: jest.fn(),
-      mergeBranch: jest.fn(),
-      deleteBranch: jest.fn(),
-      getRepoStatus: jest.fn(),
-    }));
-
-    // clean up hostRules
-    hostRules.clear();
-    hostRules.update({
-      platform: 'bitbucket-server',
-      token: 'token',
-      username: 'username',
-      password: 'password',
-      endpoint: responses.baseURL,
-    });
-  });
-
-  afterEach(() => {
-    bitbucket.cleanRepo();
-  });
-
-  function initRepo() {
-    api.get.mockReturnValueOnce({
-      body: responses['/rest/api/1.0/projects/some/repos/repo'],
-    });
-    api.get.mockReturnValueOnce({
-      body:
-        responses['/rest/api/1.0/projects/some/repos/repo/branches/default'],
-    });
-    return bitbucket.initRepo({ repository: 'some/repo' });
-  }
-
-  describe('getRepos()', () => {
-    it('returns repos', async () => {
-      api.get
-        .mockReturnValueOnce({
-          body: responses['/rest/api/1.0/projects'],
-        })
-        .mockReturnValueOnce({
-          body: responses['/rest/api/1.0/projects/some/repos'],
+  Object.entries(responses).forEach(([scenarioName, mockResponses]) => {
+    describe(scenarioName, () => {
+      let bitbucket;
+      let api;
+      let hostRules;
+      let GitStorage;
+      beforeEach(() => {
+        // reset module
+        jest.resetModules();
+        jest.mock('got', () => (url, options) => {
+          const { method } = options;
+          const body = mockResponses[url] && mockResponses[url][method];
+          if (!body) {
+            return Promise.reject(new Error(`no match for ${method} ${url}`));
+          }
+          if (body instanceof Promise) {
+            return body;
+          }
+          return Promise.resolve({ body });
         });
-      expect(await bitbucket.getRepos()).toEqual(['some/repo']);
-    });
-  });
+        jest.mock('../../../lib/platform/git/storage');
+        hostRules = require('../../../lib/util/host-rules');
+        api = require('../../../lib/platform/bitbucket-server/bb-got-wrapper');
+        jest.spyOn(api, 'get');
+        jest.spyOn(api, 'post');
+        jest.spyOn(api, 'put');
+        bitbucket = require('../../../lib/platform/bitbucket-server');
+        GitStorage = require('../../../lib/platform/git/storage');
+        GitStorage.mockImplementation(() => ({
+          initRepo: jest.fn(),
+          cleanRepo: jest.fn(),
+          getFileList: jest.fn(),
+          branchExists: jest.fn(() => true),
+          isBranchStale: jest.fn(() => false),
+          setBaseBranch: jest.fn(),
+          getBranchLastCommitTime: jest.fn(),
+          getAllRenovateBranches: jest.fn(),
+          getCommitMessages: jest.fn(),
+          getFile: jest.fn(),
+          commitFilesToBranch: jest.fn(),
+          mergeBranch: jest.fn(),
+          deleteBranch: jest.fn(),
+          getRepoStatus: jest.fn(),
+        }));
 
-  describe('initRepo()', () => {
-    it('works', async () => {
-      const res = await initRepo();
-      expect(res).toMatchSnapshot();
-    });
-  });
-
-  describe('repoForceRebase()', () => {
-    it('always return false, since bitbucket does not support force rebase', () => {
-      const actual = bitbucket.getRepoForceRebase();
-      const expected = false;
-      expect(actual).toBe(expected);
-    });
-  });
-
-  describe('setBaseBranch()', () => {
-    it('updates file list', async () => {
-      await initRepo();
-      await bitbucket.setBaseBranch('branch');
-      expect(api.get.mock.calls).toMatchSnapshot();
-    });
-  });
-
-  describe('getFileList()', () => {
-    it('sends to gitFs', async () => {
-      await initRepo();
-      await bitbucket.getFileList();
-    });
-  });
-
-  describe('branchExists()', () => {
-    describe('getFileList()', () => {
-      it('sends to gitFs', async () => {
-        await initRepo();
-        await bitbucket.branchExists();
+        // clean up hostRules
+        hostRules.clear();
+        hostRules.update({
+          platform: 'bitbucket-server',
+          token: 'token',
+          username: 'username',
+          password: 'password',
+          endpoint: mockResponses.baseURL,
+        });
       });
-    });
-  });
 
-  describe('isBranchStale()', () => {
-    it('sends to gitFs', async () => {
-      await initRepo();
-      await bitbucket.isBranchStale();
-    });
-  });
-
-  describe('deleteBranch()', () => {
-    it('sends to gitFs', async () => {
-      await initRepo();
-      await bitbucket.deleteBranch('branch');
-    });
-  });
-
-  describe('mergeBranch()', () => {
-    it('sends to gitFs', async () => {
-      await initRepo();
-      await bitbucket.mergeBranch('branch');
-    });
-  });
-
-  describe('commitFilesToBranch()', () => {
-    it('sends to gitFs', async () => {
-      await initRepo();
-      await bitbucket.commitFilesToBranch('some-branch', [{}]);
-    });
-  });
-
-  describe('getFile()', () => {
-    it('sends to gitFs', async () => {
-      await initRepo();
-      await bitbucket.getFile();
-    });
-  });
-
-  describe('getAllRenovateBranches()', () => {
-    it('sends to gitFs', async () => {
-      await initRepo();
-      await bitbucket.getAllRenovateBranches();
-    });
-  });
-
-  describe('getBranchLastCommitTime()', () => {
-    it('sends to gitFs', async () => {
-      await initRepo();
-      await bitbucket.getBranchLastCommitTime();
-    });
-  });
-
-  describe('addAssignees()', () => {
-    it('does not throw', async () => {
-      await bitbucket.addAssignees(3, ['some']);
-    });
-  });
-
-  describe('addReviewers', () => {
-    it('does not throw', async () => {
-      await bitbucket.addReviewers(5, ['some']);
-    });
-  });
-
-  describe('deleteLAbel()', () => {
-    it('does not throw', async () => {
-      await bitbucket.deleteLabel(5, 'renovate');
-    });
-  });
-
-  describe('ensureComment()', () => {
-    it('does not throw', async () => {
-      await bitbucket.ensureComment(3, 'topic', 'content');
-    });
-  });
-
-  describe('ensureCommentRemoval()', () => {
-    it('does not throw', async () => {
-      await bitbucket.ensureCommentRemoval(3, 'topic');
-    });
-  });
-
-  describe('getPrList()', () => {
-    it('exists', () => {
-      expect(bitbucket.getPrList).toBeDefined();
-      // TODO
-    });
-  });
-
-  describe('findPr()', () => {
-    it('exists', () => {
-      expect(bitbucket.findPr).toBeDefined();
-      // TODO
-    });
-  });
-
-  describe('createPr()', () => {
-    it('posts PR', async () => {
-      await initRepo();
-      api.post.mockReturnValueOnce({
-        body: {
-          id: 5,
-          fromRef: { displayId: 'renovate/some-branch' },
-          state: 'OPEN',
-        },
+      afterEach(() => {
+        bitbucket.cleanRepo();
       });
-      const { id } = await bitbucket.createPr('branch', 'title', 'body');
-      expect(id).toBe(5);
-      expect(api.post.mock.calls).toMatchSnapshot();
-    });
-  });
 
-  describe('getPr()', () => {
-    // beforeEach(() => initRepo())
-    it('returns null for no prNo', async () => {
-      expect(await bitbucket.getPr()).toBe(null);
-    });
-    it('gets a PR', async () => {
-      api.get.mockReturnValueOnce({
-        body:
-          responses['/rest/api/1.0/projects/some/repos/repo/pullrequests/5'],
+      function initRepo() {
+        return bitbucket.initRepo({ repository: 'SOME/repo' });
+      }
+
+      describe('getRepos()', () => {
+        it('returns repos', async () => {
+          expect(await bitbucket.getRepos()).toEqual(['some/repo']);
+        });
       });
-      api.get.mockReturnValueOnce({
-        body: {
-          conflicted: false,
-        },
+
+      describe('initRepo()', () => {
+        it('works', async () => {
+          const res = await initRepo();
+          expect(res).toMatchSnapshot();
+        });
       });
-      expect(await bitbucket.getPr(5)).toMatchSnapshot();
-    });
-  });
 
-  describe('getPrFiles()', () => {
-    it('returns empty files', async () => {
-      expect(await bitbucket.getPrFiles(5)).toHaveLength(0);
-    });
-  });
+      describe('repoForceRebase()', () => {
+        it('always return false, since bitbucket does not support force rebase', () => {
+          const actual = bitbucket.getRepoForceRebase();
+          const expected = false;
+          expect(actual).toBe(expected);
+        });
+      });
 
-  describe('updatePr()', () => {
-    it('puts PR', async () => {
-      await initRepo();
-      api.get.mockReturnValueOnce({ body: { version: 1 } });
-      await bitbucket.updatePr(5, 'title', 'body');
-      expect(api.put.mock.calls).toMatchSnapshot();
-    });
-  });
+      describe('setBaseBranch()', () => {
+        it('updates file list', async () => {
+          await initRepo();
+          await bitbucket.setBaseBranch('branch');
+          expect(api.get.mock.calls).toMatchSnapshot();
+        });
+      });
 
-  describe('mergePr()', () => {
-    it('posts Merge', async () => {
-      await initRepo();
-      await bitbucket.mergePr(5, 'branch');
-      expect(api.post.mock.calls).toMatchSnapshot();
-    });
-  });
+      describe('getFileList()', () => {
+        it('sends to gitFs', async () => {
+          await initRepo();
+          await bitbucket.getFileList();
+        });
+      });
 
-  describe('getPrBody()', () => {
-    it('returns diff files', () => {
-      expect(
-        bitbucket.getPrBody(
-          '<details><summary>foo</summary>bar</details>text<details>'
-        )
-      ).toMatchSnapshot();
-    });
-  });
+      describe('branchExists()', () => {
+        describe('getFileList()', () => {
+          it('sends to gitFs', async () => {
+            await initRepo();
+            await bitbucket.branchExists();
+          });
+        });
+      });
 
-  describe('getCommitMessages()', () => {
-    it('sends to gitFs', async () => {
-      await initRepo();
-      await bitbucket.getCommitMessages();
-    });
-  });
+      describe('isBranchStale()', () => {
+        it('sends to gitFs', async () => {
+          await initRepo();
+          await bitbucket.isBranchStale();
+        });
+      });
 
-  describe('getVulnerabilityAlerts()', () => {
-    it('returns empty array', async () => {
-      expect(await bitbucket.getVulnerabilityAlerts()).toEqual([]);
+      describe('deleteBranch()', () => {
+        it('sends to gitFs', async () => {
+          await initRepo();
+          await bitbucket.deleteBranch('branch');
+        });
+      });
+
+      describe('mergeBranch()', () => {
+        it('sends to gitFs', async () => {
+          await initRepo();
+          await bitbucket.mergeBranch('branch');
+        });
+      });
+
+      describe('commitFilesToBranch()', () => {
+        it('sends to gitFs', async () => {
+          await initRepo();
+          await bitbucket.commitFilesToBranch('some-branch', [{}]);
+        });
+      });
+
+      describe('getFile()', () => {
+        it('sends to gitFs', async () => {
+          await initRepo();
+          await bitbucket.getFile();
+        });
+      });
+
+      describe('getAllRenovateBranches()', () => {
+        it('sends to gitFs', async () => {
+          await initRepo();
+          await bitbucket.getAllRenovateBranches();
+        });
+      });
+
+      describe('getBranchLastCommitTime()', () => {
+        it('sends to gitFs', async () => {
+          await initRepo();
+          await bitbucket.getBranchLastCommitTime();
+        });
+      });
+
+      describe('addAssignees()', () => {
+        it('does not throw', async () => {
+          await bitbucket.addAssignees(3, ['some']);
+        });
+      });
+
+      describe('addReviewers', () => {
+        it('does not throw', async () => {
+          initRepo();
+          await bitbucket.addReviewers(5, ['name']);
+        });
+
+        it('sends the reviewer name as a reviewer', async () => {
+          initRepo();
+          await bitbucket.addReviewers(5, ['name']);
+          expect(api.post.mock.calls).toMatchSnapshot();
+        });
+      });
+
+      describe('deleteLAbel()', () => {
+        it('does not throw', async () => {
+          await bitbucket.deleteLabel(5, 'renovate');
+        });
+      });
+
+      describe('ensureComment()', () => {
+        it('does not throw', async () => {
+          await bitbucket.ensureComment(3, 'topic', 'content');
+        });
+      });
+
+      describe('ensureCommentRemoval()', () => {
+        it('does not throw', async () => {
+          await bitbucket.ensureCommentRemoval(3, 'topic');
+        });
+      });
+
+      describe('getPrList()', () => {
+        it('exists', () => {
+          expect(bitbucket.getPrList).toBeDefined();
+          // TODO
+        });
+      });
+
+      describe('findPr()', () => {
+        it('exists', () => {
+          expect(bitbucket.findPr).toBeDefined();
+          // TODO
+        });
+      });
+
+      describe('createPr()', () => {
+        it('posts PR', async () => {
+          await initRepo();
+          const { id } = await bitbucket.createPr('branch', 'title', 'body');
+          expect(id).toBe(5);
+          expect(api.post.mock.calls).toMatchSnapshot();
+        });
+      });
+
+      describe('getPr()', () => {
+        it('returns null for no prNo', async () => {
+          expect(await bitbucket.getPr()).toBe(null);
+        });
+        it('gets a PR', async () => {
+          initRepo();
+          expect(await bitbucket.getPr(5)).toMatchSnapshot();
+        });
+      });
+
+      describe('getPrFiles()', () => {
+        it('returns empty files', async () => {
+          expect(await bitbucket.getPrFiles(5)).toHaveLength(0);
+        });
+      });
+
+      describe('updatePr()', () => {
+        it('puts PR', async () => {
+          await initRepo();
+          await bitbucket.updatePr(5, 'title', 'body');
+          expect(api.put.mock.calls).toMatchSnapshot();
+        });
+      });
+
+      describe('mergePr()', () => {
+        it('posts Merge', async () => {
+          await initRepo();
+          await bitbucket.mergePr(5, 'branch');
+          expect(api.post.mock.calls).toMatchSnapshot();
+        });
+      });
+
+      describe('getPrBody()', () => {
+        it('returns diff files', () => {
+          expect(
+            bitbucket.getPrBody(
+              '<details><summary>foo</summary>bar</details>text<details>'
+            )
+          ).toMatchSnapshot();
+        });
+      });
+
+      describe('getCommitMessages()', () => {
+        it('sends to gitFs', async () => {
+          await initRepo();
+          await bitbucket.getCommitMessages();
+        });
+      });
+
+      describe('getVulnerabilityAlerts()', () => {
+        it('returns empty array', async () => {
+          expect(await bitbucket.getVulnerabilityAlerts()).toEqual([]);
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
Uses the full endpoint URL for API URLs, including the path.

A side discovery of auto-merging not conforming to the version being required (`POST ..../merge?version=1`) so also include a fix for that. Would include that in a different PR to avoid scope creep but it was easier to do in conjunction with the fixture changes of this PR.

Closes #3225
