### PR TITLE
feat: refactor exec

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 test/**/**/_fixtures
+lib/types/**/*.d.ts

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,7 @@ module.exports = {
   },
   rules: {
     'import/no-unresolved': 0, // done by typescript
+    'import/prefer-default-export': 0, // no benefit
     'require-await': 'error',
     'no-use-before-define': 0,
     'no-restricted-syntax': 0,
@@ -25,7 +26,6 @@ module.exports = {
     'no-underscore-dangle': 0,
 
     // TODO: fix lint
-    'import/prefer-default-export': 1,
     '@typescript-eslint/camelcase': 'off', // disabled until ??
     '@typescript-eslint/no-var-requires': 'off', // disable until all files converted to typescript
     '@typescript-eslint/no-use-before-define': 'off', // disable until all files converted to typescript

--- a/lib/manager/bundler/artifacts.js
+++ b/lib/manager/bundler/artifacts.js
@@ -1,6 +1,6 @@
-const { exec } = require('child-process-promise');
 const fs = require('fs-extra');
 const upath = require('upath');
+const { exec } = require('../../util/exec');
 const { getChildProcessEnv } = require('../../util/env');
 const { logger } = require('../../logger');
 
@@ -118,7 +118,6 @@ async function updateArtifacts(
     logger.debug({ cmd }, 'bundler command');
     ({ stdout, stderr } = await exec(cmd, {
       cwd,
-      shell: true,
       env,
     }));
     const duration = process.hrtime(startTime);

--- a/lib/manager/cargo/artifacts.js
+++ b/lib/manager/cargo/artifacts.js
@@ -1,7 +1,7 @@
 const upath = require('upath');
 const process = require('process');
 const fs = require('fs-extra');
-const { exec } = require('child-process-promise');
+const { exec } = require('../../util/exec');
 const { getChildProcessEnv } = require('../../util/env');
 const { logger } = require('../../logger');
 
@@ -59,7 +59,6 @@ async function updateArtifacts(
       try {
         ({ stdout, stderr } = await exec(cmd, {
           cwd,
-          shell: true,
           env,
         }));
       } catch (err) /* istanbul ignore next */ {
@@ -79,7 +78,6 @@ async function updateArtifacts(
           cmd = cmd.replace(/ --package.*/, '');
           ({ stdout, stderr } = await exec(cmd, {
             cwd,
-            shell: true,
             env,
           }));
         } else {

--- a/lib/manager/composer/artifacts.js
+++ b/lib/manager/composer/artifacts.js
@@ -1,7 +1,7 @@
 import is from '@sindresorhus/is';
+import { exec } from '../../util/exec';
 
 const URL = require('url');
-const { exec } = require('child-process-promise');
 const fs = require('fs-extra');
 const upath = require('upath');
 const { logger } = require('../../logger');
@@ -124,7 +124,6 @@ async function updateArtifacts(
     logger.debug({ cmd, args }, 'composer command');
     ({ stdout, stderr } = await exec(`${cmd} ${args}`, {
       cwd,
-      shell: true,
       env,
     }));
     const duration = process.hrtime(startTime);

--- a/lib/manager/gomod/artifacts.js
+++ b/lib/manager/gomod/artifacts.js
@@ -1,6 +1,6 @@
-const { exec } = require('child-process-promise');
 const fs = require('fs-extra');
 const upath = require('upath');
+const { exec } = require('../../util/exec');
 const hostRules = require('../../util/host-rules');
 const { getChildProcessEnv } = require('../../util/env');
 const { logger } = require('../../logger');
@@ -79,7 +79,6 @@ async function updateArtifacts(
     logger.debug({ cmd, args }, 'go get command');
     ({ stdout, stderr } = await exec(`${cmd} ${args}`, {
       cwd,
-      shell: true,
       env,
     }));
     let duration = process.hrtime(startTime);
@@ -99,7 +98,6 @@ async function updateArtifacts(
       logger.debug({ cmd, args }, 'go mod tidy command');
       ({ stdout, stderr } = await exec(`${cmd} ${args}`, {
         cwd,
-        shell: true,
         env,
       }));
       duration = process.hrtime(startTime);
@@ -132,7 +130,6 @@ async function updateArtifacts(
       logger.debug({ cmd, args }, 'go mod vendor command');
       ({ stdout, stderr } = await exec(`${cmd} ${args}`, {
         cwd,
-        shell: true,
         env,
       }));
       duration = process.hrtime(startTime);
@@ -149,7 +146,6 @@ async function updateArtifacts(
         logger.debug({ cmd, args }, 'go mod tidy command');
         ({ stdout, stderr } = await exec(`${cmd} ${args}`, {
           cwd,
-          shell: true,
           env,
         }));
         duration = process.hrtime(startTime);

--- a/lib/manager/gradle/index.js
+++ b/lib/manager/gradle/index.js
@@ -1,5 +1,5 @@
-const { exec } = require('child-process-promise');
 const fs = require('fs-extra');
+const { exec } = require('../../util/exec');
 const { logger } = require('../../logger');
 
 const gradle = require('./build-gradle');
@@ -77,7 +77,6 @@ async function executeGradle(config) {
     ({ stdout, stderr } = await exec(cmd, {
       cwd: config.localDir,
       timeout: gradleTimeout,
-      shell: true,
     }));
   } catch (err) {
     const errorStr = `Gradle command ${cmd} failed. Exit code: ${err.code}.`;

--- a/lib/manager/npm/post-update/lerna.js
+++ b/lib/manager/npm/post-update/lerna.js
@@ -1,4 +1,4 @@
-const { exec } = require('child-process-promise');
+const { exec } = require('../../../util/exec');
 const { logger } = require('../../../logger');
 
 module.exports = {
@@ -52,7 +52,6 @@ async function generateLockFiles(
     // TODO: Switch to native util.promisify once using only node 8
     ({ stdout, stderr } = await exec(cmd, {
       cwd,
-      shell: true,
       env,
     }));
     logger.debug(`npm stdout:\n${stdout}`);

--- a/lib/manager/npm/post-update/npm.js
+++ b/lib/manager/npm/post-update/npm.js
@@ -1,7 +1,7 @@
 const fs = require('fs-extra');
 const upath = require('upath');
 const { getInstalledPath } = require('get-installed-path');
-const { exec } = require('child-process-promise');
+const { exec } = require('../../../util/exec');
 const { logger } = require('../../../logger');
 
 module.exports = {
@@ -94,7 +94,6 @@ async function generateLockFile(
       // TODO: Switch to native util.promisify once using only node 8
       ({ stdout, stderr } = await exec(`${cmd} ${args}`, {
         cwd,
-        shell: true,
         env,
       }));
     }
@@ -108,7 +107,6 @@ async function generateLockFile(
           .join('');
       const updateRes = await exec(updateCmd, {
         cwd,
-        shell: true,
         env,
       });
       stdout += updateRes.stdout ? updateRes.stdout : '';
@@ -118,7 +116,6 @@ async function generateLockFile(
       logger.info('Performing npm dedupe');
       const dedupeRes = await exec(`${cmd} dedupe`, {
         cwd,
-        shell: true,
         env,
       });
       stdout += dedupeRes.stdout ? dedupeRes.stdout : '';

--- a/lib/manager/npm/post-update/pnpm.js
+++ b/lib/manager/npm/post-update/pnpm.js
@@ -1,7 +1,7 @@
 const fs = require('fs-extra');
 const upath = require('upath');
 const { getInstalledPath } = require('get-installed-path');
-const { exec } = require('child-process-promise');
+const { exec } = require('../../../util/exec');
 const { logger } = require('../../../logger');
 
 module.exports = {
@@ -77,7 +77,6 @@ async function generateLockFile(cwd, env, config) {
     // TODO: Switch to native util.promisify once using only node 8
     ({ stdout, stderr } = await exec(cmd, {
       cwd,
-      shell: true,
       env,
     }));
     logger.debug(`pnpm stdout:\n${stdout}`);

--- a/lib/manager/npm/post-update/yarn.js
+++ b/lib/manager/npm/post-update/yarn.js
@@ -1,7 +1,7 @@
 const fs = require('fs-extra');
 const upath = require('upath');
 const { getInstalledPath } = require('get-installed-path');
-const { exec } = require('child-process-promise');
+const { exec } = require('../../../util/exec');
 const { logger } = require('../../../logger');
 
 module.exports = {
@@ -87,7 +87,6 @@ async function generateLockFile(cwd, env, config = {}, upgrades = []) {
     // TODO: Switch to native util.promisify once using only node 8
     ({ stdout, stderr } = await exec(installCmd, {
       cwd,
-      shell: true,
       env,
     }));
     logger.debug(`yarn stdout:\n${stdout}`);
@@ -104,7 +103,6 @@ async function generateLockFile(cwd, env, config = {}, upgrades = []) {
         cmdExtras;
       const updateRes = await exec(updateCmd, {
         cwd,
-        shell: true,
         env,
       });
       stdout += updateRes.stdout
@@ -123,7 +121,6 @@ async function generateLockFile(cwd, env, config = {}, upgrades = []) {
         'npx yarn-deduplicate@1.1.1 --strategy fewer && yarn';
       const dedupeRes = await exec(dedupeCommand, {
         cwd,
-        shell: true,
         env,
       });
       stdout += dedupeRes.stdout
@@ -142,7 +139,6 @@ async function generateLockFile(cwd, env, config = {}, upgrades = []) {
         'npx yarn-deduplicate@1.1.1 --strategy highest && yarn';
       const dedupeRes = await exec(dedupeCommand, {
         cwd,
-        shell: true,
         env,
       });
       stdout += dedupeRes.stdout

--- a/lib/manager/pip_setup/extract.js
+++ b/lib/manager/pip_setup/extract.js
@@ -1,5 +1,5 @@
-const { exec } = require('child-process-promise');
 const { join } = require('upath');
+const { exec } = require('../../util/exec');
 const { logger } = require('../../logger');
 const { isSkipComment } = require('../../util/ignore');
 const { dependencyPattern } = require('../pip_requirements/extract');
@@ -69,7 +69,6 @@ async function extractSetupFile(content, packageFile, config) {
   logger.debug({ cmd, args }, 'python command');
   const res = await exec(`${cmd} ${args.join(' ')}`, {
     cwd,
-    shell: true,
     timeout: 5000,
   });
   // istanbul ignore if

--- a/lib/manager/pipenv/artifacts.js
+++ b/lib/manager/pipenv/artifacts.js
@@ -1,6 +1,6 @@
-const { exec } = require('child-process-promise');
 const fs = require('fs-extra');
 const upath = require('upath');
+const { exec } = require('../../util/exec');
 const { getChildProcessEnv } = require('../../util/env');
 const { logger } = require('../../logger');
 
@@ -53,7 +53,6 @@ async function updateArtifacts(
     logger.debug({ cmd, args }, 'pipenv lock command');
     ({ stdout, stderr } = await exec(`${cmd} ${args}`, {
       cwd,
-      shell: true,
       env,
     }));
     const duration = process.hrtime(startTime);

--- a/lib/manager/poetry/artifacts.js
+++ b/lib/manager/poetry/artifacts.js
@@ -1,7 +1,7 @@
 const upath = require('upath');
 const process = require('process');
 const fs = require('fs-extra');
-const { exec } = require('child-process-promise');
+const { exec } = require('../../util/exec');
 const { getChildProcessEnv } = require('../../util/env');
 
 const { logger } = require('../../logger');
@@ -66,7 +66,6 @@ async function updateArtifacts(
       cmd += ` update --lock --no-interaction ${dep}`;
       ({ stdout, stderr } = await exec(cmd, {
         cwd,
-        shell: true,
         env,
       }));
     }

--- a/lib/types/.eslintrc.js
+++ b/lib/types/.eslintrc.js
@@ -1,3 +1,0 @@
-module.exports = {
-  rules: {},
-};

--- a/lib/types/.eslintrc.js
+++ b/lib/types/.eslintrc.js
@@ -1,5 +1,3 @@
 module.exports = {
-  rules: {
-    'import/prefer-default-export': 0,
-  },
+  rules: {},
 };

--- a/lib/util/env.js
+++ b/lib/util/env.js
@@ -1,4 +1,10 @@
-function getChildProcessEnv(customEnvVars = []) {
+/**
+ *
+ * @param {string[]} customEnvVars
+ * @returns {NodeJS.ProcessEnv}
+ */
+export function getChildProcessEnv(customEnvVars = []) {
+  /** @type NodeJS.ProcessEnv */
   const env = {};
   if (global.trustLevel === 'high') {
     return Object.assign(env, process.env);
@@ -18,7 +24,3 @@ function getChildProcessEnv(customEnvVars = []) {
   });
   return env;
 }
-
-module.exports = {
-  getChildProcessEnv,
-};

--- a/lib/util/exec.ts
+++ b/lib/util/exec.ts
@@ -1,0 +1,14 @@
+// istanbul ignore file
+import { promisify } from 'util';
+import { exec as cpExec, ExecOptions } from 'child_process';
+
+const pExec = promisify(cpExec);
+
+export interface ExecResult {
+  stdout: string;
+  stderr: string;
+}
+
+export function exec(cmd: string, options?: ExecOptions): Promise<ExecResult> {
+  return pExec(cmd, { ...options, encoding: 'utf-8' });
+}

--- a/package.json
+++ b/package.json
@@ -212,6 +212,7 @@
     "collectCoverage": true,
     "collectCoverageFrom": [
       "lib/**/*.{js,ts}",
+      "!lib/**/*.d.ts",
       "!lib/versioning/maven/index.js",
       "!lib/proxy.js"
     ],

--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "cacache": "11.3.3",
     "chalk": "2.4.2",
     "changelog-filename-regex": "2.0.1",
-    "child-process-promise": "2.2.1",
     "clean-git-ref": "2.0.1",
     "commander": "2.20.0",
     "conventional-commits-detector": "1.0.2",

--- a/test/manager/cargo/artifacts.spec.js
+++ b/test/manager/cargo/artifacts.spec.js
@@ -1,9 +1,10 @@
 jest.mock('fs-extra');
-jest.mock('child-process-promise');
+jest.mock('../../../lib/util/exec');
 
 /** @type any */
 const fs = require('fs-extra');
-const { exec } = require('child-process-promise');
+/** @type any */
+const { exec } = require('../../../lib/util/exec');
 const cargo = require('../../../lib/manager/cargo/artifacts');
 
 /** @type any */

--- a/test/manager/composer/artifacts.spec.js
+++ b/test/manager/composer/artifacts.spec.js
@@ -1,10 +1,11 @@
 jest.mock('fs-extra');
-jest.mock('child-process-promise');
+jest.mock('../../../lib/util/exec');
 jest.mock('../../../lib/util/host-rules');
 
 /** @type any */
 const fs = require('fs-extra');
-const { exec } = require('child-process-promise');
+/** @type any */
+const { exec } = require('../../../lib/util/exec');
 const composer = require('../../../lib/manager/composer/artifacts');
 /** @type any */
 const hostRules = require('../../../lib/util/host-rules');

--- a/test/manager/gomod/artifacts.spec.js
+++ b/test/manager/gomod/artifacts.spec.js
@@ -1,10 +1,11 @@
 jest.mock('fs-extra');
-jest.mock('child-process-promise');
+jest.mock('../../../lib/util/exec');
 jest.mock('../../../lib/util/host-rules');
 
 /** @type any */
 const fs = require('fs-extra');
-const { exec } = require('child-process-promise');
+/** @type any */
+const { exec } = require('../../../lib/util/exec');
 const gomod = require('../../../lib/manager/gomod/artifacts');
 /** @type any */
 const hostRules = require('../../../lib/util/host-rules');

--- a/test/manager/gradle/index.spec.js
+++ b/test/manager/gradle/index.spec.js
@@ -1,11 +1,12 @@
 jest.mock('fs-extra');
-jest.mock('child-process-promise');
+jest.mock('../../../lib/util/exec');
 
 const { toUnix } = require('upath');
 /** @type any */
 const fs = require('fs-extra');
 const fsReal = require('fs');
-const { exec } = require('child-process-promise');
+/** @type any */
+const { exec } = require('../../../lib/util/exec');
 
 const manager = require('../../../lib/manager/gradle/index');
 

--- a/test/manager/pip_setup/extract.spec.js
+++ b/test/manager/pip_setup/extract.spec.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
-const { exec } = require('child-process-promise');
 const tmp = require('tmp-promise');
 const { relative } = require('path');
+const { exec } = require('../../../lib/util/exec');
 const {
   extractPackageFile,
   parsePythonVersion,
@@ -49,7 +49,7 @@ describe('lib/manager/pip_setup/extract', () => {
       const fExec = jest.fn(() => {
         throw new Error('No such file or directory');
       });
-      jest.doMock('child-process-promise', () => {
+      jest.doMock('../../../lib/util/exec', () => {
         return {
           exec: fExec,
         };
@@ -73,7 +73,7 @@ describe('lib/manager/pip_setup/extract', () => {
       const fExec = jest.fn(() =>
         Promise.resolve({ stderr: 'Python 3.7.15rc1' })
       );
-      jest.doMock('child-process-promise', () => {
+      jest.doMock('../../../lib/util/exec', () => {
         return {
           exec: fExec,
         };
@@ -85,7 +85,7 @@ describe('lib/manager/pip_setup/extract', () => {
   });
   describe('Test for presence of mock lib', () => {
     it('should test if python mock lib is installed', async () => {
-      const cp = jest.requireActual('child-process-promise');
+      const cp = jest.requireActual('../../../lib/util/exec');
       let isMockInstalled = true;
       // when binarysource === docker
       try {

--- a/test/manager/pipenv/artifacts.spec.js
+++ b/test/manager/pipenv/artifacts.spec.js
@@ -1,10 +1,11 @@
 jest.mock('fs-extra');
-jest.mock('child-process-promise');
+jest.mock('../../../lib/util/exec');
 jest.mock('../../../lib/util/host-rules');
 
 /** @type any */
 const fs = require('fs-extra');
-const { exec } = require('child-process-promise');
+/** @type any */
+const { exec } = require('../../../lib/util/exec');
 const pipenv = require('../../../lib/manager/pipenv/artifacts');
 
 /** @type any */

--- a/test/manager/poetry/artifacts.spec.js
+++ b/test/manager/poetry/artifacts.spec.js
@@ -1,9 +1,10 @@
 jest.mock('fs-extra');
-jest.mock('child-process-promise');
+jest.mock('../../../lib/util/exec');
 
 /** @type any */
 const fs = require('fs-extra');
-const { exec } = require('child-process-promise');
+/** @type any */
+const { exec } = require('../../../lib/util/exec');
 const poetry = require('../../../lib/manager/poetry/artifacts');
 
 /** @type any */

--- a/test/workers/branch/lock-files/lerna.spec.js
+++ b/test/workers/branch/lock-files/lerna.spec.js
@@ -1,7 +1,8 @@
-const { exec } = require('child-process-promise');
+/** @type any */
+const { exec } = require('../../../../lib/util/exec');
 const lernaHelper = require('../../../../lib/manager/npm/post-update/lerna');
 
-jest.mock('child-process-promise');
+jest.mock('../../../../lib/util/exec');
 
 /** @type any */
 const platform = global.platform;

--- a/test/workers/branch/lock-files/npm.spec.js
+++ b/test/workers/branch/lock-files/npm.spec.js
@@ -1,14 +1,15 @@
 const { getInstalledPath } = require('get-installed-path');
 
 jest.mock('fs-extra');
-jest.mock('child-process-promise');
+jest.mock('../../../../lib/util/exec');
 jest.mock('get-installed-path');
 
 getInstalledPath.mockImplementation(() => null);
 
 /** @type any */
 const fs = require('fs-extra');
-const { exec } = require('child-process-promise');
+/** @type any */
+const { exec } = require('../../../../lib/util/exec');
 const npmHelper = require('../../../../lib/manager/npm/post-update/npm');
 
 describe('generateLockFile', () => {

--- a/test/workers/branch/lock-files/pnpm.spec.js
+++ b/test/workers/branch/lock-files/pnpm.spec.js
@@ -1,14 +1,15 @@
 const { getInstalledPath } = require('get-installed-path');
 
 jest.mock('fs-extra');
-jest.mock('child-process-promise');
+jest.mock('../../../../lib/util/exec');
 jest.mock('get-installed-path');
 
 getInstalledPath.mockImplementation(() => null);
 
 /** @type any */
 const fs = require('fs-extra');
-const { exec } = require('child-process-promise');
+/** @type any */
+const { exec } = require('../../../../lib/util/exec');
 const pnpmHelper = require('../../../../lib/manager/npm/post-update/pnpm');
 
 describe('generateLockFile', () => {

--- a/test/workers/branch/lock-files/yarn.spec.js
+++ b/test/workers/branch/lock-files/yarn.spec.js
@@ -1,14 +1,15 @@
 const { getInstalledPath } = require('get-installed-path');
 
 jest.mock('fs-extra');
-jest.mock('child-process-promise');
+jest.mock('../../../../lib/util/exec');
 jest.mock('get-installed-path');
 
 getInstalledPath.mockImplementation(() => null);
 
 /** @type any */
 const fs = require('fs-extra');
-const { exec } = require('child-process-promise');
+/** @type any */
+const { exec } = require('../../../../lib/util/exec');
 const yarnHelper = require('../../../../lib/manager/npm/post-update/yarn');
 
 describe('generateLockFile', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2029,15 +2029,6 @@ check-error@^1.0.2:
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
   integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
 
-child-process-promise@2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/child-process-promise/-/child-process-promise-2.2.1.tgz#4730a11ef610fad450b8f223c79d31d7bdad8074"
-  integrity sha1-RzChHvYQ+tRQuPIjx50x172tgHQ=
-  dependencies:
-    cross-spawn "^4.0.2"
-    node-version "^1.0.0"
-    promise-polyfill "^6.0.1"
-
 chokidar@^2.0.4:
   version "2.1.6"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.6.tgz#b6cad653a929e244ce8a834244164d241fa954c5"
@@ -2461,14 +2452,6 @@ cross-env@5.2.0:
   dependencies:
     cross-spawn "^6.0.5"
     is-windows "^1.0.0"
-
-cross-spawn@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
-  integrity sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=
-  dependencies:
-    lru-cache "^4.0.1"
-    which "^1.2.9"
 
 cross-spawn@^5.0.1:
   version "5.1.0"
@@ -6091,11 +6074,6 @@ node-releases@^1.1.25:
   dependencies:
     semver "^5.3.0"
 
-node-version@^1.0.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/node-version/-/node-version-1.2.0.tgz#34fde3ffa8e1149bd323983479dda620e1b5060d"
-  integrity sha512-ma6oU4Sk0qOoKEAymVoTvk8EdXEobdS7m/mAGhDJ8Rouugho48crHBORAmy5BoOcv8wraPM6xumapQp5hl4iIQ==
-
 noms@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/noms/-/noms-0.0.0.tgz#da8ebd9f3af9d6760919b27d9cdc8092a7332859"
@@ -7024,11 +7002,6 @@ promise-inflight@^1.0.1, promise-inflight@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
-
-promise-polyfill@^6.0.1:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-6.1.0.tgz#dfa96943ea9c121fca4de9b5868cb39d3472e057"
-  integrity sha1-36lpQ+qcEh/KTem1hoyznTRy4Fc=
 
 promise-retry@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
This pr refactors `exec` usage.

This will fix the wrong `shell` argument and remove `child-process-promise` which is no longer used / required.