### PR TITLE
fix(bitbucket-server): fix comment version

### DIFF
--- a/lib/platform/bitbucket-server/index.js
+++ b/lib/platform/bitbucket-server/index.js
@@ -494,7 +494,7 @@ async function getCommentVersion(prNo, commentId) {
 }
 
 async function editComment(prNo, commentId, text) {
-  const version = getCommentVersion(prNo, commentId);
+  const version = await getCommentVersion(prNo, commentId);
 
   // PUT /rest/api/1.0/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}/comments/{commentId}
   await api.put(
@@ -508,7 +508,7 @@ async function editComment(prNo, commentId, text) {
 }
 
 async function deleteComment(prNo, commentId) {
-  const version = getCommentVersion(prNo, commentId);
+  const version = await getCommentVersion(prNo, commentId);
 
   // DELETE /rest/api/1.0/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}/comments/{commentId}
   await api.delete(


### PR DESCRIPTION
This pr fixes fetching the comment version.

Comments could not be updated or deleted, because of a missing await.
