### PR TITLE
fix(bitbucket): Branch automerges too early on Bitbucket Cloud

### DIFF
--- a/lib/platform/bitbucket/index.ts
+++ b/lib/platform/bitbucket/index.ts
@@ -256,6 +256,10 @@ export async function getBranchStatus(
     { branch: branchName, sha, statuses },
     'branch status check result'
   );
+  if (!statuses.length) {
+    logger.debug('empty branch status check result = returning "pending"');
+    return 'pending';
+  }
   if (noOfFailures) {
     return 'failed';
   }

--- a/lib/platform/bitbucket/index.ts
+++ b/lib/platform/bitbucket/index.ts
@@ -249,9 +249,6 @@ export async function getBranchStatus(
   const statuses = await utils.accumulateValues(
     `/2.0/repositories/${config.repository}/commit/${sha}/statuses`
   );
-  const noOfFailures = statuses.filter(
-    (status: { state: string }) => status.state === 'FAILED'
-  ).length;
   logger.debug(
     { branch: branchName, sha, statuses },
     'branch status check result'
@@ -260,8 +257,17 @@ export async function getBranchStatus(
     logger.debug('empty branch status check result = returning "pending"');
     return 'pending';
   }
+  const noOfFailures = statuses.filter(
+    (status: { state: string }) => status.state === 'FAILED'
+  ).length;
   if (noOfFailures) {
     return 'failed';
+  }
+  const noOfPending = statuses.filter(
+    (status: { state: string }) => status.state === 'INPROGRESS'
+  ).length;
+  if (noOfPending) {
+    return 'pending';
   }
   return 'success';
 }

--- a/test/platform/bitbucket/_fixtures/responses.js
+++ b/test/platform/bitbucket/_fixtures/responses.js
@@ -150,4 +150,12 @@ module.exports = {
       },
     ],
   },
+  '/2.0/repositories/some/repo/commit/branch_hash/statuses': {
+    values: [
+      {
+        key: 'foo',
+        state: 'SUCCESSFUL',
+      },
+    ],
+  },
 };

--- a/test/platform/bitbucket/_fixtures/responses.js
+++ b/test/platform/bitbucket/_fixtures/responses.js
@@ -89,6 +89,7 @@ module.exports = {
       { name: 'branch' },
       { name: 'renovate/branch' },
       { name: 'renovate/upgrade' },
+      { name: 'pending/branch' },
     ],
   },
   '/2.0/repositories/some/repo/refs/branches/master': {
@@ -99,6 +100,13 @@ module.exports = {
     name: 'branch',
     target: {
       hash: 'branch_hash',
+      parents: [{ hash: 'master_hash' }],
+    },
+  },
+  '/2.0/repositories/some/repo/refs/branches/pending/branch': {
+    name: 'pending/branch',
+    target: {
+      hash: 'pending/branch_hash',
       parents: [{ hash: 'master_hash' }],
     },
   },
@@ -155,6 +163,14 @@ module.exports = {
       {
         key: 'foo',
         state: 'SUCCESSFUL',
+      },
+    ],
+  },
+  '/2.0/repositories/some/repo/commit/pending/branch_hash/statuses': {
+    values: [
+      {
+        key: 'foo',
+        state: 'INPROGRESS',
       },
     ],
   },

--- a/test/platform/bitbucket/index.spec.ts
+++ b/test/platform/bitbucket/index.spec.ts
@@ -198,6 +198,7 @@ describe('platform/bitbucket', () => {
       expect(await getBranchStatus('master', ['foo'])).toBe('failed');
       expect(await getBranchStatus('master', true)).toBe('failed');
       expect(await getBranchStatus('branch', true)).toBe('success');
+      expect(await getBranchStatus('pending/branch', true)).toBe('pending');
       expect(await getBranchStatus('branch-with-empty-status', true)).toBe(
         'pending'
       );

--- a/test/platform/bitbucket/index.spec.ts
+++ b/test/platform/bitbucket/index.spec.ts
@@ -198,6 +198,9 @@ describe('platform/bitbucket', () => {
       expect(await getBranchStatus('master', ['foo'])).toBe('failed');
       expect(await getBranchStatus('master', true)).toBe('failed');
       expect(await getBranchStatus('branch', true)).toBe('success');
+      expect(await getBranchStatus('branch-with-empty-status', true)).toBe(
+        'pending'
+      );
     });
   });
 


### PR DESCRIPTION
Return "pending" in `getBranchStatus` when BitBucket Cloud returns an empty list of statuses.

This seems to have fixed the issue in #4622. I see another function in the same file called `getBranchStatusCheck`, but it was never called. Should I do something similar in that function, or just ignore it?

Closes #4622