### PR TITLE
docs: syntactic correction in regex

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -335,7 +335,7 @@ Finally, there are cases where Renovate's default `fileMatch` is good, but you m
 ```json
 {
   "dockerfile": {
-    "fileMatch": ["^ACTUALLY_A_DOCKERFILE.template$"]
+    "fileMatch": ["^ACTUALLY_A_DOCKERFILE\\.template$"]
   }
 }
 ```


### PR DESCRIPTION
The Config Options page provides a `fileMatch` example for `ACTUALLY_A_DOCKERFILE.template`, but uses an all-chars-matching `.` instead of a period literal `\\.`.