### PR TITLE
fix: cargo manager failing to bump complex ranges

### DIFF
--- a/lib/versioning/cargo/index.ts
+++ b/lib/versioning/cargo/index.ts
@@ -1,3 +1,4 @@
+import { logger } from '../../logger';
 import { api as npm } from '../npm';
 import { VersioningApi, RangeStrategy } from '../common';
 
@@ -14,7 +15,7 @@ function convertToCaret(item: string) {
 
 function cargo2npm(input: string) {
   let versions = input.split(',');
-  versions = versions.map(convertToCaret);
+  versions = versions.map(s => convertToCaret(s.trim()));
   return versions.join(' ');
 }
 
@@ -83,6 +84,14 @@ function getNewValue(
     fromVersion,
     toVersion
   );
+  if (newSemver == null) {
+    logger.debug(
+      `npm.getNewValue failed for converted cargo version: currentValue=${currentValue} cargo2npm(currentValue)=${cargo2npm(
+        currentValue
+      )}`
+    );
+    return null;
+  }
   let newCargo = npm2cargo(newSemver);
   // Try to reverse any caret we added
   if (newCargo.startsWith('^') && !currentValue.startsWith('^')) {

--- a/test/versioning/cargo.spec.ts
+++ b/test/versioning/cargo.spec.ts
@@ -207,4 +207,18 @@ describe('semver.getNewValue()', () => {
       semver.getNewValue('<=   1.3.4', 'replace', '1.2.3', '1.5.0')
     ).toEqual('<= 1.5.0');
   });
+  it('returns null when attempting to bump complex ranges', () => {
+    expect(
+      semver.getNewValue('>=0.1.21,<0.2', 'bump', '0.1.21', '0.1.24')
+    ).toBeNull();
+    expect(
+      semver.getNewValue('>=0.1.21,<=0.2.0', 'bump', '0.1.21', '0.1.24')
+    ).toBeNull();
+    expect(
+      semver.getNewValue('>=1.2.3,<=1', 'bump', '1.2.3', '1.2.4')
+    ).toBeNull();
+    expect(
+      semver.getNewValue('>=0.0.1,<=0.1', 'bump', '0.0.1', '0.0.2')
+    ).toBeNull();
+  });
 });


### PR DESCRIPTION
# TODO
* [x] Log an error message and return null when `cargo.getNewValue` fails to update a version because `npm.getNewValue` returned null (`cargo.getNewValue` fails to bump complex ranges, because bumping them is not supported by `npm.getNewValue`).
* [ ] Add support for bumping complex ranges to `npm.getNewValue` (and to cargo, because `npm.getNewValue` is reused by cargo)

Closes #4765