### PR TITLE
fix(datasource): parse npm repository

### DIFF
--- a/lib/datasource/npm/get.ts
+++ b/lib/datasource/npm/get.ts
@@ -5,6 +5,7 @@ import registryAuthToken from 'registry-auth-token';
 import parse from 'github-url-from-git';
 import { isBase64 } from 'validator';
 import { OutgoingHttpHeaders } from 'http';
+import is from '@sindresorhus/is';
 import { logger } from '../../logger';
 import got from '../../util/got';
 import * as hostRules from '../../util/host-rules';
@@ -144,6 +145,10 @@ export async function getDependency(
 
     // Determine repository URL
     let sourceUrl: string;
+
+    if (is.string(res.repository)) {
+      res.repository = { url: res.repository };
+    }
 
     if (res.repository && res.repository.url) {
       const extraBaseUrls = [];

--- a/test/datasource/npm/__snapshots__/index.spec.ts.snap
+++ b/test/datasource/npm/__snapshots__/index.spec.ts.snap
@@ -110,6 +110,27 @@ Object {
 }
 `;
 
+exports[`api/npm should parse repo url (string) 1`] = `
+Object {
+  "homepage": undefined,
+  "latestVersion": "0.0.1",
+  "name": "foobar",
+  "releases": Array [
+    Object {
+      "canBeUnpublished": false,
+      "gitRef": undefined,
+      "releaseTimestamp": "2018-05-06T07:21:53+02:00",
+      "version": "0.0.1",
+    },
+  ],
+  "sourceUrl": "https://github.com/renovateapp/dummy",
+  "tags": Object {
+    "latest": "0.0.1",
+  },
+  "versions": Object {},
+}
+`;
+
 exports[`api/npm should parse repo url 1`] = `
 Object {
   "homepage": undefined,

--- a/test/datasource/npm/index.spec.ts
+++ b/test/datasource/npm/index.spec.ts
@@ -201,6 +201,29 @@ describe('api/npm', () => {
     expect(res).toMatchSnapshot();
     expect(res.sourceUrl).toBeDefined();
   });
+
+  it('should parse repo url (string)', async () => {
+    const pkg = {
+      name: 'foobar',
+      versions: {
+        '0.0.1': {
+          repository: 'git:github.com/renovateapp/dummy',
+        },
+      },
+      'dist-tags': {
+        latest: '0.0.1',
+      },
+      time: {
+        '0.0.1': '2018-05-06T07:21:53+02:00',
+      },
+    };
+    nock('https://registry.npmjs.org')
+      .get('/foobar')
+      .reply(200, pkg);
+    const res = await npm.getPkgReleases({ lookupName: 'foobar' });
+    expect(res).toMatchSnapshot();
+    expect(res.sourceUrl).toBeDefined();
+  });
   it('should return deprecated', async () => {
     const deprecatedPackage = {
       name: 'foobar',


### PR DESCRIPTION
The npm datasource should support `string` for `repository` value.

https://docs.npmjs.com/files/package.json#repository