### PR TITLE
fix(gitlab-ci): skip comment lines

### DIFF
--- a/test/manager/gitlabci/__snapshots__/extract.spec.ts.snap
+++ b/test/manager/gitlabci/__snapshots__/extract.spec.ts.snap
@@ -64,3 +64,38 @@ Array [
   },
 ]
 `;
+
+exports[`lib/manager/gitlabci/extract extractPackageFile() extracts multiple image lines with comments 1`] = `
+Array [
+  Object {
+    "currentDigest": undefined,
+    "currentValue": "19.70.8-slim",
+    "datasource": "docker",
+    "depName": "renovate/renovate",
+    "depType": "image-name",
+    "managerData": Object {
+      "lineNumber": 2,
+    },
+  },
+  Object {
+    "currentDigest": undefined,
+    "currentValue": "10.4.11",
+    "datasource": "docker",
+    "depName": "mariadb",
+    "depType": "service-image",
+    "managerData": Object {
+      "lineNumber": 6,
+    },
+  },
+  Object {
+    "currentDigest": undefined,
+    "currentValue": "1.0.0",
+    "datasource": "docker",
+    "depName": "other/image",
+    "depType": "service-image",
+    "managerData": Object {
+      "lineNumber": 8,
+    },
+  },
+]
+`;

--- a/test/manager/gitlabci/_fixtures/gitlab-ci.1.yaml
+++ b/test/manager/gitlabci/_fixtures/gitlab-ci.1.yaml
@@ -1,0 +1,9 @@
+image:
+  # comment
+  name: renovate/renovate:19.70.8-slim
+
+services:
+  # comment
+  - mariadb:10.4.11
+  # another comment
+  - other/image:1.0.0

--- a/test/manager/gitlabci/extract.spec.ts
+++ b/test/manager/gitlabci/extract.spec.ts
@@ -6,6 +6,11 @@ const yamlFile = readFileSync(
   'utf8'
 );
 
+const yamlFile1 = readFileSync(
+  'test/manager/gitlabci/_fixtures/gitlab-ci.1.yaml',
+  'utf8'
+);
+
 describe('lib/manager/gitlabci/extract', () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty', () => {
@@ -15,6 +20,12 @@ describe('lib/manager/gitlabci/extract', () => {
       const res = extractPackageFile(yamlFile);
       expect(res.deps).toMatchSnapshot();
       expect(res.deps).toHaveLength(6);
+    });
+
+    it('extracts multiple image lines with comments', () => {
+      const res = extractPackageFile(yamlFile1);
+      expect(res.deps).toMatchSnapshot();
+      expect(res.deps).toHaveLength(3);
     });
   });
 });


### PR DESCRIPTION
The extract function now skips comment lines for `gitlab-ci.yml` files.

Closes #4998  <!-- Ideally each PR should be closing an open issue -->
