### PR TITLE
tests: Fix UnhandledPromiseRejectionWarning in tests

### DIFF
--- a/test/manager/index.spec.js
+++ b/test/manager/index.spec.js
@@ -21,7 +21,7 @@ describe('manager', () => {
       expect(manager.extractAllPackageFiles('dockerfile', [])).toBeNull();
     });
     it('returns non-null', () => {
-      expect(manager.extractAllPackageFiles('npm', [])).not.toBeNull();
+      expect(manager.extractAllPackageFiles('npm', {}, [])).not.toBeNull();
     });
   });
 });

--- a/test/platform/azure/index.spec.js
+++ b/test/platform/azure/index.spec.js
@@ -356,6 +356,7 @@ describe('platform/azure', () => {
           pullRequestId: 456,
           displayNumber: `Pull Request #456`,
         })),
+        createPullRequestLabel: jest.fn(() => ({})),
       }));
       azureHelper.getRenovatePRFormat.mockImplementation(() => ({
         displayNumber: 'Pull Request #456',
@@ -377,6 +378,7 @@ describe('platform/azure', () => {
           pullRequestId: 456,
           displayNumber: `Pull Request #456`,
         })),
+        createPullRequestLabel: jest.fn(() => ({})),
       }));
       azureHelper.getRenovatePRFormat.mockImplementation(() => ({
         displayNumber: 'Pull Request #456',


### PR DESCRIPTION
This PR fixes three tests cases:
 - **'should create and return a PR object'** in **`test/platform/azure/index.spec.js`**
 - **'should create and return a PR object from base branch'** in **`test/platform/azure/index.spec.js`**
**Reason**: In `/platform/azure/index.js`, inside `createPr`, the call to `azureApiGit.createPullRequestLabel` was failing which results in an unhandled rejected promise. For more information about `UnhandledPromiseRejectionWarning` refer [this](https://github.com/facebook/jest/issues/3251).
**Solution**: To solve this issue I created a mock function for `createPullRequestLabel`.
- **'returns non-null'** in **`test/manager/index.spec.js`**
**Reason**: It returns the same `UnhandledPromiseRejectionWarning`, but due to missing second argument, the `manager.extractAllPackageFiles` requires at least 3 parameters for a `nonnull` return value. The second argument needed to be a config object, and the third to be a packages list.
**Solution**: Inserted an empty object as config argument.

**NOTE**: The `DeprecationWarning` on `UnhandledPromiseRejectionWarning` is still an open issue in jest. For more info refer [this](https://github.com/facebook/jest/issues/5311)


Closes #3569  <!-- Ideally each PR should be closing an open issue -->
