### PR TITLE
test: Use relativeFile over fileBasenameNoExtension in vscode launch configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,7 +22,8 @@
       "args": [
         "--runInBand",
         "--collectCoverage=false",
-        "${fileBasenameNoExtension}"
+        "--runTestsByPath",
+        "${relativeFile}"
       ],
       "env": { "NODE_ENV": "test", "LOG_LEVEL": "debug" },
       "console": "integratedTerminal",


### PR DESCRIPTION
Just passing a file basename to Jest is too aggressive, e.g. if someone is testing `test/config/index.spec.ts` with **Jest Current File** configuration, all `test/**/index.spec.(ts|js)` files will be tested. That should be odd/wrong. Let's use `relativeFile` (`test/config/index.spec.ts`) instead of `fileBasenameNoExtension` (`index.spec`).

- https://code.visualstudio.com/docs/editor/variables-reference#_predefined-variables

> - ${relativeFile} - the current opened file relative to `workspaceFolder`
> - ${fileBasenameNoExtension} - the current opened file's basename with no file extension

---

The configuration was originally introduced in #3725.