### PR TITLE
fix(npm): lockfileUpdate for Yarn 2

### DIFF
--- a/lib/manager/npm/post-update/__snapshots__/yarn.spec.ts.snap
+++ b/lib/manager/npm/post-update/__snapshots__/yarn.spec.ts.snap
@@ -413,3 +413,46 @@ Array [
   },
 ]
 `;
+
+exports[`manager/npm/post-update/yarn performs lock file updates using yarn v2.1.0 1`] = `
+Array [
+  Object {
+    "cmd": "yarn install",
+    "options": Object {
+      "cwd": "some-dir",
+      "encoding": "utf-8",
+      "env": Object {
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+        "YARN_ENABLE_SCRIPTS": "0",
+        "YARN_HTTP_TIMEOUT": "100000",
+      },
+      "timeout": 900000,
+    },
+  },
+  Object {
+    "cmd": "yarn up some-dep",
+    "options": Object {
+      "cwd": "some-dir",
+      "encoding": "utf-8",
+      "env": Object {
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+        "YARN_ENABLE_SCRIPTS": "0",
+        "YARN_HTTP_TIMEOUT": "100000",
+      },
+      "timeout": 900000,
+    },
+  },
+]
+`;

--- a/lib/manager/npm/post-update/yarn.ts
+++ b/lib/manager/npm/post-update/yarn.ts
@@ -124,7 +124,9 @@ export async function generateLockFile(
     if (lockUpdates.length) {
       logger.debug('Performing lockfileUpdate (yarn)');
       commands.push(
-        `yarn upgrade ${lockUpdates.join(' ')} ${cmdOptions}`.trim()
+        `yarn ${isYarn1 ? 'upgrade' : 'up'} ${lockUpdates.join(
+          ' '
+        )} ${cmdOptions}`.trim()
       );
     }
 


### PR DESCRIPTION
Yarn 2 doesn't have `yarn upgrade`, instead it has `yarn up` (see https://github.com/yarnpkg/berry/issues/246). This PR fixes `lockfileUpdate` for Yarn 2.