### PR TITLE
fix: updated metadata

### DIFF
--- a/lib/datasource/metadata.ts
+++ b/lib/datasource/metadata.ts
@@ -18,8 +18,6 @@ const manualChangelogUrls = {
       'https://github.com/react-native-community/react-native-releases/blob/master/CHANGELOG.md',
   },
   pypi: {
-    'pytest-django':
-      'https://pytest-django.readthedocs.io/en/latest/changelog.html#changelog',
     django: 'https://github.com/django/django/tree/master/docs/releases',
     djangorestframework:
       'https://www.django-rest-framework.org/community/release-notes/',
@@ -33,8 +31,7 @@ const manualChangelogUrls = {
       'https://django-debug-toolbar.readthedocs.io/en/latest/changes.html',
     'firebase-admin':
       'https://firebase.google.com/support/release-notes/admin/python',
-    requests:
-      'http://docs.python-requests.org/en/master/community/updates/#release-and-version-history',
+    requests: 'https://github.com/psf/requests/blob/master/HISTORY.md',
     wagtail: 'https://github.com/wagtail/wagtail/tree/master/docs/releases',
   },
 };
@@ -48,6 +45,10 @@ const manualSourceUrls = {
       'https://github.com/hyper-expanse/library-release-workflows',
   },
   docker: {
+    'gcr.io/kaniko-project/executor':
+      'https://github.com/GoogleContainerTools/kaniko',
+    'gitlab/gitlab-ce': 'https://gitlab.com/gitlab-org/omnibus-gitlab',
+    'gitlab/gitlab-runner': 'https://gitlab.com/gitlab-org/gitlab-runner',
     node: 'https://github.com/nodejs/node',
     traefik: 'https://github.com/containous/traefik',
   },


### PR DESCRIPTION
Some new and fixed metadata urls

* `pytest-django` works by default now