### PR TITLE
fix(bitbucket-server): revert encode auth in URL

### DIFF
--- a/lib/platform/bitbucket-server/index.js
+++ b/lib/platform/bitbucket-server/index.js
@@ -124,9 +124,7 @@ async function initRepo({
   const { host, pathname } = url.parse(opts.endpoint);
   const gitUrl = GitStorage.getUrl({
     gitFs: gitFs || 'https',
-    auth: `${encodeURIComponent(opts.username)}:${encodeURIComponent(
-      opts.password
-    )}`,
+    auth: `${opts.username}:${opts.password}`,
     host: `${host}${pathname}${pathname.endsWith('/') ? '' : '/'}scm`,
     repository,
   });

--- a/test/platform/bitbucket-server/index.spec.js
+++ b/test/platform/bitbucket-server/index.spec.js
@@ -33,7 +33,6 @@ describe('platform/bitbucket-server', () => {
         jest.spyOn(api, 'delete');
         bitbucket = require('../../../lib/platform/bitbucket-server');
         GitStorage = require('../../../lib/platform/git/storage');
-        jest.spyOn(GitStorage, 'getUrl');
         GitStorage.mockImplementation(() => ({
           initRepo: jest.fn(),
           cleanRepo: jest.fn(),
@@ -59,8 +58,8 @@ describe('platform/bitbucket-server', () => {
         hostRules.update({
           platform: 'bitbucket-server',
           token: 'token',
-          username: 'user@ame',
-          password: 'passw:rd',
+          username: 'username',
+          password: 'password',
           endpoint: mockResponses.baseURL,
         });
       });
@@ -97,19 +96,6 @@ describe('platform/bitbucket-server', () => {
             repository: 'SOME/repo',
           });
           expect(res).toMatchSnapshot();
-        });
-
-        it('sends the username and password encoded', async () => {
-          expect.assertions(2);
-          GitStorage.getUrl.mockClear();
-          await bitbucket.initRepo({
-            repository: 'SOME/repo',
-          });
-          expect(GitStorage.getUrl).toHaveBeenCalledTimes(1);
-          expect(GitStorage.getUrl.mock.calls[0][0]).toHaveProperty(
-            'auth',
-            'user%40ame:passw%3Ard'
-          );
         });
 
         it('sends the host as the endpoint option', async () => {


### PR DESCRIPTION
This reverts commit 3e66e019e4d7b506e06ad2522dd66e1c3cd503ae.

TL;DR: auth encoding was already handled by Node.js's `url.format` method and I'm very sorry

I made a mistake with #3493. I thought I saw an auth error in the logs when running renovate, so I opened #3493. Later, I discovered #3494 was needed. After this was merged I ran the published version but still saw an auth error. Curiously, I saw double the amount of encoding than what I thought the password should have. To avoid further churn, I cloned renovate, created a branch and reverted #3493's commit and ran again, which was successful (created the PR for adding `renovate.json`). 

I wanted to figure out where I went wrong before proposing another PR and embarrassing myself further, not actually helping the renovate project, etc. 

* [lib/platform/bitbucket-server/index.js `initRepo`](https://github.com/PixnBits/renovate/blob/3e66e019e4d7b506e06ad2522dd66e1c3cd503ae/lib/platform/bitbucket-server/index.js#L125-L132) calls [GitStorage.getUrl](https://github.com/PixnBits/renovate/blob/3e66e019e4d7b506e06ad2522dd66e1c3cd503ae/lib/platform/git/storage.js#L326-L342) with `{ ..., auth: 'username:password', ... }`
* [GitStorage.getUrl](https://github.com/PixnBits/renovate/blob/3e66e019e4d7b506e06ad2522dd66e1c3cd503ae/lib/platform/git/storage.js#L335-L337) passes `auth` untouched to [`URL.format`](https://nodejs.org/docs/latest-v10.x/api/url.html#url_url_format_urlobject)
* the [`urlObject.auth`](https://nodejs.org/docs/latest-v10.x/api/url.html#url_urlobject_auth) entry does not mention encoding auth, but running a few lines in node show this to be the case:
```
$ node
> url.format
[Function: urlFormat]
> url.format({ protocol: 'https:', auth: 'usern@me:passw:ord', hostname: 'example.com', host: 'example.com', pathname: 'proj/repo.git' })
'https://usern%40me:passw:ord@example.com/proj/repo.git'
> url.format({ protocol: 'https:', auth: 'usern@me:passw\\ord', hostname: 'example.com', host: 'example.com', pathname: 'proj/repo.git' })
'https://usern%40me:passw%5Cord@example.com/proj/repo.git'
> url.format({ protocol: 'https:', auth: 'us:rn@me:passw\\ord', hostname: 'example.com', host: 'example.com', pathname: 'proj/repo.git' })
'https://us:rn%40me:passw%5Cord@example.com/proj/repo.git'
```
* This is backed up by digging into Node.js's source code for [`url.format`](https://github.com/nodejs/node/blob/v10.15.2/lib/url.js#L552-L574) and the [`encodeStr` method](https://github.com/nodejs/node/blob/v10.15.2/lib/internal/querystring.js#L28-L90) it calls.

I was tempted to open a PR to encode only colons in the username and password, but then I remembered these escape sequences would themselves be encoded again
```
> url.format({ protocol: 'https:', auth: 'us:rn@me:passw\\ord'.replace(/:/g, encodeURIComponent(':')), hostname: 'example.com', host: 'example.com', pathname: 'proj/repo.git' })
'https://us%253Arn%40me%253Apassw%5Cord@example.com/proj/repo.git'
```

This means there is a limitation on usernames or passwords imposed by Node.js in that they cannot use `:`.

I am terribly sorry for introducing this bug with an erroneous fix. I've also learned to spend more time inspecting 404s and 401s. 😓 