### PR TITLE
feat: add test for mock lib

### DIFF
--- a/test/manager/pip_setup/extract.spec.js
+++ b/test/manager/pip_setup/extract.spec.js
@@ -56,12 +56,21 @@ describe('lib/manager/pip_setup/extract', () => {
   });
   describe('Test for presence of mock lib', () => {
     it('should test if python mock lib is installed', async () => {
-      const pythonAlias = await getPythonAlias();
       let isMockInstalled = true;
+      // when binarysource === docker
       try {
-        await exec(`${pythonAlias} -c "from unittest import mock"`);
+        await exec(`python -c "from unittest import mock"`);
       } catch (err) {
         isMockInstalled = false;
+      }
+      if (!isMockInstalled) {
+        try {
+          const pythonAlias = await getPythonAlias();
+          await exec(`${pythonAlias} -c "from unittest import mock"`);
+          isMockInstalled = true;
+        } catch (err) {
+          isMockInstalled = false;
+        }
       }
       expect(isMockInstalled).toBeTruthy();
     });

--- a/test/manager/pip_setup/extract.spec.js
+++ b/test/manager/pip_setup/extract.spec.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const { exec } = require('child-process-promise');
 const tmp = require('tmp-promise');
 const { relative } = require('path');
 const {
@@ -51,6 +52,18 @@ describe('lib/manager/pip_setup/extract', () => {
   describe('getPythonAlias', () => {
     it('returns the python alias to use', async () => {
       expect(pythonVersions.includes(await getPythonAlias())).toBeTruthy();
+    });
+  });
+  describe('Test for presence of mock lib', () => {
+    it('should test if python mock lib is installed', async () => {
+      const pythonAlias = await getPythonAlias();
+      let isMockInstalled = true;
+      try {
+        await exec(`${pythonAlias} -c "from unittest import mock"`);
+      } catch (err) {
+        isMockInstalled = false;
+      }
+      expect(isMockInstalled).toBeTruthy();
     });
   });
   /*

--- a/test/manager/pip_setup/extract.spec.js
+++ b/test/manager/pip_setup/extract.spec.js
@@ -59,7 +59,7 @@ describe('lib/manager/pip_setup/extract', () => {
       let isMockInstalled = true;
       // when binarysource === docker
       try {
-        await exec(`python -c "from unittest import mock"`);
+        await exec(`python -c "import mock"`);
       } catch (err) {
         isMockInstalled = false;
       }


### PR DESCRIPTION
- Add test for the presence of `mock` library in system
- Depends on `getPythonAlias` function

Closes #3393 
