### PR TITLE
fix(manager): fix maven path format

### DIFF
--- a/lib/manager/maven/extract.ts
+++ b/lib/manager/maven/extract.ts
@@ -132,7 +132,8 @@ function resolveParentFile(packageFile: string, parentPath: string) {
     parentDir = dirname(parentPath);
   }
   const dir = dirname(packageFile);
-  return normalize(join(dir, parentDir, parentFile));
+  const result = normalize(join(dir, parentDir, parentFile));
+  return process.platform === 'win32' ? result.split('\\').join('/') : result;
 }
 
 export function extractPackage(rawContent: string, packageFile: string = null) {


### PR DESCRIPTION
This pr makes the path to unix style for windows, because tests would fail otherwise.