### PR TITLE
Use Go1.12 and propagate env vars

### DIFF
--- a/lib/manager/gomod/artifacts.ts
+++ b/lib/manager/gomod/artifacts.ts
@@ -38,7 +38,7 @@ export async function updateArtifacts(
     }
     await outputFile(localGoModFileName, massagedGoMod);
     const localGoSumFileName = join(config.localDir, sumFileName);
-    const customEnv = ['GOPATH', 'GOPROXY'];
+    const customEnv = ['GOPATH', 'GOPROXY', 'GOSUMDB', 'CGO_ENABLED'];
     const env = getChildProcessEnv(customEnv);
     const startTime = process.hrtime();
     let cmd: string;


### PR DESCRIPTION
## Why
Many dependencies are still not compatible with Go 1.13. While that is ideal, it is impractical at least for the use cases I face in my organization. Even when using `GOPROXY=direct` and `GOSUMDB=off` explicitly, `go get -d ./...` and `go mod tidy` result in the following errors.

## Offenders

`replace` directive issue:
```
go: github.com/apache/thrift@v0.12.0 used for two different module paths (git.apache.org/thrift.git and github.com/apache/thrift)
```

Version Tag issue:
```
......
	gopkg.in/mgutz/dat.v2/dat tested by
	gopkg.in/mgutz/dat.v2/dat.test imports
	gopkg.in/stretchr/testify.v1/assert: cannot find module providing package gopkg.in/stretchr/testify.v1/assert
```
