### PR TITLE
fix: deleteLocalFile join

### DIFF
--- a/lib/util/gitfs/fs/index.ts
+++ b/lib/util/gitfs/fs/index.ts
@@ -49,7 +49,8 @@ export async function writeLocalFile(
 }
 
 export async function deleteLocalFile(fileName: string): Promise<void> {
-  await fs.remove(fileName);
+  const localFileName = join(localDir, fileName);
+  await fs.remove(localFileName);
 }
 
 // istanbul ignore next


### PR DESCRIPTION
Code inspection revealed that each caller of this function is passing a relative file name.