### PR TITLE
feat(terraform-provider): Implement terraform helm chart update

### DIFF
--- a/lib/manager/terraform/__fixtures__/helm.tf
+++ b/lib/manager/terraform/__fixtures__/helm.tf
@@ -1,0 +1,40 @@
+# legit use cases
+## complete example
+resource "helm_release" "example" {
+  name       = "my-redis-release"
+  repository = "https://kubernetes-charts.storage.googleapis.com"
+  chart      = "redis"
+  version    = "1.0.1"
+}
+
+## example without version, this will default to latest in Terraform
+resource "helm_release" "example" {
+  name       = "my-redis-release"
+  repository = "https://kubernetes-charts.storage.googleapis.com"
+  chart      = "redis"
+}
+
+## local chart
+resource "helm_release" "local" {
+  name       = "my-local-chart"
+  chart      = "./charts/example"
+}
+
+## malformed examples
+resource "helm_release" "example" {
+  name       = "my-redis-release"
+  repository = "https://kubernetes-charts.storage.googleapis.com"
+  version    = "4.0.1"
+}
+
+resource "helm_release" "example" {
+  repository = "https://kubernetes-charts.storage.googleapis.com"
+  chart      = "redis"
+  version    = "5.0.1"
+}
+
+resource "helm_release" "example" {
+  name       = "my-redis-release"
+  chart      = "redis"
+  version    = "6.0.1"
+}

