### PR TITLE
fix(gradle): Also include buildscript repositiories

### DIFF
--- a/lib/manager/gradle/gradle-updates-report.ts
+++ b/lib/manager/gradle/gradle-updates-report.ts
@@ -41,7 +41,7 @@ allprojects {
     doLast {
         def project = ['project': project.name]
         output << project
-        def repos = (repositories + settings.pluginManagement.repositories)
+        def repos = (repositories + buildscript.repositories + settings.pluginManagement.repositories)
            .collect { "$it.url" }
            .findAll { !it.startsWith('file:') }
            .unique()


### PR DESCRIPTION
<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate

    Please ensure `Allow edits from maintainers.` checkbox is checked
-->

I have tested this fix manually: [jGleitz/atrium-ktor/pulls?pr is=closed](https://github.com/jGleitz/atrium-ktor/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aclosed). All those PRs where only created after running renovate with this fix locally.

I could not find any automated tests for this file. If somebody points me in the direction of how to test it, I will add an automated test.

Closes #5376  <!-- Ideally each PR should be closing an open issue -->
