### PR TITLE
fix(docker-compose): ignore image if built locally

### DIFF
--- a/lib/manager/docker-compose/extract.ts
+++ b/lib/manager/docker-compose/extract.ts
@@ -1,32 +1,66 @@
+import { safeLoad } from 'js-yaml';
+
 import { logger } from '../../logger';
 import { getDep } from '../dockerfile/extract';
-import { PackageFile, PackageDependency } from '../common';
+import { PackageFile } from '../common';
 
-export function extractPackageFile(content: string): PackageFile {
-  logger.debug('docker-compose.extractPackageFile()');
-  let deps: PackageDependency[] = [];
-  let lineNumber = 0;
-  for (const line of content.split('\n')) {
-    const match = line.match(/^\s*image:\s*'?"?([^\s'"]+)'?"?\s*$/);
-    if (match) {
-      const currentFrom = match[1];
-      const dep = getDep(currentFrom);
-      logger.trace(
-        {
-          depName: dep.depName,
-          currentValue: dep.currentValue,
-          currentDigest: dep.currentDigest,
-        },
-        'Docker Compose image'
-      );
-      dep.managerData = { lineNumber };
-      deps.push(dep);
-    }
-    lineNumber += 1;
+interface DockerComposeConfig {
+  version?: string;
+  services?: Record<string, DockerComposeService>;
+}
+
+interface DockerComposeService {
+  image?: string;
+  build?: {
+    context?: string;
+    dockerfile?: string;
+  };
+}
+
+class LineMapper {
+  private imageLines: { line: string; lineNumber: number; used: boolean }[];
+
+  constructor(content: string, filter: RegExp) {
+    this.imageLines = [...content.split('\n').entries()]
+      .filter(([_, line]) => filter.test(line))
+      .map(([lineNumber, line]) => ({ lineNumber, line, used: false }));
   }
-  deps = deps.filter(
-    dep => !(dep.currentValue && dep.currentValue.includes('${'))
-  );
+
+  pluckLineNumber(imageName: string): number {
+    const lineMeta = this.imageLines.find(
+      ({ line, used }) => !used && line.includes(imageName)
+    );
+    if (!lineMeta) {
+      throw Error('Unable to determine line number for image ' + imageName);
+    }
+    lineMeta.used = true; // unset plucked lines so duplicates are skipped
+    return lineMeta.lineNumber;
+  }
+}
+
+export function extractPackageFile(content: string): PackageFile | null {
+  logger.debug('docker-compose.extractPackageFile()');
+  let config: DockerComposeConfig;
+  try {
+    config = safeLoad(content);
+  } catch (err) {
+    logger.error({ err }, 'Parsing Docker Compose config YAML');
+    return null;
+  }
+  const lineMapper = new LineMapper(content, /^\s*image:/);
+
+  // Image name/tags for services are only eligible for update if they don't
+  // use variables and if the image is not built locally
+  const deps = Object.values(config.services || {})
+    .filter(service => service.image && !service.build)
+    .map(service => {
+      const dep = getDep(service.image);
+      const lineNumber = lineMapper.pluckLineNumber(service.image);
+      dep.managerData = { lineNumber };
+      return dep;
+    });
+
+  logger.trace({ deps }, 'Docker Compose image');
   if (!deps.length) {
     return null;
   }

--- a/lib/manager/docker-compose/extract.ts
+++ b/lib/manager/docker-compose/extract.ts
@@ -22,7 +22,7 @@ class LineMapper {
 
   constructor(content: string, filter: RegExp) {
     this.imageLines = [...content.split('\n').entries()]
-      .filter(([_, line]) => filter.test(line))
+      .filter(entry => filter.test(entry[1]))
       .map(([lineNumber, line]) => ({ lineNumber, line, used: false }));
   }
 
@@ -30,9 +30,7 @@ class LineMapper {
     const lineMeta = this.imageLines.find(
       ({ line, used }) => !used && line.includes(imageName)
     );
-    if (!lineMeta) {
-      throw Error('Unable to determine line number for image ' + imageName);
-    }
+
     lineMeta.used = true; // unset plucked lines so duplicates are skipped
     return lineMeta.lineNumber;
   }

--- a/test/manager/docker-compose/_fixtures/docker-compose.1.yml
+++ b/test/manager/docker-compose/_fixtures/docker-compose.1.yml
@@ -59,7 +59,7 @@ services:
       restart_policy:
         condition: on-failure
 
-  worker:
+  votingworker:
     image: dockersamples/examplevotingapp_worker
     networks:
       - frontend
@@ -89,6 +89,12 @@ services:
 
   edplugins:
     image: ${IMAGE:-synkodevelopers/edplugins}:${TAG:-latest}
+
+  debugapp:
+    image: app-local-debug
+    build:
+      context: .
+      dockerfile: Dockerfile.local
 
 networks:
   frontend:

--- a/test/manager/docker-compose/extract.spec.ts
+++ b/test/manager/docker-compose/extract.spec.ts
@@ -11,6 +11,9 @@ describe('lib/manager/docker-compose/extract', () => {
     it('returns null for empty', () => {
       expect(extractPackageFile('nothing here')).toBeNull();
     });
+    it('returns null for malformed YAML', () => {
+      expect(extractPackageFile('nothing here\n:::::::')).toBeNull();
+    });
     it('extracts multiple image lines', () => {
       const res = extractPackageFile(yamlFile);
       expect(res.deps).toMatchSnapshot();


### PR DESCRIPTION
This change does require that the config file be valid YAML, where as before it did not.

Closes #4271
