### PR TITLE
fix: Allow for auto-merge of new PRs

### DIFF
--- a/lib/platform/bitbucket-server/index.ts
+++ b/lib/platform/bitbucket-server/index.ts
@@ -786,6 +786,7 @@ export async function createPr(
   const pr = {
     id: prInfoRes.body.id,
     displayNumber: `Pull Request #${prInfoRes.body.id}`,
+    canRebase: true,
     ...utils.prInfo(prInfoRes.body),
   };
 

--- a/lib/platform/bitbucket/index.ts
+++ b/lib/platform/bitbucket/index.ts
@@ -554,7 +554,11 @@ export async function createPr(
     `/2.0/repositories/${config.repository}/pullrequests`,
     { body }
   )).body;
-  const pr = { number: prInfo.id, displayNumber: `Pull Request #${prInfo.id}` };
+  const pr = {
+    number: prInfo.id,
+    displayNumber: `Pull Request #${prInfo.id}`,
+    canRebase: true,
+  };
   // istanbul ignore if
   if (config.prList) {
     config.prList.push(pr);

--- a/lib/platform/github/index.ts
+++ b/lib/platform/github/index.ts
@@ -41,6 +41,7 @@ interface Pr {
   sha: string;
 
   sourceRepo: string;
+  canRebase: boolean;
 }
 
 interface RepoConfig {
@@ -1211,6 +1212,7 @@ export async function createPr(
       urls.homepage
     );
   }
+  pr.canRebase = true;
   return pr;
 }
 

--- a/lib/platform/gitlab/index.ts
+++ b/lib/platform/gitlab/index.ts
@@ -709,6 +709,7 @@ export async function createPr(
   pr.number = pr.iid;
   pr.branchName = branchName;
   pr.displayNumber = `Merge Request #${pr.iid}`;
+  pr.canRebase = true;
   // istanbul ignore if
   if (config.prList) {
     config.prList.push(pr);

--- a/lib/workers/pr/index.js
+++ b/lib/workers/pr/index.js
@@ -421,7 +421,7 @@ async function checkAutoMerge(pr, config) {
       return false;
     }
     // Check if it's been touched
-    if (pr.canRebase === false) {
+    if (!pr.canRebase) {
       logger.info('PR is ready for automerge but has been modified');
       return false;
     }

--- a/lib/workers/pr/index.js
+++ b/lib/workers/pr/index.js
@@ -421,7 +421,7 @@ async function checkAutoMerge(pr, config) {
       return false;
     }
     // Check if it's been touched
-    if (!pr.canRebase) {
+    if (pr.canRebase === false) {
       logger.info('PR is ready for automerge but has been modified');
       return false;
     }

--- a/test/platform/github/__snapshots__/index.spec.ts.snap
+++ b/test/platform/github/__snapshots__/index.spec.ts.snap
@@ -38,6 +38,7 @@ Array [
 exports[`platform/github createPr() should create and return a PR object 1`] = `
 Object {
   "branchName": "some-branch",
+  "canRebase": true,
   "displayNumber": "Pull Request #123",
   "number": 123,
 }
@@ -82,6 +83,7 @@ Array [
 exports[`platform/github createPr() should use defaultBranch 1`] = `
 Object {
   "branchName": "some-branch",
+  "canRebase": true,
   "displayNumber": "Pull Request #123",
   "number": 123,
 }

--- a/test/platform/gitlab/__snapshots__/index.spec.ts.snap
+++ b/test/platform/gitlab/__snapshots__/index.spec.ts.snap
@@ -30,6 +30,7 @@ Array [
 exports[`platform/gitlab createPr(branchName, title, body) returns the PR 1`] = `
 Object {
   "branchName": "some-branch",
+  "canRebase": true,
   "displayNumber": "Merge Request #12345",
   "id": 1,
   "iid": 12345,
@@ -58,6 +59,7 @@ Array [
 exports[`platform/gitlab createPr(branchName, title, body) uses default branch 1`] = `
 Object {
   "branchName": "some-branch",
+  "canRebase": true,
   "displayNumber": "Merge Request #12345",
   "id": 1,
   "iid": 12345,


### PR DESCRIPTION
Closes #4113

As I can see, we're setting `canRebase = false` explicitly, so it should work well. Another way is to set `canRebase = true` at `createPr(...)` stage, not sure what's best. @rarkins 