### PR TITLE
fix(cache): distinguish between null and undefined

### DIFF
--- a/lib/datasource/cache.ts
+++ b/lib/datasource/cache.ts
@@ -60,7 +60,7 @@ export async function cacheAble<TArg, TResult = unknown>({
   const cacheKey = JSON.stringify(lookup);
   const cachedResult = await globalCache.get<TResult>(cacheNamespace, cacheKey);
   // istanbul ignore if
-  if (cachedResult) {
+  if (cachedResult !== undefined) {
     logger.trace({ id, lookup }, 'datasource cachedResult');
     return cachedResult;
   }

--- a/lib/datasource/crate/index.ts
+++ b/lib/datasource/crate/index.ts
@@ -22,7 +22,7 @@ export async function getReleases({
     cacheKey
   );
   // istanbul ignore if
-  if (cachedResult) {
+  if (cachedResult !== undefined) {
     return cachedResult;
   }
 

--- a/lib/datasource/docker/index.ts
+++ b/lib/datasource/docker/index.ts
@@ -341,7 +341,7 @@ export async function getDigest(
     const cacheKey = `${registry}:${repository}:${newTag}`;
     const cachedResult = await globalCache.get(cacheNamespace, cacheKey);
     // istanbul ignore if
-    if (cachedResult) {
+    if (cachedResult !== undefined) {
       return cachedResult;
     }
     const manifestResponse = await getManifestResponse(
@@ -386,7 +386,7 @@ async function getTags(
       cacheKey
     );
     // istanbul ignore if
-    if (cachedResult) {
+    if (cachedResult !== undefined) {
       return cachedResult;
     }
     // AWS ECR limits the maximum number of results to 1000
@@ -495,7 +495,7 @@ async function getLabels(
     cacheKey
   );
   // istanbul ignore if
-  if (cachedResult) {
+  if (cachedResult !== undefined) {
     return cachedResult;
   }
   try {

--- a/lib/datasource/galaxy/index.ts
+++ b/lib/datasource/galaxy/index.ts
@@ -22,7 +22,7 @@ export async function getReleases({
     cacheKey
   );
   // istanbul ignore if
-  if (cachedResult) {
+  if (cachedResult !== undefined) {
     return cachedResult;
   }
 

--- a/lib/datasource/git-refs/index.ts
+++ b/lib/datasource/git-refs/index.ts
@@ -29,7 +29,7 @@ export async function getRawRefs({
       lookupName
     );
     /* istanbul ignore next line */
-    if (cachedResult) {
+    if (cachedResult !== undefined) {
       return cachedResult;
     }
 

--- a/lib/datasource/git-submodules/index.ts
+++ b/lib/datasource/git-submodules/index.ts
@@ -18,7 +18,7 @@ export async function getReleases({
     cacheKey
   );
   // istanbul ignore if
-  if (cachedResult) {
+  if (cachedResult !== undefined) {
     return cachedResult;
   }
 

--- a/lib/datasource/github-releases/index.ts
+++ b/lib/datasource/github-releases/index.ts
@@ -33,7 +33,7 @@ export async function getReleases({
     repo
   );
   // istanbul ignore if
-  if (cachedResult) {
+  if (cachedResult !== undefined) {
     return cachedResult;
   }
   try {

--- a/lib/datasource/github-tags/index.ts
+++ b/lib/datasource/github-tags/index.ts
@@ -29,7 +29,7 @@ async function getTagCommit(
     getCacheKey(githubRepo, `tag-${tag}`)
   );
   // istanbul ignore if
-  if (cachedResult) {
+  if (cachedResult !== undefined) {
     return cachedResult;
   }
   let digest: string;
@@ -81,7 +81,7 @@ export async function getDigest(
     getCacheKey(githubRepo, 'commit')
   );
   // istanbul ignore if
-  if (cachedResult) {
+  if (cachedResult !== undefined) {
     return cachedResult;
   }
   let digest: string;
@@ -95,9 +95,6 @@ export async function getDigest(
       'Error getting latest commit from GitHub repo'
     );
   }
-  if (!digest) {
-    return null;
-  }
   const cacheMinutes = 10;
   await globalCache.set(
     cacheNamespace,
@@ -105,7 +102,7 @@ export async function getDigest(
     digest,
     cacheMinutes
   );
-  return digest;
+  return digest || null;
 }
 
 /**
@@ -127,7 +124,7 @@ export async function getReleases({
     getCacheKey(repo, 'tags')
   );
   // istanbul ignore if
-  if (cachedResult) {
+  if (cachedResult !== undefined) {
     return cachedResult;
   }
   try {

--- a/lib/datasource/gitlab-tags/index.ts
+++ b/lib/datasource/gitlab-tags/index.ts
@@ -35,7 +35,7 @@ export async function getReleases({
     getCacheKey(depHost, repo)
   );
   // istanbul ignore if
-  if (cachedResult) {
+  if (cachedResult !== undefined) {
     return cachedResult;
   }
 

--- a/lib/datasource/helm/index.ts
+++ b/lib/datasource/helm/index.ts
@@ -21,7 +21,7 @@ export async function getRepositoryData(
   const cacheKey = repository;
   const cachedIndex = await globalCache.get(cacheNamespace, cacheKey);
   // istanbul ignore if
-  if (cachedIndex) {
+  if (cachedIndex !== undefined) {
     return cachedIndex;
   }
   let res: any;

--- a/lib/datasource/maven/index.ts
+++ b/lib/datasource/maven/index.ts
@@ -162,7 +162,7 @@ async function getVersionsFromMetadata(
     cacheKey
   );
   /* istanbul ignore if */
-  if (cachedVersions) {
+  if (cachedVersions !== undefined) {
     return cachedVersions;
   }
 

--- a/lib/datasource/npm/get.ts
+++ b/lib/datasource/npm/get.ts
@@ -75,7 +75,7 @@ export async function getDependency(
     pkgUrl
   );
   // istanbul ignore if
-  if (cachedResult) {
+  if (cachedResult !== undefined) {
     return cachedResult;
   }
   const headers: OutgoingHttpHeaders = {};

--- a/lib/datasource/nuget/v3.ts
+++ b/lib/datasource/nuget/v3.ts
@@ -24,7 +24,7 @@ export async function getQueryUrl(url: string): Promise<string | null> {
   const cachedResult = await globalCache.get<string>(cacheNamespace, cacheKey);
 
   // istanbul ignore if
-  if (cachedResult) {
+  if (cachedResult !== undefined) {
     return cachedResult;
   }
 

--- a/lib/datasource/orb/index.ts
+++ b/lib/datasource/orb/index.ts
@@ -31,7 +31,7 @@ export async function getReleases({
     cacheKey
   );
   // istanbul ignore if
-  if (cachedResult) {
+  if (cachedResult !== undefined) {
     return cachedResult;
   }
   const url = 'https://circleci.com/graphql-unstable';

--- a/lib/datasource/packagist/index.ts
+++ b/lib/datasource/packagist/index.ts
@@ -236,7 +236,7 @@ async function packagistOrgLookup(name: string): Promise<ReleaseResult> {
     name
   );
   // istanbul ignore if
-  if (cachedResult) {
+  if (cachedResult !== undefined) {
     return cachedResult;
   }
   let dep: ReleaseResult = null;

--- a/lib/datasource/pod/index.ts
+++ b/lib/datasource/pod/index.ts
@@ -158,7 +158,7 @@ export async function getReleases({
     podName
   );
   /* istanbul ignore next line */
-  if (cachedResult) {
+  if (cachedResult !== undefined) {
     logger.debug(`CocoaPods: Return cached result for ${podName}`);
     return cachedResult;
   }

--- a/lib/datasource/repology/index.ts
+++ b/lib/datasource/repology/index.ts
@@ -89,7 +89,7 @@ async function getCachedPackage(
     cacheKey
   );
   // istanbul ignore if
-  if (cachedResult) {
+  if (cachedResult !== undefined) {
     return cachedResult;
   }
 

--- a/lib/datasource/ruby-version/index.ts
+++ b/lib/datasource/ruby-version/index.ts
@@ -21,7 +21,7 @@ export async function getReleases(
     'all'
   );
   // istanbul ignore if
-  if (cachedResult) {
+  if (cachedResult !== undefined) {
     return cachedResult;
   }
   try {

--- a/lib/datasource/terraform-module/index.ts
+++ b/lib/datasource/terraform-module/index.ts
@@ -71,7 +71,7 @@ export async function getReleases({
     pkgUrl
   );
   // istanbul ignore if
-  if (cachedResult) {
+  if (cachedResult !== undefined) {
     return cachedResult;
   }
   try {

--- a/lib/datasource/terraform-provider/index.ts
+++ b/lib/datasource/terraform-provider/index.ts
@@ -34,7 +34,7 @@ export async function getReleases({
     pkgUrl
   );
   // istanbul ignore if
-  if (cachedResult) {
+  if (cachedResult !== undefined) {
     return cachedResult;
   }
   try {

--- a/lib/manager/bazel/update.ts
+++ b/lib/manager/bazel/update.ts
@@ -51,7 +51,7 @@ async function getHashFromUrl(url: string): Promise<string | null> {
     url
   );
   /* istanbul ignore next line */
-  if (cachedResult) {
+  if (cachedResult !== undefined) {
     return cachedResult;
   }
   try {

--- a/lib/util/cache/global/file.spec.ts
+++ b/lib/util/cache/global/file.spec.ts
@@ -6,8 +6,10 @@ describe('lib/util/cache/global/file', () => {
     init(os.tmpdir());
   });
 
-  it('gets null', async () => {
-    expect(await global.renovateCache.get('test', 'missing-key')).toBeNull();
+  it('returns undefined if no match', async () => {
+    expect(
+      await global.renovateCache.get('test', 'missing-key')
+    ).toBeUndefined();
   });
 
   it('sets and gets', async () => {
@@ -17,6 +19,6 @@ describe('lib/util/cache/global/file', () => {
 
   it('expires', async () => {
     await global.renovateCache.set('test', 'key', 1234, -5);
-    expect(await global.renovateCache.get('test', 'key')).toBeNull();
+    expect(await global.renovateCache.get('test', 'key')).toBeUndefined();
   });
 });

--- a/lib/util/cache/global/file.ts
+++ b/lib/util/cache/global/file.ts
@@ -29,7 +29,7 @@ async function get<T = never>(namespace: string, key: string): Promise<T> {
   } catch (err) {
     logger.trace({ namespace, key }, 'Cache miss');
   }
-  return null;
+  return undefined;
 }
 
 async function set(

--- a/lib/workers/pr/changelog/release-notes.ts
+++ b/lib/workers/pr/changelog/release-notes.ts
@@ -355,7 +355,7 @@ export async function addReleaseNotes(
     let releaseNotes: ChangeLogNotes;
     const cacheKey = getCacheKey(v.version);
     releaseNotes = await globalCache.get(cacheNamespace, cacheKey);
-    if (!releaseNotes) {
+    if (releaseNotes === undefined) {
       if (input.project.github != null) {
         releaseNotes = await getReleaseNotesMd(
           repository,
@@ -388,7 +388,7 @@ export async function addReleaseNotes(
       await globalCache.set(
         cacheNamespace,
         cacheKey,
-        releaseNotes,
+        releaseNotes || null,
         cacheMinutes
       );
     }

--- a/lib/workers/pr/changelog/source-github.ts
+++ b/lib/workers/pr/changelog/source-github.ts
@@ -155,7 +155,7 @@ export async function getChangeLogJSON({
         getCacheKey(prev.version, next.version)
       );
       // istanbul ignore else
-      if (!release) {
+      if (release === undefined) {
         release = {
           version: next.version,
           date: next.releaseTimestamp,

--- a/lib/workers/pr/changelog/source-gitlab.ts
+++ b/lib/workers/pr/changelog/source-gitlab.ts
@@ -135,7 +135,7 @@ export async function getChangeLogJSON({
         cacheNamespace,
         getCacheKey(prev.version, next.version)
       );
-      if (!release) {
+      if (release === undefined) {
         release = {
           version: next.version,
           date: next.releaseTimestamp,

--- a/lib/workers/repository/stats.ts
+++ b/lib/workers/repository/stats.ts
@@ -26,7 +26,7 @@ export function printRequestStats(): void {
     requestHosts[hostname] = requestHosts[hostname] || [];
     requestHosts[hostname].push(request.duration);
   }
-  logger.trace({ allRequests, requestHosts }, 'full stats');
+  logger.debug({ allRequests, requestHosts }, 'full stats');
   const hostStats: string[] = [];
   let totalRequests = 0;
   for (const [hostname, requests] of Object.entries(requestHosts)) {


### PR DESCRIPTION
Changes the global cache to treat "not found" as `undefined` instead of `null`. This allows datasources to cache their own empty/not found results as `null`.