### PR TITLE
feat(azure): small improvements for PR assignees and reviewers (corre…

### DIFF
--- a/lib/platform/azure/index.spec.ts
+++ b/lib/platform/azure/index.spec.ts
@@ -802,12 +802,25 @@ describe('platform/azure', () => {
       azureApi.gitApi.mockImplementation(
         () =>
           ({
+            getRepositories: jest.fn(() => [{ id: '1', project: { id: 2 } }]),
             createThread: jest.fn(() => [{ id: 123 }]),
             getThreads: jest.fn(() => []),
           } as any)
       );
-      await azure.addAssignees(123, ['test@bonjour.fr']);
-      expect(azureApi.gitApi).toHaveBeenCalledTimes(3);
+      azureApi.coreApi.mockImplementation(
+        () =>
+          ({
+            getTeams: jest.fn(() => [
+              { id: 3, name: 'abc' },
+              { id: 4, name: 'def' },
+            ]),
+            getTeamMembersWithExtendedProperties: jest.fn(() => [
+              { identity: { displayName: 'jyc', uniqueName: 'jyc', id: 123 } },
+            ]),
+          } as any)
+      );
+      await azure.addAssignees(123, ['test@bonjour.fr', 'jyc', 'def']);
+      expect(azureApi.gitApi).toHaveBeenCalledTimes(4);
     });
   });
 
@@ -834,7 +847,7 @@ describe('platform/azure', () => {
           } as any)
       );
       await azure.addReviewers(123, ['test@bonjour.fr', 'jyc', 'def']);
-      expect(azureApi.gitApi).toHaveBeenCalledTimes(3);
+      expect(azureApi.gitApi).toHaveBeenCalledTimes(4);
     });
   });
 


### PR DESCRIPTION
…ctly assign when display name format is used; also add assignees and reviewers for onboarding PR if assigness/reviewers have been provided as command line arguments)

<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate

    Please ensure `Allow edits from maintainers.` checkbox is checked
-->

For Azure PR assignees are added by doing a mention in a PR comment. Currently when the assignee is given by its "displayName" instead of its "uniqueName" the mention will not work correctly. For reviewers it is possible to configure the reviewers by both their "displayName" and "uniqueName", so the code change of this pull request applies the same logic for reviewers also to assignees. Being able to specify assignees by display name can be useful because Azure Devops pipelines provide the display name as an environment variable in a running pipeline, but not the unique name.
