### PR TITLE
chore: disable vscode omnisharp

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,5 +14,6 @@
   },
   "files.associations": {
     "Dockerfile.*": "dockerfile"
-  }
+  },
+  "omnisharp.autoStart": false
 }


### PR DESCRIPTION
we don't wat it to be run on our fixtures
