### PR TITLE
fix(gitlab): wrong mr link path

### DIFF
--- a/lib/platform/gitlab/__snapshots__/index.spec.ts.snap
+++ b/lib/platform/gitlab/__snapshots__/index.spec.ts.snap
@@ -1710,7 +1710,7 @@ exports[`platform/gitlab getPrBody(input) returns updated pr body 1`] = `
 
 These updates have all been created already. Click a checkbox below to force a retry/rebase of any.
 
- - [ ] <!-- rebase-branch=renovate/major-got-packages -->[build(deps): update got packages (major)](../merge_requests/2433) (\`gh-got\`, \`gl-got\`, \`got\`)
+ - [ ] <!-- rebase-branch=renovate/major-got-packages -->[build(deps): update got packages (major)](!2433) (\`gh-got\`, \`gl-got\`, \`got\`)
 "
 `;
 

--- a/lib/platform/gitlab/index.ts
+++ b/lib/platform/gitlab/index.ts
@@ -586,7 +586,7 @@ export function getPrBody(input: string): string {
     input
       .replace(/Pull Request/g, 'Merge Request')
       .replace(/PR/g, 'MR')
-      .replace(/\]\(\.\.\/pull\//g, '](../merge_requests/'),
+      .replace(/\]\(\.\.\/pull\//g, '](!'),
     60000
   );
 }


### PR DESCRIPTION
use gilab mr reference for linking
https://docs.gitlab.com/ee/user/markdown.html#special-gitlab-references
