### PR TITLE
feat(dockerfile): Recognize Dockerfile with prefix by default

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -332,7 +332,7 @@ Sometimes file matches are really simple - for example with Go Modules Renovate 
 
 At other times, the possible files is too vague for Renovate to have any default. For default, Kubernetes manifests can exist in any `*.yaml` file and we don't want Renovate to parse every single YAML file in every repository just in case some of them contain a Kubernetes manifest, so Renovate's default `fileMatch` for manager `kubernetes` is actually empty (`[]`) and needs the user to tell Renovate what directories/files to look in.
 
-Finally, there are cases where Renovate's default `fileMatch` is good, but you may be using file patterns that a bot couldn't posibly guess about. For example, Renovate's default `fileMatch` for `Dockerfile` is `['(^|/)Dockerfile$', '(^|/)Dockerfile\\.[^/]*$']`. This will catch files like `backend/Dockerfile` or `Dockerfile.base`, but it will miss files like `ACTUALLY_A_DOCKERFILE.template`. Because `fileMatch` is mergeable, you don't need to duplicate the defaults and could just add the missing file like this:
+Finally, there are cases where Renovate's default `fileMatch` is good, but you may be using file patterns that a bot couldn't posibly guess about. For example, Renovate's default `fileMatch` for `Dockerfile` is `['(^|/|\\.)Dockerfile$', '(^|/)Dockerfile\\.[^/]*$']`. This will catch files like `backend/Dockerfile`, `prefix.Dockerfile` or `Dockerfile.suffix`, but it will miss files like `ACTUALLY_A_DOCKERFILE.template`. Because `fileMatch` is mergeable, you don't need to duplicate the defaults and could just add the missing file like this:
 
 ```json
 {

--- a/lib/manager/dockerfile/index.ts
+++ b/lib/manager/dockerfile/index.ts
@@ -7,5 +7,5 @@ const language = LANGUAGE_DOCKER;
 export { extractPackageFile, language, updateDependency };
 
 export const defaultConfig = {
-  fileMatch: ['(^|/)Dockerfile$', '(^|/)Dockerfile\\.[^/]*$', '(^|/)[^/]*\\.Dockerfile$'],
+  fileMatch: ['(^|/|\\.)Dockerfile$', '(^|/)Dockerfile\\.[^/]*$'],
 };

--- a/lib/manager/dockerfile/index.ts
+++ b/lib/manager/dockerfile/index.ts
@@ -7,5 +7,5 @@ const language = LANGUAGE_DOCKER;
 export { extractPackageFile, language, updateDependency };
 
 export const defaultConfig = {
-  fileMatch: ['(^|/)Dockerfile$', '(^|/)Dockerfile\\.[^/]*$'],
+  fileMatch: ['(^|/)Dockerfile$', '(^|/)Dockerfile\\.[^/]*$', '(^|/)[^/]*\\.Dockerfile$'],
 };


### PR DESCRIPTION
In addition to Dockerfile.something, I'd like to add something.Dockerfile support to the default config. I think there's no standard for this and some people prefer Dockerfile as an extension.

Refs:

- [docker - How to name Dockerfiles - Stack Overflow](https://stackoverflow.com/a/26084010/1363488)
- [filetype.vim#L391 · vim/vim · GitHub](https://github.com/vim/vim/blob/ff78155aa1755aced96a3b343e81939c94aac721/runtime/filetype.vim#L391)
- Updates #3940 
