### PR TITLE
test(hex): Update versioning spec for Hex

### DIFF
--- a/lib/versioning/hex/index.spec.ts
+++ b/lib/versioning/hex/index.spec.ts
@@ -7,6 +7,8 @@ describe('lib/versioning/hex', () => {
       expect(hexScheme.matches('2.1.0', '~> 2.0.0')).toBe(false);
       expect(hexScheme.matches('2.0.0', '>= 2.0.0 and < 2.1.0')).toBe(true);
       expect(hexScheme.matches('2.1.0', '== 2.0.0 or < 2.1.0')).toBe(false);
+      expect(hexScheme.matches('1.9.4', '== 1.9.4')).toBe(true);
+      expect(hexScheme.matches('1.9.5', '== 1.9.4')).toBe(false);
     });
   });
   it('handles tilde greater than', () => {
@@ -32,6 +34,9 @@ describe('lib/versioning/hex', () => {
     });
     it('handles !=', () => {
       expect(hexScheme.isValid('!= 1.0.0')).toBeTruthy();
+    });
+    it('handles ==', () => {
+      expect(hexScheme.isValid('== 1.0.0')).toBeTruthy();
     });
   });
   describe('hexScheme.isLessThanRange()', () => {
@@ -69,6 +74,16 @@ describe('lib/versioning/hex', () => {
     });
   });
   describe('hexScheme.getNewValue()', () => {
+    it('handles exact', () => {
+      expect(
+        hexScheme.getNewValue({
+          currentValue: '== 1.2.3',
+          rangeStrategy: 'pin',
+          fromVersion: '1.2.3',
+          toVersion: '2.0.7',
+        })
+      ).toEqual('== 2.0.7');
+    });
     it('handles tilde greater than', () => {
       expect(
         hexScheme.getNewValue({
@@ -85,7 +100,7 @@ describe('lib/versioning/hex', () => {
           fromVersion: '1.2.3',
           toVersion: '2.0.7',
         })
-      ).toEqual('2.0.7');
+      ).toEqual('== 2.0.7');
       expect(
         hexScheme.getNewValue({
           currentValue: '~> 1.2',
@@ -109,7 +124,7 @@ describe('lib/versioning/hex', () => {
           fromVersion: '1.2.3',
           toVersion: '2.0.7',
         })
-      ).toEqual('2.0.7');
+      ).toEqual('== 2.0.7');
       expect(
         hexScheme.getNewValue({
           currentValue: '~> 1.2.0',
@@ -144,7 +159,7 @@ describe('lib/versioning/hex', () => {
         fromVersion: '1.2.3',
         toVersion: '2.0.7',
       })
-    ).toEqual('2.0.7');
+    ).toEqual('== 2.0.7');
   });
   it('handles or', () => {
     expect(
@@ -170,6 +185,6 @@ describe('lib/versioning/hex', () => {
         fromVersion: '1.2.3',
         toVersion: '2.0.7',
       })
-    ).toEqual('2.0.7');
+    ).toEqual('== 2.0.7');
   });
 });

--- a/lib/versioning/hex/index.spec.ts
+++ b/lib/versioning/hex/index.spec.ts
@@ -83,6 +83,22 @@ describe('lib/versioning/hex', () => {
           toVersion: '2.0.7',
         })
       ).toEqual('== 2.0.7');
+      expect(
+        hexScheme.getNewValue({
+          currentValue: '== 3.6.1',
+          rangeStrategy: 'bump',
+          fromVersion: '3.6.1',
+          toVersion: '3.6.2',
+        })
+      ).toEqual('~> 3.6.2');
+      expect(
+        hexScheme.getNewValue({
+          currentValue: '== 3.6.1',
+          rangeStrategy: 'replace',
+          fromVersion: '3.6.1',
+          toVersion: '3.6.2',
+        })
+      ).toEqual('~> 3.6');
     });
     it('handles tilde greater than', () => {
       expect(


### PR DESCRIPTION
As per https://github.com/renovatebot/renovate/issues/6285

This PR is to serve as aid when updating actual implementation.
This PR will intentionally fail.