### PR TITLE
fix(logging): replace password in auth gotOptions

### DIFF
--- a/lib/logger/err-serializer.js
+++ b/lib/logger/err-serializer.js
@@ -15,17 +15,25 @@ export default function errSerializer(err) {
   if (err.stack) {
     response.stack = err.stack;
   }
-  if (err.gotOptions && err.gotOptions.headers) {
-    const redactedHeaders = [
-      'authorization',
-      'private-header',
-      'Private-header',
-    ];
-    redactedHeaders.forEach(header => {
-      if (response.gotOptions.headers[header]) {
-        response.gotOptions.headers[header] = '** redacted **';
-      }
-    });
+  if (response.gotOptions) {
+    if (is.string(response.gotOptions.auth)) {
+      response.gotOptions.auth = response.gotOptions.auth.replace(
+        /:.*/,
+        ':***********'
+      );
+    }
+    if (err.gotOptions.headers) {
+      const redactedHeaders = [
+        'authorization',
+        'private-header',
+        'Private-header',
+      ];
+      redactedHeaders.forEach(header => {
+        if (response.gotOptions.headers[header]) {
+          response.gotOptions.headers[header] = '** redacted **';
+        }
+      });
+    }
   }
   const redactedFields = ['message', 'stack', 'stdout', 'stderr'];
   for (const field of redactedFields) {

--- a/test/logger/__snapshots__/err-serializer.spec.js.snap
+++ b/test/logger/__snapshots__/err-serializer.spec.js.snap
@@ -6,6 +6,7 @@ Object {
   "b": 2,
   "body": "some response body",
   "gotOptions": Object {
+    "auth": "test:***********",
     "headers": Object {
       "authorization": "** redacted **",
     },

--- a/test/logger/err-serializer.spec.js
+++ b/test/logger/err-serializer.spec.js
@@ -13,6 +13,7 @@ describe('logger/err-serializer', () => {
         headers: {
           authorization: 'Bearer abc',
         },
+        auth: 'test:token',
       },
     };
     expect(configSerializer(err)).toMatchSnapshot();


### PR DESCRIPTION
This pr replaces the password part in `gotOptions` while we log `HTTPError` from `got`.