### PR TITLE
fix(gitlabci): support ext syntax for docker img

### DIFF
--- a/lib/manager/gitlabci/extract.js
+++ b/lib/manager/gitlabci/extract.js
@@ -10,7 +10,9 @@ function extractPackageFile(content) {
     const lines = content.split('\n');
     for (let lineNumber = 0; lineNumber < lines.length; lineNumber += 1) {
       const line = lines[lineNumber];
-      const imageMatch = line.match(/^\s*image:\s*'?"?([^\s]+)'?"?\s*$/);
+      const imageMatch = line.match(
+        /^\s*(?:image|name):\s*'?"?([^\s]+)'?"?\s*$/
+      );
       if (imageMatch) {
         logger.trace(`Matched image on line ${lineNumber}`);
         const currentFrom = imageMatch[1];

--- a/lib/manager/gitlabci/extract.js
+++ b/lib/manager/gitlabci/extract.js
@@ -10,16 +10,33 @@ function extractPackageFile(content) {
     const lines = content.split('\n');
     for (let lineNumber = 0; lineNumber < lines.length; lineNumber += 1) {
       const line = lines[lineNumber];
-      const imageMatch = line.match(
-        /^\s*(?:image|name):\s*'?"?([^\s]+)'?"?\s*$/
-      );
+      const imageMatch = line.match(/^\s*image:\s*'?"?([^\s]+|)'?"?\s*$/);
       if (imageMatch) {
-        logger.trace(`Matched image on line ${lineNumber}`);
-        const currentFrom = imageMatch[1];
-        const dep = getDep(currentFrom);
-        dep.lineNumber = lineNumber;
-        dep.depType = 'image';
-        deps.push(dep);
+        switch (imageMatch[1]) {
+          case '':
+            const imageNameLine = lines[lineNumber + 1];
+            const imageNameMatch = imageNameLine.match(
+              /^\s*name:\s*'?"?([^\s]+|)'?"?\s*$/
+            );
+
+            if (imageNameMatch) {
+              lineNumber += 1;
+              logger.trace(`Matched image name on line ${lineNumber}`);
+              const currentFrom = imageNameMatch[1];
+              const dep = getDep(currentFrom);
+              dep.lineNumber = lineNumber;
+              dep.depType = 'image-name';
+              deps.push(dep);
+            }
+            break;
+          default:
+            logger.trace(`Matched image on line ${lineNumber}`);
+            const currentFrom = imageMatch[1];
+            const dep = getDep(currentFrom);
+            dep.lineNumber = lineNumber;
+            dep.depType = 'image';
+            deps.push(dep);
+        }
       }
       const services = line.match(/^\s*services:\s*$/);
       if (services) {

--- a/lib/manager/gitlabci/extract.js
+++ b/lib/manager/gitlabci/extract.js
@@ -13,7 +13,7 @@ function extractPackageFile(content) {
       const imageMatch = line.match(/^\s*image:\s*'?"?([^\s]+|)'?"?\s*$/);
       if (imageMatch) {
         switch (imageMatch[1]) {
-          case '':
+          case '': {
             const imageNameLine = lines[lineNumber + 1];
             const imageNameMatch = imageNameLine.match(
               /^\s*name:\s*'?"?([^\s]+|)'?"?\s*$/
@@ -29,13 +29,15 @@ function extractPackageFile(content) {
               deps.push(dep);
             }
             break;
-          default:
+          }
+          default: {
             logger.trace(`Matched image on line ${lineNumber}`);
             const currentFrom = imageMatch[1];
             const dep = getDep(currentFrom);
             dep.lineNumber = lineNumber;
             dep.depType = 'image';
             deps.push(dep);
+          }
         }
       }
       const services = line.match(/^\s*services:\s*$/);

--- a/lib/manager/gitlabci/update.js
+++ b/lib/manager/gitlabci/update.js
@@ -10,7 +10,9 @@ function updateDependency(currentFileContent, upgrade) {
     const lines = currentFileContent.split('\n');
     const lineToChange = lines[upgrade.lineNumber];
     if (upgrade.depType === 'image') {
-      const imageLine = new RegExp(/^(\s*image:\s*'?"?)[^\s'"]+('?"?\s*)$/);
+      const imageLine = new RegExp(
+        /^(\s*(?:image|name):\s*'?"?)[^\s'"]+('?"?\s*)$/
+      );
       if (!lineToChange.match(imageLine)) {
         logger.debug('No image line found');
         return null;

--- a/lib/manager/gitlabci/update.js
+++ b/lib/manager/gitlabci/update.js
@@ -9,7 +9,7 @@ function updateDependency(currentFileContent, upgrade) {
     const newFrom = getNewFrom(upgrade);
     const lines = currentFileContent.split('\n');
     const lineToChange = lines[upgrade.lineNumber];
-    if (upgrade.depType === 'image') {
+    if (['image', 'image-name'].includes(upgrade.depType)) {
       const imageLine = new RegExp(
         /^(\s*(?:image|name):\s*'?"?)[^\s'"]+('?"?\s*)$/
       );

--- a/test/manager/gitlabci/__snapshots__/extract.spec.js.snap
+++ b/test/manager/gitlabci/__snapshots__/extract.spec.js.snap
@@ -52,5 +52,15 @@ Array [
     "depType": "service-image",
     "lineNumber": 77,
   },
+  Object {
+    "currentDepTag": "image-name-test:1.15",
+    "currentDigest": undefined,
+    "currentFrom": "image-name-test:1.15",
+    "currentValue": "1.15",
+    "datasource": "docker",
+    "depName": "image-name-test",
+    "depType": "image-name",
+    "lineNumber": 102,
+  },
 ]
 `;

--- a/test/manager/gitlabci/_fixtures/gitlab-ci.yaml
+++ b/test/manager/gitlabci/_fixtures/gitlab-ci.yaml
@@ -95,3 +95,12 @@ release:
     <<: *docker-logout
     only:
       - tags
+
+image-name-test:
+    stage: build
+    <<: *executor-docker
+    image:
+      name: image-name-test:1.15
+      entrypoint: [""]
+    script:
+        - image-name-test Dockerfile

--- a/test/manager/gitlabci/extract.spec.js
+++ b/test/manager/gitlabci/extract.spec.js
@@ -18,7 +18,7 @@ describe('lib/manager/gitlabci/extract', () => {
     it('extracts multiple image lines', () => {
       const res = extractPackageFile(yamlFile, config);
       expect(res.deps).toMatchSnapshot();
-      expect(res.deps).toHaveLength(5);
+      expect(res.deps).toHaveLength(6);
     });
   });
 });

--- a/test/manager/gitlabci/update.spec.js
+++ b/test/manager/gitlabci/update.spec.js
@@ -41,6 +41,26 @@ describe('manager/gitlabci/update', () => {
       const res = dcUpdate.updateDependency(yamlFile, upgrade);
       expect(res).toBeNull();
     });
+    it('replaces image-name value', () => {
+      const upgrade = {
+        lineNumber: 102,
+        depType: 'image-name',
+        depName: 'image-name-test',
+        newValue: '1.35',
+      };
+      const res = dcUpdate.updateDependency(yamlFile, upgrade);
+      expect(res).not.toEqual(yamlFile);
+    });
+    it('returns same image-name value', () => {
+      const upgrade = {
+        lineNumber: 102,
+        depType: 'image-name',
+        depName: 'image-name-test',
+        newValue: '1.15',
+      };
+      const res = dcUpdate.updateDependency(yamlFile, upgrade);
+      expect(res).toEqual(yamlFile);
+    });
     it('replaces service-image update', () => {
       const upgrade = {
         lineNumber: 55,


### PR DESCRIPTION
<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate
-->

Fix detection of extended syntax for docker images in GitLab CI yml files.

Closes #3680 