### PR TITLE
tests: Improve error handling test cases

### DIFF
--- a/test/config/cli.spec.js
+++ b/test/config/cli.spec.js
@@ -38,13 +38,7 @@ describe('config/cli', () => {
     it('throws exception for invalid boolean value', () => {
       argv.push('--recreate-closed');
       argv.push('badvalue');
-      let e;
-      try {
-        cli.getConfig(argv);
-      } catch (err) {
-        e = err;
-      }
-      expect(e.message).toEqual(
+      expect(() => cli.getConfig(argv)).toThrow(
         "Invalid boolean value: expected 'true' or 'false', but got 'badvalue'"
       );
     });

--- a/test/config/cli.spec.js
+++ b/test/config/cli.spec.js
@@ -39,7 +39,9 @@ describe('config/cli', () => {
       argv.push('--recreate-closed');
       argv.push('badvalue');
       expect(() => cli.getConfig(argv)).toThrow(
-        "Invalid boolean value: expected 'true' or 'false', but got 'badvalue'"
+        Error(
+          "Invalid boolean value: expected 'true' or 'false', but got 'badvalue'"
+        )
       );
     });
     it('supports boolean space false', () => {

--- a/test/config/index.spec.js
+++ b/test/config/index.spec.js
@@ -24,24 +24,16 @@ describe('config/index', () => {
     it('throws for invalid platform', async () => {
       const env = {};
       defaultArgv.push('--platform=foo');
-      let err;
-      try {
-        await configParser.parseConfigs(env, defaultArgv);
-      } catch (e) {
-        err = e;
-      }
-      expect(err.message).toBe('Unsupported platform: foo.');
+      await expect(configParser.parseConfigs(env, defaultArgv)).rejects.toEqual(
+        Error('Unsupported platform: foo.')
+      );
     });
     it('throws for no GitHub token', async () => {
       const env = { RENOVATE_CONFIG_FILE: '/tmp/does-not-exist' };
-      let err;
-      try {
-        await configParser.parseConfigs(env, defaultArgv);
-      } catch (e) {
-        err = e;
-      }
-      expect(err.message).toBe(
-        'No authentication found for platform https://api.github.com/ (github)'
+      await expect(configParser.parseConfigs(env, defaultArgv)).rejects.toEqual(
+        Error(
+          'No authentication found for platform https://api.github.com/ (github)'
+        )
       );
     });
     it('throws for no GitLab token', async () => {
@@ -49,14 +41,10 @@ describe('config/index', () => {
         RENOVATE_CONFIG_FILE: '/tmp/does-not-exist',
         RENOVATE_PLATFORM: 'gitlab',
       };
-      let err;
-      try {
-        await configParser.parseConfigs(env, defaultArgv);
-      } catch (e) {
-        err = e;
-      }
-      expect(err.message).toBe(
-        'No authentication found for platform https://gitlab.com/api/v4/ (gitlab)'
+      await expect(configParser.parseConfigs(env, defaultArgv)).rejects.toEqual(
+        Error(
+          'No authentication found for platform https://gitlab.com/api/v4/ (gitlab)'
+        )
       );
     });
     it('throws for no Azure DevOps token', async () => {
@@ -64,14 +52,8 @@ describe('config/index', () => {
         RENOVATE_CONFIG_FILE: '/tmp/does-not-exist',
         RENOVATE_PLATFORM: 'azure',
       };
-      let err;
-      try {
-        await configParser.parseConfigs(env, defaultArgv);
-      } catch (e) {
-        err = e;
-      }
-      expect(err.message).toBe(
-        'No authentication found for platform undefined (azure)'
+      await expect(configParser.parseConfigs(env, defaultArgv)).rejects.toEqual(
+        Error('No authentication found for platform undefined (azure)')
       );
     });
     it('supports token in env', async () => {

--- a/test/config/index.spec.js
+++ b/test/config/index.spec.js
@@ -24,13 +24,13 @@ describe('config/index', () => {
     it('throws for invalid platform', async () => {
       const env = {};
       defaultArgv.push('--platform=foo');
-      await expect(configParser.parseConfigs(env, defaultArgv)).rejects.toEqual(
+      await expect(configParser.parseConfigs(env, defaultArgv)).rejects.toThrow(
         Error('Unsupported platform: foo.')
       );
     });
     it('throws for no GitHub token', async () => {
       const env = { RENOVATE_CONFIG_FILE: '/tmp/does-not-exist' };
-      await expect(configParser.parseConfigs(env, defaultArgv)).rejects.toEqual(
+      await expect(configParser.parseConfigs(env, defaultArgv)).rejects.toThrow(
         Error(
           'No authentication found for platform https://api.github.com/ (github)'
         )
@@ -41,7 +41,7 @@ describe('config/index', () => {
         RENOVATE_CONFIG_FILE: '/tmp/does-not-exist',
         RENOVATE_PLATFORM: 'gitlab',
       };
-      await expect(configParser.parseConfigs(env, defaultArgv)).rejects.toEqual(
+      await expect(configParser.parseConfigs(env, defaultArgv)).rejects.toThrow(
         Error(
           'No authentication found for platform https://gitlab.com/api/v4/ (gitlab)'
         )
@@ -52,7 +52,7 @@ describe('config/index', () => {
         RENOVATE_CONFIG_FILE: '/tmp/does-not-exist',
         RENOVATE_PLATFORM: 'azure',
       };
-      await expect(configParser.parseConfigs(env, defaultArgv)).rejects.toEqual(
+      await expect(configParser.parseConfigs(env, defaultArgv)).rejects.toThrow(
         Error('No authentication found for platform undefined (azure)')
       );
     });

--- a/test/datasource/docker.spec.js
+++ b/test/datasource/docker.spec.js
@@ -159,23 +159,15 @@ describe('api/docker', () => {
     });
     it('should throw error for 429', async () => {
       got.mockRejectedValueOnce({ statusCode: 429 });
-      let e;
-      try {
-        await docker.getDigest({ lookupName: 'some-dep' }, 'latest');
-      } catch (err) {
-        e = err;
-      }
-      expect(e.message).toBe('registry-failure');
+      await expect(
+        docker.getDigest({ lookupName: 'some-dep' }, 'latest')
+      ).rejects.toEqual(Error('registry-failure'));
     });
     it('should throw error for 5xx', async () => {
       got.mockRejectedValueOnce({ statusCode: 503 });
-      let e;
-      try {
-        await docker.getDigest({ lookupName: 'some-dep' }, 'latest');
-      } catch (err) {
-        e = err;
-      }
-      expect(e.message).toBe('registry-failure');
+      await expect(
+        docker.getDigest({ lookupName: 'some-dep' }, 'latest')
+      ).rejects.toEqual(Error('registry-failure'));
     });
   });
   describe('getPkgReleases', () => {

--- a/test/datasource/docker.spec.js
+++ b/test/datasource/docker.spec.js
@@ -161,13 +161,13 @@ describe('api/docker', () => {
       got.mockRejectedValueOnce({ statusCode: 429 });
       await expect(
         docker.getDigest({ lookupName: 'some-dep' }, 'latest')
-      ).rejects.toEqual(Error('registry-failure'));
+      ).rejects.toThrow(Error('registry-failure'));
     });
     it('should throw error for 5xx', async () => {
       got.mockRejectedValueOnce({ statusCode: 503 });
       await expect(
         docker.getDigest({ lookupName: 'some-dep' }, 'latest')
-      ).rejects.toEqual(Error('registry-failure'));
+      ).rejects.toThrow(Error('registry-failure'));
     });
   });
   describe('getPkgReleases', () => {

--- a/test/datasource/gradle-version.spec.js
+++ b/test/datasource/gradle-version.spec.js
@@ -27,15 +27,11 @@ describe('datasource/gradle', () => {
 
     it('throws for empty result', async () => {
       got.mockReturnValueOnce({ body: {} });
-      let e;
-      try {
-        await datasource.getPkgReleases({
+      await expect(
+        datasource.getPkgReleases({
           ...config,
-        });
-      } catch (err) {
-        e = err;
-      }
-      expect(e).toBeDefined();
+        })
+      ).rejects.toThrow();
     });
 
     it('throws for 404', async () => {
@@ -44,30 +40,22 @@ describe('datasource/gradle', () => {
           statusCode: 404,
         })
       );
-      let e;
-      try {
-        await datasource.getPkgReleases({
+      await expect(
+        datasource.getPkgReleases({
           ...config,
-        });
-      } catch (err) {
-        e = err;
-      }
-      expect(e).toBeDefined();
+        })
+      ).rejects.toThrow();
     });
 
     it('throws for unknown error', async () => {
       got.mockImplementationOnce(() => {
         throw new Error();
       });
-      let e;
-      try {
-        await datasource.getPkgReleases({
+      await expect(
+        datasource.getPkgReleases({
           ...config,
-        });
-      } catch (err) {
-        e = err;
-      }
-      expect(e).toBeDefined();
+        })
+      ).rejects.toThrow();
     });
 
     it('processes real data', async () => {

--- a/test/datasource/maven.spec.js
+++ b/test/datasource/maven.spec.js
@@ -136,15 +136,13 @@ describe('datasource/maven', () => {
         .reply(503);
 
       expect.assertions(1);
-      try {
-        await datasource.getPkgReleases({
+      await expect(
+        datasource.getPkgReleases({
           ...config,
           lookupName: 'org:artifact',
           registryUrls: ['http://central.maven.org/maven2/'],
-        });
-      } catch (e) {
-        expect(e.message).toEqual('registry-failure');
-      }
+        })
+      ).rejects.toEqual(Error('registry-failure'));
     });
 
     it('should return all versions of a specific library if a repository fails because invalid protocol', async () => {

--- a/test/datasource/maven.spec.js
+++ b/test/datasource/maven.spec.js
@@ -142,7 +142,7 @@ describe('datasource/maven', () => {
           lookupName: 'org:artifact',
           registryUrls: ['http://central.maven.org/maven2/'],
         })
-      ).rejects.toEqual(Error('registry-failure'));
+      ).rejects.toThrow(Error('registry-failure'));
     });
 
     it('should return all versions of a specific library if a repository fails because invalid protocol', async () => {

--- a/test/datasource/npm/index.spec.js
+++ b/test/datasource/npm/index.spec.js
@@ -268,13 +268,9 @@ describe('api/npm', () => {
     nock('https://registry.npmjs.org')
       .get('/foobar')
       .reply(200, 'oops');
-    let e;
-    try {
-      await npm.getPkgReleases({ lookupName: 'foobar' });
-    } catch (err) {
-      e = err;
-    }
-    expect(e).toBeDefined();
+    await expect(
+      npm.getPkgReleases({ lookupName: 'foobar' })
+    ).rejects.toThrow();
   });
   it('should throw error for 429', async () => {
     nock('https://registry.npmjs.org')
@@ -283,37 +279,25 @@ describe('api/npm', () => {
     nock('https://registry.npmjs.org')
       .get('/foobar')
       .reply(429);
-    let e;
-    try {
-      await npm.getPkgReleases({ lookupName: 'foobar' });
-    } catch (err) {
-      e = err;
-    }
-    expect(e).toBeDefined();
+    await expect(
+      npm.getPkgReleases({ lookupName: 'foobar' })
+    ).rejects.toThrow();
   });
   it('should throw error for 5xx', async () => {
     nock('https://registry.npmjs.org')
       .get('/foobar')
       .reply(503);
-    let e;
-    try {
-      await npm.getPkgReleases({ lookupName: 'foobar' });
-    } catch (err) {
-      e = err;
-    }
-    expect(e.message).toBe('registry-failure');
+    await expect(npm.getPkgReleases({ lookupName: 'foobar' })).rejects.toEqual(
+      Error('registry-failure')
+    );
   });
   it('should throw error for 408', async () => {
     nock('https://registry.npmjs.org')
       .get('/foobar')
       .reply(408);
-    let e;
-    try {
-      await npm.getPkgReleases({ lookupName: 'foobar' });
-    } catch (err) {
-      e = err;
-    }
-    expect(e.message).toBe('registry-failure');
+    await expect(npm.getPkgReleases({ lookupName: 'foobar' })).rejects.toEqual(
+      Error('registry-failure')
+    );
   });
   it('should retry when 408 or 5xx', async () => {
     nock('https://registry.npmjs.org')
@@ -332,13 +316,9 @@ describe('api/npm', () => {
     nock('https://registry.npmjs.org')
       .get('/foobar')
       .reply(451);
-    let e;
-    try {
-      await npm.getPkgReleases({ lookupName: 'foobar' });
-    } catch (err) {
-      e = err;
-    }
-    expect(e).toBeDefined();
+    await expect(
+      npm.getPkgReleases({ lookupName: 'foobar' })
+    ).rejects.toThrow();
   });
   it('should send an authorization header if provided', async () => {
     registryAuthToken.mockImplementation(() => ({
@@ -412,14 +392,10 @@ describe('api/npm', () => {
     expect(res).toMatchSnapshot();
   });
   it('should throw error if necessary env var is not present', () => {
-    let e;
-    try {
-      global.trustLevel = 'high';
-      // eslint-disable-next-line no-template-curly-in-string
-      npm.setNpmrc('registry=${REGISTRY_MISSING}');
-    } catch (err) {
-      e = err;
-    }
-    expect(e.message).toBe('env-replace');
+    global.trustLevel = 'high';
+    // eslint-disable-next-line no-template-curly-in-string
+    expect(() => npm.setNpmrc('registry=${REGISTRY_MISSING}')).toThrow(
+      'env-replace'
+    );
   });
 });

--- a/test/datasource/npm/index.spec.js
+++ b/test/datasource/npm/index.spec.js
@@ -287,7 +287,7 @@ describe('api/npm', () => {
     nock('https://registry.npmjs.org')
       .get('/foobar')
       .reply(503);
-    await expect(npm.getPkgReleases({ lookupName: 'foobar' })).rejects.toEqual(
+    await expect(npm.getPkgReleases({ lookupName: 'foobar' })).rejects.toThrow(
       Error('registry-failure')
     );
   });
@@ -295,7 +295,7 @@ describe('api/npm', () => {
     nock('https://registry.npmjs.org')
       .get('/foobar')
       .reply(408);
-    await expect(npm.getPkgReleases({ lookupName: 'foobar' })).rejects.toEqual(
+    await expect(npm.getPkgReleases({ lookupName: 'foobar' })).rejects.toThrow(
       Error('registry-failure')
     );
   });
@@ -395,7 +395,7 @@ describe('api/npm', () => {
     global.trustLevel = 'high';
     // eslint-disable-next-line no-template-curly-in-string
     expect(() => npm.setNpmrc('registry=${REGISTRY_MISSING}')).toThrow(
-      'env-replace'
+      Error('env-replace')
     );
   });
 });

--- a/test/datasource/ruby-version.spec.js
+++ b/test/datasource/ruby-version.spec.js
@@ -24,13 +24,7 @@ describe('datasource/gradle', () => {
     });
     it('throws for empty result', async () => {
       got.mockReturnValueOnce({ body: {} });
-      let e;
-      try {
-        await getPkgReleases();
-      } catch (err) {
-        e = err;
-      }
-      expect(e).toBeDefined();
+      await expect(getPkgReleases()).rejects.toThrow();
     });
 
     it('throws for 404', async () => {
@@ -39,13 +33,7 @@ describe('datasource/gradle', () => {
           statusCode: 404,
         })
       );
-      let e;
-      try {
-        await getPkgReleases();
-      } catch (err) {
-        e = err;
-      }
-      expect(e).toBeDefined();
+      await expect(getPkgReleases()).rejects.toThrow();
     });
   });
 });

--- a/test/manager/composer/artifacts.spec.js
+++ b/test/manager/composer/artifacts.spec.js
@@ -107,12 +107,8 @@ describe('.getArtifacts()', () => {
         'vendor/composer/07fe2366/sebastianbergmann-php-code-coverage-c896779/src/Report/Html/Renderer/Template/js/d3.min.js:  write error (disk full?).  Continue? (y/n/^C) '
       );
     });
-    let e;
-    try {
-      await composer.getArtifacts('composer.json', [], '{}', config);
-    } catch (err) {
-      e = err;
-    }
-    expect(e).toBeDefined();
+    await expect(
+      composer.getArtifacts('composer.json', [], '{}', config)
+    ).rejects.toThrow();
   });
 });

--- a/test/manager/gradle/index.spec.js
+++ b/test/manager/gradle/index.spec.js
@@ -60,13 +60,9 @@ describe('manager/gradle', () => {
       exec.mockImplementation(() => {
         throw new Error();
       });
-      let e;
-      try {
-        await manager.extractAllPackageFiles(config, ['build.gradle']);
-      } catch (err) {
-        e = err;
-      }
-      expect(e).toMatchSnapshot();
+      await expect(
+        manager.extractAllPackageFiles(config, ['build.gradle'])
+      ).rejects.toMatchSnapshot();
     });
 
     it('should return empty if there is no dependency report', async () => {

--- a/test/manager/npm/extract/index.spec.js
+++ b/test/manager/npm/extract/index.spec.js
@@ -45,17 +45,13 @@ describe('manager/npm/extract', () => {
       expect(res).toBeNull();
     });
     it('throws error if non-root renovate config', async () => {
-      let e;
-      try {
-        await npmExtract.extractPackageFile(
+      await expect(
+        npmExtract.extractPackageFile(
           '{ "renovate": {} }',
           'backend/package.json',
           defaultConfig
-        );
-      } catch (err) {
-        e = err;
-      }
-      expect(e).toBeDefined();
+        )
+      ).rejects.toThrow();
     });
     it('returns null if no deps', async () => {
       const res = await npmExtract.extractPackageFile(

--- a/test/platform/azure/azure-helper.spec.js
+++ b/test/platform/azure/azure-helper.spec.js
@@ -302,7 +302,9 @@ describe('platform/azure/helpers', () => {
       expect(() =>
         azureHelper.getProjectAndRepo('prjName/myRepoName/blalba')
       ).toThrow(
-        `prjName/myRepoName/blalba can be only structured this way : 'repository' or 'projectName/repository'!`
+        Error(
+          `prjName/myRepoName/blalba can be only structured this way : 'repository' or 'projectName/repository'!`
+        )
       );
     });
   });

--- a/test/platform/azure/azure-helper.spec.js
+++ b/test/platform/azure/azure-helper.spec.js
@@ -298,14 +298,10 @@ describe('platform/azure/helpers', () => {
       const res = await azureHelper.getProjectAndRepo('prjName/myRepoName');
       expect(res).toMatchSnapshot();
     });
-    it('should return an error', async () => {
-      let err;
-      try {
-        await azureHelper.getProjectAndRepo('prjName/myRepoName/blalba');
-      } catch (error) {
-        err = error;
-      }
-      expect(err.message).toBe(
+    it('should return an error', () => {
+      expect(() =>
+        azureHelper.getProjectAndRepo('prjName/myRepoName/blalba')
+      ).toThrow(
         `prjName/myRepoName/blalba can be only structured this way : 'repository' or 'projectName/repository'!`
       );
     });

--- a/test/platform/git/storage.spec.js
+++ b/test/platform/git/storage.spec.js
@@ -135,13 +135,7 @@ describe('platform/git/storage', () => {
       expect(merged.all).toContain('renovate/future_branch');
     });
     it('should throw if branch merge throws', async () => {
-      let e;
-      try {
-        await git.mergeBranch('not_found');
-      } catch (err) {
-        e = err;
-      }
-      expect(e).toMatchSnapshot();
+      await expect(git.mergeBranch('not_found')).rejects.toMatchSnapshot();
     });
   });
   describe('deleteBranch(branchName)', () => {
@@ -171,13 +165,9 @@ describe('platform/git/storage', () => {
       expect(res).toBeNull();
     });
     it('returns null for 404', async () => {
-      let e;
-      try {
-        await git.getFile('some-path', 'some-branch');
-      } catch (err) {
-        e = err;
-      }
-      expect(e).toMatchSnapshot();
+      await expect(
+        git.getFile('some-path', 'some-branch')
+      ).rejects.toMatchSnapshot();
     });
   });
   describe('commitFilesToBranch(branchName, files, message, parentBranch)', () => {

--- a/test/platform/github/gh-got-wrapper.spec.js
+++ b/test/platform/github/gh-got-wrapper.spec.js
@@ -79,13 +79,7 @@ describe('platform/gh-got-wrapper', () => {
           'Error updating branch: API rate limit exceeded for installation ID 48411. (403)',
       })
     );
-    let e;
-    try {
-      await get('some-url');
-    } catch (err) {
-      e = err;
-    }
-    expect(e).toBeDefined();
+    await expect(get('some-url')).rejects.toThrow();
   });
   it('should throw Bad credentials', async () => {
     ghGot.mockImplementationOnce(() =>
@@ -230,13 +224,9 @@ describe('platform/gh-got-wrapper', () => {
         statusCode: 404,
       })
     );
-    let err;
-    try {
-      await get('some-url');
-    } catch (e) {
-      err = e;
-    }
-    expect(err.statusCode).toBe(404);
+    await expect(get('some-url')).rejects.toEqual({
+      statusCode: 404,
+    });
   });
   it('should give up after 5 retries', async () => {
     ghGot.mockImplementationOnce(() =>
@@ -270,13 +260,10 @@ describe('platform/gh-got-wrapper', () => {
         message: 'Bad bot.',
       })
     );
-    let err;
-    try {
-      await get('some-url');
-    } catch (e) {
-      err = e;
-    }
-    expect(err.statusCode).toBe(403);
+    await expect(get('some-url')).rejects.toEqual({
+      statusCode: 403,
+      message: 'Bad bot.',
+    });
   });
   it('should retry posts', async () => {
     ghGot.mockImplementationOnce(() =>

--- a/test/platform/github/index.spec.js
+++ b/test/platform/github/index.spec.js
@@ -39,13 +39,9 @@ describe('platform/github', () => {
 
   describe('getRepos', () => {
     it('should throw an error if no token is provided', async () => {
-      let err;
-      try {
-        await github.getRepos();
-      } catch (e) {
-        err = e;
-      }
-      expect(err.message).toBe('No token found for getRepos');
+      await expect(github.getRepos()).rejects.toEqual(
+        Error('No token found for getRepos')
+      );
     });
     it('should return an array of repos', async () => {
       const repos = await getRepos('sometoken');
@@ -95,14 +91,10 @@ describe('platform/github', () => {
       });
     });
     it('should throw an error if no token is provided', async () => {
-      let err;
-      try {
-        await github.initRepo({ repository: 'some/repo' });
-      } catch (e) {
-        err = e;
-      }
-      expect(err.message).toBe(
-        'No token found for GitHub repository some/repo'
+      await expect(
+        github.initRepo({ repository: 'some/repo' })
+      ).rejects.toEqual(
+        Error('No token found for GitHub repository some/repo')
       );
     });
     it('should rebase', async () => {
@@ -281,16 +273,12 @@ describe('platform/github', () => {
           owner: {},
         },
       });
-      let e;
-      try {
-        await github.initRepo({
+      await expect(
+        github.initRepo({
           repository: 'some/repo',
           token: 'token',
-        });
-      } catch (err) {
-        e = err;
-      }
-      expect(e).toBeDefined();
+        })
+      ).rejects.toThrow();
     });
     it('throws not-found', async () => {
       get.mockImplementationOnce(() =>
@@ -298,16 +286,12 @@ describe('platform/github', () => {
           statusCode: 404,
         })
       );
-      let e;
-      try {
-        await github.initRepo({
+      await expect(
+        github.initRepo({
           repository: 'some/repo',
           token: 'token',
-        });
-      } catch (err) {
-        e = err;
-      }
-      expect(e).toBeDefined();
+        })
+      ).rejects.toThrow();
     });
   });
   describe('getRepoForceRebase', () => {
@@ -362,13 +346,9 @@ describe('platform/github', () => {
           statusCode: 401,
         })
       );
-      let e;
-      try {
-        await github.getRepoForceRebase();
-      } catch (err) {
-        e = err;
-      }
-      expect(e).toBeDefined();
+      await expect(github.getRepoForceRebase()).rejects.toEqual({
+        statusCode: 401,
+      });
     });
   });
   describe('setBaseBranch(branchName)', () => {
@@ -406,13 +386,7 @@ describe('platform/github', () => {
       get.mockImplementationOnce(() => {
         throw new Error('some error');
       });
-      let e;
-      try {
-        await github.getFileList('error-branch');
-      } catch (err) {
-        e = err;
-      }
-      expect(e).toBeDefined();
+      await expect(github.getFileList('error-branch')).rejects.toThrow();
     });
     it('warns if truncated result', async () => {
       get.mockImplementationOnce(() => ({
@@ -956,13 +930,9 @@ describe('platform/github', () => {
       get.patch.mockImplementationOnce(() => {
         throw new Error('3 of 3 required status checks are expected.');
       });
-      let e;
-      try {
-        await github.mergeBranch('thebranchname', 'branch');
-      } catch (err) {
-        e = err;
-      }
-      expect(e.message).toEqual('not ready');
+      await expect(
+        github.mergeBranch('thebranchname', 'branch')
+      ).rejects.toEqual(Error('not ready'));
     });
   });
   describe('getBranchLastCommitTime', () => {
@@ -2001,13 +1971,10 @@ describe('platform/github', () => {
           tree: [],
         },
       }));
-      let e;
-      try {
-        await github.getFile('package-lock.json');
-      } catch (err) {
-        e = err;
-      }
-      expect(e).toBeDefined();
+      await expect(github.getFile('package-lock.json')).rejects.toEqual({
+        statusCode: 403,
+        message: 'This API returns blobs up to 1 MB in size, OK?',
+      });
     });
     it('should return null if getFile returns nothing', async () => {
       await initRepo({ repository: 'some/repo', token: 'token' });
@@ -2051,13 +2018,9 @@ describe('platform/github', () => {
       get.mockImplementationOnce(() => {
         throw new Error('Something went wrong');
       });
-      let err;
-      try {
-        await github.getFile('package.json');
-      } catch (e) {
-        err = e;
-      }
-      expect(err.message).toBe('Something went wrong');
+      await expect(github.getFile('package.json')).rejects.toEqual(
+        Error('Something went wrong')
+      );
     });
   });
   describe('commitFilesToBranch(branchName, files, message, parentBranch)', () => {

--- a/test/platform/github/index.spec.js
+++ b/test/platform/github/index.spec.js
@@ -39,7 +39,7 @@ describe('platform/github', () => {
 
   describe('getRepos', () => {
     it('should throw an error if no token is provided', async () => {
-      await expect(github.getRepos()).rejects.toEqual(
+      await expect(github.getRepos()).rejects.toThrow(
         Error('No token found for getRepos')
       );
     });
@@ -93,7 +93,7 @@ describe('platform/github', () => {
     it('should throw an error if no token is provided', async () => {
       await expect(
         github.initRepo({ repository: 'some/repo' })
-      ).rejects.toEqual(
+      ).rejects.toThrow(
         Error('No token found for GitHub repository some/repo')
       );
     });
@@ -932,7 +932,7 @@ describe('platform/github', () => {
       });
       await expect(
         github.mergeBranch('thebranchname', 'branch')
-      ).rejects.toEqual(Error('not ready'));
+      ).rejects.toThrow(Error('not ready'));
     });
   });
   describe('getBranchLastCommitTime', () => {
@@ -2018,7 +2018,7 @@ describe('platform/github', () => {
       get.mockImplementationOnce(() => {
         throw new Error('Something went wrong');
       });
-      await expect(github.getFile('package.json')).rejects.toEqual(
+      await expect(github.getFile('package.json')).rejects.toThrow(
         Error('Something went wrong')
       );
     });

--- a/test/platform/gitlab/index.spec.js
+++ b/test/platform/gitlab/index.spec.js
@@ -30,7 +30,7 @@ describe('platform/gitlab', () => {
       return gitlab.getRepos(...args);
     }
     it('should throw an error if no token is provided', async () => {
-      await expect(gitlab.getRepos()).rejects.toEqual(
+      await expect(gitlab.getRepos()).rejects.toThrow(
         Error('No token found for getRepos')
       );
     });
@@ -38,7 +38,7 @@ describe('platform/gitlab', () => {
       get.mockImplementation(() => {
         throw new Error('getRepos error');
       });
-      await expect(gitlab.getRepos('sometoken')).rejects.toEqual(
+      await expect(gitlab.getRepos('sometoken')).rejects.toThrow(
         Error('getRepos error')
       );
     });
@@ -119,7 +119,7 @@ describe('platform/gitlab', () => {
     it('should throw an error if no token is provided', async () => {
       await expect(
         gitlab.initRepo({ repository: 'some/repo' })
-      ).rejects.toEqual(
+      ).rejects.toThrow(
         Error('No token found for GitLab repository some/repo')
       );
     });
@@ -129,19 +129,19 @@ describe('platform/gitlab', () => {
       });
       await expect(
         gitlab.initRepo({ repository: 'some/repo', token: 'sometoken' })
-      ).rejects.toEqual(Error('always error'));
+      ).rejects.toThrow(Error('always error'));
     });
     it('should throw an error if repository is archived', async () => {
       get.mockReturnValue({ body: { archived: true } });
       await expect(
         gitlab.initRepo({ repository: 'some/repo', token: 'sometoken' })
-      ).rejects.toEqual(Error('archived'));
+      ).rejects.toThrow(Error('archived'));
     });
     it('should throw an error if repository is empty', async () => {
       get.mockReturnValue({ body: { default_branch: null } });
       await expect(
         gitlab.initRepo({ repository: 'some/repo', token: 'sometoken' })
-      ).rejects.toEqual(Error('empty'));
+      ).rejects.toThrow(Error('empty'));
     });
   });
   describe('getRepoForceRebase', () => {

--- a/test/platform/gitlab/index.spec.js
+++ b/test/platform/gitlab/index.spec.js
@@ -30,25 +30,17 @@ describe('platform/gitlab', () => {
       return gitlab.getRepos(...args);
     }
     it('should throw an error if no token is provided', async () => {
-      let err;
-      try {
-        await gitlab.getRepos();
-      } catch (e) {
-        err = e;
-      }
-      expect(err.message).toBe('No token found for getRepos');
+      await expect(gitlab.getRepos()).rejects.toEqual(
+        Error('No token found for getRepos')
+      );
     });
     it('should throw an error if it receives an error', async () => {
       get.mockImplementation(() => {
         throw new Error('getRepos error');
       });
-      let err;
-      try {
-        await gitlab.getRepos('sometoken');
-      } catch (e) {
-        err = e;
-      }
-      expect(err.message).toBe('getRepos error');
+      await expect(gitlab.getRepos('sometoken')).rejects.toEqual(
+        Error('getRepos error')
+      );
     });
     it('should return an array of repos', async () => {
       const repos = await getRepos('sometoken');
@@ -125,47 +117,31 @@ describe('platform/gitlab', () => {
       expect(get.mock.calls).toMatchSnapshot();
     });
     it('should throw an error if no token is provided', async () => {
-      let err;
-      try {
-        await gitlab.initRepo({ repository: 'some/repo' });
-      } catch (e) {
-        err = e;
-      }
-      expect(err.message).toBe(
-        'No token found for GitLab repository some/repo'
+      await expect(
+        gitlab.initRepo({ repository: 'some/repo' })
+      ).rejects.toEqual(
+        Error('No token found for GitLab repository some/repo')
       );
     });
     it('should throw an error if receiving an error', async () => {
       get.mockImplementation(() => {
         throw new Error('always error');
       });
-      let err;
-      try {
-        await gitlab.initRepo({ repository: 'some/repo', token: 'sometoken' });
-      } catch (e) {
-        err = e;
-      }
-      expect(err.message).toBe('always error');
+      await expect(
+        gitlab.initRepo({ repository: 'some/repo', token: 'sometoken' })
+      ).rejects.toEqual(Error('always error'));
     });
     it('should throw an error if repository is archived', async () => {
       get.mockReturnValue({ body: { archived: true } });
-      let err;
-      try {
-        await gitlab.initRepo({ repository: 'some/repo', token: 'sometoken' });
-      } catch (e) {
-        err = e;
-      }
-      expect(err.message).toBe('archived');
+      await expect(
+        gitlab.initRepo({ repository: 'some/repo', token: 'sometoken' })
+      ).rejects.toEqual(Error('archived'));
     });
     it('should throw an error if repository is empty', async () => {
       get.mockReturnValue({ body: { default_branch: null } });
-      let err;
-      try {
-        await gitlab.initRepo({ repository: 'some/repo', token: 'sometoken' });
-      } catch (e) {
-        err = e;
-      }
-      expect(err.message).toBe('empty');
+      await expect(
+        gitlab.initRepo({ repository: 'some/repo', token: 'sometoken' })
+      ).rejects.toEqual(Error('empty'));
     });
   });
   describe('getRepoForceRebase', () => {
@@ -246,13 +222,9 @@ describe('platform/gitlab', () => {
           statusCode: 500,
         })
       );
-      let e;
-      try {
-        await gitlab.branchExists('foo');
-      } catch (err) {
-        e = err;
-      }
-      expect(e.statusCode).toBe(500);
+      await expect(gitlab.branchExists('foo')).rejects.toEqual({
+        statusCode: 500,
+      });
     });
   });
   describe('getAllRenovateBranches()', () => {
@@ -507,17 +479,14 @@ describe('platform/gitlab', () => {
       get.post.mockImplementationOnce(() => {
         throw new Error('branch-push failed');
       });
-      let e;
-      try {
-        await gitlab.mergeBranch('thebranchname');
-      } catch (err) {
-        e = err;
-      }
+
+      await expect(
+        gitlab.mergeBranch('thebranchname')
+      ).rejects.toMatchSnapshot();
 
       // deleteBranch
       get.delete.mockImplementationOnce();
 
-      expect(e).toMatchSnapshot();
       expect(get.post.mock.calls).toMatchSnapshot();
       expect(get.delete.mock.calls).toMatchSnapshot();
     });
@@ -973,13 +942,10 @@ These updates have all been created already. Click a checkbox below to force a r
     });
     it('throws error for non-404', async () => {
       get.mockImplementationOnce(() => Promise.reject({ statusCode: 403 }));
-      let e;
-      try {
-        await gitlab.getFile('some-path', 'some-branch');
-      } catch (err) {
-        e = err;
-      }
-      expect(e).toMatchSnapshot();
+
+      await expect(
+        gitlab.getFile('some-path', 'some-branch')
+      ).rejects.toMatchSnapshot();
     });
   });
   describe('commitFilesToBranch(branchName, files, message, parentBranch)', () => {

--- a/test/workers/branch/get-updated.spec.js
+++ b/test/workers/branch/get-updated.spec.js
@@ -26,13 +26,7 @@ describe('workers/branch/get-updated', () => {
       config.upgrades.push({
         manager: 'npm',
       });
-      let e;
-      try {
-        await getUpdatedPackageFiles(config);
-      } catch (err) {
-        e = err;
-      }
-      expect(e).toBeDefined();
+      await expect(getUpdatedPackageFiles(config)).rejects.toThrow();
     });
     it('handles content change', async () => {
       config.parentBranch = 'some-branch';

--- a/test/workers/branch/index.spec.js
+++ b/test/workers/branch/index.spec.js
@@ -271,7 +271,7 @@ describe('workers/branch', () => {
       prWorker.ensurePr.mockReturnValueOnce({});
       prWorker.checkAutoMerge.mockReturnValueOnce(true);
       config.releaseTimestamp = new Date().toISOString();
-      await expect(branchWorker.processBranch(config)).rejects.toEqual(
+      await expect(branchWorker.processBranch(config)).rejects.toThrow(
         Error('lockfile-error')
       );
     });

--- a/test/workers/branch/index.spec.js
+++ b/test/workers/branch/index.spec.js
@@ -271,13 +271,9 @@ describe('workers/branch', () => {
       prWorker.ensurePr.mockReturnValueOnce({});
       prWorker.checkAutoMerge.mockReturnValueOnce(true);
       config.releaseTimestamp = new Date().toISOString();
-      let e;
-      try {
-        await branchWorker.processBranch(config);
-      } catch (err) {
-        e = err;
-      }
-      expect(e.message).toEqual('lockfile-error');
+      await expect(branchWorker.processBranch(config)).rejects.toEqual(
+        Error('lockfile-error')
+      );
     });
     it('ensures PR and adds lock file error comment recreate closed', async () => {
       getUpdated.getUpdatedPackageFiles.mockReturnValueOnce({

--- a/test/workers/repository/configured.spec.js
+++ b/test/workers/repository/configured.spec.js
@@ -15,25 +15,13 @@ describe('workers/repository/configured', () => {
     });
     it('throws if disabled', () => {
       config.enabled = false;
-      let e;
-      try {
-        checkIfConfigured(config);
-      } catch (err) {
-        e = err;
-      }
-      expect(e).toBeDefined();
+      expect(() => checkIfConfigured(config)).toThrow();
     });
     it('throws if unconfigured fork', () => {
       config.enabled = true;
       config.isFork = true;
       config.renovateJsonPresent = false;
-      let e;
-      try {
-        checkIfConfigured(config);
-      } catch (err) {
-        e = err;
-      }
-      expect(e).toBeDefined();
+      expect(() => checkIfConfigured(config)).toThrow();
     });
   });
 });

--- a/test/workers/repository/onboarding/branch/index.spec.js
+++ b/test/workers/repository/onboarding/branch/index.spec.js
@@ -16,23 +16,11 @@ describe('workers/repository/onboarding/branch', () => {
       platform.getFileList.mockReturnValue([]);
     });
     it('throws if no package files', async () => {
-      let e;
-      try {
-        await checkOnboardingBranch(config);
-      } catch (err) {
-        e = err;
-      }
-      expect(e).toBeDefined();
+      await expect(checkOnboardingBranch(config)).rejects.toThrow();
     });
     it('throws if fork', async () => {
       config.isFork = true;
-      let e;
-      try {
-        await checkOnboardingBranch(config);
-      } catch (err) {
-        e = err;
-      }
-      expect(e).toBeDefined();
+      await expect(checkOnboardingBranch(config)).rejects.toThrow();
     });
     it('handles skipped onboarding combined with requireConfig = false', async () => {
       config.requireConfig = false;
@@ -78,13 +66,7 @@ describe('workers/repository/onboarding/branch', () => {
       platform.getPrList.mockReturnValueOnce([
         { branchName: 'renovate/something', state: 'open' },
       ]);
-      let e;
-      try {
-        await checkOnboardingBranch(config);
-      } catch (err) {
-        e = err;
-      }
-      expect(e).toBeDefined();
+      await expect(checkOnboardingBranch(config)).rejects.toThrow();
     });
     it('creates onboarding branch with greenkeeper migration', async () => {
       platform.getFileList.mockReturnValue(['package.json']);


### PR DESCRIPTION
Improving the jest error handling rules in the following ways:

- Replacing `try` `catch` block by `toThrow` method for simple errors. e.g.:
```
try {	
  cli.getConfig(argv);	
} catch (err) {	
  e = err;	
}	
expect(e.message).toEqual(	
   "Invalid boolean value: expected 'true' or 'false', but got 'badvalue'"
)
```
will be replaced by
```
expect(() => cli.getConfig(argv)).toThrow(
   "Invalid boolean value: expected 'true' or 'false', but got 'badvalue'"
)
```
- Using `.rejects.toEqual` when dealing with `Promise`s and with a specific error message, as `toThrow` passes the test for any error message. e.g.:
```
let err;
try {	        
   Error('Unsupported platform: foo.')
   await configParser.parseConfigs(env, defaultArgv);
} catch (e) {	
     err = e;	
}	
expect(err.message).toBe('Unsupported platform: foo.');
```
Will be replaced by
```
await expect(configParser.parseConfigs(env, defaultArgv)).rejects.toEqual(
   Error('Unsupported platform: foo.')
)
```
Closes #2028  

