### PR TITLE
feat(azure): calculate isModified

### DIFF
--- a/lib/platform/azure/azure-helper.ts
+++ b/lib/platform/azure/azure-helper.ts
@@ -191,10 +191,9 @@ export function getRenovatePRFormat(azurePr: GitPullRequest): Pr {
     pr.isConflicted = true;
   }
 
-  pr.isModified =
-    Boolean(azurePr.commits) &&
-    azurePr.commits[0].author.name !==
-      azurePr.commits[azurePr.commits.length - 1].author.name;
+  // value is updated later to be correct for
+  // specific pr's after filtering, for performance
+  pr.isModified = false;
 
   return pr;
 }

--- a/lib/platform/azure/azure-helper.ts
+++ b/lib/platform/azure/azure-helper.ts
@@ -191,7 +191,10 @@ export function getRenovatePRFormat(azurePr: GitPullRequest): Pr {
     pr.isConflicted = true;
   }
 
-  pr.isModified = false;
+  pr.isModified =
+    azurePr.commits &&
+    azurePr.commits[0].author.name !==
+      azurePr.commits[azurePr.commits.length - 1].author.name;
 
   return pr;
 }

--- a/lib/platform/azure/azure-helper.ts
+++ b/lib/platform/azure/azure-helper.ts
@@ -192,7 +192,7 @@ export function getRenovatePRFormat(azurePr: GitPullRequest): Pr {
   }
 
   pr.isModified =
-    azurePr.commits &&
+    Boolean(azurePr.commits) &&
     azurePr.commits[0].author.name !==
       azurePr.commits[azurePr.commits.length - 1].author.name;
 

--- a/lib/platform/azure/index.ts
+++ b/lib/platform/azure/index.ts
@@ -252,14 +252,6 @@ export async function getPrList(): Promise<Pr[]> {
       skip += 100;
     } while (fetchedPrs.length > 0);
 
-    // get commit info to work out if the pr is modified
-    for (let i = 0; i < prs.length; i += 1) {
-      prs[i].commits = await azureApiGit.getPullRequestCommits(
-        config.repoId,
-        prs[i].pullRequestId
-      );
-    }
-
     config.prList = prs.map(azureHelper.getRenovatePRFormat);
     logger.info({ length: config.prList.length }, 'Retrieved Pull Requests');
   }
@@ -288,6 +280,15 @@ export async function getPr(pullRequestId: number): Promise<Pr | null> {
   azurePr.labels = labels
     .filter(label => label.active)
     .map(label => label.name);
+
+  const commits = await azureApiGit.getPullRequestCommits(
+    config.repoId,
+    pullRequestId
+  );
+  azurePr.isModified =
+    commits.length > 0 &&
+    commits[0].author.name !== commits[commits.length - 1].author.name;
+
   return azurePr;
 }
 

--- a/lib/platform/azure/index.ts
+++ b/lib/platform/azure/index.ts
@@ -251,6 +251,15 @@ export async function getPrList(): Promise<Pr[]> {
       prs = prs.concat(fetchedPrs);
       skip += 100;
     } while (fetchedPrs.length > 0);
+
+    // get commit info to work out if the pr is modified
+    for (let i = 0; i < prs.length; i += 1) {
+      prs[i].commits = await azureApiGit.getPullRequestCommits(
+        config.repoId,
+        prs[i].pullRequestId
+      );
+    }
+
     config.prList = prs.map(azureHelper.getRenovatePRFormat);
     logger.info({ length: config.prList.length }, 'Retrieved Pull Requests');
   }

