### PR TITLE
fix: renovate Dockerfiles with suffix by default

### DIFF
--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -1424,7 +1424,7 @@ const options = [
     stage: 'package',
     type: 'object',
     default: {
-      fileMatch: ['(^|/)Dockerfile$'],
+      fileMatch: ['(^|/)Dockerfile$', '(^|/)Dockerfile\\.[^/]*$'],
     },
     mergeable: true,
     cli: false,

--- a/renovate-schema.json
+++ b/renovate-schema.json
@@ -980,7 +980,7 @@
       "description": "Configuration object for Dockerfile renovation",
       "type": "object",
       "default": {
-        "fileMatch": ["(^|/)Dockerfile$"]
+        "fileMatch": ["(^|/)Dockerfile$", "(^|/)Dockerfile\\.[^/]*$"]
       },
       "$ref": "#"
     },


### PR DESCRIPTION
Make docker manager by default renovate Dockerfiles with a suffix. Currently, only Dockerfile was renovated by many projects use Dockerfile.* to have multiple Dockerfiles in the same directory. This commit changes the default config to handle these cases as well.

Closes #3940 
