### PR TITLE
fix(gomod): add three dots wildcard to go get command

### DIFF
--- a/lib/manager/gomod/artifacts.ts
+++ b/lib/manager/gomod/artifacts.ts
@@ -70,7 +70,7 @@ export async function updateArtifacts(
       logger.info('Running go via global command');
       cmd = 'go';
     }
-    let args = 'get';
+    let args = 'get ./...';
     if (cmd.includes('.insteadOf')) {
       args += '"';
     }


### PR DESCRIPTION
Closes #4476

With Go `1.13` if we run `go get` in the root directory of a repo that does not have a `main` package and in only includes sub-packages, we'll get the following error:

```
Command failed: docker run --rm -v /mnt/renovate/gh/moorara/observe:/mnt/renovate/gh/moorara/observe -v /tmp/renovate-cache/others/go:/tmp/renovate-cache/others/go -e GOPATH -e GOPROXY -e CGO_ENABLED=0 -w /mnt/renovate/gh/moorara/observe renovate/go bash -c "git config --global url.\"https://x-access-token:**redacted**@github.com/\".insteadOf \"https://github.com/\" && go get"
go get .: path /mnt/renovate/gh/moorara/observe is not a package in module rooted at /mnt/renovate/gh/moorara/observe
```

So `go get` behaviour has changed a little bit in the latest release. To address that we should run `go get ./...` command. `./...` wildcard has been supported by `go` command from very early versions.
