### PR TITLE
fix(gitea): don't crash on empty body during pagination

### DIFF
--- a/lib/util/http/__snapshots__/gitea.spec.ts.snap
+++ b/lib/util/http/__snapshots__/gitea.spec.ts.snap
@@ -1,5 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`util/http/gitea handles pagination with empty response 1`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/pagination-example-3",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/pagination-example-3?page=2",
+  },
+]
+`;
+
 exports[`util/http/gitea supports pagination on data property 1`] = `
 Array [
   Object {

--- a/lib/util/http/gitea.spec.ts
+++ b/lib/util/http/gitea.spec.ts
@@ -60,9 +60,12 @@ describe(getName(__filename), () => {
       .get('/pagination-example-2?page=3')
       .reply(200, { data: ['mno', 'pqr'] });
 
-    const res = await giteaHttp.getJson<{ data: string[] }>('pagination-example-2', {
-      paginate: true,
-    });
+    const res = await giteaHttp.getJson<{ data: string[] }>(
+      'pagination-example-2',
+      {
+        paginate: true,
+      }
+    );
     expect(res.body.data).toHaveLength(6);
     expect(res.body.data).toEqual(['abc', 'def', 'ghi', 'jkl', 'mno', 'pqr']);
     expect(httpMock.getTrace()).toMatchSnapshot();
@@ -75,9 +78,12 @@ describe(getName(__filename), () => {
       .get('/pagination-example-3?page=2')
       .reply(200, { data: [] });
 
-    const res = await giteaHttp.getJson<{ data: string[] }>('pagination-example-3', {
-      paginate: true,
-    });
+    const res = await giteaHttp.getJson<{ data: string[] }>(
+      'pagination-example-3',
+      {
+        paginate: true,
+      }
+    );
     expect(res.body.data).toHaveLength(3);
     expect(res.body.data).toEqual(['abc', 'def', 'ghi']);
     expect(httpMock.getTrace()).toMatchSnapshot();

--- a/lib/util/http/gitea.spec.ts
+++ b/lib/util/http/gitea.spec.ts
@@ -60,7 +60,7 @@ describe(getName(__filename), () => {
       .get('/pagination-example-2?page=3')
       .reply(200, { data: ['mno', 'pqr'] });
 
-    const res = await giteaHttp.getJson<{ data: any }>('pagination-example-2', {
+    const res = await giteaHttp.getJson<{ data: string[] }>('pagination-example-2', {
       paginate: true,
     });
     expect(res.body.data).toHaveLength(6);
@@ -75,7 +75,7 @@ describe(getName(__filename), () => {
       .get('/pagination-example-3?page=2')
       .reply(200, { data: [] });
 
-    const res = await giteaHttp.getJson<{ data: any }>('pagination-example-3', {
+    const res = await giteaHttp.getJson<{ data: string[] }>('pagination-example-3', {
       paginate: true,
     });
     expect(res.body.data).toHaveLength(3);

--- a/lib/util/http/gitea.spec.ts
+++ b/lib/util/http/gitea.spec.ts
@@ -67,4 +67,19 @@ describe(getName(__filename), () => {
     expect(res.body.data).toEqual(['abc', 'def', 'ghi', 'jkl', 'mno', 'pqr']);
     expect(httpMock.getTrace()).toMatchSnapshot();
   });
+  it('handles pagination with empty response', async () => {
+    httpMock
+      .scope(baseUrl)
+      .get('/pagination-example-3')
+      .reply(200, { data: ['abc', 'def', 'ghi'] }, { 'x-total-count': '5' })
+      .get('/pagination-example-3?page=2')
+      .reply(200, { data: [] });
+
+    const res = await giteaHttp.getJson<{ data: any }>('pagination-example-3', {
+      paginate: true,
+    });
+    expect(res.body.data).toHaveLength(3);
+    expect(res.body.data).toEqual(['abc', 'def', 'ghi']);
+    expect(httpMock.getTrace()).toMatchSnapshot();
+  });
 });

--- a/lib/util/http/gitea.ts
+++ b/lib/util/http/gitea.ts
@@ -53,7 +53,12 @@ export class GiteaHttp extends Http<GiteaHttpOptions, GiteaHttpOptions> {
         resolvedUrl.searchParams.set('page', nextPage.toString());
 
         const nextRes = await super.request<T>(resolvedUrl.toString(), opts);
-        pc.push(...getPaginationContainer(nextRes.body));
+        const nextPc = getPaginationContainer(nextRes.body);
+        if (nextPc === null) {
+          break;
+        }
+        
+        pc.push(...nextPc);
       }
     }
 

--- a/lib/util/http/gitea.ts
+++ b/lib/util/http/gitea.ts
@@ -57,7 +57,7 @@ export class GiteaHttp extends Http<GiteaHttpOptions, GiteaHttpOptions> {
         if (nextPc === null) {
           break;
         }
-        
+
         pc.push(...nextPc);
       }
     }


### PR DESCRIPTION
Fixes https://github.com/renovatebot/renovate/issues/6600

```
         {
           "name": "renovate",
           "level": 50,
           "logContext": "KVZYKAwSe",
           "repository": "***",
           "err": {
             "message": "pc.push is not iterable (cannot read property Symbol(Symbol.iterator))",
             "stack": "TypeError: pc.push is not iterable (cannot read property Symbol(Symbol.iterator))\n    at GiteaHttp.request (/usr/src/app/node_modules/renovate/dist/util/http/gitea.js:46:20)\n    at runMicrotasks (<anonymous>)\n    at processTicksAndRejections (internal/process/task_queues.js:97:5)\n    at async GiteaHttp.requestJson (/usr/src/app/node_modules/renovate/dist/util/http/index.js:135:21)\n    at async Object.searchIssues (/usr/src/app/node_modules/renovate/dist/platform/gitea/gitea-helper.js:145:17)\n    at async Proxy.ensureIssueClosing (/usr/src/app/node_modules/renovate/dist/platform/gitea/index.js:553:27)\n    at async Object.exports.isOnboarded (/usr/src/app/node_modules/renovate/dist/workers/repository/onboarding/branch/check.js:51:9)\n    at async Object.checkOnboardingBranch (/usr/src/app/node_modules/renovate/dist/workers/repository/onboarding/branch/index.js:14:29)\n    at async Object.initRepo (/usr/src/app/node_modules/renovate/dist/workers/repository/init/index.js:44:14)\n    at async Object.renovateRepository (/usr/src/app/node_modules/renovate/dist/workers/repository/index.js:37:18)\n    at async Object.start (/usr/src/app/node_modules/renovate/dist/workers/global/index.js:76:13)\n    at async /usr/src/app/node_modules/renovate/dist/renovate.js:28:24"
           },
           "msg": "Repository has unknown error"
         }

```