### PR TITLE
fix(git): fetch long sha for branchCommits

### DIFF
--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -602,7 +602,9 @@ export async function commitFiles({
     // Fetch it after create
     const ref = `refs/heads/${branchName}:refs/remotes/origin/${branchName}`;
     await git.fetch(['origin', ref, '--depth=2', '--force']);
-    config.branchCommits[branchName] = await git.revparse([branchName]);
+    config.branchCommits[branchName] = (
+      await git.revparse([branchName])
+    ).trim();
     config.branchIsModified[branchName] = false;
     incLimitedValue(Limit.Commits);
     return commit;

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -602,7 +602,7 @@ export async function commitFiles({
     // Fetch it after create
     const ref = `refs/heads/${branchName}:refs/remotes/origin/${branchName}`;
     await git.fetch(['origin', ref, '--depth=2', '--force']);
-    config.branchCommits[branchName] = commit;
+    config.branchCommits[branchName] = await git.revparse([branchName]);
     config.branchIsModified[branchName] = false;
     incLimitedValue(Limit.Commits);
     return commit;


### PR DESCRIPTION
`git.commit()` returns a short SHA, but we need to store long SHAs in our `config.branchCommits` object. This was causing `setBranchStatus()` to fail on GitHub.

Closes #7180