### PR TITLE
fix(got): repoCache was not updated

### DIFF
--- a/lib/util/got/cache-get.js
+++ b/lib/util/got/cache-get.js
@@ -13,9 +13,6 @@ module.exports = got.create({
     if (!global.repoCache) {
       return next(options);
     }
-    if (options.useCache === false) {
-      return next(options);
-    }
     if (options.stream) {
       return next(options);
     }
@@ -27,7 +24,7 @@ module.exports = got.create({
             JSON.stringify({ href: options.href, headers: options.headers })
         )
         .digest('hex');
-      if (!global.repoCache[cacheKey]) {
+      if (!global.repoCache[cacheKey] || options.useCache === false) {
         global.repoCache[cacheKey] = next(options);
       }
       return global.repoCache[cacheKey].then(response => ({


### PR DESCRIPTION
This pr fix the `repoCache` update bug.

If we use `{useCache:false}` to bust the cache, it has not updated `repoCache`, so the next request will use the old reponse.

/cc @rarkins 