### PR TITLE
fix: do not create onboarding branch on dry run

### DIFF
--- a/lib/workers/repository/onboarding/branch/index.js
+++ b/lib/workers/repository/onboarding/branch/index.js
@@ -27,7 +27,9 @@ async function checkOnboardingBranch(config) {
     logger.info('Need to create onboarding PR');
     await createOnboardingBranch(config);
   }
-  await platform.setBaseBranch(onboardingBranch);
+  if (!config.dryRun) {
+    await platform.setBaseBranch(onboardingBranch);
+  }
   const branchList = [onboardingBranch];
   return { ...config, repoIsOnboarded, branchList };
 }


### PR DESCRIPTION
This fixes the following scenario:

- on boarding branch is created
- on boarding branch is closed (merged or not) - branch is deleted. So renovate is not configured.
- you relaunch renovate with `--dry-run true`. Then it crashes with:

```
 INFO: Creating onboarding branch (repository=user/repo)
 INFO: DRY-RUN: Would commit files to onboaring branch (repository=user/repo)
ERROR: Repository has unknown error (repository=user/repo)
       "err": {
         "message": "fatal: argument 'origin/renovate/configure' ambigu : révision inconnue ou chemin inexistant.\nUtilisez '--' pour séparer les chemins des révisions, comme ceci :\n'git <commande> [<révision>...] -- [<chemin>...]'\n",
         "stack": "Error: fatal: argument 'origin/renovate/configure' ambigu : révision inconnue ou chemin inexistant.\nUtilisez '--' pour séparer les chemins des révisions, comme ceci :\n'git <commande> [<révision>...] -- [<chemin>...]'\n\n    at /home/user/code/renovate/renovate/node_modules/simple-git/promise.js:21:26\n    at Git.<anonymous> (/home/user/code/renovate/renovate/node_modules/simple-git/src/git.js:645:18)\n    at Function.Git.fail (/home/user/code/renovate/renovate/node_modules/simple-git/src/git.js:1478:18)\n    at fail (/home/user/code/renovate/renovate/node_modules/simple-git/src/git.js:1436:20)\n    at /home/user/code/renovate/renovate/node_modules/simple-git/src/git.js:1445:16\n    at process._tickCallback (internal/process/next_tick.js:68:7)"
```