### PR TITLE
fix(datasource): centralize lookupName check

### DIFF
--- a/lib/datasource/cdnjs/index.ts
+++ b/lib/datasource/cdnjs/index.ts
@@ -50,12 +50,6 @@ export async function getDigest(
 export async function getPkgReleases({
   lookupName,
 }: Partial<GetReleasesConfig>): Promise<ReleaseResult | null> {
-  // istanbul ignore if
-  if (!lookupName) {
-    logger.warn('CDNJS lookup failure: empty lookupName');
-    return null;
-  }
-
   const [library, ...assetParts] = lookupName.split('/');
   const assetName = assetParts.join('/');
 

--- a/lib/datasource/crate/index.spec.ts
+++ b/lib/datasource/crate/index.spec.ts
@@ -105,12 +105,5 @@ describe('datasource/crate', () => {
       const res = await getPkgReleases({ lookupName: 'some_crate' });
       expect(res).toBeNull();
     });
-    it('returns null if lookupName is undefined', async () => {
-      got.mockReturnValueOnce({
-        body: res1,
-      });
-      const res = await getPkgReleases({ lookupName: undefined });
-      expect(res).toBeNull();
-    });
   });
 });

--- a/lib/datasource/crate/index.ts
+++ b/lib/datasource/crate/index.ts
@@ -12,10 +12,6 @@ export const id = 'crate';
 export async function getPkgReleases({
   lookupName,
 }: GetReleasesConfig): Promise<ReleaseResult | null> {
-  if (!lookupName) {
-    return null;
-  }
-
   const cacheNamespace = 'datasource-crate';
   const cacheKey = lookupName;
   const cachedResult = await renovateCache.get<ReleaseResult>(

--- a/lib/datasource/galaxy/index.spec.ts
+++ b/lib/datasource/galaxy/index.spec.ts
@@ -73,12 +73,5 @@ describe('datasource/galaxy', () => {
       const res = await getPkgReleases({ lookupName: 'foo.bar' });
       expect(res).toBeNull();
     });
-    it('returns null if lookupName is undefined', async () => {
-      got.mockReturnValueOnce({
-        body: res1,
-      });
-      const res = await getPkgReleases({ lookupName: undefined });
-      expect(res).toBeNull();
-    });
   });
 });

--- a/lib/datasource/galaxy/index.ts
+++ b/lib/datasource/galaxy/index.ts
@@ -7,10 +7,6 @@ export const id = 'galaxy';
 export async function getPkgReleases({
   lookupName,
 }: GetReleasesConfig): Promise<ReleaseResult | null> {
-  if (!lookupName) {
-    return null;
-  }
-
   const cacheNamespace = 'datasource-galaxy';
   const cacheKey = lookupName;
   const cachedResult = await renovateCache.get<ReleaseResult>(

--- a/lib/datasource/helm/index.ts
+++ b/lib/datasource/helm/index.ts
@@ -87,10 +87,6 @@ export async function getPkgReleases({
   lookupName,
   registryUrls,
 }: GetReleasesConfig): Promise<ReleaseResult | null> {
-  if (!lookupName) {
-    logger.warn(`lookupName was not provided to getPkgReleases`);
-    return null;
-  }
   const [helmRepository] = registryUrls;
   if (!helmRepository) {
     logger.warn(`helmRepository was not provided to getPkgReleases`);

--- a/lib/datasource/hex/index.ts
+++ b/lib/datasource/hex/index.ts
@@ -13,12 +13,6 @@ interface HexRelease {
 export async function getPkgReleases({
   lookupName,
 }: Partial<GetReleasesConfig>): Promise<ReleaseResult | null> {
-  // istanbul ignore if
-  if (!lookupName) {
-    logger.warn('hex lookup failure: No lookupName');
-    return null;
-  }
-
   // Get dependency name from lookupName.
   // If the dependency is private lookupName contains organization name as following:
   // hexPackageName:organizationName

--- a/lib/datasource/index.spec.ts
+++ b/lib/datasource/index.spec.ts
@@ -27,6 +27,13 @@ describe('datasource/index', () => {
       })
     ).toBeNull();
   });
+  it('returns null for no lookupName', async () => {
+    expect(
+      await datasource.getPkgReleases({
+        datasource: 'npm',
+      })
+    ).toBeNull();
+  });
   it('returns null for unknown datasource', async () => {
     expect(
       await datasource.getPkgReleases({

--- a/lib/datasource/index.ts
+++ b/lib/datasource/index.ts
@@ -67,6 +67,10 @@ export async function getPkgReleases(
 ): Promise<ReleaseResult | null> {
   const { datasource } = config;
   const lookupName = config.lookupName || config.depName;
+  if (!lookupName) {
+    logger.error({ config }, 'Datasource getPkgReleases without lookupName');
+    return null;
+  }
   let res;
   try {
     res = await getRawReleases({

--- a/lib/datasource/pod/index.spec.ts
+++ b/lib/datasource/pod/index.spec.ts
@@ -2,7 +2,6 @@ import { api as _api } from '../../platform/github/gh-got-wrapper';
 import { getPkgReleases } from '.';
 import { mocked } from '../../../test/util';
 import { GotResponse } from '../../platform';
-import { GetReleasesConfig } from '../common';
 
 const api = mocked(_api);
 
@@ -18,14 +17,6 @@ describe('datasource/cocoapods', () => {
     beforeEach(() => global.renovateCache.rmAll());
     it('returns null for invalid inputs', async () => {
       api.get.mockResolvedValueOnce(null);
-      expect(
-        await getPkgReleases({ registryUrls: [] } as GetReleasesConfig)
-      ).toBeNull();
-      expect(
-        await getPkgReleases({
-          lookupName: null,
-        })
-      ).toBeNull();
       expect(
         await getPkgReleases({
           lookupName: 'foobar',

--- a/lib/datasource/pod/index.ts
+++ b/lib/datasource/pod/index.ts
@@ -131,11 +131,6 @@ export async function getPkgReleases(
   registryUrls =
     registryUrls && registryUrls.length ? registryUrls : [defaultCDN];
 
-  if (!lookupName) {
-    logger.debug(config, `CocoaPods: invalid lookup name`);
-    return null;
-  }
-
   const podName = lookupName.replace(/\/.*$/, '');
 
   const cachedResult = await renovateCache.get<ReleaseResult>(

--- a/lib/workers/repository/process/lookup/index.spec.ts
+++ b/lib/workers/repository/process/lookup/index.spec.ts
@@ -1244,6 +1244,7 @@ describe('workers/repository/process/lookup', () => {
       expect(res).toMatchSnapshot();
     });
     it('handles git submodule update', async () => {
+      config.depName = 'some-path';
       config.versioning = gitVersioning.id;
       config.datasource = datasourceGitSubmodules.id;
       gitSubmodules.getPkgReleases.mockResolvedValueOnce({


### PR DESCRIPTION
Moves `lookupName` check to the datasource index to simplify implementations.
