### PR TITLE
fix: markdown table cell

### DIFF
--- a/lib/workers/pr/body/updates-table.ts
+++ b/lib/workers/pr/body/updates-table.ts
@@ -61,7 +61,9 @@ export function getPrUpdatesTable(config: BranchConfig): string {
   for (const row of tableValues) {
     let val = '|';
     for (const column of tableColumns) {
-      val += ` ${row[column].replace(/^@/, '@&#8203;')} |`;
+      val += ` ${row[column]
+        .replace(/^@/, '@&#8203;')
+        .replace(/\|/g, '\\|')} |`;
     }
     val += '\n';
     rows.push(val);

--- a/lib/workers/pr/body/updates-table.ts
+++ b/lib/workers/pr/body/updates-table.ts
@@ -61,9 +61,10 @@ export function getPrUpdatesTable(config: BranchConfig): string {
   for (const row of tableValues) {
     let val = '|';
     for (const column of tableColumns) {
-      val += ` ${row[column]
+      const content = row[column]
         .replace(/^@/, '@&#8203;')
-        .replace(/\|/g, '\\|')} |`;
+        .replace(/\|/g, '\\|');
+      val += ` ${content} |`;
     }
     val += '\n';
     rows.push(val);


### PR DESCRIPTION
`|` should be replaced with `\|` in markdown table cell.

current:

| Package | Type | Update | Change |
|---|---|---|---|
| [sphinx](http://sphinx-doc.org/) ([source](https://togithub.com/sphinx-doc/sphinx)) | dependencies | major | `^2.2` -> `^2.2, ||, ^3.0.0` |
| [sphinx-rtd-theme](https://togithub.com/rtfd/sphinx_rtd_theme) | dependencies | patch | `0.5.0rc1` -> `0.5.0rc2` |


expected:

| Package | Type | Update | Change |
|---|---|---|---|
| [sphinx](http://sphinx-doc.org/) ([source](https://togithub.com/sphinx-doc/sphinx)) | dependencies | major | `^2.2` -> `^2.2, \|\|, ^3.0.0` |
| [sphinx-rtd-theme](https://togithub.com/rtfd/sphinx_rtd_theme) | dependencies | patch | `0.5.0rc1` -> `0.5.0rc2` |
