### PR TITLE
logs: fix ruby-version manager

### DIFF
--- a/lib/manager/ruby-version/update.js
+++ b/lib/manager/ruby-version/update.js
@@ -5,6 +5,6 @@ module.exports = {
 };
 
 function updateDependency(fileContent, upgrade) {
-  logger.debug(`ruby-version.updateDependency(): ${upgrade.newVersions}`);
+  logger.debug(`ruby-version.updateDependency(): ${upgrade.newValue}`);
   return `${upgrade.newValue}\n`;
 }


### PR DESCRIPTION
Uses wrong property

relates to #4158
