### PR TITLE
fix(changelog): support 'release-' tag format.

### DIFF
--- a/lib/workers/pr/changelog/source-github.ts
+++ b/lib/workers/pr/changelog/source-github.ts
@@ -120,7 +120,7 @@ export async function getChangeLogJSON({
     if (!tags) {
       tags = await getTags(apiBaseUrl, repository);
     }
-    const regex = new RegExp(`${depName}[@-]`);
+    const regex = new RegExp(`(?:${depName}|release)[@-]`);
     const tagName = tags
       .filter((tag) => version.isVersion(tag.replace(regex, '')))
       .find((tag) => version.equals(tag.replace(regex, ''), release.version));

--- a/lib/workers/pr/changelog/source-gitlab.ts
+++ b/lib/workers/pr/changelog/source-gitlab.ts
@@ -105,7 +105,7 @@ export async function getChangeLogJSON({
     if (!tags) {
       tags = await getTags(apiBaseUrl, versioning, repository);
     }
-    const regex = regEx(`${depName}[@-]`);
+    const regex = regEx(`(?:${depName}|release)[@-]`);
     const tagName = tags
       .filter((tag) => version.isVersion(tag.replace(regex, '')))
       .find((tag) => version.equals(tag.replace(regex, ''), release.version));


### PR DESCRIPTION
Some project uses <code>release-<var>version</var></code> tag format.

Here is an example:
https://github.com/scalatest/scalatest/tags

<!-- Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App: https://cla-assistant.io/renovatebot/renovate -->

<!-- When creating this PR on GitHub, please ensure `Allow edits from maintainers.` checkbox is checked -->

<!-- Please use a conventional commit message (https://www.conventionalcommits.org/en/v1.0.0/) as your PR title -->

<!-- Ideally include at least one sentence saying what this PR achieves -->

<!-- Finish the PR with `Closes #` and then the issue number if it closes any associated issue -->
