### PR TITLE
fix(sbt): Skip deps using missing Scala versions

### DIFF
--- a/lib/manager/sbt/extract.js
+++ b/lib/manager/sbt/extract.js
@@ -73,11 +73,17 @@ function parseDepExpr(expr, ctx) {
 
   if (scopeOp && scopeOp !== '%') return null;
 
+  let skipReason = null;
+
   const groupId = resolveToken(rawGroupId);
-  const artifactId =
-    groupOp === '%'
-      ? resolveToken(rawArtifactId)
-      : `${resolveToken(rawArtifactId)}_${scalaVersion}`;
+  let artifactId = resolveToken(rawArtifactId);
+  if (groupOp === '%%') {
+    if (scalaVersion) {
+      artifactId = `${resolveToken(rawArtifactId)}_${scalaVersion}`;
+    } else {
+      skipReason = 'unsupported';
+    }
+  }
   const depName = `${groupId}:${artifactId}`;
   const currentValue = resolveToken(rawVersion);
 
@@ -107,9 +113,8 @@ function parseDepExpr(expr, ctx) {
     fileReplacePosition,
   };
 
-  if (depType) {
-    result.depType = depType;
-  }
+  if (depType) result.depType = depType;
+  if (skipReason) result.skipReason = skipReason;
 
   return result;
 }

--- a/test/manager/sbt/__snapshots__/extract.spec.js.snap
+++ b/test/manager/sbt/__snapshots__/extract.spec.js.snap
@@ -135,3 +135,29 @@ Object {
   ],
 }
 `;
+
+exports[`lib/manager/terraform/extract extractPackageFile() skips deps when scala version is missing 1`] = `
+Object {
+  "deps": Array [
+    Object {
+      "currentValue": "3.0.0",
+      "datasource": "maven",
+      "depName": "org.scalatest:scalatest",
+      "fileReplacePosition": 65,
+      "registryUrls": Array [
+        "https://repo.maven.apache.org/maven2",
+      ],
+      "skipReason": "unsupported",
+    },
+    Object {
+      "currentValue": "1.0.11",
+      "datasource": "maven",
+      "depName": "com.github.gseitz:sbt-release",
+      "fileReplacePosition": 100,
+      "registryUrls": Array [
+        "https://repo.maven.apache.org/maven2",
+      ],
+    },
+  ],
+}
+`;

--- a/test/manager/sbt/_fixtures/missing-scala-version.sbt
+++ b/test/manager/sbt/_fixtures/missing-scala-version.sbt
@@ -1,0 +1,6 @@
+libraryDependencies ++= Seq(
+  "org.scalatest" %% "scalatest" % "3.0.0"
+)
+
+val sbtReleaseVersion = "1.0.11"
+addSbtPlugin("com.github.gseitz" % "sbt-release" % sbtReleaseVersion)

--- a/test/manager/sbt/extract.spec.js
+++ b/test/manager/sbt/extract.spec.js
@@ -2,8 +2,14 @@ const fs = require('fs');
 const path = require('path');
 const { extractPackageFile } = require('../../../lib/manager/sbt/extract');
 
-const sbtPath = path.resolve(__dirname, `./_fixtures/sample.sbt`);
-const sbt = fs.readFileSync(sbtPath, 'utf8');
+const sbt = fs.readFileSync(
+  path.resolve(__dirname, `./_fixtures/sample.sbt`),
+  'utf8'
+);
+const sbtMissingScalaVersion = fs.readFileSync(
+  path.resolve(__dirname, `./_fixtures/missing-scala-version.sbt`),
+  'utf8'
+);
 
 describe('lib/manager/terraform/extract', () => {
   describe('extractPackageFile()', () => {
@@ -34,6 +40,9 @@ describe('lib/manager/terraform/extract', () => {
     });
     it('extracts deps for generic use-cases', () => {
       expect(extractPackageFile(sbt)).toMatchSnapshot();
+    });
+    it('skips deps when scala version is missing', () => {
+      expect(extractPackageFile(sbtMissingScalaVersion)).toMatchSnapshot();
     });
   });
 });


### PR DESCRIPTION
Not sure if it helps, but for now we don't resolve deps with `%%` if `scalaVersion` isn't set.

Also I've discovered variable substitution actually works here:
```scala
val sbtReleaseVersion = "1.0.11"
addSbtPlugin("com.github.gseitz" % "sbt-release" % sbtReleaseVersion)
```

Closes #3827