### PR TITLE
Add failing test case

### DIFF
--- a/test/manager/gradle/build-gradle.spec.ts
+++ b/test/manager/gradle/build-gradle.spec.ts
@@ -333,4 +333,14 @@ describe('lib/manager/gradle/updateGradleVersion', () => {
     );
     expect(updatedGradleFile).toEqual('val mysqlVersion by extra { "7.0.0" }');
   });
+  
+   it('returns no file updated if qualifier with ommitted version is defined - falsely replaces qualifier with new version', () => {
+    const gradleFile = "runtime (  'mysql:mysql-connector-java::mockServer'  )";
+    const updatedGradleFile = updateGradleVersion(
+      gradleFile,
+      { group: 'mysql', name: 'mysql-connector-java', version: '6.0.5' },
+      '7.0.0'
+    );
+    expect(updatedGradleFile).toEqual(gradleFile);
+  });
 });


### PR DESCRIPTION
In gradle qualifier dependencies can be used. e.g. testBuilder, when used in combination with contraints, the version can be ommited.  e.g: mysql:mysql-connector-java::mockServer is a valid definition. It's version is determined by a contraint

 dependencies {
            implementation "mysql:mysql-connector-java::mockServer"
            constraints {
                implementation "mysql:mysql-connector-java:6.0.5"
            }
 }

renovate updates this when a new version is found. mysql:mysql-connector-java::mockServer -> mysql:mysql-connector-java:7.0.0 which it shouldn't.

If added a testcase, but cannot do the actual fix.

<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate

    Please ensure `Allow edits from maintainers.` checkbox is checked
-->

<!-- Replace this text with a description of what this PR fixes or adds -->

Closes # <!-- Ideally each PR should be closing an open issue -->
