### PR TITLE
feat(internal): datasource registryStrategy

### DIFF
--- a/lib/datasource/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/__snapshots__/index.spec.ts.snap
@@ -22,3 +22,18 @@ Object {
   "sourceUrl": "https://github.com/nodejs/node",
 }
 `;
+
+exports[`datasource/index merges registries and returns success 1`] = `
+Object {
+  "releases": Array [
+    Object {
+      "version": "1.0.0",
+    },
+    Object {
+      "version": "1.1.0",
+    },
+  ],
+}
+`;
+
+exports[`datasource/index warns if multiple registryUrls for registryStrategy=first 1`] = `null`;

--- a/lib/datasource/cdnjs/index.ts
+++ b/lib/datasource/cdnjs/index.ts
@@ -7,13 +7,13 @@ export const id = 'cdnjs';
 
 const http = new Http(id);
 
-export interface CdnjsAsset {
+interface CdnjsAsset {
   version: string;
   files: string[];
   sri?: Record<string, string>;
 }
 
-export interface CdnjsResponse {
+interface CdnjsResponse {
   homepage?: string;
   repository?: {
     type: 'git' | unknown;
@@ -30,6 +30,7 @@ async function downloadLibrary(library: string): CachePromise<CdnjsResponse> {
 export async function getReleases({
   lookupName,
 }: GetReleasesConfig): Promise<ReleaseResult | null> {
+  // Each library contains multiple assets, so we cache at the library level instead of per-asset
   const library = lookupName.split('/')[0];
   try {
     const { assets, homepage, repository } = await cacheAble({
@@ -56,7 +57,7 @@ export async function getReleases({
     return result;
   } catch (err) {
     if (err.statusCode === 404) {
-      logger.debug({ library, err }, 'Package lookup error');
+      logger.debug({ library }, 'cdnjs library not found');
       return null;
     }
     // Throw a DatasourceError for all other types of errors

--- a/lib/datasource/common.ts
+++ b/lib/datasource/common.ts
@@ -7,7 +7,9 @@ export interface Config {
   registryUrls?: string[];
 }
 
-export type DigestConfig = Config;
+export interface DigestConfig extends Config {
+  registryUrl?: string;
+}
 
 interface ReleasesConfigBase {
   compatibility?: Record<string, string>;
@@ -17,6 +19,7 @@ interface ReleasesConfigBase {
 
 export interface GetReleasesConfig extends ReleasesConfigBase {
   lookupName: string;
+  registryUrl?: string;
 }
 
 export interface GetPkgReleasesConfig extends ReleasesConfigBase {
@@ -65,6 +68,7 @@ export interface ReleaseResult {
   sourceUrl?: string;
   tags?: Record<string, string>;
   versions?: any;
+  registryUrl?: string;
 }
 
 export interface Datasource {
@@ -74,6 +78,7 @@ export interface Datasource {
   defaultRegistryUrls?: string[];
   appendRegistryUrls?: string[];
   defaultConfig?: object;
+  registryStrategy?: 'first' | 'hunt' | 'merge';
 }
 
 export class DatasourceError extends Error {

--- a/lib/datasource/docker/index.spec.ts
+++ b/lib/datasource/docker/index.spec.ts
@@ -31,13 +31,16 @@ describe('api/docker', () => {
 
   describe('getRegistryRepository', () => {
     it('handles local registries', () => {
-      const res = docker.getRegistryRepository('registry:5000/org/package', []);
+      const res = docker.getRegistryRepository(
+        'registry:5000/org/package',
+        'https://index.docker.io'
+      );
       expect(res).toMatchSnapshot();
     });
     it('supports registryUrls', () => {
       const res = docker.getRegistryRepository(
         'my.local.registry/prefix/image',
-        ['https://my.local.registry/prefix']
+        'https://my.local.registry/prefix'
       );
       expect(res).toMatchSnapshot();
     });

--- a/lib/datasource/gitlab-tags/index.ts
+++ b/lib/datasource/gitlab-tags/index.ts
@@ -1,5 +1,4 @@
 import URL from 'url';
-import is from '@sindresorhus/is';
 import { logger } from '../../logger';
 import * as globalCache from '../../util/cache/global';
 import { GitlabHttp } from '../../util/http/gitlab';
@@ -8,6 +7,8 @@ import { GetReleasesConfig, ReleaseResult } from '../common';
 const gitlabApi = new GitlabHttp();
 
 export const id = 'gitlab-tags';
+export const defaultRegistryUrls = ['https://gitlab.com'];
+export const registryStrategy = 'first';
 
 const cacheNamespace = 'datasource-gitlab';
 function getCacheKey(depHost: string, repo: string): string {
@@ -23,13 +24,9 @@ type GitlabTag = {
 };
 
 export async function getReleases({
-  registryUrls,
+  registryUrl: depHost,
   lookupName: repo,
 }: GetReleasesConfig): Promise<ReleaseResult | null> {
-  // Use registryUrls if present, otherwise default to publid gitlab.com
-  const depHost = is.nonEmptyArray(registryUrls)
-    ? registryUrls[0].replace(/\/$/, '')
-    : 'https://gitlab.com';
   let gitlabTags: GitlabTag[];
   const cachedResult = await globalCache.get<ReleaseResult>(
     cacheNamespace,
@@ -65,7 +62,7 @@ export async function getReleases({
   }
 
   const dependency: ReleaseResult = {
-    sourceUrl: `${depHost}/${repo}`,
+    sourceUrl: URL.resolve(depHost, repo),
     releases: null,
   };
   dependency.releases = gitlabTags.map(({ name, commit }) => ({

--- a/lib/datasource/gradle-version/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/gradle-version/__snapshots__/index.spec.ts.snap
@@ -9,20 +9,8 @@ Object {
       "version": "0.7",
     },
     Object {
-      "releaseTimestamp": "2009-07-20T08:50:13+0200",
-      "version": "0.7",
-    },
-    Object {
       "releaseTimestamp": "2009-09-28T14:01:59+0200",
       "version": "0.8",
-    },
-    Object {
-      "releaseTimestamp": "2009-09-28T14:01:59+0200",
-      "version": "0.8",
-    },
-    Object {
-      "releaseTimestamp": "2010-12-19T12:50:06+1100",
-      "version": "0.9",
     },
     Object {
       "releaseTimestamp": "2010-12-19T12:50:06+1100",
@@ -33,20 +21,8 @@ Object {
       "version": "0.9.1",
     },
     Object {
-      "releaseTimestamp": "2011-01-02T11:40:57+1100",
-      "version": "0.9.1",
-    },
-    Object {
       "releaseTimestamp": "2011-01-23T13:34:21+1100",
       "version": "0.9.2",
-    },
-    Object {
-      "releaseTimestamp": "2011-01-23T13:34:21+1100",
-      "version": "0.9.2",
-    },
-    Object {
-      "releaseTimestamp": "2012-06-12T02:56:21+0200",
-      "version": "1.0",
     },
     Object {
       "releaseTimestamp": "2012-06-12T02:56:21+0200",
@@ -57,20 +33,8 @@ Object {
       "version": "1.1",
     },
     Object {
-      "releaseTimestamp": "2012-07-31T13:24:32+0000",
-      "version": "1.1",
-    },
-    Object {
       "releaseTimestamp": "2012-09-12T10:46:02+0000",
       "version": "1.2",
-    },
-    Object {
-      "releaseTimestamp": "2012-09-12T10:46:02+0000",
-      "version": "1.2",
-    },
-    Object {
-      "releaseTimestamp": "2012-11-20T11:37:38+0000",
-      "version": "1.3",
     },
     Object {
       "releaseTimestamp": "2012-11-20T11:37:38+0000",
@@ -81,20 +45,8 @@ Object {
       "version": "1.4",
     },
     Object {
-      "releaseTimestamp": "2013-01-28T03:42:46+0000",
-      "version": "1.4",
-    },
-    Object {
       "releaseTimestamp": "2013-03-27T14:09:35+0000",
       "version": "1.5",
-    },
-    Object {
-      "releaseTimestamp": "2013-03-27T14:09:35+0000",
-      "version": "1.5",
-    },
-    Object {
-      "releaseTimestamp": "2013-05-07T09:12:14+0000",
-      "version": "1.6",
     },
     Object {
       "releaseTimestamp": "2013-05-07T09:12:14+0000",
@@ -105,20 +57,8 @@ Object {
       "version": "1.7",
     },
     Object {
-      "releaseTimestamp": "2013-08-06T11:19:56+0000",
-      "version": "1.7",
-    },
-    Object {
       "releaseTimestamp": "2013-09-24T07:32:33+0000",
       "version": "1.8",
-    },
-    Object {
-      "releaseTimestamp": "2013-09-24T07:32:33+0000",
-      "version": "1.8",
-    },
-    Object {
-      "releaseTimestamp": "2013-11-19T08:20:02+0000",
-      "version": "1.9",
     },
     Object {
       "releaseTimestamp": "2013-11-19T08:20:02+0000",
@@ -129,20 +69,8 @@ Object {
       "version": "1.10",
     },
     Object {
-      "releaseTimestamp": "2013-12-17T09:28:15+0000",
-      "version": "1.10",
-    },
-    Object {
       "releaseTimestamp": "2014-02-11T11:34:39+0000",
       "version": "1.11",
-    },
-    Object {
-      "releaseTimestamp": "2014-02-11T11:34:39+0000",
-      "version": "1.11",
-    },
-    Object {
-      "releaseTimestamp": "2014-04-29T09:24:31+0000",
-      "version": "1.12",
     },
     Object {
       "releaseTimestamp": "2014-04-29T09:24:31+0000",
@@ -153,20 +81,8 @@ Object {
       "version": "2.0",
     },
     Object {
-      "releaseTimestamp": "2014-07-01T07:45:34+0000",
-      "version": "2.0",
-    },
-    Object {
       "releaseTimestamp": "2014-09-08T10:40:39+0000",
       "version": "2.1",
-    },
-    Object {
-      "releaseTimestamp": "2014-09-08T10:40:39+0000",
-      "version": "2.1",
-    },
-    Object {
-      "releaseTimestamp": "2014-11-10T13:31:44+0000",
-      "version": "2.2",
     },
     Object {
       "releaseTimestamp": "2014-11-10T13:31:44+0000",
@@ -177,20 +93,8 @@ Object {
       "version": "2.2.1",
     },
     Object {
-      "releaseTimestamp": "2014-11-24T09:45:35+0000",
-      "version": "2.2.1",
-    },
-    Object {
       "releaseTimestamp": "2015-02-16T05:09:33+0000",
       "version": "2.3",
-    },
-    Object {
-      "releaseTimestamp": "2015-02-16T05:09:33+0000",
-      "version": "2.3",
-    },
-    Object {
-      "releaseTimestamp": "2015-05-05T08:09:24+0000",
-      "version": "2.4",
     },
     Object {
       "releaseTimestamp": "2015-05-05T08:09:24+0000",
@@ -201,20 +105,8 @@ Object {
       "version": "2.5",
     },
     Object {
-      "releaseTimestamp": "2015-07-08T07:38:37+0000",
-      "version": "2.5",
-    },
-    Object {
       "releaseTimestamp": "2015-08-10T13:15:06+0000",
       "version": "2.6",
-    },
-    Object {
-      "releaseTimestamp": "2015-08-10T13:15:06+0000",
-      "version": "2.6",
-    },
-    Object {
-      "releaseTimestamp": "2015-09-14T07:26:16+0000",
-      "version": "2.7",
     },
     Object {
       "releaseTimestamp": "2015-09-14T07:26:16+0000",
@@ -225,20 +117,8 @@ Object {
       "version": "2.8",
     },
     Object {
-      "releaseTimestamp": "2015-10-20T03:46:36+0000",
-      "version": "2.8",
-    },
-    Object {
       "releaseTimestamp": "2015-11-17T07:02:17+0000",
       "version": "2.9",
-    },
-    Object {
-      "releaseTimestamp": "2015-11-17T07:02:17+0000",
-      "version": "2.9",
-    },
-    Object {
-      "releaseTimestamp": "2015-12-21T21:15:04+0000",
-      "version": "2.10",
     },
     Object {
       "releaseTimestamp": "2015-12-21T21:15:04+0000",
@@ -249,20 +129,8 @@ Object {
       "version": "2.11",
     },
     Object {
-      "releaseTimestamp": "2016-02-08T07:59:16+0000",
-      "version": "2.11",
-    },
-    Object {
       "releaseTimestamp": "2016-03-14T08:32:03+0000",
       "version": "2.12",
-    },
-    Object {
-      "releaseTimestamp": "2016-03-14T08:32:03+0000",
-      "version": "2.12",
-    },
-    Object {
-      "releaseTimestamp": "2016-04-25T04:10:10+0000",
-      "version": "2.13",
     },
     Object {
       "releaseTimestamp": "2016-04-25T04:10:10+0000",
@@ -273,20 +141,8 @@ Object {
       "version": "2.14",
     },
     Object {
-      "releaseTimestamp": "2016-06-14T07:16:37+0000",
-      "version": "2.14",
-    },
-    Object {
       "releaseTimestamp": "2016-07-18T06:38:37+0000",
       "version": "2.14.1",
-    },
-    Object {
-      "releaseTimestamp": "2016-07-18T06:38:37+0000",
-      "version": "2.14.1",
-    },
-    Object {
-      "releaseTimestamp": "2016-08-15T13:15:01+0000",
-      "version": "3.0",
     },
     Object {
       "releaseTimestamp": "2016-08-15T13:15:01+0000",
@@ -297,20 +153,8 @@ Object {
       "version": "3.1",
     },
     Object {
-      "releaseTimestamp": "2016-09-19T10:53:53+0000",
-      "version": "3.1",
-    },
-    Object {
       "releaseTimestamp": "2016-11-14T12:32:59+0000",
       "version": "3.2",
-    },
-    Object {
-      "releaseTimestamp": "2016-11-14T12:32:59+0000",
-      "version": "3.2",
-    },
-    Object {
-      "releaseTimestamp": "2016-11-22T15:19:54+0000",
-      "version": "3.2.1",
     },
     Object {
       "releaseTimestamp": "2016-11-22T15:19:54+0000",
@@ -321,20 +165,8 @@ Object {
       "version": "3.3",
     },
     Object {
-      "releaseTimestamp": "2017-01-03T15:31:04+0000",
-      "version": "3.3",
-    },
-    Object {
       "releaseTimestamp": "2017-02-20T14:49:26+0000",
       "version": "3.4",
-    },
-    Object {
-      "releaseTimestamp": "2017-02-20T14:49:26+0000",
-      "version": "3.4",
-    },
-    Object {
-      "releaseTimestamp": "2017-03-03T19:45:41+0000",
-      "version": "3.4.1",
     },
     Object {
       "releaseTimestamp": "2017-03-03T19:45:41+0000",
@@ -345,20 +177,8 @@ Object {
       "version": "3.5",
     },
     Object {
-      "releaseTimestamp": "2017-04-10T13:37:25+0000",
-      "version": "3.5",
-    },
-    Object {
       "releaseTimestamp": "2017-06-16T14:36:27+0000",
       "version": "3.5.1",
-    },
-    Object {
-      "releaseTimestamp": "2017-06-16T14:36:27+0000",
-      "version": "3.5.1",
-    },
-    Object {
-      "releaseTimestamp": "2017-06-14T15:11:08+0000",
-      "version": "4.0",
     },
     Object {
       "releaseTimestamp": "2017-06-14T15:11:08+0000",
@@ -369,20 +189,8 @@ Object {
       "version": "4.0.1",
     },
     Object {
-      "releaseTimestamp": "2017-07-07T14:02:41+0000",
-      "version": "4.0.1",
-    },
-    Object {
       "releaseTimestamp": "2017-07-26T16:19:18+0000",
       "version": "4.0.2",
-    },
-    Object {
-      "releaseTimestamp": "2017-07-26T16:19:18+0000",
-      "version": "4.0.2",
-    },
-    Object {
-      "releaseTimestamp": "2017-08-07T14:38:48+0000",
-      "version": "4.1",
     },
     Object {
       "releaseTimestamp": "2017-08-07T14:38:48+0000",
@@ -393,20 +201,8 @@ Object {
       "version": "4.2",
     },
     Object {
-      "releaseTimestamp": "2017-09-20T14:48:23+0000",
-      "version": "4.2",
-    },
-    Object {
       "releaseTimestamp": "2017-10-02T15:36:21+0000",
       "version": "4.2.1",
-    },
-    Object {
-      "releaseTimestamp": "2017-10-02T15:36:21+0000",
-      "version": "4.2.1",
-    },
-    Object {
-      "releaseTimestamp": "2017-10-30T15:43:29+0000",
-      "version": "4.3",
     },
     Object {
       "releaseTimestamp": "2017-10-30T15:43:29+0000",
@@ -417,20 +213,8 @@ Object {
       "version": "4.3.1",
     },
     Object {
-      "releaseTimestamp": "2017-11-08T08:59:45+0000",
-      "version": "4.3.1",
-    },
-    Object {
       "releaseTimestamp": "2017-12-06T09:05:06+0000",
       "version": "4.4",
-    },
-    Object {
-      "releaseTimestamp": "2017-12-06T09:05:06+0000",
-      "version": "4.4",
-    },
-    Object {
-      "releaseTimestamp": "2017-12-20T15:45:23+0000",
-      "version": "4.4.1",
     },
     Object {
       "releaseTimestamp": "2017-12-20T15:45:23+0000",
@@ -441,20 +225,8 @@ Object {
       "version": "4.5",
     },
     Object {
-      "releaseTimestamp": "2018-01-24T17:04:52+0000",
-      "version": "4.5",
-    },
-    Object {
       "releaseTimestamp": "2018-02-05T13:22:49+0000",
       "version": "4.5.1",
-    },
-    Object {
-      "releaseTimestamp": "2018-02-05T13:22:49+0000",
-      "version": "4.5.1",
-    },
-    Object {
-      "releaseTimestamp": "2018-02-28T13:36:36+0000",
-      "version": "4.6",
     },
     Object {
       "releaseTimestamp": "2018-02-28T13:36:36+0000",
@@ -465,20 +237,8 @@ Object {
       "version": "4.7",
     },
     Object {
-      "releaseTimestamp": "2018-04-18T09:09:12+0000",
-      "version": "4.7",
-    },
-    Object {
       "releaseTimestamp": "2018-06-04T10:39:58+0000",
       "version": "4.8",
-    },
-    Object {
-      "releaseTimestamp": "2018-06-04T10:39:58+0000",
-      "version": "4.8",
-    },
-    Object {
-      "releaseTimestamp": "2018-06-21T07:53:06+0000",
-      "version": "4.8.1",
     },
     Object {
       "releaseTimestamp": "2018-06-21T07:53:06+0000",
@@ -489,20 +249,8 @@ Object {
       "version": "4.9",
     },
     Object {
-      "releaseTimestamp": "2018-07-16T08:14:03+0000",
-      "version": "4.9",
-    },
-    Object {
       "releaseTimestamp": "2018-08-27T18:35:06+0000",
       "version": "4.10",
-    },
-    Object {
-      "releaseTimestamp": "2018-08-27T18:35:06+0000",
-      "version": "4.10",
-    },
-    Object {
-      "releaseTimestamp": "2018-09-12T11:33:27+0000",
-      "version": "4.10.1",
     },
     Object {
       "releaseTimestamp": "2018-09-12T11:33:27+0000",
@@ -513,20 +261,8 @@ Object {
       "version": "4.10.2",
     },
     Object {
-      "releaseTimestamp": "2018-09-19T18:10:15+0000",
-      "version": "4.10.2",
-    },
-    Object {
       "releaseTimestamp": null,
       "version": "4.10.3",
-    },
-    Object {
-      "releaseTimestamp": null,
-      "version": "4.10.3",
-    },
-    Object {
-      "releaseTimestamp": null,
-      "version": "5.0",
     },
     Object {
       "releaseTimestamp": null,

--- a/lib/datasource/gradle-version/index.ts
+++ b/lib/datasource/gradle-version/index.ts
@@ -49,7 +49,6 @@ export async function getReleases({
         releaseTimestamp: formatBuildTime(release.buildTime),
       }));
   } catch (err) /* istanbul ignore next */ {
-    // istanbul ignore if
     if (err.host === 'services.gradle.org') {
       throw new DatasourceError(err);
     }

--- a/lib/datasource/gradle-version/index.ts
+++ b/lib/datasource/gradle-version/index.ts
@@ -1,19 +1,13 @@
-import is from '@sindresorhus/is';
 import { logger } from '../../logger';
 import { Http } from '../../util/http';
 import { regEx } from '../../util/regex';
-import {
-  DatasourceError,
-  GetReleasesConfig,
-  Release,
-  ReleaseResult,
-} from '../common';
+import { DatasourceError, GetReleasesConfig, ReleaseResult } from '../common';
 
 export const id = 'gradle-version';
+export const defaultRegistryUrls = ['https://services.gradle.org/versions/all'];
+export const registryStrategy = 'merge';
 
 const http = new Http(id);
-
-const GradleVersionsServiceUrl = 'https://services.gradle.org/versions/all';
 
 interface GradleRelease {
   snapshot?: boolean;
@@ -38,41 +32,33 @@ function formatBuildTime(timeStr: string): string | null {
 }
 
 export async function getReleases({
-  registryUrls,
+  registryUrl,
 }: GetReleasesConfig): Promise<ReleaseResult> {
-  const versionsUrls = is.nonEmptyArray(registryUrls)
-    ? registryUrls
-    : [GradleVersionsServiceUrl];
-
-  const allReleases: Release[][] = await Promise.all(
-    versionsUrls.map(async (url) => {
-      try {
-        const response = await http.getJson<GradleRelease[]>(url);
-        const releases = response.body
-          .filter((release) => !release.snapshot && !release.nightly)
-          .filter(
-            (release) =>
-              // some milestone have wrong metadata and need to be filtered by version name content
-              release.rcFor === '' && !release.version.includes('milestone')
-          )
-          .map((release) => ({
-            version: release.version,
-            releaseTimestamp: formatBuildTime(release.buildTime),
-          }));
-        return releases;
-      } catch (err) /* istanbul ignore next */ {
-        // istanbul ignore if
-        if (err.host === 'services.gradle.org') {
-          throw new DatasourceError(err);
-        }
-        logger.debug({ err }, 'gradle-version err');
-        return null;
-      }
-    })
-  );
+  let releases;
+  try {
+    const response = await http.getJson<GradleRelease[]>(registryUrl);
+    releases = response.body
+      .filter((release) => !release.snapshot && !release.nightly)
+      .filter(
+        (release) =>
+          // some milestone have wrong metadata and need to be filtered by version name content
+          release.rcFor === '' && !release.version.includes('milestone')
+      )
+      .map((release) => ({
+        version: release.version,
+        releaseTimestamp: formatBuildTime(release.buildTime),
+      }));
+  } catch (err) /* istanbul ignore next */ {
+    // istanbul ignore if
+    if (err.host === 'services.gradle.org') {
+      throw new DatasourceError(err);
+    }
+    logger.debug({ err }, 'gradle-version err');
+    return null;
+  }
 
   const res: ReleaseResult = {
-    releases: Array.prototype.concat.apply([], allReleases).filter(Boolean),
+    releases,
     homepage: 'https://gradle.org',
     sourceUrl: 'https://github.com/gradle/gradle',
   };

--- a/lib/datasource/helm/index.ts
+++ b/lib/datasource/helm/index.ts
@@ -13,6 +13,7 @@ const http = new Http(id);
 export const defaultRegistryUrls = [
   'https://kubernetes-charts.storage.googleapis.com/',
 ];
+export const registryStrategy = 'first';
 
 export async function getRepositoryData(
   repository: string
@@ -101,9 +102,8 @@ export async function getRepositoryData(
 
 export async function getReleases({
   lookupName,
-  registryUrls,
+  registryUrl: helmRepository,
 }: GetReleasesConfig): Promise<ReleaseResult | null> {
-  const [helmRepository] = registryUrls;
   const repositoryData = await getRepositoryData(helmRepository);
   if (!repositoryData) {
     logger.debug(`Couldn't get index.yaml file from ${helmRepository}`);

