### PR TITLE
chore(test): lint only on linux

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,12 +111,15 @@ jobs:
           pip install --user -r requirements.txt
 
       - name: Lint
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == 12
         run: yarn lint
 
       - name: Test schema
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == 12
         run: yarn test-schema
 
       - name: Type check
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == 12
         run: yarn type-check
 
       - name: Build


### PR DESCRIPTION
* linting, schema and type check should be os and node independent

To speedup ci testing we should only run linting, schema and type check only on linux and a single node version