### PR TITLE
feat: default requireConfig to true

### DIFF
--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -145,7 +145,7 @@ const options = [
     description: 'Set to true if repositories must have a config to activate.',
     stage: 'repository',
     type: 'boolean',
-    default: false,
+    default: true,
     admin: true,
   },
   // encryption

--- a/test/workers/repository/onboarding/branch/index.spec.js
+++ b/test/workers/repository/onboarding/branch/index.spec.js
@@ -51,6 +51,7 @@ describe('workers/repository/onboarding/branch', () => {
       expect(res.repoIsOnboarded).toBe(true);
     });
     it('detects repo is onboarded via PR', async () => {
+      config.requireConfig = false;
       platform.findPr.mockReturnValue(true);
       const res = await checkOnboardingBranch(config);
       expect(res.repoIsOnboarded).toBe(true);


### PR DESCRIPTION
Defaults `requireConfig` value to `true`.

Closes #3337

BREAKING CHANGE: If you run your own bot and wish to allow config-less repositories (e.g. no `renovate.json`) then override this value to `false` in your bot config.