### PR TITLE
fix(poetry): allow empty sources in poetry config

### DIFF
--- a/lib/manager/poetry/artifacts.ts
+++ b/lib/manager/poetry/artifacts.ts
@@ -52,7 +52,7 @@ function getPoetrySources(content: string, fileName: string): PoetrySource[] {
     return [];
   }
 
-  const sources = pyprojectFile.tool?.poetry?.source;
+  const sources = pyprojectFile.tool?.poetry?.source || [];
   const sourceArray: PoetrySource[] = [];
   for (const source of sources) {
     if (source.name && source.url) {


### PR DESCRIPTION
It looks like Renovate is expecting at least one private repo source to exist in poetry pyproject.toml config files for Python projects?
This looks incorrect unless I'm missing something...

<!-- Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App: https://cla-assistant.io/renovatebot/renovate -->

<!-- When creating this PR on GitHub, please ensure `Allow edits from maintainers.` checkbox is checked -->

<!-- Please use a conventional commit message (https://www.conventionalcommits.org/en/v1.0.0/) as your PR title -->

<!-- Ideally include at least one sentence saying what this PR achieves -->

<!-- Finish the PR with `Closes #` and then the issue number if it closes any associated issue -->
