### PR TITLE
fix(bundler): update common complex ranges correctly

### DIFF
--- a/lib/versioning/ruby/strategies/replace.ts
+++ b/lib/versioning/ruby/strategies/replace.ts
@@ -1,23 +1,74 @@
 import { satisfies } from '@snyk/ruby-semver';
 import bump from './bump';
+import { logger } from '../../../logger';
+
+function countInstancesOf(str: string, char: string): number {
+  return str.split(char).length - 1;
+}
+
+function isCommonRubyMajorRange(range: string): boolean {
+  const splitRange = range.split(',').map(part => part.trim());
+  return (
+    splitRange.length === 2 &&
+    splitRange[0].startsWith('~>') &&
+    countInstancesOf(splitRange[0], '.') === 1 &&
+    splitRange[1].startsWith('>=')
+  );
+}
+
+function isCommonRubyMinorRange(range: string): boolean {
+  const splitRange = range.split(',').map(part => part.trim());
+  return (
+    splitRange.length === 2 &&
+    splitRange[0].startsWith('~>') &&
+    countInstancesOf(splitRange[0], '.') === 2 &&
+    splitRange[1].startsWith('>=')
+  );
+}
+
+function reduceOnePrecision(version: string): string {
+  const versionParts = version.split('.');
+  // istanbul ignore if
+  if (versionParts.length === 1) return version;
+  versionParts.pop();
+  return versionParts.join('.');
+}
 
 export default ({ to, range }: { range: string; to: string }): string => {
   if (satisfies(to, range)) {
     return range;
   }
-  const lastPart = range
-    .split(',')
-    .map(part => part.trim())
-    .pop();
-  const lastPartPrecision = lastPart.split('.').length;
-  const toPrecision = to.split('.').length;
-  let massagedTo: string = to;
-  if (!lastPart.startsWith('<') && toPrecision > lastPartPrecision) {
-    massagedTo = to
-      .split('.')
-      .slice(0, lastPartPrecision)
-      .join('.');
+  let newRange;
+  if (isCommonRubyMajorRange(range)) {
+    const firstPart = reduceOnePrecision(to);
+    newRange = `~> ${firstPart}, >= ${to}`;
+  } else if (isCommonRubyMinorRange(range)) {
+    const firstPart = reduceOnePrecision(to) + '.0';
+    newRange = `~> ${firstPart}, >= ${to}`;
+  } else {
+    const lastPart = range
+      .split(',')
+      .map(part => part.trim())
+      .pop();
+    const lastPartPrecision = lastPart.split('.').length;
+    const toPrecision = to.split('.').length;
+    let massagedTo: string = to;
+    if (!lastPart.startsWith('<') && toPrecision > lastPartPrecision) {
+      massagedTo = to
+        .split('.')
+        .slice(0, lastPartPrecision)
+        .join('.');
+    }
+    const newLastPart = bump({ to: massagedTo, range: lastPart });
+    newRange = range.replace(lastPart, newLastPart);
   }
-  const newLastPart = bump({ to: massagedTo, range: lastPart });
-  return range.replace(lastPart, newLastPart);
+  // istanbul ignore if
+  if (!satisfies(to, newRange)) {
+    logger.warn(
+      { range, to, newRange },
+      'Ruby versioning getNewValue problem: to version is not satisfied by new range'
+    );
+    return range;
+  }
+  return newRange;
 };

--- a/test/versioning/ruby.spec.ts
+++ b/test/versioning/ruby.spec.ts
@@ -403,6 +403,11 @@ describe('semverRuby', () => {
         semverRuby.getNewValue('>= 3.2, < 5.0', 'replace', '4.0.2', '6.0.1')
       ).toMatchSnapshot();
     });
+    it('handles updates to bundler common complex ranges', () => {
+      expect(
+        semverRuby.getNewValue('~> 5.2, >= 5.2.5', 'replace', '5.3.0', '6.0.1')
+      ).toEqual('~> 6.0, >= 6.0.1');
+    });
 
     it('returns correct version for replace strategy', () => {
       [

--- a/test/versioning/ruby.spec.ts
+++ b/test/versioning/ruby.spec.ts
@@ -403,10 +403,20 @@ describe('semverRuby', () => {
         semverRuby.getNewValue('>= 3.2, < 5.0', 'replace', '4.0.2', '6.0.1')
       ).toMatchSnapshot();
     });
-    it('handles updates to bundler common complex ranges', () => {
+    it('handles updates to bundler common complex ranges major', () => {
       expect(
         semverRuby.getNewValue('~> 5.2, >= 5.2.5', 'replace', '5.3.0', '6.0.1')
       ).toEqual('~> 6.0, >= 6.0.1');
+    });
+    it('handles updates to bundler common complex ranges minor', () => {
+      expect(
+        semverRuby.getNewValue(
+          '~> 5.2.0, >= 5.2.5',
+          'replace',
+          '5.2.5',
+          '5.3.1'
+        )
+      ).toEqual('~> 5.3.0, >= 5.3.1');
     });
 
     it('returns correct version for replace strategy', () => {


### PR DESCRIPTION
Adds custom logic to detect and update common Ruby constraints like `~> 5.2, >= 5.2.5`. Also adds a check for impossible/incorrect ranges and does not use them if generated.

Closes #5050
