### PR TITLE
feat: skip gitlab disabled and empty repos

### DIFF
--- a/lib/platform/gitlab/index.ts
+++ b/lib/platform/gitlab/index.ts
@@ -124,6 +124,7 @@ export async function initRepo({
     http_url_to_repo: string;
     forked_from_project: boolean;
     repository_access_level: 'disabled' | 'private' | 'enabled';
+    merge_requests_access_level: 'disabled' | 'private' | 'enabled';
   }>;
   try {
     res = await api.get(`projects/${config.repository}`);
@@ -142,6 +143,12 @@ export async function initRepo({
     if (res.body.repository_access_level === 'disabled') {
       logger.info(
         'Repository portion of project is disabled - throwing error to abort renovation'
+      );
+      throw new Error('disabled');
+    }
+    if (res.body.merge_requests_access_level === 'disabled') {
+      logger.info(
+        'MRs are disabled for the project - throwing error to abort renovation'
       );
       throw new Error('disabled');
     }

--- a/lib/platform/gitlab/index.ts
+++ b/lib/platform/gitlab/index.ts
@@ -120,8 +120,10 @@ export async function initRepo({
     archived: boolean;
     mirror: boolean;
     default_branch: string;
+    empty_repo: boolean;
     http_url_to_repo: string;
     forked_from_project: boolean;
+    repository_access_level: 'disabled' | 'private' | 'enabled';
   }>;
   try {
     res = await api.get(`projects/${config.repository}`);
@@ -137,7 +139,13 @@ export async function initRepo({
       );
       throw new Error('mirror');
     }
-    if (res.body.default_branch === null) {
+    if (res.body.repository_access_level === 'disabled') {
+      logger.info(
+        'Repository portion of project is disabled - throwing error to abort renovation'
+      );
+      throw new Error('disabled');
+    }
+    if (res.body.default_branch === null || res.body.empty_repo) {
       throw new Error('empty');
     }
     if (optimizeForDisabled) {

--- a/test/platform/gitlab/index.spec.ts
+++ b/test/platform/gitlab/index.spec.ts
@@ -246,7 +246,7 @@ describe('platform/gitlab', () => {
       ).rejects.toThrow(Error('disabled'));
     });
     it('should throw an error if repository has empty_repo property', async () => {
-      api.get.mockReturnValue({ body: { empty_repo: null } } as any);
+      api.get.mockReturnValue({ body: { empty_repo: true } } as any);
       await expect(
         gitlab.initRepo({
           repository: 'some/repo',

--- a/test/platform/gitlab/index.spec.ts
+++ b/test/platform/gitlab/index.spec.ts
@@ -233,6 +233,28 @@ describe('platform/gitlab', () => {
         })
       ).rejects.toThrow(Error('mirror'));
     });
+    it('should throw an error if repository access is disabled', async () => {
+      api.get.mockReturnValue({
+        body: { repository_access_level: 'disabled' },
+      } as any);
+      await expect(
+        gitlab.initRepo({
+          repository: 'some/repo',
+          localDir: '',
+          optimizeForDisabled: false,
+        })
+      ).rejects.toThrow(Error('disabled'));
+    });
+    it('should throw an error if repository has empty_repo property', async () => {
+      api.get.mockReturnValue({ body: { empty_repo: null } } as any);
+      await expect(
+        gitlab.initRepo({
+          repository: 'some/repo',
+          localDir: '',
+          optimizeForDisabled: false,
+        })
+      ).rejects.toThrow(Error('empty'));
+    });
     it('should throw an error if repository is empty', async () => {
       api.get.mockReturnValue({ body: { default_branch: null } } as any);
       await expect(

--- a/test/platform/gitlab/index.spec.ts
+++ b/test/platform/gitlab/index.spec.ts
@@ -245,6 +245,18 @@ describe('platform/gitlab', () => {
         })
       ).rejects.toThrow(Error('disabled'));
     });
+    it('should throw an error if MRs are disabled', async () => {
+      api.get.mockReturnValue({
+        body: { merge_requests_access_level: 'disabled' },
+      } as any);
+      await expect(
+        gitlab.initRepo({
+          repository: 'some/repo',
+          localDir: '',
+          optimizeForDisabled: false,
+        })
+      ).rejects.toThrow(Error('disabled'));
+    });
     it('should throw an error if repository has empty_repo property', async () => {
       api.get.mockReturnValue({ body: { empty_repo: true } } as any);
       await expect(


### PR DESCRIPTION
GitLab projects can have the repo portion disabled which causes the current `initRepos()` to fail.  This will now skip projects in this configuration as they have no code or dependencies to update.  I'm also adding a check for the `empty_repo` property as another way to check for the repo being empty which could also cause Renovate to hit errors.

Closes # 5080
