### PR TITLE
Fix PR creation not pending for GitLab

### DIFF
--- a/lib/workers/pr/index.js
+++ b/lib/workers/pr/index.js
@@ -50,10 +50,7 @@ async function ensurePr(prConfig) {
     logger.debug(
       `Branch is configured for branch automerge, branch status) is: ${await getBranchStatus()}`
     );
-    if (
-      (await getBranchStatus()) === 'pending' ||
-      (await getBranchStatus()) === 'running'
-    ) {
+    if (['created', 'pending', 'running'].includes(await getBranchStatus())) {
       logger.debug('Checking how long this branch has been pending');
       const lastCommitTime = await platform.getBranchLastCommitTime(branchName);
       const currentTime = new Date();


### PR DESCRIPTION
When using GitLab, branch status can have status `created` which should
be interpreted as pending for PR creation configuration option.