### PR TITLE
feat(composer): registryUrls support for composer packages

### DIFF
--- a/lib/config/common.ts
+++ b/lib/config/common.ts
@@ -209,6 +209,7 @@ export interface PackageRule
   excludePackagePatterns?: string[];
   matchCurrentVersion?: string | Range;
   sourceUrlPrefixes?: string[];
+  packagist?: boolean;
 
   updateTypes?: UpdateType[];
 }

--- a/lib/manager/common.ts
+++ b/lib/manager/common.ts
@@ -10,7 +10,6 @@ export interface ManagerConfig {
   dockerUser?: string;
   localDir?: string;
   registryUrls?: string[];
-  packagist?: boolean;
 }
 
 export interface ManagerData<T> {

--- a/lib/manager/common.ts
+++ b/lib/manager/common.ts
@@ -10,6 +10,7 @@ export interface ManagerConfig {
   dockerUser?: string;
   localDir?: string;
   registryUrls?: string[];
+  packagist?: boolean;
 }
 
 export interface ManagerData<T> {

--- a/lib/manager/composer/__fixtures__/composer6.json
+++ b/lib/manager/composer/__fixtures__/composer6.json
@@ -1,0 +1,12 @@
+{
+  "name": "acme/brilliant-wordpress-site",
+  "description": "My brilliant WordPress site",
+  "require": {
+    "aws/aws-sdk-php": "*"
+  },
+  "autoload": {
+    "psr-0": {
+      "Acme": "src/"
+    }
+  }
+}

--- a/lib/manager/composer/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/composer/__snapshots__/extract.spec.ts.snap
@@ -503,6 +503,75 @@ Object {
 }
 `;
 
+exports[`lib/manager/composer/extract extractPackageFile() extracts object repositories and registryUrls on with another datasource in config 1`] = `
+Object {
+  "deps": Array [
+    Object {
+      "currentValue": "*",
+      "datasource": "packagist",
+      "depName": "aws/aws-sdk-php",
+      "depType": "require",
+      "skipReason": "any-version",
+    },
+  ],
+  "registryUrls": Array [
+    "https://packagist.org",
+  ],
+}
+`;
+
+exports[`lib/manager/composer/extract extractPackageFile() extracts object repositories and registryUrls using packagist with config 1`] = `
+Object {
+  "deps": Array [
+    Object {
+      "currentValue": "*",
+      "datasource": "packagist",
+      "depName": "aws/aws-sdk-php",
+      "depType": "require",
+      "skipReason": "any-version",
+    },
+  ],
+  "registryUrls": Array [
+    "https://composer.renovatebot.com",
+    "https://packagist.org",
+  ],
+}
+`;
+
+exports[`lib/manager/composer/extract extractPackageFile() extracts object repositories and registryUrls with config 1`] = `
+Object {
+  "deps": Array [
+    Object {
+      "currentValue": "*",
+      "datasource": "packagist",
+      "depName": "aws/aws-sdk-php",
+      "depType": "require",
+      "skipReason": "any-version",
+    },
+  ],
+  "registryUrls": Array [
+    "https://composer.renovatebot.com",
+  ],
+}
+`;
+
+exports[`lib/manager/composer/extract extractPackageFile() extracts object repositories and registryUrls with datasource in config 1`] = `
+Object {
+  "deps": Array [
+    Object {
+      "currentValue": "*",
+      "datasource": "packagist",
+      "depName": "aws/aws-sdk-php",
+      "depType": "require",
+      "skipReason": "any-version",
+    },
+  ],
+  "registryUrls": Array [
+    "https://composer.renovatebot.com",
+  ],
+}
+`;
+
 exports[`lib/manager/composer/extract extractPackageFile() extracts object repositories and registryUrls with lock file 1`] = `
 Object {
   "deps": Array [

--- a/lib/manager/composer/extract.spec.ts
+++ b/lib/manager/composer/extract.spec.ts
@@ -24,6 +24,10 @@ const requirements5 = readFileSync(
   'lib/manager/composer/__fixtures__/composer5.json',
   'utf8'
 );
+const requirements6 = readFileSync(
+  'lib/manager/composer/__fixtures__/composer6.json',
+  'utf8'
+);
 const requirements5Lock = readFileSync(
   'lib/manager/composer/__fixtures__/composer5.lock',
   'utf8'
@@ -65,6 +69,71 @@ describe('lib/manager/composer/extract', () => {
       const res = await extractPackageFile(requirements5, packageFile);
       expect(res).toMatchSnapshot();
       expect(res.registryUrls).toHaveLength(2);
+    });
+    it('extracts object repositories and registryUrls with config', async () => {
+      const config = {
+        packageRules: [
+          {
+            registryUrls: ['https://composer.renovatebot.com'],
+            packagist: false,
+          },
+        ],
+      };
+      const res = await extractPackageFile(requirements6, packageFile, config);
+      expect(res).toMatchSnapshot();
+      expect(res.registryUrls).toHaveLength(1);
+      expect(res.registryUrls).not.toContain('https://packagist.org');
+      expect(res.registryUrls).toContain('https://composer.renovatebot.com');
+    });
+    it('extracts object repositories and registryUrls on with another datasource in config', async () => {
+      const config = {
+        packageRules: [
+          {
+            datasources: ['npm'],
+            registryUrls: ['https://npm.renovatebot.com'],
+            packagist: false,
+          },
+        ],
+      };
+      const res = await extractPackageFile(requirements6, packageFile, config);
+      expect(res).toMatchSnapshot();
+      expect(res.registryUrls).toHaveLength(1);
+      expect(res.registryUrls).toContain('https://packagist.org');
+      expect(res.registryUrls).not.toContain('https://npm.renovatebot.com');
+    });
+    it('extracts object repositories and registryUrls with datasource in config', async () => {
+      const config = {
+        packageRules: [
+          {
+            datasources: ['packagist'],
+            registryUrls: ['https://composer.renovatebot.com'],
+            packagist: false,
+          },
+          {
+            datasources: ['npm'],
+            registryUrls: ['https://npm.renovatebot.com'],
+          },
+        ],
+      };
+      const res = await extractPackageFile(requirements6, packageFile, config);
+      expect(res).toMatchSnapshot();
+      expect(res.registryUrls).toHaveLength(1);
+      expect(res.registryUrls).not.toContain('https://packagist.org');
+      expect(res.registryUrls).toContain('https://composer.renovatebot.com');
+    });
+    it('extracts object repositories and registryUrls using packagist with config', async () => {
+      const config = {
+        packageRules: [
+          {
+            registryUrls: ['https://composer.renovatebot.com'],
+          },
+        ],
+      };
+      const res = await extractPackageFile(requirements6, packageFile, config);
+      expect(res).toMatchSnapshot();
+      expect(res.registryUrls).toHaveLength(2);
+      expect(res.registryUrls).toContain('https://packagist.org');
+      expect(res.registryUrls).toContain('https://composer.renovatebot.com');
     });
     it('extracts dependencies with lock file', async () => {
       fs.readLocalFile.mockResolvedValue('some content');

--- a/lib/manager/composer/extract.ts
+++ b/lib/manager/composer/extract.ts
@@ -55,10 +55,13 @@ function parseRepositories(
 ): void {
   try {
     let packagist = true;
-    // adds repositories from config registryUrls
+    // adds repositories from config's packageRules
     if (packageRules) {
       packageRules.forEach((rule) => {
-        if (!rule.datasources || rule.datasources.indexOf('packagist') !== -1) {
+        if (
+          !rule.datasources ||
+          rule.datasources.indexOf(datasourcePackagist.id) !== -1
+        ) {
           packagist = rule?.packagist ?? true;
           if (rule?.registryUrls) {
             rule.registryUrls.forEach((repo) => {

--- a/lib/manager/composer/extract.ts
+++ b/lib/manager/composer/extract.ts
@@ -53,24 +53,24 @@ function parseRepositories(
   registryUrls: string[],
   packageRules?: PackageRule[]
 ): void {
-  try {
-    let packagist = true;
-    // adds repositories from config's packageRules
-    if (packageRules) {
-      packageRules.forEach((rule) => {
-        if (
-          !rule.datasources ||
-          rule.datasources.indexOf(datasourcePackagist.id) !== -1
-        ) {
-          packagist = rule?.packagist ?? true;
-          if (rule?.registryUrls) {
-            rule.registryUrls.forEach((repo) => {
-              registryUrls.push(repo);
-            });
-          }
+  let packagist = true;
+  // adds repositories from config's packageRules
+  if (packageRules) {
+    packageRules.forEach((rule) => {
+      if (
+        !rule.datasources ||
+        rule.datasources.indexOf(datasourcePackagist.id) !== -1
+      ) {
+        packagist = rule?.packagist ?? true;
+        if (rule?.registryUrls) {
+          rule.registryUrls.forEach((repo) => {
+            registryUrls.push(repo);
+          });
         }
-      });
-    }
+      }
+    });
+  }
+  try {
     if (repoJson) {
       Object.entries(repoJson).forEach(([key, repo]) => {
         if (is.object(repo)) {


### PR DESCRIPTION
Adds support of external registries defined in config packageRules / registryUrls for composer packages. Adds option disable packagist externally via packageRules. 

Use case:
Many large organizations don't use repositories section in composer.json file, instead of it they are using global composer config.json. See jfrog artifactory docs https://www.jfrog.com/confluence/display/JFROG/PHP+Composer+Repositories (Replacing the Default Repository). This PR adds compatibility for private packages without repositories section in composer.json