### PR TITLE
docs: fix typo

### DIFF
--- a/website/docs/configuration-templates.md
+++ b/website/docs/configuration-templates.md
@@ -5,7 +5,7 @@ description: How to edit Renovate's config templates
 
 # Config Template Editing
 
-Tnis document describes how you can edit the branch names, commit messages, or PR titles and content.
+This document describes how you can edit the branch names, commit messages, or PR titles and content.
 
 ## Branch Name
 


### PR DESCRIPTION
Fix a typo in the configuration template documentation.
