### PR TITLE
feat: ignoreScripts

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -460,6 +460,10 @@ Use this if you are extending a complex preset but won't want to use every "sub 
 
 It would take the entire `"config:base"` preset - which contains a lot of sub-presets - but ignore the `":prHourlyLimit2"` rule.
 
+## ignoreScripts
+
+Applicable for npm and composer only for now. Set this to `true` if running scripts causes problems.
+
 ## ignoreUnstable
 
 By default, Renovate won't update any package versions to unstable versions (e.g. `4.0.0-rc3`) unless the current version has the same major.minor.patch and was _already_ unstable (e.g. it was already on `4.0.0-rc2`). Renovate will not "jump" unstable versions automatically, e.g. if you are on `4.0.0-rc2` and newer versions `4.0.0` and `4.1.0-alpha.1` exist then Renovate will update you to `4.0.0` only. If you need to force permanent unstable updates for a package, you can add a package rule setting `ignoreUnstable` to `false`.

--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -387,6 +387,14 @@ const options: RenovateOptions[] = [
     default: 'low',
   },
   {
+    name: 'ignoreScripts',
+    description:
+      'Configure this to true if trustLevel is high but you wish to skip running scripts when updating lock files',
+    stage: 'package',
+    type: 'boolean',
+    default: false,
+  },
+  {
     name: 'platform',
     description: 'Platform type of repository',
     type: 'string',

--- a/lib/manager/common.ts
+++ b/lib/manager/common.ts
@@ -30,6 +30,7 @@ export interface UpdateArtifactsConfig extends ManagerConfig {
   compatibility?: Record<string, string>;
   cacheDir?: string;
   postUpdateOptions?: string[];
+  ignoreScripts?: boolean;
 }
 
 export interface PackageUpdateConfig {

--- a/lib/manager/composer/artifacts.ts
+++ b/lib/manager/composer/artifacts.ts
@@ -123,7 +123,7 @@ export async function updateArtifacts(
         ('update ' + updatedDeps.join(' ')).trim() + ' --with-dependencies';
     }
     args += ' --ignore-platform-reqs --no-ansi --no-interaction';
-    if (global.trustLevel !== 'high') {
+    if (global.trustLevel !== 'high' || config.ignoreScripts) {
       args += ' --no-scripts --no-autoloader';
     }
     logger.debug({ cmd, args }, 'composer command');

--- a/lib/manager/npm/post-update/pnpm.ts
+++ b/lib/manager/npm/post-update/pnpm.ts
@@ -91,7 +91,7 @@ export async function generateLockFile(
     logger.debug(`Using pnpm: ${cmd}`);
     cmd += ' install';
     cmd += ' --lockfile-only';
-    if (global.trustLevel !== 'high') {
+    if (global.trustLevel !== 'high' || config.ignoreScripts) {
       cmd += ' --ignore-scripts';
       cmd += ' --ignore-pnpmfile';
     }

--- a/renovate-schema.json
+++ b/renovate-schema.json
@@ -200,6 +200,11 @@
       "type": "string",
       "default": "low"
     },
+    "ignoreScripts": {
+      "description": "Configure this to true if trustLevel is high but you wish to skip running scripts when updating lock files",
+      "type": "boolean",
+      "default": false
+    },
     "platform": {
       "description": "Platform type of repository",
       "type": "string",


### PR DESCRIPTION
Adds new `ignoreScripts` config option. If set to true, managers such as npm and composer will skip running install scripts even if trustLevel is configured to high.

Closes #4567