### PR TITLE
fix(gradle): Support extension without classifier

### DIFF
--- a/lib/manager/gradle/build-gradle.js
+++ b/lib/manager/gradle/build-gradle.js
@@ -156,7 +156,7 @@ function updatePropertyFileGlobalVariables(
 // https://github.com/patrikerdes/gradle-use-latest-versions-plugin/blob/8cf9c3917b8b04ba41038923cab270d2adda3aa6/src/main/groovy/se/patrikerdes/DependencyUpdate.groovy#L27-L29
 function moduleStringVersionFormatMatch(dependency) {
   return new RegExp(
-    `(["']${dependency.group}:${dependency.name}:)[^$].*?((:.*?)?["'])`
+    `(["']${dependency.group}:${dependency.name}:)[^$].*?(([:@].*?)?["'])`
   );
 }
 

--- a/test/manager/gradle/build-gradle.spec.js
+++ b/test/manager/gradle/build-gradle.spec.js
@@ -37,6 +37,23 @@ describe('lib/manager/gradle/updateGradleVersion', () => {
     );
   });
 
+  it('should returns a file updated with keeping an extension if the version is found', () => {
+    const gradleFile =
+      "runtime (  'com.crashlytics.sdk.android:crashlytics:2.8.0@aar'  )";
+    const updatedGradleFile = gradle.updateGradleVersion(
+      gradleFile,
+      {
+        group: 'com.crashlytics.sdk.android',
+        name: 'crashlytics',
+        version: '2.8.0',
+      },
+      '2.10.1'
+    );
+    expect(updatedGradleFile).toEqual(
+      "runtime (  'com.crashlytics.sdk.android:crashlytics:2.10.1@aar'  )"
+    );
+  });
+
   it('should returns a file updated with keeping a classifier and an extension if the version is found', () => {
     const gradleFile = "runtime (  'junit:junit:4.0:javadoc@jar'  )";
     const updatedGradleFile = gradle.updateGradleVersion(


### PR DESCRIPTION
This is a follow-up pull request for #3995. This now supports a form such as `com.crashlytics.sdk.android:crashlytics:2.8.0@aar`.