### PR TITLE
feat(kustomize): Add support for bases defined in the resources block

### DIFF
--- a/lib/manager/kustomize/__fixtures__/depsInResources.yaml
+++ b/lib/manager/kustomize/__fixtures__/depsInResources.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: testing-namespace
+
+bases:
+- git@github.com:moredhel/remote-kustomize.git?ref=v0.0.1
+
+resources:
+- deployment.yaml
+- github.com/fluxcd/flux/deploy?ref=1.19.0
+
+images:
+- name: nginx

--- a/lib/manager/kustomize/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/kustomize/__snapshots__/extract.spec.ts.snap
@@ -56,6 +56,23 @@ Array [
 ]
 `;
 
+exports[`manager/kustomize/extract extractPackageFile() should extract bases from bases block and the resources block 1`] = `
+Array [
+  Object {
+    "currentValue": "v0.0.1",
+    "datasource": "git-tags",
+    "depName": "git@github.com:moredhel/remote-kustomize.git",
+    "lookupName": "git@github.com:moredhel/remote-kustomize.git",
+  },
+  Object {
+    "currentValue": "1.19.0",
+    "datasource": "github-tags",
+    "depName": "fluxcd/flux/deploy",
+    "lookupName": "fluxcd/flux",
+  },
+]
+`;
+
 exports[`manager/kustomize/extract extractPackageFile() should extract out image versions 1`] = `
 Array [
   Object {

--- a/lib/manager/kustomize/extract.spec.ts
+++ b/lib/manager/kustomize/extract.spec.ts
@@ -44,6 +44,11 @@ const gitImages = readFileSync(
   'utf8'
 );
 
+const kustomizeDepsInResources = readFileSync(
+  'lib/manager/kustomize/__fixtures__/depsInResources.yaml',
+  'utf8'
+);
+
 describe('manager/kustomize/extract', () => {
   it('should successfully parse a valid kustomize file', () => {
     const file = parseKustomize(kustomizeGitSSHBase);
@@ -226,6 +231,16 @@ describe('manager/kustomize/extract', () => {
     });
     it('does nothing with kustomize empty kustomize files', () => {
       expect(extractPackageFile(kustomizeEmpty)).toBeNull();
+    });
+    it('should extract bases from bases block and the resources block', () => {
+      const res = extractPackageFile(kustomizeDepsInResources);
+      expect(res).not.toBeNull();
+      expect(res.deps).toMatchSnapshot();
+      expect(res.deps).toHaveLength(2);
+      expect(res.deps[0].currentValue).toEqual('v0.0.1');
+      expect(res.deps[1].currentValue).toEqual('1.19.0');
+      expect(res.deps[1].depName).toEqual('fluxcd/flux/deploy');
+      expect(res.deps[1].lookupName).toEqual('fluxcd/flux');
     });
   });
 });

--- a/lib/manager/kustomize/extract.ts
+++ b/lib/manager/kustomize/extract.ts
@@ -90,7 +90,7 @@ export function parseKustomize(content: string): Kustomize | null {
     return null;
   }
 
-  pkg.bases = pkg.bases || [];
+  pkg.bases = (pkg.bases || []).concat(pkg.resources || []);
   pkg.images = pkg.images || [];
 
   return pkg;


### PR DESCRIPTION
<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate

    Please ensure `Allow edits from maintainers.` checkbox is checked
-->
Kustomize has deprecated putting bases under the `bases` block, instead they should be placed under `resources`. This PR updates the parser to look under `resources`.

<!-- Replace this text with a description of what this PR fixes or adds -->

Closes #6245