### PR TITLE
docs: add paths example

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -869,6 +869,19 @@ Path rules are convenient to use if you wish to apply configuration rules to cer
 }
 ```
 
+If you wish to limit renovate to apply configuration rules to certain files in the root repository directory, you have to use a negative pattern. For example you have multiple `package.json` and want to use `masterIssueApproval` only on the root `package.json`.
+
+```json
+{
+  "packageRules": [
+    {
+      "paths": ["!**/package.json"],
+      "masterIssueApproval": true
+    }
+  ]
+}
+```
+
 Important to know: Renovate will evaluate all `packageRules` and not stop once it gets a first match. Therefore, you should order your `packageRules` in order of importance so that later rules can override settings from earlier rules if necessary.
 
 ### allowedVersions

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -869,7 +869,7 @@ Path rules are convenient to use if you wish to apply configuration rules to cer
 }
 ```
 
-If you wish to limit renovate to apply configuration rules to certain files in the root repository directory, you have to use a minimatch pattern. For example you have multiple `package.json` and want to use `masterIssueApproval` only on the root `package.json`.
+If you wish to limit renovate to apply configuration rules to certain files in the root repository directory, you have to use `paths` with either a partial string match or a minimatch pattern. For example you have multiple `package.json` and want to use `masterIssueApproval` only on the root `package.json`:
 
 ```json
 {
@@ -1041,6 +1041,18 @@ Use this field if you want to have one or more package names patterns in your pa
 The above will configure `rangeStrategy` to `replace` for any package starting with `angular`.
 
 ### paths
+
+Renovate will match `paths` against both a partial string match or a minimatch glob pattern. If you want to avoid the partial string matching so that only glob matching is performed, wrap your string in `+(...)` like so:
+
+```
+  "paths": ["+(package.json)"],
+```
+
+The above will match only the root `package.json`, whereas the following would match any `package.json` in any subdirectory too:
+
+```
+  "paths": ["package.json"],
+```
 
 ### sourceUrlPrefixes
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -869,13 +869,13 @@ Path rules are convenient to use if you wish to apply configuration rules to cer
 }
 ```
 
-If you wish to limit renovate to apply configuration rules to certain files in the root repository directory, you have to use a negative pattern. For example you have multiple `package.json` and want to use `masterIssueApproval` only on the root `package.json`.
+If you wish to limit renovate to apply configuration rules to certain files in the root repository directory, you have to use a minimatch pattern. For example you have multiple `package.json` and want to use `masterIssueApproval` only on the root `package.json`.
 
 ```json
 {
   "packageRules": [
     {
-      "paths": ["!**/package.json"],
+      "paths": ["+(package.json)"],
       "masterIssueApproval": true
     }
   ]


### PR DESCRIPTION
Update docs to include a sample for root file only `packageRule`

ref
* renovatebot/config-help#519
* renovatebot/config-help#523 