### PR TITLE
fix: bug in getArtifacts for gomod manager

### DIFF
--- a/lib/manager/gomod/artifacts.js
+++ b/lib/manager/gomod/artifacts.js
@@ -57,7 +57,7 @@ async function getArtifacts(
       const volumes = [config.localDir, process.env.GOPATH];
       cmd += volumes.map(v => `-v ${v}:${v} `).join('');
       const envVars = ['GOPATH'];
-      cmd += envVars.map(e => `-e ${e} `);
+      cmd += envVars.map(e => `-e ${e} `).join('');
       cmd += '-e CGO_ENABLED=0 ';
       cmd += `-w ${cwd} `;
       cmd += `renovate/go go`;


### PR DESCRIPTION
I found a little bug in `gomod` manager. Here is the current code:

```javascript
const envVars = ['GOPATH', `GITHUB_TOKEN`];
cmd += envVars.map(e => `-e ${e} `);
```

The output will be `-e GOPATH ,-e GITHUB_TOKEN`. 

To fix this, we need to use the `join` function just like the way it is used for `volumes` array.

```javascript
const envVars = ['GOPATH', `GITHUB_TOKEN`];
cmd += envVars.map(e => `-e ${e} `).join('');
```
