### PR TITLE
feat(github): Add support for Draft PRs

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -257,7 +257,15 @@ Add config here if you wish it to apply to Docker package managers Dockerfile an
 
 ## draftPR
 
-If `draftPR` is set to true, the PR created by Renovate is set to a draft. Currently only available in Github.
+If you want the PRs created by Renovate to be considered as drafts rather than normal PRs in Github you could add this property to your `renovate.json`:
+
+```json
+{
+  "draftPR": true
+}
+```
+
+Please see [draft pull requests on Github.](https://github.blog/2019-02-14-introducing-draft-pull-requests/) for more information about draft PRs.
 
 ## enabled
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -265,7 +265,7 @@ If you want the PRs created by Renovate to be considered as drafts rather than n
 }
 ```
 
-Please see [draft pull requests on Github.](https://github.blog/2019-02-14-introducing-draft-pull-requests/) for more information about draft PRs.
+Please see [draft pull requests on Github](https://github.blog/2019-02-14-introducing-draft-pull-requests/) for more information about draft PRs.
 
 ## enabled
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -255,6 +255,10 @@ Add config here if you wish it to apply to Docker package managers Dockerfile an
 
 ## dotnet
 
+## draftPR
+
+If `draftPR` is set to true, the PR created by Renovate is set to a draft. Currently only available in Github.
+
 ## enabled
 
 The most common use of `enabled` is if you want to turn Renovate's functionality off, for some reason.

--- a/lib/config/common.ts
+++ b/lib/config/common.ts
@@ -21,6 +21,7 @@ export interface RenovateSharedConfig {
   branchName?: string;
   manager?: string;
   commitMessage?: string;
+  draftPR?: boolean;
   enabled?: boolean;
   enabledManagers?: string[];
   fileMatch?: string[];

--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -217,6 +217,12 @@ const options: RenovateOptions[] = [
     default: true,
   },
   {
+    name: 'draftPR',
+    description: 'If enabled, the PR created by Renovate is set to a draft.',
+    type: 'boolean',
+    default: false,
+  },
+  {
     name: 'dryRun',
     description:
       'If enabled, perform a dry run by logging messages instead of creating/updating/deleting branches and PRs',

--- a/lib/platform/common.ts
+++ b/lib/platform/common.ts
@@ -116,7 +116,6 @@ export interface Pr {
   state: string;
   targetBranch?: string;
   title: string;
-  draft?: boolean;
 }
 
 /**

--- a/lib/platform/common.ts
+++ b/lib/platform/common.ts
@@ -116,6 +116,7 @@ export interface Pr {
   state: string;
   targetBranch?: string;
   title: string;
+  draft?: boolean;
 }
 
 /**
@@ -139,6 +140,7 @@ export interface CreatePRConfig {
   labels?: string[] | null;
   useDefaultBranch?: boolean;
   platformOptions?: PlatformPrOptions;
+  draftPR?: boolean;
 }
 export interface EnsureIssueConfig {
   title: string;

--- a/lib/platform/github/__snapshots__/index.spec.ts.snap
+++ b/lib/platform/github/__snapshots__/index.spec.ts.snap
@@ -64,7 +64,6 @@ exports[`platform/github createPr() should create a draftPR if set in the settin
 Object {
   "branchName": "some-branch",
   "displayNumber": "Pull Request #123",
-  "draft": true,
   "isModified": false,
   "number": 123,
 }
@@ -104,7 +103,6 @@ exports[`platform/github createPr() should create and return a PR object 1`] = `
 Object {
   "branchName": "some-branch",
   "displayNumber": "Pull Request #123",
-  "draft": false,
   "isModified": false,
   "number": 123,
 }
@@ -205,7 +203,6 @@ exports[`platform/github createPr() should use defaultBranch 1`] = `
 Object {
   "branchName": "some-branch",
   "displayNumber": "Pull Request #123",
-  "draft": false,
   "isModified": false,
   "number": 123,
 }

