### PR TITLE
fix: warn if skipping release notes retrieval

### DIFF
--- a/lib/workers/pr/changelog/source-github.ts
+++ b/lib/workers/pr/changelog/source-github.ts
@@ -69,7 +69,7 @@ export async function getChangeLogJSON({
   if (!config.token) {
     logger.debug('Repository URL does not match any known hosts');
     logger.warn(
-      'No Github token has been configured. Skipping release gathering!'
+      'No github.com token has been configured. Skipping release notes retrieval'
     );
     return null;
   }

--- a/lib/workers/pr/changelog/source-github.ts
+++ b/lib/workers/pr/changelog/source-github.ts
@@ -68,6 +68,9 @@ export async function getChangeLogJSON({
   });
   if (!config.token) {
     logger.debug('Repository URL does not match any known hosts');
+    logger.warn(
+      'No Github token has been configured. Skipping release gathering!'
+    );
     return null;
   }
   const githubApiBaseURL = sourceUrl.startsWith('https://github.com/')


### PR DESCRIPTION
This PR removes the restriction which prevented the display of GH releases on the Gitlab platform.   
Other non-Github plattforms should also be affected. 

Closes #5013

Before:     
![image](https://user-images.githubusercontent.com/17493763/73137253-7e62f100-4056-11ea-9a7e-c95ccac785da.png)


After:     
![image](https://user-images.githubusercontent.com/17493763/73137260-8a4eb300-4056-11ea-8e66-f55c0bbe3b27.png)

