### PR TITLE
fix(gradle): buildGradleDependency version is undefined

### DIFF
--- a/lib/manager/gradle/index.ts
+++ b/lib/manager/gradle/index.ts
@@ -152,7 +152,11 @@ export async function extractAllPackageFiles(
 }
 
 function buildGradleDependency(config: Upgrade): GradleDependency {
-  return { group: config.depGroup, name: config.name, version: config.version };
+  return {
+    group: config.depGroup,
+    name: config.name,
+    version: config.currentValue,
+  };
 }
 
 export function updateDependency({
@@ -160,7 +164,7 @@ export function updateDependency({
   upgrade,
 }: UpdateDependencyConfig): string {
   // prettier-ignore
-  logger.debug(`gradle.updateDependency(): packageFile:${upgrade.packageFile} depName:${upgrade.depName}, version:${upgrade.currentVersion} ==> ${upgrade.newValue}`);
+  logger.debug(`gradle.updateDependency(): packageFile:${upgrade.packageFile} depName:${upgrade.depName}, version:${upgrade.currentValue} ==> ${upgrade.newValue}`);
 
   return updateGradleVersion(
     fileContent,


### PR DESCRIPTION
Gradle dependencies never had `version` property defined

Based on `branchify.ts` it seems like the previous version variables are deprecated
https://github.com/renovatebot/renovate/blob/0dab3f4067a00f58cedea856231bfda376696e32/lib/workers/repository/updates/branchify.ts#L43-L45

Perhaps `update.version` should be added there as well?