### PR TITLE
fix(helm): default registryUrls

### DIFF
--- a/lib/datasource/helm/index.ts
+++ b/lib/datasource/helm/index.ts
@@ -9,6 +9,10 @@ export const id = 'helm';
 
 const http = new Http(id);
 
+export const defaultRegistryUrls = [
+  'https://kubernetes-charts.storage.googleapis.com/',
+];
+
 export async function getRepositoryData(
   repository: string
 ): Promise<ReleaseResult[]> {


### PR DESCRIPTION
Adds a default registryUrls value for `helm` datasource. i.e. if no `registryUrls` is given then `https://kubernetes-charts.storage.googleapis.com/` will be queried.