### PR TITLE
fix: support hostRules in env

### DIFF
--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -37,7 +37,7 @@ export interface RenovateArrayOption<T extends string | object = any>
 
 export interface RenovateStringArrayOption extends RenovateArrayOption<string> {
   format?: 'regex';
-  subType: 'string';
+  subType: 'string' | 'object';
 }
 
 export interface RenovateBooleanOption extends RenovateOptionBase {
@@ -1960,6 +1960,7 @@ const options: RenovateOptions[] = [
     name: 'hostRules',
     description: 'Host rules/configuration including credentials',
     type: 'array',
+    subType: 'object',
     default: [
       {
         timeout: 60000,

--- a/renovate-schema.json
+++ b/renovate-schema.json
@@ -1318,11 +1318,6 @@
     "hostRules": {
       "description": "Host rules/configuration including credentials",
       "type": "array",
-      "default": [
-        {
-          "timeout": 60000
-        }
-      ],
       "items": {
         "allOf": [
           {
@@ -1355,7 +1350,12 @@
             }
           }
         ]
-      }
+      },
+      "default": [
+        {
+          "timeout": 60000
+        }
+      ]
     },
     "prBodyDefinitions": {
       "description": "Table column definitions for use in PR tables",


### PR DESCRIPTION
Now supports env param like this: `RENOVATE_HOST_RULES='[{"hostType":"maven","domainName":"somedomain.com","username":"someusername","password":"***********"}]'`

Closes #4984
