### PR TITLE
fix(bazel): handling of non-github URLs in git_repository

### DIFF
--- a/lib/manager/bazel/extract.ts
+++ b/lib/manager/bazel/extract.ts
@@ -172,10 +172,13 @@ export function extractPackageFile(content: string): PackageFile | null {
       if (commit) {
         dep.currentDigest = commit;
       }
-      const repo = parse(remote).substring('https://github.com/'.length);
-      dep.datasource = 'github';
-      dep.lookupName = repo;
-      deps.push(dep);
+      const githubURL = parse(remote);
+      if (githubURL) {
+        const repo = githubURL.substring('https://github.com/'.length);
+        dep.datasource = 'github';
+        dep.lookupName = repo;
+        deps.push(dep);
+      }
     } else if (
       depType === 'go_repository' &&
       depName &&


### PR DESCRIPTION
This PR adds proper null-checking after github-url-from-git.parse (which can be null).

Closes #4406
