### PR TITLE
feat: Add poetry versioning code

### DIFF
--- a/lib/versioning/poetry/index.js
+++ b/lib/versioning/poetry/index.js
@@ -1,0 +1,82 @@
+const npm = require('../npm');
+
+function notEmpty(s) {
+  return s !== '';
+}
+
+// This function works like cargo2npm, but it doesn't
+// add a '^', because poetry treats versions without operators as
+// exact versions.
+function poetry2npm(input) {
+  const versions = input
+    .split(',')
+    .map(str => str.trim())
+    .filter(notEmpty);
+  return versions.join(' ');
+}
+
+// NOTE: This function is copied from cargo versionsing code.
+// Poetry uses commas (like in cargo) instead of spaces (like in npm)
+// for AND operation.
+function npm2poetry(input) {
+  // Note: this doesn't remove the ^
+  const res = input
+    .split(' ')
+    .map(str => str.trim())
+    .filter(notEmpty);
+  const operators = ['^', '~', '=', '>', '<', '<=', '>='];
+  for (let i = 0; i < res.length - 1; i += 1) {
+    if (operators.includes(res[i])) {
+      const newValue = res[i] + ' ' + res[i + 1];
+      res.splice(i, 2, newValue);
+    }
+  }
+  return res.join(', ');
+}
+
+const isLessThanRange = (version, range) =>
+  npm.isLessThanRange(version, poetry2npm(range));
+
+const isValid = input => npm.isValid(poetry2npm(input));
+
+const isVersion = input => npm.isVersion(input);
+
+const matches = (version, range) => npm.matches(version, poetry2npm(range));
+
+const maxSatisfyingVersion = (versions, range) =>
+  npm.maxSatisfyingVersion(versions, poetry2npm(range));
+
+const minSatisfyingVersion = (versions, range) =>
+  npm.minSatisfyingVersion(versions, poetry2npm(range));
+
+const isSingleVersion = constraint =>
+  (constraint.trim().startsWith('=') &&
+    isVersion(
+      constraint
+        .trim()
+        .substring(1)
+        .trim()
+    )) ||
+  isVersion(constraint.trim());
+
+function getNewValue(currentValue, rangeStrategy, fromVersion, toVersion) {
+  const newSemver = npm.getNewValue(
+    poetry2npm(currentValue),
+    rangeStrategy,
+    fromVersion,
+    toVersion
+  );
+  const newPoetry = npm2poetry(newSemver);
+  return newPoetry;
+}
+
+module.exports = {
+  ...npm,
+  getNewValue,
+  isLessThanRange,
+  isSingleVersion,
+  isValid,
+  matches,
+  maxSatisfyingVersion,
+  minSatisfyingVersion,
+};

