### PR TITLE
docs: use https for external links

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -1133,7 +1133,7 @@ To restrict `aws-sdk` to only monthly updates, you could add this package rule:
   ]
 ```
 
-Technical details: We mostly rely on the text parsing of the library [later](http://bunkat.github.io/later/parsers.html#text) but only its concepts of "days", "time_before", and "time_after" (Renovate does not support scheduled minutes or "at an exact time" granularity).
+Technical details: We mostly rely on the text parsing of the library [later](https://bunkat.github.io/later/parsers.html#text) but only its concepts of "days", "time_before", and "time_after" (Renovate does not support scheduled minutes or "at an exact time" granularity).
 
 ## semanticCommitScope
 

--- a/docs/usage/data-security.md
+++ b/docs/usage/data-security.md
@@ -16,7 +16,7 @@ If you have any suggestions or questions about our security, please contact us a
 The most important consideration for GitHub App security is the [Private Key](https://developer.github.com/apps/building-integrations/setting-up-and-registering-github-apps/registering-github-apps/#generating-a-private-key) used to access installations. This key is metaphorically the "key to the kingdom" and is essentially the only thing anybody needs to gain access to all repositories on which the Renovate App has been installed, so we have handled it with great caution:
 
 - The key is not saved to disk _anywhere_. We do not keep a backup of it on any device, thumbdrive, or password manager.
-- The key is saved in one location - as an [AWS EC2 Parameter Store](http://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html) "Secure String"
+- The key is saved in one location - as an [AWS EC2 Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html) "Secure String"
 - The EC2 instance we run Renovate on gains access to this Secure String using its IAM Role permissions
 - The private key is not exposed/saved to "env" at any time
 - There exists no generated AWS "Access Key" that has permissions to either (a) read from EC2 Parameter Store, or (b) create IAM users or roles with permissions to access the secure string, or (c) create a new EC2 instance that could gain access

--- a/docs/usage/dependency-pinning.md
+++ b/docs/usage/dependency-pinning.md
@@ -82,7 +82,7 @@ With this approach, updates will be essentially "silent" - causing no notificati
 
 ##### Scheduling
 
-Although it can feel satisfying to receive updates "immediately" when they're available, the reality is that you usually don't _need_ updates so frequently. And worse still, npm package versions that are less than 24 hours [can be unpublished](http://blog.npmjs.org/post/141905368000/changes-to-npms-unpublish-policy), which would really break your build if you've pinned to a version that no longer exists.
+Although it can feel satisfying to receive updates "immediately" when they're available, the reality is that you usually don't _need_ updates so frequently. And worse still, npm package versions that are less than 24 hours [can be unpublished](https://blog.npmjs.org/post/141905368000/changes-to-npms-unpublish-policy), which would really break your build if you've pinned to a version that no longer exists.
 
 So to reduce the interruptions of automated dependency updates, consider putting Renovate on a schedule, such as:
 

--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -62,7 +62,7 @@ The timezone must be one of the valid
 
 Now that your timezone is set, you can define days of week or hours of the day
 in which renovate will make changes. For this we rely on text parsing of the
-library [later](http://bunkat.github.io/later/parsers.html#text) and its
+library [later](https://bunkat.github.io/later/parsers.html#text) and its
 concepts of "days", "time_before", and "time_after".
 
 Example scheduling:

--- a/lib/manager/sbt/readme.md
+++ b/lib/manager/sbt/readme.md
@@ -78,7 +78,7 @@ Another option might be to use ScalaJS. I don't know it but it has same syntax a
 
 If we can use Scala or ScalaJS, the idea would be to execute the `build.sbt` or `plugins.sbt` file and work on the `libraryDependencies` or `dependencyOverrides` variables.
 
-_Update (thanks to @ChristianMurphy)_: https://github.com/scalameta/scalameta running on http://www.scala-js.org could be a way to parse Scala without depending on a JDK.
+_Update (thanks to @ChristianMurphy)_: https://github.com/scalameta/scalameta running on https://www.scala-js.org could be a way to parse Scala without depending on a JDK.
 E.G. https://astexplorer.net/#/gist/027dce11e6927b4ad39ea097ce6289b9/ea4d1048f32063a71d727d01178ae6d01087a62f
 
 ---


### PR DESCRIPTION
This excludes some examples like `http://example.com` or `http://localhost`