### PR TITLE
feat: add option assignAutomerge 

### DIFF
--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -1135,6 +1135,13 @@ const options = [
     subType: 'string',
   },
   {
+    name: 'assignAutomerge'
+    description:
+      'Assign reviewers and assignees even if the PR is to be automerged',
+    type: 'boolean',
+    default: false,
+  },
+  {
     name: 'reviewers',
     description:
       'Requested reviewers for Pull Requests (username in GitHub/GitLab/Bitbucket, email or username in Azure DevOps)',

--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -1135,7 +1135,7 @@ const options = [
     subType: 'string',
   },
   {
-    name: 'assignAutomerge'
+    name: 'assignAutomerge',
     description:
       'Assign reviewers and assignees even if the PR is to be automerged',
     type: 'boolean',

--- a/lib/workers/pr/index.js
+++ b/lib/workers/pr/index.js
@@ -318,6 +318,7 @@ async function ensurePr(prConfig) {
     // Skip assign and review if automerging PR
     if (
       config.automerge &&
+      !config.assignAutomerge &&
       !['failure', 'error', 'failed'].includes(await getBranchStatus())
     ) {
       logger.debug(

--- a/renovate-schema.json
+++ b/renovate-schema.json
@@ -762,6 +762,11 @@
         "type": "string"
       }
     },
+    "assignAutomerge": {
+      "description": "Assign reviewers and assignees even if the PR is to be automerged",
+      "type": "boolean",
+      "default": false
+    },
     "reviewers": {
       "description": "Requested reviewers for Pull Requests (username in GitHub/GitLab/Bitbucket, email or username in Azure DevOps)",
       "type": "array",

--- a/test/workers/pr/index.spec.js
+++ b/test/workers/pr/index.spec.js
@@ -291,6 +291,16 @@ describe('workers/pr', () => {
       expect(platform.addAssignees).toHaveBeenCalledTimes(0);
       expect(platform.addReviewers).toHaveBeenCalledTimes(0);
     });
+    it('should add assignees and reviewers to new PR if automerging enabled but configured to always assign', async () => {
+      config.assignees = ['bar'];
+      config.reviewers = ['baz'];
+      config.automerge = true;
+      config.assignAutomerge = true;
+      const pr = await prWorker.ensurePr(config);
+      expect(pr).toMatchObject({ displayNumber: 'New Pull Request' });
+      expect(platform.addAssignees).toHaveBeenCalledTimes(1);
+      expect(platform.addReviewers).toHaveBeenCalledTimes(1);
+    });
     it('should return unmodified existing PR', async () => {
       platform.getBranchPr.mockReturnValueOnce(existingPr);
       config.semanticCommitScope = null;

--- a/website/docs/configuration-options.md
+++ b/website/docs/configuration-options.md
@@ -25,6 +25,10 @@ If you have any questions about the below config options, or would like to get h
 
 Add configuration here if you want to enable or disable something in particular for Ansible files and override the default Docker settings.
 
+## assignAutomerge
+
+By default, Renovate will not assign reviewers and assignees if the PR is to be automerged, unless the status check failed. By configuring this setting, you can enable Renovate to always assign reviewers and assignees.
+
 ## assignees
 
 Must be valid usernames.


### PR DESCRIPTION
<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate
-->

Add the new option `assignAutomerge` which would instruct Renovate to assign reviewers and assignees even if the PR is to be automerged. 

This was tested against a GitLab test repo: https://gitlab.com/hugo-automation-test/renovate-test/merge_requests/1

Closes #4153 <!-- Ideally each PR should be closing an open issue -->
