### PR TITLE
feat(sbt): support scalaVersion defined with a trailing comma

### DIFF
--- a/lib/manager/sbt/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/sbt/__snapshots__/extract.spec.ts.snap
@@ -279,6 +279,36 @@ Object {
 }
 `;
 
+exports[`lib/manager/sbt/extract extractPackageFile() extracts deps when scala version is defined in a variable with a trailing comma 1`] = `
+Object {
+  "deps": Array [
+    Object {
+      "currentValue": "0.0.2",
+      "datasource": "sbt-package",
+      "depName": "org.example:bar_2.12",
+      "registryUrls": Array [
+        "https://repo.maven.apache.org/maven2",
+      ],
+    },
+  ],
+}
+`;
+
+exports[`lib/manager/sbt/extract extractPackageFile() extracts deps when scala version is defined with a trailing comma 1`] = `
+Object {
+  "deps": Array [
+    Object {
+      "currentValue": "0.0.2",
+      "datasource": "sbt-package",
+      "depName": "org.example:bar_2.12",
+      "registryUrls": Array [
+        "https://repo.maven.apache.org/maven2",
+      ],
+    },
+  ],
+}
+`;
+
 exports[`lib/manager/sbt/extract extractPackageFile() skips deps when scala version is missing 1`] = `
 Object {
   "deps": Array [

--- a/lib/manager/sbt/extract.spec.ts
+++ b/lib/manager/sbt/extract.spec.ts
@@ -59,5 +59,24 @@ describe('lib/manager/sbt/extract', () => {
     it('extract deps from native scala file with variables', () => {
       expect(extractPackageFile(sbtDependencyFile)).toMatchSnapshot();
     });
+    it('extracts deps when scala version is defined with a trailing comma', () => {
+      const content = `
+        lazy val commonSettings = Seq(
+          scalaVersion := "2.12.10",
+        )
+        libraryDependencies += "org.example" %% "bar" % "0.0.2"
+      `;
+      expect(extractPackageFile(content)).toMatchSnapshot();
+    });
+    it('extracts deps when scala version is defined in a variable with a trailing comma', () => {
+      const content = `
+        val ScalaVersion = "2.12.10"
+        lazy val commonSettings = Seq(
+          scalaVersion := ScalaVersion,
+        )
+        libraryDependencies += "org.example" %% "bar" % "0.0.2"
+      `;
+      expect(extractPackageFile(content)).toMatchSnapshot();
+    });
   });
 });

--- a/lib/manager/sbt/extract.ts
+++ b/lib/manager/sbt/extract.ts
@@ -19,10 +19,10 @@ const isPluginDep = (str: string): boolean =>
 const isStringLiteral = (str: string): boolean => /^"[^"]*"$/.test(str);
 
 const isScalaVersion = (str: string): boolean =>
-  /^\s*scalaVersion\s*:=\s*"[^"]*"\s*$/.test(str);
+  /^\s*scalaVersion\s*:=\s*"[^"]*"[\s,]*$/.test(str);
 
 const getScalaVersion = (str: string): string =>
-  str.replace(/^\s*scalaVersion\s*:=\s*"/, '').replace(/"\s*$/, '');
+  str.replace(/^\s*scalaVersion\s*:=\s*"/, '').replace(/"[\s,]*$/, '');
 
 /*
   https://www.scala-sbt.org/release/docs/Cross-Build.html#Publishing+conventions
@@ -51,10 +51,10 @@ const normalizeScalaVersion = (str: string): string => {
 };
 
 const isScalaVersionVariable = (str: string): boolean =>
-  /^\s*scalaVersion\s*:=\s*[_a-zA-Z][_a-zA-Z0-9]*\s*$/.test(str);
+  /^\s*scalaVersion\s*:=\s*[_a-zA-Z][_a-zA-Z0-9]*[\s,]*$/.test(str);
 
 const getScalaVersionVariable = (str: string): string =>
-  str.replace(/^\s*scalaVersion\s*:=\s*/, '').replace(/\s*$/, '');
+  str.replace(/^\s*scalaVersion\s*:=\s*/, '').replace(/[\s,]*$/, '');
 
 const isResolver = (str: string): boolean =>
   /^\s*(resolvers\s*\+\+?=\s*(Seq\()?)?"[^"]*"\s*at\s*"[^"]*"[\s,)]*$/.test(


### PR DESCRIPTION
e.g. https://github.com/tarao/nonempty-scala/blob/c319e56c45ce4ca3e98bdadde0b70505694b1dca/build.sbt#L5-L9