### PR TITLE
fix: add platform and repository to localdir

### DIFF
--- a/lib/workers/repository/index.js
+++ b/lib/workers/repository/index.js
@@ -27,8 +27,11 @@ async function renovateRepository(repoConfig) {
     }
     const tmpDir = path.join(os.tmpdir(), '/renovate');
     await fs.ensureDir(tmpDir);
-    config.localDir =
-      config.localDir || path.join(tmpDir, config.platform, config.repository);
+    config.localDir = path.join(
+      config.localDir || tmpDir,
+      config.platform,
+      config.repository
+    );
     await fs.ensureDir(config.localDir);
     logger.debug('Using localDir: ' + config.localDir);
     config = await initRepo(config);


### PR DESCRIPTION
This fixes the `localDir` path if set via config

see #3272
