### PR TITLE
docs: extra explanation about github api token when self hosting

### DIFF
--- a/docs/development/self-hosting.md
+++ b/docs/development/self-hosting.md
@@ -149,6 +149,8 @@ Don't forget to configure `platform=gitea` somewhere in config.
 
 If you are running on any platform except github.com, it's important to also configure `GITHUB_COM_TOKEN` containing a personal access token for github.com. This account can actually be _any_ account on GitHub, and needs only read-only access. It's used when fetching release notes for repositories in order to increase the hourly API limit.
 
+**Note:** If you're using renovate in a project where dependencies are loaded from github (such as go modules hosted on github) it is highly reccomended to add a github token as you will run in the rate limit from the github api, which will lead to renovate closing and reopening PRs because it could not get reliable info on updated dependencies.
+
 ## File/directory usage
 
 By default, Renovate will store all files within a `renovate/` subdirectory of the operating system's temporary directory, e.g. `/tmp/renovate/`.


### PR DESCRIPTION
This PR clarifies the docs about using renovate self hosted with dependencies which are hosted on github and their api limits.

See #6283