### PR TITLE
refactor: enforce requireConfig

### DIFF
--- a/lib/workers/repository/onboarding/branch/check.js
+++ b/lib/workers/repository/onboarding/branch/check.js
@@ -64,25 +64,6 @@ const isOnboarded = async config => {
     logger.debug('Config not mandatory so repo is considered onboarded');
     return true;
   }
-  const mergedPrExists = (await platform.getPrList()).some(
-    p => p.state === 'merged' && p.branchName.startsWith(config.branchPrefix)
-  );
-  if (mergedPrExists) {
-    logger.info(
-      'Repo is not onboarded but at least one merged PR exists - treat as onboarded'
-    );
-    let body = `Hi,\n\nYou will need to add a config to this repository if you want ${appName}  to continue creating PRs. ${appName} will soon begin skipping all repositories that don't have a valid config found, even if you've received PRs before.\n\n`;
-    body +=
-      'To keep functionality exactly the same, you can add an empty JSON config (`{}`) to your repo in any of the following files: ';
-    body += configFileNames
-      .filter(filename => filename !== 'package.json')
-      .map(filename => `\`${filename}\``)
-      .join(', ');
-    const once = true;
-    // await platform.ensureIssue(title, body, once);
-    logger.trace({ title, body, once }, 'Warning issue');
-    return true;
-  }
   logger.info('Repo is not onboarded and no merged PRs exist');
   if (!config.suppressNotifications.includes('onboardingClose')) {
     // ensure PR comment

--- a/test/workers/repository/onboarding/branch/index.spec.js
+++ b/test/workers/repository/onboarding/branch/index.spec.js
@@ -55,15 +55,6 @@ describe('workers/repository/onboarding/branch', () => {
       const res = await checkOnboardingBranch(config);
       expect(res.repoIsOnboarded).toBe(true);
     });
-    it('detects repo is onboarded via PR and merged', async () => {
-      config.requireConfig = true;
-      platform.findPr.mockReturnValue(true);
-      platform.getPrList.mockReturnValueOnce([
-        { branchName: 'renovate/something', state: 'merged' },
-      ]);
-      const res = await checkOnboardingBranch(config);
-      expect(res.repoIsOnboarded).toBe(true);
-    });
     it('throws if no required config', async () => {
       config.requireConfig = true;
       platform.findPr.mockReturnValue(true);


### PR DESCRIPTION
Previously we maintained an exception to the rule that if `requireConfig` was true then we still support repositories without a config if they have previously merged PRs. Now such repositories will be skipped.

Closes #3338 

BREAKING CHANGE: requireConfig is now enforced, if enabled. If a repository has no config but merged PRs, it will still be skipped.