### PR TITLE
feat(internal): make datasource loading syncronous

### DIFF
--- a/lib/datasource/common.ts
+++ b/lib/datasource/common.ts
@@ -69,7 +69,7 @@ export interface ReleaseResult {
   registryUrl?: string;
 }
 
-export interface Datasource {
+export interface DatasourceApi {
   id: string;
   getDigest?(config: DigestConfig, newValue?: string): Promise<string | null>;
   getReleases(config: GetReleasesConfig): Promise<ReleaseResult | null>;
@@ -78,3 +78,6 @@ export interface Datasource {
   defaultConfig?: object;
   registryStrategy?: 'first' | 'hunt' | 'merge';
 }
+
+// TODO: remove, only for compatabillity
+export type Datasource = DatasourceApi;

--- a/lib/datasource/index.spec.ts
+++ b/lib/datasource/index.spec.ts
@@ -30,7 +30,7 @@ describe('datasource/index', () => {
     expect(datasource.getDatasources()).toBeDefined();
     expect(datasource.getDatasourceList()).toBeDefined();
   });
-  it('validates dataource', async () => {
+  it('validates dataource', () => {
     function validateDatasource(
       module: datasource.Datasource,
       name: string
@@ -49,13 +49,13 @@ describe('datasource/index', () => {
     expect(Array.from(dss.keys())).toEqual(Object.keys(loadedDs));
 
     for (const dsName of dss.keys()) {
-      const ds = await dss.get(dsName);
+      const ds = dss.get(dsName);
       expect(validateDatasource(ds, dsName)).toBe(true);
     }
   });
-  it('returns if digests are supported', async () => {
+  it('returns if digests are supported', () => {
     expect(
-      await datasource.supportsDigests({ datasource: datasourceGithubTags.id })
+      datasource.supportsDigests({ datasource: datasourceGithubTags.id })
     ).toBe(true);
   });
   it('returns null for no datasource', async () => {

--- a/lib/datasource/index.ts
+++ b/lib/datasource/index.ts
@@ -19,13 +19,12 @@ import { addMetaData } from './metadata';
 
 export * from './common';
 
-export const getDatasources = (): Map<string, Promise<Datasource>> =>
-  datasources;
+export const getDatasources = (): Map<string, Datasource> => datasources;
 export const getDatasourceList = (): string[] => Array.from(datasources.keys());
 
 const cacheNamespace = 'datasource-releases';
 
-function load(datasource: string): Promise<Datasource> {
+function load(datasource: string): Datasource {
   return datasources.get(datasource);
 }
 
@@ -170,7 +169,7 @@ async function fetchReleases(
     logger.warn('Unknown datasource: ' + datasourceName);
     return null;
   }
-  const datasource = await load(datasourceName);
+  const datasource = load(datasourceName);
   const registryUrls = resolveRegistryUrls(datasource, config.registryUrls);
   let dep: ReleaseResult = null;
   try {
@@ -275,15 +274,15 @@ export async function getPkgReleases(
   return res;
 }
 
-export async function supportsDigests(config: DigestConfig): Promise<boolean> {
-  return 'getDigest' in (await load(config.datasource));
+export function supportsDigests(config: DigestConfig): boolean {
+  return 'getDigest' in load(config.datasource);
 }
 
 export async function getDigest(
   config: DigestConfig,
   value?: string
 ): Promise<string | null> {
-  const datasource = await load(config.datasource);
+  const datasource = load(config.datasource);
   const lookupName = config.lookupName || config.depName;
   const registryUrls = resolveRegistryUrls(datasource, config.registryUrls);
   return datasource.getDigest(
@@ -292,7 +291,7 @@ export async function getDigest(
   );
 }
 
-export async function getDefaultConfig(datasource: string): Promise<object> {
-  const loadedDatasource = await load(datasource);
-  return loadedDatasource?.defaultConfig || {};
+export function getDefaultConfig(datasource: string): Promise<object> {
+  const loadedDatasource = load(datasource);
+  return Promise.resolve(loadedDatasource?.defaultConfig || {});
 }

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -364,7 +364,7 @@ export async function lookupUpdates(
     }
   }
   // Add digests if necessary
-  if (config.newDigest || (await supportsDigests(config))) {
+  if (config.newDigest || supportsDigests(config)) {
     if (
       config.currentDigest &&
       config.datasource !== datasourceGitSubmodules.id

--- a/tools/generate-imports.ts
+++ b/tools/generate-imports.ts
@@ -68,16 +68,7 @@ async function generate({
 (async () => {
   try {
     // datasources
-    shell.echo('> datasources');
-    let code = `
-import { Datasource } from './common';
-const api = new Map<string, Promise<Datasource>>();
-export default api;
-`;
-    for (const ds of findModules('lib/datasource')) {
-      code += `api.set('${ds}', import('./${ds}'));\n`;
-    }
-    await updateFile('lib/datasource/api.generated.ts', code);
+    await generate({ path: 'datasource', types: ['DatasourceApi'] });
 
     // managers
     await generate({ path: 'manager', types: ['ManagerApi'] });


### PR DESCRIPTION
* Load `datasource` synchronous like `manager` and `versioning`.
* Unify dynamic code generation.

ref: #6747