### PR TITLE
 fix(bitbucket-server): delay pr refresh

### DIFF
--- a/lib/platform/bitbucket-server/index.ts
+++ b/lib/platform/bitbucket-server/index.ts
@@ -254,6 +254,8 @@ export async function deleteBranch(branchName: string, closePr = false) {
         `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests/${pr.number}/decline?version=${pr.version}`
       );
 
+      // wait for pr change propagation
+      await delay(1000);
       await getPr(pr.number, true);
     }
   }
@@ -850,6 +852,8 @@ export async function updatePr(
         },
       }
     );
+    // wait for pr change propagation
+    await delay(1000);
     await getPr(prNo, true);
   } catch (err) {
     if (err.statusCode === 404) {
@@ -875,6 +879,8 @@ export async function mergePr(prNo: number, branchName: string) {
     await api.post(
       `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests/${prNo}/merge?version=${pr.version}`
     );
+    // wait for pr change propagation
+    await delay(1000);
     await getPr(prNo, true);
   } catch (err) {
     if (err.statusCode === 404) {

--- a/lib/platform/bitbucket-server/index.ts
+++ b/lib/platform/bitbucket-server/index.ts
@@ -761,13 +761,15 @@ export async function getPr(prNo: number, refreshCache?: boolean) {
 
   if (pr.state === 'open') {
     const mergeRes = await api.get(
-      `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests/${prNo}/merge`
+      `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests/${prNo}/merge`,
+      { useCache: !refreshCache }
     );
     pr.isConflicted = !!mergeRes.body.conflicted;
     pr.canMerge = !!mergeRes.body.canMerge;
 
     const prCommits = (await api.get(
-      `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests/${prNo}/commits?withCounts=true`
+      `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests/${prNo}/commits?withCounts=true`,
+      { useCache: !refreshCache }
     )).body;
 
     if (prCommits.totalCount === 1) {

--- a/test/platform/bitbucket-server/__snapshots__/index.spec.ts.snap
+++ b/test/platform/bitbucket-server/__snapshots__/index.spec.ts.snap
@@ -16,9 +16,15 @@ Array [
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5",
@@ -28,9 +34,15 @@ Array [
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
+    Object {
+      "useCache": false,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
+    Object {
+      "useCache": false,
+    },
   ],
 ]
 `;
@@ -80,9 +92,15 @@ Array [
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
+    Object {
+      "useCache": true,
+    },
   ],
 ]
 `;
@@ -136,9 +154,15 @@ Array [
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
+    Object {
+      "useCache": true,
+    },
   ],
 ]
 `;
@@ -186,9 +210,15 @@ Array [
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
+    Object {
+      "useCache": true,
+    },
   ],
 ]
 `;
@@ -551,9 +581,15 @@ Array [
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
+    Object {
+      "useCache": true,
+    },
   ],
 ]
 `;
@@ -749,9 +785,15 @@ Array [
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/3/merge",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/3/commits?withCounts=true",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5",
@@ -761,9 +803,15 @@ Array [
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5",
@@ -773,9 +821,15 @@ Array [
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
+    Object {
+      "useCache": true,
+    },
   ],
 ]
 `;
@@ -817,9 +871,15 @@ Array [
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
+    Object {
+      "useCache": true,
+    },
   ],
 ]
 `;
@@ -946,9 +1006,15 @@ Array [
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5",
@@ -958,9 +1024,15 @@ Array [
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
+    Object {
+      "useCache": false,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
+    Object {
+      "useCache": false,
+    },
   ],
 ]
 `;
@@ -989,9 +1061,15 @@ Array [
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
+    Object {
+      "useCache": true,
+    },
   ],
 ]
 `;
@@ -1026,9 +1104,15 @@ Array [
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
+    Object {
+      "useCache": true,
+    },
   ],
 ]
 `;
@@ -1057,9 +1141,15 @@ Array [
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
+    Object {
+      "useCache": true,
+    },
   ],
 ]
 `;
@@ -1188,9 +1278,15 @@ Array [
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5",
@@ -1200,9 +1296,15 @@ Array [
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
+    Object {
+      "useCache": false,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
+    Object {
+      "useCache": false,
+    },
   ],
 ]
 `;
@@ -1245,9 +1347,15 @@ Array [
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
+    Object {
+      "useCache": true,
+    },
   ],
 ]
 `;
@@ -1296,9 +1404,15 @@ Array [
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
+    Object {
+      "useCache": true,
+    },
   ],
 ]
 `;
@@ -1341,9 +1455,15 @@ Array [
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
+    Object {
+      "useCache": true,
+    },
   ],
 ]
 `;
@@ -1386,9 +1506,15 @@ Array [
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5",
@@ -1398,9 +1524,15 @@ Array [
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
+    Object {
+      "useCache": false,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
+    Object {
+      "useCache": false,
+    },
   ],
 ]
 `;
@@ -1450,9 +1582,15 @@ Array [
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
+    Object {
+      "useCache": true,
+    },
   ],
 ]
 `;
@@ -1506,9 +1644,15 @@ Array [
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
+    Object {
+      "useCache": true,
+    },
   ],
 ]
 `;
@@ -1556,9 +1700,15 @@ Array [
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
+    Object {
+      "useCache": true,
+    },
   ],
 ]
 `;
@@ -1921,9 +2071,15 @@ Array [
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
+    Object {
+      "useCache": true,
+    },
   ],
 ]
 `;
@@ -2119,9 +2275,15 @@ Array [
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/3/merge",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/3/commits?withCounts=true",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5",
@@ -2131,9 +2293,15 @@ Array [
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5",
@@ -2143,9 +2311,15 @@ Array [
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
+    Object {
+      "useCache": true,
+    },
   ],
 ]
 `;
@@ -2187,9 +2361,15 @@ Array [
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
+    Object {
+      "useCache": true,
+    },
   ],
 ]
 `;
@@ -2316,9 +2496,15 @@ Array [
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5",
@@ -2328,9 +2514,15 @@ Array [
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
+    Object {
+      "useCache": false,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
+    Object {
+      "useCache": false,
+    },
   ],
 ]
 `;
@@ -2359,9 +2551,15 @@ Array [
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
+    Object {
+      "useCache": true,
+    },
   ],
 ]
 `;
@@ -2396,9 +2594,15 @@ Array [
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
+    Object {
+      "useCache": true,
+    },
   ],
 ]
 `;
@@ -2427,9 +2631,15 @@ Array [
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
+    Object {
+      "useCache": true,
+    },
   ],
 ]
 `;
@@ -2558,9 +2768,15 @@ Array [
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5",
@@ -2570,9 +2786,15 @@ Array [
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
+    Object {
+      "useCache": false,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
+    Object {
+      "useCache": false,
+    },
   ],
 ]
 `;
@@ -2615,9 +2837,15 @@ Array [
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
+    Object {
+      "useCache": true,
+    },
   ],
 ]
 `;
@@ -2666,9 +2894,15 @@ Array [
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
+    Object {
+      "useCache": true,
+    },
   ],
 ]
 `;
@@ -2711,9 +2945,15 @@ Array [
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
+    Object {
+      "useCache": true,
+    },
   ],
 ]
 `;


### PR DESCRIPTION
This pr add some delay before the refreshed pr is loaded.

Bitbucket server semms to update the pr asynchronous. If bbs is under load, renovate could be to fast with fetching the updated pr.

We should add a local version cache to bbs for only storing the current pr version.
We get the current version after a pr change over rest. So we only need the delay for git push.