### PR TITLE
feat(azure): support Azure DevOps Server authentication methods

### DIFF
--- a/lib/platform/azure/__snapshots__/azure-got-wrapper.spec.ts.snap
+++ b/lib/platform/azure/__snapshots__/azure-got-wrapper.spec.ts.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`platform/azure/azure-got-wrapper gitApi should set token and endpoint 1`] = `
+exports[`platform/azure/azure-got-wrapper gitApi should set personal access token and endpoint 1`] = `
 WebApi {
   "authHandler": PersonalAccessTokenCredentialHandler {
-    "token": "token",
+    "token": "1234567890123456789012345678901234567890123456789012",
   },
   "isNoProxyHost": [Function],
   "options": Object {
@@ -23,7 +23,7 @@ WebApi {
       "_socketTimeout": undefined,
       "handlers": Array [
         PersonalAccessTokenCredentialHandler {
-          "token": "token",
+          "token": "1234567890123456789012345678901234567890123456789012",
         },
       ],
       "requestOptions": Object {
@@ -31,12 +31,12 @@ WebApi {
       },
     },
   },
-  "serverUrl": "https://dev.azure.com/renovate12345",
+  "serverUrl": "https://dev.azure.com/renovate1",
   "vsoClient": VsoClient {
     "_initializationPromise": Promise {},
     "_locationsByAreaPromises": Object {},
-    "basePath": "/renovate12345",
-    "baseUrl": "https://dev.azure.com/renovate12345",
+    "basePath": "/renovate1",
+    "baseUrl": "https://dev.azure.com/renovate1",
     "restClient": RestClient {
       "client": HttpClient {
         "_allowRedirects": true,
@@ -51,7 +51,136 @@ WebApi {
         "_socketTimeout": undefined,
         "handlers": Array [
           PersonalAccessTokenCredentialHandler {
+            "token": "1234567890123456789012345678901234567890123456789012",
+          },
+        ],
+        "requestOptions": Object {
+          "ignoreSslError": false,
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`platform/azure/azure-got-wrapper gitApi should set bearer token and endpoint 1`] = `
+WebApi {
+  "authHandler": BearerCredentialHandler {
+    "token": "token",
+  },
+  "isNoProxyHost": [Function],
+  "options": Object {
+    "ignoreSslError": false,
+  },
+  "rest": RestClient {
+    "client": HttpClient {
+      "_allowRedirects": true,
+      "_allowRetries": false,
+      "_certConfig": undefined,
+      "_disposed": false,
+      "_httpProxy": undefined,
+      "_ignoreSslError": false,
+      "_keepAlive": false,
+      "_maxRedirects": 50,
+      "_maxRetries": 1,
+      "_socketTimeout": undefined,
+      "handlers": Array [
+        BearerCredentialHandler {
+          "token": "token",
+        },
+      ],
+      "requestOptions": Object {
+        "ignoreSslError": false,
+      },
+    },
+  },
+  "serverUrl": "https://dev.azure.com/renovate2",
+  "vsoClient": VsoClient {
+    "_initializationPromise": Promise {},
+    "_locationsByAreaPromises": Object {},
+    "basePath": "/renovate2",
+    "baseUrl": "https://dev.azure.com/renovate2",
+    "restClient": RestClient {
+      "client": HttpClient {
+        "_allowRedirects": true,
+        "_allowRetries": false,
+        "_certConfig": undefined,
+        "_disposed": false,
+        "_httpProxy": undefined,
+        "_ignoreSslError": false,
+        "_keepAlive": false,
+        "_maxRedirects": 50,
+        "_maxRetries": 1,
+        "_socketTimeout": undefined,
+        "handlers": Array [
+          BearerCredentialHandler {
             "token": "token",
+          },
+        ],
+        "requestOptions": Object {
+          "ignoreSslError": false,
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`platform/azure/azure-got-wrapper gitApi should set password and endpoint 1`] = `
+WebApi {
+  "authHandler": BasicCredentialHandler {
+    "password": "pass",
+    "username": "user",
+  },
+  "isNoProxyHost": [Function],
+  "options": Object {
+    "ignoreSslError": false,
+  },
+  "rest": RestClient {
+    "client": HttpClient {
+      "_allowRedirects": true,
+      "_allowRetries": false,
+      "_certConfig": undefined,
+      "_disposed": false,
+      "_httpProxy": undefined,
+      "_ignoreSslError": false,
+      "_keepAlive": false,
+      "_maxRedirects": 50,
+      "_maxRetries": 1,
+      "_socketTimeout": undefined,
+      "handlers": Array [
+        BasicCredentialHandler {
+          "password": "pass",
+          "username": "user",
+        },
+      ],
+      "requestOptions": Object {
+        "ignoreSslError": false,
+      },
+    },
+  },
+  "serverUrl": "https://dev.azure.com/renovate3",
+  "vsoClient": VsoClient {
+    "_initializationPromise": Promise {},
+    "_locationsByAreaPromises": Object {},
+    "basePath": "/renovate3",
+    "baseUrl": "https://dev.azure.com/renovate3",
+    "restClient": RestClient {
+      "client": HttpClient {
+        "_allowRedirects": true,
+        "_allowRetries": false,
+        "_certConfig": undefined,
+        "_disposed": false,
+        "_httpProxy": undefined,
+        "_ignoreSslError": false,
+        "_keepAlive": false,
+        "_maxRedirects": 50,
+        "_maxRetries": 1,
+        "_socketTimeout": undefined,
+        "handlers": Array [
+          BasicCredentialHandler {
+            "password": "pass",
+            "username": "user",
           },
         ],
         "requestOptions": Object {

--- a/lib/platform/azure/__snapshots__/azure-helper.spec.ts.snap
+++ b/lib/platform/azure/__snapshots__/azure-helper.spec.ts.snap
@@ -1,5 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`platform/azure/helpers getStorageExtraCloneOpts should configure basic auth 1`] = `
+Object {
+  "--config": "http.extraheader=AUTHORIZATION: basic dXNlcjpwYXNz",
+}
+`;
+
+exports[`platform/azure/helpers getStorageExtraCloneOpts should configure personal access token 1`] = `
+Object {
+  "--config": "http.extraheader=AUTHORIZATION: basic OjEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=",
+}
+`;
+
+exports[`platform/azure/helpers getStorageExtraCloneOpts should configure bearer token 1`] = `
+Object {
+  "--config": "http.extraheader=AUTHORIZATION: bearer token",
+}
+`;
+
 exports[`platform/azure/helpers getAzureBranchObj should be the branch object formated 1`] = `
 Object {
   "name": "refs/heads/branchName",

--- a/lib/platform/azure/azure-got-wrapper.spec.ts
+++ b/lib/platform/azure/azure-got-wrapper.spec.ts
@@ -12,18 +12,52 @@ describe('platform/azure/azure-got-wrapper', () => {
   });
 
   describe('gitApi', () => {
-    it('should throw an error if no token is provided', () => {
-      expect(azure.gitApi).toThrow('No token found for azure');
-      expect(azure.coreApi).toThrow('No token found for azure');
-      expect(azure.policyApi).toThrow('No token found for azure');
+    it('should throw an error if no config found', () => {
+      expect(azure.gitApi).toThrow('No config found for azure');
+      expect(azure.coreApi).toThrow('No config found for azure');
+      expect(azure.policyApi).toThrow('No config found for azure');
     });
-    it('should set token and endpoint', () => {
+    it('should set personal access token and endpoint', () => {
+      hostRules.add({
+        hostType: PLATFORM_TYPE_AZURE,
+        token: '1234567890123456789012345678901234567890123456789012',
+        baseUrl: 'https://dev.azure.com/renovate1',
+      });
+      azure.setEndpoint('https://dev.azure.com/renovate1');
+
+      const res = azure.azureObj();
+
+      delete res.rest.client.userAgent;
+      delete res.vsoClient.restClient.client.userAgent;
+
+      // We will track if the lib azure-devops-node-api change
+      expect(res).toMatchSnapshot();
+    });
+    it('should set bearer token and endpoint', () => {
       hostRules.add({
         hostType: PLATFORM_TYPE_AZURE,
         token: 'token',
-        baseUrl: 'https://dev.azure.com/renovate12345',
+        baseUrl: 'https://dev.azure.com/renovate2',
       });
-      azure.setEndpoint('https://dev.azure.com/renovate12345');
+      azure.setEndpoint('https://dev.azure.com/renovate2');
+
+      const res = azure.azureObj();
+
+      delete res.rest.client.userAgent;
+      delete res.vsoClient.restClient.client.userAgent;
+
+      // We will track if the lib azure-devops-node-api change
+      expect(res).toMatchSnapshot();
+    });
+
+    it('should set password and endpoint', () => {
+      hostRules.add({
+        hostType: PLATFORM_TYPE_AZURE,
+        username: 'user',
+        password: 'pass',
+        baseUrl: 'https://dev.azure.com/renovate3',
+      });
+      azure.setEndpoint('https://dev.azure.com/renovate3');
 
       const res = azure.azureObj();
 

--- a/lib/platform/azure/azure-got-wrapper.ts
+++ b/lib/platform/azure/azure-got-wrapper.ts
@@ -6,7 +6,7 @@ import { getHandlerFromToken, getBasicHandler } from 'azure-devops-node-api';
 import { IRequestHandler } from 'azure-devops-node-api/interfaces/common/VsoBaseInterfaces';
 import * as hostRules from '../../util/host-rules';
 import { PLATFORM_TYPE_AZURE } from '../../constants/platforms';
-import { HostRule } from '../../util/host-rules';
+import { HostRule } from '../../types';
 
 const hostType = PLATFORM_TYPE_AZURE;
 let endpoint: string;
@@ -20,6 +20,9 @@ function getAuthenticationHandler(config: HostRule): IRequestHandler {
 
 export function azureObj(): azure.WebApi {
   const config = hostRules.find({ hostType, url: endpoint });
+  if (!config.token && !(config.username && config.password)) {
+    throw new Error(`No config found for azure`);
+  }
   const authHandler = getAuthenticationHandler(config);
   return new azure.WebApi(endpoint, authHandler);
 }

--- a/lib/platform/azure/azure-helper.spec.ts
+++ b/lib/platform/azure/azure-helper.spec.ts
@@ -13,6 +13,26 @@ describe('platform/azure/helpers', () => {
     azureApi = require('./azure-got-wrapper');
   });
 
+  describe('getStorageExtraCloneOpts', () => {
+    it('should configure basic auth', () => {
+      const res = azureHelper.getStorageExtraCloneOpts({
+        username: 'user',
+        password: 'pass',
+      });
+      expect(res).toMatchSnapshot();
+    });
+    it('should configure personal access token', () => {
+      const res = azureHelper.getStorageExtraCloneOpts({
+        token: '1234567890123456789012345678901234567890123456789012',
+      });
+      expect(res).toMatchSnapshot();
+    });
+    it('should configure bearer token', () => {
+      const res = azureHelper.getStorageExtraCloneOpts({ token: 'token' });
+      expect(res).toMatchSnapshot();
+    });
+  });
+
   describe('getNewBranchName', () => {
     it('should add refs/heads', () => {
       const res = azureHelper.getNewBranchName('testBB');

--- a/lib/platform/azure/azure-helper.ts
+++ b/lib/platform/azure/azure-helper.ts
@@ -14,7 +14,7 @@ import {
   PR_STATE_MERGED,
   PR_STATE_OPEN,
 } from '../../constants/pull-requests';
-import { HostRule } from '../../util/host-rules';
+import { HostRule } from '../../types';
 
 const mergePolicyGuid = 'fa4e907d-c16b-4a4c-9dfa-4916e5d171ab'; // Magic GUID for merge strategy policy configurations
 

--- a/lib/platform/azure/azure-helper.ts
+++ b/lib/platform/azure/azure-helper.ts
@@ -5,6 +5,7 @@ import {
   GitPullRequest,
 } from 'azure-devops-node-api/interfaces/GitInterfaces';
 
+import { Options } from 'simple-git/promise';
 import * as azureApi from './azure-got-wrapper';
 import { logger } from '../../logger';
 import { Pr } from '../common';
@@ -13,8 +14,28 @@ import {
   PR_STATE_MERGED,
   PR_STATE_OPEN,
 } from '../../constants/pull-requests';
+import { HostRule } from '../../util/host-rules';
 
 const mergePolicyGuid = 'fa4e907d-c16b-4a4c-9dfa-4916e5d171ab'; // Magic GUID for merge strategy policy configurations
+
+function toBase64(from: string): string {
+  return Buffer.from(from).toString('base64');
+}
+
+export function getStorageExtraCloneOpts(config: HostRule): Options {
+  let header: string;
+  const headerName = 'AUTHORIZATION';
+  if (!config.token && config.username && config.password) {
+    header = `${headerName}: basic ${toBase64(
+      `${config.username}:${config.password}`
+    )}`;
+  } else if (config.token.length !== 52) {
+    header = `${headerName}: bearer ${config.token}`;
+  } else {
+    header = `${headerName}: basic ${toBase64(`:${config.token}`)}`;
+  }
+  return { '--config': `http.extraheader=${header}` };
+}
 
 export function getNewBranchName(branchName?: string): string {
   if (branchName && !branchName.startsWith('refs/heads/')) {

--- a/lib/platform/azure/index.spec.ts
+++ b/lib/platform/azure/index.spec.ts
@@ -82,11 +82,29 @@ describe('platform/azure', () => {
       expect.assertions(1);
       expect(() => azure.initPlatform({})).toThrow();
     });
-    it('should throw if no token', () => {
+    it('should throw if no token nor a username and password', () => {
       expect.assertions(1);
       expect(() =>
         azure.initPlatform({
           endpoint: 'https://dev.azure.com/renovate12345',
+        })
+      ).toThrow();
+    });
+    it('should throw if a username but no password', () => {
+      expect.assertions(1);
+      expect(() =>
+        azure.initPlatform({
+          endpoint: 'https://dev.azure.com/renovate12345',
+          username: 'user',
+        })
+      ).toThrow();
+    });
+    it('should throw if a password but no username', () => {
+      expect.assertions(1);
+      expect(() =>
+        azure.initPlatform({
+          endpoint: 'https://dev.azure.com/renovate12345',
+          password: 'pass',
         })
       ).toThrow();
     });

--- a/lib/platform/azure/index.ts
+++ b/lib/platform/azure/index.ts
@@ -58,12 +58,16 @@ const defaults: any = {
 export function initPlatform({
   endpoint,
   token,
+  username,
+  password,
 }: RenovateConfig): Promise<PlatformConfig> {
   if (!endpoint) {
     throw new Error('Init: You must configure an Azure DevOps endpoint');
   }
-  if (!token) {
-    throw new Error('Init: You must configure an Azure DevOps token');
+  if (!token && !(username && password)) {
+    throw new Error(
+      'Init: You must configure an Azure DevOps token, or a username and password'
+    );
   }
   // TODO: Add a connection check that endpoint/token combination are valid
   const res = {
@@ -149,12 +153,13 @@ export async function initRepo({
     url: defaults.endpoint,
   });
   const url =
-    defaults.endpoint.replace('https://', `https://token:${opts.token}@`) +
+    defaults.endpoint +
     `${encodeURIComponent(projectName)}/_git/${encodeURIComponent(repoName)}`;
   await config.storage.initRepo({
     ...config,
     localDir,
     url,
+    extraCloneOpts: azureHelper.getStorageExtraCloneOpts(opts),
   });
   const repoConfig: RepoConfig = {
     baseBranch: config.baseBranch,

--- a/lib/platform/git/storage.spec.ts
+++ b/lib/platform/git/storage.spec.ts
@@ -54,6 +54,9 @@ describe('platform/git/storage', () => {
     await git.initRepo({
       localDir: tmpDir.path,
       url: origin.path,
+      extraCloneOpts: {
+        '--config': 'extra.clone.config=test-extra-config-value',
+      },
     });
   });
 
@@ -399,6 +402,12 @@ describe('platform/git/storage', () => {
       });
       expect(await fs.exists(tmpDir.path + '/.gitmodules')).toBeTruthy();
       await repo.reset(['--hard', 'HEAD^']);
+    });
+
+    it('should use extra clone configuration', async () => {
+      const repo = Git(tmpDir.path).silent(true);
+      const res = (await repo.raw(['config', 'extra.clone.config'])).trim();
+      expect(res).toBe('test-extra-config-value');
     });
   });
 });

--- a/lib/platform/git/storage.ts
+++ b/lib/platform/git/storage.ts
@@ -39,6 +39,7 @@ interface StorageConfig {
   baseBranch?: string;
   url: string;
   gitPrivateKey?: string;
+  extraCloneOpts?: Git.Options;
 }
 
 interface LocalConfig extends StorageConfig {
@@ -183,7 +184,13 @@ export class Storage {
       const cloneStart = process.hrtime();
       try {
         // clone only the default branch
-        await this._git.clone(config.url, '.', ['--depth=2']);
+        let opts = ['--depth=2'];
+        if (config.extraCloneOpts) {
+          opts = opts.concat(
+            Object.entries(config.extraCloneOpts).map(e => `${e[0]}=${e[1]}`)
+          );
+        }
+        await this._git.clone(config.url, '.', opts);
       } catch (err) /* istanbul ignore next */ {
         logger.debug({ err }, 'git clone error');
         throw new Error(PLATFORM_FAILURE);

--- a/lib/workers/global/index.ts
+++ b/lib/workers/global/index.ts
@@ -85,7 +85,7 @@ export async function start(): Promise<0 | 1> {
       await repositoryWorker.renovateRepository(repoConfig);
     }
     setMeta({});
-    logger.debug(`Renovate existing successfully`);
+    logger.debug(`Renovate exiting successfully`);
   } catch (err) /* istanbul ignore next */ {
     if (err.message.startsWith('Init: ')) {
       logger.fatal(err.message.substring(6));


### PR DESCRIPTION
<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate

    Please ensure `Allow edits from maintainers.` checkbox is checked
-->

I am using "Azure DevOps Server" (former TFS) instead of "Azure DevOps Services", and one without "personal access token" authentication enabled. The only way I am able to authenticate calls to the Azure DevOps Server REST API and git repositories is either via basic username/password (for local development) or via bearer token (for Azure DevOps pipelines). Currently renovate only supports personal access token authentication, which is the most common use case and Azure DevOps preferred way, so this is good. But to also support other authentication types I propose the change of this PR.

I've tested the changes for
* for Azure DevOps Server with username/password and bearer authentication
* for Azure DevOps Services with personal access tokens (=> so there should be no impact for existing users)

I have not yet looked into unit tests (draft pull request) as I would first like to get feedback if this is a change that might be considered for merging.

The code uses "http.extraheader" configuration for git clones as it seems the only way that git clones work consistently for Azure DevOps Server and Azure DevOps Services (https://github.com/microsoft/azure-pipelines-agent/issues/1601, https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/pipeline-options-for-git?view=azure-devops).
