### PR TITLE
fix: bugfix for hourly limit for azure & bugfix for ignorePrefix conf…

### DIFF
--- a/lib/config/presets/index.ts
+++ b/lib/config/presets/index.ts
@@ -145,7 +145,7 @@ export async function resolveConfigPresets(
   ignorePresets?: string[],
   existingPresets: string[] = []
 ): Promise<RenovateConfig> {
-  if (!ignorePresets) {
+  if (!ignorePresets || ignorePresets.length === 0) {
     ignorePresets = inputConfig.ignorePresets || []; // eslint-disable-line
   }
   logger.trace(

--- a/lib/platform/azure/azure-helper.ts
+++ b/lib/platform/azure/azure-helper.ts
@@ -161,6 +161,8 @@ export function getRenovatePRFormat(azurePr: GitPullRequest): Pr {
   pr.number = azurePr.pullRequestId;
   pr.body = azurePr.description;
   pr.targetBranch = getBranchNameWithoutRefsheadsPrefix(azurePr.targetRefName);
+  pr.branchName = pr.targetBranch;
+  pr.createdAt = pr.creationDate;
 
   // status
   // export declare enum PullRequestStatus {

--- a/test/platform/azure/__snapshots__/azure-helper.spec.ts.snap
+++ b/test/platform/azure/__snapshots__/azure-helper.spec.ts.snap
@@ -57,6 +57,8 @@ Array [
 exports[`platform/azure/helpers getRenovatePRFormat should be formated (closed v2) 1`] = `
 Object {
   "body": undefined,
+  "branchName": undefined,
+  "createdAt": undefined,
   "displayNumber": "Pull Request #undefined",
   "isModified": false,
   "number": undefined,
@@ -69,6 +71,8 @@ Object {
 exports[`platform/azure/helpers getRenovatePRFormat should be formated (closed) 1`] = `
 Object {
   "body": undefined,
+  "branchName": undefined,
+  "createdAt": undefined,
   "displayNumber": "Pull Request #undefined",
   "isModified": false,
   "number": undefined,
@@ -81,6 +85,8 @@ Object {
 exports[`platform/azure/helpers getRenovatePRFormat should be formated (isConflicted) 1`] = `
 Object {
   "body": undefined,
+  "branchName": undefined,
+  "createdAt": undefined,
   "displayNumber": "Pull Request #undefined",
   "isConflicted": true,
   "isModified": false,
@@ -94,6 +100,8 @@ Object {
 exports[`platform/azure/helpers getRenovatePRFormat should be formated (not closed) 1`] = `
 Object {
   "body": undefined,
+  "branchName": undefined,
+  "createdAt": undefined,
   "displayNumber": "Pull Request #undefined",
   "isModified": false,
   "number": undefined,


### PR DESCRIPTION
…iguration ignored in nested configuration

<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate

    Please ensure `Allow edits from maintainers.` checkbox is checked
-->

For Azure the check on the PR hourly limit does not seem to behave correctly because renovate tests on the fields `branchName` and `createdAt` in function `getPrHourlyRemaining` of `lib/workers/repository/process/limits.ts`, but these fields are not set by `getPrList` for the azure platform.

Additionally there appears to be an issue ignoring presets in shareable config presets. For example in this setup:
* Shareable config preset named e.g. @mypreset has something like
  ```json
  {
    "extends": ["config:base"],
    "ignorePresets": [":prHourlyLimit2"],
    ...
  }
* renovate.json file in the project like this:
  ```json
  {
    "extends": ["@mypreset"]
    ...
  }
  ```

Then the ignorePreset from the shareable config preset is not applied.
