### PR TITLE
fix(npm): set CI=true in Yarn generateLockFile

### DIFF
--- a/lib/manager/npm/post-update/__snapshots__/yarn.spec.ts.snap
+++ b/lib/manager/npm/post-update/__snapshots__/yarn.spec.ts.snap
@@ -8,6 +8,7 @@ Array [
       "cwd": "some-dir",
       "encoding": "utf-8",
       "env": Object {
+        "CI": "true",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",
@@ -30,6 +31,7 @@ Array [
       "cwd": "some-dir",
       "encoding": "utf-8",
       "env": Object {
+        "CI": "true",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",
@@ -47,6 +49,7 @@ Array [
       "cwd": "some-dir",
       "encoding": "utf-8",
       "env": Object {
+        "CI": "true",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",
@@ -64,6 +67,7 @@ Array [
       "cwd": "some-dir",
       "encoding": "utf-8",
       "env": Object {
+        "CI": "true",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",
@@ -81,6 +85,7 @@ Array [
       "cwd": "some-dir",
       "encoding": "utf-8",
       "env": Object {
+        "CI": "true",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",
@@ -98,6 +103,7 @@ Array [
       "cwd": "some-dir",
       "encoding": "utf-8",
       "env": Object {
+        "CI": "true",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",
@@ -120,6 +126,7 @@ Array [
       "cwd": "some-dir",
       "encoding": "utf-8",
       "env": Object {
+        "CI": "true",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",
@@ -144,6 +151,7 @@ Array [
       "cwd": "some-dir",
       "encoding": "utf-8",
       "env": Object {
+        "CI": "true",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",
@@ -163,6 +171,7 @@ Array [
       "cwd": "some-dir",
       "encoding": "utf-8",
       "env": Object {
+        "CI": "true",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",
@@ -187,6 +196,7 @@ Array [
       "cwd": "some-dir",
       "encoding": "utf-8",
       "env": Object {
+        "CI": "true",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",
@@ -204,6 +214,7 @@ Array [
       "cwd": "some-dir",
       "encoding": "utf-8",
       "env": Object {
+        "CI": "true",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",
@@ -221,6 +232,7 @@ Array [
       "cwd": "some-dir",
       "encoding": "utf-8",
       "env": Object {
+        "CI": "true",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",
@@ -238,6 +250,7 @@ Array [
       "cwd": "some-dir",
       "encoding": "utf-8",
       "env": Object {
+        "CI": "true",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",
@@ -255,6 +268,7 @@ Array [
       "cwd": "some-dir",
       "encoding": "utf-8",
       "env": Object {
+        "CI": "true",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",
@@ -277,6 +291,7 @@ Array [
       "cwd": "some-dir",
       "encoding": "utf-8",
       "env": Object {
+        "CI": "true",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",
@@ -301,6 +316,7 @@ Array [
       "cwd": "some-dir",
       "encoding": "utf-8",
       "env": Object {
+        "CI": "true",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",
@@ -320,6 +336,7 @@ Array [
       "cwd": "some-dir",
       "encoding": "utf-8",
       "env": Object {
+        "CI": "true",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",
@@ -344,6 +361,7 @@ Array [
       "cwd": "some-dir",
       "encoding": "utf-8",
       "env": Object {
+        "CI": "true",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",
@@ -361,6 +379,7 @@ Array [
       "cwd": "some-dir",
       "encoding": "utf-8",
       "env": Object {
+        "CI": "true",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",
@@ -383,6 +402,7 @@ Array [
       "cwd": "some-dir",
       "encoding": "utf-8",
       "env": Object {
+        "CI": "true",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",
@@ -400,6 +420,7 @@ Array [
       "cwd": "some-dir",
       "encoding": "utf-8",
       "env": Object {
+        "CI": "true",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",

--- a/lib/manager/npm/post-update/yarn.ts
+++ b/lib/manager/npm/post-update/yarn.ts
@@ -64,6 +64,7 @@ export async function generateLockFile(
     const extraEnv: ExecOptions['extraEnv'] = {
       NPM_CONFIG_CACHE: env.NPM_CONFIG_CACHE,
       npm_config_store: env.npm_config_store,
+      CI: 'true',
     };
 
     if (


### PR DESCRIPTION
This PR set the environment variable `CI` to `true` when running Yarn. This will:
- disable progress bars (this is already disabled by non-tty output)
- print the build output on the command line (Yarn 2)
- only print a one-line report of any cache changes (Yarn 2, #7206, most of output produced by Yarn is `➤ YN0013: │ XYZ can't be found in the cache and will be fetched from the remote registry`)
- disable telemetry (Yarn 2)