### PR TITLE
chore(ci): downgrade macos vm image

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,7 +52,7 @@ jobs:
           nodeVersion: '10.x'
           pythonVersion: '3.7'
     pool:
-      vmImage: macOS-10.14
+      vmImage: macOS-10.13
 
     steps:
       - template: .azure/steps.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,7 @@ pr:
 variables:
   YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
   CI: true
+  Agent.Source.Git.ShallowFetchDepth: 1
 
 jobs:
   - job: 'Windows'

--- a/test/datasource/orb.spec.ts
+++ b/test/datasource/orb.spec.ts
@@ -2,6 +2,9 @@ import _got from '../../lib/util/got';
 import * as datasource from '../../lib/datasource';
 
 jest.mock('../../lib/util/got');
+jest.mock('simple-git', () => {
+  throw new Error('Test');
+});
 
 const got: any = _got;
 


### PR DESCRIPTION
Workaround for https://developercommunity.visualstudio.com/content/problem/822502/azure-devops-job-does-not-start-no-other-builds-in.html