### PR TITLE
fix: autoclosed digests when cache is enabled

### DIFF
--- a/lib/workers/repository/process/lookup/__snapshots__/index.spec.ts.snap
+++ b/lib/workers/repository/process/lookup/__snapshots__/index.spec.ts.snap
@@ -180,7 +180,6 @@ Object {
 
 exports[`workers/repository/process/lookup .lookupUpdates() handles git submodule update 1`] = `
 Object {
-  "skipReason": "unsupported-value",
   "updates": Array [
     Object {
       "fromVersion": undefined,

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -430,6 +430,9 @@ export async function lookupUpdates(
       }
     }
   }
+  if (res.updates.length) {
+    delete res.skipReason;
+  }
   // Strip out any non-changed ones
   res.updates = res.updates
     .filter((update) => update.newDigest !== null)


### PR DESCRIPTION
Cached skipReason was disabling digest lookups on subsequent runs. Now deleted if res.updates is non-empty.

Closes #6750