### PR TITLE
feat(composer): Inject repositories via config

### DIFF
--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -1501,6 +1501,19 @@ const options = [
     cli: false,
   },
   {
+    name: 'customRepositories',
+    description: 'Configuration object for composer.json repositories',
+    stage: 'package',
+    type: 'object|array',
+    parent: 'composer',
+    default: {
+      fileMatch: ['(^|/)([\\w-]*)composer.json$'],
+      versionScheme: 'composer',
+    },
+    mergeable: true,
+    cli: false,
+  },
+  {
     name: 'php',
     description: 'Configuration object for php',
     stage: 'package',

--- a/lib/manager/composer/extract.js
+++ b/lib/manager/composer/extract.js
@@ -37,7 +37,7 @@ function parseRepositories(repoJson, repositories, registryUrls) {
   }
 }
 
-async function extractPackageFile(content, fileName) {
+async function extractPackageFile(content, fileName, config) {
   logger.trace(`composer.extractPackageFile(${fileName})`);
   let composerJson;
   try {
@@ -66,6 +66,13 @@ async function extractPackageFile(content, fileName) {
     res.composerLock = false;
   }
 
+  if (config && config.composer && config.composer.customRepositories) {
+    parseRepositories(
+      config.composer.customRepositories,
+      repositories,
+      registryUrls
+    );
+  }
   // handle composer.json repositories
   if (composerJson.repositories) {
     parseRepositories(composerJson.repositories, repositories, registryUrls);

--- a/lib/manager/composer/readme.md
+++ b/lib/manager/composer/readme.md
@@ -133,7 +133,11 @@ Details: https://getcomposer.org/doc/05-repositories.md#hosting-your-own
 
 #### Will users need the capability to specify a custom host/registry to look up? Can it be found within the package files, or within other files inside the repository, or would it require Renovate configuration?
 
-Yes. There is an optional [`repositories`](https://getcomposer.org/doc/05-repositories.md#repository) field allowed at the root of any composer file. There should usually be no need to override this by config.
+Yes. There is an optional [`repositories`](https://getcomposer.org/doc/05-repositories.md#repository) field allowed at the root of any composer file.
+
+Users can use composer plugins in their projects, that can add additional repository info, which is not visible in the composer.json file itsself.
+The command for this would be something like `$composer->getRepositoryManager()->addRepository($repository)`.
+More info can be found in the composer [apidoc](https://getcomposer.org/apidoc/master/Composer/Repository/RepositoryManager.html)
 
 ---
 

--- a/renovate-schema.json
+++ b/renovate-schema.json
@@ -1038,7 +1038,11 @@
             "properties": {
               "customRepositories": {
                 "description": "Configuration object for composer.json repositories",
-                "type": ["object", "array"]
+                "type": "object|array",
+                "default": {
+                  "fileMatch": ["(^|/)([\\w-]*)composer.json$"],
+                  "versionScheme": "composer"
+                }
               }
             }
           }

--- a/renovate-schema.json
+++ b/renovate-schema.json
@@ -1030,7 +1030,20 @@
         "fileMatch": ["(^|/)([\\w-]*)composer.json$"],
         "versionScheme": "composer"
       },
-      "$ref": "#"
+      "$ref": "#",
+      "items": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "customRepositories": {
+                "description": "Configuration object for composer.json repositories",
+                "type": ["object", "array"]
+              }
+            }
+          }
+        ]
+      }
     },
     "php": {
       "description": "Configuration object for php",

--- a/test/manager/composer/__snapshots__/extract.spec.js.snap
+++ b/test/manager/composer/__snapshots__/extract.spec.js.snap
@@ -679,3 +679,38 @@ Object {
   ],
 }
 `;
+
+exports[`lib/manager/composer/extract extractPackageFile() extracts repositories from config 1`] = `
+Object {
+  "composerLock": false,
+  "deps": Array [
+    Object {
+      "currentValue": "*",
+      "datasource": "packagist",
+      "depName": "aws/aws-sdk-php",
+      "depType": "require",
+      "skipReason": "any-version",
+    },
+    Object {
+      "currentValue": "dev-trunk",
+      "datasource": "packagist",
+      "depName": "awesome/vcs",
+      "depType": "require",
+      "skipReason": "unsupported-constraint",
+    },
+    Object {
+      "currentValue": ">=7.0.2",
+      "datasource": "gitTags",
+      "depName": "custom-config/injected",
+      "depType": "require",
+      "lookupName": "ssh://git@my-example-git.com:injected.git",
+    },
+  ],
+  "registryUrls": Array [
+    Object {
+      "type": "composer",
+      "url": "https://custom-registry.org",
+    },
+  ],
+}
+`;

--- a/test/manager/composer/_fixtures/composer6.json
+++ b/test/manager/composer/_fixtures/composer6.json
@@ -1,0 +1,15 @@
+{
+  "name": "acme/git-sources",
+  "description": "Fetch Packages via git",
+
+  "require": {
+      "aws/aws-sdk-php":"*",
+      "awesome/vcs":"dev-trunk",
+      "custom-config/injected":">=7.0.2"
+  },
+  "autoload": {
+      "psr-0": {
+          "Acme": "src/"
+      }
+  }
+}

--- a/test/manager/composer/_fixtures/composer6_config.json
+++ b/test/manager/composer/_fixtures/composer6_config.json
@@ -1,0 +1,14 @@
+{
+  "composer": {
+    "customRepositories": {
+      "custom-registry": {
+        "type": "composer",
+        "url": "https://custom-registry.org"
+      },
+      "custom-config/injected": {
+        "type": "git",
+        "url": "ssh://git@my-example-git.com:injected.git"
+      }
+    }
+  }
+}

--- a/test/manager/composer/extract.spec.js
+++ b/test/manager/composer/extract.spec.js
@@ -28,6 +28,14 @@ const requirements5Lock = fs.readFileSync(
   'test/manager/composer/_fixtures/composer5.lock',
   'utf8'
 );
+const requirements6 = fs.readFileSync(
+  'test/manager/composer/_fixtures/composer6.json',
+  'utf8'
+);
+const requirements6Config = fs.readFileSync(
+  'test/manager/composer/_fixtures/composer6_config.json',
+  'utf8'
+);
 
 describe('lib/manager/composer/extract', () => {
   describe('extractPackageFile()', () => {
@@ -63,6 +71,12 @@ describe('lib/manager/composer/extract', () => {
     it('extracts object repositories and registryUrls with lock file', async () => {
       platform.getFile.mockReturnValueOnce(requirements5Lock);
       const res = await extractPackageFile(requirements5, packageFile);
+      expect(res).toMatchSnapshot();
+      expect(res.registryUrls).toHaveLength(1);
+    });
+    it('extracts repositories from config', async () => {
+      const config = JSON.parse(requirements6Config);
+      const res = await extractPackageFile(requirements6, packageFile, config);
       expect(res).toMatchSnapshot();
       expect(res.registryUrls).toHaveLength(1);
     });

--- a/website/docs/configuration-options.md
+++ b/website/docs/configuration-options.md
@@ -188,6 +188,32 @@ This is used to manually restrict which versions are possible to upgrade to base
 
 Warning: composer support is in alpha stage so you probably only want to run this if you are helping get it feature-ready.
 
+### customRepositories
+
+Add custom repositories as you would do in your [composer.json](https://getcomposer.org/doc/04-schema.md#repositories)
+
+Currently special handled types are vcs and git (vcs being an alias for git). Everything else will be handled as a registry url.
+
+Repositories configured in composer.json take preceedence over the config entries.
+Repositories with type git will use git-tags as datasource instead of packagist
+
+```json
+"composer": {
+  "customRepositories": [
+      {
+          "type": "composer",
+          "url": "http://packages.example.com"
+      },
+      {
+          "name": "seldaek/monolog",
+          "type": "git",
+          "url": "https://github.com/Seldaek/monolog"
+      }
+  ]
+}
+
+```
+
 ## deps-edn
 
 ## description


### PR DESCRIPTION
Adds a new config field -> config.composer.customRepositories (prefixed with custom as to not confuse with config.repositories)

Includes tests and documentation updates

Closes #4115  