### PR TITLE
feat(gradle):infer gradle-wrapper url from distributionUrl

### DIFF
--- a/lib/manager/gradle-wrapper/__fixtures__/gradle-wrapper-custom-distribution-url.properties
+++ b/lib/manager/gradle-wrapper/__fixtures__/gradle-wrapper-custom-distribution-url.properties
@@ -1,0 +1,7 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+# @See https://gradle.org/releases/
+distributionUrl=https\://artifactory/gradle-wrapper-cache/distributions/gradle-4.8-bin.zip
+distributionSha256Sum=336b6898b491f6334502d8074a6b8c2d73ed83b92123106bd4bf837f04111043

--- a/lib/manager/gradle-wrapper/__snapshots__/update.spec.ts.snap
+++ b/lib/manager/gradle-wrapper/__snapshots__/update.spec.ts.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`manager/gradle-wrapper/update updateDependency replaces existing value (custom distributionUrl) 1`] = `
+"distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+# @See https://gradle.org/releases/
+distributionUrl=https\\\\://artifactory/gradle-wrapper-cache/distributions/gradle-5.0-bin.zip
+distributionSha256Sum=17847c8e12b2bcfce26a79f425f082c31d4ded822f99a66127eee2d96bf18216
+"
+`;
+
 exports[`manager/gradle-wrapper/update updateDependency replaces existing value 1`] = `
 "distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists

--- a/lib/manager/gradle-wrapper/search.ts
+++ b/lib/manager/gradle-wrapper/search.ts
@@ -1,2 +1,4 @@
 export const DISTRIBUTION_URL_REGEX = /^(?<assignment>distributionUrl\s*=\s*)\S*-(?<version>(\d|\.)+)-(?<type>bin|all)\.zip\s*$/;
 export const DISTRIBUTION_CHECKSUM_REGEX = /^(?<assignment>distributionSha256Sum\s*=\s*)(?<checksum>(\w){64}).*$/;
+export const DOWNLOAD_URL_REGEX = /^(?<http>http)\S*-(?<version>(\d|\.)+)-(?<type>bin|all)\.zip\s*$/;
+export const VERSION_REGEX = /-(?<version>(\d|\.)+)-/;

--- a/lib/manager/gradle-wrapper/update.spec.ts
+++ b/lib/manager/gradle-wrapper/update.spec.ts
@@ -11,6 +11,10 @@ const propertiesFile2 = fs.readFileSync(
   'lib/manager/gradle-wrapper/__fixtures__/gradle-wrapper-2.properties',
   'utf8'
 );
+const propertiesFileCustomDistUrl = fs.readFileSync(
+  'lib/manager/gradle-wrapper/__fixtures__/gradle-wrapper-custom-distribution-url.properties',
+  'utf8'
+);
 const whitespacePropertiesFile = readFileSync(
   resolve(__dirname, './__fixtures__/gradle-wrapper-whitespace.properties'),
   'utf8'
@@ -71,6 +75,23 @@ describe('manager/gradle-wrapper/update', () => {
       expect(res).not.toEqual(propertiesFile2);
       expect(res).toMatch(
         'https\\://services.gradle.org/distributions/gradle-5.0-all.zip'
+      );
+      expect(res).toMatch(testUpgrades[5].checksum);
+    });
+
+    it('replaces existing value (custom distributionUrl)', async () => {
+      got.mockReturnValueOnce({
+        body: testUpgrades[5].checksum,
+      });
+      const res = await dcUpdate.updateDependency({
+        fileContent: propertiesFileCustomDistUrl,
+        upgrade: testUpgrades[5].data,
+      });
+      expect(res).toMatchSnapshot();
+      expect(res).not.toBeNull();
+      expect(res).not.toEqual(propertiesFileCustomDistUrl);
+      expect(res).toMatch(
+        'https\\://artifactory/gradle-wrapper-cache/distributions/gradle-5.0-bin.zip'
       );
       expect(res).toMatch(testUpgrades[5].checksum);
     });

--- a/lib/manager/gradle-wrapper/update.ts
+++ b/lib/manager/gradle-wrapper/update.ts
@@ -1,7 +1,11 @@
 import got from '../../util/got';
 import { logger } from '../../logger';
 import { UpdateDependencyConfig } from '../common';
-import { DISTRIBUTION_CHECKSUM_REGEX, DISTRIBUTION_URL_REGEX } from './search';
+import {
+  DISTRIBUTION_CHECKSUM_REGEX,
+  DOWNLOAD_URL_REGEX,
+  VERSION_REGEX,
+} from './search';
 
 function replaceType(url: string): string {
   return url.replace('bin', 'all');
@@ -41,7 +45,10 @@ export async function updateDependency({
 
     lines[upgrade.managerData.lineNumber] = lines[
       upgrade.managerData.lineNumber
-    ].replace(DISTRIBUTION_URL_REGEX, `$<assignment>${downloadUrl}`);
+    ].replace(
+      VERSION_REGEX,
+      `-${DOWNLOAD_URL_REGEX.exec(downloadUrl).groups.version}-`
+    );
 
     if (upgrade.managerData.checksumLineNumber) {
       lines[upgrade.managerData.checksumLineNumber] = lines[


### PR DESCRIPTION
Closes # https://github.com/renovatebot/renovate/issues/4807

Now `gradle-wrapper` url is now inferred from the `distributionUrl` from the `gradle-wrapper.properties`.



