### PR TITLE
fix(gitea): immortal PRs for Gitea

### DIFF
--- a/lib/platform/gitea/__snapshots__/index.spec.ts.snap
+++ b/lib/platform/gitea/__snapshots__/index.spec.ts.snap
@@ -60,23 +60,23 @@ Object {
 }
 `;
 
-exports[`platform/gitea getPr should return enriched pull request which exists 1`] = `
+exports[`platform/gitea getPr should return enriched pull request which exists if open 1`] = `
 Object {
-  "body": "other random pull request",
-  "branchName": "other-head-ref",
+  "body": "some random pull request",
+  "branchName": "some-head-ref",
   "canMerge": true,
-  "closedAt": "2016-01-09T10:03:21Z",
-  "createdAt": "2011-08-18T22:30:38Z",
-  "displayNumber": "Pull Request #2",
+  "closedAt": null,
+  "createdAt": "2015-03-22T20:36:16Z",
+  "displayNumber": "Pull Request #1",
   "isConflicted": false,
   "isModified": false,
   "isStale": false,
-  "number": 2,
-  "sha": "other-head-sha",
+  "number": 1,
+  "sha": "some-head-sha",
   "sourceRepo": "some/repo",
-  "state": "closed",
-  "targetBranch": "other-base-ref",
-  "title": "Other PR",
+  "state": "open",
+  "targetBranch": "some-base-ref",
+  "title": "Some PR",
 }
 `;
 

