### PR TITLE
fix(deps): Update Composer to v1.9.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -107,7 +107,7 @@ ENV PATH $PATH:/opt/elixir-${ELIXIR_VERSION}/bin
 RUN apt-get update && apt-get install -y php-cli php-mbstring && \
     rm -rf /var/lib/apt/lists/*
 
-ENV COMPOSER_VERSION=1.8.6
+ENV COMPOSER_VERSION=1.9.3
 
 RUN php -r "copy('https://github.com/composer/composer/releases/download/$COMPOSER_VERSION/composer.phar', '/usr/local/bin/composer');"
 


### PR DESCRIPTION
Solves an issue with deprecated GitHub API calls: https://github.com/composer/composer/issues/8454#issuecomment-581875987

Closes #5442
