### PR TITLE
refactor: simplify util/git state

### DIFF
--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -105,8 +105,6 @@ let config: LocalConfig = {} as any;
 
 let git: Git.SimpleGit | undefined;
 
-let cwd: string | undefined;
-
 let privateKeySet = false;
 
 async function resetToBranch(branchName: string): Promise<void> {
@@ -162,25 +160,20 @@ export async function initRepo(args: StorageConfig): Promise<void> {
   cleanRepo();
 
   config = { ...args } as any;
-  const newConfig: LocalConfig = config;
 
-  cwd = newConfig.localDir;
-  const newCwd = cwd;
-
-  newConfig.branchExists = {};
-  logger.debug('Initializing git repository into ' + newCwd);
-  const gitHead = join(newCwd, '.git/HEAD');
+  config.branchExists = {};
+  logger.debug('Initializing git repository into ' + config.localDir);
+  const gitHead = join(config.localDir, '.git/HEAD');
   let clone = true;
 
   if (await fs.exists(gitHead)) {
     try {
-      git = Git(newCwd).silent(true);
-      await git.raw(['remote', 'set-url', 'origin', newConfig.url]);
+      git = Git(config.localDir).silent(true);
+      await git.raw(['remote', 'set-url', 'origin', config.url]);
       const fetchStart = Date.now();
       await git.fetch(['--depth=10']);
-      newConfig.baseBranch =
-        newConfig.baseBranch || (await getDefaultBranch(git));
-      await resetToBranch(newConfig.baseBranch);
+      config.baseBranch = config.baseBranch || (await getDefaultBranch(git));
+      await resetToBranch(config.baseBranch);
       await cleanLocalBranches();
       await git.raw(['remote', 'prune', 'origin']);
       const durationMs = Math.round(Date.now() - fetchStart);
@@ -191,18 +184,18 @@ export async function initRepo(args: StorageConfig): Promise<void> {
     }
   }
   if (clone) {
-    await fs.emptyDir(newCwd);
-    git = Git(newCwd).silent(true);
+    await fs.emptyDir(config.localDir);
+    git = Git(config.localDir).silent(true);
     const cloneStart = Date.now();
     try {
       // clone only the default branch
       let opts = ['--depth=2'];
-      if (newConfig.extraCloneOpts) {
+      if (config.extraCloneOpts) {
         opts = opts.concat(
-          Object.entries(newConfig.extraCloneOpts).map((e) => `${e[0]}=${e[1]}`)
+          Object.entries(config.extraCloneOpts).map((e) => `${e[0]}=${e[1]}`)
         );
       }
-      await git.clone(newConfig.url, '.', opts);
+      await git.clone(config.url, '.', opts);
     } catch (err) /* istanbul ignore next */ {
       logger.debug({ err }, 'git clone error');
       if (err.message?.includes('write error: No space left on device')) {
@@ -248,7 +241,7 @@ export async function initRepo(args: StorageConfig): Promise<void> {
     throw new Error(REPOSITORY_TEMPORARY_ERROR);
   }
 
-  newConfig.baseBranch = newConfig.baseBranch || (await getDefaultBranch(git));
+  config.baseBranch = config.baseBranch || (await getDefaultBranch(git));
 }
 
 // istanbul ignore next
@@ -501,7 +494,7 @@ export async function commitFiles({
 }: CommitFilesConfig): Promise<string | null> {
   logger.debug(`Committing files to branch ${branchName}`);
   if (!privateKeySet) {
-    await writePrivateKey(cwd);
+    await writePrivateKey(config.localDir);
     privateKeySet = true;
   }
   try {
@@ -514,7 +507,7 @@ export async function commitFiles({
       // istanbul ignore if
       if (file.name === '|delete|') {
         deleted.push(file.contents);
-      } else if (await isDirectory(join(cwd, file.name))) {
+      } else if (await isDirectory(join(config.localDir, file.name))) {
         fileNames.push(file.name);
         await git.add(file.name);
       } else {
@@ -526,7 +519,7 @@ export async function commitFiles({
         } else {
           contents = file.contents;
         }
-        await fs.outputFile(join(cwd, file.name), contents);
+        await fs.outputFile(join(config.localDir, file.name), contents);
       }
     }
     // istanbul ignore if


### PR DESCRIPTION
Removes unnecessary newConfig and cwd. However I'm not sure why they were ever this way in the first place - hopefully for legacy reasons that no longer apply.