### PR TITLE
WIP: feat(manager): Composer update-lockfile strategy

### DIFF
--- a/lib/manager/common.ts
+++ b/lib/manager/common.ts
@@ -238,6 +238,11 @@ export interface ManagerApi {
   updateDependency?(
     updateDependencyConfig: UpdateDependencyConfig
   ): Result<string | null>;
+
+  getAdditionalFiles?(
+    config: PostUpdateConfig,
+    packageFiles: AdditionalPackageFiles
+  ): Promise<WriteExistingFilesResult>;
 }
 
 // TODO: name and properties used by npm manager

--- a/lib/manager/common.ts
+++ b/lib/manager/common.ts
@@ -1,6 +1,6 @@
 import { ReleaseType } from 'semver';
 import { RangeStrategy, SkipReason } from '../types';
-import { ValidationMessage, GlobalConfig, UpdateType } from '../config/common';
+import { GlobalConfig, UpdateType, ValidationMessage } from '../config/common';
 
 export type Result<T> = T | Promise<T>;
 
@@ -100,6 +100,10 @@ export interface PackageFile<T = Record<string, any>>
   yarnrc?: string;
   yarnWorkspacesPackages?: string[] | string;
   matchStrings?: string[];
+}
+
+export interface AdditionalPackageFiles {
+  npm?: Partial<PackageFile>[];
 }
 
 export interface Package<T> extends ManagerData<T> {
@@ -249,4 +253,14 @@ export interface PostUpdateConfig extends ManagerConfig, Record<string, any> {
   yarnLock?: string;
   branchName?: string;
   parentBranch?: string;
+}
+
+export interface UpdatedArtifacts {
+  name: string;
+  contents: string | Buffer;
+}
+
+export interface WriteExistingFilesResult {
+  artifactErrors: ArtifactError[];
+  updatedArtifacts: UpdatedArtifacts[];
 }

--- a/lib/manager/npm/index.ts
+++ b/lib/manager/npm/index.ts
@@ -4,6 +4,7 @@ import * as npmVersioning from '../../versioning/npm';
 export { extractAllPackageFiles } from './extract';
 export { updateDependency } from './update';
 export { getRangeStrategy } from './range';
+export { getAdditionalFiles } from './post-update';
 
 export const language = LANGUAGE_JAVASCRIPT;
 export const supportsLockFileMaintenance = true;

--- a/lib/manager/npm/post-update/index.ts
+++ b/lib/manager/npm/post-update/index.ts
@@ -10,7 +10,15 @@ import * as yarn from './yarn';
 import * as pnpm from './pnpm';
 import * as hostRules from '../../../util/host-rules';
 import { getChildProcessEnv } from '../../../util/exec/env';
-import { PostUpdateConfig, PackageFile, Upgrade } from '../../common';
+import {
+  AdditionalPackageFiles,
+  ArtifactError,
+  PackageFile,
+  PostUpdateConfig,
+  UpdatedArtifacts,
+  Upgrade,
+  WriteExistingFilesResult,
+} from '../../common';
 import { platform } from '../../../platform';
 import { SYSTEM_INSUFFICIENT_DISK_SPACE } from '../../../constants/error-messages';
 import { DatasourceError } from '../../../datasource/common';
@@ -284,20 +292,6 @@ export async function writeUpdatedPackageFiles(
   }
 }
 
-export interface AdditionalPackageFiles {
-  npm?: Partial<PackageFile>[];
-}
-
-interface ArtifactError {
-  lockFile: string;
-  stderr: string;
-}
-
-interface UpdatedArtifacts {
-  name: string;
-  contents: string | Buffer;
-}
-
 // istanbul ignore next
 async function getNpmrcContent(dir: string): Promise<string | null> {
   const npmrcFilePath = upath.join(dir, '.npmrc');
@@ -354,10 +348,6 @@ async function resetNpmrcContent(
   }
 }
 
