### PR TITLE
fix: Azure fetch all PRs, not just open

### DIFF
--- a/lib/platform/azure/index.js
+++ b/lib/platform/azure/index.js
@@ -254,7 +254,7 @@ async function findPr(branchName, prTitle, state = 'all') {
   let prsFiltered = [];
   try {
     const azureApiGit = await azureApi.gitApi();
-    const prs = await azureApiGit.getPullRequests(config.repoId, {status: 4});
+    const prs = await azureApiGit.getPullRequests(config.repoId, { status: 4 });
 
     prsFiltered = prs.filter(
       item => item.sourceRefName === azureHelper.getNewBranchName(branchName)

--- a/lib/platform/azure/index.js
+++ b/lib/platform/azure/index.js
@@ -254,7 +254,7 @@ async function findPr(branchName, prTitle, state = 'all') {
   let prsFiltered = [];
   try {
     const azureApiGit = await azureApi.gitApi();
-    const prs = await azureApiGit.getPullRequests(config.repoId, {});
+    const prs = await azureApiGit.getPullRequests(config.repoId, {status: 4});
 
     prsFiltered = prs.filter(
       item => item.sourceRefName === azureHelper.getNewBranchName(branchName)
@@ -329,7 +329,7 @@ async function getPr(pullRequestId) {
     return null;
   }
   const azureApiGit = await azureApi.gitApi();
-  const prs = await azureApiGit.getPullRequests(config.repoId, {});
+  const prs = await azureApiGit.getPullRequests(config.repoId, { status: 4 });
   const azurePr = prs.filter(item => item.pullRequestId === pullRequestId);
   if (azurePr.length === 0) {
     return null;


### PR DESCRIPTION
Requesting PRs without setting status, limits the PRs returned to those that are open only. See https://github.com/Microsoft/azure-devops-node-api/blob/master/api/interfaces/GitInterfaces.ts#L2812-L2833

Fixes #3367 