### PR TITLE
feat(nvm): support .nvmrc files at any depth

### DIFF
--- a/lib/manager/nvm/index.ts
+++ b/lib/manager/nvm/index.ts
@@ -6,6 +6,6 @@ export { extractPackageFile } from './extract';
 export const language = LANGUAGE_NODE;
 
 export const defaultConfig = {
-  fileMatch: ['^.nvmrc$'],
+  fileMatch: ['(^|/)\\.nvmrc$'],
   versioning: nodeVersioning.id,
 };


### PR DESCRIPTION
Previous regex only supported `.nvmrc` in the root directory. Now nvmrc at any directory depth is allowed.

Actually, the previous regex didn't escape the `.`, so `anvmrc`, `bnvmrc`, etc. were also valid files 😅

Fixes #6106