### PR TITLE
feat(presets): Add opentelemetry as well-known monorepo

### DIFF
--- a/lib/config/presets/internal/monorepo.ts
+++ b/lib/config/presets/internal/monorepo.ts
@@ -86,6 +86,7 @@ const repoGroups = {
   nrwl: 'https://github.com/nrwl/',
   nuxtjs: 'https://github.com/nuxt/nuxt.js',
   openfeign: 'https://github.com/OpenFeign/feign',
+  opentelemetry: 'https://github.com/open-telemetry/opentelemetry-js',
   picasso: 'https://github.com/qlik-oss/picasso.js',
   pollyjs: 'https://github.com/Netflix/pollyjs',
   pouchdb: 'https://github.com/pouchdb/pouchdb',


### PR DESCRIPTION
This PR adds the OpenTelemetry to the list of well-known monorepos. 

OpenTelemetry makes robust, portable telemetry a built-in feature of cloud-native software. - https://opentelemetry.io/ It is the successor of opencensus and opentracing.

The monorepo can be found at https://github.com/open-telemetry/opentelemetry-js. The packages are scoped with `@opentelemetry`.

Currently all `@opentelemetry` packages are updated with extra PR/MRs. This is bad as it can lead to runtime problems and merge conflicts.

Is this enough to just add this to the list or is there anything else to do?