### PR TITLE
fix(internal): forward legacy http url

### DIFF
--- a/lib/util/http/legacy.ts
+++ b/lib/util/http/legacy.ts
@@ -26,6 +26,12 @@ Object.defineProperty(HttpError.prototype, 'headers', {
   },
 });
 
+Object.defineProperty(HttpError.prototype, 'url', {
+  get: function url(this: HttpError) {
+    return this.response?.url;
+  },
+});
+
 export type GotLegacyError<E = unknown, T = unknown> = HttpError & {
   statusCode?: number;
   body: {


### PR DESCRIPTION
This should successfully log the the datasource url.

ref: renovatebot/github-action#136