### PR TITLE
fix: show warning when unable to create pull request (#4611)

### DIFF
--- a/lib/workers/pr/index.js
+++ b/lib/workers/pr/index.js
@@ -269,7 +269,7 @@ async function ensurePr(prConfig) {
         logger.info({ branch: branchName, pr: pr.number }, 'PR created');
       }
     } catch (err) /* istanbul ignore next */ {
-      logger.debug({ err }, 'Pull request creation error');
+      logger.warn({ err }, 'Pull request creation error');
       if (err.body && err.body.message === 'Validation failed') {
         if (err.body.errors && err.body.errors.length) {
           if (


### PR DESCRIPTION
Renovate was unable to create a PR but did not log why, now always show a warning log message

Closes #4611 
