### PR TITLE
Use local auth.json file when available

### DIFF
--- a/lib/manager/composer/__fixtures__/auth1.json
+++ b/lib/manager/composer/__fixtures__/auth1.json
@@ -1,0 +1,14 @@
+{
+  "http-basic": {
+    "git.domain.com": {
+      "username": "username",
+      "password": "password"
+    }
+  },
+  "github-oauth": {
+    "github.com": "repogithubtoken"
+  },
+  "gitlab-token": {
+    "gitlab.com": "repogitlabtoken"
+  }
+}

--- a/lib/manager/composer/__fixtures__/auth2.json
+++ b/lib/manager/composer/__fixtures__/auth2.json
@@ -1,0 +1,5 @@
+{
+  "gitlab-oauth": {
+    "gitlab.com": "repogitlabtoken"
+  }
+}

--- a/lib/manager/composer/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/manager/composer/__snapshots__/artifacts.spec.ts.snap
@@ -45,6 +45,29 @@ Array [
 ]
 `;
 
+exports[`.updateArtifacts() does not write auth.json if no hostRules 1`] = `
+Array [
+  Object {
+    "cmd": "composer update --with-dependencies --ignore-platform-reqs --no-ansi --no-interaction --no-scripts --no-autoloader",
+    "options": Object {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": Object {
+        "COMPOSER_CACHE_DIR": "/tmp/renovate/cache/others/composer",
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "timeout": 900000,
+    },
+  },
+]
+`;
+
 exports[`.updateArtifacts() performs lockFileMaintenance 1`] = `
 Array [
   Object {
@@ -194,3 +217,5 @@ Array [
   },
 ]
 `;
+
+exports[`.updateArtifacts() uses hostRules to write auth.json 2`] = `"{\\"http-basic\\":{\\"packagist.renovatebot.com\\":{\\"username\\":\\"some-username\\",\\"password\\":\\"some-password\\"},\\"example.com\\":{\\"username\\":\\"other-username\\",\\"password\\":\\"other-password\\"}}}"`;

--- a/lib/manager/composer/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/composer/__snapshots__/extract.spec.ts.snap
@@ -1,5 +1,68 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`lib/manager/composer/extract extractHostRulesFromAuthFile() adds hostRules for everything in auth.json 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      Object {
+        "domainName": "github.com",
+        "hostType": "github",
+        "token": "repogithubtoken",
+      },
+    ],
+    Array [
+      Object {
+        "domainName": "gitlab.com",
+        "hostType": "gitlab",
+        "token": "repogitlabtoken",
+      },
+    ],
+    Array [
+      Object {
+        "domainName": "git.domain.com",
+        "hostType": "composer",
+        "password": "password",
+        "username": "username",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`lib/manager/composer/extract extractHostRulesFromAuthFile() adds hostRules for gitlab-oauth in auth.json 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      Object {
+        "domainName": "gitlab.com",
+        "hostType": "gitlab",
+        "token": "repogitlabtoken",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
 exports[`lib/manager/composer/extract extractPackageFile() extracts dependencies with lock file 1`] = `
 Object {
   "deps": Array [

--- a/lib/manager/composer/artifacts.ts
+++ b/lib/manager/composer/artifacts.ts
@@ -20,7 +20,85 @@ import {
 } from '../../util/fs';
 import { getRepoStatus } from '../../util/git';
 import * as hostRules from '../../util/host-rules';
-import { UpdateArtifact, UpdateArtifactsResult } from '../common';
+import {
+  UpdateArtifact,
+  UpdateArtifactsConfig,
+  UpdateArtifactsResult,
+} from '../common';
+import { ComposerAuthConfig, HOST_TYPE_COMPOSER } from './extract';
+
+function generateAuthJson(
+  config: UpdateArtifactsConfig
+): ComposerAuthConfig | null {
+  const authJson: ComposerAuthConfig = {};
+  let credentials = hostRules.find({
+    hostType: PLATFORM_TYPE_GITHUB,
+    url: 'https://api.github.com/',
+  });
+  // istanbul ignore if
+  if (credentials && credentials.token) {
+    authJson['github-oauth'] = {
+      'github.com': credentials.token,
+    };
+  }
+  credentials = hostRules.find({
+    hostType: PLATFORM_TYPE_GITLAB,
+    url: 'https://gitlab.com/api/v4/',
+  });
+  // istanbul ignore if
+  if (credentials && credentials.token) {
+    authJson['gitlab-token'] = {
+      'gitlab.com': credentials.token,
+    };
+  }
+  try {
+    // istanbul ignore else
+    if (is.array(config.registryUrls)) {
+      for (const regUrl of config.registryUrls) {
+        if (regUrl) {
+          const { host } = URL.parse(regUrl);
+          const hostRule = hostRules.find({
+            hostType: datasourcePackagist.id,
+            url: regUrl,
+          });
+          // istanbul ignore else
+          if (hostRule.username && hostRule.password) {
+            logger.debug('Setting packagist auth for host ' + host);
+            authJson['http-basic'] = authJson['http-basic'] || {};
+            authJson['http-basic'][host] = {
+              username: hostRule.username,
+              password: hostRule.password,
+            };
+          } else {
+            logger.debug('No packagist auth found for ' + regUrl);
+          }
+        }
+      }
+    } else if (config.registryUrls) {
+      logger.warn(
+        { registryUrls: config.registryUrls },
+        'Non-array composer registryUrls'
+      );
+    }
+  } catch (err) /* istanbul ignore next */ {
+    logger.warn({ err }, 'Error setting registryUrls auth for composer');
+  }
+
+  const composerHostRules = hostRules.findAll({
+    hostType: HOST_TYPE_COMPOSER,
+  });
+
+  for (const hostRule of composerHostRules) {
+    logger.debug('Setting http basic auth for domain ' + hostRule.domainName);
+    authJson['http-basic'] = authJson['http-basic'] || {};
+    authJson['http-basic'][hostRule.domainName] = {
+      username: hostRule.username,
+      password: hostRule.password,
+    };
+  }
+
+  return Object.keys(authJson).length > 0 ? authJson : null;
+}
 
 export async function updateArtifacts({
   packageFileName,
@@ -48,62 +126,12 @@ export async function updateArtifacts({
     if (config.isLockFileMaintenance) {
       await deleteLocalFile(lockFileName);
     }
-    const authJson = {};
-    let credentials = hostRules.find({
-      hostType: PLATFORM_TYPE_GITHUB,
-      url: 'https://api.github.com/',
-    });
-    // istanbul ignore if
-    if (credentials && credentials.token) {
-      authJson['github-oauth'] = {
-        'github.com': credentials.token,
-      };
-    }
-    credentials = hostRules.find({
-      hostType: PLATFORM_TYPE_GITLAB,
-      url: 'https://gitlab.com/api/v4/',
-    });
-    // istanbul ignore if
-    if (credentials && credentials.token) {
-      authJson['gitlab-token'] = {
-        'gitlab.com': credentials.token,
-      };
-    }
-    try {
-      // istanbul ignore else
-      if (is.array(config.registryUrls)) {
-        for (const regUrl of config.registryUrls) {
-          if (regUrl) {
-            const { host } = URL.parse(regUrl);
-            const hostRule = hostRules.find({
-              hostType: datasourcePackagist.id,
-              url: regUrl,
-            });
-            // istanbul ignore else
-            if (hostRule.username && hostRule.password) {
-              logger.debug('Setting packagist auth for host ' + host);
-              authJson['http-basic'] = authJson['http-basic'] || {};
-              authJson['http-basic'][host] = {
-                username: hostRule.username,
-                password: hostRule.password,
-              };
-            } else {
-              logger.debug('No packagist auth found for ' + regUrl);
-            }
-          }
-        }
-      } else if (config.registryUrls) {
-        logger.warn(
-          { registryUrls: config.registryUrls },
-          'Non-array composer registryUrls'
-        );
-      }
-    } catch (err) /* istanbul ignore next */ {
-      logger.warn({ err }, 'Error setting registryUrls auth for composer');
-    }
+
+    const authJson = generateAuthJson(config);
     if (authJson) {
       await writeLocalFile('auth.json', JSON.stringify(authJson));
     }
+
     const execOptions: ExecOptions = {
       cwdFile: packageFileName,
       extraEnv: {

--- a/lib/manager/composer/extract.spec.ts
+++ b/lib/manager/composer/extract.spec.ts
@@ -1,8 +1,10 @@
 import { readFileSync } from 'fs';
-import { fs } from '../../../test/util';
+import { fs, hostRules } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
+jest.mock('fs-extra');
 jest.mock('../../util/fs');
+jest.mock('../../util/host-rules');
 
 const requirements1 = readFileSync(
   'lib/manager/composer/__fixtures__/composer1.json',
@@ -26,6 +28,14 @@ const requirements5 = readFileSync(
 );
 const requirements5Lock = readFileSync(
   'lib/manager/composer/__fixtures__/composer5.lock',
+  'utf8'
+);
+const auth1Json = readFileSync(
+  'lib/manager/composer/__fixtures__/auth1.json',
+  'utf8'
+);
+const auth2Json = readFileSync(
+  'lib/manager/composer/__fixtures__/auth2.json',
   'utf8'
 );
 
@@ -70,6 +80,29 @@ describe('lib/manager/composer/extract', () => {
       fs.readLocalFile.mockResolvedValue('some content');
       const res = await extractPackageFile(requirements1, packageFile);
       expect(res).toMatchSnapshot();
+    });
+  });
+  describe('extractHostRulesFromAuthFile()', () => {
+    let packageFile;
+    beforeEach(() => {
+      jest.resetAllMocks();
+      packageFile = 'composer.json';
+    });
+    it('adds hostRules for everything in auth.json', async () => {
+      fs.pathExists.mockReturnValueOnce(true as any);
+      fs.readJson.mockReturnValueOnce(JSON.parse(auth1Json));
+      await extractPackageFile('{}', packageFile);
+
+      expect(hostRules.add).toHaveBeenCalledTimes(3);
+      expect(hostRules.add).toMatchSnapshot();
+    });
+    it('adds hostRules for gitlab-oauth in auth.json', async () => {
+      fs.pathExists.mockReturnValueOnce(true as any);
+      fs.readJson.mockReturnValueOnce(JSON.parse(auth2Json));
+      await extractPackageFile('{}', packageFile);
+
+      expect(hostRules.add).toHaveBeenCalledTimes(1);
+      expect(hostRules.add).toMatchSnapshot();
     });
   });
 });

--- a/lib/util/fs/proxies.ts
+++ b/lib/util/fs/proxies.ts
@@ -27,6 +27,14 @@ export async function readFile(
 }
 
 // istanbul ignore next
+export async function readJson(
+  file: string,
+  options?: fs.ReadOptions
+): Promise<any> {
+  return fs.readJson(file, options);
+}
+
+// istanbul ignore next
 export async function writeFile(
   fileName: string,
   fileContent: string


### PR DESCRIPTION
This ensures renovate bot reads a local `auth.json` file if it is available next to `composer.json` and uses it as the default before modyfing it.

I wasn't sure if values from a local `auth.json` should be overwritten or not. I added a test that tests that the values are correctly overwritten by renovate bot, but I'm happy to change it. I just went for overwritting for now, as it requires less modifications to the code. 
Let me know what you think the expected behaviour should be.

Does NOT fix issue in #5616.


