### PR TITLE
refactor: ensureCommentRemoval parameters to an object

### DIFF
--- a/lib/platform/azure/index.spec.ts
+++ b/lib/platform/azure/index.spec.ts
@@ -791,11 +791,11 @@ describe('platform/azure', () => {
             updateThread: jest.fn(),
           } as any)
       );
-      await azure.ensureCommentRemoval(42, 'some-subject');
+      await azure.ensureCommentRemoval({ number: 42, topic: 'some-subject' });
       expect(azureApi.gitApi).toHaveBeenCalledTimes(3);
     });
     it('nothing should happen, no number', async () => {
-      await azure.ensureCommentRemoval(0, 'test');
+      await azure.ensureCommentRemoval({ number: 0, topic: 'test' });
       expect(azureApi.gitApi).toHaveBeenCalledTimes(0);
     });
     it('comment not found', async () => {
@@ -809,7 +809,7 @@ describe('platform/azure', () => {
             updateThread: jest.fn(),
           } as any)
       );
-      await azure.ensureCommentRemoval(42, 'some-subject');
+      await azure.ensureCommentRemoval({ number: 42, topic: 'some-subject' });
       expect(azureApi.gitApi).toHaveBeenCalledTimes(3);
     });
   });

--- a/lib/platform/azure/index.ts
+++ b/lib/platform/azure/index.ts
@@ -21,6 +21,7 @@ import {
   CommitFilesConfig,
   CreatePRConfig,
   EnsureCommentConfig,
+  EnsureCommentRemovalConfig,
   EnsureIssueResult,
   FindPRConfig,
   Issue,
@@ -572,10 +573,10 @@ export async function ensureComment({
   return true;
 }
 
-export async function ensureCommentRemoval(
-  issueNo: number,
-  topic: string
-): Promise<void> {
+export async function ensureCommentRemoval({
+  number: issueNo,
+  topic,
+}: EnsureCommentRemovalConfig): Promise<void> {
   logger.debug(`ensureCommentRemoval(issueNo, topic)(${issueNo}, ${topic})`);
   if (issueNo) {
     const azureApiGit = await azureApi.gitApi();

--- a/lib/platform/bitbucket-server/index.spec.ts
+++ b/lib/platform/bitbucket-server/index.spec.ts
@@ -487,7 +487,7 @@ describe('platform/bitbucket-server', () => {
       describe('ensureCommentRemoval()', () => {
         it('does not throw', async () => {
           expect.assertions(1);
-          await bitbucket.ensureCommentRemoval(5, 'topic');
+          await bitbucket.ensureCommentRemoval({ number: 5, topic: 'topic' });
           expect(api.get.mock.calls).toMatchSnapshot();
         });
 
@@ -496,7 +496,10 @@ describe('platform/bitbucket-server', () => {
           await initRepo();
           api.get.mockClear();
 
-          await bitbucket.ensureCommentRemoval(5, 'some-subject');
+          await bitbucket.ensureCommentRemoval({
+            number: 5,
+            topic: 'some-subject',
+          });
           expect(api.get.mock.calls).toMatchSnapshot();
           expect(api.delete).toHaveBeenCalledTimes(1);
         });
@@ -506,7 +509,7 @@ describe('platform/bitbucket-server', () => {
           await initRepo();
           api.get.mockClear();
 
-          await bitbucket.ensureCommentRemoval(5, 'topic');
+          await bitbucket.ensureCommentRemoval({ number: 5, topic: 'topic' });
           expect(api.get.mock.calls).toMatchSnapshot();
           expect(api.delete).toHaveBeenCalledTimes(0);
         });

--- a/lib/platform/bitbucket-server/index.ts
+++ b/lib/platform/bitbucket-server/index.ts
@@ -19,6 +19,7 @@ import {
   CommitFilesConfig,
   CreatePRConfig,
   EnsureCommentConfig,
+  EnsureCommentRemovalConfig,
   EnsureIssueConfig,
   EnsureIssueResult,
   FindPRConfig,
@@ -883,10 +884,10 @@ export async function ensureComment({
   }
 }
 
-export async function ensureCommentRemoval(
-  prNo: number,
-  topic: string
-): Promise<void> {
+export async function ensureCommentRemoval({
+  number: prNo,
+  topic,
+}: EnsureCommentRemovalConfig): Promise<void> {
   try {
     logger.debug(`Ensuring comment "${topic}" in #${prNo} is removed`);
     const comments = await getComments(prNo);

--- a/lib/platform/bitbucket/index.spec.ts
+++ b/lib/platform/bitbucket/index.spec.ts
@@ -377,7 +377,7 @@ describe('platform/bitbucket', () => {
 
   describe('ensureCommentRemoval()', () => {
     it('does not throw', async () => {
-      await bitbucket.ensureCommentRemoval(3, 'topic');
+      await bitbucket.ensureCommentRemoval({ number: 3, topic: 'topic' });
     });
   });
 

--- a/lib/platform/bitbucket/index.ts
+++ b/lib/platform/bitbucket/index.ts
@@ -17,6 +17,7 @@ import {
   CommitFilesConfig,
   CreatePRConfig,
   EnsureCommentConfig,
+  EnsureCommentRemovalConfig,
   EnsureIssueConfig,
   EnsureIssueResult,
   FindPRConfig,
@@ -708,10 +709,10 @@ export function ensureComment({
   });
 }
 
-export function ensureCommentRemoval(
-  prNo: number,
-  topic: string
-): Promise<void> {
+export function ensureCommentRemoval({
+  number: prNo,
+  topic,
+}: EnsureCommentRemovalConfig): Promise<void> {
   return comments.ensureCommentRemoval(config, prNo, topic);
 }
 

--- a/lib/platform/common.ts
+++ b/lib/platform/common.ts
@@ -149,6 +149,11 @@ export interface EnsureCommentConfig {
   topic: string;
   content: string;
 }
+export interface EnsureCommentRemovalConfig {
+  number: number;
+  topic?: string;
+  content?: string;
+}
 /**
  * TODO: Proper typing
  */
@@ -188,7 +193,9 @@ export interface Platform {
     branchName: string,
     context: string
   ): Promise<BranchStatus | null>;
-  ensureCommentRemoval(number: number, subject: string): Promise<void>;
+  ensureCommentRemoval(
+    ensureCommentRemoval: EnsureCommentRemovalConfig
+  ): Promise<void>;
   deleteBranch(branchName: string, closePr?: boolean): Promise<void>;
   ensureComment(ensureComment: EnsureCommentConfig): Promise<boolean>;
   branchExists(branchName: string): Promise<boolean>;

--- a/lib/platform/gitea/index.spec.ts
+++ b/lib/platform/gitea/index.spec.ts
@@ -1325,7 +1325,7 @@ index 0000000..2173594
     it('should remove existing comment', async () => {
       helper.getComments.mockResolvedValueOnce(mockComments);
       await initFakeRepo();
-      await gitea.ensureCommentRemoval(1, 'some-topic');
+      await gitea.ensureCommentRemoval({ number: 1, topic: 'some-topic' });
 
       expect(helper.deleteComment).toHaveBeenCalledTimes(1);
       expect(helper.deleteComment).toHaveBeenCalledWith(
@@ -1338,7 +1338,7 @@ index 0000000..2173594
       helper.getComments.mockResolvedValueOnce(mockComments);
       helper.deleteComment.mockRejectedValueOnce(new Error());
       await initFakeRepo();
-      await gitea.ensureCommentRemoval(1, 'some-topic');
+      await gitea.ensureCommentRemoval({ number: 1, topic: 'some-topic' });
 
       expect(logger.warn).toHaveBeenCalledTimes(1);
     });
@@ -1346,7 +1346,7 @@ index 0000000..2173594
     it('should abort silently if comment is missing', async () => {
       helper.getComments.mockResolvedValueOnce(mockComments);
       await initFakeRepo();
-      await gitea.ensureCommentRemoval(1, 'missing');
+      await gitea.ensureCommentRemoval({ number: 1, topic: 'missing' });
 
       expect(helper.deleteComment).not.toHaveBeenCalled();
     });

--- a/lib/platform/gitea/index.ts
+++ b/lib/platform/gitea/index.ts
@@ -22,6 +22,7 @@ import {
   CommitFilesConfig,
   CreatePRConfig,
   EnsureCommentConfig,
+  EnsureCommentRemovalConfig,
   EnsureIssueConfig,
   FindPRConfig,
   Issue,
@@ -817,7 +818,10 @@ const platform: Platform = {
     }
   },
 
-  async ensureCommentRemoval(issue: number, topic: string): Promise<void> {
+  async ensureCommentRemoval({
+    number: issue,
+    topic,
+  }: EnsureCommentRemovalConfig): Promise<void> {
     const commentList = await helper.getComments(config.repository, issue);
     const comment = findCommentByTopic(commentList, topic);
 

--- a/lib/platform/github/index.spec.ts
+++ b/lib/platform/github/index.spec.ts
@@ -1438,7 +1438,7 @@ describe('platform/github', () => {
         .delete('/repos/some/repo/issues/comments/1234')
         .reply(200);
       await github.initRepo({ repository: 'some/repo', token: 'token' } as any);
-      await github.ensureCommentRemoval(42, 'some-subject');
+      await github.ensureCommentRemoval({ number: 42, topic: 'some-subject' });
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
   });

--- a/lib/platform/github/index.ts
+++ b/lib/platform/github/index.ts
@@ -33,6 +33,7 @@ import {
   CommitFilesConfig,
   CreatePRConfig,
   EnsureCommentConfig,
+  EnsureCommentRemovalConfig,
   EnsureIssueConfig,
   EnsureIssueResult,
   FindPRConfig,
@@ -1620,10 +1621,10 @@ export async function ensureComment({
   }
 }
 
-export async function ensureCommentRemoval(
-  issueNo: number,
-  topic: string
-): Promise<void> {
+export async function ensureCommentRemoval({
+  number: issueNo,
+  topic,
+}: EnsureCommentRemovalConfig): Promise<void> {
   logger.debug(`Ensuring comment "${topic}" in #${issueNo} is removed`);
   const comments = await getComments(issueNo);
   let commentId: number;

--- a/lib/platform/gitlab/index.spec.ts
+++ b/lib/platform/gitlab/index.spec.ts
@@ -857,7 +857,7 @@ describe('platform/gitlab', () => {
           body: [{ id: 1234, body: '### some-subject\n\nblablabla' }],
         })
       );
-      await gitlab.ensureCommentRemoval(42, 'some-subject');
+      await gitlab.ensureCommentRemoval({ number: 42, topic: 'some-subject' });
       expect(api.delete).toHaveBeenCalledTimes(1);
     });
   });

--- a/lib/platform/gitlab/index.ts
+++ b/lib/platform/gitlab/index.ts
@@ -25,6 +25,7 @@ import {
   CommitFilesConfig,
   CreatePRConfig,
   EnsureCommentConfig,
+  EnsureCommentRemovalConfig,
   EnsureIssueConfig,
   FindPRConfig,
   GotResponse,
@@ -941,10 +942,10 @@ export async function ensureComment({
   return true;
 }
 
-export async function ensureCommentRemoval(
-  issueNo: number,
-  topic: string
-): Promise<void> {
+export async function ensureCommentRemoval({
+  number: issueNo,
+  topic,
+}: EnsureCommentRemovalConfig): Promise<void> {
   logger.debug(`Ensuring comment "${topic}" in #${issueNo} is removed`);
   const comments = await getComments(issueNo);
   let commentId: number;

--- a/lib/workers/branch/index.ts
+++ b/lib/workers/branch/index.ts
@@ -177,7 +177,10 @@ export async function processBranch(
                   branchPr.number
               );
             } else {
-              await platform.ensureCommentRemoval(branchPr.number, topic);
+              await platform.ensureCommentRemoval({
+                number: branchPr.number,
+                topic,
+              });
             }
           } else {
             let content = emojify(
@@ -622,10 +625,10 @@ export async function processBranch(
               content,
             });
             // TODO: remoe this soon once they're all cleared out
-            await platform.ensureCommentRemoval(
-              pr.number,
-              ':warning: Lock file problem'
-            );
+            await platform.ensureCommentRemoval({
+              number: pr.number,
+              topic: ':warning: Lock file problem',
+            });
           }
         }
         const context = `renovate/artifacts`;
@@ -659,7 +662,7 @@ export async function processBranch(
               'DRY-RUN: Would ensure comment removal in PR #' + pr.number
             );
           } else {
-            await platform.ensureCommentRemoval(pr.number, topic);
+            await platform.ensureCommentRemoval({ number: pr.number, topic });
           }
         }
         const prAutomerged = await checkAutoMerge(pr, config);

--- a/lib/workers/repository/finalise/validate.ts
+++ b/lib/workers/repository/finalise/validate.ts
@@ -111,7 +111,7 @@ export async function validatePrs(config: RenovateConfig): Promise<void> {
             `DRY-RUN: Would ensure validation comment removal in PR #${pr.number}`
           );
         } else {
-          await platform.ensureCommentRemoval(pr.number, topic);
+          await platform.ensureCommentRemoval({ number: pr.number, topic });
         }
       }
       // istanbul ignore else


### PR DESCRIPTION
This is done in preparation for #6002 to allow `ensureCommentRemoval` to remove
comments either by text or by topic.

<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate

    Please ensure `Allow edits from maintainers.` checkbox is checked
-->

<!-- Replace this text with a description of what this PR fixes or adds -->

Closes # <!-- Ideally each PR should be closing an open issue -->
