### PR TITLE
fix(npm): use registry url in cache key

### DIFF
--- a/lib/datasource/npm/get.js
+++ b/lib/datasource/npm/get.js
@@ -36,13 +36,6 @@ async function getDependency(name) {
     return JSON.parse(memcache[name]);
   }
 
-  // Now check the persistent cache
-  const cacheNamespace = 'datasource-npm';
-  const cachedResult = await renovateCache.get(cacheNamespace, name);
-  if (cachedResult) {
-    return cachedResult;
-  }
-
   const scope = name.split('/')[0];
   let regUrl;
   const npmrc = getNpmrc();
@@ -55,6 +48,12 @@ async function getDependency(name) {
     regUrl,
     encodeURIComponent(name).replace(/^%40/, '@')
   );
+  // Now check the persistent cache
+  const cacheNamespace = 'datasource-npm';
+  const cachedResult = await renovateCache.get(cacheNamespace, pkgUrl);
+  if (cachedResult) {
+    return cachedResult;
+  }
   const authInfo = registryAuthToken(regUrl, { npmrc });
   const headers = {};
 
@@ -197,7 +196,7 @@ async function getDependency(name) {
       ? parseInt(process.env.RENOVATE_CACHE_NPM_MINUTES, 10)
       : 5;
     if (!name.startsWith('@')) {
-      await renovateCache.set(cacheNamespace, name, dep, cacheMinutes);
+      await renovateCache.set(cacheNamespace, pkgUrl, dep, cacheMinutes);
     }
     return dep;
   } catch (err) {

--- a/test/datasource/npm/index.spec.js
+++ b/test/datasource/npm/index.spec.js
@@ -366,8 +366,13 @@ describe('api/npm', () => {
     const dep = {
       name: 'abc123',
     };
-    await global.renovateCache.set('datasource-npm', 'foobar', dep, 10);
-    const res = await npm.getPkgReleases({ lookupName: 'foobar' });
+    await global.renovateCache.set(
+      'datasource-npm',
+      'https://registry.npmjs.org/abc123',
+      dep,
+      10
+    );
+    const res = await npm.getPkgReleases({ lookupName: 'abc123' });
     expect(res).toEqual(dep);
   });
   it('should fetch package info from custom registry', async () => {


### PR DESCRIPTION
Uses the full url for caching instead of the namespace/name. This is to avoid any namespace clashes where users with private registries "reuse" someone else's package name instead of namespacing their own.