### PR TITLE
fix(gomod): skip indirect dependencies

### DIFF
--- a/lib/manager/gomod/extract.ts
+++ b/lib/manager/gomod/extract.ts
@@ -54,7 +54,7 @@ export function extractPackageFile(content: string): PackageFile | null {
         deps.push(dep);
       }
       const requireMatch = line.match(/^require\s+([^\s]+)\s+([^\s]+)/);
-      if (requireMatch) {
+      if (requireMatch && !line.endsWith('// indirect')) {
         logger.trace({ lineNumber }, `require line: "${line}"`);
         const dep = getDep(lineNumber, requireMatch, 'require');
         deps.push(dep);
@@ -66,7 +66,7 @@ export function extractPackageFile(content: string): PackageFile | null {
           line = lines[lineNumber];
           const multiMatch = line.match(/^\s+([^\s]+)\s+([^\s]+)/);
           logger.trace(`reqLine: "${line}"`);
-          if (multiMatch) {
+          if (multiMatch && !line.endsWith('// indirect')) {
             logger.trace({ lineNumber }, `require line: "${line}"`);
             const dep = getDep(lineNumber, multiMatch, 'require');
             dep.managerData.multiLine = true;

--- a/test/manager/gomod/__snapshots__/extract.spec.ts.snap
+++ b/test/manager/gomod/__snapshots__/extract.spec.ts.snap
@@ -720,16 +720,6 @@ Array [
   Object {
     "currentValue": "v1.0.0",
     "datasource": "go",
-    "depName": "github.com/davecgh/go-spew",
-    "depNameShort": "davecgh/go-spew",
-    "depType": "require",
-    "managerData": Object {
-      "lineNumber": 4,
-    },
-  },
-  Object {
-    "currentValue": "v1.0.0",
-    "datasource": "go",
     "depName": "golang.org/x/foo",
     "depNameShort": "golang.org/x/foo",
     "depType": "require",

--- a/test/manager/gomod/__snapshots__/update.spec.ts.snap
+++ b/test/manager/gomod/__snapshots__/update.spec.ts.snap
@@ -5,7 +5,7 @@ exports[`manager/gomod/update updateDependency replaces major gopkg.in updates 1
 
 require github.com/pkg/errors v0.7.0
 require github.com/aws/aws-sdk-go v1.15.21
-require github.com/davecgh/go-spew v1.0.0
+require github.com/davecgh/go-spew v1.0.0 // indirect
 require golang.org/x/foo v1.0.0
 require github.com/rarkins/foo abcdef1
 require gopkg.in/russross/blackfriday.v2 v2.0.0
@@ -79,7 +79,7 @@ require (
 	gopkg.in/src-d/go-git.v4 v4.0.0-20180807092216-43d17e14b714
 	gopkg.in/warnings.v0 v0.1.2
 	gopkg.in/yaml.v2 v2.2.1
-
+	golang.org/x/net v0.0.0-20191003171128-d98b1b443823 // indirect
 )
 "
 `;
@@ -89,7 +89,7 @@ exports[`manager/gomod/update updateDependency replaces two values in one file 1
 
 require github.com/pkg/errors v0.8.0
 require github.com/aws/aws-sdk-go v1.15.36
-require github.com/davecgh/go-spew v1.0.0
+require github.com/davecgh/go-spew v1.0.0 // indirect
 require golang.org/x/foo v1.0.0
 require github.com/rarkins/foo abcdef1
 require gopkg.in/russross/blackfriday.v1 v1.0.0

--- a/test/manager/gomod/_fixtures/1/go.mod
+++ b/test/manager/gomod/_fixtures/1/go.mod
@@ -2,7 +2,7 @@ module github.com/renovate-tests/gomod1
 
 require github.com/pkg/errors v0.7.0
 require github.com/aws/aws-sdk-go v1.15.21
-require github.com/davecgh/go-spew v1.0.0
+require github.com/davecgh/go-spew v1.0.0 // indirect
 require golang.org/x/foo v1.0.0
 require github.com/rarkins/foo abcdef1
 require gopkg.in/russross/blackfriday.v1 v1.0.0

--- a/test/manager/gomod/_fixtures/2/go.mod
+++ b/test/manager/gomod/_fixtures/2/go.mod
@@ -59,5 +59,5 @@ require (
 	gopkg.in/src-d/go-git.v4 v4.0.0-20180807092216-43d17e14b714
 	gopkg.in/warnings.v0 v0.1.2
 	gopkg.in/yaml.v2 v2.2.1
-
+	golang.org/x/net v0.0.0-20191003171128-d98b1b443823 // indirect
 )

--- a/test/manager/gomod/extract.spec.ts
+++ b/test/manager/gomod/extract.spec.ts
@@ -12,7 +12,7 @@ describe('lib/manager/gomod/extract', () => {
     it('extracts single-line requires', () => {
       const res = extractPackageFile(gomod1).deps;
       expect(res).toMatchSnapshot();
-      expect(res).toHaveLength(8);
+      expect(res).toHaveLength(7);
       expect(res.filter(e => e.skipReason)).toHaveLength(1);
       expect(res.filter(e => e.depType === 'replace')).toHaveLength(1);
     });


### PR DESCRIPTION
Skip any go.mod dependencies ending in // indirect

Closes #4586, Closes #4615