### PR TITLE
fix(circleci): leading dash is optional

### DIFF
--- a/lib/manager/circleci/__fixtures__/config3.yml
+++ b/lib/manager/circleci/__fixtures__/config3.yml
@@ -1,0 +1,20 @@
+aliases:  
+  - &nodejs
+    image: cimg/node:14.8.0
+
+version: 2
+jobs:
+  checkout: 
+    <<: *defaults
+    docker:
+      - *nodejs
+    steps:
+      - run: yarn build:runtime
+
+  release_docker:
+    <<: *defaults
+    machine:
+      image: ubuntu-1604:201903-01
+      docker_layer_caching: true
+    steps:
+      - run: ./scripts.sh

--- a/lib/manager/circleci/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/circleci/__snapshots__/extract.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/manager/circleci/extract extractPackageFile() extracts  1`] = `
+exports[`lib/manager/circleci/extract extractPackageFile() extracts image without leading dash 1`] = `
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",

--- a/lib/manager/circleci/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/circleci/__snapshots__/extract.spec.ts.snap
@@ -1,5 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`lib/manager/circleci/extract extractPackageFile() extracts  1`] = `
+Array [
+  Object {
+    "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
+    "commitMessageTopic": "Node.js",
+    "currentDigest": undefined,
+    "currentValue": "14.8.0",
+    "datasource": "docker",
+    "depName": "cimg/node",
+    "depType": "docker",
+    "replaceString": "cimg/node:14.8.0",
+    "versioning": "docker",
+  },
+  Object {
+    "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
+    "currentDigest": undefined,
+    "currentValue": "201903-01",
+    "datasource": "docker",
+    "depName": "ubuntu-1604",
+    "depType": "docker",
+    "replaceString": "ubuntu-1604:201903-01",
+    "versioning": "docker",
+  },
+]
+`;
+
 exports[`lib/manager/circleci/extract extractPackageFile() extracts multiple image lines 1`] = `
 Array [
   Object {

--- a/lib/manager/circleci/extract.spec.ts
+++ b/lib/manager/circleci/extract.spec.ts
@@ -9,6 +9,10 @@ const file2 = readFileSync(
   'lib/manager/circleci/__fixtures__/config2.yml',
   'utf8'
 );
+const file3 = readFileSync(
+  'lib/manager/circleci/__fixtures__/config3.yml',
+  'utf8'
+);
 
 describe('lib/manager/circleci/extract', () => {
   describe('extractPackageFile()', () => {
@@ -24,6 +28,10 @@ describe('lib/manager/circleci/extract', () => {
       const res = extractPackageFile(file2);
       expect(res.deps).toMatchSnapshot();
       // expect(res.deps).toHaveLength(4);
+    });
+    it('extracts ', () => {
+      const res = extractPackageFile(file3);
+      expect(res.deps).toMatchSnapshot();
     });
   });
 });

--- a/lib/manager/circleci/extract.spec.ts
+++ b/lib/manager/circleci/extract.spec.ts
@@ -29,7 +29,7 @@ describe('lib/manager/circleci/extract', () => {
       expect(res.deps).toMatchSnapshot();
       // expect(res.deps).toHaveLength(4);
     });
-    it('extracts ', () => {
+    it('extracts image without leading dash', () => {
       const res = extractPackageFile(file3);
       expect(res.deps).toMatchSnapshot();
     });

--- a/lib/manager/circleci/extract.ts
+++ b/lib/manager/circleci/extract.ts
@@ -39,7 +39,7 @@ export function extractPackageFile(content: string): PackageFile | null {
           }
         } while (foundOrb);
       }
-      const match = /^\s*- image:\s*'?"?([^\s'"]+)'?"?\s*$/.exec(line);
+      const match = /^\s*-? image:\s*'?"?([^\s'"]+)'?"?\s*$/.exec(line);
       if (match) {
         const currentFrom = match[1];
         const dep = getDep(currentFrom);


### PR DESCRIPTION
in circleci yaml there is multiple way to specify images
and the leading dash is not mandatory.


```yml
  - &nodejs
    image: cimg/node:14.8.0
```
cf:
https://circleci.com/docs/2.0/executor-types/

N.B: 
There is currently one use case that is not supported but not documented.

```yml
  - &nodejs: cimg/node:14.8.0

  - &docker-setup-for-execution
    - image: *nodejs
```

<!-- Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App: https://cla-assistant.io/renovatebot/renovate -->

<!-- When creating this PR on GitHub, please ensure `Allow edits from maintainers.` checkbox is checked -->

<!-- Please use a conventional commit message (https://www.conventionalcommits.org/en/v1.0.0/) as your PR title -->

<!-- Ideally include at least one sentence saying what this PR achieves -->

<!-- Finish the PR with `Closes #` and then the issue number if it closes any associated issue -->
