### PR TITLE
fix(bitbucket-server): wrong version number.

### DIFF
--- a/lib/platform/bitbucket-server/index.js
+++ b/lib/platform/bitbucket-server/index.js
@@ -275,7 +275,7 @@ async function deleteBranch(branchName, closePr = false) {
       await api.post(
         `./rest/api/1.0/projects/${config.projectKey}/repos/${
           config.repositorySlug
-        }/pull-requests/${pr.number}/decline?version=${pr.version + 1}`
+        }/pull-requests/${pr.number}/decline?version=${pr.version}`
       );
     }
   }


### PR DESCRIPTION
This fixes a wrong version number used to decline the repo. This is a regression cause by #3257 and #3261.