### PR TITLE
refactor(gitea): Use nock for tests

### DIFF
--- a/lib/platform/gitea/__snapshots__/gitea-got-wrapper.spec.ts.snap
+++ b/lib/platform/gitea/__snapshots__/gitea-got-wrapper.spec.ts.snap
@@ -1,36 +1,86 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`platform/gitea/gitea-got-wrapper supports pagination on data property 1`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/pagination-example-2",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/pagination-example-2?page=2",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/pagination-example-2?page=3",
+  },
+]
+`;
+
+exports[`platform/gitea/gitea-got-wrapper supports responses without pagination when enabled 1`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/pagination-example-1",
+  },
+]
+`;
+
 exports[`platform/gitea/gitea-got-wrapper supports root-level pagination 1`] = `
 Array [
-  Array [
-    "https://gitea.renovatebot.com/api/v1/pagination-example-1",
-    Object {
-      "baseUrl": "https://gitea.renovatebot.com/api/v1",
-      "hostType": "gitea",
-      "json": true,
-      "method": "GET",
-      "paginate": true,
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
     },
-  ],
-  Array [
-    "https://gitea.renovatebot.com/api/v1/pagination-example-1?page=2",
-    Object {
-      "baseUrl": "https://gitea.renovatebot.com/api/v1",
-      "hostType": "gitea",
-      "json": true,
-      "method": "GET",
-      "paginate": true,
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/pagination-example-1",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
     },
-  ],
-  Array [
-    "https://gitea.renovatebot.com/api/v1/pagination-example-1?page=3",
-    Object {
-      "baseUrl": "https://gitea.renovatebot.com/api/v1",
-      "hostType": "gitea",
-      "json": true,
-      "method": "GET",
-      "paginate": true,
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/pagination-example-1?page=2",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
     },
-  ],
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/pagination-example-1?page=3",
+  },
 ]
 `;

