### PR TITLE
fix(presets): include '@typescript-eslint' with eslint preset

### DIFF
--- a/lib/config/presets/__snapshots__/index.spec.ts.snap
+++ b/lib/config/presets/__snapshots__/index.spec.ts.snap
@@ -318,6 +318,7 @@ Object {
     "babel-eslint",
   ],
   "packagePatterns": Array [
+    "^@typescript-eslint/",
     "^eslint",
     "^stylelint",
   ],
@@ -406,6 +407,7 @@ Object {
     "babel-eslint",
   ],
   "packagePatterns": Array [
+    "^@typescript-eslint/",
     "^eslint",
   ],
 }
@@ -422,6 +424,7 @@ Object {
     "remark-lint",
   ],
   "packagePatterns": Array [
+    "^@typescript-eslint/",
     "^eslint",
     "^stylelint",
     "\\\\btslint\\\\b",
@@ -446,6 +449,7 @@ Object {
         "remark-lint",
       ],
       "packagePatterns": Array [
+        "^@typescript-eslint/",
         "^eslint",
         "^stylelint",
         "\\\\btslint\\\\b",
@@ -464,6 +468,7 @@ Object {
         "babel-eslint",
       ],
       "packagePatterns": Array [
+        "^@typescript-eslint/",
         "^eslint",
       ],
     },

--- a/lib/config/presets/index.spec.ts
+++ b/lib/config/presets/index.spec.ts
@@ -143,14 +143,14 @@ describe('config/presets', () => {
       config.extends = ['packages:eslint'];
       const res = await presets.resolveConfigPresets(config);
       expect(res).toMatchSnapshot();
-      expect(res.packagePatterns).toHaveLength(1);
+      expect(res.packagePatterns).toHaveLength(2);
     });
     it('resolves linters', async () => {
       config.extends = ['packages:linters'];
       const res = await presets.resolveConfigPresets(config);
       expect(res).toMatchSnapshot();
       expect(res.packageNames).toHaveLength(3);
-      expect(res.packagePatterns).toHaveLength(3);
+      expect(res.packagePatterns).toHaveLength(4);
     });
     it('resolves nested groups', async () => {
       config.extends = [':automergeLinters'];
@@ -159,7 +159,7 @@ describe('config/presets', () => {
       const rule = res.packageRules[0];
       expect(rule.automerge).toBe(true);
       expect(rule.packageNames).toHaveLength(3);
-      expect(rule.packagePatterns).toHaveLength(3);
+      expect(rule.packagePatterns).toHaveLength(4);
     });
     it('migrates automerge in presets', async () => {
       config.extends = ['ikatyang:library'];

--- a/lib/config/presets/internal/packages.ts
+++ b/lib/config/presets/internal/packages.ts
@@ -21,7 +21,7 @@ export const presets: Record<string, Preset> = {
   eslint: {
     description: 'All eslint packages',
     packageNames: ['babel-eslint'],
-    packagePatterns: ['^eslint'],
+    packagePatterns: ['^@typescript-eslint/', '^eslint'],
   },
   stylelint: {
     description: 'All stylelint packages',


### PR DESCRIPTION
This updates the eslint package preset to include the @typescript-eslint monorepo. This is a suite of plugins and configs that enables eslint to support typescript.

<!-- Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App: https://cla-assistant.io/renovatebot/renovate -->

<!-- When creating this PR on GitHub, please ensure `Allow edits from maintainers.` checkbox is checked -->

<!-- Please use a conventional commit message (https://www.conventionalcommits.org/en/v1.0.0/) as your PR title -->

<!-- Ideally include at least one sentence saying what this PR achieves -->

<!-- Finish the PR with `Closes #` and then the issue number if it closes any associated issue -->
