### PR TITLE
docs: Fix kubernetes manifest example

### DIFF
--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -71,6 +71,7 @@ spec:
                   valueFrom:
                     secretKeyRef:
                       key: github-token
+                      name: renovate-env
                 - name: RENOVATE_AUTODISCOVER
                   valueFrom:
                     secretKeyRef:


### PR DESCRIPTION
Add a missing section **name** in the k8s manifest example to self-hosting.