### PR TITLE
fix(git): add dashes after git log <rev>

### DIFF
--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -397,7 +397,13 @@ export async function isBranchModified(branchName: string): Promise<boolean> {
   }
   // Retrieve the author of the most recent commit
   const lastAuthor = (
-    await git.raw(['log', '-1', '--pretty=format:%ae', `origin/${branchName}`])
+    await git.raw([
+      'log',
+      '-1',
+      '--pretty=format:%ae',
+      `origin/${branchName}`,
+      '--',
+    ])
   ).trim();
   const { gitAuthorEmail } = config;
   if (


### PR DESCRIPTION
To fix an ambiguous argument error from git, following this notation:

    git <command> [<revision>...] -- [<file>...]

Without it, there's the possibility to get this error:

```json
{
  "task": {
    "concatStdErr": false,
    "format": "utf-8",
    "commands": [
      "log",
      "-1",
      "--pretty=format:%ae",
      "origin/renovate/configure"
    ]
  },
  "message": "fatal: ambiguous argument 'origin/renovate/configure': unknown revision or path not in the working tree.\nUse '--' to separate paths from revisions, like this:\n'git <command> [<revision>...] -- [<file>...]'\n",
  "stack": "Error: fatal: ambiguous argument 'origin/renovate/configure': unknown revision or path not in the working tree.\nUse '--' to separate paths from revisions, like this:\n'git <command> [<revision>...] -- [<file>...]'\n\n    at GitExecutorChain.onFatalException (/usr/src/app/node_modules/simple-git/src/lib/runners/git-executor-chain.ts:66:77)\n    at GitExecutorChain.<anonymous> (/usr/src/app/node_modules/simple-git/src/lib/runners/git-executor-chain.ts:58:21)\n    at Generator.throw (<anonymous>)\n    at rejected (/usr/src/app/node_modules/simple-git/src/lib/runners/git-executor-chain.js:6:65)\n    at runMicrotasks (<anonymous>)\n    at processTicksAndRejections (internal/process/task_queues.js:97:5)"
}
```