### PR TITLE
fix: post-upgrade tasks see the latest changes to any files when running

### DIFF
--- a/lib/workers/branch/index.ts
+++ b/lib/workers/branch/index.ts
@@ -1,4 +1,3 @@
-import { join } from 'path';
 import is from '@sindresorhus/is';
 import { concat } from 'lodash';
 import { DateTime } from 'luxon';
@@ -353,7 +352,7 @@ export async function processBranch(
             } else {
               contents = file.contents;
             }
-            await writeLocalFile(join(config.localDir, file.name), contents);
+            await writeLocalFile(file.name, contents);
           }
         }
 


### PR DESCRIPTION
This PR fixes the post-upgrade tasks commit for pending changes to files back to the file system. The problem with the current code is that `writeLocalFile` appends the local directory to any path given to it as a parameter, so we are actually saving `localDir + localDir + filename` rather than just `localDir + filename`.

I haven't added any here but I would like to cover this code if possible with an integration test so we can ensure that it continues working. Any thoughts or suggestions on how best to do that?