### PR TITLE
fix(versioning): ignore git commit hash in loose/docker versioning

### DIFF
--- a/lib/versioning/docker/index.spec.ts
+++ b/lib/versioning/docker/index.spec.ts
@@ -11,6 +11,24 @@ describe('docker.', () => {
       expect(docker.isValid('3')).toBe('3');
       expect(docker.isValid('foo')).toBeNull();
     });
+    it('it should return null if the version string looks like a git commit hash', () => {
+      [
+        '0a1b2c3',
+        '0a1b2c3d',
+        '0a1b2c3d4e5f6a7b8c9d0a1b2c3d4e5f6a7b8c9d',
+      ].forEach((version) => {
+        expect(docker.isValid(version)).toBeNull();
+      });
+      [
+        '0a1b2c3d4e5f6a7b8c9d0a1b2c3d4e5f6a7b8c9d0',
+        '0a1b2C3',
+        '0z1b2c3',
+        '0A1b2c3d4e5f6a7b8c9d0a1b2c3d4e5f6a7b8c9d',
+        '123098140293',
+      ].forEach((version) => {
+        expect(docker.isValid(version)).toBe(version);
+      });
+    });
   });
   describe('getMajor(version)', () => {
     it('should support all versions length', () => {

--- a/lib/versioning/docker/index.ts
+++ b/lib/versioning/docker/index.ts
@@ -8,13 +8,18 @@ export const urls = [
 ];
 export const supportsRanges = false;
 
-const versionRe = /^(?<version>\d+(?:\.\d+)*)(?<prerelease>.*)$/;
+const versionPattern = /^(?<version>\d+(?:\.\d+)*)(?<prerelease>.*)$/;
+const commitHashPattern = /^[a-f0-9]{7,40}$/;
+const numericPattern = /^[0-9]+$/;
 
 function parse(version: string): generic.GenericVersion {
+  if (commitHashPattern.test(version) && !numericPattern.test(version)) {
+    return null;
+  }
   const versionPieces = version.replace(/^v/, '').split('-');
   const prefix = versionPieces.shift();
   const suffix = versionPieces.join('-');
-  const m = versionRe.exec(prefix);
+  const m = versionPattern.exec(prefix);
   if (!m?.groups) {
     return null;
   }

--- a/lib/versioning/docker/readme.md
+++ b/lib/versioning/docker/readme.md
@@ -13,3 +13,7 @@ It's pretty "wild west" for tagging and not always compliant with semver. Docker
 **Are ranges supported?**
 
 No. Although a tag like `12.15` might seem like it means `12.15.x`, it is a tag of its own and may or may not point to an of the available `12.15.x` tags, including `12.15.0`.
+
+**Are commit hashes supported?**
+
+No. An image tag that looks like a Git commit hash should be ignored by Renovate.

--- a/lib/versioning/loose/index.spec.ts
+++ b/lib/versioning/loose/index.spec.ts
@@ -29,6 +29,24 @@ describe('loose.', () => {
         expect(loose.isValid(version)).toBeNull();
       });
     });
+    it('it should return null if the version string looks like a git commit hash', () => {
+      [
+        '0a1b2c3',
+        '0a1b2c3d',
+        '0a1b2c3d4e5f6a7b8c9d0a1b2c3d4e5f6a7b8c9d',
+      ].forEach((version) => {
+        expect(loose.isValid(version)).toBeNull();
+      });
+      [
+        '0a1b2c3d4e5f6a7b8c9d0a1b2c3d4e5f6a7b8c9d0',
+        '0a1b2C3',
+        '0z1b2c3',
+        '0A1b2c3d4e5f6a7b8c9d0a1b2c3d4e5f6a7b8c9d',
+        '123098140293',
+      ].forEach((version) => {
+        expect(loose.isValid(version)).toBe(version);
+      });
+    });
   });
   describe('isGreaterThan(version)', () => {
     it('it should compare using release number than suffix', () => {

--- a/lib/versioning/loose/index.ts
+++ b/lib/versioning/loose/index.ts
@@ -6,10 +6,15 @@ export const displayName = 'Loose';
 export const urls = [];
 export const supportsRanges = false;
 
-const pattern = /^v?(\d+(?:\.\d+)*)(.*)$/;
+const versionPattern = /^v?(\d+(?:\.\d+)*)(.*)$/;
+const commitHashPattern = /^[a-f0-9]{7,40}$/;
+const numericPattern = /^[0-9]+$/;
 
 function parse(version: string): any {
-  const matches = pattern.exec(version);
+  if (commitHashPattern.test(version) && !numericPattern.test(version)) {
+    return null;
+  }
+  const matches = versionPattern.exec(version);
   if (!matches) {
     return null;
   }

--- a/lib/versioning/loose/readme.md
+++ b/lib/versioning/loose/readme.md
@@ -1,1 +1,1 @@
-Renovate's "loose" versioning was created for cases where no strict versioning is in place. It works like semver if semver-compliant versions are supplied, but otherwise is "best effort". Essentially it just does its best to sort versions.
+Renovate's "loose" versioning was created for cases where no strict versioning is in place. It works like semver if semver-compliant versions are supplied, but otherwise is "best effort". Essentially it just does its best to sort versions and ignore versions that are not sortable.


### PR DESCRIPTION
<!-- Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App: https://cla-assistant.io/renovatebot/renovate -->

<!-- When creating this PR on GitHub, please ensure `Allow edits from maintainers.` checkbox is checked -->

<!-- Please use a conventional commit message (https://www.conventionalcommits.org/en/v1.0.0/) as your PR title -->

<!-- Ideally include at least one sentence saying what this PR achieves -->

<!-- Finish the PR with `Closes #` and then the issue number if it closes any associated issue -->

Implements Solution: in loose versioning, check if the string is a valid git commit SHA and return isValid=false: https://github.com/renovatebot/renovate/issues/6913#issuecomment-668744708

Closes https://github.com/renovatebot/renovate/issues/6913