### PR TITLE
refactor: parentBranch -> reuseExistingBranch

### DIFF
--- a/lib/manager/common.ts
+++ b/lib/manager/common.ts
@@ -258,5 +258,5 @@ export interface PostUpdateConfig extends ManagerConfig, Record<string, any> {
   npmLock?: string;
   yarnLock?: string;
   branchName?: string;
-  parentBranch?: string;
+  reuseExistingBranch?: boolean;
 }

--- a/lib/manager/npm/post-update/index.ts
+++ b/lib/manager/npm/post-update/index.ts
@@ -484,7 +484,7 @@ export async function getAdditionalFiles(
     } else {
       const existingContent = await platform.getFile(
         lockFile,
-        config.reuseExistingBranch ? config.branchName : undefined
+        config.reuseExistingBranch ? config.branchName : config.baseBranch
       );
       if (res.lockFile !== existingContent) {
         logger.debug(`${lockFile} needs updating`);
@@ -549,7 +549,7 @@ export async function getAdditionalFiles(
     } else {
       const existingContent = await platform.getFile(
         lockFileName,
-        config.reuseExistingBranch ? config.branchName : undefined
+        config.reuseExistingBranch ? config.branchName : config.baseBranch
       );
       if (res.lockFile !== existingContent) {
         logger.debug('yarn.lock needs updating');
@@ -646,7 +646,7 @@ export async function getAdditionalFiles(
     } else {
       const existingContent = await platform.getFile(
         lockFile,
-        config.reuseExistingBranch ? config.branchName : undefined
+        config.reuseExistingBranch ? config.branchName : config.baseBranch
       );
       if (res.lockFile !== existingContent) {
         logger.debug('pnpm-lock.yaml needs updating');
@@ -742,7 +742,7 @@ export async function getAdditionalFiles(
         logger.trace('Checking for ' + filename);
         const existingContent = await platform.getFile(
           filename,
-          config.reuseExistingBranch ? config.branchName : undefined
+          config.reuseExistingBranch ? config.branchName : config.baseBranch
         );
         if (existingContent) {
           logger.trace('Found lock file');

--- a/lib/manager/npm/post-update/index.ts
+++ b/lib/manager/npm/post-update/index.ts
@@ -378,7 +378,7 @@ export async function getAdditionalFiles(
   logger.debug('Getting updated lock files');
   if (
     config.updateType === 'lockFileMaintenance' &&
-    config.parentBranch &&
+    config.reuseExistingBranch &&
     (await platform.branchExists(config.branchName))
   ) {
     logger.debug('Skipping lockFileMaintenance update');
@@ -484,7 +484,7 @@ export async function getAdditionalFiles(
     } else {
       const existingContent = await platform.getFile(
         lockFile,
-        config.parentBranch
+        config.reuseExistingBranch ? config.branchName : undefined
       );
       if (res.lockFile !== existingContent) {
         logger.debug(`${lockFile} needs updating`);
@@ -549,7 +549,7 @@ export async function getAdditionalFiles(
     } else {
       const existingContent = await platform.getFile(
         lockFileName,
-        config.parentBranch
+        config.reuseExistingBranch ? config.branchName : undefined
       );
       if (res.lockFile !== existingContent) {
         logger.debug('yarn.lock needs updating');
@@ -646,7 +646,7 @@ export async function getAdditionalFiles(
     } else {
       const existingContent = await platform.getFile(
         lockFile,
-        config.parentBranch
+        config.reuseExistingBranch ? config.branchName : undefined
       );
       if (res.lockFile !== existingContent) {
         logger.debug('pnpm-lock.yaml needs updating');
@@ -742,7 +742,7 @@ export async function getAdditionalFiles(
         logger.trace('Checking for ' + filename);
         const existingContent = await platform.getFile(
           filename,
-          config.parentBranch
+          config.reuseExistingBranch ? config.branchName : undefined
         );
         if (existingContent) {
           logger.trace('Found lock file');

--- a/lib/workers/branch/__snapshots__/get-updated.spec.ts.snap
+++ b/lib/workers/branch/__snapshots__/get-updated.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`workers/branch/get-updated getUpdatedPackageFiles() handles autoreplace base updated 1`] = `
 Object {
   "artifactErrors": Array [],
-  "parentBranch": undefined,
+  "reuseExistingBranch": undefined,
   "updatedArtifacts": Array [],
   "updatedPackageFiles": Array [
     Object {
@@ -17,7 +17,7 @@ Object {
 exports[`workers/branch/get-updated getUpdatedPackageFiles() handles autoreplace branch needs update 1`] = `
 Object {
   "artifactErrors": Array [],
-  "parentBranch": undefined,
+  "reuseExistingBranch": false,
   "updatedArtifacts": Array [],
   "updatedPackageFiles": Array [
     Object {
@@ -31,7 +31,7 @@ Object {
 exports[`workers/branch/get-updated getUpdatedPackageFiles() handles autoreplace branch no update 1`] = `
 Object {
   "artifactErrors": Array [],
-  "parentBranch": undefined,
+  "reuseExistingBranch": undefined,
   "updatedArtifacts": Array [],
   "updatedPackageFiles": Array [],
 }
@@ -40,7 +40,7 @@ Object {
 exports[`workers/branch/get-updated getUpdatedPackageFiles() handles content change 1`] = `
 Object {
   "artifactErrors": Array [],
-  "parentBranch": undefined,
+  "reuseExistingBranch": false,
   "updatedArtifacts": Array [],
   "updatedPackageFiles": Array [
     Object {
@@ -54,7 +54,7 @@ Object {
 exports[`workers/branch/get-updated getUpdatedPackageFiles() handles empty 1`] = `
 Object {
   "artifactErrors": Array [],
-  "parentBranch": undefined,
+  "reuseExistingBranch": undefined,
   "updatedArtifacts": Array [],
   "updatedPackageFiles": Array [],
 }
@@ -63,7 +63,7 @@ Object {
 exports[`workers/branch/get-updated getUpdatedPackageFiles() handles git submodules 1`] = `
 Object {
   "artifactErrors": Array [],
-  "parentBranch": undefined,
+  "reuseExistingBranch": undefined,
   "updatedArtifacts": Array [],
   "updatedPackageFiles": Array [
     Object {
@@ -82,7 +82,7 @@ Object {
       "stderr": "some error",
     },
   ],
-  "parentBranch": "some-branch",
+  "reuseExistingBranch": true,
   "updatedArtifacts": Array [],
   "updatedPackageFiles": Array [
     Object {
@@ -96,7 +96,7 @@ Object {
 exports[`workers/branch/get-updated getUpdatedPackageFiles() handles lock files 1`] = `
 Object {
   "artifactErrors": Array [],
-  "parentBranch": "some-branch",
+  "reuseExistingBranch": true,
   "updatedArtifacts": Array [
     Object {
       "contents": "some contents",
@@ -115,7 +115,7 @@ Object {
 exports[`workers/branch/get-updated getUpdatedPackageFiles() handles lockFileMaintenance 1`] = `
 Object {
   "artifactErrors": Array [],
-  "parentBranch": undefined,
+  "reuseExistingBranch": undefined,
   "updatedArtifacts": Array [
     Object {
       "contents": "some contents",
@@ -134,7 +134,7 @@ Object {
       "stderr": "some error",
     },
   ],
-  "parentBranch": undefined,
+  "reuseExistingBranch": undefined,
   "updatedArtifacts": Array [],
   "updatedPackageFiles": Array [],
 }

--- a/lib/workers/branch/auto-replace.spec.ts
+++ b/lib/workers/branch/auto-replace.spec.ts
@@ -21,7 +21,7 @@ describe('workers/branch/auto-replace', () => {
         ...JSON.parse(JSON.stringify(defaultConfig)),
         manager: 'html',
       };
-      reuseExistingBranch = undefined;
+      reuseExistingBranch = false;
     });
     it('rebases if the deps list has changed', async () => {
       upgrade.baseDeps = extractPackageFile(sampleHtml).deps;

--- a/lib/workers/branch/auto-replace.spec.ts
+++ b/lib/workers/branch/auto-replace.spec.ts
@@ -14,30 +14,30 @@ jest.mock('../../util/fs');
 
 describe('workers/branch/auto-replace', () => {
   describe('doAutoReplace', () => {
-    let parentBranch: string;
+    let reuseExistingBranch: boolean;
     let upgrade: BranchUpgradeConfig;
     beforeEach(() => {
       upgrade = {
         ...JSON.parse(JSON.stringify(defaultConfig)),
         manager: 'html',
       };
-      parentBranch = undefined;
+      reuseExistingBranch = undefined;
     });
     it('rebases if the deps list has changed', async () => {
       upgrade.baseDeps = extractPackageFile(sampleHtml).deps;
-      parentBranch = 'some existing branch';
+      reuseExistingBranch = true;
       const res = await doAutoReplace(
         upgrade,
         'existing content',
-        parentBranch
+        reuseExistingBranch
       );
       expect(res).toBeNull();
     });
     it('rebases if the deps to update has changed', async () => {
       upgrade.baseDeps = extractPackageFile(sampleHtml).deps;
       upgrade.baseDeps[0].currentValue = '1.0.0';
-      parentBranch = 'some existing branch';
-      const res = await doAutoReplace(upgrade, sampleHtml, parentBranch);
+      reuseExistingBranch = true;
+      const res = await doAutoReplace(upgrade, sampleHtml, reuseExistingBranch);
       expect(res).toBeNull();
     });
     it('updates version only', async () => {
@@ -51,7 +51,7 @@ describe('workers/branch/auto-replace', () => {
       upgrade.newValue = '7.1.1';
       upgrade.newDigest = 'some-digest';
       upgrade.depIndex = 0;
-      const res = await doAutoReplace(upgrade, src, parentBranch);
+      const res = await doAutoReplace(upgrade, src, reuseExistingBranch);
       expect(res).toMatchSnapshot();
     });
     it('handles a double attempt', async () => {
@@ -64,7 +64,7 @@ describe('workers/branch/auto-replace', () => {
       upgrade.currentValue = '7.1.0';
       upgrade.newValue = '7.1.1';
       upgrade.depIndex = 1;
-      const res = await doAutoReplace(upgrade, src, parentBranch);
+      const res = await doAutoReplace(upgrade, src, reuseExistingBranch);
       expect(res).toMatchSnapshot();
     });
     it('handles already updated', async () => {
@@ -78,9 +78,13 @@ describe('workers/branch/auto-replace', () => {
       upgrade.newValue = '7.1.1';
       upgrade.depIndex = 0;
       upgrade.replaceString = script;
-      parentBranch = 'something';
+      reuseExistingBranch = true;
       const srcAlreadyUpdated = src.replace('7.1.0', '7.1.1');
-      const res = await doAutoReplace(upgrade, srcAlreadyUpdated, parentBranch);
+      const res = await doAutoReplace(
+        upgrade,
+        srcAlreadyUpdated,
+        reuseExistingBranch
+      );
       expect(res).toMatchSnapshot();
     });
     it('returns existing content if replaceString mismatch', async () => {
@@ -94,7 +98,11 @@ describe('workers/branch/auto-replace', () => {
       upgrade.newValue = '7.1.1';
       upgrade.depIndex = 0;
       upgrade.replaceString = script;
-      const res = await doAutoReplace(upgrade, 'wrong source', parentBranch);
+      const res = await doAutoReplace(
+        upgrade,
+        'wrong source',
+        reuseExistingBranch
+      );
       expect(res).toEqual('wrong source');
     });
     it('updates version and integrity', async () => {
@@ -111,7 +119,7 @@ describe('workers/branch/auto-replace', () => {
       upgrade.newDigest = 'sha256-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
       upgrade.depIndex = 0;
       upgrade.replaceString = script;
-      const res = await doAutoReplace(upgrade, src, parentBranch);
+      const res = await doAutoReplace(upgrade, src, reuseExistingBranch);
       expect(res).toMatchSnapshot();
     });
     it('updates with autoReplaceNewString', async () => {
@@ -130,7 +138,7 @@ describe('workers/branch/auto-replace', () => {
         'node:8.11.3-alpine@sha256:d743b4141b02fcfb8beb68f92b4cd164f60ee457bf2d053f36785bf86de16b0d';
       upgrade.autoReplaceStringTemplate =
         '{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}';
-      const res = await doAutoReplace(upgrade, dockerfile, parentBranch);
+      const res = await doAutoReplace(upgrade, dockerfile, reuseExistingBranch);
       expect(res).toMatchSnapshot();
     });
   });

--- a/lib/workers/branch/auto-replace.ts
+++ b/lib/workers/branch/auto-replace.ts
@@ -103,7 +103,7 @@ export async function checkBranchDepsMatchBaseDeps(
 export async function doAutoReplace(
   upgrade: BranchUpgradeConfig,
   existingContent: string,
-  parentBranch: string | null
+  reuseExistingBranch: boolean
 ): Promise<string | null> {
   const {
     packageFile,
@@ -114,7 +114,7 @@ export async function doAutoReplace(
     newDigest,
     autoReplaceStringTemplate,
   } = upgrade;
-  if (parentBranch) {
+  if (reuseExistingBranch) {
     if (!(await checkBranchDepsMatchBaseDeps(upgrade, existingContent))) {
       logger.debug(
         { packageFile, depName },

--- a/lib/workers/branch/get-updated.spec.ts
+++ b/lib/workers/branch/get-updated.spec.ts
@@ -92,7 +92,6 @@ describe('workers/branch/get-updated', () => {
       expect(res).toMatchSnapshot();
     });
     it('handles lockFileMaintenance', async () => {
-      // config.reuseExistingBranch = 'some-branch';
       config.upgrades.push({
         manager: 'composer',
         updateType: 'lockFileMaintenance',
@@ -109,7 +108,6 @@ describe('workers/branch/get-updated', () => {
       expect(res).toMatchSnapshot();
     });
     it('handles lockFileMaintenance error', async () => {
-      // config.reuseExistingBranch = 'some-branch';
       config.upgrades.push({
         manager: 'composer',
         updateType: 'lockFileMaintenance',

--- a/lib/workers/branch/get-updated.spec.ts
+++ b/lib/workers/branch/get-updated.spec.ts
@@ -46,7 +46,7 @@ describe('workers/branch/get-updated', () => {
       await expect(getUpdatedPackageFiles(config)).rejects.toThrow();
     });
     it('handles autoreplace branch needs update', async () => {
-      config.parentBranch = 'some branch';
+      config.reuseExistingBranch = true;
       config.upgrades.push({ manager: 'html', branchName: undefined });
       autoReplace.doAutoReplace.mockResolvedValueOnce(null);
       autoReplace.doAutoReplace.mockResolvedValueOnce('updated-file');
@@ -58,14 +58,14 @@ describe('workers/branch/get-updated', () => {
       expect(res).toMatchSnapshot();
     });
     it('handles null content', async () => {
-      config.parentBranch = 'some-branch';
+      config.reuseExistingBranch = true;
       config.upgrades.push({
         manager: 'npm',
       } as never);
       await expect(getUpdatedPackageFiles(config)).rejects.toThrow();
     });
     it('handles content change', async () => {
-      config.parentBranch = 'some-branch';
+      config.reuseExistingBranch = true;
       config.upgrades.push({
         manager: 'npm',
       } as never);
@@ -74,7 +74,7 @@ describe('workers/branch/get-updated', () => {
       expect(res).toMatchSnapshot();
     });
     it('handles lock files', async () => {
-      config.parentBranch = 'some-branch';
+      config.reuseExistingBranch = true;
       config.upgrades.push({
         manager: 'composer',
         branchName: undefined,
@@ -92,7 +92,7 @@ describe('workers/branch/get-updated', () => {
       expect(res).toMatchSnapshot();
     });
     it('handles lockFileMaintenance', async () => {
-      // config.parentBranch = 'some-branch';
+      // config.reuseExistingBranch = 'some-branch';
       config.upgrades.push({
         manager: 'composer',
         updateType: 'lockFileMaintenance',
@@ -109,7 +109,7 @@ describe('workers/branch/get-updated', () => {
       expect(res).toMatchSnapshot();
     });
     it('handles lockFileMaintenance error', async () => {
-      // config.parentBranch = 'some-branch';
+      // config.reuseExistingBranch = 'some-branch';
       config.upgrades.push({
         manager: 'composer',
         updateType: 'lockFileMaintenance',
@@ -126,7 +126,7 @@ describe('workers/branch/get-updated', () => {
       expect(res).toMatchSnapshot();
     });
     it('handles lock file errors', async () => {
-      config.parentBranch = 'some-branch';
+      config.reuseExistingBranch = true;
       config.upgrades.push({
         manager: 'composer',
         branchName: undefined,

--- a/lib/workers/branch/get-updated.ts
+++ b/lib/workers/branch/get-updated.ts
@@ -38,13 +38,7 @@ export async function getUpdatedPackageFiles(
       lockFileMaintenanceFiles.push(packageFile);
     } else {
       let existingContent = updatedFileContents[packageFile];
-      // istanbul ignore if
-      if (existingContent) {
-        logger.debug({ packageFile }, 'Reusing updated contents');
-      } else {
-        logger.debug(
-          `platform.getFile(${packageFile}, ${reuseExistingBranch})`
-        );
+      if (!existingContent) {
         existingContent = await platform.getFile(
           packageFile,
           reuseExistingBranch ? config.branchName : config.baseBranch

--- a/lib/workers/branch/get-updated.ts
+++ b/lib/workers/branch/get-updated.ts
@@ -47,7 +47,7 @@ export async function getUpdatedPackageFiles(
         );
         existingContent = await platform.getFile(
           packageFile,
-          reuseExistingBranch ? config.branchName : undefined
+          reuseExistingBranch ? config.branchName : config.baseBranch
         );
       }
       // istanbul ignore if
@@ -168,7 +168,7 @@ export async function getUpdatedPackageFiles(
           updatedFileContents[packageFile] ||
           (await platform.getFile(
             packageFile,
-            config.reuseExistingBranch ? config.branchName : undefined
+            config.reuseExistingBranch ? config.branchName : config.baseBranch
           ));
         const results = await updateArtifacts({
           packageFileName: packageFile,

--- a/lib/workers/branch/get-updated.ts
+++ b/lib/workers/branch/get-updated.ts
@@ -10,7 +10,7 @@ import { doAutoReplace } from './auto-replace';
 
 export interface PackageFilesResult {
   artifactErrors: ArtifactError[];
-  parentBranch?: string;
+  reuseExistingBranch?: boolean;
   updatedPackageFiles: File[];
   updatedArtifacts: File[];
 }
@@ -19,9 +19,9 @@ export async function getUpdatedPackageFiles(
   config: BranchConfig
 ): Promise<PackageFilesResult> {
   logger.trace({ config });
-  const { branchName, parentBranch } = config;
+  const { branchName, reuseExistingBranch } = config;
   logger.debug(
-    { parentBranch, branchName },
+    { reuseExistingBranch, branchName },
     'manager.getUpdatedPackageFiles()'
   );
   const updatedFileContents: Record<string, string> = {};
@@ -42,23 +42,32 @@ export async function getUpdatedPackageFiles(
       if (existingContent) {
         logger.debug({ packageFile }, 'Reusing updated contents');
       } else {
-        logger.debug(`platform.getFile(${packageFile}, ${parentBranch})`);
-        existingContent = await platform.getFile(packageFile, parentBranch);
+        logger.debug(
+          `platform.getFile(${packageFile}, ${reuseExistingBranch})`
+        );
+        existingContent = await platform.getFile(
+          packageFile,
+          reuseExistingBranch ? config.branchName : undefined
+        );
       }
       // istanbul ignore if
-      if (config.parentBranch && !existingContent) {
+      if (config.reuseExistingBranch && !existingContent) {
         logger.debug(
           { packageFile, depName },
           'Rebasing branch after file not found'
         );
         return getUpdatedPackageFiles({
           ...config,
-          parentBranch: undefined,
+          reuseExistingBranch: false,
         });
       }
       const updateDependency = get(manager, 'updateDependency');
       if (!updateDependency) {
-        const res = await doAutoReplace(upgrade, existingContent, parentBranch);
+        const res = await doAutoReplace(
+          upgrade,
+          existingContent,
+          reuseExistingBranch
+        );
         if (res) {
           if (res === existingContent) {
             logger.debug({ packageFile, depName }, 'No content changed');
@@ -67,10 +76,10 @@ export async function getUpdatedPackageFiles(
             updatedFileContents[packageFile] = res;
           }
           continue; // eslint-disable-line no-continue
-        } else if (parentBranch) {
+        } else if (reuseExistingBranch) {
           return getUpdatedPackageFiles({
             ...config,
-            parentBranch: undefined,
+            reuseExistingBranch: false,
           });
         }
         logger.error({ packageFile, depName }, 'Could not autoReplace');
@@ -81,14 +90,14 @@ export async function getUpdatedPackageFiles(
         upgrade,
       });
       if (!newContent) {
-        if (config.parentBranch) {
+        if (config.reuseExistingBranch) {
           logger.debug(
             { packageFile, depName },
             'Rebasing branch after error updating content'
           );
           return getUpdatedPackageFiles({
             ...config,
-            parentBranch: undefined,
+            reuseExistingBranch: false,
           });
         }
         logger.debug(
@@ -98,7 +107,7 @@ export async function getUpdatedPackageFiles(
         throw new Error(WORKER_FILE_UPDATE_FAILED);
       }
       if (newContent !== existingContent) {
-        if (config.parentBranch) {
+        if (config.reuseExistingBranch) {
           // This ensure it's always 1 commit from the bot
           logger.debug(
             { packageFile, depName },
@@ -106,7 +115,7 @@ export async function getUpdatedPackageFiles(
           );
           return getUpdatedPackageFiles({
             ...config,
-            parentBranch: undefined,
+            reuseExistingBranch: false,
           });
         }
         logger.debug({ packageFile, depName }, 'Updating packageFile content');
@@ -149,7 +158,7 @@ export async function getUpdatedPackageFiles(
       }
     }
   }
-  if (!config.parentBranch) {
+  if (!config.reuseExistingBranch) {
     // Only perform lock file maintenance if it's a fresh commit
     for (const packageFile of lockFileMaintenanceFiles) {
       const manager = packageFileManagers[packageFile];
@@ -157,7 +166,10 @@ export async function getUpdatedPackageFiles(
       if (updateArtifacts) {
         const packageFileContents =
           updatedFileContents[packageFile] ||
-          (await platform.getFile(packageFile, config.parentBranch));
+          (await platform.getFile(
+            packageFile,
+            config.reuseExistingBranch ? config.branchName : undefined
+          ));
         const results = await updateArtifacts({
           packageFileName: packageFile,
           updatedDeps: [],
@@ -178,7 +190,7 @@ export async function getUpdatedPackageFiles(
     }
   }
   return {
-    parentBranch: config.parentBranch, // Need to overwrite original config
+    reuseExistingBranch: config.reuseExistingBranch, // Need to overwrite original config
     updatedPackageFiles,
     updatedArtifacts,
     artifactErrors,

--- a/lib/workers/branch/index.spec.ts
+++ b/lib/workers/branch/index.spec.ts
@@ -19,7 +19,7 @@ import * as _automerge from './automerge';
 import * as _checkExisting from './check-existing';
 import * as _commit from './commit';
 import * as _getUpdated from './get-updated';
-import * as _parent from './parent';
+import * as _reuse from './reuse';
 import * as _schedule from './schedule';
 import * as _statusChecks from './status-checks';
 import * as branchWorker from '.';
@@ -27,7 +27,7 @@ import * as branchWorker from '.';
 jest.mock('./get-updated');
 jest.mock('./schedule');
 jest.mock('./check-existing');
-jest.mock('./parent');
+jest.mock('./reuse');
 jest.mock('../../manager/npm/post-update');
 jest.mock('./status-checks');
 jest.mock('./automerge');
@@ -39,7 +39,7 @@ jest.mock('fs-extra');
 const getUpdated = mocked(_getUpdated);
 const schedule = mocked(_schedule);
 const checkExisting = mocked(_checkExisting);
-const parent = mocked(_parent);
+const reuse = mocked(_reuse);
 const npmPostExtract = mocked(_npmPostExtract);
 const statusChecks = mocked(_statusChecks);
 const automerge = mocked(_automerge);
@@ -127,7 +127,7 @@ describe('workers/branch', () => {
         state: PR_STATE_CLOSED,
       } as never);
       await branchWorker.processBranch(config);
-      expect(parent.getParentBranch).toHaveBeenCalledTimes(0);
+      expect(reuse.shouldReuseExistingBranch).toHaveBeenCalledTimes(0);
     });
     it('skips branch if closed digest PR found', async () => {
       schedule.isScheduledNow.mockReturnValueOnce(false);
@@ -138,7 +138,7 @@ describe('workers/branch', () => {
         state: PR_STATE_CLOSED,
       });
       await branchWorker.processBranch(config);
-      expect(parent.getParentBranch).toHaveBeenCalledTimes(0);
+      expect(reuse.shouldReuseExistingBranch).toHaveBeenCalledTimes(0);
     });
     it('skips branch if closed minor PR found', async () => {
       schedule.isScheduledNow.mockReturnValueOnce(false);
@@ -148,7 +148,7 @@ describe('workers/branch', () => {
         state: PR_STATE_CLOSED,
       });
       await branchWorker.processBranch(config);
-      expect(parent.getParentBranch).toHaveBeenCalledTimes(0);
+      expect(reuse.shouldReuseExistingBranch).toHaveBeenCalledTimes(0);
     });
     it('skips branch if merged PR found', async () => {
       schedule.isScheduledNow.mockReturnValueOnce(false);
@@ -158,7 +158,7 @@ describe('workers/branch', () => {
         state: PR_STATE_MERGED,
       });
       await branchWorker.processBranch(config);
-      expect(parent.getParentBranch).toHaveBeenCalledTimes(0);
+      expect(reuse.shouldReuseExistingBranch).toHaveBeenCalledTimes(0);
     });
     it('throws error if closed PR found', async () => {
       schedule.isScheduledNow.mockReturnValueOnce(false);
@@ -546,7 +546,7 @@ describe('workers/branch', () => {
           ...config,
           dryRun: true,
           updateType: 'lockFileMaintenance',
-          parentBranch: undefined,
+          reuseExistingBranch: false,
           updatedArtifacts: [{ name: '|delete|', contents: 'dummy' }],
         })
       ).toEqual('done');
@@ -607,7 +607,7 @@ describe('workers/branch', () => {
         await branchWorker.processBranch({
           ...config,
           updateType: 'lockFileMaintenance',
-          parentBranch: undefined,
+          reuseExistingBranch: false,
           updatedArtifacts: [{ name: '|delete|', contents: 'dummy' }],
         })
       ).toEqual('done');

--- a/lib/workers/branch/index.ts
+++ b/lib/workers/branch/index.ts
@@ -35,7 +35,7 @@ import { tryBranchAutomerge } from './automerge';
 import { prAlreadyExisted } from './check-existing';
 import { commitFilesToBranch } from './commit';
 import { getUpdatedPackageFiles } from './get-updated';
-import { getParentBranch } from './parent';
+import { shouldReuseExistingBranch } from './reuse';
 import { isScheduledNow } from './schedule';
 import { setStability, setUnpublishable } from './status-checks';
 
@@ -281,11 +281,11 @@ export async function processBranch(
     // istanbul ignore if
     if (masterIssueCheck === 'rebase' || config.masterIssueRebaseAllOpen) {
       logger.debug('Manual rebase requested via master issue');
-      delete config.parentBranch;
+      config.reuseExistingBranch = false;
     } else {
-      Object.assign(config, await getParentBranch(config));
+      Object.assign(config, await shouldReuseExistingBranch(config));
     }
-    logger.debug(`Using parentBranch: ${config.parentBranch}`);
+    logger.debug(`Using reuseExistingBranch: ${config.reuseExistingBranch}`);
     const res = await getUpdatedPackageFiles(config);
     // istanbul ignore if
     if (res.artifactErrors && config.artifactErrors) {

--- a/lib/workers/branch/lock-files/index.spec.ts
+++ b/lib/workers/branch/lock-files/index.spec.ts
@@ -333,7 +333,7 @@ describe('manager/npm/post-update', () => {
     });
     it('returns no error and empty lockfiles if lock file maintenance exists', async () => {
       config.updateType = 'lockFileMaintenance';
-      config.parentBranch = 'renovate/lock-file-maintenance';
+      config.reuseExistingBranch = true;
       platform.branchExists.mockResolvedValueOnce(true);
       const res = await getAdditionalFiles(config, { npm: [{}] });
       expect(res).toMatchSnapshot();

--- a/lib/workers/branch/reuse.spec.ts
+++ b/lib/workers/branch/reuse.spec.ts
@@ -127,7 +127,7 @@ describe('workers/branch/parent', () => {
         isModified: true,
       });
       const res = await shouldReuseExistingBranch(config);
-      expect(res.reuseExistingBranch).not.toBeUndefined();
+      expect(res.reuseExistingBranch).toBe(true);
     });
   });
 });

--- a/lib/workers/common.ts
+++ b/lib/workers/common.ts
@@ -42,7 +42,7 @@ export interface BranchUpgradeConfig
   manager?: string;
   packageFile?: string;
 
-  parentBranch?: string;
+  reuseExistingBranch?: boolean;
   prBanner?: string;
   prBodyNotes?: string[];
   prBodyTemplate?: string;


### PR DESCRIPTION
This refactor removes the last traces of `parentBranch` and renames it to `reuseExistingBranch` to be more understandable.