### PR TITLE
fix(bitbucket): add canMerge to pr

### DIFF
--- a/lib/platform/bitbucket/index.ts
+++ b/lib/platform/bitbucket/index.ts
@@ -540,6 +540,7 @@ export async function getPr(prNo: number) {
     const commits = await utils.accumulateValues(pr.links.commits.href);
     if (commits.length === 1) {
       res.canRebase = true;
+      res.canMerge = true;
     }
   }
   if (await branchExists(pr.source.branch.name)) {

--- a/test/platform/bitbucket/__snapshots__/index.spec.ts.snap
+++ b/test/platform/bitbucket/__snapshots__/index.spec.ts.snap
@@ -161,6 +161,7 @@ exports[`platform/bitbucket getBranchPr() bitbucket finds PR for branch 1`] = `
 Object {
   "body": "summary",
   "branchName": "branch",
+  "canMerge": true,
   "canRebase": true,
   "createdAt": "2018-07-02T07:02:25.275030+00:00",
   "displayNumber": "Pull Request #5",
@@ -176,6 +177,7 @@ exports[`platform/bitbucket getPr() exists 1`] = `
 Object {
   "body": "summary",
   "branchName": "branch",
+  "canMerge": true,
   "canRebase": true,
   "createdAt": "2018-07-02T07:02:25.275030+00:00",
   "displayNumber": "Pull Request #5",


### PR DESCRIPTION
Automerge logic checks for `pr.canMerge` https://github.com/renovatebot/renovate/blob/master/lib/workers/pr/index.js#L401.

Using bitbucket (cloud).
When trying to automerge with status checks it fails when checking for the `pr.canMerge` flag.
I looked into the code and found that on bitbucket-server that is set to whatever the response is from the API.
 
Sadly i’m not sure if this is the correct way to solve the problem, but it seems to work for me.