### PR TITLE
fix(bazel): pass registry for container_pull

### DIFF
--- a/lib/manager/bazel/__fixtures__/WORKSPACE1
+++ b/lib/manager/bazel/__fixtures__/WORKSPACE1
@@ -110,3 +110,11 @@ load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_too
 go_rules_dependencies()
 
 go_register_toolchains()
+
+container_pull(
+    name = "py3_image_base",
+    digest = "sha256:d5a717649fd93ea5b9c430d7f84e4c37ba219eb53bd73ed1d4a5a98e9edd84a7",
+    registry = "gcr.io",
+    repository = "distroless/python3-debian10",
+    tag = "latest",
+)

--- a/lib/manager/bazel/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/bazel/__snapshots__/extract.spec.ts.snap
@@ -19,6 +19,9 @@ Array [
           tag=\\"v1.0.0-alpha31.cli-migrations\\"
         )",
     },
+    "registryUrls": Array [
+      "index.docker.io",
+    ],
     "versioning": "docker",
   },
 ]
@@ -64,6 +67,27 @@ Array [
 
 exports[`lib/manager/bazel/extract extractPackageFile() extracts multiple types of dependencies 1`] = `
 Array [
+  Object {
+    "currentDigest": "sha256:d5a717649fd93ea5b9c430d7f84e4c37ba219eb53bd73ed1d4a5a98e9edd84a7",
+    "currentValue": "latest",
+    "datasource": "docker",
+    "depName": "py3_image_base",
+    "depType": "container_pull",
+    "lookupName": "distroless/python3-debian10",
+    "managerData": Object {
+      "def": "container_pull(
+    name = \\"py3_image_base\\",
+    digest = \\"sha256:d5a717649fd93ea5b9c430d7f84e4c37ba219eb53bd73ed1d4a5a98e9edd84a7\\",
+    registry = \\"gcr.io\\",
+    repository = \\"distroless/python3-debian10\\",
+    tag = \\"latest\\",
+)",
+    },
+    "registryUrls": Array [
+      "gcr.io",
+    ],
+    "versioning": "docker",
+  },
   Object {
     "currentDigest": "446923c3756ceeaa75888f52fcbdd48bb314fbf8",
     "datasource": "github-releases",

--- a/lib/manager/bazel/__snapshots__/update.spec.ts.snap
+++ b/lib/manager/bazel/__snapshots__/update.spec.ts.snap
@@ -113,6 +113,14 @@ load(\\"@io_bazel_rules_go//go:def.bzl\\", \\"go_rules_dependencies\\", \\"go_re
 go_rules_dependencies()
 
 go_register_toolchains()
+
+container_pull(
+    name = \\"py3_image_base\\",
+    digest = \\"sha256:d5a717649fd93ea5b9c430d7f84e4c37ba219eb53bd73ed1d4a5a98e9edd84a7\\",
+    registry = \\"gcr.io\\",
+    repository = \\"distroless/python3-debian10\\",
+    tag = \\"latest\\",
+)
 "
 `;
 

--- a/lib/manager/bazel/extract.ts
+++ b/lib/manager/bazel/extract.ts
@@ -244,6 +244,7 @@ export function extractPackageFile(content: string): PackageFile | null {
       dep.versioning = dockerVersioning.id;
       dep.datasource = datasourceDocker.id;
       dep.lookupName = repository;
+      dep.registryUrls = [registry];
       deps.push(dep);
     } else {
       logger.debug(


### PR DESCRIPTION
Simply pass extracted `registry` to `dep.registryUrls`

Closes #6412 
