### PR TITLE
refactor: centralize matchAt and replaceAt

### DIFF
--- a/lib/manager/cargo/update.ts
+++ b/lib/manager/cargo/update.ts
@@ -3,26 +3,7 @@ import { parse } from 'toml';
 import { logger } from '../../logger';
 import { UpdateDependencyConfig } from '../common';
 import { CargoConfig, CargoSection } from './types';
-
-// Return true if the match string is found at index in content
-function matchAt(content: string, index: number, match: string): boolean {
-  return content.substring(index, index + match.length) === match;
-}
-
-// Replace oldString with newString at location index of content
-function replaceAt(
-  content: string,
-  index: number,
-  oldString: string,
-  newString: string
-): string {
-  logger.debug(`Replacing ${oldString} with ${newString} at index ${index}`);
-  return (
-    content.substr(0, index) +
-    newString +
-    content.substr(index + oldString.length)
-  );
-}
+import { matchAt, replaceAt } from '../../util/string';
 
 export function updateDependency({
   fileContent,

--- a/lib/manager/helm-requirements/update.ts
+++ b/lib/manager/helm-requirements/update.ts
@@ -4,26 +4,7 @@ import is from '@sindresorhus/is';
 
 import { logger } from '../../logger';
 import { UpdateDependencyConfig } from '../common';
-
-// Return true if the match string is found at index in content
-function matchAt(content: string, index: number, match: string): boolean {
-  return content.substring(index, index + match.length) === match;
-}
-
-// Replace oldString with newString at location index of content
-function replaceAt(
-  content: string,
-  index: number,
-  oldString: string,
-  newString: string
-): string {
-  logger.debug(`Replacing ${oldString} with ${newString} at index ${index}`);
-  return (
-    content.substr(0, index) +
-    newString +
-    content.substr(index + oldString.length)
-  );
-}
+import { matchAt, replaceAt } from '../../util/string';
 
 export function updateDependency({
   fileContent,

--- a/lib/manager/helmfile/update.ts
+++ b/lib/manager/helmfile/update.ts
@@ -4,26 +4,7 @@ import is from '@sindresorhus/is';
 
 import { logger } from '../../logger';
 import { UpdateDependencyConfig } from '../common';
-
-// Return true if the match string is found at index in content
-function matchAt(content: string, index: number, match: string): boolean {
-  return content.substring(index, index + match.length) === match;
-}
-
-// Replace oldString with newString at location index of content
-function replaceAt(
-  content: string,
-  index: number,
-  oldString: string,
-  newString: string
-): string {
-  logger.debug(`Replacing ${oldString} with ${newString} at index ${index}`);
-  return (
-    content.substr(0, index) +
-    newString +
-    content.substr(index + oldString.length)
-  );
-}
+import { matchAt, replaceAt } from '../../util/string';
 
 export function updateDependency({
   fileContent,

--- a/lib/manager/npm/update.ts
+++ b/lib/manager/npm/update.ts
@@ -2,26 +2,7 @@ import { isEqual } from 'lodash';
 import { inc, ReleaseType } from 'semver';
 import { logger } from '../../logger';
 import { UpdateDependencyConfig } from '../common';
-
-// Return true if the match string is found at index in content
-function matchAt(content: string, index: number, match: string): boolean {
-  return content.substring(index, index + match.length) === match;
-}
-
-// Replace oldString with newString at location index of content
-function replaceAt(
-  content: string,
-  index: number,
-  oldString: string,
-  newString: string
-): string {
-  logger.debug(`Replacing ${oldString} with ${newString} at index ${index}`);
-  return (
-    content.substr(0, index) +
-    newString +
-    content.substr(index + oldString.length)
-  );
-}
+import { matchAt, replaceAt } from '../../util/string';
 
 export function bumpPackageVersion(
   content: string,

--- a/lib/manager/pipenv/update.ts
+++ b/lib/manager/pipenv/update.ts
@@ -2,26 +2,7 @@ import { isEqual } from 'lodash';
 import { parse } from 'toml';
 import { logger } from '../../logger';
 import { UpdateDependencyConfig } from '../common';
-
-// Return true if the match string is found at index in content
-function matchAt(content: string, index: number, match: string): boolean {
-  return content.substring(index, index + match.length) === match;
-}
-
-// Replace oldString with newString at location index of content
-function replaceAt(
-  content: string,
-  index: number,
-  oldString: string,
-  newString: string
-): string {
-  logger.debug(`Replacing ${oldString} with ${newString} at index ${index}`);
-  return (
-    content.substr(0, index) +
-    newString +
-    content.substr(index + oldString.length)
-  );
-}
+import { matchAt, replaceAt } from '../../util/string';
 
 export function updateDependency({
   fileContent,

--- a/lib/util/string.ts
+++ b/lib/util/string.ts
@@ -1,0 +1,25 @@
+import { logger } from '../logger';
+
+// Return true if the match string is found at index in content
+export function matchAt(
+  content: string,
+  index: number,
+  match: string
+): boolean {
+  return content.substring(index, index + match.length) === match;
+}
+
+// Replace oldString with newString at location index of content
+export function replaceAt(
+  content: string,
+  index: number,
+  oldString: string,
+  newString: string
+): string {
+  logger.trace(`Replacing ${oldString} with ${newString} at index ${index}`);
+  return (
+    content.substr(0, index) +
+    newString +
+    content.substr(index + oldString.length)
+  );
+}


### PR DESCRIPTION
Note: poetry replaceAt/matchAt functions are slightly different and cannot be refactored yet.
