### PR TITLE
fix(pep440): accept versions without == prefix

### DIFF
--- a/lib/manager/poetry/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/poetry/__snapshots__/extract.spec.ts.snap
@@ -19,7 +19,7 @@ Object {
       "managerData": Object {
         "nestedVersion": false,
       },
-      "versioning": "poetry",
+      "versioning": "pep440",
     },
     Object {
       "currentValue": "1.1.0",
@@ -29,7 +29,7 @@ Object {
       "managerData": Object {
         "nestedVersion": false,
       },
-      "versioning": "poetry",
+      "versioning": "pep440",
     },
     Object {
       "currentValue": "1.0a1",
@@ -39,7 +39,7 @@ Object {
       "managerData": Object {
         "nestedVersion": false,
       },
-      "skipReason": "unknown-version",
+      "versioning": "pep440",
     },
     Object {
       "currentValue": "1.0b2",
@@ -49,7 +49,7 @@ Object {
       "managerData": Object {
         "nestedVersion": false,
       },
-      "skipReason": "unknown-version",
+      "versioning": "pep440",
     },
     Object {
       "currentValue": "1.0rc1",
@@ -59,7 +59,7 @@ Object {
       "managerData": Object {
         "nestedVersion": false,
       },
-      "skipReason": "unknown-version",
+      "versioning": "pep440",
     },
     Object {
       "currentValue": "1.0.dev4",
@@ -69,7 +69,7 @@ Object {
       "managerData": Object {
         "nestedVersion": false,
       },
-      "skipReason": "unknown-version",
+      "versioning": "pep440",
     },
     Object {
       "currentValue": "1.0c1",
@@ -79,7 +79,7 @@ Object {
       "managerData": Object {
         "nestedVersion": false,
       },
-      "skipReason": "unknown-version",
+      "versioning": "pep440",
     },
     Object {
       "currentValue": "2012.2",
@@ -89,7 +89,7 @@ Object {
       "managerData": Object {
         "nestedVersion": false,
       },
-      "versioning": "poetry",
+      "versioning": "pep440",
     },
     Object {
       "currentValue": "1.0.dev456",
@@ -99,7 +99,7 @@ Object {
       "managerData": Object {
         "nestedVersion": false,
       },
-      "skipReason": "unknown-version",
+      "versioning": "pep440",
     },
     Object {
       "currentValue": "1.0a1",
@@ -109,7 +109,7 @@ Object {
       "managerData": Object {
         "nestedVersion": false,
       },
-      "skipReason": "unknown-version",
+      "versioning": "pep440",
     },
     Object {
       "currentValue": "1.0a2.dev456",
@@ -119,7 +119,7 @@ Object {
       "managerData": Object {
         "nestedVersion": false,
       },
-      "skipReason": "unknown-version",
+      "versioning": "pep440",
     },
     Object {
       "currentValue": "1.0a12.dev456",
@@ -129,7 +129,7 @@ Object {
       "managerData": Object {
         "nestedVersion": false,
       },
-      "skipReason": "unknown-version",
+      "versioning": "pep440",
     },
     Object {
       "currentValue": "1.0a12",
@@ -139,7 +139,7 @@ Object {
       "managerData": Object {
         "nestedVersion": false,
       },
-      "skipReason": "unknown-version",
+      "versioning": "pep440",
     },
     Object {
       "currentValue": "1.0b1.dev456",
@@ -149,7 +149,7 @@ Object {
       "managerData": Object {
         "nestedVersion": false,
       },
-      "skipReason": "unknown-version",
+      "versioning": "pep440",
     },
     Object {
       "currentValue": "1.0b2",
@@ -159,7 +159,7 @@ Object {
       "managerData": Object {
         "nestedVersion": false,
       },
-      "skipReason": "unknown-version",
+      "versioning": "pep440",
     },
     Object {
       "currentValue": "1.0b2.post345.dev456",
@@ -169,7 +169,7 @@ Object {
       "managerData": Object {
         "nestedVersion": false,
       },
-      "skipReason": "unknown-version",
+      "versioning": "pep440",
     },
     Object {
       "currentValue": "1.0b2.post345",
@@ -179,7 +179,7 @@ Object {
       "managerData": Object {
         "nestedVersion": false,
       },
-      "skipReason": "unknown-version",
+      "versioning": "pep440",
     },
     Object {
       "currentValue": "1.0rc1.dev456",
@@ -189,7 +189,7 @@ Object {
       "managerData": Object {
         "nestedVersion": false,
       },
-      "skipReason": "unknown-version",
+      "versioning": "pep440",
     },
     Object {
       "currentValue": "1.0rc1",
@@ -199,7 +199,7 @@ Object {
       "managerData": Object {
         "nestedVersion": false,
       },
-      "skipReason": "unknown-version",
+      "versioning": "pep440",
     },
     Object {
       "currentValue": "1.0",
@@ -209,7 +209,7 @@ Object {
       "managerData": Object {
         "nestedVersion": false,
       },
-      "versioning": "poetry",
+      "versioning": "pep440",
     },
     Object {
       "currentValue": "1.0+abc.5",
@@ -219,7 +219,7 @@ Object {
       "managerData": Object {
         "nestedVersion": false,
       },
-      "skipReason": "unknown-version",
+      "versioning": "pep440",
     },
     Object {
       "currentValue": "1.0+abc.7",
@@ -229,7 +229,7 @@ Object {
       "managerData": Object {
         "nestedVersion": false,
       },
-      "skipReason": "unknown-version",
+      "versioning": "pep440",
     },
     Object {
       "currentValue": "1.0+5",
@@ -239,7 +239,7 @@ Object {
       "managerData": Object {
         "nestedVersion": false,
       },
-      "skipReason": "unknown-version",
+      "versioning": "pep440",
     },
     Object {
       "currentValue": "1.0.post456.dev34",
@@ -249,7 +249,7 @@ Object {
       "managerData": Object {
         "nestedVersion": false,
       },
-      "skipReason": "unknown-version",
+      "versioning": "pep440",
     },
     Object {
       "currentValue": "1.0.post456",
@@ -259,7 +259,7 @@ Object {
       "managerData": Object {
         "nestedVersion": false,
       },
-      "skipReason": "unknown-version",
+      "versioning": "pep440",
     },
     Object {
       "currentValue": "1.1.dev1",
@@ -269,7 +269,7 @@ Object {
       "managerData": Object {
         "nestedVersion": false,
       },
-      "skipReason": "unknown-version",
+      "versioning": "pep440",
     },
     Object {
       "currentValue": "~=3.1",
@@ -441,7 +441,7 @@ Array [
     "managerData": Object {
       "nestedVersion": false,
     },
-    "versioning": "poetry",
+    "versioning": "pep440",
   },
   Object {
     "currentValue": "0.0.0",
@@ -451,7 +451,7 @@ Array [
     "managerData": Object {
       "nestedVersion": false,
     },
-    "versioning": "poetry",
+    "versioning": "pep440",
   },
   Object {
     "currentValue": "^0.6.0",

--- a/lib/versioning/pep440/index.spec.ts
+++ b/lib/versioning/pep440/index.spec.ts
@@ -1,8 +1,12 @@
 import pep440 from '.';
 
 describe('pep440.isValid(input)', () => {
-  it('should return null for irregular versions', () => {
-    expect(pep440.isValid('17.04.0')).toBeFalsy();
+  it('should support a version without equals', () => {
+    expect(pep440.isValid('0.750')).toBeTruthy();
+    expect(pep440.isValid('1.2.3')).toBeTruthy();
+  });
+  it('should support irregular versions', () => {
+    expect(pep440.isValid('17.04.0')).toBeTruthy();
   });
   it('should support simple pep440', () => {
     expect(pep440.isValid('==1.2.3')).toBeTruthy();
@@ -83,6 +87,9 @@ describe('pep440.getNewValue()', () => {
 
   // cases: [currentValue, expectedBump]
   [
+    // plain version
+    ['1.0.0', '1.2.3'],
+
     // simple cases
     ['==1.0.3', '==1.2.3'],
     ['>=1.2.0', '>=1.2.3'],

--- a/lib/versioning/pep440/index.ts
+++ b/lib/versioning/pep440/index.ts
@@ -31,7 +31,8 @@ const isStable = (input: string): boolean => {
 };
 
 // If this is left as an alias, inputs like "17.04.0" throw errors
-export const isValid = (input: string): string => validRange(input);
+export const isValid = (input: string): string =>
+  validRange(input) || isVersion(input);
 
 const maxSatisfyingVersion = (versions: string[], range: string): string => {
   const found = filter(versions, range).sort(sortVersions);

--- a/lib/versioning/pep440/range.ts
+++ b/lib/versioning/pep440/range.ts
@@ -45,6 +45,9 @@ export function getNewValue({
   if (rangeStrategy === 'pin') {
     return '==' + toVersion;
   }
+  if (currentValue === fromVersion) {
+    return toVersion;
+  }
   const ranges: Range[] = parseRange(currentValue);
   if (!ranges) {
     logger.warn('Invalid currentValue: ' + currentValue);


### PR DESCRIPTION
Change pep440 versioning to allow "naked" versions without `==` prefix. This leads to a lot more Poetry extracted dependencies using the `pep440` versioning.

Closes #6176 
