### PR TITLE
docs: describe npm depTypes

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -596,19 +596,12 @@ Check out our [Node.js documentation](https://docs.renovatebot.com/node) for a c
 
 The following dep types are currently supported by the npm manager :
 
-### dependencies
-
-### devDependencies
-
-### optionalDependencies
-
-### peerDependencies
-
-### engines
-
-### volta
-
-Renovate will update any node and yarn version specified under `volta`.
+1. `dependencies`
+2. `devDependencies`
+3. `optionalDependencies`
+4. `peerDependencies`
+5. `engines`
+6. `volta` : Renovate will update any node and yarn version specified under `volta`.
 
 ```json
 {

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -596,12 +596,23 @@ Check out our [Node.js documentation](https://docs.renovatebot.com/node) for a c
 
 The following dep types are currently supported by the npm manager :
 
-1. `dependencies`
-2. `devDependencies`
-3. `optionalDependencies`
-4. `peerDependencies`
-5. `engines`
-6. `volta` : Renovate will update any node and yarn version specified under `volta`.
+- `dependencies`
+- `devDependencies`
+- `optionalDependencies`
+- `peerDependencies`
+- `engines` : Renovate will update any `node`, `npm` and `yarn` version specified under `engines`.
+
+```json
+{
+  "engines": {
+    "node": "10.15.3",
+    "npm": "6.9.0",
+    "yarn": "1.14.0"
+  }
+}
+```
+
+- `volta` : Renovate will update any `node` and `yarn` version specified under `volta`.
 
 ```json
 {

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -267,7 +267,7 @@ Example:
 
 ## encrypted
 
-See https://docs.renovatebot.com/private-modules for details on how this is used to encrypt npm tokens.
+See [Private npm module support](https://docs.renovatebot.com/private-modules) for details on how this is used to encrypt npm tokens.
 
 ## engines
 
@@ -623,11 +623,11 @@ Currently `volta` supports only `node` and `yarn` to be pinned. Check out this g
 
 ## npmToken
 
-See https://docs.renovatebot.com/private-modules for details on how this is used. Typically you would encrypt it and put it inside the `encrypted` object.
+See [Private npm module support](https://docs.renovatebot.com/private-modules) for details on how this is used. Typically you would encrypt it and put it inside the `encrypted` object.
 
 ## npmrc
 
-See https://docs.renovatebot.com/private-modules for details on how this is used.
+See [Private npm module support](https://docs.renovatebot.com/private-modules) for details on how this is used.
 
 ## nuget
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -285,7 +285,7 @@ Be careful you know what you're doing with this option. The initial intended use
 
 ## extends
 
-See https://docs.renovatebot.com/config-presets for details.
+See [shareable config presets](https://docs.renovatebot.com/config-presets) for details.
 
 ## fileMatch
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -594,36 +594,14 @@ Check out our [Node.js documentation](https://docs.renovatebot.com/node) for a c
 
 ## npm
 
-The following dep types are currently supported by the npm manager :
+The following `depTypes` are currently supported by the npm manager :
 
 - `dependencies`
 - `devDependencies`
 - `optionalDependencies`
 - `peerDependencies`
 - `engines` : Renovate will update any `node`, `npm` and `yarn` version specified under `engines`.
-
-```json
-{
-  "engines": {
-    "node": "10.15.3",
-    "npm": "6.9.0",
-    "yarn": "1.14.0"
-  }
-}
-```
-
 - `volta` : Renovate will update any `node` and `yarn` version specified under `volta`.
-
-```json
-{
-  "volta": {
-    "node": "10.15.3",
-    "yarn": "1.14.0"
-  }
-}
-```
-
-Currently `volta` supports only `node` and `yarn` to be pinned. Check out this guide [Understanding Volta](https://docs.volta.sh/guide/understanding) to learn more.
 
 ## npmToken
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -594,6 +594,33 @@ Check out our [Node.js documentation](https://docs.renovatebot.com/node) for a c
 
 ## npm
 
+The following dep types are currently supported by the npm manager :
+
+### dependencies
+
+### devDependencies
+
+### optionalDependencies
+
+### peerDependencies
+
+### engines
+
+### volta
+
+Renovate will update any node and yarn version specified under `volta`.
+
+```json
+{
+  "volta": {
+    "node": "10.15.3",
+    "yarn": "1.14.0"
+  }
+}
+```
+
+Currently `volta` supports only `node` and `yarn` to be pinned. Check out this guide [Understanding Volta](https://docs.volta.sh/guide/understanding) to learn more.
+
 ## npmToken
 
 See https://docs.renovatebot.com/private-modules for details on how this is used. Typically you would encrypt it and put it inside the `encrypted` object.

--- a/docs/usage/node.md
+++ b/docs/usage/node.md
@@ -12,6 +12,7 @@ Renovate can upgrade the [Node.js](https://nodejs.org/en/) runtime used by your 
 Renovate is capable of managing the Node.js version in the following files:
 
 - The [`engines`](https://docs.npmjs.com/files/package.json#engines) field in [`package.json`](https://docs.npmjs.com/files/package.json).
+- The [`volta`](https://docs.volta.sh/guide/understanding#managing-your-project) field in [`package.json`](https://docs.npmjs.com/files/package.json).
 - The [`.nvmrc`](https://github.com/creationix/nvm#nvmrc) file for the [Node Version Manager](https://github.com/creationix/nvm).
 - The [`node_js`](https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Specifying-Node.js-versions) field in [`.travis.yml`](https://docs.travis-ci.com/user/customizing-the-build/).
 


### PR DESCRIPTION
Added list of various dep types supported by npm manager under `npm` section of docs.
Added `volta` description under node.
Wrapped doc links with description.


Closes #4529 
