### PR TITLE
fix(datasource): Improve go datasource sourceMatch regex

### DIFF
--- a/lib/datasource/go/index.ts
+++ b/lib/datasource/go/index.ts
@@ -30,7 +30,7 @@ async function getDatasource(name: string): Promise<DataSource | null> {
       hostType: 'go',
     })).body;
     const sourceMatch = res.match(
-      new RegExp(`<meta name="go-source" content="${name}\\s+([^\\s]+)`)
+      new RegExp(`<meta\\s+name="go-source"\\s+content="${name}\\s+([^\\s]+)`)
     );
     if (sourceMatch) {
       const [, goSourceUrl] = sourceMatch;


### PR DESCRIPTION
Fixes the go datasource regex to allow newlines at arbitrary places where also spaces are allowed.
This especially fixes "k8s.io/apiserver" dependencies, as they have newlines everywhere.
