### PR TITLE
test: Add test fixture with PEP440 versions for Poetry

### DIFF
--- a/test/manager/poetry/__snapshots__/extract.spec.ts.snap
+++ b/test/manager/poetry/__snapshots__/extract.spec.ts.snap
@@ -164,6 +164,317 @@ Array [
 ]
 `;
 
+exports[`lib/manager/poetry/extract extractPackageFile() extracts pep440 dependencies 1`] = `
+Array [
+  Object {
+    "currentValue": "0.2",
+    "datasource": "pypi",
+    "depName": "dep1",
+    "depType": "dependencies",
+    "managerData": Object {
+      "nestedVersion": false,
+    },
+  },
+  Object {
+    "currentValue": "1.1.0",
+    "datasource": "pypi",
+    "depName": "dep2",
+    "depType": "dependencies",
+    "managerData": Object {
+      "nestedVersion": false,
+    },
+  },
+  Object {
+    "currentValue": "1.0a1",
+    "datasource": "pypi",
+    "depName": "dep3",
+    "depType": "dependencies",
+    "managerData": Object {
+      "nestedVersion": false,
+    },
+  },
+  Object {
+    "currentValue": "1.0b2",
+    "datasource": "pypi",
+    "depName": "dep4",
+    "depType": "dependencies",
+    "managerData": Object {
+      "nestedVersion": false,
+    },
+  },
+  Object {
+    "currentValue": "1.0rc1",
+    "datasource": "pypi",
+    "depName": "dep5",
+    "depType": "dependencies",
+    "managerData": Object {
+      "nestedVersion": false,
+    },
+  },
+  Object {
+    "currentValue": "1.0.dev4",
+    "datasource": "pypi",
+    "depName": "dep6",
+    "depType": "dependencies",
+    "managerData": Object {
+      "nestedVersion": false,
+    },
+  },
+  Object {
+    "currentValue": "1.0c1",
+    "datasource": "pypi",
+    "depName": "dep7",
+    "depType": "dependencies",
+    "managerData": Object {
+      "nestedVersion": false,
+    },
+  },
+  Object {
+    "currentValue": "2012.2",
+    "datasource": "pypi",
+    "depName": "dep8",
+    "depType": "dependencies",
+    "managerData": Object {
+      "nestedVersion": false,
+    },
+  },
+  Object {
+    "currentValue": "1.0.dev456",
+    "datasource": "pypi",
+    "depName": "dep9",
+    "depType": "dependencies",
+    "managerData": Object {
+      "nestedVersion": false,
+    },
+  },
+  Object {
+    "currentValue": "1.0a1",
+    "datasource": "pypi",
+    "depName": "dep10",
+    "depType": "dependencies",
+    "managerData": Object {
+      "nestedVersion": false,
+    },
+  },
+  Object {
+    "currentValue": "1.0a2.dev456",
+    "datasource": "pypi",
+    "depName": "dep11",
+    "depType": "dependencies",
+    "managerData": Object {
+      "nestedVersion": false,
+    },
+  },
+  Object {
+    "currentValue": "1.0a12.dev456",
+    "datasource": "pypi",
+    "depName": "dep12",
+    "depType": "dependencies",
+    "managerData": Object {
+      "nestedVersion": false,
+    },
+  },
+  Object {
+    "currentValue": "1.0a12",
+    "datasource": "pypi",
+    "depName": "dep13",
+    "depType": "dependencies",
+    "managerData": Object {
+      "nestedVersion": false,
+    },
+  },
+  Object {
+    "currentValue": "1.0b1.dev456",
+    "datasource": "pypi",
+    "depName": "dep14",
+    "depType": "dependencies",
+    "managerData": Object {
+      "nestedVersion": false,
+    },
+  },
+  Object {
+    "currentValue": "1.0b2",
+    "datasource": "pypi",
+    "depName": "dep15",
+    "depType": "dependencies",
+    "managerData": Object {
+      "nestedVersion": false,
+    },
+  },
+  Object {
+    "currentValue": "1.0b2.post345.dev456",
+    "datasource": "pypi",
+    "depName": "dep16",
+    "depType": "dependencies",
+    "managerData": Object {
+      "nestedVersion": false,
+    },
+  },
+  Object {
+    "currentValue": "1.0b2.post345",
+    "datasource": "pypi",
+    "depName": "dep17",
+    "depType": "dependencies",
+    "managerData": Object {
+      "nestedVersion": false,
+    },
+  },
+  Object {
+    "currentValue": "1.0rc1.dev456",
+    "datasource": "pypi",
+    "depName": "dep18",
+    "depType": "dependencies",
+    "managerData": Object {
+      "nestedVersion": false,
+    },
+  },
+  Object {
+    "currentValue": "1.0rc1",
+    "datasource": "pypi",
+    "depName": "dep19",
+    "depType": "dependencies",
+    "managerData": Object {
+      "nestedVersion": false,
+    },
+  },
+  Object {
+    "currentValue": "1.0",
+    "datasource": "pypi",
+    "depName": "dep20",
+    "depType": "dependencies",
+    "managerData": Object {
+      "nestedVersion": false,
+    },
+  },
+  Object {
+    "currentValue": "1.0+abc.5",
+    "datasource": "pypi",
+    "depName": "dep21",
+    "depType": "dependencies",
+    "managerData": Object {
+      "nestedVersion": false,
+    },
+  },
+  Object {
+    "currentValue": "1.0+abc.7",
+    "datasource": "pypi",
+    "depName": "dep22",
+    "depType": "dependencies",
+    "managerData": Object {
+      "nestedVersion": false,
+    },
+  },
+  Object {
+    "currentValue": "1.0+5",
+    "datasource": "pypi",
+    "depName": "dep23",
+    "depType": "dependencies",
+    "managerData": Object {
+      "nestedVersion": false,
+    },
+  },
+  Object {
+    "currentValue": "1.0.post456.dev34",
+    "datasource": "pypi",
+    "depName": "dep24",
+    "depType": "dependencies",
+    "managerData": Object {
+      "nestedVersion": false,
+    },
+  },
+  Object {
+    "currentValue": "1.0.post456",
+    "datasource": "pypi",
+    "depName": "dep25",
+    "depType": "dependencies",
+    "managerData": Object {
+      "nestedVersion": false,
+    },
+  },
+  Object {
+    "currentValue": "1.1.dev1",
+    "datasource": "pypi",
+    "depName": "dep26",
+    "depType": "dependencies",
+    "managerData": Object {
+      "nestedVersion": false,
+    },
+  },
+  Object {
+    "currentValue": "~=3.1",
+    "datasource": "pypi",
+    "depName": "dep27",
+    "depType": "dependencies",
+    "managerData": Object {
+      "nestedVersion": false,
+    },
+  },
+  Object {
+    "currentValue": "~=3.1.2",
+    "datasource": "pypi",
+    "depName": "dep28",
+    "depType": "dependencies",
+    "managerData": Object {
+      "nestedVersion": false,
+    },
+  },
+  Object {
+    "currentValue": "~=3.1a1",
+    "datasource": "pypi",
+    "depName": "dep29",
+    "depType": "dependencies",
+    "managerData": Object {
+      "nestedVersion": false,
+    },
+  },
+  Object {
+    "currentValue": "==3.1",
+    "datasource": "pypi",
+    "depName": "dep30",
+    "depType": "dependencies",
+    "managerData": Object {
+      "nestedVersion": false,
+    },
+  },
+  Object {
+    "currentValue": "==3.1.*",
+    "datasource": "pypi",
+    "depName": "dep31",
+    "depType": "dependencies",
+    "managerData": Object {
+      "nestedVersion": false,
+    },
+  },
+  Object {
+    "currentValue": "~=3.1.0, !=3.1.3",
+    "datasource": "pypi",
+    "depName": "dep32",
+    "depType": "dependencies",
+    "managerData": Object {
+      "nestedVersion": false,
+    },
+  },
+  Object {
+    "currentValue": "<=2.0",
+    "datasource": "pypi",
+    "depName": "dep33",
+    "depType": "dependencies",
+    "managerData": Object {
+      "nestedVersion": false,
+    },
+  },
+  Object {
+    "currentValue": "<2.0",
+    "datasource": "pypi",
+    "depName": "dep34",
+    "depType": "dependencies",
+    "managerData": Object {
+      "nestedVersion": false,
+    },
+  },
+]
+`;
+
 exports[`lib/manager/poetry/extract extractPackageFile() extracts registries 1`] = `
 Array [
   "https://foo.bar/simple/",

--- a/test/manager/poetry/_fixtures/pyproject.9.toml
+++ b/test/manager/poetry/_fixtures/pyproject.9.toml
@@ -1,0 +1,41 @@
+[tool.poetry]
+name = "example 9"
+version = "0.1.0"
+description = ""
+authors = ["John Doe <john.doe@gmail.com>"]
+
+[tool.poetry.dependencies]
+dep1 = "0.2"
+dep2 = "1.1.0"
+dep3 = "1.0a1"
+dep4 = "1.0b2"
+dep5 = "1.0rc1"
+dep6 = "1.0.dev4"
+dep7 = "1.0c1"
+dep8 = "2012.2"
+dep9 = "1.0.dev456"
+dep10 = "1.0a1"
+dep11 = "1.0a2.dev456"
+dep12 = "1.0a12.dev456"
+dep13 = "1.0a12"
+dep14 = "1.0b1.dev456"
+dep15 = "1.0b2"
+dep16 = "1.0b2.post345.dev456"
+dep17 = "1.0b2.post345"
+dep18 = "1.0rc1.dev456"
+dep19 = "1.0rc1"
+dep20 = "1.0"
+dep21 = "1.0+abc.5"
+dep22 = "1.0+abc.7"
+dep23 = "1.0+5"
+dep24 = "1.0.post456.dev34"
+dep25 = "1.0.post456"
+dep26 = "1.1.dev1"
+dep27 = "~=3.1" # version 3.1 or later, but not version 4.0 or later.
+dep28 = "~=3.1.2" # version 3.1.2 or later, but not version 3.2.0 or later.
+dep29 = "~=3.1a1" # version 3.1a1 or later, but not version 4.0 or later.
+dep30 = "==3.1" # specifically version 3.1 (or 3.1.0), excludes all pre-releases, post releases, developmental releases and any 3.1.x maintenance releases.
+dep31 = "==3.1.*" # any version that starts with 3.1. Equivalent to the ~=3.1.0 compatible release clause.
+dep32 = "~=3.1.0, !=3.1.3" # version 3.1.0 or later, but not version 3.1.3 and not version 3.2.0 or later.
+dep33 = "<=2.0"
+dep34 = "<2.0"

--- a/test/manager/poetry/extract.spec.ts
+++ b/test/manager/poetry/extract.spec.ts
@@ -41,6 +41,11 @@ const pyproject8toml = readFileSync(
   'utf8'
 );
 
+const pyproject9toml = readFileSync(
+  'test/manager/poetry/_fixtures/pyproject.9.toml',
+  'utf8'
+);
+
 describe('lib/manager/poetry/extract', () => {
   describe('extractPackageFile()', () => {
     let filename: string;
@@ -124,6 +129,11 @@ describe('lib/manager/poetry/extract', () => {
       expect(res[0].currentValue).toBe('1.2.3');
       expect(res[0].skipReason).toBe('path-dependency');
       expect(res).toHaveLength(2);
+    });
+    it('extracts pep440 dependencies', () => {
+      const res = extractPackageFile(pyproject9toml, filename);
+      expect(res.deps).toMatchSnapshot();
+      expect(res.deps).toHaveLength(34);
     });
   });
 });


### PR DESCRIPTION
This PR adds a test fixture for the Poetry manager that uses [PEP440](https://www.python.org/dev/peps/pep-0440/) versions that should be valid versions. 

It is related to #5011.

The test suite should fail.
