### PR TITLE
feat: Support multiple assignees in Gitlab

### DIFF
--- a/test/platform/gitlab/__snapshots__/index.spec.ts.snap
+++ b/test/platform/gitlab/__snapshots__/index.spec.ts.snap
@@ -3,18 +3,19 @@
 exports[`platform/gitlab addAssignees(issueNo, assignees) should add the given assignees to the issue 1`] = `
 Array [
   Array [
-    "projects/undefined/merge_requests/42?assignee_id=123",
+    "projects/undefined/merge_requests/42",
+    Object {
+      "body": Object {
+        "assignee_ids": Array [
+          123,
+        ],
+      },
+    },
   ],
 ]
 `;
 
-exports[`platform/gitlab addAssignees(issueNo, assignees) should warn if more than one assignee 1`] = `
-Array [
-  Array [
-    "projects/undefined/merge_requests/42?assignee_id=123",
-  ],
-]
-`;
+exports[`platform/gitlab addAssignees(issueNo, assignees) should warn if more than one assignee 1`] = `Array []`;
 
 exports[`platform/gitlab commitFilesToBranch() sends to gitFs 1`] = `
 Array [


### PR DESCRIPTION
* According to their offical docs -https://docs.gitlab.com/ee/api/merge_requests.html#update-mr , with the new release , assignee_ids is supported.
Closes #3745 
