### PR TITLE
feat(composer+git): Add support for custom git repositories with composer

### DIFF
--- a/lib/datasource/git-tags/index.js
+++ b/lib/datasource/git-tags/index.js
@@ -5,17 +5,29 @@ const cacheNamespace = 'git-tags';
 const cacheMinutes = 10;
 
 async function getPkgReleases({ lookupName }) {
+  // transform to https because isomorphic-git doesn't support ssh yet
+  // discuss: use native git?
+  const lookupNameHttps = lookupName.replace(
+    /^git@(.+?):(.+)/,
+    'https://$1/$2'
+  );
+  if (lookupName !== lookupNameHttps) {
+    logger.info(`git lookup: Transformed ${lookupName} to ${lookupNameHttps}`);
+  }
   try {
-    const cachedResult = await renovateCache.get(cacheNamespace, lookupName);
+    const cachedResult = await renovateCache.get(
+      cacheNamespace,
+      lookupNameHttps
+    );
     /* istanbul ignore next line */
     if (cachedResult) return cachedResult;
 
     const { username, password, token } = hostRules.find({
       hostType: 'git',
-      url: lookupName,
+      url: lookupNameHttps,
     });
     const info = await getRemoteInfo({
-      url: lookupName,
+      url: lookupNameHttps,
       username,
       password,
       token,
@@ -35,15 +47,20 @@ async function getPkgReleases({ lookupName }) {
           return accum;
         },
         {
-          sourceUrl: lookupName,
+          sourceUrl: lookupNameHttps,
           releases: [],
         }
       );
-      await renovateCache.set(cacheNamespace, lookupName, result, cacheMinutes);
+      await renovateCache.set(
+        cacheNamespace,
+        lookupNameHttps,
+        result,
+        cacheMinutes
+      );
       return result;
     }
   } catch (e) {
-    logger.debug(`Error looking up for tags in ${lookupName}`);
+    logger.debug(`Error looking up tags in ${lookupNameHttps}`);
   }
   return null;
 }

--- a/lib/datasource/git-tags/index.js
+++ b/lib/datasource/git-tags/index.js
@@ -1,4 +1,5 @@
 const { getRemoteInfo } = require('isomorphic-git');
+const hostRules = require('../../util/host-rules');
 
 const cacheNamespace = 'git-tags';
 const cacheMinutes = 10;
