### PR TITLE
fix(config): fix cyclic imports

### DIFF
--- a/lib/config/index.ts
+++ b/lib/config/index.ts
@@ -4,14 +4,13 @@ import * as defaultsParser from './defaults';
 import * as fileParser from './file';
 import * as cliParser from './cli';
 import * as envParser from './env';
-
-// eslint-disable-next-line import/no-cycle
 import { resolveConfigPresets } from './presets';
 import { get, getLanguageList, getManagerList } from '../manager';
 import { RenovateConfig, RenovateConfigStage } from './common';
-import { clone } from '../util/clone';
+import { mergeChildConfig } from './utils';
 
 export * from './common';
+export { mergeChildConfig };
 
 export interface ManagerConfig extends RenovateConfig {
   language: string;
@@ -98,43 +97,6 @@ export async function parseConfigs(
   delete config.logFile;
   delete config.logFileLevel;
   return config;
-}
-
-export function mergeChildConfig<T extends RenovateConfig = RenovateConfig>(
-  parent: T,
-  child: RenovateConfig
-): T {
-  logger.trace({ parent, child }, `mergeChildConfig`);
-  if (!child) {
-    return parent;
-  }
-  const parentConfig = clone(parent);
-  const childConfig = clone(child);
-  const config: Record<string, any> = { ...parentConfig, ...childConfig };
-  for (const option of definitions.getOptions()) {
-    if (
-      option.mergeable &&
-      childConfig[option.name] &&
-      parentConfig[option.name]
-    ) {
-      logger.trace(`mergeable option: ${option.name}`);
-      if (option.type === 'array') {
-        config[option.name] = (parentConfig[option.name] || []).concat(
-          config[option.name] || []
-        );
-      } else {
-        config[option.name] = mergeChildConfig(
-          parentConfig[option.name],
-          childConfig[option.name]
-        );
-      }
-      logger.trace(
-        { result: config[option.name] },
-        `Merged config.${option.name}`
-      );
-    }
-  }
-  return Object.assign(config, config.force);
 }
 
 export function filterConfig(

--- a/lib/config/presets.ts
+++ b/lib/config/presets.ts
@@ -1,13 +1,12 @@
 import is from '@sindresorhus/is';
 import { logger } from '../logger';
-// eslint-disable-next-line import/no-cycle
-import * as configParser from './index';
 import * as massage from './massage';
 import * as migration from './migration';
 import * as github from '../datasource/github';
 import * as npm from '../datasource/npm';
 import * as gitlab from '../datasource/gitlab';
 import { RenovateConfig } from './common';
+import { mergeChildConfig } from './utils';
 
 const datasources = {
   github,
@@ -81,13 +80,13 @@ export async function resolveConfigPresets(
         ) {
           delete presetConfig.description;
         }
-        config = configParser.mergeChildConfig(config, presetConfig);
+        config = mergeChildConfig(config, presetConfig);
       }
     }
   }
   logger.trace({ config }, `Post-preset resolve config`);
   // Now assign "regular" config on top
-  config = configParser.mergeChildConfig(config, inputConfig);
+  config = mergeChildConfig(config, inputConfig);
   delete config.extends;
   delete config.ignorePresets;
   logger.trace({ config }, `Post-merge resolve config`);

--- a/lib/config/utils.ts
+++ b/lib/config/utils.ts
@@ -22,8 +22,8 @@ export function mergeChildConfig<T extends RenovateConfig = RenovateConfig>(
     ) {
       logger.trace(`mergeable option: ${option.name}`);
       if (option.type === 'array') {
-        config[option.name] = (parentConfig[option.name] || []).concat(
-          config[option.name] || []
+        config[option.name] = parentConfig[option.name].concat(
+          config[option.name]
         );
       } else {
         config[option.name] = mergeChildConfig(

--- a/lib/config/utils.ts
+++ b/lib/config/utils.ts
@@ -1,0 +1,41 @@
+import { RenovateConfig } from './common';
+import { logger } from '../logger';
+import { clone } from '../util/clone';
+import * as definitions from './definitions';
+
+export function mergeChildConfig<T extends RenovateConfig = RenovateConfig>(
+  parent: T,
+  child: RenovateConfig
+): T {
+  logger.trace({ parent, child }, `mergeChildConfig`);
+  if (!child) {
+    return parent;
+  }
+  const parentConfig = clone(parent);
+  const childConfig = clone(child);
+  const config: Record<string, any> = { ...parentConfig, ...childConfig };
+  for (const option of definitions.getOptions()) {
+    if (
+      option.mergeable &&
+      childConfig[option.name] &&
+      parentConfig[option.name]
+    ) {
+      logger.trace(`mergeable option: ${option.name}`);
+      if (option.type === 'array') {
+        config[option.name] = (parentConfig[option.name] || []).concat(
+          config[option.name] || []
+        );
+      } else {
+        config[option.name] = mergeChildConfig(
+          parentConfig[option.name],
+          childConfig[option.name]
+        );
+      }
+      logger.trace(
+        { result: config[option.name] },
+        `Merged config.${option.name}`
+      );
+    }
+  }
+  return Object.assign(config, config.force);
+}


### PR DESCRIPTION
This pr fixes the cyclic imports.

I also removed the two array else path from `mergeChildConfig`. They could never be happen because of the `if defined` check.