### PR TITLE
chore: group @types/jest to jest packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -46,6 +46,10 @@
     {
       "packageNames": ["semantic-release"],
       "semanticCommitType": "build"
+    },
+    {
+      "packageNames": ["@types/jest"],
+      "groupName": "jest monorepo"
     }
   ]
 }


### PR DESCRIPTION
I think we should group the `@types/jest` to the other `jest` packages.