### PR TITLE
refactor: Optimize jest rules to best practice

### DIFF
--- a/test/datasource/npm/index.spec.js
+++ b/test/datasource/npm/index.spec.js
@@ -52,7 +52,7 @@ describe('api/npm', () => {
       .get('/foobar')
       .reply(200, missingVersions);
     const res = await npm.getPkgReleases({ lookupName: 'foobar' });
-    expect(res).toBe(null);
+    expect(res).toBeNull();
   });
   it('should fetch package info from npm', async () => {
     nock('https://registry.npmjs.org')
@@ -381,7 +381,7 @@ describe('api/npm', () => {
     const npmrc = '//registry.npmjs.org/:_authToken=abcdefghijklmnopqrstuvwxyz';
     const res1 = await npm.getPkgReleases({ lookupName: 'foobar', npmrc });
     const res2 = await npm.getPkgReleases({ lookupName: 'foobar', npmrc });
-    expect(res1).not.toBe(null);
+    expect(res1).not.toBeNull();
     expect(res1).toEqual(res2);
   });
   it('should use global cache', async () => {

--- a/test/manager/bazel/update.spec.js
+++ b/test/manager/bazel/update.spec.js
@@ -195,7 +195,7 @@ http_archive(
         throw new Error('some error');
       });
       const res = await bazelfile.updateDependency(content, upgrade);
-      expect(res).toBe(null);
+      expect(res).toBeNull();
     });
   });
 });

