### PR TITLE
feat(gitea): support organization labels

### DIFF
--- a/lib/platform/gitea/gitea-helper.spec.ts
+++ b/lib/platform/gitea/gitea-helper.spec.ts
@@ -622,6 +622,20 @@ describe('platform/gitea/gitea-helper', () => {
     });
   });
 
+  describe('getOrgLabels', () => {
+    it('should call /api/v1/orgs/[org]/labels endpoint', async () => {
+      mockAPI<ght.Label[]>(
+        {
+          urlPattern: `/api/v1/orgs/${mockRepo.owner.username}/labels`,
+        },
+        [mockLabel, otherMockLabel]
+      );
+
+      const res = await helper.getOrgLabels(mockRepo.owner.username);
+      expect(res).toEqual([mockLabel, otherMockLabel]);
+    });
+  });
+
   describe('unassignLabel', () => {
     it('should call /api/v1/repos/[repo]/issues/[issue]/labels/[label] endpoint', async () => {
       mockAPI({

--- a/lib/platform/gitea/gitea-helper.ts
+++ b/lib/platform/gitea/gitea-helper.ts
@@ -399,6 +399,16 @@ export async function getRepoLabels(
   return res.body;
 }
 
+export async function getOrgLabels(
+  orgName: string,
+  options?: GiteaGotOptions
+): Promise<Label[]> {
+  const url = `orgs/${orgName}/labels`;
+  const res: GotResponse<Label[]> = await api.get(url, options);
+
+  return res.body;
+}
+
 export async function unassignLabel(
   repoPath: string,
   issue: number,

--- a/lib/platform/gitea/index.spec.ts
+++ b/lib/platform/gitea/index.spec.ts
@@ -135,9 +135,24 @@ describe('platform/gitea', () => {
     { id: 3, body: '### some-topic\n\nsome-content' },
   ];
 
-  const mockLabels: ght.Label[] = [
+  const mockRepoLabels: ght.Label[] = [
     { id: 1, name: 'some-label', description: 'its a me', color: '#000000' },
     { id: 2, name: 'other-label', description: 'labelario', color: '#ffffff' },
+  ];
+
+  const mockOrgLabels: ght.Label[] = [
+    {
+      id: 3,
+      name: 'some-org-label',
+      description: 'its a org me',
+      color: '#0000aa',
+    },
+    {
+      id: 4,
+      name: 'other-org-label',
+      description: 'org labelario',
+      color: '#ffffaa',
+    },
   ];
 
   const gsmInitRepo = jest.fn();
@@ -789,7 +804,10 @@ describe('platform/gitea', () => {
 
     it('should resolve and apply optional labels to pull request', async () => {
       helper.createPR.mockResolvedValueOnce(mockNewPR);
-      helper.getRepoLabels.mockResolvedValueOnce(mockLabels);
+      helper.getRepoLabels.mockResolvedValueOnce(mockRepoLabels);
+      helper.getOrgLabels.mockResolvedValueOnce(mockOrgLabels);
+
+      const mockLabels = mockRepoLabels.concat(mockOrgLabels);
 
       await initFakeRepo();
       await gitea.createPr({
@@ -1157,8 +1175,9 @@ index 0000000..2173594
 
   describe('deleteLabel', () => {
     it('should delete a label which exists', async () => {
-      const mockLabel = mockLabels[0];
-      helper.getRepoLabels.mockResolvedValueOnce(mockLabels);
+      const mockLabel = mockRepoLabels[0];
+      helper.getRepoLabels.mockResolvedValueOnce(mockRepoLabels);
+      helper.getOrgLabels.mockRejectedValueOnce(new Error());
       await initFakeRepo();
       await gitea.deleteLabel(42, mockLabel.name);
 
@@ -1171,7 +1190,8 @@ index 0000000..2173594
     });
 
     it('should gracefully fail with warning if label is missing', async () => {
-      helper.getRepoLabels.mockResolvedValueOnce(mockLabels);
+      helper.getRepoLabels.mockResolvedValueOnce(mockRepoLabels);
+      helper.getOrgLabels.mockResolvedValueOnce([]);
       await initFakeRepo();
       await gitea.deleteLabel(42, 'missing');
 


### PR DESCRIPTION
Closes https://github.com/renovatebot/renovate/issues/6017

As per https://github.com/go-gitea/gitea/pull/10814 Gitea supports organization-wide labels. Such labels can be used on PR creation however they are not listed when queried using per-repo API.

This PR adds code that fetches organization labels for repo, allowing such labels to be applied by Renovate during PR creation.

This change is fully backwards compatible.