### PR TITLE
fix(gomod): use go get to generate pseudo versions for digest updates

### DIFF
--- a/lib/manager/gomod/update.ts
+++ b/lib/manager/gomod/update.ts
@@ -1,4 +1,3 @@
-import { DateTime } from 'luxon';
 import { logger } from '../../logger';
 import { Upgrade } from '../common';
 
@@ -57,9 +56,10 @@ export function updateDependency(
         { depName, lineToChange, newDigestRightSized },
         'gomod: need to update digest'
       );
-      const currentDateTime = DateTime.local().toFormat('yyyyMMddHHmmss');
-      const newValue = `v0.0.0-${currentDateTime}-${newDigestRightSized}`;
-      newLine = lineToChange.replace(updateLineExp, `$1$2${newValue}`);
+      newLine = lineToChange.replace(
+        updateLineExp,
+        `$1$2${newDigestRightSized}`
+      );
     } else {
       newLine = lineToChange.replace(updateLineExp, `$1$2${upgrade.newValue}`);
     }


### PR DESCRIPTION
Instead of generating the pseudo version ourselves, replace the existing pseudo version with a digest only and let “go get” massage it into a valid pseudo version.

Closes #4310
