### PR TITLE
fix(buildkite): Support no-config plugins

### DIFF
--- a/lib/manager/buildkite/extract.ts
+++ b/lib/manager/buildkite/extract.ts
@@ -23,7 +23,7 @@ export function extractPackageFile(content: string): PackageFile | null {
         logger.debug(`serviceImageLine: "${line}"`);
         const { currentIndent } = line.match(/^(?<currentIndent>\s*)/).groups;
         const depLineMatch = line.match(
-          /^\s+(?:-\s+)?(?<depName>[^#]+)#(?<currentValue>[^:]+):/
+          /^\s+(?:-\s+)?(?<depName>[^#]+)#(?<currentValue>[^:]+)/
         );
         if (currentIndent.length <= pluginsIndent.length) {
           isPluginsSection = false;

--- a/lib/manager/buildkite/update.ts
+++ b/lib/manager/buildkite/update.ts
@@ -11,7 +11,7 @@ export function updateDependency(
     logger.debug(`buildkite.updateDependency: ${upgrade.newValue}`);
     const lines = currentFileContent.split('\n');
     const lineToChange = lines[lineIdx];
-    const depLine = regEx(`^(\\s+[^#]+#)[^:]+(:.*)$`);
+    const depLine = regEx(`^(\\s+[^#]+#)[^:]+(.*)$`);
     if (!lineToChange.match(depLine)) {
       logger.debug('No image line found');
       return null;


### PR DESCRIPTION
Buildkite plugins that don't have required config options may be expressed as:

```yaml
- plugins:
    - my-plugin#v1.0.0
```

Note that there is no trailing colon; matching on it should be unnecessary given that the preceding capture groups exclude this character.
