### PR TITLE
feat(pr): remove and re-create automergeComment when rebasing

### DIFF
--- a/lib/workers/pr/index.spec.ts
+++ b/lib/workers/pr/index.spec.ts
@@ -85,6 +85,18 @@ describe('workers/pr', () => {
       pr.isModified = false;
       platform.getBranchStatus.mockResolvedValueOnce(BranchStatus.green);
       await prWorker.checkAutoMerge(pr, config);
+      expect(platform.ensureCommentRemoval).toHaveBeenCalledTimes(0);
+      expect(platform.ensureComment).toHaveBeenCalledTimes(1);
+    });
+    it('should remove previous automerge comment when rebasing', async () => {
+      config.automerge = true;
+      config.automergeType = 'pr-comment';
+      config.automergeComment = '!merge';
+      config.rebaseRequested = true;
+      pr.isModified = false;
+      platform.getBranchStatus.mockResolvedValueOnce(BranchStatus.green);
+      await prWorker.checkAutoMerge(pr, config);
+      expect(platform.ensureCommentRemoval).toHaveBeenCalledTimes(1);
       expect(platform.ensureComment).toHaveBeenCalledTimes(1);
     });
     it('should not automerge if enabled and pr is mergeable but cannot rebase', async () => {

--- a/lib/workers/pr/index.ts
+++ b/lib/workers/pr/index.ts
@@ -437,6 +437,7 @@ export async function checkAutoMerge(
     automergeType,
     automergeComment,
     requiredStatusChecks,
+    rebaseRequested,
   } = config;
   logger.debug(
     { automerge, automergeType, automergeComment },
@@ -480,6 +481,12 @@ export async function checkAutoMerge(
           'DRY-RUN: Would add PR automerge comment to PR #' + pr.number
         );
         return false;
+      }
+      if (rebaseRequested) {
+        await platform.ensureCommentRemoval({
+          number: pr.number,
+          content: automergeComment,
+        });
       }
       return platform.ensureComment({
         number: pr.number,


### PR DESCRIPTION
<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate

    Please ensure `Allow edits from maintainers.` checkbox is checked
-->

This PR will change the behavior of the `pr-comment` automerge strategy to try to remove and re-create the `automergeComment` after a rebase has hapened.
This is needed because some merge bots (such as `bors-ng`) do not try to merge again after a rebase has happened.

Update: This PR only addresses the original issue described in #5021 but does no longer address my proposed changes in https://github.com/renovatebot/renovate/issues/5021#issuecomment-584599546 because of some complications (https://github.com/renovatebot/renovate/pull/6002#pullrequestreview-396000479).

Closes #5021
