### PR TITLE
fix(bitbucket): Close PRs when deleting branches

### DIFF
--- a/lib/platform/bitbucket/index.js
+++ b/lib/platform/bitbucket/index.js
@@ -177,7 +177,17 @@ function getFile(filePath, branchName) {
   return config.storage.getFile(filePath, branchName);
 }
 
-function deleteBranch(branchName) {
+async function deleteBranch(branchName, closePr) {
+  if (closePr) {
+    const pr = await findPr(branchName, null, 'open');
+    if (pr) {
+      await api.post(
+        `/2.0/repositories/${config.repository}/pullrequests/${
+          pr.number
+        }/decline`
+      );
+    }
+  }
   return config.storage.deleteBranch(branchName);
 }
 

--- a/test/platform/bitbucket/__snapshots__/index.spec.js.snap
+++ b/test/platform/bitbucket/__snapshots__/index.spec.js.snap
@@ -46,6 +46,16 @@ Array [
 ]
 `;
 
+exports[`platform/bitbucket deleteBranch() should handle closing PRs when none exist 1`] = `Array []`;
+
+exports[`platform/bitbucket deleteBranch() should handle closing PRs when some exist 1`] = `
+Array [
+  Array [
+    "/2.0/repositories/some/repo/pullrequests/5/decline",
+  ],
+]
+`;
+
 exports[`platform/bitbucket ensureIssue() creates new issue 1`] = `
 Array [
   Array [

--- a/test/platform/bitbucket/index.spec.js
+++ b/test/platform/bitbucket/index.spec.js
@@ -204,6 +204,20 @@ describe('platform/bitbucket', () => {
         await bitbucket.deleteBranch();
       });
     });
+    it('should handle closing PRs when none exist', async () => {
+      await initRepo();
+      await mocked(async () => {
+        await bitbucket.deleteBranch('some-branch', true);
+        expect(api.post.mock.calls).toMatchSnapshot();
+      });
+    });
+    it('should handle closing PRs when some exist', async () => {
+      await initRepo();
+      await mocked(async () => {
+        await bitbucket.deleteBranch('branch', true);
+        expect(api.post.mock.calls).toMatchSnapshot();
+      });
+    });
   });
 
   describe('mergeBranch()', () => {


### PR DESCRIPTION
Instead of leaving dangling PRs with titles like "* - autoclosed", start respecting the closePr flag in Bitbucket