--- a/lib/manager/terraform/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/terraform/__snapshots__/extract.spec.ts.snap
@@ -1,5 +1,73 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`lib/manager/terraform/extract extractPackageFile() extract helm releases 1`] = `
+Object {
+  "deps": Array [
+    Object {
+      "currentValue": "1.0.1",
+      "datasource": "helm",
+      "depName": "redis",
+      "depNameShort": "redis",
+      "depType": "helm",
+      "registryUrls": Array [
+        "https://kubernetes-charts.storage.googleapis.com",
+      ],
+    },
+    Object {
+      "datasource": "helm",
+      "depName": "redis",
+      "depNameShort": "redis",
+      "depType": "helm",
+      "registryUrls": Array [
+        "https://kubernetes-charts.storage.googleapis.com",
+      ],
+      "skipReason": "unsupported-version",
+    },
+    Object {
+      "datasource": "helm",
+      "depName": "./charts/example",
+      "depNameShort": "./charts/example",
+      "depType": "helm",
+      "registryUrls": Array [
+        undefined,
+      ],
+      "skipReason": "local-chart",
+    },
+    Object {
+      "currentValue": "4.0.1",
+      "datasource": "helm",
+      "depName": undefined,
+      "depNameShort": undefined,
+      "depType": "helm",
+      "registryUrls": Array [
+        "https://kubernetes-charts.storage.googleapis.com",
+      ],
+      "skipReason": "invalid-name",
+    },
+    Object {
+      "currentValue": "5.0.1",
+      "datasource": "helm",
+      "depName": "redis",
+      "depNameShort": "redis",
+      "depType": "helm",
+      "registryUrls": Array [
+        "https://kubernetes-charts.storage.googleapis.com",
+      ],
+    },
+    Object {
+      "currentValue": "6.0.1",
+      "datasource": "helm",
+      "depName": "redis",
+      "depNameShort": "redis",
+      "depType": "helm",
+      "registryUrls": Array [
+        undefined,
+      ],
+    },
+  ],
+}
+`;
+
 exports[`lib/manager/terraform/extract extractPackageFile() extracts 1`] = `
 Object {
   "deps": Array [

--- a/lib/manager/terraform/extract.spec.ts
+++ b/lib/manager/terraform/extract.spec.ts
@@ -6,6 +6,7 @@ const tf2 = `module "relative" {
   source = "../../modules/fe"
 }
 `;
+const helm = readFileSync('lib/manager/terraform/__fixtures__/helm.tf', 'utf8');
 
 describe('lib/manager/terraform/extract', () => {
   describe('extractPackageFile()', () => {
@@ -20,6 +21,12 @@ describe('lib/manager/terraform/extract', () => {
     });
     it('returns null if only local deps', () => {
       expect(extractPackageFile(tf2)).toBeNull();
+    });
+    it('extract helm releases', () => {
+      const res = extractPackageFile(helm);
+      expect(res).toMatchSnapshot();
+      expect(res.deps).toHaveLength(6);
+      expect(res.deps.filter((dep) => dep.skipReason)).toHaveLength(3);
     });
   });
 });

--- a/lib/manager/terraform/resources.ts
+++ b/lib/manager/terraform/resources.ts
@@ -1,0 +1,57 @@
+import * as datasourceHelm from '../../datasource/helm';
+import { SkipReason } from '../../types';
+import { isValid } from '../../versioning/cargo';
+import { PackageDependency } from '../common';
+import {
+  ExtractionResult,
+  TerraformDependencyTypes,
+  checkIfStringIsPath,
+  keyValueExtractionRegex,
+} from './util';
+
+export function extractTerraformResource(
+  startingLine: number,
+  lines: string[]
+): ExtractionResult {
+  let lineNumber = startingLine;
+  let line;
+  const deps: PackageDependency[] = [];
+  const dep: PackageDependency = {
+    managerData: {
+      terraformDependencyType: TerraformDependencyTypes.resource,
+    },
+  };
+
+  do {
+    lineNumber += 1;
+    line = lines[lineNumber];
+    const kvMatch = keyValueExtractionRegex.exec(line);
+    if (kvMatch) {
+      if (kvMatch.groups.key === 'version') {
+        dep.currentValue = kvMatch.groups.value;
+      } else if (kvMatch.groups.key === 'chart') {
+        dep.managerData.chart = kvMatch.groups.value;
+      } else if (kvMatch.groups.key === 'repository') {
+        dep.managerData.repository = kvMatch.groups.value;
+      }
+    }
+  } while (line.trim() !== '}');
+  deps.push(dep);
+  return { lineNumber, dependencies: deps };
+}
+export function analyseTerraformResource(dep: PackageDependency): void {
+  /* eslint-disable no-param-reassign */
+  if (dep.managerData.chart == null) {
+    dep.skipReason = SkipReason.InvalidName;
+  } else if (checkIfStringIsPath(dep.managerData.chart)) {
+    dep.skipReason = SkipReason.LocalChart;
+  } else if (!isValid(dep.currentValue)) {
+    dep.skipReason = SkipReason.UnsupportedVersion;
+  }
+  dep.depType = 'helm';
+  dep.registryUrls = [dep.managerData.repository];
+  dep.depName = dep.managerData.chart;
+  dep.depNameShort = dep.managerData.chart;
+  dep.datasource = datasourceHelm.id;
+  /* eslint-enable no-param-reassign */
+}

--- a/lib/manager/terraform/resources.ts
+++ b/lib/manager/terraform/resources.ts
@@ -1,6 +1,6 @@
 import * as datasourceHelm from '../../datasource/helm';
 import { SkipReason } from '../../types';
-import { isValid } from '../../versioning/cargo';
+import { isValid } from '../../versioning/hashicorp';
 import { PackageDependency } from '../common';
 import {
   ExtractionResult,

--- a/lib/manager/terraform/resources.ts
+++ b/lib/manager/terraform/resources.ts
@@ -39,6 +39,7 @@ export function extractTerraformResource(
   deps.push(dep);
   return { lineNumber, dependencies: deps };
 }
+
 export function analyseTerraformResource(dep: PackageDependency): void {
   /* eslint-disable no-param-reassign */
   if (dep.managerData.chart == null) {

--- a/lib/manager/terraform/util.ts
+++ b/lib/manager/terraform/util.ts
@@ -12,6 +12,7 @@ export enum TerraformDependencyTypes {
   module = 'module',
   provider = 'provider',
   required_providers = 'required_providers',
+  resource = 'resource',
 }
 
 export function getTerraformDependencyType(
@@ -27,6 +28,9 @@ export function getTerraformDependencyType(
     case 'required_providers': {
       return TerraformDependencyTypes.required_providers;
     }
+    case 'resource': {
+      return TerraformDependencyTypes.resource;
+    }
     default: {
       return TerraformDependencyTypes.unknown;
     }
@@ -40,4 +44,10 @@ export function checkFileContainsDependency(
   return checkList.some((check) => {
     return content.includes(check);
   });
+}
+
+export function checkIfStringIsPath(path: string): boolean {
+  const regex = /(.|..)?(\/[^/])+/;
+  const match = regex.exec(path);
+  return !!match;
 }

--- a/lib/manager/terraform/util.ts
+++ b/lib/manager/terraform/util.ts
@@ -46,8 +46,8 @@ export function checkFileContainsDependency(
   });
 }
 
+const pathStringRegex = /(.|..)?(\/[^/])+/;
 export function checkIfStringIsPath(path: string): boolean {
-  const regex = /(.|..)?(\/[^/])+/;
-  const match = regex.exec(path);
+  const match = pathStringRegex.exec(path);
   return !!match;
 }


### PR DESCRIPTION
This PR contains following features: 

-  implement the renovating of helm_release resources in Terraform code. 
- fix for a not reported bug, which has been introduced earlier. The bug occurs if Terraform modules use a GIT source
- some refactors? 

Closes #6624

I plan to introduce some additional refactors as the extractor code has become quite huge during the last year. Probably pulling out some login into separate files. 