### PR TITLE
docs: reviewers for Bitbucket is supported now

### DIFF
--- a/lib/platform/bitbucket/README.md
+++ b/lib/platform/bitbucket/README.md
@@ -2,10 +2,6 @@
 
 Bitbucket Cloud support is considered in "beta" release status. Mostly, it just needs more feedback/testing. If you have been using it and think it's reliable, please let us know.
 
-## Unsupported platform features/concepts
-
-- Adding assignees to PRs not supported (does not seem to be a Bitbucket concept)
-
 ## Features requiring implementation
 
 - Creating issues not implemented yet, e.g. when there is a config error


### PR DESCRIPTION
Forgot to update this file in line with the changes in https://github.com/renovatebot/renovate/pull/3509

Reviewers for Bitbucket is supported now