### PR TITLE
fix(pipenv): Ignore git dependencies without versions in Pipfile

### DIFF
--- a/lib/manager/pipenv/extract.js
+++ b/lib/manager/pipenv/extract.js
@@ -51,6 +51,9 @@ function extractFromSection(pipfile, section, registryUrls) {
       if (requirements.version) {
         currentValue = requirements.version;
         pipenvNestedVersion = true;
+      } else if (requirements.git) {
+        logger.debug('Skipping git dependency');
+        return null;
       } else {
         currentValue = requirements;
         pipenvNestedVersion = false;

--- a/test/manager/pipenv/extract.spec.js
+++ b/test/manager/pipenv/extract.spec.js
@@ -26,6 +26,12 @@ describe('lib/manager/pipenv/extract', () => {
       expect(res).toMatchSnapshot();
       expect(res).toHaveLength(5);
     });
+    it('ignores git dependencies', () => {
+      const content =
+        '[packages]\r\nflask = {git = "https://github.com/pallets/flask.git"}\r\nwerkzeug = ">=0.14"';
+      const res = extractPackageFile(content, config).deps;
+      expect(res).toHaveLength(1);
+    });
     it('ignores invalid package names', () => {
       const content = '[packages]\r\nfoo = "==1.0.0"\r\n_invalid = "==1.0.0"';
       const res = extractPackageFile(content, config).deps;


### PR DESCRIPTION
This PR fixes parsing Pipfile with git dependencies, for example

```toml
[packages]
flask = {git = "https://github.com/pallets/flask.git"}
werkzeug = ">=0.14"
```

Closes #3282
