### PR TITLE
chore: run linux tests first

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,8 +18,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        # linux tests run by circle-ci
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         node-version: [10.x, 12.x]
         python-version: [3.8]
 


### PR DESCRIPTION
Linux tests are faster, so thes should com first and they (hopefully) don't get canceled by broken windows tests