### PR TITLE
fix(maven): datasource url contains colon triggers error

### DIFF
--- a/lib/workers/pr/changelog/index.js
+++ b/lib/workers/pr/changelog/index.js
@@ -19,6 +19,9 @@ async function getChangeLogJSON(args) {
     return null;
   }
   try {
+    // eslint-disable-next-line no-param-reassign
+    args.sourceUrl = args.sourceUrl.replace('github.com:', 'github.com');
+
     const res = await sourceGithub.getChangeLogJSON({ ...args });
     return res;
   } catch (err) /* istanbul ignore next */ {

--- a/lib/workers/pr/changelog/release-notes.js
+++ b/lib/workers/pr/changelog/release-notes.js
@@ -14,8 +14,11 @@ module.exports = {
   addReleaseNotes,
 };
 
-async function getReleaseList(githubApiBaseURL, repository) {
+async function getReleaseList(githubApiBaseURL, rawRepository) {
   logger.trace('getReleaseList()');
+  let repository = rawRepository;
+  if (rawRepository.match(/^:/g)) repository = rawRepository.slice(1);
+
   try {
     let url = githubApiBaseURL.replace(/\/?$/, '/');
     url += `repos/${repository}/releases?per_page=100`;


### PR DESCRIPTION
Fixing getReleaseList error related to the colon inside URL.

<!-- Replace this text with a description of what this PR fixes or adds -->

Closes #3289
