### PR TITLE
feat: Add JSON5 parser

### DIFF
--- a/lib/config/app-strings.js
+++ b/lib/config/app-strings.js
@@ -4,7 +4,9 @@ const appSlug = 'renovate';
 
 const configFileNames = [
   'renovate.json',
+  'renovate.json5',
   '.github/renovate.json',
+  '.github/renovate.json5',
   '.renovaterc',
   '.renovaterc.json',
   'package.json',

--- a/lib/workers/repository/init/config.js
+++ b/lib/workers/repository/init/config.js
@@ -1,4 +1,6 @@
 const jsonValidator = require('json-dup-key-validator');
+const JSON5 = require('json5');
+const path = require('path');
 
 const { mergeChildConfig } = require('../../../config');
 const { migrateAndValidate } = require('../../../config/migrate-validate');
@@ -53,39 +55,58 @@ async function mergeRenovateConfig(config) {
     if (!renovateConfig.length) {
       renovateConfig = '{}';
     }
-    let allowDuplicateKeys = true;
-    let jsonValidationError = jsonValidator.validate(
-      renovateConfig,
-      allowDuplicateKeys
-    );
-    if (jsonValidationError) {
-      const error = new Error('config-validation');
-      error.configFile = configFile;
-      error.validationError = 'Invalid JSON (parsing failed)';
-      error.validationMessage = jsonValidationError;
-      throw error;
-    }
-    allowDuplicateKeys = false;
-    jsonValidationError = jsonValidator.validate(
-      renovateConfig,
-      allowDuplicateKeys
-    );
-    if (jsonValidationError) {
-      const error = new Error('config-validation');
-      error.configFile = configFile;
-      error.validationError = 'Duplicate keys in JSON';
-      error.validationMessage = JSON.stringify(jsonValidationError);
-      throw error;
-    }
-    try {
-      renovateJson = JSON.parse(renovateConfig);
-    } catch (err) /* istanbul ignore next */ {
-      logger.debug({ renovateConfig }, 'Error parsing renovate config');
-      const error = new Error('config-validation');
-      error.configFile = configFile;
-      error.validationError = 'Invalid JSON (parsing failed)';
-      error.validationMessage = 'JSON.parse error: ' + err.message;
-      throw error;
+
+    const fileType = path.extname(configFile);
+
+    if (fileType === '.json5') {
+      try {
+        renovateJson = JSON5.parse(renovateConfig);
+      } catch (err) /* istanbul ignore next */ {
+        logger.debug(
+          { renovateConfig },
+          'Error parsing renovate config renovate.json5'
+        );
+        const error = new Error('config-validation');
+        error.configFile = configFile;
+        error.validationError = 'Invalid JSON5 (parsing failed)';
+        error.validationMessage = 'JSON5.parse error: ' + err.message;
+        throw error;
+      }
+    } else {
+      let allowDuplicateKeys = true;
+      let jsonValidationError = jsonValidator.validate(
+        renovateConfig,
+        allowDuplicateKeys
+      );
+      if (jsonValidationError) {
+        const error = new Error('config-validation');
+        error.configFile = configFile;
+        error.validationError = 'Invalid JSON (parsing failed)';
+        error.validationMessage = jsonValidationError;
+        throw error;
+      }
+      allowDuplicateKeys = false;
+      jsonValidationError = jsonValidator.validate(
+        renovateConfig,
+        allowDuplicateKeys
+      );
+      if (jsonValidationError) {
+        const error = new Error('config-validation');
+        error.configFile = configFile;
+        error.validationError = 'Duplicate keys in JSON';
+        error.validationMessage = JSON.stringify(jsonValidationError);
+        throw error;
+      }
+      try {
+        renovateJson = JSON.parse(renovateConfig);
+      } catch (err) /* istanbul ignore next */ {
+        logger.debug({ renovateConfig }, 'Error parsing renovate config');
+        const error = new Error('config-validation');
+        error.configFile = configFile;
+        error.validationError = 'Invalid JSON (parsing failed)';
+        error.validationMessage = 'JSON.parse error: ' + err.message;
+        throw error;
+      }
     }
     logger.info({ configFile, config: renovateJson }, 'Repository config');
   }

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "js-yaml": "3.13.1",
     "json-dup-key-validator": "1.0.2",
     "json-stringify-pretty-compact": "2.0.0",
+    "json5": "2.1.0",
     "later": "1.2.0",
     "linkify-markdown": "1.0.0",
     "lodash": "4.17.11",

--- a/test/workers/repository/init/config.spec.js
+++ b/test/workers/repository/init/config.spec.js
@@ -66,6 +66,13 @@ describe('workers/repository/init/config', () => {
       expect(e.validationError).toMatchSnapshot();
       expect(e.validationMessage).toMatchSnapshot();
     });
+    it('finds and parse renovate.json5', async () => {
+      platform.getFileList.mockReturnValue(['package.json', 'renovate.json5']);
+      platform.getFile.mockReturnValue(`{
+        // this is json5 format
+      }`);
+      await mergeRenovateConfig(config);
+    });
     it('finds .github/renovate.json', async () => {
       platform.getFileList.mockReturnValue([
         'package.json',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4256,7 +4256,7 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
-json5@^2.1.0:
+json5@2.1.0, json5@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.0.tgz#e7a0c62c48285c628d20a10b85c89bb807c32850"
   integrity sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==


### PR DESCRIPTION
<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate
-->
Added support for `renovate.json5` filename. Now configuration can be parsed from a `json5` format file.

Closes #3484 