--- a/test/platform/azure/__snapshots__/index.spec.ts.snap
+++ b/test/platform/azure/__snapshots__/index.spec.ts.snap
@@ -90,9 +90,18 @@ exports[`platform/azure getBranchPr(branchName) should return the pr 1`] = `null
 
 exports[`platform/azure getPr(prNo) should return a pr in the right format 1`] = `
 Object {
+  "isModified": false,
   "labels": Array [
     "renovate",
   ],
+  "pullRequestId": 1234,
+}
+`;
+
+exports[`platform/azure getPr(prNo) should return a pr thats been modified 1`] = `
+Object {
+  "isModified": true,
+  "labels": Array [],
   "pullRequestId": 1234,
 }
 `;

--- a/test/platform/azure/index.spec.ts
+++ b/test/platform/azure/index.spec.ts
@@ -479,14 +479,57 @@ describe('platform/azure', () => {
             getPullRequestLabels: jest
               .fn()
               .mockReturnValue([{ active: true, name: 'renovate' }]),
-            getPullRequestCommits: jest.fn().mockReturnValue([]),
+            getPullRequestCommits: jest.fn().mockReturnValue([
+              {
+                author: {
+                  name: 'renovate',
+                },
+              },
+            ]),
           } as any)
       );
       azureHelper.getRenovatePRFormat.mockImplementation(
         () =>
           ({
             pullRequestId: 1234,
-            labels: ['renovate'],
+          } as any)
+      );
+      const pr = await azure.getPr(1234);
+      expect(pr).toMatchSnapshot();
+    });
+    it('should return a pr thats been modified', async () => {
+      await initRepo({ repository: 'some/repo' });
+      azureApi.gitApi.mockImplementation(
+        () =>
+          ({
+            getPullRequests: jest
+              .fn()
+              .mockReturnValue([])
+              .mockReturnValueOnce([
+                {
+                  pullRequestId: 1234,
+                },
+              ]),
+            getPullRequestLabels: jest.fn().mockReturnValue([]),
+            getPullRequestCommits: jest.fn().mockReturnValue([
+              {
+                author: {
+                  name: 'renovate',
+                },
+              },
+              {
+                author: {
+                  name: 'end user',
+                },
+              },
+            ]),
+          } as any)
+      );
+      azureHelper.getRenovatePRFormat.mockImplementation(
+        () =>
+          ({
+            pullRequestId: 1234,
+            isModified: false,
           } as any)
       );
       const pr = await azure.getPr(1234);

--- a/test/platform/azure/index.spec.ts
+++ b/test/platform/azure/index.spec.ts
@@ -252,6 +252,7 @@ describe('platform/azure', () => {
                   state: 'closed',
                 },
               ]),
+            getPullRequestCommits: jest.fn().mockReturnValue([]),
           } as any)
       );
       azureHelper.getNewBranchName.mockImplementationOnce(
@@ -288,6 +289,7 @@ describe('platform/azure', () => {
                   state: 'closed',
                 },
               ]),
+            getPullRequestCommits: jest.fn().mockReturnValue([]),
           } as any)
       );
       azureHelper.getNewBranchName.mockImplementationOnce(
@@ -324,6 +326,7 @@ describe('platform/azure', () => {
                   state: 'closed',
                 },
               ]),
+            getPullRequestCommits: jest.fn().mockReturnValue([]),
           } as any)
       );
       azureHelper.getNewBranchName.mockImplementationOnce(
@@ -388,6 +391,7 @@ describe('platform/azure', () => {
                   status: 2,
                 },
               ]),
+            getPullRequestCommits: jest.fn().mockReturnValue([]),
           } as any)
       );
       azureHelper.getNewBranchName.mockImplementation(
@@ -475,6 +479,7 @@ describe('platform/azure', () => {
             getPullRequestLabels: jest
               .fn()
               .mockReturnValue([{ active: true, name: 'renovate' }]),
+            getPullRequestCommits: jest.fn().mockReturnValue([]),
           } as any)
       );
       azureHelper.getRenovatePRFormat.mockImplementation(

--- a/test/platform/azure/index.spec.ts
+++ b/test/platform/azure/index.spec.ts
@@ -215,6 +215,7 @@ describe('platform/azure', () => {
                   state: 'open',
                 },
               ]),
+            getPullRequestCommits: jest.fn().mockReturnValue([]),
           } as any)
       );
       azureHelper.getNewBranchName.mockImplementationOnce(


### PR DESCRIPTION
Related to #1149

Because isModified is always false on azure, renovate will overwrite any new commits, which is extremely annoying.

I understand this isn't the most robust, but it makes things alot better for users, so I'll try to make any updates you require if it isn't too much work.