### PR TITLE
feat(bitbucket-server): fetch only own pr's

### DIFF
--- a/lib/platform/bitbucket-server/index.ts
+++ b/lib/platform/bitbucket-server/index.ts
@@ -20,6 +20,8 @@ interface BbsConfig {
   storage: GitStorage;
 
   prVersions: Map<number, number>;
+
+  username: string;
 }
 
 let config: BbsConfig = {} as any;
@@ -115,6 +117,7 @@ export async function initRepo({
     gitPrivateKey,
     repository,
     prVersions: new Map<number, number>(),
+    username: opts!.username,
   } as any;
 
   /* istanbul ignore else */
@@ -623,8 +626,13 @@ export async function getPrList(_args?: any) {
   logger.debug(`getPrList()`);
   // istanbul ignore next
   if (!config.prList) {
+    const query = new URLSearchParams({
+      state: 'ALL',
+      'role.1': 'AUTHOR',
+      'username.1': config.username,
+    }).toString();
     const values = await utils.accumulateValues(
-      `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests?state=ALL&limit=100`
+      `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests?${query}`
     );
 
     config.prList = values.map(utils.prInfo);

--- a/test/platform/bitbucket-server/__snapshots__/index.spec.ts.snap
+++ b/test/platform/bitbucket-server/__snapshots__/index.spec.ts.snap
@@ -259,7 +259,7 @@ Array [
     "./rest/api/1.0/projects/SOME/repos/repo/branches/default",
   ],
   Array [
-    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests?state=ALL&limit=100",
+    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests?state=ALL&role.1=AUTHOR&username.1=abc&limit=100",
     undefined,
   ],
 ]
@@ -490,7 +490,7 @@ Array [
     "./rest/api/1.0/projects/SOME/repos/repo/branches/default",
   ],
   Array [
-    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests?state=ALL&limit=100",
+    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests?state=ALL&role.1=AUTHOR&username.1=abc&limit=100",
     undefined,
   ],
 ]
@@ -519,7 +519,7 @@ Array [
     "./rest/api/1.0/projects/SOME/repos/repo/branches/default",
   ],
   Array [
-    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests?state=ALL&limit=100",
+    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests?state=ALL&role.1=AUTHOR&username.1=abc&limit=100",
     undefined,
   ],
 ]
@@ -534,7 +534,7 @@ Array [
     "./rest/api/1.0/projects/SOME/repos/repo/branches/default",
   ],
   Array [
-    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests?state=ALL&limit=100",
+    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests?state=ALL&role.1=AUTHOR&username.1=abc&limit=100",
     undefined,
   ],
 ]
@@ -570,7 +570,7 @@ Array [
     "./rest/api/1.0/projects/SOME/repos/repo/branches/default",
   ],
   Array [
-    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests?state=ALL&limit=100",
+    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests?state=ALL&role.1=AUTHOR&username.1=abc&limit=100",
     undefined,
   ],
   Array [
@@ -961,7 +961,7 @@ Array [
     "./rest/api/1.0/projects/SOME/repos/repo/branches/default",
   ],
   Array [
-    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests?state=ALL&limit=100",
+    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests?state=ALL&role.1=AUTHOR&username.1=abc&limit=100",
     undefined,
   ],
 ]
@@ -1713,7 +1713,7 @@ Array [
     "./rest/api/1.0/projects/SOME/repos/repo/branches/default",
   ],
   Array [
-    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests?state=ALL&limit=100",
+    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests?state=ALL&role.1=AUTHOR&username.1=abc&limit=100",
     undefined,
   ],
 ]
@@ -1944,7 +1944,7 @@ Array [
     "./rest/api/1.0/projects/SOME/repos/repo/branches/default",
   ],
   Array [
-    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests?state=ALL&limit=100",
+    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests?state=ALL&role.1=AUTHOR&username.1=abc&limit=100",
     undefined,
   ],
 ]
@@ -1973,7 +1973,7 @@ Array [
     "./rest/api/1.0/projects/SOME/repos/repo/branches/default",
   ],
   Array [
-    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests?state=ALL&limit=100",
+    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests?state=ALL&role.1=AUTHOR&username.1=abc&limit=100",
     undefined,
   ],
 ]
@@ -1988,7 +1988,7 @@ Array [
     "./rest/api/1.0/projects/SOME/repos/repo/branches/default",
   ],
   Array [
-    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests?state=ALL&limit=100",
+    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests?state=ALL&role.1=AUTHOR&username.1=abc&limit=100",
     undefined,
   ],
 ]
@@ -2024,7 +2024,7 @@ Array [
     "./rest/api/1.0/projects/SOME/repos/repo/branches/default",
   ],
   Array [
-    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests?state=ALL&limit=100",
+    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests?state=ALL&role.1=AUTHOR&username.1=abc&limit=100",
     undefined,
   ],
   Array [
@@ -2415,7 +2415,7 @@ Array [
     "./rest/api/1.0/projects/SOME/repos/repo/branches/default",
   ],
   Array [
-    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests?state=ALL&limit=100",
+    "./rest/api/1.0/projects/SOME/repos/repo/pull-requests?state=ALL&role.1=AUTHOR&username.1=abc&limit=100",
     undefined,
   ],
 ]

--- a/test/platform/bitbucket-server/_fixtures/responses.js
+++ b/test/platform/bitbucket-server/_fixtures/responses.js
@@ -154,7 +154,7 @@ function generateServerResponses(endpoint) {
     [`${endpoint}/rest/api/1.0/projects/SOME/repos/repo/pull-requests`]: {
       POST: generatePR(endpoint, 'SOME', 'repo'),
     },
-    [`${endpoint}/rest/api/1.0/projects/SOME/repos/repo/pull-requests?state=ALL&limit=100`]: {
+    [`${endpoint}/rest/api/1.0/projects/SOME/repos/repo/pull-requests?state=ALL&role.1=AUTHOR&username.1=abc&limit=100`]: {
       GET: {
         isLastPage: true,
         values: [generatePR(endpoint, 'SOME', 'repo')],


### PR DESCRIPTION
This pr add's a user filter to the `getPrList` request to only fetch the renovate pr's.

Not yet live tested. The earliest i can do it is tomorrow.