### PR TITLE
fix(maven): Use documented default value for `relativePath`

### DIFF
--- a/lib/manager/maven/extract.ts
+++ b/lib/manager/maven/extract.ts
@@ -179,8 +179,9 @@ export function extractPackage(rawContent: string, packageFile: string = null) {
     });
   }
 
-  const parentPath = project.valueWithPath('parent.relativePath');
-  if (parentPath) {
+  if (packageFile && project.childNamed('parent')) {
+    const parentPath =
+      project.valueWithPath('parent.relativePath') || '../pom.xml';
     result.parent = resolveParentFile(packageFile, parentPath);
   }
 

--- a/test/manager/maven/__snapshots__/index.spec.ts.snap
+++ b/test/manager/maven/__snapshots__/index.spec.ts.snap
@@ -143,6 +143,7 @@ Array [
       },
     ],
     "packageFile": "random.pom.xml",
+    "parent": "../pom.xml",
   },
 ]
 `;


### PR DESCRIPTION
It's not always necessary to be explicit (https://github.com/renovatebot/config-help/issues/309#issuecomment-515155858)

https://maven.apache.org/ref/3.0.3/maven-model/maven.html#class_parent