### PR TITLE
fix(github): lazy fetch user and emails

### DIFF
--- a/lib/platform/github/__snapshots__/index.spec.ts.snap
+++ b/lib/platform/github/__snapshots__/index.spec.ts.snap
@@ -4544,6 +4544,14 @@ Array [
 ]
 `;
 
+exports[`platform/github initPlatform() should support gitAuthor and username 1`] = `
+Object {
+  "endpoint": "https://api.github.com/",
+  "gitAuthor": "renovate@whitesourcesoftware.com",
+  "renovateUsername": "renovate-bot",
+}
+`;
+
 exports[`platform/github initPlatform() should throw if user failure 1`] = `
 Array [
   Object {

--- a/lib/platform/github/index.spec.ts
+++ b/lib/platform/github/index.spec.ts
@@ -93,6 +93,15 @@ describe('platform/github', () => {
       ).toMatchSnapshot();
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
+    it('should support gitAuthor and username', async () => {
+      expect(
+        await github.initPlatform({
+          token: 'abc123',
+          username: 'renovate-bot',
+          gitAuthor: 'renovate@whitesourcesoftware.com',
+        } as any)
+      ).toMatchSnapshot();
+    });
     it('should support default endpoint with email', async () => {
       httpMock
         .scope(githubApiHost)

--- a/lib/platform/github/user.ts
+++ b/lib/platform/github/user.ts
@@ -1,0 +1,60 @@
+import { logger } from '../../logger';
+import * as githubHttp from '../../util/http/github';
+
+const githubApi = new githubHttp.GithubHttp();
+
+export interface UserDetails {
+  username: string;
+  name: string;
+}
+
+let userDetails: UserDetails;
+
+export async function getUserDetails(
+  endpoint: string,
+  token: string
+): Promise<UserDetails> {
+  if (userDetails) {
+    return userDetails;
+  }
+  try {
+    const userData = (
+      await githubApi.getJson<{ login: string; name: string }>(
+        endpoint + 'user',
+        {
+          token,
+        }
+      )
+    ).body;
+    userDetails = {
+      username: userData.login,
+      name: userData.name,
+    };
+    return userDetails;
+  } catch (err) {
+    logger.debug({ err }, 'Error authenticating with GitHub');
+    throw new Error('Init: Authentication failure');
+  }
+}
+
+let userEmail: string;
+
+export async function getUserEmail(
+  endpoint: string,
+  token: string
+): Promise<string | null> {
+  try {
+    const emails = (
+      await githubApi.getJson<{ email: string }[]>(endpoint + 'user/emails', {
+        token,
+      })
+    ).body;
+    userEmail = emails?.[0].email || null;
+    return userEmail;
+  } catch (err) {
+    logger.debug(
+      'Cannot read user/emails endpoint on GitHub to retrieve gitAuthor'
+    );
+    return null;
+  }
+}


### PR DESCRIPTION
github.initPlatform will only query for username and gitAuthor if they are not configured.