### PR TITLE
chore(ci): add docker cache

### DIFF
--- a/.github/workflows/dockerimages.yml
+++ b/.github/workflows/dockerimages.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   PLATFORM: linux/amd64
-  CACHE_IMAGE: renovate/cache-test
+  DOCKER_REPO: renovate/cache-test
 
 jobs:
   build:
@@ -24,13 +24,14 @@ jobs:
         tag: [latest, slim]
 
     env:
-      DOCKERFILE: Dockerfile.${{ matrix.tag }}
+      DOCKER_FILE: Dockerfile.${{ matrix.tag }}
+      DOCKER_TAG: ${{ matrix.tag }}
 
     steps:
-      - name: Init env for other tags
+      - name: Overwrite env for latest tag
         if: matrix.tag == 'latest'
         run: |
-          echo "::set-env name=DOCKERFILE::Dockerfile"
+          echo "::set-env name=DOCKER_FILE::Dockerfile"
 
       - name: Set up Docker Buildx
         id: buildx
@@ -45,55 +46,27 @@ jobs:
           docker buildx build \
             --platform ${PLATFORM} \
             --output=type=docker \
-            --cache-from=${CACHE_IMAGE}:cache-${{ matrix.tag }} \
+            --cache-from=${DOCKER_REPO}:cache-${DOCKER_TAG} \
             --tag=renovate \
-            --file=./${DOCKERFILE} .
+            --file=./${DOCKER_FILE} .
+
       - name: Test the Docker image
         run: |
           docker run --rm -t renovate --version
+
       - name: Image history
         run: docker history renovate
       - name: Image size
         run: docker image ls | grep renovate
 
-  push:
-    name: Release push
-    runs-on: ubuntu-latest
-
-    needs: build
-    if: github.event_name == 'push' && github.ref == 'refs/heads/chore/docker-cache'
-
-    timeout-minutes: 20
-
-    strategy:
-      matrix:
-        tag: [latest, slim]
-
-    env:
-      DOCKERFILE: Dockerfile.${{ matrix.tag }}
-
-    steps:
-      - name: Init env for other tags
-        if: matrix.tag == 'latest'
+      - name: Push the Docker image
+        if: github.event_name == 'push' && github.ref == 'refs/heads/chore/docker-cache'
         run: |
-          echo "::set-env name=DOCKERFILE::Dockerfile"
-
-      - name: Set up Docker Buildx
-        uses: crazy-max/ghaction-docker-buildx@v1
-        with:
-          version: v0.3.1
-
-      - uses: actions/checkout@v2
-
-      - name: Log into registry
-        run: echo "${{ secrets.DOCKER_RENOVATERELEASE_TOKEN }}" | docker login -u renovaterelease --password-stdin
-
-      - name: Build the Docker image
-        run: |
+          echo "${{ secrets.DOCKER_RENOVATERELEASE_TOKEN }}" | docker login -u renovaterelease --password-stdin
           docker buildx build \
             --platform ${PLATFORM} \
             --output=type=registry \
-            --cache-from=${CACHE_IMAGE}:cache-${{ matrix.tag }} \
-            --cache-to=${CACHE_IMAGE}:cache-${{ matrix.tag }} \
-            --tag=${CACHE_IMAGE}:test-${{ matrix.tag }} \
-            --file=./${DOCKERFILE} .
+            --cache-from=${DOCKER_REPO}:cache-${DOCKER_TAG} \
+            --cache-to=${DOCKER_REPO}:cache-${DOCKER_TAG} \
+            --tag=${DOCKER_REPO}:test-${DOCKER_TAG} \
+            --file=./${DOCKER_FILE} .

--- a/.github/workflows/dockerimages.yml
+++ b/.github/workflows/dockerimages.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - chore/docker-cache
 
   pull_request:
 
@@ -60,7 +59,7 @@ jobs:
         run: docker image ls | grep renovate
 
       - name: Push the Docker image
-        if: github.event_name == 'push' && github.ref == 'refs/heads/chore/docker-cache'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: |
           echo "${{ secrets.DOCKER_RENOVATERELEASE_TOKEN }}" | docker login -u renovaterelease --password-stdin
           docker buildx build \

--- a/.github/workflows/dockerimages.yml
+++ b/.github/workflows/dockerimages.yml
@@ -95,6 +95,8 @@ jobs:
         run: |
           docker buildx build \
             --platform ${PLATFORM} \
