### PR TITLE
fix(bitbucket): Decline PRs by separate API call

### DIFF
--- a/lib/platform/bitbucket/__snapshots__/index.spec.ts.snap
+++ b/lib/platform/bitbucket/__snapshots__/index.spec.ts.snap
@@ -1194,18 +1194,29 @@ Array [
     "url": "https://api.bitbucket.org/2.0/repositories/some/repo/pullrequests/5",
   },
   Object {
-    "body": "{\\"title\\":\\"title\\",\\"state\\":\\"DECLINED\\"}",
+    "body": "{\\"title\\":\\"title\\"}",
     "headers": Object {
       "accept": "application/json",
       "accept-encoding": "gzip, deflate",
       "authorization": "Basic YWJjOjEyMw==",
-      "content-length": "36",
+      "content-length": "17",
       "content-type": "application/json",
       "host": "api.bitbucket.org",
       "user-agent": "https://github.com/renovatebot/renovate",
     },
     "method": "PUT",
     "url": "https://api.bitbucket.org/2.0/repositories/some/repo/pullrequests/5",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "authorization": "Basic YWJjOjEyMw==",
+      "host": "api.bitbucket.org",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "POST",
+    "url": "https://api.bitbucket.org/2.0/repositories/some/repo/pullrequests/5/decline",
   },
 ]
 `;

--- a/lib/platform/bitbucket/index.spec.ts
+++ b/lib/platform/bitbucket/index.spec.ts
@@ -755,6 +755,8 @@ describe('platform/bitbucket', () => {
         .get('/2.0/repositories/some/repo/pullrequests/5')
         .reply(200, { values: [pr] })
         .put('/2.0/repositories/some/repo/pullrequests/5')
+        .reply(200)
+        .post('/2.0/repositories/some/repo/pullrequests/5/decline')
         .reply(200);
       await bitbucket.updatePr({
         number: pr.id,

--- a/lib/platform/bitbucket/index.ts
+++ b/lib/platform/bitbucket/index.ts
@@ -717,7 +717,7 @@ export async function updatePr({
   number: prNo,
   prTitle: title,
   prBody: description,
-  state: _state,
+  state,
 }: UpdatePrConfig): Promise<void> {
   logger.debug(`updatePr(${prNo}, ${title}, body)`);
   // Updating a PR in Bitbucket will clear the reviewers if reviewers is not present
@@ -727,11 +727,6 @@ export async function updatePr({
     )
   ).body;
 
-  const state = {
-    [PrState.Open]: 'OPEN',
-    [PrState.Closed]: 'DECLINED',
-  }[_state];
-
   await bitbucketHttp.putJson(
     `/2.0/repositories/${config.repository}/pullrequests/${prNo}`,
     {
@@ -739,10 +734,15 @@ export async function updatePr({
         title,
         description: sanitize(description),
         reviewers: pr.reviewers,
-        ...(state && { state }),
       },
     }
   );
+
+  if (state === PrState.Closed && pr) {
+    await bitbucketHttp.postJson(
+      `/2.0/repositories/${config.repository}/pullrequests/${prNo}/decline`
+    );
+  }
 }
 
 export async function mergePr(


### PR DESCRIPTION
I found Bitbucket actually doesn't support PR state change in single request (with title and body)