### PR TITLE
feat(github): Support for team assignment.

### DIFF
--- a/lib/platform/github/index.js
+++ b/lib/platform/github/index.js
@@ -866,12 +866,19 @@ async function addAssignees(issueNo, assignees) {
 
 async function addReviewers(prNo, reviewers) {
   logger.debug(`Adding reviewers ${reviewers} to #${prNo}`);
+
+  const userReviewers = reviewers.filter(e => !e.startsWith('team:'));
+  const teamReviewers = reviewers
+    .filter(e => e.startsWith('team:'))
+    .map(e => e.replace(/^team:/, ''));
+
   await get.post(
     `repos/${config.parentRepo ||
       config.repository}/pulls/${prNo}/requested_reviewers`,
     {
       body: {
-        reviewers,
+        reviewers: userReviewers,
+        team_reviewers: teamReviewers,
       },
     }
   );

--- a/test/platform/github/__snapshots__/index.spec.js.snap
+++ b/test/platform/github/__snapshots__/index.spec.js.snap
@@ -26,6 +26,9 @@ Array [
           "someuser",
           "someotheruser",
         ],
+        "team_reviewers": Array [
+          "someteam",
+        ],
       },
     },
   ],

--- a/test/platform/github/index.spec.js
+++ b/test/platform/github/index.spec.js
@@ -1050,7 +1050,11 @@ describe('platform/github', () => {
         repository: 'some/repo',
       });
       get.post.mockReturnValueOnce({});
-      await github.addReviewers(42, ['someuser', 'someotheruser']);
+      await github.addReviewers(42, [
+        'someuser',
+        'someotheruser',
+        'team:someteam',
+      ]);
       expect(get.post.mock.calls).toMatchSnapshot();
     });
   });

--- a/website/docs/configuration-options.md
+++ b/website/docs/configuration-options.md
@@ -976,7 +976,7 @@ Similar to `ignoreUnstable`, this option controls whether to update to versions 
 
 ## reviewers
 
-Must be valid usernames. If on GitHub and assigning a *team* to review, use the prefix `team:`, e.g. a string like `team:someteam`.
+Must be valid usernames. If on GitHub and assigning a team to review, use the prefix `team:`, e.g. provide a value like `team:someteam`.
 
 ## rollbackPrs
 

--- a/website/docs/configuration-options.md
+++ b/website/docs/configuration-options.md
@@ -976,7 +976,7 @@ Similar to `ignoreUnstable`, this option controls whether to update to versions 
 
 ## reviewers
 
-Must be valid usernames. Note: does not currently work with the GitHub App due to an outstanding GitHub API bug.
+Must be valid usernames. If on GitHub and assigning a *team* to review, use the prefix `team:`, e.g. a string like `team:someteam`.
 
 ## rollbackPrs
 


### PR DESCRIPTION
Add support of assigning GitHub teams to PRs opened by Renovate. Tested with GitHub private organization using API tokens. 

Ref #1908