### PR TITLE
fix(worker): no config error on dryRun

### DIFF
--- a/lib/workers/repository/error-config.js
+++ b/lib/workers/repository/error-config.js
@@ -23,7 +23,11 @@ async function raiseConfigWarningIssue(config, error) {
     logger.info('Updating onboarding PR with config error notice');
     body = `## Action Required: Fix ${appName} Configuration\n\n${body}`;
     body += `\n\nOnce you have resolved this problem (in this onboarding branch), ${appName} will return to providing you with a preview of your repository's configuration.`;
-    await platform.updatePr(pr.number, onboardingPrTitle, body);
+    if (config.dryRun) {
+      logger.info('DRY-RUN: Would update PR #' + pr.number);
+    } else await platform.updatePr(pr.number, onboardingPrTitle, body);
+  } else if (config.dryRun) {
+    logger.info('DRY-RUN: Would ensure config error issue');
   } else {
     const res = await platform.ensureIssue(
       `Action Required: Fix ${appName} Configuration`,

--- a/test/workers/repository/error-config.spec.js
+++ b/test/workers/repository/error-config.spec.js
@@ -18,12 +18,34 @@ describe('workers/repository/error-config', () => {
       const res = await raiseConfigWarningIssue(config, error);
       expect(res).toBeUndefined();
     });
+    it('creates issues (dryRun)', async () => {
+      const error = new Error('config-validation');
+      error.configFile = 'package.json';
+      error.validationMessage = 'some-message';
+      platform.ensureIssue.mockReturnValue('created');
+      const res = await raiseConfigWarningIssue(
+        { ...config, dryRun: true },
+        error
+      );
+      expect(res).toBeUndefined();
+    });
     it('handles onboarding', async () => {
       const error = new Error('config-validation');
       error.configFile = 'package.json';
       error.validationMessage = 'some-message';
       platform.getBranchPr.mockReturnValueOnce({ number: 1, state: 'open' });
       const res = await raiseConfigWarningIssue(config, error);
+      expect(res).toBeUndefined();
+    });
+    it('handles onboarding (dryRun)', async () => {
+      const error = new Error('config-validation');
+      error.configFile = 'package.json';
+      error.validationMessage = 'some-message';
+      platform.getBranchPr.mockReturnValueOnce({ number: 1, state: 'open' });
+      const res = await raiseConfigWarningIssue(
+        { ...config, dryRun: true },
+        error
+      );
       expect(res).toBeUndefined();
     });
   });


### PR DESCRIPTION
Renovate should not raise config error issue / pr while on `dryRun`