### PR TITLE
fix(gitFs): force update diverged branches

### DIFF
--- a/lib/platform/git/storage.ts
+++ b/lib/platform/git/storage.ts
@@ -220,7 +220,7 @@ class Storage {
     logger.debug('Setting branchPrefix: ' + branchPrefix);
     this._config.branchPrefix = branchPrefix;
     const ref = `refs/heads/${branchPrefix}*:refs/remotes/origin/${branchPrefix}*`;
-    await this._git!.fetch(['origin', ref, '--depth=2']);
+    await this._git!.fetch(['origin', ref, '--depth=2', '--force']);
   }
 
   async getFileList(branchName?: string) {

--- a/test/platform/git/storage.spec.ts
+++ b/test/platform/git/storage.spec.ts
@@ -290,5 +290,35 @@ describe('platform/git/storage', () => {
       expect(msg).toMatchSnapshot();
       expect(msg).toContain('past message2');
     });
+
+    it('should set branch prefix', async () => {
+      const repo = Git(base.path).silent(true);
+      await repo.checkoutBranch('renovate/test', 'master');
+      await fs.writeFile(base.path + '/test', 'lorem ipsum');
+      await repo.add(['test']);
+      await repo.commit('past message2');
+      await repo.checkout('master');
+
+      await git.initRepo({
+        localDir: tmpDir.path,
+        url: base.path,
+      });
+
+      await git.setBranchPrefix('renovate/');
+      expect(await git.branchExists('renovate/test')).toBe(true);
+      const cid = await git.getBranchCommit('renovate/test');
+
+      await git.initRepo({
+        localDir: tmpDir.path,
+        url: base.path,
+      });
+
+      await repo.checkout('renovate/test');
+      await repo.commit('past message3', ['--amend']);
+
+      await git.setBranchPrefix('renovate/');
+      expect(await git.branchExists('renovate/test')).toBe(true);
+      expect(await git.getBranchCommit('renovate/test')).not.toEqual(cid);
+    });
   });
 });


### PR DESCRIPTION
This pr forces the update of renovate remote branches, because they can be diverged when persistance is enabled.
