### PR TITLE
fix(gitFs): fix fetch arguments

### DIFF
--- a/lib/platform/git/storage.js
+++ b/lib/platform/git/storage.js
@@ -85,7 +85,7 @@ class Storage {
           git = Git(cwd).silent(true);
           await git.raw(['remote', 'set-url', 'origin', config.url]);
           const fetchStart = process.hrtime();
-          await git.fetch([config.url, '--depth=2', '--no-single-branch']);
+          await git.fetch([config.url, '--depth=2']);
           await determineBaseBranch();
           await resetToBranch(config.baseBranch);
           await cleanLocalBranches();


### PR DESCRIPTION
This pr removes the `--no-single-branch` arg from `git fetch`, because this is not supported there.


`git fetch` always gets all configured remote branches and tags, if not configured otherwise.


live test against gitlab self-hosted works