### PR TITLE
fix: gitAuthor parsing

### DIFF
--- a/lib/platform/__snapshots__/index.spec.ts.snap
+++ b/lib/platform/__snapshots__/index.spec.ts.snap
@@ -210,3 +210,17 @@ Object {
   "platform": "bitbucket",
 }
 `;
+
+exports[`platform parses bot email 1`] = `
+Object {
+  "address": "some[bot]@users.noreply.github.com",
+  "name": "some[bot]",
+}
+`;
+
+exports[`platform parses bot name and email 1`] = `
+Object {
+  "address": "some[bot]@users.noreply.github.com",
+  "name": "some[bot]",
+}
+`;

--- a/lib/platform/__snapshots__/index.spec.ts.snap
+++ b/lib/platform/__snapshots__/index.spec.ts.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`platform escapes names 1`] = `"name [what]"`;
+
 exports[`platform has a list of supported methods for azure 1`] = `
 Array [
   "addAssignees",

--- a/lib/platform/index.spec.ts
+++ b/lib/platform/index.spec.ts
@@ -116,4 +116,28 @@ describe('platform', () => {
     const bitbucketMethods = Object.keys(bitbucketServer).sort();
     expect(bitbucketMethods).toMatchObject(githubMethods);
   });
+
+  it('returns null if empty email given', () => {
+    expect(platform.parseGitAuthor(undefined)).toBeNull();
+  });
+  it('parses bot email', () => {
+    expect(
+      platform.parseGitAuthor('some[bot]@users.noreply.github.com')
+    ).toMatchSnapshot();
+  });
+  it('parses bot name and email', () => {
+    expect(
+      platform.parseGitAuthor(
+        '"some[bot]" <some[bot]@users.noreply.github.com>'
+      )
+    ).toMatchSnapshot();
+  });
+  it('escapes names', () => {
+    expect(
+      platform.parseGitAuthor('name [what] <name@what.com>')
+    ).not.toBeNull();
+  });
+  it('gives up', () => {
+    expect(platform.parseGitAuthor('a.b.c')).toBeNull();
+  });
 });

--- a/lib/platform/index.spec.ts
+++ b/lib/platform/index.spec.ts
@@ -134,8 +134,8 @@ describe('platform', () => {
   });
   it('escapes names', () => {
     expect(
-      platform.parseGitAuthor('name [what] <name@what.com>')
-    ).not.toBeNull();
+      platform.parseGitAuthor('name [what] <name@what.com>').name
+    ).toMatchSnapshot();
   });
   it('gives up', () => {
     expect(platform.parseGitAuthor('a.b.c')).toBeNull();


### PR DESCRIPTION
Adds parsing for invalid address types:
- github [bot] addresses
- emails where the name part should be quoted but isn’t
