### PR TITLE
chore(internal): simplify devcontainer image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,14 +1,4 @@
-#-------------------------------------------------------------------------------------------------------------
-# Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
-#-------------------------------------------------------------------------------------------------------------
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0.108.0-12@sha256:0afe371ce3995bb57590075d902619c2098c9071e8a4cd71f7c00082faede09f
 
-# To fully customize the contents of this image, use the following Dockerfile instead:
-# https://github.com/microsoft/vscode-dev-containers/tree/v0.106.0/containers/typescript-node-12/.devcontainer/Dockerfile
-FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-12@sha256:0afe371ce3995bb57590075d902619c2098c9071e8a4cd71f7c00082faede09f
-
-ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update \
-   && apt-get -y install --no-install-recommends git python-minimal build-essential \
-   && rm -rf /var/lib/apt/lists/*
-ENV DEBIAN_FRONTEND=dialog
+# see https://mcr.microsoft.com/v2/vscode/devcontainers/typescript-node/tags/list for tags
+# all renovate dev tools are already installed

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,7 @@
 FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0.108.0-12@sha256:0afe371ce3995bb57590075d902619c2098c9071e8a4cd71f7c00082faede09f
 
 # see https://mcr.microsoft.com/v2/vscode/devcontainers/typescript-node/tags/list for tags
-# all renovate dev tools are already installed
+# Add missing renovate dev tools
+RUN DEBIAN_FRONTEND=noninteractive apt-get update \
+   && apt-get -y install --no-install-recommends --no-upgrade build-essential \
+   && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,9 +6,6 @@
   "settings": {
     "terminal.integrated.shell.linux": "/bin/bash"
   },
-  "extensions": [
-    "dbaeumer.vscode-eslint",
-    "esbenp.prettier-vscode"
-  ],
+  "extensions": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"],
   "postCreateCommand": "yarn install"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,5 +6,9 @@
   "settings": {
     "terminal.integrated.shell.linux": "/bin/bash"
   },
+  "extensions": [
+		"dbaeumer.vscode-eslint",
+		"esbenp.prettier-vscode"
+	]
   "postCreateCommand": "yarn install"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,8 +7,8 @@
     "terminal.integrated.shell.linux": "/bin/bash"
   },
   "extensions": [
-		"dbaeumer.vscode-eslint",
-		"esbenp.prettier-vscode"
-	]
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode"
+  ],
   "postCreateCommand": "yarn install"
 }


### PR DESCRIPTION
See https://mcr.microsoft.com/v2/vscode/devcontainers/typescript-node/tags/list for tags

All renovate dev tools are already installed (v0.108.0):
* node: 12.16.1
* npm: 6.13.4
* yarn: 1.22.4
* python: 2.7.13, 3.5.3