### PR TITLE
fix(master-issue): skip updating if exiting early due to automerge

### DIFF
--- a/lib/workers/repository/index.js
+++ b/lib/workers/repository/index.js
@@ -29,7 +29,9 @@ async function renovateRepository(repoConfig) {
       config
     );
     await ensureOnboardingPr(config, packageFiles, branches);
-    await ensureMasterIssue(config, branches);
+    if (res !== 'automerged') {
+      await ensureMasterIssue(config, branches);
+    }
     await finaliseRepo(config, branchList);
     repoResult = processResult(config, res);
   } catch (err) /* istanbul ignore next */ {


### PR DESCRIPTION
Skip updating master issue after an automerge.

Closes #4089
