### PR TITLE
feat(changelog): Support Maven style tag format

### DIFF
--- a/lib/workers/pr/changelog/source-github.js
+++ b/lib/workers/pr/changelog/source-github.js
@@ -98,9 +98,10 @@ async function getChangeLogJSON({
     if (!tags) {
       tags = await getTags(endpoint, versionScheme, repository);
     }
+    const regex = new RegExp(`${depName}[@\-]`);
     const tagName = tags
-      .filter(tag => isVersion(tag.replace(`${depName}@`, '')))
-      .find(tag => equals(tag.replace(`${depName}@`, ''), release.version));
+      .filter(tag => isVersion(tag.replace(regex, '')))
+      .find(tag => equals(tag.replace(regex, ''), release.version));
     if (tagName) {
       return tagName;
     }

--- a/lib/workers/pr/changelog/source-github.js
+++ b/lib/workers/pr/changelog/source-github.js
@@ -98,7 +98,7 @@ async function getChangeLogJSON({
     if (!tags) {
       tags = await getTags(endpoint, versionScheme, repository);
     }
-    const regex = new RegExp(`${depName}[@\-]`);
+    const regex = new RegExp(`${depName}[@-]`);
     const tagName = tags
       .filter(tag => isVersion(tag.replace(regex, '')))
       .find(tag => equals(tag.replace(regex, ''), release.version));


### PR DESCRIPTION
https://maven.apache.org/maven-release/maven-release-plugin/examples/prepare-release.html#Overriding_the_default_tag_name_format

> By default, if you do not specify a tag name, a default tag name of `artifactId`-`version` will be suggested (and if running non-interactively used).

An example is https://github.com/google/dagger/releases: e.g. `dagger-2.24`