### PR TITLE
refactor: mavenProps

### DIFF
--- a/lib/manager/maven/extract.js
+++ b/lib/manager/maven/extract.js
@@ -215,6 +215,16 @@ function resolveProps(packages) {
   }));
 }
 
+function cleanResult(packageFiles) {
+  packageFiles.forEach(packageFile => {
+    delete packageFile.mavenProps; // eslint-disable-line no-param-reassign
+    packageFile.deps.forEach(dep => {
+      delete dep.propSource; // eslint-disable-line no-param-reassign
+    });
+  });
+  return packageFiles;
+}
+
 async function extractAllPackageFiles(config, packageFiles) {
   const packages = [];
   for (const packageFile of packageFiles) {
@@ -231,7 +241,7 @@ async function extractAllPackageFiles(config, packageFiles) {
     }
   }
 
-  return resolveProps(packages);
+  return cleanResult(resolveProps(packages));
 }
 
 module.exports = {

--- a/test/manager/maven/__snapshots__/index.spec.js.snap
+++ b/test/manager/maven/__snapshots__/index.spec.js.snap
@@ -10,7 +10,6 @@ Array [
         "datasource": "maven",
         "depName": "org.example:parent",
         "fileReplacePosition": 186,
-        "propSource": null,
         "registryUrls": Array [
           "https://repo.maven.apache.org/maven2",
           "https://maven.atlassian.com/content/repositories/atlassian-public/",
@@ -21,7 +20,6 @@ Array [
         "datasource": "maven",
         "depName": "org.example:foo",
         "fileReplacePosition": 905,
-        "propSource": null,
         "registryUrls": Array [
           "https://repo.maven.apache.org/maven2",
           "https://maven.atlassian.com/content/repositories/atlassian-public/",
@@ -32,7 +30,6 @@ Array [
         "datasource": "maven",
         "depName": "org.example:bar",
         "fileReplacePosition": 1053,
-        "propSource": null,
         "registryUrls": Array [
           "https://repo.maven.apache.org/maven2",
           "https://maven.atlassian.com/content/repositories/atlassian-public/",
@@ -43,7 +40,6 @@ Array [
         "datasource": "maven",
         "depName": "org.apache.maven.scm:maven-scm-provider-gitexe",
         "fileReplacePosition": 1485,
-        "propSource": null,
         "registryUrls": Array [
           "https://repo.maven.apache.org/maven2",
           "https://maven.atlassian.com/content/repositories/atlassian-public/",
@@ -54,7 +50,6 @@ Array [
         "datasource": "maven",
         "depName": "org.example:\${artifact-id-placeholder}",
         "fileReplacePosition": 2230,
-        "propSource": null,
         "registryUrls": Array [
           "https://repo.maven.apache.org/maven2",
           "https://maven.atlassian.com/content/repositories/atlassian-public/",
@@ -66,7 +61,6 @@ Array [
         "datasource": "maven",
         "depName": "\${group-id-placeholder}:baz",
         "fileReplacePosition": 2380,
-        "propSource": null,
         "registryUrls": Array [
           "https://repo.maven.apache.org/maven2",
           "https://maven.atlassian.com/content/repositories/atlassian-public/",
@@ -79,7 +73,6 @@ Array [
         "depName": "org.example:quux",
         "fileReplacePosition": 698,
         "groupName": "quuxVersion",
-        "propSource": "random.pom.xml",
         "registryUrls": Array [
           "https://repo.maven.apache.org/maven2",
           "https://maven.atlassian.com/content/repositories/atlassian-public/",
@@ -91,7 +84,6 @@ Array [
         "depName": "org.example:quux-test",
         "fileReplacePosition": 698,
         "groupName": "quuxVersion",
-        "propSource": "random.pom.xml",
         "registryUrls": Array [
           "https://repo.maven.apache.org/maven2",
           "https://maven.atlassian.com/content/repositories/atlassian-public/",
@@ -102,7 +94,6 @@ Array [
         "datasource": "maven",
         "depName": "org.example:quuz",
         "fileReplacePosition": 2832,
-        "propSource": null,
         "registryUrls": Array [
           "https://repo.maven.apache.org/maven2",
           "https://maven.atlassian.com/content/repositories/atlassian-public/",
@@ -113,7 +104,6 @@ Array [
         "datasource": "maven",
         "depName": "org.example:quuuz",
         "fileReplacePosition": 2972,
-        "propSource": null,
         "registryUrls": Array [
           "https://repo.maven.apache.org/maven2",
           "https://maven.atlassian.com/content/repositories/atlassian-public/",
@@ -125,7 +115,6 @@ Array [
         "datasource": "maven",
         "depName": "org.example:hard-range",
         "fileReplacePosition": 3130,
-        "propSource": null,
         "registryUrls": Array [
           "https://repo.maven.apache.org/maven2",
           "https://maven.atlassian.com/content/repositories/atlassian-public/",
@@ -136,7 +125,6 @@ Array [
         "datasource": "maven",
         "depName": "org.example:profile-artifact",
         "fileReplacePosition": 3392,
-        "propSource": null,
         "registryUrls": Array [
           "https://repo.maven.apache.org/maven2",
           "https://maven.atlassian.com/content/repositories/atlassian-public/",
@@ -148,30 +136,12 @@ Array [
         "datasource": "maven",
         "depName": "org.apache.maven.plugins:maven-checkstyle-plugin",
         "fileReplacePosition": 3668,
-        "propSource": null,
         "registryUrls": Array [
           "https://repo.maven.apache.org/maven2",
           "https://maven.atlassian.com/content/repositories/atlassian-public/",
         ],
       },
     ],
-    "mavenProps": Object {
-      "quuxGroup": Object {
-        "fileReplacePosition": 631,
-        "packageFile": "random.pom.xml",
-        "val": "org.example",
-      },
-      "quuxId": Object {
-        "fileReplacePosition": 667,
-        "packageFile": "random.pom.xml",
-        "val": "quux",
-      },
-      "quuxVersion": Object {
-        "fileReplacePosition": 698,
-        "packageFile": "random.pom.xml",
-        "val": "1.2.3.4",
-      },
-    },
     "packageFile": "random.pom.xml",
   },
 ]


### PR DESCRIPTION
@zharinov these `mavenProps` don't appear to be used outside the `extract` function. Could they instead be stripped out before we return the result of the extract function?