### PR TITLE
docs: Add json5 file type in config options

### DIFF
--- a/website/docs/configuration-options.md
+++ b/website/docs/configuration-options.md
@@ -10,8 +10,10 @@ This document describes all the configuration options you may configure in a Ren
 You can store your Renovate configuration file in one of the following locations:
 
 - `.github/renovate.json`
+- `.github/renovate.json5`
 - `.renovaterc.json`
 - `renovate.json`
+- `renovate.json5`
 - `.renovaterc`
 - `package.json` _(within a `"renovate"` section)_
 


### PR DESCRIPTION
Added `.github/renovate.json5` and `renovate.json5` file type in the configuration options
