### PR TITLE
fix: force optional options

### DIFF
--- a/lib/util/fs/proxies.ts
+++ b/lib/util/fs/proxies.ts
@@ -40,7 +40,7 @@ export function outputFile(
   data: any,
   options?: WriteFileOptions | string
 ): Promise<void> {
-  return fs.outputFile(file, data, options);
+  return fs.outputFile(file, data, options ?? {});
 }
 
 export function remove(dir: string): Promise<void> {
@@ -68,5 +68,5 @@ export function move(
   dest: string,
   options?: MoveOptions
 ): Promise<void> {
-  return fs.move(src, dest, options);
+  return fs.move(src, dest, options ?? {});
 }


### PR DESCRIPTION
`fs-extra` is using `arguments.length` to compute optional args and callback version. So if we pass `undefined` as options it will crash because of wrong argument count.

Closes #6811