### PR TITLE
feat: gemstash compatibility added

### DIFF
--- a/lib/datasource/rubygems/get.ts
+++ b/lib/datasource/rubygems/get.ts
@@ -86,7 +86,6 @@ export async function getDependency(
         rubyPlatform,
       })
     );
-
   } else {
     const versions = (await fetch(dependency, registry, VERSIONS_PATH)) || [];
 

--- a/lib/datasource/rubygems/get.ts
+++ b/lib/datasource/rubygems/get.ts
@@ -71,9 +71,9 @@ export async function getDependency(
   }
 
   const testendpoint = (await http.get(VERSIONS_PATH));
-  let releases = {};
+  let releases;
 
-  if (testendpoint.statusCode == 404 ) {
+  if (testendpoint.statusCode == 404) {
     // Let's try with the dependencies.json endpoint then
     const versions = (await fetch_deps(dependency, registry, DEPENDENCIES_PATH)) || [];
 

--- a/lib/datasource/rubygems/get.ts
+++ b/lib/datasource/rubygems/get.ts
@@ -71,7 +71,7 @@ export async function getDependency(
   }
 
   const testendpoint = (await http.get(VERSIONS_PATH));
-  const releases = {};
+  let releases = {};
 
   if (testendpoint.statusCode == 404 ) {
     // Let's try with the dependencies.json endpoint then

--- a/lib/datasource/rubygems/get.ts
+++ b/lib/datasource/rubygems/get.ts
@@ -75,8 +75,6 @@ export async function getDependency(
 
   if (testendpoint.statusCode === 404) {
     logger.debug({ dependency }, '/api/v1/versions does not exist. Using /api/v1/dependencies.json');
-
-    // Let's try with the dependencies.json endpoint then
     const versions = (await fetch_deps(dependency, registry, DEPENDENCIES_PATH)) || [];
 
     releases = versions.map(

--- a/lib/datasource/rubygems/get.ts
+++ b/lib/datasource/rubygems/get.ts
@@ -74,6 +74,8 @@ export async function getDependency(
   let releases;
 
   if (testendpoint.statusCode === 404) {
+    logger.debug({ dependency }, '/api/v1/versions does not exist. Using /api/v1/dependencies.json');
+
     // Let's try with the dependencies.json endpoint then
     const versions = (await fetch_deps(dependency, registry, DEPENDENCIES_PATH)) || [];
 

--- a/lib/datasource/rubygems/get.ts
+++ b/lib/datasource/rubygems/get.ts
@@ -71,12 +71,13 @@ export async function getDependency(
   }
 
   const testendpoint = (await http.get(VERSIONS_PATH));
+  const releases = {};
 
   if (testendpoint.statusCode == 404 ) {
     // Let's try with the dependencies.json endpoint then
     const versions = (await fetch_deps(dependency, registry, DEPENDENCIES_PATH)) || [];
 
-    const releases = versions.map(
+    releases = versions.map(
       ({
         number: version,
         platform: rubyPlatform,
@@ -89,7 +90,7 @@ export async function getDependency(
   } else {
     const versions = (await fetch(dependency, registry, VERSIONS_PATH)) || [];
 
-    const releases = versions.map(
+    releases = versions.map(
       ({
         number: version,
         platform: rubyPlatform,

--- a/lib/datasource/rubygems/get.ts
+++ b/lib/datasource/rubygems/get.ts
@@ -73,7 +73,7 @@ export async function getDependency(
   const testendpoint = (await http.get(VERSIONS_PATH));
   let releases;
 
-  if (testendpoint.statusCode == 404) {
+  if (testendpoint.statusCode === 404) {
     // Let's try with the dependencies.json endpoint then
     const versions = (await fetch_deps(dependency, registry, DEPENDENCIES_PATH)) || [];
 

--- a/lib/datasource/rubygems/get.ts
+++ b/lib/datasource/rubygems/get.ts
@@ -9,6 +9,7 @@ const http = new Http(id);
 
 const INFO_PATH = '/api/v1/gems';
 const VERSIONS_PATH = '/api/v1/versions';
+const DEPENDENCIES_PATH = 'api/v1/dependencies.json';
 
 const getHeaders = (): OutgoingHttpHeaders => {
   return { hostType: id };


### PR DESCRIPTION
This PR adds a check to use the `api/v1/dependencies.json` endpoint if `api/v1/versions` does not exist.

It is currently the case for the Gemstash repository.

Closes #6787 
