### PR TITLE
feat(bitbucket-server): Implement repoForceRebase()

### DIFF
--- a/lib/platform/bitbucket-server/index.spec.ts
+++ b/lib/platform/bitbucket-server/index.spec.ts
@@ -157,11 +157,65 @@ describe('platform/bitbucket-server', () => {
       });
 
       describe('repoForceRebase()', () => {
-        it('always return false, since bitbucket does not support force rebase', async () => {
+        it('returns false on missing mergeConfig', async () => {
           expect.assertions(1);
+          api.get.mockResolvedValueOnce({
+            body: {
+              mergeConfig: null,
+            },
+          } as any);
           const actual = await bitbucket.getRepoForceRebase();
           expect(actual).toBe(false);
         });
+
+        it('returns false on missing defaultStrategy', async () => {
+          expect.assertions(1);
+          api.get.mockResolvedValueOnce({
+            body: {
+              mergeConfig: {
+                defaultStrategy: null,
+              },
+            },
+          } as any);
+          const actual = await bitbucket.getRepoForceRebase();
+          expect(actual).toBe(false);
+        });
+
+        it.each(['ff-only', 'rebase-ff-only', 'squash-ff-only'])(
+          'return true if %s strategy is enabled',
+          async id => {
+            expect.assertions(1);
+            api.get.mockResolvedValueOnce({
+              body: {
+                mergeConfig: {
+                  defaultStrategy: {
+                    id,
+                  },
+                },
+              },
+            } as any);
+            const actual = await bitbucket.getRepoForceRebase();
+            expect(actual).toBe(true);
+          }
+        );
+
+        it.each(['no-ff', 'ff', 'rebase-no-ff', 'squash'])(
+          'return false if %s strategy is enabled',
+          async id => {
+            expect.assertions(1);
+            api.get.mockResolvedValueOnce({
+              body: {
+                mergeConfig: {
+                  defaultStrategy: {
+                    id,
+                  },
+                },
+              },
+            } as any);
+            const actual = await bitbucket.getRepoForceRebase();
+            expect(actual).toBe(false);
+          }
+        );
       });
 
       describe('setBaseBranch()', () => {


### PR DESCRIPTION
In bitbucket server there is a similar concept than on github for requiring prs to be up2date with the base branch before merging. 
It's based on which merge strategies are enabled and in the case of renovate bot which is the default one.
In the interface it looks like this:
<img width="2154" alt="Screenshot 2020-03-23 at 17 40 49" src="https://user-images.githubusercontent.com/231804/77340397-875a0100-6d2d-11ea-80eb-72dc263f055b.png">

In the API there does not seem to be a way to choose the merge strategy when merging a PR, so the default always applies.

In this PR I query the [API](https://docs.atlassian.com/bitbucket-server/rest/7.0.1/bitbucket-rest.html#idp342) for the repo settings (which needs REPO_READ permission, so should be fine). If the default strategy requires fast-forward/rebase the function returns `true` otherwise `false`

<details>
  <summary>Example response from the API</summary>
  
```
{
  "mergeConfig": {
    "commitSummaries": 20,
    "defaultStrategy": {
      "description": "If the source branch is out of date with the target branch, reject the merge request. Otherwise, update the target branch to the latest commit on the source branch.",
      "enabled": true,
      "flag": "--ff-only",
      "id": "ff-only",
      "name": "Fast-forward only"
    },
    "strategies": [
      {
        "description": "Always create a new merge commit and update the target branch to it, even if the source branch is already up to date with the target branch.",
        "enabled": false,
        "flag": "--no-ff",
        "id": "no-ff",
        "name": "Merge commit"
      },
      {
        "description": "If the source branch is out of date with the target branch, create a merge commit. Otherwise, update the target branch to the latest commit on the source branch.",
        "enabled": false,
        "flag": "--ff",
        "id": "ff",
        "name": "Fast-forward"
      },
      {
        "description": "If the source branch is out of date with the target branch, reject the merge request. Otherwise, update the target branch to the latest commit on the source branch.",
        "enabled": true,
        "flag": "--ff-only",
        "id": "ff-only",
        "name": "Fast-forward only"
      },
      {
        "description": "Rebase commits from the source branch onto the target branch, creating a new non-merge commit for each incoming commit, and create a merge commit to update the target branch.",
        "enabled": false,
        "flag": "rebase + merge --no-ff",
        "id": "rebase-no-ff",
        "name": "Rebase and merge"
      },
      {
        "description": "Rebase commits from the source branch onto the target branch, creating a new non-merge commit for each incoming commit, and fast-forward the target branch with the resulting commits.",
        "enabled": true,
        "flag": "rebase + merge --ff-only",
        "id": "rebase-ff-only",
        "name": "Rebase and fast-forward"
      },
      {
        "description": "Combine all commits into one new non-merge commit on the target branch.",
        "enabled": false,
        "flag": "--squash",
        "id": "squash",
        "name": "Squash"
      },
      {
        "description": "If the source branch is out of date with the target branch, reject the merge request. Otherwise, combine all commits into one new non-merge commit on the target branch.",
        "enabled": true,
        "flag": "--squash --ff-only",
        "id": "squash-ff-only",
        "name": "Squash, fast-forward only"
      }
    ],
    "type": "REPOSITORY"
  },
  "com.atlassian.bitbucket.server.bitbucket-bundled-hooks:requiredApprovers": {
    "enable": false,
    "count": 0
  },
  "requiredAllApprovers": false,
  "needsWork": false,
  "requiredApprovers": 0,
  "requiredAllTasksComplete": false,
  "com.atlassian.bitbucket.server.bitbucket-build:requiredBuilds": {
    "enable": true,
    "count": 1
  },
  "requiredSuccessfulBuilds": 1
}
```
</details>

Let me know what you think.

This should solve the problem I'm facing that renovate bot is unable to merge with the following error from the bitbucket-server API:
```json
{
       "body": {
           "errors": [
             {
               "context": null,
               "message": "The merge could not be completed because the repository is configured to require fast-forward merges and the target branch contains commits which are not present in the source branch. To perform this merge, either merge 'master' into 'renovate/package-4.x', or rebase 'renovate/package-4.x' onto 'master'.",
               "exceptionName": "com.atlassian.bitbucket.scm.MergeException",
               "isConflicted": false
             }
           ]
         },
}
```