### PR TITLE
chore(coverage): enable coverage on master

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
             node-version: 10
 
     env:
-      coverage: ${{ matrix.os == 'ubuntu-latest' && matrix.node-version == 12 && github.ref != 'refs/heads/master' }}
+      coverage: ${{ matrix.os == 'ubuntu-latest' && matrix.node-version == 12 }}
 
     steps:
       - name: Set up Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
Otherwise we get missing base report on codecov
