### PR TITLE
feat(gradle): Support template expression for version variables in gradle

### DIFF
--- a/lib/manager/gradle/build-gradle.ts
+++ b/lib/manager/gradle/build-gradle.ts
@@ -22,10 +22,12 @@ interface UpdateFunction {
   ): string;
 }
 
+const groovyQuotes = `(?:["'](?:""|'')?)`;
+
 // https://github.com/patrikerdes/gradle-use-latest-versions-plugin/blob/8cf9c3917b8b04ba41038923cab270d2adda3aa6/src/main/groovy/se/patrikerdes/DependencyUpdate.groovy#L27-L29
 function moduleStringVersionFormatMatch(dependency: GradleDependency): RegExp {
   return new RegExp(
-    `(["']${dependency.group}:${dependency.name}:)[^$].*?(([:@].*?)?["'])`
+    `(${groovyQuotes}${dependency.group}:${dependency.name}:)[^$].*?(([:@].*?)?${groovyQuotes})`
   );
 }
 
@@ -33,7 +35,7 @@ function groovyPluginStringVersionFormatMatch(
   dependency: GradleDependency
 ): RegExp {
   return new RegExp(
-    `(id\\s+["']${dependency.group}["']\\s+version\\s+["'])[^$].*?(["'])`
+    `(id\\s+${groovyQuotes}${dependency.group}${groovyQuotes}\\s+version\\s+${groovyQuotes})[^$].*?(${groovyQuotes})`
   );
 }
 
@@ -48,9 +50,9 @@ function kotlinPluginStringVersionFormatMatch(
 function moduleMapVersionFormatMatch(dependency: GradleDependency): RegExp {
   // prettier-ignore
   return new RegExp(
-    `(group\\s*:\\s*["']${dependency.group}["']\\s*,\\s*` +
-    `name\\s*:\\s*["']${dependency.name}["']\\s*,\\s*` +
-    `version\\s*:\\s*["']).*?(["'])`
+    `(group\\s*:\\s*${groovyQuotes}${dependency.group}${groovyQuotes}\\s*,\\s*` +
+    `name\\s*:\\s*${groovyQuotes}${dependency.name}${groovyQuotes}\\s*,\\s*` +
+    `version\\s*:\\s*${groovyQuotes})[^{}$"']+?(${groovyQuotes})`
   );
 }
 
@@ -61,7 +63,7 @@ function moduleKotlinNamedArgumentVersionFormatMatch(
   return new RegExp(
     `(group\\s*=\\s*"${dependency.group}"\\s*,\\s*` +
     `name\\s*=\\s*"${dependency.name}"\\s*,\\s*` +
-    `version\\s*=\\s*").*?(")`
+    `version\\s*=\\s*")[^{}$]*?(")`
   );
 }
 
@@ -70,9 +72,9 @@ function moduleMapVariableVersionFormatMatch(
 ): RegExp {
   // prettier-ignore
   return new RegExp(
-    `group\\s*:\\s*["']${dependency.group}["']\\s*,\\s*` +
-    `name\\s*:\\s*["']${dependency.name}["']\\s*,\\s*` +
-    `version\\s*:\\s*([^\\s"')]+)\\s*`
+    `group\\s*:\\s*${groovyQuotes}${dependency.group}${groovyQuotes}\\s*,\\s*` +
+    `name\\s*:\\s*${groovyQuotes}${dependency.name}${groovyQuotes}\\s*,\\s*` +
+    `version\\s*:\\s*(?:${groovyQuotes}\\$)?{?([^\\s"'{}$)]+)}?${groovyQuotes}?\\s*`
   );
 }
 
@@ -83,7 +85,7 @@ function moduleKotlinNamedArgumentVariableVersionFormatMatch(
   return new RegExp(
     `group\\s*=\\s*"${dependency.group}"\\s*,\\s*` +
     `name\\s*=\\s*"${dependency.name}"\\s*,\\s*` +
-    `version\\s*=\\s*([^\\s"]+?)[\\s\\),]`
+    `version\\s*=\\s*(?:"\\$)?{?([^\\s"{}$]+?)}?"?[\\s\\),]`
   );
 }
 
@@ -91,7 +93,7 @@ function moduleStringVariableInterpolationVersionFormatMatch(
   dependency: GradleDependency
 ): RegExp {
   return new RegExp(
-    `["']${dependency.group}:${dependency.name}:\\$([^{].*?)["']`
+    `${groovyQuotes}${dependency.group}:${dependency.name}:\\$([^{].*?)${groovyQuotes}`
   );
 }
 
@@ -99,7 +101,7 @@ function moduleStringVariableExpressionVersionFormatMatch(
   dependency: GradleDependency
 ): RegExp {
   return new RegExp(
-    `["']${dependency.group}:${dependency.name}:\\$\{([^{].*?)}["']`
+    `${groovyQuotes}${dependency.group}:${dependency.name}:\\$\{([^{].*?)}${groovyQuotes}`
   );
 }
 

--- a/test/manager/gradle/build-gradle.spec.ts
+++ b/test/manager/gradle/build-gradle.spec.ts
@@ -66,7 +66,7 @@ describe('lib/manager/gradle/updateGradleVersion', () => {
     );
   });
 
