### PR TITLE
Small maven datasource authentication fixes

### DIFF
--- a/lib/datasource/maven/index.js
+++ b/lib/datasource/maven/index.js
@@ -138,7 +138,7 @@ async function downloadHttpProtocol(pkgUrl) {
     if (isNotFoundError(err)) {
       logger.debug(`Url not found ${pkgUrl}`);
     } else if (isPermissionsIssue(err)) {
-      logger.info(
+      logger.warn(
         { pkgUrl },
         'Dependency lookup unauthorized. Please add authentication with a hostRule'
       );

--- a/website/docs/configuration-options.md
+++ b/website/docs/configuration-options.md
@@ -280,11 +280,13 @@ Example for configuring `docker` auth:
 
 ```json
 {
-  "hostRules": {
-    "platform": "docker",
-    "username": "<some-username>",
-    "password": "<some-password>"
-  }
+  "hostRules": [
+    {
+      "platform": "docker",
+      "username": "<some-username>",
+      "password": "<some-password>"
+    }
+  ]
 }
 ```
 


### PR DESCRIPTION
The documentation states that hostRules can be an object but actually renovate expects a list.

Also, set permission issues verbosity to warning because this is an issue that must be addressed, not just some minor info imo.