--- a/lib/platform/gitea/__snapshots__/index.spec.ts.snap
+++ b/lib/platform/gitea/__snapshots__/index.spec.ts.snap
@@ -43,7 +43,7 @@ Object {
 exports[`platform/gitea getPr should fallback to direct fetching if cache fails 1`] = `
 Object {
   "body": "some random pull request",
-  "branchName": "some-head-ref",
+  "branchName": "some-head-branch",
   "canMerge": true,
   "closedAt": null,
   "createdAt": "2015-03-22T20:36:16Z",
@@ -55,7 +55,7 @@ Object {
   "sha": "some-head-sha",
   "sourceRepo": "some/repo",
   "state": "open",
-  "targetBranch": "some-base-ref",
+  "targetBranch": "some-base-branch",
   "title": "Some PR",
 }
 `;
@@ -63,7 +63,7 @@ Object {
 exports[`platform/gitea getPr should return enriched pull request which exists if open 1`] = `
 Object {
   "body": "some random pull request",
-  "branchName": "some-head-ref",
+  "branchName": "some-head-branch",
   "canMerge": true,
   "closedAt": null,
   "createdAt": "2015-03-22T20:36:16Z",
@@ -75,7 +75,7 @@ Object {
   "sha": "some-head-sha",
   "sourceRepo": "some/repo",
   "state": "open",
-  "targetBranch": "some-base-ref",
+  "targetBranch": "some-base-branch",
   "title": "Some PR",
 }
 `;
@@ -84,7 +84,7 @@ exports[`platform/gitea getPrList should return list of pull requests 1`] = `
 Array [
   Object {
     "body": "some random pull request",
-    "branchName": "some-head-ref",
+    "branchName": "some-head-branch",
     "canMerge": true,
     "closedAt": null,
     "createdAt": "2015-03-22T20:36:16Z",
@@ -96,12 +96,12 @@ Array [
     "sha": "some-head-sha",
     "sourceRepo": "some/repo",
     "state": "open",
-    "targetBranch": "some-base-ref",
+    "targetBranch": "some-base-branch",
     "title": "Some PR",
   },
   Object {
     "body": "other random pull request",
-    "branchName": "other-head-ref",
+    "branchName": "other-head-branch",
     "canMerge": true,
     "closedAt": "2016-01-09T10:03:21Z",
     "createdAt": "2011-08-18T22:30:38Z",
@@ -113,7 +113,7 @@ Array [
     "sha": "other-head-sha",
     "sourceRepo": "some/repo",
     "state": "closed",
-    "targetBranch": "other-base-ref",
+    "targetBranch": "other-base-branch",
     "title": "Other PR",
   },
 ]

--- a/lib/platform/gitea/gitea-helper.spec.ts
+++ b/lib/platform/gitea/gitea-helper.spec.ts
@@ -77,6 +77,7 @@ describe('platform/gitea/gitea-helper', () => {
     base: { ref: mockRepo.default_branch },
     head: {
       ref: 'pull-req-13',
+      label: 'pull-req-13',
       sha: mockCommitHash,
       repo: mockRepo,
     },

--- a/lib/platform/gitea/gitea-helper.spec.ts
+++ b/lib/platform/gitea/gitea-helper.spec.ts
@@ -76,7 +76,6 @@ describe('platform/gitea/gitea-helper', () => {
     diff_url: `https://gitea.renovatebot.com/${mockRepo.full_name}/pulls/13.diff`,
     base: { ref: mockRepo.default_branch },
     head: {
-      ref: 'pull-req-13',
       label: 'pull-req-13',
       sha: mockCommitHash,
       repo: mockRepo,
@@ -362,7 +361,7 @@ describe('platform/gitea/gitea-helper', () => {
             title: mockPR.title,
             body: mockPR.body,
             base: mockPR.base.ref,
-            head: mockPR.head.ref,
+            head: mockPR.head.label,
             assignees: [mockUser.username],
             labels: [mockLabel.id],
           },
@@ -375,7 +374,7 @@ describe('platform/gitea/gitea-helper', () => {
         title: mockPR.title,
         body: mockPR.body,
         base: mockPR.base.ref,
-        head: mockPR.head.ref,
+        head: mockPR.head.label,
         assignees: [mockUser.username],
         labels: [mockLabel.id],
       });

--- a/lib/platform/gitea/gitea-helper.ts
+++ b/lib/platform/gitea/gitea-helper.ts
@@ -29,6 +29,7 @@ export interface PR {
   };
   head?: {
     ref: string;
+    label: string;
     sha: string;
     repo?: Repo;
   };

--- a/lib/platform/gitea/gitea-helper.ts
+++ b/lib/platform/gitea/gitea-helper.ts
@@ -28,7 +28,6 @@ export interface PR {
     ref: string;
   };
   head?: {
-    ref: string;
     label: string;
     sha: string;
     repo?: Repo;

--- a/lib/platform/gitea/index.spec.ts
+++ b/lib/platform/gitea/index.spec.ts
@@ -66,10 +66,9 @@ describe('platform/gitea', () => {
       created_at: '2015-03-22T20:36:16Z',
       closed_at: null,
       mergeable: true,
-      base: { ref: 'some-base-ref' },
+      base: { ref: 'some-base-branch' },
       head: {
-        ref: 'some-head-ref',
-        label: 'some-head-ref',
+        label: 'some-head-branch',
         sha: 'some-head-sha',
         repo: partial<ght.Repo>({ full_name: mockRepo.full_name }),
       },
@@ -83,10 +82,9 @@ describe('platform/gitea', () => {
       created_at: '2011-08-18T22:30:38Z',
       closed_at: '2016-01-09T10:03:21Z',
       mergeable: true,
-      base: { ref: 'other-base-ref' },
+      base: { ref: 'other-base-branch' },
       head: {
-        ref: 'other-head-ref',
-        label: 'other-head-ref',
+        label: 'other-head-branch',
         sha: 'other-head-sha',
         repo: partial<ght.Repo>({ full_name: mockRepo.full_name }),
       },
@@ -651,8 +649,8 @@ describe('platform/gitea', () => {
       helper.searchPRs.mockResolvedValueOnce(mockPRs);
       await initFakeRepo();
 
-      const res = await gitea.findPr({ branchName: mockPR.head.ref });
-      expect(res).toHaveProperty('branchName', mockPR.head.ref);
+      const res = await gitea.findPr({ branchName: mockPR.head.label });
+      expect(res).toHaveProperty('branchName', mockPR.head.label);
     });
 
     it('should find pull request with title', async () => {
@@ -661,10 +659,10 @@ describe('platform/gitea', () => {
       await initFakeRepo();
 
       const res = await gitea.findPr({
-        branchName: mockPR.head.ref,
+        branchName: mockPR.head.label,
         prTitle: mockPR.title,
       });
-      expect(res).toHaveProperty('branchName', mockPR.head.ref);
+      expect(res).toHaveProperty('branchName', mockPR.head.label);
       expect(res).toHaveProperty('title', mockPR.title);
     });
 
@@ -674,10 +672,10 @@ describe('platform/gitea', () => {
       await initFakeRepo();
 
       const res = await gitea.findPr({
-        branchName: mockPR.head.ref,
+        branchName: mockPR.head.label,
         state: mockPR.state,
       });
-      expect(res).toHaveProperty('branchName', mockPR.head.ref);
+      expect(res).toHaveProperty('branchName', mockPR.head.label);
       expect(res).toHaveProperty('state', mockPR.state);
     });
 
@@ -688,7 +686,7 @@ describe('platform/gitea', () => {
 
       expect(
         await gitea.findPr({
-          branchName: mockPR.head.ref,
+          branchName: mockPR.head.label,
           state: `!${mockPR.state}` as ght.PRState,
         })
       ).toBeNull();
@@ -700,11 +698,11 @@ describe('platform/gitea', () => {
       await initFakeRepo();
 
       const res = await gitea.findPr({
-        branchName: mockPR.head.ref,
+        branchName: mockPR.head.label,
         prTitle: mockPR.title,
         state: mockPR.state,
       });
-      expect(res).toHaveProperty('branchName', mockPR.head.ref);
+      expect(res).toHaveProperty('branchName', mockPR.head.label);
       expect(res).toHaveProperty('title', mockPR.title);
       expect(res).toHaveProperty('state', mockPR.state);
     });
@@ -722,7 +720,6 @@ describe('platform/gitea', () => {
       number: 42,
       state: 'open',
       head: {
-        ref: 'pr-branch',
         label: 'pr-branch',
         sha: mockCommitHash,
         repo: partial<ght.Repo>({ full_name: mockRepo.full_name }),
@@ -747,7 +744,7 @@ describe('platform/gitea', () => {
       await initFakeRepo();
       await gitea.setBaseBranch('devel');
       const res = await gitea.createPr({
-        branchName: mockNewPR.head.ref,
+        branchName: mockNewPR.head.label,
         prTitle: mockNewPR.title,
         prBody: mockNewPR.body,
       });
@@ -758,7 +755,7 @@ describe('platform/gitea', () => {
       expect(helper.createPR).toHaveBeenCalledTimes(1);
       expect(helper.createPR).toHaveBeenCalledWith(mockRepo.full_name, {
         base: 'devel',
-        head: mockNewPR.head.ref,
+        head: mockNewPR.head.label,
         title: mockNewPR.title,
         body: mockNewPR.body,
         labels: [],
@@ -771,7 +768,7 @@ describe('platform/gitea', () => {
       await initFakeRepo();
       await gitea.setBaseBranch('devel');
       const res = await gitea.createPr({
-        branchName: mockNewPR.head.ref,
+        branchName: mockNewPR.head.label,
         prTitle: mockNewPR.title,
         prBody: mockNewPR.body,
         useDefaultBranch: true,
@@ -783,7 +780,7 @@ describe('platform/gitea', () => {
       expect(helper.createPR).toHaveBeenCalledTimes(1);
       expect(helper.createPR).toHaveBeenCalledWith(mockRepo.full_name, {
         base: mockNewPR.base.ref,
-        head: mockNewPR.head.ref,
+        head: mockNewPR.head.label,
         title: mockNewPR.title,
         body: mockNewPR.body,
         labels: [],
@@ -796,7 +793,7 @@ describe('platform/gitea', () => {
 
       await initFakeRepo();
       await gitea.createPr({
-        branchName: mockNewPR.head.ref,
+        branchName: mockNewPR.head.label,
         prTitle: mockNewPR.title,
         prBody: mockNewPR.body,
         labels: mockLabels.map((l) => l.name),
@@ -805,7 +802,7 @@ describe('platform/gitea', () => {
       expect(helper.createPR).toHaveBeenCalledTimes(1);
       expect(helper.createPR).toHaveBeenCalledWith(mockRepo.full_name, {
         base: mockNewPR.base.ref,
-        head: mockNewPR.head.ref,
+        head: mockNewPR.head.label,
         title: mockNewPR.title,
         body: mockNewPR.body,
         labels: mockLabels.map((l) => l.id),
@@ -819,7 +816,7 @@ describe('platform/gitea', () => {
       await initFakeRepo();
       await gitea.getPrList();
       await gitea.createPr({
-        branchName: mockNewPR.head.ref,
+        branchName: mockNewPR.head.label,
         prTitle: mockNewPR.title,
         prBody: mockNewPR.body,
         useDefaultBranch: true,
@@ -836,7 +833,7 @@ describe('platform/gitea', () => {
 
       await initFakeRepo();
       const res = await gitea.createPr({
-        branchName: mockNewPR.head.ref,
+        branchName: mockNewPR.head.label,
         prTitle: mockNewPR.title,
         prBody: mockNewPR.body,
         useDefaultBranch: true,
@@ -851,7 +848,7 @@ describe('platform/gitea', () => {
 
       await initFakeRepo();
       const res = await gitea.createPr({
-        branchName: mockNewPR.head.ref,
+        branchName: mockNewPR.head.label,
         prTitle: 'new-title',
         prBody: 'new-body',
         useDefaultBranch: true,
@@ -872,7 +869,7 @@ describe('platform/gitea', () => {
       await initFakeRepo();
       await expect(
         gitea.createPr({
-          branchName: mockNewPR.head.ref,
+          branchName: mockNewPR.head.label,
           prTitle: mockNewPR.title,
           prBody: mockNewPR.body,
         })
@@ -1341,7 +1338,7 @@ index 0000000..2173594
       helper.searchPRs.mockResolvedValueOnce(mockPRs);
       await initFakeRepo();
 
-      expect(await gitea.getBranchPr(mockPR.head.ref)).toHaveProperty(
+      expect(await gitea.getBranchPr(mockPR.head.label)).toHaveProperty(
         'number',
         mockPR.number
       );
@@ -1375,7 +1372,7 @@ index 0000000..2173594
       const mockPR = mockPRs[0];
       helper.searchPRs.mockResolvedValueOnce(mockPRs);
       await initFakeRepo();
-      await gitea.deleteBranch(mockPR.head.ref, true);
+      await gitea.deleteBranch(mockPR.head.label, true);
 
       expect(helper.closePR).toHaveBeenCalledTimes(1);
       expect(helper.closePR).toHaveBeenCalledWith(
@@ -1383,7 +1380,7 @@ index 0000000..2173594
         mockPR.number
       );
       expect(gsmDeleteBranch).toHaveBeenCalledTimes(1);
-      expect(gsmDeleteBranch).toHaveBeenCalledWith(mockPR.head.ref);
+      expect(gsmDeleteBranch).toHaveBeenCalledWith(mockPR.head.label);
     });
 
     it('should skip closing pull request if missing', async () => {

--- a/lib/platform/gitea/index.spec.ts
+++ b/lib/platform/gitea/index.spec.ts
@@ -587,8 +587,8 @@ describe('platform/gitea', () => {
   });
 
   describe('getPr', () => {
-    it('should return enriched pull request which exists', async () => {
-      const mockPR = mockPRs[1];
+    it('should return enriched pull request which exists if open', async () => {
+      const mockPR = mockPRs[0];
       helper.searchPRs.mockResolvedValueOnce(mockPRs);
       helper.getBranch.mockResolvedValueOnce(
         partial<ght.Branch>({

--- a/lib/platform/gitea/index.spec.ts
+++ b/lib/platform/gitea/index.spec.ts
@@ -69,6 +69,7 @@ describe('platform/gitea', () => {
       base: { ref: 'some-base-ref' },
       head: {
         ref: 'some-head-ref',
+        label: 'some-head-ref',
         sha: 'some-head-sha',
         repo: partial<ght.Repo>({ full_name: mockRepo.full_name }),
       },
@@ -85,6 +86,7 @@ describe('platform/gitea', () => {
       base: { ref: 'other-base-ref' },
       head: {
         ref: 'other-head-ref',
+        label: 'other-head-ref',
         sha: 'other-head-sha',
         repo: partial<ght.Repo>({ full_name: mockRepo.full_name }),
       },
@@ -721,6 +723,7 @@ describe('platform/gitea', () => {
       state: 'open',
       head: {
         ref: 'pr-branch',
+        label: 'pr-branch',
         sha: mockCommitHash,
         repo: partial<ght.Repo>({ full_name: mockRepo.full_name }),
       },

--- a/lib/platform/gitea/index.ts
+++ b/lib/platform/gitea/index.ts
@@ -473,11 +473,13 @@ const platform: Platform = {
     }
 
     // Enrich pull request with additional information which is more expensive to fetch
-    if (pr.isStale === undefined) {
-      pr.isStale = await platform.isBranchStale(pr.branchName);
-    }
-    if (pr.isModified === undefined) {
-      pr.isModified = await isPRModified(config.repository, pr.branchName);
+    if (pr.state !== 'closed') {
+      if (pr.isStale === undefined) {
+        pr.isStale = await platform.isBranchStale(pr.branchName);
+      }
+      if (pr.isModified === undefined) {
+        pr.isModified = await isPRModified(config.repository, pr.branchName);
+      }
     }
 
     return pr;

--- a/lib/platform/gitea/index.ts
+++ b/lib/platform/gitea/index.ts
@@ -80,7 +80,7 @@ function toRenovatePR(data: helper.PR): Pr | null {
 
   if (
     !data.base?.ref ||
-    !data.head?.ref ||
+    !data.head?.label ||
     !data.head?.sha ||
     !data.head?.repo?.full_name
   ) {
@@ -97,7 +97,7 @@ function toRenovatePR(data: helper.PR): Pr | null {
     title: data.title,
     body: data.body,
     sha: data.head.sha,
-    branchName: data.head.ref,
+    branchName: data.head.label,
     targetBranch: data.base.ref,
     sourceRepo: data.head.repo.full_name,
     createdAt: data.created_at,


### PR DESCRIPTION
Closes https://github.com/renovatebot/renovate/issues/6018

As per https://github.com/go-gitea/gitea/pull/10413, Gitea now supports exposing name of deleted branch on closed PR, however this is done by `label`, not `ref`. (`ref` must always be a valid reference)

This PR changes `toRenovatePR` to always access `label` when fetching branch name, as it will contain proper branch name for both open and closed PRs.

This effectively solves the issue of Renovate recreating closed PRs on Gitea, however we should keep the immortal message until Gitea 1.12 is officially released.

The change is fully backwards compatible.