### PR TITLE
fix(npm): correct Yarn lockedVersion for scoped package

### DIFF
--- a/lib/manager/npm/__fixtures__/yarn2.2/package.json
+++ b/lib/manager/npm/__fixtures__/yarn2.2/package.json
@@ -10,6 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@babel/runtime": "^7.11.2",
     "chalk": "^2.4.1"
   }
 }

--- a/lib/manager/npm/__fixtures__/yarn2.2/yarn.lock
+++ b/lib/manager/npm/__fixtures__/yarn2.2/yarn.lock
@@ -5,6 +5,15 @@ __metadata:
   version: 4
   cacheKey: 6
 
+"@babel/runtime@npm:^7.11.2":
+  version: 7.11.2
+  resolution: "@babel/runtime@npm:7.11.2"
+  dependencies:
+    regenerator-runtime: ^0.13.4
+  checksum: 2f127ad60a0f0568faa0044e5b48329d8166c7fd3a0a3ce774070010a1c441ebf5570f526dd6bb26e214fb1a01bb987ab6a4c3f60a00f04d02448939f4c61e1e
+  languageName: node
+  linkType: hard
+
 "ansi-styles@npm:^3.2.1":
   version: 3.2.1
   resolution: "ansi-styles@npm:3.2.1"
@@ -55,6 +64,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"regenerator-runtime@npm:^0.13.4":
+  version: 0.13.7
+  resolution: "regenerator-runtime@npm:0.13.7"
+  checksum: 6ef567c662088b1b292214920cbd72443059298d477f72e1a37e0a113bafbfac9057cbfe35ae617284effc4b423493326a78561bbff7b04162c7949bdb9624e8
+  languageName: node
+  linkType: hard
+
 "supports-color@npm:^5.3.0":
   version: 5.5.0
   resolution: "supports-color@npm:5.5.0"
@@ -68,6 +84,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "yarn2@workspace:."
   dependencies:
+    "@babel/runtime": ^7.11.2
     chalk: ^2.4.1
   languageName: unknown
   linkType: soft

--- a/lib/manager/npm/extract/__snapshots__/yarn.spec.ts.snap
+++ b/lib/manager/npm/extract/__snapshots__/yarn.spec.ts.snap
@@ -27,12 +27,14 @@ Object {
 
 exports[`manager/npm/extract/yarn .getYarnLock() extracts yarn 2 cache version 1`] = `
 Object {
+  "@babel/runtime@^7.11.2": "7.11.2",
   "ansi-styles@^3.2.1": "3.2.1",
   "chalk@^2.4.1": "2.4.2",
   "color-convert@^1.9.0": "1.9.3",
   "color-name@1.1.3": "1.1.3",
   "escape-string-regexp@^1.0.5": "1.0.5",
   "has-flag@^3.0.0": "3.0.0",
+  "regenerator-runtime@^0.13.4": "0.13.7",
   "supports-color@^5.3.0": "5.5.0",
   "yarn2@.": "0.0.0-use.local",
 }

--- a/lib/manager/npm/extract/yarn.spec.ts
+++ b/lib/manager/npm/extract/yarn.spec.ts
@@ -49,7 +49,7 @@ describe('manager/npm/extract/yarn', () => {
       expect(res.isYarn1).toBe(false);
       expect(res.cacheVersion).toBe(6);
       expect(res.lockedVersions).toMatchSnapshot();
-      expect(Object.keys(res.lockedVersions)).toHaveLength(8);
+      expect(Object.keys(res.lockedVersions)).toHaveLength(10);
     });
   });
 });

--- a/lib/manager/npm/extract/yarn.ts
+++ b/lib/manager/npm/extract/yarn.ts
@@ -23,7 +23,7 @@ export async function getYarnLock(
       } else {
         for (const entry of key.split(', ')) {
           const { scope, name, range } = structUtils.parseDescriptor(entry);
-          const packageName = scope ? `${scope}/${name}` : name;
+          const packageName = scope ? `@${scope}/${name}` : name;
           const { selector } = structUtils.parseRange(range);
 
           logger.trace({ entry, version: val.version });


### PR DESCRIPTION
The `scope` returned by `structUtils.parseDescriptor` doesn't include the scope symbol (`@`), resulting in locked version not being available for scoped packages. This PR adds the scope symbol to scoped packages.