### PR TITLE
fix(typos): Fixed typos in developer docs

### DIFF
--- a/docs/adding-a-package-manager.md
+++ b/docs/adding-a-package-manager.md
@@ -1,6 +1,6 @@
 # Adding a Package Manager
 
-This document describes the steps to take if you are interest in adding new language/package manager support.
+This document describes the steps to take if you are interested in adding new language/package manager support.
 
 ### Background
 
@@ -71,4 +71,4 @@ Set to true if this package manager needs to update lock files in addition to pa
 
 ##### `updateDependency(fileContent, upgrade)`
 
-This function is the final one called for most managers. It's purpose is to patch the package file with the new value (described in the upgrade) and return an updated file. If the file was already updated then it would return the same contents as it was provided.
+This function is the final one called for most managers. Its purpose is to patch the package file with the new value (described in the upgrade) and return an updated file. If the file was already updated then it would return the same contents as it was provided.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,6 +1,6 @@
 # Deployment
 
-Before deploying the script for scheduled runs, it's recommend you test your
+Before deploying the script for scheduled runs, it's recommended you test your
 settings locally first.
 
 ## Server cron

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -138,7 +138,7 @@ If you are running on any platform except github.com, it's important to also con
 
 ## File/directory usage
 
-By default, Renovate will store all files within a `renovate/` subdirectory of the operating system's tempororary directory, e.g. `/tmp/renovate/`.
+By default, Renovate will store all files within a `renovate/` subdirectory of the operating system's temporary directory, e.g. `/tmp/renovate/`.
 
 Repository data will be copied or cloned into unique subdirectories under `repos/`, e.g. `/tmp/renovate/repos/github/owner1/repo-a/`.
 


### PR DESCRIPTION
Fixed typos in developer docs. Only changed incorrect words and not each and every grammatical changes.

Closes: #4277