### PR TITLE
build: add config validator to Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,5 +4,6 @@
 !hooks
 !lib
 !bin/yarn*
+!bin/config-validator.js
 !tsconfig*.json
 !data


### PR DESCRIPTION
This PR creates a new exception from the wildcard ignore rule, to allow the config validator to be in the docker image.

Closes #4097