### PR TITLE
feat: only install graddle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update && apt-get install -y gpg curl wget unzip xz-utils git openss
 
 ## Gradle
 
-RUN apt-get update && apt-get install -y --no-install-recommends openjdk-8-jdk gradle && \
+RUN apt-get update && apt-get install -y --no-install-recommends gradle && \
     rm -rf /var/lib/apt/lists/*
 
 ## Node.js


### PR DESCRIPTION
This will reduce the docker image size by ~450mb.

The current version installs the full java8 sdk, but graddle brings the java11 headless sdk.

@ikesyo If you prefer java8, we can use [openjdk-8-jre-headless](https://packages.ubuntu.com/bionic-updates/gradle) as alternate

