### PR TITLE
feat: Cache searchqueryservice URL for NuGet datasource

### DIFF
--- a/lib/datasource/nuget/v3.js
+++ b/lib/datasource/nuget/v3.js
@@ -22,6 +22,7 @@ async function getQueryUrl(url) {
   const cacheKey = `${url}:${resourceType}`;
   const cachedResult = await renovateCache.get(cacheNamespace, cacheKey);
 
+  // istanbul ignore if
   if (cachedResult) {
     return cachedResult;
   }

--- a/lib/datasource/nuget/v3.js
+++ b/lib/datasource/nuget/v3.js
@@ -10,6 +10,7 @@ module.exports = {
 
 // https://api.nuget.org/v3/index.json is a default official nuget feed
 const defaultNugetFeed = 'https://api.nuget.org/v3/index.json';
+const cacheNamespace = 'datasource-nuget';
 
 function getDefaultFeed() {
   return defaultNugetFeed;
@@ -17,6 +18,14 @@ function getDefaultFeed() {
 
 async function getQueryUrl(url) {
   // https://docs.microsoft.com/en-us/nuget/api/search-query-service-resource
+  const resourceType = 'SearchQueryService';
+  const cacheKey = `${url}:${resourceType}`;
+  const cachedResult = await renovateCache.get(cacheNamespace, cacheKey);
+
+  if (cachedResult) {
+    return cachedResult;
+  }
+
   try {
     const servicesIndexRaw = await got(url, { json: true, platform: 'nuget' });
     if (servicesIndexRaw.statusCode !== 200) {
@@ -27,9 +36,18 @@ async function getQueryUrl(url) {
       return null;
     }
     const searchQueryService = servicesIndexRaw.body.resources.find(
-      resource => resource['@type'] === 'SearchQueryService'
+      resource => resource['@type'] === resourceType
     );
-    return searchQueryService['@id'];
+    const searchQueryServiceId = searchQueryService['@id'];
+
+    const cacheMinutes = 60;
+    await renovateCache.set(
+      cacheNamespace,
+      cacheKey,
+      searchQueryServiceId,
+      cacheMinutes
+    );
+    return searchQueryServiceId;
   } catch (e) {
     logger.debug(
       { e },

--- a/test/datasource/nuget.spec.js
+++ b/test/datasource/nuget.spec.js
@@ -65,6 +65,7 @@ const configV3NotNugetOrg = {
 };
 
 describe('datasource/nuget', () => {
+  beforeEach(() => global.renovateCache.rmAll());
   describe('getPkgReleases', () => {
     beforeEach(() => {
       jest.resetAllMocks();


### PR DESCRIPTION
Caching the `searchQueryService` URL for one hour for NuGet datasource

Closes #3560 