--- a/lib/platform/github/__snapshots__/index.spec.ts.snap
+++ b/lib/platform/github/__snapshots__/index.spec.ts.snap
@@ -60,10 +60,51 @@ Array [
 ]
 `;
 
+exports[`platform/github createPr() should create a draftPR if set in the settings 1`] = `
+Object {
+  "branchName": "some-branch",
+  "displayNumber": "Pull Request #123",
+  "draft": true,
+  "isModified": false,
+  "number": 123,
+}
+`;
+
+exports[`platform/github createPr() should create a draftPR if set in the settings 2`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "authorization": "token abc123",
+      "host": "api.github.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://api.github.com/repos/some/repo",
+  },
+  Object {
+    "body": "{\\"title\\":\\"PR draft\\",\\"head\\":\\"some:some-branch\\",\\"base\\":\\"master\\",\\"body\\":\\"This is a result of a draft\\",\\"draft\\":true}",
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "authorization": "token abc123",
+      "content-length": 112,
+      "content-type": "application/json",
+      "host": "api.github.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "POST",
+    "url": "https://api.github.com/repos/some/repo/pulls",
+  },
+]
+`;
+
 exports[`platform/github createPr() should create and return a PR object 1`] = `
 Object {
   "branchName": "some-branch",
   "displayNumber": "Pull Request #123",
+  "draft": false,
   "isModified": false,
   "number": 123,
 }
@@ -83,12 +124,12 @@ Array [
     "url": "https://api.github.com/repos/some/repo",
   },
   Object {
-    "body": "{\\"title\\":\\"The Title\\",\\"head\\":\\"some:some-branch\\",\\"base\\":\\"master\\",\\"body\\":\\"Hello world\\"}",
+    "body": "{\\"title\\":\\"The Title\\",\\"head\\":\\"some:some-branch\\",\\"base\\":\\"master\\",\\"body\\":\\"Hello world\\",\\"draft\\":false}",
     "headers": Object {
       "accept": "application/json",
       "accept-encoding": "gzip, deflate",
       "authorization": "token abc123",
-      "content-length": 84,
+      "content-length": 98,
       "content-type": "application/json",
       "host": "api.github.com",
       "user-agent": "https://github.com/renovatebot/renovate",
@@ -164,6 +205,7 @@ exports[`platform/github createPr() should use defaultBranch 1`] = `
 Object {
   "branchName": "some-branch",
   "displayNumber": "Pull Request #123",
+  "draft": false,
   "isModified": false,
   "number": 123,
 }
