### PR TITLE
feat(poetry): enable lock file maintenance

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -716,7 +716,7 @@ By default, Renovate will use group names in Pull Request titles only when the P
 
 ## lockFileMaintenance
 
-This feature can be used to refresh lock files and keep them up-to-date. "Maintaining" a lock file means recreating it so that every dependency version within it is updated to the latest. Supported lock files are `package-lock.json`, `yarn.lock` and `composer.lock`. Others may be added via feature request.
+This feature can be used to refresh lock files and keep them up-to-date. "Maintaining" a lock file means recreating it so that every dependency version within it is updated to the latest. Supported lock files are `package-lock.json`, `yarn.lock`, `composer.lock` and `poetry.lock`. Others may be added via feature request.
 
 This feature is disabled by default. If you wish to enable this feature then you could add this to your configuration:
 

--- a/lib/manager/poetry/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/manager/poetry/__snapshots__/artifacts.spec.ts.snap
@@ -80,3 +80,24 @@ Array [
   },
 ]
 `;
+
+exports[`.updateArtifacts() returns updated poetry.lock when doing lockfile maintenance 1`] = `
+Array [
+  Object {
+    "cmd": "poetry update --lock --no-interaction",
+    "options": Object {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": Object {
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+    },
+  },
+]
+`;

--- a/lib/manager/poetry/artifacts.spec.ts
+++ b/lib/manager/poetry/artifacts.spec.ts
@@ -116,4 +116,21 @@ describe('.updateArtifacts()', () => {
       })
     ).toMatchSnapshot();
   });
+  it('returns updated poetry.lock when doing lockfile maintenance', async () => {
+    fs.readFile.mockResolvedValueOnce('Old poetry.lock' as any);
+    const execSnapshots = mockExecAll(exec);
+    fs.readFile.mockReturnValueOnce('New poetry.lock' as any);
+    expect(
+      await updateArtifacts({
+        packageFileName: 'pyproject.toml',
+        updatedDeps: [],
+        newPackageFileContent: '{}',
+        config: {
+          ...config,
+          isLockFileMaintenance: true,
+        },
+      })
+    ).not.toBeNull();
+    expect(execSnapshots).toMatchSnapshot();
+  });
 });

--- a/lib/manager/poetry/index.ts
+++ b/lib/manager/poetry/index.ts
@@ -5,4 +5,4 @@ export { updateDependency } from './update';
 export { updateArtifacts } from './artifacts';
 
 export const language = LANGUAGE_PYTHON;
-export const supportsLockFileMaintenance = false;
+export const supportsLockFileMaintenance = true;


### PR DESCRIPTION
Implements support for the `lockFileMaintenance` option in poetry projects.

This implementation was inspired by the composer implementation of the same feature.