### PR TITLE
fix(gomod): ignore indirect dependencies

### DIFF
--- a/lib/manager/gomod/update.ts
+++ b/lib/manager/gomod/update.ts
@@ -27,6 +27,13 @@ export function updateDependency(
       );
       return null;
     }
+    if (lineToChange.endsWith('// indirect')) {
+      logger.debug(
+        { lineToChange, depName },
+        'will not update indirect dependency'
+      );
+      return null;
+    }
     let updateLineExp: RegExp;
     if (depType === 'replace') {
       updateLineExp = new RegExp(

--- a/test/manager/gomod/_fixtures/3/go.mod
+++ b/test/manager/gomod/_fixtures/3/go.mod
@@ -1,0 +1,6 @@
+module github.com/renovate-tests/gomod3
+
+require (
+  golang.org/x/net v0.0.0-20191003171128-d98b1b443823 // indirect
+  require github.com/pkg/errors v0.7.0
+)

--- a/test/manager/gomod/update.spec.ts
+++ b/test/manager/gomod/update.spec.ts
@@ -3,6 +3,7 @@ import { updateDependency } from '../../../lib/manager/gomod/update';
 
 const gomod1 = readFileSync('test/manager/gomod/_fixtures/1/go.mod', 'utf8');
 const gomod2 = readFileSync('test/manager/gomod/_fixtures/2/go.mod', 'utf8');
+const gomod3 = readFileSync('test/manager/gomod/_fixtures/3/go.mod', 'utf8');
 
 describe('manager/gomod/update', () => {
   describe('updateDependency', () => {
@@ -234,6 +235,16 @@ describe('manager/gomod/update', () => {
       const res = updateDependency(gomod1, upgrade);
       expect(res).not.toEqual(gomod1);
       expect(res.includes(upgrade.newDigest.substring(0, 12))).toBe(true);
+    });
+    it('do not replace indirect dependency', () => {
+      const upgrade = {
+        depName: 'golang.org/x/net',
+        managerData: { lineNumber: 3 },
+        newValue: 'v0.0.0-20191003171128-d98b1b443829',
+        depType: 'require',
+      };
+      const res = updateDependency(gomod3, upgrade);
+      expect(res).toBeNull();
     });
   });
 });


### PR DESCRIPTION
Ignores indirect dependencies on gomod.

Not sure if this is the best way of doing this, I'm not used to write TS/JS/etc.

Closes https://github.com/renovatebot/renovate/issues/4586
