### PR TITLE
fix: reverse upgrades order before filtering

### DIFF
--- a/lib/workers/repository/updates/branchify.ts
+++ b/lib/workers/repository/updates/branchify.ts
@@ -118,8 +118,9 @@ export async function branchifyUpgrades(
     });
     const seenUpdates = {};
     // Filter out duplicates
-    branchUpgrades[branchName] = branchUpgrades[branchName].filter(
-      (upgrade) => {
+    branchUpgrades[branchName] = branchUpgrades[branchName]
+      .reverse()
+      .filter((upgrade) => {
         const {
           manager,
           packageFile,
@@ -145,8 +146,8 @@ export async function branchifyUpgrades(
         }
         seenUpdates[upgradeKey] = newValue;
         return true;
-      }
-    );
+      })
+      .reverse();
     const branch = generateBranchConfig(branchUpgrades[branchName]);
     branch.branchName = branchName;
     branch.packageFiles = packageFiles;


### PR DESCRIPTION
Reverse updates in a branch before de-duplicating them, and then reverse them back again after. If there are duplicate updates, the later ones are usually "bigger" (e.g. major instead of minor, or patch instead of digest) so we should pick them first.