### PR TITLE
fix(platform): remove wrong bitbucket-server description

### DIFF
--- a/lib/platform/bitbucket-server/__snapshots__/index.spec.ts.snap
+++ b/lib/platform/bitbucket-server/__snapshots__/index.spec.ts.snap
@@ -53,7 +53,6 @@ Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5",
     Object {
       "body": Object {
-        "description": undefined,
         "reviewers": Array [
           Object {
             "user": Object {
@@ -111,7 +110,6 @@ Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5",
     Object {
       "body": Object {
-        "description": undefined,
         "reviewers": Array [
           Object {
             "user": Object {
@@ -173,7 +171,6 @@ Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5",
     Object {
       "body": Object {
-        "description": undefined,
         "reviewers": Array [
           Object {
             "user": Object {
@@ -229,7 +226,6 @@ Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5",
     Object {
       "body": Object {
-        "description": undefined,
         "reviewers": Array [
           Object {
             "user": Object {
@@ -1620,7 +1616,6 @@ Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5",
     Object {
       "body": Object {
-        "description": undefined,
         "reviewers": Array [
           Object {
             "user": Object {
@@ -1678,7 +1673,6 @@ Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5",
     Object {
       "body": Object {
-        "description": undefined,
         "reviewers": Array [
           Object {
             "user": Object {
@@ -1740,7 +1734,6 @@ Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5",
     Object {
       "body": Object {
-        "description": undefined,
         "reviewers": Array [
           Object {
             "user": Object {
@@ -1796,7 +1789,6 @@ Array [
     "./rest/api/1.0/projects/SOME/repos/repo/pull-requests/5",
     Object {
       "body": Object {
-        "description": undefined,
         "reviewers": Array [
           Object {
             "user": Object {

--- a/lib/platform/bitbucket-server/index.ts
+++ b/lib/platform/bitbucket-server/index.ts
@@ -732,7 +732,6 @@ export async function addReviewers(
       {
         body: {
           title: pr.title,
-          description: pr.description,
           version: pr.version,
           reviewers: Array.from(reviewersSet).map(name => ({ user: { name } })),
         },


### PR DESCRIPTION
This pr removed the wrong `description`parameter from `addReviewers`.

`pr.description` is always `undefined`, so not needed to pass.