### PR TITLE
feat(gitlab): do not discover projects without MR enabled.

### DIFF
--- a/lib/platform/gitlab/index.ts
+++ b/lib/platform/gitlab/index.ts
@@ -80,7 +80,7 @@ export async function initPlatform({
 export async function getRepos(): Promise<string[]> {
   logger.info('Autodiscovering GitLab repositories');
   try {
-    const url = `projects?membership=true&per_page=100`;
+    const url = `projects?membership=true&per_page=100&with_merge_requests_enabled=true`;
     const res = await api.get(url, { paginate: true });
     logger.info(`Discovered ${res.body.length} project(s)`);
     return res.body.map(

--- a/test/platform/gitlab/__snapshots__/index.spec.ts.snap
+++ b/test/platform/gitlab/__snapshots__/index.spec.ts.snap
@@ -264,7 +264,7 @@ Array [
 exports[`platform/gitlab getRepos should return an array of repos 1`] = `
 Array [
   Array [
-    "projects?membership=true&per_page=100",
+    "projects?membership=true&per_page=100&with_merge_requests_enabled=true",
     Object {
       "paginate": true,
     },


### PR DESCRIPTION
On Gitlab there are different reasons to do not have MRs enabled, like having documentation only projects, or issues tracker.

Renovate shouldn't try to download repos from such projects, since they do not have repositories.

This contribution has been sponsored by [Nextbit](https://www.nextbit.it/)