### PR TITLE
fix(pnpm): stop ignore pnpmfile

### DIFF
--- a/lib/manager/npm/post-update/pnpm.ts
+++ b/lib/manager/npm/post-update/pnpm.ts
@@ -91,8 +91,10 @@ export async function generateLockFile(
     logger.debug(`Using pnpm: ${cmd}`);
     cmd += ' install';
     cmd += ' --lockfile-only';
-    cmd += ' --ignore-scripts';
-    cmd += ' --ignore-pnpmfile';
+    if (global.trustLevel !== 'high') {
+      cmd += ' --ignore-scripts';
+      cmd += ' --ignore-pnpmfile';
+    }
     // TODO: Switch to native util.promisify once using only node 8
     ({ stdout, stderr } = await exec(cmd, {
       cwd,


### PR DESCRIPTION
Pnpfile contains hooks that can be required to install packages correct. And because of this it shouldn't be ignored by default
