### PR TITLE
refactor: github presets use util/http/github

### DIFF
--- a/lib/config/presets/github/__snapshots__/index.spec.ts.snap
+++ b/lib/config/presets/github/__snapshots__/index.spec.ts.snap
@@ -58,7 +58,7 @@ exports[`config/presets/github/index getPreset() should return custom.json 1`] =
 Array [
   Object {
     "headers": Object {
-      "accept": "application/vnd.github.machine-man-preview+json",
+      "accept": "application/vnd.github.v3+json",
       "accept-encoding": "gzip, deflate",
       "authorization": "token abc",
       "host": "api.github.com",
@@ -90,7 +90,7 @@ exports[`config/presets/github/index getPreset() should throws not-found 1`] = `
 Array [
   Object {
     "headers": Object {
-      "accept": "application/vnd.github.machine-man-preview+json",
+      "accept": "application/vnd.github.v3+json",
       "accept-encoding": "gzip, deflate",
       "authorization": "token abc",
       "host": "api.github.com",

--- a/lib/config/presets/github/index.spec.ts
+++ b/lib/config/presets/github/index.spec.ts
@@ -132,17 +132,11 @@ describe(getName(__filename), () => {
         .reply(200, {
           content: Buffer.from('{"foo":"bar"}').toString('base64'),
         });
-
-      try {
-        global.appMode = true;
-        const content = await github.getPreset({
-          packageName: 'some/repo',
-          presetName: 'custom',
-        });
-        expect(content).toEqual({ foo: 'bar' });
-      } finally {
-        delete global.appMode;
-      }
+      const content = await github.getPreset({
+        packageName: 'some/repo',
+        presetName: 'custom',
+      });
+      expect(content).toEqual({ foo: 'bar' });
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
 
@@ -153,18 +147,12 @@ describe(getName(__filename), () => {
         .reply(200, {
           content: Buffer.from('{}').toString('base64'),
         });
-
-      try {
-        global.appMode = true;
-        await expect(
-          github.getPreset({
-            packageName: 'some/repo',
-            presetName: 'somefile/somename/somesubname',
-          })
-        ).rejects.toThrow(PRESET_NOT_FOUND);
-      } finally {
-        delete global.appMode;
-      }
+      await expect(
+        github.getPreset({
+          packageName: 'some/repo',
+          presetName: 'somefile/somename/somesubname',
+        })
+      ).rejects.toThrow(PRESET_NOT_FOUND);
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
   });

--- a/lib/config/presets/github/index.ts
+++ b/lib/config/presets/github/index.ts
@@ -1,13 +1,12 @@
-import { PLATFORM_TYPE_GITHUB } from '../../../constants/platforms';
 import { logger } from '../../../logger';
 import { ExternalHostError } from '../../../types/errors/external-host-error';
-import { Http, HttpOptions } from '../../../util/http';
+import { GithubHttp } from '../../../util/http/github';
 import { Preset, PresetConfig } from '../common';
 import { PRESET_DEP_NOT_FOUND, fetchPreset } from '../util';
 
 export const Endpoint = 'https://api.github.com/';
 
-const http = new Http(PLATFORM_TYPE_GITHUB);
+const http = new GithubHttp();
 
 export async function fetchJSONFile(
   repo: string,
@@ -15,16 +14,9 @@ export async function fetchJSONFile(
   endpoint: string
 ): Promise<Preset> {
   const url = `${endpoint}repos/${repo}/contents/${fileName}`;
-  const opts: HttpOptions = {
-    headers: {
-      accept: global.appMode
-        ? 'application/vnd.github.machine-man-preview+json'
-        : 'application/vnd.github.v3+json',
-    },
-  };
   let res: { body: { content: string } };
   try {
-    res = await http.getJson(url, opts);
+    res = await http.getJson(url);
   } catch (err) {
     // istanbul ignore if: not testable with nock
     if (err instanceof ExternalHostError) {


### PR DESCRIPTION
Refactors github presets to use the specialized GithubHttp module instead of Http.