### PR TITLE
fix: fix git fetch args again

### DIFF
--- a/lib/platform/git/storage.js
+++ b/lib/platform/git/storage.js
@@ -85,10 +85,7 @@ class Storage {
           git = Git(cwd).silent(true);
           await git.raw(['remote', 'set-url', 'origin', config.url]);
           const fetchStart = process.hrtime();
-          await git.fetch(config.url, {
-            '--depth': '2',
-            '--no-single-branch': true,
-          });
+          await git.fetch([config.url, '--depth=2', '--no-single-branch']);
           await determineBaseBranch();
           await resetToBranch(config.baseBranch);
           await cleanLocalBranches();


### PR DESCRIPTION
This pr fixes the git fetch args again.

If the branch arg is undefined, the remote arg will not appended to the command line.
So the current implementation will simply pull origin.

regression of #3663
