### PR TITLE
chore(ci): use stable cache task

### DIFF
--- a/.azure/steps.yml
+++ b/.azure/steps.yml
@@ -26,20 +26,18 @@ steps:
     fetchDepth: 5
     path: renovate
 
-  - task: CacheBeta@0
+  - task: Cache@2
     inputs:
       key: yarn_cache | $(Agent.OS) | $(Build.SourcesDirectory)/yarn.lock
       path: $(YARN_CACHE_FOLDER)
     displayName: Cache Yarn packages
     continueOnError: true
 
-  # does not work on linux or mac :-(
-  - task: CacheBeta@0
+  - task: Cache@2
     inputs:
       key: yarn | "$(nodeVersion)" | $(Agent.OS) | $(Build.SourcesDirectory)/yarn.lock
       path: $(Build.SourcesDirectory)/node_modules
     displayName: Cache node_modules
-    condition: eq(variables['Agent.OS'], 'Windows_NT')
     continueOnError: true
 
   - bash: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,6 @@ pr:
 variables:
   YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
   CI: true
-  AZP_CACHING_TAR: true
 
 jobs:
   - job: 'Windows'


### PR DESCRIPTION
The public documentation hasn't been updated, but the task is available. See [here](https://github.com/microsoft/azure-pipelines-tasks/tree/master/Tasks/CacheV2).

Fixes #4757