### PR TITLE
fix(presets): use default endpoint on platform missmatch

### DIFF
--- a/lib/config/presets/__snapshots__/github.spec.ts.snap
+++ b/lib/config/presets/__snapshots__/github.spec.ts.snap
@@ -1,0 +1,70 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`config/presets/github getPreset() uses default endpoint 1`] = `
+Array [
+  Array [
+    "https://api.github.com/repos/some/repo/contents/default.json",
+    Object {
+      "headers": Object {
+        "accept": "application/vnd.github.v3+json",
+      },
+      "hooks": Object {
+        "beforeRedirect": Array [
+          [Function],
+        ],
+      },
+      "hostType": "github",
+      "json": true,
+      "method": "get",
+    },
+  ],
+  Array [
+    "https://api.github.com/repos/some/repo/contents/renovate.json",
+    Object {
+      "headers": Object {
+        "accept": "application/vnd.github.v3+json",
+      },
+      "hooks": Object {
+        "beforeRedirect": Array [
+          [Function],
+        ],
+      },
+      "hostType": "github",
+      "json": true,
+      "method": "get",
+    },
+  ],
+  Array [
+    "https://api.github.com/repos/some/repo/contents/default.json",
+    Object {
+      "headers": Object {
+        "accept": "application/vnd.github.v3+json",
+      },
+      "hooks": Object {
+        "beforeRedirect": Array [
+          [Function],
+        ],
+      },
+      "hostType": "github",
+      "json": true,
+      "method": "get",
+    },
+  ],
+  Array [
+    "https://api.github.com/repos/some/repo/contents/renovate.json",
+    Object {
+      "headers": Object {
+        "accept": "application/vnd.github.v3+json",
+      },
+      "hooks": Object {
+        "beforeRedirect": Array [
+          [Function],
+        ],
+      },
+      "hostType": "github",
+      "json": true,
+      "method": "get",
+    },
+  ],
+]
+`;

--- a/lib/config/presets/__snapshots__/gitlab.spec.ts.snap
+++ b/lib/config/presets/__snapshots__/gitlab.spec.ts.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`config/presets/gitlab getPreset() uses default endpoint 1`] = `
+Array [
+  Array [
+    "https://gitlab.com/api/v4/projects/some%2Frepo/repository/branches",
+  ],
+  Array [
+    "https://gitlab.com/api/v4/projects/some%2Frepo/repository/branches",
+  ],
+]
+`;

--- a/lib/config/presets/github.spec.ts
+++ b/lib/config/presets/github.spec.ts
@@ -1,14 +1,18 @@
+import { PartialDeep } from 'type-fest';
 import * as github from './github';
 import _got from '../../util/got';
 import * as _hostRules from '../../util/host-rules';
 import { PLATFORM_FAILURE } from '../../constants/error-messages';
+import { mocked } from '../../../test/util';
+import { GotResponse } from '../../platform';
+import { PLATFORM_TYPE_GITHUB } from '../../constants/platforms';
 
 jest.mock('../../platform/github/gh-got-wrapper');
 jest.mock('../../util/got');
 jest.mock('../../util/host-rules');
 
