### PR TITLE
feat(rubygems): Always use "rubygems.org" as a default registry url

### DIFF
--- a/lib/datasource/rubygems/get-rubygems-org.ts
+++ b/lib/datasource/rubygems/get-rubygems-org.ts
@@ -2,16 +2,9 @@ import got from '../../util/got';
 import { logger } from '../../logger';
 import { ReleaseResult } from '../common';
 
-let lastSync: Date;
-let packageReleases: Record<string, string[]>;
-
-export function resetCache(): void {
-  lastSync = new Date('2000-01-01');
-  packageReleases = Object.create(null); // Because we might need a "constructor" key
-}
-resetCache();
-
-const contentLength = 0;
+let lastSync = new Date('2000-01-01');
+let packageReleases: Record<string, string[]> = Object.create(null); // Because we might need a "constructor" key
+let contentLength = 0;
 
 async function updateRubyGemsVersions(): Promise<void> {
   const url = 'https://rubygems.org/versions';
@@ -21,17 +14,15 @@ async function updateRubyGemsVersions(): Promise<void> {
       range: `bytes=${contentLength}-`,
     },
   };
-  let newLines: string[];
+  let newLines: string;
   try {
     logger.debug('Rubygems: Fetching rubygems.org versions');
-    const res = await got(url, options);
-    const isValidBody = res && res.body && typeof res.body === 'string';
-    const body = isValidBody ? res.body : null;
-    newLines = body ? body.split('\n') : [];
+    newLines = (await got(url, options)).body;
   } catch (err) /* istanbul ignore next */ {
     if (err.statusCode !== 416) {
       logger.warn({ err }, 'Rubygems error - resetting cache');
-      resetCache();
+      contentLength = 0;
+      packageReleases = Object.create(null); // Because we might need a "constructor" key
       throw new Error('registry-failure');
     }
     logger.debug('Rubygems: No update');
@@ -71,7 +62,7 @@ async function updateRubyGemsVersions(): Promise<void> {
     }
   }
 
