### PR TITLE
feat(composer): Add support for custom git repositories

### DIFF
--- a/lib/manager/composer/extract.js
+++ b/lib/manager/composer/extract.js
@@ -5,6 +5,38 @@ const semverComposer = require('../../versioning/composer');
 
 export { extractPackageFile };
 
+/**
+ * Parse the repositories field from a composer.json
+ *
+ * Entries with type vcs or git will be added to repositories,
+ * other entries will be added to registryUrls
+ *
+ * @param repoJson
+ * @param repositories
+ * @param registryUrls
+ */
+function parseRepositories(repoJson, repositories, registryUrls) {
+  try {
+    Object.entries(repoJson).forEach(([key, repo]) => {
+      const name = is.array(repoJson) ? repo.name : key;
+      switch (repo.type) {
+        case 'vcs':
+        case 'git':
+          // eslint-disable-next-line no-param-reassign
+          repositories[name] = repo;
+          break;
+        default:
+          registryUrls.push(repo);
+      }
+    });
+  } catch (e) /* istanbul ignore next */ {
+    logger.info(
+      { repositories: repoJson },
+      'Error parsing composer.json repositories config'
+    );
+  }
+}
+
 async function extractPackageFile(content, fileName) {
   logger.trace(`composer.extractPackageFile(${fileName})`);
   let composerJson;
@@ -13,6 +45,33 @@ async function extractPackageFile(content, fileName) {
   } catch (err) {
     logger.info({ fileName }, 'Invalid JSON');
     return null;
+  }
+  const repositories = {};
+  const registryUrls = [];
+  const res = {};
+
+  // handle lockfile
+  const lockfilePath = fileName.replace(/\.json$/, '.lock');
+  const lockContents = await platform.getFile(lockfilePath);
+  let lockParsed;
+  if (lockContents) {
+    logger.debug({ packageFile: fileName }, 'Found composer lock file');
+    res.composerLock = lockfilePath;
+    try {
+      lockParsed = JSON.parse(lockContents);
+    } catch (err) /* istanbul ignore next */ {
+      logger.warn({ err }, 'Error processing composer.lock');
+    }
+  } else {
+    res.composerLock = false;
+  }
+
+  // handle composer.json repositories
+  if (composerJson.repositories) {
+    parseRepositories(composerJson.repositories, repositories, registryUrls);
+  }
+  if (registryUrls.length !== 0) {
+    res.registryUrls = registryUrls;
   }
   const deps = [];
   const depTypes = ['require', 'require-dev'];
@@ -23,11 +82,27 @@ async function extractPackageFile(content, fileName) {
           composerJson[depType]
         )) {
           const currentValue = version.trim();
+          // Default datasource and lookupName
+          let datasource = 'packagist';
+          let lookupName = depName;
+
+          // Check custom repositories by type
+          if (repositories[depName]) {
+            // eslint-disable-next-line default-case
+            switch (repositories[depName].type) {
+              case 'vcs':
+              case 'git':
+                datasource = 'gitTags';
+                lookupName = repositories[depName].url;
+                break;
+            }
+          }
           const dep = {
             depType,
             depName,
             currentValue,
-            datasource: 'packagist',
+            datasource,
+            lookupName,
           };
           if (!depName.includes('/')) {
             dep.skipReason = 'unsupported';
@@ -37,6 +112,14 @@ async function extractPackageFile(content, fileName) {
           }
           if (currentValue === '*') {
             dep.skipReason = 'any-version';
+          }
+          if (lockParsed) {
+            const lockedDep = lockParsed.packages.find(
+              item => item.name === dep.depName
+            );
+            if (lockedDep && semverComposer.isVersion(lockedDep.version)) {
+              dep.lockedVersion = lockedDep.version.replace(/^v/i, '');
+            }
           }
           deps.push(dep);
         }
@@ -49,48 +132,7 @@ async function extractPackageFile(content, fileName) {
   if (!deps.length) {
     return null;
   }
-  const res = { deps };
-  const filePath = fileName.replace(/\.json$/, '.lock');
-  const lockContents = await platform.getFile(filePath);
-  // istanbul ignore if
-  if (lockContents) {
-    logger.debug({ packageFile: fileName }, 'Found composer lock file');
-    res.composerLock = filePath;
-    try {
-      const lockParsed = JSON.parse(lockContents);
-      for (const dep of res.deps) {
-        const lockedDep = lockParsed.packages.find(
-          item => item.name === dep.depName
-        );
-        if (lockedDep && semverComposer.isVersion(lockedDep.version)) {
-          dep.lockedVersion = lockedDep.version.replace(/^v/i, '');
-        }
-      }
-    } catch (err) {
-      logger.warn({ err }, 'Error processing composer.lock');
-    }
-  } else {
-    res.composerLock = false;
-  }
-  if (composerJson.repositories) {
-    if (is.array(composerJson.repositories)) {
-      res.registryUrls = composerJson.repositories;
-    } else if (is.object(composerJson.repositories)) {
-      try {
-        res.registryUrls = [];
-        for (const repository of Object.values(composerJson.repositories)) {
-          res.registryUrls.push(repository);
-        }
-      } catch (err) /* istanbul ignore next */ {
-        logger.warn({ err }, 'Error extracting composer repositories');
-      }
-    } /* istanbul ignore next */ else {
-      logger.info(
-        { repositories: composerJson.repositories },
-        'Unknown composer repositories'
-      );
-    }
-  }
+  res.deps = deps;
   if (composerJson.type) {
     res.composerJsonType = composerJson.type;
   }

--- a/lib/manager/composer/extract.js
+++ b/lib/manager/composer/extract.js
@@ -102,8 +102,10 @@ async function extractPackageFile(content, fileName) {
             depName,
             currentValue,
             datasource,
-            lookupName,
           };
+          if (depName !== lookupName) {
+            dep.lookupName = lookupName;
+          }
           if (!depName.includes('/')) {
             dep.skipReason = 'unsupported';
           }

--- a/test/manager/composer/__snapshots__/extract.spec.js.snap
+++ b/test/manager/composer/__snapshots__/extract.spec.js.snap
@@ -9,6 +9,7 @@ Object {
       "datasource": "packagist",
       "depName": "php",
       "depType": "require",
+      "lookupName": "php",
       "skipReason": "unsupported",
     },
     Object {
@@ -16,6 +17,7 @@ Object {
       "datasource": "packagist",
       "depName": "symfony/assetic-bundle",
       "depType": "require",
+      "lookupName": "symfony/assetic-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -23,6 +25,7 @@ Object {
       "datasource": "packagist",
       "depName": "symfony/monolog-bundle",
       "depType": "require",
+      "lookupName": "symfony/monolog-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -30,6 +33,7 @@ Object {
       "datasource": "packagist",
       "depName": "symfony/swiftmailer-bundle",
       "depType": "require",
+      "lookupName": "symfony/swiftmailer-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -37,18 +41,21 @@ Object {
       "datasource": "packagist",
       "depName": "symfony/symfony",
       "depType": "require",
+      "lookupName": "symfony/symfony",
     },
     Object {
       "currentValue": "2.2.2",
       "datasource": "packagist",
       "depName": "doctrine/common",
       "depType": "require",
+      "lookupName": "doctrine/common",
     },
     Object {
       "currentValue": "dev-master",
       "datasource": "packagist",
       "depName": "doctrine/doctrine-bundle",
       "depType": "require",
+      "lookupName": "doctrine/doctrine-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -56,6 +63,7 @@ Object {
       "datasource": "packagist",
       "depName": "doctrine/doctrine-fixtures-bundle",
       "depType": "require",
+      "lookupName": "doctrine/doctrine-fixtures-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -63,12 +71,14 @@ Object {
       "datasource": "packagist",
       "depName": "doctrine/orm",
       "depType": "require",
+      "lookupName": "doctrine/orm",
     },
     Object {
       "currentValue": "dev-master",
       "datasource": "packagist",
       "depName": "exercise/elastica-bundle",
       "depType": "require",
+      "lookupName": "exercise/elastica-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -76,6 +86,7 @@ Object {
       "datasource": "packagist",
       "depName": "friendsofsymfony/rest-bundle",
       "depType": "require",
+      "lookupName": "friendsofsymfony/rest-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -83,6 +94,7 @@ Object {
       "datasource": "packagist",
       "depName": "friendsofsymfony/user-bundle",
       "depType": "require",
+      "lookupName": "friendsofsymfony/user-bundle",
       "skipReason": "any-version",
     },
     Object {
@@ -90,6 +102,7 @@ Object {
       "datasource": "packagist",
       "depName": "fzaninotto/faker",
       "depType": "require",
+      "lookupName": "fzaninotto/faker",
       "skipReason": "any-version",
     },
     Object {
@@ -97,12 +110,14 @@ Object {
       "datasource": "packagist",
       "depName": "jms/di-extra-bundle",
       "depType": "require",
+      "lookupName": "jms/di-extra-bundle",
     },
     Object {
       "currentValue": "*",
       "datasource": "packagist",
       "depName": "jms/payment-core-bundle",
       "depType": "require",
+      "lookupName": "jms/payment-core-bundle",
       "skipReason": "any-version",
     },
     Object {
@@ -110,12 +125,14 @@ Object {
       "datasource": "packagist",
       "depName": "jms/security-extra-bundle",
       "depType": "require",
+      "lookupName": "jms/security-extra-bundle",
     },
     Object {
       "currentValue": "dev-master",
       "datasource": "packagist",
       "depName": "knplabs/knp-menu-bundle",
       "depType": "require",
+      "lookupName": "knplabs/knp-menu-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -123,6 +140,7 @@ Object {
       "datasource": "packagist",
       "depName": "knplabs/knp-paginator-bundle",
       "depType": "require",
+      "lookupName": "knplabs/knp-paginator-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -130,6 +148,7 @@ Object {
       "datasource": "packagist",
       "depName": "liip/imagine-bundle",
       "depType": "require",
+      "lookupName": "liip/imagine-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -137,6 +156,7 @@ Object {
       "datasource": "packagist",
       "depName": "merk/dough-bundle",
       "depType": "require",
+      "lookupName": "merk/dough-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -144,6 +164,7 @@ Object {
       "datasource": "packagist",
       "depName": "sensio/distribution-bundle",
       "depType": "require",
+      "lookupName": "sensio/distribution-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -151,6 +172,7 @@ Object {
       "datasource": "packagist",
       "depName": "sensio/framework-extra-bundle",
       "depType": "require",
+      "lookupName": "sensio/framework-extra-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -158,6 +180,7 @@ Object {
       "datasource": "packagist",
       "depName": "sensio/generator-bundle",
       "depType": "require",
+      "lookupName": "sensio/generator-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -165,6 +188,7 @@ Object {
       "datasource": "packagist",
       "depName": "simplethings/entity-audit-bundle",
       "depType": "require",
+      "lookupName": "simplethings/entity-audit-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -172,6 +196,7 @@ Object {
       "datasource": "packagist",
       "depName": "stof/doctrine-extensions-bundle",
       "depType": "require",
+      "lookupName": "stof/doctrine-extensions-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -179,6 +204,7 @@ Object {
       "datasource": "packagist",
       "depName": "twig/extensions",
       "depType": "require",
+      "lookupName": "twig/extensions",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -186,12 +212,14 @@ Object {
       "datasource": "packagist",
       "depName": "behat/behat",
       "depType": "require-dev",
+      "lookupName": "behat/behat",
     },
     Object {
       "currentValue": "*",
       "datasource": "packagist",
       "depName": "behat/behat-bundle",
       "depType": "require-dev",
+      "lookupName": "behat/behat-bundle",
       "skipReason": "any-version",
     },
     Object {
@@ -199,6 +227,7 @@ Object {
       "datasource": "packagist",
       "depName": "behat/mink-bundle",
       "depType": "require-dev",
+      "lookupName": "behat/mink-bundle",
       "skipReason": "any-version",
     },
     Object {
@@ -206,6 +235,7 @@ Object {
       "datasource": "packagist",
       "depName": "behat/sahi-client",
       "depType": "require-dev",
+      "lookupName": "behat/sahi-client",
       "skipReason": "any-version",
     },
     Object {
@@ -213,6 +243,7 @@ Object {
       "datasource": "packagist",
       "depName": "behat/common-contexts",
       "depType": "require-dev",
+      "lookupName": "behat/common-contexts",
       "skipReason": "any-version",
     },
   ],
@@ -228,6 +259,7 @@ Object {
       "datasource": "packagist",
       "depName": "php",
       "depType": "require",
+      "lookupName": "php",
       "skipReason": "unsupported",
     },
     Object {
@@ -235,6 +267,7 @@ Object {
       "datasource": "packagist",
       "depName": "symfony/assetic-bundle",
       "depType": "require",
+      "lookupName": "symfony/assetic-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -242,6 +275,7 @@ Object {
       "datasource": "packagist",
       "depName": "symfony/monolog-bundle",
       "depType": "require",
+      "lookupName": "symfony/monolog-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -249,6 +283,7 @@ Object {
       "datasource": "packagist",
       "depName": "symfony/swiftmailer-bundle",
       "depType": "require",
+      "lookupName": "symfony/swiftmailer-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -256,18 +291,21 @@ Object {
       "datasource": "packagist",
       "depName": "symfony/symfony",
       "depType": "require",
+      "lookupName": "symfony/symfony",
     },
     Object {
       "currentValue": "2.2.2",
       "datasource": "packagist",
       "depName": "doctrine/common",
       "depType": "require",
+      "lookupName": "doctrine/common",
     },
     Object {
       "currentValue": "dev-master",
       "datasource": "packagist",
       "depName": "doctrine/doctrine-bundle",
       "depType": "require",
+      "lookupName": "doctrine/doctrine-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -275,6 +313,7 @@ Object {
       "datasource": "packagist",
       "depName": "doctrine/doctrine-fixtures-bundle",
       "depType": "require",
+      "lookupName": "doctrine/doctrine-fixtures-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -282,12 +321,14 @@ Object {
       "datasource": "packagist",
       "depName": "doctrine/orm",
       "depType": "require",
+      "lookupName": "doctrine/orm",
     },
     Object {
       "currentValue": "dev-master",
       "datasource": "packagist",
       "depName": "exercise/elastica-bundle",
       "depType": "require",
+      "lookupName": "exercise/elastica-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -295,6 +336,7 @@ Object {
       "datasource": "packagist",
       "depName": "friendsofsymfony/rest-bundle",
       "depType": "require",
+      "lookupName": "friendsofsymfony/rest-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -302,6 +344,7 @@ Object {
       "datasource": "packagist",
       "depName": "friendsofsymfony/user-bundle",
       "depType": "require",
+      "lookupName": "friendsofsymfony/user-bundle",
       "skipReason": "any-version",
     },
     Object {
@@ -309,6 +352,7 @@ Object {
       "datasource": "packagist",
       "depName": "fzaninotto/faker",
       "depType": "require",
+      "lookupName": "fzaninotto/faker",
       "skipReason": "any-version",
     },
     Object {
@@ -316,12 +360,14 @@ Object {
       "datasource": "packagist",
       "depName": "jms/di-extra-bundle",
       "depType": "require",
+      "lookupName": "jms/di-extra-bundle",
     },
     Object {
       "currentValue": "*",
       "datasource": "packagist",
       "depName": "jms/payment-core-bundle",
       "depType": "require",
+      "lookupName": "jms/payment-core-bundle",
       "skipReason": "any-version",
     },
     Object {
@@ -329,12 +375,14 @@ Object {
       "datasource": "packagist",
       "depName": "jms/security-extra-bundle",
       "depType": "require",
+      "lookupName": "jms/security-extra-bundle",
     },
     Object {
       "currentValue": "dev-master",
       "datasource": "packagist",
       "depName": "knplabs/knp-menu-bundle",
       "depType": "require",
+      "lookupName": "knplabs/knp-menu-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -342,6 +390,7 @@ Object {
       "datasource": "packagist",
       "depName": "knplabs/knp-paginator-bundle",
       "depType": "require",
+      "lookupName": "knplabs/knp-paginator-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -349,6 +398,7 @@ Object {
       "datasource": "packagist",
       "depName": "liip/imagine-bundle",
       "depType": "require",
+      "lookupName": "liip/imagine-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -356,6 +406,7 @@ Object {
       "datasource": "packagist",
       "depName": "merk/dough-bundle",
       "depType": "require",
+      "lookupName": "merk/dough-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -363,6 +414,7 @@ Object {
       "datasource": "packagist",
       "depName": "sensio/distribution-bundle",
       "depType": "require",
+      "lookupName": "sensio/distribution-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -370,6 +422,7 @@ Object {
       "datasource": "packagist",
       "depName": "sensio/framework-extra-bundle",
       "depType": "require",
+      "lookupName": "sensio/framework-extra-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -377,6 +430,7 @@ Object {
       "datasource": "packagist",
       "depName": "sensio/generator-bundle",
       "depType": "require",
+      "lookupName": "sensio/generator-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -384,6 +438,7 @@ Object {
       "datasource": "packagist",
       "depName": "simplethings/entity-audit-bundle",
       "depType": "require",
+      "lookupName": "simplethings/entity-audit-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -391,6 +446,7 @@ Object {
       "datasource": "packagist",
       "depName": "stof/doctrine-extensions-bundle",
       "depType": "require",
+      "lookupName": "stof/doctrine-extensions-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -398,6 +454,7 @@ Object {
       "datasource": "packagist",
       "depName": "twig/extensions",
       "depType": "require",
+      "lookupName": "twig/extensions",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -405,12 +462,14 @@ Object {
       "datasource": "packagist",
       "depName": "behat/behat",
       "depType": "require-dev",
+      "lookupName": "behat/behat",
     },
     Object {
       "currentValue": "*",
       "datasource": "packagist",
       "depName": "behat/behat-bundle",
       "depType": "require-dev",
+      "lookupName": "behat/behat-bundle",
       "skipReason": "any-version",
     },
     Object {
@@ -418,6 +477,7 @@ Object {
       "datasource": "packagist",
       "depName": "behat/mink-bundle",
       "depType": "require-dev",
+      "lookupName": "behat/mink-bundle",
       "skipReason": "any-version",
     },
     Object {
@@ -425,6 +485,7 @@ Object {
       "datasource": "packagist",
       "depName": "behat/sahi-client",
       "depType": "require-dev",
+      "lookupName": "behat/sahi-client",
       "skipReason": "any-version",
     },
     Object {
@@ -432,6 +493,7 @@ Object {
       "datasource": "packagist",
       "depName": "behat/common-contexts",
       "depType": "require-dev",
+      "lookupName": "behat/common-contexts",
       "skipReason": "any-version",
     },
   ],
@@ -448,6 +510,7 @@ Object {
       "datasource": "packagist",
       "depName": "php",
       "depType": "require",
+      "lookupName": "php",
       "skipReason": "unsupported",
     },
     Object {
@@ -455,12 +518,14 @@ Object {
       "datasource": "packagist",
       "depName": "composer/installers",
       "depType": "require",
+      "lookupName": "composer/installers",
     },
     Object {
       "currentValue": "*",
       "datasource": "packagist",
       "depName": "johnpbloch/wordpress",
       "depType": "require",
+      "lookupName": "johnpbloch/wordpress",
       "skipReason": "any-version",
     },
     Object {
@@ -468,18 +533,21 @@ Object {
       "datasource": "packagist",
       "depName": "vlucas/phpdotenv",
       "depType": "require",
+      "lookupName": "vlucas/phpdotenv",
     },
     Object {
       "currentValue": "^1.0",
       "datasource": "packagist",
       "depName": "oscarotero/env",
       "depType": "require",
+      "lookupName": "oscarotero/env",
     },
     Object {
       "currentValue": "*",
       "datasource": "packagist",
       "depName": "wpackagist-plugin/tinymce-advanced",
       "depType": "require",
+      "lookupName": "wpackagist-plugin/tinymce-advanced",
       "skipReason": "any-version",
     },
     Object {
@@ -487,6 +555,7 @@ Object {
       "datasource": "packagist",
       "depName": "wpackagist-plugin/acf-content-analysis-for-yoast-seo",
       "depType": "require",
+      "lookupName": "wpackagist-plugin/acf-content-analysis-for-yoast-seo",
       "skipReason": "any-version",
     },
     Object {
@@ -494,6 +563,7 @@ Object {
       "datasource": "packagist",
       "depName": "wpackagist-plugin/duplicate-post",
       "depType": "require",
+      "lookupName": "wpackagist-plugin/duplicate-post",
       "skipReason": "any-version",
     },
     Object {
@@ -501,6 +571,7 @@ Object {
       "datasource": "packagist",
       "depName": "wpackagist-plugin/simple-image-sizes",
       "depType": "require",
+      "lookupName": "wpackagist-plugin/simple-image-sizes",
       "skipReason": "any-version",
     },
     Object {
@@ -508,6 +579,7 @@ Object {
       "datasource": "packagist",
       "depName": "wpackagist-plugin/wordpress-seo",
       "depType": "require",
+      "lookupName": "wpackagist-plugin/wordpress-seo",
       "skipReason": "any-version",
     },
     Object {
@@ -515,6 +587,7 @@ Object {
       "datasource": "packagist",
       "depName": "wpackagist-plugin/timber-library",
       "depType": "require",
+      "lookupName": "wpackagist-plugin/timber-library",
       "skipReason": "any-version",
     },
     Object {
@@ -522,6 +595,7 @@ Object {
       "datasource": "packagist",
       "depName": "wp-sync-db/wp-sync-db",
       "depType": "require",
+      "lookupName": "wp-sync-db/wp-sync-db",
       "skipReason": "any-version",
     },
     Object {
@@ -529,6 +603,7 @@ Object {
       "datasource": "packagist",
       "depName": "asha23/wp-seed-timber",
       "depType": "require",
+      "lookupName": "asha23/wp-seed-timber",
       "skipReason": "any-version",
     },
   ],
@@ -565,6 +640,43 @@ Object {
 }
 `;
 
+exports[`lib/manager/composer/extract extractPackageFile() extracts object repositories and registryUrls 1`] = `
+Object {
+  "composerLock": false,
+  "deps": Array [
+    Object {
+      "currentValue": "*",
+      "datasource": "packagist",
+      "depName": "aws/aws-sdk-php",
+      "depType": "require",
+      "lookupName": "aws/aws-sdk-php",
+      "skipReason": "any-version",
+    },
+    Object {
+      "currentValue": "dev-trunk",
+      "datasource": "gitTags",
+      "depName": "awesome/vcs",
+      "depType": "require",
+      "lookupName": "https://my-vcs.example/my-vcs-repo",
+      "skipReason": "unsupported-constraint",
+    },
+    Object {
+      "currentValue": ">=7.0.2",
+      "datasource": "gitTags",
+      "depName": "awesome/git",
+      "depType": "require",
+      "lookupName": "git@my-git.example:my-git-repo",
+    },
+  ],
+  "registryUrls": Array [
+    Object {
+      "type": "composer",
+      "url": "https://wpackagist.org",
+    },
+  ],
+}
+`;
+
 exports[`lib/manager/composer/extract extractPackageFile() extracts registryUrls 1`] = `
 Object {
   "composerLock": false,
@@ -574,6 +686,7 @@ Object {
       "datasource": "packagist",
       "depName": "aws/aws-sdk-php",
       "depType": "require",
+      "lookupName": "aws/aws-sdk-php",
       "skipReason": "any-version",
     },
     Object {
@@ -581,6 +694,7 @@ Object {
       "datasource": "packagist",
       "depName": "wpackagist-plugin/akismet",
       "depType": "require",
+      "lookupName": "wpackagist-plugin/akismet",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -588,13 +702,52 @@ Object {
       "datasource": "packagist",
       "depName": "wpackagist-plugin/wordpress-seo",
       "depType": "require",
+      "lookupName": "wpackagist-plugin/wordpress-seo",
     },
     Object {
       "currentValue": "*",
       "datasource": "packagist",
       "depName": "wpackagist-theme/hueman",
       "depType": "require",
+      "lookupName": "wpackagist-theme/hueman",
       "skipReason": "any-version",
+    },
+  ],
+  "registryUrls": Array [
+    Object {
+      "type": "composer",
+      "url": "https://wpackagist.org",
+    },
+  ],
+}
+`;
+
+exports[`lib/manager/composer/extract extractPackageFile() extracts repositories and registryUrls 1`] = `
+Object {
+  "composerLock": false,
+  "deps": Array [
+    Object {
+      "currentValue": "*",
+      "datasource": "packagist",
+      "depName": "aws/aws-sdk-php",
+      "depType": "require",
+      "lookupName": "aws/aws-sdk-php",
+      "skipReason": "any-version",
+    },
+    Object {
+      "currentValue": "dev-trunk",
+      "datasource": "gitTags",
+      "depName": "awesome/vcs",
+      "depType": "require",
+      "lookupName": "https://my-vcs.example/my-vcs-repo",
+      "skipReason": "unsupported-constraint",
+    },
+    Object {
+      "currentValue": ">=7.0.2",
+      "datasource": "gitTags",
+      "depName": "awesome/git",
+      "depType": "require",
+      "lookupName": "https://my-git.example/my-git-repo",
     },
   ],
   "registryUrls": Array [

--- a/test/manager/composer/__snapshots__/extract.spec.js.snap
+++ b/test/manager/composer/__snapshots__/extract.spec.js.snap
@@ -9,7 +9,6 @@ Object {
       "datasource": "packagist",
       "depName": "php",
       "depType": "require",
-      "lookupName": "php",
       "skipReason": "unsupported",
     },
     Object {
@@ -17,7 +16,6 @@ Object {
       "datasource": "packagist",
       "depName": "symfony/assetic-bundle",
       "depType": "require",
-      "lookupName": "symfony/assetic-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -25,7 +23,6 @@ Object {
       "datasource": "packagist",
       "depName": "symfony/monolog-bundle",
       "depType": "require",
-      "lookupName": "symfony/monolog-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -33,7 +30,6 @@ Object {
       "datasource": "packagist",
       "depName": "symfony/swiftmailer-bundle",
       "depType": "require",
-      "lookupName": "symfony/swiftmailer-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -41,21 +37,18 @@ Object {
       "datasource": "packagist",
       "depName": "symfony/symfony",
       "depType": "require",
-      "lookupName": "symfony/symfony",
     },
     Object {
       "currentValue": "2.2.2",
       "datasource": "packagist",
       "depName": "doctrine/common",
       "depType": "require",
-      "lookupName": "doctrine/common",
     },
     Object {
       "currentValue": "dev-master",
       "datasource": "packagist",
       "depName": "doctrine/doctrine-bundle",
       "depType": "require",
-      "lookupName": "doctrine/doctrine-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -63,7 +56,6 @@ Object {
       "datasource": "packagist",
       "depName": "doctrine/doctrine-fixtures-bundle",
       "depType": "require",
-      "lookupName": "doctrine/doctrine-fixtures-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -71,14 +63,12 @@ Object {
       "datasource": "packagist",
       "depName": "doctrine/orm",
       "depType": "require",
-      "lookupName": "doctrine/orm",
     },
     Object {
       "currentValue": "dev-master",
       "datasource": "packagist",
       "depName": "exercise/elastica-bundle",
       "depType": "require",
-      "lookupName": "exercise/elastica-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -86,7 +76,6 @@ Object {
       "datasource": "packagist",
       "depName": "friendsofsymfony/rest-bundle",
       "depType": "require",
-      "lookupName": "friendsofsymfony/rest-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -94,7 +83,6 @@ Object {
       "datasource": "packagist",
       "depName": "friendsofsymfony/user-bundle",
       "depType": "require",
-      "lookupName": "friendsofsymfony/user-bundle",
       "skipReason": "any-version",
     },
     Object {
@@ -102,7 +90,6 @@ Object {
       "datasource": "packagist",
       "depName": "fzaninotto/faker",
       "depType": "require",
-      "lookupName": "fzaninotto/faker",
       "skipReason": "any-version",
     },
     Object {
@@ -110,14 +97,12 @@ Object {
       "datasource": "packagist",
       "depName": "jms/di-extra-bundle",
       "depType": "require",
-      "lookupName": "jms/di-extra-bundle",
     },
     Object {
       "currentValue": "*",
       "datasource": "packagist",
       "depName": "jms/payment-core-bundle",
       "depType": "require",
-      "lookupName": "jms/payment-core-bundle",
       "skipReason": "any-version",
     },
     Object {
@@ -125,14 +110,12 @@ Object {
       "datasource": "packagist",
       "depName": "jms/security-extra-bundle",
       "depType": "require",
-      "lookupName": "jms/security-extra-bundle",
     },
     Object {
       "currentValue": "dev-master",
       "datasource": "packagist",
       "depName": "knplabs/knp-menu-bundle",
       "depType": "require",
-      "lookupName": "knplabs/knp-menu-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -140,7 +123,6 @@ Object {
       "datasource": "packagist",
       "depName": "knplabs/knp-paginator-bundle",
       "depType": "require",
-      "lookupName": "knplabs/knp-paginator-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -148,7 +130,6 @@ Object {
       "datasource": "packagist",
       "depName": "liip/imagine-bundle",
       "depType": "require",
-      "lookupName": "liip/imagine-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -156,7 +137,6 @@ Object {
       "datasource": "packagist",
       "depName": "merk/dough-bundle",
       "depType": "require",
-      "lookupName": "merk/dough-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -164,7 +144,6 @@ Object {
       "datasource": "packagist",
       "depName": "sensio/distribution-bundle",
       "depType": "require",
-      "lookupName": "sensio/distribution-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -172,7 +151,6 @@ Object {
       "datasource": "packagist",
       "depName": "sensio/framework-extra-bundle",
       "depType": "require",
-      "lookupName": "sensio/framework-extra-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -180,7 +158,6 @@ Object {
       "datasource": "packagist",
       "depName": "sensio/generator-bundle",
       "depType": "require",
-      "lookupName": "sensio/generator-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -188,7 +165,6 @@ Object {
       "datasource": "packagist",
       "depName": "simplethings/entity-audit-bundle",
       "depType": "require",
-      "lookupName": "simplethings/entity-audit-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -196,7 +172,6 @@ Object {
       "datasource": "packagist",
       "depName": "stof/doctrine-extensions-bundle",
       "depType": "require",
-      "lookupName": "stof/doctrine-extensions-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -204,7 +179,6 @@ Object {
       "datasource": "packagist",
       "depName": "twig/extensions",
       "depType": "require",
-      "lookupName": "twig/extensions",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -212,14 +186,12 @@ Object {
       "datasource": "packagist",
       "depName": "behat/behat",
       "depType": "require-dev",
-      "lookupName": "behat/behat",
     },
     Object {
       "currentValue": "*",
       "datasource": "packagist",
       "depName": "behat/behat-bundle",
       "depType": "require-dev",
-      "lookupName": "behat/behat-bundle",
       "skipReason": "any-version",
     },
     Object {
@@ -227,7 +199,6 @@ Object {
       "datasource": "packagist",
       "depName": "behat/mink-bundle",
       "depType": "require-dev",
-      "lookupName": "behat/mink-bundle",
       "skipReason": "any-version",
     },
     Object {
@@ -235,7 +206,6 @@ Object {
       "datasource": "packagist",
       "depName": "behat/sahi-client",
       "depType": "require-dev",
-      "lookupName": "behat/sahi-client",
       "skipReason": "any-version",
     },
     Object {
@@ -243,7 +213,6 @@ Object {
       "datasource": "packagist",
       "depName": "behat/common-contexts",
       "depType": "require-dev",
-      "lookupName": "behat/common-contexts",
       "skipReason": "any-version",
     },
   ],
@@ -259,7 +228,6 @@ Object {
       "datasource": "packagist",
       "depName": "php",
       "depType": "require",
-      "lookupName": "php",
       "skipReason": "unsupported",
     },
     Object {
@@ -267,7 +235,6 @@ Object {
       "datasource": "packagist",
       "depName": "symfony/assetic-bundle",
       "depType": "require",
-      "lookupName": "symfony/assetic-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -275,7 +242,6 @@ Object {
       "datasource": "packagist",
       "depName": "symfony/monolog-bundle",
       "depType": "require",
-      "lookupName": "symfony/monolog-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -283,7 +249,6 @@ Object {
       "datasource": "packagist",
       "depName": "symfony/swiftmailer-bundle",
       "depType": "require",
-      "lookupName": "symfony/swiftmailer-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -291,21 +256,18 @@ Object {
       "datasource": "packagist",
       "depName": "symfony/symfony",
       "depType": "require",
-      "lookupName": "symfony/symfony",
     },
     Object {
       "currentValue": "2.2.2",
       "datasource": "packagist",
       "depName": "doctrine/common",
       "depType": "require",
-      "lookupName": "doctrine/common",
     },
     Object {
       "currentValue": "dev-master",
       "datasource": "packagist",
       "depName": "doctrine/doctrine-bundle",
       "depType": "require",
-      "lookupName": "doctrine/doctrine-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -313,7 +275,6 @@ Object {
       "datasource": "packagist",
       "depName": "doctrine/doctrine-fixtures-bundle",
       "depType": "require",
-      "lookupName": "doctrine/doctrine-fixtures-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -321,14 +282,12 @@ Object {
       "datasource": "packagist",
       "depName": "doctrine/orm",
       "depType": "require",
-      "lookupName": "doctrine/orm",
     },
     Object {
       "currentValue": "dev-master",
       "datasource": "packagist",
       "depName": "exercise/elastica-bundle",
       "depType": "require",
-      "lookupName": "exercise/elastica-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -336,7 +295,6 @@ Object {
       "datasource": "packagist",
       "depName": "friendsofsymfony/rest-bundle",
       "depType": "require",
-      "lookupName": "friendsofsymfony/rest-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -344,7 +302,6 @@ Object {
       "datasource": "packagist",
       "depName": "friendsofsymfony/user-bundle",
       "depType": "require",
-      "lookupName": "friendsofsymfony/user-bundle",
       "skipReason": "any-version",
     },
     Object {
@@ -352,7 +309,6 @@ Object {
       "datasource": "packagist",
       "depName": "fzaninotto/faker",
       "depType": "require",
-      "lookupName": "fzaninotto/faker",
       "skipReason": "any-version",
     },
     Object {
@@ -360,14 +316,12 @@ Object {
       "datasource": "packagist",
       "depName": "jms/di-extra-bundle",
       "depType": "require",
-      "lookupName": "jms/di-extra-bundle",
     },
     Object {
       "currentValue": "*",
       "datasource": "packagist",
       "depName": "jms/payment-core-bundle",
       "depType": "require",
-      "lookupName": "jms/payment-core-bundle",
       "skipReason": "any-version",
     },
     Object {
@@ -375,14 +329,12 @@ Object {
       "datasource": "packagist",
       "depName": "jms/security-extra-bundle",
       "depType": "require",
-      "lookupName": "jms/security-extra-bundle",
     },
     Object {
       "currentValue": "dev-master",
       "datasource": "packagist",
       "depName": "knplabs/knp-menu-bundle",
       "depType": "require",
-      "lookupName": "knplabs/knp-menu-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -390,7 +342,6 @@ Object {
       "datasource": "packagist",
       "depName": "knplabs/knp-paginator-bundle",
       "depType": "require",
-      "lookupName": "knplabs/knp-paginator-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -398,7 +349,6 @@ Object {
       "datasource": "packagist",
       "depName": "liip/imagine-bundle",
       "depType": "require",
-      "lookupName": "liip/imagine-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -406,7 +356,6 @@ Object {
       "datasource": "packagist",
       "depName": "merk/dough-bundle",
       "depType": "require",
-      "lookupName": "merk/dough-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -414,7 +363,6 @@ Object {
       "datasource": "packagist",
       "depName": "sensio/distribution-bundle",
       "depType": "require",
-      "lookupName": "sensio/distribution-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -422,7 +370,6 @@ Object {
       "datasource": "packagist",
       "depName": "sensio/framework-extra-bundle",
       "depType": "require",
-      "lookupName": "sensio/framework-extra-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -430,7 +377,6 @@ Object {
       "datasource": "packagist",
       "depName": "sensio/generator-bundle",
       "depType": "require",
-      "lookupName": "sensio/generator-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -438,7 +384,6 @@ Object {
       "datasource": "packagist",
       "depName": "simplethings/entity-audit-bundle",
       "depType": "require",
-      "lookupName": "simplethings/entity-audit-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -446,7 +391,6 @@ Object {
       "datasource": "packagist",
       "depName": "stof/doctrine-extensions-bundle",
       "depType": "require",
-      "lookupName": "stof/doctrine-extensions-bundle",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -454,7 +398,6 @@ Object {
       "datasource": "packagist",
       "depName": "twig/extensions",
       "depType": "require",
-      "lookupName": "twig/extensions",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -462,14 +405,12 @@ Object {
       "datasource": "packagist",
       "depName": "behat/behat",
       "depType": "require-dev",
-      "lookupName": "behat/behat",
     },
     Object {
       "currentValue": "*",
       "datasource": "packagist",
       "depName": "behat/behat-bundle",
       "depType": "require-dev",
-      "lookupName": "behat/behat-bundle",
       "skipReason": "any-version",
     },
     Object {
@@ -477,7 +418,6 @@ Object {
       "datasource": "packagist",
       "depName": "behat/mink-bundle",
       "depType": "require-dev",
-      "lookupName": "behat/mink-bundle",
       "skipReason": "any-version",
     },
     Object {
@@ -485,7 +425,6 @@ Object {
       "datasource": "packagist",
       "depName": "behat/sahi-client",
       "depType": "require-dev",
-      "lookupName": "behat/sahi-client",
       "skipReason": "any-version",
     },
     Object {
@@ -493,7 +432,6 @@ Object {
       "datasource": "packagist",
       "depName": "behat/common-contexts",
       "depType": "require-dev",
-      "lookupName": "behat/common-contexts",
       "skipReason": "any-version",
     },
   ],
@@ -510,7 +448,6 @@ Object {
       "datasource": "packagist",
       "depName": "php",
       "depType": "require",
-      "lookupName": "php",
       "skipReason": "unsupported",
     },
     Object {
@@ -518,14 +455,12 @@ Object {
       "datasource": "packagist",
       "depName": "composer/installers",
       "depType": "require",
-      "lookupName": "composer/installers",
     },
     Object {
       "currentValue": "*",
       "datasource": "packagist",
       "depName": "johnpbloch/wordpress",
       "depType": "require",
-      "lookupName": "johnpbloch/wordpress",
       "skipReason": "any-version",
     },
     Object {
@@ -533,21 +468,18 @@ Object {
       "datasource": "packagist",
       "depName": "vlucas/phpdotenv",
       "depType": "require",
-      "lookupName": "vlucas/phpdotenv",
     },
     Object {
       "currentValue": "^1.0",
       "datasource": "packagist",
       "depName": "oscarotero/env",
       "depType": "require",
-      "lookupName": "oscarotero/env",
     },
     Object {
       "currentValue": "*",
       "datasource": "packagist",
       "depName": "wpackagist-plugin/tinymce-advanced",
       "depType": "require",
-      "lookupName": "wpackagist-plugin/tinymce-advanced",
       "skipReason": "any-version",
     },
     Object {
@@ -555,7 +487,6 @@ Object {
       "datasource": "packagist",
       "depName": "wpackagist-plugin/acf-content-analysis-for-yoast-seo",
       "depType": "require",
-      "lookupName": "wpackagist-plugin/acf-content-analysis-for-yoast-seo",
       "skipReason": "any-version",
     },
     Object {
@@ -563,7 +494,6 @@ Object {
       "datasource": "packagist",
       "depName": "wpackagist-plugin/duplicate-post",
       "depType": "require",
-      "lookupName": "wpackagist-plugin/duplicate-post",
       "skipReason": "any-version",
     },
     Object {
@@ -571,7 +501,6 @@ Object {
       "datasource": "packagist",
       "depName": "wpackagist-plugin/simple-image-sizes",
       "depType": "require",
-      "lookupName": "wpackagist-plugin/simple-image-sizes",
       "skipReason": "any-version",
     },
     Object {
@@ -579,7 +508,6 @@ Object {
       "datasource": "packagist",
       "depName": "wpackagist-plugin/wordpress-seo",
       "depType": "require",
-      "lookupName": "wpackagist-plugin/wordpress-seo",
       "skipReason": "any-version",
     },
     Object {
@@ -587,7 +515,6 @@ Object {
       "datasource": "packagist",
       "depName": "wpackagist-plugin/timber-library",
       "depType": "require",
-      "lookupName": "wpackagist-plugin/timber-library",
       "skipReason": "any-version",
     },
     Object {
@@ -595,7 +522,6 @@ Object {
       "datasource": "packagist",
       "depName": "wp-sync-db/wp-sync-db",
       "depType": "require",
-      "lookupName": "wp-sync-db/wp-sync-db",
       "skipReason": "any-version",
     },
     Object {
@@ -603,7 +529,6 @@ Object {
       "datasource": "packagist",
       "depName": "asha23/wp-seed-timber",
       "depType": "require",
-      "lookupName": "asha23/wp-seed-timber",
       "skipReason": "any-version",
     },
   ],
@@ -649,7 +574,6 @@ Object {
       "datasource": "packagist",
       "depName": "aws/aws-sdk-php",
       "depType": "require",
-      "lookupName": "aws/aws-sdk-php",
       "skipReason": "any-version",
     },
     Object {
@@ -688,7 +612,6 @@ Object {
       "datasource": "packagist",
       "depName": "aws/aws-sdk-php",
       "depType": "require",
-      "lookupName": "aws/aws-sdk-php",
       "skipReason": "any-version",
     },
     Object {
@@ -696,7 +619,6 @@ Object {
       "datasource": "packagist",
       "depName": "wpackagist-plugin/akismet",
       "depType": "require",
-      "lookupName": "wpackagist-plugin/akismet",
       "skipReason": "unsupported-constraint",
     },
     Object {
@@ -704,14 +626,12 @@ Object {
       "datasource": "packagist",
       "depName": "wpackagist-plugin/wordpress-seo",
       "depType": "require",
-      "lookupName": "wpackagist-plugin/wordpress-seo",
     },
     Object {
       "currentValue": "*",
       "datasource": "packagist",
       "depName": "wpackagist-theme/hueman",
       "depType": "require",
-      "lookupName": "wpackagist-theme/hueman",
       "skipReason": "any-version",
     },
   ],
@@ -733,7 +653,6 @@ Object {
       "datasource": "packagist",
       "depName": "aws/aws-sdk-php",
       "depType": "require",
-      "lookupName": "aws/aws-sdk-php",
       "skipReason": "any-version",
     },
     Object {

--- a/test/manager/composer/__snapshots__/extract.spec.js.snap
+++ b/test/manager/composer/__snapshots__/extract.spec.js.snap
@@ -640,9 +640,9 @@ Object {
 }
 `;
 
-exports[`lib/manager/composer/extract extractPackageFile() extracts object repositories and registryUrls 1`] = `
+exports[`lib/manager/composer/extract extractPackageFile() extracts object repositories and registryUrls with lock file 1`] = `
 Object {
-  "composerLock": false,
+  "composerLock": "composer.lock",
   "deps": Array [
     Object {
       "currentValue": "*",
@@ -657,6 +657,7 @@ Object {
       "datasource": "gitTags",
       "depName": "awesome/vcs",
       "depType": "require",
+      "lockedVersion": "1.1.0",
       "lookupName": "https://my-vcs.example/my-vcs-repo",
       "skipReason": "unsupported-constraint",
     },
@@ -665,6 +666,7 @@ Object {
       "datasource": "gitTags",
       "depName": "awesome/git",
       "depType": "require",
+      "lockedVersion": "1.2.0",
       "lookupName": "git@my-git.example:my-git-repo",
     },
   ],

--- a/test/manager/composer/_fixtures/composer4.json
+++ b/test/manager/composer/_fixtures/composer4.json
@@ -1,0 +1,30 @@
+{
+  "name": "acme/git-sources",
+  "description": "Fetch Packages via git",
+  "repositories":[
+      {
+          "name": "awesome/vcs",
+          "type":"vcs",
+          "url":"https://my-vcs.example/my-vcs-repo"
+      },
+      {
+          "name": "awesome/git",
+          "type":"git",
+          "url":"https://my-git.example/my-git-repo"
+      },
+      {
+        "type": "composer",
+        "url": "https://wpackagist.org"
+      }
+  ],
+  "require": {
+      "aws/aws-sdk-php":"*",
+      "awesome/vcs":"dev-trunk",
+      "awesome/git":">=7.0.2"
+  },
+  "autoload": {
+      "psr-0": {
+          "Acme": "src/"
+      }
+  }
+}

--- a/test/manager/composer/_fixtures/composer5.json
+++ b/test/manager/composer/_fixtures/composer5.json
@@ -1,0 +1,28 @@
+{
+  "name": "acme/git-sources",
+  "description": "Fetch Packages via git",
+  "repositories":{
+    "awesome/vcs": {
+          "type":"vcs",
+          "url":"https://my-vcs.example/my-vcs-repo"
+      },
+    "awesome/git": {
+          "type":"git",
+          "url":"git@my-git.example:my-git-repo"
+      },
+      "wpackagist": {
+        "type": "composer",
+        "url": "https://wpackagist.org"
+      }
+  },
+  "require": {
+      "aws/aws-sdk-php":"*",
+      "awesome/vcs":"dev-trunk",
+      "awesome/git":">=7.0.2"
+  },
+  "autoload": {
+      "psr-0": {
+          "Acme": "src/"
+      }
+  }
+}

--- a/test/manager/composer/_fixtures/composer5.lock
+++ b/test/manager/composer/_fixtures/composer5.lock
@@ -1,0 +1,28 @@
+{
+  "_readme": [
+    "This file locks the dependencies of your project to a known state",
+    "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+    "This file is @generated automatically"
+  ],
+  "content-hash": "h34j5h3p3g4ug34u34543j5h34j53h5j",
+  "packages": [
+    {
+      "name": "awesome/vcs",
+      "version": "1.1.0",
+      "source": {
+        "type": "git",
+        "url": "https://my-vcs.example/my-vcs-repo",
+        "reference": "3j5b345j3b45j345j345h34j5h345j34h5j34h5j"
+      }
+    },
+    {
+      "name": "awesome/git",
+      "version": "1.2.0",
+      "source": {
+        "type": "git",
+        "url": "git@my-git.example/awesome.git",
+        "reference": "3j5b345j3b45j345j345h34j5h345j34h5j34h5j"
+      }
+    }
+  ]
+}

--- a/test/manager/composer/extract.spec.js
+++ b/test/manager/composer/extract.spec.js
@@ -24,6 +24,10 @@ const requirements5 = fs.readFileSync(
   'test/manager/composer/_fixtures/composer5.json',
   'utf8'
 );
+const requirements5Lock = fs.readFileSync(
+  'test/manager/composer/_fixtures/composer5.lock',
+  'utf8'
+);
 
 describe('lib/manager/composer/extract', () => {
   describe('extractPackageFile()', () => {
@@ -56,7 +60,8 @@ describe('lib/manager/composer/extract', () => {
       expect(res).toMatchSnapshot();
       expect(res.registryUrls).toHaveLength(1);
     });
-    it('extracts object repositories and registryUrls', async () => {
+    it('extracts object repositories and registryUrls with lock file', async () => {
+      platform.getFile.mockReturnValueOnce(requirements5Lock);
       const res = await extractPackageFile(requirements5, packageFile);
       expect(res).toMatchSnapshot();
       expect(res.registryUrls).toHaveLength(1);

--- a/test/manager/composer/extract.spec.js
+++ b/test/manager/composer/extract.spec.js
@@ -16,6 +16,14 @@ const requirements3 = fs.readFileSync(
   'test/manager/composer/_fixtures/composer3.json',
   'utf8'
 );
+const requirements4 = fs.readFileSync(
+  'test/manager/composer/_fixtures/composer4.json',
+  'utf8'
+);
+const requirements5 = fs.readFileSync(
+  'test/manager/composer/_fixtures/composer5.json',
+  'utf8'
+);
 
 describe('lib/manager/composer/extract', () => {
   describe('extractPackageFile()', () => {
@@ -42,6 +50,16 @@ describe('lib/manager/composer/extract', () => {
       const res = await extractPackageFile(requirements3, packageFile);
       expect(res).toMatchSnapshot();
       expect(res.registryUrls).toHaveLength(3);
+    });
+    it('extracts repositories and registryUrls', async () => {
+      const res = await extractPackageFile(requirements4, packageFile);
+      expect(res).toMatchSnapshot();
+      expect(res.registryUrls).toHaveLength(1);
+    });
+    it('extracts object repositories and registryUrls', async () => {
+      const res = await extractPackageFile(requirements5, packageFile);
+      expect(res).toMatchSnapshot();
+      expect(res.registryUrls).toHaveLength(1);
     });
     it('extracts dependencies with lock file', async () => {
       platform.getFile.mockReturnValueOnce('some content');


### PR DESCRIPTION
Due to massive changes and some refactoring, i decided to replace my previous PR #4019 with a new one.

This PR adds support for custom git repositories for the composer manager.

The composer.json repositories field will now use git-tags datasource for types vcs and git.

scrapped: <strike>Additionally, repositories can be injected via config. This is a workaround to composer plugins being able to inject repositories using `$composer->getRepositoryManager()->addRepository($repository)`. This is the only way i found to inject custom datasources into `extract.js`</strike>

Also, this pr adds some restructuring to get rid of duplicate code
Replaces #4019 
Closes #3811 
