### PR TITLE
logs: fix typo

### DIFF
--- a/lib/util/exec/docker/index.ts
+++ b/lib/util/exec/docker/index.ts
@@ -104,7 +104,7 @@ async function getDockerTag(
   }
   logger.warn(
     { constraint },
-    'Failed to find a tag satisfying ruby constraint, using "latest" tag instead'
+    'Failed to find a tag satisfying constraint, using "latest" tag instead'
   );
   return 'latest';
 }


### PR DESCRIPTION
Another `ruby` leftover 🙃 