### PR TITLE
feat: regex manager [WIP]

### DIFF
--- a/lib/manager/regex/extract.ts
+++ b/lib/manager/regex/extract.ts
@@ -1,0 +1,59 @@
+import handlebars from 'handlebars';
+import * as versioning from '../../versioning';
+import { ExtractConfig, PackageFile, PackageDependency } from '../common';
+import { logger } from '../../logger';
+import { regEx } from '../../util/regex';
+
+export interface RegexManagerConfig extends ExtractConfig {
+  extractRegex: string;
+  depName: string;
+  currentValue: string;
+  datasource: string;
+  versionScheme: string;
+  lookupName?: string;
+}
+
+export function extractPackageFile(
+  content: string,
+  fileName: string,
+  config: RegexManagerConfig
+): Promise<PackageFile | null> {
+  if (
+    !(
+      config.extractRegex &&
+      config.depName &&
+      config.currentValue &&
+      config.datasource &&
+      config.versionScheme
+    )
+  ) {
+    logger.warn({ config }, 'Missing required fields for regex manager');
+    return null;
+  }
+  logger.trace({ content, fileName }, 'Regex manager extract');
+  const extractRegex = regEx(config.extractRegex);
+  const matches = content.match(extractRegex);
+  if (!matches) {
+    logger.debug('No matches');
+    return null;
+  }
+  console.warn(matches);
+  const deps = [];
+  for (const match of matches) {
+    const dep: PackageDependency = {
+      depName: handlebars.compile(config.depName)(match.groups),
+      currentValue: handlebars.compile(config.currentValue)(match.groups),
+      datasource: handlebars.compile(config.datasource)(match.groups),
+      versionScheme: handlebars.compile(config.versionScheme)(match.groups),
+    };
+    const versionScheme = versioning.get(config.versionScheme);
+    if (!versionScheme.isValid(dep.currentValue)) {
+      dep.skipReason = 'unsupported-version';
+    }
+    deps.push(dep);
+  }
+  if (!deps.length) {
+    return null;
+  }
+  return { deps };
+}

--- a/lib/manager/regex/index.ts
+++ b/lib/manager/regex/index.ts
@@ -1,0 +1,2 @@
+export { extractPackageFile } from './extract';
+export { updateDependency } from './update';

--- a/lib/manager/regex/update.ts
+++ b/lib/manager/regex/update.ts
@@ -1,0 +1,10 @@
+import { logger } from '../../logger';
+import { Upgrade } from '../common';
+
+export function updateDependency(
+  _fileContent: string,
+  upgrade: Upgrade
+): string {
+  logger.debug(`nvm.updateDependency(): ${upgrade.newVersion}`);
+  return `${upgrade.newValue}\n`;
+}

--- a/test/manager/regex/extract.spec.ts
+++ b/test/manager/regex/extract.spec.ts
@@ -1,0 +1,35 @@
+import {
+  RegexManagerConfig,
+  extractPackageFile,
+} from '../../../lib/manager/regex/extract';
+
+describe('lib/manager/regex/extract', () => {
+  describe('extractPackageFile()', () => {
+    it('returns null if missing fields', () => {
+      const config: RegexManagerConfig = {
+        extractRegex: '',
+        depName: '',
+        currentValue: '',
+        datasource: '',
+        versionScheme: null,
+      };
+      const res = extractPackageFile('', '', config);
+      expect(res).toBeNull();
+    });
+    it('matches', () => {
+      const config: RegexManagerConfig = {
+        extractRegex: '(?<depName>.*?)=(?<currentValue>.*?)\n',
+        depName: '{{depName}}',
+        currentValue: '{{currentValue}}',
+        datasource: 'npm',
+        versionScheme: 'semver',
+      };
+      const res = extractPackageFile(
+        'lodash=4.0.0\nexpress=4.0.0\n',
+        '',
+        config
+      );
+      expect(res).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
Adds a generic "regex" manager allowing custom extraction and updates using existing datasources and versionSchemes. The goal of this is to also function as a "fallback" for times when Renovate *misses* things in existing package managers.

Still just the beginnings so marked as WIP.

This will probably close quite a few feature requests in one go. TBD.
