### PR TITLE
fix: Cache the right thing in gitlab datasource

### DIFF
--- a/lib/datasource/gitlab/index.js
+++ b/lib/datasource/gitlab/index.js
@@ -99,7 +99,7 @@ async function getPkgReleases({ registryUrls, lookupName: repo, lookupType }) {
   await renovateCache.set(
     cacheNamespace,
     getCacheKey(depHost, repo, lookupType),
-    versions,
+    dependency,
     cacheMinutes
   );
   return dependency;


### PR DESCRIPTION
It's caching the wrong thing, so on subsequent runs it errors with 

```
{"name":"renovate","hostname":"app-775fd44cbd-zcsgh","pid":6588,"level":50,"repository":"blah,"err":{"message":"Cannot read property 'map' of undefined","stack":"TypeError: Cannot read property 'map' of undefined\n    at lookupUpdates (/usr/src/app/dist/workers/repository/process/lookup/index.js:53:14)"},"msg":"Repository has unknown error","time":"2019-08-02T12:50:04.825Z","v":0}
```