### PR TITLE
feat(presets): add Reach UI monorepo

### DIFF
--- a/lib/config/presets/internal/monorepo.ts
+++ b/lib/config/presets/internal/monorepo.ts
@@ -29,6 +29,7 @@ const repoGroups = {
   'mdc-react': 'material-components/material-components-web-react',
   'ngx-formly': 'https://github.com/ngx-formly/ngx-formly',
   'ngxs-store': 'https://github.com/ngxs/store',
+  'reach-ui': 'https://github.com/reach/reach-ui',
   'react-apollo': 'https://github.com/apollographql/react-apollo',
   'react-dnd': 'https://github.com/react-dnd/react-dnd',
   'react-navigation': 'https://github.com/react-navigation/react-navigation',


### PR DESCRIPTION
Adds Reach UI (e.g. [@reach/combobox](https://www.npmjs.com/package/@reach/combobox), [@reach/listbox](https://www.npmjs.com/package/@reach/listbox)) as a well-known monorepo.