### PR TITLE
feat(git): Add support for ssh via simple-git

### DIFF
--- a/lib/datasource/git-tags/index.js
+++ b/lib/datasource/git-tags/index.js
@@ -1,5 +1,5 @@
 const simpleGit = require('simple-git/promise');
-const semver = require('semver');
+const semver = require('../../versioning/semver');
 
 const cacheNamespace = 'git-tags';
 const cacheMinutes = 10;
@@ -23,8 +23,8 @@ async function getPkgReleases({ lookupName }) {
     // extract valid tags from git ls-remote which looks like 'commithash\trefs/tags/1.2.3
     const tags = lsRemote
       .replace(/^.+?refs\/tags\//gm, '')
-      .trim()
-      .split('\n');
+      .split('\n')
+      .filter(tag => semver.isVersion(tag));
     const result = {
       sourceUrl: lookupName,
       releases: tags.map(tag => ({

--- a/lib/datasource/git-tags/index.js
+++ b/lib/datasource/git-tags/index.js
@@ -20,8 +20,11 @@ async function getPkgReleases({ lookupName }) {
       '--tags',
       lookupName,
     ]);
-    // get stable tags via regex. stable meaning only digits, dots and a leading 'v' will be allowed
-    const tags = String(lsRemote).match(/(v?[\d.]+)$/gm);
+    // extract valid tags from git ls-remote which looks like 'commithash\trefs/tags/1.2.3
+    const tags = lsRemote
+      .replace(/^.+?refs\/tags\//gm, '')
+      .trim()
+      .split('\n');
     const result = {
       sourceUrl: lookupName,
       releases: tags.map(tag => ({

--- a/lib/datasource/git-tags/index.js
+++ b/lib/datasource/git-tags/index.js
@@ -1,4 +1,5 @@
 const simpleGit = require('simple-git/promise');
+const semver = require('semver');
 
 const cacheNamespace = 'git-tags';
 const cacheMinutes = 10;
@@ -24,7 +25,7 @@ async function getPkgReleases({ lookupName }) {
     const result = {
       sourceUrl: lookupName,
       releases: tags.map(tag => ({
-        version: tag.replace(/^v(?=[0-9])/, ''),
+        version: semver.isValid(tag),
         gitref: tag,
       })),
     };

--- a/lib/datasource/git-tags/index.js
+++ b/lib/datasource/git-tags/index.js
@@ -1,41 +1,38 @@
-const { getRemoteInfo } = require('isomorphic-git');
+const simpleGit = require('simple-git/promise');
 
 const cacheNamespace = 'git-tags';
 const cacheMinutes = 10;
 
+// git will prompt for known hosts or passwords, unless we activate BatchMode
+process.env.GIT_SSH_COMMAND = 'ssh -o BatchMode=yes';
+
 async function getPkgReleases({ lookupName }) {
+  const git = simpleGit();
   try {
     const cachedResult = await renovateCache.get(cacheNamespace, lookupName);
     /* istanbul ignore next line */
     if (cachedResult) return cachedResult;
 
-    const info = await getRemoteInfo({
-      url: lookupName,
-    });
-    if (info && info.refs && info.refs.tags) {
-      const tags = Object.keys(info.refs.tags);
-      const result = tags.reduce(
-        (accum, gitRef) => {
-          if (!/\^/.test(gitRef)) {
-            // exclude things like '1.2.3^{}'
-            const version = gitRef.replace(/^v(?=[0-9])/, ''); // 'v1.2.3' => '1.2.3'
-            accum.releases.push({
-              version,
-              gitRef,
-            });
-          }
-          return accum;
-        },
-        {
-          sourceUrl: lookupName,
-          releases: [],
-        }
-      );
-      await renovateCache.set(cacheNamespace, lookupName, result, cacheMinutes);
-      return result;
-    }
+    // fetch remote tags
+    const lsRemote = await git.listRemote([
+      '--sort=-v:refname',
+      '--tags',
+      lookupName,
+    ]);
+    // get stable tags via regex. stable meaning only digits, dots and a leading 'v' will be allowed
+    const tags = String(lsRemote).match(/(v?[\d.]+)$/gm);
+    const result = {
+      sourceUrl: lookupName,
+      releases: tags.map(tag => ({
+        version: tag.replace(/^v(?=[0-9])/, ''),
+        gitref: tag,
+      })),
+    };
+
+    await renovateCache.set(cacheNamespace, lookupName, result, cacheMinutes);
+    return result;
   } catch (e) {
-    logger.debug(`Error looking up for tags in ${lookupName}`);
+    logger.debug(`Error looking up tags in ${lookupName}`);
   }
   return null;
 }

--- a/package.json
+++ b/package.json
@@ -111,7 +111,6 @@
     "handlebars": "4.1.2",
     "hasha": "5.0.0",
     "ini": "1.3.5",
-    "isomorphic-git": "0.55.2",
     "js-yaml": "3.13.1",
     "json-dup-key-validator": "1.0.2",
     "json-stringify-pretty-compact": "2.0.0",

--- a/test/datasource/git-tags.spec.js
+++ b/test/datasource/git-tags.spec.js
@@ -1,42 +1,43 @@
-const { getRemoteInfo } = require('isomorphic-git');
+const simpleGit = require('simple-git/promise');
 const { getPkgReleases } = require('../../lib/datasource/git-tags');
 
-jest.mock('isomorphic-git');
+jest.mock('simple-git/promise.js');
 
-const lookupName = 'vapor';
-const registryUrls = ['https://github.com/vapor/vapor.git'];
-const registryUrlsAlt = ['https://github.com/vapor/vapor/'];
+// const lookupName = 'vapor';
+const lookupName = 'https://github.com/example/example.git';
 
 describe('datasource/git-tags', () => {
   beforeEach(() => global.renovateCache.rmAll());
   describe('getPkgReleases', () => {
     it('returns nil if response is wrong', async () => {
-      getRemoteInfo.mockReturnValue(Promise.resolve(null));
-      const versions = await getPkgReleases({ lookupName, registryUrls });
+      simpleGit.mockReturnValue({
+        listRemote() {
+          return Promise.resolve(null);
+        },
+      });
+      const versions = await getPkgReleases({ lookupName });
       expect(versions).toEqual(null);
     });
     it('returns nil if remote call throws exception', async () => {
-      getRemoteInfo.mockImplementation(() => {
-        throw new Error();
+      simpleGit.mockReturnValue({
+        listRemote() {
+          throw new Error();
+        },
       });
-      const versions = await getPkgReleases({ lookupName, registryUrls });
+      const versions = await getPkgReleases({ lookupName });
       expect(versions).toEqual(null);
     });
     it('returns versions filtered from tags', async () => {
-      getRemoteInfo.mockReturnValue(
-        Promise.resolve({
-          refs: {
-            tags: {
-              '0.0.1': 'foo',
-              'v0.0.2': 'bar',
-              'v0.0.2^{}': 'baz',
-            },
-          },
-        })
-      );
+      simpleGit.mockReturnValue({
+        listRemote() {
+          return Promise.resolve(
+            'commithash1\trefs/tags/0.0.1\ncommithash2\trefs/tags/v0.0.2\ncommithash3\trefs/tags/v0.0.2^{}'
+          );
+        },
+      });
+
       const versions = await getPkgReleases({
         lookupName,
-        registryUrls: registryUrlsAlt,
       });
       const result = versions.releases.map(x => x.version).sort();
       expect(result).toEqual(['0.0.1', '0.0.2']);


### PR DESCRIPTION
Edit: I have striked out scrapped changes and outdated information

<strike>**BREAKING CHANGE:** Requires native git installation on host system

Note: This is a wip and requires more tests and documentation improvements

TODOs: (might need help with this one)
- Improve documentation (e.g. how to configure ssh)
- Improve Unit Tests (currently lacking code coverage)
- Add default configuration options
</strike>

# SSH for git (#4022)

This PR replaces isomporphic-git with simple-git to support all native git functions. However, this means that the host system needs to provide <strike>git and</strike> SSH (when using git via ssh)

Users should also provide an SSH key on the host system, as well as known_hosts

<strike>

## Options
Two new options are introduced: (TODO: Add to documentation and default config)
- gitTags.strictHostKeyChecking (default: true) - Allow git to connect to unknown hosts via ssh
- gitTags.transformSshToHttps (default false) - Instead of using ssh (git@domain) it will be transformed to a https identifier, as most git-tools (github, gitlab, bitbucket etc.) will allow ssh and https via the same uri
    - `ssh://git@my-domain:my-project` -> `https://my-domain/my-project`

## Host Rules for git
Using host rules for git, one can inject authentication for https repositories:
```javascript
{
      hostType: 'git',
      url: 'my-git',
      username: 'my-user',
      // password: 'my-pass',
      token: 'my-token', //preferred
}
```
</strike>

## Future Scope
This will allow for improved composer integration, referencing #3811 

Closes #4022 
