### PR TITLE
build: update golang to 1.13.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -118,7 +118,7 @@ RUN chmod +x /usr/local/bin/composer
 RUN apt-get update && apt-get install -y bzr mercurial && \
     rm -rf /var/lib/apt/lists/*
 
-ENV GOLANG_VERSION 1.13
+ENV GOLANG_VERSION 1.13.4
 
 # Disable GOPROXY and GOSUMDB until we offer a solid solution to configure
 # private repositories.


### PR DESCRIPTION
update to latest golang version.
in golang, `1.13.0` is not exists. its just `1.13`.
`1.13` is not means `~1.13.0`. 😿

https://golang.org/dl/go1.13.linux-amd64.tar.gz 🙆 exists
https://golang.org/dl/go1.13.4.linux-amd64.tar.gz 🙆 exists
https://golang.org/dl/go1.13.0.linux-amd64.tar.gz 🙅 not exists