### PR TITLE
fix: missing release notes

### DIFF
--- a/lib/datasource/metadata.js
+++ b/lib/datasource/metadata.js
@@ -79,7 +79,12 @@ function addMetaData(dep, datasource, lookupName) {
     dep.sourceUrl = manualSourceUrls[datasource][depName];
   }
   if (dep.sourceUrl && dep.sourceUrl.includes('github.com')) {
-    dep.sourceUrl = parse(dep.sourceUrl);
+    dep.sourceUrl = parse(
+      dep.sourceUrl
+        .split('/')
+        .slice(0, 5)
+        .join('/')
+    );
   }
   if (
     !dep.sourceUrl &&

--- a/test/datasource/__snapshots__/metadata.spec.js.snap
+++ b/test/datasource/__snapshots__/metadata.spec.js.snap
@@ -1,0 +1,74 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`datasource/terraform Should handle manualChangelogUrls 1`] = `
+Object {
+  "changelogUrl": "https://github.com/django/django/tree/master/docs/releases",
+  "releases": Array [
+    Object {
+      "releaseTimestamp": "2018-07-13T10:14:17",
+      "version": "2.0.0",
+    },
+    Object {
+      "releaseTimestamp": "2017-10-24T10:09:16",
+      "version": "2.0.0.dev1",
+    },
+    Object {
+      "releaseTimestamp": "2019-01-20T19:59:28",
+      "version": "2.1.0",
+    },
+    Object {
+      "releaseTimestamp": "2019-07-16T18:29:00",
+      "version": "2.2.0",
+    },
+  ],
+  "sourceUrl": "https://github.com/django/django",
+}
+`;
+
+exports[`datasource/terraform Should handle manualSourceUrls 1`] = `
+Object {
+  "releases": Array [
+    Object {
+      "releaseTimestamp": "2018-07-13T10:14:17",
+      "version": "2.0.0",
+    },
+    Object {
+      "releaseTimestamp": "2017-10-24T10:09:16",
+      "version": "2.0.0.dev1",
+    },
+    Object {
+      "releaseTimestamp": "2019-01-20T19:59:28",
+      "version": "2.1.0",
+    },
+    Object {
+      "releaseTimestamp": "2019-07-16T18:29:00",
+      "version": "2.2.0",
+    },
+  ],
+  "sourceUrl": "https://github.com/nedbat/coveragepy",
+}
+`;
+
+exports[`datasource/terraform Should handle parsing of sourceUrls correctly 1`] = `
+Object {
+  "releases": Array [
+    Object {
+      "releaseTimestamp": "2018-07-13T10:14:17",
+      "version": "2.0.0",
+    },
+    Object {
+      "releaseTimestamp": "2017-10-24T10:09:16",
+      "version": "2.0.0.dev1",
+    },
+    Object {
+      "releaseTimestamp": "2019-01-20T19:59:28",
+      "version": "2.1.0",
+    },
+    Object {
+      "releaseTimestamp": "2019-07-16T18:29:00",
+      "version": "2.2.0",
+    },
+  ],
+  "sourceUrl": "https://github.com/carltongibson/django-filter",
+}
+`;

--- a/test/datasource/metadata.spec.js
+++ b/test/datasource/metadata.spec.js
@@ -1,0 +1,67 @@
+const { addMetaData } = require('../../lib/datasource/metadata');
+
+describe('datasource/terraform', () => {
+  it('Should do nothing if dep is not specified', () => {
+    expect(addMetaData()).toBeUndefined();
+  });
+
+  it('Should handle manualChangelogUrls', () => {
+    const dep = {
+      releases: [
+        { version: '2.0.0', releaseTimestamp: '2018-07-13T10:14:17' },
+        {
+          version: '2.0.0.dev1',
+          releaseTimestamp: '2017-10-24T10:09:16',
+        },
+        { version: '2.1.0', releaseTimestamp: '2019-01-20T19:59:28' },
+        { version: '2.2.0', releaseTimestamp: '2019-07-16T18:29:00' },
+      ],
+    };
+
+    const datasource = 'pypi';
+    const lookupName = 'django';
+
+    addMetaData(dep, datasource, lookupName);
+    expect(dep).toMatchSnapshot();
+  });
+
+  it('Should handle manualSourceUrls', () => {
+    const dep = {
+      releases: [
+        { version: '2.0.0', releaseTimestamp: '2018-07-13T10:14:17' },
+        {
+          version: '2.0.0.dev1',
+          releaseTimestamp: '2017-10-24T10:09:16',
+        },
+        { version: '2.1.0', releaseTimestamp: '2019-01-20T19:59:28' },
+        { version: '2.2.0', releaseTimestamp: '2019-07-16T18:29:00' },
+      ],
+    };
+
+    const datasource = 'pypi';
+    const lookupName = 'coverage';
+
+    addMetaData(dep, datasource, lookupName);
+    expect(dep).toMatchSnapshot();
+  });
+
+  it('Should handle parsing of sourceUrls correctly', () => {
+    const dep = {
+      sourceUrl: 'https://github.com/carltongibson/django-filter/tree/master',
+      releases: [
+        { version: '2.0.0', releaseTimestamp: '2018-07-13T10:14:17' },
+        {
+          version: '2.0.0.dev1',
+          releaseTimestamp: '2017-10-24T10:09:16',
+        },
+        { version: '2.1.0', releaseTimestamp: '2019-01-20T19:59:28' },
+        { version: '2.2.0', releaseTimestamp: '2019-07-16T18:29:00' },
+      ],
+    };
+    const datasource = 'pypi';
+    const lookupName = 'django-filter';
+
+    addMetaData(dep, datasource, lookupName);
+    expect(dep).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
Handles the parsing of sourceUrls correctly, earlier it was being set to undefined. Needed a massage to scrap un-needed parts of the source url to be parsed correctly.

Closes #3092 
