### PR TITLE
feat(bitbucket-server): add getPrFiles

### DIFF
--- a/lib/platform/bitbucket-server/index.js
+++ b/lib/platform/bitbucket-server/index.js
@@ -725,11 +725,20 @@ async function getPr(prNo, refreshCache) {
 }
 
 // Return a list of all modified files in a PR
-function getPrFiles(mrNo) {
-  logger.debug(`getPrFiles(${mrNo})`);
-  // TODO: Needs implementation
-  // Used only by Renovate if you want it to validate user PRs that contain modifications of the Renovate config
-  return [];
+// https://docs.atlassian.com/bitbucket-server/rest/6.0.0/bitbucket-rest.html
+async function getPrFiles(prNo) {
+  logger.debug(`getPrFiles(${prNo})`);
+  if (!prNo) {
+    return [];
+  }
+
+  // GET /rest/api/1.0/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}/changes
+  const values = await utils.accumulateValues(
+    `./rest/api/1.0/projects/${config.projectKey}/repos/${
+      config.repositorySlug
+    }/pull-requests/${prNo}/changes?withComments=false`
+  );
+  return values.map(f => f.path.toString);
 }
 
 async function updatePr(prNo, title, description) {

--- a/test/platform/bitbucket-server/__snapshots__/index.spec.js.snap
+++ b/test/platform/bitbucket-server/__snapshots__/index.spec.js.snap
@@ -510,6 +510,21 @@ exports[`platform/bitbucket-server endpoint with no path getPr() returns null fo
 
 exports[`platform/bitbucket-server endpoint with no path getPrBody() returns diff files 1`] = `"**foo**bartext"`;
 
+exports[`platform/bitbucket-server endpoint with no path getPrFiles() returns one file 1`] = `
+Array [
+  Array [
+    "./rest/api/1.0/projects/SOME/repos/repo",
+  ],
+  Array [
+    "./rest/api/1.0/projects/SOME/repos/repo/branches/default",
+  ],
+  Array [
+    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/changes?withComments=false&limit=100",
+    undefined,
+  ],
+]
+`;
+
 exports[`platform/bitbucket-server endpoint with no path getPrList() has pr 1`] = `
 Array [
   Object {
@@ -1484,6 +1499,21 @@ Array [
 exports[`platform/bitbucket-server endpoint with path getPr() returns null for no prNo 1`] = `Array []`;
 
 exports[`platform/bitbucket-server endpoint with path getPrBody() returns diff files 1`] = `"**foo**bartext"`;
+
+exports[`platform/bitbucket-server endpoint with path getPrFiles() returns one file 1`] = `
+Array [
+  Array [
+    "./rest/api/1.0/projects/SOME/repos/repo",
+  ],
+  Array [
+    "./rest/api/1.0/projects/SOME/repos/repo/branches/default",
+  ],
+  Array [
+    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/changes?withComments=false&limit=100",
+    undefined,
+  ],
+]
+`;
 
 exports[`platform/bitbucket-server endpoint with path getPrList() has pr 1`] = `
 Array [

--- a/test/platform/bitbucket-server/_fixtures/responses.js
+++ b/test/platform/bitbucket-server/_fixtures/responses.js
@@ -416,6 +416,56 @@ function generateServerResponses(endpoint) {
         truncated: false,
       },
     },
+    [`${endpoint}/rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/changes?withComments=false&limit=100`]: {
+      GET: {
+        "size": 1,
+        "limit": 25,
+        "isLastPage": true,
+        "values": [
+            {
+                "contentId": "5c279d6c7a3a053a145905aa9682ce02c16449e9",
+                "fromContentId": "7b86ad1a05b4259b8fa54497a8be0bd359a405bd",
+                "path": {
+                    "components": [
+                        "path",
+                        "to",
+                        "unreviewed",
+                        "file.txt"
+                    ],
+                    "parent": "path/to/unreviewed",
+                    "name": "file.txt",
+                    "extension": "txt",
+                    "toString": "path/to/unreviewed/file.txt"
+                },
+                "executable": false,
+                "percentUnchanged": 98,
+                "type": "MOVE",
+                "nodeType": "FILE",
+                "srcPath": {
+                    "components": [
+                        "path",
+                        "to",
+                        "file.txt"
+                    ],
+                    "parent": "path/to",
+                    "name": "file.txt",
+                    "extension": "txt",
+                    "toString": "path/to/file.txt"
+                },
+                "srcExecutable": false,
+                "links": {
+                    "self": [
+                        null
+                    ]
+                },
+                "properties": {
+                    "unreviewedCommits": 1
+                }
+            }
+        ],
+        "start": 0
+      },
+    },
     [`${endpoint}/rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits`]: {
       GET: {
         values: [{}],

--- a/test/platform/bitbucket-server/index.spec.js
+++ b/test/platform/bitbucket-server/index.spec.js
@@ -418,7 +418,14 @@ describe('platform/bitbucket-server', () => {
       describe('getPrFiles()', () => {
         it('returns empty files', async () => {
           expect.assertions(1);
-          expect(await bitbucket.getPrFiles(5)).toHaveLength(0);
+          expect(await bitbucket.getPrFiles(null)).toHaveLength(0);
+        });
+
+        it('returns one file', async () => {
+          expect.assertions(2);
+          await initRepo();
+          expect(await bitbucket.getPrFiles(5)).toHaveLength(1);
+          expect(api.get.mock.calls).toMatchSnapshot();
         });
       });
 


### PR DESCRIPTION
This pr implements the `getPrFiles` required by renovate to validate config changes.
