### PR TITLE
Cache GitHub requests

### DIFF
--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -100,6 +100,14 @@ const options = [
     admin: true,
     type: 'string',
   },
+  {
+    name: 'cacheApi',
+    description:
+      'If enabled, cache GitHub API requests using If-Modified-Since / If-None-Match.',
+    admin: true,
+    type: 'boolean',
+    default: false,
+  },
   // Log options
   {
     name: 'logLevel',

--- a/lib/platform/github/gh-got-wrapper.js
+++ b/lib/platform/github/gh-got-wrapper.js
@@ -10,6 +10,20 @@ const { maskToken } = require('../../util/mask');
 let cache = {};
 let stats = {};
 
+const cacheNamespace = 'github';
+const cacheMap = {
+  async get(key) {
+    const cacheResult = await renovateCache.get(cacheNamespace, key);
+    return cacheResult === null ? undefined : cacheResult;
+  },
+  async set(key, value) {
+    await renovateCache.set(cacheNamespace, key, value, 1e6);
+  },
+  async delete(key) {
+    await renovateCache.rm(cacheNamespace, key);
+  },
+};
+
 async function get(path, options, retries = 5) {
   const { host } = URL.parse(path);
   const opts = {
@@ -19,7 +33,11 @@ async function get(path, options, retries = 5) {
   opts.baseUrl = opts.endpoint;
   delete opts.endpoint;
   const method = opts.method || 'get';
-  const useCache = opts.useCache || true;
+  const useCache = opts.useCache || true; // in-memory cache
+  opts.cache = cacheMap; /* persistent cache - always validated, but
+                            hits don't count against request limit */
+  opts.shared = false; // https://github.com/kornelski/http-cache-semantics/issues/9
+  opts.forceRefresh = true; // always revalidate
   if (method.toLowerCase() === 'post' && path === 'graphql') {
     // GitHub Enterprise uses unversioned graphql path
     opts.baseUrl = opts.baseUrl.replace(/\/v3\/?$/, '/');

--- a/lib/platform/github/gh-got-wrapper.js
+++ b/lib/platform/github/gh-got-wrapper.js
@@ -34,10 +34,12 @@ async function get(path, options, retries = 5) {
   delete opts.endpoint;
   const method = opts.method || 'get';
   const useCache = opts.useCache || true; // in-memory cache
-  opts.cache = cacheMap; /* persistent cache - always validated, but
-                            hits don't count against request limit */
-  opts.shared = false; // https://github.com/kornelski/http-cache-semantics/issues/9
-  opts.forceRefresh = true; // always revalidate
+  if (true /* TODO */) {
+    opts.cache = cacheMap; /* persistent cache - always validated, but
+                              hits don't count against request limit */
+    opts.shared = false; // https://github.com/kornelski/http-cache-semantics/issues/9
+    opts.forceRefresh = true; // always revalidate
+  }
   if (method.toLowerCase() === 'post' && path === 'graphql') {
     // GitHub Enterprise uses unversioned graphql path
     opts.baseUrl = opts.baseUrl.replace(/\/v3\/?$/, '/');


### PR DESCRIPTION
Cache requests to the GitHub API as recommended by
https://developer.github.com/v3/#conditional-requests .

Avoids using up rate-limit points and re-downloading the same data for
repeated requests.

Data is never stale; cache is used only when the server claims nothing
has changed since our last request.

Requires https://github.com/lukechilds/cacheable-request/pull/77.