--- a/lib/versioning/poetry/readme.md
+++ b/lib/versioning/poetry/readme.md
@@ -1,0 +1,27 @@
+# Poetry versioning
+
+## Documentation and URLs
+
+https://poetry.eustace.io/docs/versions/
+
+## What type of versioning is used?
+
+Poetry uses [Semantic Versioning 2.0](https://semver.org).
+
+## Are ranges supported? How?
+
+Poetry supports ranges in a similar manner to npm, but not identical. The important differences are:
+
+##### Use of commas
+
+Multiple version requirements can be separated with a comma, e.g. `>= 1.2, < 1.5`. We interpret this to mean AND.
+
+## Range Strategy support
+
+Poetry versioning should support all range strategies - pin, replace, bump, extend.
+
+## Implementation plan/status
+
+- [x] Add poetry2npm and npm2poetry functions to leverage existing npm semver logic
+- [x] Exact version support
+- [x] Range support

--- a/test/versioning/poetry.spec.js
+++ b/test/versioning/poetry.spec.js
@@ -1,6 +1,5 @@
 const semver = require('../../lib/versioning/poetry');
 
-// TODO: Add tests for multiple requirements
 describe('semver.isValid(input)', () => {
   it('should return null for irregular versions', () => {
     expect(!!semver.isValid('17.04.0')).toBe(false);
@@ -11,7 +10,6 @@ describe('semver.isValid(input)', () => {
   it('should support semver with dash', () => {
     expect(!!semver.isValid('1.2.3-foo')).toBe(true);
   });
-  // TODO: Check if poetry requires this.
   it('should reject semver without dash', () => {
     expect(!!semver.isValid('1.2.3foo')).toBe(false);
   });

--- a/test/versioning/poetry.spec.js
+++ b/test/versioning/poetry.spec.js
@@ -41,10 +41,107 @@ describe('semver.isSingleVersion()', () => {
     expect(!!semver.isSingleVersion('1.*')).toBe(false);
   });
 });
+describe('semver.matches()', () => {
+  it('handles comma', () => {
+    expect(semver.matches('4.2.0', '4.2, >= 3.0, < 5.0.0')).toBe(true);
+    expect(semver.matches('4.2.0', '2.0, >= 3.0, < 5.0.0')).toBe(false);
+    expect(semver.matches('4.2.2', '4.2.0, < 4.2.4')).toBe(false);
+    expect(semver.matches('4.2.2', '^4.2.0, < 4.2.4')).toBe(true);
+    expect(semver.matches('4.2.0', '4.3.0, 3.0.0')).toBe(false);
+    expect(semver.matches('4.2.0', '> 5.0.0, <= 6.0.0')).toBe(false);
+  });
+});
+describe('semver.isLessThanRange()', () => {
+  it('handles comma', () => {
+    expect(semver.isLessThanRange('0.9.0', '>= 1.0.0 <= 2.0.0')).toBe(true);
+    expect(semver.isLessThanRange('1.9.0', '>= 1.0.0 <= 2.0.0')).toBe(false);
+  });
+});
+describe('semver.minSatisfyingVersion()', () => {
+  it('handles comma', () => {
+    expect(
+      semver.minSatisfyingVersion(
+        ['0.4.0', '0.5.0', '4.2.0', '4.3.0', '5.0.0'],
+        '4.*, > 4.2'
+      )
+    ).toBe('4.3.0');
+    expect(
+      semver.minSatisfyingVersion(
+        ['0.4.0', '0.5.0', '4.2.0', '5.0.0'],
+        '^4.0.0'
+      )
+    ).toBe('4.2.0');
+    expect(
+      semver.minSatisfyingVersion(
+        ['0.4.0', '0.5.0', '4.2.0', '5.0.0'],
+        '^4.0.0, = 0.5.0'
+      )
+    ).toBe(null);
+    expect(
+      semver.minSatisfyingVersion(
+        ['0.4.0', '0.5.0', '4.2.0', '5.0.0'],
+        '^4.0.0, > 4.1.0, <= 4.3.5'
+      )
+    ).toBe('4.2.0');
+    expect(
+      semver.minSatisfyingVersion(
+        ['0.4.0', '0.5.0', '4.2.0', '5.0.0'],
+        '^6.2.0, 3.*'
+      )
+    ).toBe(null);
+  });
+});
+describe('semver.maxSatisfyingVersion()', () => {
+  it('handles comma', () => {
+    expect(
+      semver.maxSatisfyingVersion(
+        ['4.2.1', '0.4.0', '0.5.0', '4.0.0', '4.2.0', '5.0.0'],
+        '4.*.0, < 4.2.5'
+      )
+    ).toBe('4.2.1');
+    expect(
+      semver.maxSatisfyingVersion(
+        ['0.4.0', '0.5.0', '4.0.0', '4.2.0', '5.0.0', '5.0.3'],
+        '5.0, > 5.0.0'
+      )
+    ).toBe('5.0.3');
+  });
+});
+
 describe('semver.getNewValue()', () => {
+  it('bumps exact', () => {
+    expect(semver.getNewValue('1.0.0', 'bump', '1.0.0', '1.1.0')).toEqual(
+      '1.1.0'
+    );
+    expect(semver.getNewValue('   1.0.0', 'bump', '1.0.0', '1.1.0')).toEqual(
+      '1.1.0'
+    );
+  });
   it('bumps equals', () => {
     expect(semver.getNewValue('=1.0.0', 'bump', '1.0.0', '1.1.0')).toEqual(
       '=1.1.0'
+    );
+    expect(semver.getNewValue('=  1.0.0', 'bump', '1.0.0', '1.1.0')).toEqual(
+      '=1.1.0'
+    );
+  });
+  it('bumps equals space', () => {
+    expect(semver.getNewValue('= 1.0.0', 'bump', '1.0.0', '1.1.0')).toEqual(
+      '=1.1.0'
+    );
+    expect(semver.getNewValue('  = 1.0.0', 'bump', '1.0.0', '1.1.0')).toEqual(
+      '=1.1.0'
+    );
+    expect(semver.getNewValue('  =   1.0.0', 'bump', '1.0.0', '1.1.0')).toEqual(
+      '=1.1.0'
+    );
+    expect(semver.getNewValue('=    1.0.0', 'bump', '1.0.0', '1.1.0')).toEqual(
+      '=1.1.0'
+    );
+  });
+  it('bumps version range', () => {
+    expect(semver.getNewValue('1.0.0', 'bump', '1.0.0', '1.1.0')).toEqual(
+      '1.1.0'
     );
   });
   it('bumps short caret to same', () => {
@@ -52,36 +149,20 @@ describe('semver.getNewValue()', () => {
       '^1.0'
     );
   });
-  it('bumps caret to prerelease', () => {
-    expect(
-      semver.getNewValue('^1', 'bump', '1.0.0', '1.0.7-prerelease.1')
-    ).toEqual('^1.0.7-prerelease.1');
-  });
   it('replaces with newer', () => {
-    expect(semver.getNewValue('^1.0.0', 'replace', '1.0.0', '1.0.7')).toEqual(
-      '^1.0.7'
+    expect(semver.getNewValue('^1.0.0', 'replace', '1.0.0', '2.0.7')).toEqual(
+      '^2.0.0'
     );
   });
-  // TODO: Find out if poetry supports this.
-  // it('supports tilde greater than', () => {
-  //   expect(semver.getNewValue('~> 1.0.0', 'replace', '1.0.0', '1.1.7')).toEqual(
-  //     '~> 1.1.0'
-  //   );
-  // });
-  it('bumps short caret to new', () => {
-    expect(semver.getNewValue('^1.0', 'bump', '1.0.0', '1.1.7')).toEqual(
-      '^1.1'
+  it('replaces naked version', () => {
+    expect(semver.getNewValue('1.0.0', 'replace', '1.0.0', '2.0.7')).toEqual(
+      '2.0.7'
     );
   });
-  it('bumps short tilde', () => {
-    expect(semver.getNewValue('~1.0', 'bump', '1.0.0', '1.1.7')).toEqual(
-      '~1.1'
+  it('replaces with version range', () => {
+    expect(semver.getNewValue('1.0.0', 'replace', '1.0.0', '^2.0.7')).toEqual(
+      '^2.0.7'
     );
-  });
-  it('bumps tilde to prerelease', () => {
-    expect(
-      semver.getNewValue('~1.0', 'bump', '1.0.0', '1.0.7-prerelease.1')
-    ).toEqual('~1.0.7-prerelease.1');
   });
   it('updates naked caret', () => {
     expect(semver.getNewValue('^1', 'bump', '1.0.0', '2.1.7')).toEqual('^2');
@@ -98,9 +179,29 @@ describe('semver.getNewValue()', () => {
     expect(semver.getNewValue('5.0', 'bump', '5.0.0', '5.1.7')).toEqual('5.1');
     expect(semver.getNewValue('5.0', 'bump', '5.0.0', '6.1.7')).toEqual('6.1');
   });
+  it('replaces minor', () => {
+    expect(semver.getNewValue('5.0', 'replace', '5.0.0', '6.1.7')).toEqual(
+      '6.1'
+    );
+  });
   it('replaces equals', () => {
     expect(semver.getNewValue('=1.0.0', 'replace', '1.0.0', '1.1.0')).toEqual(
       '=1.1.0'
+    );
+  });
+  it('bumps caret to prerelease', () => {
+    expect(
+      semver.getNewValue('^1', 'bump', '1.0.0', '1.0.7-prerelease.1')
+    ).toEqual('^1.0.7-prerelease.1');
+  });
+  it('replaces with newer', () => {
+    expect(semver.getNewValue('^1.0.0', 'replace', '1.0.0', '1.0.7')).toEqual(
+      '^1.0.7'
+    );
+  });
+  it('bumps short tilde', () => {
+    expect(semver.getNewValue('~1.0', 'bump', '1.0.0', '1.1.7')).toEqual(
+      '~1.1'
     );
   });
   it('handles long asterisk', () => {
@@ -117,5 +218,27 @@ describe('semver.getNewValue()', () => {
     expect(
       semver.getNewValue('~0.6.1', 'replace', '0.6.8', '0.7.0-rc.2')
     ).toEqual('~0.7.0-rc');
+  });
+  it('handles less than version requirements', () => {
+    expect(semver.getNewValue('<1.3.4', 'replace', '1.2.3', '1.5.0')).toEqual(
+      '<1.5.1'
+    );
+    expect(semver.getNewValue('< 1.3.4', 'replace', '1.2.3', '1.5.0')).toEqual(
+      '< 1.5.1'
+    );
+    expect(
+      semver.getNewValue('<   1.3.4', 'replace', '1.2.3', '1.5.0')
+    ).toEqual('< 1.5.1');
+  });
+  it('handles less than equals version requirements', () => {
+    expect(semver.getNewValue('<=1.3.4', 'replace', '1.2.3', '1.5.0')).toEqual(
+      '<=1.5.0'
+    );
+    expect(semver.getNewValue('<= 1.3.4', 'replace', '1.2.3', '1.5.0')).toEqual(
+      '<= 1.5.0'
+    );
+    expect(
+      semver.getNewValue('<=   1.3.4', 'replace', '1.2.3', '1.5.0')
+    ).toEqual('<= 1.5.0');
   });
 });

--- a/test/versioning/poetry.spec.js
+++ b/test/versioning/poetry.spec.js
@@ -1,0 +1,121 @@
+const semver = require('../../lib/versioning/poetry');
+
+// TODO: Add tests for multiple requirements
+describe('semver.isValid(input)', () => {
+  it('should return null for irregular versions', () => {
+    expect(!!semver.isValid('17.04.0')).toBe(false);
+  });
+  it('should support simple semver', () => {
+    expect(!!semver.isValid('1.2.3')).toBe(true);
+  });
+  it('should support semver with dash', () => {
+    expect(!!semver.isValid('1.2.3-foo')).toBe(true);
+  });
+  // TODO: Check if poetry requires this.
+  it('should reject semver without dash', () => {
+    expect(!!semver.isValid('1.2.3foo')).toBe(false);
+  });
+  it('should support ranges', () => {
+    expect(!!semver.isValid('~1.2.3')).toBe(true);
+    expect(!!semver.isValid('^1.2.3')).toBe(true);
+    expect(!!semver.isValid('>1.2.3')).toBe(true);
+  });
+  it('should reject github repositories', () => {
+    expect(!!semver.isValid('renovatebot/renovate')).toBe(false);
+    expect(!!semver.isValid('renovatebot/renovate#master')).toBe(false);
+    expect(
+      !!semver.isValid('https://github.com/renovatebot/renovate.git')
+    ).toBe(false);
+  });
+});
+describe('semver.isSingleVersion()', () => {
+  it('returns true if naked version', () => {
+    expect(!!semver.isSingleVersion('1.2.3')).toBe(true);
+    expect(!!semver.isSingleVersion('1.2.3-alpha.1')).toBe(true);
+  });
+  it('returns true if equals', () => {
+    expect(!!semver.isSingleVersion('=1.2.3')).toBe(true);
+    expect(!!semver.isSingleVersion('= 1.2.3')).toBe(true);
+  });
+  it('returns false when not version', () => {
+    expect(!!semver.isSingleVersion('1.*')).toBe(false);
+  });
+});
+describe('semver.getNewValue()', () => {
+  it('bumps equals', () => {
+    expect(semver.getNewValue('=1.0.0', 'bump', '1.0.0', '1.1.0')).toEqual(
+      '=1.1.0'
+    );
+  });
+  it('bumps short caret to same', () => {
+    expect(semver.getNewValue('^1.0', 'bump', '1.0.0', '1.0.7')).toEqual(
+      '^1.0'
+    );
+  });
+  it('bumps caret to prerelease', () => {
+    expect(
+      semver.getNewValue('^1', 'bump', '1.0.0', '1.0.7-prerelease.1')
+    ).toEqual('^1.0.7-prerelease.1');
+  });
+  it('replaces with newer', () => {
+    expect(semver.getNewValue('^1.0.0', 'replace', '1.0.0', '1.0.7')).toEqual(
+      '^1.0.7'
+    );
+  });
+  // TODO: Find out if poetry supports this.
+  // it('supports tilde greater than', () => {
+  //   expect(semver.getNewValue('~> 1.0.0', 'replace', '1.0.0', '1.1.7')).toEqual(
+  //     '~> 1.1.0'
+  //   );
+  // });
+  it('bumps short caret to new', () => {
+    expect(semver.getNewValue('^1.0', 'bump', '1.0.0', '1.1.7')).toEqual(
+      '^1.1'
+    );
+  });
+  it('bumps short tilde', () => {
+    expect(semver.getNewValue('~1.0', 'bump', '1.0.0', '1.1.7')).toEqual(
+      '~1.1'
+    );
+  });
+  it('bumps tilde to prerelease', () => {
+    expect(
+      semver.getNewValue('~1.0', 'bump', '1.0.0', '1.0.7-prerelease.1')
+    ).toEqual('~1.0.7-prerelease.1');
+  });
+  it('updates naked caret', () => {
+    expect(semver.getNewValue('^1', 'bump', '1.0.0', '2.1.7')).toEqual('^2');
+  });
+  it('bumps naked tilde', () => {
+    expect(semver.getNewValue('~1', 'bump', '1.0.0', '1.1.7')).toEqual('~1');
+  });
+  it('bumps naked major', () => {
+    expect(semver.getNewValue('5', 'bump', '5.0.0', '5.1.7')).toEqual('5');
+    expect(semver.getNewValue('5', 'bump', '5.0.0', '6.1.7')).toEqual('6');
+  });
+  it('bumps naked minor', () => {
+    expect(semver.getNewValue('5.0', 'bump', '5.0.0', '5.0.7')).toEqual('5.0');
+    expect(semver.getNewValue('5.0', 'bump', '5.0.0', '5.1.7')).toEqual('5.1');
+    expect(semver.getNewValue('5.0', 'bump', '5.0.0', '6.1.7')).toEqual('6.1');
+  });
+  it('replaces equals', () => {
+    expect(semver.getNewValue('=1.0.0', 'replace', '1.0.0', '1.1.0')).toEqual(
+      '=1.1.0'
+    );
+  });
+  it('handles long asterisk', () => {
+    expect(semver.getNewValue('1.0.*', 'replace', '1.0.0', '1.1.0')).toEqual(
+      '1.1.*'
+    );
+  });
+  it('handles short asterisk', () => {
+    expect(semver.getNewValue('1.*', 'replace', '1.0.0', '2.1.0')).toEqual(
+      '2.*'
+    );
+  });
+  it('handles updating from stable to unstable', () => {
+    expect(
+      semver.getNewValue('~0.6.1', 'replace', '0.6.8', '0.7.0-rc.2')
+    ).toEqual('~0.7.0-rc');
+  });
+});


### PR DESCRIPTION
Add versioning code for poetry manager. It is a wrapper around `npm` versioning code, and it is based on `cargo` wrapper.