### PR TITLE
feat(bundler): use renovate cache

### DIFF
--- a/lib/manager/bundler/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/manager/bundler/__snapshots__/artifacts.spec.ts.snap
@@ -26,11 +26,12 @@ Array [
     },
   },
   Object {
-    "cmd": "docker run --rm --name=renovate_ruby --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -w \\"/tmp/github/some/repo\\" renovate/ruby:1.2.0 bash -l -c \\"ruby --version && gem install bundler --no-document && bundle lock --update foo bar\\"",
+    "cmd": "docker run --rm --name=renovate_ruby --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/cache\\":\\"/tmp/cache\\" -e GEM_HOME -w \\"/tmp/github/some/repo\\" renovate/ruby:1.2.0 bash -l -c \\"ruby --version && gem install bundler && bundle lock --update foo bar\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
       "env": Object {
+        "GEM_HOME": "/tmp/cache/others/gem",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",
@@ -71,11 +72,12 @@ Array [
     },
   },
   Object {
-    "cmd": "docker run --rm --name=renovate_ruby --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -w \\"/tmp/github/some/repo\\" renovate/ruby:latest bash -l -c \\"ruby --version && gem install bundler -v 3.2.1 --no-document && bundle lock --update foo bar\\"",
+    "cmd": "docker run --rm --name=renovate_ruby --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/cache\\":\\"/tmp/cache\\" -e GEM_HOME -w \\"/tmp/github/some/repo\\" renovate/ruby:latest bash -l -c \\"ruby --version && gem install bundler -v 3.2.1 && bundle lock --update foo bar\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
       "env": Object {
+        "GEM_HOME": "/tmp/cache/others/gem",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",
@@ -116,12 +118,13 @@ Array [
     },
   },
   Object {
-    "cmd": "docker run --rm --name=renovate_ruby --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -e BUNDLE_GEMS__PRIVATE__COM -w \\"/tmp/github/some/repo\\" renovate/ruby:1.2.0 bash -l -c \\"ruby --version && gem install bundler --no-document && bundle lock --update foo bar\\"",
+    "cmd": "docker run --rm --name=renovate_ruby --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/cache\\":\\"/tmp/cache\\" -e BUNDLE_GEMS__PRIVATE__COM -e GEM_HOME -w \\"/tmp/github/some/repo\\" renovate/ruby:1.2.0 bash -l -c \\"ruby --version && gem install bundler && bundle lock --update foo bar\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
       "env": Object {
         "BUNDLE_GEMS__PRIVATE__COM": "some-user:some-password",
+        "GEM_HOME": "/tmp/cache/others/gem",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",
@@ -162,11 +165,12 @@ Array [
     },
   },
   Object {
-    "cmd": "docker run --rm --name=renovate_ruby --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -w \\"/tmp/github/some/repo\\" renovate/ruby:latest bash -l -c \\"ruby --version && gem install bundler --no-document && bundle lock --update foo bar\\"",
+    "cmd": "docker run --rm --name=renovate_ruby --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/cache\\":\\"/tmp/cache\\" -e GEM_HOME -w \\"/tmp/github/some/repo\\" renovate/ruby:latest bash -l -c \\"ruby --version && gem install bundler && bundle lock --update foo bar\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
       "env": Object {
+        "GEM_HOME": "/tmp/cache/others/gem",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",
@@ -189,6 +193,7 @@ Array [
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
       "env": Object {
+        "GEM_HOME": "/tmp/cache/others/gem",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",
@@ -223,6 +228,7 @@ Array [
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
       "env": Object {
+        "GEM_HOME": "/tmp/cache/others/gem",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",
@@ -247,6 +253,7 @@ Array [
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
       "env": Object {
+        "GEM_HOME": "/tmp/cache/others/gem",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",
@@ -280,6 +287,7 @@ Array [
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
       "env": Object {
+        "GEM_HOME": "/tmp/cache/others/gem",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",
@@ -313,6 +321,7 @@ Array [
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
       "env": Object {
+        "GEM_HOME": "/tmp/cache/others/gem",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",

--- a/lib/manager/bundler/artifacts.spec.ts
+++ b/lib/manager/bundler/artifacts.spec.ts
@@ -41,9 +41,12 @@ describe('bundler.updateArtifacts()', () => {
     jest.resetAllMocks();
     jest.resetModules();
 
+    delete process.env.GEM_HOME;
+
     config = {
       // `join` fixes Windows CI
       localDir: join('/tmp/github/some/repo'),
+      cacheDir: join('/tmp/cache'),
       dockerUser: 'foobar',
     };
 

--- a/lib/manager/bundler/artifacts.ts
+++ b/lib/manager/bundler/artifacts.ts
@@ -18,6 +18,7 @@ import {
   getAuthenticationHeaderValue,
   getDomain,
 } from './host-rules';
+import { getGemHome } from './utils';
 
 const hostConfigVariablePrefix = 'BUNDLE_';
 
@@ -115,7 +116,7 @@ export async function updateArtifacts(
     }
     const preCommands = [
       'ruby --version',
-      `gem install bundler${bundlerVersion} --no-document`,
+      `gem install bundler${bundlerVersion}`,
     ];
 
     const bundlerHostRulesVariables = findAllAuthenticatable({
@@ -126,7 +127,10 @@ export async function updateArtifacts(
 
     const execOptions: ExecOptions = {
       cwdFile: packageFileName,
-      extraEnv: bundlerHostRulesVariables,
+      extraEnv: {
+        ...bundlerHostRulesVariables,
+        GEM_HOME: await getGemHome(config),
+      },
       docker: {
         image: 'renovate/ruby',
         tagScheme: 'ruby',

--- a/lib/manager/bundler/utils.ts
+++ b/lib/manager/bundler/utils.ts
@@ -1,0 +1,14 @@
+import { join } from 'upath';
+import { logger } from '../../logger';
+import { ensureDir } from '../../util/fs';
+import { UpdateArtifactsConfig } from '../common';
+
+export async function getGemHome(
+  config: UpdateArtifactsConfig
+): Promise<string> {
+  const cacheDir =
+    process.env.GEM_HOME || join(config.cacheDir, './others/gem');
+  await ensureDir(cacheDir);
+  logger.debug(`Using gem home ${cacheDir}`);
+  return cacheDir;
+}


### PR DESCRIPTION
This allows renovate to cache the gem files, useful for docker, so bundler install can reused for multiple branches