### PR TITLE
fix: Use two spaces for bazel go_repository comments

### DIFF
--- a/lib/manager/bazel/update.js
+++ b/lib/manager/bazel/update.js
@@ -19,7 +19,7 @@ async function updateDependency(fileContent, upgrade) {
       if (upgrade.currentDigest && upgrade.updateType !== 'digest') {
         newDef = newDef.replace(
           /commit = "[^"]+".*?\n/,
-          `commit = "${upgrade.newDigest}", # ${upgrade.newValue}\n`
+          `commit = "${upgrade.newDigest}",  # ${upgrade.newValue}\n`
         );
       }
     } else if (upgrade.depType === 'http_archive') {

--- a/test/manager/bazel/__snapshots__/update.spec.js.snap
+++ b/test/manager/bazel/__snapshots__/update.spec.js.snap
@@ -13,7 +13,7 @@ go_repository(
 go_repository(
     name = \\"com_github_google_uuid\\",
     importpath = \\"github.com/google/uuid\\",
-    commit = \\"aaa09d789f3dba190787f8b4454c7d3c936fe123\\", # v1.0.3
+    commit = \\"aaa09d789f3dba190787f8b4454c7d3c936fe123\\",  # v1.0.3
 )
 
 go_repository(

--- a/test/manager/bazel/update.spec.js
+++ b/test/manager/bazel/update.spec.js
@@ -51,7 +51,7 @@ describe('manager/bazel/update', () => {
       expect(res).toMatchSnapshot();
       expect(res).not.toEqual(content);
       expect(
-        res.includes('"aaa09d789f3dba190787f8b4454c7d3c936fe123", # v1.0.3')
+        res.includes('"aaa09d789f3dba190787f8b4454c7d3c936fe123",  # v1.0.3')
       ).toBe(true);
     });
     it('updates http archive', async () => {


### PR DESCRIPTION
Gazelle formats WORKSPACE file imports with two spaces between `,` and `#`.

Example diff:
```
go_repository(
  name = "com_github_hashicorp_golang_lru",
- commit = "7087cb70de9f7a8bc0a10c375cb0d2280a8edf9c", # v0.5.1
+ commit = "7087cb70de9f7a8bc0a10c375cb0d2280a8edf9c",  # v0.5.1
  importpath = "github.com/hashicorp/golang-lru",
 )
```