### PR TITLE
feat(internal): global init callback

### DIFF
--- a/lib/util/emoji.ts
+++ b/lib/util/emoji.ts
@@ -1,5 +1,6 @@
 import emoji from 'node-emoji';
 import { RenovateConfig } from '../config';
+import { addInitializationCallback } from '../workers/global/initialize';
 
 let unicodeEmoji = false;
 
@@ -10,3 +11,5 @@ export function setEmojiConfig(_config: RenovateConfig): void {
 export function emojify(text: string): string {
   return unicodeEmoji ? emoji.emojify(text) : text;
 }
+
+addInitializationCallback(setEmojiConfig);

--- a/lib/workers/global/index.ts
+++ b/lib/workers/global/index.ts
@@ -11,6 +11,7 @@ import { setEmojiConfig } from '../../util/emoji';
 import * as hostRules from '../../util/host-rules';
 import * as repositoryWorker from '../repository';
 import { autodiscoverRepositories } from './autodiscover';
+import { initialize } from './initialize';
 import * as limits from './limits';
 
 type RenovateConfig = configParser.RenovateConfig;
@@ -64,9 +65,7 @@ export async function start(): Promise<0 | 1> {
     config = await setDirectories(config);
     globalCache.init(config);
     config = await autodiscoverRepositories(config);
-
-    limits.init(config);
-    setEmojiConfig(config);
+    await initialize(config);
     // Iterate through repositories sequentially
     for (const repository of config.repositories) {
       if (limits.getLimitRemaining('prCommitsPerRunLimit') <= 0) {

--- a/lib/workers/global/initialize.ts
+++ b/lib/workers/global/initialize.ts
@@ -1,0 +1,13 @@
+import { RenovateConfig } from '../../config/common';
+
+const initializations = [];
+
+export function addInitializationCallback(callback: any): void {
+  initializations.push(callback);
+}
+
+export async function initialize(config: RenovateConfig): Promise<void> {
+  for (const callback of initializations) {
+    await callback(config);
+  }
+}


### PR DESCRIPTION
Adds global `initialize` function (to be followed by `finalize` function) designed so that modules can register their own initialization callbacks to the global worker.