### PR TITLE
fix(gitlab): Include ref in /projects/:id/statuses/:sha call

### DIFF
--- a/lib/platform/gitlab/__snapshots__/index.spec.ts.snap
+++ b/lib/platform/gitlab/__snapshots__/index.spec.ts.snap
@@ -2219,11 +2219,11 @@ Array [
     "url": "https://gitlab.com/api/v4/user",
   },
   Object {
-    "body": "{\\"state\\":\\"success\\",\\"description\\":\\"some-description\\",\\"context\\":\\"some-context\\",\\"target_url\\":\\"some-url\\"}",
+    "body": "{\\"state\\":\\"success\\",\\"ref\\":\\"0d9c7726c3d628b7e28af234595cfd20febdbf8e\\",\\"description\\":\\"some-description\\",\\"context\\":\\"some-context\\",\\"target_url\\":\\"some-url\\"}",
     "headers": Object {
       "accept": "application/json",
       "accept-encoding": "gzip, deflate",
-      "content-length": 101,
+      "content-length": 150,
       "content-type": "application/json",
       "host": "gitlab.com",
       "private-token": "abc123",
@@ -2271,11 +2271,11 @@ Array [
     "url": "https://gitlab.com/api/v4/user",
   },
   Object {
-    "body": "{\\"state\\":\\"failed\\",\\"description\\":\\"some-description\\",\\"context\\":\\"some-context\\",\\"target_url\\":\\"some-url\\"}",
+    "body": "{\\"state\\":\\"failed\\",\\"ref\\":\\"0d9c7726c3d628b7e28af234595cfd20febdbf8e\\",\\"description\\":\\"some-description\\",\\"context\\":\\"some-context\\",\\"target_url\\":\\"some-url\\"}",
     "headers": Object {
       "accept": "application/json",
       "accept-encoding": "gzip, deflate",
-      "content-length": 100,
+      "content-length": 149,
       "content-type": "application/json",
       "host": "gitlab.com",
       "private-token": "abc123",
@@ -2323,11 +2323,11 @@ Array [
     "url": "https://gitlab.com/api/v4/user",
   },
   Object {
-    "body": "{\\"state\\":\\"pending\\",\\"description\\":\\"some-description\\",\\"context\\":\\"some-context\\",\\"target_url\\":\\"some-url\\"}",
+    "body": "{\\"state\\":\\"pending\\",\\"ref\\":\\"0d9c7726c3d628b7e28af234595cfd20febdbf8e\\",\\"description\\":\\"some-description\\",\\"context\\":\\"some-context\\",\\"target_url\\":\\"some-url\\"}",
     "headers": Object {
       "accept": "application/json",
       "accept-encoding": "gzip, deflate",
-      "content-length": 101,
+      "content-length": 150,
       "content-type": "application/json",
       "host": "gitlab.com",
       "private-token": "abc123",

--- a/lib/platform/gitlab/index.ts
+++ b/lib/platform/gitlab/index.ts
@@ -643,9 +643,9 @@ export async function setBranchStatus({
   url: targetUrl,
 }: BranchStatusConfig): Promise<void> {
   // First, get the branch commit SHA
-  const branchSha = await config.storage.getBranchCommit(branchName);
+  const ref = await config.storage.getBranchCommit(branchName);
   // Now, check the statuses for that commit
-  const url = `projects/${config.repository}/statuses/${branchSha}`;
+  const url = `projects/${config.repository}/statuses/${ref}`;
   let state = 'success';
   if (renovateState === BranchStatus.yellow) {
     state = 'pending';
@@ -654,6 +654,7 @@ export async function setBranchStatus({
   }
   const options: any = {
     state,
+    ref,
     description,
     context,
   };


### PR DESCRIPTION
If you don't explicitly pass ` ref` to https://docs.gitlab.com/ee/api/commits.html#post-the-build-status-to-a-commit, GitLab seems to guess https://gitlab.com/gitlab-org/gitlab/-/issues/14064. Which is leading to it creating a separate pipeline.

The issue says if you explicitly pass a `ref` then it resolves the issue.

Closes #5743
