### PR TITLE
fix(azure): correct naming for branches

### DIFF
--- a/lib/platform/azure/index.ts
+++ b/lib/platform/azure/index.ts
@@ -280,7 +280,9 @@ export async function findPr(
   try {
     const prs = await getPrList();
 
-    prsFiltered = prs.filter(item => item.head.ref === branchName);
+    prsFiltered = prs.filter(
+      item => item.sourceRefName === azureHelper.getNewBranchName(branchName)
+    );
 
     if (prTitle) {
       prsFiltered = prsFiltered.filter(item => item.title === prTitle);

--- a/test/platform/azure/__snapshots__/index.spec.ts.snap
+++ b/test/platform/azure/__snapshots__/index.spec.ts.snap
@@ -52,10 +52,8 @@ Array [
 
 exports[`platform/azure findPr(branchName, prTitle, state) returns pr if found it all state 1`] = `
 Object {
-  "head": Object {
-    "ref": "branch-a",
-  },
   "number": 1,
+  "sourceRefName": "refs/heads/branch-a",
   "state": "closed",
   "title": "branch a pr",
 }
@@ -63,10 +61,8 @@ Object {
 
 exports[`platform/azure findPr(branchName, prTitle, state) returns pr if found it close 1`] = `
 Object {
-  "head": Object {
-    "ref": "branch-a",
-  },
   "number": 1,
+  "sourceRefName": "refs/heads/branch-a",
   "state": "closed",
   "title": "branch a pr",
 }
@@ -74,10 +70,8 @@ Object {
 
 exports[`platform/azure findPr(branchName, prTitle, state) returns pr if found it open 1`] = `
 Object {
-  "head": Object {
-    "ref": "branch-a",
-  },
   "number": 1,
+  "sourceRefName": "refs/heads/branch-a",
   "state": "open",
   "title": "branch a pr",
 }
@@ -85,10 +79,8 @@ Object {
 
 exports[`platform/azure findPr(branchName, prTitle, state) returns pr if found not open 1`] = `
 Object {
-  "head": Object {
-    "ref": "branch-a",
-  },
   "number": 1,
+  "sourceRefName": "refs/heads/branch-a",
   "state": "closed",
   "title": "branch a pr",
 }

--- a/test/platform/azure/index.spec.ts
+++ b/test/platform/azure/index.spec.ts
@@ -222,7 +222,7 @@ describe('platform/azure', () => {
         () =>
           ({
             number: 1,
-            head: { ref: 'branch-a' },
+            sourceRefName: 'refs/heads/branch-a',
             title: 'branch a pr',
             state: 'open',
           } as any)
@@ -254,7 +254,7 @@ describe('platform/azure', () => {
         () =>
           ({
             number: 1,
-            head: { ref: 'branch-a' },
+            sourceRefName: 'refs/heads/branch-a',
             title: 'branch a pr',
             state: 'closed',
           } as any)
@@ -286,7 +286,7 @@ describe('platform/azure', () => {
         () =>
           ({
             number: 1,
-            head: { ref: 'branch-a' },
+            sourceRefName: 'refs/heads/branch-a',
             title: 'branch a pr',
             state: 'closed',
           } as any)
@@ -318,7 +318,7 @@ describe('platform/azure', () => {
         () =>
           ({
             number: 1,
-            head: { ref: 'branch-a' },
+            sourceRefName: 'refs/heads/branch-a',
             title: 'branch a pr',
             state: 'closed',
           } as any)


### PR DESCRIPTION
Incorrect filtering by branch name in #5008 