### PR TITLE
docs: fix developer typo

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,5 +1,5 @@
 # Renovate Developer Docs
 
-This directory is intended to provide documentation for developers/contributors on the Renovate project. For user-facing documentation - e.g. for how to confiure Renovate as a user - please see https://renovatebot.com/docs
+This directory is intended to provide documentation for developers/contributors on the Renovate project. For user-facing documentation - e.g. for how to configure Renovate as a user - please see https://renovatebot.com/docs
 
 If you would like to contribute to Renovate or get it running locally for some others reason, please check out [contributing.md](../.github/contributing.md) for steps on how to set up the project locally.


### PR DESCRIPTION
Fix typo in Renovate Developer Docs.