### PR TITLE
refactor: convert commitFilesToBranch function params

### DIFF
--- a/lib/platform/azure/index.ts
+++ b/lib/platform/azure/index.ts
@@ -6,7 +6,7 @@ import {
 import * as azureHelper from './azure-helper';
 import * as azureApi from './azure-got-wrapper';
 import * as hostRules from '../../util/host-rules';
-import GitStorage, { StatusResult, File } from '../git/storage';
+import GitStorage, { StatusResult, CommitFilesConfig } from '../git/storage';
 import { logger } from '../../logger';
 import {
   PlatformConfig,
@@ -341,18 +341,18 @@ export /* istanbul ignore next */ function mergeBranch(
   return config.storage.mergeBranch(branchName);
 }
 
-export /* istanbul ignore next */ function commitFilesToBranch(
-  branchName: string,
-  files: File[],
-  message: string,
-  parentBranch = config.baseBranch
-): Promise<void> {
-  return config.storage.commitFilesToBranch(
+export /* istanbul ignore next */ function commitFilesToBranch({
+  branchName,
+  files,
+  message,
+  parentBranch = config.baseBranch,
+}: CommitFilesConfig): Promise<void> {
+  return config.storage.commitFilesToBranch({
     branchName,
     files,
     message,
-    parentBranch
-  );
+    parentBranch,
+  });
 }
 
 export /* istanbul ignore next */ function getCommitMessages(): Promise<

--- a/lib/platform/bitbucket-server/index.ts
+++ b/lib/platform/bitbucket-server/index.ts
@@ -4,7 +4,7 @@ import delay from 'delay';
 import { api } from './bb-got-wrapper';
 import * as utils from './utils';
 import * as hostRules from '../../util/host-rules';
-import GitStorage, { File, StatusResult } from '../git/storage';
+import GitStorage, { StatusResult, CommitFilesConfig } from '../git/storage';
 import { logger } from '../../logger';
 import {
   PlatformConfig,
@@ -409,25 +409,30 @@ export function getAllRenovateBranches(
   return config.storage.getAllRenovateBranches(branchPrefix);
 }
 
-export async function commitFilesToBranch(
-  branchName: string,
-  files: File[],
-  message: string,
-  parentBranch: string = config.baseBranch
-): Promise<void> {
+export async function commitFilesToBranch({
+  branchName,
+  files,
+  message,
+  parentBranch = config.baseBranch,
+}: CommitFilesConfig): Promise<void> {
   logger.debug(
     `commitFilesToBranch(${JSON.stringify(
-      { branchName, filesLength: files.length, message, parentBranch },
+      {
+        branchName,
+        filesLength: files.length,
+        message,
+        parentBranch,
+      },
       null,
       2
     )})`
   );
-  await config.storage.commitFilesToBranch(
+  await config.storage.commitFilesToBranch({
     branchName,
     files,
     message,
-    parentBranch
-  );
+    parentBranch,
+  });
 
   // wait for pr change propagation
   await delay(1000);

--- a/lib/platform/bitbucket/index.ts
+++ b/lib/platform/bitbucket/index.ts
@@ -4,7 +4,7 @@ import { api } from './bb-got-wrapper';
 import * as utils from './utils';
 import * as hostRules from '../../util/host-rules';
 import { logger } from '../../logger';
-import GitStorage, { StatusResult, File } from '../git/storage';
+import GitStorage, { StatusResult, CommitFilesConfig } from '../git/storage';
 import { readOnlyIssueBody } from '../utils/read-only-issue-body';
 import * as comments from './comments';
 import {
@@ -263,18 +263,18 @@ export function mergeBranch(branchName: string): Promise<void> {
   return config.storage.mergeBranch(branchName);
 }
 
-export function commitFilesToBranch(
-  branchName: string,
-  files: File[],
-  message: string,
-  parentBranch = config.baseBranch
-): Promise<void> {
-  return config.storage.commitFilesToBranch(
+export function commitFilesToBranch({
+  branchName,
+  files,
+  message,
+  parentBranch = config.baseBranch,
+}: CommitFilesConfig): Promise<void> {
+  return config.storage.commitFilesToBranch({
     branchName,
     files,
     message,
-    parentBranch
-  );
+    parentBranch,
+  });
 }
 
 export function getCommitMessages(): Promise<string[]> {

--- a/lib/platform/common.ts
+++ b/lib/platform/common.ts
@@ -1,7 +1,7 @@
 import got from 'got';
 import Git from 'simple-git/promise';
 import { RenovateConfig } from '../config/common';
-import { File } from './git/storage';
+import { CommitFilesConfig } from './git/storage';
 
 export interface FileData {
   name: string;
@@ -168,12 +168,7 @@ export interface Platform {
   ): Promise<boolean>;
   branchExists(branchName: string): Promise<boolean>;
   setBaseBranch(baseBranch: string): Promise<void>;
-  commitFilesToBranch(
-    branchName: string,
-    updatedFiles: File[],
-    commitMessage: string,
-    parentBranch?: string
-  ): Promise<void>;
+  commitFilesToBranch(commitFile: CommitFilesConfig): Promise<void>;
   getPr(number: number): Promise<Pr>;
   findPr(
     branchName: string,

--- a/lib/platform/git/storage.ts
+++ b/lib/platform/git/storage.ts
@@ -42,6 +42,13 @@ interface LocalConfig extends StorageConfig {
   branchPrefix: string;
 }
 
+export type CommitFilesConfig = {
+  branchName: string;
+  files: File[];
+  message: string;
+  parentBranch?: string;
+};
+
 // istanbul ignore next
 function checkForPlatformFailure(err: Error): void {
   if (process.env.NODE_ENV === 'test') {
@@ -462,12 +469,12 @@ export class Storage {
     }
   }
 
-  async commitFilesToBranch(
-    branchName: string,
-    files: File[],
-    message: string,
-    parentBranch = this._config.baseBranch
-  ): Promise<void> {
+  async commitFilesToBranch({
+    branchName,
+    files,
+    message,
+    parentBranch = this._config.baseBranch,
+  }: CommitFilesConfig): Promise<void> {
     logger.debug(`Committing files to branch ${branchName}`);
     try {
       await this._git!.reset('hard');

--- a/lib/platform/github/index.ts
+++ b/lib/platform/github/index.ts
@@ -6,7 +6,7 @@ import URL from 'url';
 import { logger } from '../../logger';
 import { api } from './gh-got-wrapper';
 import * as hostRules from '../../util/host-rules';
-import GitStorage, { StatusResult, File } from '../git/storage';
+import GitStorage, { StatusResult, CommitFilesConfig } from '../git/storage';
 import {
   PlatformConfig,
   RepoParams,
@@ -553,18 +553,18 @@ export function mergeBranch(branchName: string): Promise<void> {
 }
 
 // istanbul ignore next
-export function commitFilesToBranch(
-  branchName: string,
-  files: File[],
-  message: string,
-  parentBranch = config.baseBranch
-): Promise<void> {
-  return config.storage.commitFilesToBranch(
+export function commitFilesToBranch({
+  branchName,
+  files,
+  message,
+  parentBranch = config.baseBranch,
+}: CommitFilesConfig): Promise<void> {
+  return config.storage.commitFilesToBranch({
     branchName,
     files,
     message,
-    parentBranch
-  );
+    parentBranch,
+  });
 }
 
 // istanbul ignore next

--- a/lib/platform/gitlab/index.ts
+++ b/lib/platform/gitlab/index.ts
@@ -3,7 +3,7 @@ import is from '@sindresorhus/is';
 
 import { api } from './gl-got-wrapper';
 import * as hostRules from '../../util/host-rules';
-import GitStorage, { StatusResult } from '../git/storage';
+import GitStorage, { StatusResult, CommitFilesConfig } from '../git/storage';
 import {
   PlatformConfig,
   RepoParams,
@@ -520,18 +520,18 @@ export function isBranchStale(branchName: string): Promise<boolean> {
   return config.storage.isBranchStale(branchName);
 }
 
-export function commitFilesToBranch(
-  branchName: string,
-  files: any[],
-  message: string,
-  parentBranch = config.baseBranch
-): Promise<void> {
-  return config.storage.commitFilesToBranch(
+export function commitFilesToBranch({
+  branchName,
+  files,
+  message,
+  parentBranch = config.baseBranch,
+}: CommitFilesConfig): Promise<void> {
+  return config.storage.commitFilesToBranch({
     branchName,
     files,
     message,
-    parentBranch
-  );
+    parentBranch,
+  });
 }
 
 export function getFile(

--- a/lib/workers/branch/commit.ts
+++ b/lib/workers/branch/commit.ts
@@ -39,12 +39,12 @@ export async function commitFilesToBranch(
       logger.info('DRY-RUN: Would commit files to branch ' + config.branchName);
     } else {
       // API will know whether to create new branch or not
-      await platform.commitFilesToBranch(
-        config.branchName,
-        updatedFiles,
-        config.commitMessage,
-        config.baseBranch || undefined
-      );
+      await platform.commitFilesToBranch({
+        branchName: config.branchName,
+        files: updatedFiles,
+        message: config.commitMessage,
+        parentBranch: config.baseBranch || undefined,
+      });
       logger.info({ branch: config.branchName }, `files committed`);
     }
   } else {

--- a/lib/workers/repository/onboarding/branch/create.ts
+++ b/lib/workers/repository/onboarding/branch/create.ts
@@ -28,15 +28,15 @@ export async function createOnboardingBranch(
   if (config.dryRun) {
     logger.info('DRY-RUN: Would commit files to onboarding branch');
   } else {
-    await platform.commitFilesToBranch(
-      config.onboardingBranch,
-      [
+    await platform.commitFilesToBranch({
+      branchName: config.onboardingBranch,
+      files: [
         {
           name: defaultConfigFile,
           contents,
         },
       ],
-      commitMessage
-    );
+      message: commitMessage,
+    });
   }
 }

--- a/lib/workers/repository/onboarding/branch/rebase.ts
+++ b/lib/workers/repository/onboarding/branch/rebase.ts
@@ -48,15 +48,15 @@ export async function rebaseOnboardingBranch(
   if (config.dryRun) {
     logger.info('DRY-RUN: Would rebase files in onboarding branch');
   } else {
-    await platform.commitFilesToBranch(
-      config.onboardingBranch,
-      [
+    await platform.commitFilesToBranch({
+      branchName: config.onboardingBranch,
+      files: [
         {
           name: defaultConfigFile,
           contents,
         },
       ],
-      commitMessage
-    );
+      message: commitMessage,
+    });
   }
 }

--- a/test/platform/bitbucket-server/index.spec.ts
+++ b/test/platform/bitbucket-server/index.spec.ts
@@ -211,11 +211,11 @@ describe('platform/bitbucket-server', () => {
         it('sends to gitFs', async () => {
           expect.assertions(1);
           await initRepo();
-          await bitbucket.commitFilesToBranch(
-            'some-branch',
-            [{ name: 'test', contents: 'dummy' }],
-            'message'
-          );
+          await bitbucket.commitFilesToBranch({
+            branchName: 'some-branch',
+            files: [{ name: 'test', contents: 'dummy' }],
+            message: 'message',
+          });
           expect(api.get.mock.calls).toMatchSnapshot();
         });
       });

--- a/test/platform/bitbucket/index.spec.ts
+++ b/test/platform/bitbucket/index.spec.ts
@@ -473,7 +473,11 @@ describe('platform/bitbucket', () => {
     it('sends to gitFs', async () => {
       await initRepo();
       await mocked(async () => {
-        await bitbucket.commitFilesToBranch('test', [], 'message');
+        await bitbucket.commitFilesToBranch({
+          branchName: 'test',
+          files: [],
+          message: 'message',
+        });
       });
     });
   });

--- a/test/platform/git/storage.spec.ts
+++ b/test/platform/git/storage.spec.ts
@@ -166,12 +166,12 @@ describe('platform/git/storage', () => {
     it('should throw if branch merge is stale', async () => {
       expect.assertions(1);
       await git.setBranchPrefix('renovate/');
-      await git.commitFilesToBranch(
-        'test',
-        [{ name: 'some-new-file', contents: 'some new-contents' }],
-        'test mesage',
-        'renovate/past_branch'
-      );
+      await git.commitFilesToBranch({
+        branchName: 'test',
+        files: [{ name: 'some-new-file', contents: 'some new-contents' }],
+        message: 'test mesage',
+        parentBranch: 'renovate/past_branch',
+      });
 
       await git.setBaseBranch('master');
 
@@ -210,28 +210,28 @@ describe('platform/git/storage', () => {
       ).rejects.toMatchSnapshot();
     });
   });
-  describe('commitFilesToBranch(branchName, files, message, parentBranch)', () => {
+  describe('commitFilesToBranch({branchName, files, message, parentBranch})', () => {
     it('creates file', async () => {
       const file = {
         name: 'some-new-file',
         contents: 'some new-contents',
       };
-      await git.commitFilesToBranch(
-        'renovate/past_branch',
-        [file],
-        'Create something'
-      );
+      await git.commitFilesToBranch({
+        branchName: 'renovate/past_branch',
+        files: [file],
+        message: 'Create something',
+      });
     });
     it('deletes file', async () => {
       const file = {
         name: '|delete|',
         contents: 'file_to_delete',
       };
-      await git.commitFilesToBranch(
-        'renovate/something',
-        [file],
-        'Delete something'
-      );
+      await git.commitFilesToBranch({
+        branchName: 'renovate/something',
+        files: [file],
+        message: 'Delete something',
+      });
     });
     it('updates multiple files', async () => {
       const files = [
@@ -244,11 +244,11 @@ describe('platform/git/storage', () => {
           contents: 'other updated content',
         },
       ];
-      await git.commitFilesToBranch(
-        'renovate/something',
+      await git.commitFilesToBranch({
+        branchName: 'renovate/something',
         files,
-        'Update something'
-      );
+        message: 'Update something',
+      });
     });
     it('updates git submodules', async () => {
       const files = [
@@ -257,11 +257,11 @@ describe('platform/git/storage', () => {
           contents: 'some content',
         },
       ];
-      await git.commitFilesToBranch(
-        'renovate/something',
+      await git.commitFilesToBranch({
+        branchName: 'renovate/something',
         files,
-        'Update something'
-      );
+        message: 'Update something',
+      });
     });
   });
 

--- a/test/platform/gitlab/index.spec.ts
+++ b/test/platform/gitlab/index.spec.ts
@@ -931,7 +931,11 @@ These updates have all been created already. Click a checkbox below to force a r
     it('sends to gitFs', async () => {
       expect.assertions(1);
       await initRepo();
-      await gitlab.commitFilesToBranch('some-branch', [{}], '');
+      await gitlab.commitFilesToBranch({
+        branchName: 'some-branch',
+        files: [{ name: 'SomeFile', contents: 'Some Content' }],
+        message: '',
+      });
       expect(api.get.mock.calls).toMatchSnapshot();
     });
   });

--- a/test/workers/branch/__snapshots__/commit.spec.ts.snap
+++ b/test/workers/branch/__snapshots__/commit.spec.ts.snap
@@ -3,15 +3,17 @@
 exports[`workers/branch/automerge commitFilesToBranch commits files 1`] = `
 Array [
   Array [
-    "renovate/some-branch",
-    Array [
-      Object {
-        "contents": "some contents",
-        "name": "package.json",
-      },
-    ],
-    "some commit message",
-    undefined,
+    Object {
+      "branchName": "renovate/some-branch",
+      "files": Array [
+        Object {
+          "contents": "some contents",
+          "name": "package.json",
+        },
+      ],
+      "message": "some commit message",
+      "parentBranch": undefined,
+    },
   ],
 ]
 `;

--- a/test/workers/repository/onboarding/branch/index.spec.js
+++ b/test/workers/repository/onboarding/branch/index.spec.js
@@ -84,7 +84,7 @@ describe('workers/repository/onboarding/branch', () => {
       platform.getFile.mockReturnValue(pJsonContent);
       await checkOnboardingBranch(config);
       expect(
-        platform.commitFilesToBranch.mock.calls[0][1][0].contents
+        platform.commitFilesToBranch.mock.calls[0][0].files[0].contents
       ).toMatchSnapshot();
     });
     it('updates onboarding branch', async () => {


### PR DESCRIPTION
1.  New Interface is created named CommitFile
2. Every function call is refactored. Instead of 4 arguments, the new function will have only one argument.
3. Updated tests and snapshots accordingly.



<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate
-->

<!-- Replace this text with a description of what this PR fixes or adds -->

#4996 