### PR TITLE
onboarding/branch/create: Fix typo

### DIFF
--- a/lib/workers/repository/onboarding/branch/create.js
+++ b/lib/workers/repository/onboarding/branch/create.js
@@ -24,7 +24,7 @@ async function createOnboardingBranch(config) {
   }
   // istanbul ignore if
   if (config.dryRun) {
-    logger.info('DRY-RUN: Would commit files to onboaring branch');
+    logger.info('DRY-RUN: Would commit files to onboarding branch');
   } else {
     await platform.commitFilesToBranch(
       onboardingBranch,


### PR DESCRIPTION
It's "onboarding", not "onboaring" 😉 