### PR TITLE
docs: Fix link in docs/readme.md

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -2,4 +2,4 @@
 
 This directory is intended to provide documentation for developers/contributors on the Renovate project. For user-facing documentation - e.g. for how to confiure Renovate as a user - please see https://renovatebot.com/docs
 
-If you would like to contribute to Renovate or get it running locally for some others reason, please check out `../contributing.md` for steps on how to set up the project locally.
+If you would like to contribute to Renovate or get it running locally for some others reason, please check out [contributing.md](../.github/contributing.md) for steps on how to set up the project locally.


### PR DESCRIPTION
Fix missing link for `contribution.md` file
