### PR TITLE
feat: Add prcreation == approval

### DIFF
--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -883,7 +883,7 @@ const options = [
     name: 'prCreation',
     description: 'When to create the PR for a branch.',
     type: 'string',
-    allowedValues: ['immediate', 'not-pending', 'status-success'],
+    allowedValues: ['immediate', 'not-pending', 'status-success', 'approval'],
     default: 'immediate',
   },
   {

--- a/lib/workers/branch/index.js
+++ b/lib/workers/branch/index.js
@@ -363,6 +363,9 @@ async function processBranch(branchConfig, prHourlyLimitReached, packageFiles) {
     );
     const pr = await prWorker.ensurePr(config);
     // TODO: ensurePr should check for automerge itself
+    if (pr === 'needs-approval') {
+      return 'needs-pr-approval';
+    }
     if (pr) {
       const topic = ':warning: Artifact update problem';
       if (config.artifactErrors && config.artifactErrors.length) {

--- a/lib/workers/branch/index.js
+++ b/lib/workers/branch/index.js
@@ -363,7 +363,7 @@ async function processBranch(branchConfig, prHourlyLimitReached, packageFiles) {
     );
     const pr = await prWorker.ensurePr(config);
     // TODO: ensurePr should check for automerge itself
-    if (pr === 'needs-approval') {
+    if (pr === 'needs-pr-approval') {
       return 'needs-pr-approval';
     }
     if (pr) {

--- a/lib/workers/pr/index.js
+++ b/lib/workers/pr/index.js
@@ -82,7 +82,7 @@ async function ensurePr(prConfig) {
     !existingPr &&
     masterIssueCheck !== 'approvePr'
   ) {
-    return 'needs-approval';
+    return 'needs-pr-approval';
   } else if (
     config.prCreation === 'not-pending' &&
     !existingPr &&

--- a/lib/workers/pr/index.js
+++ b/lib/workers/pr/index.js
@@ -12,6 +12,7 @@ async function ensurePr(prConfig) {
   logger.trace({ config }, 'ensurePr');
   // If there is a group, it will use the config of the first upgrade in the array
   const { branchName, prTitle, upgrades } = config;
+  const masterIssueCheck = (config.masterIssueChecks || {})[config.branchName];
   // Check if existing PR exists
   const existingPr = await platform.getBranchPr(branchName);
   if (existingPr) {
@@ -76,6 +77,12 @@ async function ensurePr(prConfig) {
       return null;
     }
     logger.debug('Branch status success');
+  } else if (
+    config.prCreation === 'approval' &&
+    !existingPr &&
+    !(masterIssueCheck === 'approvePr')
+  ) {
+    return 'needs-approval';
   } else if (
     config.prCreation === 'not-pending' &&
     !existingPr &&

--- a/lib/workers/pr/index.js
+++ b/lib/workers/pr/index.js
@@ -80,7 +80,7 @@ async function ensurePr(prConfig) {
   } else if (
     config.prCreation === 'approval' &&
     !existingPr &&
-    !(masterIssueCheck === 'approvePr')
+    masterIssueCheck !== 'approvePr'
   ) {
     return 'needs-approval';
   } else if (

--- a/lib/workers/repository/master-issue.js
+++ b/lib/workers/repository/master-issue.js
@@ -23,7 +23,12 @@ function getListItem(branch, type, pr) {
 
 async function ensureMasterIssue(config, branches) {
   if (
-    !(config.masterIssue || branches.some(branch => branch.masterIssueApproval))
+    !(
+      config.masterIssue ||
+      branches.some(
+        branch => branch.masterIssueApproval || branch.masterIssuePrApproval
+      )
+    )
   ) {
     return;
   }

--- a/lib/workers/repository/master-issue.js
+++ b/lib/workers/repository/master-issue.js
@@ -115,6 +115,7 @@ async function ensureMasterIssue(config, branches) {
   }
   const otherRes = [
     'needs-approval',
+    'needs-pr-approval',
     'not-scheduled',
     'pr-hourly-limit-reached',
     'already-existed',

--- a/lib/workers/repository/master-issue.js
+++ b/lib/workers/repository/master-issue.js
@@ -108,6 +108,18 @@ async function ensureMasterIssue(config, branches) {
     }
     issueBody += '\n';
   }
+  const awaitingPr = branches.filter(
+    branch => branch.res === 'needs-pr-approval'
+  );
+  if (awaitingPr.length) {
+    issueBody += '## PR Creation Approval Required\n\n';
+    issueBody +=
+      "These branches exist but PRs won't be created until you tick the checkbox.\n\n";
+    for (const branch of awaitingPr) {
+      issueBody += getListItem(branch, 'approvePr');
+    }
+    issueBody += '\n';
+  }
   const prEdited = branches.filter(branch => branch.res === 'pr-edited');
   if (prEdited.length) {
     issueBody += '## Edited/Blocked\n\n';
@@ -160,18 +172,6 @@ async function ensureMasterIssue(config, branches) {
         '!open'
       );
       issueBody += getListItem(branch, 'recreate', pr);
-    }
-    issueBody += '\n';
-  }
-  const awaitingPr = branches.filter(
-    branch => branch.res === 'needs-pr-approval'
-  );
-  if (awaitingPr.length) {
-    issueBody += '## PR approvals\n\n';
-    issueBody +=
-      'These branches haves been created and will create a PR only if you click a checkBox below \n\n';
-    for (const branch of awaitingPr) {
-      issueBody += getListItem(branch, 'approvePr');
     }
     issueBody += '\n';
   }

--- a/lib/workers/repository/master-issue.js
+++ b/lib/workers/repository/master-issue.js
@@ -61,7 +61,7 @@ async function ensureMasterIssue(config, branches) {
   );
   if (pendingApprovals.length) {
     issueBody += '## Pending Approval\n\n';
-    issueBody += `These PRs will be created by ${appName} only once you click their checkbox below.\n\n`;
+    issueBody += `These branches will be created by ${appName} only once you click their checkbox below.\n\n`;
     for (const branch of pendingApprovals) {
       issueBody += getListItem(branch, 'approve');
     }
@@ -154,6 +154,18 @@ async function ensureMasterIssue(config, branches) {
         '!open'
       );
       issueBody += getListItem(branch, 'recreate', pr);
+    }
+    issueBody += '\n';
+  }
+  const awaitingPr = branches.filter(
+    branch => branch.res === 'needs-pr-approval'
+  );
+  if (awaitingPr.length) {
+    issueBody += '## PR approvals\n\n';
+    issueBody +=
+      'These branches haves been created and will create a PR only if you click a checkBox below \n\n';
+    for (const branch of awaitingPr) {
+      issueBody += getListItem(branch, 'approvePr');
     }
     issueBody += '\n';
   }

--- a/lib/workers/repository/process/index.js
+++ b/lib/workers/repository/process/index.js
@@ -14,8 +14,11 @@ async function processRepo(config) {
   if (
     config.masterIssue ||
     config.masterIssueApproval ||
+    config.prCreation === 'approval' ||
     (config.packageRules &&
-      config.packageRules.some(rule => rule.masterIssueApproval))
+      config.packageRules.some(
+        rule => rule.masterIssueApproval || rule.prCreation === 'approval'
+      ))
   ) {
     config.masterIssueTitle =
       config.masterIssueTitle || `Update Dependencies (${appName} Bot)`;

--- a/lib/workers/repository/process/index.js
+++ b/lib/workers/repository/process/index.js
@@ -21,7 +21,7 @@ async function processRepo(config) {
       config.masterIssueTitle || `Update Dependencies (${appName} Bot)`;
     const issue = await platform.findIssue(config.masterIssueTitle);
     if (issue) {
-      const checkMatch = ' - \\[x\\] <!-- ([a-z]+)-branch=([^\\s]+) -->';
+      const checkMatch = ' - \\[x\\] <!-- ([a-zA-Z]+)-branch=([^\\s]+) -->';
       const checked = issue.body.match(new RegExp(checkMatch, 'g'));
       if (checked && checked.length) {
         checked.forEach(check => {

--- a/lib/workers/repository/updates/generate.js
+++ b/lib/workers/repository/updates/generate.js
@@ -265,6 +265,9 @@ function generateBranchConfig(branchUpgrades) {
   config.masterIssueApproval = config.upgrades.some(
     upgrade => upgrade.masterIssueApproval
   );
+  config.masterIssuePrApproval = config.upgrades.some(
+    upgrade => upgrade.prCreation === 'approval'
+  );
   config.automerge = config.upgrades.every(upgrade => upgrade.automerge);
   config.blockedByPin = config.upgrades.every(upgrade => upgrade.blockedByPin);
   const tableRows = config.upgrades

--- a/renovate-schema.json
+++ b/renovate-schema.json
@@ -579,7 +579,7 @@
     "prCreation": {
       "description": "When to create the PR for a branch.",
       "type": "string",
-      "enum": ["immediate", "not-pending", "status-success"],
+      "enum": ["immediate", "not-pending", "status-success", "approval"],
       "default": "immediate"
     },
     "prNotPendingHours": {

--- a/test/workers/branch/index.spec.js
+++ b/test/workers/branch/index.spec.js
@@ -188,6 +188,21 @@ describe('workers/branch', () => {
       expect(automerge.tryBranchAutomerge).toHaveBeenCalledTimes(1);
       expect(prWorker.ensurePr).toHaveBeenCalledTimes(0);
     });
+    it('returns if branch exists and prCreation set to approval', async () => {
+      getUpdated.getUpdatedPackageFiles.mockReturnValueOnce({
+        updatedPackageFiles: [{}],
+      });
+      npmPostExtract.getAdditionalFiles.mockReturnValueOnce({
+        artifactErrors: [],
+        updatedArtifacts: [{}],
+      });
+      platform.branchExists.mockReturnValueOnce(true);
+      automerge.tryBranchAutomerge.mockReturnValueOnce('failed');
+      prWorker.ensurePr.mockReturnValueOnce('needs-approval');
+      expect(await branchWorker.processBranch(config)).toEqual(
+        'needs-pr-approval'
+      );
+    });
     it('ensures PR and tries automerge', async () => {
       getUpdated.getUpdatedPackageFiles.mockReturnValueOnce({
         updatedPackageFiles: [{}],

--- a/test/workers/branch/index.spec.js
+++ b/test/workers/branch/index.spec.js
@@ -198,7 +198,7 @@ describe('workers/branch', () => {
       });
       platform.branchExists.mockReturnValueOnce(true);
       automerge.tryBranchAutomerge.mockReturnValueOnce('failed');
-      prWorker.ensurePr.mockReturnValueOnce('needs-approval');
+      prWorker.ensurePr.mockReturnValueOnce('needs-pr-approval');
       expect(await branchWorker.processBranch(config)).toEqual(
         'needs-pr-approval'
       );

--- a/test/workers/pr/index.spec.js
+++ b/test/workers/pr/index.spec.js
@@ -150,7 +150,7 @@ describe('workers/pr', () => {
       platform.getBranchStatus.mockReturnValueOnce('success');
       config.prCreation = 'approval';
       const pr = await prWorker.ensurePr(config);
-      expect(pr).toBe('needs-approval');
+      expect(pr).toBe('needs-pr-approval');
     });
     it('should create PR if success', async () => {
       platform.getBranchStatus.mockReturnValueOnce('success');

--- a/test/workers/pr/index.spec.js
+++ b/test/workers/pr/index.spec.js
@@ -146,6 +146,12 @@ describe('workers/pr', () => {
       const pr = await prWorker.ensurePr(config);
       expect(pr).toBeNull();
     });
+    it('should return needs-approval if prCreation set to approval', async () => {
+      platform.getBranchStatus.mockReturnValueOnce('success');
+      config.prCreation = 'approval';
+      const pr = await prWorker.ensurePr(config);
+      expect(pr).toBe('needs-approval');
+    });
     it('should create PR if success', async () => {
       platform.getBranchStatus.mockReturnValueOnce('success');
       config.prCreation = 'status-success';

--- a/test/workers/repository/_fixtures/master-issue_with_3_PR_in_approval.txt
+++ b/test/workers/repository/_fixtures/master-issue_with_3_PR_in_approval.txt
@@ -1,0 +1,10 @@
+This [master issue](https://renovatebot.com/blog/master-issue) contains a list of Renovate updates and their statuses.
+
+## PR Creation Approval Required
+
+These branches exist but PRs won't be created until you tick the checkbox.
+
+ - [ ] <!-- approvePr-branch=branchName1 -->pr1
+ - [ ] <!-- approvePr-branch=branchName2 -->pr2 (`dep2`, `dep3`)
+ - [ ] <!-- approvePr-branch=branchName3 -->pr3
+

--- a/test/workers/repository/_fixtures/master-issue_with_8_PR.txt
+++ b/test/workers/repository/_fixtures/master-issue_with_8_PR.txt
@@ -2,7 +2,7 @@ This [master issue](https://renovatebot.com/blog/master-issue) contains a list o
 
 ## Pending Approval
 
-These PRs will be created by Renovate only once you click their checkbox below.
+These branches will be created by Renovate only once you click their checkbox below.
 
  - [ ] <!-- approve-branch=branchName1 -->pr1
  - [ ] <!-- approve-branch=branchName2 -->pr2

--- a/test/workers/repository/master-issue.spec.js
+++ b/test/workers/repository/master-issue.spec.js
@@ -326,5 +326,46 @@ describe('workers/repository/master-issue', () => {
       // same with dry run
       await dryRun(branches, platform, 0, 0, 0, 2);
     });
+
+    it('checks an issue with 3 PR in approval', async () => {
+      const branches = [
+        {
+          prTitle: 'pr1',
+          upgrades: [{ depName: 'dep1' }],
+          res: 'needs-pr-approval',
+          branchName: 'branchName1',
+        },
+        {
+          prTitle: 'pr2',
+          upgrades: [{ depName: 'dep2' }, { depName: 'dep3' }],
+          res: 'needs-pr-approval',
+          branchName: 'branchName2',
+        },
+        {
+          prTitle: 'pr3',
+          upgrades: [{ depName: 'dep3' }],
+          res: 'needs-pr-approval',
+          branchName: 'branchName3',
+        },
+      ];
+      config.masterIssue = true;
+      config.masterIssuePrApproval = true;
+      await masterIssue.ensureMasterIssue(config, branches);
+      expect(platform.ensureIssueClosing).toHaveBeenCalledTimes(0);
+      expect(platform.ensureIssue).toHaveBeenCalledTimes(1);
+      expect(platform.ensureIssue.mock.calls[0][0]).toBe(
+        config.masterIssueTitle
+      );
+      expect(platform.ensureIssue.mock.calls[0][1]).toBe(
+        fs.readFileSync(
+          'test/workers/repository/_fixtures/master-issue_with_3_PR_in_approval.txt',
+          'utf8'
+        )
+      );
+      expect(platform.findPr).toHaveBeenCalledTimes(0);
+
+      // same with dry run
+      await dryRun(branches, platform);
+    });
   });
 });

--- a/test/workers/repository/updates/__snapshots__/generate.spec.js.snap
+++ b/test/workers/repository/updates/__snapshots__/generate.spec.js.snap
@@ -18,6 +18,7 @@ Object {
   "displayFrom": "",
   "displayTo": "0.6.0",
   "masterIssueApproval": false,
+  "masterIssuePrApproval": false,
   "newValue": "0.6.0",
   "prTitle": "some-title",
   "prettyDepType": "dependency",


### PR DESCRIPTION
* In pr worker checking for ` config.prCreation === 'approval' && !existingPr && masterIssueCheck !== 'approvePr'` and if true, flagging the branch.
* After this masterIssueApproval flag will create list of branches that have not been created yet while prCreation== approval will create list of branches which have been created but not raised a PR.

Closes #3928 
