### PR TITLE
feat(gradle-version): source releases from registryUrls

### DIFF
--- a/test/datasource/__snapshots__/gradle-version.spec.ts.snap
+++ b/test/datasource/__snapshots__/gradle-version.spec.ts.snap
@@ -1,5 +1,674 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`datasource/gradle getPkgReleases calls configured registryUrls 1`] = `
+Object {
+  "homepage": "https://gradle.org",
+  "releases": Array [
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-0.7-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-0.7-bin.zip",
+      "version": "0.7.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-0.7-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-0.7-bin.zip",
+      "version": "0.7.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-0.8-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-0.8-bin.zip",
+      "version": "0.8.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-0.8-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-0.8-bin.zip",
+      "version": "0.8.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-0.9-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-0.9-bin.zip",
+      "version": "0.9.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-0.9-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-0.9-bin.zip",
+      "version": "0.9.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-0.9.1-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-0.9.1-bin.zip",
+      "version": "0.9.1",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-0.9.1-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-0.9.1-bin.zip",
+      "version": "0.9.1",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-0.9.2-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-0.9.2-bin.zip",
+      "version": "0.9.2",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-0.9.2-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-0.9.2-bin.zip",
+      "version": "0.9.2",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-1.0-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-1.0-bin.zip",
+      "version": "1.0.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-1.0-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-1.0-bin.zip",
+      "version": "1.0.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-1.1-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-1.1-bin.zip",
+      "version": "1.1.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-1.1-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-1.1-bin.zip",
+      "version": "1.1.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-1.2-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-1.2-bin.zip",
+      "version": "1.2.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-1.2-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-1.2-bin.zip",
+      "version": "1.2.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-1.3-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-1.3-bin.zip",
+      "version": "1.3.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-1.3-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-1.3-bin.zip",
+      "version": "1.3.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-1.4-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-1.4-bin.zip",
+      "version": "1.4.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-1.4-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-1.4-bin.zip",
+      "version": "1.4.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-1.5-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-1.5-bin.zip",
+      "version": "1.5.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-1.5-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-1.5-bin.zip",
+      "version": "1.5.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-1.6-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-1.6-bin.zip",
+      "version": "1.6.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-1.6-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-1.6-bin.zip",
+      "version": "1.6.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-1.7-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-1.7-bin.zip",
+      "version": "1.7.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-1.7-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-1.7-bin.zip",
+      "version": "1.7.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-1.8-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-1.8-bin.zip",
+      "version": "1.8.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-1.8-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-1.8-bin.zip",
+      "version": "1.8.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-1.9-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-1.9-bin.zip",
+      "version": "1.9.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-1.9-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-1.9-bin.zip",
+      "version": "1.9.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-1.10-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-1.10-bin.zip",
+      "version": "1.10.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-1.10-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-1.10-bin.zip",
+      "version": "1.10.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-1.11-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-1.11-bin.zip",
+      "version": "1.11.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-1.11-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-1.11-bin.zip",
+      "version": "1.11.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-1.12-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-1.12-bin.zip",
+      "version": "1.12.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-1.12-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-1.12-bin.zip",
+      "version": "1.12.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-2.0-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-2.0-bin.zip",
+      "version": "2.0.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-2.0-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-2.0-bin.zip",
+      "version": "2.0.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-2.1-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-2.1-bin.zip",
+      "version": "2.1.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-2.1-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-2.1-bin.zip",
+      "version": "2.1.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-2.2-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-2.2-bin.zip",
+      "version": "2.2.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-2.2-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-2.2-bin.zip",
+      "version": "2.2.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-2.2.1-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-2.2.1-bin.zip",
+      "version": "2.2.1",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-2.2.1-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-2.2.1-bin.zip",
+      "version": "2.2.1",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-2.3-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-2.3-bin.zip",
+      "version": "2.3.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-2.3-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-2.3-bin.zip",
+      "version": "2.3.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-2.4-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-2.4-bin.zip",
+      "version": "2.4.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-2.4-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-2.4-bin.zip",
+      "version": "2.4.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-2.5-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-2.5-bin.zip",
+      "version": "2.5.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-2.5-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-2.5-bin.zip",
+      "version": "2.5.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-2.6-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-2.6-bin.zip",
+      "version": "2.6.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-2.6-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-2.6-bin.zip",
+      "version": "2.6.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-2.7-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-2.7-bin.zip",
+      "version": "2.7.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-2.7-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-2.7-bin.zip",
+      "version": "2.7.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-2.8-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-2.8-bin.zip",
+      "version": "2.8.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-2.8-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-2.8-bin.zip",
+      "version": "2.8.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-2.9-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-2.9-bin.zip",
+      "version": "2.9.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-2.9-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-2.9-bin.zip",
+      "version": "2.9.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-2.10-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-2.10-bin.zip",
+      "version": "2.10.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-2.10-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-2.10-bin.zip",
+      "version": "2.10.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-2.11-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-2.11-bin.zip",
+      "version": "2.11.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-2.11-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-2.11-bin.zip",
+      "version": "2.11.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-2.12-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-2.12-bin.zip",
+      "version": "2.12.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-2.12-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-2.12-bin.zip",
+      "version": "2.12.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-2.13-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-2.13-bin.zip",
+      "version": "2.13.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-2.13-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-2.13-bin.zip",
+      "version": "2.13.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-2.14-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-2.14-bin.zip",
+      "version": "2.14.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-2.14-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-2.14-bin.zip",
+      "version": "2.14.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-2.14.1-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-2.14.1-bin.zip",
+      "version": "2.14.1",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-2.14.1-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-2.14.1-bin.zip",
+      "version": "2.14.1",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-3.0-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-3.0-bin.zip",
+      "version": "3.0.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-3.0-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-3.0-bin.zip",
+      "version": "3.0.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-3.1-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-3.1-bin.zip",
+      "version": "3.1.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-3.1-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-3.1-bin.zip",
+      "version": "3.1.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-3.2-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-3.2-bin.zip",
+      "version": "3.2.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-3.2-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-3.2-bin.zip",
+      "version": "3.2.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-3.2.1-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-3.2.1-bin.zip",
+      "version": "3.2.1",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-3.2.1-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-3.2.1-bin.zip",
+      "version": "3.2.1",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-3.3-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-3.3-bin.zip",
+      "version": "3.3.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-3.3-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-3.3-bin.zip",
+      "version": "3.3.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-3.4-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-3.4-bin.zip",
+      "version": "3.4.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-3.4-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-3.4-bin.zip",
+      "version": "3.4.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-3.4.1-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-3.4.1-bin.zip",
+      "version": "3.4.1",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-3.4.1-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-3.4.1-bin.zip",
+      "version": "3.4.1",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-3.5-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-3.5-bin.zip",
+      "version": "3.5.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-3.5-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-3.5-bin.zip",
+      "version": "3.5.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-3.5.1-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-3.5.1-bin.zip",
+      "version": "3.5.1",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-3.5.1-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-3.5.1-bin.zip",
+      "version": "3.5.1",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-4.0-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-4.0-bin.zip",
+      "version": "4.0.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-4.0-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-4.0-bin.zip",
+      "version": "4.0.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-4.0.1-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-4.0.1-bin.zip",
+      "version": "4.0.1",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-4.0.1-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-4.0.1-bin.zip",
+      "version": "4.0.1",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-4.0.2-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-4.0.2-bin.zip",
+      "version": "4.0.2",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-4.0.2-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-4.0.2-bin.zip",
+      "version": "4.0.2",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-4.1-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-4.1-bin.zip",
+      "version": "4.1.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-4.1-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-4.1-bin.zip",
+      "version": "4.1.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-4.2-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-4.2-bin.zip",
+      "version": "4.2.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-4.2-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-4.2-bin.zip",
+      "version": "4.2.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-4.2.1-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-4.2.1-bin.zip",
+      "version": "4.2.1",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-4.2.1-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-4.2.1-bin.zip",
+      "version": "4.2.1",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-4.3-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-4.3-bin.zip",
+      "version": "4.3.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-4.3-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-4.3-bin.zip",
+      "version": "4.3.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-4.3.1-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-4.3.1-bin.zip",
+      "version": "4.3.1",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-4.3.1-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-4.3.1-bin.zip",
+      "version": "4.3.1",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-4.4-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-4.4-bin.zip",
+      "version": "4.4.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-4.4-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-4.4-bin.zip",
+      "version": "4.4.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-4.4.1-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-4.4.1-bin.zip",
+      "version": "4.4.1",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-4.4.1-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-4.4.1-bin.zip",
+      "version": "4.4.1",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-4.5-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-4.5-bin.zip",
+      "version": "4.5.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-4.5-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-4.5-bin.zip",
+      "version": "4.5.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-4.5.1-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-4.5.1-bin.zip",
+      "version": "4.5.1",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-4.5.1-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-4.5.1-bin.zip",
+      "version": "4.5.1",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-4.6-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-4.6-bin.zip",
+      "version": "4.6.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-4.6-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-4.6-bin.zip",
+      "version": "4.6.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-4.7-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-4.7-bin.zip",
+      "version": "4.7.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-4.7-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-4.7-bin.zip",
+      "version": "4.7.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-4.8-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-4.8-bin.zip",
+      "version": "4.8.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-4.8-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-4.8-bin.zip",
+      "version": "4.8.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-4.8.1-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-4.8.1-bin.zip",
+      "version": "4.8.1",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-4.8.1-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-4.8.1-bin.zip",
+      "version": "4.8.1",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-4.9-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-4.9-bin.zip",
+      "version": "4.9.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-4.9-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-4.9-bin.zip",
+      "version": "4.9.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-4.10-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-4.10-bin.zip",
+      "version": "4.10.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-4.10-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-4.10-bin.zip",
+      "version": "4.10.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-4.10.1-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-4.10.1-bin.zip",
+      "version": "4.10.1",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-4.10.1-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-4.10.1-bin.zip",
+      "version": "4.10.1",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-4.10.2-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-4.10.2-bin.zip",
+      "version": "4.10.2",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-4.10.2-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-4.10.2-bin.zip",
+      "version": "4.10.2",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-4.10.3-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-4.10.3-bin.zip",
+      "version": "4.10.3",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-4.10.3-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-4.10.3-bin.zip",
+      "version": "4.10.3",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-5.0-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-5.0-bin.zip",
+      "version": "5.0.0",
+    },
+    Object {
+      "checksumUrl": "https://services.gradle.org/distributions/gradle-5.0-bin.zip.sha256",
+      "downloadUrl": "https://services.gradle.org/distributions/gradle-5.0-bin.zip",
+      "version": "5.0.0",
+    },
+  ],
+  "sourceUrl": "https://github.com/gradle/gradle",
+}
+`;
+
 exports[`datasource/gradle getPkgReleases processes real data 1`] = `
 Object {
   "homepage": "https://gradle.org",

--- a/test/datasource/gradle-version.spec.ts
+++ b/test/datasource/gradle-version.spec.ts
@@ -61,6 +61,27 @@ describe('datasource/gradle', () => {
         body: JSON.parse(allResponse),
       });
       const res = await datasource.getPkgReleases(config);
+      expect(got).toHaveBeenCalledTimes(1);
+      expect(got.mock.calls[0][0]).toEqual(
+        'https://services.gradle.org/versions/all'
+      );
+      expect(res).toMatchSnapshot();
+      expect(res).not.toBeNull();
+    });
+
+    it('calls configured registryUrls', async () => {
+      got.mockReturnValue({
+        body: JSON.parse(allResponse),
+      });
+      const res = await datasource.getPkgReleases({
+        ...config,
+        registryUrls: ['https://foo.bar', 'http://baz.qux'],
+      });
+      expect(got).toHaveBeenCalledTimes(2);
+      expect(got.mock.calls[0][0]).toEqual('https://foo.bar');
+      expect(got.mock.calls[1][0]).toEqual('http://baz.qux');
+      // This will have every release duplicated, because we used the same
+      // mocked data for both responses.
       expect(res).toMatchSnapshot();
       expect(res).not.toBeNull();
     });


### PR DESCRIPTION
<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate
-->

<!-- Replace this text with a description of what this PR fixes or adds -->

Allow users to configure a custom registry from which available Gradle releases are sourced, using the existing `registryUrls` configuration.  Continue to default to the public Gradle service if no such URLs are specified.

Closes #4676.