### PR TITLE
feat: Add `rebaseConflictedPrs` configuration

### DIFF
--- a/lib/config/definitions.js
+++ b/lib/config/definitions.js
@@ -863,6 +863,12 @@ const options = [
     default: false,
   },
   {
+    name: 'rebaseConflictedPrs',
+    description: 'Auto-rebase when there is conflict in PRs',
+    type: 'boolean',
+    default: true,
+  },
+  {
     name: 'rebaseStalePrs',
     description: 'Rebase any PRs that are not up-to-date with the base branch',
     type: 'boolean',

--- a/lib/workers/branch/parent.js
+++ b/lib/workers/branch/parent.js
@@ -62,8 +62,13 @@ async function getParentBranch(config) {
   // Now check if PR is unmergeable. If so then we also rebase
   if (pr && pr.isConflicted) {
     logger.debug('PR is conflicted');
+
     if (pr.canRebase) {
       logger.info(`Branch is not mergeable and needs rebasing`);
+      if (!config.rebaseConflictedPrs) {
+        logger.info('rebaseConflictedPrs is disabled');
+        return { parentBranch: branchName, canRebase: true };
+      }
       // Setting parentBranch back to undefined means that we'll use the default branch
       return { parentBranch: undefined };
     }

--- a/renovate-schema.json
+++ b/renovate-schema.json
@@ -561,6 +561,11 @@
       "type": "boolean",
       "default": false
     },
+    "rebaseConflictedPrs": {
+      "description": "Auto-rebase when there is conflict in PRs",
+      "type": "boolean",
+      "default": true
+    },
     "rebaseStalePrs": {
       "description": "Rebase any PRs that are not up-to-date with the base branch",
       "type": "boolean",

--- a/test/workers/branch/parent.spec.js
+++ b/test/workers/branch/parent.spec.js
@@ -10,6 +10,7 @@ describe('workers/branch/parent', () => {
       config = {
         branchName: 'renovate/some-branch',
         rebaseLabel: 'rebase',
+        rebaseConflictedPrs: true,
       };
     });
     afterEach(() => {
@@ -39,6 +40,16 @@ describe('workers/branch/parent', () => {
       platform.getBranchPr.mockReturnValue({
         isConflicted: true,
         canRebase: false,
+      });
+      const res = await getParentBranch(config);
+      expect(res.parentBranch).toBe(config.branchName);
+    });
+    it('returns branchName if unmergeable and can rebase, but rebaseConflictedPrs is disabled', async () => {
+      config.rebaseConflictedPrs = false;
+      platform.branchExists.mockReturnValue(true);
+      platform.getBranchPr.mockReturnValue({
+        isConflicted: true,
+        canRebase: true,
       });
       const res = await getParentBranch(config);
       expect(res.parentBranch).toBe(config.branchName);

--- a/website/docs/configuration-options.md
+++ b/website/docs/configuration-options.md
@@ -955,6 +955,10 @@ For example, if your `package.json` specifies a value for `left-pad` of `^1.0.0`
 
 This feature supports simple caret (`^`) and tilde (`~`) ranges only, like `^1.0.0` and `~1.0.0`.
 
+## rebaseConflictedPrs
+
+This field defaults to `true` which means Renovate will rebase whenever there is a merge conflict with the master branch. However, this default behavior may result in costing a lot of CI cycles. If you wish to disable auto-rebasing in case of merge conflicts with the master branch, set it's value to `false`.
+
 ## rebaseLabel
 
 On GitHub it is possible to add a label to a PR to manually request Renovate to recreate/rebase it. By default this label is `"rebase"` however you can configure it to anything you want by changing this `rebaseLabel` field.


### PR DESCRIPTION
`rebaseConflictedPrs` is used to enable or disable auto-rebase
in case of merge conflicts with the master branch. It is `true`
by default which means branches will be rebased if there are conflicts
in a PR. By setting it to `false`, Renovate no longer will rebase it
with the master branch if there are merge conflicts.

Closes #4184