### PR TITLE
fix(manager): gradle needs a jdk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ ENV RENOVATE_BINARY_SOURCE=docker
 FROM final-base as latest
 
 RUN apt-get update && \
-    apt-get install -y gpg wget unzip xz-utils openssh-client bsdtar build-essential openjdk-8-jre-headless dirmngr && \
+    apt-get install -y gpg wget unzip xz-utils openssh-client bsdtar build-essential openjdk-8-jdk-headless dirmngr && \
     rm -rf /var/lib/apt/lists/*
 
 


### PR DESCRIPTION
For gradle kotlin support a jdk is required (at least for java 8).

This adds additionally 40MB to the image.

Closes #5992
