### PR TITLE
fix(git): clone default branch to depth 10

### DIFF
--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -236,7 +236,7 @@ export async function syncGit(): Promise<void> {
     const cloneStart = Date.now();
     try {
       // clone only the default branch
-      const opts = ['--depth=2'];
+      const opts = ['--depth=10'];
       if (config.extraCloneOpts) {
         Object.entries(config.extraCloneOpts).forEach((e) =>
           opts.push(e[0], `${e[1]}`)


### PR DESCRIPTION
Necessary for accurate detection of semantic commits.
