### PR TITLE
fix: do not throw on merge failure

### DIFF
--- a/lib/platform/bitbucket-server/index.ts
+++ b/lib/platform/bitbucket-server/index.ts
@@ -129,7 +129,9 @@ export async function initRepo({
 
   try {
     const info = (await api.get(
-      `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}`
+      `./rest/api/1.0/projects/${config.projectKey}/repos/${
+        config.repositorySlug
+      }`
     )).body;
     platformConfig.privateRepo = info.is_private;
     platformConfig.isFork = !!info.parent;
@@ -137,7 +139,9 @@ export async function initRepo({
     config.owner = info.project.key;
     logger.debug(`${repository} owner = ${config.owner}`);
     config.defaultBranch = (await api.get(
-      `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/branches/default`
+      `./rest/api/1.0/projects/${config.projectKey}/repos/${
+        config.repositorySlug
+      }/branches/default`
     )).body.displayId;
     config.baseBranch = config.defaultBranch;
     config.mergeMethod = 'merge';
@@ -251,7 +255,9 @@ export async function deleteBranch(branchName: string, closePr = false) {
     const pr = await getBranchPr(branchName);
     if (pr) {
       await api.post(
-        `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests/${pr.number}/decline?version=${pr.version}`
+        `./rest/api/1.0/projects/${config.projectKey}/repos/${
+          config.repositorySlug
+        }/pull-requests/${pr.number}/decline?version=${pr.version}`
       );
 
       await getPr(pr.number, true);
@@ -451,7 +457,9 @@ export async function addReviewers(prNo: number, reviewers: string[]) {
     const reviewersSet = new Set([...pr.reviewers, ...reviewers]);
 
     await api.put(
-      `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests/${prNo}`,
+      `./rest/api/1.0/projects/${config.projectKey}/repos/${
+        config.repositorySlug
+      }/pull-requests/${prNo}`,
       {
         body: {
           title: pr.title,
@@ -484,7 +492,9 @@ export function deleteLabel(issueNo: number, label: string) {
 async function getComments(prNo: number) {
   // GET /rest/api/1.0/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}/activities
   let comments = await utils.accumulateValues(
-    `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests/${prNo}/activities`
+    `./rest/api/1.0/projects/${config.projectKey}/repos/${
+      config.repositorySlug
+    }/pull-requests/${prNo}/activities`
   );
 
   comments = comments
@@ -502,7 +512,9 @@ async function getComments(prNo: number) {
 async function addComment(prNo: number, text: string) {
   // POST /rest/api/1.0/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}/comments
   await api.post(
-    `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests/${prNo}/comments`,
+    `./rest/api/1.0/projects/${config.projectKey}/repos/${
+      config.repositorySlug
+    }/pull-requests/${prNo}/comments`,
     {
       body: { text },
     }
@@ -512,7 +524,9 @@ async function addComment(prNo: number, text: string) {
 async function getCommentVersion(prNo: number, commentId: number) {
   // GET /rest/api/1.0/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}/comments/{commentId}
   const { version } = (await api.get(
-    `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests/${prNo}/comments/${commentId}`
+    `./rest/api/1.0/projects/${config.projectKey}/repos/${
+      config.repositorySlug
+    }/pull-requests/${prNo}/comments/${commentId}`
   )).body;
 
   return version;
@@ -523,7 +537,9 @@ async function editComment(prNo: number, commentId: number, text: string) {
 
   // PUT /rest/api/1.0/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}/comments/{commentId}
   await api.put(
-    `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests/${prNo}/comments/${commentId}`,
+    `./rest/api/1.0/projects/${config.projectKey}/repos/${
+      config.repositorySlug
+    }/pull-requests/${prNo}/comments/${commentId}`,
     {
       body: { text, version },
     }
@@ -535,7 +551,9 @@ async function deleteComment(prNo: number, commentId: number) {
 
   // DELETE /rest/api/1.0/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}/comments/{commentId}
   await api.delete(
-    `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests/${prNo}/comments/${commentId}?version=${version}`
+    `./rest/api/1.0/projects/${config.projectKey}/repos/${
+      config.repositorySlug
+    }/pull-requests/${prNo}/comments/${commentId}?version=${version}`
   );
 }
 
@@ -609,7 +627,9 @@ export async function getPrList(_args?: any) {
   // istanbul ignore next
   if (!config.prList) {
     const values = await utils.accumulateValues(
-      `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests?state=ALL&limit=100`
+      `./rest/api/1.0/projects/${config.projectKey}/repos/${
+        config.repositorySlug
+      }/pull-requests?state=ALL&limit=100`
     );
 
     config.prList = values.map(utils.prInfo);
@@ -679,11 +699,15 @@ export async function createPr(
   if (config.bbUseDefaultReviewers) {
     logger.debug(`fetching default reviewers`);
     const { id } = (await api.get(
-      `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}`
+      `./rest/api/1.0/projects/${config.projectKey}/repos/${
+        config.repositorySlug
+      }`
     )).body;
 
     const defReviewers = (await api.get(
-      `./rest/default-reviewers/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/reviewers?sourceRefId=refs/heads/${branchName}&targetRefId=refs/heads/${base}&sourceRepoId=${id}&targetRepoId=${id}`
+      `./rest/default-reviewers/1.0/projects/${config.projectKey}/repos/${
+        config.repositorySlug
+      }/reviewers?sourceRefId=refs/heads/${branchName}&targetRefId=refs/heads/${base}&sourceRepoId=${id}&targetRepoId=${id}`
     )).body;
 
     reviewers = defReviewers.map((u: { name: string }) => ({
@@ -705,7 +729,9 @@ export async function createPr(
   let prInfoRes;
   try {
     prInfoRes = await api.post(
-      `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests`,
+      `./rest/api/1.0/projects/${config.projectKey}/repos/${
+        config.repositorySlug
+      }/pull-requests`,
       { body }
     );
   } catch (err) /* istanbul ignore next */ {
@@ -747,7 +773,9 @@ export async function getPr(prNo: number, refreshCache?: boolean) {
   }
 
   const res = await api.get(
-    `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests/${prNo}`,
+    `./rest/api/1.0/projects/${config.projectKey}/repos/${
+      config.repositorySlug
+    }/pull-requests/${prNo}`,
     { useCache: !refreshCache }
   );
 
@@ -761,13 +789,17 @@ export async function getPr(prNo: number, refreshCache?: boolean) {
 
   if (pr.state === 'open') {
     const mergeRes = await api.get(
-      `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests/${prNo}/merge`
+      `./rest/api/1.0/projects/${config.projectKey}/repos/${
+        config.repositorySlug
+      }/pull-requests/${prNo}/merge`
     );
     pr.isConflicted = !!mergeRes.body.conflicted;
     pr.canMerge = !!mergeRes.body.canMerge;
 
     const prCommits = (await api.get(
-      `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests/${prNo}/commits?withCounts=true`
+      `./rest/api/1.0/projects/${config.projectKey}/repos/${
+        config.repositorySlug
+      }/pull-requests/${prNo}/commits?withCounts=true`
     )).body;
 
     if (prCommits.totalCount === 1) {
@@ -819,7 +851,9 @@ export async function getPrFiles(prNo: number) {
 
   // GET /rest/api/1.0/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}/changes
   const values = await utils.accumulateValues(
-    `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests/${prNo}/changes?withComments=false`
+    `./rest/api/1.0/projects/${config.projectKey}/repos/${
+      config.repositorySlug
+    }/pull-requests/${prNo}/changes?withComments=false`
   );
   return values.map((f: { path: string }) => f.path.toString);
 }
@@ -838,7 +872,9 @@ export async function updatePr(
     }
 
     await api.put(
-      `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests/${prNo}`,
+      `./rest/api/1.0/projects/${config.projectKey}/repos/${
+        config.repositorySlug
+      }/pull-requests/${prNo}`,
       {
         body: {
           title,
@@ -871,14 +907,17 @@ export async function mergePr(prNo: number, branchName: string) {
       throw Object.assign(new Error('not-found'), { statusCode: 404 });
     }
     await api.post(
-      `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests/${prNo}/merge?version=${pr.version}`
+      `./rest/api/1.0/projects/${config.projectKey}/repos/${
+        config.repositorySlug
+      }/pull-requests/${prNo}/merge?version=${pr.version}`
     );
     await getPr(prNo, true);
   } catch (err) {
     if (err.statusCode === 404) {
       throw new Error('not-found');
     } else if (err.statusCode === 409) {
-      throw new Error('repository-changed');
+      logger.warn({ err }, `Failed to merge PR`);
+      return false;
     } else {
       logger.warn({ err }, `Failed to merge PR`);
       return false;

--- a/lib/platform/bitbucket-server/index.ts
+++ b/lib/platform/bitbucket-server/index.ts
@@ -129,9 +129,7 @@ export async function initRepo({
 
   try {
     const info = (await api.get(
-      `./rest/api/1.0/projects/${config.projectKey}/repos/${
-        config.repositorySlug
-      }`
+      `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}`
     )).body;
     platformConfig.privateRepo = info.is_private;
     platformConfig.isFork = !!info.parent;
@@ -139,9 +137,7 @@ export async function initRepo({
     config.owner = info.project.key;
     logger.debug(`${repository} owner = ${config.owner}`);
     config.defaultBranch = (await api.get(
-      `./rest/api/1.0/projects/${config.projectKey}/repos/${
-        config.repositorySlug
-      }/branches/default`
+      `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/branches/default`
     )).body.displayId;
     config.baseBranch = config.defaultBranch;
     config.mergeMethod = 'merge';
@@ -255,9 +251,7 @@ export async function deleteBranch(branchName: string, closePr = false) {
     const pr = await getBranchPr(branchName);
     if (pr) {
       await api.post(
-        `./rest/api/1.0/projects/${config.projectKey}/repos/${
-          config.repositorySlug
-        }/pull-requests/${pr.number}/decline?version=${pr.version}`
+        `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests/${pr.number}/decline?version=${pr.version}`
       );
 
       await getPr(pr.number, true);
@@ -457,9 +451,7 @@ export async function addReviewers(prNo: number, reviewers: string[]) {
     const reviewersSet = new Set([...pr.reviewers, ...reviewers]);
 
     await api.put(
-      `./rest/api/1.0/projects/${config.projectKey}/repos/${
-        config.repositorySlug
-      }/pull-requests/${prNo}`,
+      `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests/${prNo}`,
       {
         body: {
           title: pr.title,
@@ -492,9 +484,7 @@ export function deleteLabel(issueNo: number, label: string) {
 async function getComments(prNo: number) {
   // GET /rest/api/1.0/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}/activities
   let comments = await utils.accumulateValues(
-    `./rest/api/1.0/projects/${config.projectKey}/repos/${
-      config.repositorySlug
-    }/pull-requests/${prNo}/activities`
+    `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests/${prNo}/activities`
   );
 
   comments = comments
@@ -512,9 +502,7 @@ async function getComments(prNo: number) {
 async function addComment(prNo: number, text: string) {
   // POST /rest/api/1.0/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}/comments
   await api.post(
-    `./rest/api/1.0/projects/${config.projectKey}/repos/${
-      config.repositorySlug
-    }/pull-requests/${prNo}/comments`,
+    `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests/${prNo}/comments`,
     {
       body: { text },
     }
@@ -524,9 +512,7 @@ async function addComment(prNo: number, text: string) {
 async function getCommentVersion(prNo: number, commentId: number) {
   // GET /rest/api/1.0/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}/comments/{commentId}
   const { version } = (await api.get(
-    `./rest/api/1.0/projects/${config.projectKey}/repos/${
-      config.repositorySlug
-    }/pull-requests/${prNo}/comments/${commentId}`
+    `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests/${prNo}/comments/${commentId}`
   )).body;
 
   return version;
@@ -537,9 +523,7 @@ async function editComment(prNo: number, commentId: number, text: string) {
 
   // PUT /rest/api/1.0/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}/comments/{commentId}
   await api.put(
-    `./rest/api/1.0/projects/${config.projectKey}/repos/${
-      config.repositorySlug
-    }/pull-requests/${prNo}/comments/${commentId}`,
+    `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests/${prNo}/comments/${commentId}`,
     {
       body: { text, version },
     }
@@ -551,9 +535,7 @@ async function deleteComment(prNo: number, commentId: number) {
 
   // DELETE /rest/api/1.0/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}/comments/{commentId}
   await api.delete(
-    `./rest/api/1.0/projects/${config.projectKey}/repos/${
-      config.repositorySlug
-    }/pull-requests/${prNo}/comments/${commentId}?version=${version}`
+    `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests/${prNo}/comments/${commentId}?version=${version}`
   );
 }
 
@@ -627,9 +609,7 @@ export async function getPrList(_args?: any) {
   // istanbul ignore next
   if (!config.prList) {
     const values = await utils.accumulateValues(
-      `./rest/api/1.0/projects/${config.projectKey}/repos/${
-        config.repositorySlug
-      }/pull-requests?state=ALL&limit=100`
+      `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests?state=ALL&limit=100`
     );
 
     config.prList = values.map(utils.prInfo);
@@ -699,15 +679,11 @@ export async function createPr(
   if (config.bbUseDefaultReviewers) {
     logger.debug(`fetching default reviewers`);
     const { id } = (await api.get(
-      `./rest/api/1.0/projects/${config.projectKey}/repos/${
-        config.repositorySlug
-      }`
+      `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}`
     )).body;
 
     const defReviewers = (await api.get(
-      `./rest/default-reviewers/1.0/projects/${config.projectKey}/repos/${
-        config.repositorySlug
-      }/reviewers?sourceRefId=refs/heads/${branchName}&targetRefId=refs/heads/${base}&sourceRepoId=${id}&targetRepoId=${id}`
+      `./rest/default-reviewers/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/reviewers?sourceRefId=refs/heads/${branchName}&targetRefId=refs/heads/${base}&sourceRepoId=${id}&targetRepoId=${id}`
     )).body;
 
     reviewers = defReviewers.map((u: { name: string }) => ({
@@ -729,9 +705,7 @@ export async function createPr(
   let prInfoRes;
   try {
     prInfoRes = await api.post(
-      `./rest/api/1.0/projects/${config.projectKey}/repos/${
-        config.repositorySlug
-      }/pull-requests`,
+      `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests`,
       { body }
     );
   } catch (err) /* istanbul ignore next */ {
@@ -773,9 +747,7 @@ export async function getPr(prNo: number, refreshCache?: boolean) {
   }
 
   const res = await api.get(
-    `./rest/api/1.0/projects/${config.projectKey}/repos/${
-      config.repositorySlug
-    }/pull-requests/${prNo}`,
+    `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests/${prNo}`,
     { useCache: !refreshCache }
   );
 
@@ -789,17 +761,13 @@ export async function getPr(prNo: number, refreshCache?: boolean) {
 
   if (pr.state === 'open') {
     const mergeRes = await api.get(
-      `./rest/api/1.0/projects/${config.projectKey}/repos/${
-        config.repositorySlug
-      }/pull-requests/${prNo}/merge`
+      `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests/${prNo}/merge`
     );
     pr.isConflicted = !!mergeRes.body.conflicted;
     pr.canMerge = !!mergeRes.body.canMerge;
 
     const prCommits = (await api.get(
-      `./rest/api/1.0/projects/${config.projectKey}/repos/${
-        config.repositorySlug
-      }/pull-requests/${prNo}/commits?withCounts=true`
+      `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests/${prNo}/commits?withCounts=true`
     )).body;
 
     if (prCommits.totalCount === 1) {
@@ -851,9 +819,7 @@ export async function getPrFiles(prNo: number) {
 
   // GET /rest/api/1.0/projects/{projectKey}/repos/{repositorySlug}/pull-requests/{pullRequestId}/changes
   const values = await utils.accumulateValues(
-    `./rest/api/1.0/projects/${config.projectKey}/repos/${
-      config.repositorySlug
-    }/pull-requests/${prNo}/changes?withComments=false`
+    `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests/${prNo}/changes?withComments=false`
   );
   return values.map((f: { path: string }) => f.path.toString);
 }
@@ -872,9 +838,7 @@ export async function updatePr(
     }
 
     await api.put(
-      `./rest/api/1.0/projects/${config.projectKey}/repos/${
-        config.repositorySlug
-      }/pull-requests/${prNo}`,
+      `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests/${prNo}`,
       {
         body: {
           title,
@@ -907,9 +871,7 @@ export async function mergePr(prNo: number, branchName: string) {
       throw Object.assign(new Error('not-found'), { statusCode: 404 });
     }
     await api.post(
-      `./rest/api/1.0/projects/${config.projectKey}/repos/${
-        config.repositorySlug
-      }/pull-requests/${prNo}/merge?version=${pr.version}`
+      `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests/${prNo}/merge?version=${pr.version}`
     );
     await getPr(prNo, true);
   } catch (err) {

--- a/test/platform/bitbucket-server/index.spec.ts
+++ b/test/platform/bitbucket-server/index.spec.ts
@@ -630,14 +630,10 @@ describe('platform/bitbucket-server', () => {
         it('throws conflicted', async () => {
           expect.assertions(3);
           await initRepo();
-          api.post.mockReturnValueOnce(
-            Promise.reject({
-              statusCode: 409,
-            })
-          );
-          await expect(bitbucket.mergePr(5, 'branch')).rejects.toThrow(
-            'repository-changed'
-          );
+          api.post.mockRejectedValueOnce({
+            statusCode: 409,
+          });
+          expect(await bitbucket.mergePr(5, 'branch')).toBeFalsy();
           expect(api.get.mock.calls).toMatchSnapshot();
           expect(api.post.mock.calls).toMatchSnapshot();
         });


### PR DESCRIPTION
The bitbucket-server platform currently throws `repository-changed` if a pr merge failed.

With this fix it will log the error and simply returns `false` like the other platforms.
