### PR TITLE
feat(composer): No no-scripts and no-autoloader on trust level high. …

### DIFF
--- a/lib/manager/composer/artifacts.ts
+++ b/lib/manager/composer/artifacts.ts
@@ -118,8 +118,10 @@ export async function updateArtifacts(
       args =
         ('update ' + updatedDeps.join(' ')).trim() + ' --with-dependencies';
     }
-    args +=
-      ' --ignore-platform-reqs --no-ansi --no-interaction --no-scripts --no-autoloader';
+    args += ' --ignore-platform-reqs --no-ansi --no-interaction';
+    if (global.trustLevel !== 'high') {
+      args += ' --no-scripts --no-autoloader';
+    }
     logger.debug({ cmd, args }, 'composer command');
     ({ stdout, stderr } = await exec(`${cmd} ${args}`, {
       cwd,


### PR DESCRIPTION
Removes ```--no-scripts``` and ```--no-autoloader``` flags from composer commands if "trustLevel" is set to "high".

Closes #4531
