### PR TITLE
fix(azure): remove 'refs/heads/' from target branch

### DIFF
--- a/lib/platform/azure/azure-helper.ts
+++ b/lib/platform/azure/azure-helper.ts
@@ -177,7 +177,7 @@ export function getRenovatePRFormat(azurePr: {
   pr.displayNumber = `Pull Request #${azurePr.pullRequestId}`;
   pr.number = azurePr.pullRequestId;
   pr.body = azurePr.description;
-  pr.targetBranch = azurePr.targetRefName.replace('refs/heads/', '');
+  pr.targetBranch = getBranchNameWithoutRefsheadsPrefix(azurePr.targetRefName);
 
   // status
   // export declare enum PullRequestStatus {

--- a/lib/platform/azure/azure-helper.ts
+++ b/lib/platform/azure/azure-helper.ts
@@ -177,7 +177,7 @@ export function getRenovatePRFormat(azurePr: {
   pr.displayNumber = `Pull Request #${azurePr.pullRequestId}`;
   pr.number = azurePr.pullRequestId;
   pr.body = azurePr.description;
-  pr.targetBranch = azurePr.targetRefName;
+  pr.targetBranch = azurePr.targetRefName.replace('refs/heads/', '');
 
   // status
   // export declare enum PullRequestStatus {


### PR DESCRIPTION
Azure DevOps returns the target branch in the form of `/ref/heads/master`, but Renovate expects just `master`

Fixes #4812