### PR TITLE
support docker version openjdk:8u131-jre-alpine

### DIFF
--- a/lib/versioning/docker/index.ts
+++ b/lib/versioning/docker/index.ts
@@ -3,8 +3,7 @@ import { VersioningApi } from '../common';
 
 function parse(version: string) {
   // openjdk:8u131-jre-alpine -> 8.131-jre-alpine
-  version = version.replace(/([0-9]*)(u)([0-9]*)/, "$1.$3")
-  const versionPieces = version.replace(/^v/, '').split('-');
+  const versionPieces = version.replace(/([0-9]*)(u)([0-9]*)/, "$1.$3").replace(/^v/, '').split('-');
   const prefix = versionPieces.shift();
   const suffix = versionPieces.join('-');
   const release = prefix.split('.').map(Number);

--- a/lib/versioning/docker/index.ts
+++ b/lib/versioning/docker/index.ts
@@ -2,6 +2,8 @@ import * as generic from '../loose/generic';
 import { VersioningApi } from '../common';
 
 function parse(version: string) {
+  // openjdk:8u131-jre-alpine -> 8.131-jre-alpine
+  version = version.replace(/([0-9]*)(u)([0-9]*)/, "$1.$3")
   const versionPieces = version.replace(/^v/, '').split('-');
   const prefix = versionPieces.shift();
   const suffix = versionPieces.join('-');


### PR DESCRIPTION
This PR fixes docker parse of version like openjdk:8u131-jre-alpine by replacing from (Number)u(Number) to Number.Number. 8u131-jre-alpine becomes 8.131-jre-alpine

I signed CLA.
Please, let me know if I need to do anything else so this could be merged.