### PR TITLE
feat(internal): Make changelog JSON available to commit message body

### DIFF
--- a/lib/util/template/index.ts
+++ b/lib/util/template/index.ts
@@ -32,6 +32,7 @@ export const exposedConfigOptions = [
 
 export const allowedFields = {
   baseDir: 'The full directory with path that the dependency has been found in',
+  body: 'The body of the release notes',
   currentValue: 'The extracted current value of the dependency being updated',
   currentVersion: 'The current version that is being updated',
   datasource: 'The datasource used to look up the upgrade',
@@ -46,12 +47,14 @@ export const allowedFields = {
   displayTo: 'The to value, formatted for display',
   fromVersion:
     'The version that would be currently installed. For example, if currentValue is ^3.0.0 then currentVersion might be 3.1.0.',
+  hasReleaseNotes: 'true if the upgrade has release notes',
   isLockfileUpdate: 'true if the branch is a lock file update',
   isMajor: 'true if the upgrade is major',
   isPatch: 'true if the upgrade is a patch upgrade',
   isRange: 'true if the new value is a range',
   isSingleVersion:
     'true if the upgrade is to a single version rather than a range',
+  logJSON: 'ChangeLogResult object for the upgrade',
   lookupName: 'The full name that was used to look up the dependency.',
   newDigest: 'The new digest value',
   newDigestShort:
@@ -67,13 +70,18 @@ export const allowedFields = {
   parentDir:
     'The name of the directory that the dependency was found in, without full path',
   platform: 'VCS platform in use, e.g. "github", "gitlab", etc.',
+  project: 'ChangeLogProject object',
   recreateClosed: 'If true, this PR will be recreated if closed',
   references: 'A list of references for the upgrade',
   releases: 'An array of releases for an upgrade',
+  releaseNotes: 'A ChangeLogNotes object for the release',
   repository: 'The current repository',
   toVersion: 'The new version in the upgrade, e.g. "3.1.0"',
   updateType: 'One of digest, pin, rollback, patch, minor, major',
   upgrades: 'An array of upgrade objects in the branch',
+  url: 'The url of the release notes',
+  version: 'The version number of the changelog',
+  versions: 'An array of ChangeLogRelease objects in the upgrade',
 };
 
 function getFilteredObject(input: any): any {

--- a/lib/workers/repository/changelog/index.ts
+++ b/lib/workers/repository/changelog/index.ts
@@ -7,10 +7,10 @@ async function embedChangelog(upgrade): Promise<void> {
 }
 
 // istanbul ignore next
-export async function embedChangelogs(branches): Promise<void> {
+export async function embedChangelogs(branchUpgrades): Promise<void> {
   const upgrades = [];
-  for (const branch of branches) {
-    for (const upgrade of branch.upgrades) {
+  for (const branchName of Object.keys(branchUpgrades)) {
+    for (const upgrade of branchUpgrades[branchName]) {
       upgrades.push(upgrade);
     }
   }

--- a/lib/workers/repository/index.ts
+++ b/lib/workers/repository/index.ts
@@ -3,7 +3,6 @@ import { RenovateConfig } from '../../config';
 import { logger, setMeta } from '../../logger';
 import { platform } from '../../platform';
 import { addSplit, getSplits, splitInit } from '../../util/split';
-import { embedChangelogs } from './changelog';
 import handleError from './error';
 import { finaliseRepo } from './finalise';
 import { initRepo } from './init';
@@ -38,8 +37,6 @@ export async function renovateRepository(
       config
     );
     await ensureOnboardingPr(config, packageFiles, branches);
-    await embedChangelogs(branches);
-    addSplit('changelogs');
     const res = await updateRepo(config, branches, branchList);
     addSplit('update');
     if (res !== 'automerged') {

--- a/lib/workers/repository/updates/branchify.ts
+++ b/lib/workers/repository/updates/branchify.ts
@@ -4,6 +4,7 @@ import { RenovateConfig, ValidationMessage } from '../../../config';
 import { addMeta, logger, removeMeta } from '../../../logger';
 import * as template from '../../../util/template';
 import { BranchConfig, BranchUpgradeConfig } from '../../common';
+import { embedChangelogs } from '../changelog';
 import { flattenUpdates } from './flatten';
 import { generateBranchConfig } from './generate';
 import { Merge } from 'type-fest';
@@ -109,6 +110,7 @@ export async function branchifyUpgrades(
     );
   }
   logger.debug(`Returning ${Object.keys(branchUpgrades).length} branch(es)`);
+  await embedChangelogs(branchUpgrades);
   for (const branchName of Object.keys(branchUpgrades)) {
     // Add branch name to metadata before generating branch config
     addMeta({


### PR DESCRIPTION
<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate

    Please ensure `Allow edits from maintainers.` checkbox is checked
-->

I think I've kept the concurrent changelog fetching

Example of this working is here: https://github.com/mikebryant/renovate-test-changelogjson/pull/5/commits

Closes #6337
