### PR TITLE
fix(sbt): strip inline comments

### DIFF
--- a/lib/manager/sbt/__fixtures__/sample.sbt
+++ b/lib/manager/sbt/__fixtures__/sample.sbt
@@ -4,29 +4,29 @@ scalaVersion := "2.9.10"
 libraryDependencies += "org.example" % "foo" % "0.0.1"
 libraryDependencies += "org.example" %% "bar" % "0.0.2"
 libraryDependencies ++= Seq(
-  "org.example" %% "baz" % "0.0.3",
-  "org.example" % "qux" % "0.0.4"
+  "org.example" %% "baz" % "0.0.3",  // comment
+  "org.example" % "qux" % "0.0.4"    // comment
 )
 libraryDependencies += ("org.scala-lang" % "scala-library" % "2.13.3" classifier "sources") % Test
 
-dependencyOverrides += "org.example" % "quux" % "0.0.5"
+dependencyOverrides += "org.example" % "quux" % "0.0.5" // comment
 dependencyOverrides ++= {
-  val groupIdExample = "org.example"
-  val artifactIdExample = "corge"
-  lazy val versionExample = "0.0.8"
+  val groupIdExample = "org.example" // comment
+  val artifactIdExample = "corge"    // comment
+  lazy val versionExample = "0.0.8"  // comment
 
   Seq(
-    groupIdExample %% "quuz" % "0.0.6" % "test",
-    "org.example" % artifactIdExample % "0.0.7" % Provided
-    ,"org.example" % "grault" % versionExample % Test,
+    groupIdExample %% "quuz" % "0.0.6" % "test",           // comment
+    "org.example" % artifactIdExample % "0.0.7" % Provided // comment
+    ,"org.example" % "grault" % versionExample % Test,     // comment
   )
 }
 
 resolvers += "Repo #1" at "https://example.com/repos/1/"
 resolvers ++= Seq(
-  "Repo #2" at "https://example.com/repos/2/",
-  "Repo #3" at "https://example.com/repos/3/",
-  "Repo #4" at "https://example.com/repos/4/"
+  "Repo #2" at "https://example.com/repos/2/", // comment
+  "Repo #3" at "https://example.com/repos/3/", // comment
+  "Repo #4" at "https://example.com/repos/4/"  // comment
 )
 resolvers ++= Seq("Repo #5" at "https://example.com/repos/5/")
 

--- a/lib/manager/sbt/extract.ts
+++ b/lib/manager/sbt/extract.ts
@@ -6,7 +6,7 @@ import { get } from '../../versioning';
 import * as mavenVersioning from '../../versioning/maven';
 import { PackageDependency, PackageFile } from '../common';
 
-const isComment = (str: string): boolean => /^\s*\/\//.test(str);
+const stripComment = (str: string): string => str.replace(/(^|\s+)\/\/.*$/, '');
 
 const isSingleLineDep = (str: string): boolean =>
   /^\s*(libraryDependencies|dependencyOverrides)\s*\+=\s*/.test(str);
@@ -206,7 +206,7 @@ function parseSbtLine(
 
   let dep: PackageDependency = null;
   let scalaVersionVariable: string = null;
-  if (!isComment(line)) {
+  if (line !== '') {
     if (isScalaVersion(line)) {
       isMultiDeps = false;
       const rawScalaVersion = getScalaVersion(line);
@@ -296,7 +296,7 @@ export function extractPackageFile(content: string): PackageFile {
   if (!content) {
     return null;
   }
-  const lines = content.split(/\n/);
+  const lines = content.split(/\n/).map(stripComment);
   return lines.reduce(parseSbtLine, {
     registryUrls: [MAVEN_REPO],
     deps: [],


### PR DESCRIPTION
This pull request strips inline comments in build.sbt. This doesn't support multi-line comments but I believe inline comments are more widely used and this should be the first step.