### PR TITLE
fix(pypi): detect pypi releases with underscores

### DIFF
--- a/lib/datasource/pypi/index.ts
+++ b/lib/datasource/pypi/index.ts
@@ -85,10 +85,12 @@ function extractVersionFromLinkText(
   text: string,
   depName: string
 ): string | null {
-  const prefix = `${depName}-`;
-  const suffix = '.tar.gz';
-  if (text.startsWith(prefix) && text.endsWith(suffix)) {
-    return text.replace(prefix, '').replace(/\.tar\.gz$/, '');
+  const srcPrefixes = [`${depName}-`, `${depName.replace(/-/g, '_')}-`];
+  for (const prefix of srcPrefixes) {
+    const suffix = '.tar.gz';
+    if (text.startsWith(prefix) && text.endsWith(suffix)) {
+      return text.replace(prefix, '').replace(/\.tar\.gz$/, '');
+    }
   }
 
   // pep-0427 wheel packages

--- a/test/datasource/__snapshots__/pypi.spec.ts.snap
+++ b/test/datasource/__snapshots__/pypi.spec.ts.snap
@@ -80,6 +80,16 @@ Object {
 }
 `;
 
+exports[`datasource/pypi getPkgReleases process data from simple endpoint with hyphens replaced with underscores 1`] = `
+Object {
+  "releases": Array [
+    Object {
+      "version": "0.0.5",
+    },
+  ],
+}
+`;
+
 exports[`datasource/pypi getPkgReleases processes real data 1`] = `
 Object {
   "releases": Array [

--- a/test/datasource/pypi.spec.ts
+++ b/test/datasource/pypi.spec.ts
@@ -16,6 +16,9 @@ const htmlResponse = fs.readFileSync(
 const badResponse = fs.readFileSync(
   'test/datasource/pypi/_fixtures/versions-html-badfile.html'
 );
+const mixedHyphensResponse = fs.readFileSync(
+  'test/datasource/pypi/_fixtures/versions-html-mixed-hyphens.html'
+);
 
 describe('datasource/pypi', () => {
   describe('getPkgReleases', () => {
@@ -200,6 +203,22 @@ describe('datasource/pypi', () => {
           compatibility: { python: '2.7' },
           datasource: DATASOURCE_PYPI,
           depName: 'dj-database-url',
+        })
+      ).toMatchSnapshot();
+    });
+    it('process data from simple endpoint with hyphens replaced with underscores', async () => {
+      got.mockReturnValueOnce({
+        body: mixedHyphensResponse + '',
+      });
+      const config = {
+        registryUrls: ['https://pypi.org/simple/'],
+      };
+      expect(
+        await datasource.getPkgReleases({
+          ...config,
+          compatibility: { python: '2.7' },
+          datasource: DATASOURCE_PYPI,
+          depName: 'image-collector',
         })
       ).toMatchSnapshot();
     });

--- a/test/datasource/pypi/_fixtures/versions-html-mixed-hyphens.html
+++ b/test/datasource/pypi/_fixtures/versions-html-mixed-hyphens.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html><head>
+<meta http-equiv="content-type" content="text/html; charset=UTF-8">
+    <title>Links for image-collector</title>
+  </head>
+  <body>
+    <h1>Links for image-collector</h1>
+    <a href="https://files.pythonhosted.org/packages/51/c0/77ecbdbea16c542b4e86eee4b5651474a8f1d109e073f4ef9d6c623c272a/image_collector-0.0.5.tar.gz#sha256=5222ffadfe6aad36c3d2923ce767377aebca76f254b904be6b0e962dabe20573">image_collector-0.0.5.tar.gz</a><br>
+    
+
+</body></html>
+<!--SERIAL 5311541-->


### PR DESCRIPTION
If a pypi package:
 - Has only src releases
 - Has an index name with hyphens
 - Has src tarballs with underscores
Then releases of the package weren't being detected.
