### PR TITLE
fix: cache-bust branch status after updating a status (#4884)

### DIFF
--- a/lib/platform/bitbucket-server/utils.ts
+++ b/lib/platform/bitbucket-server/utils.ts
@@ -61,3 +61,15 @@ export async function accumulateValues<T = any>(
 
   return accumulator;
 }
+
+export interface BitbucketCommitStatus {
+  failed: number;
+  inProgress: number;
+  successful: number;
+}
+
+export type BitbucketBranchState = 'SUCCESSFUL' | 'FAILED' | 'INPROGRESS';
+export interface BitbucketStatus {
+  key: string;
+  state: BitbucketBranchState;
+}

--- a/lib/platform/bitbucket/utils.ts
+++ b/lib/platform/bitbucket/utils.ts
@@ -34,6 +34,12 @@ export interface RepoInfo {
   has_issues: boolean;
 }
 
+export type BitbucketBranchState = 'SUCCESSFUL' | 'FAILED' | 'INPROGRESS';
+export interface BitbucketStatus {
+  key: string;
+  state: BitbucketBranchState;
+}
+
 export function repoInfoTransformer(repoInfoBody: any): RepoInfo {
   return {
     isFork: !!repoInfoBody.parent,
@@ -53,10 +59,10 @@ export const prStates = {
 };
 
 export const buildStates: {
-  [key: string]: string;
-  success: string;
-  failed: string;
-  pending: string;
+  [key: string]: BitbucketBranchState;
+  success: BitbucketBranchState;
+  failed: BitbucketBranchState;
+  pending: BitbucketBranchState;
 } = {
   success: 'SUCCESSFUL',
   failed: 'FAILED',

--- a/lib/platform/github/index.ts
+++ b/lib/platform/github/index.ts
@@ -992,6 +992,29 @@ export async function getBranchPr(branchName: string): Promise<Pr | null> {
   return existingPr ? getPr(existingPr.number) : null;
 }
 
+type BranchState = 'failure' | 'pending' | 'success';
+
+interface BranchStatus {
+  context: string;
+  state: BranchState;
+}
+
+interface CombinedBranchStatus {
+  state: BranchState;
+  statuses: BranchStatus[];
+}
+
+async function getStatus(
+  branchName: string,
+  useCache = true
+): Promise<CombinedBranchStatus> {
+  const commitStatusUrl = `repos/${config.repository}/commits/${escapeHash(
+    branchName
+  )}/status`;
+
+  return (await api.get(commitStatusUrl, { useCache })).body;
+}
+
 // Returns the combined status for a branch.
 export async function getBranchStatus(
   branchName: string,
@@ -1008,12 +1031,9 @@ export async function getBranchStatus(
     logger.warn({ requiredStatusChecks }, `Unsupported requiredStatusChecks`);
     return 'failed';
   }
-  const commitStatusUrl = `repos/${config.repository}/commits/${escapeHash(
-    branchName
-  )}/status`;
   let commitStatus;
   try {
-    commitStatus = (await api.get(commitStatusUrl)).body;
+    commitStatus = await getStatus(branchName);
   } catch (err) /* istanbul ignore next */ {
     if (err.statusCode === 404) {
       logger.info(
@@ -1085,15 +1105,24 @@ export async function getBranchStatus(
   return 'pending';
 }
 
+async function getStatusCheck(
+  branchName: string,
+  useCache = true
+): Promise<BranchStatus[]> {
+  const branchCommit = await config.storage.getBranchCommit(branchName);
+
+  const url = `repos/${config.repository}/commits/${branchCommit}/statuses`;
+
+  return (await api.get(url, { useCache })).body;
+}
+
 export async function getBranchStatusCheck(
   branchName: string,
   context: string
 ): Promise<string> {
-  const branchCommit = await config.storage.getBranchCommit(branchName);
-  const url = `repos/${config.repository}/commits/${branchCommit}/statuses`;
   try {
-    const res = await api.get(url);
-    for (const check of res.body) {
+    const res = await getStatusCheck(branchName);
+    for (const check of res) {
       if (check.context === context) {
         return check.state;
       }
@@ -1136,6 +1165,10 @@ export async function setBranchStatus(
     options.target_url = targetUrl;
   }
   await api.post(url, { body: options });
+
+  // update status cache
+  await getStatus(branchName, false);
+  await getStatusCheck(branchName, false);
 }
 
 // Issue

--- a/lib/platform/gitlab/index.ts
+++ b/lib/platform/gitlab/index.ts
@@ -245,6 +245,24 @@ export function branchExists(branchName: string): Promise<boolean> {
   return config.storage.branchExists(branchName);
 }
 
+type BranchState = 'pending' | 'running' | 'success' | 'failed' | 'canceled';
+
+interface BranchStatus {
+  status: BranchState;
+  name: string;
+  allow_failure?: boolean;
+}
+
+async function getStatus(
+  branchName: string,
+  useCache = true
+): Promise<BranchStatus[]> {
+  const branchSha = await config.storage.getBranchCommit(branchName);
+  const url = `projects/${config.repository}/repository/commits/${branchSha}/statuses`;
+
+  return (await api.get(url, { paginate: true, useCache })).body;
+}
+
 // Returns the combined status for a branch.
 export async function getBranchStatus(
   branchName: string,
@@ -265,19 +283,15 @@ export async function getBranchStatus(
     throw new Error('repository-changed');
   }
 
-  // First, get the branch commit SHA
-  const branchSha = await config.storage.getBranchCommit(branchName);
-  // Now, check the statuses for that commit
-  const url = `projects/${config.repository}/repository/commits/${branchSha}/statuses`;
-  const res = await api.get(url, { paginate: true });
-  logger.debug(`Got res with ${res.body.length} results`);
-  if (res.body.length === 0) {
+  const res = await getStatus(branchName);
+  logger.debug(`Got res with ${res.length} results`);
+  if (res.length === 0) {
     // Return 'pending' if we have no status checks
     return 'pending';
   }
   let status = 'success';
   // Return 'success' if all are success
-  res.body.forEach((check: { status: string; allow_failure?: boolean }) => {
+  res.forEach(check => {
     // If one is failed then don't overwrite that
     if (status !== 'failure') {
       if (!check.allow_failure) {
@@ -556,16 +570,12 @@ export async function getBranchStatusCheck(
   branchName: string,
   context: string
 ): Promise<string | null> {
-  // First, get the branch commit SHA
-  const branchSha = await config.storage.getBranchCommit(branchName);
-  // Now, check the statuses for that commit
-  const url = `projects/${config.repository}/repository/commits/${branchSha}/statuses`;
   // cache-bust in case we have rebased
-  const res = await api.get(url, { useCache: false });
-  logger.debug(`Got res with ${res.body.length} results`);
-  for (const check of res.body) {
+  const res = await getStatus(branchName, false);
+  logger.debug(`Got res with ${res.length} results`);
+  for (const check of res) {
     if (check.name === context) {
-      return check.state;
+      return check.status;
     }
   }
   return null;
@@ -592,6 +602,9 @@ export async function setBranchStatus(
   }
   try {
     await api.post(url, { body: options });
+
+    // update status cache
+    await getStatus(branchName, false);
   } catch (err) /* istanbul ignore next */ {
     if (
       err.body &&

--- a/test/platform/bitbucket-server/__snapshots__/index.spec.ts.snap
+++ b/test/platform/bitbucket-server/__snapshots__/index.spec.ts.snap
@@ -606,9 +606,15 @@ Array [
   ],
   Array [
     "./rest/build-status/1.0/commits/stats/0d9c7726c3d628b7e28af234595cfd20febdbf8e",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/build-status/1.0/commits/stats/0d9c7726c3d628b7e28af234595cfd20febdbf8e",
+    Object {
+      "useCache": true,
+    },
   ],
 ]
 `;
@@ -623,9 +629,15 @@ Array [
   ],
   Array [
     "./rest/build-status/1.0/commits/stats/0d9c7726c3d628b7e28af234595cfd20febdbf8e",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/build-status/1.0/commits/stats/0d9c7726c3d628b7e28af234595cfd20febdbf8e",
+    Object {
+      "useCache": true,
+    },
   ],
 ]
 `;
@@ -640,6 +652,9 @@ Array [
   ],
   Array [
     "./rest/build-status/1.0/commits/stats/0d9c7726c3d628b7e28af234595cfd20febdbf8e",
+    Object {
+      "useCache": true,
+    },
   ],
 ]
 `;
@@ -654,7 +669,9 @@ Array [
   ],
   Array [
     "./rest/build-status/1.0/commits/0d9c7726c3d628b7e28af234595cfd20febdbf8e?limit=100",
-    undefined,
+    Object {
+      "useCache": true,
+    },
   ],
 ]
 `;
@@ -669,11 +686,15 @@ Array [
   ],
   Array [
     "./rest/build-status/1.0/commits/0d9c7726c3d628b7e28af234595cfd20febdbf8e?limit=100",
-    undefined,
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/build-status/1.0/commits/0d9c7726c3d628b7e28af234595cfd20febdbf8e?limit=100",
-    undefined,
+    Object {
+      "useCache": true,
+    },
   ],
 ]
 `;
@@ -688,7 +709,9 @@ Array [
   ],
   Array [
     "./rest/build-status/1.0/commits/0d9c7726c3d628b7e28af234595cfd20febdbf8e?limit=100",
-    undefined,
+    Object {
+      "useCache": true,
+    },
   ],
 ]
 `;
@@ -703,7 +726,9 @@ Array [
   ],
   Array [
     "./rest/build-status/1.0/commits/0d9c7726c3d628b7e28af234595cfd20febdbf8e?limit=100",
-    undefined,
+    Object {
+      "useCache": true,
+    },
   ],
 ]
 `;
@@ -1187,27 +1212,87 @@ exports[`platform/bitbucket-server endpoint with no path setBranchStatus() shoul
 Array [
   Array [
     "./rest/build-status/1.0/commits/0d9c7726c3d628b7e28af234595cfd20febdbf8e?limit=100",
-    undefined,
+    Object {
+      "useCache": true,
+    },
+  ],
+  Array [
+    "./rest/build-status/1.0/commits/stats/0d9c7726c3d628b7e28af234595cfd20febdbf8e",
+    Object {
+      "useCache": false,
+    },
   ],
   Array [
     "./rest/build-status/1.0/commits/0d9c7726c3d628b7e28af234595cfd20febdbf8e?limit=100",
-    undefined,
+    Object {
+      "useCache": false,
+    },
   ],
   Array [
     "./rest/build-status/1.0/commits/0d9c7726c3d628b7e28af234595cfd20febdbf8e?limit=100",
-    undefined,
+    Object {
+      "useCache": true,
+    },
+  ],
+  Array [
+    "./rest/build-status/1.0/commits/stats/0d9c7726c3d628b7e28af234595cfd20febdbf8e",
+    Object {
+      "useCache": false,
+    },
   ],
   Array [
     "./rest/build-status/1.0/commits/0d9c7726c3d628b7e28af234595cfd20febdbf8e?limit=100",
-    undefined,
+    Object {
+      "useCache": false,
+    },
   ],
   Array [
     "./rest/build-status/1.0/commits/0d9c7726c3d628b7e28af234595cfd20febdbf8e?limit=100",
-    undefined,
+    Object {
+      "useCache": true,
+    },
+  ],
+  Array [
+    "./rest/build-status/1.0/commits/stats/0d9c7726c3d628b7e28af234595cfd20febdbf8e",
+    Object {
+      "useCache": false,
+    },
   ],
   Array [
     "./rest/build-status/1.0/commits/0d9c7726c3d628b7e28af234595cfd20febdbf8e?limit=100",
-    undefined,
+    Object {
+      "useCache": false,
+    },
+  ],
+  Array [
+    "./rest/build-status/1.0/commits/0d9c7726c3d628b7e28af234595cfd20febdbf8e?limit=100",
+    Object {
+      "useCache": true,
+    },
+  ],
+  Array [
+    "./rest/build-status/1.0/commits/stats/0d9c7726c3d628b7e28af234595cfd20febdbf8e",
+    Object {
+      "useCache": false,
+    },
+  ],
+  Array [
+    "./rest/build-status/1.0/commits/0d9c7726c3d628b7e28af234595cfd20febdbf8e?limit=100",
+    Object {
+      "useCache": false,
+    },
+  ],
+  Array [
+    "./rest/build-status/1.0/commits/0d9c7726c3d628b7e28af234595cfd20febdbf8e?limit=100",
+    Object {
+      "useCache": true,
+    },
+  ],
+  Array [
+    "./rest/build-status/1.0/commits/0d9c7726c3d628b7e28af234595cfd20febdbf8e?limit=100",
+    Object {
+      "useCache": true,
+    },
   ],
 ]
 `;
@@ -2088,9 +2173,15 @@ Array [
   ],
   Array [
     "./rest/build-status/1.0/commits/stats/0d9c7726c3d628b7e28af234595cfd20febdbf8e",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/build-status/1.0/commits/stats/0d9c7726c3d628b7e28af234595cfd20febdbf8e",
+    Object {
+      "useCache": true,
+    },
   ],
 ]
 `;
@@ -2105,9 +2196,15 @@ Array [
   ],
   Array [
     "./rest/build-status/1.0/commits/stats/0d9c7726c3d628b7e28af234595cfd20febdbf8e",
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/build-status/1.0/commits/stats/0d9c7726c3d628b7e28af234595cfd20febdbf8e",
+    Object {
+      "useCache": true,
+    },
   ],
 ]
 `;
@@ -2122,6 +2219,9 @@ Array [
   ],
   Array [
     "./rest/build-status/1.0/commits/stats/0d9c7726c3d628b7e28af234595cfd20febdbf8e",
+    Object {
+      "useCache": true,
+    },
   ],
 ]
 `;
@@ -2136,7 +2236,9 @@ Array [
   ],
   Array [
     "./rest/build-status/1.0/commits/0d9c7726c3d628b7e28af234595cfd20febdbf8e?limit=100",
-    undefined,
+    Object {
+      "useCache": true,
+    },
   ],
 ]
 `;
@@ -2151,11 +2253,15 @@ Array [
   ],
   Array [
     "./rest/build-status/1.0/commits/0d9c7726c3d628b7e28af234595cfd20febdbf8e?limit=100",
-    undefined,
+    Object {
+      "useCache": true,
+    },
   ],
   Array [
     "./rest/build-status/1.0/commits/0d9c7726c3d628b7e28af234595cfd20febdbf8e?limit=100",
-    undefined,
+    Object {
+      "useCache": true,
+    },
   ],
 ]
 `;
@@ -2170,7 +2276,9 @@ Array [
   ],
   Array [
     "./rest/build-status/1.0/commits/0d9c7726c3d628b7e28af234595cfd20febdbf8e?limit=100",
-    undefined,
+    Object {
+      "useCache": true,
+    },
   ],
 ]
 `;
@@ -2185,7 +2293,9 @@ Array [
   ],
   Array [
     "./rest/build-status/1.0/commits/0d9c7726c3d628b7e28af234595cfd20febdbf8e?limit=100",
-    undefined,
+    Object {
+      "useCache": true,
+    },
   ],
 ]
 `;
@@ -2669,27 +2779,87 @@ exports[`platform/bitbucket-server endpoint with path setBranchStatus() should b
 Array [
   Array [
     "./rest/build-status/1.0/commits/0d9c7726c3d628b7e28af234595cfd20febdbf8e?limit=100",
-    undefined,
+    Object {
+      "useCache": true,
+    },
+  ],
+  Array [
+    "./rest/build-status/1.0/commits/stats/0d9c7726c3d628b7e28af234595cfd20febdbf8e",
+    Object {
+      "useCache": false,
+    },
   ],
   Array [
     "./rest/build-status/1.0/commits/0d9c7726c3d628b7e28af234595cfd20febdbf8e?limit=100",
-    undefined,
+    Object {
+      "useCache": false,
+    },
   ],
   Array [
     "./rest/build-status/1.0/commits/0d9c7726c3d628b7e28af234595cfd20febdbf8e?limit=100",
-    undefined,
+    Object {
+      "useCache": true,
+    },
+  ],
+  Array [
+    "./rest/build-status/1.0/commits/stats/0d9c7726c3d628b7e28af234595cfd20febdbf8e",
+    Object {
+      "useCache": false,
+    },
   ],
   Array [
     "./rest/build-status/1.0/commits/0d9c7726c3d628b7e28af234595cfd20febdbf8e?limit=100",
-    undefined,
+    Object {
+      "useCache": false,
+    },
   ],
   Array [
     "./rest/build-status/1.0/commits/0d9c7726c3d628b7e28af234595cfd20febdbf8e?limit=100",
-    undefined,
+    Object {
+      "useCache": true,
+    },
+  ],
+  Array [
+    "./rest/build-status/1.0/commits/stats/0d9c7726c3d628b7e28af234595cfd20febdbf8e",
+    Object {
+      "useCache": false,
+    },
   ],
   Array [
     "./rest/build-status/1.0/commits/0d9c7726c3d628b7e28af234595cfd20febdbf8e?limit=100",
-    undefined,
+    Object {
+      "useCache": false,
+    },
+  ],
+  Array [
+    "./rest/build-status/1.0/commits/0d9c7726c3d628b7e28af234595cfd20febdbf8e?limit=100",
+    Object {
+      "useCache": true,
+    },
+  ],
+  Array [
+    "./rest/build-status/1.0/commits/stats/0d9c7726c3d628b7e28af234595cfd20febdbf8e",
+    Object {
+      "useCache": false,
+    },
+  ],
+  Array [
+    "./rest/build-status/1.0/commits/0d9c7726c3d628b7e28af234595cfd20febdbf8e?limit=100",
+    Object {
+      "useCache": false,
+    },
+  ],
+  Array [
+    "./rest/build-status/1.0/commits/0d9c7726c3d628b7e28af234595cfd20febdbf8e?limit=100",
+    Object {
+      "useCache": true,
+    },
+  ],
+  Array [
+    "./rest/build-status/1.0/commits/0d9c7726c3d628b7e28af234595cfd20febdbf8e?limit=100",
+    Object {
+      "useCache": true,
+    },
   ],
 ]
 `;

--- a/test/platform/bitbucket-server/_fixtures/responses.js
+++ b/test/platform/bitbucket-server/_fixtures/responses.js
@@ -560,6 +560,9 @@ function generateServerResponses(endpoint) {
         ],
       },
     },
+    [`${endpoint}/rest/build-status/1.0/commits/stats/0d9c7726c3d628b7e28af234595cfd20febdbf8e`]: {
+      GET: {},
+    },
     [`${endpoint}/rest/build-status/1.0/commits/0d9c7726c3d628b7e28af234595cfd20febdbf8e?limit=100`]: {
       GET: {
         isLastPage: true,

--- a/test/platform/github/index.spec.ts
+++ b/test/platform/github/index.spec.ts
@@ -844,6 +844,12 @@ describe('platform/github', () => {
             },
           } as any)
       );
+      api.get.mockResolvedValueOnce({
+        body: {},
+      } as any);
+      api.get.mockResolvedValueOnce({
+        body: {},
+      } as any);
       await github.setBranchStatus(
         'some-branch',
         'some-context',
@@ -1459,6 +1465,12 @@ describe('platform/github', () => {
             },
           } as any)
       );
+      api.get.mockResolvedValueOnce({
+        body: {},
+      } as any);
+      api.get.mockResolvedValueOnce({
+        body: [],
+      } as any);
       const pr = await github.createPr(
         'some-branch',
         'The Title',

--- a/test/platform/gitlab/index.spec.ts
+++ b/test/platform/gitlab/index.spec.ts
@@ -447,9 +447,9 @@ describe('platform/gitlab', () => {
     it('returns status if name found', async () => {
       api.get.mockReturnValueOnce({
         body: [
-          { name: 'context-1', state: 'pending' },
-          { name: 'some-context', state: 'success' },
-          { name: 'context-3', state: 'failed' },
+          { name: 'context-1', status: 'pending' },
+          { name: 'some-context', status: 'success' },
+          { name: 'context-3', status: 'failed' },
         ],
       } as any);
       const res = await gitlab.getBranchStatusCheck(


### PR DESCRIPTION
<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate
-->

Disable cache for method `getBranchStatus` because it leads to a problem when checking the stability of the update

Closes #4884 
