### PR TITLE
fix(presets): replace to vercel/next.js from zeit/next.js

### DIFF
--- a/lib/config/presets/internal/monorepo.ts
+++ b/lib/config/presets/internal/monorepo.ts
@@ -81,7 +81,7 @@ const repoGroups = {
     'https://github.com/neutrinojs/neutrino',
     'https://github.com/mozilla-neutrino/neutrino-dev',
   ],
-  nextjs: 'https://github.com/zeit/next.js',
+  nextjs: 'https://github.com/vercel/next.js',
   ngrx: 'https://github.com/ngrx/',
   nrwl: 'https://github.com/nrwl/',
   nuxtjs: 'https://github.com/nuxt/nuxt.js',

--- a/lib/config/presets/internal/monorepo.ts
+++ b/lib/config/presets/internal/monorepo.ts
@@ -81,7 +81,10 @@ const repoGroups = {
     'https://github.com/neutrinojs/neutrino',
     'https://github.com/mozilla-neutrino/neutrino-dev',
   ],
-  nextjs: 'https://github.com/vercel/next.js',
+  nextjs: [
+    'https://github.com/zeit/next.js', // for compatibility
+    'https://github.com/vercel/next.js',
+  ],
   ngrx: 'https://github.com/ngrx/',
   nrwl: 'https://github.com/nrwl/',
   nuxtjs: 'https://github.com/nuxt/nuxt.js',


### PR DESCRIPTION
Next.js repository has changed organization.

ref: https://github.com/vercel/next.js/pull/13463