+            --output "type=docker" \
             --cache-from ${CACHE_IMAGE}:cache-${{ matrix.tag }} \
             --cache-to ${CACHE_IMAGE}:cache-${{ matrix.tag }} \
+            --tag ${IMAGE} \
             --file ./${DOCKERFILE} .

--- a/.github/workflows/dockerimages.yml
+++ b/.github/workflows/dockerimages.yml
@@ -44,10 +44,10 @@ jobs:
         run: |
           docker buildx build \
             --platform ${PLATFORM} \
-            --output "type=docker" \
-            --cache-from ${CACHE_IMAGE}:cache-${{ matrix.tag }} \
-            --tag renovate \
-            --file ./${DOCKERFILE} .
+            --output=type=docker \
+            --cache-from=${CACHE_IMAGE}:cache-${{ matrix.tag }} \
+            --tag=renovate \
+            --file=./${DOCKERFILE} .
       - name: Test the Docker image
         run: |
           docker run --rm -t renovate --version
@@ -63,7 +63,7 @@ jobs:
     needs: build
     if: github.event_name == 'push' && github.ref == 'refs/heads/chore/docker-cache'
 
-    timeout-minutes: 10
+    timeout-minutes: 20
 
     strategy:
       matrix:
@@ -92,8 +92,8 @@ jobs:
         run: |
           docker buildx build \
             --platform ${PLATFORM} \
-            --output "type=docker" \
-            --cache-from ${CACHE_IMAGE}:cache-${{ matrix.tag }} \
-            --cache-to ${CACHE_IMAGE}:cache-${{ matrix.tag }} \
-            --tag renovate \
-            --file ./${DOCKERFILE} .
+            --output=type=registry \
+            --cache-from=${CACHE_IMAGE}:cache-${{ matrix.tag }} \
+            --cache-to=${CACHE_IMAGE}:cache-${{ matrix.tag }} \
+            --tag=${CACHE_IMAGE}:test-${{ matrix.tag }} \
+            --file=./${DOCKERFILE} .

--- a/.github/workflows/dockerimages.yml
+++ b/.github/workflows/dockerimages.yml
@@ -63,7 +63,7 @@ jobs:
     name: Release push
     runs-on: ubuntu-latest
 
-    needs: test
+    needs: build
     if: github.event_name == 'push' && github.ref == 'refs/heads/chore/docker-cache'
 
     timeout-minutes: 10

--- a/.github/workflows/dockerimages.yml
+++ b/.github/workflows/dockerimages.yml
@@ -1,23 +1,36 @@
 name: Docker Images CI
 
-on: [pull_request]
+on:
+  push:
+    branches:
+      - master
+      - chore/docker-cache
+
+  pull_request:
 
 env:
   PLATFORM: linux/amd64
+  CACHE_IMAGE: renovate/cache-test
 
 jobs:
   build:
     name: Build image
     runs-on: ubuntu-latest
 
+    timeout-minutes: 20
+
     strategy:
       matrix:
-        file: [Dockerfile, Dockerfile.slim]
+        tag: [latest, slim]
+
+    env:
+      DOCKERFILE: Dockerfile.${{ matrix.tag }}
 
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
+      - name: Init env for other tags
+        if: matrix.tag == 'latest'
+        run: |
+          echo "::set-env name=DOCKERFILE::Dockerfile"
 
       - name: Set up Docker Buildx
         id: buildx
@@ -25,16 +38,63 @@ jobs:
         with:
           version: v0.3.1
 
+      - uses: actions/checkout@v2
+
       - name: Build the Docker image
         run: |
           docker buildx build \
             --platform ${PLATFORM} \
             --output "type=docker" \
+            --cache-from $(CACHE_IMAGE):cache-${{ matrix.tag }} \
             --tag renovate \
-            --file ./${{ matrix.file }} .
+            --file ./$(DOCKERFILE) .
+
+      - name: Test the Docker image
+        run: |
+          docker run --rm -t renovate --version
 
       - name: Image history
         run: docker history renovate
 
       - name: Image size
         run: docker image ls | grep renovate
