### PR TITLE
fix(config): log error when config file has syntax error

### DIFF
--- a/lib/config/file.ts
+++ b/lib/config/file.ts
@@ -14,15 +14,13 @@ export function getConfig(env: NodeJS.ProcessEnv): RenovateConfig {
     // eslint-disable-next-line global-require,import/no-dynamic-require
     config = require(configFile);
   } catch (err) {
+    // istanbul ignore if
     if (err instanceof SyntaxError) {
-      // extract first line of error stack message
-      const errorStackMessage = err.stack.split('\n')[0];
-      const file = errorStackMessage.split(':')[0];
-      const line = errorStackMessage.split(':')[1];
-      logger.fatal({ file, line }, err.message);
-    } else {
-      logger.debug('No config file found on disk - skipping');
+      logger.fatal(`Could not parse config file \n ${err.stack}`);
+      process.exit(1);
     }
+    // Do nothing
+    logger.debug('No config file found on disk - skipping');
   }
   const { isMigrated, migratedConfig } = migrateConfig(config);
   if (isMigrated) {

--- a/lib/config/file.ts
+++ b/lib/config/file.ts
@@ -14,8 +14,15 @@ export function getConfig(env: NodeJS.ProcessEnv): RenovateConfig {
     // eslint-disable-next-line global-require,import/no-dynamic-require
     config = require(configFile);
   } catch (err) {
-    // Do nothing
-    logger.debug('No config file found on disk - skipping');
+    if (err instanceof SyntaxError) {
+      // extract first line of error stack message
+      const errorStackMessage = err.stack.split('\n')[0];
+      const file = errorStackMessage.split(':')[0];
+      const line = errorStackMessage.split(':')[1];
+      logger.fatal({ file, line }, err.message);
+    } else {
+      logger.debug('No config file found on disk - skipping');
+    }
   }
   const { isMigrated, migratedConfig } = migrateConfig(config);
   if (isMigrated) {

--- a/test/config/file.spec.ts
+++ b/test/config/file.spec.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import fs from 'fs';
 import * as file from '../../lib/config/file';
 import customConfig from './config/_fixtures/file';
 
@@ -21,5 +22,31 @@ describe('config/file', () => {
       expect(res).toMatchSnapshot();
       expect(res.rangeStrategy).toEqual('bump');
     });
+    it('informs user when error in parsing config.js', () => {
+      const configFile = path.resolve(__dirname, './config/_fixtures/file3.js');
+      const fileContent = `module.exports = {
+        "platform": "github",
+        "token":"abcdef",
+        "logFileLevel": "warn",
+        "logLevel": "info",
+        "onboarding": false,
+        "gitAuthor": "Renovate Bot <bot@renovateapp.com>"
+        "onboardingConfig": {
+          "extends": ["config:base"],
+        },
+        "repositories": [ "test/test" ],
+      };`;
+      fs.writeFileSync(configFile, fileContent, { encoding: 'utf8' });
+      expect(
+        file.getConfig({ RENOVATE_CONFIG_FILE: configFile })
+      ).toStrictEqual({});
+      fs.unlinkSync(configFile);
+    });
+  });
+  it('handles when invalid file location is provided', () => {
+    const configFile = path.resolve(__dirname, './config/_fixtures/file4.js');
+    expect(file.getConfig({ RENOVATE_CONFIG_FILE: configFile })).toStrictEqual(
+      {}
+    );
   });
 });


### PR DESCRIPTION
I have implemented this solution by matching if the error is an instance of SyntaxError. Is this how it expected to work?

I am still not able to reach 100% code coverage after many attempts. Some help is much needed.
Issue #4894 