### PR TITLE
test(config): mock config.js

### DIFF
--- a/test/config/index.spec.ts
+++ b/test/config/index.spec.ts
@@ -1,12 +1,14 @@
-import { env as _env } from 'process';
 import argv from './config/_fixtures/argv';
 import { getConfig } from '../../lib/config/defaults';
 import * as _npm from '../../lib/datasource/npm';
 import presetDefaults from './npm/_fixtures/renovate-config-default.json';
 
 jest.mock('../../lib/datasource/npm');
-jest.mock('../../config.js');
-jest.mock(_env.RENOVATE_CONFIG_FILE);
+try {
+  jest.mock('../../config.js');
+} catch (err) {
+  // file does not exist
+}
 
 const npm: any = _npm;
 const defaultConfig = getConfig();

--- a/test/config/index.spec.ts
+++ b/test/config/index.spec.ts
@@ -1,9 +1,12 @@
+import { env as _env } from 'process';
 import argv from './config/_fixtures/argv';
 import { getConfig } from '../../lib/config/defaults';
 import * as _npm from '../../lib/datasource/npm';
 import presetDefaults from './npm/_fixtures/renovate-config-default.json';
 
 jest.mock('../../lib/datasource/npm');
+jest.mock('../../config.js');
+jest.mock(_env.RENOVATE_CONFIG_FILE);
 
 const npm: any = _npm;
 const defaultConfig = getConfig();


### PR DESCRIPTION
Not sure if mocking `RENOVATE_CONFIG_FILE` is strictly needed, but included anyway. I think the chances of someone setting that to run tests is very, very low.

EDIT: Removed `RENOVATE_CONFIG_FILE` mock

Fixes #4603 