@@ -9,8 +10,15 @@ async function getPkgReleases({ lookupName }) {
     /* istanbul ignore next line */
     if (cachedResult) return cachedResult;
 
+    const { username, password, token } = hostRules.find({
+      hostType: 'git',
+      url: lookupName,
+    });
     const info = await getRemoteInfo({
       url: lookupName,
+      username,
+      password,
+      token,
     });
     if (info && info.refs && info.refs.tags) {
       const tags = Object.keys(info.refs.tags);

--- a/lib/manager/composer/extract.js
+++ b/lib/manager/composer/extract.js
@@ -5,7 +5,40 @@ module.exports = {
   extractPackageFile,
 };
 
-async function extractPackageFile(content, fileName) {
+/**
+ * Parse the repositories field from a composer.json or the config
+ *
+ * Entries with type vcs, git, gitlab or github will be added to repositories,
+ * other entries will be added to registryUrls
+ *
+ * @param repoJson
+ * @param repositories
+ * @param registryUrls
+ */
+function parseRepos(repoJson, repositories, registryUrls) {
+  if (is.array(repoJson)) {
+    repoJson.forEach(repo => {
+      if (repo.type && !['vcs', 'git'].indexOf(repo.type) !== -1) {
+        // eslint-disable-next-line no-param-reassign
+        repositories[repo.name] = repo;
+      } else {
+        registryUrls.push(repo);
+      }
+    });
+  } else if (is.object(repoJson)) {
+    try {
+      for (const repository of Object.values(repoJson)) {
+        registryUrls.push(repository);
+      }
+    } catch (err) /* istanbul ignore next */ {
+      logger.warn({ err }, 'Error extracting composer repositories');
+    }
+  } /* istanbul ignore next */ else {
+    logger.info({ repositories: repoJson }, 'Unknown composer repositories');
+  }
+}
+
+async function extractPackageFile(content, fileName, config) {
   logger.trace(`composer.extractPackageFile(${fileName})`);
   let composerJson;
   try {
@@ -13,6 +46,18 @@ async function extractPackageFile(content, fileName) {
   } catch (err) {
     logger.info({ fileName }, 'Invalid JSON');
     return null;
+  }
+  const repositories = {};
+  const registryUrls = [];
+  const res = {};
+  if (config.composer && config.composer.repositories) {
+    parseRepos(config.composer.repositories, repositories, registryUrls);
+  }
+  if (composerJson.repositories) {
+    parseRepos(composerJson.repositories, repositories, registryUrls);
+  }
+  if (registryUrls.length !== 0) {
+    res.registryUrls = registryUrls;
   }
   const deps = [];
   const depTypes = ['require', 'require-dev'];
@@ -23,11 +68,28 @@ async function extractPackageFile(content, fileName) {
           composerJson[depType]
         )) {
           const currentValue = version.trim();
+          // Default datasource and lookupName
+          let datasource = 'packagist';
+          let lookupName = depName;
+
+          // Check custom repositories by type
+          if (repositories[depName]) {
+            switch (repositories[depName].type) {
+              case 'vcs':
+              case 'git':
+                datasource = 'gitTags';
+                lookupName = repositories[depName].url;
+                break;
+              default:
+                break;
+            }
+          }
           const dep = {
             depType,
             depName,
             currentValue,
-            datasource: 'packagist',
+            datasource,
+            lookupName,
           };
           if (!depName.includes('/')) {
             dep.skipReason = 'unsupported';
@@ -49,7 +111,7 @@ async function extractPackageFile(content, fileName) {
   if (!deps.length) {
     return null;
   }
-  const res = { deps };
+  res.deps = deps;
   const filePath = fileName.replace(/\.json$/, '.lock');
   const lockContents = await platform.getFile(filePath);
   // istanbul ignore if
@@ -71,25 +133,6 @@ async function extractPackageFile(content, fileName) {
     }
   } else {
     res.composerLock = false;
-  }
-  if (composerJson.repositories) {
-    if (is.array(composerJson.repositories)) {
-      res.registryUrls = composerJson.repositories;
-    } else if (is.object(composerJson.repositories)) {
-      try {
-        res.registryUrls = [];
-        for (const repository of Object.values(composerJson.repositories)) {
-          res.registryUrls.push(repository);
-        }
-      } catch (err) /* istanbul ignore next */ {
-        logger.warn({ err }, 'Error extracting composer repositories');
-      }
-    } /* istanbul ignore next */ else {
-      logger.info(
-        { repositories: composerJson.repositories },
-        'Unknown composer repositories'
-      );
-    }
   }
   if (composerJson.type) {
     res.composerJsonType = composerJson.type;

--- a/lib/manager/composer/extract.js
+++ b/lib/manager/composer/extract.js
@@ -50,7 +50,7 @@ async function extractPackageFile(content, fileName, config) {
   const repositories = {};
   const registryUrls = [];
   const res = {};
-  if (config.composer && config.composer.repositories) {
+  if (config && config.composer && config.composer.repositories) {
     parseRepos(config.composer.repositories, repositories, registryUrls);
   }
   if (composerJson.repositories) {

--- a/lib/manager/composer/readme.md
+++ b/lib/manager/composer/readme.md
@@ -133,7 +133,10 @@ Details: https://getcomposer.org/doc/05-repositories.md#hosting-your-own
 
 #### Will users need the capability to specify a custom host/registry to look up? Can it be found within the package files, or within other files inside the repository, or would it require Renovate configuration?
 
-Yes. There is an optional [`repositories`](https://getcomposer.org/doc/05-repositories.md#repository) field allowed at the root of any composer file. There should usually be no need to override this by config.
+Yes. There is an optional [`repositories`](https://getcomposer.org/doc/05-repositories.md#repository) field allowed at the root of any composer file.
+
+Users can use composer plugins in their projects, that can add additional repository info, which is not visible in the composer.json file itsself.
+The command for this would like something like `$composer->getRepositoryManager()->addRepository($repository)`
 
 ---
 

--- a/website/docs/configuration-options.md
+++ b/website/docs/configuration-options.md
@@ -188,6 +188,28 @@ This is used to manually restrict which versions are possible to upgrade to base
 
 Warning: composer support is in alpha stage so you probably only want to run this if you are helping get it feature-ready.
 
+### repositories
+
+Add custom repositories as you would do in your [composer.json](https://getcomposer.org/doc/04-schema.md#repositories)
+
+Currently special handled types are vcs and git (vcs being an alias for git). Everything else will be handled as a registry url.
+
+Repositories configured in composer.json take preceedence over the config entries.
+Repositories with type git will use gitTags as datasource instead of packagist
+
+```json
+"repositories": [
+    {
+        "type": "composer",
+        "url": "http://packages.example.com"
+    },
+    {
+        "type": "git",
+        "url": "https://github.com/Seldaek/monolog"
+    }
+]
+```
+
 ## deps-edn
 
 ## description


### PR DESCRIPTION
This is my first time contributing to an open source project, so bear with me ;)

_(Should each commit get its own PR? Let me know and i will split it up if possible)_

Relates to #3811 

# Why?
- Instead of waiting for an update to handle  #3811, I decided to help out an awesome project.
- I am currently working on integrating renovatebot to work on our self-hosted gitlab installation, which is not reachable from outside our intranet
- Composer repositories are referenced as `"url": "git@internal-gitlab:project.git"`
- The following changes will allow usage of self-hosted Renovatebot to work with composer git repositories in a self-hosted GitLab
- Tested by running Renovatebot in an alpine based docker image against our own GitLab instance

# This PR adds three features:

## Custom git repositories with Composer
- repository types git and vcs will be interpreted as git repositories and use git-tags as datasource
    - _Is there a high risk that other vcs types besides git are used?_
- repositories will be read from composer.json and can be defined in config.composer.repositories
- kinda relies on the git-tags changes below, as ssh repository urls can not be resolved with isomorphic-git
- might require additional authentication `composer config -g http-basic.{domain} {username} {password}`

## Allow git-tags datasource to read from HostRules
- With this change, renovate can clone repositories that require authentication
```javascript
// config.js
hostRules: [{
    hostType: 'git',
    url: 'example.com',
    username: 'myUser',
    // use either token or password
    password: 'myPassword',
    // token: 'myToken', 
}]
```

## Semi-support for git@domain:path repositories
- Transform ssh+git urls (git@github.com:project) to https urls, since isomorphic-git does not support 
    - _Possibly change this to actually use ssh via native git call?_
- Why?
    - Composer allows using ssh for custom repositories. However, isomorphic-git does not support this.
    - This will allow renovate to clone git from https urls, but composer can still update via ssh

## What still needs to be done?
While i tried to improve documentation, i am not quite sure what else needs to be updated.

Besides docs, i guess tests need to be updated/improved as well

## Future Scope
- Handle other repository types like github, gitlab