--- a/lib/datasource/index.ts
+++ b/lib/datasource/index.ts
@@ -29,6 +29,122 @@ function load(datasource: string): Promise<Datasource> {
 
 type GetReleasesInternalConfig = GetReleasesConfig & GetPkgReleasesConfig;
 
+function firstRegistry(
+  config: GetReleasesInternalConfig,
+  datasource: Datasource,
+  registryUrls: string[]
+): Promise<ReleaseResult> {
+  if (!registryUrls?.length) {
+    logger.warn(
+      { datasource: datasource.id, depName: config.depName },
+      'No registryUrls found for datasource lookup'
+    );
+    return null;
+  }
+  if (registryUrls.length > 1) {
+    logger.warn(
+      { datasource: datasource.id, depName: config.depName, registryUrls },
+      'Excess registryUrls found for datasource lookup - using first configured only'
+    );
+  }
+  const registryUrl = registryUrls[0];
+  return datasource.getReleases({
+    ...config,
+    registryUrl,
+  });
+}
+
+async function huntRegistries(
+  config: GetReleasesInternalConfig,
+  datasource: Datasource,
+  registryUrls: string[]
+): Promise<ReleaseResult> {
+  if (!registryUrls?.length) {
+    logger.warn(
+      { datasource: datasource.id, depName: config.depName },
+      'No registryUrls found for datasource lookup'
+    );
+    return null;
+  }
+  let res: ReleaseResult;
+  let datasourceError;
+  for (const registryUrl of registryUrls) {
+    try {
+      res =
+        res ||
+        (await datasource.getReleases({
+          ...config,
+          registryUrl,
+        }));
+    } catch (err) {
+      if (err instanceof DatasourceError) {
+        throw err;
+      }
+      // We'll always save the last-thrown error
+      datasourceError = err;
+      logger.trace({ err }, 'datasource hunt failure');
+    }
+  }
+  if (res === undefined && datasourceError) {
+    // if we failed to get a result and also got an error then throw it
+    throw datasourceError;
+  }
+  return res;
+}
+
+async function mergeRegistries(
+  config: GetReleasesInternalConfig,
+  datasource: Datasource,
+  registryUrls: string[]
+): Promise<ReleaseResult> {
+  if (!registryUrls?.length) {
+    logger.warn(
+      { datasource: datasource.id, depName: config.depName },
+      'No registryUrls found for datasource lookup'
+    );
+    return null;
+  }
+  let combinedRes: ReleaseResult;
+  let datasourceError;
+  for (const registryUrl of registryUrls) {
+    try {
+      const res = await datasource.getReleases({
+        ...config,
+        registryUrl,
+      });
+      if (combinedRes) {
+        combinedRes = { ...res, ...combinedRes };
+        combinedRes.releases = [...combinedRes.releases, ...res.releases];
+      } else {
+        combinedRes = res;
+      }
+    } catch (err) {
+      if (err instanceof DatasourceError) {
+        throw err;
+      }
+      // We'll always save the last-thrown error
+      datasourceError = err;
+      logger.trace({ err }, 'datasource merge failure');
+    }
+  }
+  if (combinedRes === undefined && datasourceError) {
+    // if we failed to get a result and also got an error then throw it
+    throw datasourceError;
+  }
+  // De-duplicate releases
+  if (combinedRes?.releases?.length) {
+    const seenVersions = [];
+    combinedRes.releases = combinedRes.releases.filter((release) => {
+      if (seenVersions.includes(release.version)) {
+        return false;
+      }
+      seenVersions.push(release.version);
+      return true;
+    });
+  }
+  return combinedRes;
+}
+
 function resolveRegistryUrls(
   datasource: Datasource,
   extractedUrls: string[]
@@ -49,11 +165,20 @@ async function fetchReleases(
   }
   const datasource = await load(datasourceName);
   const registryUrls = resolveRegistryUrls(datasource, config.registryUrls);
-  let dep = await datasource.getReleases({
-    ...config,
-    registryUrls,
-  });
-  if (!(dep && dep.releases.length)) {
+  let dep: ReleaseResult;
+  if (datasource.registryStrategy === 'first') {
+    dep = await firstRegistry(config, datasource, registryUrls);
+  } else if (datasource.registryStrategy === 'hunt') {
+    dep = await huntRegistries(config, datasource, registryUrls);
+  } else if (datasource.registryStrategy === 'merge') {
+    dep = await mergeRegistries(config, datasource, registryUrls);
+  } else {
+    dep = await datasource.getReleases({
+      ...config,
+      registryUrls,
+    });
+  }
+  if (dep?.releases?.length === 0) {
     dep = null;
   }
   addMetaData(dep, datasourceName, config.lookupName);
@@ -131,10 +256,11 @@ export async function getDigest(
   config: DigestConfig,
   value?: string
 ): Promise<string | null> {
+  const datasource = await load(config.datasource);
   const lookupName = config.lookupName || config.depName;
-  const { registryUrls } = config;
-  return (await load(config.datasource)).getDigest(
-    { lookupName, registryUrls },
+  const registryUrls = resolveRegistryUrls(datasource, config.registryUrls);
+  return datasource.getDigest(
+    { lookupName, registryUrl: registryUrls[0] },
     value
   );
 }

--- a/lib/datasource/index.ts
+++ b/lib/datasource/index.ts
@@ -147,6 +147,7 @@ async function fetchReleases(
   const registryUrls = resolveRegistryUrls(datasource, config.registryUrls);
   let dep: ReleaseResult;
   if (datasource.registryStrategy) {
+    // istanbul ignore if
     if (!registryUrls.length) {
       logger.warn(
         { datasource: datasourceName, depName: config.depName },
@@ -167,10 +168,7 @@ async function fetchReleases(
       registryUrls,
     });
   }
-  if (!dep) {
-    return null;
-  }
-  if (!dep.releases?.length) {
+  if (!dep?.releases?.length) {
     return null;
   }
   addMetaData(dep, datasourceName, config.lookupName);

--- a/lib/datasource/packagist/index.ts
+++ b/lib/datasource/packagist/index.ts
@@ -1,5 +1,4 @@
 import URL from 'url';
-import is from '@sindresorhus/is';
 
 import pAll from 'p-all';
 import { logger } from '../../logger';
@@ -10,6 +9,8 @@ import { Http, HttpOptions } from '../../util/http';
 import { DatasourceError, GetReleasesConfig, ReleaseResult } from '../common';
 
 export const id = 'packagist';
+export const defaultRegistryUrls = ['https://packagist.org'];
+export const registryStrategy = 'hunt';
 
 const http = new Http(id);
 
@@ -325,19 +326,8 @@ async function packageLookup(
 
 export async function getReleases({
   lookupName,
-  registryUrls,
+  registryUrl,
 }: GetReleasesConfig): Promise<ReleaseResult> {
   logger.trace(`getReleases(${lookupName})`);
-
-  let res: ReleaseResult;
-  const registries = is.nonEmptyArray(registryUrls)
-    ? registryUrls
-    : ['https://packagist.org'];
-  for (const regUrl of registries) {
-    res = await packageLookup(regUrl, lookupName);
-    if (res) {
-      break;
-    }
-  }
-  return res;
+  return packageLookup(registryUrl, lookupName);
 }

--- a/lib/datasource/pypi/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/pypi/__snapshots__/index.spec.ts.snap
@@ -394,21 +394,6 @@ Array [
 ]
 `;
 
-exports[`datasource/pypi getReleases supports custom datasource url from environmental variable 1`] = `
-Array [
-  Object {
-    "headers": Object {
-      "accept": "application/json",
-      "accept-encoding": "gzip, deflate",
-      "host": "my.pypi.python",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
-    "url": "https://my.pypi.python/pypi/azure-cli-monitor/json",
-  },
-]
-`;
-
 exports[`datasource/pypi getReleases supports multiple custom datasource urls 1`] = `
 Array [
   Object {

--- a/lib/datasource/pypi/index.spec.ts
+++ b/lib/datasource/pypi/index.spec.ts
@@ -82,20 +82,6 @@ describe('datasource/pypi', () => {
       });
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
-    it('supports custom datasource url from environmental variable', async () => {
-      httpMock
-        .scope('https://my.pypi.python/pypi/')
-        .get('/azure-cli-monitor/json')
-        .reply(200, JSON.parse(res1));
-      const pipIndexUrl = process.env.PIP_INDEX_URL;
-      process.env.PIP_INDEX_URL = 'https://my.pypi.python/pypi/';
-      await getPkgReleases({
-        datasource,
-        depName: 'azure-cli-monitor',
-      });
-      expect(httpMock.getTrace()).toMatchSnapshot();
-      process.env.PIP_INDEX_URL = pipIndexUrl;
-    });
     it('supports multiple custom datasource urls', async () => {
       httpMock
         .scope('https://custom.pypi.net/foo')

--- a/lib/datasource/pypi/index.ts
+++ b/lib/datasource/pypi/index.ts
@@ -1,5 +1,4 @@
 import url from 'url';
-import is from '@sindresorhus/is';
 import changelogFilenameRegex from 'changelog-filename-regex';
 import { parse } from 'node-html-parser';
 import { logger } from '../../logger';
@@ -9,6 +8,11 @@ import * as pep440 from '../../versioning/pep440';
 import { GetReleasesConfig, ReleaseResult } from '../common';
 
 export const id = 'pypi';
+export const defaultRegistryUrls = [
+  process.env.PIP_INDEX_URL || 'https://pypi.org/pypi/',
+];
+export const registryStrategy = 'hunt';
+
 const github_repo_pattern = /^https?:\/\/github\.com\/[^\\/]+\/[^\\/]+$/;
 const http = new Http(id);
 
@@ -208,36 +212,13 @@ async function getSimpleDependency(
 export async function getReleases({
   compatibility,
   lookupName,
-  registryUrls,
+  registryUrl,
 }: GetReleasesConfig): Promise<ReleaseResult | null> {
-  let hostUrls = ['https://pypi.org/pypi/'];
-  if (is.nonEmptyArray(registryUrls)) {
-    hostUrls = registryUrls;
+  const hostUrl = registryUrl + (registryUrl.endsWith('/') ? '' : '/');
+  if (hostUrl.endsWith('/simple/') || hostUrl.endsWith('/+simple/')) {
+    logger.trace({ lookupName, hostUrl }, 'Looking up pypi simple dependency');
+    return getSimpleDependency(lookupName, hostUrl);
   }
-  if (process.env.PIP_INDEX_URL) {
-    hostUrls = [process.env.PIP_INDEX_URL];
-  }
-  let dep: ReleaseResult;
-  for (let index = 0; index < hostUrls.length && !dep; index += 1) {
-    let hostUrl = hostUrls[index];
-    hostUrl += hostUrl.endsWith('/') ? '' : '/';
-    if (hostUrl.endsWith('/simple/') || hostUrl.endsWith('/+simple/')) {
-      logger.trace(
-        { lookupName, hostUrl },
-        'Looking up pypi simple dependency'
-      );
-      dep = await getSimpleDependency(lookupName, hostUrl);
-    } else {
-      logger.trace({ lookupName, hostUrl }, 'Looking up pypi api dependency');
-      dep = await getDependency(lookupName, hostUrl, compatibility);
-    }
-    if (dep !== null) {
-      logger.trace({ lookupName, hostUrl }, 'Found pypi result');
-    }
-  }
-  if (dep) {
-    return dep;
-  }
-  logger.debug({ lookupName, registryUrls }, 'No pypi result - returning null');
-  return null;
+  logger.trace({ lookupName, hostUrl }, 'Looking up pypi api dependency');
+  return getDependency(lookupName, hostUrl, compatibility);
 }

--- a/lib/datasource/pypi/index.ts
+++ b/lib/datasource/pypi/index.ts
@@ -3,6 +3,7 @@ import changelogFilenameRegex from 'changelog-filename-regex';
 import { parse } from 'node-html-parser';
 import { logger } from '../../logger';
 import { Http } from '../../util/http';
+import { ensureTrailingSlash } from '../../util/url';
 import { matches } from '../../versioning/pep440';
 import * as pep440 from '../../versioning/pep440';
 import { GetReleasesConfig, ReleaseResult } from '../common';
@@ -214,7 +215,7 @@ export async function getReleases({
   lookupName,
   registryUrl,
 }: GetReleasesConfig): Promise<ReleaseResult | null> {
-  const hostUrl = registryUrl + (registryUrl.endsWith('/') ? '' : '/');
+  const hostUrl = ensureTrailingSlash(registryUrl);
   if (hostUrl.endsWith('/simple/') || hostUrl.endsWith('/+simple/')) {
     logger.trace({ lookupName, hostUrl }, 'Looking up pypi simple dependency');
     return getSimpleDependency(lookupName, hostUrl);

--- a/lib/datasource/rubygems/index.ts
+++ b/lib/datasource/rubygems/index.ts
@@ -1,3 +1,4 @@
 export { getReleases } from './releases';
 export { id } from './common';
 export const defaultRegistryUrls = ['https://rubygems.org'];
+export const registryStrategy = 'hunt';

--- a/lib/datasource/rubygems/releases.ts
+++ b/lib/datasource/rubygems/releases.ts
@@ -4,20 +4,11 @@ import { getRubygemsOrgDependency } from './get-rubygems-org';
 
 export async function getReleases({
   lookupName,
-  registryUrls,
+  registryUrl,
 }: GetReleasesConfig): Promise<ReleaseResult | null> {
-  for (const registry of registryUrls) {
-    let pkg: ReleaseResult;
-    // prettier-ignore
-    if (registry.endsWith('rubygems.org')) { // lgtm [js/incomplete-url-substring-sanitization]
-      pkg = await getRubygemsOrgDependency(lookupName);
-    } else {
-      pkg = await getDependency({ dependency: lookupName, registry });
+  // prettier-ignore
+  if (registryUrl.endsWith('rubygems.org')) { // lgtm [js/incomplete-url-substring-sanitization]
+      return getRubygemsOrgDependency(lookupName);
     }
-    if (pkg) {
-      return pkg;
-    }
-  }
-
-  return null;
+  return getDependency({ dependency: lookupName, registry: registryUrl });
 }

--- a/lib/datasource/sbt-package/index.ts
+++ b/lib/datasource/sbt-package/index.ts
@@ -73,11 +73,11 @@ export async function getReleases({
   const artifactIdSplit = artifactId.split('_');
   const [artifact, scalaVersion] = artifactIdSplit;
 
-  const repoRoot = registryUrl.replace(/\/?$/, '');
+  const repoRoot = ensureTrailingSlash(registryUrl);
   const searchRoots: string[] = [];
   // Optimize lookup order
-  searchRoots.push(`${repoRoot}/${groupIdSplit.join('/')}`);
-  searchRoots.push(`${repoRoot}/${groupIdSplit.join('.')}`);
+  searchRoots.push(`${repoRoot}${groupIdSplit.join('/')}`);
+  searchRoots.push(`${repoRoot}${groupIdSplit.join('.')}`);
 
   for (let idx = 0; idx < searchRoots.length; idx += 1) {
     const searchRoot = searchRoots[idx];

--- a/lib/datasource/sbt-package/index.ts
+++ b/lib/datasource/sbt-package/index.ts
@@ -8,6 +8,7 @@ import { parseIndexDir } from '../sbt-plugin/util';
 export const id = 'sbt-package';
 
 export const defaultRegistryUrls = [MAVEN_REPO];
+export const registryStrategy = 'hunt';
 
 const ensureTrailingSlash = (str: string): string => str.replace(/\/?$/, '/');
 
@@ -65,20 +66,18 @@ export async function resolvePackageReleases(
 
 export async function getReleases({
   lookupName,
-  registryUrls,
+  registryUrl,
 }: GetReleasesConfig): Promise<ReleaseResult | null> {
   const [groupId, artifactId] = lookupName.split(':');
   const groupIdSplit = groupId.split('.');
   const artifactIdSplit = artifactId.split('_');
   const [artifact, scalaVersion] = artifactIdSplit;
 
-  const repoRoots = registryUrls.map((x) => x.replace(/\/?$/, ''));
+  const repoRoot = registryUrl.replace(/\/?$/, '');
   const searchRoots: string[] = [];
-  repoRoots.forEach((repoRoot) => {
-    // Optimize lookup order
-    searchRoots.push(`${repoRoot}/${groupIdSplit.join('/')}`);
-    searchRoots.push(`${repoRoot}/${groupIdSplit.join('.')}`);
-  });
+  // Optimize lookup order
+  searchRoots.push(`${repoRoot}/${groupIdSplit.join('/')}`);
+  searchRoots.push(`${repoRoot}/${groupIdSplit.join('.')}`);
 
   for (let idx = 0; idx < searchRoots.length; idx += 1) {
     const searchRoot = searchRoots[idx];

--- a/lib/datasource/sbt-plugin/index.ts
+++ b/lib/datasource/sbt-plugin/index.ts
@@ -8,6 +8,7 @@ import { SBT_PLUGINS_REPO, parseIndexDir } from './util';
 export const id = 'sbt-plugin';
 
 export const defaultRegistryUrls = [SBT_PLUGINS_REPO];
+export const registryStrategy = 'hunt';
 
 const ensureTrailingSlash = (str: string): string => str.replace(/\/?$/, '/');
 
@@ -62,20 +63,18 @@ async function resolvePluginReleases(
 
 export async function getReleases({
   lookupName,
-  registryUrls,
+  registryUrl,
 }: GetReleasesConfig): Promise<ReleaseResult | null> {
   const [groupId, artifactId] = lookupName.split(':');
   const groupIdSplit = groupId.split('.');
   const artifactIdSplit = artifactId.split('_');
   const [artifact, scalaVersion] = artifactIdSplit;
 
-  const repoRoots = registryUrls.map((x) => x.replace(/\/?$/, ''));
+  const repoRoot = registryUrl.replace(/\/?$/, '');
   const searchRoots: string[] = [];
-  repoRoots.forEach((repoRoot) => {
-    // Optimize lookup order
-    searchRoots.push(`${repoRoot}/${groupIdSplit.join('.')}`);
-    searchRoots.push(`${repoRoot}/${groupIdSplit.join('/')}`);
-  });
+  // Optimize lookup order
+  searchRoots.push(`${repoRoot}/${groupIdSplit.join('.')}`);
+  searchRoots.push(`${repoRoot}/${groupIdSplit.join('/')}`);
 
   for (let idx = 0; idx < searchRoots.length; idx += 1) {
     const searchRoot = searchRoots[idx];

--- a/lib/datasource/sbt-plugin/index.ts
+++ b/lib/datasource/sbt-plugin/index.ts
@@ -70,11 +70,11 @@ export async function getReleases({
   const artifactIdSplit = artifactId.split('_');
   const [artifact, scalaVersion] = artifactIdSplit;
 
-  const repoRoot = registryUrl.replace(/\/?$/, '');
+  const repoRoot = ensureTrailingSlash(registryUrl);
   const searchRoots: string[] = [];
   // Optimize lookup order
-  searchRoots.push(`${repoRoot}/${groupIdSplit.join('.')}`);
-  searchRoots.push(`${repoRoot}/${groupIdSplit.join('/')}`);
+  searchRoots.push(`${repoRoot}${groupIdSplit.join('.')}`);
+  searchRoots.push(`${repoRoot}${groupIdSplit.join('/')}`);
 
   for (let idx = 0; idx < searchRoots.length; idx += 1) {
     const searchRoot = searchRoots[idx];

--- a/lib/datasource/terraform-provider/index.ts
+++ b/lib/datasource/terraform-provider/index.ts
@@ -22,7 +22,6 @@ interface TerraformProvider {
  */
 export async function getReleases({
   lookupName,
-  registryUrls,
 }: GetReleasesConfig): Promise<ReleaseResult | null> {
   const repository = `hashicorp/${lookupName}`;
 

--- a/lib/workers/repository/process/lookup/index.spec.ts
+++ b/lib/workers/repository/process/lookup/index.spec.ts
@@ -28,7 +28,8 @@ jest.mock('../../../../datasource/git-submodules');
 
 qJson.latestVersion = '1.4.1';
 
-const docker = mocked(datasourceDocker);
+const docker = mocked(datasourceDocker) as any;
+docker.defaultRegistryUrls = ['https://index.docker.io'];
 const gitSubmodules = mocked(datasourceGitSubmodules);
 
 let config: lookup.LookupUpdateConfig;


### PR DESCRIPTION
datasource implementations can export a `registryStrategy` field that is used by the datasource index/controller to manage the approach:
- ‘first’: send only the first registryUrl
- ‘hunt’: return the first successful result
- ‘merge’: try all registries and combined/deduplicate the results

This way they don't all need to reimplement the same logic.

Closes #6533