### PR TITLE
feat(go): add support for gitlab in go datasource

### DIFF
--- a/lib/datasource/go/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/go/__snapshots__/index.spec.ts.snap
@@ -125,6 +125,33 @@ Array [
 ]
 `;
 
+exports[`datasource/go getReleases support gitlab 1`] = `
+Object {
+  "releases": Array [
+    Object {
+      "version": "v1.0.0",
+    },
+    Object {
+      "version": "v2.0.0",
+    },
+  ],
+}
+`;
+
+exports[`datasource/go getReleases support gitlab 2`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept-encoding": "gzip, deflate",
+      "host": "golang.org",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://golang.org/x/text?go-get=1",
+  },
+]
+`;
+
 exports[`datasource/go getReleases works for known servers 1`] = `
 Array [
   Array [

--- a/lib/datasource/go/index.ts
+++ b/lib/datasource/go/index.ts
@@ -82,50 +82,50 @@ export async function getReleases({
   logger.trace(`go.getReleases(${lookupName})`);
   const source = await getDatasource(lookupName);
   if (
-    source &&
-    (source.datasource === github.id || source.datasource === gitlab.id)
+    !source ||
+    (source.datasource !== github.id && source.datasource !== gitlab.id)
   ) {
-    const res =
-      source.datasource === github.id
-        ? await github.getReleases(source)
-        : await gitlab.getReleases(source);
-    // istanbul ignore if
-    if (!res) {
-      return res;
-    }
-    /**
-     * github.com/org/mod/submodule should be tagged as submodule/va.b.c
-     * and that tag should be used instead of just va.b.c, although for compatibility
-     * the old behaviour stays the same.
-     */
-    const nameParts = lookupName.split('/');
-    logger.trace({ nameParts, releases: res.releases }, 'go.getReleases');
-    if (nameParts.length > 3) {
-      const prefix = nameParts.slice(3, nameParts.length).join('/');
-      logger.trace(`go.getReleases.prefix:${prefix}`);
-      const submodReleases = res.releases
-        .filter(
-          (release) => release.version && release.version.startsWith(prefix)
-        )
-        .map((release) => {
-          const r2 = release;
-          r2.version = r2.version.replace(`${prefix}/`, '');
-          return r2;
-        });
-      logger.trace({ submodReleases }, 'go.getReleases');
-      if (submodReleases.length > 0) {
-        res.releases = submodReleases;
-        return res;
-      }
-    }
-    if (res?.releases) {
-      res.releases = res.releases.filter(
-        (release) => release.version && release.version.startsWith('v')
-      );
-    }
+    return null;
+  }
+  const res =
+    source.datasource === github.id
+      ? await github.getReleases(source)
+      : await gitlab.getReleases(source);
+  // istanbul ignore if
+  if (!res) {
     return res;
   }
-  return null;
+  /**
+   * github.com/org/mod/submodule should be tagged as submodule/va.b.c
+   * and that tag should be used instead of just va.b.c, although for compatibility
+   * the old behaviour stays the same.
+   */
+  const nameParts = lookupName.split('/');
+  logger.trace({ nameParts, releases: res.releases }, 'go.getReleases');
+  if (nameParts.length > 3) {
+    const prefix = nameParts.slice(3, nameParts.length).join('/');
+    logger.trace(`go.getReleases.prefix:${prefix}`);
+    const submodReleases = res.releases
+      .filter(
+        (release) => release.version && release.version.startsWith(prefix)
+      )
+      .map((release) => {
+        const r2 = release;
+        r2.version = r2.version.replace(`${prefix}/`, '');
+        return r2;
+      });
+    logger.trace({ submodReleases }, 'go.getReleases');
+    if (submodReleases.length > 0) {
+      res.releases = submodReleases;
+      return res;
+    }
+  }
+  if (res?.releases) {
+    res.releases = res.releases.filter(
+      (release) => release.version && release.version.startsWith('v')
+    );
+  }
+  return res;
 }
 
 /**

--- a/lib/datasource/go/index.ts
+++ b/lib/datasource/go/index.ts
@@ -81,10 +81,7 @@ export async function getReleases({
 }: GetReleasesConfig): Promise<ReleaseResult | null> {
   logger.trace(`go.getReleases(${lookupName})`);
   const source = await getDatasource(lookupName);
-  if (
-    !source ||
-    (source.datasource !== github.id && source.datasource !== gitlab.id)
-  ) {
+  if (source?.datasource !== github.id && source?.datasource !== gitlab.id) {
     return null;
   }
   const res =


### PR DESCRIPTION
feat: support gitlab for go datasource
- all go datasources with "gitlab." within the hostname are redirected to gitlab-tags datasource
- Example:
  - one public gitlab repository and one company gitlab repository with gitlab token
```
go.mod:
require (
  gitlab.com/gitlab-org/gitaly v13.0.0
  gitlab.mycompany.org/team1/project v0.6.1
)
```
- before this PR:
```
"depName": "gitlab.com/gitlab-org/gitaly",
"currentValue": "v13.0.0",
"updates": [],
 "warnings": [
   {
     "depName": "gitlab.com/gitlab-org/gitaly",
     "message": "Failed to look up dependency gitlab.com/gitlab-org/gitaly"
   }


"depName": "gitlab.mycompany.org/team1/project",
"currentValue": "v0.6.1",
"updates": [],
"warnings": [
   {
     "depName": "gitlab.mycompany.org/team1/project",
     "message": "Failed to look up dependency gitlab.mycompany.org/team1/project"
   }
```
- after this PR
```
"depName": "gitlab.com/gitlab-org/gitaly",
"updates": [
  {
    "fromVersion": "v13.0.0",
    "toVersion": "v13.2.2",
    "newValue": "v13.2.2",
  }
],
"depName": "gitlab.mycompany.org/team1/project",
"updates": [
  {
    "fromVersion": "v0.6.1",
    "toVersion": "v0.6.2",
    "newValue": "v0.6.2",
  }
],
```