### PR TITLE
fix(config): init cache early

### DIFF
--- a/lib/workers/global/index.js
+++ b/lib/workers/global/index.js
@@ -18,6 +18,7 @@ module.exports = {
 async function start() {
   initLogger();
   try {
+    cache.init(os.tmpdir());
     let config = await configParser.parseConfigs(process.env, process.argv);
     config = await setDirectories(config);
     setMeta(config);


### PR DESCRIPTION
This allows for presets to be used from `config.js`. If no presets are enabled, then the directory isn't created

Closes #3518
