### PR TITLE
feat(onboarding): configurable branch and title

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -71,7 +71,15 @@ RFC5322-compliant string if you wish to customise the git author for commits.
 
 Set this to `false` if (a) you configure Renovate entirely on the bot side (i.e. empty `renovate.json` in repositories) and (b) you wish to run Renovate on every repository the bot has access to, and (c) you wish to skip the onboarding PRs.
 
+## onboardingBranch
+
+Note that this setting is independent of `branchPrefix`. For example, if you configure `branchPrefix` to be `renovate-` then you'd still have the onboarding PR created with branch `renovate/configure` until you configure `onboardingBranch=renovate-configure` or similar. If you have an existing Renovate installation and you change `onboardingBranch` then it's possible that you'll get onboarding PRs for repositories that had previously closed the onboarding PR unmerged.
+
 ## onboardingConfig
+
+## onboardingPrTitle
+
+Similarly to `onboardingBranch`, if you have an existing Renovate installation and you change `onboardingPrTitle` then it's possible that you'll get onboarding PRs for repositories that had previously closed the onboarding PR unmerged.
 
 ## optimizeForDisabled
 

--- a/lib/config/app-strings.ts
+++ b/lib/config/app-strings.ts
@@ -12,9 +12,6 @@ export const configFileNames = [
   'package.json',
 ];
 
