### PR TITLE
refactor(composer): Obtain COMPOSER_AUTH only from "hostRules"

### DIFF
--- a/lib/manager/composer/artifacts.ts
+++ b/lib/manager/composer/artifacts.ts
@@ -1,4 +1,3 @@
-import URL from 'url';
 import is from '@sindresorhus/is';
 import { quote } from 'shlex';
 import upath from 'upath';
@@ -66,7 +65,7 @@ function getAuthJson(): string | null {
       }
     });
 
-  return Object.keys(authJson).length ? JSON.stringify(authJson) : null;
+  return is.emptyObject(authJson) ? null : JSON.stringify(authJson);
 }
 
 export async function updateArtifacts({

--- a/lib/manager/composer/artifacts.ts
+++ b/lib/manager/composer/artifacts.ts
@@ -20,11 +20,7 @@ import {
 } from '../../util/fs';
 import { getRepoStatus } from '../../util/git';
 import * as hostRules from '../../util/host-rules';
-import {
-  UpdateArtifact,
-  UpdateArtifactsConfig,
-  UpdateArtifactsResult,
-} from '../common';
+import { UpdateArtifact, UpdateArtifactsResult } from '../common';
 
 interface UserPass {
   username: string;
@@ -37,62 +33,40 @@ interface AuthJson {
   'http-basic'?: Record<string, UserPass>;
 }
 
-function getAuthJson(config: UpdateArtifactsConfig): string | null {
+function getAuthJson(): string | null {
   const authJson: AuthJson = {};
-  let credentials = hostRules.find({
+
+  const githubCredentials = hostRules.find({
     hostType: PLATFORM_TYPE_GITHUB,
     url: 'https://api.github.com/',
   });
-  // istanbul ignore if
-  if (credentials?.token) {
+  if (githubCredentials?.token) {
     authJson['github-oauth'] = {
-      'github.com': credentials.token,
+      'github.com': githubCredentials.token,
     };
   }
-  credentials = hostRules.find({
+
+  const gitlabCredentials = hostRules.find({
     hostType: PLATFORM_TYPE_GITLAB,
     url: 'https://gitlab.com/api/v4/',
   });
-  // istanbul ignore if
-  if (credentials?.token) {
+  if (gitlabCredentials?.token) {
     authJson['gitlab-token'] = {
-      'gitlab.com': credentials.token,
+      'gitlab.com': gitlabCredentials.token,
     };
   }
-  try {
-    // istanbul ignore else
-    if (is.array(config.registryUrls)) {
-      for (const regUrl of config.registryUrls) {
-        if (regUrl) {
-          const { host } = URL.parse(regUrl);
-          const hostRule = hostRules.find({
-            hostType: datasourcePackagist.id,
-            url: regUrl,
-          });
-          // istanbul ignore else
-          if (hostRule.username && hostRule.password) {
-            logger.debug('Setting packagist auth for host ' + host);
-            authJson['http-basic'] = authJson['http-basic'] || {};
-            authJson['http-basic'][host] = {
-              username: hostRule.username,
-              password: hostRule.password,
-            };
-          } else {
-            logger.debug('No packagist auth found for ' + regUrl);
-          }
-        }
-      }
-    } else if (config.registryUrls) {
-      logger.warn(
-        { registryUrls: config.registryUrls },
-        'Non-array composer registryUrls'
-      );
-    }
-  } catch (err) /* istanbul ignore next */ {
-    logger.warn({ err }, 'Error setting registryUrls auth for composer');
-  }
 
-  return is.emptyObject(authJson) ? null : JSON.stringify(authJson);
+  hostRules
+    .findAll({ hostType: datasourcePackagist.id })
+    ?.forEach(({ username, password, hostName, domainName }) => {
+      const host = hostName || domainName;
+      if (host && username && password) {
+        authJson['http-basic'] = authJson['http-basic'] || {};
+        authJson['http-basic'][host] = { username, password };
+      }
+    });
+
+  return Object.keys(authJson).length ? JSON.stringify(authJson) : null;
 }
 
 export async function updateArtifacts({
@@ -126,7 +100,7 @@ export async function updateArtifacts({
       cwdFile: packageFileName,
       extraEnv: {
         COMPOSER_CACHE_DIR: cacheDir,
-        COMPOSER_AUTH: getAuthJson(config),
+        COMPOSER_AUTH: getAuthJson(),
       },
       docker: {
         image: 'renovate/composer',


### PR DESCRIPTION
Ref: #6932, #5653, #6907

Potentially destructive PR. It works for github `token` auth. Though we have at least one report of successful execution, I don't know yet how to test with `http-basic` myself.