### PR TITLE
fix(bitbucket-server): Do not cache branch status.

### DIFF
--- a/lib/platform/bitbucket-server/index.js
+++ b/lib/platform/bitbucket-server/index.js
@@ -317,7 +317,8 @@ async function getBranchStatus(branchName, requiredStatusChecks) {
 
   try {
     const commitStatus = (await api.get(
-      `./rest/build-status/1.0/commits/stats/${branchCommit}`
+      `./rest/build-status/1.0/commits/stats/${branchCommit}`,
+      { useCache: false }
     )).body;
 
     logger.debug({ commitStatus }, 'branch status check result');

--- a/test/platform/bitbucket-server/__snapshots__/index.spec.js.snap
+++ b/test/platform/bitbucket-server/__snapshots__/index.spec.js.snap
@@ -333,9 +333,15 @@ Array [
   ],
   Array [
     "./rest/build-status/1.0/commits/stats/0d9c7726c3d628b7e28af234595cfd20febdbf8e",
+    Object {
+      "useCache": false,
+    },
   ],
   Array [
     "./rest/build-status/1.0/commits/stats/0d9c7726c3d628b7e28af234595cfd20febdbf8e",
+    Object {
+      "useCache": false,
+    },
   ],
 ]
 `;
@@ -350,9 +356,15 @@ Array [
   ],
   Array [
     "./rest/build-status/1.0/commits/stats/0d9c7726c3d628b7e28af234595cfd20febdbf8e",
+    Object {
+      "useCache": false,
+    },
   ],
   Array [
     "./rest/build-status/1.0/commits/stats/0d9c7726c3d628b7e28af234595cfd20febdbf8e",
+    Object {
+      "useCache": false,
+    },
   ],
 ]
 `;
@@ -367,6 +379,9 @@ Array [
   ],
   Array [
     "./rest/build-status/1.0/commits/stats/0d9c7726c3d628b7e28af234595cfd20febdbf8e",
+    Object {
+      "useCache": false,
+    },
   ],
 ]
 `;
@@ -1308,9 +1323,15 @@ Array [
   ],
   Array [
     "./rest/build-status/1.0/commits/stats/0d9c7726c3d628b7e28af234595cfd20febdbf8e",
+    Object {
+      "useCache": false,
+    },
   ],
   Array [
     "./rest/build-status/1.0/commits/stats/0d9c7726c3d628b7e28af234595cfd20febdbf8e",
+    Object {
+      "useCache": false,
+    },
   ],
 ]
 `;
@@ -1325,9 +1346,15 @@ Array [
   ],
   Array [
     "./rest/build-status/1.0/commits/stats/0d9c7726c3d628b7e28af234595cfd20febdbf8e",
+    Object {
+      "useCache": false,
+    },
   ],
   Array [
     "./rest/build-status/1.0/commits/stats/0d9c7726c3d628b7e28af234595cfd20febdbf8e",
+    Object {
+      "useCache": false,
+    },
   ],
 ]
 `;
@@ -1342,6 +1369,9 @@ Array [
   ],
   Array [
     "./rest/build-status/1.0/commits/stats/0d9c7726c3d628b7e28af234595cfd20febdbf8e",
+    Object {
+      "useCache": false,
+    },
   ],
 ]
 `;


### PR DESCRIPTION
This pr fixes a caching error for the current branch status.
This pr also relates to #3276.