### PR TITLE
docs: Add a paragraph to link to later.js for schedules

### DIFF
--- a/docs/usage/noise-reduction.md
+++ b/docs/usage/noise-reduction.md
@@ -74,6 +74,8 @@ Or perhaps at least weekly:
   ]
 ```
 
+If you're wondering what is supported and not, under the hood, the schedule is parsed using [later.js](https://bunkat.github.io/later/) using the `later.parse.text(scheduleString)` API. [This page](https://bunkat.github.io/later/parsers.html#text) explains the supported syntax or you can experiment on the [RunKit playground](https://npm.runkit.com/later).
+
 ## Automerging
 
 Automerging is a Renovate feature that can save you a lot of time/noise directly, while also benefiting grouping and scheduling. In short: it means that Renovate can merge PRs or even branches itself if they pass your tests.


### PR DESCRIPTION
<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate
-->

I find it unclear what exactly is supported by Renovate in terms of parsing text for schedules. By looking at the code, I can see that it seems to use later.js which has good documentation. I've added a link to their documentation for people who want to know more.
