### PR TITLE
fix(bitbucket): allow custom Bitbucket Cloud endpoint

### DIFF
--- a/lib/platform/bitbucket/bb-got-wrapper.spec.ts
+++ b/lib/platform/bitbucket/bb-got-wrapper.spec.ts
@@ -32,6 +32,17 @@ describe('platform/gl-got-wrapper', () => {
     const res = await api.post('some-url');
     expect(res.body).toEqual(body);
   });
+  it('accepts custom baseUrl', async () => {
+    got.mockImplementation(() => ({} as any));
+
+    await api.post('some-url');
+    expect(got.mock.calls[0][1].baseUrl).toBe('https://api.bitbucket.org/');
+
+    const customBaseUrl = 'https://api-test.bitbucket.org';
+    api.setBaseUrl(customBaseUrl);
+    await api.post('some-url');
+    expect(got.mock.calls[1][1].baseUrl).toBe(customBaseUrl);
+  });
   it('returns cached', async () => {
     got.mockReturnValueOnce({
       body: {},

--- a/lib/platform/bitbucket/bb-got-wrapper.ts
+++ b/lib/platform/bitbucket/bb-got-wrapper.ts
@@ -3,6 +3,7 @@ import got from '../../util/got';
 import { GotApi, GotApiOptions, GotResponse } from '../common';
 import { PLATFORM_TYPE_BITBUCKET } from '../../constants/platforms';
 
+let baseUrl = 'https://api.bitbucket.org/';
 async function get(
   path: string,
   options: GotApiOptions & GotJSONOptions
@@ -10,7 +11,7 @@ async function get(
   const opts: GotApiOptions & GotJSONOptions = {
     json: true,
     hostType: PLATFORM_TYPE_BITBUCKET,
-    baseUrl: 'https://api.bitbucket.org/',
+    baseUrl,
     ...options,
   };
   const res = await got(path, opts);
@@ -25,5 +26,10 @@ for (const x of helpers) {
   (api as any)[x] = (url: string, opts: any): Promise<GotResponse> =>
     get(url, { ...opts, method: x.toUpperCase() });
 }
+
+// eslint-disable-next-line @typescript-eslint/unbound-method
+api.setBaseUrl = (newBaseUrl: string): void => {
+  baseUrl = newBaseUrl;
+};
 
 export default api;

--- a/lib/platform/bitbucket/index.spec.ts
+++ b/lib/platform/bitbucket/index.spec.ts
@@ -3,21 +3,25 @@ import responses from './__fixtures__/responses';
 import { GotApi, RepoParams, Platform } from '../common';
 import { REPOSITORY_DISABLED } from '../../constants/error-messages';
 import { BranchStatus } from '../../types';
+import { logger as _logger } from '../../logger';
 
 describe('platform/bitbucket', () => {
   let bitbucket: Platform;
   let api: jest.Mocked<GotApi>;
   let hostRules: jest.Mocked<typeof import('../../util/host-rules')>;
   let GitStorage: jest.Mocked<import('../git/storage').Storage> & jest.Mock;
+  let logger: jest.Mocked<typeof _logger>;
   beforeEach(async () => {
     // reset module
     jest.resetModules();
     jest.mock('./bb-got-wrapper');
     jest.mock('../git/storage');
     jest.mock('../../util/host-rules');
+    jest.mock('../../logger');
     hostRules = require('../../util/host-rules');
     api = require('./bb-got-wrapper').api;
     bitbucket = await import('.');
+    logger = (await import('../../logger')).logger as any;
     GitStorage = require('../git/storage').Storage;
     GitStorage.mockImplementation(() => ({
       initRepo: jest.fn(),
@@ -87,13 +91,12 @@ describe('platform/bitbucket', () => {
       expect(() => bitbucket.initPlatform({})).toThrow();
     });
     it('should show warning message if custom endpoint', async () => {
-      jest.spyOn(console, 'warn');
       await bitbucket.initPlatform({
         endpoint: 'endpoint',
         username: 'abc',
         password: '123',
       });
-      expect(console.warn).toHaveBeenCalledWith(
+      expect(logger.warn).toHaveBeenCalledWith(
         'Init: Bitbucket Cloud endpoint should generally be https://api.bitbucket.org/ but is being configured to a different value. Did you mean to use Bitbucket Server?'
       );
     });

--- a/lib/platform/bitbucket/index.spec.ts
+++ b/lib/platform/bitbucket/index.spec.ts
@@ -86,15 +86,16 @@ describe('platform/bitbucket', () => {
       expect.assertions(1);
       expect(() => bitbucket.initPlatform({})).toThrow();
     });
-    it('should throw if wrong endpoint', () => {
-      expect.assertions(1);
-      expect(() =>
-        bitbucket.initPlatform({
-          endpoint: 'endpoint',
-          username: 'abc',
-          password: '123',
-        })
-      ).toThrow();
+    it('should show warning message if custom endpoint', async () => {
+      jest.spyOn(console, 'warn');
+      await bitbucket.initPlatform({
+        endpoint: 'endpoint',
+        username: 'abc',
+        password: '123',
+      });
+      expect(console.warn).toHaveBeenCalledWith(
+        'Init: Bitbucket Cloud endpoint should generally be https://api.bitbucket.org/ but is being configured to a different value. Did you mean to use Bitbucket Server?'
+      );
     });
     it('should init', async () => {
       expect(

--- a/lib/platform/bitbucket/index.ts
+++ b/lib/platform/bitbucket/index.ts
@@ -1,3 +1,4 @@
+import URL from 'url';
 import parseDiff from 'parse-diff';
 import addrs from 'email-addresses';
 import { api } from './bb-got-wrapper';
@@ -32,6 +33,8 @@ import { PLATFORM_TYPE_BITBUCKET } from '../../constants/platforms';
 import { BranchStatus } from '../../types';
 import { RenovateConfig } from '../../config';
 
+const BITBUCKET_PROD_ENDPOINT = 'https://api.bitbucket.org/';
+
 let config: utils.Config = {} as any;
 
 export function initPlatform({
@@ -44,14 +47,14 @@ export function initPlatform({
       'Init: You must configure a Bitbucket username and password'
     );
   }
-  if (endpoint && endpoint !== 'https://api.bitbucket.org/') {
-    console.warn(
-      'Init: Bitbucket Cloud endpoint should generally be https://api.bitbucket.org/ but is being configured to a different value. Did you mean to use Bitbucket Server?'
+  if (endpoint && endpoint !== BITBUCKET_PROD_ENDPOINT) {
+    logger.warn(
+      `Init: Bitbucket Cloud endpoint should generally be ${BITBUCKET_PROD_ENDPOINT} but is being configured to a different value. Did you mean to use Bitbucket Server?`
     );
   }
   // TODO: Add a connection check that endpoint/username/password combination are valid
   const platformConfig: PlatformConfig = {
-    endpoint: 'https://api.bitbucket.org/',
+    endpoint: endpoint || BITBUCKET_PROD_ENDPOINT,
   };
   return Promise.resolve(platformConfig);
 }
@@ -76,12 +79,14 @@ export async function initRepo({
   localDir,
   optimizeForDisabled,
   bbUseDefaultReviewers,
+  endpoint = BITBUCKET_PROD_ENDPOINT,
 }: RepoParams): Promise<RepoConfig> {
   logger.debug(`initRepo("${repository}")`);
   const opts = hostRules.find({
     hostType: PLATFORM_TYPE_BITBUCKET,
-    url: 'https://api.bitbucket.org/',
+    url: endpoint,
   });
+  api.setBaseUrl(endpoint);
   config = {
     repository,
     username: opts.username,
@@ -130,10 +135,17 @@ export async function initRepo({
     throw err;
   }
 
+  const { hostname } = URL.parse(endpoint);
+
+  // Converts API hostnames to their respective HTTP git hosts:
+  // `api.bitbucket.org`  to `bitbucket.org`
+  // `api-staging.<host>` to `staging.<host>`
+  const hostnameWithoutApiPrefix = /api[.|-](.+)/.exec(hostname)[1];
+
   const url = GitStorage.getUrl({
     protocol: 'https',
     auth: `${opts.username}:${opts.password}`,
-    hostname: 'bitbucket.org',
+    hostname: hostnameWithoutApiPrefix,
     repository,
   });
 

--- a/lib/platform/bitbucket/index.ts
+++ b/lib/platform/bitbucket/index.ts
@@ -45,8 +45,8 @@ export function initPlatform({
     );
   }
   if (endpoint && endpoint !== 'https://api.bitbucket.org/') {
-    throw new Error(
-      'Init: Bitbucket Cloud endpoint can only be https://api.bitbucket.org/'
+    console.warn(
+      'Init: Bitbucket Cloud endpoint should generally be https://api.bitbucket.org/ but is being configured to a different value. Did you mean to use Bitbucket Server?'
     );
   }
   // TODO: Add a connection check that endpoint/username/password combination are valid


### PR DESCRIPTION
The Bitbucket Cloud team would like to use Renovate to keep our various repos which we host on an internal instance up to date, so allowing the `endpoint` to be set will allow that. The `console.warn` will help Bitbucket Server users find out if they have selected the wrong `platform` while providing an `endpoint` value.

Closes #5585 
