### PR TITLE
test(manager): remove GOPATH env var during tests

### DIFF
--- a/lib/manager/gomod/artifacts.spec.ts
+++ b/lib/manager/gomod/artifacts.spec.ts
@@ -53,6 +53,7 @@ describe('.updateArtifacts()', () => {
     jest.resetAllMocks();
     jest.resetModules();
 
+    delete process.env.GOPATH;
     env.getChildProcessEnv.mockReturnValue({ ...envMock.basic, ...goEnv });
     setUtilConfig(config);
     resetPrefetchedImages();


### PR DESCRIPTION
Stop using developers GOPATH env var during tests

Closes #5751 
