### PR TITLE
fix(github-actions): handle updates of yaml file defined actions

### DIFF
--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -1591,7 +1591,10 @@ const options: RenovateOptions[] = [
     stage: 'package',
     type: 'object',
     default: {
-      fileMatch: ['^\\.github/main.workflow$'],
+      fileMatch: [
+        '^\\.github/main.workflow$',
+        '^\\.github/workflows/[^/]+\\.ya?ml$',
+      ],
       pinDigests: true,
     },
     mergeable: true,

--- a/lib/manager/github-actions/extract.ts
+++ b/lib/manager/github-actions/extract.ts
@@ -7,7 +7,11 @@ export function extractPackageFile(content: string): PackageFile | null {
   const deps: PackageDependency[] = [];
   let lineNumber = 0;
   for (const line of content.split('\n')) {
-    const match = line.match(/^\s+uses = "docker:\/\/([^"]+)"\s*$/);
+    // old github actions syntax will be deprecated on September 30, 2019
+    // after that, the first line can be removed
+    const match =
+      line.match(/^\s+uses = "docker:\/\/([^"]+)"\s*$/) ||
+      line.match(/^\s+uses: docker:\/\/([^"]+)\s*$/);
     if (match) {
       const currentFrom = match[1];
       const dep = getDep(currentFrom);

--- a/lib/manager/github-actions/update.ts
+++ b/lib/manager/github-actions/update.ts
@@ -11,7 +11,7 @@ export function updateDependency(
     logger.debug(`github-actions.updateDependency(): ${newFrom}`);
     const lines = fileContent.split('\n');
     const lineToChange = lines[upgrade.managerData.lineNumber];
-    const imageLine = new RegExp(/^(\s+uses = "docker:\/\/)[^"]+("\s*)$/);
+    const imageLine = new RegExp(/^(.+docker:\/\/)[^"]+(")?$/);
     if (!lineToChange.match(imageLine)) {
       logger.debug('No image line found');
       return null;

--- a/lib/manager/github-actions/update.ts
+++ b/lib/manager/github-actions/update.ts
@@ -11,7 +11,7 @@ export function updateDependency(
     logger.debug(`github-actions.updateDependency(): ${newFrom}`);
     const lines = fileContent.split('\n');
     const lineToChange = lines[upgrade.managerData.lineNumber];
-    const imageLine = new RegExp(/^(.+docker:\/\/)[^"]+(")?$/);
+    const imageLine = new RegExp(/^(.+docker:\/\/)[^"]+("\s*)?$/);
     if (!lineToChange.match(imageLine)) {
       logger.debug('No image line found');
       return null;

--- a/renovate-schema.json
+++ b/renovate-schema.json
@@ -1048,7 +1048,10 @@
       "description": "Configuration object for GitHub Actions workflow renovation. Also inherits settings from `docker` object.",
       "type": "object",
       "default": {
-        "fileMatch": ["^\\.github/main.workflow$"],
+        "fileMatch": [
+          "^\\.github/main.workflow$",
+          "^\\.github/workflows/[^/]+\\.ya?ml$"
+        ],
         "pinDigests": true
       },
       "$ref": "#"

--- a/test/manager/github-actions/__snapshots__/extract.spec.ts.snap
+++ b/test/manager/github-actions/__snapshots__/extract.spec.ts.snap
@@ -25,3 +25,29 @@ Array [
   },
 ]
 `;
+
+exports[`lib/manager/github-actions/extract extractPackageFile() extracts multiple image lines from yaml configuration file 1`] = `
+Array [
+  Object {
+    "currentDigest": undefined,
+    "currentValue": undefined,
+    "datasource": "docker",
+    "depName": "replicated/dockerfilelint",
+    "managerData": Object {
+      "lineNumber": 17,
+    },
+    "versionScheme": "docker",
+  },
+  Object {
+    "commitMessageTopic": "Node.js",
+    "currentDigest": "sha256:7b65413af120ec5328077775022c78101f103258a1876ec2f83890bce416e896",
+    "currentValue": "6",
+    "datasource": "docker",
+    "depName": "node",
+    "managerData": Object {
+      "lineNumber": 31,
+    },
+    "versionScheme": "docker",
+  },
+]
+`;

--- a/test/manager/github-actions/_fixtures/workflow.yml.1
+++ b/test/manager/github-actions/_fixtures/workflow.yml.1
@@ -1,0 +1,32 @@
+name: Run linters
+
+on: [push]
+
+jobs:
+  shell_lint:
+    name: Shell lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Shell lint
+        uses: actions/bin/shellcheck@master
+        run: ./entrypoint.sh
+  docker_lint:
+    name: Docker lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Docker lint
+        uses: docker://replicated/dockerfilelint
+        run: Dockerfile
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build
+        uses: actions/docker/cli@master
+        run: build -t conventional-commits .
+  node_6_test:
+    name: Node 6 Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Node 6 test
+        uses: docker://node:6@sha256:7b65413af120ec5328077775022c78101f103258a1876ec2f83890bce416e896

--- a/test/manager/github-actions/extract.spec.ts
+++ b/test/manager/github-actions/extract.spec.ts
@@ -6,6 +6,11 @@ const workflow1 = readFileSync(
   'utf8'
 );
 
+const workflow2 = readFileSync(
+  'test/manager/github-actions/_fixtures/workflow.yml.1',
+  'utf8'
+);
+
 describe('lib/manager/github-actions/extract', () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty', () => {
@@ -13,6 +18,11 @@ describe('lib/manager/github-actions/extract', () => {
     });
     it('extracts multiple image lines from docker_container', () => {
       const res = extractPackageFile(workflow1);
+      expect(res.deps).toMatchSnapshot();
+      expect(res.deps).toHaveLength(2);
+    });
+    it('extracts multiple image lines from yaml configuration file', () => {
+      const res = extractPackageFile(workflow2);
       expect(res.deps).toMatchSnapshot();
       expect(res.deps).toHaveLength(2);
     });

--- a/test/manager/github-actions/update.spec.ts
+++ b/test/manager/github-actions/update.spec.ts
@@ -6,6 +6,11 @@ const workflow1 = readFileSync(
   'utf8'
 );
 
+const workflow2 = readFileSync(
+  'test/manager/github-actions/_fixtures/workflow.yml.1',
+  'utf8'
+);
+
 describe('manager/github-actions/update', () => {
   describe('updateDependency', () => {
     it('replaces existing uses value', () => {
@@ -36,6 +41,32 @@ describe('manager/github-actions/update', () => {
     });
     it('returns null if error', () => {
       const res = updateDependency(null, null);
+      expect(res).toBeNull();
+    });
+    it('replaces existing uses value in yaml file', () => {
+      const upgrade = {
+        managerData: { lineNumber: 17 },
+        depName: 'replicated/dockerfilelint',
+        newDigest: 'sha256:abcdefghijklmnop',
+      };
+      const res = updateDependency(workflow2, upgrade);
+      expect(res).not.toEqual(workflow2);
+      expect(res.includes(upgrade.newDigest)).toBe(true);
+    });
+    it('returns same in yaml file', () => {
+      const upgrade = {
+        managerData: { lineNumber: 17 },
+        depName: 'replicated/dockerfilelint',
+      };
+      const res = updateDependency(workflow2, upgrade);
+      expect(res).toEqual(workflow2);
+    });
+    it('returns null if mismatch in yaml file', () => {
+      const upgrade = {
+        managerData: { lineNumber: 12 },
+        newFrom: 'registry:2.6.2@sha256:abcdefghijklmnop',
+      };
+      const res = updateDependency(workflow2, upgrade);
       expect(res).toBeNull();
     });
   });


### PR DESCRIPTION
New version of github actions takes configuration from yaml files.
Current github-actions manager handled only the old configuration
files. Old configuration will be deprecated on September 30, 2019.

<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate
-->


