### PR TITLE
feat(gradle): Add basic Gradle Kotlin DSL support

### DIFF
--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -1644,7 +1644,11 @@ const options = [
     stage: 'package',
     type: 'object',
     default: {
-      fileMatch: ['\\.gradle$', '(^|/)gradle.properties$'],
+      fileMatch: [
+        '\\.gradle(\\.kts)?$',
+        '(^|/)gradle.properties$',
+        '(^|/)buildSrc/.*',
+      ],
       timeout: 300,
       versionScheme: 'maven',
     },

--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -1644,11 +1644,7 @@ const options = [
     stage: 'package',
     type: 'object',
     default: {
-      fileMatch: [
-        '\\.gradle(\\.kts)?$',
-        '(^|/)gradle.properties$',
-        '(^|/)buildSrc/.*',
-      ],
+      fileMatch: ['\\.gradle(\\.kts)?$', '(^|/)gradle.properties$'],
       timeout: 300,
       versionScheme: 'maven',
     },

--- a/lib/manager/gradle/build-gradle.ts
+++ b/lib/manager/gradle/build-gradle.ts
@@ -64,6 +64,7 @@ export function collectVersionVariables(
       moduleStringVariableExpressionVersionFormatMatch(dependency),
       moduleStringVariableInterpolationVersionFormatMatch(dependency),
       moduleMapVariableVersionFormatMatch(dependency),
+      moduleKotlinNamedArgumentVariableVersionFormatMatch(dependency),
     ];
 
     for (const regex of regexes) {
@@ -86,8 +87,10 @@ function updateVersionLiterals(
 ) {
   const regexes: RegExp[] = [
     moduleStringVersionFormatMatch(dependency),
-    pluginStringVersionFormatMatch(dependency),
+    groovyPluginStringVersionFormatMatch(dependency),
+    kotlinPluginStringVersionFormatMatch(dependency),
     moduleMapVersionFormatMatch(dependency),
+    moduleKotlinNamedArgumentVersionFormatMatch(dependency),
   ];
   for (const regex of regexes) {
     if (buildGradleContent.match(regex)) {
@@ -106,6 +109,7 @@ function updateLocalVariables(
     moduleMapVariableVersionFormatMatch(dependency),
     moduleStringVariableInterpolationVersionFormatMatch(dependency),
     moduleStringVariableExpressionVersionFormatMatch(dependency),
+    moduleKotlinNamedArgumentVariableVersionFormatMatch(dependency),
   ];
   for (const regex of regexes) {
     const match = buildGradleContent.match(regex);
@@ -161,9 +165,15 @@ function moduleStringVersionFormatMatch(dependency: GradleDependency) {
   );
 }
 
-function pluginStringVersionFormatMatch(dependency: GradleDependency) {
+function groovyPluginStringVersionFormatMatch(dependency: GradleDependency) {
   return new RegExp(
     `(id\\s+["']${dependency.group}["']\\s+version\\s+["'])[^$].*?(["'])`
+  );
+}
+
+function kotlinPluginStringVersionFormatMatch(dependency: GradleDependency) {
+  return new RegExp(
+    `(id\\("${dependency.group}"\\)\\s+version\\s+")[^$].*?(")`
   );
 }
 
@@ -176,12 +186,34 @@ function moduleMapVersionFormatMatch(dependency: GradleDependency) {
   );
 }
 
+function moduleKotlinNamedArgumentVersionFormatMatch(
+  dependency: GradleDependency
+) {
+  // prettier-ignore
+  return new RegExp(
+    `(group\\s*=\\s*"${dependency.group}"\\s*,\\s*` +
+    `name\\s*=\\s*"${dependency.name}"\\s*,\\s*` +
+    `version\\s*=\\s*").*?(")`
+  );
+}
+
 function moduleMapVariableVersionFormatMatch(dependency: GradleDependency) {
   // prettier-ignore
   return new RegExp(
     `group\\s*:\\s*["']${dependency.group}["']\\s*,\\s*` +
     `name\\s*:\\s*["']${dependency.name}["']\\s*,\\s*` +
     `version\\s*:\\s*([^\\s"']+?)\\s`
+  );
+}
+
+function moduleKotlinNamedArgumentVariableVersionFormatMatch(
+  dependency: GradleDependency
+) {
+  // prettier-ignore
+  return new RegExp(
+    `group\\s*=\\s*"${dependency.group}"\\s*,\\s*` +
+    `name\\s*=\\s*"${dependency.name}"\\s*,\\s*` +
+    `version\\s*=\\s*([^\\s"]+?)[\\s\\),]`
   );
 }
 

--- a/lib/manager/gradle/index.ts
+++ b/lib/manager/gradle/index.ts
@@ -22,8 +22,12 @@ export async function extractAllPackageFiles(
   config: ExtractConfig,
   packageFiles: string[]
 ): Promise<PackageFile[]> {
-  if (!packageFiles.some(packageFile => packageFile === 'build.gradle')) {
-    logger.warn('No root build.gradle found - skipping');
+  if (
+    !packageFiles.some(packageFile =>
+      ['build.gradle', 'build.gradle.kts'].includes(packageFile)
+    )
+  ) {
+    logger.warn('No root build.gradle nor build.gradle.kts found - skipping');
     return null;
   }
   logger.info('Extracting dependencies from all gradle files');

--- a/renovate-schema.json
+++ b/renovate-schema.json
@@ -1130,11 +1130,7 @@
       "description": "Configuration object for build.gradle files",
       "type": "object",
       "default": {
-        "fileMatch": [
-          "\\.gradle(\\.kts)?$",
-          "(^|/)gradle.properties$",
-          "(^|/)buildSrc/.*"
-        ],
+        "fileMatch": ["\\.gradle(\\.kts)?$", "(^|/)gradle.properties$"],
         "timeout": 300,
         "versionScheme": "maven"
       },

--- a/renovate-schema.json
+++ b/renovate-schema.json
@@ -1130,7 +1130,11 @@
       "description": "Configuration object for build.gradle files",
       "type": "object",
       "default": {
-        "fileMatch": ["\\.gradle$", "(^|/)gradle.properties$"],
+        "fileMatch": [
+          "\\.gradle(\\.kts)?$",
+          "(^|/)gradle.properties$",
+          "(^|/)buildSrc/.*"
+        ],
         "timeout": 300,
         "versionScheme": "maven"
       },

--- a/test/manager/gradle/__snapshots__/index.spec.ts.snap
+++ b/test/manager/gradle/__snapshots__/index.spec.ts.snap
@@ -79,6 +79,85 @@ Array [
 ]
 `;
 
+exports[`manager/gradle extractPackageFile should return gradle.kts dependencies 1`] = `
+Array [
+  Object {
+    "datasource": "maven",
+    "deps": Array [
+      Object {
+        "currentValue": null,
+        "depGroup": "org.springframework.boot",
+        "depName": "org.springframework.boot:spring-boot-starter-jersey",
+        "name": "spring-boot-starter-jersey",
+        "registryUrls": Array [
+          "https://repo.maven.apache.org/maven2/",
+          "https://jitpack.io",
+        ],
+      },
+      Object {
+        "currentValue": "1.0-groovy-2.4",
+        "depGroup": "org.spockframework",
+        "depName": "org.spockframework:spock-core",
+        "name": "spock-core",
+        "registryUrls": Array [
+          "https://repo.maven.apache.org/maven2/",
+          "https://jitpack.io",
+        ],
+      },
+      Object {
+        "currentValue": "3.1",
+        "depGroup": "cglib",
+        "depName": "cglib:cglib-nodep",
+        "name": "cglib-nodep",
+        "registryUrls": Array [
+          "https://repo.maven.apache.org/maven2/",
+          "https://jitpack.io",
+        ],
+      },
+    ],
+    "manager": "gradle",
+    "packageFile": "build.gradle.kts",
+  },
+  Object {
+    "datasource": "maven",
+    "deps": Array [
+      Object {
+        "currentValue": null,
+        "depGroup": "org.springframework.boot",
+        "depName": "org.springframework.boot:spring-boot-starter-jersey",
+        "name": "spring-boot-starter-jersey",
+        "registryUrls": Array [
+          "https://repo.maven.apache.org/maven2/",
+          "https://jitpack.io",
+        ],
+      },
+      Object {
+        "currentValue": "1.0-groovy-2.4",
+        "depGroup": "org.spockframework",
+        "depName": "org.spockframework:spock-core",
+        "name": "spock-core",
+        "registryUrls": Array [
+          "https://repo.maven.apache.org/maven2/",
+          "https://jitpack.io",
+        ],
+      },
+      Object {
+        "currentValue": "3.1",
+        "depGroup": "cglib",
+        "depName": "cglib:cglib-nodep",
+        "name": "cglib-nodep",
+        "registryUrls": Array [
+          "https://repo.maven.apache.org/maven2/",
+          "https://jitpack.io",
+        ],
+      },
+    ],
+    "manager": "gradle",
+    "packageFile": "subproject/build.gradle.kts",
+  },
+]
+`;
+
 exports[`manager/gradle extractPackageFile should throw registry failure if gradle execution fails 1`] = `[Error: registry-failure]`;
 
 exports[`manager/gradle extractPackageFile should use repositories only for current project 1`] = `

--- a/test/manager/gradle/index.spec.ts
+++ b/test/manager/gradle/index.spec.ts
@@ -42,6 +42,14 @@ describe('manager/gradle', () => {
       expect(dependencies).toMatchSnapshot();
     });
 
+    it('should return gradle.kts dependencies', async () => {
+      const dependencies = await manager.extractAllPackageFiles(config, [
+        'build.gradle.kts',
+        'subproject/build.gradle.kts',
+      ]);
+      expect(dependencies).toMatchSnapshot();
+    });
+
     it('should return empty if there are no dependencies', async () => {
       fs.readFile.mockResolvedValue(fsReal.readFileSync(
         'test/datasource/gradle/_fixtures/updatesReportEmpty.json',
@@ -199,6 +207,35 @@ describe('manager/gradle', () => {
       );
       expect(buildGradleContentUpdated).not.toMatch(
         'id "com.github.ben-manes.versions" version "0.20.0"'
+      );
+    });
+
+    it('should update an existing plugin dependency with Kotlin DSL', () => {
+      const buildGradleContent = `
+        plugins {
+            id("com.github.ben-manes.versions") version "0.20.0"
+        }
+        `;
+      const upgrade = {
+        depGroup: 'com.github.ben-manes.versions',
+        name: 'com.github.ben-manes.versions.gradle.plugin',
+        version: '0.20.0',
+        newValue: '0.21.0',
+      };
+      const buildGradleContentUpdated = manager.updateDependency(
+        buildGradleContent,
+        upgrade
+      );
+
+      expect(buildGradleContent).not.toMatch(
+        'id("com.github.ben-manes.versions") version "0.21.0"'
+      );
+
+      expect(buildGradleContentUpdated).toMatch(
+        'id("com.github.ben-manes.versions") version "0.21.0"'
+      );
+      expect(buildGradleContentUpdated).not.toMatch(
+        'id("com.github.ben-manes.versions") version "0.20.0"'
       );
     });
   });

--- a/website/docs/java.md
+++ b/website/docs/java.md
@@ -13,11 +13,11 @@ Renovate detects versions specified as string `'group:artifact:version'` and as 
 
 ### File Support
 
-Renovate can update `build.gradle` files in the root of the repository and any `*.gradle` file inside any subdirectory as multi-project configurations.
+Renovate can update `build.gradle`/`build.gradle.kts` files in the root of the repository and any `*.gradle`/`*.gradle.kts` file inside any subdirectory as multi-project configurations.
 
 Renovate does not support:
 
-- Projects without a `build.gradle` file in the root of the repository.
+- Projects without neither `build.gradle` nor `build.gradle.kts` file in the root of the repository.
 - Android projects that requires extra configuration to run. (e.g. setting the android SDK)
 
 ### How It Works


### PR DESCRIPTION
This partially implements #3054.

- `*.gradle.kts` ~~and `buildSrc/**/*`~~ files are now recognized
- Kotlin's named arguments are supported, such as: `implementation(group = "...", name = "...", version = "...")`