### PR TITLE
fix(npm): fix lockfileUpdate commands for Yarn 2

### DIFF
--- a/lib/manager/npm/post-update/__snapshots__/yarn.spec.ts.snap
+++ b/lib/manager/npm/post-update/__snapshots__/yarn.spec.ts.snap
@@ -458,7 +458,7 @@ Array [
     },
   },
   Object {
-    "cmd": "yarn up some-dep",
+    "cmd": "yarn up some-dep@^1.0.0",
     "options": Object {
       "cwd": "some-dir",
       "encoding": "utf-8",

--- a/lib/manager/npm/post-update/yarn.spec.ts
+++ b/lib/manager/npm/post-update/yarn.spec.ts
@@ -84,6 +84,7 @@ describe(getName(__filename), () => {
       const res = await yarnHelper.generateLockFile('some-dir', {}, config, [
         {
           depName: 'some-dep',
+          newValue: '^1.0.0',
           isLockfileUpdate: true,
         },
       ]);


### PR DESCRIPTION
[`yarn up`](https://yarnpkg.com/cli/up) upgrades the dependency to the latest release, regardless of the version range specified in the package file unlike [`yarn upgrade`](https://classic.yarnpkg.com/en/docs/cli/upgrade/). Therefore, the range should be specified in the command to upgrade while satisfying the version range (yarnpkg/berry#1822).

Example PRs: https://github.com/ylemkimon/test-renovate/pull/4, https://github.com/ylemkimon/test-renovate/pull/5, https://github.com/ylemkimon/test-renovate/pull/6, https://github.com/ylemkimon/test-renovate/pull/7

I've missed this in #7222 and I apologize.