### PR TITLE
fix(go): match go-source by go module prefix

### DIFF
--- a/lib/datasource/go/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/go/__snapshots__/index.spec.ts.snap
@@ -14,6 +14,20 @@ Array [
 ]
 `;
 
+exports[`datasource/go getDigest returns null for no go-source tag 1`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept-encoding": "gzip, deflate",
+      "host": "golang.org",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://golang.org/y/text?go-get=1",
+  },
+]
+`;
+
 exports[`datasource/go getDigest returns null for wrong name 1`] = `
 Array [
   Object {

--- a/lib/datasource/go/index.spec.ts
+++ b/lib/datasource/go/index.spec.ts
@@ -34,6 +34,16 @@ describe('datasource/go', () => {
   });
 
   describe('getDigest', () => {
+    it('returns null for no go-source tag', async () => {
+      httpMock
+        .scope('https://golang.org/')
+        .get('/y/text?go-get=1')
+        .reply(200, '');
+      github.getDigest.mockResolvedValueOnce('abcdefabcdefabcdefabcdef');
+      const res = await getDigest({ lookupName: 'golang.org/y/text' }, null);
+      expect(res).toBeNull();
+      expect(httpMock.getTrace()).toMatchSnapshot();
+    });
     it('returns null for wrong name', async () => {
       httpMock
         .scope('https://golang.org/')

--- a/lib/datasource/go/index.ts
+++ b/lib/datasource/go/index.ts
@@ -37,10 +37,14 @@ async function getDatasource(goModule: string): Promise<DataSource | null> {
   const pkgUrl = `https://${goModule}?go-get=1`;
   const res = (await http.get(pkgUrl)).body;
   const sourceMatch = regEx(
-    `<meta\\s+name="go-source"\\s+content="${goModule}\\s+([^\\s]+)`
+    `<meta\\s+name="go-source"\\s+content="([^\\s]+)\\s+([^\\s]+)`
   ).exec(res);
   if (sourceMatch) {
-    const [, goSourceUrl] = sourceMatch;
+    const [, prefix, goSourceUrl] = sourceMatch;
+    if (!goModule.startsWith(prefix)) {
+      logger.trace({ goModule }, 'go-source header prefix not match');
+      return null;
+    }
     logger.debug({ goModule, goSourceUrl }, 'Go lookup source url');
     if (goSourceUrl?.startsWith('https://github.com/')) {
       return {


### PR DESCRIPTION
<!-- Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App: https://cla-assistant.io/renovatebot/renovate -->

<!-- When creating this PR on GitHub, please ensure `Allow edits from maintainers.` checkbox is checked -->

<!-- Please use a conventional commit message (https://www.conventionalcommits.org/en/v1.0.0/) as your PR title -->

<!-- Ideally include at least one sentence saying what this PR achieves -->
The `go-source` meta might contains only the prefix of the go module.
e.g. `curl --verbose "https://golang.org/x/build/revdial/v2?go-get=1"` =>
```
<meta name="go-import" content="golang.org/x/build git https://go.googlesource.com/build">
<meta name="go-source" content="golang.org/x/build https://github.com/golang/build/ https://github.com/golang/build/tree/master{/dir} https://github.com/golang/build/blob/master{/dir}/{file}#L{line}">
<meta http-equiv="refresh" content="0; url=https://godoc.org/golang.org/x/build/revdial/v2">
```
The proposed solution here is to take `go-source` content as prefix and compare it with go module by `startsWith`.

<!-- Finish the PR with `Closes #` and then the issue number if it closes any associated issue -->
