### PR TITLE
fix: remove checkbox hints + checkbox formatting for bitbucket via readOnlyIssueBody() transformer

### DIFF
--- a/lib/platform/bitbucket/index.js
+++ b/lib/platform/bitbucket/index.js
@@ -356,7 +356,6 @@ async function closeIssue(issueNumber) {
 async function ensureIssue(title, body) {
   logger.debug(`ensureIssue()`);
   try {
-    body = readOnlyIssueBody(body);
     const issues = await findOpenIssues(title);
     if (issues.length) {
       // Close any duplicates
@@ -369,7 +368,9 @@ async function ensureIssue(title, body) {
         await api.put(
           `/2.0/repositories/${config.repository}/issues/${issue.id}`,
           {
-            body: { content: { raw: body, markup: 'markdown' } },
+            body: {
+              content: { raw: readOnlyIssueBody(body), markup: 'markdown' },
+            },
           }
         );
         return 'updated';
@@ -379,7 +380,7 @@ async function ensureIssue(title, body) {
       await api.post(`/2.0/repositories/${config.repository}/issues`, {
         body: {
           title,
-          content: { raw: body, markup: 'markdown' },
+          content: { raw: readOnlyIssueBody(body), markup: 'markdown' },
         },
       });
       return 'created';

--- a/lib/platform/bitbucket/index.js
+++ b/lib/platform/bitbucket/index.js
@@ -3,6 +3,7 @@ const api = require('./bb-got-wrapper');
 const utils = require('./utils');
 const hostRules = require('../../util/host-rules');
 const GitStorage = require('../git/storage');
+const { readOnlyIssueBody } = require('../utils/read-only-issue-body');
 const { appSlug } = require('../../config/app-strings');
 
 let config = {};
@@ -355,6 +356,7 @@ async function closeIssue(issueNumber) {
 async function ensureIssue(title, body) {
   logger.debug(`ensureIssue()`);
   try {
+    body = readOnlyIssueBody(body);
     const issues = await findOpenIssues(title);
     if (issues.length) {
       // Close any duplicates

--- a/lib/platform/utils/read-only-issue-body.js
+++ b/lib/platform/utils/read-only-issue-body.js
@@ -1,0 +1,12 @@
+function readOnlyIssueBody(body) {
+  return body
+    .replace(' only once you click their checkbox below', '')
+    .replace(' unless you click a checkbox below', '')
+    .replace(' To discard all commits and start over, check the box below.', '')
+    .replace(/ Click (?:on |)a checkbox.*\./g, '')
+    .replace(/\[ ] <!-- \w*-branch.*-->/g, '');
+}
+
+module.exports = {
+  readOnlyIssueBody,
+};

--- a/test/platform/utils/_fixtures/issue-body.txt
+++ b/test/platform/utils/_fixtures/issue-body.txt
@@ -1,0 +1,11 @@
+## Edited/Blocked
+
+These updates have been manually edited so Renovate will no longer make changes. To discard all commits and start over, check the box below.
+
+- [ ] <!-- rebase-branch=renovate/docker-renovate-renovate-16.x -->[Update renovate/renovate Docker tag to v16.13.8](../pull/2)
+
+## Closed/Ignored
+
+These updates were closed unmerged and will not be recreated unless you click a checkbox below.
+
+- [ ] <!-- recreate-branch=renovate/docker-renovate-renovate-16.10.8 -->[Update renovate/renovate:16.10.8 Docker digest to 6f9a209](../pull/1)

--- a/test/platform/utils/read-only-issue-body.spec.js
+++ b/test/platform/utils/read-only-issue-body.spec.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const {
+  readOnlyIssueBody,
+} = require('../../../lib/platform/utils/read-only-issue-body');
+
+const issueBody = fs.readFileSync(
+  'test/platform/utils/_fixtures/issue-body.txt',
+  'utf8'
+);
+
+describe('platform/utils/read-only-issue-body', () => {
+  describe('.readOnlyIssueBody', () => {
+    it('removes all checkbox formatting', () => {
+      expect(readOnlyIssueBody(issueBody)).toEqual(
+        expect.not.stringContaining('[ ] <!--')
+      );
+    });
+
+    it('removes all checkbox-related instructions', () => {
+      expect(readOnlyIssueBody(issueBody)).toEqual(
+        expect.not.stringMatching(
+          /click (?:(?:on |)a|their) checkbox|check the box below/gi
+        )
+      );
+    });
+  });
+});


### PR DESCRIPTION

![Screenshot_2019-05-21_08-39-54](https://user-images.githubusercontent.com/12934156/58071066-0594c680-7ba4-11e9-8c6c-5a64c97e3975.png)
<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate
-->

Removes checkbox hints + checkbox formatting from bitbucket issue body.
Azure does not currently implement issues.

Closes #3714
