### PR TITLE
chore(ci): make clear pip cache work cross platform

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Clear pip cache
         if: steps.pip_cache_packages.outputs.cache-hit != 'true'
-        run: rm -rf ${{ steps.init.outputs.pip_cache }}
+        run: python -c "from pip._internal.locations import USER_CACHE_DIR; from shutil import rmtree; rmtree(USER_CACHE_DIR, ignore_errors=True)"
 
       - name: Installing dependencies
         shell: bash


### PR DESCRIPTION
`rm -rf` is not a vailid command in Windows CMD.

Master build before: https://github.com/Dahlgren/renovate/actions/runs/40382111
Temporary whitelisted branch after: https://github.com/Dahlgren/renovate/actions/runs/40427911

`ignore_errors=True` is required if path does not yet exists, https://github.com/Dahlgren/renovate/runs/449592197?check_suite_focus=true. The `ignore_errors` could be swapped for a `os.path.isdir` check. The command could also be somewhat shorted by using the already created environment variable instead of pip property again.

Another alternative would be to use `rm -rf` on Linux + macOS and `rmdir /s` or equivalent on Windows. But then there would be two different steps to "maintain"