### PR TITLE
fix: sanitize github vulnerability alert bodies

### DIFF
--- a/lib/util/markdown.ts
+++ b/lib/util/markdown.ts
@@ -1,0 +1,18 @@
+// Generic replacements/link-breakers
+export function sanitizeMarkdown(markdown: string): string {
+  let res = markdown;
+  // Put a zero width space after every # followed by a digit
+  res = res.replace(/#(\d)/gi, '#&#8203;$1');
+  // Put a zero width space after every @ symbol to prevent unintended hyperlinking
+  res = res.replace(/@/g, '@&#8203;');
+  res = res.replace(/(`\[?@)&#8203;/g, '$1');
+  res = res.replace(/([a-z]@)&#8203;/gi, '$1');
+  res = res.replace(/\/compare\/@&#8203;/g, '/compare/@');
+  res = res.replace(/(\(https:\/\/[^)]*?)\.\.\.@&#8203;/g, '$1...@');
+  res = res.replace(/([\s(])#(\d+)([)\s]?)/g, '$1#&#8203;$2$3');
+  // convert escaped backticks back to `
+  const backTickRe = /&#x60;([^/]*?)&#x60;/g;
+  res = res.replace(backTickRe, '`$1`');
+  res = res.replace(/`#&#8203;(\d+)`/g, '`#$1`');
+  return res;
+}

--- a/lib/workers/pr/body/changelogs.ts
+++ b/lib/workers/pr/body/changelogs.ts
@@ -1,3 +1,4 @@
+import { sanitizeMarkdown } from '../../../util/markdown';
 import * as template from '../../../util/template';
 import { BranchConfig } from '../../common';
 import releaseNotesHbs from '../changelog/hbs-template';
@@ -11,26 +12,6 @@ export function getChangelogs(config: BranchConfig): string {
   releaseNotes +=
     '\n\n---\n\n' + template.compile(releaseNotesHbs, config, false) + '\n\n';
   releaseNotes = releaseNotes.replace(/### \[`vv/g, '### [`v');
-  // Generic replacements/link-breakers
-
-  // Put a zero width space after every # followed by a digit
-  releaseNotes = releaseNotes.replace(/#(\d)/gi, '#&#8203;$1');
-  // Put a zero width space after every @ symbol to prevent unintended hyperlinking
-  releaseNotes = releaseNotes.replace(/@/g, '@&#8203;');
-  releaseNotes = releaseNotes.replace(/(`\[?@)&#8203;/g, '$1');
-  releaseNotes = releaseNotes.replace(/([a-z]@)&#8203;/gi, '$1');
-  releaseNotes = releaseNotes.replace(/\/compare\/@&#8203;/g, '/compare/@');
-  releaseNotes = releaseNotes.replace(
-    /(\(https:\/\/[^)]*?)\.\.\.@&#8203;/g,
-    '$1...@'
-  );
-  releaseNotes = releaseNotes.replace(
-    /([\s(])#(\d+)([)\s]?)/g,
-    '$1#&#8203;$2$3'
-  );
-  // convert escaped backticks back to `
-  const backTickRe = /&#x60;([^/]*?)&#x60;/g;
-  releaseNotes = releaseNotes.replace(backTickRe, '`$1`');
-  releaseNotes = releaseNotes.replace(/`#&#8203;(\d+)`/g, '`#$1`');
+  releaseNotes = sanitizeMarkdown(releaseNotes);
   return releaseNotes;
 }

--- a/lib/workers/repository/init/vulnerability.ts
+++ b/lib/workers/repository/init/vulnerability.ts
@@ -8,6 +8,7 @@ import * as datasourceRubygems from '../../../datasource/rubygems';
 import { logger } from '../../../logger';
 import { platform } from '../../../platform';
 import { SecurityAdvisory } from '../../../types';
+import { sanitizeMarkdown } from '../../../util/markdown';
 import * as allVersioning from '../../../versioning';
 import * as mavenVersioning from '../../../versioning/maven';
 import * as npmVersioning from '../../../versioning/npm';
@@ -146,7 +147,8 @@ export async function detectVulnerabilityAlerts(
             }
             content += heading;
             content += '\n\n';
-            content += advisory.description;
+            // eslint-disable-next-line no-loop-func
+            content += sanitizeMarkdown(advisory.description);
             return content;
           })
         );


### PR DESCRIPTION
Although we already sanitized release notes, vulnerability alert content could also contain usernames or issues numbers, and needs to be sanitized too. The logic for sanitizing changelogs has been externalized into lib/util and reused by the vulnerability alert parsing logic.