### PR TITLE
feat(docker): add insecureRegistry hostRule

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -378,6 +378,23 @@ Renovate will match against all baseUrls. It does not do a "longest match" algor
 
 ### hostType
 
+### insecureRegistry
+
+Enable this option to allow Renovate to connect to an [insecure docker registry](https://docs.docker.com/registry/insecure/) that is http only.
+Warning: This is insecure and is not recommended.
+Example:
+
+```json
+{
+  "hostRules": [
+    {
+      "hostName": "reg.insecure.com",
+      "insecureRegistry": true
+    }
+  ]
+}
+```
+
 ### timeout
 
 Use this figure to adjust the timeout for queries. The default is 60s, which is quite high. To adjust it down to 10s for all queries, do this:

--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -1942,6 +1942,15 @@ const options: RenovateOptions[] = [
     env: false,
   },
   {
+    name: 'insecureRegistry',
+    description: 'explicity turn on insecure docker registry access (http)',
+    type: 'boolean',
+    stage: 'repository',
+    parent: 'hostRules',
+    cli: false,
+    env: false,
+  },
+  {
     name: 'prBodyDefinitions',
     description: 'Table column definitions for use in PR tables',
     type: 'object',

--- a/lib/datasource/docker/index.ts
+++ b/lib/datasource/docker/index.ts
@@ -32,6 +32,10 @@ function getRegistryRepository(lookupName: string, registryUrls: string[]) {
   if (!registry.match('^https?://')) {
     registry = `https://${registry}`;
   }
+  const opts = hostRules.find({ url: registry });
+  if (opts.insecureRegistry) {
+    registry = registry.replace('https', 'http');
+  }
   if (registry.endsWith('.docker.io') && !repository.includes('/')) {
     repository = 'library/' + repository;
   }

--- a/lib/util/host-rules.ts
+++ b/lib/util/host-rules.ts
@@ -12,7 +12,7 @@ export interface HostRule {
   token?: string;
   username?: string;
   password?: string;
-
+  insecureRegistry?: boolean;
   timeout?: number;
 }
 

--- a/renovate-schema.json
+++ b/renovate-schema.json
@@ -1282,6 +1282,10 @@
               "timeout": {
                 "description": "timeout (in milliseconds) for queries to external endpoints",
                 "type": "integer"
+              },
+              "insecureRegistry": {
+                "description": "explicity turn on insecure docker registry access (http)",
+                "type": "boolean"
               }
             }
           }

--- a/test/datasource/docker.spec.ts
+++ b/test/datasource/docker.spec.ts
@@ -91,6 +91,17 @@ describe('api/docker', () => {
         'sha256:b3d6068234f3a18ebeedd2dab81e67b6a192e81192a099df4112ecfc7c3be84f'
       );
     });
+    it('supports docker insecure registry', async () => {
+      got.mockReturnValueOnce({
+        headers: {},
+      });
+      got.mockReturnValueOnce({
+        headers: { 'docker-content-digest': 'some-digest' },
+      });
+      hostRules.find.mockReturnValueOnce({ insecureRegistry: true });
+      const res = await docker.getDigest({ lookupName: 'some-dep' });
+      expect(res).toBe('some-digest');
+    });
     it('supports basic authentication', async () => {
       got.mockReturnValueOnce({
         headers: {


### PR DESCRIPTION
<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate
-->

This PR adds support for insecure docker registries by allowing for an `insecureRegistry` hostRule to be specified. 

If a `hostRules` match is found and `"insecureRegistry": true`, then `https` is replaced with `http` so that the connection can be made to that registry with the http protocol.

Added documentation, a warning about using it (since it is insecure) and unit tests. Tested this locally against a private insecure docker registry, and it works.

Closes #4536
