### PR TITLE
feat: commitBodyTable

### DIFF
--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -1003,7 +1003,7 @@ const options = [
     description:
       'If enabled, append a table in the commit message body describing all updates in the commit',
     type: 'boolean',
-    default: true,
+    default: false,
   },
   {
     name: 'commitMessagePrefix',

--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -999,6 +999,13 @@ const options = [
     cli: false,
   },
   {
+    name: 'commitBodyTable',
+    description:
+      'If enabled, append a table in the commit message body describing all updates in the commit',
+    type: 'boolean',
+    default: true,
+  },
+  {
     name: 'commitMessagePrefix',
     description:
       'Prefix to add to start of commit messages and PR titles. Uses a semantic prefix if semanticCommits enabled',

--- a/lib/workers/repository/updates/generate.js
+++ b/lib/workers/repository/updates/generate.js
@@ -7,9 +7,11 @@ function ifTypesGroup(depNames, hasGroupName, branchUpgrades) {
   return (
     depNames.length === 2 &&
     !hasGroupName &&
-    ((branchUpgrades[0].depName.startsWith('@types/') &&
+    ((branchUpgrades[0].depName &&
+      branchUpgrades[0].depName.startsWith('@types/') &&
       branchUpgrades[0].depName.endsWith(branchUpgrades[1].depName)) ||
-      (branchUpgrades[1].depName.startsWith('@types/') &&
+      (branchUpgrades[1].depName &&
+        branchUpgrades[1].depName.startsWith('@types/') &&
         branchUpgrades[1].depName.endsWith(branchUpgrades[0].depName)))
   );
 }
@@ -222,6 +224,7 @@ function generateBranchConfig(branchUpgrades) {
   if (
     depNames.length === 2 &&
     !hasGroupName &&
+    config.upgrades[0].depName &&
     config.upgrades[0].depName.startsWith('@types/') &&
     config.upgrades[0].depName.endsWith(config.upgrades[1].depName)
   ) {

--- a/lib/workers/repository/updates/generate.js
+++ b/lib/workers/repository/updates/generate.js
@@ -1,6 +1,7 @@
 const handlebars = require('handlebars');
 const { DateTime } = require('luxon');
 const semver = require('semver');
+const mdTable = require('markdown-table');
 const { mergeChildConfig } = require('../../../config');
 
 function ifTypesGroup(depNames, hasGroupName, branchUpgrades) {
@@ -260,7 +261,53 @@ function generateBranchConfig(branchUpgrades) {
     logger.debug('Overriding schedule for Pin PR');
     config.schedule = [];
   }
+  const tableRows = config.upgrades
+    .map(upgrade => getTableValues(upgrade))
+    .filter(Boolean);
+  if (tableRows.length) {
+    let table = [];
+    table.push(['datasource', 'package', 'from', 'to']);
+    table = table.concat(tableRows);
+    config.commitMessage += '\n\n' + mdTable(table) + '\n';
+  }
   return config;
+}
+
+function getTableValues(upgrade) {
+  if (!upgrade.commitBodyTable) {
+    return null;
+  }
+  const {
+    datasource,
+    lookupName,
+    depName,
+    fromVersion,
+    toVersion,
+    displayFrom,
+    displayTo,
+  } = upgrade;
+  const name = lookupName || depName;
+  const from = fromVersion || displayFrom;
+  const to = toVersion || displayTo;
+  if (datasource && name && from && to) {
+    return [datasource, name, from, to];
+  }
+  if (upgrade.updateType === 'lockFileMaintenance') {
+    return [datasource, 'ALL (Lock file maintenance)', '', ''];
+  }
+  logger.debug(
+    {
+      datasource,
+      lookupName,
+      depName,
+      fromVersion,
+      toVersion,
+      displayFrom,
+      displayTo,
+    },
+    'Cannot determine table values'
+  );
+  return null;
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "lodash": "4.17.11",
     "luxon": "1.15.0",
     "markdown-it": "8.4.2",
+    "markdown-table": "1.1.3",
     "minimatch": "3.0.4",
     "moment": "2.24.0",
     "moment-timezone": "0.5.25",

--- a/renovate-schema.json
+++ b/renovate-schema.json
@@ -661,6 +661,11 @@
       "description": "Commit message body template. Will be appended to commit message, separated by two line returns.",
       "type": "string"
     },
+    "commitBodyTable": {
+      "description": "If enabled, append a table in the commit message body describing all updates in the commit",
+      "type": "boolean",
+      "default": true
+    },
     "commitMessagePrefix": {
       "description": "Prefix to add to start of commit messages and PR titles. Uses a semantic prefix if semanticCommits enabled",
       "type": "string"

--- a/renovate-schema.json
+++ b/renovate-schema.json
@@ -664,7 +664,7 @@
     "commitBodyTable": {
       "description": "If enabled, append a table in the commit message body describing all updates in the commit",
       "type": "boolean",
-      "default": true
+      "default": false
     },
     "commitMessagePrefix": {
       "description": "Prefix to add to start of commit messages and PR titles. Uses a semantic prefix if semanticCommits enabled",

--- a/test/workers/repository/updates/__snapshots__/generate.spec.js.snap
+++ b/test/workers/repository/updates/__snapshots__/generate.spec.js.snap
@@ -1,9 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`workers/repository/updates/generate generateBranchConfig() adds commit message body 1`] = `
-"Update dependency some-dep to v1.2.0
+"Update dependency some-dep
 
-[skip-ci]"
+[skip-ci]
+
+| datasource | package                     | from | to  |
+| ---------- | --------------------------- | ---- | --- |
+| npm        | ALL (Lock file maintenance) |      |     |
+"
 `;
 
 exports[`workers/repository/updates/generate generateBranchConfig() handles @types specially (reversed) 1`] = `

--- a/test/workers/repository/updates/generate.spec.js
+++ b/test/workers/repository/updates/generate.spec.js
@@ -423,6 +423,7 @@ describe('workers/repository/updates/generate', () => {
         },
         {
           ...defaultConfig,
+          commitBodyTable: true,
           datasource: 'npm',
           updateType: 'lockFileMaintenance',
         },

--- a/test/workers/repository/updates/generate.spec.js
+++ b/test/workers/repository/updates/generate.spec.js
@@ -366,6 +366,7 @@ describe('workers/repository/updates/generate', () => {
       const branch = [
         {
           ...defaultConfig,
+          commitBodyTable: false,
           depName: 'some-dep',
           packageFile: 'foo/bar/package.json',
           semanticCommits: true,
@@ -420,6 +421,11 @@ describe('workers/repository/updates/generate', () => {
           isSingleVersion: true,
           toVersion: '1.2.0',
         },
+        {
+          ...defaultConfig,
+          datasource: 'npm',
+          updateType: 'lockFileMaintenance',
+        },
       ];
       const res = generateBranchConfig(branch);
       expect(res.commitMessage).toMatchSnapshot();
@@ -440,15 +446,21 @@ describe('workers/repository/updates/generate', () => {
     it('handles @types specially', () => {
       const branch = [
         {
+          commitBodyTable: true,
+          datasource: 'npm',
           depName: '@types/some-dep',
           groupName: null,
           branchName: 'some-branch',
           prTitle: 'some-title',
           lazyGrouping: true,
           currentValue: '0.5.7',
+          fromVersion: '0.5.7',
+          toVersion: '0.5.8',
           group: {},
         },
         {
+          commitBodyTable: true,
+          datasource: 'npm',
           depName: 'some-dep',
           groupName: null,
           branchName: 'some-branch',

--- a/website/docs/configuration-options.md
+++ b/website/docs/configuration-options.md
@@ -148,6 +148,8 @@ For example, To add `[skip ci]` to every commit you could configure:
   "commitBody": "[skip ci]"
 ```
 
+## commitBodyTable
+
 ## commitMessage
 
 Editing of `commitMessage` directly is now deprecated and not recommended. Please instead edit the fields such as `commitMessageAction`, `commitMessageExtra`, etc.

--- a/yarn.lock
+++ b/yarn.lock
@@ -5689,6 +5689,11 @@ markdown-it@8.4.2:
     mdurl "^1.0.1"
     uc.micro "^1.0.5"
 
+markdown-table@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.3.tgz#9fcb69bcfdb8717bfd0398c6ec2d93036ef8de60"
+  integrity sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==
+
 markdown-table@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.2.tgz#c78db948fa879903a41bce522e3b96f801c63786"


### PR DESCRIPTION
Adds a default table to each commit message body, listing the updates within the commit. This makes it easier to see at a glance within the commit history about what was updated (e.g. for people who have an "Update all" grouping).

Example:
![image](https://user-images.githubusercontent.com/6311784/58757314-9e173900-850a-11e9-9f7f-0d696d342737.png)