--- a/test/manager/poetry/extract.spec.js
+++ b/test/manager/poetry/extract.spec.js
@@ -28,7 +28,7 @@ describe('lib/manager/poetry/extract', () => {
       config = {};
     });
     it('returns null for empty', () => {
-      expect(extractPackageFile('nothing here', config)).toBe(null);
+      expect(extractPackageFile('nothing here', config)).toBeNull();
     });
     it('extracts multiple dependencies', () => {
       const res = extractPackageFile(pyproject1toml, config);

--- a/test/manager/poetry/update.spec.js
+++ b/test/manager/poetry/update.spec.js
@@ -65,7 +65,7 @@ describe('manager/poetry/update', () => {
         nestedVersion: true,
       };
       const res = updateDependency(pyproject2toml, upgrade);
-      expect(res).toBe(null);
+      expect(res).toBeNull();
     });
     it('upgrades extras', () => {
       const upgrade = {
@@ -91,7 +91,7 @@ describe('manager/poetry/update', () => {
     });
     it('returns null if upgrade is null', () => {
       const res = updateDependency(null, null);
-      expect(res).toBe(null);
+      expect(res).toBeNull();
     });
     it('handles nonexistent depType gracefully', () => {
       const upgrade = {
@@ -100,7 +100,7 @@ describe('manager/poetry/update', () => {
         newValue: '1.0.0',
       };
       const res = updateDependency(pyproject1toml, upgrade);
-      expect(res).toBe(null);
+      expect(res).toBeNull();
     });
     it('handles nonexistent depType gracefully', () => {
       const upgrade = {
@@ -109,7 +109,7 @@ describe('manager/poetry/update', () => {
         newValue: '1.0.0',
       };
       const res = updateDependency(pyproject2toml, upgrade);
-      expect(res).toBe(null);
+      expect(res).toBeNull();
     });
     it('handles nonexistent depName gracefully', () => {
       const upgrade = {
@@ -118,7 +118,7 @@ describe('manager/poetry/update', () => {
         newValue: '1.0.0',
       };
       const res = updateDependency(pyproject1toml, upgrade);
-      expect(res).toBe(null);
+      expect(res).toBeNull();
     });
     it('handles nonexistent depName with nested value gracefully', () => {
       const upgrade = {
@@ -128,7 +128,7 @@ describe('manager/poetry/update', () => {
         newValue: '1.0.0',
       };
       const res = updateDependency(pyproject2toml, upgrade);
-      expect(res).toBe(null);
+      expect(res).toBeNull();
     });
   });
 });

--- a/test/manager/travis/extract.spec.js
+++ b/test/manager/travis/extract.spec.js
@@ -8,7 +8,7 @@ describe('lib/manager/travis/extract', () => {
     });
     it('returns empty if fails to parse', () => {
       const res = extractPackageFile('blahhhhh:foo:@what\n', config);
-      expect(res).toBe(null);
+      expect(res).toBeNull();
     });
     it('returns results', () => {
       const res = extractPackageFile('node_js:\n  - 6\n  - 8\n', config);

--- a/test/platform/bitbucket-server/index.spec.js
+++ b/test/platform/bitbucket-server/index.spec.js
@@ -241,14 +241,14 @@ describe('platform/bitbucket-server', () => {
             true
           );
           expect(api.get.mock.calls).toMatchSnapshot();
-          expect(api.post.mock.calls).toHaveLength(1);
+          expect(api.post).toHaveBeenCalledTimes(1);
 
           api.get.mockClear();
           api.post.mockClear();
 
           expect(await bitbucket.ensureComment(5, null, 'content')).toBe(true);
           expect(api.get.mock.calls).toMatchSnapshot();
-          expect(api.post.mock.calls).toHaveLength(1);
+          expect(api.post).toHaveBeenCalledTimes(1);
         });
 
         it('add updates comment if necessary', async () => {
@@ -260,8 +260,8 @@ describe('platform/bitbucket-server', () => {
             await bitbucket.ensureComment(5, 'some-subject', 'some\ncontent')
           ).toBe(true);
           expect(api.get.mock.calls).toMatchSnapshot();
-          expect(api.post.mock.calls).toHaveLength(0);
-          expect(api.put.mock.calls).toHaveLength(1);
+          expect(api.post).toHaveBeenCalledTimes(0);
+          expect(api.put).toHaveBeenCalledTimes(1);
 
           api.get.mockClear();
           api.put.mockClear();
@@ -270,8 +270,8 @@ describe('platform/bitbucket-server', () => {
             true
           );
           expect(api.get.mock.calls).toMatchSnapshot();
-          expect(api.post.mock.calls).toHaveLength(1);
-          expect(api.put.mock.calls).toHaveLength(0);
+          expect(api.post).toHaveBeenCalledTimes(1);
+          expect(api.put).toHaveBeenCalledTimes(0);
         });
 
         it('skips comment', async () => {
@@ -283,14 +283,14 @@ describe('platform/bitbucket-server', () => {
             await bitbucket.ensureComment(5, 'some-subject', 'blablabla')
           ).toBe(true);
           expect(api.get.mock.calls).toMatchSnapshot();
-          expect(api.put.mock.calls).toHaveLength(0);
+          expect(api.put).toHaveBeenCalledTimes(0);
 
           api.get.mockClear();
           api.put.mockClear();
 
           expect(await bitbucket.ensureComment(5, null, '!merge')).toBe(true);
           expect(api.get.mock.calls).toMatchSnapshot();
-          expect(api.put.mock.calls).toHaveLength(0);
+          expect(api.put).toHaveBeenCalledTimes(0);
         });
       });
 
@@ -308,7 +308,7 @@ describe('platform/bitbucket-server', () => {
 
           await bitbucket.ensureCommentRemoval(5, 'some-subject');
           expect(api.get.mock.calls).toMatchSnapshot();
-          expect(api.delete.mock.calls).toHaveLength(1);
+          expect(api.delete).toHaveBeenCalledTimes(1);
         });
 
         it('deletes nothing', async () => {
@@ -318,7 +318,7 @@ describe('platform/bitbucket-server', () => {
 
           await bitbucket.ensureCommentRemoval(5, 'topic');
           expect(api.get.mock.calls).toMatchSnapshot();
-          expect(api.delete.mock.calls).toHaveLength(0);
+          expect(api.delete).toHaveBeenCalledTimes(0);
         });
       });
 

--- a/test/versioning/cargo.spec.js
+++ b/test/versioning/cargo.spec.js
@@ -27,24 +27,22 @@ describe('semver.maxSatisfyingVersion()', () => {
 });
 describe('semver.isValid()', () => {
   it('simple constraints are valid', () => {
-    expect(Boolean(semver.isValid('1'))).toBe(true);
-    expect(Boolean(semver.isValid('1.2'))).toBe(true);
-    expect(Boolean(semver.isValid('1.2.3'))).toBe(true);
-    expect(Boolean(semver.isValid('^1.2.3'))).toBe(true);
-    expect(Boolean(semver.isValid('~1.2.3'))).toBe(true);
-    expect(Boolean(semver.isValid('1.2.*'))).toBe(true);
+    expect(semver.isValid('1')).toBeTruthy();
+    expect(semver.isValid('1.2')).toBeTruthy();
+    expect(semver.isValid('1.2.3')).toBeTruthy();
+    expect(semver.isValid('^1.2.3')).toBeTruthy();
+    expect(semver.isValid('~1.2.3')).toBeTruthy();
+    expect(semver.isValid('1.2.*')).toBeTruthy();
   });
   it('handles comma', () => {
-    expect(Boolean(semver.isValid('< 3.0, >= 1.0.0 <= 2.0.0'))).toBe(true);
-    expect(Boolean(semver.isValid('< 3.0, >= 1.0.0 <= 2.0.0, = 5.1.2'))).toBe(
-      true
-    );
+    expect(semver.isValid('< 3.0, >= 1.0.0 <= 2.0.0')).toBeTruthy();
+    expect(semver.isValid('< 3.0, >= 1.0.0 <= 2.0.0, = 5.1.2')).toBeTruthy();
   });
 });
 describe('semver.isVersion()', () => {
   it('handles comma', () => {
-    expect(Boolean(semver.isVersion('1.2.3'))).toBe(true);
-    expect(Boolean(semver.isValid('1.2'))).toBe(true);
+    expect(semver.isVersion('1.2.3')).toBeTruthy();
+    expect(semver.isValid('1.2')).toBeTruthy();
   });
 });
 describe('semver.isLessThanRange()', () => {
@@ -86,22 +84,22 @@ describe('semver.minSatisfyingVersion()', () => {
 });
 describe('semver.isSingleVersion()', () => {
   it('returns false if naked version', () => {
-    expect(Boolean(semver.isSingleVersion('1.2.3'))).toBe(false);
-    expect(Boolean(semver.isSingleVersion('1.2.3-alpha.1'))).toBe(false);
+    expect(semver.isSingleVersion('1.2.3')).toBeFalsy();
+    expect(semver.isSingleVersion('1.2.3-alpha.1')).toBeFalsy();
   });
   it('returns true if equals', () => {
-    expect(Boolean(semver.isSingleVersion('=1.2.3'))).toBe(true);
-    expect(Boolean(semver.isSingleVersion('= 1.2.3'))).toBe(true);
-    expect(Boolean(semver.isSingleVersion('  = 1.2.3'))).toBe(true);
+    expect(semver.isSingleVersion('=1.2.3')).toBeTruthy();
+    expect(semver.isSingleVersion('= 1.2.3')).toBeTruthy();
+    expect(semver.isSingleVersion('  = 1.2.3')).toBeTruthy();
   });
   it('returns false for partial versions', () => {
-    expect(Boolean(semver.isSingleVersion('1'))).toBe(false);
-    expect(Boolean(semver.isSingleVersion('1.2'))).toBe(false);
+    expect(semver.isSingleVersion('1')).toBeFalsy();
+    expect(semver.isSingleVersion('1.2')).toBeFalsy();
   });
   it('returns false for wildcard constraints', () => {
-    expect(Boolean(semver.isSingleVersion('*'))).toBe(false);
-    expect(Boolean(semver.isSingleVersion('1.*'))).toBe(false);
-    expect(Boolean(semver.isSingleVersion('1.2.*'))).toBe(false);
+    expect(semver.isSingleVersion('*')).toBeFalsy();
+    expect(semver.isSingleVersion('1.*')).toBeFalsy();
+    expect(semver.isSingleVersion('1.2.*')).toBeFalsy();
   });
 });
 describe('semver.getNewValue()', () => {

--- a/test/versioning/composer.spec.js
+++ b/test/versioning/composer.spec.js
@@ -26,39 +26,39 @@ describe('semver.isGreaterThan(a, b)', () => {
 });
 describe('semver.isSingleVersion(input)', () => {
   it('should pad short version', () => {
-    expect(Boolean(semver.isSingleVersion('v1.2'))).toBe(true);
+    expect(semver.isSingleVersion('v1.2')).toBeTruthy();
   });
 });
 describe('semver.isStable(input)', () => {
   it('should pad short version', () => {
-    expect(Boolean(semver.isStable('v1.2'))).toBe(true);
+    expect(semver.isStable('v1.2')).toBeTruthy();
   });
 });
 describe('semver.isValid(input)', () => {
   it('should support simple semver', () => {
-    expect(Boolean(semver.isValid('1.2.3'))).toBe(true);
+    expect(semver.isValid('1.2.3')).toBeTruthy();
   });
   it('should support semver with dash', () => {
-    expect(Boolean(semver.isValid('1.2.3-foo'))).toBe(true);
+    expect(semver.isValid('1.2.3-foo')).toBeTruthy();
   });
   it('should reject semver without dash', () => {
-    expect(Boolean(semver.isValid('1.2.3foo'))).toBe(false);
+    expect(semver.isValid('1.2.3foo')).toBeFalsy();
   });
   it('should support ranges', () => {
-    expect(Boolean(semver.isValid('~1.2.3'))).toBe(true);
-    expect(Boolean(semver.isValid('^1.2.3'))).toBe(true);
-    expect(Boolean(semver.isValid('>1.2.3'))).toBe(true);
+    expect(semver.isValid('~1.2.3')).toBeTruthy();
+    expect(semver.isValid('^1.2.3')).toBeTruthy();
+    expect(semver.isValid('>1.2.3')).toBeTruthy();
   });
 });
 describe('semver.isVersion(input)', () => {
   it('should support simple semver', () => {
-    expect(Boolean(semver.isValid('1.2.3'))).toBe(true);
+    expect(semver.isValid('1.2.3')).toBeTruthy();
   });
   it('should support shortened version', () => {
-    expect(Boolean(semver.isValid('2.5'))).toBe(true);
+    expect(semver.isValid('2.5')).toBeTruthy();
   });
   it('should support shortened v version', () => {
-    expect(Boolean(semver.isValid('v2.5'))).toBe(true);
+    expect(semver.isValid('v2.5')).toBeTruthy();
   });
 });
 describe('semver.isLessThanRange()', () => {

--- a/test/versioning/npm.spec.js
+++ b/test/versioning/npm.spec.js
@@ -2,41 +2,41 @@ const semver = require('../../lib/versioning/npm');
 
 describe('semver.isValid(input)', () => {
   it('should return null for irregular versions', () => {
-    expect(Boolean(semver.isValid('17.04.0'))).toBe(false);
+    expect(semver.isValid('17.04.0')).toBeFalsy();
   });
   it('should support simple semver', () => {
-    expect(Boolean(semver.isValid('1.2.3'))).toBe(true);
+    expect(semver.isValid('1.2.3')).toBeTruthy();
   });
   it('should support semver with dash', () => {
-    expect(Boolean(semver.isValid('1.2.3-foo'))).toBe(true);
+    expect(semver.isValid('1.2.3-foo')).toBeTruthy();
   });
   it('should reject semver without dash', () => {
-    expect(Boolean(semver.isValid('1.2.3foo'))).toBe(false);
+    expect(semver.isValid('1.2.3foo')).toBeFalsy();
   });
   it('should support ranges', () => {
-    expect(Boolean(semver.isValid('~1.2.3'))).toBe(true);
-    expect(Boolean(semver.isValid('^1.2.3'))).toBe(true);
-    expect(Boolean(semver.isValid('>1.2.3'))).toBe(true);
+    expect(semver.isValid('~1.2.3')).toBeTruthy();
+    expect(semver.isValid('^1.2.3')).toBeTruthy();
+    expect(semver.isValid('>1.2.3')).toBeTruthy();
   });
   it('should reject github repositories', () => {
-    expect(Boolean(semver.isValid('renovatebot/renovate'))).toBe(false);
-    expect(Boolean(semver.isValid('renovatebot/renovate#master'))).toBe(false);
+    expect(semver.isValid('renovatebot/renovate')).toBeFalsy();
+    expect(semver.isValid('renovatebot/renovate#master')).toBeFalsy();
     expect(
-      Boolean(semver.isValid('https://github.com/renovatebot/renovate.git'))
-    ).toBe(false);
+      semver.isValid('https://github.com/renovatebot/renovate.git')
+    ).toBeFalsy();
   });
 });
 describe('semver.isSingleVersion()', () => {
   it('returns true if naked version', () => {
-    expect(Boolean(semver.isSingleVersion('1.2.3'))).toBe(true);
-    expect(Boolean(semver.isSingleVersion('1.2.3-alpha.1'))).toBe(true);
+    expect(semver.isSingleVersion('1.2.3')).toBeTruthy();
+    expect(semver.isSingleVersion('1.2.3-alpha.1')).toBeTruthy();
   });
   it('returns true if equals', () => {
-    expect(Boolean(semver.isSingleVersion('=1.2.3'))).toBe(true);
-    expect(Boolean(semver.isSingleVersion('= 1.2.3'))).toBe(true);
+    expect(semver.isSingleVersion('=1.2.3')).toBeTruthy();
+    expect(semver.isSingleVersion('= 1.2.3')).toBeTruthy();
   });
   it('returns false when not version', () => {
-    expect(Boolean(semver.isSingleVersion('1.x'))).toBe(false);
+    expect(semver.isSingleVersion('1.x')).toBeFalsy();
   });
 });
 describe('semver.getNewValue()', () => {

--- a/test/versioning/pep440.spec.js
+++ b/test/versioning/pep440.spec.js
@@ -2,50 +2,50 @@ const pep440 = require('../../lib/versioning/pep440');
 
 describe('pep440.isValid(input)', () => {
   it('should return null for irregular versions', () => {
-    expect(Boolean(pep440.isValid('17.04.0'))).toBe(false);
+    expect(pep440.isValid('17.04.0')).toBeFalsy();
   });
   it('should support simple pep440', () => {
-    expect(Boolean(pep440.isValid('==1.2.3'))).toBe(true);
+    expect(pep440.isValid('==1.2.3')).toBeTruthy();
   });
   it('should support pep440 with RC', () => {
-    expect(Boolean(pep440.isValid('==1.2.3rc0'))).toBe(true);
+    expect(pep440.isValid('==1.2.3rc0')).toBeTruthy();
   });
   it('should support ranges', () => {
-    expect(Boolean(pep440.isValid('~=1.2.3'))).toBe(true);
-    expect(Boolean(pep440.isValid('==1.2.*'))).toBe(true);
-    expect(Boolean(pep440.isValid('>1.2.3'))).toBe(true);
+    expect(pep440.isValid('~=1.2.3')).toBeTruthy();
+    expect(pep440.isValid('==1.2.*')).toBeTruthy();
+    expect(pep440.isValid('>1.2.3')).toBeTruthy();
   });
   it('should reject github repositories', () => {
-    expect(Boolean(pep440.isValid('renovatebot/renovate'))).toBe(false);
-    expect(Boolean(pep440.isValid('renovatebot/renovate#master'))).toBe(false);
+    expect(pep440.isValid('renovatebot/renovate')).toBeFalsy();
+    expect(pep440.isValid('renovatebot/renovate#master')).toBeFalsy();
     expect(
-      Boolean(pep440.isValid('https://github.com/renovatebot/renovate.git'))
-    ).toBe(false);
+      pep440.isValid('https://github.com/renovatebot/renovate.git')
+    ).toBeFalsy();
   });
 });
 
 describe('pep440.isStable(version)', () => {
   it('returns correct value', () => {
-    expect(pep440.isStable('1.2.3')).toBe(true);
-    expect(pep440.isStable('1.2.3rc0')).toBe(false);
+    expect(pep440.isStable('1.2.3')).toBeTruthy();
+    expect(pep440.isStable('1.2.3rc0')).toBeFalsy();
   });
   it('returns false when version invalid', () => {
-    expect(pep440.isStable('not_version')).toBe(false);
+    expect(pep440.isStable('not_version')).toBeFalsy();
   });
 });
 
 describe('pep440.isSingleVersion()', () => {
   it('returns true if naked version', () => {
-    expect(Boolean(pep440.isSingleVersion('1.2.3'))).toBe(true);
-    expect(Boolean(pep440.isSingleVersion('1.2.3rc0'))).toBe(true);
+    expect(pep440.isSingleVersion('1.2.3')).toBeTruthy();
+    expect(pep440.isSingleVersion('1.2.3rc0')).toBeTruthy();
   });
   it('returns true if double equals', () => {
-    expect(Boolean(pep440.isSingleVersion('==1.2.3'))).toBe(true);
-    expect(Boolean(pep440.isSingleVersion('==1.2'))).toBe(true);
-    expect(Boolean(pep440.isSingleVersion('== 1.2.3'))).toBe(true);
+    expect(pep440.isSingleVersion('==1.2.3')).toBeTruthy();
+    expect(pep440.isSingleVersion('==1.2')).toBeTruthy();
+    expect(pep440.isSingleVersion('== 1.2.3')).toBeTruthy();
   });
   it('returns false when not version', () => {
-    expect(Boolean(pep440.isSingleVersion('==1.*'))).toBe(false);
+    expect(pep440.isSingleVersion('==1.*')).toBeFalsy();
   });
 });
 

--- a/test/versioning/poetry.spec.js
+++ b/test/versioning/poetry.spec.js
@@ -2,41 +2,41 @@ const semver = require('../../lib/versioning/poetry');
 
 describe('semver.isValid(input)', () => {
   it('should return null for irregular versions', () => {
-    expect(Boolean(semver.isValid('17.04.0'))).toBe(false);
+    expect(semver.isValid('17.04.0')).toBeFalsy();
   });
   it('should support simple semver', () => {
-    expect(Boolean(semver.isValid('1.2.3'))).toBe(true);
+    expect(semver.isValid('1.2.3')).toBeTruthy();
   });
   it('should support semver with dash', () => {
-    expect(Boolean(semver.isValid('1.2.3-foo'))).toBe(true);
+    expect(semver.isValid('1.2.3-foo')).toBeTruthy();
   });
   it('should reject semver without dash', () => {
-    expect(Boolean(semver.isValid('1.2.3foo'))).toBe(false);
+    expect(semver.isValid('1.2.3foo')).toBeFalsy();
   });
   it('should support ranges', () => {
-    expect(Boolean(semver.isValid('~1.2.3'))).toBe(true);
-    expect(Boolean(semver.isValid('^1.2.3'))).toBe(true);
-    expect(Boolean(semver.isValid('>1.2.3'))).toBe(true);
+    expect(semver.isValid('~1.2.3')).toBeTruthy();
+    expect(semver.isValid('^1.2.3')).toBeTruthy();
+    expect(semver.isValid('>1.2.3')).toBeTruthy();
   });
   it('should reject github repositories', () => {
-    expect(Boolean(semver.isValid('renovatebot/renovate'))).toBe(false);
-    expect(Boolean(semver.isValid('renovatebot/renovate#master'))).toBe(false);
+    expect(semver.isValid('renovatebot/renovate')).toBeFalsy();
+    expect(semver.isValid('renovatebot/renovate#master')).toBeFalsy();
     expect(
-      Boolean(semver.isValid('https://github.com/renovatebot/renovate.git'))
-    ).toBe(false);
+      semver.isValid('https://github.com/renovatebot/renovate.git')
+    ).toBeFalsy();
   });
 });
 describe('semver.isSingleVersion()', () => {
   it('returns true if naked version', () => {
-    expect(Boolean(semver.isSingleVersion('1.2.3'))).toBe(true);
-    expect(Boolean(semver.isSingleVersion('1.2.3-alpha.1'))).toBe(true);
+    expect(semver.isSingleVersion('1.2.3')).toBeTruthy();
+    expect(semver.isSingleVersion('1.2.3-alpha.1')).toBeTruthy();
   });
   it('returns true if equals', () => {
-    expect(Boolean(semver.isSingleVersion('=1.2.3'))).toBe(true);
-    expect(Boolean(semver.isSingleVersion('= 1.2.3'))).toBe(true);
+    expect(semver.isSingleVersion('=1.2.3')).toBeTruthy();
+    expect(semver.isSingleVersion('= 1.2.3')).toBeTruthy();
   });
   it('returns false when not version', () => {
-    expect(Boolean(semver.isSingleVersion('1.*'))).toBe(false);
+    expect(semver.isSingleVersion('1.*')).toBeFalsy();
   });
 });
 describe('semver.matches()', () => {

--- a/test/versioning/semver.spec.js
+++ b/test/versioning/semver.spec.js
@@ -2,41 +2,41 @@ const semver = require('../../lib/versioning/semver');
 
 describe('semver.isValid(input)', () => {
   it('should return null for irregular versions', () => {
-    expect(Boolean(semver.isValid('17.04.0'))).toBe(false);
+    expect(semver.isValid('17.04.0')).toBeFalsy();
   });
   it('should support simple semver', () => {
-    expect(Boolean(semver.isValid('1.2.3'))).toBe(true);
+    expect(semver.isValid('1.2.3')).toBeTruthy();
   });
   it('should support semver with dash', () => {
-    expect(Boolean(semver.isValid('1.2.3-foo'))).toBe(true);
+    expect(semver.isValid('1.2.3-foo')).toBeTruthy();
   });
   it('should reject semver without dash', () => {
-    expect(Boolean(semver.isValid('1.2.3foo'))).toBe(false);
+    expect(semver.isValid('1.2.3foo')).toBeFalsy();
   });
   it('should reject ranges', () => {
-    expect(Boolean(semver.isValid('~1.2.3'))).toBe(false);
-    expect(Boolean(semver.isValid('^1.2.3'))).toBe(false);
-    expect(Boolean(semver.isValid('>1.2.3'))).toBe(false);
+    expect(semver.isValid('~1.2.3')).toBeFalsy();
+    expect(semver.isValid('^1.2.3')).toBeFalsy();
+    expect(semver.isValid('>1.2.3')).toBeFalsy();
   });
   it('should reject github repositories', () => {
-    expect(Boolean(semver.isValid('renovatebot/renovate'))).toBe(false);
-    expect(Boolean(semver.isValid('renovatebot/renovate#master'))).toBe(false);
+    expect(semver.isValid('renovatebot/renovate')).toBeFalsy();
+    expect(semver.isValid('renovatebot/renovate#master')).toBeFalsy();
     expect(
-      Boolean(semver.isValid('https://github.com/renovatebot/renovate.git'))
-    ).toBe(false);
+      semver.isValid('https://github.com/renovatebot/renovate.git')
+    ).toBeFalsy();
   });
 });
 describe('semver.isSingleVersion()', () => {
   it('returns true if naked version', () => {
-    expect(Boolean(semver.isSingleVersion('1.2.3'))).toBe(true);
-    expect(Boolean(semver.isSingleVersion('1.2.3-alpha.1'))).toBe(true);
+    expect(semver.isSingleVersion('1.2.3')).toBeTruthy();
+    expect(semver.isSingleVersion('1.2.3-alpha.1')).toBeTruthy();
   });
   it('returns false if equals', () => {
-    expect(Boolean(semver.isSingleVersion('=1.2.3'))).toBe(false);
-    expect(Boolean(semver.isSingleVersion('= 1.2.3'))).toBe(false);
+    expect(semver.isSingleVersion('=1.2.3')).toBeFalsy();
+    expect(semver.isSingleVersion('= 1.2.3')).toBeFalsy();
   });
   it('returns false when not version', () => {
-    expect(Boolean(semver.isSingleVersion('1.x'))).toBe(false);
+    expect(semver.isSingleVersion('1.x')).toBeFalsy();
   });
 });
 describe('semver.getNewValue()', () => {


### PR DESCRIPTION
<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate
-->
1. Replaces `toBe(null)` by `toBeNull()` 
2. Replaces explicit coercion of truthy and falsy values by `toBeTruthy()` and `toBeFalsy()`   
3. Replace `mock.calls` length check from `toHaveLength()` by `toHaveBeenCalledTimes()`
Closes  #2028 


