### PR TITLE
fix(bazel): http_archive url not updated

### DIFF
--- a/lib/manager/bazel/update.js
+++ b/lib/manager/bazel/update.js
@@ -60,7 +60,9 @@ async function updateDependency(fileContent, upgrade) {
         .createHash('sha256')
         .update(file)
         .digest('hex');
-      const currentPattern = /(urls\s*=\s*\[")[^"]+("])/;
+      const currentPattern = upgrade.def.includes('urls')
+        ? /(urls\s*=\s*\[")[^"]+("])/
+        : /(url\s*=\s*")[^"]+(")/;
       newDef = upgrade.def.replace(currentPattern, `$1${newUrl}$2`);
       newDef = newDef.replace(/(sha256\s*=\s*)"[^"]+"/, `$1"${hash}"`);
       newDef = newDef.replace(


### PR DESCRIPTION
lib/manager/bazel/update.js -> updateDependency wasn't looking for a `url` rule (only `urls`).
Closes #3369 
Tested on real repo with a dependancy mentioned [here](https://github.com/bazelbuild/rules_k8s/pull/279/files) (notice the last line).
![Drawing (2)](https://user-images.githubusercontent.com/22542906/54548690-2167ca80-49b1-11e9-802d-7bf57b93c8f1.png)
![update](https://user-images.githubusercontent.com/22542906/54548770-4e1be200-49b1-11e9-9dbb-7e85d610cc06.png)
![Drawing (3)](https://user-images.githubusercontent.com/22542906/54548871-84f1f800-49b1-11e9-8989-eb4e7b82c413.png)
