### PR TITLE
refactor(exec): Explicit `extraEnv` defaults and nullable docker commands

### DIFF
--- a/lib/util/exec/docker/index.ts
+++ b/lib/util/exec/docker/index.ts
@@ -3,7 +3,7 @@ import {
   VolumesPair,
   DockerOptions,
   ExecConfig,
-  DockerExtraCommands,
+  Opt,
   rawExec,
 } from '../common';
 import { logger } from '../../../logger';
@@ -57,7 +57,7 @@ function prepareVolumes(volumes: VolumeOption[] = []): string[] {
   });
 }
 
-function prepareCommands(commands: DockerExtraCommands = []): string[] {
+function prepareCommands(commands: Opt<string>[]): string[] {
   return commands.filter(command => command && typeof command === 'string');
 }
 
@@ -66,15 +66,10 @@ export async function generateDockerCommand(
   options: DockerOptions,
   config: ExecConfig
 ): Promise<string> {
-  const {
-    image,
-    tag,
-    envVars,
-    cwd,
-    volumes = [],
-    preCommands,
-    postCommands,
-  } = options;
+  const { image, tag, envVars, cwd } = options;
+  const volumes = options.volumes || [];
+  const preCommands = options.preCommands || [];
+  const postCommands = options.postCommands || [];
   const { localDir, cacheDir, dockerUser } = config;
 
   const result = ['docker run --rm'];

--- a/lib/util/exec/index.ts
+++ b/lib/util/exec/index.ts
@@ -41,7 +41,12 @@ function createChildEnv(
   env: NodeJS.ProcessEnv,
   extraEnv: ExtraEnv
 ): ExtraEnv<string> {
-  const extraEnvKeys = Object.keys(extraEnv || {});
+  const extraEnvEntries = Object.entries({ ...extraEnv }).filter(([_, val]) => {
+    if (val === null) return false;
+    if (val === undefined) return false;
+    return true;
+  });
+  const extraEnvKeys = Object.keys(extraEnvEntries);
 
   const childEnv =
     env || extraEnv
@@ -66,7 +71,9 @@ function dockerEnvVars(
   childEnv: ExtraEnv<string>
 ): string[] {
   const extraEnvKeys = Object.keys(extraEnv || {});
-  return extraEnvKeys.filter(key => typeof childEnv[key] !== 'undefined');
+  return extraEnvKeys.filter(
+    key => typeof childEnv[key] === 'string' && childEnv[key].length > 0
+  );
 }
 
 export async function exec(

--- a/test/util/exec.spec.ts
+++ b/test/util/exec.spec.ts
@@ -168,7 +168,14 @@ describe(`Child process execution wrapper`, () => {
         execConfig,
         processEnv,
         inCmd,
-        inOpts: { extraEnv: { SELECTED_ENV_VAR: 'Default value' } },
+        inOpts: {
+          extraEnv: {
+            SELECTED_ENV_VAR: envMock.full.SELECTED_ENV_VAR,
+            FILTERED_ENV_VAR: null,
+            FOO: null,
+            BAR: undefined,
+          },
+        },
         outCmd,
         outOpts: [{ cwd, encoding, env: envMock.filtered }],
       },
@@ -182,7 +189,12 @@ describe(`Child process execution wrapper`, () => {
         inCmd,
         inOpts: {
           docker,
-          extraEnv: { SELECTED_ENV_VAR: 'Default value' },
+          extraEnv: {
+            SELECTED_ENV_VAR: envMock.full.SELECTED_ENV_VAR,
+            FILTERED_ENV_VAR: null,
+            FOO: null,
+            BAR: undefined,
+          },
           cwd,
         },
         outCmd: [
@@ -190,24 +202,6 @@ describe(`Child process execution wrapper`, () => {
           `docker run --rm ${defaultVolumes} -e SELECTED_ENV_VAR ${defaultCwd} ${image} bash -l -c "${inCmd}"`,
         ],
         outOpts: [dockerPullOpts, { cwd, encoding, env: envMock.filtered }],
-      },
-    ],
-
-    [
-      'Extra env vars with empty values',
-      {
-        execConfig,
-        processEnv,
-        inCmd,
-        inOpts: {
-          extraEnv: {
-            SELECTED_ENV_VAR: null, // pick from process.env
-            FOO: null,
-            BAR: undefined,
-          },
-        },
-        outCmd,
-        outOpts: [{ cwd, encoding, env: envMock.filtered }],
       },
     ],
 
@@ -323,6 +317,30 @@ describe(`Child process execution wrapper`, () => {
         outCmd: [
           dockerPullCmd,
           `docker run --rm ${defaultVolumes} -w "${cwd}" ${image} bash -l -c "preCommand1 && preCommand2 && ${inCmd} && postCommand1 && postCommand2"`,
+        ],
+        outOpts: [dockerPullOpts, { cwd, encoding, env: envMock.basic }],
+      },
+    ],
+
+    [
+      'Docker commands are nullable',
+      {
+        execConfig: {
+          ...execConfig,
+          binarySource: BinarySource.Docker,
+        },
+        processEnv,
+        inCmd,
+        inOpts: {
+          docker: {
+            image,
+            preCommands: null,
+            postCommands: undefined,
+          },
+        },
+        outCmd: [
+          dockerPullCmd,
+          `docker run --rm ${defaultVolumes} -w "${cwd}" ${image} bash -l -c "${inCmd}"`,
         ],
         outOpts: [dockerPullOpts, { cwd, encoding, env: envMock.basic }],
       },


### PR DESCRIPTION
Remove not obvious `extraEnv` default values behavior (it's better to set them explicitly).
Allow nullable pre/post commands.
These little changes would reduce usage of `if` branches in `artifacts.ts` files.

ref #2863