### PR TITLE
fix(workers): do not prune on dryRun

### DIFF
--- a/lib/workers/repository/finalise/prune.js
+++ b/lib/workers/repository/finalise/prune.js
@@ -2,18 +2,26 @@ module.exports = {
   pruneStaleBranches,
 };
 
-async function cleanUpBranches(remainingBranches) {
+async function cleanUpBranches({ dryRun }, remainingBranches) {
   for (const branchName of remainingBranches) {
     try {
       const pr = await platform.findPr(branchName, null, 'open');
       if (pr) {
         if (!pr.title.endsWith('- autoclosed')) {
-          await platform.updatePr(pr.number, `${pr.title} - autoclosed`);
+          if (dryRun)
+            logger.info(
+              `DRY-RUN: Would update pr ${pr.number} to ${
+                pr.title
+              } - autoclosed`
+            );
+          else await platform.updatePr(pr.number, `${pr.title} - autoclosed`);
         }
       }
       const closePr = true;
       logger.info({ branch: branchName }, `Deleting orphan branch`);
-      await platform.deleteBranch(branchName, closePr);
+      if (dryRun)
+        logger.info(`DRY-RUN: Would deleting orphan branch ${branchName}`);
+      else await platform.deleteBranch(branchName, closePr);
       if (pr) {
         logger.info({ prNo: pr.number, prTitle: pr.title }, 'PR autoclosed');
       }
@@ -54,5 +62,5 @@ async function pruneStaleBranches(config, branchList) {
     return;
   }
 
-  await cleanUpBranches(remainingBranches);
+  await cleanUpBranches(config, remainingBranches);
 }

--- a/test/workers/repository/finalise/prune.spec.js
+++ b/test/workers/repository/finalise/prune.spec.js
@@ -39,5 +39,17 @@ describe('workers/repository/finalise/prune', () => {
       expect(platform.deleteBranch).toHaveBeenCalledTimes(1);
       expect(platform.updatePr).toHaveBeenCalledTimes(1);
     });
+    it('does nothing on dryRun', async () => {
+      config.branchList = ['renovate/a', 'renovate/b'];
+      config.dryRun = true;
+      platform.getAllRenovateBranches.mockReturnValueOnce(
+        config.branchList.concat(['renovate/c'])
+      );
+      platform.findPr.mockReturnValueOnce({ title: 'foo' });
+      await cleanup.pruneStaleBranches(config, config.branchList);
+      expect(platform.getAllRenovateBranches).toHaveBeenCalledTimes(1);
+      expect(platform.deleteBranch).toHaveBeenCalledTimes(0);
+      expect(platform.updatePr).toHaveBeenCalledTimes(0);
+    });
   });
 });


### PR DESCRIPTION
This pr add a `dryRun` check while pruning orphaned pr's and branches.