### PR TITLE
feat(schedule): Support month (M) in schedules

### DIFF
--- a/lib/workers/branch/schedule.ts
+++ b/lib/workers/branch/schedule.ts
@@ -49,10 +49,10 @@ export function hasValidSchedule(
     }
     if (
       !parsedSchedule.schedules.some(
-        s => s.d !== undefined || s.D || s.t_a !== undefined || s.t_b
+        s => s.M || s.d !== undefined || s.D || s.t_a !== undefined || s.t_b
       )
     ) {
-      message = `Schedule "${scheduleText}" has no days of week or time of day`;
+      message = `Schedule "${scheduleText}" has no months, days of week or time of day`;
       return true;
     }
     // It must be OK
@@ -119,6 +119,16 @@ export function isScheduledNow(config) {
     logger.debug({ parsedSchedule }, `Checking schedule "${scheduleText}"`);
     // Later library returns array of schedules
     return parsedSchedule.schedules.some(schedule => {
+      // Check if months are defined
+      if (schedule.M) {
+        const currentMonth = parseInt(now.format('M'), 10);
+        if (!schedule.M.includes(currentMonth)) {
+          logger.debug(
+            `Does not match schedule because ${currentMonth} is not in ${schedule.M}`
+          );
+          return false;
+        }
+      }
       // Check if days are defined
       if (schedule.d) {
         // We need to compare text instead of numbers because

--- a/test/workers/branch/schedule.spec.js
+++ b/test/workers/branch/schedule.spec.js
@@ -215,5 +215,17 @@ describe('workers/branch/schedule', () => {
       const res = schedule.isScheduledNow(config);
       expect(res).toBe(false);
     });
+    it('approves on months of year', () => {
+      config.schedule = ['of January'];
+      mockDate.set('2017-01-02T06:00:00.000'); // Locally Monday, 2 January 2017 6am
+      const res = schedule.isScheduledNow(config);
+      expect(res).toBe(true);
+    });
+    it('rejects on months of year', () => {
+      config.schedule = ['of January'];
+      mockDate.set('2017-02-02T06:00:00.000'); // Locally Thursday, 2 February 2017 6am
+      const res = schedule.isScheduledNow(config);
+      expect(res).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
Compare the `M` part of the schedule parsed by later so that schedules like `every Monday of February-April` are handled correctly.

Fixes: #4831


