### PR TITLE
fix: nodejs 11 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ notifications:
 language: node_js
 
 node_js:
-  - '10.15.0'
+  - 'lts/dubnium'
+  - '11'
 
 sudo: false
 

--- a/lib/config/validation.js
+++ b/lib/config/validation.js
@@ -283,10 +283,10 @@ async function validateConfig(config, isPreset, parentPath) {
   }
   function sortAll(a, b) {
     if (a.depName === b.depName) {
-      return a.message > b.message;
+      return a.message > b.message ? 1 : -1;
     }
     // istanbul ignore next
-    return a.depName > b.depName;
+    return a.depName > b.depName ? 1 : -1;
   }
   errors.sort(sortAll);
   warnings.sort(sortAll);

--- a/lib/versioning/ruby/index.js
+++ b/lib/versioning/ruby/index.js
@@ -65,7 +65,7 @@ const getNewValue = (currentValue, rangeStrategy, fromVersion, toVersion) => {
   }
 };
 
-const sortVersions = (left, right) => gt(left, right);
+const sortVersions = (left, right) => (gt(left, right) ? 1 : -1);
 
 module.exports = {
   equals,

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   },
   "homepage": "https://renovatebot.com",
   "engines": {
-    "node": "^10.13.0"
+    "node": "^10.13||^11"
   },
   "dependencies": {
     "@renovate/pep440": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   },
   "homepage": "https://renovatebot.com",
   "engines": {
-    "node": "^10.13||^11"
+    "node": "^10.13.0 || ^11.0.0"
   },
   "dependencies": {
     "@renovate/pep440": "0.4.1",

--- a/test/config/__snapshots__/validation.spec.js.snap
+++ b/test/config/__snapshots__/validation.spec.js.snap
@@ -4,10 +4,6 @@ exports[`config/validation validateConfig(config) errors for all types 1`] = `
 Array [
   Object {
     "depName": "Configuration Error",
-    "message": "extends: Invalid timezone: Europe/Brussel",
-  },
-  Object {
-    "depName": "Configuration Error",
     "message": "Configuration option \`enabled\` should be boolean. Found: 1 (number)",
   },
   Object {
@@ -37,6 +33,10 @@ Array [
   Object {
     "depName": "Configuration Error",
     "message": "Invalid schedule: \`Schedule \\"every 15 mins every weekday\\" should not specify minutes\`",
+  },
+  Object {
+    "depName": "Configuration Error",
+    "message": "extends: Invalid timezone: Europe/Brussel",
   },
   Object {
     "depName": "Configuration Error",


### PR DESCRIPTION
Due to an update in the v8 runtime, Node.js `Array.prototype.sort()` is now stable (See [here](https://github.com/nodejs/node/pull/22754#issuecomment-423452575)).

These changes allow for tests to pass on both Node.js 10 and 11.

Fixes #3445