### PR TITLE
improvement: maven versionScheme : match qualifiers case insensitively

### DIFF
--- a/lib/versioning/maven/compare.ts
+++ b/lib/versioning/maven/compare.ts
@@ -172,8 +172,9 @@ export enum QualifierTypes {
 }
 
 export function qualifierType(token: Token): number {
-  if (typeof token.val !== 'string') {
-    return null;
+  switch (token.type) {
+    case TYPE_NUMBER:
+      return;
   }
   const val = token.val.toLowerCase();
   if (val === 'alpha' || (token.isTransition && val === 'a')) {

--- a/lib/versioning/maven/compare.ts
+++ b/lib/versioning/maven/compare.ts
@@ -172,7 +172,10 @@ export enum QualifierTypes {
 }
 
 export function qualifierType(token: Token): number {
-  const val = token.val;
+  if (typeof token.val !== 'string') {
+    return null;
+  }
+  const val = token.val.toLowerCase();
   if (val === 'alpha' || (token.isTransition && val === 'a')) {
     return QualifierTypes.Alpha;
   }


### PR DESCRIPTION
Currently, the `maven` `versionScheme` matches qualifiers case sensitively, however there are many Maven projects that use the upper case equivalent instead, eg. `2.0.0-M3`, which is currently not detected correctly.

This PR updates `qualifierType()` to be case insensitive by calling `string.prototype.toLowerCase()` on the `Token.val` (all the qualifiers are currently lower case).