### PR TITLE
fix: skip empty commits

### DIFF
--- a/lib/platform/git/storage.ts
+++ b/lib/platform/git/storage.ts
@@ -528,10 +528,11 @@ export class Storage {
       }
       await this._git!.commit(message);
       if (!(await this.hasDiff(`origin/${branchName}`))) {
-        logger.warn(
+        logger.info(
           { branchName, fileNames },
-          'No file changes detected. Is this an empty force push?'
+          'No file changes detected. Skipping commit'
         );
+        return;
       }
       await this._git!.push('origin', `${branchName}:${branchName}`, {
         '--force': true,


### PR DESCRIPTION
Skips the git commit force push if git returns no diff between the local branch and server branch of the same name.

Closes #5009, Closes #5083, Closes #5074