### PR TITLE
chore(ci): use latest VM images

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,7 @@ jobs:
           nodeVersion: '12.x'
           pythonVersion: '3.7'
     pool:
-      vmImage: vs2017-win2016
+      vmImage: windows-2019
     steps:
       - bash: |
           set -e
@@ -42,7 +42,7 @@ jobs:
           nodeVersion: '10.x'
           pythonVersion: '3.7'
     pool:
-      vmImage: ubuntu-16.04
+      vmImage: ubuntu-18.04
     steps:
       - template: .azure/steps.yml
 


### PR DESCRIPTION
See [Microsoft-hosted agents](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops#use-a-microsoft-hosted-agent) for a complete list of available images.

These don't update very often, but what do you think about targeting `windows-latest`, `ubuntu-latest`, and `macOS-latest`?
