### PR TITLE
feat(yarn): update yarn-deduplicate to v2

### DIFF
--- a/lib/manager/npm/post-update/yarn.ts
+++ b/lib/manager/npm/post-update/yarn.ts
@@ -86,7 +86,7 @@ export async function generateLockFile(
     ) {
       logger.debug('Performing yarn dedupe fewer');
       const dedupeCommand =
-        'npx yarn-deduplicate@2 --strategy fewer && yarn';
+        'npx yarn-deduplicate@2.0.0 --strategy fewer && yarn';
       const dedupeRes = await exec(dedupeCommand, {
         cwd,
         env,
@@ -101,7 +101,7 @@ export async function generateLockFile(
     ) {
       logger.debug('Performing yarn dedupe highest');
       const dedupeCommand =
-        'npx yarn-deduplicate@2 --strategy highest && yarn';
+        'npx yarn-deduplicate@2.0.0 --strategy highest && yarn';
       const dedupeRes = await exec(dedupeCommand, {
         cwd,
         env,

--- a/lib/manager/npm/post-update/yarn.ts
+++ b/lib/manager/npm/post-update/yarn.ts
@@ -85,8 +85,7 @@ export async function generateLockFile(
       config.postUpdateOptions.includes('yarnDedupeFewer')
     ) {
       logger.debug('Performing yarn dedupe fewer');
-      const dedupeCommand =
-        'npx yarn-deduplicate --strategy fewer && yarn';
+      const dedupeCommand = 'npx yarn-deduplicate --strategy fewer && yarn';
       const dedupeRes = await exec(dedupeCommand, {
         cwd,
         env,
@@ -100,8 +99,7 @@ export async function generateLockFile(
       config.postUpdateOptions.includes('yarnDedupeHighest')
     ) {
       logger.debug('Performing yarn dedupe highest');
-      const dedupeCommand =
-        'npx yarn-deduplicate --strategy highest && yarn';
+      const dedupeCommand = 'npx yarn-deduplicate --strategy highest && yarn';
       const dedupeRes = await exec(dedupeCommand, {
         cwd,
         env,

--- a/lib/manager/npm/post-update/yarn.ts
+++ b/lib/manager/npm/post-update/yarn.ts
@@ -86,7 +86,7 @@ export async function generateLockFile(
     ) {
       logger.debug('Performing yarn dedupe fewer');
       const dedupeCommand =
-        'npx yarn-deduplicate@1.1.1 --strategy fewer && yarn';
+        'npx yarn-deduplicate@2 --strategy fewer && yarn';
       const dedupeRes = await exec(dedupeCommand, {
         cwd,
         env,
@@ -101,7 +101,7 @@ export async function generateLockFile(
     ) {
       logger.debug('Performing yarn dedupe highest');
       const dedupeCommand =
-        'npx yarn-deduplicate@1.1.1 --strategy highest && yarn';
+        'npx yarn-deduplicate@2 --strategy highest && yarn';
       const dedupeRes = await exec(dedupeCommand, {
         cwd,
         env,

--- a/lib/manager/npm/post-update/yarn.ts
+++ b/lib/manager/npm/post-update/yarn.ts
@@ -86,7 +86,7 @@ export async function generateLockFile(
     ) {
       logger.debug('Performing yarn dedupe fewer');
       const dedupeCommand =
-        'npx yarn-deduplicate@2.0.0 --strategy fewer && yarn';
+        'npx yarn-deduplicate --strategy fewer && yarn';
       const dedupeRes = await exec(dedupeCommand, {
         cwd,
         env,
@@ -101,7 +101,7 @@ export async function generateLockFile(
     ) {
       logger.debug('Performing yarn dedupe highest');
       const dedupeCommand =
-        'npx yarn-deduplicate@2.0.0 --strategy highest && yarn';
+        'npx yarn-deduplicate --strategy highest && yarn';
       const dedupeRes = await exec(dedupeCommand, {
         cwd,
         env,

--- a/lib/workers/branch/lock-files/__snapshots__/yarn.spec.ts.snap
+++ b/lib/workers/branch/lock-files/__snapshots__/yarn.spec.ts.snap
@@ -103,7 +103,7 @@ Array [
     },
   },
   Object {
-    "cmd": "npx yarn-deduplicate@1.1.1 --strategy fewer && yarn",
+    "cmd": "npx yarn-deduplicate@2.0.0 --strategy fewer && yarn",
     "options": Object {
       "cwd": "some-dir",
       "encoding": "utf-8",
@@ -120,7 +120,7 @@ Array [
     },
   },
   Object {
-    "cmd": "npx yarn-deduplicate@1.1.1 --strategy highest && yarn",
+    "cmd": "npx yarn-deduplicate@2.0.0 --strategy highest && yarn",
     "options": Object {
       "cwd": "some-dir",
       "encoding": "utf-8",

--- a/lib/workers/branch/lock-files/__snapshots__/yarn.spec.ts.snap
+++ b/lib/workers/branch/lock-files/__snapshots__/yarn.spec.ts.snap
@@ -103,7 +103,7 @@ Array [
     },
   },
   Object {
-    "cmd": "npx yarn-deduplicate@2.0.0 --strategy fewer && yarn",
+    "cmd": "npx yarn-deduplicate --strategy fewer && yarn",
     "options": Object {
       "cwd": "some-dir",
       "encoding": "utf-8",
@@ -120,7 +120,7 @@ Array [
     },
   },
   Object {
-    "cmd": "npx yarn-deduplicate@2.0.0 --strategy highest && yarn",
+    "cmd": "npx yarn-deduplicate --strategy highest && yarn",
     "options": Object {
       "cwd": "some-dir",
       "encoding": "utf-8",


### PR DESCRIPTION
<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate

    Please ensure `Allow edits from maintainers.` checkbox is checked
-->

Update yarn-deduplicate to v2
I saw we had diffs on duplicated dependencies yarn.lock after some renovate prs were merged. After investigation, we don't have the same version, it could be related.

https://github.com/atlassian/yarn-deduplicate/blob/master/CHANGELOG.md
