### PR TITLE
fix(cargo): set default rangeStrategy to 'bump'

### DIFF
--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -1469,6 +1469,7 @@ const options: RenovateOptions[] = [
       managerBranchPrefix: 'rust-',
       fileMatch: ['(^|/)Cargo.toml$'],
       versionScheme: 'cargo',
+      rangeStrategy: 'bump',
     },
     mergeable: true,
   },

--- a/renovate-schema.json
+++ b/renovate-schema.json
@@ -948,7 +948,8 @@
         "commitMessageTopic": "Rust crate {{depName}}",
         "managerBranchPrefix": "rust-",
         "fileMatch": ["(^|/)Cargo.toml$"],
-        "versionScheme": "cargo"
+        "versionScheme": "cargo",
+        "rangeStrategy": "bump"
       },
       "$ref": "#"
     },


### PR DESCRIPTION
Change cargo manager's default `rangeStrategy` to `bump`.

It fixes unexpected "downgrading" behavior when updating normal versions like `0.9.21`, which are treated as caret ranges by cargo.

For example if rangeStrategy is 'replace', an update like `0.9.21` -> `0.9.22` will result in newValue = `0.9.0`, because "caret range" `0.9.0` contains both `=0.9.21` and `=0.9.22`.

Tested with an example crate on gitlab.

Closes #4620
