### PR TITLE
fix(gitFs): cache fileList results

### DIFF
--- a/lib/platform/git/__snapshots__/storage.spec.ts.snap
+++ b/lib/platform/git/__snapshots__/storage.spec.ts.snap
@@ -11,6 +11,8 @@ Array [
 
 exports[`platform/git/storage getFile(filePath, branchName) returns null for 404 1`] = `[Error: repository-changed]`;
 
+exports[`platform/git/storage getFileList() defaults to master 1`] = `Array []`;
+
 exports[`platform/git/storage getFileList() should exclude submodules 1`] = `
 Array [
   ".gitmodules",
@@ -24,14 +26,6 @@ exports[`platform/git/storage getFileList() should return the correct files 1`] 
 Array [
   "file_to_delete",
   "future_file",
-  "master_file",
-  "past_file",
-]
-`;
-
-exports[`platform/git/storage getFileList() should return the correct files 2`] = `
-Array [
-  "file_to_delete",
   "master_file",
   "past_file",
 ]

--- a/lib/platform/git/storage.spec.ts
+++ b/lib/platform/git/storage.spec.ts
@@ -87,7 +87,6 @@ describe('platform/git/storage', () => {
     });
     it('should return the correct files', async () => {
       expect(await git.getFileList('renovate/future_branch')).toMatchSnapshot();
-      expect(await git.getFileList()).toMatchSnapshot();
     });
     it('should exclude submodules', async () => {
       const repo = Git(base.path).silent(true);
@@ -98,8 +97,11 @@ describe('platform/git/storage', () => {
         url: base.path,
       });
       expect(await fs.exists(tmpDir.path + '/.gitmodules')).toBeTruthy();
-      expect(await git.getFileList()).toMatchSnapshot();
+      expect(await git.getFileList('master')).toMatchSnapshot();
       await repo.reset(['--hard', 'HEAD^']);
+    });
+    it('defaults to master', async () => {
+      expect(await git.getFileList()).toMatchSnapshot();
     });
   });
   describe('branchExists(branchName)', () => {

--- a/lib/platform/git/storage.ts
+++ b/lib/platform/git/storage.ts
@@ -110,7 +110,7 @@ export class Storage {
     // eslint-disable-next-line no-multi-assign
     const config: LocalConfig = (this._config = {
       ...args,
-      fileList: [],
+      fileList: {},
     } as any);
     // eslint-disable-next-line no-multi-assign
     const cwd = (this._cwd = config.localDir);

--- a/lib/platform/git/storage.ts
+++ b/lib/platform/git/storage.ts
@@ -33,6 +33,7 @@ interface LocalConfig extends StorageConfig {
   baseBranchSha: string;
   branchExists: Record<string, boolean>;
   branchPrefix: string;
+  fileList: Record<string, Promise<string[]>>;
 }
 
 // istanbul ignore next
@@ -107,7 +108,10 @@ export class Storage {
   async initRepo(args: StorageConfig): Promise<void> {
     this.cleanRepo();
     // eslint-disable-next-line no-multi-assign
-    const config: LocalConfig = (this._config = { ...args } as any);
+    const config: LocalConfig = (this._config = {
+      ...args,
+      fileList: [],
+    } as any);
     // eslint-disable-next-line no-multi-assign
     const cwd = (this._cwd = config.localDir);
     this._config.branchExists = {};
@@ -309,6 +313,13 @@ export class Storage {
 
   async getFileList(branchName?: string): Promise<string[]> {
     const branch = branchName || this._config.baseBranch;
+    if (this._config.fileList[branch] === undefined) {
+      this._config.fileList[branch] = this.getFileListInner(branchName);
+    }
+    return this._config.fileList[branch];
+  }
+
+  async getFileListInner(branch: string): Promise<string[]> {
     const exists = await this.branchExists(branch);
     if (!exists) {
       return [];
@@ -352,7 +363,7 @@ export class Storage {
     if (this._config.branchExists[branchName] !== undefined) {
       return this._config.branchExists[branchName];
     }
-    if (!branchName.startsWith(this._config.branchPrefix)) {
+    if (!branchName?.startsWith(this._config.branchPrefix)) {
       // fetch the branch only if it's not part of the existing branchPrefix
       try {
         await this._git.raw([


### PR DESCRIPTION
I realized that calling `git` to get the file list every time is potentially slow, so we should cache the list per-branch per repo run.