### PR TITLE
feat(datasource): Support devpi simple indices URLs.

### DIFF
--- a/lib/datasource/pypi/index.ts
+++ b/lib/datasource/pypi/index.ts
@@ -43,7 +43,7 @@ export async function getPkgReleases({
   for (let hostUrl of hostUrls) {
     hostUrl += hostUrl.endsWith('/') ? '' : '/';
     let dep: ReleaseResult;
-    if (hostUrl.endsWith('/simple/')) {
+    if (hostUrl.endsWith('/simple/') || hostUrl.endsWith('/+simple/')) {
       dep = await getSimpleDependency(lookupName, hostUrl);
     } else {
       dep = await getDependency(lookupName, hostUrl, compatibility);

--- a/test/datasource/__snapshots__/pypi.spec.ts.snap
+++ b/test/datasource/__snapshots__/pypi.spec.ts.snap
@@ -1,5 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`datasource/pypi getPkgReleases process data from +simple endpoint 1`] = `
+Object {
+  "releases": Array [
+    Object {
+      "version": "0.1.2",
+    },
+    Object {
+      "version": "0.1.3",
+    },
+    Object {
+      "version": "0.1.4",
+    },
+    Object {
+      "version": "0.2.0",
+    },
+    Object {
+      "version": "0.2.1",
+    },
+    Object {
+      "version": "0.2.2",
+    },
+    Object {
+      "version": "0.3.0",
+    },
+    Object {
+      "version": "0.4.0",
+    },
+    Object {
+      "version": "0.4.1",
+    },
+    Object {
+      "version": "0.4.2",
+    },
+    Object {
+      "version": "0.5.0",
+    },
+  ],
+}
+`;
+
 exports[`datasource/pypi getPkgReleases process data from simple endpoint 1`] = `
 Object {
   "releases": Array [

--- a/test/datasource/pypi.spec.ts
+++ b/test/datasource/pypi.spec.ts
@@ -186,6 +186,22 @@ describe('datasource/pypi', () => {
         })
       ).toMatchSnapshot();
     });
+    it('process data from +simple endpoint', async () => {
+      got.mockReturnValueOnce({
+        body: htmlResponse + '',
+      });
+      const config = {
+        registryUrls: ['https://some.registry.org/+simple/'],
+      };
+      expect(
+        await datasource.getPkgReleases({
+          ...config,
+          compatibility: { python: '2.7' },
+          datasource: 'pypi',
+          depName: 'dj-database-url',
+        })
+      ).toMatchSnapshot();
+    });
     it('returns null for empty resonse', async () => {
       got.mockReturnValueOnce({});
       const config = {


### PR DESCRIPTION
Devpi preprends a `+` before simple indices. This commit adds support
for them.

Closes #4507