### PR TITLE
test: mock chalk for multi platform support

### DIFF
--- a/test/logger/__snapshots__/pretty-stdout.spec.ts.snap
+++ b/test/logger/__snapshots__/pretty-stdout.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`logger/pretty-stdout formatRecord(rec) formats record 1`] = `
-"[90mTRACE[39m: test message
+"TRACE: test message
        \\"config\\": {\\"a\\": \\"b\\", \\"d\\": [\\"e\\", \\"f\\"]}
 "
 `;

--- a/test/logger/pretty-stdout.spec.ts
+++ b/test/logger/pretty-stdout.spec.ts
@@ -1,6 +1,13 @@
 import chalk from 'chalk';
 import * as prettyStdout from '../../lib/logger/pretty-stdout';
 
+jest.mock('chalk', () =>
+  ['bgRed', 'blue', 'gray', 'green', 'magenta', 'red'].reduce(
+    (r, c) => Object.defineProperty(r, c, { value: (s: string) => s }),
+    {}
+  )
+);
+
 describe('logger/pretty-stdout', () => {
   describe('getMeta(rec)', () => {
     it('returns empty string if null rec', () => {
@@ -62,6 +69,12 @@ describe('logger/pretty-stdout', () => {
     });
   });
   describe('formatRecord(rec)', () => {
+    beforeEach(() => {
+      process.env.FORCE_COLOR = '1';
+    });
+    afterEach(() => {
+      delete process.env.FORCE_COLOR;
+    });
     it('formats record', () => {
       const rec: prettyStdout.BunyanRecord = {
         level: 10,


### PR DESCRIPTION
This is required, because some older consoles do not support ansi colors and some tests would fail

Also some ci services would fail (eg azure)