### PR TITLE
fix(datasource): nuget should check all feeds

### DIFF
--- a/test/datasource/nuget.spec.ts
+++ b/test/datasource/nuget.spec.ts
@@ -24,6 +24,10 @@ const pkgListV2 = fs.readFileSync(
   'test/datasource/nuget/_fixtures/nunitV2.xml',
   'utf8'
 );
+const pkgListV2NoRelease = fs.readFileSync(
+  'test/datasource/nuget/_fixtures/nunitV2_no_release.xml',
+  'utf8'
+);
 const pkgListV2WithoutProjectUrl = fs.readFileSync(
   'test/datasource/nuget/_fixtures/nunitV2_withoutProjectUrl.xml',
   'utf8'
@@ -321,6 +325,16 @@ describe('datasource/nuget', () => {
       expect(res).not.toBeNull();
       expect(res).toMatchSnapshot();
       expect(res.sourceUrl).toBeDefined();
+    });
+    it('processes real data no relase (v2)', async () => {
+      got.mockReturnValueOnce({
+        body: pkgListV2NoRelease,
+        statusCode: 200,
+      });
+      const res = await datasource.getPkgReleases({
+        ...configV2,
+      });
+      expect(res).toBeNull();
     });
     it('processes real data without project url (v2)', async () => {
       got.mockReturnValueOnce({

--- a/test/datasource/nuget/_fixtures/nunitV2_no_release.xml
+++ b/test/datasource/nuget/_fixtures/nunitV2_no_release.xml
@@ -1,0 +1,6 @@
+<feed xml:base="https://www.nuget.org/api/v2" xmlns="http://www.w3.org/2005/Atom" xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata" xmlns:georss="http://www.georss.org/georss" xmlns:gml="http://www.opengis.net/gml">
+  <id>http://schemas.datacontract.org/2004/07/</id>
+  <title/>
+  <updated>2019-02-04T12:51:36Z</updated>
+  <link rel="self" href="https://www.nuget.org/api/v2/Packages"/>
+</feed>


### PR DESCRIPTION
This pr fixes a wrong behavior, when a package is not found in a feed (v2).

The old behavior was to return a dependency without releases, so other feeds where not checked.