### PR TITLE
fix(storage): do not throw error when no remote branch to delete (#4314)

### DIFF
--- a/lib/platform/git/storage.ts
+++ b/lib/platform/git/storage.ts
@@ -381,8 +381,7 @@ export class Storage {
       logger.debug({ branchName }, 'Deleted remote branch');
     } catch (err) /* istanbul ignore next */ {
       checkForPlatformFailure(err);
-      logger.info({ branchName, err }, 'Error deleting remote branch');
-      throw new Error('repository-changed');
+      logger.debug({ branchName }, 'No remote branch to delete');
     }
     try {
       await this._deleteLocalBranch(branchName);


### PR DESCRIPTION
When branch we need to delete is orphan (has no remote), we don't need to throw an error.

Closes #4314
