### PR TITLE
Support GitLab-hosted changelogs #3323

### DIFF
--- a/lib/datasource/npm/get.ts
+++ b/lib/datasource/npm/get.ts
@@ -174,6 +174,9 @@ export async function getDependency(
         extraBaseUrls,
       });
     }
+    if(sourceUrl==undefined){
+      sourceUrl = res.repository.url;
+    }
     if (res.homepage && res.homepage.includes('://github.com')) {
       delete res.homepage;
     }

--- a/lib/util/host-rules.ts
+++ b/lib/util/host-rules.ts
@@ -153,6 +153,14 @@ export function find(search: HostRuleSearch) {
   return res;
 }
 
+export function getPlatformByHostOrUrl(url){
+  let {host} = URL.parse(url);
+  for(let rule of hostRules){
+    if(rule.baseUrl == url || rule.hostName == host || rule.domainName == host){
+      return rule
+    }
+  }
+}
 export function hosts({ hostType }: { hostType: string }) {
   return hostRules
     .filter(rule => rule.hostType === hostType)

--- a/lib/workers/pr/changelog/index.js
+++ b/lib/workers/pr/changelog/index.js
@@ -3,6 +3,7 @@ const versioning = require('../../../versioning');
 const sourceGithub = require('./source-github');
 const { getReleases } = require('./releases');
 const sourceGitlab = require('./source-gitlab');
+const hostRules = require('../../../util/host-rules');
 const util = require('util');
 const URL = require('url');
 
@@ -18,24 +19,20 @@ async function getChangeLogJSON(args) {
   logger.debug(util.inspect(args, { showHidden: false, depth: null }));
   let { sourceUrl, versionScheme, fromVersion, toVersion, homepage } = args;
   const version = versioning.get(versionScheme);
-  if (!sourceUrl && !homepage) {
+  if (!sourceUrl) {
     logger.debug(
       `no sourceUrl or homepage provided for ${args.depName}, can't provide release notes!`
     );
     return null;
-  } else {
-    if (!sourceUrl) {
-      let tmpSourceUrl = URL.parse(args.homepage);
-      args.sourceUrl = `${tmpSourceUrl.protocol}//${tmpSourceUrl.hostname}/${tmpSourceUrl.pathname}`;
-    }
   }
   if (!fromVersion || version.equals(fromVersion, toVersion)) {
     return null;
   }
   const releases = args.releases || (await getReleases(args));
-
+  const host_type = hostRules.getPlatformByHostOrUrl(sourceUrl).hostType;
+  logger.debug(`Using ${host_type} changelog extractor.`)
   try {
-    if (args.sourceUrl.includes('gitlab')) {
+    if (host_type=='gitlab') {
       logger.debug(
         `Running changelog creation for gitlab with parameters ${JSON.stringify(args)}`
       );

--- a/lib/workers/pr/changelog/index.js
+++ b/lib/workers/pr/changelog/index.js
@@ -2,26 +2,49 @@ const { logger } = require('../../../logger');
 const versioning = require('../../../versioning');
 const sourceGithub = require('./source-github');
 const { getReleases } = require('./releases');
+const sourceGitlab = require('./source-gitlab');
+const util = require('util');
+const URL = require('url');
 
 module.exports = {
   getChangeLogJSON,
 };
 
 async function getChangeLogJSON(args) {
-  const { sourceUrl, versionScheme, fromVersion, toVersion } = args;
-  if (!sourceUrl) {
-    return null;
-  }
+  logger.debug(
+    `get platform name as ${args.platform} in function getChangeLogJSON`
+  );
+  logger.debug(`args for getChangeLogJSON`);
+  logger.debug(util.inspect(args, { showHidden: false, depth: null }));
+  let { sourceUrl, versionScheme, fromVersion, toVersion, homepage } = args;
   const version = versioning.get(versionScheme);
+  if (!sourceUrl && !homepage) {
+    logger.debug(
+      `no sourceUrl or homepage provided for ${args.depName}, can't provide release notes!`
+    );
+    return null;
+  } else {
+    if (!sourceUrl) {
+      let tmpSourceUrl = URL.parse(args.homepage);
+      args.sourceUrl = `${tmpSourceUrl.protocol}//${tmpSourceUrl.hostname}/${tmpSourceUrl.pathname}`;
+    }
+  }
   if (!fromVersion || version.equals(fromVersion, toVersion)) {
     return null;
   }
-
   const releases = args.releases || (await getReleases(args));
 
   try {
-    const res = await sourceGithub.getChangeLogJSON({ ...args, releases });
-    return res;
+    if (args.sourceUrl.includes('gitlab')) {
+      logger.debug(
+        `Running changelog creation for gitlab with parameters ${JSON.stringify(args)}`
+      );
+      const res = await sourceGitlab.getChangeLogJSON({ ...args, releases });
+      return res;
+    } else {
+      const res = await sourceGithub.getChangeLogJSON({ ...args, releases });
+      return res;
+    }
   } catch (err) /* istanbul ignore next */ {
     logger.error({ err }, 'getChangeLogJSON error');
     return null;

--- a/lib/workers/pr/changelog/release-notes-gitlab.js
+++ b/lib/workers/pr/changelog/release-notes-gitlab.js
@@ -1,0 +1,185 @@
+import changelogFilenameRegex from 'changelog-filename-regex';
+import { api } from '../../../platform/gitlab/gl-got-wrapper';
+import { logger } from '../../../logger';
+
+const glGot = api.get;
+
+export {
+  getReleaseList,
+  getReleaseNotesMd,
+  getReleaseNotes,
+  addReleaseNotes,
+};
+
+async function getReleaseList(githubApiBaseURL, repository, repoid) {
+  logger.trace('getReleaseList()');
+  if (!githubApiBaseURL) {
+    return [];
+  }
+  try {
+    let url = githubApiBaseURL.replace(/\/?$/, '/');
+    logger.debug(`getReleaseList: ${getReleaseList}`);
+    url = `${url}projects/${repoid}/releases?per_page=100`;
+    const res = await glGot(url);
+    return res.body.map(release => ({
+      url: '',
+      id: release.id,
+      tag: release.tag_name,
+      name: release.name,
+      body: release.description,
+      commitid: release.commit.id,
+    }));
+  } catch (err) {
+    logger.info({ repository, err }, 'getReleaseList error');
+    return [];
+  }
+}
+
+
+
+async function getReleaseNotes(
+  repository,
+  version,
+  depName,
+  githubBaseURL,
+  githubApiBaseURL,
+  repoid
+) {
+  logger.trace(`getReleaseNotes(${repository}, ${version}, ${depName})`);
+  const releaseList = await getReleaseList(
+    githubApiBaseURL,
+    repository,
+    repoid
+  );
+  logger.debug(
+    `getReleaseList parameters: ${githubApiBaseURL}, ${repository}, ${repoid} release array: ${JSON.stringify(releaseList)}`
+  );
+  let releaseNotes;
+  releaseList.forEach(release => {
+    if (
+      release.tag === version ||
+      release.tag === `v${version}` ||
+      release.tag === `${depName}-${version}`
+    ) {
+      releaseNotes = release;
+      releaseNotes.url = `${githubBaseURL}${repository}/commit/${release.commitid}?view=parallel`;
+      releaseNotes.body = release.body;
+      if (!releaseNotes.body.length) {
+        logger.debug(`No release notes found for ${JSON.stringify(release)}`);
+        return undefined;
+      }
+    }
+  });
+  logger.trace({ releaseNotes });
+  return releaseNotes;
+}
+
+async function getReleaseNotesMd(
+  repository,
+  version,
+  githubBaseURL,
+  githubApiBaseURL,
+  repoid
+) {
+  logger.trace(`getReleaseNotesMd(${repository}, ${version})`);
+  let changelogFile;
+  let changelogMd = '';
+  let filePath = githubApiBaseURL.replace(/\/?$/, '/');
+  try {
+    let apiPrefix = githubApiBaseURL.replace(/\/?$/, '/');
+
+    apiPrefix = `${apiPrefix}projects/${repoid}/repository/tree?per_page=100`;
+    const filesRes = await glGot(apiPrefix);
+    const files = filesRes.body
+      .map(f => f.path)
+      .filter(f => changelogFilenameRegex.test(f.split('/').pop()));
+    if (!files.length) {
+      logger.trace('no changelog file found');
+      return null;
+    }
+
+    [changelogFile] = files;
+    if (files.length > 1) {
+      logger.info(
+        `Multiple candidates for changelog file, using ${changelogFile[0]}`
+      );
+    }
+    filePath = `${filePath}projects/${repoid}/repository/files/${changelogFile[0]}?ref=${version}`;
+    const fileRes = await glGot(filePath);
+    changelogMd =
+      Buffer.from(fileRes.body.content, 'base64').toString() + '\n#\n##';
+  } catch (err) {
+    logger.debug(
+      `got ${err.statusCode} for ${filePath} can't fetch changelog file`
+    );
+    return null;
+  }
+  const url = `${githubBaseURL}/${repository}`;
+  return { changelogMd, url };
+}
+
+async function addReleaseNotes(input) {
+  if (
+    !(
+      input &&
+      input.project &&
+      input.project.github &&
+      input.versions &&
+      input.project.repoid
+    )
+  ) {
+    logger.debug('Missing project or versions');
+    return input;
+  }
+  const output = { ...input, versions: [] };
+  const repository = input.project.github.replace(/\.git$/, '');
+  const cacheNamespace = 'changelog-gitlab-notes';
+  function getCacheKey(version) {
+    return `${repository}:${version}`;
+  }
+  for (const v of input.versions) {
+    let releaseNotes;
+    const cacheKey = getCacheKey(v.version);
+    releaseNotes = await renovateCache.get(cacheNamespace, cacheKey);
+    if (!releaseNotes) {
+      releaseNotes = await getReleaseNotes(
+        repository,
+        v.version,
+        input.project.depName,
+        input.project.githubBaseURL,
+        input.project.githubApiBaseURL,
+        input.project.repoid
+      );
+
+      if (!releaseNotes) {
+        logger.trace(
+          `No valid  release notes found for v${v.version} fetching changelog.MD`
+        );
+
+        releaseNotes = await getReleaseNotesMd(
+          repository,
+          v.version,
+          input.project.githubBaseURL,
+          input.project.githubApiBaseURL,
+          input.project.repoid
+        );
+      }
+      if (!releaseNotes && v.compare.url) {
+        releaseNotes = { url: v.compare.url };
+      }
+      const cacheMinutes = 55;
+      await renovateCache.set(
+        cacheNamespace,
+        cacheKey,
+        releaseNotes,
+        cacheMinutes
+      );
+    }
+    output.versions.push({
+      ...v,
+      releaseNotes,
+    });
+    output.hasReleaseNotes = output.hasReleaseNotes || !!releaseNotes;
+  }
+  return output;
+}

--- a/lib/workers/pr/changelog/source-gitlab.js
+++ b/lib/workers/pr/changelog/source-gitlab.js
@@ -1,0 +1,194 @@
+import { api } from '../../../platform/gitlab/gl-got-wrapper';
+
+const URL = require('url');
+const { logger } = require('../../../logger');
+const hostRules = require('../../../util/host-rules');
+const versioning = require('../../../versioning');
+const { addReleaseNotes } = require('./release-notes-gitlab');
+
+const glGot = api.get;
+
+export { getChangeLogJSON };
+async function getprojectid(githubApiBaseURL, repository) {
+  let url = githubApiBaseURL
+    ? githubApiBaseURL.replace(/\/?$/, '/')
+    : 'https://gitlab.com/api/v4/';
+  let project = repository.split('/').pop();
+  let repopath = repository.replace(RegExp('^/'), '');
+  let search_string = `${url}search?scope=projects&search=${project}&per_page=100`;
+  let repoid = null;
+  try {
+    const res = await glGot(search_string, {
+      paginate: true,
+    });
+    logger.debug(
+      `Response for query ${search_string}:\n ${JSON.stringify(
+        res.body
+      )}\n status code:\n ${res.statusCode}`
+    );
+    for (let i of res.body) {
+      if (i.path_with_namespace.includes(repopath)) {
+        repoid = i.id;
+      }
+    }
+  } catch (err) {
+    logger.info(`Can't get project for ${repository}`);
+    logger.debug({ err });
+  }
+  if (repoid == null) {
+    logger.debug(
+      `can't get repoid for ${repository} with ${repopath} search string is ${search_string}`
+    );
+  }
+  return repoid;
+}
+async function getTags(endpoint, versionScheme, repository, repoid) {
+  let url = endpoint
+    ? endpoint.replace(/\/?$/, '/')
+    : 'https://gitlab.com/api/v4/';
+  let tagsearch = `${endpoint}projects/${repoid}/repository/tags?per_page=100`;
+  try {
+    const res = await glGot(tagsearch, {
+      paginate: true,
+    });
+
+    const tags = (res && res.body) || [];
+
+    if (!tags.length) {
+      logger.debug({ repository }, 'repository has no gitlab tags');
+    }
+
+    return tags.map(tag => tag.name);
+  } catch (err) {
+    logger.info({ sourceRepo: repository }, 'Failed to fetch gitlab tags');
+    logger.debug({ err });
+    return [];
+  }
+}
+
+async function getChangeLogJSON({
+  endpoint,
+  versionScheme,
+  fromVersion,
+  toVersion,
+  sourceUrl,
+  releases,
+  depName,
+  manager,
+}) {
+  const version = versioning.get(versionScheme);
+  logger.debug(`source url is: ${sourceUrl}`);
+  logger.debug(`endpoint url is: ${endpoint}`);
+  const { protocol, host, pathname } = URL.parse(sourceUrl);
+  const githubBaseURL = `${protocol}//${host}/`;
+  logger.debug(`Gitlab base url: ${githubBaseURL}`);
+  const url = `${protocol}//${host}/`;
+  const config = hostRules.find({
+    hostType: 'gitlab',
+    url,
+  });
+  logger.debug(`Host rules for ${url} : ${config}`);
+  logger.debug(`GItlab  url: ${url}`);
+  if (!config.token) {
+    logger.debug('Repository URL does not match any known hosts');
+    return null;
+  }
+  const githubApiBaseURL = sourceUrl.startsWith('https://gitlab.com/')
+    ? 'https://gitlab.com/api/v4/'
+    : `${protocol}//${host}/api/v4/`;
+  logger.debug(`Gitlab githubApiBaseURL url: ${githubApiBaseURL}`);
+  const repository = pathname.slice(1).replace(/\/$/, '');
+  if (repository.split('/').length < 2 && repository.split('/').length > 3) {
+    logger.info({ sourceUrl }, 'Invalid gitlab URL found');
+    return null;
+  }
+  if (!(releases && releases.length)) {
+    logger.debug('No releases');
+    return null;
+  }
+  let repoid = await getprojectid(githubApiBaseURL, repository);
+  // Probably unnecessary checks from source-gitlab.js,here for the sake of keeping things consistent.
+  const validReleases = [...releases]
+    .filter(release => version.isVersion(release.version))
+    .sort((a, b) => version.sortVersions(a.version, b.version));
+
+  if (validReleases.length < 2) {
+    logger.debug('Not enough valid releases');
+    return null;
+  }
+
+  let tags;
+
+  async function getRef(release) {
+    if (!tags) {
+      tags = await getTags(githubApiBaseURL, versionScheme, repository, repoid);
+    }
+    const regex = new RegExp(`${depName}[@-]`);
+    const tagName = tags
+      .filter(tag => version.isVersion(tag.replace(regex, '')))
+      .find(tag => version.equals(tag.replace(regex, ''), release.version));
+    if (tagName) {
+      return tagName;
+    }
+    return null;
+  }
+
+  const cacheNamespace = 'changelog-gitlab-release';
+  function getCacheKey(prev, next) {
+    return `${manager}:${depName}:${prev}:${next}`;
+  }
+
+  const changelogReleases = [];
+  // compare versions
+  const include = v =>
+    version.isGreaterThan(v, fromVersion) &&
+    !version.isGreaterThan(v, toVersion);
+  for (let i = 1; i < validReleases.length; i += 1) {
+    const prev = validReleases[i - 1];
+    const next = validReleases[i];
+    if (include(next.version)) {
+      let release = await renovateCache.get(
+        cacheNamespace,
+        getCacheKey(prev.version, next.version)
+      );
+      if (!release) {
+        release = {
+          version: next.version,
+          date: next.releaseTimestamp,
+          // put empty changes so that existing templates won't break
+          changes: [],
+          compare: {},
+        };
+        const prevHead = await getRef(prev);
+        const nextHead = await getRef(next);
+        if (prevHead && nextHead) {
+          release.compare.url = `${githubBaseURL}${repository}/compare/${prevHead}...${nextHead}`;
+        }
+        const cacheMinutes = 55;
+        await renovateCache.set(
+          cacheNamespace,
+          getCacheKey(prev.version, next.version),
+          release,
+          cacheMinutes
+        );
+      }
+      changelogReleases.unshift(release);
+    }
+  }
+
+  let res = {
+    project: {
+      githubApiBaseURL,
+      githubBaseURL,
+      github: repository,
+      repoid: repoid,
+      repository: sourceUrl,
+      depName,
+    },
+    versions: changelogReleases,
+  };
+
+  res = await addReleaseNotes(res);
+
+  return res;
+}


### PR DESCRIPTION
Hello,
I do not think this i quite ready yet, however I have managed to get renovate to work with gitlab releases and gitlab-based changelog md files to an extent.
Please see https://gitlab.com/v.ivanov000/gltest/merge_requests/1 as an example.



Would close #3323
