### PR TITLE
fix(maven): Use full URL as the cache key

### DIFF
--- a/lib/datasource/maven/index.ts
+++ b/lib/datasource/maven/index.ts
@@ -194,7 +194,7 @@ async function filterMissingArtifacts(
   versions: string[]
 ): Promise<string[]> {
   const cacheNamespace = 'datasource-maven-metadata';
-  const cacheKey = dependency.dependencyUrl;
+  const cacheKey = `${repoUrl}${dependency.dependencyUrl}`;
   let artifactsInfo: ArtifactsInfo | null = await packageCache.get<
     ArtifactsInfo
   >(cacheNamespace, cacheKey);


### PR DESCRIPTION
It may or may not close #7005, but I think we should do this anyway.
