### PR TITLE
fix(bitbucket-server): store pr versions

### DIFF
--- a/lib/platform/bitbucket-server/index.ts
+++ b/lib/platform/bitbucket-server/index.ts
@@ -18,6 +18,8 @@ interface BbsConfig {
   repository: string;
   repositorySlug: string;
   storage: GitStorage;
+
+  prVersions: Map<number, number>;
 }
 
 let config: BbsConfig = {} as any;
@@ -25,6 +27,13 @@ let config: BbsConfig = {} as any;
 const defaults: any = {
   hostType: 'bitbucket-server',
 };
+
+/* istanbul ignore next */
+function updatePrVersion(pr: number, version: number) {
+  const res = Math.max(config.prVersions.get(pr) || 0, version);
+  config.prVersions.set(pr, res);
+  return res;
+}
 
 export function initPlatform({
   endpoint,
@@ -100,7 +109,13 @@ export async function initRepo({
   });
 
   const [projectKey, repositorySlug] = repository.split('/');
-  config = { projectKey, repositorySlug, gitPrivateKey, repository } as any;
+  config = {
+    projectKey,
+    repositorySlug,
+    gitPrivateKey,
+    repository,
+    prVersions: new Map<number, number>(),
+  } as any;
 
   /* istanbul ignore else */
   if (bbUseDefaultReviewers !== false) {
@@ -250,13 +265,11 @@ export async function deleteBranch(branchName: string, closePr = false) {
     // getBranchPr
     const pr = await getBranchPr(branchName);
     if (pr) {
-      await api.post(
+      const { body } = await api.post(
         `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests/${pr.number}/decline?version=${pr.version}`
       );
 
-      // wait for pr change propagation
-      await delay(1000);
-      await getPr(pr.number, true);
+      updatePrVersion(pr, body);
     }
   }
   return config.storage.deleteBranch(branchName);
@@ -733,6 +746,8 @@ export async function createPr(
     ...utils.prInfo(prInfoRes.body),
   };
 
+  updatePrVersion(pr.number, pr.version);
+
   // istanbul ignore if
   if (config.prList) {
     config.prList.push(pr);
@@ -760,6 +775,8 @@ export async function getPr(prNo: number, refreshCache?: boolean) {
       (r: { user: { name: any } }) => r.user.name
     ),
   };
+
+  pr.version = updatePrVersion(pr.number, pr.version);
 
   if (pr.state === 'open') {
     const mergeRes = await api.get(
@@ -841,7 +858,7 @@ export async function updatePr(
       throw Object.assign(new Error('not-found'), { statusCode: 404 });
     }
 
-    await api.put(
+    const { body } = await api.put(
       `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests/${prNo}`,
       {
         body: {
@@ -852,9 +869,8 @@ export async function updatePr(
         },
       }
     );
-    // wait for pr change propagation
-    await delay(1000);
-    await getPr(prNo, true);
+
+    updatePrVersion(prNo, body.version);
   } catch (err) {
     if (err.statusCode === 404) {
       throw new Error('not-found');
@@ -876,12 +892,10 @@ export async function mergePr(prNo: number, branchName: string) {
     if (!pr) {
       throw Object.assign(new Error('not-found'), { statusCode: 404 });
     }
-    await api.post(
+    const { body } = await api.post(
       `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests/${prNo}/merge?version=${pr.version}`
     );
-    // wait for pr change propagation
-    await delay(1000);
-    await getPr(prNo, true);
+    updatePrVersion(prNo, body.version);
   } catch (err) {
     if (err.statusCode === 404) {
       throw new Error('not-found');

--- a/test/platform/bitbucket-server/__snapshots__/index.spec.ts.snap
+++ b/test/platform/bitbucket-server/__snapshots__/index.spec.ts.snap
@@ -1016,24 +1016,6 @@ Array [
       "useCache": true,
     },
   ],
-  Array [
-    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5",
-    Object {
-      "useCache": false,
-    },
-  ],
-  Array [
-    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
-    Object {
-      "useCache": false,
-    },
-  ],
-  Array [
-    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
-    Object {
-      "useCache": false,
-    },
-  ],
 ]
 `;
 
@@ -1286,24 +1268,6 @@ Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
     Object {
       "useCache": true,
-    },
-  ],
-  Array [
-    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5",
-    Object {
-      "useCache": false,
-    },
-  ],
-  Array [
-    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
-    Object {
-      "useCache": false,
-    },
-  ],
-  Array [
-    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
-    Object {
-      "useCache": false,
     },
   ],
 ]
@@ -2506,24 +2470,6 @@ Array [
       "useCache": true,
     },
   ],
-  Array [
-    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5",
-    Object {
-      "useCache": false,
-    },
-  ],
-  Array [
-    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
-    Object {
-      "useCache": false,
-    },
-  ],
-  Array [
-    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
-    Object {
-      "useCache": false,
-    },
-  ],
 ]
 `;
 
@@ -2776,24 +2722,6 @@ Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
     Object {
       "useCache": true,
-    },
-  ],
-  Array [
-    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5",
-    Object {
-      "useCache": false,
-    },
-  ],
-  Array [
-    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge",
-    Object {
-      "useCache": false,
-    },
-  ],
-  Array [
-    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/commits?withCounts=true",
-    Object {
-      "useCache": false,
     },
   ],
 ]


### PR DESCRIPTION
This pr stores the pr versions in the local config to avoid reloading the full pr.

This is also a workaround for a got cache bug, because it is not updated when using `{useCache:false}`.
So the next same `GET` request would use the first cached response.

/cc @rarkins 