### PR TITLE
feat(java): use java 11 in favour of java 8.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && apt-get install -y gpg curl wget unzip xz-utils git openss
 
 ## Gradle
 
-RUN apt-get update && apt-get install -y --no-install-recommends openjdk-8-jre-headless gradle && \
+RUN apt-get update && apt-get install -y --no-install-recommends openjdk-11-jre-headless gradle && \
     rm -rf /var/lib/apt/lists/*
 
 ## Node.js


### PR DESCRIPTION
When running gradle using java 8 on a project that depends on libraries built with newer java versions, as of gradle 5.3 the renovate run breaks because of the "Automatic target JVM version" check. -->  https://docs.gradle.org/current/userguide/upgrading_version_5.html#changes_5.3

<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate

    Please ensure `Allow edits from maintainers.` checkbox is checked
-->

<!-- Replace this text with a description of what this PR fixes or adds -->

Closes # <!-- Ideally each PR should be closing an open issue -->
