### PR TITLE
fix(npm): Pass auth variables for artifacts update

### DIFF
--- a/lib/manager/npm/post-update/index.ts
+++ b/lib/manager/npm/post-update/index.ts
@@ -429,7 +429,6 @@ export async function getAdditionalFiles(
     );
     const res = await npm.generateLockFile(
       fullLockFileDir,
-      env,
       fileName,
       config,
       upgrades
@@ -492,7 +491,6 @@ export async function getAdditionalFiles(
     );
     const res = await yarn.generateLockFile(
       upath.join(config.localDir, lockFileDir),
-      env,
       config,
       upgrades
     );
@@ -594,7 +592,6 @@ export async function getAdditionalFiles(
     );
     const res = await pnpm.generateLockFile(
       upath.join(config.localDir, lockFileDir),
-      env,
       config,
       upgrades
     );
@@ -670,7 +667,6 @@ export async function getAdditionalFiles(
       lernaPackageFile,
       fullLearnaFileDir,
       config,
-      env,
       skipInstalls
     );
     // istanbul ignore else

--- a/lib/manager/npm/post-update/lerna.spec.ts
+++ b/lib/manager/npm/post-update/lerna.spec.ts
@@ -32,14 +32,13 @@ describe(getName(__filename), () => {
       env.getChildProcessEnv.mockReturnValue(envMock.basic);
     });
     it('returns if no lernaClient', async () => {
-      const res = await lernaHelper.generateLockFiles({}, 'some-dir', {}, {});
+      const res = await lernaHelper.generateLockFiles({}, 'some-dir', {});
       expect(res.error).toBe(false);
     });
     it('returns if invalid lernaClient', async () => {
       const res = await lernaHelper.generateLockFiles(
         lernaPkgFile('foo'),
         'some-dir',
-        {},
         {}
       );
       expect(res.error).toBe(false);
@@ -50,7 +49,6 @@ describe(getName(__filename), () => {
       const res = await lernaHelper.generateLockFiles(
         lernaPkgFile('npm'),
         'some-dir',
-        {},
         {},
         skipInstalls
       );
@@ -64,7 +62,6 @@ describe(getName(__filename), () => {
         lernaPkgFile('npm'),
         'some-dir',
         {},
-        {},
         skipInstalls
       );
       expect(res.error).toBe(false);
@@ -75,8 +72,7 @@ describe(getName(__filename), () => {
       const res = await lernaHelper.generateLockFiles(
         lernaPkgFile('yarn'),
         'some-dir',
-        { compatibility: { yarn: '^1.10.0' } },
-        {}
+        { compatibility: { yarn: '^1.10.0' } }
       );
       expect(execSnapshots).toMatchSnapshot();
       expect(res.error).toBe(false);
@@ -86,7 +82,6 @@ describe(getName(__filename), () => {
       const res = await lernaHelper.generateLockFiles(
         lernaPkgFileWithoutLernaDep('npm'),
         'some-dir',
-        {},
         {}
       );
       expect(res.error).toBe(false);
@@ -100,8 +95,7 @@ describe(getName(__filename), () => {
         {
           dockerMapDotfiles: true,
           compatibility: { npm: '^6.0.0' },
-        },
-        {}
+        }
       );
       expect(res.error).toBe(false);
       expect(execSnapshots).toMatchSnapshot();
@@ -112,7 +106,6 @@ describe(getName(__filename), () => {
       const res = await lernaHelper.generateLockFiles(
         lernaPkgFile('npm'),
         'some-dir',
-        {},
         {}
       );
       delete global.trustLevel;

--- a/lib/manager/npm/post-update/lerna.ts
+++ b/lib/manager/npm/post-update/lerna.ts
@@ -3,6 +3,7 @@ import { quote } from 'shlex';
 import { join } from 'upath';
 import { logger } from '../../../logger';
 import { ExecOptions, exec } from '../../../util/exec';
+import { getChildProcessEnv } from '../../../util/exec/env';
 import { PackageFile, PostUpdateConfig } from '../../common';
 import { getNodeConstraint } from './node-version';
 import { optimizeCommand } from './yarn';
@@ -30,7 +31,6 @@ export async function generateLockFiles(
   lernaPackageFile: Partial<PackageFile>,
   cwd: string,
   config: PostUpdateConfig,
-  env: NodeJS.ProcessEnv,
   skipInstalls?: boolean
 ): Promise<GenerateLockFileResult> {
   const lernaClient = lernaPackageFile.lernaClient;
@@ -78,10 +78,14 @@ export async function generateLockFiles(
     const tagConstraint = await getNodeConstraint(config);
     const execOptions: ExecOptions = {
       cwd,
-      extraEnv: {
-        NPM_CONFIG_CACHE: env.NPM_CONFIG_CACHE,
-        npm_config_store: env.npm_config_store,
-      },
+      extraEnv: getChildProcessEnv([
+        'NPM_CONFIG_CACHE',
+        'YARN_CACHE_FOLDER',
+        'npm_config_store',
+        'NPM_AUTH',
+        'NPM_EMAIL',
+        'NPM_TOKEN',
+      ]),
       docker: {
         image: 'renovate/node',
         tagScheme: 'npm',

--- a/lib/manager/npm/post-update/npm.spec.ts
+++ b/lib/manager/npm/post-update/npm.spec.ts
@@ -33,7 +33,6 @@ describe('generateLockFile', () => {
     ];
     const res = await npmHelper.generateLockFile(
       'some-dir',
-      {},
       'package-lock.json',
       { dockerMapDotfiles, skipInstalls, postUpdateOptions },
       updates
@@ -52,7 +51,6 @@ describe('generateLockFile', () => {
     ];
     const res = await npmHelper.generateLockFile(
       'some-dir',
-      {},
       'package-lock.json',
       { skipInstalls },
       updates
@@ -70,7 +68,6 @@ describe('generateLockFile', () => {
     const skipInstalls = true;
     const res = await npmHelper.generateLockFile(
       'some-dir',
-      {},
       'npm-shrinkwrap.json',
       { skipInstalls }
     );
@@ -99,7 +96,6 @@ describe('generateLockFile', () => {
     const skipInstalls = true;
     const res = await npmHelper.generateLockFile(
       'some-dir',
-      {},
       'npm-shrinkwrap.json',
       { skipInstalls }
     );
@@ -123,7 +119,6 @@ describe('generateLockFile', () => {
     const binarySource = BinarySource.Global;
     const res = await npmHelper.generateLockFile(
       'some-dir',
-      {},
       'package-lock.json',
       { skipInstalls, binarySource }
     );
@@ -139,7 +134,6 @@ describe('generateLockFile', () => {
     }) as never;
     const res = await npmHelper.generateLockFile(
       'some-dir',
-      {},
       'package-lock.json'
     );
     expect(fs.readFile).toHaveBeenCalledTimes(1);
@@ -152,7 +146,6 @@ describe('generateLockFile', () => {
     fs.readFile = jest.fn(() => 'package-lock-contents') as never;
     const res = await npmHelper.generateLockFile(
       'some-dir',
-      {},
       'package-lock.json'
     );
     expect(fs.readFile).toHaveBeenCalledTimes(1);
@@ -164,7 +157,6 @@ describe('generateLockFile', () => {
     fs.readFile = jest.fn(() => 'package-lock-contents') as never;
     const res = await npmHelper.generateLockFile(
       'some-dir',
-      {},
       'package-lock.json',
       { binarySource: BinarySource.Docker, compatibility: { npm: '^6.0.0' } }
     );
@@ -177,7 +169,6 @@ describe('generateLockFile', () => {
     fs.readFile = jest.fn(() => 'package-lock-contents') as never;
     const res = await npmHelper.generateLockFile(
       'some-dir',
-      {},
       'package-lock.json',
       {},
       [{ isLockFileMaintenance: true }]

--- a/lib/manager/npm/post-update/npm.ts
+++ b/lib/manager/npm/post-update/npm.ts
@@ -4,6 +4,7 @@ import { join } from 'upath';
 import { SYSTEM_INSUFFICIENT_DISK_SPACE } from '../../../constants/error-messages';
 import { logger } from '../../../logger';
 import { ExecOptions, exec } from '../../../util/exec';
+import { getChildProcessEnv } from '../../../util/exec/env';
 import { move, pathExists, readFile, remove } from '../../../util/fs';
 import { PostUpdateConfig, Upgrade } from '../../common';
 import { getNodeConstraint } from './node-version';
@@ -16,7 +17,6 @@ export interface GenerateLockFileResult {
 
 export async function generateLockFile(
   cwd: string,
-  env: NodeJS.ProcessEnv,
   filename: string,
   config: PostUpdateConfig = {},
   upgrades: Upgrade[] = []
@@ -44,7 +44,14 @@ export async function generateLockFile(
     const tagConstraint = await getNodeConstraint(config);
     const execOptions: ExecOptions = {
       cwd,
-      extraEnv: env,
+      extraEnv: getChildProcessEnv([
+        'NPM_CONFIG_CACHE',
+        'YARN_CACHE_FOLDER',
+        'npm_config_store',
+        'NPM_AUTH',
+        'NPM_EMAIL',
+        'NPM_TOKEN',
+      ]),
       docker: {
         image: 'renovate/node',
         tagScheme: 'npm',

--- a/lib/manager/npm/post-update/npm.ts
+++ b/lib/manager/npm/post-update/npm.ts
@@ -44,10 +44,7 @@ export async function generateLockFile(
     const tagConstraint = await getNodeConstraint(config);
     const execOptions: ExecOptions = {
       cwd,
-      extraEnv: {
-        NPM_CONFIG_CACHE: env.NPM_CONFIG_CACHE,
-        npm_config_store: env.npm_config_store,
-      },
+      extraEnv: env,
       docker: {
         image: 'renovate/node',
         tagScheme: 'npm',

--- a/lib/manager/npm/post-update/pnpm.spec.ts
+++ b/lib/manager/npm/post-update/pnpm.spec.ts
@@ -27,7 +27,7 @@ describe('generateLockFile', () => {
     config.dockerMapDotfiles = true;
     const execSnapshots = mockExecAll(exec);
     fs.readFile = jest.fn(() => 'package-lock-contents') as never;
-    const res = await pnpmHelper.generateLockFile('some-dir', {}, config);
+    const res = await pnpmHelper.generateLockFile('some-dir', config);
     expect(fs.readFile).toHaveBeenCalledTimes(1);
     expect(res.lockFile).toEqual('package-lock-contents');
     expect(execSnapshots).toMatchSnapshot();
@@ -37,7 +37,7 @@ describe('generateLockFile', () => {
     fs.readFile = jest.fn(() => {
       throw new Error('not found');
     }) as never;
-    const res = await pnpmHelper.generateLockFile('some-dir', {}, config);
+    const res = await pnpmHelper.generateLockFile('some-dir', config);
     expect(fs.readFile).toHaveBeenCalledTimes(1);
     expect(res.error).toBe(true);
     expect(res.lockFile).not.toBeDefined();
@@ -46,7 +46,7 @@ describe('generateLockFile', () => {
   it('finds pnpm globally', async () => {
     const execSnapshots = mockExecAll(exec);
     fs.readFile = jest.fn(() => 'package-lock-contents') as never;
-    const res = await pnpmHelper.generateLockFile('some-dir', {}, config);
+    const res = await pnpmHelper.generateLockFile('some-dir', config);
     expect(fs.readFile).toHaveBeenCalledTimes(1);
     expect(res.lockFile).toEqual('package-lock-contents');
     expect(execSnapshots).toMatchSnapshot();
@@ -54,7 +54,7 @@ describe('generateLockFile', () => {
   it('performs lock file maintenance', async () => {
     const execSnapshots = mockExecAll(exec);
     fs.readFile = jest.fn(() => 'package-lock-contents') as never;
-    const res = await pnpmHelper.generateLockFile('some-dir', {}, config, [
+    const res = await pnpmHelper.generateLockFile('some-dir', config, [
       { isLockFileMaintenance: true },
     ]);
     expect(fs.readFile).toHaveBeenCalledTimes(1);

--- a/lib/manager/npm/post-update/pnpm.ts
+++ b/lib/manager/npm/post-update/pnpm.ts
@@ -36,10 +36,7 @@ export async function generateLockFile(
     const tagConstraint = await getNodeConstraint(config);
     const execOptions: ExecOptions = {
       cwd,
-      extraEnv: {
-        NPM_CONFIG_CACHE: env.NPM_CONFIG_CACHE,
-        npm_config_store: env.npm_config_store,
-      },
+      extraEnv: env,
       docker: {
         image: 'renovate/node',
         tagScheme: 'npm',

--- a/lib/manager/npm/post-update/pnpm.ts
+++ b/lib/manager/npm/post-update/pnpm.ts
@@ -3,6 +3,7 @@ import { quote } from 'shlex';
 import { join } from 'upath';
 import { logger } from '../../../logger';
 import { ExecOptions, exec } from '../../../util/exec';
+import { getChildProcessEnv } from '../../../util/exec/env';
 import { readFile, remove } from '../../../util/fs';
 import { PostUpdateConfig, Upgrade } from '../../common';
 import { getNodeConstraint } from './node-version';
@@ -16,7 +17,6 @@ export interface GenerateLockFileResult {
 
 export async function generateLockFile(
   cwd: string,
-  env: NodeJS.ProcessEnv,
   config: PostUpdateConfig,
   upgrades: Upgrade[] = []
 ): Promise<GenerateLockFileResult> {
@@ -36,7 +36,14 @@ export async function generateLockFile(
     const tagConstraint = await getNodeConstraint(config);
     const execOptions: ExecOptions = {
       cwd,
-      extraEnv: env,
+      extraEnv: getChildProcessEnv([
+        'NPM_CONFIG_CACHE',
+        'YARN_CACHE_FOLDER',
+        'npm_config_store',
+        'NPM_AUTH',
+        'NPM_EMAIL',
+        'NPM_TOKEN',
+      ]),
       docker: {
         image: 'renovate/node',
         tagScheme: 'npm',

--- a/lib/manager/npm/post-update/yarn.spec.ts
+++ b/lib/manager/npm/post-update/yarn.spec.ts
@@ -45,7 +45,7 @@ describe(getName(__filename), () => {
         },
         postUpdateOptions: ['yarnDedupeFewer', 'yarnDedupeHighest'],
       };
-      const res = await yarnHelper.generateLockFile('some-dir', {}, config);
+      const res = await yarnHelper.generateLockFile('some-dir', config);
       expect(fs.readFile).toHaveBeenCalledTimes(2);
       expect(fs.remove).toHaveBeenCalledTimes(0);
       expect(res.lockFile).toEqual('package-lock-contents');
@@ -62,7 +62,7 @@ describe(getName(__filename), () => {
 
       fs.readFile.mockResolvedValue(null); // .yarnrc
       fs.readFile.mockResolvedValue('package-lock-contents' as never);
-      const res = await yarnHelper.generateLockFile('some-dir', {}, {}, [
+      const res = await yarnHelper.generateLockFile('some-dir', {}, [
         {
           depName: 'some-dep',
           isLockfileUpdate: true,
@@ -84,7 +84,7 @@ describe(getName(__filename), () => {
         'yarn-offline-mirror ./npm-packages-offline-cache' as never
       );
       fs.readFile.mockReturnValueOnce('package-lock-contents' as never);
-      const res = await yarnHelper.generateLockFile('some-dir', {}, {}, [
+      const res = await yarnHelper.generateLockFile('some-dir', {}, [
         {
           depName: 'some-dep',
           isLockfileUpdate: true,
@@ -110,7 +110,7 @@ describe(getName(__filename), () => {
         },
         postUpdateOptions: ['yarnDedupeFewer', 'yarnDedupeHighest'],
       };
-      const res = await yarnHelper.generateLockFile('some-dir', {}, config, [
+      const res = await yarnHelper.generateLockFile('some-dir', config, [
         { isLockFileMaintenance: true },
       ]);
       expect(fs.readFile).toHaveBeenCalledTimes(2);
@@ -128,7 +128,7 @@ describe(getName(__filename), () => {
     fs.readFile.mockImplementationOnce(() => {
       throw new Error('not-found');
     });
-    const res = await yarnHelper.generateLockFile('some-dir', {});
+    const res = await yarnHelper.generateLockFile('some-dir');
     expect(fs.readFile).toHaveBeenCalledTimes(2);
     expect(res.error).toBe(true);
     expect(res.lockFile).not.toBeDefined();

--- a/lib/manager/npm/post-update/yarn.ts
+++ b/lib/manager/npm/post-update/yarn.ts
@@ -70,10 +70,7 @@ export async function generateLockFile(
     const tagConstraint = await getNodeConstraint(config);
     const execOptions: ExecOptions = {
       cwd,
-      extraEnv: {
-        NPM_CONFIG_CACHE: env.NPM_CONFIG_CACHE,
-        npm_config_store: env.npm_config_store,
-      },
+      extraEnv: env,
       docker: {
         image: 'renovate/node',
         tagScheme: 'npm',

--- a/lib/manager/npm/post-update/yarn.ts
+++ b/lib/manager/npm/post-update/yarn.ts
@@ -7,6 +7,7 @@ import { id as npmId } from '../../../datasource/npm';
 import { logger } from '../../../logger';
 import { ExternalHostError } from '../../../types/errors/external-host-error';
 import { ExecOptions, exec } from '../../../util/exec';
+import { getChildProcessEnv } from '../../../util/exec/env';
 import { readFile, remove } from '../../../util/fs';
 import { PostUpdateConfig, Upgrade } from '../../common';
 import { getNodeConstraint } from './node-version';
@@ -39,7 +40,6 @@ export const optimizeCommand =
 
 export async function generateLockFile(
   cwd: string,
-  env: NodeJS.ProcessEnv,
   config: PostUpdateConfig = {},
   upgrades: Upgrade[] = []
 ): Promise<GenerateLockFileResult> {
@@ -70,7 +70,14 @@ export async function generateLockFile(
     const tagConstraint = await getNodeConstraint(config);
     const execOptions: ExecOptions = {
       cwd,
-      extraEnv: env,
+      extraEnv: getChildProcessEnv([
+        'NPM_CONFIG_CACHE',
+        'YARN_CACHE_FOLDER',
+        'npm_config_store',
+        'NPM_AUTH',
+        'NPM_EMAIL',
+        'NPM_TOKEN',
+      ]),
       docker: {
         image: 'renovate/node',
         tagScheme: 'npm',


### PR DESCRIPTION
Closes #6961 (hopefully)

Looks like it's safe to pass entire `env` parameter, since it was obtained with `getChildProcessEnv()`, which filters everything except 3 npm-specific vars.