--- a/lib/platform/gitea/__snapshots__/gitea-helper.spec.ts.snap
+++ b/lib/platform/gitea/__snapshots__/gitea-helper.spec.ts.snap
@@ -1,0 +1,736 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`platform/gitea/gitea-helper closeIssue should call /api/v1/repos/[repo]/issues/[issue] endpoint 1`] = `
+Array [
+  Object {
+    "body": "{\\"state\\":\\"closed\\"}",
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "content-length": 18,
+      "content-type": "application/json",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "PATCH",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/issues/7",
+  },
+]
+`;
+
+exports[`platform/gitea/gitea-helper closePR should call /api/v1/repos/[repo]/pulls/[pull] endpoint 1`] = `
+Array [
+  Object {
+    "body": "{\\"state\\":\\"closed\\"}",
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "content-length": 18,
+      "content-type": "application/json",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "PATCH",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/pulls/13",
+  },
+]
+`;
+
+exports[`platform/gitea/gitea-helper createComment should call /api/v1/repos/[repo]/issues/[issue]/comments endpoint 1`] = `
+Array [
+  Object {
+    "body": "{\\"body\\":\\"some-comment\\"}",
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "content-length": 23,
+      "content-type": "application/json",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "POST",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/issues/7/comments",
+  },
+]
+`;
+
+exports[`platform/gitea/gitea-helper createCommitStatus should call /api/v1/repos/[repo]/statuses/[commit] endpoint 1`] = `
+Array [
+  Object {
+    "body": "{\\"state\\":\\"success\\",\\"context\\":\\"some-context\\",\\"description\\":\\"some-description\\",\\"target_url\\":\\"https://gitea.renovatebot.com/commit-status\\"}",
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "content-length": 136,
+      "content-type": "application/json",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "POST",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/statuses/0d9c7726c3d628b7e28af234595cfd20febdbf8e",
+  },
+]
+`;
+
+exports[`platform/gitea/gitea-helper createIssue should call /api/v1/repos/[repo]/issues endpoint 1`] = `
+Array [
+  Object {
+    "body": "{\\"state\\":\\"open\\",\\"title\\":\\"Some Issue\\",\\"body\\":\\"just some issue\\",\\"assignees\\":[\\"admin\\"]}",
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "content-length": 84,
+      "content-type": "application/json",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "POST",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/issues",
+  },
+]
+`;
+
+exports[`platform/gitea/gitea-helper createPR should call /api/v1/repos/[repo]/pulls endpoint 1`] = `
+Array [
+  Object {
+    "body": "{\\"state\\":\\"open\\",\\"title\\":\\"Some PR\\",\\"body\\":\\"Lorem ipsum dolor sit amet\\",\\"base\\":\\"master\\",\\"head\\":\\"pull-req-13\\",\\"assignees\\":[\\"admin\\"],\\"labels\\":[100]}",
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "content-length": 144,
+      "content-type": "application/json",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "POST",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/pulls",
+  },
+]
+`;
+
+exports[`platform/gitea/gitea-helper deleteComment should call /api/v1/repos/[repo]/issues/comments/[comment] endpoint 1`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "DELETE",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/issues/comments/31",
+  },
+]
+`;
+
+exports[`platform/gitea/gitea-helper getBranch should call /api/v1/repos/[repo]/branches/[branch] endpoint 1`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/branches/some-branch",
+  },
+]
+`;
+
+exports[`platform/gitea/gitea-helper getBranch should properly escape branch names 1`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/branches/other%2Fbranch%2Fwith%2Fslashes",
+  },
+]
+`;
+
+exports[`platform/gitea/gitea-helper getCombinedCommitStatus should call /api/v1/repos/[repo]/commits/[branch]/statuses endpoint 1`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/commits/some-branch/statuses",
+  },
+]
+`;
+
+exports[`platform/gitea/gitea-helper getCombinedCommitStatus should properly determine worst commit status 1`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/commits/some-branch/statuses",
+  },
+]
+`;
+
+exports[`platform/gitea/gitea-helper getCombinedCommitStatus should properly determine worst commit status 2`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/commits/some-branch/statuses",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/commits/some-branch/statuses",
+  },
+]
+`;
+
+exports[`platform/gitea/gitea-helper getCombinedCommitStatus should properly determine worst commit status 3`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/commits/some-branch/statuses",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/commits/some-branch/statuses",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/commits/some-branch/statuses",
+  },
+]
+`;
+
+exports[`platform/gitea/gitea-helper getCombinedCommitStatus should properly determine worst commit status 4`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/commits/some-branch/statuses",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/commits/some-branch/statuses",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/commits/some-branch/statuses",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/commits/some-branch/statuses",
+  },
+]
+`;
+
+exports[`platform/gitea/gitea-helper getCombinedCommitStatus should properly determine worst commit status 5`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/commits/some-branch/statuses",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/commits/some-branch/statuses",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/commits/some-branch/statuses",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/commits/some-branch/statuses",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/commits/some-branch/statuses",
+  },
+]
+`;
+
+exports[`platform/gitea/gitea-helper getCombinedCommitStatus should properly determine worst commit status 6`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/commits/some-branch/statuses",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/commits/some-branch/statuses",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/commits/some-branch/statuses",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/commits/some-branch/statuses",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/commits/some-branch/statuses",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/commits/some-branch/statuses",
+  },
+]
+`;
+
+exports[`platform/gitea/gitea-helper getComments should call /api/v1/repos/[repo]/issues/[issue]/comments endpoint 1`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/issues/7/comments",
+  },
+]
+`;
+
+exports[`platform/gitea/gitea-helper getCurrentUser should call /api/v1/user endpoint 1`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/user",
+  },
+]
+`;
+
+exports[`platform/gitea/gitea-helper getOrgLabels should call /api/v1/orgs/[org]/labels endpoint 1`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/orgs/admin/labels",
+  },
+]
+`;
+
+exports[`platform/gitea/gitea-helper getPR should call /api/v1/repos/[repo]/pulls/[pull] endpoint 1`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/pulls/13",
+  },
+]
+`;
+
+exports[`platform/gitea/gitea-helper getRepo should call /api/v1/repos/[repo] endpoint 1`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo",
+  },
+]
+`;
+
+exports[`platform/gitea/gitea-helper getRepoContents should call /api/v1/repos/[repo]/contents/[file] endpoint 1`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/contents/dummy.txt?",
+  },
+]
+`;
+
+exports[`platform/gitea/gitea-helper getRepoContents should properly escape paths 1`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/contents/nested%2Fpath%2Fdummy.txt?",
+  },
+]
+`;
+
+exports[`platform/gitea/gitea-helper getRepoContents should support passing reference by query 1`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/contents/dummy.txt?ref=0d9c7726c3d628b7e28af234595cfd20febdbf8e",
+  },
+]
+`;
+
+exports[`platform/gitea/gitea-helper getRepoLabels should call /api/v1/repos/[repo]/labels endpoint 1`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/labels",
+  },
+]
+`;
+
+exports[`platform/gitea/gitea-helper mergePR should call /api/v1/repos/[repo]/pulls/[pull]/merge endpoint 1`] = `
+Array [
+  Object {
+    "body": "{\\"Do\\":\\"rebase\\"}",
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "content-length": 15,
+      "content-type": "application/json",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "POST",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/pulls/13/merge",
+  },
+]
+`;
+
+exports[`platform/gitea/gitea-helper searchIssues should call /api/v1/repos/[repo]/issues endpoint 1`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/issues?",
+  },
+]
+`;
+
+exports[`platform/gitea/gitea-helper searchIssues should construct proper query parameters 1`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/issues?state=open",
+  },
+]
+`;
+
+exports[`platform/gitea/gitea-helper searchPRs should call /api/v1/repos/[repo]/pulls endpoint 1`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/pulls?",
+  },
+]
+`;
+
+exports[`platform/gitea/gitea-helper searchPRs should construct proper query parameters 1`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/pulls?state=open&labels=100&labels=200",
+  },
+]
+`;
+
+exports[`platform/gitea/gitea-helper searchRepos should abort if ok flag was not set 1`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/search?",
+  },
+]
+`;
+
+exports[`platform/gitea/gitea-helper searchRepos should call /api/v1/repos/search endpoint 1`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/search?",
+  },
+]
+`;
+
+exports[`platform/gitea/gitea-helper searchRepos should construct proper query parameters 1`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/search?uid=13",
+  },
+]
+`;
+
+exports[`platform/gitea/gitea-helper unassignLabel should call /api/v1/repos/[repo]/issues/[issue]/labels/[label] endpoint 1`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "DELETE",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/issues/7/labels/100",
+  },
+]
+`;
+
+exports[`platform/gitea/gitea-helper updateComment should call /api/v1/repos/[repo]/issues/comments/[comment] endpoint 1`] = `
+Array [
+  Object {
+    "body": "{\\"body\\":\\"new-body\\"}",
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "content-length": 19,
+      "content-type": "application/json",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "PATCH",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/issues/comments/31",
+  },
+]
+`;
+
+exports[`platform/gitea/gitea-helper updateIssue should call /api/v1/repos/[repo]/issues/[issue] endpoint 1`] = `
+Array [
+  Object {
+    "body": "{\\"state\\":\\"closed\\",\\"title\\":\\"new-title\\",\\"body\\":\\"new-body\\",\\"assignees\\":[\\"renovate\\"]}",
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "content-length": 81,
+      "content-type": "application/json",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "PATCH",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/issues/7",
+  },
+]
+`;
+
+exports[`platform/gitea/gitea-helper updatePR should call /api/v1/repos/[repo]/pulls/[pull] endpoint 1`] = `
+Array [
+  Object {
+    "body": "{\\"state\\":\\"closed\\",\\"title\\":\\"new-title\\",\\"body\\":\\"new-body\\",\\"assignees\\":[\\"renovate\\"],\\"labels\\":[200]}",
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "content-length": 96,
+      "content-type": "application/json",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "PATCH",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/some/repo/pulls/13",
+  },
+]
+`;

--- a/lib/platform/gitea/gitea-got-wrapper.spec.ts
+++ b/lib/platform/gitea/gitea-got-wrapper.spec.ts
@@ -1,86 +1,62 @@
-import { GotResponse } from '..';
-import { partial } from '../../../test/util';
-import { GotFn } from '../../util/got';
-import { GiteaGotApi } from './gitea-got-wrapper';
+import * as httpMock from '../../../test/httpMock';
+import { api } from './gitea-got-wrapper';
 
 describe('platform/gitea/gitea-got-wrapper', () => {
-  let api: GiteaGotApi;
-  let got: jest.Mocked<GotFn> & jest.Mock;
+  const baseUrl = 'https://gitea.renovatebot.com/api/v1';
 
-  const baseURL = 'https://gitea.renovatebot.com/api/v1';
-
-  beforeEach(async () => {
+  beforeEach(() => {
     jest.resetAllMocks();
-    jest.mock('../../util/got');
 
-    api = (await import('./gitea-got-wrapper')).api as any;
-    got = (await import('../../util/got')).api as any;
-    api.setBaseUrl(baseURL);
+    httpMock.reset();
+    httpMock.setup();
+
+    api.setBaseUrl(baseUrl);
   });
 
   it('supports responses without pagination when enabled', async () => {
-    got.mockResolvedValueOnce(
-      partial<GotResponse>({
-        body: { hello: 'world' },
-      })
-    );
+    httpMock
+      .scope(baseUrl)
+      .get('/pagination-example-1')
+      .reply(200, { hello: 'world' });
 
     const res = await api.get('pagination-example-1', { paginate: true });
     expect(res.body).toEqual({ hello: 'world' });
+    expect(httpMock.getTrace()).toMatchSnapshot();
   });
 
   it('supports root-level pagination', async () => {
-    got.mockResolvedValueOnce(
-      partial<GotResponse>({
-        body: ['abc', 'def', 'ghi'],
-        headers: { 'x-total-count': '5' },
-        url: `${baseURL}/pagination-example-1`,
-      })
-    );
-    got.mockResolvedValueOnce(
-      partial<GotResponse>({
-        body: ['jkl'],
-      })
-    );
-    got.mockResolvedValueOnce(
-      partial<GotResponse>({
-        body: ['mno', 'pqr'],
-      })
-    );
+    httpMock
+      .scope(baseUrl)
+      .get('/pagination-example-1')
+      .reply(200, ['abc', 'def', 'ghi'], { 'x-total-count': '5' })
+      .get('/pagination-example-1?page=2')
+      .reply(200, ['jkl'])
+      .get('/pagination-example-1?page=3')
+      .reply(200, ['mno', 'pqr']);
 
-    const res = await api.get(`${baseURL}/pagination-example-1`, {
+    const res = await api.get(`${baseUrl}/pagination-example-1`, {
       paginate: true,
     });
+    httpMock.getTrace();
 
     expect(res.body).toHaveLength(6);
     expect(res.body).toEqual(['abc', 'def', 'ghi', 'jkl', 'mno', 'pqr']);
-    expect(got.mock.calls).toMatchSnapshot();
-    expect(got).toHaveBeenCalledTimes(3);
+    expect(httpMock.getTrace()).toMatchSnapshot();
   });
 
   it('supports pagination on data property', async () => {
-    got.mockResolvedValueOnce(
-      partial<GotResponse>({
-        body: { data: ['abc', 'def', 'ghi'] },
-        headers: { 'x-total-count': '5' },
-        url: `${baseURL}/pagination-example-2`,
-      })
-    );
-    got.mockResolvedValueOnce(
-      partial<GotResponse>({
-        body: { data: ['jkl'] },
-      })
-    );
-    got.mockResolvedValueOnce(
-      partial<GotResponse>({
-        body: { data: ['mno', 'pqr'] },
-      })
-    );
+    httpMock
+      .scope(baseUrl)
+      .get('/pagination-example-2')
+      .reply(200, { data: ['abc', 'def', 'ghi'] }, { 'x-total-count': '5' })
+      .get('/pagination-example-2?page=2')
+      .reply(200, { data: ['jkl'] })
+      .get('/pagination-example-2?page=3')
+      .reply(200, { data: ['mno', 'pqr'] });
 
     const res = await api.get('pagination-example-2', { paginate: true });
-
     expect(res.body.data).toHaveLength(6);
     expect(res.body.data).toEqual(['abc', 'def', 'ghi', 'jkl', 'mno', 'pqr']);
-    expect(got).toHaveBeenCalledTimes(3);
+    expect(httpMock.getTrace()).toMatchSnapshot();
   });
 });

--- a/lib/platform/gitea/gitea-helper.spec.ts
+++ b/lib/platform/gitea/gitea-helper.spec.ts
@@ -1,16 +1,10 @@
-import { URL } from 'url';
-import { GotResponse } from '..';
-import { partial } from '../../../test/util';
+import * as httpMock from '../../../test/httpMock';
 import { PR_STATE_CLOSED } from '../../constants/pull-requests';
-import { GiteaGotApi, GiteaGotOptions } from './gitea-got-wrapper';
+import { api } from './gitea-got-wrapper';
 import * as ght from './gitea-helper';
-import { PRSearchParams } from './gitea-helper';
 
 describe('platform/gitea/gitea-helper', () => {
-  let helper: typeof import('./gitea-helper');
-  let api: jest.Mocked<GiteaGotApi>;
-
-  const baseURL = 'https://gitea.renovatebot.com/api/v1';
+  const baseUrl = 'https://gitea.renovatebot.com/api/v1';
 
   const mockCommitHash = '0d9c7726c3d628b7e28af234595cfd20febdbf8e';
 
@@ -143,136 +137,75 @@ describe('platform/gitea/gitea-helper', () => {
     path: 'nested/path/dummy.txt',
   };
 
-  const mockAPI = <B extends object = undefined, P extends object = {}>(
-    userOptions: {
-      method?: 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete';
-      urlPattern?: string | RegExp;
-      queryParams?: Record<string, string[]>;
-      postParams?: P;
-    },
-    body: B = undefined
-  ) => {
-    // Merge default options with user options
-    const options = {
-      method: 'get',
-      ...userOptions,
-    };
-
-    // Mock request implementation once and verify request
-    api[options.method].mockImplementationOnce(
-      (rawUrl: string, apiOpts?: GiteaGotOptions): Promise<GotResponse<B>> => {
-        // Construct and parse absolute URL
-        const absoluteUrl = rawUrl.includes('://')
-          ? rawUrl
-          : `${baseURL}/${rawUrl}`;
-        const url = new URL(absoluteUrl);
-
-        // Check optional URL pattern matcher
-        if (options.urlPattern !== undefined) {
-          const regex =
-            options.urlPattern instanceof RegExp
-              ? options.urlPattern
-              : new RegExp(`^${options.urlPattern}$`);
-
-          if (!regex.exec(url.pathname)) {
-            throw new Error(
-              `expected url [${url.pathname}] to match pattern: ${options.urlPattern}`
-            );
-          }
-        }
-
-        // Check optional query params
-        if (options.queryParams !== undefined) {
-          for (const [key, expected] of Object.entries(options.queryParams)) {
-            expect(url.searchParams.getAll(key)).toEqual(expected);
-          }
-        }
-
-        // Check optional post parameters
-        if (options.postParams !== undefined) {
-          expect(apiOpts.body).toEqual(options.postParams);
-        }
-
-        return Promise.resolve(
-          partial<GotResponse<B>>({ body })
-        );
-      }
-    );
-  };
-
-  beforeEach(async () => {
+  beforeEach(() => {
     jest.resetAllMocks();
-    jest.mock('./gitea-got-wrapper');
-
-    helper = (await import('./gitea-helper')) as any;
-    api = (await import('./gitea-got-wrapper')).api as any;
+    httpMock.reset();
+    httpMock.setup();
+    api.setBaseUrl(baseUrl);
   });
 
   describe('getCurrentUser', () => {
     it('should call /api/v1/user endpoint', async () => {
-      mockAPI<ght.User>({ urlPattern: '/api/v1/user' }, mockUser);
+      httpMock.scope(baseUrl).get('/user').reply(200, mockUser);
 
-      const res = await helper.getCurrentUser();
+      const res = await ght.getCurrentUser();
       expect(res).toEqual(mockUser);
+      expect(httpMock.getTrace()).toMatchSnapshot();
     });
   });
 
   describe('searchRepos', () => {
     it('should call /api/v1/repos/search endpoint', async () => {
-      mockAPI<ght.RepoSearchResults>(
-        { urlPattern: '/api/v1/repos/search' },
-        {
+      httpMock
+        .scope(baseUrl)
+        .get('/repos/search')
+        .reply(200, {
           ok: true,
           data: [mockRepo, otherMockRepo],
-        }
-      );
+        });
 
-      const res = await helper.searchRepos({});
+      const res = await ght.searchRepos({});
       expect(res).toEqual([mockRepo, otherMockRepo]);
+      expect(httpMock.getTrace()).toMatchSnapshot();
     });
 
     it('should construct proper query parameters', async () => {
-      mockAPI<ght.RepoSearchResults>(
-        {
-          urlPattern: '/api/v1/repos/search',
-          queryParams: {
-            uid: ['13'],
-          },
-        },
-        {
+      httpMock
+        .scope(baseUrl)
+        .get('/repos/search?uid=13')
+        .reply(200, {
           ok: true,
           data: [otherMockRepo],
-        }
-      );
+        });
 
-      const res = await helper.searchRepos({
+      const res = await ght.searchRepos({
         uid: 13,
       });
       expect(res).toEqual([otherMockRepo]);
+      expect(httpMock.getTrace()).toMatchSnapshot();
     });
 
     it('should abort if ok flag was not set', async () => {
-      mockAPI<ght.RepoSearchResults>(
-        { urlPattern: '/api/v1/repos/search' },
-        {
-          ok: false,
-          data: [],
-        }
-      );
+      httpMock.scope(baseUrl).get('/repos/search').reply(200, {
+        ok: false,
+        data: [],
+      });
 
-      await expect(helper.searchRepos({})).rejects.toThrow();
+      await expect(ght.searchRepos({})).rejects.toThrow();
+      expect(httpMock.getTrace()).toMatchSnapshot();
     });
   });
 
   describe('getRepo', () => {
     it('should call /api/v1/repos/[repo] endpoint', async () => {
-      mockAPI<ght.Repo>(
-        { urlPattern: `/api/v1/repos/${mockRepo.full_name}` },
-        mockRepo
-      );
+      httpMock
+        .scope(baseUrl)
+        .get(`/repos/${mockRepo.full_name}`)
+        .reply(200, mockRepo);
 
-      const res = await helper.getRepo(mockRepo.full_name);
+      const res = await ght.getRepo(mockRepo.full_name);
       expect(res).toEqual(mockRepo);
+      expect(httpMock.getTrace()).toMatchSnapshot();
     });
   });
 
@@ -280,65 +213,63 @@ describe('platform/gitea/gitea-helper', () => {
     it('should call /api/v1/repos/[repo]/contents/[file] endpoint', async () => {
       // The official API only returns the base64-encoded content, so we strip `contentString`
       // from our mock to verify base64 decoding.
-      mockAPI<ght.RepoContents>(
-        {
-          urlPattern: `/api/v1/repos/${mockRepo.full_name}/contents/${mockContents.path}`,
-        },
-        { ...mockContents, contentString: undefined }
-      );
+      httpMock
+        .scope(baseUrl)
+        .get(`/repos/${mockRepo.full_name}/contents/${mockContents.path}`)
+        .reply(200, { ...mockContents, contentString: undefined });
 
-      const res = await helper.getRepoContents(
+      const res = await ght.getRepoContents(
         mockRepo.full_name,
         mockContents.path
       );
       expect(res).toEqual(mockContents);
+      expect(httpMock.getTrace()).toMatchSnapshot();
     });
 
     it('should support passing reference by query', async () => {
-      mockAPI<ght.RepoContents>(
-        {
-          urlPattern: `/api/v1/repos/${mockRepo.full_name}/contents/${mockContents.path}`,
-          queryParams: {
-            ref: [mockCommitHash],
-          },
-        },
-        { ...mockContents, contentString: undefined }
-      );
+      httpMock
+        .scope(baseUrl)
+        .get(
+          `/repos/${mockRepo.full_name}/contents/${mockContents.path}?ref=${mockCommitHash}`
+        )
+        .reply(200, { ...mockContents, contentString: undefined });
 
-      const res = await helper.getRepoContents(
+      const res = await ght.getRepoContents(
         mockRepo.full_name,
         mockContents.path,
         mockCommitHash
       );
       expect(res).toEqual(mockContents);
+      expect(httpMock.getTrace()).toMatchSnapshot();
     });
 
     it('should properly escape paths', async () => {
       const escapedPath = encodeURIComponent(otherMockContents.path);
 
-      mockAPI<ght.RepoContents>(
-        {
-          urlPattern: `/api/v1/repos/${mockRepo.full_name}/contents/${escapedPath}`,
-        },
-        otherMockContents
-      );
+      httpMock
+        .scope(baseUrl)
+        .get(`/repos/${mockRepo.full_name}/contents/${escapedPath}`)
+        .reply(200, otherMockContents);
 
-      const res = await helper.getRepoContents(
+      const res = await ght.getRepoContents(
         mockRepo.full_name,
         otherMockContents.path
       );
       expect(res).toEqual(otherMockContents);
+      expect(httpMock.getTrace()).toMatchSnapshot();
     });
 
     it('should not fail if no content is returned', async () => {
-      mockAPI<ght.RepoContents>(
-        {
-          urlPattern: `/api/v1/repos/${mockRepo.full_name}/contents/${mockContents.path}`,
-        },
-        { ...mockContents, content: undefined, contentString: undefined }
-      );
+      httpMock
+        .scope(baseUrl)
+        .get(`/repos/${mockRepo.full_name}/contents/${mockContents.path}`)
+        .reply(200, {
+          ...mockContents,
+          content: undefined,
+          contentString: undefined,
+        });
 
-      const res = await helper.getRepoContents(
+      const res = await ght.getRepoContents(
         mockRepo.full_name,
         mockContents.path
       );
@@ -352,24 +283,12 @@ describe('platform/gitea/gitea-helper', () => {
 
   describe('createPR', () => {
     it('should call /api/v1/repos/[repo]/pulls endpoint', async () => {
-      mockAPI<ght.PR, Required<ght.PRCreateParams>>(
-        {
-          method: 'post',
-          urlPattern: `/api/v1/repos/${mockRepo.full_name}/pulls`,
-          postParams: {
-            state: mockPR.state,
-            title: mockPR.title,
-            body: mockPR.body,
-            base: mockPR.base.ref,
-            head: mockPR.head.label,
-            assignees: [mockUser.username],
-            labels: [mockLabel.id],
-          },
-        },
-        mockPR
-      );
+      httpMock
+        .scope(baseUrl)
+        .post(`/repos/${mockRepo.full_name}/pulls`)
+        .reply(200, mockPR);
 
-      const res = await helper.createPR(mockRepo.full_name, {
+      const res = await ght.createPR(mockRepo.full_name, {
         state: mockPR.state,
         title: mockPR.title,
         body: mockPR.body,
@@ -379,6 +298,7 @@ describe('platform/gitea/gitea-helper', () => {
         labels: [mockLabel.id],
       });
       expect(res).toEqual(mockPR);
+      expect(httpMock.getTrace()).toMatchSnapshot();
     });
   });
 
@@ -391,22 +311,12 @@ describe('platform/gitea/gitea-helper', () => {
         body: 'new-body',
       };
 
-      mockAPI<ght.PR, Required<ght.PRUpdateParams>>(
-        {
-          method: 'patch',
-          urlPattern: `/api/v1/repos/${mockRepo.full_name}/pulls/${mockPR.number}`,
-          postParams: {
-            state: 'closed',
-            title: 'new-title',
-            body: 'new-body',
-            assignees: [otherMockUser.username],
-            labels: [otherMockLabel.id],
-          },
-        },
-        updatedMockPR
-      );
+      httpMock
+        .scope(baseUrl)
+        .patch(`/repos/${mockRepo.full_name}/pulls/${mockPR.number}`)
+        .reply(200, updatedMockPR);
 
-      const res = await helper.updatePR(mockRepo.full_name, mockPR.number, {
+      const res = await ght.updatePR(mockRepo.full_name, mockPR.number, {
         state: PR_STATE_CLOSED,
         title: 'new-title',
         body: 'new-body',
@@ -414,113 +324,97 @@ describe('platform/gitea/gitea-helper', () => {
         labels: [otherMockLabel.id],
       });
       expect(res).toEqual(updatedMockPR);
+      expect(httpMock.getTrace()).toMatchSnapshot();
     });
   });
 
   describe('closePR', () => {
     it('should call /api/v1/repos/[repo]/pulls/[pull] endpoint', async () => {
-      mockAPI<undefined, ght.PRUpdateParams>({
-        method: 'patch',
-        urlPattern: `/api/v1/repos/${mockRepo.full_name}/pulls/${mockPR.number}`,
-        postParams: {
-          state: 'closed',
-        },
-      });
+      httpMock
+        .scope(baseUrl)
+        .patch(`/repos/${mockRepo.full_name}/pulls/${mockPR.number}`)
+        .reply(200);
 
-      const res = await helper.closePR(mockRepo.full_name, mockPR.number);
+      const res = await ght.closePR(mockRepo.full_name, mockPR.number);
       expect(res).toBeUndefined();
+      expect(httpMock.getTrace()).toMatchSnapshot();
     });
   });
 
   describe('mergePR', () => {
     it('should call /api/v1/repos/[repo]/pulls/[pull]/merge endpoint', async () => {
-      mockAPI<undefined, ght.PRMergeParams>({
-        method: 'patch',
-        urlPattern: `/api/v1/repos/${mockRepo.full_name}/pulls/${mockPR.number}/merge`,
-        postParams: {
-          Do: 'rebase',
-        },
-      });
+      httpMock
+        .scope(baseUrl)
+        .post(`/repos/${mockRepo.full_name}/pulls/${mockPR.number}/merge`)
+        .reply(200);
 
-      const res = await helper.mergePR(
+      const res = await ght.mergePR(
         mockRepo.full_name,
         mockPR.number,
         'rebase'
       );
       expect(res).toBeUndefined();
+      expect(httpMock.getTrace()).toMatchSnapshot();
     });
   });
 
   describe('getPR', () => {
     it('should call /api/v1/repos/[repo]/pulls/[pull] endpoint', async () => {
-      mockAPI<ght.PR>(
-        {
-          urlPattern: `/api/v1/repos/${mockRepo.full_name}/pulls/${mockPR.number}`,
-        },
-        mockPR
-      );
+      httpMock
+        .scope(baseUrl)
+        .get(`/repos/${mockRepo.full_name}/pulls/${mockPR.number}`)
+        .reply(200, mockPR);
 
-      const res = await helper.getPR(mockRepo.full_name, mockPR.number);
+      const res = await ght.getPR(mockRepo.full_name, mockPR.number);
       expect(res).toEqual(mockPR);
+      expect(httpMock.getTrace()).toMatchSnapshot();
     });
   });
 
   describe('searchPRs', () => {
     it('should call /api/v1/repos/[repo]/pulls endpoint', async () => {
-      mockAPI<ght.PR[]>(
-        {
-          urlPattern: `/api/v1/repos/${mockRepo.full_name}/pulls`,
-        },
-        [mockPR]
-      );
+      httpMock
+        .scope(baseUrl)
+        .get(`/repos/${mockRepo.full_name}/pulls`)
+        .reply(200, [mockPR]);
 
-      const res = await helper.searchPRs(mockRepo.full_name, {});
+      const res = await ght.searchPRs(mockRepo.full_name, {});
       expect(res).toEqual([mockPR]);
+      expect(httpMock.getTrace()).toMatchSnapshot();
     });
 
     it('should construct proper query parameters', async () => {
-      mockAPI<ght.PR[], Required<PRSearchParams>>(
-        {
-          urlPattern: `/api/v1/repos/${mockRepo.full_name}/pulls`,
-          queryParams: {
-            state: ['open'],
-            labels: [`${mockLabel.id}`, `${otherMockLabel.id}`],
-          },
-        },
-        [mockPR]
-      );
+      httpMock
+        .scope(baseUrl)
+        .get(
+          `/repos/${mockRepo.full_name}/pulls?state=open&labels=${mockLabel.id}&labels=${otherMockLabel.id}`
+        )
+        .reply(200, [mockPR]);
 
-      const res = await helper.searchPRs(mockRepo.full_name, {
+      const res = await ght.searchPRs(mockRepo.full_name, {
         state: 'open',
         labels: [mockLabel.id, otherMockLabel.id],
       });
       expect(res).toEqual([mockPR]);
+      expect(httpMock.getTrace()).toMatchSnapshot();
     });
   });
 
   describe('createIssue', () => {
     it('should call /api/v1/repos/[repo]/issues endpoint', async () => {
-      mockAPI<ght.Issue, Required<ght.IssueCreateParams>>(
-        {
-          method: 'post',
-          urlPattern: `/api/v1/repos/${mockRepo.full_name}/issues`,
-          postParams: {
-            state: mockIssue.state,
-            title: mockIssue.title,
-            body: mockIssue.body,
-            assignees: [mockUser.username],
-          },
-        },
-        mockIssue
-      );
+      httpMock
+        .scope(baseUrl)
+        .post(`/repos/${mockRepo.full_name}/issues`)
+        .reply(200, mockIssue);
 
-      const res = await helper.createIssue(mockRepo.full_name, {
+      const res = await ght.createIssue(mockRepo.full_name, {
         state: mockIssue.state,
         title: mockIssue.title,
         body: mockIssue.body,
         assignees: [mockUser.username],
       });
       expect(res).toEqual(mockIssue);
+      expect(httpMock.getTrace()).toMatchSnapshot();
     });
   });
 
@@ -534,143 +428,122 @@ describe('platform/gitea/gitea-helper', () => {
         assignees: [otherMockUser],
       };
 
-      mockAPI<ght.Issue, Required<ght.IssueUpdateParams>>(
-        {
-          method: 'patch',
-          urlPattern: `/api/v1/repos/${mockRepo.full_name}/issues/${mockIssue.number}`,
-          postParams: {
-            state: 'closed',
-            title: 'new-title',
-            body: 'new-body',
-            assignees: [otherMockUser.username],
-          },
-        },
-        updatedMockIssue
-      );
+      httpMock
+        .scope(baseUrl)
+        .patch(`/repos/${mockRepo.full_name}/issues/${mockIssue.number}`)
+        .reply(200, updatedMockIssue);
 
-      const res = await helper.updateIssue(
-        mockRepo.full_name,
-        mockIssue.number,
-        {
-          state: 'closed',
-          title: 'new-title',
-          body: 'new-body',
-          assignees: [otherMockUser.username],
-        }
-      );
+      const res = await ght.updateIssue(mockRepo.full_name, mockIssue.number, {
+        state: 'closed',
+        title: 'new-title',
+        body: 'new-body',
+        assignees: [otherMockUser.username],
+      });
       expect(res).toEqual(updatedMockIssue);
+      expect(httpMock.getTrace()).toMatchSnapshot();
     });
   });
 
   describe('closeIssue', () => {
     it('should call /api/v1/repos/[repo]/issues/[issue] endpoint', async () => {
-      mockAPI<ght.IssueUpdateParams>({
-        method: 'patch',
-        urlPattern: `/api/v1/repos/${mockRepo.full_name}/issues/${mockIssue.number}`,
-        postParams: {
-          state: 'closed',
-        },
-      });
+      httpMock
+        .scope(baseUrl)
+        .patch(`/repos/${mockRepo.full_name}/issues/${mockIssue.number}`)
+        .reply(200);
 
-      const res = await helper.closeIssue(mockRepo.full_name, mockIssue.number);
+      const res = await ght.closeIssue(mockRepo.full_name, mockIssue.number);
       expect(res).toBeUndefined();
+      expect(httpMock.getTrace()).toMatchSnapshot();
     });
   });
 
   describe('searchIssues', () => {
     it('should call /api/v1/repos/[repo]/issues endpoint', async () => {
-      mockAPI<ght.Issue[]>(
-        {
-          urlPattern: `/api/v1/repos/${mockRepo.full_name}/issues`,
-        },
-        [mockIssue]
-      );
+      httpMock
+        .scope(baseUrl)
+        .get(`/repos/${mockRepo.full_name}/issues`)
+        .reply(200, [mockIssue]);
 
-      const res = await helper.searchIssues(mockRepo.full_name, {});
+      const res = await ght.searchIssues(mockRepo.full_name, {});
       expect(res).toEqual([mockIssue]);
+      expect(httpMock.getTrace()).toMatchSnapshot();
     });
 
     it('should construct proper query parameters', async () => {
-      mockAPI<ght.Issue[], Required<PRSearchParams>>(
-        {
-          urlPattern: `/api/v1/repos/${mockRepo.full_name}/issues`,
-          queryParams: {
-            state: ['open'],
-          },
-        },
-        [mockIssue]
-      );
+      httpMock
+        .scope(baseUrl)
+        .get(`/repos/${mockRepo.full_name}/issues?state=open`)
+        .reply(200, [mockIssue]);
 
-      const res = await helper.searchIssues(mockRepo.full_name, {
+      const res = await ght.searchIssues(mockRepo.full_name, {
         state: 'open',
       });
       expect(res).toEqual([mockIssue]);
+      expect(httpMock.getTrace()).toMatchSnapshot();
     });
   });
 
   describe('getRepoLabels', () => {
     it('should call /api/v1/repos/[repo]/labels endpoint', async () => {
-      mockAPI<ght.Label[]>(
-        {
-          urlPattern: `/api/v1/repos/${mockRepo.full_name}/labels`,
-        },
-        [mockLabel, otherMockLabel]
-      );
+      httpMock
+        .scope(baseUrl)
+        .get(`/repos/${mockRepo.full_name}/labels`)
+        .reply(200, [mockLabel, otherMockLabel]);
 
-      const res = await helper.getRepoLabels(mockRepo.full_name);
+      const res = await ght.getRepoLabels(mockRepo.full_name);
       expect(res).toEqual([mockLabel, otherMockLabel]);
+      expect(httpMock.getTrace()).toMatchSnapshot();
     });
   });
 
   describe('getOrgLabels', () => {
     it('should call /api/v1/orgs/[org]/labels endpoint', async () => {
-      mockAPI<ght.Label[]>(
-        {
-          urlPattern: `/api/v1/orgs/${mockRepo.owner.username}/labels`,
-        },
-        [mockLabel, otherMockLabel]
-      );
+      httpMock
+        .scope(baseUrl)
+        .get(`/orgs/${mockRepo.owner.username}/labels`)
+        .reply(200, [mockLabel, otherMockLabel]);
 
-      const res = await helper.getOrgLabels(mockRepo.owner.username);
+      const res = await ght.getOrgLabels(mockRepo.owner.username);
       expect(res).toEqual([mockLabel, otherMockLabel]);
+      expect(httpMock.getTrace()).toMatchSnapshot();
     });
   });
 
   describe('unassignLabel', () => {
     it('should call /api/v1/repos/[repo]/issues/[issue]/labels/[label] endpoint', async () => {
-      mockAPI({
-        method: 'delete',
-        urlPattern: `/api/v1/repos/${mockRepo.full_name}/issues/${mockIssue.number}/labels/${mockLabel.id}`,
-      });
+      httpMock
+        .scope(baseUrl)
+        .delete(
+          `/repos/${mockRepo.full_name}/issues/${mockIssue.number}/labels/${mockLabel.id}`
+        )
+        .reply(200);
 
-      const res = await helper.unassignLabel(
+      const res = await ght.unassignLabel(
         mockRepo.full_name,
         mockIssue.number,
         mockLabel.id
       );
       expect(res).toBeUndefined();
+      expect(httpMock.getTrace()).toMatchSnapshot();
     });
   });
 
   describe('createComment', () => {
     it('should call /api/v1/repos/[repo]/issues/[issue]/comments endpoint', async () => {
-      mockAPI<ght.Comment, Required<ght.CommentCreateParams>>(
-        {
-          method: 'post',
-          urlPattern: `/api/v1/repos/${mockRepo.full_name}/issues/${mockIssue.number}/comments`,
-          postParams: {
-            body: mockComment.body,
-          },
-        },
-        mockComment
-      );
+      httpMock
+        .scope(baseUrl)
+        .post(
+          `/repos/${mockRepo.full_name}/issues/${mockIssue.number}/comments`
+        )
+        .reply(200, mockComment);
 
-      const res = await helper.createComment(
+      const res = await ght.createComment(
         mockRepo.full_name,
         mockIssue.number,
         mockComment.body
       );
       expect(res).toEqual(mockComment);
+      expect(httpMock.getTrace()).toMatchSnapshot();
     });
   });
 
@@ -681,75 +554,57 @@ describe('platform/gitea/gitea-helper', () => {
         body: 'new-body',
       };
 
-      mockAPI<ght.Comment, Required<ght.CommentUpdateParams>>(
-        {
-          method: 'patch',
-          urlPattern: `/api/v1/repos/${mockRepo.full_name}/issues/comments/${mockComment.id}`,
-          postParams: {
-            body: 'new-body',
-          },
-        },
-        updatedMockComment
-      );
+      httpMock
+        .scope(baseUrl)
+        .patch(`/repos/${mockRepo.full_name}/issues/comments/${mockComment.id}`)
+        .reply(200, updatedMockComment);
 
-      const res = await helper.updateComment(
+      const res = await ght.updateComment(
         mockRepo.full_name,
         mockComment.id,
         'new-body'
       );
       expect(res).toEqual(updatedMockComment);
+      expect(httpMock.getTrace()).toMatchSnapshot();
     });
   });
 
   describe('deleteComment', () => {
     it('should call /api/v1/repos/[repo]/issues/comments/[comment] endpoint', async () => {
-      mockAPI({
-        method: 'delete',
-        urlPattern: `/api/v1/repos/${mockRepo.full_name}/issues/comments/${mockComment.id}`,
-      });
+      httpMock
+        .scope(baseUrl)
+        .delete(
+          `/repos/${mockRepo.full_name}/issues/comments/${mockComment.id}`
+        )
+        .reply(200);
 
-      const res = await helper.deleteComment(
-        mockRepo.full_name,
-        mockComment.id
-      );
+      const res = await ght.deleteComment(mockRepo.full_name, mockComment.id);
       expect(res).toBeUndefined();
+      expect(httpMock.getTrace()).toMatchSnapshot();
     });
   });
 
   describe('getComments', () => {
     it('should call /api/v1/repos/[repo]/issues/[issue]/comments endpoint', async () => {
-      mockAPI<ght.Comment[]>(
-        {
-          urlPattern: `/api/v1/repos/${mockRepo.full_name}/issues/${mockIssue.number}/comments`,
-        },
-        [mockComment]
-      );
+      httpMock
+        .scope(baseUrl)
+        .get(`/repos/${mockRepo.full_name}/issues/${mockIssue.number}/comments`)
+        .reply(200, [mockComment]);
 
-      const res = await helper.getComments(
-        mockRepo.full_name,
-        mockIssue.number
-      );
+      const res = await ght.getComments(mockRepo.full_name, mockIssue.number);
       expect(res).toEqual([mockComment]);
+      expect(httpMock.getTrace()).toMatchSnapshot();
     });
   });
 
   describe('createCommitStatus', () => {
     it('should call /api/v1/repos/[repo]/statuses/[commit] endpoint', async () => {
-      mockAPI<ght.CommitStatus, Required<ght.CommitStatusCreateParams>>(
-        {
-          method: 'post',
-          urlPattern: `/api/v1/repos/${mockRepo.full_name}/statuses/${mockCommitHash}`,
-          postParams: {
-            state: mockCommitStatus.status,
-            context: mockCommitStatus.context,
-            description: mockCommitStatus.description,
-            target_url: mockCommitStatus.target_url,
-          },
-        },
-        mockCommitStatus
-      );
+      httpMock
+        .scope(baseUrl)
+        .post(`/repos/${mockRepo.full_name}/statuses/${mockCommitHash}`)
+        .reply(200, mockCommitStatus);
 
-      const res = await helper.createCommitStatus(
+      const res = await ght.createCommitStatus(
         mockRepo.full_name,
         mockCommitHash,
         {
@@ -760,24 +615,24 @@ describe('platform/gitea/gitea-helper', () => {
         }
       );
       expect(res).toEqual(mockCommitStatus);
+      expect(httpMock.getTrace()).toMatchSnapshot();
     });
   });
 
   describe('getCombinedCommitStatus', () => {
     it('should call /api/v1/repos/[repo]/commits/[branch]/statuses endpoint', async () => {
-      mockAPI<ght.CommitStatus[]>(
-        {
-          urlPattern: `/api/v1/repos/${mockRepo.full_name}/commits/${mockBranch.name}/statuses`,
-        },
-        [mockCommitStatus, otherMockCommitStatus]
-      );
+      httpMock
+        .scope(baseUrl)
+        .get(`/repos/${mockRepo.full_name}/commits/${mockBranch.name}/statuses`)
+        .reply(200, [mockCommitStatus, otherMockCommitStatus]);
 
-      const res = await helper.getCombinedCommitStatus(
+      const res = await ght.getCombinedCommitStatus(
         mockRepo.full_name,
         mockBranch.name
       );
       expect(res.worstStatus).not.toEqual('unknown');
       expect(res.statuses).toEqual([mockCommitStatus, otherMockCommitStatus]);
+      expect(httpMock.getTrace()).toMatchSnapshot();
     });
 
     it('should properly determine worst commit status', async () => {
@@ -829,52 +684,48 @@ describe('platform/gitea/gitea-helper', () => {
           status,
           created_at,
         });
-        mockAPI<ght.CommitStatus[]>(
-          {
-            urlPattern: `/api/v1/repos/${mockRepo.full_name}/commits/${mockBranch.name}/statuses`,
-          },
-          commitStatuses
-        );
+        httpMock
+          .scope(baseUrl)
+          .get(
+            `/repos/${mockRepo.full_name}/commits/${mockBranch.name}/statuses`
+          )
+          .reply(200, commitStatuses);
 
         // Expect to get the current state back as the worst status, as all previous commit statuses
         // should be less important than the one which just got added
-        const res = await helper.getCombinedCommitStatus(
+        const res = await ght.getCombinedCommitStatus(
           mockRepo.full_name,
           mockBranch.name
         );
         expect(res.worstStatus).toEqual(expected);
+        expect(httpMock.getTrace()).toMatchSnapshot();
       }
     });
   });
 
   describe('getBranch', () => {
     it('should call /api/v1/repos/[repo]/branches/[branch] endpoint', async () => {
-      mockAPI<ght.Branch>(
-        {
-          urlPattern: `/api/v1/repos/${mockRepo.full_name}/branches/${mockBranch.name}`,
-        },
-        mockBranch
-      );
+      httpMock
+        .scope(baseUrl)
+        .get(`/repos/${mockRepo.full_name}/branches/${mockBranch.name}`)
+        .reply(200, mockBranch);
 
-      const res = await helper.getBranch(mockRepo.full_name, mockBranch.name);
+      const res = await ght.getBranch(mockRepo.full_name, mockBranch.name);
       expect(res).toEqual(mockBranch);
+      expect(httpMock.getTrace()).toMatchSnapshot();
     });
 
     it('should properly escape branch names', async () => {
       const escapedBranchName = encodeURIComponent(otherMockBranch.name);
 
-      mockAPI<ght.Branch>(
-        {
-          urlPattern: `/api/v1/repos/${mockRepo.full_name}/branches/${escapedBranchName}`,
-        },
-        otherMockBranch
-      );
+      httpMock
+        .scope(baseUrl)
+        .get(`/repos/${mockRepo.full_name}/branches/${escapedBranchName}`)
+        .reply(200, otherMockBranch);
 
-      const res = await helper.getBranch(
-        mockRepo.full_name,
-        otherMockBranch.name
-      );
+      const res = await ght.getBranch(mockRepo.full_name, otherMockBranch.name);
       expect(res).toEqual(otherMockBranch);
+      expect(httpMock.getTrace()).toMatchSnapshot();
     });
   });
 });

--- a/lib/platform/gitea/index.spec.ts
+++ b/lib/platform/gitea/index.spec.ts
@@ -173,7 +173,6 @@ describe('platform/gitea', () => {
     jest.resetModules();
     jest.clearAllMocks();
     jest.mock('./gitea-helper');
-    jest.mock('./gitea-got-wrapper');
     jest.mock('../git/storage');
     jest.mock('../../logger');
 


### PR DESCRIPTION
Non-destructive PR. All http mocks are done in `gitea-helper.spec.ts`, so we don't need to use it with `index.spec.ts`.

Ref: #5865
