### PR TITLE
chore(build): fix vscode eslint config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
     "javascript",
     { "language": "typescript", "autoFix": true }
   ],
+  "eslint.options": { "configFile": "../.tslintrc.js" },
   "[javascript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },


### PR DESCRIPTION
this pr configures vscode-eslint to use the `.tslintrc.js`