### PR TITLE
feat: use official yarn install script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -130,7 +130,9 @@ RUN pip install --user pipenv
 
 ENV YARN_VERSION=1.15.2
 
-RUN npm i -g yarn@${YARN_VERSION}
+RUN curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version ${YARN_VERSION}
+
+ENV PATH="/home/ubuntu/.yarn/bin:/home/ubuntu/.config/yarn/global/node_modules/.bin:$PATH"
 
 COPY package.json .
 COPY yarn.lock .


### PR DESCRIPTION
This PR replaces the `npm i -g yarn` with the official install script.

Closes #3451 
