### PR TITLE
fix(git): wrong config argument passing

### DIFF
--- a/lib/platform/azure/__snapshots__/azure-helper.spec.ts.snap
+++ b/lib/platform/azure/__snapshots__/azure-helper.spec.ts.snap
@@ -109,19 +109,19 @@ Object {
 
 exports[`platform/azure/helpers getStorageExtraCloneOpts should configure basic auth 1`] = `
 Object {
-  "--config": "http.extraheader=AUTHORIZATION: basic dXNlcjpwYXNz",
+  "-c": "http.extraheader=AUTHORIZATION: basic dXNlcjpwYXNz",
 }
 `;
 
 exports[`platform/azure/helpers getStorageExtraCloneOpts should configure bearer token 1`] = `
 Object {
-  "--config": "http.extraheader=AUTHORIZATION: bearer token",
+  "-c": "http.extraheader=AUTHORIZATION: bearer token",
 }
 `;
 
 exports[`platform/azure/helpers getStorageExtraCloneOpts should configure personal access token 1`] = `
 Object {
-  "--config": "http.extraheader=AUTHORIZATION: basic OjEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=",
+  "-c": "http.extraheader=AUTHORIZATION: basic OjEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=",
 }
 `;
 

--- a/lib/platform/azure/azure-helper.ts
+++ b/lib/platform/azure/azure-helper.ts
@@ -29,7 +29,7 @@ export function getStorageExtraCloneOpts(config: HostRule): GitOptions {
   } else {
     header = `${headerName}: basic ${toBase64(`:${config.token}`)}`;
   }
-  return { '--config': `http.extraheader=${header}` };
+  return { '-c': `http.extraheader=${header}` };
 }
 
 export function getNewBranchName(branchName?: string): string {

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -419,7 +419,7 @@ describe('platform/git', () => {
         localDir: tmpDir.path,
         url: origin.path,
         extraCloneOpts: {
-          '--config': 'extra.clone.config=test-extra-config-value',
+          '-c': 'extra.clone.config=test-extra-config-value',
         },
       });
       git.getBranchCommit('master');

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -112,14 +112,14 @@ let privateKeySet = false;
 
 async function fetchBranchCommits(): Promise<void> {
   config.branchCommits = {};
-  const opts = ['--heads', config.url];
+  const opts = ['ls-remote', '--heads', config.url];
   if (config.extraCloneOpts) {
-    opts.push(
-      ...Object.entries(config.extraCloneOpts).map((e) => `${e[0]}=${e[1]}`)
+    Object.entries(config.extraCloneOpts).forEach((e) =>
+      opts.unshift(e[0], `${e[1]}`)
     );
   }
   try {
-    (await git.listRemote(opts))
+    (await git.raw(opts))
       .split('\n')
       .filter(Boolean)
       .map((line) => line.trim().split(/\s+/))
@@ -238,8 +238,8 @@ export async function syncGit(): Promise<void> {
       // clone only the default branch
       const opts = ['--depth=2'];
       if (config.extraCloneOpts) {
-        opts.push(
-          ...Object.entries(config.extraCloneOpts).map((e) => `${e[0]}=${e[1]}`)
+        Object.entries(config.extraCloneOpts).forEach((e) =>
+          opts.push(e[0], `${e[1]}`)
         );
       }
       await git.clone(config.url, '.', opts);


### PR DESCRIPTION
For `git ls-remote` the `--config` argument mus come before `ls-remote` and the short version `-c` must be used.

Looks very hacki now. I like to refactor it later.

closes #7148