### PR TITLE
Detect binary and module npm packages as libraries

### DIFF
--- a/lib/manager/npm/extract/type.ts
+++ b/lib/manager/npm/extract/type.ts
@@ -6,8 +6,12 @@ export function mightBeABrowserLibrary(packageJson: NpmPackage): boolean {
     // it's not published
     return false;
   }
-  if (packageJson.main === undefined) {
-    // it can't be required
+  if (
+    packageJson.main === undefined &&
+    packageJson.module === undefined &&
+    packageJson.bin === undefined
+  ) {
+    // it can't be required nor does it have a binary
     return false;
   }
   // TODO: how can we know if it's a node.js library only, and not browser?


### PR DESCRIPTION
I'm not 100% sure this is correct in all cases, but I wanted to start the conversation with this PR.

I came accross this in one of our repos where we started pinning dependencies and enabling automerge for devDependencies.

For at least one package I noticed it was detected as project even though it is not. It's also not really a library, I would rather call it a cli tool. (https://github.com/researchgate/emailonacid/blob/master/packages/emailonacid-proxy/package.json)

But for the sake of the `mightBeABrowserLibrary` check I think it should be considered a library. 

In order to fix the above problem I added two more checks, so that in total in order to be considered a library you need to have one of the fields `main`, `module` or `bin` in your `package.json`.

Not sure if there are other opinions on this?