### PR TITLE
fix(gitlab): follow pagination in getbranchstatus for gitlab

### DIFF
--- a/lib/platform/gitlab/index.ts
+++ b/lib/platform/gitlab/index.ts
@@ -329,7 +329,7 @@ export async function getBranchStatus(
   const branchSha = await config.storage.getBranchCommit(branchName);
   // Now, check the statuses for that commit
   const url = `projects/${config.repository}/repository/commits/${branchSha}/statuses`;
-  const res = await api.get(url);
+  const res = await api.get(url, { paginate: true });
   logger.debug(`Got res with ${res.body.length} results`);
   if (res.body.length === 0) {
     // Return 'pending' if we have no status checks

--- a/test/platform/gitlab/index.spec.ts
+++ b/test/platform/gitlab/index.spec.ts
@@ -418,44 +418,6 @@ describe('platform/gitlab', () => {
       );
     });
   });
-  describe('Paginated getBranchStatus(branchName, requiredStatusChecks)', () => {
-    it('returns success if all pages contain success', async () => {
-      api.get.mockResolvedValueOnce({
-        headers: {
-          link:
-            '<URL&page=2&per_page=1>; rel="next", <URL&page=1&per_page=1>; rel="first", <URL&page=2&per_page=1>; rel="last"',
-        },
-        body: [{ status: 'success' }],
-      } as any);
-      api.get.mockResolvedValueOnce({
-        headers: {
-          link:
-            '<URL&page=1&per_page=1>; rel="first", <URL&page=2&per_page=1>; rel="last"',
-        },
-        body: [{ status: 'success' }],
-      } as any);
-      const res = await gitlab.getBranchStatus('somebranch', null);
-      expect(res).toEqual('success');
-    });
-    it('returns failed if any page contains failed', async () => {
-      api.get.mockResolvedValueOnce({
-        headers: {
-          link:
-            '<URL&page=2&per_page=1>; rel="next", <URL&page=1&per_page=1>; rel="first", <URL&page=2&per_page=1>; rel="last"',
-        },
-        body: [{ status: 'success' }],
-      } as any);
-      api.get.mockResolvedValueOnce({
-        headers: {
-          link:
-            '<URL&page=1&per_page=1>; rel="first", <URL&page=2&per_page=1>; rel="last"',
-        },
-        body: [{ status: 'failed' }],
-      } as any);
-      const res = await gitlab.getBranchStatus('somebranch', null);
-      expect(res).toEqual('failed');
-    });
-  });
   describe('getBranchStatusCheck', () => {
     beforeEach(() => initRepo());
     it('returns null if no results', async () => {

--- a/test/platform/gitlab/index.spec.ts
+++ b/test/platform/gitlab/index.spec.ts
@@ -418,6 +418,44 @@ describe('platform/gitlab', () => {
       );
     });
   });
+  describe('Paginated getBranchStatus(branchName, requiredStatusChecks)', () => {
+    it('returns success if all pages contain success', async () => {
+      api.get.mockResolvedValueOnce({
+        headers: {
+          link:
+            '<URL&page=2&per_page=1>; rel="next", <URL&page=1&per_page=1>; rel="first", <URL&page=2&per_page=1>; rel="last"',
+        },
+        body: [{ status: 'success' }],
+      } as any);
+      api.get.mockResolvedValueOnce({
+        headers: {
+          link:
+            '<URL&page=1&per_page=1>; rel="first", <URL&page=2&per_page=1>; rel="last"',
+        },
+        body: [{ status: 'success' }],
+      } as any);
+      const res = await gitlab.getBranchStatus('somebranch', null);
+      expect(res).toEqual('success');
+    });
+    it('returns failed if any page contains failed', async () => {
+      api.get.mockResolvedValueOnce({
+        headers: {
+          link:
+            '<URL&page=2&per_page=1>; rel="next", <URL&page=1&per_page=1>; rel="first", <URL&page=2&per_page=1>; rel="last"',
+        },
+        body: [{ status: 'success' }],
+      } as any);
+      api.get.mockResolvedValueOnce({
+        headers: {
+          link:
+            '<URL&page=1&per_page=1>; rel="first", <URL&page=2&per_page=1>; rel="last"',
+        },
+        body: [{ status: 'failed' }],
+      } as any);
+      const res = await gitlab.getBranchStatus('somebranch', null);
+      expect(res).toEqual('failed');
+    });
+  });
   describe('getBranchStatusCheck', () => {
     beforeEach(() => initRepo());
     it('returns null if no results', async () => {


### PR DESCRIPTION
There are cases where the first page of results is not representative of the entire branch's status, so we need to follow all pages in the result.

I _think_ this should be sufficient to fix the issue, but I don't really know enough node/jest to understand how the tests should work. Maybe something like the following?

```typescript
describe('Paginated getBranchStatus(branchName, requiredStatusChecks)', () => {
  beforeEach(() => {
    api.get.mockReturnValueOnce({
      headers: {
        Link: '<URL&page=2&per_page=1>; rel="next", <URL&page=1&per_page=1>; rel="first", <URL&page=2&per_page=1>; rel="last"',
      },
      body: [{ status: 'success' }],
    } as any);
    api.get.mockReturnValueOnce({
      headers: {
        Link: '<URL&page=1&per_page=1>; rel="first", <URL&page=2&per_page=1>; rel="last"',
      },
      body: [{ status: 'success' }],
    } as any);
  });
  it('returns success if all pages contain success', async () => {
    const res = await gitlab.getBranchStatus('somebranch', null);
    expect(res).toEqual('success');
  });
});
describe('Paginated getBranchStatus(branchName, requiredStatusChecks)', () => {
  beforeEach(() => {
    api.get.mockReturnValueOnce({
      headers: {
        Link: '<URL&page=2&per_page=1>; rel="next", <URL&page=1&per_page=1>; rel="first", <URL&page=2&per_page=1>; rel="last"',
      },
      body: [{ status: 'success' }],
    } as any);
    api.get.mockReturnValueOnce({
      headers: {
        Link: '<URL&page=1&per_page=1>; rel="first", <URL&page=2&per_page=1>; rel="last"',
      },
      body: [{ status: 'failed' }],
    } as any);
  });
  it('returns failed if any page contains failed', async () => {
    const res = await gitlab.getBranchStatus('somebranch', null);
    expect(res).toEqual('failed');
  });
});
```

Closes #4340