### PR TITLE
fix(maven): pkgUrl can be string

### DIFF
--- a/lib/datasource/maven/util.js
+++ b/lib/datasource/maven/util.js
@@ -5,8 +5,13 @@ module.exports = {
   downloadHttpProtocol,
 };
 
+/**
+ * @param {import('url').URL | string} pkgUrl
+ */
 function isMavenCentral(pkgUrl) {
-  return pkgUrl.host === 'central.maven.org';
+  return (
+    (typeof pkgUrl === 'string' ? pkgUrl : pkgUrl.host) === 'central.maven.org'
+  );
 }
 
 function isTemporalError(err) {


### PR DESCRIPTION
Indirect used by `downloadHttpProtocol` from sbt datasource

related to #4183 