### PR TITLE
fix: Add url to GITHUB_COM_TOKEN config required for change logs

### DIFF
--- a/lib/config/env.ts
+++ b/lib/config/env.ts
@@ -62,6 +62,7 @@ export function getConfig(env: NodeJS.ProcessEnv): RenovateConfig {
       hostType: PLATFORM_TYPE_GITHUB,
       domainName: 'github.com',
       token: env.GITHUB_COM_TOKEN,
+      url: 'https://api.github.com/',
     });
   }
 


### PR DESCRIPTION
The url property is used for the lookup in https://github.com/renovatebot/renovate/blob/9617248f86adb5007b370353926e6c022ab8092e/lib/workers/pr/changelog/source-github.ts#L76-L82

Without it you get the `WARN: No github.com token has been configured. Skipping release notes retrieval` even with `GITHUB_COM_TOKEN` set