### PR TITLE
fix(datasource): massage GitHub sourceUrl with http and/or www

### DIFF
--- a/lib/datasource/metadata.js
+++ b/lib/datasource/metadata.js
@@ -68,6 +68,7 @@ function addMetaData(dep, datasource, lookupName) {
   if (!dep) {
     return;
   }
+
   const depName = lookupName ? lookupName.toLowerCase() : null;
   if (
     manualChangelogUrls[datasource] &&
@@ -78,24 +79,29 @@ function addMetaData(dep, datasource, lookupName) {
   if (manualSourceUrls[datasource] && manualSourceUrls[datasource][depName]) {
     dep.sourceUrl = manualSourceUrls[datasource][depName];
   }
+
+  /**
+   * @param {string} url
+   */
+  const massageGithubUrl = url => {
+    return url
+      .replace('http:', 'https:')
+      .replace('www.github.com', 'github.com')
+      .split('/')
+      .slice(0, 5)
+      .join('/');
+  };
   if (dep.sourceUrl && dep.sourceUrl.includes('github.com')) {
-    dep.sourceUrl = parse(
-      dep.sourceUrl
-        .split('/')
-        .slice(0, 5)
-        .join('/')
-    );
+    dep.sourceUrl = parse(massageGithubUrl(dep.sourceUrl));
   }
   if (
     !dep.sourceUrl &&
     dep.changelogUrl &&
-    dep.changelogUrl.startsWith('https://github.com/')
+    dep.changelogUrl.match(/^https?:\/\/(www\.)?github\.com/)
   ) {
-    dep.sourceUrl = dep.changelogUrl
-      .split('/')
-      .slice(0, 5)
-      .join('/');
+    dep.sourceUrl = massageGithubUrl(dep.changelogUrl);
   }
+
   // Clean up any empty urls
   const urls = ['homepage', 'sourceUrl', 'changelogUrl'];
   for (const url of urls) {

--- a/test/datasource/__snapshots__/metadata.spec.js.snap
+++ b/test/datasource/__snapshots__/metadata.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`datasource/terraform Should handle manualChangelogUrls 1`] = `
+exports[`datasource/metadata Should handle manualChangelogUrls 1`] = `
 Object {
   "changelogUrl": "https://github.com/django/django/tree/master/docs/releases",
   "releases": Array [
@@ -25,7 +25,7 @@ Object {
 }
 `;
 
-exports[`datasource/terraform Should handle manualSourceUrls 1`] = `
+exports[`datasource/metadata Should handle manualSourceUrls 1`] = `
 Object {
   "releases": Array [
     Object {
@@ -49,7 +49,7 @@ Object {
 }
 `;
 
-exports[`datasource/terraform Should handle parsing of sourceUrls correctly 1`] = `
+exports[`datasource/metadata Should handle parsing of sourceUrls correctly 1`] = `
 Object {
   "releases": Array [
     Object {

--- a/test/datasource/metadata.spec.js
+++ b/test/datasource/metadata.spec.js
@@ -1,6 +1,6 @@
 const { addMetaData } = require('../../lib/datasource/metadata');
 
-describe('datasource/terraform', () => {
+describe('datasource/metadata', () => {
   it('Should do nothing if dep is not specified', () => {
     expect(addMetaData()).toBeUndefined();
   });
@@ -63,5 +63,17 @@ describe('datasource/terraform', () => {
 
     addMetaData(dep, datasource, lookupName);
     expect(dep).toMatchSnapshot();
+  });
+
+  it('Should handle parsing/converting of GitHub sourceUrls with http and www correctly', () => {
+    const dep = {
+      sourceUrl: 'http://www.github.com/mockk/mockk/',
+      releases: [{ version: '1.9.3' }],
+    };
+    const datasource = 'maven';
+    const lookupName = 'io.mockk:mockk';
+
+    addMetaData(dep, datasource, lookupName);
+    expect(dep.sourceUrl).toEqual('https://github.com/mockk/mockk');
   });
 });


### PR DESCRIPTION
This is related/similar to https://github.com/renovatebot/renovate/commit/2e7e36bb5a063077cd27744d1860f25f0ae03ddd.