### PR TITLE
fix: ignore Kotlin dependencies embedded in gradle build script

### DIFF
--- a/lib/manager/gradle/gradle-updates-report.ts
+++ b/lib/manager/gradle/gradle-updates-report.ts
@@ -34,7 +34,6 @@ export async function createRenovateGradlePlugin(
   const content = `
 import groovy.json.JsonOutput
 import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency
-import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 import java.util.concurrent.ConcurrentLinkedQueue
 
 def output = new ConcurrentLinkedQueue<>();
@@ -55,12 +54,12 @@ allprojects {
         .collect { it.dependencies + it.dependencyConstraints }
         .flatten()
         .findAll { it instanceof DefaultExternalModuleDependency || it instanceof DependencyConstraint }
+        .findAll { 'Pinned to the embedded Kotlin' != it.reason } // Embedded Kotlin dependencies
         .collect { ['name':it.name, 'group':it.group, 'version':it.version] }
       project.dependencies = deps
     }
   }
 }
-
 gradle.buildFinished {
    def outputFile = new File('${GRADLE_DEPENDENCY_REPORT_FILENAME}')
    def json = JsonOutput.toJson(output)


### PR DESCRIPTION
[See here for test output before and after](https://gist.github.com/JamieMagee/c4cd10d43b8eea0b62e1e68b816ab476)

For future reference, the reason comes from [here](https://github.com/gradle/gradle/blob/5a2e4aed03dbfb92ab7c11b26fc6c347f067c93f/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/EmbeddedKotlinProvider.kt#L45)

Fixes #6124
