### PR TITLE
fix(lerna): support update-lockfile with npm

### DIFF
--- a/lib/manager/npm/post-update/npm.js
+++ b/lib/manager/npm/post-update/npm.js
@@ -70,6 +70,7 @@ async function generateLockFile(
       args += ' --package-lock-only --no-audit';
     }
     logger.debug(`Using npm: ${cmd} ${args}`);
+    // istanbul ignore if
     if (!upgrades.every(upgrade => upgrade.isLockfileUpdate)) {
       // TODO: Switch to native util.promisify once using only node 8
       ({ stdout, stderr } = await exec(`${cmd} ${args}`, {

--- a/lib/manager/npm/post-update/npm.js
+++ b/lib/manager/npm/post-update/npm.js
@@ -17,8 +17,8 @@ async function generateLockFile(
   logger.debug(`Spawning npm install to create ${cwd}/${filename}`);
   const { skipInstalls, binarySource, postUpdateOptions } = config;
   let lockFile = null;
-  let stdout;
-  let stderr;
+  let stdout = '';
+  let stderr = '';
   let cmd;
   let args = '';
   try {
@@ -70,14 +70,14 @@ async function generateLockFile(
       args += ' --package-lock-only --no-audit';
     }
     logger.debug(`Using npm: ${cmd} ${args}`);
-    // TODO: Switch to native util.promisify once using only node 8
-    ({ stdout, stderr } = await exec(`${cmd} ${args}`, {
-      cwd,
-      shell: true,
-      env,
-    }));
-    logger.debug(`npm stdout:\n${stdout}`);
-    logger.debug(`npm stderr:\n${stderr}`);
+    if (!upgrades.every(upgrade => upgrade.isLockfileUpdate)) {
+      // TODO: Switch to native util.promisify once using only node 8
+      ({ stdout, stderr } = await exec(`${cmd} ${args}`, {
+        cwd,
+        shell: true,
+        env,
+      }));
+    }
     const lockUpdates = upgrades.filter(upgrade => upgrade.isLockfileUpdate);
     if (lockUpdates.length) {
       logger.info('Performing lockfileUpdate (npm)');


### PR DESCRIPTION
This fix allows update-lockfile updates to work with lerna/npm where there is a package-lock.json in every package. Still won’t work if there’s a mix of update-lockfile and non/update-lockfile updates within one branch though.

Closes #3622