### PR TITLE
fix(onboarding): Do not create onboarding branches when onboarding is disabled

### DIFF
--- a/lib/workers/repository/onboarding/branch/check.js
+++ b/lib/workers/repository/onboarding/branch/check.js
@@ -60,7 +60,7 @@ const isOnboarded = async config => {
   // If onboarding has been disabled and config files are required then the
   // repository has not been onboarded yet
   if (config.requireConfig && config.onboarding === false) {
-    return false;
+    throw new Error('disabled');
   }
 
   const pr = await closedPrExists(config);

--- a/test/workers/repository/onboarding/branch/index.spec.js
+++ b/test/workers/repository/onboarding/branch/index.spec.js
@@ -52,10 +52,8 @@ describe('workers/repository/onboarding/branch', () => {
       config.onboarding = false;
       platform.getFileList.mockReturnValueOnce(['package.json']);
       platform.getFile.mockReturnValueOnce('{}');
-      platform.findPr.mockReturnValueOnce(null);
-      platform.getBranchPr.mockReturnValueOnce({});
-      const res = await checkOnboardingBranch(config);
-      expect(res.repoIsOnboarded).toBe(false);
+      const onboardingResult = checkOnboardingBranch(config);
+      await expect(onboardingResult).rejects.toThrow('disabled');
     });
     it('detects repo is onboarded via file', async () => {
       platform.getFileList.mockReturnValueOnce(['renovate.json']);


### PR DESCRIPTION
This change stops the the creation of onboarding PRs with the following config:

```
{
  onboarding: false,
  autodiscover: true,
  requireConfig: true
}
```

Closes #3334
