### PR TITLE
fix(ci): use script instead of pwsh

### DIFF
--- a/.azure/steps.yml
+++ b/.azure/steps.yml
@@ -9,10 +9,10 @@ steps:
       versionSpec: '$(pythonVersion)'
     displayName: 'Install Python'
 
-  - pwsh: python -m pip install --upgrade pip
+  - script: python -m pip install --upgrade pip
     displayName: 'Install python tools'
 
-  - pwsh: |
+  - script: |
       git config --global user.email 'bot@renovateapp.com'
       git config --global user.name  'Renovate Bot'
       node --version
@@ -25,21 +25,21 @@ steps:
     fetchDepth: 5
     path: renovate
 
-  - pwsh: |
+  - script: |
       yarn install --frozen-lockfile --link-duplicates
       pip install --user -r requirements.txt
     displayName: 'Installing Dependencies'
 
-  - pwsh: |
+  - script: |
       yarn lint
       yarn test-schema
       yarn type-check
     displayName: 'Lint'
 
-  - pwsh: yarn build
+  - script: yarn build
     displayName: 'Build'
 
-  - pwsh: yarn jest --maxWorkers=2 --ci --reporters=default --reporters=jest-junit --coverageReporters=text-summary --coverageReporters=cobertura
+  - script: yarn jest --maxWorkers=2 --ci --reporters=default --reporters=jest-junit --coverageReporters=text-summary --coverageReporters=cobertura
     displayName: 'Unit Tests'
 
   - task: PublishTestResults@2
@@ -56,5 +56,5 @@ steps:
     displayName: 'Publish coverage results'
     condition: succeededOrFailed()
 
-  - pwsh: yarn test-e2e
+  - script: yarn test-e2e
     displayName: 'E2E Tests'


### PR DESCRIPTION
pwsh doesn't cancel if native command fails.


Lint should fail: https://dev.azure.com/renovatebot/renovate/_build/results?buildId=437