### PR TITLE
fix(bitbucket-server): handle empty repo

### DIFF
--- a/lib/manager/poetry/artifacts.ts
+++ b/lib/manager/poetry/artifacts.ts
@@ -52,7 +52,7 @@ function getPoetrySources(content: string, fileName: string): PoetrySource[] {
     return [];
   }
 
-  const sources = pyprojectFile.tool?.poetry?.source;
+  const sources = pyprojectFile.tool?.poetry?.source || [];
   const sourceArray: PoetrySource[] = [];
   for (const source of sources) {
     if (source.name && source.url) {

--- a/lib/platform/bitbucket-server/__snapshots__/index.spec.ts.snap
+++ b/lib/platform/bitbucket-server/__snapshots__/index.spec.ts.snap
@@ -2278,6 +2278,35 @@ Array [
 ]
 `;
 
+exports[`platform/bitbucket-server/index endpoint with no path initRepo() throws empty 1`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "authorization": "Basic YWJjOjEyMw==",
+      "host": "stash.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+      "x-atlassian-token": "no-check",
+    },
+    "method": "GET",
+    "url": "https://stash.renovatebot.com/rest/api/1.0/projects/SOME/repos/repo",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "authorization": "Basic YWJjOjEyMw==",
+      "host": "stash.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+      "x-atlassian-token": "no-check",
+    },
+    "method": "GET",
+    "url": "https://stash.renovatebot.com/rest/api/1.0/projects/SOME/repos/repo/branches/default",
+  },
+]
+`;
+
 exports[`platform/bitbucket-server/index endpoint with no path initRepo() works 1`] = `
 Object {
   "defaultBranch": "master",
@@ -6021,6 +6050,35 @@ Array [
     },
     "method": "GET",
     "url": "https://stash.renovatebot.com/vcs/rest/api/1.0/projects/SOME/repos/repo/browse/renovate.json?limit=20000",
+  },
+]
+`;
+
+exports[`platform/bitbucket-server/index endpoint with path initRepo() throws empty 1`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "authorization": "Basic YWJjOjEyMw==",
+      "host": "stash.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+      "x-atlassian-token": "no-check",
+    },
+    "method": "GET",
+    "url": "https://stash.renovatebot.com/vcs/rest/api/1.0/projects/SOME/repos/repo",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "authorization": "Basic YWJjOjEyMw==",
+      "host": "stash.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+      "x-atlassian-token": "no-check",
+    },
+    "method": "GET",
+    "url": "https://stash.renovatebot.com/vcs/rest/api/1.0/projects/SOME/repos/repo/branches/default",
   },
 ]
 `;

--- a/lib/platform/bitbucket-server/index.spec.ts
+++ b/lib/platform/bitbucket-server/index.spec.ts
@@ -4,6 +4,7 @@ import { getName } from '../../../test/util';
 import {
   REPOSITORY_CHANGED,
   REPOSITORY_DISABLED,
+  REPOSITORY_EMPTY,
   REPOSITORY_NOT_FOUND,
 } from '../../constants/error-messages';
 import { BranchStatus, PrState } from '../../types';
@@ -289,6 +290,27 @@ describe(getName(__filename), () => {
             optimizeForDisabled: true,
           });
           expect(res).toMatchSnapshot();
+          expect(httpMock.getTrace()).toMatchSnapshot();
+        });
+
+        it('throws empty', async () => {
+          expect.assertions(2);
+          httpMock
+            .scope(urlHost)
+            .get(`${urlPath}/rest/api/1.0/projects/SOME/repos/repo`)
+            .reply(200, repoMock(url, 'SOME', 'repo'))
+            .get(
+              `${urlPath}/rest/api/1.0/projects/SOME/repos/repo/branches/default`
+            )
+            .reply(204);
+          await expect(
+            bitbucket.initRepo({
+              endpoint: 'https://stash.renovatebot.com/vcs/',
+              repository: 'SOME/repo',
+              localDir: '',
+              optimizeForDisabled: false,
+            })
+          ).rejects.toThrow(REPOSITORY_EMPTY);
           expect(httpMock.getTrace()).toMatchSnapshot();
         });
 

--- a/lib/platform/bitbucket-server/index.ts
+++ b/lib/platform/bitbucket-server/index.ts
@@ -196,14 +196,17 @@ export async function initRepo({
     ).body;
     config.owner = info.project.key;
     logger.debug(`${repository} owner = ${config.owner}`);
-    const defaultBranch = (
-      await bitbucketServerHttp.getJson<{ displayId: string }>(
-        `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/branches/default`
-      )
-    ).body.displayId;
+    const branchRes = await bitbucketServerHttp.getJson<{ displayId: string }>(
+      `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/branches/default`
+    );
+
+    if (branchRes.statusCode === 204) {
+      throw new Error(REPOSITORY_EMPTY);
+    }
+
     config.mergeMethod = 'merge';
     const repoConfig: RepoResult = {
-      defaultBranch,
+      defaultBranch: branchRes.body.displayId,
       isFork: !!info.parent,
     };
     return repoConfig;
@@ -212,9 +215,7 @@ export async function initRepo({
     if (err.statusCode === 404) {
       throw new Error(REPOSITORY_NOT_FOUND);
     }
-    if (err.statusCode === 204) {
-      throw new Error(REPOSITORY_EMPTY);
-    }
+
     logger.debug({ err }, 'Unknown Bitbucket initRepo error');
     throw err;
   }

--- a/lib/util/http/__snapshots__/index.spec.ts.snap
+++ b/lib/util/http/__snapshots__/index.spec.ts.snap
@@ -6,6 +6,7 @@ Object {
   "headers": Object {
     "content-type": "application/json",
   },
+  "statusCode": 200,
 }
 `;
 
@@ -13,6 +14,7 @@ exports[`util/http/index get 1`] = `
 Object {
   "body": "",
   "headers": Object {},
+  "statusCode": 200,
 }
 `;
 
@@ -22,6 +24,7 @@ Object {
     "test": true,
   },
   "headers": Object {},
+  "statusCode": 200,
 }
 `;
 
@@ -31,6 +34,7 @@ Object {
   "headers": Object {
     "content-type": "application/json",
   },
+  "statusCode": 200,
 }
 `;
 
@@ -40,6 +44,7 @@ Object {
   "headers": Object {
     "content-type": "application/json",
   },
+  "statusCode": 200,
 }
 `;
 
@@ -49,6 +54,7 @@ Object {
   "headers": Object {
     "content-type": "application/json",
   },
+  "statusCode": 200,
 }
 `;
 
@@ -58,6 +64,7 @@ Object {
   "headers": Object {
     "content-type": "application/json",
   },
+  "statusCode": 200,
 }
 `;
 
@@ -67,5 +74,6 @@ Object {
   "headers": Object {
     "x-some-header": "abc",
   },
+  "statusCode": 200,
 }
 `;

--- a/lib/util/http/index.ts
+++ b/lib/util/http/index.ts
@@ -39,6 +39,7 @@ export interface InternalHttpOptions extends HttpOptions {
 }
 
 export interface HttpResponse<T = string> {
+  statusCode: number;
   body: T;
   headers: any;
 }
@@ -46,6 +47,7 @@ export interface HttpResponse<T = string> {
 function cloneResponse<T>(response: any): HttpResponse<T> {
   // clone body and headers so that the cached result doesn't get accidentally mutated
   return {
+    statusCode: response.statusCode,
     body: clone<T>(response.body),
     headers: clone(response.headers),
   };


### PR DESCRIPTION
Status 204 indicates success, so it can't be covered by the catch block. Instead we need to check the response, that's why i need to pass the `statusCode`