### PR TITLE
feat(bundler): recursively attempt to resolve locked dependencies

### DIFF
--- a/lib/workers/branch/index.ts
+++ b/lib/workers/branch/index.ts
@@ -419,12 +419,8 @@ export async function processBranch(
     }
     if (err.message === 'update-failure') {
       logger.warn('Error updating branch: update failure');
-    } else if (
-      err.message === 'bundler-fs' ||
-      err.message === 'bundler-credentials' ||
-      err.message === 'bundler-unknown'
-    ) {
-      // we have already warned, so just return
+    } else if (err.message.startsWith('bundler-')) {
+      // we have already warned inside the bundler artifacts error handling, so just return
       return 'error';
     } else if (
       err.messagee &&


### PR DESCRIPTION
Bundler helpfully tells us which locked dependencies caused the lock file update to fail. We parse these, check if there are any new ones we hadn’t unlocked previously, and call the function recursively if so.

Closes #5036