### PR TITLE
fix(docker): Unpack access_token correctly from auth header from docker registries that support it

### DIFF
--- a/lib/datasource/docker/index.ts
+++ b/lib/datasource/docker/index.ts
@@ -134,7 +134,9 @@ async function getAuthHeaders(
     logger.trace(
       `Obtaining docker registry token for ${repository} using url ${authUrl}`
     );
-    const { access_token: token } = (await got(authUrl, opts)).body;
+    const authResponse = (await got(authUrl, opts)).body;
+
+    const token = authResponse.token || authResponse.access_token;
     // istanbul ignore if
     if (!token) {
       logger.warn('Failed to obtain docker registry token');

--- a/lib/datasource/docker/index.ts
+++ b/lib/datasource/docker/index.ts
@@ -134,7 +134,7 @@ async function getAuthHeaders(
     logger.trace(
       `Obtaining docker registry token for ${repository} using url ${authUrl}`
     );
-    const { token } = (await got(authUrl, opts)).body;
+    const { access_token: token } = (await got(authUrl, opts)).body;
     // istanbul ignore if
     if (!token) {
       logger.warn('Failed to obtain docker registry token');


### PR DESCRIPTION
<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate

    Please ensure `Allow edits from maintainers.` checkbox is checked
-->

<!-- Replace this text with a description of what this PR fixes or adds -->

Closes #5263
