### PR TITLE
fix(storage): defer clone of submodules

### DIFF
--- a/lib/platform/git/storage.ts
+++ b/lib/platform/git/storage.ts
@@ -121,13 +121,13 @@ export class Storage {
       logger.info({ cloneSeconds }, 'git clone completed');
     }
     const submodules = await this.getSubmodules();
-    submodules.forEach(async submodule => {
+    for (const submodule of submodules) {
       try {
         await this._git.submoduleUpdate(['--init', '--', submodule]);
       } catch (err) {
         logger.warn(`Unable to initialise git submodule at ${submodule}`);
       }
-    });
+    }
     try {
       const latestCommitDate = (await this._git!.log({ n: 1 })).latest.date;
       logger.debug({ latestCommitDate }, 'latest commit');

--- a/test/platform/git/storage.spec.ts
+++ b/test/platform/git/storage.spec.ts
@@ -85,7 +85,7 @@ describe('platform/git/storage', () => {
       expect(await git.getFileList()).toMatchSnapshot();
     });
     it('should exclude submodules', async () => {
-      const repo = await Git(base.path).silent(true);
+      const repo = Git(base.path).silent(true);
       await repo.submoduleAdd(base.path, 'submodule');
       await repo.commit('Add submodule');
       await git.initRepo({
@@ -345,6 +345,34 @@ describe('platform/git/storage', () => {
       await git.setBranchPrefix('renovate/');
       expect(await git.branchExists('renovate/test')).toBe(true);
       expect(await git.getBranchCommit('renovate/test')).not.toEqual(cid);
+    });
+
+    it('should fail clone ssh submodule', async () => {
+      const repo = Git(base.path).silent(true);
+      await fs.writeFile(
+        base.path + '/.gitmodules',
+        `
+      [submodule "test"]
+        path = test
+        url = ssh://0.0.0.0
+      `.trim()
+      );
+      await repo.add('.gitmodules');
+      await repo.raw([
+        'update-index',
+        '--add',
+        '--cacheinfo',
+        '160000',
+        '4b825dc642cb6eb9a060e54bf8d69288fbee4904',
+        'test',
+      ]);
+      await repo.commit('Add submodule');
+      await git.initRepo({
+        localDir: tmpDir.path,
+        url: base.path,
+      });
+      expect(await fs.exists(tmpDir.path + '/.gitmodules')).toBeTruthy();
+      repo.reset(['--hard', 'HEAD^']);
     });
   });
 });

--- a/test/platform/git/storage.spec.ts
+++ b/test/platform/git/storage.spec.ts
@@ -351,11 +351,7 @@ describe('platform/git/storage', () => {
       const repo = Git(base.path).silent(true);
       await fs.writeFile(
         base.path + '/.gitmodules',
-        `
-      [submodule "test"]
-        path = test
-        url = ssh://0.0.0.0
-      `.trim()
+        '[submodule "test"]\npath=test\nurl=ssh://0.0.0.0'
       );
       await repo.add('.gitmodules');
       await repo.raw([


### PR DESCRIPTION
Delaying the clone of submodules until after the initial clone allows us to wrap everything in a try/catch. Note that this no longer clones recursively, but it should be enough for most use cases.

Fixes #4547
