### PR TITLE
feat(npm): call lerna directly instead of via npx

### DIFF
--- a/lib/manager/npm/post-update/__snapshots__/lerna.spec.ts.snap
+++ b/lib/manager/npm/post-update/__snapshots__/lerna.spec.ts.snap
@@ -20,7 +20,7 @@ Array [
     },
   },
   Object {
-    "cmd": "npx lerna@latest bootstrap --no-ci --  --no-audit --package-lock-only",
+    "cmd": "lerna bootstrap --no-ci --  --no-audit --package-lock-only",
     "options": Object {
       "cwd": "some-dir",
       "encoding": "utf-8",
@@ -59,7 +59,7 @@ Array [
     },
   },
   Object {
-    "cmd": "npx lerna@latest bootstrap --no-ci -- --ignore-scripts  --no-audit --package-lock-only",
+    "cmd": "lerna bootstrap --no-ci -- --ignore-scripts  --no-audit --package-lock-only",
     "options": Object {
       "cwd": "some-dir",
       "encoding": "utf-8",
@@ -98,7 +98,7 @@ Array [
     },
   },
   Object {
-    "cmd": "npx lerna@2.0.0 bootstrap --no-ci -- --ignore-scripts  --no-audit --package-lock-only",
+    "cmd": "lerna bootstrap --no-ci -- --ignore-scripts  --no-audit --package-lock-only",
     "options": Object {
       "cwd": "some-dir",
       "encoding": "utf-8",
@@ -137,7 +137,7 @@ Array [
     },
   },
   Object {
-    "cmd": "npx lerna@2.0.0 bootstrap --no-ci -- --ignore-scripts --ignore-engines --ignore-platform",
+    "cmd": "lerna bootstrap --no-ci -- --ignore-scripts --ignore-engines --ignore-platform",
     "options": Object {
       "cwd": "some-dir",
       "encoding": "utf-8",
@@ -176,7 +176,7 @@ Array [
     },
   },
   Object {
-    "cmd": "npx lerna@latest bootstrap --no-ci -- --ignore-scripts  --no-audit --package-lock-only",
+    "cmd": "lerna bootstrap --no-ci -- --ignore-scripts  --no-audit --package-lock-only",
     "options": Object {
       "cwd": "some-dir",
       "encoding": "utf-8",
@@ -215,7 +215,7 @@ Array [
     },
   },
   Object {
-    "cmd": "npx lerna@2.0.0 bootstrap --no-ci -- --ignore-scripts  --no-audit",
+    "cmd": "lerna bootstrap --no-ci -- --ignore-scripts  --no-audit",
     "options": Object {
       "cwd": "some-dir",
       "encoding": "utf-8",

--- a/lib/manager/npm/post-update/lerna.ts
+++ b/lib/manager/npm/post-update/lerna.ts
@@ -92,9 +92,8 @@ export async function generateLockFiles(
       lernaVersion = 'latest';
     }
     logger.debug('Using lerna version ' + lernaVersion);
-    cmd.push(
-      `npx lerna@${quote(lernaVersion)} bootstrap --no-ci -- ${cmdOptions}`
-    );
+    preCommands.push(`npm i -g lerna@${quote(lernaVersion)}`);
+    cmd.push(`lerna bootstrap --no-ci -- ${cmdOptions}`);
     await exec(cmd, execOptions);
   } catch (err) /* istanbul ignore next */ {
     logger.debug(


### PR DESCRIPTION
Closes #6433

BREAKING CHANGE: If installing renovate from npm, and also using lerna, then you now must install lerna prior to running renovate.
