### PR TITLE
fix(bitbucket-server): get only writable repos.

### DIFF
--- a/lib/platform/bitbucket-server/index.js
+++ b/lib/platform/bitbucket-server/index.js
@@ -1,5 +1,4 @@
 const url = require('url');
-const _ = require('lodash');
 const addrs = require('email-addresses');
 
 const api = require('./bb-got-wrapper');
@@ -70,16 +69,10 @@ async function getRepos(token, endpoint) {
   }
   hostRules.update({ ...opts, platform, default: true });
   try {
-    const projects = await utils.accumulateValues('./rest/api/1.0/projects');
-    const repos = await Promise.all(
-      projects.map(({ key }) =>
-        // TODO: can we filter this by permission=REPO_WRITE?
-        utils.accumulateValues(`./rest/api/1.0/projects/${key}/repos`)
-      )
+    const repos = await utils.accumulateValues(
+      `./rest/api/1.0/repos?permission=REPO_WRITE&state=AVAILABLE`
     );
-    const result = _.flatten(repos).map(
-      r => `${r.project.key.toLowerCase()}/${r.name}`
-    );
+    const result = repos.map(r => `${r.project.key.toLowerCase()}/${r.slug}`);
     logger.debug({ result }, 'result of getRepos()');
     return result;
   } catch (err) /* istanbul ignore next */ {

--- a/test/_fixtures/bitbucket-server/responses.js
+++ b/test/_fixtures/bitbucket-server/responses.js
@@ -119,23 +119,12 @@ function generatePR(endpoint, projectKey, repositorySlug) {
 function generateServerResponses(endpoint) {
   return {
     baseURL: endpoint,
-    [`${endpoint}/rest/api/1.0/projects?limit=100`]: {
+    [`${endpoint}/rest/api/1.0/repos?permission=REPO_WRITE&state=AVAILABLE&limit=100`]: {
       'GET': {
       size: 1,
       limit: 100,
       isLastPage: true,
-      values: [
-        {
-          key: 'SOME',
-          id: 1964,
-          name: 'Some',
-          public: false,
-          type: 'NORMAL',
-          links: {
-            self: [{ href: `${endpoint}/projects/SOME` }],
-          },
-        },
-      ],
+      values: [generateRepo(endpoint, 'SOME', 'repo')],
       start: 0,
     },
     },


### PR DESCRIPTION
This pr uses the [repos api](https://docs.atlassian.com/bitbucket-server/rest/6.0.0/bitbucket-rest.html#idp354) to get writable repos. This will now find personal repos too.

Requires BitBucket Server 5.13 (the state flag)!
