### PR TITLE
feat: add http2 option

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -572,6 +572,10 @@ Renovate does not do a "longest match" algorithm to pick between multiple matchi
 
 If you have any uncertainty about exactly which hosts a service uses, then it can be more reliable to use `domainName` instead of `hostName` or `baseUrl`. e.g. configure `"hostName": "docker.io"` to cover both `index.docker.io` and `auth.docker.io` and any other host that's in use.
 
+### enableHttp2
+
+Enable got [http2](https://github.com/sindresorhus/got/blob/v11.5.2/readme.md#http2) support.
+
 ### hostName
 
 ### hostType

--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -1667,6 +1667,16 @@ const options: RenovateOptions[] = [
     env: false,
   },
   {
+    name: 'enableHttp2',
+    description: 'Enable got http2 support.',
+    type: 'boolean',
+    stage: 'repository',
+    parent: 'hostRules',
+    default: false,
+    cli: false,
+    env: false,
+  },
+  {
     name: 'prBodyDefinitions',
     description: 'Table column definitions for use in PR tables',
     type: 'object',

--- a/lib/types/host-rules.ts
+++ b/lib/types/host-rules.ts
@@ -16,4 +16,5 @@ export interface HostRule {
   abortOnError?: boolean;
   abortIgnoreStatusCodes?: number[];
   enabled?: boolean;
+  enableHttp2?: boolean;
 }

--- a/lib/util/http/host-rules.ts
+++ b/lib/util/http/host-rules.ts
@@ -1,4 +1,5 @@
 import { logger } from '../../logger';
+import { hasProxy } from '../../proxy';
 import * as hostRules from '../host-rules';
 import { GotOptions } from './types';
 
@@ -30,5 +31,9 @@ export function applyHostRules(url: string, inOptions: GotOptions): GotOptions {
       options[param] = foundRules[param];
     }
   });
+
+  if (!hasProxy() && foundRules.enableHttp2 === true) {
+    options.http2 = true;
+  }
   return options;
 }


### PR DESCRIPTION
With this pr we can use `enableHttp2=true` with a `hostRule` to allow got to use http2 requests.

This should improve http requests, as we theoretically only need one tcp socket per host (depends on got implementation, only https).