### PR TITLE
fix: make sure docker is used before trying to remove container

### DIFF
--- a/lib/manager/cocoapods/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/manager/cocoapods/__snapshots__/artifacts.spec.ts.snap
@@ -153,12 +153,6 @@ Array [
       "timeout": 900000,
     },
   },
-  Object {
-    "cmd": "docker ps --filter name=renovate_cocoapods -aq | xargs --no-run-if-empty docker rm -f",
-    "options": Object {
-      "encoding": "utf-8",
-    },
-  },
 ]
 `;
 

--- a/lib/util/exec/index.ts
+++ b/lib/util/exec/index.ts
@@ -149,8 +149,10 @@ export async function exec(
       res = await rawExec(rawExecCommand, rawExecOptions);
     } catch (err) {
       logger.trace({ err }, 'rawExec err');
-      clearTimeout(timer);
-      await removeDockerContainer(docker.image);
+      if (useDocker) {
+        clearTimeout(timer);
+        await removeDockerContainer(docker.image);
+      }
       throw err;
     }
     clearTimeout(timer);


### PR DESCRIPTION
We are seeing the following errors in our logs in https://app.renovatebot.com/dashboard:

```json
{
  "cmd": "node /home/ubuntu/renovateapp/node_modules/yarn/bin/yarn.js",
  "err": {
    "message": "Cannot read property 'image' of undefined",
    "stack": "TypeError: Cannot read property 'image' of undefined\n    at Object.exec (/home/ubuntu/renovateapp/node_modules/renovate/dist/util/exec/index.js:109:57)\n    at runMicrotasks ()\n    at processTicksAndRejections (internal/process/task_queues.js:93:5)"
  },
  "stdout": "",
  "stderr": "",
  "type": "yarn"
}
```

Looking at the code, it seems like what is actually happening is that another error is being thrown. But since #5673, `removeDockerContainer(docker.image)` is being run without verifying that `useDocker = true` inside the catch, so it ends up throwing the error message about `docker` being undefined rather than throwing the actual error.

It looks like simply adding an if statement checking this would make it log the correct error.