-const got: any = _got;
-const hostRules: any = _hostRules;
+const got: jest.Mock<PartialDeep<GotResponse>> = _got as never;
+const hostRules = mocked(_hostRules);
 
 describe('config/presets/github', () => {
   beforeEach(() => {
@@ -72,13 +76,20 @@ describe('config/presets/github', () => {
 
     it('uses default endpoint', async () => {
       await github.getPreset('some/repo', 'default').catch((_) => {});
+      await github
+        .getPreset('some/repo', 'default', {
+          endpoint: 'https://api.github.example.org',
+        })
+        .catch((_) => {});
       expect(got.mock.calls[0][0]).toEqual(
         'https://api.github.com/repos/some/repo/contents/default.json'
       );
+      expect(got.mock.calls).toMatchSnapshot();
     });
     it('uses custom endpoint', async () => {
       await github
         .getPreset('some/repo', 'default', {
+          platform: PLATFORM_TYPE_GITHUB,
           endpoint: 'https://api.github.example.org',
         })
         .catch((_) => {});

--- a/lib/config/presets/github.ts
+++ b/lib/config/presets/github.ts
@@ -4,9 +4,9 @@ import { Http, HttpOptions } from '../../util/http';
 import { PLATFORM_FAILURE } from '../../constants/error-messages';
 import { ensureTrailingSlash } from '../../util/url';
 import { RenovateConfig } from '../common';
+import { PLATFORM_TYPE_GITHUB } from '../../constants/platforms';
 
-const id = 'github';
-const http = new Http(id);
+const http = new Http(PLATFORM_TYPE_GITHUB);
 
 async function fetchJSONFile(
   repo: string,
@@ -49,7 +49,9 @@ export async function getPreset(
   baseConfig?: RenovateConfig
 ): Promise<Preset> {
   const endpoint = ensureTrailingSlash(
-    baseConfig?.endpoint ?? 'https://api.github.com/'
+    (baseConfig?.platform === PLATFORM_TYPE_GITHUB
+      ? baseConfig?.endpoint
+      : null) ?? 'https://api.github.com/'
   );
   if (presetName === 'default') {
     try {

--- a/lib/config/presets/gitlab.spec.ts
+++ b/lib/config/presets/gitlab.spec.ts
@@ -1,11 +1,13 @@
+import { PartialDeep } from 'type-fest';
 import * as gitlab from './gitlab';
 import { api } from '../../platform/gitlab/gl-got-wrapper';
 import { GotResponse } from '../../platform';
+import { PLATFORM_TYPE_GITLAB } from '../../constants/platforms';
 
 jest.mock('../../platform/gitlab/gl-got-wrapper');
 jest.mock('../../util/got');
 
-const glGot: jest.Mock<Promise<Partial<GotResponse>>> = api.get as never;
+const glGot: jest.Mock<Promise<PartialDeep<GotResponse>>> = api.get as never;
 
 describe('config/presets/gitlab', () => {
   beforeEach(() => {
@@ -55,13 +57,20 @@ describe('config/presets/gitlab', () => {
     });
     it('uses default endpoint', async () => {
       await gitlab.getPreset('some/repo', 'default').catch((_) => {});
+      await gitlab
+        .getPreset('some/repo', 'default', {
+          endpoint: 'https://gitlab.example.org/api/v4',
+        })
+        .catch((_) => {});
       expect(glGot.mock.calls[0][0]).toEqual(
         'https://gitlab.com/api/v4/projects/some%2Frepo/repository/branches'
       );
+      expect(glGot.mock.calls).toMatchSnapshot();
     });
     it('uses custom endpoint', async () => {
       await gitlab
         .getPreset('some/repo', 'default', {
+          platform: PLATFORM_TYPE_GITLAB,
           endpoint: 'https://gitlab.example.org/api/v4',
         })
         .catch((_) => {});

--- a/lib/config/presets/gitlab.ts
+++ b/lib/config/presets/gitlab.ts
@@ -3,6 +3,7 @@ import { logger } from '../../logger';
 import { Preset } from './common';
 import { ensureTrailingSlash } from '../../util/url';
 import { RenovateConfig } from '../common';
+import { PLATFORM_TYPE_GITLAB } from '../../constants/platforms';
 
 const { get: glGot } = api;
 
@@ -35,7 +36,9 @@ export async function getPreset(
   baseConfig?: RenovateConfig
 ): Promise<Preset> {
   const endpoint = ensureTrailingSlash(
-    baseConfig?.endpoint ?? 'https://gitlab.com/api/v4/'
+    (baseConfig?.platform === PLATFORM_TYPE_GITLAB
+      ? baseConfig?.endpoint
+      : null) ?? 'https://gitlab.com/api/v4/'
   );
   if (presetName !== 'default') {
     // TODO: proper error contructor


### PR DESCRIPTION
regression of #3019

We need to use the default endpoint if current platform does not match preset fetch api, otherwise we try to fetch presets from wrong url. 