### PR TITLE
 fix(bitbucket-server): refresh pr after update /merge /delete.

### DIFF
--- a/lib/platform/bitbucket-server/index.js
+++ b/lib/platform/bitbucket-server/index.js
@@ -277,6 +277,8 @@ async function deleteBranch(branchName, closePr = false) {
           config.repositorySlug
         }/pull-requests/${pr.number}/decline?version=${pr.version + 1}`
       );
+
+      await getPr(pr.number, true);
     }
   }
   return config.storage.deleteBranch(branchName);
@@ -766,6 +768,7 @@ async function updatePr(prNo, title, description) {
         },
       }
     );
+    await getPr(prNo, true);
   } catch (err) {
     if (err.statusCode === 404) {
       throw new Error('not-found');
@@ -792,6 +795,7 @@ async function mergePr(prNo, branchName) {
         config.repositorySlug
       }/pull-requests/${prNo}/merge?version=${pr.version}`
     );
+    await getPr(prNo, true);
   } catch (err) {
     if (err.statusCode === 404) {
       throw new Error('not-found');

--- a/test/platform/bitbucket-server/__snapshots__/index.spec.js.snap
+++ b/test/platform/bitbucket-server/__snapshots__/index.spec.js.snap
@@ -582,6 +582,15 @@ Array [
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
   ],
+  Array [
+    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5",
+    Object {
+      "useCache": false,
+    },
+  ],
+  Array [
+    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
+  ],
 ]
 `;
 
@@ -795,6 +804,15 @@ Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5",
     Object {
       "useCache": true,
+    },
+  ],
+  Array [
+    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
+  ],
+  Array [
+    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5",
+    Object {
+      "useCache": false,
     },
   ],
   Array [
@@ -1539,6 +1557,15 @@ Array [
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
   ],
+  Array [
+    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5",
+    Object {
+      "useCache": false,
+    },
+  ],
+  Array [
+    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
+  ],
 ]
 `;
 
@@ -1752,6 +1779,15 @@ Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5",
     Object {
       "useCache": true,
+    },
+  ],
+  Array [
+    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
+  ],
+  Array [
+    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5",
+    Object {
+      "useCache": false,
     },
   ],
   Array [


### PR DESCRIPTION
After a pr update / merge or branch delete we have to flush the pr cache to get the actual version.