### PR TITLE
Use package-lock as shrinkwrap when maintaining shrinkwrap

### DIFF
--- a/lib/manager/npm/post-update/npm.ts
+++ b/lib/manager/npm/post-update/npm.ts
@@ -1,4 +1,4 @@
-import { readFile } from 'fs-extra';
+import { readFile, pathExistsSync, move } from 'fs-extra';
 import { join } from 'upath';
 import { getInstalledPath } from 'get-installed-path';
 import { exec } from '../../../util/exec';
@@ -139,6 +139,15 @@ export async function generateLockFile(
     }
     const duration = process.hrtime(startTime);
     const seconds = Math.round(duration[0] + duration[1] / 1e9);
+    if (
+      filename === 'npm-shrinkwrap.json' &&
+      pathExistsSync(join(cwd, 'package-lock.json'))
+    ) {
+      await move(
+        join(cwd, 'package-lock.json'),
+        join(cwd, 'npm-shrinkwrap.json')
+      );
+    }
     lockFile = await readFile(join(cwd, filename), 'utf8');
     logger.info(
       { seconds, type: filename, stdout, stderr },

--- a/lib/manager/npm/post-update/npm.ts
+++ b/lib/manager/npm/post-update/npm.ts
@@ -1,4 +1,4 @@
-import { readFile, pathExistsSync, move } from 'fs-extra';
+import { readFile, move, pathExists } from 'fs-extra';
 import { join } from 'upath';
 import { getInstalledPath } from 'get-installed-path';
 import { exec } from '../../../util/exec';
@@ -141,7 +141,7 @@ export async function generateLockFile(
     const seconds = Math.round(duration[0] + duration[1] / 1e9);
     if (
       filename === 'npm-shrinkwrap.json' &&
-      pathExistsSync(join(cwd, 'package-lock.json'))
+      (await pathExists(join(cwd, 'package-lock.json')))
     ) {
       await move(
         join(cwd, 'package-lock.json'),

--- a/test/workers/branch/lock-files/npm.spec.js
+++ b/test/workers/branch/lock-files/npm.spec.js
@@ -73,7 +73,7 @@ describe('generateLockFile', () => {
       stdout: '',
       stderror: '',
     });
-    fs.pathExistsSync.mockReturnValueOnce(true);
+    fs.pathExists.mockResolvedValueOnce(true);
     fs.move = jest.fn();
     fs.readFile = jest.fn(() => 'package-lock-contents');
     const skipInstalls = true;
@@ -83,7 +83,7 @@ describe('generateLockFile', () => {
       'npm-shrinkwrap.json',
       { skipInstalls }
     );
-    expect(fs.pathExistsSync).toHaveBeenCalledWith(
+    expect(fs.pathExists).toHaveBeenCalledWith(
       path.join('some-dir', 'package-lock.json')
     );
     expect(fs.move).toHaveBeenCalledTimes(1);
@@ -109,7 +109,7 @@ describe('generateLockFile', () => {
       stdout: '',
       stderror: '',
     });
-    fs.pathExistsSync.mockReturnValueOnce(false);
+    fs.pathExists.mockResolvedValueOnce(false);
     fs.move = jest.fn();
     fs.readFile = jest.fn(() => 'package-lock-contents');
     const skipInstalls = true;
@@ -119,7 +119,7 @@ describe('generateLockFile', () => {
       'npm-shrinkwrap.json',
       { skipInstalls }
     );
-    expect(fs.pathExistsSync).toHaveBeenCalledWith(
+    expect(fs.pathExists).toHaveBeenCalledWith(
       path.join('some-dir', 'package-lock.json')
     );
     expect(fs.move).toHaveBeenCalledTimes(0);

--- a/test/workers/branch/lock-files/npm.spec.js
+++ b/test/workers/branch/lock-files/npm.spec.js
@@ -6,6 +6,7 @@ jest.mock('get-installed-path');
 
 getInstalledPath.mockImplementation(() => null);
 
+const path = require('path');
 /** @type any */
 const fs = require('fs-extra');
 /** @type any */
@@ -59,6 +60,74 @@ describe('generateLockFile', () => {
       updates
     );
     expect(fs.readFile).toHaveBeenCalledTimes(1);
+    expect(res.error).toBeUndefined();
+    expect(res.lockFile).toEqual('package-lock-contents');
+  });
+  it('performs npm-shrinkwrap.json updates', async () => {
+    getInstalledPath.mockReturnValueOnce('node_modules/npm');
+    exec.mockReturnValueOnce({
+      stdout: '',
+      stderror: '',
+    });
+    exec.mockReturnValueOnce({
+      stdout: '',
+      stderror: '',
+    });
+    fs.pathExistsSync.mockReturnValueOnce(true);
+    fs.move = jest.fn();
+    fs.readFile = jest.fn(() => 'package-lock-contents');
+    const skipInstalls = true;
+    const res = await npmHelper.generateLockFile(
+      'some-dir',
+      {},
+      'npm-shrinkwrap.json',
+      { skipInstalls }
+    );
+    expect(fs.pathExistsSync).toHaveBeenCalledWith(
+      path.join('some-dir', 'package-lock.json')
+    );
+    expect(fs.move).toHaveBeenCalledTimes(1);
+    expect(fs.move).toHaveBeenCalledWith(
+      path.join('some-dir', 'package-lock.json'),
+      path.join('some-dir', 'npm-shrinkwrap.json')
+    );
+    expect(fs.readFile).toHaveBeenCalledTimes(1);
+    expect(fs.readFile).toHaveBeenCalledWith(
+      path.join('some-dir', 'npm-shrinkwrap.json'),
+      'utf8'
+    );
+    expect(res.error).toBeUndefined();
+    expect(res.lockFile).toEqual('package-lock-contents');
+  });
+  it('performs npm-shrinkwrap.json updates (no package-lock.json)', async () => {
+    getInstalledPath.mockReturnValueOnce('node_modules/npm');
+    exec.mockReturnValueOnce({
+      stdout: '',
+      stderror: '',
+    });
+    exec.mockReturnValueOnce({
+      stdout: '',
+      stderror: '',
+    });
+    fs.pathExistsSync.mockReturnValueOnce(false);
+    fs.move = jest.fn();
+    fs.readFile = jest.fn(() => 'package-lock-contents');
+    const skipInstalls = true;
+    const res = await npmHelper.generateLockFile(
+      'some-dir',
+      {},
+      'npm-shrinkwrap.json',
+      { skipInstalls }
+    );
+    expect(fs.pathExistsSync).toHaveBeenCalledWith(
+      path.join('some-dir', 'package-lock.json')
+    );
+    expect(fs.move).toHaveBeenCalledTimes(0);
+    expect(fs.readFile).toHaveBeenCalledTimes(1);
+    expect(fs.readFile).toHaveBeenCalledWith(
+      path.join('some-dir', 'npm-shrinkwrap.json'),
+      'utf8'
+    );
     expect(res.error).toBeUndefined();
     expect(res.lockFile).toEqual('package-lock-contents');
   });


### PR DESCRIPTION
Fixes https://github.com/renovatebot/renovate/issues/4772

When running the `lockFileMaintenance`, the lock file is removed before it gets recreated. When the lock file is not present, npm creates a `package-lock.json` by default, so we need to rename it to `npm-shrinkwrap.json` when we want to get an updated version.

---

I chose to move the file, although I can see that it probably does not matter - I could have probably just passed the `package-lock.json` instead of `filename` into `readFile()` for the use case, but I wasn't 100% sure that the file itself is really never used from the filesystem.

The `pathExistsSync(package-lock.json)` check is necessary, because the issue only exhibits itself when in `lockFileMaintenance` mode - when doing a regular dependency update, the `npm-shrinkwrap.json` is not removed, and so npm knows to update it, rather than create a new `package-lock.json`.