### PR TITLE
fix(changelog): Support Maven style tag format

### DIFF
--- a/lib/workers/pr/changelog/release-notes.js
+++ b/lib/workers/pr/changelog/release-notes.js
@@ -1,9 +1,9 @@
-import { api } from '../../../platform/github/gh-got-wrapper';
+import changelogFilenameRegex from 'changelog-filename-regex';
+import { linkify } from 'linkify-markdown';
+import MarkdownIt from 'markdown-it';
 
-const changelogFilenameRegex = require('changelog-filename-regex');
-const { linkify } = require('linkify-markdown');
-const MarkdownIt = require('markdown-it');
-const { logger } = require('../../../logger');
+import { api } from '../../../platform/github/gh-got-wrapper';
+import { logger } from '../../../logger';
 
 const ghGot = api.get;
 
@@ -70,14 +70,19 @@ function massageBody(input, githubBaseURL) {
 async function getReleaseNotes(
   repository,
   version,
+  depName,
   githubBaseURL,
   githubApiBaseURL
 ) {
-  logger.trace(`getReleaseNotes(${repository}, ${version})`);
+  logger.trace(`getReleaseNotes(${repository}, ${version}, ${depName})`);
   const releaseList = await getReleaseList(githubApiBaseURL, repository);
   let releaseNotes;
   releaseList.forEach(release => {
-    if (release.tag === version || release.tag === `v${version}`) {
+    if (
+      release.tag === version ||
+      release.tag === `v${version}` ||
+      release.tag === `${depName}-${version}`
+    ) {
       releaseNotes = release;
       releaseNotes.url = `${githubBaseURL}${repository}/releases/${release.tag}`;
       releaseNotes.body = massageBody(releaseNotes.body, githubBaseURL);
@@ -124,7 +129,7 @@ async function getReleaseNotesMd(
   githubBaseURL,
   githubApiBaseUrl
 ) {
-  logger.trace(`getReleaseNotes(${repository}, ${version})`);
+  logger.trace(`getReleaseNotesMd(${repository}, ${version})`);
   const skippedRepos = ['facebook/react-native'];
   // istanbul ignore if
   if (skippedRepos.includes(repository)) {
@@ -230,6 +235,7 @@ async function addReleaseNotes(input) {
         releaseNotes = await getReleaseNotes(
           repository,
           v.version,
+          input.project.depName,
           input.project.githubBaseURL,
           input.project.githubApiBaseURL
         );

--- a/lib/workers/pr/changelog/source-github.js
+++ b/lib/workers/pr/changelog/source-github.js
@@ -158,6 +158,7 @@ async function getChangeLogJSON({
       githubBaseURL,
       github: repository,
       repository: sourceUrl,
+      depName,
     },
     versions: changelogReleases,
   };

--- a/test/workers/pr/changelog/__snapshots__/index.spec.js.snap
+++ b/test/workers/pr/changelog/__snapshots__/index.spec.js.snap
@@ -4,6 +4,7 @@ exports[`workers/pr/changelog getChangeLogJSON filters unnecessary warns 1`] = `
 Object {
   "hasReleaseNotes": true,
   "project": Object {
+    "depName": "@renovate/no",
     "github": "chalk/chalk",
     "githubApiBaseURL": "https://api.github.com/",
     "githubBaseURL": "https://github.com/",
@@ -54,6 +55,7 @@ exports[`workers/pr/changelog getChangeLogJSON supports github enterprise and gi
 Object {
   "hasReleaseNotes": true,
   "project": Object {
+    "depName": "renovate",
     "github": "chalk/chalk",
     "githubApiBaseURL": "https://github-enterprise.example.com/",
     "githubBaseURL": "https://github-enterprise.example.com/",
@@ -104,6 +106,7 @@ exports[`workers/pr/changelog getChangeLogJSON supports github enterprise and gi
 Object {
   "hasReleaseNotes": true,
   "project": Object {
+    "depName": "renovate",
     "github": "chalk/chalk",
     "githubApiBaseURL": "https://api.github.com/",
     "githubBaseURL": "https://github.com/",
@@ -154,6 +157,7 @@ exports[`workers/pr/changelog getChangeLogJSON supports node engines 1`] = `
 Object {
   "hasReleaseNotes": true,
   "project": Object {
+    "depName": "renovate",
     "github": "chalk/chalk",
     "githubApiBaseURL": "https://api.github.com/",
     "githubBaseURL": "https://github.com/",
@@ -204,6 +208,7 @@ exports[`workers/pr/changelog getChangeLogJSON uses GitHub tags 1`] = `
 Object {
   "hasReleaseNotes": true,
   "project": Object {
+    "depName": "renovate",
     "github": "chalk/chalk",
     "githubApiBaseURL": "https://api.github.com/",
     "githubBaseURL": "https://github.com/",
@@ -258,6 +263,7 @@ exports[`workers/pr/changelog getChangeLogJSON works without Github 1`] = `
 Object {
   "hasReleaseNotes": true,
   "project": Object {
+    "depName": "renovate",
     "github": "chalk/chalk",
     "githubApiBaseURL": "https://api.github.com/",
     "githubBaseURL": "https://github.com/",

--- a/test/workers/pr/changelog/__snapshots__/release-notes.spec.js.snap
+++ b/test/workers/pr/changelog/__snapshots__/release-notes.spec.js.snap
@@ -1,8 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`workers/pr/release-notes getReleaseNotes() gets release notes 1`] = `undefined`;
-
 exports[`workers/pr/release-notes getReleaseNotes() gets release notes with body 1`] = `
+Object {
+  "body": "some body [#123](https://github.com/some/other-repository/issues/123), [#124](https://github.com/some/yet-other-repository/issues/124)
+",
+  "id": undefined,
+  "name": undefined,
+  "tag": "1.0.1",
+  "url": "https://github.com/some/other-repository/releases/1.0.1",
+}
+`;
+
+exports[`workers/pr/release-notes getReleaseNotes() gets release notes with body 2`] = `
 Object {
   "body": "some body [#123](https://github.com/some/other-repository/issues/123), [#124](https://github.com/some/yet-other-repository/issues/124)
 ",
@@ -10,6 +19,17 @@ Object {
   "name": undefined,
   "tag": "v1.0.1",
   "url": "https://github.com/some/other-repository/releases/v1.0.1",
+}
+`;
+
+exports[`workers/pr/release-notes getReleaseNotes() gets release notes with body 3`] = `
+Object {
+  "body": "some body [#123](https://github.com/some/other-repository/issues/123), [#124](https://github.com/some/yet-other-repository/issues/124)
+",
+  "id": undefined,
+  "name": undefined,
+  "tag": "other-1.0.1",
+  "url": "https://github.com/some/other-repository/releases/other-1.0.1",
 }
 `;
 

--- a/test/workers/pr/changelog/release-notes.spec.js
+++ b/test/workers/pr/changelog/release-notes.spec.js
@@ -39,37 +39,42 @@ describe('workers/pr/release-notes', () => {
     });
   });
   describe('getReleaseNotes()', () => {
-    it('gets release notes', async () => {
+    it('should return undefined for release notes without body', async () => {
       ghGot.mockReturnValueOnce({
         body: [{ tag_name: 'v1.0.0' }, { tag_name: 'v1.0.1' }],
       });
       const res = await getReleaseNotes(
         'some/repository',
         '1.0.0',
+        'some',
         'https://github.com/',
         'https://api.github.com/'
       );
-      expect(res).toMatchSnapshot();
+      expect(res).toBeUndefined();
     });
-    it('gets release notes with body', async () => {
-      ghGot.mockReturnValueOnce({
-        body: [
-          { tag_name: 'v1.0.0' },
-          {
-            tag_name: 'v1.0.1',
-            body:
-              'some body #123, [#124](https://github.com/some/yet-other-repository/issues/124)',
-          },
-        ],
-      });
-      const res = await getReleaseNotes(
-        'some/other-repository',
-        '1.0.1',
-        'https://github.com/',
-        'https://api.github.com/'
-      );
-      expect(res).toMatchSnapshot();
-    });
+    it.each([[''], ['v'], ['other-']])(
+      'gets release notes with body',
+      async prefix => {
+        ghGot.mockReturnValueOnce({
+          body: [
+            { tag_name: `${prefix}1.0.0` },
+            {
+              tag_name: `${prefix}1.0.1`,
+              body:
+                'some body #123, [#124](https://github.com/some/yet-other-repository/issues/124)',
+            },
+          ],
+        });
+        const res = await getReleaseNotes(
+          'some/other-repository',
+          '1.0.1',
+          'other',
+          'https://github.com/',
+          'https://api.github.com/'
+        );
+        expect(res).toMatchSnapshot();
+      }
+    );
   });
   describe('getReleaseNotesMd()', () => {
     it('handles not found', async () => {


### PR DESCRIPTION
A follow-up to #4246 which was insufficient.

`release-notes.js` should be updated in addition to `source-github.js`.