### PR TITLE
fix(git): aonly allow fast-forward merge

### DIFF
--- a/lib/platform/git/storage.ts
+++ b/lib/platform/git/storage.ts
@@ -338,7 +338,7 @@ export class Storage {
     await this._git!.reset('hard');
     await this._git!.checkout(['-B', branchName, 'origin/' + branchName]);
     await this._git!.checkout(this._config.baseBranch);
-    await this._git!.merge([branchName]);
+    await this._git!.merge(['--ff-only', branchName]);
     await this._git!.push('origin', this._config.baseBranch);
   }
 

--- a/test/platform/git/storage.spec.ts
+++ b/test/platform/git/storage.spec.ts
@@ -149,6 +149,20 @@ describe('platform/git/storage', () => {
     it('should throw if branch merge throws', async () => {
       await expect(git.mergeBranch('not_found')).rejects.toThrow();
     });
+    it('should throw if branch merge is stale', async () => {
+      expect.assertions(1);
+      await git.setBranchPrefix('renovate/');
+      await git.commitFilesToBranch(
+        'test',
+        [{ name: 'some-new-file', contents: 'some new-contents' }],
+        'test mesage',
+        'renovate/past_branch'
+      );
+
+      await git.setBaseBranch('master');
+
+      await expect(git.mergeBranch('test')).rejects.toThrow();
+    });
   });
   describe('deleteBranch(branchName)', () => {
     it('should send delete', async () => {


### PR DESCRIPTION
Renovate branch merges should only be fast-forward, so forcing it.