### PR TITLE
fix: explicit caching of null for docker lookups

### DIFF
--- a/lib/datasource/docker/index.ts
+++ b/lib/datasource/docker/index.ts
@@ -368,7 +368,7 @@ export async function getDigest(
     );
   }
   const cacheMinutes = 30;
-  await globalCache.set(cacheNamespace, cacheKey, null, cacheMinutes);
+  await globalCache.set(cacheNamespace, cacheKey, digest, cacheMinutes);
   return digest;
 }
 


### PR DESCRIPTION
I've just noticed that my self-hosted Renovate instance started ripping away all planned Docker image upgrades from existing pull requests after it has been auto-upgraded to `renovate/renovate:21.12.3@sha256:b72b88f48ac06c45e1d1fe7248e441ff3892d832c54b49e0df46974b630469a9`.

Luckily I was quickly able to identify the cause - while https://github.com/renovatebot/renovate/commit/b277dfe7bbe68fe3bcf7ed756430506cabc86f3f says it does fix the caching of null lookups, it ends up explicitly caching `null` every time :grin:

https://github.com/renovatebot/renovate/blob/b277dfe7bbe68fe3bcf7ed756430506cabc86f3f/lib/datasource/docker/index.ts#L371

This causes all lookups for a Docker image to fail as soon as the cache kicks in, so it only works properly for the first time. This PR fixes that bug by actually storing the digest. I explicitly did not add a check to see if `digest` evaluates to true, as it seems that it is now desired to also cache negative lookups as `null`, at least based on what I could gather from https://github.com/renovatebot/renovate/commit/0345b40a181134236d65ccebd450efd46700deb9.