### PR TITLE
feat(maven): configure default maven repo

### DIFF
--- a/lib/manager/maven/extract.js
+++ b/lib/manager/maven/extract.js
@@ -30,7 +30,7 @@ function depFromNode(node) {
     const versionNode = node.descendantWithPath('version');
     const fileReplacePosition = versionNode.position;
     const datasource = 'maven';
-    const registryUrls = [DEFAULT_MAVEN_REPO];
+    const registryUrls = [];
     return {
       datasource,
       depName,
@@ -91,7 +91,15 @@ function applyProps(dep, props) {
   return result;
 }
 
-function extractDependencies(raw) {
+function getDefaultRepository(config) {
+  let repo = DEFAULT_MAVEN_REPO;
+  if (config && config.maven && config.maven.defaultRepo) {
+    repo = config.maven.defaultRepo;
+  }
+  return repo;
+}
+
+function extractDependencies(raw, config) {
   if (!raw) return null;
 
   const project = parsePom(raw);
@@ -125,6 +133,14 @@ function extractDependencies(raw) {
 
   const withProps = dep => applyProps(dep, props);
   result.deps = deepExtract(project).map(withProps);
+
+  const defaultRepo = getDefaultRepository(config);
+
+  result.deps.forEach(dep => {
+    if (dep.registryUrls) {
+      dep.registryUrls.push(defaultRepo);
+    }
+  });
 
   const repositories = project.childNamed('repositories');
   if (repositories && repositories.children) {

--- a/lib/manager/maven/index.js
+++ b/lib/manager/maven/index.js
@@ -5,7 +5,7 @@ async function extractAllPackageFiles(config, packageFiles) {
   for (const packageFile of packageFiles) {
     const content = await platform.getFile(packageFile);
     if (content) {
-      const deps = extractDependencies(content);
+      const deps = extractDependencies(content, config);
       if (deps) {
         mavenFiles.push({
           packageFile,

--- a/test/manager/maven/index.spec.js
+++ b/test/manager/maven/index.spec.js
@@ -38,6 +38,28 @@ describe('manager/maven', () => {
       expect(pkg.manager).toEqual('maven');
       expect(pkg.deps).not.toBeNull();
     });
+
+    it('should use defaultRepo from config', async () => {
+      platform.getFile.mockReturnValueOnce(pomContent);
+      const config = {
+        maven: { defaultRepo: 'https://mirror.example.org/maven2' },
+      };
+      const packages = await extractAllPackageFiles(config, ['random.pom.xml']);
+      expect(packages.length).toEqual(1);
+
+      const pkg = packages[0];
+      expect(pkg.packageFile).toEqual('random.pom.xml');
+      expect(pkg.manager).toEqual('maven');
+      expect(pkg.deps).not.toBeNull();
+
+      const dep = pkg.deps[0];
+      expect(dep).not.toBeNull();
+      expect(dep.registryUrls).not.toBeNull();
+      expect(dep.registryUrls.length).toBeGreaterThanOrEqual(1);
+
+      const registryUrl = dep.registryUrls[0];
+      expect(registryUrl).toEqual('https://mirror.example.org/maven2');
+    });
   });
 
   describe('updateDependency', () => {


### PR DESCRIPTION
Currently, the default maven repository is hardcoded to Maven Central in `lib/manager/maven/extract.js`.  Many organizations have their own mirror of Maven Central and require developers to use that.  Also, many of our internal artifacts will only be available in our enterprise repository.

This change allows you to provide an alternative repository URL for the default repository in the renovate configuration:

```json
  "maven": {
    "enabled": "true",
    "defaultRepo": "https://mirror.example.org/maven2"
  }
```