### PR TITLE
fix(worker): fix github endpoint for changelog

### DIFF
--- a/lib/workers/pr/changelog/__snapshots__/index.spec.ts.snap
+++ b/lib/workers/pr/changelog/__snapshots__/index.spec.ts.snap
@@ -153,6 +153,57 @@ Object {
 }
 `;
 
+exports[`workers/pr/changelog getChangeLogJSON supports github.com and github enterprise changelog 1`] = `
+Object {
+  "hasReleaseNotes": true,
+  "project": Object {
+    "apiBaseUrl": "https://github-enterprise.example.com/",
+    "baseUrl": "https://github-enterprise.example.com/",
+    "depName": "renovate",
+    "github": "chalk/chalk",
+    "repository": "https://github-enterprise.example.com/chalk/chalk",
+  },
+  "versions": Array [
+    Object {
+      "changes": Array [],
+      "compare": Object {},
+      "date": undefined,
+      "releaseNotes": null,
+      "version": "2.5.2",
+    },
+    Object {
+      "changes": Array [],
+      "compare": Object {},
+      "date": "2017-12-24T03:20:46.238Z",
+      "releaseNotes": null,
+      "version": "2.4.2",
+    },
+    Object {
+      "changes": Array [],
+      "compare": Object {
+        "url": "https://github-enterprise.example.com/chalk/chalk/compare/npm_2.2.2...npm_2.3.0",
+      },
+      "date": "2017-10-24T03:20:46.238Z",
+      "releaseNotes": Object {
+        "url": "https://github-enterprise.example.com/chalk/chalk/compare/npm_2.2.2...npm_2.3.0",
+      },
+      "version": "2.3.0",
+    },
+    Object {
+      "changes": Array [],
+      "compare": Object {
+        "url": "https://github-enterprise.example.com/chalk/chalk/compare/npm_1.0.0...npm_2.2.2",
+      },
+      "date": undefined,
+      "releaseNotes": Object {
+        "url": "https://github-enterprise.example.com/chalk/chalk/compare/npm_1.0.0...npm_2.2.2",
+      },
+      "version": "2.2.2",
+    },
+  ],
+}
+`;
+
 exports[`workers/pr/changelog getChangeLogJSON supports node engines 1`] = `
 Object {
   "hasReleaseNotes": true,

--- a/lib/workers/pr/changelog/index.spec.ts
+++ b/lib/workers/pr/changelog/index.spec.ts
@@ -175,6 +175,19 @@ describe('workers/pr/changelog', () => {
           endpoint: 'https://github-enterprise.example.com/',
         })
       ).toMatchSnapshot();
+      expect(ghGot).toHaveBeenNthCalledWith(
+        1,
+        'https://github.com/repos/chalk/chalk/tags?per_page=100',
+        { paginate: true }
+      );
+      expect(ghGot).toHaveBeenNthCalledWith(
+        2,
+        'https://api.github.com/repos/chalk/chalk/contents/'
+      );
+      expect(ghGot).toHaveBeenNthCalledWith(
+        3,
+        'https://api.github.com/repos/chalk/chalk/releases?per_page=100'
+      );
     });
     it('supports github enterprise and github enterprise changelog', async () => {
       hostRules.add({
@@ -190,6 +203,46 @@ describe('workers/pr/changelog', () => {
           endpoint: 'https://github-enterprise.example.com/',
         })
       ).toMatchSnapshot();
+      expect(ghGot).toHaveBeenNthCalledWith(
+        1,
+        'https://github-enterprise.example.com/repos/chalk/chalk/tags?per_page=100',
+        { paginate: true }
+      );
+      expect(ghGot).toHaveBeenNthCalledWith(
+        2,
+        'https://github-enterprise.example.com/repos/chalk/chalk/contents/'
+      );
+      expect(ghGot).toHaveBeenNthCalledWith(
+        3,
+        'https://github-enterprise.example.com/repos/chalk/chalk/releases?per_page=100'
+      );
+    });
+
+    it('supports github.com and github enterprise changelog', async () => {
+      hostRules.add({
+        hostType: PLATFORM_TYPE_GITHUB,
+        baseUrl: 'https://github-enterprise.example.com/',
+        token: 'abc',
+      });
+      expect(
+        await getChangeLogJSON({
+          ...upgrade,
+          sourceUrl: 'https://github-enterprise.example.com/chalk/chalk',
+        })
+      ).toMatchSnapshot();
+      expect(ghGot).toHaveBeenNthCalledWith(
+        1,
+        'https://github-enterprise.example.com/repos/chalk/chalk/tags?per_page=100',
+        { paginate: true }
+      );
+      expect(ghGot).toHaveBeenNthCalledWith(
+        2,
+        'https://github-enterprise.example.com/repos/chalk/chalk/contents/'
+      );
+      expect(ghGot).toHaveBeenNthCalledWith(
+        3,
+        'https://github-enterprise.example.com/repos/chalk/chalk/releases?per_page=100'
+      );
     });
   });
 });


### PR DESCRIPTION
The changelog retrival url is always constructed from `sourceUrl` now.

Closes #6140 

I've added no tests in favor of #5699
