### PR TITLE
feat(gitlab): use repository URL from API

### DIFF
--- a/test/platform/gitlab/__snapshots__/index.spec.ts.snap
+++ b/test/platform/gitlab/__snapshots__/index.spec.ts.snap
@@ -266,6 +266,17 @@ Array [
 ]
 `;
 
+exports[`platform/gitlab initRepo should fall back if http_url_to_repo is empty 1`] = `
+Array [
+  Array [
+    "projects/some%2Frepo%2Fproject",
+  ],
+  Array [
+    "user",
+  ],
+]
+`;
+
 exports[`platform/gitlab setBaseBranch(branchName) sets the base branch 1`] = `
 Array [
   Array [

--- a/test/platform/gitlab/index.spec.ts
+++ b/test/platform/gitlab/index.spec.ts
@@ -116,6 +116,7 @@ describe('platform/gitlab', () => {
         ({
           body: {
             default_branch: 'master',
+            http_url_to_repo: 'https://gitlab.com/some/repo.git',
           },
         } as any)
     );
@@ -162,6 +163,17 @@ describe('platform/gitlab', () => {
       await expect(
         gitlab.initRepo({ repository: 'some/repo', localDir: '' })
       ).rejects.toThrow(Error('empty'));
+    });
+    it('should throw an error if http_url_to_repo is empty', async () => {
+      api.get.mockReturnValue({
+        body: {
+          default_branch: 'master',
+          http_url_to_repo: null,
+        },
+      } as any);
+      await expect(
+        gitlab.initRepo({ repository: 'some/repo', localDir: '' })
+      ).rejects.toThrow(Error('no http_url_to_repo found'));
     });
   });
   describe('getRepoForceRebase', () => {

--- a/test/platform/gitlab/index.spec.ts
+++ b/test/platform/gitlab/index.spec.ts
@@ -164,16 +164,15 @@ describe('platform/gitlab', () => {
         gitlab.initRepo({ repository: 'some/repo', localDir: '' })
       ).rejects.toThrow(Error('empty'));
     });
-    it('should throw an error if http_url_to_repo is empty', async () => {
+    it('should fall back if http_url_to_repo is empty', async () => {
       api.get.mockReturnValue({
         body: {
           default_branch: 'master',
           http_url_to_repo: null,
         },
       } as any);
-      await expect(
-        gitlab.initRepo({ repository: 'some/repo', localDir: '' })
-      ).rejects.toThrow(Error('no http_url_to_repo found'));
+      await initRepo({ repository: 'some/repo/project', token: 'some-token' });
+      expect(api.get.mock.calls).toMatchSnapshot();
     });
   });
   describe('getRepoForceRebase', () => {


### PR DESCRIPTION
This allows to access gitlab servers running with a [relative url root](https://docs.gitlab.com/omnibus/settings/configuration.html#configuring-a-relative-url-for-gitlab)

<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate
-->

<!-- Replace this text with a description of what this PR fixes or adds -->

Closes #3899  <!-- Ideally each PR should be closing an open issue -->
