### PR TITLE
refactor(gradle-wrapper): Extract Regexes & Named Capturing Groups

### DIFF
--- a/lib/manager/gradle-wrapper/extract.ts
+++ b/lib/manager/gradle-wrapper/extract.ts
@@ -3,6 +3,7 @@ import { logger } from '../../logger';
 import { PackageFile, PackageDependency } from '../common';
 import * as semverVersioning from '../../versioning/semver';
 import * as datasourceGradleVersion from '../../datasource/gradle-version';
+import { DISTRIBUTION_CHECKSUM_REGEX, DISTRIBUTION_URL_REGEX } from './search';
 
 export function extractPackageFile(fileContent: string): PackageFile | null {
   logger.debug('gradle-wrapper.extractPackageFile()');
@@ -10,24 +11,23 @@ export function extractPackageFile(fileContent: string): PackageFile | null {
 
   let lineNumber = 0;
   for (const line of lines) {
-    const match = /^distributionUrl\s*=\s*\S*-((\d|\.)+)-(bin|all)\.zip\s*$/.exec(
-      line
-    );
-    if (match) {
+    const distributionUrlMatch = DISTRIBUTION_URL_REGEX.exec(line);
+    if (distributionUrlMatch) {
       const dependency: PackageDependency = {
         datasource: datasourceGradleVersion.id,
         depType: 'gradle-wrapper',
         depName: 'gradle',
-        currentValue: coerce(match[1]).toString(),
-        managerData: { lineNumber, gradleWrapperType: match[3] },
+        currentValue: coerce(distributionUrlMatch.groups.version).toString(),
+        managerData: {
+          lineNumber,
+          gradleWrapperType: distributionUrlMatch.groups.type,
+        },
         versioning: semverVersioning.id,
       };
 
       let shaLineNumber = 0;
       for (const shaLine of lines) {
-        const shaMatch = /^distributionSha256Sum\s*=\s*((\w){64}).*$/.test(
-          shaLine
-        );
+        const shaMatch = DISTRIBUTION_CHECKSUM_REGEX.test(shaLine);
         if (shaMatch) {
           dependency.managerData.checksumLineNumber = shaLineNumber;
           break;

--- a/lib/manager/gradle-wrapper/search.ts
+++ b/lib/manager/gradle-wrapper/search.ts
@@ -1,0 +1,2 @@
+export const DISTRIBUTION_URL_REGEX = /^(?<assignment>distributionUrl\s*=\s*)\S*-(?<version>(\d|\.)+)-(?<type>bin|all)\.zip\s*$/;
+export const DISTRIBUTION_CHECKSUM_REGEX = /^(?<assignment>distributionSha256Sum\s*=\s*)(?<checksum>(\w){64}).*$/;

--- a/lib/manager/gradle-wrapper/update.ts
+++ b/lib/manager/gradle-wrapper/update.ts
@@ -1,6 +1,7 @@
 import got from '../../util/got';
 import { logger } from '../../logger';
 import { UpdateDependencyConfig } from '../common';
+import { DISTRIBUTION_CHECKSUM_REGEX, DISTRIBUTION_URL_REGEX } from './search';
 
 function replaceType(url: string): string {
   return url.replace('bin', 'all');
@@ -40,12 +41,12 @@ export async function updateDependency({
 
     lines[upgrade.managerData.lineNumber] = lines[
       upgrade.managerData.lineNumber
-    ].replace(/(distributionUrl\s*=\s*)\S*/, `$1${downloadUrl}`);
+    ].replace(DISTRIBUTION_URL_REGEX, `$<assignment>${downloadUrl}`);
 
     if (upgrade.managerData.checksumLineNumber) {
       lines[upgrade.managerData.checksumLineNumber] = lines[
         upgrade.managerData.checksumLineNumber
-      ].replace(/(distributionSha256Sum\s*=\s*)\S*/, `$1${checksum}`);
+      ].replace(DISTRIBUTION_CHECKSUM_REGEX, `$<assignment>${checksum}`);
     }
     // TODO: insert if not present
 


### PR DESCRIPTION
As suggested in #5740 

> We should move the regexes to module scope, otherwise they are recreated on every loop iteration, which is unnessessary

This PR pulls the regexes up. It shares the regexes between the two modules and also uses named capturing groups for easier access.

<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate

    Please ensure `Allow edits from maintainers.` checkbox is checked
-->

<!-- Replace this text with a description of what this PR fixes or adds -->


