### PR TITLE
docs: add logFormat documentation

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -96,6 +96,13 @@ The `git` commands are run locally in the cloned repo instead of globally to red
 
 ## logFileLevel
 
+## logFormat
+
+The log format can’t be configured with a configuration option. Set the environment variable `LOG_FORMAT` to the desired format. Available options:
+
+- unset: Default multi-line log format
+- `JSON`: Each log message is a JSON object on one line.
+
 ## logLevel
 
 ## onboarding


### PR DESCRIPTION
This PR adds some documentation about the logFormat configuration.

I added this after having a question about how to set the log format in https://github.com/renovatebot/config-help/issues/774.

If there are other formats, please drop me a line so that I can add them.