### PR TITLE
feat(go): add GOPRIVATE env to golang updateArtifacts function

### DIFF
--- a/lib/manager/gomod/artifacts.ts
+++ b/lib/manager/gomod/artifacts.ts
@@ -65,6 +65,7 @@ export async function updateArtifacts({
       extraEnv: {
         GOPATH: goPath,
         GOPROXY: process.env.GOPROXY,
+        GOPRIVATE: process.env.GOPRIVATE,
         GONOSUMDB: process.env.GONOSUMDB,
         CGO_ENABLED: config.binarySource === BinarySource.Docker ? '0' : null,
       },


### PR DESCRIPTION
feat: add GOPRIVATE environment variable to golang update artifacts process.
- since go 1.13 these env var provides better proxy control for "go get"