### PR TITLE
fix: `ignorePaths` should not explicitly check for substring matches

### DIFF
--- a/lib/workers/repository/extract/file-match.js
+++ b/lib/workers/repository/extract/file-match.js
@@ -27,7 +27,7 @@ function filterIgnoredFiles(fileList, ignorePaths) {
     file =>
       !ignorePaths.some(
         ignorePath =>
-          file.includes(ignorePath) ||
+          file === ignorePath ||
           minimatch(file, ignorePath, { dot: true })
       )
   );

--- a/test/workers/repository/extract/__snapshots__/file-match.spec.js.snap
+++ b/test/workers/repository/extract/__snapshots__/file-match.spec.js.snap
@@ -1,8 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`workers/repository/extract/file-match filterIgnoredFiles() ignores partial matches 1`] = `
+exports[`workers/repository/extract/file-match filterIgnoredFiles() does not ignore partial string / substring matches 1`] = `
 Array [
   "package.json",
+  "frontend/package.json",
+]
+`;
+
+exports[`workers/repository/extract/file-match filterIgnoredFiles() only ignores exact string matches 1`] = `
+Array [
+  "frontend/package.json",
 ]
 `;
 

--- a/test/workers/repository/extract/file-match.spec.js
+++ b/test/workers/repository/extract/file-match.spec.js
@@ -25,11 +25,17 @@ describe('workers/repository/extract/file-match', () => {
       const res = fileMatch.filterIgnoredFiles(fileList, []);
       expect(res).toEqual(fileList);
     });
-    it('ignores partial matches', () => {
-      const ignoredPaths = ['frontend'];
+    it('only ignores exact string matches', () => {
+      const ignoredPaths = ['package.json'];
       const res = fileMatch.filterIgnoredFiles(fileList, ignoredPaths);
       expect(res).toMatchSnapshot();
       expect(res).toHaveLength(1);
+    });
+    it('does not ignore partial string / substring matches', () => {
+      const ignoredPaths = ['frontend'];
+      const res = fileMatch.filterIgnoredFiles(fileList, ignoredPaths);
+      expect(res).toMatchSnapshot();
+      expect(res).toHaveLength(2);
     });
     it('returns minimatch matches', () => {
       const ignoredPaths = ['frontend/**'];


### PR DESCRIPTION
BREAKING CHANGE: `ignorePaths` should not explicitly check for substring matches

Before this change, `ignorePaths` and `includePaths` are inconsistent:
* `ignorePaths` allows substring matches (or glob matches)
* `includePaths` requires exact string matches (or glob matches).

Having `ignorePaths` specifically check for substring matching is undesirable because:
* Substring matching can be achieved with glob matching if desired
* Substring matching can result in ignoring more paths than intended

I realize this is a breaking change that could result in renovatebot managing additional paths so I'm open to alternatives if that's too risky.

### EXAMPLE:

I want to only ignore the top-level package.json in a repository.

Files:
* `package.json`
* `frontend/package.json`

Configuration:
* `"ignorePaths": ["package.json"]`

Unfortunately, due to substring matching, this matches all `package.json` files in the repository.

If I actually wanted to match all `package.json` files in the repository, I should have intentionally used the glob pattern `**/package.json`.

As a workaround, I can use `"includePaths": ["frontend/**"]`, but this is not as scalable / correct, as I would have to update it if I added more folders later.