### PR TITLE
build: release docker as first

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,15 +1,15 @@
 {
   "plugins": [
     "@semantic-release/commit-analyzer",
-    "@semantic-release/github",
-    "@semantic-release/npm",
     "@semantic-release/release-notes-generator",
     [
       "@semantic-release/exec",
       {
         "publishCmd": "./.github/workflows/release-docker.sh ${nextRelease.version} ${nextRelease.gitHead}"
       }
-    ]
+    ],
+    "@semantic-release/github",
+    "@semantic-release/npm"
   ],
   "analyzeCommits": {
     "preset": "angular",


### PR DESCRIPTION
This hopefully publishs our docker images before npm, because npm publish currently seems to be flaky.