### PR TITLE
fix(nuget): handle missing properties

### DIFF
--- a/lib/datasource/nuget/v2.ts
+++ b/lib/datasource/nuget/v2.ts
@@ -8,7 +8,7 @@ import { id } from './common';
 const http = new Http(id);
 
 function getPkgProp(pkgInfo: XmlElement, propName: string): string {
-  return pkgInfo.childNamed('m:properties').childNamed(`d:${propName}`).val;
+  return pkgInfo.childNamed('m:properties').childNamed(`d:${propName}`)?.val;
 }
 
 export async function getReleases(


### PR DESCRIPTION
`childNamed` can return `null | undefined`

Closes #6435 
