### PR TITLE
fix(gradle): Typecheck before accessing repositories URIs

### DIFF
--- a/lib/manager/gradle/gradle-updates-report.ts
+++ b/lib/manager/gradle/gradle-updates-report.ts
@@ -32,6 +32,7 @@ async function createRenovateGradlePlugin(localDir: string): Promise<void> {
   const content = `
 import groovy.json.JsonOutput
 import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency
+import org.gradle.api.artifacts.repositories.UrlArtifactRepository
 import java.util.concurrent.ConcurrentLinkedQueue
 
 def output = new ConcurrentLinkedQueue<>();
@@ -42,8 +43,8 @@ allprojects {
         def project = ['project': project.name]
         output << project
         def repos = (repositories + buildscript.repositories + settings.pluginManagement.repositories)
+           .findAll { it instanceof UrlArtifactRepository && it.url.scheme ==~ /https?/ }
            .collect { "$it.url" }
-           .findAll { !it.startsWith('file:') }
            .unique()
         project.repositories = repos
         def deps = (buildscript.configurations + configurations + settings.buildscript.configurations)


### PR DESCRIPTION
<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate

    Please ensure `Allow edits from maintainers.` checkbox is checked
-->

This why one should use statically typed languages.

<!-- Replace this text with a description of what this PR fixes or adds -->

Closes #5398  <!-- Ideally each PR should be closing an open issue -->