-  for (const line of newLines) {
+  for (const line of newLines.split('\n')) {
     processLine(line);
   }
   lastSync = new Date();

--- a/lib/datasource/rubygems/releases.ts
+++ b/lib/datasource/rubygems/releases.ts
@@ -3,15 +3,21 @@ import { getDependency } from './get';
 import { getRubygemsOrgDependency } from './get-rubygems-org';
 import { PkgReleaseConfig, ReleaseResult } from '../common';
 
+const isDefaultUrl = (url: string): boolean => url.endsWith('rubygems.org');
+
 export async function getPkgReleases({
   lookupName,
   registryUrls,
 }: PkgReleaseConfig): Promise<ReleaseResult | null> {
-  const registries = is.nonEmptyArray(registryUrls) ? registryUrls : [];
+  const defaultRegistry = 'https://rubygems.org';
+  const registries = is.nonEmptyArray(registryUrls)
+    ? registryUrls.filter(url => !isDefaultUrl(url))
+    : [];
+  registries.unshift(defaultRegistry);
 
   for (const registry of registries) {
     let pkg: ReleaseResult;
-    if (registry.endsWith('rubygems.org')) {
+    if (isDefaultUrl(registry)) {
       pkg = await getRubygemsOrgDependency(lookupName);
     } else {
       pkg = await getDependency({ dependency: lookupName, registry });

--- a/lib/datasource/rubygems/releases.ts
+++ b/lib/datasource/rubygems/releases.ts
@@ -3,21 +3,18 @@ import { getDependency } from './get';
 import { getRubygemsOrgDependency } from './get-rubygems-org';
 import { PkgReleaseConfig, ReleaseResult } from '../common';
 
-const isDefaultUrl = (url: string): boolean => url.endsWith('rubygems.org');
-
 export async function getPkgReleases({
   lookupName,
   registryUrls,
 }: PkgReleaseConfig): Promise<ReleaseResult | null> {
   const defaultRegistry = 'https://rubygems.org';
   const registries = is.nonEmptyArray(registryUrls)
-    ? registryUrls.filter(url => !isDefaultUrl(url))
-    : [];
-  registries.unshift(defaultRegistry);
+    ? registryUrls
+    : [defaultRegistry];
 
   for (const registry of registries) {
     let pkg: ReleaseResult;
-    if (isDefaultUrl(registry)) {
+    if (registry.endsWith('rubygems.org')) {
       pkg = await getRubygemsOrgDependency(lookupName);
     } else {
       pkg = await getDependency({ dependency: lookupName, registry });

--- a/test/datasource/rubygems/__snapshots__/index.spec.ts.snap
+++ b/test/datasource/rubygems/__snapshots__/index.spec.ts.snap
@@ -2397,6 +2397,20 @@ Object {
 }
 `;
 
+exports[`datasource/rubygems getPkgReleases uses rubygems.org if no registry urls were provided 1`] = `
+Object {
+  "name": "1pass",
+  "releases": Array [
+    Object {
+      "version": "0.1.0",
+    },
+    Object {
+      "version": "0.1.1",
+    },
+  ],
+}
+`;
+
 exports[`datasource/rubygems getPkgReleases works with real data 1`] = `
 Object {
   "changelogUrl": null,

--- a/test/datasource/rubygems/index.spec.ts
+++ b/test/datasource/rubygems/index.spec.ts
@@ -69,6 +69,24 @@ describe('datasource/rubygems', () => {
       ).toBeUndefined();
     });
 
+    it('uses rubygems.org if no registry urls were provided', async () => {
+      got.mockReturnValue({ body: rubygemsOrgVersions });
+
+      expect(
+        await rubygems.getPkgReleases({
+          ...params,
+          registryUrls: [],
+        })
+      ).toBeNull();
+
+      const res = await rubygems.getPkgReleases({
+        lookupName: '1pass',
+        registryUrls: [],
+      });
+      expect(res).not.toBeNull();
+      expect(res).toMatchSnapshot();
+    });
+
     it('works with real data', async () => {
       got
         .mockReturnValueOnce({ body: railsInfo })

--- a/test/datasource/rubygems/index.spec.ts
+++ b/test/datasource/rubygems/index.spec.ts
@@ -2,7 +2,6 @@ import _got from '../../../lib/util/got';
 import railsInfo from './_fixtures/rails/info.json';
 import railsVersions from './_fixtures/rails/versions.json';
 import * as rubygems from '../../../lib/datasource/rubygems';
-import { resetCache } from '../../../lib/datasource/rubygems/get-rubygems-org';
 
 const got: any = _got;
 
@@ -37,7 +36,6 @@ describe('datasource/rubygems', () => {
     };
 
     beforeEach(() => {
-      resetCache();
       process.env.RENOVATE_SKIP_CACHE = 'true';
       jest.resetAllMocks();
     });
@@ -73,7 +71,6 @@ describe('datasource/rubygems', () => {
 
     it('works with real data', async () => {
       got
-        .mockReturnValueOnce({ body: rubygemsOrgVersions })
         .mockReturnValueOnce({ body: railsInfo })
         .mockReturnValueOnce({ body: railsVersions });
 
@@ -82,7 +79,6 @@ describe('datasource/rubygems', () => {
 
     it('uses multiple source urls', async () => {
       got
-        .mockReturnValueOnce({ body: rubygemsOrgVersions })
         .mockImplementationOnce(() =>
           Promise.reject({
             statusCode: 404,
@@ -95,10 +91,7 @@ describe('datasource/rubygems', () => {
     });
 
     it('returns null if mismatched name', async () => {
-      got
-        .mockReturnValueOnce({ body: rubygemsOrgVersions })
-        .mockReturnValueOnce({ body: { ...railsInfo, name: 'oooops' } })
-        .mockReturnValueOnce({ body: null });
+      got.mockReturnValueOnce({ body: { ...railsInfo, name: 'oooops' } });
       expect(await rubygems.getPkgReleases(params)).toBeNull();
     });
 

--- a/test/datasource/rubygems/index.spec.ts
+++ b/test/datasource/rubygems/index.spec.ts
@@ -2,6 +2,7 @@ import _got from '../../../lib/util/got';
 import railsInfo from './_fixtures/rails/info.json';
 import railsVersions from './_fixtures/rails/versions.json';
 import * as rubygems from '../../../lib/datasource/rubygems';
+import { resetCache } from '../../../lib/datasource/rubygems/get-rubygems-org';
 
 const got: any = _got;
 
@@ -36,6 +37,7 @@ describe('datasource/rubygems', () => {
     };
 
     beforeEach(() => {
+      resetCache();
       process.env.RENOVATE_SKIP_CACHE = 'true';
       jest.resetAllMocks();
     });
@@ -71,6 +73,7 @@ describe('datasource/rubygems', () => {
 
     it('works with real data', async () => {
       got
+        .mockReturnValueOnce({ body: rubygemsOrgVersions })
         .mockReturnValueOnce({ body: railsInfo })
         .mockReturnValueOnce({ body: railsVersions });
 
@@ -79,6 +82,7 @@ describe('datasource/rubygems', () => {
 
     it('uses multiple source urls', async () => {
       got
+        .mockReturnValueOnce({ body: rubygemsOrgVersions })
         .mockImplementationOnce(() =>
           Promise.reject({
             statusCode: 404,
@@ -91,7 +95,10 @@ describe('datasource/rubygems', () => {
     });
 
     it('returns null if mismatched name', async () => {
-      got.mockReturnValueOnce({ body: { ...railsInfo, name: 'oooops' } });
+      got
+        .mockReturnValueOnce({ body: rubygemsOrgVersions })
+        .mockReturnValueOnce({ body: { ...railsInfo, name: 'oooops' } })
+        .mockReturnValueOnce({ body: null });
       expect(await rubygems.getPkgReleases(params)).toBeNull();
     });
 


### PR DESCRIPTION
So it will be possible to use rubygems datasource from [dockerbuilder](https://github.com/renovatebot/dockerbuilder). For now, it just crashes.