### PR TITLE
fix(nuget): add support for alternate nuget config file names

### DIFF
--- a/lib/manager/nuget/__fixtures__/with-lower-case-config-file/nuget.config
+++ b/lib/manager/nuget/__fixtures__/with-lower-case-config-file/nuget.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="Contoso" value="https://contoso.com/packages/" />
+  </packageSources>
+</configuration>

--- a/lib/manager/nuget/__fixtures__/with-lower-case-config-file/with-lower-case-config-file.csproj
+++ b/lib/manager/nuget/__fixtures__/with-lower-case-config-file/with-lower-case-config-file.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <Version>0.1.0</Version>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Autofac" Version="4.5.0" />
+  </ItemGroup>
+</Project>

--- a/lib/manager/nuget/__fixtures__/with-pascal-case-config-file/NuGet.Config
+++ b/lib/manager/nuget/__fixtures__/with-pascal-case-config-file/NuGet.Config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="Contoso" value="https://contoso.com/packages/" />
+  </packageSources>
+</configuration>

--- a/lib/manager/nuget/__fixtures__/with-pascal-case-config-file/with-pascal-case-config-file.csproj
+++ b/lib/manager/nuget/__fixtures__/with-pascal-case-config-file/with-pascal-case-config-file.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <Version>0.1.0</Version>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Autofac" Version="4.5.0" />
+  </ItemGroup>
+</Project>

--- a/lib/manager/nuget/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/nuget/__snapshots__/extract.spec.ts.snap
@@ -17,6 +17,40 @@ Object {
 }
 `;
 
+exports[`lib/manager/nuget/extract extractPackageFile() considers lower-case nuget.config 1`] = `
+Object {
+  "deps": Array [
+    Object {
+      "currentValue": "4.5.0",
+      "datasource": "nuget",
+      "depName": "Autofac",
+      "depType": "nuget",
+      "registryUrls": Array [
+        "https://api.nuget.org/v3/index.json#protocolVersion=3",
+        "https://contoso.com/packages/",
+      ],
+    },
+  ],
+}
+`;
+
+exports[`lib/manager/nuget/extract extractPackageFile() considers pascal-case NuGet.Config 1`] = `
+Object {
+  "deps": Array [
+    Object {
+      "currentValue": "4.5.0",
+      "datasource": "nuget",
+      "depName": "Autofac",
+      "depType": "nuget",
+      "registryUrls": Array [
+        "https://api.nuget.org/v3/index.json#protocolVersion=3",
+        "https://contoso.com/packages/",
+      ],
+    },
+  ],
+}
+`;
+
 exports[`lib/manager/nuget/extract extractPackageFile() extracts all dependencies 1`] = `
 Array [
   Object {

--- a/lib/manager/nuget/extract.spec.ts
+++ b/lib/manager/nuget/extract.spec.ts
@@ -24,8 +24,33 @@ describe('lib/manager/nuget/extract', () => {
       const res = await extractPackageFile(sample, packageFile, config);
       expect(res.deps).toMatchSnapshot();
     });
+
     it('considers NuGet.config', async () => {
       const packageFile = 'with-config-file/with-config-file.csproj';
+      const contents = readFileSync(
+        path.join(config.localDir, packageFile),
+        'utf8'
+      );
+
+      expect(
+        await extractPackageFile(contents, packageFile, config)
+      ).toMatchSnapshot();
+    });
+    it('considers lower-case nuget.config', async () => {
+      const packageFile =
+        'with-lower-case-config-file/with-lower-case-config-file.csproj';
+      const contents = readFileSync(
+        path.join(config.localDir, packageFile),
+        'utf8'
+      );
+
+      expect(
+        await extractPackageFile(contents, packageFile, config)
+      ).toMatchSnapshot();
+    });
+    it('considers pascal-case NuGet.Config', async () => {
+      const packageFile =
+        'with-pascal-case-config-file/with-pascal-case-config-file.csproj';
       const contents = readFileSync(
         path.join(config.localDir, packageFile),
         'utf8'

--- a/lib/manager/nuget/extract.ts
+++ b/lib/manager/nuget/extract.ts
@@ -22,7 +22,9 @@ async function determineRegistryUrls(
   packageFile: string,
   localDir: string
 ): Promise<string[]> {
-  const nuGetConfigPath = await findUp('NuGet.config', {
+  // Valid file names taken from https://github.com/NuGet/NuGet.Client/blob/f64621487c0b454eda4b98af853bf4a528bef72a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs#L34
+  const nuGetConfigFileNames = ['nuget.config', 'NuGet.config', 'NuGet.Config'];
+  const nuGetConfigPath = await findUp(nuGetConfigFileNames, {
     cwd: path.dirname(path.join(localDir, packageFile)),
     type: 'file',
   });


### PR DESCRIPTION
Fixes #5914