### PR TITLE
feat(ruby): Allow for versions with leading 'v'

### DIFF
--- a/test/versioning/ruby.spec.ts
+++ b/test/versioning/ruby.spec.ts
@@ -52,18 +52,25 @@ describe('semverRuby', () => {
 
   describe('.isVersion', () => {
     it('returns true when version is valid', () => {
+      expect(semverRuby.isVersion('0')).toBe(true);
+      expect(semverRuby.isVersion('v0')).toBe(true);
+      expect(semverRuby.isVersion('v1')).toBe(true);
+      expect(semverRuby.isVersion('v1.2')).toBe(true);
+      expect(semverRuby.isVersion('v1.2.3')).toBe(true);
       expect(semverRuby.isVersion('1')).toBe(true);
       expect(semverRuby.isVersion('1.1')).toBe(true);
       expect(semverRuby.isVersion('1.1.2')).toBe(true);
       expect(semverRuby.isVersion('1.1.2.3')).toBe(true);
       expect(semverRuby.isVersion('1.1.2-4')).toBe(true);
       expect(semverRuby.isVersion('1.1.2.pre.4')).toBe(true);
+      expect(semverRuby.isVersion('v1.1.2.pre.4')).toBe(true);
     });
 
     it('returns false when version is invalid', () => {
       expect(semverRuby.isVersion(undefined)).toBe(false);
       expect(semverRuby.isVersion('')).toBe(false);
       expect(semverRuby.isVersion(null)).toBe(false);
+      expect(semverRuby.isVersion('v')).toBe(false);
       expect(semverRuby.isVersion('tottally-not-a-version')).toBe(false);
     });
   });
@@ -349,6 +356,7 @@ describe('semverRuby', () => {
     it('returns correct version for pin strategy', () => {
       [
         ['1.2.3', '1.0.3', 'pin', '1.0.3', '1.2.3'],
+        ['v1.2.3', 'v1.0.3', 'pin', '1.0.3', '1.2.3'],
         ['1.2.3', '= 1.0.3', 'pin', '1.0.3', '1.2.3'],
         ['1.2.3', '!= 1.0.3', 'pin', '1.0.4', '1.2.3'],
         ['1.2.3', '> 1.0.3', 'pin', '1.0.4', '1.2.3'],
@@ -367,6 +375,7 @@ describe('semverRuby', () => {
     it('returns correct version for bump strategy', () => {
       [
         ['1.2.3', '1.0.3', 'bump', '1.0.3', '1.2.3'],
+        ['v1.2.3', 'v1.0.3', 'bump', '1.0.3', '1.2.3'],
         ['= 1.2.3', '= 1.0.3', 'bump', '1.0.3', '1.2.3'],
         ['!= 1.0.3', '!= 1.0.3', 'bump', '1.0.0', '1.2.3'],
         ['> 1.2.2', '> 1.0.3', 'bump', '1.0.4', '1.2.3'],
@@ -396,6 +405,7 @@ describe('semverRuby', () => {
     it('returns correct version for replace strategy', () => {
       [
         ['1.2.3', '1.0.3', 'replace', '1.0.3', '1.2.3'],
+        ['v1.2.3', 'v1.0.3', 'replace', '1.0.3', '1.2.3'],
         ['= 1.2.3', '= 1.0.3', 'replace', '1.0.3', '1.2.3'],
         ['!= 1.0.3', '!= 1.0.3', 'replace', '1.0.0', '1.2.3'],
         ['< 1.2.4', '< 1.0.3', 'replace', '1.0.0', '1.2.3'],


### PR DESCRIPTION
These prefixes are common in github tags, so this PR will help to close #4789.
