### PR TITLE
fix: Update poetry.lock file if it is in a subdirectory

### DIFF
--- a/lib/manager/poetry/artifacts.js
+++ b/lib/manager/poetry/artifacts.js
@@ -18,13 +18,8 @@ async function getArtifacts(
     logger.debug('No updated poetry deps - returning null');
     return null;
   }
-  const splitPackageFileName = packageFileName.split('/');
-  const subDirectory = splitPackageFileName
-    .slice(0, splitPackageFileName.length - 1)
-    .join('/');
+  const subDirectory = upath.parse(packageFileName).dir;
   const lockFileName = upath.join(subDirectory, 'poetry.lock');
-  logger.info(packageFileName);
-  logger.info(lockFileName);
   let existingLockFileContent = await platform.getFile(lockFileName);
   let oldLockFileName;
   if (!existingLockFileContent) {

--- a/lib/manager/poetry/artifacts.js
+++ b/lib/manager/poetry/artifacts.js
@@ -18,11 +18,17 @@ async function getArtifacts(
     logger.debug('No updated poetry deps - returning null');
     return null;
   }
-  const lockFileName = 'poetry.lock';
+  const splitPackageFileName = packageFileName.split('/');
+  const subDirectory = splitPackageFileName
+    .slice(0, splitPackageFileName.length - 1)
+    .join('/');
+  const lockFileName = upath.join(subDirectory, 'poetry.lock');
+  logger.info(packageFileName);
+  logger.info(lockFileName);
   let existingLockFileContent = await platform.getFile(lockFileName);
   let oldLockFileName;
   if (!existingLockFileContent) {
-    oldLockFileName = 'pyproject.lock';
+    oldLockFileName = upath.join(subDirectory, 'pyproject.lock');
     existingLockFileContent = await platform.getFile(oldLockFileName);
     // istanbul ignore if
     if (existingLockFileContent) {
@@ -40,7 +46,7 @@ async function getArtifacts(
   try {
     await fs.outputFile(localPackageFileName, newPackageFileContent);
     logger.debug(`Updating ${lockFileName}`);
-    const cwd = config.localDir;
+    const cwd = upath.join(config.localDir, subDirectory);
     const env =
       global.trustLevel === 'high'
         ? process.env


### PR DESCRIPTION
Now if `poetry.lock` and `pyproject.toml` files are in a subdirectory, `poetry.lock` files are updated properly.

Closes #3600