-export const onboardingBranch = 'renovate/configure';
-export const onboardingPrTitle = 'Configure Renovate';
-
 export const urls = {
   documentation: 'https://docs.renovatebot.com/',
   help: 'https://github.com/renovatebot/config-help/issues',

--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -77,6 +77,24 @@ export type RenovateOptions =
 
 const options: RenovateOptions[] = [
   {
+    name: 'onboardingBranch',
+    description:
+      'Change this value in order to override the default onboarding branch name.',
+    type: 'string',
+    default: 'renovate/configure',
+    admin: true,
+    cli: false,
+  },
+  {
+    name: 'onboardingPrTitle',
+    description:
+      'Change this value in order to override the default onboarding PR title.',
+    type: 'string',
+    default: 'Configure Renovate',
+    admin: true,
+    cli: false,
+  },
+  {
     name: 'extends',
     description:
       'Configuration presets to use/extend. Note: does not work if configured in config.js',

--- a/lib/workers/repository/error-config.js
+++ b/lib/workers/repository/error-config.js
@@ -1,9 +1,5 @@
 const { logger } = require('../../logger');
-const {
-  appName,
-  onboardingBranch,
-  onboardingPrTitle,
-} = require('../../config/app-strings');
+const { appName } = require('../../config/app-strings');
 const { platform } = require('../../platform');
 
 module.exports = {
@@ -20,14 +16,14 @@ async function raiseConfigWarningIssue(config, error) {
   if (error.validationMessage) {
     body += `Message: \`${error.validationMessage}\`\n`;
   }
-  const pr = await platform.getBranchPr(onboardingBranch);
+  const pr = await platform.getBranchPr(config.onboardingBranch);
   if (pr && pr.state && pr.state.startsWith('open')) {
     logger.info('Updating onboarding PR with config error notice');
     body = `## Action Required: Fix ${appName} Configuration\n\n${body}`;
     body += `\n\nOnce you have resolved this problem (in this onboarding branch), ${appName} will return to providing you with a preview of your repository's configuration.`;
     if (config.dryRun) {
       logger.info('DRY-RUN: Would update PR #' + pr.number);
-    } else await platform.updatePr(pr.number, onboardingPrTitle, body);
+    } else await platform.updatePr(pr.number, config.onboardingPrTitle, body);
   } else if (config.dryRun) {
     logger.info('DRY-RUN: Would ensure config error issue');
   } else {

--- a/lib/workers/repository/onboarding/branch/check.ts
+++ b/lib/workers/repository/onboarding/branch/check.ts
@@ -4,8 +4,6 @@ import {
   appName,
   appSlug,
   configFileNames,
-  onboardingBranch,
-  onboardingPrTitle,
 } from '../../../../config/app-strings';
 import { RenovateConfig } from '../../../../config';
 
@@ -39,8 +37,8 @@ const packageJsonConfigExists = async (): Promise<boolean> => {
 // TODO: types
 export type Pr = any;
 
-const closedPrExists = (): Promise<Pr> =>
-  platform.findPr(onboardingBranch, onboardingPrTitle, '!open');
+const closedPrExists = (config: RenovateConfig): Promise<Pr> =>
+  platform.findPr(config.onboardingBranch, config.onboardingPrTitle, '!open');
 
 export const isOnboarded = async (config: RenovateConfig): Promise<boolean> => {
   logger.debug('isOnboarded()');
@@ -69,7 +67,7 @@ export const isOnboarded = async (config: RenovateConfig): Promise<boolean> => {
     throw new Error('disabled');
   }
 
-  const pr = await closedPrExists();
+  const pr = await closedPrExists(config);
   if (!pr) {
     logger.debug('Found no closed onboarding PR');
     return false;
@@ -91,5 +89,7 @@ export const isOnboarded = async (config: RenovateConfig): Promise<boolean> => {
   throw new Error('disabled');
 };
 
-export const onboardingPrExists = async (): Promise<boolean> =>
-  (await platform.getBranchPr(onboardingBranch)) != null;
+export const onboardingPrExists = async (
+  config: RenovateConfig
+): Promise<boolean> =>
+  (await platform.getBranchPr(config.onboardingBranch)) != null;

--- a/lib/workers/repository/onboarding/branch/create.ts
+++ b/lib/workers/repository/onboarding/branch/create.ts
@@ -1,9 +1,6 @@
 import { logger } from '../../../../logger';
 import { getOnboardingConfig } from './config';
-import {
-  configFileNames,
-  onboardingBranch,
-} from '../../../../config/app-strings';
+import { configFileNames } from '../../../../config/app-strings';
 import { RenovateConfig } from '../../../../config';
 import { platform } from '../../../../platform';
 
@@ -32,7 +29,7 @@ export async function createOnboardingBranch(
     logger.info('DRY-RUN: Would commit files to onboarding branch');
   } else {
     await platform.commitFilesToBranch(
-      onboardingBranch,
+      config.onboardingBranch,
       [
         {
           name: defaultConfigFile,

--- a/lib/workers/repository/onboarding/branch/index.ts
+++ b/lib/workers/repository/onboarding/branch/index.ts
@@ -3,7 +3,6 @@ import { extractAllDependencies } from '../../extract';
 import { createOnboardingBranch } from './create';
 import { rebaseOnboardingBranch } from './rebase';
 import { isOnboarded, onboardingPrExists } from './check';
-import { onboardingBranch } from '../../../../config/app-strings';
 import { RenovateConfig } from '../../../../config';
 import { platform } from '../../../../platform';
 
@@ -21,7 +20,7 @@ export async function checkOnboardingBranch(
     throw new Error('fork');
   }
   logger.info('Repo is not onboarded');
-  if (await onboardingPrExists()) {
+  if (await onboardingPrExists(config)) {
     logger.debug('Onboarding PR already exists');
     await rebaseOnboardingBranch(config);
   } else {
@@ -33,8 +32,8 @@ export async function checkOnboardingBranch(
     await createOnboardingBranch(config);
   }
   if (!config.dryRun) {
-    await platform.setBaseBranch(onboardingBranch);
+    await platform.setBaseBranch(config.onboardingBranch);
   }
-  const branchList = [onboardingBranch];
+  const branchList = [config.onboardingBranch];
   return { ...config, repoIsOnboarded, branchList };
 }

--- a/lib/workers/repository/onboarding/branch/rebase.ts
+++ b/lib/workers/repository/onboarding/branch/rebase.ts
@@ -1,9 +1,6 @@
 import { logger } from '../../../../logger';
 import { getOnboardingConfig } from './config';
-import {
-  configFileNames,
-  onboardingBranch,
-} from '../../../../config/app-strings';
+import { configFileNames } from '../../../../config/app-strings';
 import { RenovateConfig } from '../../../../config';
 import { platform } from '../../../../platform';
 
@@ -29,14 +26,14 @@ export async function rebaseOnboardingBranch(
   config: RenovateConfig
 ): Promise<void> {
   logger.debug('Checking if onboarding branch needs rebasing');
-  const pr = await platform.getBranchPr(onboardingBranch);
+  const pr = await platform.getBranchPr(config.onboardingBranch);
   if (pr.isModified) {
     logger.info('Onboarding branch has been edited and cannot be rebased');
     return;
   }
   const existingContents = await platform.getFile(
     defaultConfigFile,
-    onboardingBranch
+    config.onboardingBranch
   );
   const contents = await getOnboardingConfig(config);
   if (contents === existingContents && !pr.isStale) {
@@ -52,7 +49,7 @@ export async function rebaseOnboardingBranch(
     logger.info('DRY-RUN: Would rebase files in onboarding branch');
   } else {
     await platform.commitFilesToBranch(
-      onboardingBranch,
+      config.onboardingBranch,
       [
         {
           name: defaultConfigFile,

--- a/lib/workers/repository/onboarding/pr/config-description.ts
+++ b/lib/workers/repository/onboarding/pr/config-description.ts
@@ -1,10 +1,6 @@
 import { emojify } from '../../../../util/emoji';
 import { logger } from '../../../../logger';
-import {
-  appName,
-  configFileNames,
-  onboardingPrTitle,
-} from '../../../../config/app-strings';
+import { appName, configFileNames } from '../../../../config/app-strings';
 import { RenovateConfig } from '../../../../config';
 import { PackageFile } from '../../../../manager/common';
 
@@ -54,7 +50,7 @@ export function getConfigDesc(
     descriptionArr = descriptionArr.filter(val => !val.includes('Docker-only'));
   }
   let desc = `\n### Configuration Summary\n\nBased on the default config's presets, ${appName} will:\n\n`;
-  desc += `  - Start dependency updates only once this ${onboardingPrTitle} PR is merged\n`;
+  desc += `  - Start dependency updates only once this onboarding PR is merged\n`;
   descriptionArr.forEach(d => {
     desc += `  - ${d}\n`;
   });

--- a/lib/workers/repository/onboarding/pr/index.ts
+++ b/lib/workers/repository/onboarding/pr/index.ts
@@ -5,12 +5,7 @@ import { getConfigDesc } from './config-description';
 import { getErrors, getWarnings, getDepWarnings } from './errors-warnings';
 import { getBaseBranchDesc } from './base-branch';
 import { getPrList, BranchConfig } from './pr-list';
-import {
-  appName,
-  onboardingBranch,
-  onboardingPrTitle,
-  urls,
-} from '../../../../config/app-strings';
+import { appName, urls } from '../../../../config/app-strings';
 import { emojify } from '../../../../util/emoji';
 import { RenovateConfig } from '../../../../config';
 import { PackageFile } from '../../../../manager/common';
@@ -25,7 +20,7 @@ export async function ensureOnboardingPr(
   }
   logger.debug('ensureOnboardingPr()');
   logger.trace({ config });
-  const existingPr = await platform.getBranchPr(onboardingBranch);
+  const existingPr = await platform.getBranchPr(config.onboardingBranch);
   logger.debug('Filling in onboarding PR template');
   let prTemplate = `Welcome to [${appName}](${urls.homepage})! This is an onboarding PR to help you understand and configure settings before regular Pull Requests begin.\n\n`;
   prTemplate += config.requireConfig
@@ -127,8 +122,8 @@ If you need any further assistance then you can also [request help here](${urls.
       logger.info('DRY-RUN: Would create onboarding PR');
     } else {
       const pr = await platform.createPr(
-        onboardingBranch,
-        onboardingPrTitle,
+        config.onboardingBranch,
+        config.onboardingPrTitle,
         prBody,
         labels,
         useDefaultBranch
@@ -147,7 +142,7 @@ If you need any further assistance then you can also [request help here](${urls.
       )
     ) {
       logger.info('Onboarding PR already exists but cannot find it');
-      await platform.deleteBranch(onboardingBranch);
+      await platform.deleteBranch(config.onboardingBranch);
       return;
     }
     throw err;

--- a/lib/workers/repository/process/limits.js
+++ b/lib/workers/repository/process/limits.js
@@ -2,8 +2,6 @@ const moment = require('moment');
 const { logger } = require('../../../logger');
 const { platform } = require('../../../platform');
 
-const { onboardingBranch } = require('../../../config/app-strings');
-
 module.exports = {
   getPrHourlyRemaining,
   getConcurrentPrsRemaining,
@@ -21,7 +19,7 @@ async function getPrHourlyRemaining(config) {
     try {
       const soFarThisHour = prList.filter(
         pr =>
-          pr.branchName !== onboardingBranch &&
+          pr.branchName !== config.onboardingBranch &&
           moment(pr.createdAt).isAfter(currentHourStart)
       );
       const prsRemaining = config.prHourlyLimit - soFarThisHour.length;

--- a/renovate-schema.json
+++ b/renovate-schema.json
@@ -3,6 +3,16 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "properties": {
+    "onboardingBranch": {
+      "description": "Change this value in order to override the default onboarding branch name.",
+      "type": "string",
+      "default": "renovate/configure"
+    },
+    "onboardingPrTitle": {
+      "description": "Change this value in order to override the default onboarding PR title.",
+      "type": "string",
+      "default": "Configure Renovate"
+    },
     "extends": {
       "description": "Configuration presets to use/extend. Note: does not work if configured in config.js",
       "type": "array",

--- a/test/workers/repository/onboarding/pr/__snapshots__/config-description.spec.js.snap
+++ b/test/workers/repository/onboarding/pr/__snapshots__/config-description.spec.js.snap
@@ -6,7 +6,7 @@ exports[`workers/repository/onboarding/pr/config-description getConfigDesc() ass
 
 Based on the default config's presets, Renovate will:
 
-  - Start dependency updates only once this Configure Renovate PR is merged
+  - Start dependency updates only once this onboarding PR is merged
   - Run Renovate on following schedule: before 5am
 
 :abcd: Would you like to change the way Renovate is upgrading your dependencies? Simply edit the \`renovate.json\` in this branch with your custom config and the list of Pull Requests in the \\"What to Expect\\" section below will be updated the next time Renovate runs.
@@ -21,7 +21,7 @@ exports[`workers/repository/onboarding/pr/config-description getConfigDesc() ret
 
 Based on the default config's presets, Renovate will:
 
-  - Start dependency updates only once this Configure Renovate PR is merged
+  - Start dependency updates only once this onboarding PR is merged
   - description 1
   - description two
   - something else
@@ -38,7 +38,7 @@ exports[`workers/repository/onboarding/pr/config-description getConfigDesc() ret
 
 Based on the default config's presets, Renovate will:
 
-  - Start dependency updates only once this Configure Renovate PR is merged
+  - Start dependency updates only once this onboarding PR is merged
   - description 1
   - description two
   - something else


### PR DESCRIPTION
Adds options onboardingBranch and onboardingPrTitle to allow bot administrators to change the branch name and/or title in oboarding PRs.

Note: `onboardingBranch` and `branchPrefix` are independent options.

Closes #3443
