### PR TITLE
fix(npm): remove unnecessary type guard

### DIFF
--- a/lib/manager/npm/extract/index.ts
+++ b/lib/manager/npm/extract/index.ts
@@ -158,10 +158,6 @@ export async function extractPackageFile(
       dep.skipReason = 'invalid-name';
       return dep;
     }
-    if (typeof input !== 'string') {
-      dep.skipReason = 'invalid-value';
-      return dep;
-    }
     dep.currentValue = input.trim();
     if (depType === 'engines') {
       if (depName === 'node') {


### PR DESCRIPTION
`input` is always guaranteed to be a string.
