### PR TITLE
feat: Add "rebase all" functionality in master issue

### DIFF
--- a/lib/workers/branch/index.js
+++ b/lib/workers/branch/index.js
@@ -199,7 +199,7 @@ async function processBranch(branchConfig, prHourlyLimitReached, packageFiles) {
       return 'pending';
     }
     // istanbul ignore if
-    if (masterIssueCheck === 'rebase') {
+    if (masterIssueCheck === 'rebase' || config.masterIssueRebaseAllOpen) {
       logger.info('Manual rebase requested via master issue');
       delete config.parentBranch;
     } else {

--- a/lib/workers/repository/master-issue.js
+++ b/lib/workers/repository/master-issue.js
@@ -138,5 +138,10 @@ async function ensureMasterIssue(config, branches) {
     }
     issueBody += '\n';
   }
+  issueBody += '## Rebase All\n\n';
+  issueBody += ' - [ ] ';
+  issueBody += '<!-- rebase-branch=renovate/all -->';
+  issueBody += 'Rebase all open PR';
+  issueBody += '\n';
   await platform.ensureIssue(config.masterIssueTitle, issueBody);
 }

--- a/lib/workers/repository/master-issue.js
+++ b/lib/workers/repository/master-issue.js
@@ -121,6 +121,13 @@ async function ensureMasterIssue(config, branches) {
       const pr = await platform.getBranchPr(branch.branchName);
       issueBody += getListItem(branch, 'rebase', pr);
     }
+    if (inProgress.length > 2) {
+      issueBody += ' - [ ] ';
+      issueBody += '<!-- rebase-all-open-prs -->';
+      issueBody +=
+        '**Check this option to rebase all the above open PRs at once**';
+      issueBody += '\n';
+    }
     issueBody += '\n';
   }
   const alreadyExisted = branches.filter(
@@ -138,13 +145,6 @@ async function ensureMasterIssue(config, branches) {
       );
       issueBody += getListItem(branch, 'recreate', pr);
     }
-    issueBody += '\n';
-  }
-  if (inProgress.length > 1) {
-    issueBody += '## Rebase All\n\n';
-    issueBody += ' - [ ] ';
-    issueBody += '<!-- rebase-all-open-prs -->';
-    issueBody += 'Rebase all open PR';
     issueBody += '\n';
   }
 

--- a/lib/workers/repository/master-issue.js
+++ b/lib/workers/repository/master-issue.js
@@ -138,10 +138,13 @@ async function ensureMasterIssue(config, branches) {
     }
     issueBody += '\n';
   }
-  issueBody += '## Rebase All\n\n';
-  issueBody += ' - [ ] ';
-  issueBody += '<!-- rebase-branch=renovate/all -->';
-  issueBody += 'Rebase all open PR';
-  issueBody += '\n';
+  if (inProgress.length > 1) {
+    issueBody += '## Rebase All\n\n';
+    issueBody += ' - [ ] ';
+    issueBody += '<!-- rebase-all-open-prs -->';
+    issueBody += 'Rebase all open PR';
+    issueBody += '\n';
+  }
+
   await platform.ensureIssue(config.masterIssueTitle, issueBody);
 }

--- a/lib/workers/repository/process/index.js
+++ b/lib/workers/repository/process/index.js
@@ -23,6 +23,11 @@ async function processRepo(config) {
           const [, type, branchName] = check.match(new RegExp(checkMatch));
           config.masterIssueChecks[branchName] = type;
         });
+      }
+      const checkAllMatch = ' - \\[x\\] <!-- rebase-all-open-prs -->';
+      const checkedRebaseAll = issue.body.match(new RegExp(checkAllMatch));
+      if (checkedRebaseAll) {
+        config.masterIssueRebaseAllOpen = true;
         /* eslint-enable no-param-reassign */
       }
     }


### PR DESCRIPTION
An additional checkbox is added in the master issue under heading name **Rebase all**.
Checking the box will rebase all the **PRs** opened by **renovate Bot**.

After adding checkbox the master issue looks something like this:
![Screen Shot 2019-04-25 at 7 03 39 PM](https://user-images.githubusercontent.com/6683645/56751739-64813e80-67a4-11e9-89b9-799a68f2fe20.png)


Closes #2765  <!-- Ideally each PR should be closing an open issue -->
