### PR TITLE
fix(gradle): invoke gradlew directly, not with /bin/sh (#4630)

### DIFF
--- a/lib/manager/gradle/index.ts
+++ b/lib/manager/gradle/index.ts
@@ -161,7 +161,7 @@ async function getGradleCommandLine(
   return cmd + ' ' + GRADLE_DEPENDENCY_REPORT_OPTIONS;
 }
 
-async function canExecute(path) {
+async function canExecute(path: string): Promise<boolean> {
   try {
     await access(path, constants.X_OK);
     return true;

--- a/test/manager/gradle/index.spec.ts
+++ b/test/manager/gradle/index.spec.ts
@@ -30,6 +30,7 @@ describe('manager/gradle', () => {
     fs.readFile.mockResolvedValue(updatesDependenciesReport as any);
     fs.mkdir.mockResolvedValue();
     fs.exists.mockResolvedValue(true);
+    fs.access.mockResolvedValue(undefined);
     exec.mockResolvedValue({ stdout: 'gradle output', stderr: '' } as never);
     platform.getFile.mockResolvedValue('some content');
   });
@@ -107,6 +108,19 @@ describe('manager/gradle', () => {
     });
 
     it('should execute gradlew when available', async () => {
+      await manager.extractAllPackageFiles(config, ['build.gradle']);
+
+      expect(exec.mock.calls[0][0]).toBe(
+        './gradlew --init-script renovate-plugin.gradle renovate'
+      );
+      expect(exec.mock.calls[0][1]).toMatchObject({
+        cwd: 'localDir',
+        timeout: 20000,
+      });
+    });
+
+    it('should run gradlew through `sh` when available but not executable', async () => {
+      fs.access.mockRejectedValue(undefined);
       await manager.extractAllPackageFiles(config, ['build.gradle']);
 
       expect(exec.mock.calls[0][0]).toBe(


### PR DESCRIPTION
<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate
-->

<!-- Replace this text with a description of what this PR fixes or adds -->

Closes #4630.  In addition to the automated test, I tested this manually with the project that I described in that issue.