### PR TITLE
fix(yarn): allow overwriting of yarnrc file

### DIFF
--- a/lib/manager/common.ts
+++ b/lib/manager/common.ts
@@ -22,7 +22,7 @@ export interface ExtractConfig extends ManagerConfig {
   gradle?: { timeout?: number };
   aliases?: Record<string, string>;
   ignoreNpmrcFile?: boolean;
-
+  yarnrc?: string;
   skipInstalls?: boolean;
   versioning?: string;
 }

--- a/lib/manager/npm/extract/index.ts
+++ b/lib/manager/npm/extract/index.ts
@@ -118,7 +118,10 @@ export async function extractPackageFile(
     }
   }
   const yarnrcFileName = getSiblingFileName(fileName, '.yarnrc');
-  const yarnrc = (await readLocalFile(yarnrcFileName, 'utf8')) || undefined;
+  let yarnrc;
+  if (!is.string(config.yarnrc)) {
+    yarnrc = (await readLocalFile(yarnrcFileName, 'utf8')) || undefined;
+  }
 
   let lernaDir: string;
   let lernaPackages: string[];

--- a/lib/manager/npm/post-update/index.ts
+++ b/lib/manager/npm/post-update/index.ts
@@ -132,8 +132,7 @@ export async function writeExistingFiles(
   }
   if (is.string(config.yarnrc)) {
     logger.debug(`Writing repo .yarnrc (${config.localDir})`);
-    const yarnrcFileName = upath.join(config.localDir, '.yarnrc');
-    await outputFile(yarnrcFileName, config.yarnrc);
+    await outputFile(upath.join(config.localDir, '.yarnrc'), config.yarnrc);
   }
   if (!packageFiles.npm) {
     return;

--- a/lib/manager/npm/post-update/index.ts
+++ b/lib/manager/npm/post-update/index.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import is from '@sindresorhus/is';
 import upath from 'upath';
 import { SYSTEM_INSUFFICIENT_DISK_SPACE } from '../../../constants/error-messages';
 import { id as npmId } from '../../../datasource/npm';
@@ -129,9 +130,10 @@ export async function writeExistingFiles(
     logger.debug('Removing ignored .npmrc file before artifact generation');
     await remove(npmrcFile);
   }
-  if (config.yarnrc) {
+  if (is.string(config.yarnrc)) {
     logger.debug(`Writing repo .yarnrc (${config.localDir})`);
-    await outputFile(upath.join(config.localDir, '.yarnrc'), config.yarnrc);
+    const yarnrcFileName = upath.join(config.localDir, '.yarnrc');
+    await outputFile(yarnrcFileName, config.yarnrc);
   }
   if (!packageFiles.npm) {
     return;


### PR DESCRIPTION
Skip reading the `.yarnrc` file if `yarnrc` is already in config.

Closes #6884 
