### PR TITLE
docs: fix bors-ng example

### DIFF
--- a/website/docs/configuration-options.md
+++ b/website/docs/configuration-options.md
@@ -63,7 +63,7 @@ Example use:
 {
   "automerge": true,
   "automergeType": "pr-comment",
-  "automergeComment": "@bors: r+"
+  "automergeComment": "bors: r+"
 }
 ```
 


### PR DESCRIPTION
Your description of the merge option links to bors-ng, but the command example that you use is for homu-as-deployed-by-rust-lang.

I admit it's kind of confusing. Just roll with it.
