### PR TITLE
chore: add default vscode launch configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 .DS_Store
 .cache
 /*.log
-/.vscode
 /.idea
 /package-lock.json
 *.pyc

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "debug",
+      "program": "${workspaceFolder}/lib/renovate.ts",
+      "env": { "LOG_LEVEL": "debug" },
+      "console": "integratedTerminal",
+      "runtimeArgs": [
+        "--nolazy",
+        "--preserve-symlinks",
+        "-r",
+        "ts-node/register"
+      ],
+      "protocol": "inspector",
+      "skipFiles": ["<node_internals>/**/*.js"]
+    }
+  ]
+}


### PR DESCRIPTION
This adds a default vscode launch configuration to debug renovate. I'd also like to add a default test debug configuration.

@ViceIce I made 2 small changes to your suggested configuration:
1. Use the integrated terminal instead of launching a new one
2. Change the `program` to use `/` instead of `\` (Can you let me know if this still works on your machine?)

 @rarkins Should I leave the `.vscode` git ignored, so that if anyone overwrites/changes this default config that it doesn't get added to regular commits, or overwritten when people pull?