### PR TITLE
feat(sbt): Support private variable version resolving

### DIFF
--- a/lib/manager/sbt/__fixtures__/private-variable-dependency-file.scala
+++ b/lib/manager/sbt/__fixtures__/private-variable-dependency-file.scala
@@ -1,0 +1,15 @@
+import sbt._
+
+object Dependencies {
+  val moreSettings = Seq(
+    scalaVersion := "2.13.0-RC5"
+  )
+
+  private val abcVersion = "1.2.3"
+
+  private lazy val ujson = "com.example" %% "foo" % "0.7.1"
+
+  lazy val abc = "com.abc" % "abc" % abcVersion
+
+  lazy val dependentLibraries = Seq(ujson, abc)
+}

--- a/lib/manager/sbt/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/sbt/__snapshots__/extract.spec.ts.snap
@@ -1,5 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`lib/manager/sbt/extract extractPackageFile() extract deps from native scala file with private variables 1`] = `
+Object {
+  "deps": Array [
+    Object {
+      "currentValue": "0.7.1",
+      "datasource": "sbt-package",
+      "depName": "com.example:foo",
+      "lookupName": "com.example:foo_2.13.0-RC5",
+      "registryUrls": Array [
+        "https://repo.maven.apache.org/maven2",
+      ],
+    },
+    Object {
+      "currentValue": "1.2.3",
+      "datasource": "sbt-package",
+      "depName": "com.abc:abc",
+      "lookupName": "com.abc:abc",
+      "registryUrls": Array [
+        "https://repo.maven.apache.org/maven2",
+      ],
+    },
+  ],
+}
+`;
+
 exports[`lib/manager/sbt/extract extractPackageFile() extract deps from native scala file with variables 1`] = `
 Object {
   "deps": Array [

--- a/lib/manager/sbt/extract.spec.ts
+++ b/lib/manager/sbt/extract.spec.ts
@@ -20,6 +20,11 @@ const sbtDependencyFile = readFileSync(
   'utf8'
 );
 
+const sbtPrivateVariableDependencyFile = readFileSync(
+  resolve(__dirname, `./__fixtures__/private-variable-dependency-file.scala`),
+  'utf8'
+);
+
 describe('lib/manager/sbt/extract', () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty', () => {
@@ -77,6 +82,11 @@ describe('lib/manager/sbt/extract', () => {
         libraryDependencies += "org.example" %% "bar" % "0.0.2"
       `;
       expect(extractPackageFile(content)).toMatchSnapshot();
+    });
+    it('extract deps from native scala file with private variables', () => {
+      expect(
+        extractPackageFile(sbtPrivateVariableDependencyFile)
+      ).toMatchSnapshot();
     });
   });
 });

--- a/lib/manager/sbt/extract.ts
+++ b/lib/manager/sbt/extract.ts
@@ -66,20 +66,26 @@ const getResolverUrl = (str: string): string =>
     .replace(/"[\s,)]*$/, '');
 
 const isVarDependency = (str: string): boolean =>
-  /^\s*(lazy\s*)?val\s[_a-zA-Z][_a-zA-Z0-9]*\s*=.*(%%?).*%.*/.test(str);
+  /^\s*(private\s*)?(lazy\s*)?val\s[_a-zA-Z][_a-zA-Z0-9]*\s*=.*(%%?).*%.*/.test(
+    str
+  );
 
 const isVarDef = (str: string): boolean =>
-  /^\s*(lazy\s*)?val\s+[_a-zA-Z][_a-zA-Z0-9]*\s*=\s*"[^"]*"\s*$/.test(str);
+  /^\s*(private\s*)?(lazy\s*)?val\s+[_a-zA-Z][_a-zA-Z0-9]*\s*=\s*"[^"]*"\s*$/.test(
+    str
+  );
 
 const getVarName = (str: string): string =>
-  str.replace(/^\s*(lazy\s*)?val\s+/, '').replace(/\s*=\s*"[^"]*"\s*$/, '');
+  str
+    .replace(/^\s*(private\s*)?(lazy\s*)?val\s+/, '')
+    .replace(/\s*=\s*"[^"]*"\s*$/, '');
 
 const isVarName = (str: string): boolean =>
   /^[_a-zA-Z][_a-zA-Z0-9]*$/.test(str);
 
 const getVarInfo = (str: string, ctx: ParseContext): { val: string } => {
   const rightPart = str.replace(
-    /^\s*(lazy\s*)?val\s+[_a-zA-Z][_a-zA-Z0-9]*\s*=\s*"/,
+    /^\s*(private\s*)?(lazy\s*)?val\s+[_a-zA-Z][_a-zA-Z0-9]*\s*=\s*"/,
     ''
   );
   const val = rightPart.replace(/"\s*$/, '');
@@ -210,7 +216,7 @@ function parseSbtLine(
     } else if (isVarDependency(line)) {
       isMultiDeps = false;
       const depExpr = line.replace(
-        /^\s*(lazy\s*)?val\s[_a-zA-Z][_a-zA-Z0-9]*\s*=\s*/,
+        /^\s*(private\s*)?(lazy\s*)?val\s[_a-zA-Z][_a-zA-Z0-9]*\s*=\s*/,
         ''
       );
       dep = parseDepExpr(depExpr, {


### PR DESCRIPTION
ref: https://github.com/renovatebot/renovate/issues/3827
<!--
    Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App:
    https://cla-assistant.io/renovateapp/renovate

    Please ensure `Allow edits from maintainers.` checkbox is checked
-->

<!-- Replace this text with a description of what this PR fixes or adds -->

<!--Closes # --><!-- Ideally each PR should be closing an open issue -->

Thanks to https://github.com/renovatebot/renovate/pull/3828 , I could update scala packages automatically.

In my use case, I make private variable which shows package version.

For example

Dependencies.scala
```scala
object Dependencies
{
  private val somePackageVersion = "1.2.3"
  private val anotherPackageVersion = "2.3.4"
  
  private val somePackage = "foo" % "bar" % somePackageVersion
  private val anotherPackage = "buz" % "piyo" % anotherPackageVersion

  lazy val myAwesomeLibraryDependencies = Seq(somePackage, anotherPackage)
}
```

build.sbt
```sbt
~...

libraryDependencies ++= myAwesomeLibraryDependencies
```

If renovate supports private variable, it would be able to parse this structure.