### PR TITLE
 feat(bitbucket-server): add branch status handling

### DIFF
--- a/lib/platform/bitbucket-server/index.js
+++ b/lib/platform/bitbucket-server/index.js
@@ -305,62 +305,101 @@ function getRepoStatus() {
 
 // Returns the combined status for a branch.
 // umbrella for status checks
-// TODO: coverage
-// istanbul ignore next
+// https://docs.atlassian.com/bitbucket-server/rest/6.0.0/bitbucket-build-rest.html#idp2
 async function getBranchStatus(branchName, requiredStatusChecks) {
   logger.debug(
     `getBranchStatus(${branchName}, requiredStatusChecks=${!!requiredStatusChecks})`
   );
-  const prList = await getPrList();
-  const prForBranch = prList.find(x => x.branchName === branchName);
 
-  if (!prForBranch) {
-    logger.info(`There is no open PR for branch: ${branchName}`);
-    // do no harm
-    // TODO: is it correct way?
+  if (!requiredStatusChecks) {
+    // null means disable status checks, so it always succeeds
+    logger.debug('Status checks disabled = returning "success"');
+    return 'success';
+  }
+
+  const branchCommit = await config.storage.getBranchCommit(branchName);
+
+  try {
+    const commitStatus = await api.get(
+      `./rest/build-status/1.0/commits/stats/${branchCommit}?includeUnique=true`
+    ).body;
+
+    logger.debug({ commitStatus }, 'branch status check result');
+
+    if (commitStatus.failed > 0) return 'failed';
+    if (commitStatus.inProgress > 0) return 'pending';
+    return commitStatus.successful > 0 ? 'success' : 'pending';
+  } catch (err) {
+    logger.warn({ err }, `Failed to check branch status`);
     return 'failed';
   }
-  logger.debug({ prForBranch }, 'PRFORBRANCH');
-
-  const res = await api.get(
-    `./rest/api/1.0/projects/${config.projectKey}/repos/${
-      config.repositorySlug
-    }/pull-requests/${prForBranch.number}/merge`
-  );
-
-  const { canMerge } = res.body;
-  return canMerge ? 'success' : 'failed';
 }
 
-// TODO: coverage
-// istanbul ignore next
+// https://docs.atlassian.com/bitbucket-server/rest/6.0.0/bitbucket-build-rest.html#idp2
 async function getBranchStatusCheck(branchName, context) {
   logger.debug(`getBranchStatusCheck(${branchName}, context=${context})`);
-  const prList = await getPrList();
-  const prForBranch = prList.find(x => x.branchName === branchName);
-  if (!prForBranch) {
-    logger.info(`There is no open PR for branch: ${branchName}`);
-    // do no harm
-    // TODO is it right?
-    return null;
-  }
-  const res = await api.get(
-    `./rest/api/1.0/projects/${config.projectKey}/repos/${
-      config.repositorySlug
-    }/pull-requests/${prForBranch.number}/merge`
-  );
 
-  const { canMerge } = res.body;
-  return canMerge ? 'success' : 'failed';
+  const branchCommit = await config.storage.getBranchCommit(branchName);
+
+  try {
+    const states = await utils.accumulateValues(
+      `./rest/build-status/1.0/commits/${branchCommit}`
+    );
+
+    for (const state of states) {
+      if (state.key === context) {
+        switch (state.state) {
+          case 'SUCCESSFUL':
+            return 'success';
+          case 'INPROGRESS':
+            return 'pending';
+          case 'FAILED':
+          default:
+            return 'failure';
+        }
+      }
+    }
+  } catch (err) {
+    logger.warn({ err }, `Failed to check branch status`);
+  }
+  return null;
 }
 
-// TODO: coverage
-// istanbul ignore next
-function setBranchStatus(branchName) {
+async function setBranchStatus(
+  branchName,
+  context,
+  description,
+  state,
+  targetUrl
+) {
   logger.debug(`setBranchStatus(${branchName})`);
-  // TODO: Needs implementation
-  // This used when Renovate is adding its own status checks, such as for lock file failure or for unpublishSafe=true
-  // BB Server doesnt support it AFAIK
+
+  const branchCommit = await config.storage.getBranchCommit(branchName);
+
+  try {
+    const body = {
+      key: context,
+      description,
+      url: targetUrl || 'https://renovatebot.com',
+    };
+
+    switch (state) {
+      case 'success':
+        body.state = 'SUCCESSFUL';
+        break;
+      case 'pending':
+        body.state = 'INPROGRESS';
+        break;
+      case 'failure':
+      default:
+        body.state = 'FAILED';
+        break;
+    }
+
+    await api.post(`./rest/build-status/1.0/commits/${branchCommit}`, { body });
+  } catch (err) {
+    logger.warn({ err }, `Failed to set branch status`);
+  }
 }
 
 // Issue


### PR DESCRIPTION
This pr uses the bitbucket server build api to get and set branch states.

This pr superseeds pr #3246 