### PR TITLE
feat(preset): add docusaurus monorepo

### DIFF
--- a/lib/config/presets/internal/monorepo.ts
+++ b/lib/config/presets/internal/monorepo.ts
@@ -52,6 +52,7 @@ const repoGroups = {
   chromely: 'https://github.com/chromelyapps/Chromely',
   clarity: 'https://github.com/vmware/clarity',
   commitlint: 'https://github.com/conventional-changelog/commitlint',
+  docusaurus: 'https://github.com/facebook/docusaurus',
   dropwizard: 'https://github.com/dropwizard/dropwizard',
   emotion: 'https://github.com/emotion-js/emotion',
   expo: 'https://github.com/expo/expo',


### PR DESCRIPTION
Adds docusaurus (e.g. [@docusaurus/core](https://www.npmjs.com/package/@docusaurus/core), [@docusaurus/theme-classic](https://www.npmjs.com/package/@docusaurus/theme-classic)) as a well-known monorepo.