### PR TITLE
chore(ci): skip java tests on most platforms

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,12 +15,18 @@ jobs:
     name: test
     runs-on: ${{ matrix.os }}
 
+    # tests shouldn't nee more than 10 min
+    timeout-minutes: 15
+
     strategy:
-      max-parallel: 4
+      max-parallel: 6
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         node-version: [10.x, 12.x]
         python-version: [3.8]
+        exclude:
+          - os: windows-latest
+            node-version: 10.x
 
     steps:
       - name: Set up Node.js ${{ matrix.node-version }}
@@ -34,9 +40,14 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Set up Java 11
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '10.x'
         uses: actions/setup-java@v1
         with:
           java-version: 11
+
+      - name: Skip Java tests
+        if: matrix.os != 'ubuntu-latest' || matrix.node-version != '10.x'
+        run: echo "::set-env name=SKIP_JAVA_TESTS::true"
 
       - name: Init platform
         id: init

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,11 +22,11 @@ jobs:
       max-parallel: 6
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [10.x, 12.x]
+        node-version: [10, 12]
         python-version: [3.8]
         exclude:
           - os: windows-latest
-            node-version: 10.x
+            node-version: 10
 
     steps:
       - name: Set up Node.js ${{ matrix.node-version }}
@@ -40,13 +40,13 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Set up Java 11
-        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '10.x'
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == 12 && github.ref != 'refs/heads/master'
         uses: actions/setup-java@v1
         with:
           java-version: 11
 
       - name: Skip Java tests
-        if: matrix.os != 'ubuntu-latest' || matrix.node-version != '10.x'
+        if: matrix.os != 'ubuntu-latest' || matrix.node-version != 12 || github.ref == 'refs/heads/master'
         run: echo "::set-env name=SKIP_JAVA_TESTS::true"
 
       - name: Init platform


### PR DESCRIPTION
Because the java tests are slow we run them only on a single platform