### PR TITLE
fix(bitbucket-server): use endpoint path in repo URL

### DIFF
--- a/lib/platform/bitbucket-server/index.js
+++ b/lib/platform/bitbucket-server/index.js
@@ -121,13 +121,13 @@ async function initRepo({
   config = { projectKey, repositorySlug, gitPrivateKey };
 
   // Always gitFs
-  const { host } = url.parse(opts.endpoint);
+  const { host, pathname } = url.parse(opts.endpoint);
   const gitUrl = GitStorage.getUrl({
     gitFs: gitFs || 'https',
     auth: `${encodeURIComponent(opts.username)}:${encodeURIComponent(
       opts.password
     )}`,
-    host: `${host}/scm`,
+    host: `${host}${pathname}${pathname.endsWith('/') ? '' : '/'}scm`,
     repository,
   });
 

--- a/test/platform/bitbucket-server/index.spec.js
+++ b/test/platform/bitbucket-server/index.spec.js
@@ -111,6 +111,19 @@ describe('platform/bitbucket-server', () => {
             'user%40ame:passw%3Ard'
           );
         });
+
+        it('sends the host as the endpoint option', async () => {
+          expect.assertions(2);
+          GitStorage.getUrl.mockClear();
+          await bitbucket.initRepo({
+            repository: 'SOME/repo',
+          });
+          expect(GitStorage.getUrl).toHaveBeenCalledTimes(1);
+          expect(GitStorage.getUrl.mock.calls[0][0]).toHaveProperty(
+            'host',
+            `${mockResponses.baseURL.replace('https://', '')}/scm`
+          );
+        });
       });
 
       describe('repoForceRebase()', () => {


### PR DESCRIPTION
The path in the endpoint configuration, if present, needs to be used in the URL generated for the git clone.