### PR TITLE
feat: Add ruby-version manager

### DIFF
--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -1216,7 +1216,6 @@ const options = [
   },
   {
     name: 'ruby-version',
-    releaseStatus: 'unpublished',
     stage: 'package',
     type: 'object',
     default: {

--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -1215,6 +1215,18 @@ const options = [
     mergeable: true,
   },
   {
+    name: 'ruby-version',
+    releaseStatus: 'unpublished',
+    stage: 'package',
+    type: 'object',
+    default: {
+      fileMatch: ['^.ruby-version$'],
+      versionScheme: 'ruby',
+    },
+    mergeable: true,
+    cli: false,
+  },
+  {
     name: 'terraform',
     description: 'Configuration object for Terraform module renovation',
     stage: 'repository',

--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -1220,7 +1220,7 @@ const options = [
     stage: 'package',
     type: 'object',
     default: {
-      fileMatch: ['^.ruby-version$'],
+      fileMatch: ['(^|/)\\.ruby-version$'],
       versionScheme: 'ruby',
     },
     mergeable: true,

--- a/lib/manager/index.js
+++ b/lib/manager/index.js
@@ -25,6 +25,7 @@ const managerList = [
   'poetry',
   'terraform',
   'travis',
+  'ruby-version',
 ];
 const managers = {};
 for (const manager of managerList) {

--- a/lib/manager/ruby-version/extract.js
+++ b/lib/manager/ruby-version/extract.js
@@ -10,7 +10,6 @@ function extractPackageFile(content) {
     depName: 'ruby',
     currentValue: content.trim(),
     datasource: 'rubyVersion',
-    purl: 'pkg:ruby-version',
   };
   if (!ruby.isValid(dep.currentValue)) {
     dep.skipReason = 'unsupported-version';

--- a/lib/manager/ruby-version/extract.js
+++ b/lib/manager/ruby-version/extract.js
@@ -9,7 +9,7 @@ function extractPackageFile(content) {
   const dep = {
     depName: 'ruby',
     currentValue: content.trim(),
-    datasource: 'ruby-version',
+    datasource: 'rubyVersion',
     purl: 'pkg:ruby-version',
   };
   if (!ruby.isValid(dep.currentValue)) {

--- a/lib/manager/ruby-version/extract.js
+++ b/lib/manager/ruby-version/extract.js
@@ -1,0 +1,19 @@
+const ruby = require('../../versioning/ruby');
+
+module.exports = {
+  extractPackageFile,
+};
+
+function extractPackageFile(content) {
+  logger.trace('ruby-version.extractPackageFile()');
+  const dep = {
+    depName: 'ruby',
+    currentValue: content.trim(),
+    datasource: 'ruby-version',
+    purl: 'pkg:ruby-version',
+  };
+  if (!ruby.isValid(dep.currentValue)) {
+    dep.skipReason = 'unsupported-version';
+  }
+  return { deps: [dep] };
+}

--- a/lib/manager/ruby-version/index.js
+++ b/lib/manager/ruby-version/index.js
@@ -1,0 +1,10 @@
+const { extractPackageFile } = require('./extract');
+const { updateDependency } = require('./update');
+
+const language = 'ruby';
+
+module.exports = {
+  extractPackageFile,
+  language,
+  updateDependency,
+};

--- a/lib/manager/ruby-version/update.js
+++ b/lib/manager/ruby-version/update.js
@@ -1,0 +1,8 @@
+module.exports = {
+  updateDependency,
+};
+
+function updateDependency(fileContent, upgrade) {
+  logger.debug(`ruby-version.updateDependency(): ${upgrade.newVersions}`);
+  return `${upgrade.newValue}\n`;
+}

--- a/renovate-schema.json
+++ b/renovate-schema.json
@@ -813,6 +813,14 @@
       },
       "$ref": "#"
     },
+    "ruby-version": {
+      "type": "object",
+      "default": {
+        "fileMatch": ["^.ruby-version$"],
+        "versionScheme": "ruby"
+      },
+      "$ref": "#"
+    },
     "terraform": {
       "description": "Configuration object for Terraform module renovation",
       "type": "object",

--- a/renovate-schema.json
+++ b/renovate-schema.json
@@ -816,7 +816,7 @@
     "ruby-version": {
       "type": "object",
       "default": {
-        "fileMatch": ["^.ruby-version$"],
+        "fileMatch": ["(^|/)\\.ruby-version$"],
         "versionScheme": "ruby"
       },
       "$ref": "#"

--- a/test/config/__snapshots__/validation.spec.js.snap
+++ b/test/config/__snapshots__/validation.spec.js.snap
@@ -87,7 +87,7 @@ Array [
     "depName": "Configuration Error",
     "message": "packageRules:
         You have included an unsupported manager in a package rule. Your list: foo. 
-        Supported managers are: (ansible, bazel, buildkite, bundler, cargo, circleci, composer, docker-compose, dockerfile, github-actions, gitlabci, gomod, gradle, gradle-wrapper, kubernetes, maven, meteor, npm, nuget, nvm, pip_requirements, pip_setup, pipenv, poetry, terraform, travis).",
+        Supported managers are: (ansible, bazel, buildkite, bundler, cargo, circleci, composer, docker-compose, dockerfile, github-actions, gitlabci, gomod, gradle, gradle-wrapper, kubernetes, maven, meteor, npm, nuget, nvm, pip_requirements, pip_setup, pipenv, poetry, terraform, travis, ruby-version).",
   },
 ]
 `;

--- a/test/manager/ruby-version/__snapshots__/extract.spec.js.snap
+++ b/test/manager/ruby-version/__snapshots__/extract.spec.js.snap
@@ -6,7 +6,6 @@ Array [
     "currentValue": "8.4.0",
     "datasource": "rubyVersion",
     "depName": "ruby",
-    "purl": "pkg:ruby-version",
   },
 ]
 `;
@@ -17,7 +16,6 @@ Array [
     "currentValue": "latestn",
     "datasource": "rubyVersion",
     "depName": "ruby",
-    "purl": "pkg:ruby-version",
     "skipReason": "unsupported-version",
   },
 ]
@@ -29,7 +27,6 @@ Array [
     "currentValue": "8.4",
     "datasource": "rubyVersion",
     "depName": "ruby",
-    "purl": "pkg:ruby-version",
   },
 ]
 `;

--- a/test/manager/ruby-version/__snapshots__/extract.spec.js.snap
+++ b/test/manager/ruby-version/__snapshots__/extract.spec.js.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`lib/manager/ruby-version/extract extractPackageFile() returns a result 1`] = `
+Array [
+  Object {
+    "currentValue": "8.4.0",
+    "datasource": "ruby-version",
+    "depName": "ruby",
+    "purl": "pkg:ruby-version",
+  },
+]
+`;
+
+exports[`lib/manager/ruby-version/extract extractPackageFile() skips non ranges 1`] = `
+Array [
+  Object {
+    "currentValue": "latestn",
+    "datasource": "ruby-version",
+    "depName": "ruby",
+    "purl": "pkg:ruby-version",
+    "skipReason": "unsupported-version",
+  },
+]
+`;
+
+exports[`lib/manager/ruby-version/extract extractPackageFile() supports ranges 1`] = `
+Array [
+  Object {
+    "currentValue": "8.4",
+    "datasource": "ruby-version",
+    "depName": "ruby",
+    "purl": "pkg:ruby-version",
+  },
+]
+`;

--- a/test/manager/ruby-version/__snapshots__/extract.spec.js.snap
+++ b/test/manager/ruby-version/__snapshots__/extract.spec.js.snap
@@ -4,7 +4,7 @@ exports[`lib/manager/ruby-version/extract extractPackageFile() returns a result 
 Array [
   Object {
     "currentValue": "8.4.0",
-    "datasource": "ruby-version",
+    "datasource": "rubyVersion",
     "depName": "ruby",
     "purl": "pkg:ruby-version",
   },
@@ -15,7 +15,7 @@ exports[`lib/manager/ruby-version/extract extractPackageFile() skips non ranges 
 Array [
   Object {
     "currentValue": "latestn",
-    "datasource": "ruby-version",
+    "datasource": "rubyVersion",
     "depName": "ruby",
     "purl": "pkg:ruby-version",
     "skipReason": "unsupported-version",
@@ -27,7 +27,7 @@ exports[`lib/manager/ruby-version/extract extractPackageFile() supports ranges 1
 Array [
   Object {
     "currentValue": "8.4",
-    "datasource": "ruby-version",
+    "datasource": "rubyVersion",
     "depName": "ruby",
     "purl": "pkg:ruby-version",
   },

--- a/test/manager/ruby-version/__snapshots__/update.spec.js.snap
+++ b/test/manager/ruby-version/__snapshots__/update.spec.js.snap
@@ -1,0 +1,6 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`manager/nvm/update updateDependency updates values 1`] = `
+"8.9.1
+"
+`;

--- a/test/manager/ruby-version/extract.spec.js
+++ b/test/manager/ruby-version/extract.spec.js
@@ -1,0 +1,20 @@
+const {
+  extractPackageFile,
+} = require('../../../lib/manager/ruby-version/extract');
+
+describe('lib/manager/ruby-version/extract', () => {
+  describe('extractPackageFile()', () => {
+    it('returns a result', () => {
+      const res = extractPackageFile('8.4.0\n');
+      expect(res.deps).toMatchSnapshot();
+    });
+    it('supports ranges', () => {
+      const res = extractPackageFile('8.4\n');
+      expect(res.deps).toMatchSnapshot();
+    });
+    it('skips non ranges', () => {
+      const res = extractPackageFile('latestn');
+      expect(res.deps).toMatchSnapshot();
+    });
+  });
+});

--- a/test/manager/ruby-version/update.spec.js
+++ b/test/manager/ruby-version/update.spec.js
@@ -1,0 +1,15 @@
+const {
+  updateDependency,
+} = require('../../../lib/manager/ruby-version/update');
+
+describe('manager/nvm/update', () => {
+  describe('updateDependency', () => {
+    it('updates values', () => {
+      const upgrade = {
+        newValue: '8.9.1',
+      };
+      const res = updateDependency('8.9.0\n', upgrade);
+      expect(res).toMatchSnapshot();
+    });
+  });
+});

--- a/test/workers/repository/extract/__snapshots__/index.spec.js.snap
+++ b/test/workers/repository/extract/__snapshots__/index.spec.js.snap
@@ -74,6 +74,9 @@ Object {
   "poetry": Array [
     Object {},
   ],
+  "ruby-version": Array [
+    Object {},
+  ],
   "terraform": Array [
     Object {},
   ],

--- a/website/docs/configuration-options.md
+++ b/website/docs/configuration-options.md
@@ -885,6 +885,8 @@ Set this to false either globally, per-language, or per-package if you want to d
 
 ## ruby
 
+## ruby-version
+
 ## schedule
 
 The `schedule` option allows you to define times of week or month for Renovate updates. Running Renovate around the clock may seem too "noisy" for some projects and therefore `schedule` is a good way to reduce the noise by reducing the timeframe in which Renovate will operate on your repository.


### PR DESCRIPTION
# Todo
1. [x] Implement `extractPackageFile`
2. [x] Implement `updateDependency`
3. [x] Add tests
4. [x] Test with an actual repository

This PR should add support for updating `.ruby-version` files.

Closes #3090
