### PR TITLE
feat(autodiscover): add autodiscoverFilter option

### DIFF
--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -288,6 +288,13 @@ const options = [
     default: false,
   },
   {
+    name: 'autodiscoverFilter',
+    description: 'Filter the list of autodiscovered repositories',
+    stage: 'global',
+    type: 'string',
+    default: null,
+  },
+  {
     name: 'repositories',
     description: 'List of Repositories',
     stage: 'global',

--- a/lib/workers/global/autodiscover.js
+++ b/lib/workers/global/autodiscover.js
@@ -1,4 +1,5 @@
 const is = require('@sindresorhus/is');
+const minimatch = require('minimatch');
 const { getPlatformApi } = require('../../platform');
 const hostRules = require('../../util/host-rules');
 
@@ -12,7 +13,7 @@ async function autodiscoverRepositories(config) {
   }
   const credentials = hostRules.find(config, {});
   // Autodiscover list of repositories
-  const discovered = await getPlatformApi(config.platform).getRepos(
+  let discovered = await getPlatformApi(config.platform).getRepos(
     credentials.token,
     credentials.endpoint
   );
@@ -22,6 +23,14 @@ async function autodiscoverRepositories(config) {
       'The account associated with your token does not have access to any repos'
     );
     return config;
+  }
+  if (config.autodiscoverFilter) {
+    discovered = discovered.filter(minimatch.filter(config.autodiscoverFilter));
+    if (!discovered.length) {
+      // Soft fail (no error thrown) if no accessible repositories match the filter
+      logger.info('None of the discovered repositories matched the filter');
+      return config;
+    }
   }
   logger.info(`Discovered ${discovered.length} repositories`);
   // istanbul ignore if

--- a/test/workers/global/autodiscover.spec.js
+++ b/test/workers/global/autodiscover.spec.js
@@ -57,6 +57,6 @@ describe('lib/workers/global/autodiscover', () => {
       'another-project/another-repo',
     ]);
     const res = await autodiscoverRepositories(config);
-    expect(res.repositories).toEqual([]);
+    expect(res).toEqual(config);
   });
 });

--- a/test/workers/global/autodiscover.spec.js
+++ b/test/workers/global/autodiscover.spec.js
@@ -34,4 +34,15 @@ describe('lib/workers/global/autodiscover', () => {
     const res = await autodiscoverRepositories(config);
     expect(res.repositories).toHaveLength(2);
   });
+  it('filters autodiscovered github repos', async () => {
+    config.autodiscover = true;
+    config.autodiscoverFilter = 'project/re*';
+    config.platform = 'github';
+    hostRules.find = jest.fn(() => ({
+      token: 'abc',
+    }));
+    ghApi.getRepos = jest.fn(() => ['project/repo', 'project/another-repo']);
+    const res = await autodiscoverRepositories(config);
+    expect(res.repositories).toEqual(['project/repo']);
+  });
 });

--- a/test/workers/global/autodiscover.spec.js
+++ b/test/workers/global/autodiscover.spec.js
@@ -45,4 +45,18 @@ describe('lib/workers/global/autodiscover', () => {
     const res = await autodiscoverRepositories(config);
     expect(res.repositories).toEqual(['project/repo']);
   });
+  it('filters autodiscovered github repos but nothing matches', async () => {
+    config.autodiscover = true;
+    config.autodiscoverFilter = 'project/re*';
+    config.platform = 'github';
+    hostRules.find = jest.fn(() => ({
+      token: 'abc',
+    }));
+    ghApi.getRepos = jest.fn(() => [
+      'another-project/repo',
+      'another-project/another-repo',
+    ]);
+    const res = await autodiscoverRepositories(config);
+    expect(res.repositories).toEqual([]);
+  });
 });

--- a/website/docs/self-hosted-configuration.md
+++ b/website/docs/self-hosted-configuration.md
@@ -9,7 +9,11 @@ The below configuration options are applicable only if you are running your own 
 
 ## autodiscover
 
-Be cautious when using this option - it will run Renovate over _every_ repository that the bot account has access to.
+Be cautious when using this option - it will run Renovate over _every_ repository that the bot account has access to. To filter this list, use `autodiscoverFilter`.
+
+## autodiscoverFilter
+
+A [minimatch](https://www.npmjs.com/package/minimatch) glob-style pattern for filtering `autodiscover`ed repositories. Ex: `project/*`
 
 ## binarySource
 


### PR DESCRIPTION
adds a `autodiscoverFilter` option which can be a [minimatch](https://www.npmjs.com/package/minimatch) glob-style pattern for filtering `autodiscover`ed repositories. Ex: `project/*`

Closes #3341 
