### PR TITLE
fix(docker): Fixes issue with private docker registry on amazon s3

### DIFF
--- a/lib/datasource/docker/index.js
+++ b/lib/datasource/docker/index.js
@@ -391,7 +391,10 @@ async function getLabels(registry, repository, tag) {
         hooks: {
           beforeRedirect: [
             options => {
-              if (options.search.indexOf('X-Amz-Algorithm') !== -1) {
+              if (
+                options.search &&
+                options.search.indexOf('X-Amz-Algorithm') !== -1
+              ) {
                 // docker registry is hosted on amazon, redirect url includes authentication.
                 // eslint-disable-next-line no-param-reassign
                 delete options.headers.authorization;

--- a/lib/datasource/docker/index.js
+++ b/lib/datasource/docker/index.js
@@ -388,6 +388,17 @@ async function getLabels(registry, repository, tag) {
       const url = `${registry}/v2/${repository}/blobs/${configDigest}`;
       const configResponse = await got(url, {
         headers,
+        hooks: {
+          beforeRedirect: [
+            options => {
+              if (options.search.indexOf('X-Amz-Algorithm') !== -1) {
+                // docker registry is hosted on amazon, redirect url includes authentication.
+                // eslint-disable-next-line no-param-reassign
+                delete options.headers.authorization;
+              }
+            },
+          ],
+        },
       });
       labels = JSON.parse(configResponse.body).config.Labels;
     }


### PR DESCRIPTION
When renovate goes to download a blob from a docker registry, if the response is a redirect, and the redirect url contains the string `X-Amz-Algorithm`, delete the `Authorization` header from the redirect request.

This solves an issue when private docker registries are hosted on amazon and use Amazon S3 Transfer Acceleration. See issue #3877 for more details.

Closes #3877
