### PR TITLE
fix(maven): Fixes issue with private maven registry on amazon s3

### DIFF
--- a/lib/datasource/maven/util.ts
+++ b/lib/datasource/maven/util.ts
@@ -38,7 +38,23 @@ export async function downloadHttpProtocol(
 ): Promise<string | null> {
   let raw: { body: string };
   try {
-    raw = await got(pkgUrl, { hostType });
+    raw = await got(pkgUrl, {
+      hostType,
+      hooks: {
+        beforeRedirect: [
+          (options: any) => {
+            if (
+              options.search &&
+              options.search.indexOf('X-Amz-Algorithm') !== -1
+            ) {
+              // maven repository is hosted on amazon, redirect url includes authentication.
+              // eslint-disable-next-line no-param-reassign
+              delete options.auth;
+            }
+          },
+        ],
+      },
+    });
   } catch (err) {
     if (isNotFoundError(err)) {
       logger.debug(`Url not found ${pkgUrl}`);

--- a/test/datasource/maven.spec.ts
+++ b/test/datasource/maven.spec.ts
@@ -2,6 +2,8 @@ import nock from 'nock';
 import fs from 'fs';
 import * as datasource from '../../lib/datasource';
 
+const hostRules = require('../../lib/util/host-rules');
+
 const MYSQL_VERSIONS = [
   '6.0.5',
   '6.0.6',
@@ -29,6 +31,12 @@ const config = {
 
 describe('datasource/maven', () => {
   beforeEach(() => {
+    hostRules.add({
+      hostType: 'maven',
+      hostName: 'frontend_for_private_s3_repository',
+      username: 'username',
+      password: 'password',
+    });
     nock.disableNetConnect();
     nock('http://central.maven.org')
       .get('/maven2/mysql/mysql-connector-java/maven-metadata.xml')
@@ -47,6 +55,30 @@ describe('datasource/maven', () => {
     nock('http://empty_repo')
       .get('/mysql/mysql-connector-java/maven-metadata.xml')
       .reply(200, 'non-sense');
+    nock('http://frontend_for_private_s3_repository')
+      .get('/maven2/mysql/mysql-connector-java/maven-metadata.xml')
+      .basicAuth({ user: 'username', pass: 'password' })
+      .reply(302, '', {
+        Location:
+          'http://private_s3_repository/maven2/mysql/mysql-connector-java/maven-metadata.xml?X-Amz-Algorithm=AWS4-HMAC-SHA256',
+      })
+      .get(
+        '/maven2/mysql/mysql-connector-java/8.0.12/mysql-connector-java-8.0.12.pom'
+      )
+      .basicAuth({ user: 'username', pass: 'password' })
+      .reply(302, '', {
+        Location:
+          'http://private_s3_repository/maven2/mysql/mysql-connector-java/8.0.12/mysql-connector-java-8.0.12.pom?X-Amz-Algorithm=AWS4-HMAC-SHA256',
+      });
+    nock('http://private_s3_repository', { badheaders: ['authorization'] })
+      .get(
+        '/maven2/mysql/mysql-connector-java/maven-metadata.xml?X-Amz-Algorithm=AWS4-HMAC-SHA256'
+      )
+      .reply(200, MYSQL_MAVEN_METADATA)
+      .get(
+        '/maven2/mysql/mysql-connector-java/8.0.12/mysql-connector-java-8.0.12.pom?X-Amz-Algorithm=AWS4-HMAC-SHA256'
+      )
+      .reply(200, MYSQL_MAVEN_MYSQL_POM);
   });
 
   afterEach(() => {
@@ -225,6 +257,15 @@ describe('datasource/maven', () => {
         ],
       });
       expect(releases.sourceUrl).toEqual('https://github.com/realm/realm-java');
+    });
+
+    it('should remove authentication header when redirected with authentication in query string', async () => {
+      const releases = await datasource.getPkgReleases({
+        ...config,
+        lookupName: 'mysql:mysql-connector-java',
+        registryUrls: ['http://frontend_for_private_s3_repository/maven2'],
+      });
+      expect(releases.releases).toEqual(generateReleases(MYSQL_VERSIONS));
     });
   });
 });


### PR DESCRIPTION
When Renovate tries to download an artifact from a Maven repository, if the response is a redirect, and the redirect URL contains the string `X-Amz-Algorithm`, delete the `Authorization` header from the redirect request.

This fixes an issue when a private Maven repository is hosted on Amazon S3. 

Similar to issue #3877 but for Maven instead of Docker. This PR is based on the fix for that issue which you can see here: #3878 
