### PR TITLE
feat(config): Add support for prBodyTemplate

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -1189,6 +1189,12 @@ e.g. if you wish to add an extra Warning to major updates:
 }
 ```
 
+## prBodyTemplate
+
+This setting controls which sections are rendered in the body of the pull request.
+
+The available sections are header, table, notes, changelogs, configDescription, controls, footer.
+
 ## prConcurrentLimit
 
 This setting - if enabled - limits Renovate to a maximum of x concurrent PRs open at any time.

--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -1296,6 +1296,15 @@ const options: RenovateOptions[] = [
     cli: false,
   },
   {
+    name: 'prBodyTemplate',
+    description:
+      'Pull Request body template. Controls which sections are rendered in the body.',
+    type: 'string',
+    default:
+      '{{{header}}}{{{table}}}{{{notes}}}{{{changelogs}}}{{{configDescription}}}{{{controls}}}{{{footer}}}',
+    cli: false,
+  },
+  {
     name: 'prTitle',
     description:
       'Pull Request title template (deprecated). Now uses commitMessage.',

--- a/lib/workers/pr/body/index.ts
+++ b/lib/workers/pr/body/index.ts
@@ -75,9 +75,7 @@ export async function getPrBody(config: BranchConfig): Promise<string> {
     controls: getControls(),
     footer: getPrFooter(config),
   };
-  const defaultPrBodyTemplate =
-    '{{{header}}}{{{table}}}{{{notes}}}{{{changelogs}}}{{{configDescription}}}{{{controls}}}{{{footer}}}';
-  const prBodyTemplate = config.prBodyTemplate || defaultPrBodyTemplate;
+  const prBodyTemplate = config.prBodyTemplate;
   let prBody = template.compile(prBodyTemplate, content, false);
   prBody = prBody.trim();
   prBody = prBody.replace(/\n\n\n+/g, '\n\n');


### PR DESCRIPTION
<!-- Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App: https://cla-assistant.io/renovatebot/renovate -->

<!-- When creating this PR on GitHub, please ensure `Allow edits from maintainers.` checkbox is checked -->

<!-- Please use a conventional commit message (https://www.conventionalcommits.org/en/v1.0.0/) as your PR title -->

<!-- Ideally include at least one sentence saying what this PR achieves -->

<!-- Finish the PR with `Closes #` and then the issue number if it closes any associated issue -->

`prBodyTemplate` is read from the config, but since there is no definition it's not configurable via environment variables, only via a config file. This PR allows configuring it with an env variable.