-  it('returns a file updated if the version defined as map is found', () => {
+  it('returns an updated file if the version in single quotes defined as map is found', () => {
     const gradleFile = `compile group  : 'mysql'               ,
                name   : 'mysql-connector-java',
                version: '6.0.5'`;
@@ -79,6 +79,54 @@ describe('lib/manager/gradle/updateGradleVersion', () => {
       `compile group  : 'mysql'               ,
                name   : 'mysql-connector-java',
                version: '7.0.0'`
+    );
+  });
+
+  it('returns an updated file if the version in double quotes defined as map is found', () => {
+    const gradleFile = `compile group  : 'mysql'               ,
+               name   : 'mysql-connector-java',
+               version: "6.0.5"`;
+    const updatedGradleFile = updateGradleVersion(
+      gradleFile,
+      { group: 'mysql', name: 'mysql-connector-java', version: '6.0.5' },
+      '7.0.0'
+    );
+    expect(updatedGradleFile).toEqual(
+      `compile group  : 'mysql'               ,
+               name   : 'mysql-connector-java',
+               version: "7.0.0"`
+    );
+  });
+
+  it('returns an updated file if the version in triple single quotes defined as map is found', () => {
+    const gradleFile = `compile group  : 'mysql'               ,
+               name   : 'mysql-connector-java',
+               version: '''6.0.5'''`;
+    const updatedGradleFile = updateGradleVersion(
+      gradleFile,
+      { group: 'mysql', name: 'mysql-connector-java', version: '6.0.5' },
+      '7.0.0'
+    );
+    expect(updatedGradleFile).toEqual(
+      `compile group  : 'mysql'               ,
+               name   : 'mysql-connector-java',
+               version: '''7.0.0'''`
+    );
+  });
+
+  it('returns an updated file if the version in triple double quotes defined as map is found', () => {
+    const gradleFile = `compile group  : 'mysql'               ,
+               name   : 'mysql-connector-java',
+               version: """6.0.5"""`;
+    const updatedGradleFile = updateGradleVersion(
+      gradleFile,
+      { group: 'mysql', name: 'mysql-connector-java', version: '6.0.5' },
+      '7.0.0'
+    );
+    expect(updatedGradleFile).toEqual(
+      `compile group  : 'mysql'               ,
+               name   : 'mysql-connector-java',
+               version: """7.0.0"""`
     );
   });
 
@@ -146,6 +194,86 @@ describe('lib/manager/gradle/updateGradleVersion', () => {
     );
   });
 
+  it('returns an updated file if the version defined in a variable in a simple template string without curly braces as a map is found', () => {
+    const gradleFile = `String mysqlVersion = "6.0.5"
+               compile group  : 'mysql'               ,
+               name           : 'mysql-connector-java',
+               version        : "$mysqlVersion"
+               `;
+    const updatedGradleFile = updateGradleVersion(
+      gradleFile,
+      { group: 'mysql', name: 'mysql-connector-java', version: '6.0.5' },
+      '7.0.0'
+    );
+    expect(updatedGradleFile).toEqual(
+      `String mysqlVersion = "7.0.0"
+               compile group  : 'mysql'               ,
+               name           : 'mysql-connector-java',
+               version        : "$mysqlVersion"
+               `
+    );
+  });
+
+  it('returns an updated file if the version defined in a variable in a simple template string with curly braces as a map is found', () => {
+    const gradleFile = `String mysqlVersion = "6.0.5"
+               compile group  : 'mysql'               ,
+               name           : 'mysql-connector-java',
+               version        : "\${mysqlVersion}"
+               `;
+    const updatedGradleFile = updateGradleVersion(
+      gradleFile,
+      { group: 'mysql', name: 'mysql-connector-java', version: '6.0.5' },
+      '7.0.0'
+    );
+    expect(updatedGradleFile).toEqual(
+      `String mysqlVersion = "7.0.0"
+               compile group  : 'mysql'               ,
+               name           : 'mysql-connector-java',
+               version        : "\${mysqlVersion}"
+               `
+    );
+  });
+
+  it('returns an updated file if the version defined in a variable in a triple template string without curly braces as a map is found', () => {
+    const gradleFile = `String mysqlVersion = "6.0.5"
+               compile group  : 'mysql'               ,
+               name           : 'mysql-connector-java',
+               version        : """$mysqlVersion"""
+               `;
+    const updatedGradleFile = updateGradleVersion(
+      gradleFile,
+      { group: 'mysql', name: 'mysql-connector-java', version: '6.0.5' },
+      '7.0.0'
+    );
+    expect(updatedGradleFile).toEqual(
+      `String mysqlVersion = "7.0.0"
+               compile group  : 'mysql'               ,
+               name           : 'mysql-connector-java',
+               version        : """$mysqlVersion"""
+               `
+    );
+  });
+
+  it('returns an updated file if the version defined in a variable in a triple template string with curly braces as a map is found', () => {
+    const gradleFile = `String mysqlVersion = "6.0.5"
+               compile group  : 'mysql'               ,
+               name           : 'mysql-connector-java',
+               version        : """\${mysqlVersion}"""
+               `;
+    const updatedGradleFile = updateGradleVersion(
+      gradleFile,
+      { group: 'mysql', name: 'mysql-connector-java', version: '6.0.5' },
+      '7.0.0'
+    );
+    expect(updatedGradleFile).toEqual(
+      `String mysqlVersion = "7.0.0"
+               compile group  : 'mysql'               ,
+               name           : 'mysql-connector-java',
+               version        : """\${mysqlVersion}"""
+               `
+    );
+  });
+
   it('should returns a file updated if the version defined in a variable as a Kotlin named argument is found', () => {
     const gradleFile = `val mysqlVersion = "6.0.5"
                compile(group = "mysql"               ,
@@ -162,6 +290,46 @@ describe('lib/manager/gradle/updateGradleVersion', () => {
                compile(group = "mysql"               ,
                name          = "mysql-connector-java",
                version       = mysqlVersion)
+               `
+    );
+  });
+
+  it('returns an updated file if the version defined in a variable in a template string without curly braces as a Kotlin named argument is found', () => {
+    const gradleFile = `val mysqlVersion = "6.0.5"
+               compile(group = "mysql"               ,
+               name          = "mysql-connector-java",
+               version       = "$mysqlVersion")
+               `;
+    const updatedGradleFile = updateGradleVersion(
+      gradleFile,
+      { group: 'mysql', name: 'mysql-connector-java', version: '6.0.5' },
+      '7.0.0'
+    );
+    expect(updatedGradleFile).toEqual(
+      `val mysqlVersion = "7.0.0"
+               compile(group = "mysql"               ,
+               name          = "mysql-connector-java",
+               version       = "$mysqlVersion")
+               `
+    );
+  });
+
+  it('returns an updated file if the version defined in a variable in a template string with curly braces as a Kotlin named argument is found', () => {
+    const gradleFile = `val mysqlVersion = "6.0.5"
+               compile(group = "mysql"               ,
+               name          = "mysql-connector-java",
+               version       = "\${mysqlVersion}")
+               `;
+    const updatedGradleFile = updateGradleVersion(
+      gradleFile,
+      { group: 'mysql', name: 'mysql-connector-java', version: '6.0.5' },
+      '7.0.0'
+    );
+    expect(updatedGradleFile).toEqual(
+      `val mysqlVersion = "7.0.0"
+               compile(group = "mysql"               ,
+               name          = "mysql-connector-java",
+               version       = "\${mysqlVersion}")
                `
     );
   });


### PR DESCRIPTION
<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate

    Please ensure `Allow edits from maintainers.` checkbox is checked
-->
Supports using string interpolation for the version if using Gradle’s map or named arguments syntax.

As the other regexes, the matching is quite loose and will match some (mostly syntactically invalid) other cases. But I think they will not create relevant false positives.

Also adds support for Groovy’s three-quotes-string (`'''` and `"""`). Supporting them properly was required to differentiate correctly between literals and variables. I then added the support throughout the file.
<!-- Replace this text with a description of what this PR fixes or adds -->

Closes #4838  <!-- Ideally each PR should be closing an open issue -->
