### PR TITLE
fix(gitlab): Restore auth for versions older than 12.2

### DIFF
--- a/lib/util/http/auth.spec.ts
+++ b/lib/util/http/auth.spec.ts
@@ -1,6 +1,9 @@
 import { NormalizedOptions } from 'got';
 import { getName, partial } from '../../../test/util';
-import { PLATFORM_TYPE_GITEA } from '../../constants/platforms';
+import {
+  PLATFORM_TYPE_GITEA,
+  PLATFORM_TYPE_GITLAB,
+} from '../../constants/platforms';
 import { applyAuthorization, removeAuthorization } from './auth';
 import { GotOptions } from './types';
 
@@ -62,6 +65,48 @@ describe(getName(__filename), () => {
           },
           "hostType": "gitea",
           "token": "XXXX",
+        }
+      `);
+    });
+
+    it(`gitlab personal access token`, () => {
+      const opts: GotOptions = {
+        headers: {},
+        // Personal Access Token is exactly 20 characters long
+        token: '01234567890123456789',
+        hostType: PLATFORM_TYPE_GITLAB,
+      };
+
+      applyAuthorization(opts);
+
+      expect(opts).toMatchInlineSnapshot(`
+        Object {
+          "headers": Object {
+            "Private-token": "01234567890123456789",
+          },
+          "hostType": "gitlab",
+          "token": "01234567890123456789",
+        }
+      `);
+    });
+
+    it(`gitlab oauth token`, () => {
+      const opts: GotOptions = {
+        headers: {},
+        token:
+          'a40bdd925a0c0b9c4cdd19d101c0df3b2bcd063ab7ad6706f03bcffcec01e863',
+        hostType: PLATFORM_TYPE_GITLAB,
+      };
+
+      applyAuthorization(opts);
+
+      expect(opts).toMatchInlineSnapshot(`
+        Object {
+          "headers": Object {
+            "authorization": "Bearer a40bdd925a0c0b9c4cdd19d101c0df3b2bcd063ab7ad6706f03bcffcec01e863",
+          },
+          "hostType": "gitlab",
+          "token": "a40bdd925a0c0b9c4cdd19d101c0df3b2bcd063ab7ad6706f03bcffcec01e863",
         }
       `);
     });

--- a/lib/util/http/auth.ts
+++ b/lib/util/http/auth.ts
@@ -3,6 +3,7 @@ import { NormalizedOptions } from 'got';
 import {
   PLATFORM_TYPE_GITEA,
   PLATFORM_TYPE_GITHUB,
+  PLATFORM_TYPE_GITLAB,
 } from '../../constants/platforms';
 import { GotOptions } from './types';
 
@@ -26,8 +27,15 @@ export function applyAuthorization(inOptions: GotOptions): GotOptions {
           );
         }
       }
+    } else if (options.hostType === PLATFORM_TYPE_GITLAB) {
+      // GitLab versions earlier than 12.2 only support authentication with
+      // a personal access token, which is 20 characters long.
+      if (options.token.length === 20) {
+        options.headers['Private-token'] = options.token;
+      } else {
+        options.headers.authorization = `Bearer ${options.token}`;
+      }
     } else {
-      // For GitLab the bearer token can be a Personal Access Token or an OAuth2 token.
       options.headers.authorization = `Bearer ${options.token}`;
     }
     delete options.token;


### PR DESCRIPTION
<!-- Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App: https://cla-assistant.io/renovatebot/renovate -->

<!-- When creating this PR on GitHub, please ensure `Allow edits from maintainers.` checkbox is checked -->

<!-- Please use a conventional commit message (https://www.conventionalcommits.org/en/v1.0.0/) as your PR title -->

<!-- Ideally include at least one sentence saying what this PR achieves -->

<!-- Finish the PR with `Closes #` and then the issue number if it closes any associated issue -->

Follow up to https://github.com/renovatebot/renovate/pull/7131 to use the Private-token header when the token looks like a Personal Access Token.
