### PR TITLE
Azure DevOps (Service & Server) OLD

### DIFF
--- a/lib/platform/azure/index.ts
+++ b/lib/platform/azure/index.ts
@@ -1,10 +1,12 @@
-import * as azureHelper from './azure-helper';
 import * as azureApi from './azure-got-wrapper';
+import * as azureHelper from './azure-helper';
 import * as hostRules from '../../util/host-rules';
-import { appSlug } from '../../config/app-strings';
+
+import { PlatformConfig, RepoConfig, RepoParams } from '../common';
+
 import GitStorage from '../git/storage';
+import { appSlug } from '../../config/app-strings';
 import { logger } from '../../logger';
-import { PlatformConfig, RepoParams, RepoConfig } from '../common';
 import { sanitize } from '../../util/sanitize';
 
 interface Config {
@@ -115,7 +117,7 @@ export async function initRepo({
     url: defaults.endpoint,
   });
   const url =
-    defaults.endpoint.replace('https://', `https://token:${opts.token}@`) +
+    defaults.endpoint.replace('https://', `https://:${opts.token}@`) +
     `${encodeURIComponent(projectName)}/_git/${encodeURIComponent(repoName)}`;
   await config.storage.initRepo({
     ...config,


### PR DESCRIPTION
Azure DevOps exists in two versions: 
- Service (previously VSTS, the cloud version)
- Server (previously TFS, the on-premise version)

I was working a lot with the cloud version and renovate is working fine there.
But with the on-premise version, the way to clone the repo is a little bit different.

This PR is to get the clone cmd working on the two versions of DevOps.