### PR TITLE
feat(internal): optional global agent

### DIFF
--- a/lib/proxy.spec.ts
+++ b/lib/proxy.spec.ts
@@ -5,7 +5,7 @@ describe('proxy', () => {
   const httpsProxy = 'http://example.org/https-proxy';
   const noProxy = 'http://example.org/no-proxy';
 
-  beforeAll(() => {
+  beforeEach(() => {
     delete process.env.HTTP_PROXY;
     delete process.env.HTTPS_PROXY;
     delete process.env.NO_PROXY;
@@ -23,12 +23,8 @@ describe('proxy', () => {
     const result = bootstrap();
     expect(result.HTTPS_PROXY).toEqual(httpsProxy);
   });
-  it('respects no_proxy', () => {
-    process.env.no_proxy = noProxy;
-    const result = bootstrap();
-    expect(result.NO_PROXY).toEqual(noProxy);
-  });
   it('does nothing', () => {
+    process.env.no_proxy = noProxy;
     const result = bootstrap();
     expect(result).toBeUndefined();
     expect(hasProxy()).toBeFalse();

--- a/lib/proxy.spec.ts
+++ b/lib/proxy.spec.ts
@@ -14,19 +14,17 @@ describe('proxy', () => {
 
   it('respects HTTP_PROXY', () => {
     process.env.HTTP_PROXY = httpProxy;
-    const result = bootstrap();
-    expect(result.HTTP_PROXY).toEqual(httpProxy);
+    bootstrap();
     expect(hasProxy()).toBeTrue();
   });
   it('respects HTTPS_PROXY', () => {
     process.env.HTTPS_PROXY = httpsProxy;
-    const result = bootstrap();
-    expect(result.HTTPS_PROXY).toEqual(httpsProxy);
+    bootstrap();
+    expect(hasProxy()).toBeTrue();
   });
   it('does nothing', () => {
     process.env.no_proxy = noProxy;
-    const result = bootstrap();
-    expect(result).toBeUndefined();
+    bootstrap();
     expect(hasProxy()).toBeFalse();
   });
 });

--- a/lib/proxy.spec.ts
+++ b/lib/proxy.spec.ts
@@ -1,4 +1,4 @@
-import { bootstrap } from './proxy';
+import { bootstrap, hasProxy } from './proxy';
 
 describe('proxy', () => {
   const httpProxy = 'http://example.org/http-proxy';
@@ -16,6 +16,7 @@ describe('proxy', () => {
     process.env.HTTP_PROXY = httpProxy;
     const result = bootstrap();
     expect(result.HTTP_PROXY).toEqual(httpProxy);
+    expect(hasProxy()).toBeTrue();
   });
   it('respects HTTPS_PROXY', () => {
     process.env.HTTPS_PROXY = httpsProxy;
@@ -26,5 +27,10 @@ describe('proxy', () => {
     process.env.no_proxy = noProxy;
     const result = bootstrap();
     expect(result.NO_PROXY).toEqual(noProxy);
+  });
+  it('does nothing', () => {
+    const result = bootstrap();
+    expect(result).toBeUndefined();
+    expect(hasProxy()).toBeFalse();
   });
 });

--- a/lib/proxy.ts
+++ b/lib/proxy.ts
@@ -27,6 +27,7 @@ export function bootstrap(): void {
       environmentVariableNamespace: '',
     });
   } else {
+    // for testing only, does not reset global agent
     agent = undefined;
   }
 }

--- a/lib/proxy.ts
+++ b/lib/proxy.ts
@@ -1,3 +1,4 @@
+import is from '@sindresorhus/is';
 import {
   ProxyAgentConfigurationType,
   createGlobalProxyAgent,
@@ -5,7 +6,9 @@ import {
 
 const envVars = ['HTTP_PROXY', 'HTTPS_PROXY', 'NO_PROXY'];
 
-export function bootstrap(): ProxyAgentConfigurationType {
+let agent: ProxyAgentConfigurationType | undefined;
+
+export function bootstrap(): ProxyAgentConfigurationType | undefined {
   envVars.forEach((envVar) => {
     /* istanbul ignore if: env is case-insensitive on windows */
     if (
@@ -15,7 +18,22 @@ export function bootstrap(): ProxyAgentConfigurationType {
       process.env[envVar] = process.env[envVar.toLowerCase()];
     }
   });
-  return createGlobalProxyAgent({
-    environmentVariableNamespace: '',
-  });
+
+  if (
+    is.nonEmptyString(process.env.HTTP_PROXY) ||
+    is.nonEmptyString(process.env.HTTPS_PROXY)
+  ) {
+    agent = createGlobalProxyAgent({
+      environmentVariableNamespace: '',
+    });
+  } else {
+    agent = undefined;
+  }
+
+  return agent;
+}
+
+// will be used by our http layer later
+export function hasProxy(): boolean {
+  return agent !== undefined;
 }

--- a/lib/proxy.ts
+++ b/lib/proxy.ts
@@ -8,7 +8,7 @@ const envVars = ['HTTP_PROXY', 'HTTPS_PROXY', 'NO_PROXY'];
 
 let agent: ProxyAgentConfigurationType | undefined;
 
-export function bootstrap(): ProxyAgentConfigurationType | undefined {
+export function bootstrap(): void {
   envVars.forEach((envVar) => {
     /* istanbul ignore if: env is case-insensitive on windows */
     if (
@@ -29,8 +29,6 @@ export function bootstrap(): ProxyAgentConfigurationType | undefined {
   } else {
     agent = undefined;
   }
-
-  return agent;
 }
 
 // will be used by our http layer later

--- a/lib/proxy.ts
+++ b/lib/proxy.ts
@@ -1,12 +1,9 @@
 import is from '@sindresorhus/is';
-import {
-  ProxyAgentConfigurationType,
-  createGlobalProxyAgent,
-} from 'global-agent';
+import { createGlobalProxyAgent } from 'global-agent';
 
 const envVars = ['HTTP_PROXY', 'HTTPS_PROXY', 'NO_PROXY'];
 
-let agent: ProxyAgentConfigurationType | undefined;
+let agent = false;
 
 export function bootstrap(): void {
   envVars.forEach((envVar) => {
@@ -23,16 +20,17 @@ export function bootstrap(): void {
     is.nonEmptyString(process.env.HTTP_PROXY) ||
     is.nonEmptyString(process.env.HTTPS_PROXY)
   ) {
-    agent = createGlobalProxyAgent({
+    createGlobalProxyAgent({
       environmentVariableNamespace: '',
     });
+    agent = true;
   } else {
     // for testing only, does not reset global agent
-    agent = undefined;
+    agent = false;
   }
 }
 
 // will be used by our http layer later
 export function hasProxy(): boolean {
-  return agent !== undefined;
+  return agent === true;
 }


### PR DESCRIPTION
Only create a proxy-agent when proxy env is configured.

This is in preparation for got v11 http2 support, as `global-agent` does not support this.

ref: #3547, gajus/global-agent#22