+
+  push:
+    name: Release push
+    runs-on: ubuntu-latest
+
+    needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/chore/docker-cache'
+
+    timeout-minutes: 10
+
+    strategy:
+      matrix:
+        tag: [latest, slim]
+
+    env:
+      DOCKERFILE: Dockerfile.${{ matrix.tag }}
+
+    steps:
+      - name: Init env for other tags
+        if: matrix.tag == 'latest'
+        run: |
+          echo "::set-env name=DOCKERFILE::Dockerfile"
+
+      - name: Set up Docker Buildx
+        uses: crazy-max/ghaction-docker-buildx@v1
+        with:
+          version: v0.3.1
+
+      - uses: actions/checkout@v2
+
+      - name: Log into registry
+        run: echo "${{ secrets.DOCKER_RENOVATERELEASE_TOKEN }}" | docker login -u renovaterelease --password-stdin
+
+      - name: Build the Docker image
+        run: |
+          docker buildx build \
+            --platform ${PLATFORM} \
+            --cache-from $(CACHE_IMAGE):cache-${{ matrix.tag }} \
+            --cache-to $(CACHE_IMAGE):cache-${{ matrix.tag }} \
+            --file ./$(DOCKERFILE) .

--- a/.github/workflows/dockerimages.yml
+++ b/.github/workflows/dockerimages.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        tag: [latest, slim]
+        tag: [slim] #[latest, slim]
 
     env:
       DOCKERFILE: Dockerfile.${{ matrix.tag }}
@@ -40,21 +40,21 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      # - name: Build the Docker image
-      #   run: |
-      #     docker buildx build \
-      #       --platform ${PLATFORM} \
-      #       --output "type=docker" \
-      #       --cache-from ${CACHE_IMAGE}:cache-${{ matrix.tag }} \
-      #       --tag renovate \
-      #       --file ./${DOCKERFILE} .
-      # - name: Test the Docker image
-      #   run: |
-      #     docker run --rm -t renovate --version
-      # - name: Image history
-      #   run: docker history renovate
-      # - name: Image size
-      #   run: docker image ls | grep renovate
+      - name: Build the Docker image
+        run: |
+          docker buildx build \
+            --platform ${PLATFORM} \
+            --output "type=docker" \
+            --cache-from ${CACHE_IMAGE}:cache-${{ matrix.tag }} \
+            --tag renovate \
+            --file ./${DOCKERFILE} .
+      - name: Test the Docker image
+        run: |
+          docker run --rm -t renovate --version
+      - name: Image history
+        run: docker history renovate
+      - name: Image size
+        run: docker image ls | grep renovate
 
   push:
     name: Release push
@@ -67,7 +67,7 @@ jobs:
 
     strategy:
       matrix:
-        tag: [slim] #[latest, slim]
+        tag: [latest, slim]
 
     env:
       DOCKERFILE: Dockerfile.${{ matrix.tag }}

--- a/.github/workflows/dockerimages.yml
+++ b/.github/workflows/dockerimages.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        tag: [slim] #[latest, slim]
+        tag: [latest, slim]
 
     env:
       DOCKERFILE: Dockerfile.${{ matrix.tag }}

--- a/.github/workflows/dockerimages.yml
+++ b/.github/workflows/dockerimages.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        tag: [slim] #[latest, slim]
+        tag: [latest, slim]
 
     env:
       DOCKERFILE: Dockerfile.${{ matrix.tag }}
@@ -40,24 +40,21 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - name: Build the Docker image
-        run: |
-          docker buildx build \
-            --platform ${PLATFORM} \
-            --output "type=docker" \
-            --cache-from ${CACHE_IMAGE}:cache-${{ matrix.tag }} \
-            --tag renovate \
-            --file ./${DOCKERFILE} .
-
-      - name: Test the Docker image
-        run: |
-          docker run --rm -t renovate --version
-
-      - name: Image history
-        run: docker history renovate
-
-      - name: Image size
-        run: docker image ls | grep renovate
+      # - name: Build the Docker image
+      #   run: |
+      #     docker buildx build \
+      #       --platform ${PLATFORM} \
+      #       --output "type=docker" \
+      #       --cache-from ${CACHE_IMAGE}:cache-${{ matrix.tag }} \
+      #       --tag renovate \
+      #       --file ./${DOCKERFILE} .
+      # - name: Test the Docker image
+      #   run: |
+      #     docker run --rm -t renovate --version
+      # - name: Image history
+      #   run: docker history renovate
+      # - name: Image size
+      #   run: docker image ls | grep renovate
 
   push:
     name: Release push
