### PR TITLE
feat: allow config files in .gitlab directory

### DIFF
--- a/docs/development/configuration.md
+++ b/docs/development/configuration.md
@@ -7,7 +7,15 @@ Configuration is supported via any or all of the below:
 - Configuration file
 - Environment
 - CLI
-- `renovate.json`, `renovate.json5`, `.github/renovate.json`, `.github/renovate.json5`, `.renovaterc.json`, or `.renovaterc` in target repository
+- Configuration file in target repository at one of the following paths:
+  - `renovate.json`
+  - `renovate.json5`
+  - `.github/renovate.json`
+  - `.github/renovate.json5`
+  - `.gitlab/renovate.json`
+  - `.gitlab/renovate.json5`
+  - `.renovaterc.json`
+  - `.renovaterc`
 - `renovate` field of `package.json` in target repository
 
 The above are listed in **_reverse order_** of preference. e.g. CLI values will override environment values if they conflict.

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -11,6 +11,8 @@ You can store your Renovate configuration file in one of the following locations
 
 - `.github/renovate.json`
 - `.github/renovate.json5`
+- `.gitlab/renovate.json`
+- `.gitlab/renovate.json5`
 - `.renovaterc.json`
 - `renovate.json`
 - `renovate.json5`

--- a/lib/config/app-strings.ts
+++ b/lib/config/app-strings.ts
@@ -3,6 +3,8 @@ export const configFileNames = [
   'renovate.json5',
   '.github/renovate.json',
   '.github/renovate.json5',
+  '.gitlab/renovate.json',
+  '.gitlab/renovate.json5',
   '.renovaterc',
   '.renovaterc.json',
   'package.json',

--- a/test/workers/repository/init/config.spec.ts
+++ b/test/workers/repository/init/config.spec.ts
@@ -87,6 +87,14 @@ describe('workers/repository/init/config', () => {
       platform.getFile.mockResolvedValue('{}');
       await mergeRenovateConfig(config);
     });
+    it('finds .gitlab/renovate.json', async () => {
+      platform.getFileList.mockResolvedValue([
+        'package.json',
+        '.gitlab/renovate.json',
+      ]);
+      platform.getFile.mockResolvedValue('{}');
+      await mergeRenovateConfig(config);
+    });
     it('finds .renovaterc.json', async () => {
       platform.getFileList.mockResolvedValue([
         'package.json',


### PR DESCRIPTION
This adds config files in the `.gitlab` directory to the list of paths for `renovate.json`.

Note: I did this by grepping for renovate.json but I am absolutely useless with js/ts. So I think the test I added is possibly redundant since the `.github` one covers the scenario, but let me know so I can revert that :)

I also changed the formatting in the development docs a bit as the text was getting unreadable with such a long list. 

Closes #5583
