### PR TITLE
feat(bazel): support http_file

### DIFF
--- a/docs/usage/bazel.md
+++ b/docs/usage/bazel.md
@@ -34,9 +34,9 @@ git_repository(
 
 New versions will be detected using the list of **tags** for that repository on GitHub.
 
-## http_archive
+## http_archive and http_file
 
-Renovate will update any `http_archive` declaration that contains the following:
+Renovate will update any `http_archive` or `http_file` declaration that contains the following:
 
 1.  name
 2.  url matching `https://github.com/<owner>/<repo>/releases/download/<semver>/<repo>.tar.gz`

--- a/lib/manager/bazel/__fixtures__/WORKSPACE1
+++ b/lib/manager/bazel/__fixtures__/WORKSPACE1
@@ -118,3 +118,10 @@ container_pull(
     repository = "distroless/python3-debian10",
     tag = "latest",
 )
+
+http_file(
+    name="distroless",
+    sha256="f7a6ecfb8174a1dd4713ea3b21621072996ada7e8f1a69e6ae7581be137c6dd6",
+    strip_prefix="distroless-446923c3756ceeaa75888f52fcbdd48bb314fbf8",
+    urls=["https://github.com/GoogleContainerTools/distroless/archive/446923c3756ceeaa75888f52fcbdd48bb314fbf8.tar.gz"]
+)

--- a/lib/manager/bazel/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/bazel/__snapshots__/extract.spec.ts.snap
@@ -174,6 +174,22 @@ Array [
     "repo": "GoogleContainerTools/distroless",
   },
   Object {
+    "currentDigest": "446923c3756ceeaa75888f52fcbdd48bb314fbf8",
+    "datasource": "github-releases",
+    "depName": "distroless",
+    "depType": "http_file",
+    "lookupName": "GoogleContainerTools/distroless",
+    "managerData": Object {
+      "def": "http_file(
+    name=\\"distroless\\",
+    sha256=\\"f7a6ecfb8174a1dd4713ea3b21621072996ada7e8f1a69e6ae7581be137c6dd6\\",
+    strip_prefix=\\"distroless-446923c3756ceeaa75888f52fcbdd48bb314fbf8\\",
+    urls=[\\"https://github.com/GoogleContainerTools/distroless/archive/446923c3756ceeaa75888f52fcbdd48bb314fbf8.tar.gz\\"]
+)",
+    },
+    "repo": "GoogleContainerTools/distroless",
+  },
+  Object {
     "currentValue": "v1.0.5",
     "datasource": "go",
     "depName": "com_github_bitly_go-nsq",

--- a/lib/manager/bazel/__snapshots__/update.spec.ts.snap
+++ b/lib/manager/bazel/__snapshots__/update.spec.ts.snap
@@ -121,6 +121,13 @@ container_pull(
     repository = \\"distroless/python3-debian10\\",
     tag = \\"latest\\",
 )
+
+http_file(
+    name=\\"distroless\\",
+    sha256=\\"f7a6ecfb8174a1dd4713ea3b21621072996ada7e8f1a69e6ae7581be137c6dd6\\",
+    strip_prefix=\\"distroless-446923c3756ceeaa75888f52fcbdd48bb314fbf8\\",
+    urls=[\\"https://github.com/GoogleContainerTools/distroless/archive/446923c3756ceeaa75888f52fcbdd48bb314fbf8.tar.gz\\"]
+)
 "
 `;
 

--- a/lib/manager/bazel/extract.ts
+++ b/lib/manager/bazel/extract.ts
@@ -79,6 +79,7 @@ function parseContent(content: string): string[] {
   return [
     'container_pull',
     'http_archive',
+    'http_file',
     'go_repository',
     'git_repository',
   ].reduce(
@@ -215,7 +216,7 @@ export function extractPackageFile(content: string): PackageFile | null {
       }
       deps.push(dep);
     } else if (
-      depType === 'http_archive' &&
+      (depType === 'http_archive' || depType === 'http_file') &&
       depName &&
       parseUrl(url) &&
       sha256

--- a/lib/manager/bazel/update.ts
+++ b/lib/manager/bazel/update.ts
@@ -113,7 +113,10 @@ export async function updateDependency({
           `$1"${upgrade.newDigest}",  # ${upgrade.newValue}\n`
         );
       }
-    } else if (upgrade.depType === 'http_archive' && upgrade.newValue) {
+    } else if (
+      (upgrade.depType === 'http_archive' || upgrade.depType === 'http_file') &&
+      upgrade.newValue
+    ) {
       newDef = updateWithNewVersion(
         upgrade.managerData.def,
         upgrade.currentValue,
@@ -141,7 +144,10 @@ export async function updateDependency({
       }
       logger.debug({ hash }, 'Calculated hash');
       newDef = setNewHash(newDef, hash);
-    } else if (upgrade.depType === 'http_archive' && upgrade.newDigest) {
+    } else if (
+      (upgrade.depType === 'http_archive' || upgrade.depType === 'http_file') &&
+      upgrade.newDigest
+    ) {
       const [, shortRepo] = upgrade.repo.split('/');
       const url = `https://github.com/${upgrade.repo}/archive/${upgrade.newDigest}.tar.gz`;
       const hash = await getHashFromUrl(url);


### PR DESCRIPTION
Add support for [`http_file`](https://docs.bazel.build/versions/master/repo/http.html#http_file) to the Bazel manager. `http_file` works similarly to `http_archive`, so the implementation and test here are quite straightforward.

This PR addresses the underlying usecase in #6422.

<!-- Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App: https://cla-assistant.io/renovatebot/renovate -->

<!-- When creating this PR on GitHub, please ensure `Allow edits from maintainers.` checkbox is checked -->

<!-- Please use a conventional commit message (https://www.conventionalcommits.org/en/v1.0.0/) as your PR title -->

<!-- Ideally include at least one sentence saying what this PR achieves -->

<!-- Finish the PR with `Closes #` and then the issue number if it closes any associated issue -->
