### PR TITLE
refactor: global cache

### DIFF
--- a/lib/config/presets/github/index.spec.ts
+++ b/lib/config/presets/github/index.spec.ts
@@ -1,6 +1,7 @@
 import { mocked } from '../../../../test/util';
 import { PLATFORM_FAILURE } from '../../../constants/error-messages';
 import { GotResponse } from '../../../platform';
+import * as globalCache from '../../../util/cache/global';
 import { clear } from '../../../util/cache/run';
 import _got from '../../../util/got';
 import * as _hostRules from '../../../util/host-rules';
@@ -16,7 +17,7 @@ const hostRules = mocked(_hostRules);
 describe('config/presets/github', () => {
   beforeEach(() => {
     got.mockReset();
-    return global.renovateCache.rmAll();
+    return globalCache.rmAll();
   });
   describe('fetchJSONFile()', () => {
     beforeEach(() => {

--- a/lib/config/presets/gitlab/index.spec.ts
+++ b/lib/config/presets/gitlab/index.spec.ts
@@ -1,5 +1,6 @@
 import { GotResponse } from '../../../platform';
 import { api } from '../../../platform/gitlab/gl-got-wrapper';
+import * as globalCache from '../../../util/cache/global';
 import * as gitlab from '.';
 import { PartialDeep } from 'type-fest';
 
@@ -11,7 +12,7 @@ const glGot: jest.Mock<Promise<PartialDeep<GotResponse>>> = api.get as never;
 describe('config/presets/gitlab', () => {
   beforeEach(() => {
     glGot.mockReset();
-    return global.renovateCache.rmAll();
+    return globalCache.rmAll();
   });
   describe('getPreset()', () => {
     it('throws if non-default', async () => {

--- a/lib/config/presets/local/index.spec.ts
+++ b/lib/config/presets/local/index.spec.ts
@@ -1,3 +1,4 @@
+import * as globalCache from '../../../util/cache/global';
 import * as github from '../github';
 import * as gitlab from '../gitlab';
 import * as local from '.';
@@ -18,7 +19,7 @@ describe('config/presets/local', () => {
     gitlabGetPreset.mockResolvedValueOnce({ resolved: 'preset' });
     githubGetPreset.mockReset();
     githubGetPreset.mockResolvedValueOnce({ resolved: 'preset' });
-    return global.renovateCache.rmAll();
+    return globalCache.rmAll();
   });
   describe('getPreset()', () => {
     it('throws for unsupported platform', async () => {

--- a/lib/config/presets/npm/index.spec.ts
+++ b/lib/config/presets/npm/index.spec.ts
@@ -1,4 +1,5 @@
 import nock from 'nock';
+import * as globalCache from '../../../util/cache/global';
 import * as npm from '.';
 
 jest.mock('registry-auth-token');
@@ -10,7 +11,7 @@ describe('config/presets/npm', () => {
     jest.resetAllMocks();
     global.trustLevel = 'low';
     nock.cleanAll();
-    return global.renovateCache.rmAll();
+    return globalCache.rmAll();
   });
   afterEach(() => {
     delete process.env.RENOVATE_CACHE_NPM_MINUTES;

--- a/lib/datasource/cache.ts
+++ b/lib/datasource/cache.ts
@@ -1,4 +1,5 @@
 import { logger } from '../logger';
+import * as globalCache from '../util/cache/global';
 
 /**
  * Cache callback result which has to be returned by the `CacheCallback` function.
@@ -57,10 +58,7 @@ export async function cacheAble<TArg, TResult = unknown>({
 }: CacheConfig<TArg, TResult>): Promise<TResult> {
   const cacheNamespace = `datasource-${id}`;
   const cacheKey = JSON.stringify(lookup);
-  const cachedResult = await renovateCache.get<TResult>(
-    cacheNamespace,
-    cacheKey
-  );
+  const cachedResult = await globalCache.get<TResult>(cacheNamespace, cacheKey);
   // istanbul ignore if
   if (cachedResult) {
     logger.trace({ id, lookup }, 'datasource cachedResult');
@@ -71,7 +69,7 @@ export async function cacheAble<TArg, TResult = unknown>({
   if (isPrivate) {
     logger.trace({ id, lookup }, 'Skipping datasource cache for private data');
   } else {
-    await renovateCache.set(cacheNamespace, cacheKey, data, minutes);
+    await globalCache.set(cacheNamespace, cacheKey, data, minutes);
   }
   return data;
 }

--- a/lib/datasource/cdnjs/index.spec.ts
+++ b/lib/datasource/cdnjs/index.spec.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import { DATASOURCE_FAILURE } from '../../constants/error-messages';
+import * as globalCache from '../../util/cache/global';
 import _got from '../../util/got';
 import { getReleases } from '.';
 
@@ -22,7 +23,7 @@ describe('datasource/cdnjs', () => {
   describe('getReleases', () => {
     beforeEach(() => {
       jest.clearAllMocks();
-      return global.renovateCache.rmAll();
+      return globalCache.rmAll();
     });
     it('throws for empty result', async () => {
       got.mockResolvedValueOnce(null);

--- a/lib/datasource/crate/index.ts
+++ b/lib/datasource/crate/index.ts
@@ -1,4 +1,5 @@
 import { logger } from '../../logger';
+import * as globalCache from '../../util/cache/global';
 import { Http } from '../../util/http';
 import {
   DatasourceError,
@@ -16,7 +17,7 @@ export async function getReleases({
 }: GetReleasesConfig): Promise<ReleaseResult | null> {
   const cacheNamespace = 'datasource-crate';
   const cacheKey = lookupName;
-  const cachedResult = await renovateCache.get<ReleaseResult>(
+  const cachedResult = await globalCache.get<ReleaseResult>(
     cacheNamespace,
     cacheKey
   );
@@ -92,7 +93,7 @@ export async function getReleases({
     });
 
     const cacheMinutes = 10;
-    await renovateCache.set(cacheNamespace, cacheKey, result, cacheMinutes);
+    await globalCache.set(cacheNamespace, cacheKey, result, cacheMinutes);
     return result;
   } catch (err) {
     if (err.statusCode === 404 || err.code === 'ENOTFOUND') {

--- a/lib/datasource/docker/index.spec.ts
+++ b/lib/datasource/docker/index.spec.ts
@@ -2,6 +2,7 @@ import AWS from 'aws-sdk';
 import AWSMock from 'aws-sdk-mock';
 import { getPkgReleases } from '..';
 import { DATASOURCE_FAILURE } from '../../constants/error-messages';
+import * as globalCache from '../../util/cache/global';
 import { clear } from '../../util/cache/run';
 import _got from '../../util/got';
 import * as _hostRules from '../../util/host-rules';
@@ -36,7 +37,7 @@ describe('api/docker', () => {
         password: 'some-password',
       });
       hostRules.hosts = jest.fn(() => []);
-      return global.renovateCache.rmAll();
+      return globalCache.rmAll();
     });
     it('returns null if no token', async () => {
       got.mockReturnValueOnce({ body: {} });
@@ -281,7 +282,7 @@ describe('api/docker', () => {
     beforeEach(() => {
       jest.clearAllMocks();
       clear();
-      return global.renovateCache.rmAll();
+      return globalCache.rmAll();
     });
     it('returns null if no token', async () => {
       got.mockReturnValueOnce({ body: {} });

--- a/lib/datasource/docker/index.ts
+++ b/lib/datasource/docker/index.ts
@@ -7,6 +7,7 @@ import parseLinkHeader from 'parse-link-header';
 import wwwAuthenticate from 'www-authenticate';
 import { logger } from '../../logger';
 import { HostRule } from '../../types';
+import * as globalCache from '../../util/cache/global';
 import * as hostRules from '../../util/host-rules';
 import { Http, HttpResponse } from '../../util/http';
 import { DatasourceError, GetReleasesConfig, ReleaseResult } from '../common';
@@ -334,7 +335,7 @@ export async function getDigest(
   try {
     const cacheNamespace = 'datasource-docker-digest';
     const cacheKey = `${registry}:${repository}:${newTag}`;
-    const cachedResult = await renovateCache.get(cacheNamespace, cacheKey);
+    const cachedResult = await globalCache.get(cacheNamespace, cacheKey);
     // istanbul ignore if
     if (cachedResult) {
       return cachedResult;
@@ -350,7 +351,7 @@ export async function getDigest(
     const digest = extractDigestFromResponse(manifestResponse);
     logger.debug({ digest }, 'Got docker digest');
     const cacheMinutes = 30;
-    await renovateCache.set(cacheNamespace, cacheKey, digest, cacheMinutes);
+    await globalCache.set(cacheNamespace, cacheKey, digest, cacheMinutes);
     return digest;
   } catch (err) /* istanbul ignore next */ {
     if (err instanceof DatasourceError) {
@@ -376,7 +377,7 @@ async function getTags(
   try {
     const cacheNamespace = 'datasource-docker-tags';
     const cacheKey = `${registry}:${repository}`;
-    const cachedResult = await renovateCache.get<string[]>(
+    const cachedResult = await globalCache.get<string[]>(
       cacheNamespace,
       cacheKey
     );
@@ -405,7 +406,7 @@ async function getTags(
       page += 1;
     } while (url && page < 20);
     const cacheMinutes = 15;
-    await renovateCache.set(cacheNamespace, cacheKey, tags, cacheMinutes);
+    await globalCache.set(cacheNamespace, cacheKey, tags, cacheMinutes);
     return tags;
   } catch (err) /* istanbul ignore next */ {
     if (err instanceof DatasourceError) {
@@ -485,7 +486,7 @@ async function getLabels(
   logger.debug(`getLabels(${registry}, ${repository}, ${tag})`);
   const cacheNamespace = 'datasource-docker-labels';
   const cacheKey = `${registry}:${repository}:${tag}`;
-  const cachedResult = await renovateCache.get<Record<string, string>>(
+  const cachedResult = await globalCache.get<Record<string, string>>(
     cacheNamespace,
     cacheKey
   );
@@ -542,7 +543,7 @@ async function getLabels(
       );
     }
     const cacheMinutes = 60;
-    await renovateCache.set(cacheNamespace, cacheKey, labels, cacheMinutes);
+    await globalCache.set(cacheNamespace, cacheKey, labels, cacheMinutes);
     return labels;
   } catch (err) {
     if (err instanceof DatasourceError) {

--- a/lib/datasource/galaxy/index.ts
+++ b/lib/datasource/galaxy/index.ts
@@ -1,4 +1,5 @@
 import { logger } from '../../logger';
+import * as globalCache from '../../util/cache/global';
 import { Http } from '../../util/http';
 import {
   DatasourceError,
@@ -16,7 +17,7 @@ export async function getReleases({
 }: GetReleasesConfig): Promise<ReleaseResult | null> {
   const cacheNamespace = 'datasource-galaxy';
   const cacheKey = lookupName;
-  const cachedResult = await renovateCache.get<ReleaseResult>(
+  const cachedResult = await globalCache.get<ReleaseResult>(
     cacheNamespace,
     cacheKey
   );
@@ -93,7 +94,7 @@ export async function getReleases({
       }
     );
     const cacheMinutes = 10;
-    await renovateCache.set(cacheNamespace, cacheKey, result, cacheMinutes);
+    await globalCache.set(cacheNamespace, cacheKey, result, cacheMinutes);
     return result;
   } catch (err) {
     if (

--- a/lib/datasource/git-refs/index.spec.ts
+++ b/lib/datasource/git-refs/index.spec.ts
@@ -1,5 +1,6 @@
 import fs from 'fs-extra';
 import _simpleGit from 'simple-git/promise';
+import * as globalCache from '../../util/cache/global';
 import { getDigest, getReleases } from '.';
 
 jest.mock('simple-git/promise');
@@ -13,7 +14,7 @@ const lsRemote1 = fs.readFileSync(
 );
 
 describe('datasource/git-refs', () => {
-  beforeEach(() => global.renovateCache.rmAll());
+  beforeEach(() => globalCache.rmAll());
   describe('getReleases', () => {
     it('returns nil if response is wrong', async () => {
       simpleGit.mockReturnValue({

--- a/lib/datasource/git-refs/index.ts
+++ b/lib/datasource/git-refs/index.ts
@@ -1,5 +1,6 @@
 import simpleGit from 'simple-git/promise';
 import { logger } from '../../logger';
+import * as globalCache from '../../util/cache/global';
 import * as semver from '../../versioning/semver';
 import { DigestConfig, GetReleasesConfig, ReleaseResult } from '../common';
 
@@ -23,7 +24,7 @@ export async function getRawRefs({
   try {
     const cacheNamespace = 'git-raw-refs';
 
-    const cachedResult = await renovateCache.get<RawRefs[]>(
+    const cachedResult = await globalCache.get<RawRefs[]>(
       cacheNamespace,
       lookupName
     );
@@ -67,7 +68,7 @@ export async function getRawRefs({
       })
       .filter(Boolean)
       .filter((ref) => ref.type !== 'pull' && !ref.value.endsWith('^{}'));
-    await renovateCache.set(cacheNamespace, lookupName, refs, cacheMinutes);
+    await globalCache.set(cacheNamespace, lookupName, refs, cacheMinutes);
     return refs;
   } catch (err) {
     logger.error({ err }, `Git-Raw-Refs lookup error in ${lookupName}`);

--- a/lib/datasource/git-submodules/index.spec.ts
+++ b/lib/datasource/git-submodules/index.spec.ts
@@ -1,4 +1,5 @@
 import _simpleGit from 'simple-git/promise';
+import * as globalCache from '../../util/cache/global';
 import { getDigest, getReleases } from '.';
 
 jest.mock('simple-git/promise');
@@ -8,7 +9,7 @@ const lookupName = 'https://github.com/example/example.git';
 const registryUrls = [lookupName, 'master'];
 
 describe('datasource/git-submoduless', () => {
-  beforeEach(() => global.renovateCache.rmAll());
+  beforeEach(() => globalCache.rmAll());
   describe('getReleases', () => {
     it('returns null if response is wrong', async () => {
       simpleGit.mockReturnValue({

--- a/lib/datasource/git-submodules/index.ts
+++ b/lib/datasource/git-submodules/index.ts
@@ -2,6 +2,7 @@ import { URL } from 'url';
 import Git from 'simple-git/promise';
 
 import { logger } from '../../logger';
+import * as globalCache from '../../util/cache/global';
 import { DigestConfig, GetReleasesConfig, ReleaseResult } from '../common';
 
 export const id = 'git-submodules';
@@ -12,7 +13,7 @@ export async function getReleases({
 }: GetReleasesConfig): Promise<ReleaseResult | null> {
   const cacheNamespace = 'datasource-git-submodules';
   const cacheKey = `${registryUrls[0]}-${registryUrls[1]}`;
-  const cachedResult = await renovateCache.get<ReleaseResult>(
+  const cachedResult = await globalCache.get<ReleaseResult>(
     cacheNamespace,
     cacheKey
   );
@@ -41,7 +42,7 @@ export async function getReleases({
       ],
     };
     const cacheMinutes = 60;
-    await renovateCache.set(cacheNamespace, cacheKey, result, cacheMinutes);
+    await globalCache.set(cacheNamespace, cacheKey, result, cacheMinutes);
     return result;
   } catch (err) {
     logger.debug({ err }, `Git-SubModules lookup error in ${lookupName}`);

--- a/lib/datasource/git-tags/index.spec.ts
+++ b/lib/datasource/git-tags/index.spec.ts
@@ -1,5 +1,6 @@
 import fs from 'fs-extra';
 import _simpleGit from 'simple-git/promise';
+import * as globalCache from '../../util/cache/global';
 import { getDigest, getReleases } from '.';
 
 jest.mock('simple-git/promise');
@@ -13,7 +14,7 @@ const lsRemote1 = fs.readFileSync(
 );
 
 describe('datasource/git-tags', () => {
-  beforeEach(() => global.renovateCache.rmAll());
+  beforeEach(() => globalCache.rmAll());
   describe('getReleases', () => {
     it('returns nil if response is wrong', async () => {
       simpleGit.mockReturnValue({

--- a/lib/datasource/github-releases/index.spec.ts
+++ b/lib/datasource/github-releases/index.spec.ts
@@ -1,4 +1,5 @@
 import { api } from '../../platform/github/gh-got-wrapper';
+import * as globalCache from '../../util/cache/global';
 
 import * as github from '.';
 
@@ -9,9 +10,9 @@ jest.mock('../../util/host-rules');
 const ghGot: any = api.get;
 
 describe('datasource/github-releases', () => {
-  beforeEach(() => global.renovateCache.rmAll());
+  beforeEach(() => globalCache.rmAll());
   describe('getReleases', () => {
-    beforeAll(() => global.renovateCache.rmAll());
+    beforeAll(() => globalCache.rmAll());
     it('returns releases', async () => {
       const body = [
         { tag_name: 'a', published_at: '2020-03-09T13:00:00Z' },

--- a/lib/datasource/github-releases/index.ts
+++ b/lib/datasource/github-releases/index.ts
@@ -1,5 +1,6 @@
 import { logger } from '../../logger';
 import { api } from '../../platform/github/gh-got-wrapper';
+import * as globalCache from '../../util/cache/global';
 import { GetReleasesConfig, ReleaseResult } from '../common';
 
 const { get: ghGot } = api;
@@ -27,7 +28,7 @@ export async function getReleases({
   lookupName: repo,
 }: GetReleasesConfig): Promise<ReleaseResult | null> {
   let githubReleases: GithubRelease[];
-  const cachedResult = await renovateCache.get<ReleaseResult>(
+  const cachedResult = await globalCache.get<ReleaseResult>(
     cacheNamespace,
     repo
   );
@@ -58,6 +59,6 @@ export async function getReleases({
     releaseTimestamp: published_at,
   }));
   const cacheMinutes = 10;
-  await renovateCache.set(cacheNamespace, repo, dependency, cacheMinutes);
+  await globalCache.set(cacheNamespace, repo, dependency, cacheMinutes);
   return dependency;
 }

--- a/lib/datasource/github-tags/index.spec.ts
+++ b/lib/datasource/github-tags/index.spec.ts
@@ -1,5 +1,5 @@
 import { api } from '../../platform/github/gh-got-wrapper';
-
+import * as globalCache from '../../util/cache/global';
 import * as _hostRules from '../../util/host-rules';
 import * as github from '.';
 
@@ -11,12 +11,12 @@ const ghGot: any = api.get;
 const hostRules: any = _hostRules;
 
 describe('datasource/github-tags', () => {
-  beforeEach(() => global.renovateCache.rmAll());
+  beforeEach(() => globalCache.rmAll());
   describe('getDigest', () => {
     beforeEach(() => {
       jest.resetAllMocks();
       hostRules.hosts = jest.fn(() => []);
-      return global.renovateCache.rmAll();
+      return globalCache.rmAll();
     });
     it('returns null if no token', async () => {
       ghGot.mockReturnValueOnce({ body: [] });
@@ -59,7 +59,7 @@ describe('datasource/github-tags', () => {
     });
   });
   describe('getReleases', () => {
-    beforeAll(() => global.renovateCache.rmAll());
+    beforeAll(() => globalCache.rmAll());
     it('returns tags', async () => {
       const body = [{ name: 'v1.0.0' }, { name: 'v1.1.0' }];
       ghGot.mockReturnValueOnce({ headers: {}, body });

--- a/lib/datasource/github-tags/index.ts
+++ b/lib/datasource/github-tags/index.ts
@@ -1,5 +1,6 @@
 import { logger } from '../../logger';
 import { api } from '../../platform/github/gh-got-wrapper';
+import * as globalCache from '../../util/cache/global';
 import { DigestConfig, GetReleasesConfig, ReleaseResult } from '../common';
 
 const { get: ghGot } = api;
@@ -15,7 +16,7 @@ async function getTagCommit(
   githubRepo: string,
   tag: string
 ): Promise<string | null> {
-  const cachedResult = await renovateCache.get<string>(
+  const cachedResult = await globalCache.get<string>(
     cacheNamespace,
     getCacheKey(githubRepo, `tag-${tag}`)
   );
@@ -44,7 +45,7 @@ async function getTagCommit(
     return null;
   }
   const cacheMinutes = 120;
-  await renovateCache.set(
+  await globalCache.set(
     cacheNamespace,
     getCacheKey(githubRepo, `tag-${tag}`),
     digest,
@@ -67,7 +68,7 @@ export async function getDigest(
   if (newValue && newValue.length) {
     return getTagCommit(githubRepo, newValue);
   }
-  const cachedResult = await renovateCache.get(
+  const cachedResult = await globalCache.get(
     cacheNamespace,
     getCacheKey(githubRepo, 'commit')
   );
@@ -89,7 +90,7 @@ export async function getDigest(
     return null;
   }
   const cacheMinutes = 10;
-  await renovateCache.set(
+  await globalCache.set(
     cacheNamespace,
     getCacheKey(githubRepo, 'commit'),
     digest,
@@ -112,7 +113,7 @@ export async function getReleases({
   lookupName: repo,
 }: GetReleasesConfig): Promise<ReleaseResult | null> {
   let versions: string[];
-  const cachedResult = await renovateCache.get<ReleaseResult>(
+  const cachedResult = await globalCache.get<ReleaseResult>(
     cacheNamespace,
     getCacheKey(repo, 'tags')
   );
@@ -147,7 +148,7 @@ export async function getReleases({
     gitRef: version,
   }));
   const cacheMinutes = 10;
-  await renovateCache.set(
+  await globalCache.set(
     cacheNamespace,
     getCacheKey(repo, 'tags'),
     dependency,

--- a/lib/datasource/gitlab-tags/index.spec.ts
+++ b/lib/datasource/gitlab-tags/index.spec.ts
@@ -1,4 +1,5 @@
 import { api } from '../../platform/gitlab/gl-got-wrapper';
+import * as globalCache from '../../util/cache/global';
 import * as gitlab from '.';
 
 jest.mock('../../platform/gitlab/gl-got-wrapper');
@@ -8,10 +9,10 @@ const glGot: any = api.get;
 
 describe('datasource/gitlab-tags', () => {
   beforeEach(() => {
-    return global.renovateCache.rmAll();
+    return globalCache.rmAll();
   });
   describe('getReleases', () => {
-    beforeAll(() => global.renovateCache.rmAll());
+    beforeAll(() => globalCache.rmAll());
     it('returns tags', async () => {
       const body = [
         {

--- a/lib/datasource/gitlab-tags/index.ts
+++ b/lib/datasource/gitlab-tags/index.ts
@@ -1,6 +1,7 @@
 import is from '@sindresorhus/is';
 import { logger } from '../../logger';
 import { api } from '../../platform/gitlab/gl-got-wrapper';
+import * as globalCache from '../../util/cache/global';
 import { GetReleasesConfig, ReleaseResult } from '../common';
 
 const { get: glGot } = api;
@@ -29,7 +30,7 @@ export async function getReleases({
     ? registryUrls[0].replace(/\/$/, '')
     : 'https://gitlab.com';
   let gitlabTags: GitlabTag[];
-  const cachedResult = await renovateCache.get<ReleaseResult>(
+  const cachedResult = await globalCache.get<ReleaseResult>(
     cacheNamespace,
     getCacheKey(depHost, repo)
   );
@@ -70,7 +71,7 @@ export async function getReleases({
   }));
 
   const cacheMinutes = 10;
-  await renovateCache.set(
+  await globalCache.set(
     cacheNamespace,
     getCacheKey(depHost, repo),
     dependency,

--- a/lib/datasource/gradle-version/index.spec.ts
+++ b/lib/datasource/gradle-version/index.spec.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import * as globalCache from '../../util/cache/global';
 import _got from '../../util/got';
 import * as gradleVersion from '.';
 
@@ -19,7 +20,7 @@ describe('datasource/gradle-version', () => {
         lookupName: 'abc',
       };
       jest.clearAllMocks();
-      return global.renovateCache.rmAll();
+      return globalCache.rmAll();
     });
 
     it('processes real data', async () => {

--- a/lib/datasource/helm/index.spec.ts
+++ b/lib/datasource/helm/index.spec.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import * as globalCache from '../../util/cache/global';
 import _got from '../../util/got';
 import { getReleases, getRepositoryData } from '.';
 
@@ -16,7 +17,7 @@ describe('datasource/helm', () => {
   describe('getReleases', () => {
     beforeEach(() => {
       jest.resetAllMocks();
-      return global.renovateCache.rmAll();
+      return globalCache.rmAll();
     });
     it('returns null if lookupName was not provided', async () => {
       expect(
@@ -143,7 +144,7 @@ describe('datasource/helm', () => {
       const cacheMinutes = 10;
       got.mockReturnValueOnce({ body: indexYaml });
       const repositoryData = await getRepositoryData(repository);
-      await global.renovateCache.set(
+      await globalCache.set(
         cacheNamespace,
         cacheKey,
         repositoryData,

--- a/lib/datasource/helm/index.ts
+++ b/lib/datasource/helm/index.ts
@@ -1,6 +1,7 @@
 import yaml from 'js-yaml';
 
 import { logger } from '../../logger';
+import * as globalCache from '../../util/cache/global';
 import { Http } from '../../util/http';
 import { DatasourceError, GetReleasesConfig, ReleaseResult } from '../common';
 
@@ -13,7 +14,7 @@ export async function getRepositoryData(
 ): Promise<ReleaseResult[]> {
   const cacheNamespace = 'datasource-helm';
   const cacheKey = repository;
-  const cachedIndex = await renovateCache.get(cacheNamespace, cacheKey);
+  const cachedIndex = await globalCache.get(cacheNamespace, cacheKey);
   if (cachedIndex) {
     return cachedIndex;
   }
@@ -77,7 +78,7 @@ export async function getRepositoryData(
       })
     );
     const cacheMinutes = 20;
-    await renovateCache.set(cacheNamespace, cacheKey, result, cacheMinutes);
+    await globalCache.set(cacheNamespace, cacheKey, result, cacheMinutes);
     return result;
   } catch (err) {
     logger.warn(`Failed to parse index.yaml from ${repository}`);

--- a/lib/datasource/maven/index.spec.ts
+++ b/lib/datasource/maven/index.spec.ts
@@ -3,6 +3,7 @@ import { resolve } from 'path';
 import nock from 'nock';
 import { getPkgReleases } from '..';
 import { DATASOURCE_FAILURE } from '../../constants/error-messages';
+import * as globalCache from '../../util/cache/global';
 import * as hostRules from '../../util/host-rules';
 import * as mavenVersioning from '../../versioning/maven';
 import * as maven from '.';
@@ -97,7 +98,7 @@ describe('datasource/maven', () => {
         .head(path)
         .reply(status, '', {});
     });
-    return global.renovateCache.rmAll();
+    return globalCache.rmAll();
   });
 
   afterEach(() => {

--- a/lib/datasource/maven/index.ts
+++ b/lib/datasource/maven/index.ts
@@ -3,6 +3,7 @@ import fs from 'fs-extra';
 import pAll from 'p-all';
 import { XmlDocument } from 'xmldoc';
 import { logger } from '../../logger';
+import * as globalCache from '../../util/cache/global';
 import mavenVersion from '../../versioning/maven';
 import { compare } from '../../versioning/maven/compare';
 import { GetReleasesConfig, ReleaseResult } from '../common';
@@ -156,7 +157,7 @@ async function getVersionsFromMetadata(
 
   const cacheNamespace = 'datasource-maven-metadata';
   const cacheKey = metadataUrl.toString();
-  const cachedVersions = await renovateCache.get<string[]>(
+  const cachedVersions = await globalCache.get<string[]>(
     cacheNamespace,
     cacheKey
   );
@@ -171,7 +172,7 @@ async function getVersionsFromMetadata(
   }
 
   const versions = extractVersions(mavenMetadata);
-  await renovateCache.set<string[]>(cacheNamespace, cacheKey, versions, 10);
+  await globalCache.set(cacheNamespace, cacheKey, versions, 10);
   return versions;
 }
 
@@ -208,7 +209,7 @@ async function filterMissingArtifacts(
 ): Promise<string[]> {
   const cacheNamespace = 'datasource-maven-metadata';
   const cacheKey = dependency.dependencyUrl;
-  let artifactsInfo: ArtifactsInfo | null = await renovateCache.get<
+  let artifactsInfo: ArtifactsInfo | null = await globalCache.get<
     ArtifactsInfo
   >(cacheNamespace, cacheKey);
 
@@ -240,12 +241,7 @@ async function filterMissingArtifacts(
       ? 60
       : 24 * 60;
 
-    await renovateCache.set<ArtifactsInfo>(
-      cacheNamespace,
-      cacheKey,
-      artifactsInfo,
-      cacheTTL
-    );
+    await globalCache.set(cacheNamespace, cacheKey, artifactsInfo, cacheTTL);
   }
 
   return versions.filter((v) => artifactsInfo[v]);

--- a/lib/datasource/npm/get.ts
+++ b/lib/datasource/npm/get.ts
@@ -6,6 +6,7 @@ import moment from 'moment';
 import registryAuthToken from 'registry-auth-token';
 import getRegistryUrl from 'registry-auth-token/registry-url';
 import { logger } from '../../logger';
+import * as globalCache from '../../util/cache/global';
 import { find } from '../../util/host-rules';
 import { Http, HttpOptions } from '../../util/http';
 import { maskToken } from '../../util/mask';
@@ -69,7 +70,7 @@ export async function getDependency(
   );
   // Now check the persistent cache
   const cacheNamespace = 'datasource-npm';
-  const cachedResult = await renovateCache.get<NpmDependency>(
+  const cachedResult = await globalCache.get<NpmDependency>(
     cacheNamespace,
     pkgUrl
   );
@@ -218,7 +219,7 @@ export async function getDependency(
       whitelistedPublicScopes.includes(scope) ||
       !packageName.startsWith('@')
     ) {
-      await renovateCache.set(cacheNamespace, pkgUrl, dep, cacheMinutes);
+      await globalCache.set(cacheNamespace, pkgUrl, dep, cacheMinutes);
     }
     return dep;
   } catch (err) {

--- a/lib/datasource/npm/index.spec.ts
+++ b/lib/datasource/npm/index.spec.ts
@@ -3,6 +3,7 @@ import nock from 'nock';
 import _registryAuthToken from 'registry-auth-token';
 import { getName } from '../../../test/util';
 import { DATASOURCE_FAILURE } from '../../constants/error-messages';
+import * as globalCache from '../../util/cache/global';
 import { clear } from '../../util/cache/run';
 import * as hostRules from '../../util/host-rules';
 import * as npm from '.';
@@ -55,7 +56,7 @@ describe(getName(__filename), () => {
       },
     };
     nock.cleanAll();
-    return global.renovateCache.rmAll();
+    return globalCache.rmAll();
   });
   afterEach(() => {
     delete process.env.RENOVATE_CACHE_NPM_MINUTES;

--- a/lib/datasource/nuget/index.spec.ts
+++ b/lib/datasource/nuget/index.spec.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import * as globalCache from '../../util/cache/global';
 import _got from '../../util/got';
 import * as _hostRules from '../../util/host-rules';
 import * as nuget from '.';
@@ -82,7 +83,7 @@ const configV3NotNugetOrg = {
 };
 
 describe('datasource/nuget', () => {
-  beforeEach(() => global.renovateCache.rmAll());
+  beforeEach(() => globalCache.rmAll());
   describe('getReleases', () => {
     beforeEach(() => {
       jest.resetAllMocks();

--- a/lib/datasource/nuget/v3.ts
+++ b/lib/datasource/nuget/v3.ts
@@ -1,6 +1,7 @@
 import * as semver from 'semver';
 import { XmlDocument } from 'xmldoc';
 import { logger } from '../../logger';
+import * as globalCache from '../../util/cache/global';
 import { Http } from '../../util/http';
 import { ReleaseResult } from '../common';
 
@@ -20,10 +21,7 @@ export async function getQueryUrl(url: string): Promise<string | null> {
   // https://docs.microsoft.com/en-us/nuget/api/search-query-service-resource
   const resourceType = 'SearchQueryService';
   const cacheKey = `${url}:${resourceType}`;
-  const cachedResult = await renovateCache.get<string>(
-    cacheNamespace,
-    cacheKey
-  );
+  const cachedResult = await globalCache.get<string>(cacheNamespace, cacheKey);
 
   // istanbul ignore if
   if (cachedResult) {
@@ -40,7 +38,7 @@ export async function getQueryUrl(url: string): Promise<string | null> {
     const searchQueryServiceId = searchQueryService['@id'];
 
     const cacheMinutes = 60;
-    await renovateCache.set(
+    await globalCache.set(
       cacheNamespace,
       cacheKey,
       searchQueryServiceId,

--- a/lib/datasource/orb/index.spec.ts
+++ b/lib/datasource/orb/index.spec.ts
@@ -1,3 +1,4 @@
+import * as globalCache from '../../util/cache/global';
 import _got from '../../util/got';
 import * as datasource from '.';
 
@@ -30,7 +31,7 @@ describe('datasource/orb', () => {
   describe('getReleases', () => {
     beforeEach(() => {
       jest.clearAllMocks();
-      return global.renovateCache.rmAll();
+      return globalCache.rmAll();
     });
     it('returns null for empty result', async () => {
       got.mockReturnValueOnce({ body: {} });

--- a/lib/datasource/orb/index.ts
+++ b/lib/datasource/orb/index.ts
@@ -1,4 +1,5 @@
 import { logger } from '../../logger';
+import * as globalCache from '../../util/cache/global';
 import { Http } from '../../util/http';
 import { GetReleasesConfig, ReleaseResult } from '../common';
 
@@ -25,7 +26,7 @@ export async function getReleases({
   logger.debug({ lookupName }, 'orb.getReleases()');
   const cacheNamespace = 'orb';
   const cacheKey = lookupName;
-  const cachedResult = await renovateCache.get<ReleaseResult>(
+  const cachedResult = await globalCache.get<ReleaseResult>(
     cacheNamespace,
     cacheKey
   );
@@ -65,7 +66,7 @@ export async function getReleases({
     }));
     logger.trace({ dep }, 'dep');
     const cacheMinutes = 15;
-    await renovateCache.set(cacheNamespace, cacheKey, dep, cacheMinutes);
+    await globalCache.set(cacheNamespace, cacheKey, dep, cacheMinutes);
     return dep;
   } catch (err) /* istanbul ignore next */ {
     logger.debug({ err }, 'CircleCI Orb lookup error');

--- a/lib/datasource/packagist/index.spec.ts
+++ b/lib/datasource/packagist/index.spec.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import * as globalCache from '../../util/cache/global';
 import { clear } from '../../util/cache/run';
 import _got from '../../util/got';
 import * as _hostRules from '../../util/host-rules';
@@ -36,7 +37,7 @@ describe('datasource/packagist', () => {
           'https://packagist.org',
         ],
       };
-      return global.renovateCache.rmAll();
+      return globalCache.rmAll();
     });
     it('supports custom registries', async () => {
       config = {

--- a/lib/datasource/packagist/index.ts
+++ b/lib/datasource/packagist/index.ts
@@ -3,6 +3,7 @@ import is from '@sindresorhus/is';
 
 import pAll from 'p-all';
 import { logger } from '../../logger';
+import * as globalCache from '../../util/cache/global';
 import { get, set } from '../../util/cache/run';
 import * as hostRules from '../../util/host-rules';
 import { Http, HttpOptions } from '../../util/http';
@@ -124,7 +125,7 @@ async function getPackagistFile(
   const cacheNamespace = 'datasource-packagist-files';
   const cacheKey = regUrl + key;
   // Check the persistent cache for public registries
-  const cachedResult = await renovateCache.get(cacheNamespace, cacheKey);
+  const cachedResult = await globalCache.get(cacheNamespace, cacheKey);
   // istanbul ignore if
   if (cachedResult && cachedResult.sha256 === sha256) {
     return cachedResult.res;
@@ -132,7 +133,7 @@ async function getPackagistFile(
   const res = (await http.getJson<PackagistFile>(regUrl + '/' + fileName, opts))
     .body;
   const cacheMinutes = 1440; // 1 day
-  await renovateCache.set(
+  await globalCache.set(
     cacheNamespace,
     cacheKey,
     { res, sha256 },
@@ -226,7 +227,7 @@ function getAllCachedPackages(regUrl: string): Promise<AllPackages | null> {
 
 async function packagistOrgLookup(name: string): Promise<ReleaseResult> {
   const cacheNamespace = 'datasource-packagist-org';
-  const cachedResult = await renovateCache.get<ReleaseResult>(
+  const cachedResult = await globalCache.get<ReleaseResult>(
     cacheNamespace,
     name
   );
@@ -245,7 +246,7 @@ async function packagistOrgLookup(name: string): Promise<ReleaseResult> {
     logger.trace({ dep }, 'dep');
   }
   const cacheMinutes = 10;
-  await renovateCache.set(cacheNamespace, name, dep, cacheMinutes);
+  await globalCache.set(cacheNamespace, name, dep, cacheMinutes);
   return dep;
 }
 

--- a/lib/datasource/pod/index.spec.ts
+++ b/lib/datasource/pod/index.spec.ts
@@ -2,6 +2,7 @@ import { getPkgReleases } from '..';
 import { mocked } from '../../../test/util';
 import { GotResponse } from '../../platform';
 import { api as _api } from '../../platform/github/gh-got-wrapper';
+import * as globalCache from '../../util/cache/global';
 import { clear } from '../../util/cache/run';
 import * as rubyVersioning from '../../versioning/ruby';
 import * as pod from '.';
@@ -22,7 +23,7 @@ describe('datasource/cocoapods', () => {
     beforeEach(() => {
       jest.resetAllMocks();
       clear();
-      return global.renovateCache.rmAll();
+      return globalCache.rmAll();
     });
 
     it('returns null for invalid inputs', async () => {

--- a/lib/datasource/pod/index.ts
+++ b/lib/datasource/pod/index.ts
@@ -1,6 +1,7 @@
 import crypto from 'crypto';
 import { logger } from '../../logger';
 import { api } from '../../platform/github/gh-got-wrapper';
+import * as globalCache from '../../util/cache/global';
 import { GetReleasesConfig, ReleaseResult } from '../common';
 
 export const id = 'pod';
@@ -129,7 +130,7 @@ export async function getReleases({
 }: GetReleasesConfig): Promise<ReleaseResult | null> {
   const podName = lookupName.replace(/\/.*$/, '');
 
-  const cachedResult = await renovateCache.get<ReleaseResult>(
+  const cachedResult = await globalCache.get<ReleaseResult>(
     cacheNamespace,
     podName
   );
@@ -156,7 +157,7 @@ export async function getReleases({
   }
 
   if (result) {
-    await renovateCache.set(cacheNamespace, podName, result, cacheMinutes);
+    await globalCache.set(cacheNamespace, podName, result, cacheMinutes);
   }
 
   return result;

--- a/lib/datasource/ruby-version/index.spec.ts
+++ b/lib/datasource/ruby-version/index.spec.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import * as globalCache from '../../util/cache/global';
 import _got from '../../util/got';
 import { getReleases } from '.';
 
@@ -14,7 +15,7 @@ const rubyReleasesHtml = fs.readFileSync(
 describe('datasource/gradle', () => {
   describe('getReleases', () => {
     beforeEach(() => {
-      return global.renovateCache.rmAll();
+      return globalCache.rmAll();
     });
     it('parses real data', async () => {
       got.mockReturnValueOnce({

--- a/lib/datasource/ruby-version/index.ts
+++ b/lib/datasource/ruby-version/index.ts
@@ -1,5 +1,6 @@
 import { parse } from 'node-html-parser';
 
+import * as globalCache from '../../util/cache/global';
 import { Http } from '../../util/http';
 import { isVersion } from '../../versioning/ruby';
 import { DatasourceError, GetReleasesConfig, ReleaseResult } from '../common';
@@ -15,7 +16,7 @@ export async function getReleases(
 ): Promise<ReleaseResult> {
   // First check the persistent cache
   const cacheNamespace = 'datasource-ruby-version';
-  const cachedResult = await renovateCache.get<ReleaseResult>(
+  const cachedResult = await globalCache.get<ReleaseResult>(
     cacheNamespace,
     'all'
   );
@@ -47,7 +48,7 @@ export async function getReleases(
         }
       }
     }
-    await renovateCache.set(cacheNamespace, 'all', res, 15);
+    await globalCache.set(cacheNamespace, 'all', res, 15);
     return res;
   } catch (err) {
     throw new DatasourceError(err);

--- a/lib/datasource/terraform-module/index.spec.ts
+++ b/lib/datasource/terraform-module/index.spec.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import * as globalCache from '../../util/cache/global';
 import _got from '../../util/got';
 import * as terraform from '.';
 
@@ -14,7 +15,7 @@ describe('datasource/terraform-module', () => {
   describe('getReleases', () => {
     beforeEach(() => {
       jest.clearAllMocks();
-      return global.renovateCache.rmAll();
+      return globalCache.rmAll();
     });
     it('returns null for empty result', async () => {
       got.mockReturnValueOnce({ body: {} });

--- a/lib/datasource/terraform-module/index.ts
+++ b/lib/datasource/terraform-module/index.ts
@@ -1,5 +1,6 @@
 import is from '@sindresorhus/is';
 import { logger } from '../../logger';
+import * as globalCache from '../../util/cache/global';
 import { Http } from '../../util/http';
 import { GetReleasesConfig, ReleaseResult } from '../common';
 
@@ -65,7 +66,7 @@ export async function getReleases({
   );
   const cacheNamespace = 'terraform-module';
   const pkgUrl = `${registry}/v1/modules/${repository}`;
-  const cachedResult = await renovateCache.get<ReleaseResult>(
+  const cachedResult = await globalCache.get<ReleaseResult>(
     cacheNamespace,
     pkgUrl
   );
@@ -97,7 +98,7 @@ export async function getReleases({
     }
     logger.trace({ dep }, 'dep');
     const cacheMinutes = 30;
-    await renovateCache.set(cacheNamespace, pkgUrl, dep, cacheMinutes);
+    await globalCache.set(cacheNamespace, pkgUrl, dep, cacheMinutes);
     return dep;
   } catch (err) {
     if (err.statusCode === 404 || err.code === 'ENOTFOUND') {

--- a/lib/datasource/terraform-provider/index.spec.ts
+++ b/lib/datasource/terraform-provider/index.spec.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import * as globalCache from '../../util/cache/global';
 import _got from '../../util/got';
 import * as terraformProvider from '.';
 
@@ -14,7 +15,7 @@ describe('datasource/terraform', () => {
   describe('getReleases', () => {
     beforeEach(() => {
       jest.clearAllMocks();
-      return global.renovateCache.rmAll();
+      return globalCache.rmAll();
     });
     it('returns null for empty result', async () => {
       got.mockReturnValueOnce({ body: {} });

--- a/lib/datasource/terraform-provider/index.ts
+++ b/lib/datasource/terraform-provider/index.ts
@@ -1,4 +1,5 @@
 import { logger } from '../../logger';
+import * as globalCache from '../../util/cache/global';
 import { Http } from '../../util/http';
 import { GetReleasesConfig, ReleaseResult } from '../common';
 
@@ -28,7 +29,7 @@ export async function getReleases({
   logger.debug({ lookupName }, 'terraform-provider.getDependencies()');
   const cacheNamespace = 'terraform-providers';
   const pkgUrl = `https://registry.terraform.io/v1/providers/${repository}`;
-  const cachedResult = await renovateCache.get<ReleaseResult>(
+  const cachedResult = await globalCache.get<ReleaseResult>(
     cacheNamespace,
     pkgUrl
   );
@@ -55,7 +56,7 @@ export async function getReleases({
     }
     logger.trace({ dep }, 'dep');
     const cacheMinutes = 30;
-    await renovateCache.set(cacheNamespace, pkgUrl, dep, cacheMinutes);
+    await globalCache.set(cacheNamespace, pkgUrl, dep, cacheMinutes);
     return dep;
   } catch (err) {
     if (err.statusCode === 404 || err.code === 'ENOTFOUND') {

--- a/lib/manager/bazel/update.ts
+++ b/lib/manager/bazel/update.ts
@@ -1,5 +1,6 @@
 import { fromStream } from 'hasha';
 import { logger } from '../../logger';
+import * as globalCache from '../../util/cache/global';
 import { Http } from '../../util/http';
 import { regEx } from '../../util/regex';
 import { UpdateDependencyConfig } from '../common';
@@ -45,7 +46,7 @@ function extractUrls(content: string): string[] | null {
 
 async function getHashFromUrl(url: string): Promise<string | null> {
   const cacheNamespace = 'url-sha256';
-  const cachedResult = await renovateCache.get<string | null>(
+  const cachedResult = await globalCache.get<string | null>(
     cacheNamespace,
     url
   );
@@ -58,7 +59,7 @@ async function getHashFromUrl(url: string): Promise<string | null> {
       algorithm: 'sha256',
     });
     const cacheMinutes = 3 * 24 * 60; // 3 days
-    await renovateCache.set(cacheNamespace, url, hash, cacheMinutes);
+    await globalCache.set(cacheNamespace, url, hash, cacheMinutes);
     return hash;
   } catch (err) /* istanbul ignore next */ {
     return null;

--- a/lib/util/cache/global.ts
+++ b/lib/util/cache/global.ts
@@ -1,0 +1,16 @@
+export function get<T = any>(namespace: string, key: string): Promise<T> {
+  return renovateCache.get(namespace, key);
+}
+
+export function set(
+  namespace: string,
+  key: string,
+  value: any,
+  minutes: number
+): Promise<void> {
+  return renovateCache.set(namespace, key, value, minutes);
+}
+
+export function rmAll(): Promise<void> {
+  return renovateCache.rmAll();
+}

--- a/lib/workers/pr/changelog/index.spec.ts
+++ b/lib/workers/pr/changelog/index.spec.ts
@@ -1,6 +1,7 @@
 import { mocked, partial } from '../../../../test/util';
 import { PLATFORM_TYPE_GITHUB } from '../../../constants/platforms';
 import { api } from '../../../platform/github/gh-got-wrapper';
+import * as globalCache from '../../../util/cache/global';
 import * as hostRules from '../../../util/host-rules';
 import * as semverVersioning from '../../../versioning/semver';
 import { BranchConfig } from '../../common';
@@ -42,7 +43,7 @@ describe('workers/pr/changelog', () => {
         baseUrl: 'https://api.github.com/',
         token: 'abc',
       });
-      await global.renovateCache.rmAll();
+      await globalCache.rmAll();
     });
     it('returns null if @types', async () => {
       expect(

--- a/lib/workers/pr/changelog/release-notes.ts
+++ b/lib/workers/pr/changelog/release-notes.ts
@@ -5,6 +5,7 @@ import MarkdownIt from 'markdown-it';
 
 import { logger } from '../../../logger';
 import { api } from '../../../platform/github/gh-got-wrapper';
+import * as globalCache from '../../../util/cache/global';
 import { ChangeLogNotes, ChangeLogResult } from './common';
 
 const { get: ghGot } = api;
@@ -247,7 +248,7 @@ export async function addReleaseNotes(
   for (const v of input.versions) {
     let releaseNotes: ChangeLogNotes;
     const cacheKey = getCacheKey(v.version);
-    releaseNotes = await renovateCache.get(cacheNamespace, cacheKey);
+    releaseNotes = await globalCache.get(cacheNamespace, cacheKey);
     if (!releaseNotes) {
       releaseNotes = await getReleaseNotesMd(
         repository,
@@ -270,7 +271,7 @@ export async function addReleaseNotes(
         releaseNotes = { url: v.compare.url };
       }
       const cacheMinutes = 55;
-      await renovateCache.set(
+      await globalCache.set(
         cacheNamespace,
         cacheKey,
         releaseNotes,

--- a/lib/workers/pr/changelog/source-github.ts
+++ b/lib/workers/pr/changelog/source-github.ts
@@ -3,6 +3,7 @@ import { PLATFORM_TYPE_GITHUB } from '../../../constants/platforms';
 import { Release } from '../../../datasource';
 import { logger } from '../../../logger';
 import { api } from '../../../platform/github/gh-got-wrapper';
+import * as globalCache from '../../../util/cache/global';
 import * as hostRules from '../../../util/host-rules';
 import * as allVersioning from '../../../versioning';
 import { BranchUpgradeConfig } from '../../common';
@@ -133,7 +134,7 @@ export async function getChangeLogJSON({
     const prev = validReleases[i - 1];
     const next = validReleases[i];
     if (include(next.version)) {
-      let release = await renovateCache.get(
+      let release = await globalCache.get(
         cacheNamespace,
         getCacheKey(prev.version, next.version)
       );
@@ -152,7 +153,7 @@ export async function getChangeLogJSON({
           release.compare.url = `${baseUrl}${repository}/compare/${prevHead}...${nextHead}`;
         }
         const cacheMinutes = 55;
-        await renovateCache.set(
+        await globalCache.set(
           cacheNamespace,
           getCacheKey(prev.version, next.version),
           release,


### PR DESCRIPTION
Adds a wrapper about the global `renovateCache` as a first step towards removing the global altogether.