### PR TITLE
fix: snapshot test failures on some systems

### DIFF
--- a/lib/manager/pip_setup/extract.js
+++ b/lib/manager/pip_setup/extract.js
@@ -24,6 +24,7 @@ async function getPythonAlias() {
     try {
       const { stdout, stderr } = await exec(`${pythonVersion} --version`);
       const version = parsePythonVersion(stdout || stderr);
+      // istanbul ignore if
       if (version[0] >= 3 && version[1] >= 7) {
         return pythonVersion;
       }

--- a/lib/manager/pip_setup/extract.js
+++ b/lib/manager/pip_setup/extract.js
@@ -5,7 +5,7 @@ const { isSkipComment } = require('../../util/ignore');
 const { dependencyPattern } = require('../pip_requirements/extract');
 
 const pythonVersions = ['python', 'python3', 'python3.7'];
-
+let pythonAlias = null;
 module.exports = {
   extractPackageFile,
   extractSetupFile,
@@ -66,13 +66,11 @@ async function extractSetupFile(content, packageFile, config) {
     );
   } else {
     logger.info('Running python via global command');
-    const cacheNamespace = 'python-alias';
-    const alias = await renovateCache.get(cacheNamespace, 'pythonAlias');
-    if (alias) {
-      cmd = alias;
+    if (pythonAlias) {
+      cmd = pythonAlias;
     } else {
       cmd = await getPythonAlias();
-      await renovateCache.set(cacheNamespace, 'pythonAlias', cmd, 60 * 24);
+      pythonAlias = cmd;
     }
   }
   logger.debug({ cmd, args }, 'python command');

--- a/lib/manager/pip_setup/extract.js
+++ b/lib/manager/pip_setup/extract.js
@@ -20,19 +20,23 @@ function parsePythonVersion(str) {
 }
 
 async function getPythonAlias() {
+  if (pythonAlias) {
+    return pythonAlias;
+  }
+  pythonAlias = pythonVersions[0]; // fallback to 'python'
   for (const pythonVersion of pythonVersions) {
     try {
       const { stdout, stderr } = await exec(`${pythonVersion} --version`);
       const version = parsePythonVersion(stdout || stderr);
       // istanbul ignore if
       if (version[0] >= 3 && version[1] >= 7) {
-        return pythonVersion;
+        pythonAlias = pythonVersion;
       }
     } catch (err) {
       logger.info(`${pythonVersion} alias not found`);
     }
   }
-  return pythonVersions[0]; // fallback to 'python'
+  return pythonAlias;
 }
 
 async function extractSetupFile(content, packageFile, config) {
@@ -66,12 +70,7 @@ async function extractSetupFile(content, packageFile, config) {
     );
   } else {
     logger.info('Running python via global command');
-    if (pythonAlias) {
-      cmd = pythonAlias;
-    } else {
-      cmd = await getPythonAlias();
-      pythonAlias = cmd;
-    }
+    cmd = await getPythonAlias();
   }
   logger.debug({ cmd, args }, 'python command');
   let stdout;

--- a/lib/manager/pip_setup/extract.js
+++ b/lib/manager/pip_setup/extract.js
@@ -13,7 +13,6 @@ module.exports = {
   getPythonAlias,
   pythonVersions,
 };
-const cacheNamespace = 'python-alias';
 
 function parsePythonVersion(str) {
   const arr = str.split(' ')[1].split('.');
@@ -66,12 +65,13 @@ async function extractSetupFile(content, packageFile, config) {
     );
   } else {
     logger.info('Running python via global command');
+    const cacheNamespace = 'python-alias';
     const alias = await renovateCache.get(cacheNamespace, 'pythonAlias');
     if (alias) {
       cmd = alias;
     } else {
       cmd = await getPythonAlias();
-      await renovateCache.set(cacheNamespace, 'pythonAlias', cmd);
+      await renovateCache.set(cacheNamespace, 'pythonAlias', cmd, 60 * 24);
     }
   }
   logger.debug({ cmd, args }, 'python command');

--- a/lib/manager/pip_setup/extract.js
+++ b/lib/manager/pip_setup/extract.js
@@ -8,6 +8,28 @@ module.exports = {
   extractPackageFile,
   extractSetupFile,
 };
+const cacheNamespace = 'python-alias';
+const pythonVersions = ['python', 'python3', 'python3.7'];
+
+function parsePythonVersion(str) {
+  const arr = str.split(' ')[1].split('.');
+  return [parseInt(arr[0], 10), parseInt(arr[1], 10)];
+}
+
+async function getPythonAlias() {
+  for (const pythonVersion of pythonVersions) {
+    try {
+      const { stdout, stderr } = await exec(`${pythonVersion} --version`);
+      const version = parsePythonVersion(stdout || stderr);
+      if (version[0] >= 3 && version[1] >= 7) {
+        return pythonVersion;
+      }
+    } catch (err) {
+      logger.info(`${pythonVersion} alias not found`);
+    }
+  }
+  return pythonVersions[0]; // fallback to 'python'
+}
 
 async function extractSetupFile(content, packageFile, config) {
   const cwd = config.localDir;
@@ -40,7 +62,13 @@ async function extractSetupFile(content, packageFile, config) {
     );
   } else {
     logger.info('Running python via global command');
-    cmd = 'python';
+    const alias = await renovateCache.get(cacheNamespace, 'pythonAlias');
+    if (alias) {
+      cmd = alias;
+    } else {
+      cmd = await getPythonAlias();
+      await renovateCache.set(cacheNamespace, 'pythonAlias', cmd);
+    }
   }
   logger.debug({ cmd, args }, 'python command');
   let stdout;

--- a/lib/manager/pip_setup/extract.js
+++ b/lib/manager/pip_setup/extract.js
@@ -4,12 +4,16 @@ const { join } = require('upath');
 const { isSkipComment } = require('../../util/ignore');
 const { dependencyPattern } = require('../pip_requirements/extract');
 
+const pythonVersions = ['python', 'python3', 'python3.7'];
+
 module.exports = {
   extractPackageFile,
   extractSetupFile,
+  parsePythonVersion,
+  getPythonAlias,
+  pythonVersions,
 };
 const cacheNamespace = 'python-alias';
-const pythonVersions = ['python', 'python3', 'python3.7'];
 
 function parsePythonVersion(str) {
   const arr = str.split(' ')[1].split('.');

--- a/lib/manager/pip_setup/extract.js
+++ b/lib/manager/pip_setup/extract.js
@@ -33,7 +33,7 @@ async function getPythonAlias() {
         pythonAlias = pythonVersion;
       }
     } catch (err) {
-      logger.info(`${pythonVersion} alias not found`);
+      logger.debug(`${pythonVersion} alias not found`);
     }
   }
   return pythonAlias;

--- a/test/manager/pip_setup/extract.spec.js
+++ b/test/manager/pip_setup/extract.spec.js
@@ -3,6 +3,9 @@ const tmp = require('tmp-promise');
 const { relative } = require('path');
 const {
   extractPackageFile,
+  parsePythonVersion,
+  getPythonAlias,
+  pythonVersions,
   // extractSetupFile,
 } = require('../../../lib/manager/pip_setup/extract');
 
@@ -37,6 +40,17 @@ describe('lib/manager/pip_setup/extract', () => {
           config
         )
       ).toBe(null);
+    });
+  });
+
+  describe('parsePythonVersion', () => {
+    it('returns major and minor version numbers', () => {
+      expect(parsePythonVersion('Python 2.7.15rc1')).toEqual([2, 7]);
+    });
+  });
+  describe('getPythonAlias', () => {
+    it('returns major and minor version numbers', async () => {
+      expect(pythonVersions.includes(await getPythonAlias())).toBeTruthy();
     });
   });
   /*

--- a/test/manager/pip_setup/extract.spec.js
+++ b/test/manager/pip_setup/extract.spec.js
@@ -49,7 +49,7 @@ describe('lib/manager/pip_setup/extract', () => {
     });
   });
   describe('getPythonAlias', () => {
-    it('returns major and minor version numbers', async () => {
+    it('returns the python alias to use', async () => {
       expect(pythonVersions.includes(await getPythonAlias())).toBeTruthy();
     });
   });


### PR DESCRIPTION
- The function is calling python command which can be aliased to different python versions on different systems, the function depends on mock library which comes pre-installed on python v3.7+
- Add a python alias detection command which gets the correct python command which is aliased to python3.7+

Closes #3392 
