### PR TITLE
chore: update release config

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -23,6 +23,58 @@
       }
     ]
   },
+  "generateNotes": {
+    "types": [
+      {
+        "type": "feat",
+        "section": "Features"
+      },
+      {
+        "type": "feature",
+        "section": "Features"
+      },
+      {
+        "type": "fix",
+        "section": "Bug Fixes"
+      },
+      {
+        "type": "perf",
+        "section": "Performance Improvements"
+      },
+      {
+        "type": "revert",
+        "section": "Reverts"
+      },
+      {
+        "type": "docs",
+        "section": "Documentation"
+      },
+      {
+        "type": "style",
+        "section": "Styles"
+      },
+      {
+        "type": "chore",
+        "section": "Miscellaneous Chores"
+      },
+      {
+        "type": "refactor",
+        "section": "Code Refactoring"
+      },
+      {
+        "type": "test",
+        "section": "Tests"
+      },
+      {
+        "type": "build",
+        "section": "Build System"
+      },
+      {
+        "type": "ci",
+        "section": "Continuous Integration"
+      }
+    ]
+  },
   "preset": "conventionalcommits",
   "tagFormat": "${version}"
 }

--- a/.releaserc
+++ b/.releaserc
@@ -23,7 +23,8 @@
       }
     ]
   },
-  "generateNotes": {
+  "preset": "conventionalcommits",
+  "presetConfig": {
     "types": [
       {
         "type": "feat",
@@ -75,6 +76,5 @@
       }
     ]
   },
-  "preset": "conventionalcommits",
   "tagFormat": "${version}"
 }

--- a/.releaserc
+++ b/.releaserc
@@ -11,7 +11,7 @@
     ]
   ],
   "analyzeCommits": {
-    "preset": "angular",
+    "preset": "conventionalcommits",
     "releaseRules": [
       {
         "type": "docs",

--- a/.releaserc
+++ b/.releaserc
@@ -11,7 +11,6 @@
     ]
   ],
   "analyzeCommits": {
-    "preset": "conventionalcommits",
     "releaseRules": [
       {
         "type": "docs",
@@ -24,5 +23,6 @@
       }
     ]
   },
+  "preset": "conventionalcommits",
   "tagFormat": "${version}"
 }

--- a/package.json
+++ b/package.json
@@ -216,6 +216,7 @@
     "aws-sdk-mock": "4.5.0",
     "babel-jest": "25.1.0",
     "babel-plugin-dynamic-import-node": "2.3.0",
+    "conventional-changelog-conventionalcommits": "4.2.3",
     "copyfiles": "2.2.0",
     "cross-env": "7.0.2",
     "eslint": "6.8.0",
@@ -242,7 +243,7 @@
     "typescript": "3.8.3"
   },
   "resolutions": {
-    "jest-silent-reporter/jest-util":">=25.1.0",
+    "jest-silent-reporter/jest-util": ">=25.1.0",
     "jest-junit/jest-validate": ">=25.1.0",
     "**/acorn": ">=6.4.1 <7.0.0 || >=7.1.1",
     "**/kind-of": ">=6.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2750,6 +2750,15 @@ conventional-changelog-angular@^5.0.0:
     compare-func "^1.3.1"
     q "^1.5.1"
 
+conventional-changelog-conventionalcommits@4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.2.3.tgz#22855b32d57d0328951c1c2dc01b172a5f24ea37"
+  integrity sha512-atGa+R4vvEhb8N/8v3IoW59gCBJeeFiX6uIbPu876ENAmkMwsenyn0R21kdDHJFLQdy6zW4J6b4xN8KI3b9oww==
+  dependencies:
+    compare-func "^1.3.1"
+    lodash "^4.17.15"
+    q "^1.5.1"
+
 conventional-changelog-writer@^4.0.0:
   version "4.0.11"
   resolved "https://registry.yarnpkg.com/conventional-changelog-writer/-/conventional-changelog-writer-4.0.11.tgz#9f56d2122d20c96eb48baae0bf1deffaed1edba4"


### PR DESCRIPTION
This  pr switches semantic relase preset from `angular` to `conventionalcommits`.