### PR TITLE
fix: Add +incompatiblity tag to major upgrade for V2+

### DIFF
--- a/lib/manager/gomod/update.js
+++ b/lib/manager/gomod/update.js
@@ -4,6 +4,15 @@ module.exports = {
   updateDependency,
 };
 
+function addIncompatibilityTag(line) {
+  let newLine = line;
+  if (newLine.endsWith('+incompatible')) {
+    return newLine;
+  }
+  newLine += '+incompatible';
+  return newLine;
+}
+
 function updateDependency(currentFileContent, upgrade) {
   try {
     logger.debug(`gomod.updateDependency: ${upgrade.newValue}`);
@@ -81,10 +90,11 @@ function updateDependency(currentFileContent, upgrade) {
             `/v${upgrade.newMajor}$1`
           );
         }
+        newLine = addIncompatibilityTag(newLine);
       }
     }
     if (lineToChange.endsWith('+incompatible')) {
-      newLine += '+incompatible';
+      newLine = addIncompatibilityTag(newLine);
     }
     if (newLine === lineToChange) {
       logger.debug('No changes necessary');

--- a/test/manager/gomod/update.spec.js
+++ b/test/manager/gomod/update.spec.js
@@ -57,6 +57,20 @@ describe('manager/gomod/update', () => {
       expect(res.includes(upgrade.newValue)).toBe(true);
       expect(res.includes('github.com/pkg/errors/v2')).toBe(true);
     });
+    it('replaces major updates > 1 with "+incompatible" tag', () => {
+      const upgrade = {
+        depName: 'github.com/pkg/errors',
+        lineNumber: 2,
+        newMajor: 2,
+        updateType: 'major',
+        currentValue: 'v0.7.0',
+        newValue: 'v2.0.0+incompatible',
+      };
+      const res = goUpdate.updateDependency(gomod1, upgrade);
+      expect(res).not.toEqual(gomod2);
+      expect(res.includes(upgrade.newValue)).toBe(true);
+      expect(res.includes('github.com/pkg/errors/v2')).toBe(true);
+    });
     it('replaces major gopkg.in updates', () => {
       const upgrade = {
         depName: 'gopkg.in/russross/blackfriday.v1',


### PR DESCRIPTION
This **PR** resolves the issue of adding `+incompatible` tag when upgrading `golang` packages to from V0 or V1 to V2. It does this based on the assumption that no V2+ package have module support. That's why it is a partial fix.
Partially fix #3557 

