### PR TITLE
fix: add missing await statements

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -50,6 +50,7 @@ module.exports = {
     // TODO: fix lint
     '@typescript-eslint/camelcase': 0, // disabled until ??
     '@typescript-eslint/no-explicit-any': 0,
+    '@typescript-eslint/no-floating-promises': 2,
     '@typescript-eslint/no-non-null-assertion': 0,
     '@typescript-eslint/no-unused-vars': [
       2,

--- a/lib/manager/bundler/artifacts.spec.ts
+++ b/lib/manager/bundler/artifacts.spec.ts
@@ -27,11 +27,16 @@ jest.mock('../../../lib/platform');
 jest.mock('../../../lib/datasource/docker');
 jest.mock('../../../lib/util/host-rules');
 jest.mock('./host-rules');
+jest.mock('../../util/exec/docker/index', () =>
+  require('../../../test/util').mockPartial('../../util/exec/docker/index', {
+    removeDanglingContainers: jest.fn(),
+  })
+);
 
 let config;
 
 describe('bundler.updateArtifacts()', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     jest.resetAllMocks();
     jest.resetModules();
 
@@ -44,7 +49,7 @@ describe('bundler.updateArtifacts()', () => {
     env.getChildProcessEnv.mockReturnValue(envMock.basic);
     bundlerHostRules.findAllAuthenticatable.mockReturnValue([]);
     resetPrefetchedImages();
-    setUtilConfig(config);
+    await setUtilConfig(config);
   });
   it('returns null by default', async () => {
     expect(
@@ -114,8 +119,8 @@ describe('bundler.updateArtifacts()', () => {
     expect(execSnapshots).toMatchSnapshot();
   });
   describe('Docker', () => {
-    beforeEach(() => {
-      setUtilConfig({ ...config, binarySource: BinarySource.Docker });
+    beforeEach(async () => {
+      await setUtilConfig({ ...config, binarySource: BinarySource.Docker });
     });
     it('.ruby-version', async () => {
       platform.getFile.mockResolvedValueOnce('Current Gemfile.lock');

--- a/lib/manager/cocoapods/artifacts.spec.ts
+++ b/lib/manager/cocoapods/artifacts.spec.ts
@@ -28,10 +28,10 @@ const config = {
 };
 
 describe('.updateArtifacts()', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     jest.resetAllMocks();
     env.getChildProcessEnv.mockReturnValue(envMock.basic);
-    setExecConfig(config);
+    await setExecConfig(config);
 
     datasource.getReleases.mockResolvedValue({
       releases: [
@@ -114,7 +114,7 @@ describe('.updateArtifacts()', () => {
   });
   it('returns updated Podfile', async () => {
     const execSnapshots = mockExecAll(exec);
-    setExecConfig({ ...config, binarySource: BinarySource.Docker });
+    await setExecConfig({ ...config, binarySource: BinarySource.Docker });
     platform.getFile.mockResolvedValueOnce('Old Podfile');
     platform.getRepoStatus.mockResolvedValueOnce({
       modified: ['Podfile.lock'],
@@ -164,7 +164,7 @@ describe('.updateArtifacts()', () => {
   it('dynamically selects Docker image tag', async () => {
     const execSnapshots = mockExecAll(exec);
 
-    setExecConfig({
+    await setExecConfig({
       ...config,
       binarySource: 'docker',
       dockerUser: 'ubuntu',
@@ -189,7 +189,7 @@ describe('.updateArtifacts()', () => {
   it('falls back to the `latest` Docker image tag', async () => {
     const execSnapshots = mockExecAll(exec);
 
-    setExecConfig({
+    await setExecConfig({
       ...config,
       binarySource: 'docker',
       dockerUser: 'ubuntu',

--- a/lib/manager/cocoapods/artifacts.spec.ts
+++ b/lib/manager/cocoapods/artifacts.spec.ts
@@ -132,7 +132,7 @@ describe('.updateArtifacts()', () => {
   });
   it('returns updated Podfile and Pods files', async () => {
     const execSnapshots = mockExecAll(exec);
-    setExecConfig({ ...config, binarySource: BinarySource.Docker });
+    await setExecConfig({ ...config, binarySource: BinarySource.Docker });
     platform.getFile.mockResolvedValueOnce('Old Podfile');
     platform.getFile.mockResolvedValueOnce('Old Manifest.lock');
     platform.getRepoStatus.mockResolvedValueOnce({

--- a/lib/manager/composer/artifacts.spec.ts
+++ b/lib/manager/composer/artifacts.spec.ts
@@ -22,6 +22,11 @@ const fs: jest.Mocked<typeof _fs> = _fs as any;
 const exec: jest.Mock<typeof _exec> = _exec as any;
 const env = mocked(_env);
 const platform = mocked(_platform);
+jest.mock('../../util/exec/docker/index', () =>
+  require('../../../test/util').mockPartial('../../util/exec/docker/index', {
+    removeDanglingContainers: jest.fn(),
+  })
+);
 
 const config = {
   // `join` fixes Windows CI
@@ -31,11 +36,11 @@ const config = {
 };
 
 describe('.updateArtifacts()', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     jest.resetAllMocks();
     jest.resetModules();
     env.getChildProcessEnv.mockReturnValue(envMock.basic);
-    setUtilConfig(config);
+    await setUtilConfig(config);
     resetPrefetchedImages();
   });
   it('returns if no composer.lock found', async () => {
@@ -124,7 +129,7 @@ describe('.updateArtifacts()', () => {
     expect(execSnapshots).toMatchSnapshot();
   });
   it('supports docker mode', async () => {
-    setUtilConfig({ ...config, binarySource: BinarySource.Docker });
+    await setUtilConfig({ ...config, binarySource: BinarySource.Docker });
     platform.getFile.mockResolvedValueOnce('Current composer.lock');
 
     const execSnapshots = mockExecAll(exec);

--- a/lib/manager/gradle-wrapper/artifacts.spec.ts
+++ b/lib/manager/gradle-wrapper/artifacts.spec.ts
@@ -26,8 +26,8 @@ async function resetTestFiles() {
 }
 
 describe(getName(__filename), () => {
-  beforeAll(() => {
-    setUtilConfig(config);
+  beforeAll(async () => {
+    await setUtilConfig(config);
   });
   beforeEach(() => {
     jest.resetAllMocks();

--- a/lib/manager/gradle/index.spec.ts
+++ b/lib/manager/gradle/index.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
 import fs from 'fs-extra';
 import * as upath from 'upath';
 import { exec as _exec } from 'child_process';

--- a/lib/manager/poetry/artifacts.spec.ts
+++ b/lib/manager/poetry/artifacts.spec.ts
@@ -12,6 +12,11 @@ import { resetPrefetchedImages } from '../../util/exec/docker';
 jest.mock('fs-extra');
 jest.mock('child_process');
 jest.mock('../../util/exec/env');
+jest.mock('../../util/exec/docker/index', () =>
+  require('../../../test/util').mockPartial('../../util/exec/docker/index', {
+    removeDanglingContainers: jest.fn(),
+  })
+);
 
 const fs: jest.Mocked<typeof _fs> = _fs as any;
 const exec: jest.Mock<typeof _exec> = _exec as any;
@@ -22,10 +27,10 @@ const config = {
 };
 
 describe('.updateArtifacts()', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     jest.resetAllMocks();
     env.getChildProcessEnv.mockReturnValue(envMock.basic);
-    setExecConfig(config);
+    await setExecConfig(config);
     resetPrefetchedImages();
   });
   it('returns null if no poetry.lock found', async () => {
@@ -80,7 +85,7 @@ describe('.updateArtifacts()', () => {
     expect(execSnapshots).toMatchSnapshot();
   });
   it('returns updated poetry.lock using docker', async () => {
-    setExecConfig({
+    await setExecConfig({
       ...config,
       binarySource: BinarySource.Docker,
       dockerUser: 'foobar',

--- a/lib/platform/azure/index.spec.ts
+++ b/lib/platform/azure/index.spec.ts
@@ -48,8 +48,8 @@ describe('platform/azure', () => {
     });
   });
 
-  afterEach(() => {
-    azure.cleanRepo();
+  afterEach(async () => {
+    await azure.cleanRepo();
   });
 
   // do we need the args?

--- a/lib/platform/bitbucket/index.spec.ts
+++ b/lib/platform/bitbucket/index.spec.ts
@@ -48,8 +48,8 @@ describe('platform/bitbucket', () => {
     });
   });
 
-  afterEach(() => {
-    bitbucket.cleanRepo();
+  afterEach(async () => {
+    await bitbucket.cleanRepo();
   });
 
   async function mockedGet(path: string) {

--- a/lib/platform/github/index.ts
+++ b/lib/platform/github/index.ts
@@ -242,7 +242,7 @@ export async function initRepo({
 }: RepoParams): Promise<RepoConfig> {
   logger.debug(`initRepo("${repository}")`);
   // config is used by the platform api itself, not necessary for the app layer to know
-  cleanRepo();
+  await cleanRepo();
   // istanbul ignore if
   if (endpoint) {
     // Necessary for Renovate Pro - do not remove

--- a/lib/platform/gitlab/index.spec.ts
+++ b/lib/platform/gitlab/index.spec.ts
@@ -54,8 +54,8 @@ describe('platform/gitlab', () => {
     });
   });
 
-  afterEach(() => {
-    gitlab.cleanRepo();
+  afterEach(async () => {
+    await gitlab.cleanRepo();
   });
 
   describe('initPlatform()', () => {
@@ -164,8 +164,8 @@ describe('platform/gitlab', () => {
     });
   });
   describe('cleanRepo()', () => {
-    it('exists', () => {
-      gitlab.cleanRepo();
+    it('exists', async () => {
+      await gitlab.cleanRepo();
     });
   });
 

--- a/lib/renovate.ts
+++ b/lib/renovate.ts
@@ -5,6 +5,7 @@ import * as globalWorker from './workers/global';
 
 proxy.bootstrap();
 
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
 (async (): Promise<void> => {
   process.exitCode = await globalWorker.start();
 })();

--- a/lib/util/exec/exec.spec.ts
+++ b/lib/util/exec/exec.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
 import {
   exec as _cpExec,
   ExecOptions as ChildProcessExecOptions,

--- a/test/util.ts
+++ b/test/util.ts
@@ -11,16 +11,24 @@ export function mocked<T>(module: T): jest.Mocked<T> {
   return module as never;
 }
 
-export function mockPartial(
-  moduleName: string,
-  overrides?: unknown
-): typeof jest {
+/**
+ * Partially mock a module, providing an object with explicit mocks
+ * @param moduleName The module to mock
+ * @param overrides An object containing the mocks
+ * @example
+ * jest.mock('../../util/exec/docker/index', () =>
+ *   require('../../../test/util').mockPartial('../../util/exec/docker/index', {
+ *     removeDanglingContainers: jest.fn(),
+ *   })
+ * );
+ */
+export function mockPartial(moduleName: string, overrides?: object): unknown {
   const absolutePath = upath.join(module.parent.filename, '../', moduleName);
   const originalModule = jest.requireActual(absolutePath);
   return {
     __esModule: true,
     ...originalModule,
-    ...(overrides as object),
+    ...overrides,
   };
 }
 

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,3 +1,4 @@
+import * as upath from 'upath';
 import { platform as _platform } from '../lib/platform';
 import { getConfig } from '../lib/config/defaults';
 import { RenovateConfig as _RenovateConfig } from '../lib/config';
@@ -8,6 +9,19 @@ import { RenovateConfig as _RenovateConfig } from '../lib/config';
  */
 export function mocked<T>(module: T): jest.Mocked<T> {
   return module as never;
+}
+
+export function mockPartial(
+  moduleName: string,
+  overrides?: unknown
+): typeof jest {
+  const absolutePath = upath.join(module.parent.filename, '../', moduleName);
+  const originalModule = jest.requireActual(absolutePath);
+  return {
+    __esModule: true,
+    ...originalModule,
+    ...(overrides as object),
+  };
 }
 
 /**

--- a/tools/check-re2.mjs
+++ b/tools/check-re2.mjs
@@ -1,5 +1,6 @@
 import shell from 'shelljs';
 
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
 (async () => {
   shell.echo('-n', 'Checking re2 ... ');
   try {

--- a/tools/generate-imports.ts
+++ b/tools/generate-imports.ts
@@ -57,6 +57,7 @@ async function generate({
   await updateFile(`lib/${path}/api.generated.ts`, code.replace(/^\s+/gm, ''));
 }
 
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
 (async () => {
   try {
     // datasources

--- a/tools/release.mjs
+++ b/tools/release.mjs
@@ -21,7 +21,7 @@ shell.echo(`Publishing version: ${version}`);
 //   err = true;
 // }
 
-// eslint-disable-next-line promise/valid-params
+// eslint-disable-next-line promise/valid-params,@typescript-eslint/no-floating-promises
 import('./dispatch-release.mjs').catch();
 
 // if (err) {


### PR DESCRIPTION
Fixes promises that aren't awaited, except in a few cases:
- Top level awaits ([still a proposal feature](https://v8.dev/features/top-level-await))
- `lib/util/exec/exec/spec.ts` & `lib/manager/gradle/index.spec.ts` as the imports are not so straightforward.

This PR also includes a new test util method, `mockPartial`, which will call `jest.requireActual` on a module, then apply the overrides passed to it.