### PR TITLE
fix(gitlab): GPG Signing not works for GitLab

### DIFF
--- a/lib/platform/gitlab/index.ts
+++ b/lib/platform/gitlab/index.ts
@@ -23,6 +23,7 @@ import { RenovateConfig } from '../../config';
 const defaultConfigFile = configFileNames[0];
 let config: {
   storage: GitStorage;
+  gitPrivateKey?: string;
   repository: string;
   localDir: string;
   defaultBranch: string;
@@ -107,11 +108,13 @@ export function cleanRepo(): void {
 // Initialize GitLab by getting base branch
 export async function initRepo({
   repository,
+  gitPrivateKey,
   localDir,
   optimizeForDisabled,
 }: RepoParams): Promise<RepoConfig> {
   config = {} as any;
   config.repository = urlEscape(repository);
+  config.gitPrivateKey = gitPrivateKey;
   config.localDir = localDir;
   let res: GotResponse<{
     archived: boolean;


### PR DESCRIPTION
GitLab's PlatformConfig is not implemented to support GPG commit signing yet.
This PR will fill `config.gitPrivateKey` for GitLab if it is configured.

```
07:30:45 |   | DEBUG: Combined config
07:30:45 |   | "config": {
07:30:45 |   | "baseDir": "/var/renovate/",
07:30:45 |   | "endpoint": "XXXXXXXXX",
07:30:45 |   | "token": "***********",
07:30:45 |   | "platform": "gitlab",
07:30:45 |   | "logLevel": "debug",
07:30:45 |   | "onboarding": true,
07:30:45 |   | "onboardingConfig": {
07:30:45 |   | "extends": [
07:30:45 |   | "config:base"
07:30:45 |   | ]
07:30:45 |   | },
07:30:45 |   | "autodiscover": false,
07:30:45 |   | "autodiscoverFilter": "",
07:30:45 |   | "repositories": [
07:30:45 |   | "XXXXXXXXX"
07:30:45 |   | ],
07:30:45 |   | "gitAuthor": "Renovate Bot <XXXXXXXXX>",
07:30:45 |   | "gitPrivateKey": "***********",
07:30:45 |   | "hostRules": []
07:30:45 |   | }

...

07:30:47 |   | DEBUG: No git private key present - commits will be unsigned (repository=XXXXXXXXX)
07:30:47 |   | INFO: Setting git author (repository=XXXXXXXXX)
```