-export interface WriteExistingFilesResult {
-  artifactErrors: ArtifactError[];
-  updatedArtifacts: UpdatedArtifacts[];
-}
 // istanbul ignore next
 export async function getAdditionalFiles(
   config: PostUpdateConfig,

--- a/lib/manager/npm/post-update/index.ts
+++ b/lib/manager/npm/post-update/index.ts
@@ -293,7 +293,7 @@ interface ArtifactError {
   stderr: string;
 }
 
-interface UpdatedArtifcats {
+interface UpdatedArtifacts {
   name: string;
   contents: string | Buffer;
 }
@@ -356,7 +356,7 @@ async function resetNpmrcContent(
 
 export interface WriteExistingFilesResult {
   artifactErrors: ArtifactError[];
-  updatedArtifacts: UpdatedArtifcats[];
+  updatedArtifacts: UpdatedArtifacts[];
 }
 // istanbul ignore next
 export async function getAdditionalFiles(
@@ -365,7 +365,7 @@ export async function getAdditionalFiles(
 ): Promise<WriteExistingFilesResult> {
   logger.trace({ config }, 'getAdditionalFiles');
   const artifactErrors: ArtifactError[] = [];
-  const updatedArtifacts: UpdatedArtifcats[] = [];
+  const updatedArtifacts: UpdatedArtifacts[] = [];
   if (!(packageFiles.npm && packageFiles.npm.length)) {
     return { artifactErrors, updatedArtifacts };
   }

--- a/lib/workers/branch/index.spec.ts
+++ b/lib/workers/branch/index.spec.ts
@@ -3,7 +3,7 @@ import * as branchWorker from '.';
 import * as _schedule from './schedule';
 import * as _checkExisting from './check-existing';
 import * as _parent from './parent';
-import * as _npmPostExtract from '../../manager/npm/post-update';
+import * as _npm from '../../manager/npm';
 import * as _commit from './commit';
 import * as _statusChecks from './status-checks';
 import * as _automerge from './automerge';
@@ -27,7 +27,7 @@ jest.mock('./get-updated');
 jest.mock('./schedule');
 jest.mock('./check-existing');
 jest.mock('./parent');
-jest.mock('../../manager/npm/post-update');
+jest.mock('../../manager/npm');
 jest.mock('./status-checks');
 jest.mock('./automerge');
 jest.mock('./commit');
@@ -39,7 +39,7 @@ const getUpdated = mocked(_getUpdated);
 const schedule = mocked(_schedule);
 const checkExisting = mocked(_checkExisting);
 const parent = mocked(_parent);
-const npmPostExtract = mocked(_npmPostExtract);
+const npm = mocked(_npm);
 const statusChecks = mocked(_statusChecks);
 const automerge = mocked(_automerge);
 const commit = mocked(_commit);
@@ -63,7 +63,7 @@ describe('workers/branch', () => {
         branchName: 'renovate/some-branch',
         errors: [],
         warnings: [],
-        upgrades: [{ depName: 'some-dep-name' } as never],
+        upgrades: [{ manager: 'npm', depName: 'some-dep-name' } as never],
       } as never;
       schedule.isScheduledNow.mockReturnValue(true);
       commit.commitFilesToBranch.mockResolvedValue('abc123');
@@ -207,7 +207,7 @@ describe('workers/branch', () => {
       getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce({
         ...updatedPackageFiles,
       });
-      npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
+      npm.getAdditionalFiles.mockResolvedValueOnce({
         artifactErrors: [],
         updatedArtifacts: [],
       });
@@ -220,7 +220,7 @@ describe('workers/branch', () => {
       getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce({
         ...updatedPackageFiles,
       });
-      npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
+      npm.getAdditionalFiles.mockResolvedValueOnce({
         artifactErrors: [],
         updatedArtifacts: [],
       });
@@ -232,7 +232,7 @@ describe('workers/branch', () => {
       getUpdated.getUpdatedPackageFiles.mockReturnValueOnce({
         updatedPackageFiles: [{}],
       } as never);
-      npmPostExtract.getAdditionalFiles.mockReturnValueOnce({
+      npm.getAdditionalFiles.mockReturnValueOnce({
         artifactErrors: [],
         updatedArtifacts: [{}],
       } as never);
@@ -249,7 +249,7 @@ describe('workers/branch', () => {
       getUpdated.getUpdatedPackageFiles.mockReturnValueOnce({
         updatedPackageFiles: [{}],
       } as never);
-      npmPostExtract.getAdditionalFiles.mockReturnValueOnce({
+      npm.getAdditionalFiles.mockReturnValueOnce({
         artifactErrors: [],
         updatedArtifacts: [{}],
       } as never);
@@ -268,7 +268,7 @@ describe('workers/branch', () => {
       getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce({
         updatedPackageFiles: [{}],
       } as never);
-      npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
+      npm.getAdditionalFiles.mockResolvedValueOnce({
         artifactErrors: [],
         updatedArtifacts: [{}],
       } as never);
@@ -284,7 +284,7 @@ describe('workers/branch', () => {
       getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce({
         updatedPackageFiles: [{}],
       } as never);
-      npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
+      npm.getAdditionalFiles.mockResolvedValueOnce({
         artifactErrors: [],
         updatedArtifacts: [{}],
       } as never);
@@ -303,7 +303,7 @@ describe('workers/branch', () => {
       getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce({
         updatedPackageFiles: [{}],
       } as never);
-      npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
+      npm.getAdditionalFiles.mockResolvedValueOnce({
         artifactErrors: [],
         updatedArtifacts: [{}],
       } as never);
@@ -320,7 +320,7 @@ describe('workers/branch', () => {
       getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce({
         updatedPackageFiles: [{}],
       } as never);
-      npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
+      npm.getAdditionalFiles.mockResolvedValueOnce({
         artifactErrors: [],
         updatedArtifacts: [{}],
       } as never);
@@ -339,7 +339,7 @@ describe('workers/branch', () => {
       getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce({
         updatedPackageFiles: [{}],
       } as never);
-      npmPostExtract.getAdditionalFiles.mockReturnValueOnce({
+      npm.getAdditionalFiles.mockReturnValueOnce({
         artifactErrors: [],
         updatedArtifacts: [{}],
       } as never);
@@ -360,7 +360,7 @@ describe('workers/branch', () => {
       getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce({
         updatedPackageFiles: [{}],
       } as never);
-      npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
+      npm.getAdditionalFiles.mockResolvedValueOnce({
         artifactErrors: [{}],
         updatedArtifacts: [{}],
       } as never);
@@ -382,7 +382,7 @@ describe('workers/branch', () => {
       getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce({
         updatedPackageFiles: [{}],
       } as never);
-      npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
+      npm.getAdditionalFiles.mockResolvedValueOnce({
         artifactErrors: [{}],
         updatedArtifacts: [{}],
       } as never);
@@ -405,7 +405,7 @@ describe('workers/branch', () => {
       getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce({
         updatedPackageFiles: [{}],
       } as never);
-      npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
+      npm.getAdditionalFiles.mockResolvedValueOnce({
         artifactErrors: [{}],
         updatedArtifacts: [{}],
       } as never);
@@ -428,7 +428,7 @@ describe('workers/branch', () => {
       getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce({
         updatedPackageFiles: [{}],
       } as never);
-      npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
+      npm.getAdditionalFiles.mockResolvedValueOnce({
         artifactErrors: [{}],
         updatedArtifacts: [{}],
       } as never);
@@ -448,7 +448,7 @@ describe('workers/branch', () => {
       getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce({
         updatedPackageFiles: [{}],
       } as never);
-      npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
+      npm.getAdditionalFiles.mockResolvedValueOnce({
         artifactErrors: [{}],
         updatedArtifacts: [{}],
       } as never);
@@ -477,7 +477,7 @@ describe('workers/branch', () => {
       getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce({
         updatedPackageFiles: [{}],
       } as never);
-      npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
+      npm.getAdditionalFiles.mockResolvedValueOnce({
         artifactErrors: [{}],
         updatedArtifacts: [{}],
       } as never);
@@ -487,7 +487,7 @@ describe('workers/branch', () => {
       getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce({
         updatedPackageFiles: [{}],
       } as never);
-      npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
+      npm.getAdditionalFiles.mockResolvedValueOnce({
         artifactErrors: [],
         updatedArtifacts: [{}],
       } as never);
@@ -525,7 +525,7 @@ describe('workers/branch', () => {
         updatedPackageFiles: [{}],
         artifactErrors: [{}],
       } as never);
-      npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
+      npm.getAdditionalFiles.mockResolvedValueOnce({
         artifactErrors: [],
         updatedArtifacts: [{}],
       } as never);
@@ -556,7 +556,7 @@ describe('workers/branch', () => {
         updatedPackageFiles: [{}],
         artifactErrors: [{}],
       } as never);
-      npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
+      npm.getAdditionalFiles.mockResolvedValueOnce({
         artifactErrors: [],
         updatedArtifacts: [{}],
       } as never);
@@ -588,7 +588,7 @@ describe('workers/branch', () => {
         updatedPackageFiles: [{}],
         artifactErrors: [],
       } as never);
-      npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
+      npm.getAdditionalFiles.mockResolvedValueOnce({
         artifactErrors: [],
         updatedArtifacts: [{}],
       } as never);
@@ -617,7 +617,7 @@ describe('workers/branch', () => {
         updatedPackageFiles: [{}],
         artifactErrors: [],
       } as never);
-      npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
+      npm.getAdditionalFiles.mockResolvedValueOnce({
         artifactErrors: [],
         updatedArtifacts: [{}],
       } as never);

--- a/lib/workers/repository/process/write.ts
+++ b/lib/workers/repository/process/write.ts
@@ -1,10 +1,9 @@
-import { logger, addMeta, removeMeta } from '../../../logger';
+import { addMeta, logger, removeMeta } from '../../../logger';
 import { processBranch } from '../../branch';
 import { getPrsRemaining } from './limits';
 import { getLimitRemaining } from '../../global/limits';
 import { RenovateConfig } from '../../../config';
-import { PackageFile } from '../../../manager/common';
-import { AdditionalPackageFiles } from '../../../manager/npm/post-update';
+import { AdditionalPackageFiles, PackageFile } from '../../../manager/common';
 import { BranchConfig } from '../../common';
 
 export type WriteUpdateResult = 'done' | 'automerged';


### PR DESCRIPTION
I'm currently working on the update-lockfile strategy for composer.  

I started to refactor the npm way to be able to do the same for composer in a generic way. Could you have a look to confirm that I am on the good path to do that ?

1. I extracted a runComposer function to be able to run any composer command without to build command definition all the time (still work to do to be decoupled from updateArtifacts)
2. I extracted getAdditionalFiles related interfaces from npm post-update
3. I moved getAdditionalFiles to the ManagerApi interface 

Remaining works to do : 

1. Refactor composer versioning to handle update-lockfile strategy
2. Decouple runComposer from updateArtifacts
3. Implement getAdditionalFiles for composer manager


Closes #3521
