### PR TITLE
fix(gradle): use URI in place of UrlArtifactRepository

### DIFF
--- a/lib/manager/gradle/gradle-updates-report.ts
+++ b/lib/manager/gradle/gradle-updates-report.ts
@@ -32,7 +32,7 @@ async function createRenovateGradlePlugin(localDir: string): Promise<void> {
   const content = `
 import groovy.json.JsonOutput
 import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency
-import org.gradle.api.artifacts.repositories.UrlArtifactRepository
+import java.net.URI
 import java.util.concurrent.ConcurrentLinkedQueue
 
 def output = new ConcurrentLinkedQueue<>();
@@ -43,7 +43,7 @@ allprojects {
         def project = ['project': project.name]
         output << project
         def repos = (repositories + buildscript.repositories + settings.pluginManagement.repositories)
-           .findAll { it instanceof UrlArtifactRepository && it.url.scheme ==~ /https?/ }
+           .findAll { it instanceof URI && it.url.scheme ==~ /https?/ }
            .collect { "$it.url" }
            .unique()
         project.repositories = repos


### PR DESCRIPTION
Tested on gradle 5 & 6. [Internally UrlArtifactRepository is just a thin wrapper around URI
](https://github.com/JLLeitschuh/gradle/blob/master/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/UrlArtifactRepository.java)

Fixes #5424 

