### PR TITLE
test: fix TS1208 errors

### DIFF
--- a/test/platform/azure/azure-got-wrapper.spec.ts
+++ b/test/platform/azure/azure-got-wrapper.spec.ts
@@ -1,6 +1,8 @@
+import * as _hostRules from '../../../lib/util/host-rules';
+
 describe('platform/azure/azure-got-wrapper', () => {
-  let hostRules: typeof import('../../../lib/util/host-rules');
   let azure: typeof import('../../../lib/platform/azure/azure-got-wrapper');
+  let hostRules: typeof _hostRules;
   beforeEach(() => {
     // reset module
     jest.resetModules();
@@ -20,6 +22,7 @@ describe('platform/azure/azure-got-wrapper', () => {
         baseUrl: 'https://dev.azure.com/renovate12345',
       });
       azure.setEndpoint('https://dev.azure.com/renovate12345');
+
       const res = await azure.azureObj();
 
       delete res.rest.client.userAgent;

--- a/test/platform/azure/azure-helper.spec.ts
+++ b/test/platform/azure/azure-helper.spec.ts
@@ -1,4 +1,4 @@
-const { Readable } = require('stream');
+import { Readable } from 'stream';
 
 describe('platform/azure/helpers', () => {
   let azureHelper: typeof import('../../../lib/platform/azure/azure-helper');

--- a/test/platform/azure/index.spec.ts
+++ b/test/platform/azure/index.spec.ts
@@ -1,4 +1,7 @@
+import * as _hostRules from '../../../lib/util/host-rules';
+
 describe('platform/azure', () => {
+  let hostRules: jest.Mocked<typeof _hostRules>;
   let azure: jest.Mocked<typeof import('../../../lib/platform/azure')>;
   let azureApi: jest.Mocked<
     typeof import('../../../lib/platform/azure/azure-got-wrapper')
@@ -6,7 +9,6 @@ describe('platform/azure', () => {
   let azureHelper: jest.Mocked<
     typeof import('../../../lib/platform/azure/azure-helper')
   >;
-  let hostRules: jest.Mocked<typeof import('../../../lib/util/host-rules')>;
   let GitStorage;
   beforeEach(() => {
     // reset module

--- a/test/platform/gitlab/index.spec.ts
+++ b/test/platform/gitlab/index.spec.ts
@@ -1,9 +1,11 @@
+import * as _hostRules from '../../../lib/util/host-rules';
+
 describe('platform/gitlab', () => {
   let gitlab: typeof import('../../../lib/platform/gitlab');
   let api: jest.Mocked<
     typeof import('../../../lib/platform/gitlab/gl-got-wrapper').api
   >;
-  let hostRules: jest.Mocked<typeof import('../../../lib/util/host-rules')>;
+  let hostRules: jest.Mocked<typeof _hostRules>;
   let GitStorage: jest.Mocked<
     typeof import('../../../lib/platform/git/storage')
   > &


### PR DESCRIPTION
All ts files have to have an import or export because of
`isolatedModules` flag.