### PR TITLE
fix(gomod): handling of the "+incompatible" tag.

### DIFF
--- a/lib/manager/gomod/update.js
+++ b/lib/manager/gomod/update.js
@@ -75,6 +75,9 @@ function updateDependency(currentFileContent, upgrade) {
         }
       }
     }
+    if (lineToChange.endsWith('+incompatible')) {
+      newLine += '+incompatible';
+    }
     if (newLine === lineToChange) {
       logger.debug('No changes necessary');
       return currentFileContent;

--- a/test/_fixtures/go/1/go.mod
+++ b/test/_fixtures/go/1/go.mod
@@ -6,5 +6,6 @@ require github.com/davecgh/go-spew v1.0.0
 require golang.org/x/foo v1.0.0
 require github.com/rarkins/foo abcdef1
 require gopkg.in/russross/blackfriday.v1 v1.0.0
+require github.com/Azure/azure-sdk-for-go v25.1.0+incompatible
 
 replace github.com/pkg/errors => ../errors

--- a/test/manager/gomod/__snapshots__/extract.spec.js.snap
+++ b/test/manager/gomod/__snapshots__/extract.spec.js.snap
@@ -628,5 +628,13 @@ Array [
     "depType": "require",
     "lineNumber": 7,
   },
+  Object {
+    "currentValue": "v25.1.0+incompatible",
+    "datasource": "go",
+    "depName": "github.com/Azure/azure-sdk-for-go",
+    "depNameShort": "Azure/azure-sdk-for-go",
+    "depType": "require",
+    "lineNumber": 8,
+  },
 ]
 `;

--- a/test/manager/gomod/__snapshots__/update.spec.js.snap
+++ b/test/manager/gomod/__snapshots__/update.spec.js.snap
@@ -9,6 +9,7 @@ require github.com/davecgh/go-spew v1.0.0
 require golang.org/x/foo v1.0.0
 require github.com/rarkins/foo abcdef1
 require gopkg.in/russross/blackfriday.v2 v2.0.0
+require github.com/Azure/azure-sdk-for-go v25.1.0+incompatible
 
 replace github.com/pkg/errors => ../errors
 "
@@ -90,6 +91,7 @@ require github.com/davecgh/go-spew v1.0.0
 require golang.org/x/foo v1.0.0
 require github.com/rarkins/foo abcdef1
 require gopkg.in/russross/blackfriday.v1 v1.0.0
+require github.com/Azure/azure-sdk-for-go v25.1.0+incompatible
 
 replace github.com/pkg/errors => ../errors
 "

--- a/test/manager/gomod/extract.spec.js
+++ b/test/manager/gomod/extract.spec.js
@@ -16,7 +16,7 @@ describe('lib/manager/gomod/extract', () => {
     it('extracts single-line requires', () => {
       const res = extractPackageFile(gomod1, config).deps;
       expect(res).toMatchSnapshot();
-      expect(res).toHaveLength(6);
+      expect(res).toHaveLength(7);
       expect(res.filter(e => e.skipReason).length).toBe(1);
     });
     it('extracts multi-line requires', () => {

--- a/test/manager/gomod/update.spec.js
+++ b/test/manager/gomod/update.spec.js
@@ -176,5 +176,16 @@ describe('manager/gomod/update', () => {
       const res = goUpdate.updateDependency(gomod2, upgrade);
       expect(res).toBe(null);
     });
+    it('handles +incompatible tag', () => {
+      const upgrade = {
+        depName: 'github.com/Azure/azure-sdk-for-go',
+        lineNumber: 8,
+        newValue: 'v26.0.0',
+      };
+      const res = goUpdate.updateDependency(gomod1, upgrade);
+      expect(res).not.toEqual(gomod1);
+      // Assert that the version still contains +incompatible tag.
+      expect(res.includes(upgrade.newValue + '+incompatible')).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate
-->

Renovate does not currently handle [+incompatible](https://github.com/golang/go/wiki/Modules#can-a-module-consume-a-v2-package-that-has-not-opted-into-modules-what-does-incompatible-mean) suffix correctly.

For example, create a repository with the following:

`main.go`
```
package main

import (
  "fmt"
  _ "github.com/Azure/azure-sdk-for-go"
)

func main() {
  fmt.Println("Hello, World!")
}
```

Then run:

```
go mod init github.com/russellrollins/test
go get -u github.com/Azure/azure-sdk-for-go@v25.1.0
go build
```

This should succeed and your `go.mod` file should now look like:

```
module github.com/russellrollins/test

go 1.12

require github.com/Azure/azure-sdk-for-go v25.1.0+incompatible
```

Next, upgrade Azure to the most recent release:

```
go get -u github.com/Azure/azure-sdk-for-go
```

Your `go.mod` file should now look like:

```
module github.com/russellrollins/test

go 1.12

require github.com/Azure/azure-sdk-for-go v26.1.0+incompatible
```

However, if Renovate performs the same update, it will instead update to `github.com/Azure/azure-sdk-for-go v26.1.0` dropping the `+incompatible` suffix. This will cause future builds to update the `go.mod` file, and makes the build harder to reproduce.

This PR attempts to address this issue by preserving the `+incompatible` suffix if it is currently present. If a repo switches to the go modules, and `+incompatible` is no longer necessary, this will cause a similar issue in the opposite direction. However, the case of switching dependency management solutions is less common than the case of releasing new version.