### PR TITLE
feat(terraform): gitTags support

### DIFF
--- a/lib/manager/terraform/__fixtures__/1.tf
+++ b/lib/manager/terraform/__fixtures__/1.tf
@@ -1,14 +1,14 @@
 module "foo" {
-  source  = "github.com/hashicorp/example?ref=v1.0.0"
+  source = "github.com/hashicorp/example?ref=v1.0.0"
 }
 
 module "bar" {
-  source  = "github.com/hashicorp/example?ref=next"
+  source = "github.com/hashicorp/example?ref=next"
 }
 
 module "consul" {
-  source    = "hashicorp/consul/aws"
-  version   = "0.1.0"
+  source  = "hashicorp/consul/aws"
+  version = "0.1.0"
 }
 
 module "container_definition" {
@@ -16,17 +16,17 @@ module "container_definition" {
   name           = "hello"
   image          = "tutum/hello-world"
   mem_soft_limit = 256
-  port_mappings  = [{
+  port_mappings = [{
     containerPort = 80
     hostPort      = 80
   }]
 }
 
 module "task_definition" {
-  source                = "github.com/tieto-cem/terraform-aws-ecs-task-definition?ref=v0.1.0"
-  name                  = "mytask"
+  source = "github.com/tieto-cem/terraform-aws-ecs-task-definition?ref=v0.1.0"
+  name   = "mytask"
   container_definitions = [
-    "${module.container_definition.json}"]
+  "${module.container_definition.json}"]
 }
 module "consul" {
   source = "git@github.com:hashicorp/example.git?ref=v2.0.0"
@@ -43,15 +43,15 @@ module "web_server_sg" {
 }
 
 module "vote_service_sg" {
-  source = "terraform-aws-modules/security-group/aws"
+  source  = "terraform-aws-modules/security-group/aws"
   version = "<= 2.4.0"
 
   name        = "user-service"
   description = "Security group for user-service with custom ports open within VPC, and PostgreSQL publicly open"
   vpc_id      = "vpc-12345678"
 
-  ingress_cidr_blocks      = ["10.10.0.0/16"]
-  ingress_rules            = ["https-443-tcp"]
+  ingress_cidr_blocks = ["10.10.0.0/16"]
+  ingress_rules       = ["https-443-tcp"]
   ingress_with_cidr_blocks = [
     {
       from_port   = 8080
@@ -68,22 +68,22 @@ module "vote_service_sg" {
 }
 
 module "consul" {
-  source = "app.terraform.io/example-corp/k8s-cluster/azurerm"
+  source  = "app.terraform.io/example-corp/k8s-cluster/azurerm"
   version = "~> 1.1.0"
 }
 
 module "consul2" {
-  source = "app.terraform.io/example-corp/k8s-cluster/azurerm"
+  source  = "app.terraform.io/example-corp/k8s-cluster/azurerm"
   version = "~> 1.1"
 }
 
 module "consul3" {
-  source = "app.terraform.io/example-corp/k8s-cluster/azurerm"
+  source  = "app.terraform.io/example-corp/k8s-cluster/azurerm"
   version = "~~ 1.1"
 }
 
 module "consul3" {
-  source = "hashicorp/consul/aws"
+  source  = "hashicorp/consul/aws"
   version = ">= 1.0.0, <= 2.0.0"
 }
 
@@ -101,13 +101,13 @@ provider "azurerm" {
 }
 
 provider "gitlab" {
-  alias = "main"
+  alias   = "main"
   version = "=2.4"
 }
 
 provider "gitlab" {
-    token = "${var.gitlab_token}"
-    version = "=1.3"
+  token   = "${var.gitlab_token}"
+  version = "=1.3"
 }
 
 provider "helm" {
@@ -126,4 +126,12 @@ provider "newrelic" {
   version = "V1.9"
 
   api_key = "${var.newrelic_api_key}"
+}
+
+module "foobar" {
+  source = "https://bitbucket.com/hashicorp/example?ref=v1.0.0"
+}
+
+module "gittags" {
+  source = "git::https://bitbucket.com/hashicorp/example?ref=v1.0.0"
 }

--- a/lib/manager/terraform/__fixtures__/1.tf
+++ b/lib/manager/terraform/__fixtures__/1.tf
@@ -135,3 +135,7 @@ module "foobar" {
 module "gittags" {
   source = "git::https://bitbucket.com/hashicorp/example?ref=v1.0.0"
 }
+
+module "gittags_badversion" {
+  source = "git::https://bitbucket.com/hashicorp/example?ref=next"
+}

--- a/lib/manager/terraform/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/terraform/__snapshots__/extract.spec.ts.snap
@@ -242,6 +242,28 @@ Object {
       "moduleName": "newrelic",
       "skipReason": "unsupported-version",
     },
+    Object {
+      "managerData": Object {
+        "terraformDependencyType": "module",
+      },
+      "moduleName": "foobar",
+      "skipReason": "no-version",
+      "source": "https://bitbucket.com/hashicorp/example?ref=v1.0.0",
+    },
+    Object {
+      "currentValue": "v1.0.0",
+      "datasource": "git-tags",
+      "depName": "bitbucket.com/hashicorp/example",
+      "depNameShort": "hashicorp/example",
+      "depType": "gitTags",
+      "lookupName": "https://bitbucket.com/hashicorp/example",
+      "managerData": Object {
+        "lineNumber": 135,
+        "terraformDependencyType": "module",
+      },
+      "moduleName": "gittags",
+      "source": "git::https://bitbucket.com/hashicorp/example?ref=v1.0.0",
+    },
   ],
 }
 `;

--- a/lib/manager/terraform/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/terraform/__snapshots__/extract.spec.ts.snap
@@ -264,6 +264,21 @@ Object {
       "moduleName": "gittags",
       "source": "git::https://bitbucket.com/hashicorp/example?ref=v1.0.0",
     },
+    Object {
+      "currentValue": "next",
+      "datasource": "git-tags",
+      "depName": "bitbucket.com/hashicorp/example",
+      "depNameShort": "hashicorp/example",
+      "depType": "gitTags",
+      "lookupName": "https://bitbucket.com/hashicorp/example",
+      "managerData": Object {
+        "lineNumber": 139,
+        "terraformDependencyType": "module",
+      },
+      "moduleName": "gittags_badversion",
+      "skipReason": "unsupported-version",
+      "source": "git::https://bitbucket.com/hashicorp/example?ref=next",
+    },
   ],
 }
 `;

--- a/lib/manager/terraform/extract.spec.ts
+++ b/lib/manager/terraform/extract.spec.ts
@@ -19,15 +19,15 @@ describe('lib/manager/terraform/extract', () => {
     it('extracts', () => {
       const res = extractPackageFile(tf1);
       expect(res).toMatchSnapshot();
-      expect(res.deps).toHaveLength(19);
-      expect(res.deps.filter(dep => dep.skipReason)).toHaveLength(7);
+      expect(res.deps).toHaveLength(21);
+      expect(res.deps.filter(dep => dep.skipReason)).toHaveLength(8);
       expect(
         res.deps.filter(
           dep =>
             dep.managerData.terraformDependencyType ===
             TerraformDependencyTypes.module
         )
-      ).toHaveLength(14);
+      ).toHaveLength(16);
       expect(
         res.deps.filter(
           dep =>

--- a/lib/manager/terraform/extract.spec.ts
+++ b/lib/manager/terraform/extract.spec.ts
@@ -19,15 +19,15 @@ describe('lib/manager/terraform/extract', () => {
     it('extracts', () => {
       const res = extractPackageFile(tf1);
       expect(res).toMatchSnapshot();
-      expect(res.deps).toHaveLength(21);
-      expect(res.deps.filter(dep => dep.skipReason)).toHaveLength(8);
+      expect(res.deps).toHaveLength(22);
+      expect(res.deps.filter(dep => dep.skipReason)).toHaveLength(9);
       expect(
         res.deps.filter(
           dep =>
             dep.managerData.terraformDependencyType ===
             TerraformDependencyTypes.module
         )
-      ).toHaveLength(16);
+      ).toHaveLength(17);
       expect(
         res.deps.filter(
           dep =>

--- a/lib/manager/terraform/extract.ts
+++ b/lib/manager/terraform/extract.ts
@@ -56,8 +56,8 @@ export function extractPackageFile(content: string): PackageFile | null {
         };
         if (tfDepType === TerraformDependencyTypes.unknown) {
           /* istanbul ignore next */ logger.trace(
-          `Could not identify TerraformDependencyType ${terraformDependency[1]} on line ${lineNumber}.`
-        );
+            `Could not identify TerraformDependencyType ${terraformDependency[1]} on line ${lineNumber}.`
+          );
         } else {
           do {
             lineNumber += 1;

--- a/lib/manager/terraform/update.spec.ts
+++ b/lib/manager/terraform/update.spec.ts
@@ -5,55 +5,93 @@ const tf1 = readFileSync('lib/manager/terraform/__fixtures__/1.tf', 'utf8');
 
 describe('manager/terraform/update', () => {
   describe('updateDependency', () => {
-    it('replaces existing value', () => {
-      const upgrade = {
-        depType: 'github',
-        depName: 'foo',
-        managerData: { lineNumber: 1 },
-        depNameShort: 'hashicorp/example',
-        newValue: 'v1.0.1',
-      };
-      const res = updateDependency({ fileContent: tf1, upgrade });
-      expect(res).not.toEqual(tf1);
-      expect(res.includes(upgrade.newValue)).toBe(true);
+    describe('github', () => {
+      it('replaces existing value', () => {
+        const upgrade = {
+          depType: 'github',
+          depName: 'foo',
+          managerData: { lineNumber: 1 },
+          depNameShort: 'hashicorp/example',
+          newValue: 'v1.0.1',
+        };
+        const res = updateDependency({ fileContent: tf1, upgrade });
+        expect(res).not.toEqual(tf1);
+        expect(res.includes(upgrade.newValue)).toBe(true);
+      });
+      it('returns same', () => {
+        const upgrade = {
+          depType: 'github',
+          depName: 'foo',
+          managerData: { lineNumber: 1 },
+          depNameShort: 'hashicorp/example',
+          newValue: 'v1.0.0',
+        };
+        const res = updateDependency({ fileContent: tf1, upgrade });
+        expect(res).toEqual(tf1);
+      });
+      it('returns null if wrong line', () => {
+        const upgrade = {
+          depType: 'github',
+          depName: 'foo',
+          managerData: { lineNumber: 2 },
+          depNameShort: 'hashicorp/example',
+          newValue: 'v1.0.0',
+        };
+        const res = updateDependency({ fileContent: tf1, upgrade });
+        expect(res).toBeNull();
+      });
+      it('updates github versions', () => {
+        const upgrade = {
+          depType: 'github',
+          currentValue: 'v0.1.0',
+          newValue: 'v0.1.3',
+          depName: 'github.com/tieto-cem/terraform-aws-ecs-task-definition',
+          depNameShort: 'tieto-cem/terraform-aws-ecs-task-definition',
+          managerData: { lineNumber: 14 },
+          moduleName: 'container_definition',
+          source:
+            'github.com/tieto-cem/terraform-aws-ecs-task-definition//modules/container-definition?ref=v0.1.0',
+        };
+        const res = updateDependency({ fileContent: tf1, upgrade });
+        expect(res).not.toEqual(tf1);
+        expect(res.includes(upgrade.newValue)).toBe(true);
+      });
     });
-    it('returns same', () => {
-      const upgrade = {
-        depType: 'github',
-        depName: 'foo',
-        managerData: { lineNumber: 1 },
-        depNameShort: 'hashicorp/example',
-        newValue: 'v1.0.0',
-      };
-      const res = updateDependency({ fileContent: tf1, upgrade });
-      expect(res).toEqual(tf1);
-    });
-    it('returns null if wrong line', () => {
-      const upgrade = {
-        depType: 'github',
-        depName: 'foo',
-        managerData: { lineNumber: 2 },
-        depNameShort: 'hashicorp/example',
-        newValue: 'v1.0.0',
-      };
-      const res = updateDependency({ fileContent: tf1, upgrade });
-      expect(res).toBeNull();
-    });
-    it('updates github versions', () => {
-      const upgrade = {
-        depType: 'github',
-        currentValue: 'v0.1.0',
-        newValue: 'v0.1.3',
-        depName: 'github.com/tieto-cem/terraform-aws-ecs-task-definition',
-        depNameShort: 'tieto-cem/terraform-aws-ecs-task-definition',
-        managerData: { lineNumber: 14 },
-        moduleName: 'container_definition',
-        source:
-          'github.com/tieto-cem/terraform-aws-ecs-task-definition//modules/container-definition?ref=v0.1.0',
-      };
-      const res = updateDependency({ fileContent: tf1, upgrade });
-      expect(res).not.toEqual(tf1);
-      expect(res.includes(upgrade.newValue)).toBe(true);
+    describe('gitTags', () => {
+      it('replaces existing value', () => {
+        const upgrade = {
+          depType: 'gitTags',
+          depName: 'bitbucket.com/hashicorp/example',
+          managerData: { lineNumber: 131 },
+          depNameShort: 'hashicorp/example',
+          newValue: 'v1.0.1',
+        };
+        const res = updateDependency({ fileContent: tf1, upgrade });
+        expect(res).not.toEqual(tf1);
+        expect(res.includes(upgrade.newValue)).toBe(true);
+      });
+      it('returns same', () => {
+        const upgrade = {
+          depType: 'gitTags',
+          depName: 'foobar',
+          managerData: { lineNumber: 131 },
+          depNameShort: 'hashicorp/example',
+          newValue: 'v1.0.0',
+        };
+        const res = updateDependency({ fileContent: tf1, upgrade });
+        expect(res).toEqual(tf1);
+      });
+      it('returns null if wrong line', () => {
+        const upgrade = {
+          depType: 'gitTags',
+          depName: 'foobar',
+          managerData: { lineNumber: 2 },
+          depNameShort: 'hashicorp/example',
+          newValue: 'v1.0.0',
+        };
+        const res = updateDependency({ fileContent: tf1, upgrade });
+        expect(res).toBeNull();
+      });
     });
     it('skips terraform versions wrong line', () => {
       const upgrade = {

--- a/lib/manager/terraform/update.ts
+++ b/lib/manager/terraform/update.ts
@@ -15,6 +15,11 @@ export function updateDependency({
         return null;
       }
       newLine = lineToChange.replace(/\?ref=.*"/, `?ref=${upgrade.newValue}"`);
+    } else if (upgrade.depType === 'gitTags') {
+      if (!lineToChange.includes(upgrade.depNameShort)) {
+        return null;
+      }
+      newLine = lineToChange.replace(/\?ref=.*"/, `?ref=${upgrade.newValue}"`);
     } else if (upgrade.depType === 'terraform') {
       if (!/version\s*=\s*"/.test(lineToChange)) {
         return null;


### PR DESCRIPTION
This PR adds support for the GitTags datasource for the Terraform manager.

Closes #5228, #3209