@@ -98,5 +95,5 @@ jobs:
             --output "type=docker" \
             --cache-from ${CACHE_IMAGE}:cache-${{ matrix.tag }} \
             --cache-to ${CACHE_IMAGE}:cache-${{ matrix.tag }} \
-            --tag ${IMAGE} \
+            --tag renovate \
             --file ./${DOCKERFILE} .

--- a/.github/workflows/dockerimages.yml
+++ b/.github/workflows/dockerimages.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        tag: [latest, slim]
+        tag: [slim] #[latest, slim]
 
     env:
       DOCKERFILE: Dockerfile.${{ matrix.tag }}
@@ -45,9 +45,9 @@ jobs:
           docker buildx build \
             --platform ${PLATFORM} \
             --output "type=docker" \
-            --cache-from $(CACHE_IMAGE):cache-${{ matrix.tag }} \
+            --cache-from ${CACHE_IMAGE}:cache-${{ matrix.tag }} \
             --tag renovate \
-            --file ./$(DOCKERFILE) .
+            --file ./${DOCKERFILE} .
 
       - name: Test the Docker image
         run: |
@@ -70,7 +70,7 @@ jobs:
 
     strategy:
       matrix:
-        tag: [latest, slim]
+        tag: [slim] #[latest, slim]
 
     env:
       DOCKERFILE: Dockerfile.${{ matrix.tag }}
@@ -95,6 +95,6 @@ jobs:
         run: |
           docker buildx build \
             --platform ${PLATFORM} \
-            --cache-from $(CACHE_IMAGE):cache-${{ matrix.tag }} \
-            --cache-to $(CACHE_IMAGE):cache-${{ matrix.tag }} \
-            --file ./$(DOCKERFILE) .
+            --cache-from ${CACHE_IMAGE}:cache-${{ matrix.tag }} \
+            --cache-to ${CACHE_IMAGE}:cache-${{ matrix.tag }} \
+            --file ./${DOCKERFILE} .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,9 @@
-name: Docker Images CI
+name: Release CI
 
 on:
   push:
-    branches:
-      - master
-
-  pull_request:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
 
 env:
   PLATFORM: linux/amd64
@@ -13,11 +11,10 @@ env:
   DOCKER_REPO: renovate/cache-test
 
 jobs:
-  build:
-    name: Build image
+  docker-release:
     runs-on: ubuntu-latest
 
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     strategy:
       matrix:
@@ -59,14 +56,44 @@ jobs:
       - name: Image size
         run: docker image ls | grep renovate
 
+      - name: Generate tags
+        run: |
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
+
+          # Tag base
+          tags="${DOCKER_REPO}:${DOCKER_TAG}"
+          echo "Tagging ${DOCKER_REPO}:${DOCKER_TAG}"
+
+          SEMVER_REGEX="^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)?$"
+
+          if ! [[ "$VERSION" =~ $SEMVER_REGEX ]]; then
+            echo Not a semver tag - skipping
+            exit 1
+          fi
+
+          major=${BASH_REMATCH[1]}
+          minor=${BASH_REMATCH[2]}
+          patch=${BASH_REMATCH[3]}
+          slim=${DOCKER_TAG#latest}
+          slim=${slim:+-}${slim}
+
+
+          # Tag for versions additional
+          for tag in {"${major}${slim}","${major}.${minor}${slim}","${major}.${minor}.${patch}${slim}"}; do
+            echo "Tagging ${DOCKER_REPO}:${tag}"
+            tags+=",${DOCKER_REPO}:${tag}"
+          done
+
+          echo "::set-env name=TAGS::${tags}"
+
       - name: Push the Docker image
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: |
           echo "${{ secrets.DOCKER_RENOVATERELEASE_TOKEN }}" | docker login -u renovaterelease --password-stdin
           docker buildx build \
             --platform ${PLATFORM} \
             --output=type=registry \
             --cache-from=${DOCKER_REPO}:cache-${DOCKER_TAG} \
-            --cache-to=${DOCKER_REPO}:cache-${DOCKER_TAG} \
-            --tag=${DOCKER_REPO}:test-${DOCKER_TAG} \
+            --tag=${TAGS} \
             --file=./${DOCKER_FILE} .


### PR DESCRIPTION
This pr add docker caching to our github docker workflow.

Additionally it build and pushed docker release images to the test repo on git tags.

When all is working fine we just  need to update the `DOCKER_REPO` env var to push to another docker repo.

ref #5439 