### PR TITLE
refactor(workers): Introduce strict variant of BranchConfig type

### DIFF
--- a/lib/workers/branch/check-existing.spec.ts
+++ b/lib/workers/branch/check-existing.spec.ts
@@ -1,16 +1,17 @@
 import { defaultConfig, partial, platform } from '../../../test/util';
 import { PrState } from '../../types';
-import { BranchConfig } from '../common';
+import { BranchConfigCoerced } from '../common';
 import { prAlreadyExisted } from './check-existing';
 
 describe('workers/branch/check-existing', () => {
   describe('prAlreadyExisted', () => {
-    let config: BranchConfig;
+    let config: BranchConfigCoerced;
     beforeEach(() => {
-      config = partial<BranchConfig>({
+      config = partial<BranchConfigCoerced>({
         ...defaultConfig,
         branchName: 'some-branch',
         prTitle: 'some-title',
+        recreateClosed: null,
       });
       jest.resetAllMocks();
     });

--- a/lib/workers/branch/check-existing.ts
+++ b/lib/workers/branch/check-existing.ts
@@ -2,10 +2,10 @@ import { REPOSITORY_CHANGED } from '../../constants/error-messages';
 import { logger } from '../../logger';
 import { Pr, platform } from '../../platform';
 import { PrState } from '../../types';
-import { BranchConfig } from '../common';
+import { BranchConfigCoerced } from '../common';
 
 export async function prAlreadyExisted(
-  config: BranchConfig
+  config: BranchConfigCoerced
 ): Promise<Pr | null> {
   logger.trace({ config }, 'prAlreadyExisted');
   if (config.recreateClosed) {

--- a/lib/workers/branch/index.spec.ts
+++ b/lib/workers/branch/index.spec.ts
@@ -8,7 +8,7 @@ import * as _npmPostExtract from '../../manager/npm/post-update';
 import { PrState } from '../../types';
 import * as _exec from '../../util/exec';
 import { File, StatusResult } from '../../util/git';
-import { BranchConfig, PrResult, ProcessBranchResult } from '../common';
+import { BranchConfigCoerced, PrResult, ProcessBranchResult } from '../common';
 import * as _prWorker from '../pr';
 import * as _automerge from './automerge';
 import * as _checkExisting from './check-existing';
@@ -51,7 +51,7 @@ describe('workers/branch', () => {
       artifactErrors: [],
       updatedArtifacts: [],
     };
-    let config: BranchConfig;
+    let config: BranchConfigCoerced;
     beforeEach(() => {
       prWorker.ensurePr = jest.fn();
       prWorker.checkAutoMerge = jest.fn();

--- a/lib/workers/branch/index.ts
+++ b/lib/workers/branch/index.ts
@@ -28,7 +28,7 @@ import {
   isBranchModified,
 } from '../../util/git';
 import { regEx } from '../../util/regex';
-import { BranchConfig, PrResult, ProcessBranchResult } from '../common';
+import { BranchConfigCoerced, PrResult, ProcessBranchResult } from '../common';
 import { checkAutoMerge, ensurePr } from '../pr';
 import { tryBranchAutomerge } from './automerge';
 import { prAlreadyExisted } from './check-existing';
@@ -51,11 +51,11 @@ function rebaseCheck(config: RenovateConfig, branchPr: Pr): boolean {
 const rebasingRegex = /\*\*Rebasing\*\*: .*/;
 
 export async function processBranch(
-  branchConfig: BranchConfig,
+  branchConfig: BranchConfigCoerced,
   prLimitReached?: boolean,
   commitLimitReached?: boolean
 ): Promise<ProcessBranchResult> {
-  const config: BranchConfig = { ...branchConfig };
+  const config: BranchConfigCoerced = { ...branchConfig };
   const dependencies = config.upgrades
     .map((upgrade) => upgrade.depName)
     .filter((v) => v) // remove nulls (happens for lock file maintenance)

--- a/lib/workers/coerce.spec.ts
+++ b/lib/workers/coerce.spec.ts
@@ -1,0 +1,33 @@
+import { coerceBranchConfig } from './coerce';
+
+describe('workers/coerce', () => {
+  it('nullify empty', () => {
+    const config = {};
+    expect(coerceBranchConfig(config)).toEqual({
+      recreateClosed: null,
+    });
+  });
+  it('preserve undefined', () => {
+    const config = {
+      recreateClosed: undefined,
+    };
+    expect(coerceBranchConfig(config)).toEqual(config);
+  });
+  it('success', () => {
+    const config = {
+      foo: 'foo',
+      bar: 42,
+    };
+    expect(coerceBranchConfig(config)).toEqual({
+      ...config,
+      recreateClosed: null,
+    });
+  });
+  it('error', () => {
+    const config = {
+      foo: 'bar',
+      recreateClosed: 'should be a boolean',
+    };
+    expect(coerceBranchConfig(config)).toEqual(config);
+  });
+});

--- a/lib/workers/coerce.ts
+++ b/lib/workers/coerce.ts
@@ -1,0 +1,24 @@
+import merge from 'deepmerge';
+import * as t from 'zod';
+import { logger } from '../logger';
+import { BranchConfigCoerced } from './common';
+
+const branchConfig = t
+  .object({
+    recreateClosed: t.boolean().nullable(),
+  })
+  .nonstrict();
+
+const defaults = {
+  recreateClosed: null,
+};
+
+export function coerceBranchConfig(config: unknown): BranchConfigCoerced {
+  const merged = merge(defaults, config) as BranchConfigCoerced;
+  try {
+    branchConfig.parse(merged);
+  } catch (err) {
+    logger.debug({ err }, 'Coercion error');
+  }
+  return merged;
+}

--- a/lib/workers/common.ts
+++ b/lib/workers/common.ts
@@ -115,3 +115,7 @@ export interface BranchConfig
   upgrades: BranchUpgradeConfig[];
   packageFiles?: Record<string, PackageFile[]>;
 }
+
+export interface BranchConfigCoerced extends BranchConfig {
+  recreateClosed: boolean | null;
+}

--- a/lib/workers/repository/process/extract-update.ts
+++ b/lib/workers/repository/process/extract-update.ts
@@ -4,6 +4,7 @@ import { RenovateConfig } from '../../../config';
 import { logger } from '../../../logger';
 import { PackageFile } from '../../../manager/common';
 import { getCache } from '../../../util/cache/repository';
+import { coerceBranchConfig } from '../../coerce';
 import { BranchConfig } from '../../common';
 import { extractAllDependencies } from '../extract';
 import { branchifyUpgrades } from '../updates/branchify';
@@ -110,7 +111,7 @@ export async function update(
   let res: WriteUpdateResult | undefined;
   // istanbul ignore else
   if (config.repoIsOnboarded) {
-    res = await writeUpdates(config, branches);
+    res = await writeUpdates(config, branches.map(coerceBranchConfig));
   }
 
   return res;

--- a/lib/workers/repository/process/write.spec.ts
+++ b/lib/workers/repository/process/write.spec.ts
@@ -1,6 +1,6 @@
 import { RenovateConfig, getConfig, mocked } from '../../../../test/util';
 import * as _branchWorker from '../../branch';
-import { BranchConfig, ProcessBranchResult } from '../../common';
+import { BranchConfigCoerced, ProcessBranchResult } from '../../common';
 import * as _limits from './limits';
 import { writeUpdates } from './write';
 
@@ -20,7 +20,7 @@ beforeEach(() => {
 describe('workers/repository/write', () => {
   describe('writeUpdates()', () => {
     it('skips branches blocked by pin', async () => {
-      const branches: BranchConfig[] = [
+      const branches: BranchConfigCoerced[] = [
         { updateType: 'pin' },
         { blockedByPin: true },
         {},
@@ -30,7 +30,7 @@ describe('workers/repository/write', () => {
       expect(branchWorker.processBranch).toHaveBeenCalledTimes(2);
     });
     it('stops after automerge', async () => {
-      const branches: BranchConfig[] = [
+      const branches: BranchConfigCoerced[] = [
         {},
         {},
         { automergeType: 'pr-comment', requiredStatusChecks: null },

--- a/lib/workers/repository/process/write.ts
+++ b/lib/workers/repository/process/write.ts
@@ -1,7 +1,7 @@
 import { RenovateConfig } from '../../../config';
 import { addMeta, logger, removeMeta } from '../../../logger';
 import { processBranch } from '../../branch';
-import { BranchConfig, ProcessBranchResult } from '../../common';
+import { BranchConfigCoerced, ProcessBranchResult } from '../../common';
 import { getLimitRemaining } from '../../global/limits';
 import { getPrsRemaining } from './limits';
 
@@ -9,7 +9,7 @@ export type WriteUpdateResult = 'done' | 'automerged';
 
 export async function writeUpdates(
   config: RenovateConfig,
-  allBranches: BranchConfig[]
+  allBranches: BranchConfigCoerced[]
 ): Promise<WriteUpdateResult> {
   let branches = allBranches;
   logger.debug(

--- a/package.json
+++ b/package.json
@@ -169,7 +169,8 @@
     "upath": "1.2.0",
     "validate-npm-package-name": "3.0.0",
     "www-authenticate": "0.6.2",
-    "xmldoc": "1.1.2"
+    "xmldoc": "1.1.2",
+    "zod": "^1.11.1"
   },
   "optionalDependencies": {
     "re2": "1.15.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10931,3 +10931,8 @@ yargs@^8.0.2:
     which-module "^2.0.0"
     y18n "^3.2.1"
     yargs-parser "^7.0.0"
+
+zod@^1.11.1:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-1.11.1.tgz#b093202a3c4e4dae2463006f81933b22ccc2a144"
+  integrity sha512-qJE3F34NzKahp4kFCEeBK4qiLaynwylSg5jOtX6dlQlcBiDEMt78BAtrjSx/qk3Q65SzNe/40LgZE/h1ACcyIg==


### PR DESCRIPTION
Ref #7154

@rarkins @JamieMagee @viceice 

Here is the idea to discuss.

I'm trying to restrict types in `lib/workers` directory. As we can't yet rely on the the `strictNullChecks` option, I tried to introduce thin boundary which will restrict `BranchConfig` fields (and log warnings for bad ones). The only one field is migrated in this PR, others can be migrated in separate PRs, gradually eliminating original interface.

I have a hypothesis that given enough runtime checkpoints (e.g. near `JSON.parse` and `http.request`), we also can gradually get rid of TypeScript strict null check errors, and hopefully have cleaner `XYZConfig` types. Once `strictNullChecks` is enabled, most of validator libraries I've encountered today will be able to leverage schemas for inference, such that we can validate/coerce our inputs and have their types too.