### PR TITLE
fix(manager): Fix extraction of gitlab-ci includes

### DIFF
--- a/lib/manager/gitlabci-include/extract.ts
+++ b/lib/manager/gitlabci-include/extract.ts
@@ -37,7 +37,7 @@ export function extractPackageFile(
         const dep = extractDepFromInclude(includeObj);
         if (dep) {
           if (config.endpoint) {
-            dep.registryUrls = [config.endpoint.replace('/api/v4/', '')];
+            dep.registryUrls = [config.endpoint.replace(/\/api\/v4\/?/, '')];
           }
           deps.push(dep);
         }

--- a/test/manager/gitlabci-include/__snapshots__/extract.spec.ts.snap
+++ b/test/manager/gitlabci-include/__snapshots__/extract.spec.ts.snap
@@ -7,26 +7,17 @@ Array [
     "datasource": "gitlab",
     "depName": "mikebryant/include-source-example",
     "depType": "repository",
-    "registryUrls": Array [
-      "http://gitlab.test",
-    ],
   },
   Object {
     "currentValue": "master",
     "datasource": "gitlab",
     "depName": "mikebryant/include-source-example2",
     "depType": "repository",
-    "registryUrls": Array [
-      "http://gitlab.test",
-    ],
   },
   Object {
     "datasource": "gitlab",
     "depName": "mikebryant/include-source-example3",
     "depType": "repository",
-    "registryUrls": Array [
-      "http://gitlab.test",
-    ],
     "skipReason": "unknown-version",
   },
 ]

--- a/test/manager/gitlabci-include/extract.spec.ts
+++ b/test/manager/gitlabci-include/extract.spec.ts
@@ -1,6 +1,5 @@
 import fs from 'fs';
 import { extractPackageFile } from '../../../lib/manager/gitlabci-include/extract';
-import { ExtractConfig } from '../../../lib/manager/common';
 
 const yamlFile = fs.readFileSync(
   'test/manager/gitlabci-include/_fixtures/gitlab-ci.yaml',
@@ -9,21 +8,27 @@ const yamlFile = fs.readFileSync(
 
 describe('lib/manager/gitlabci-include/extract', () => {
   describe('extractPackageFile()', () => {
-    let config: ExtractConfig;
-    beforeEach(() => {
-      config = {
-        endpoint: 'http://gitlab.test/api/v4/',
-      };
-    });
     it('returns null for empty', () => {
       expect(
-        extractPackageFile('nothing here', '.gitlab-ci.yml', config)
+        extractPackageFile('nothing here', '.gitlab-ci.yml', {})
       ).toBeNull();
     });
     it('extracts multiple include blocks', () => {
-      const res = extractPackageFile(yamlFile, '.gitlab-ci.yml', config);
+      const res = extractPackageFile(yamlFile, '.gitlab-ci.yml', {});
       expect(res.deps).toMatchSnapshot();
       expect(res.deps).toHaveLength(3);
+    });
+    it('normalizes configured endpoints', () => {
+      const endpoints = [
+        'http://gitlab.test/api/v4',
+        'http://gitlab.test/api/v4/',
+      ];
+      endpoints.forEach(endpoint => {
+        const res = extractPackageFile(yamlFile, '.gitlab-ci.yml', {
+          endpoint,
+        });
+        expect(res.deps[0].registryUrls[0]).toEqual('http://gitlab.test');
+      });
     });
   });
 });


### PR DESCRIPTION
The extraction logic failed to extract the GitLab URI correctly
when the configured platform endpoint does not have a trailing
slash. This commit changes the logic to handle scenarios with
and without trailing slash

Fixes #4270