### PR TITLE
feat(gitlab): Improve performance for projects with a lot of branches

### DIFF
--- a/lib/platform/common.ts
+++ b/lib/platform/common.ts
@@ -4,6 +4,7 @@ export interface IGotApiOptions {
   useCache?: boolean;
   hostType?: string;
   body?: any;
+  query?: string | { [key: string]: string | number } | URLSearchParams;
 }
 
 export interface IGotApi<TOptions extends object = any> {


### PR DESCRIPTION
GitLab supports searching for PRs by providing a branch prefix. If we do
this this way faster for projects with a lot of branches.

Current behaviour:
1. `getBranchPr(branchName)` retrieves ALL open MRs, just to filter out the ones for this branch
2. `getPrList()` retrieves ALL open MRs just to filter the ones out matching all renovate branches
3. `findPR(branchName, title?, state)` uses `getPrList()` and then filters for matching criteria

Behaviour after:
1. `findPR(branchName, title?, state)` does an API request which includes the branch name in the search. As usually there only exists one MR per branch, this is a rather efficient query.
2. `getPRList()` does call `findPR()` for every existing branch, so that is N requests.
3. `getBranchPr(branchName)` now uses `findPR`

So instead of receiving all MRs multiple times, we have N requests for all existing renovate branches, this much more performant for big projects that have a lot of MRs