### PR TITLE
feat(dotnet): support dotnet-tools

### DIFF
--- a/lib/manager/nuget/__fixtures__/with-config-file/NuGet.config
+++ b/lib/manager/nuget/__fixtures__/with-config-file/NuGet.config
@@ -4,5 +4,6 @@
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
     <add key="Contoso" value="https://contoso.com/packages/" />
+    <remove key="test" />
   </packageSources>
 </configuration>

--- a/lib/manager/nuget/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/nuget/__snapshots__/extract.spec.ts.snap
@@ -1,5 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`lib/manager/nuget/extract extractPackageFile() .config/dotnet-tools.json with-config 1`] = `
+Object {
+  "deps": Array [
+    Object {
+      "currentValue": "2.0.0",
+      "datasource": "nuget",
+      "depName": "minver-cli",
+      "depType": "nuget",
+      "registryUrls": Array [
+        "https://api.nuget.org/v3/index.json#protocolVersion=3",
+        "https://contoso.com/packages/",
+      ],
+    },
+  ],
+}
+`;
+
+exports[`lib/manager/nuget/extract extractPackageFile() .config/dotnet-tools.json works 1`] = `
+Object {
+  "deps": Array [
+    Object {
+      "currentValue": "2.0.0",
+      "datasource": "nuget",
+      "depName": "minver-cli",
+      "depType": "nuget",
+    },
+  ],
+}
+`;
+
 exports[`lib/manager/nuget/extract extractPackageFile() considers NuGet.config 1`] = `
 Object {
   "deps": Array [

--- a/lib/manager/nuget/extract.spec.ts
+++ b/lib/manager/nuget/extract.spec.ts
@@ -1,10 +1,11 @@
 import { readFileSync } from 'fs';
 import * as path from 'path';
+import { ExtractConfig } from '../common';
 import { extractPackageFile } from './extract';
 
 describe('lib/manager/nuget/extract', () => {
   describe('extractPackageFile()', () => {
-    let config;
+    let config: ExtractConfig;
     beforeEach(() => {
       config = {
         localDir: path.resolve('lib/manager/nuget/__fixtures__'),
@@ -83,6 +84,49 @@ describe('lib/manager/nuget/extract', () => {
       expect(
         await extractPackageFile(contents, packageFile, config)
       ).toMatchSnapshot();
+    });
+
+    describe('.config/dotnet-tools.json', () => {
+      const packageFile = '.config/dotnet-tools.json';
+      const contents = `{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "minver-cli": {
+      "version": "2.0.0",
+      "commands": ["minver"]
+    }
+  }
+}`;
+      it('works', async () => {
+        expect(
+          await extractPackageFile(contents, packageFile, config)
+        ).toMatchSnapshot();
+      });
+
+      it('with-config', async () => {
+        expect(
+          await extractPackageFile(
+            contents,
+            `with-config-file/${packageFile}`,
+            config
+          )
+        ).toMatchSnapshot();
+      });
+
+      it('wrong version', async () => {
+        expect(
+          await extractPackageFile(
+            contents.replace('"version": 1,', '"version": 2,'),
+            packageFile,
+            config
+          )
+        ).toBeNull();
+      });
+
+      it('does not throw', async () => {
+        expect(await extractPackageFile('{{', packageFile, config)).toBeNull();
+      });
     });
   });
 });

--- a/lib/manager/nuget/index.ts
+++ b/lib/manager/nuget/index.ts
@@ -5,5 +5,9 @@ export { extractPackageFile } from './extract';
 export const language = LANGUAGE_DOT_NET;
 
 export const defaultConfig = {
-  fileMatch: ['\\.(?:cs|fs|vb)proj$'],
+  fileMatch: [
+    '\\.(?:cs|fs|vb)proj$',
+    '\\.(?:props|targets)$',
+    '\\.config\\/dotnet-tools\\.json$',
+  ],
 };

--- a/lib/manager/nuget/types.ts
+++ b/lib/manager/nuget/types.ts
@@ -1,0 +1,11 @@
+export interface DotnetToolsManifest {
+  readonly version: number;
+  readonly isRoot: boolean;
+
+  readonly tools: Record<string, DotnetTool>;
+}
+
+export interface DotnetTool {
+  readonly version: string;
+  readonly commands: string[];
+}


### PR DESCRIPTION
* add support for `.config/dotnet-tools.json` files
* adds `*.props` and `*.targets` files to `fileMatch` (often used for shared configs)

Closes #4816

/cc @fgreinacher