@@ -183,12 +225,12 @@ Array [
     "url": "https://api.github.com/repos/some/repo",
   },
   Object {
-    "body": "{\\"title\\":\\"The Title\\",\\"head\\":\\"some:some-branch\\",\\"base\\":\\"master\\",\\"body\\":\\"Hello world\\"}",
+    "body": "{\\"title\\":\\"The Title\\",\\"head\\":\\"some:some-branch\\",\\"base\\":\\"master\\",\\"body\\":\\"Hello world\\",\\"draft\\":false}",
     "headers": Object {
       "accept": "application/json",
       "accept-encoding": "gzip, deflate",
       "authorization": "token abc123",
-      "content-length": 84,
+      "content-length": 98,
       "content-type": "application/json",
       "host": "api.github.com",
       "user-agent": "https://github.com/renovatebot/renovate",

--- a/lib/platform/github/__snapshots__/index.spec.ts.snap
+++ b/lib/platform/github/__snapshots__/index.spec.ts.snap
@@ -64,6 +64,7 @@ exports[`platform/github createPr() should create a draftPR if set in the settin
 Object {
   "branchName": "some-branch",
   "displayNumber": "Pull Request #123",
+  "draft": true,
   "isModified": false,
   "number": 123,
 }
@@ -103,6 +104,7 @@ exports[`platform/github createPr() should create and return a PR object 1`] = `
 Object {
   "branchName": "some-branch",
   "displayNumber": "Pull Request #123",
+  "draft": false,
   "isModified": false,
   "number": 123,
 }
@@ -203,6 +205,7 @@ exports[`platform/github createPr() should use defaultBranch 1`] = `
 Object {
   "branchName": "some-branch",
   "displayNumber": "Pull Request #123",
+  "draft": false,
   "isModified": false,
   "number": 123,
 }

--- a/lib/platform/github/index.spec.ts
+++ b/lib/platform/github/index.spec.ts
@@ -1575,7 +1575,6 @@ describe('platform/github', () => {
         useDefaultBranch: true,
       });
       expect(pr).toMatchSnapshot();
-      expect(pr.draft).toBe(false);
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
     it('should create a draftPR if set in the settings', async () => {
@@ -1594,7 +1593,6 @@ describe('platform/github', () => {
         draftPR: true,
       });
       expect(pr).toMatchSnapshot();
-      expect(pr.draft).toBe(true);
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
   });

--- a/lib/platform/github/index.spec.ts
+++ b/lib/platform/github/index.spec.ts
@@ -1575,6 +1575,26 @@ describe('platform/github', () => {
         useDefaultBranch: true,
       });
       expect(pr).toMatchSnapshot();
+      expect(pr.draft).toBe(false);
+      expect(httpMock.getTrace()).toMatchSnapshot();
+    });
+    it('should create a draftPR if set in the settings', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      initRepoMock(scope, 'some/repo');
+      scope.post('/repos/some/repo/pulls').reply(200, {
+        number: 123,
+      });
+      await github.initRepo({ repository: 'some/repo', token: 'token' } as any);
+      const pr = await github.createPr({
+        branchName: 'some-branch',
+        prTitle: 'PR draft',
+        prBody: 'This is a result of a draft',
+        labels: null,
+        useDefaultBranch: true,
+        draftPR: true,
+      });
+      expect(pr).toMatchSnapshot();
+      expect(pr.draft).toBe(true);
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
   });

--- a/lib/platform/github/index.ts
+++ b/lib/platform/github/index.ts
@@ -1619,6 +1619,7 @@ export async function createPr({
   labels,
   useDefaultBranch,
   platformOptions = {},
+  draftPR = false,
 }: CreatePRConfig): Promise<Pr> {
   const body = sanitize(rawBody);
   const base = useDefaultBranch ? config.defaultBranch : config.baseBranch;
@@ -1630,6 +1631,7 @@ export async function createPr({
       head,
       base,
       body,
+      draft: draftPR,
     },
   };
   // istanbul ignore if
@@ -1637,14 +1639,17 @@ export async function createPr({
     options.token = config.forkToken;
     options.body.maintainer_can_modify = true;
   }
-  logger.debug({ title, head, base }, 'Creating PR');
+  logger.debug({ title, head, base, draft: draftPR }, 'Creating PR');
   const pr = (
     await githubApi.postJson<GhPr>(
       `repos/${config.parentRepo || config.repository}/pulls`,
       options
     )
   ).body;
-  logger.debug({ branch: branchName, pr: pr.number }, 'PR created');
+  logger.debug(
+    { branch: branchName, pr: pr.number, draft: pr.draft },
+    'PR created'
+  );
   // istanbul ignore if
   if (config.prList) {
     config.prList.push(pr);

--- a/lib/platform/github/index.ts
+++ b/lib/platform/github/index.ts
@@ -1667,7 +1667,6 @@ export async function createPr({
       url: 'https://github.com/renovatebot/renovate',
     });
   }
-  pr.draft = draftPR;
   pr.isModified = false;
   return pr;
 }

--- a/lib/platform/github/index.ts
+++ b/lib/platform/github/index.ts
@@ -1647,7 +1647,7 @@ export async function createPr({
     )
   ).body;
   logger.debug(
-    { branch: branchName, pr: pr.number, draft: pr.draft },
+    { branch: branchName, pr: pr.number, draft: draftPR },
     'PR created'
   );
   // istanbul ignore if

--- a/lib/platform/github/index.ts
+++ b/lib/platform/github/index.ts
@@ -1667,6 +1667,7 @@ export async function createPr({
       url: 'https://github.com/renovatebot/renovate',
     });
   }
+  pr.draft = draftPR;
   pr.isModified = false;
   return pr;
 }

--- a/lib/workers/pr/__snapshots__/index.spec.ts.snap
+++ b/lib/workers/pr/__snapshots__/index.spec.ts.snap
@@ -42,6 +42,7 @@ exports[`workers/pr ensurePr should add note about Pin 1`] = `
 Array [
   Object {
     "branchName": "renovate/dummy-1.x",
+    "draftPR": false,
     "labels": Array [],
     "platformOptions": Object {
       "azureAutoComplete": false,
@@ -72,6 +73,7 @@ exports[`workers/pr ensurePr should create PR if success 1`] = `
 Array [
   Object {
     "branchName": "renovate/dummy-1.x",
+    "draftPR": false,
     "labels": Array [],
     "platformOptions": Object {
       "azureAutoComplete": false,
@@ -89,6 +91,7 @@ exports[`workers/pr ensurePr should create PR if success for gitlab deps 1`] = `
 Array [
   Object {
     "branchName": "renovate/gitlabdummy-1.x",
+    "draftPR": false,
     "labels": Array [],
     "platformOptions": Object {
       "azureAutoComplete": false,
@@ -106,6 +109,7 @@ exports[`workers/pr ensurePr should create group PR 1`] = `
 Array [
   Object {
     "branchName": "renovate/dummy-1.x",
+    "draftPR": false,
     "labels": Array [],
     "platformOptions": Object {
       "azureAutoComplete": false,
@@ -123,6 +127,7 @@ exports[`workers/pr ensurePr should create privateRepo PR if success 1`] = `
 Array [
   Object {
     "branchName": "renovate/dummy-1.x",
+    "draftPR": false,
     "labels": Array [],
     "platformOptions": Object {
       "azureAutoComplete": false,

--- a/lib/workers/pr/index.ts
+++ b/lib/workers/pr/index.ts
@@ -354,6 +354,7 @@ export async function ensurePr(
           labels: config.labels,
           useDefaultBranch: false,
           platformOptions,
+          draftPR: config.draftPR,
         });
         logger.info({ pr: pr.number, prTitle }, 'PR created');
       }


### PR DESCRIPTION
<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate

    Please ensure `Allow edits from maintainers.` checkbox is checked
-->

<!-- Replace this text with a description of what this PR fixes or adds -->

This PR implements the ability to set the config option "draftPR" to true in renovate.json for example. Every PR that is created by Renovate on github is converted to a draft pull request.

See pictures below for it in action.
<img width="1169" alt="Skjermbilde 2020-05-30 kl  22 09 55" src="https://user-images.githubusercontent.com/42898343/83340217-ba90b180-a2d5-11ea-82f6-9c4baa729dd8.png">

<img width="1054" alt="Skjermbilde 2020-05-30 kl  22 12 47" src="https://user-images.githubusercontent.com/42898343/83340213-b795c100-a2d5-11ea-89b9-013f42173d4b.png">

NOTE: lib/versioning/regex/index.spec.ts and lib/util/regex.spec.ts are currently failing, but I am not quite sure why and how to fix it. Any leads much appreciated :)

Closes #5850 <!-- Ideally each PR should be closing an open issue -->
