### PR TITLE
feat(preset): add fullcalendar monorepo

### DIFF
--- a/lib/config/presets/internal/monorepo.ts
+++ b/lib/config/presets/internal/monorepo.ts
@@ -128,6 +128,7 @@ const patternGroups = {
   wordpress: '^@wordpress/',
   angularmaterial: ['^@angular/material', '^@angular/cdk'],
   'aws-java-sdk': '^com.amazonaws:aws-java-sdk-',
+  fullcalendar: '^@fullcalendar/',
 };
 
 export const presets: Record<string, Preset> = {};


### PR DESCRIPTION
<!-- Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App: https://cla-assistant.io/renovatebot/renovate -->

<!-- When creating this PR on GitHub, please ensure `Allow edits from maintainers.` checkbox is checked -->

<!-- Please use a conventional commit message (https://www.conventionalcommits.org/en/v1.0.0/) as your PR title -->

<!-- Ideally include at least one sentence saying what this PR achieves -->

<!-- Finish the PR with `Closes #` and then the issue number if it closes any associated issue -->

This adds `@fullcalendar` as monorepo.

They do have an actual monorepo (https://github.com/fullcalendar/fullcalendar), but are also releasing for example `@fullcalendar/vue` from https://github.com/fullcalendar/fullcalendar-vue
