### PR TITLE
fix: fix a typo in the documentation

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -785,7 +785,7 @@ The above will enable set `rangeStrategy` to `pin` only for the package `angular
 
 ### packagePatterns
 
-Use this field if you want to have one or more package names patterns in your package rule. See also `excludedPackagePatterns`.
+Use this field if you want to have one or more package names patterns in your package rule. See also `excludePackagePatterns`.
 
 ```
   "packageRules": [{


### PR DESCRIPTION
`excludedPackagePatterns` -> `excludePackagePatterns`
