### PR TITLE
feat(go): add support for github enterprise in go datasource

### DIFF
--- a/lib/datasource/github-tags/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/github-tags/__snapshots__/index.spec.ts.snap
@@ -138,3 +138,35 @@ Array [
   },
 ]
 `;
+
+exports[`datasource/github-tags getReleases supports ghe 1`] = `
+Object {
+  "releases": Array [
+    Object {
+      "gitRef": "v1.0.0",
+      "version": "v1.0.0",
+    },
+    Object {
+      "gitRef": "v1.1.0",
+      "version": "v1.1.0",
+    },
+  ],
+  "sourceUrl": "https://git.enterprise.com/some/dep2",
+}
+`;
+
+exports[`datasource/github-tags getReleases supports ghe 2`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate",
+      "authorization": "token some-token",
+      "host": "git.enterprise.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://git.enterprise.com/api/v3/repos/some/dep2/tags?per_page=100",
+  },
+]
+`;

--- a/lib/datasource/github-tags/index.spec.ts
+++ b/lib/datasource/github-tags/index.spec.ts
@@ -7,6 +7,7 @@ jest.mock('../../util/host-rules');
 const hostRules: any = _hostRules;
 
 const githubApiHost = 'https://api.github.com';
+const githubEnterpriseApiHost = 'https://git.enterprise.com';
 
 describe('datasource/github-tags', () => {
   beforeEach(() => {
@@ -100,6 +101,20 @@ describe('datasource/github-tags', () => {
       const res = await getPkgReleases({ datasource: github.id, depName });
       expect(res).toMatchSnapshot();
       expect(res.releases).toHaveLength(2);
+      expect(httpMock.getTrace()).toMatchSnapshot();
+    });
+
+    it('supports ghe', async () => {
+      const body = [{ name: 'v1.0.0' }, { name: 'v1.1.0' }];
+      httpMock
+        .scope(githubEnterpriseApiHost)
+        .get(`/api/v3/repos/${depName}/tags?per_page=100`)
+        .reply(200, body);
+      const res = await github.getReleases({
+        registryUrl: 'https://git.enterprise.com',
+        lookupName: depName,
+      });
+      expect(res).toMatchSnapshot();
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
   });

--- a/lib/datasource/github-tags/index.ts
+++ b/lib/datasource/github-tags/index.ts
@@ -2,6 +2,7 @@ import { logger } from '../../logger';
 import * as packageCache from '../../util/cache/package';
 import { GithubHttp } from '../../util/http/github';
 import { DigestConfig, GetReleasesConfig, ReleaseResult } from '../common';
+import URL from 'url';
 
 export const id = 'github-tags';
 
@@ -119,6 +120,7 @@ export async function getDigest(
  *  - Return a dependency object containing sourceUrl string and releases array
  */
 export async function getReleases({
+  registryUrl: depHost,
   lookupName: repo,
 }: GetReleasesConfig): Promise<ReleaseResult | null> {
   const cachedResult = await packageCache.get<ReleaseResult>(
@@ -129,8 +131,15 @@ export async function getReleases({
   if (cachedResult) {
     return cachedResult;
   }
+
+  // default to GitHub.com if no GHE host is specified.
+  const sourceUrlBase = depHost ?? `https://github.com/`;
+  const apiBaseUrl = depHost
+    ? URL.resolve(depHost, 'api/v3/')
+    : `https://api.github.com/`;
+
   // tag
-  const url = `https://api.github.com/repos/${repo}/tags?per_page=100`;
+  const url = URL.resolve(apiBaseUrl, `repos/${repo}/tags?per_page=100`);
   type GitHubTag = {
     name: string;
   }[];
@@ -141,7 +150,7 @@ export async function getReleases({
     })
   ).body.map((o) => o.name);
   const dependency: ReleaseResult = {
-    sourceUrl: 'https://github.com/' + repo,
+    sourceUrl: URL.resolve(sourceUrlBase, repo),
     releases: null,
   };
   dependency.releases = versions.map((version) => ({

--- a/lib/datasource/github-tags/index.ts
+++ b/lib/datasource/github-tags/index.ts
@@ -1,8 +1,8 @@
+import URL from 'url';
 import { logger } from '../../logger';
 import * as packageCache from '../../util/cache/package';
 import { GithubHttp } from '../../util/http/github';
 import { DigestConfig, GetReleasesConfig, ReleaseResult } from '../common';
-import URL from 'url';
 
 export const id = 'github-tags';
 

--- a/lib/datasource/go/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/go/__snapshots__/index.spec.ts.snap
@@ -166,6 +166,33 @@ Array [
 ]
 `;
 
+exports[`datasource/go getReleases support ghe 1`] = `
+Object {
+  "releases": Array [
+    Object {
+      "version": "v1.0.0",
+    },
+    Object {
+      "version": "v2.0.0",
+    },
+  ],
+}
+`;
+
+exports[`datasource/go getReleases support ghe 2`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept-encoding": "gzip, deflate",
+      "host": "git.enterprise.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://git.enterprise.com/example/module?go-get=1",
+  },
+]
+`;
+
 exports[`datasource/go getReleases works for known servers 1`] = `
 Array [
   Array [

--- a/lib/datasource/go/index.ts
+++ b/lib/datasource/go/index.ts
@@ -1,3 +1,4 @@
+import URL from 'url';
 import { logger } from '../../logger';
 import { Http } from '../../util/http';
 import { regEx } from '../../util/regex';
@@ -9,7 +10,6 @@ export const id = 'go';
 
 const http = new Http(id);
 const gitlabRegExp = /^(https:\/\/[^/]*gitlab.[^/]*)\/(.*)$/;
-const httpRegExp = /^(https:\/\/[^/]*)\/(.*)$/;
 
 interface DataSource {
   datasource: string;
@@ -79,14 +79,15 @@ async function getDatasource(goModule: string): Promise<DataSource | null> {
       logger.debug({ goModule, goImportURL }, 'Go lookup import url');
 
       // get server base url from import url
-      const httpMatch = httpRegExp.exec(goImportURL);
+      const parsedUrl = URL.parse(goImportURL);
 
+      // split the go module from the URL: host/go/module -> go/module
       const split = goModule.split('/');
       const lookupName = split[1] + '/' + split[2];
 
       return {
         datasource: github.id,
-        registryUrl: httpMatch[1],
+        registryUrl: `${parsedUrl.protocol}//${parsedUrl.host}`,
         lookupName,
       };
     }

--- a/lib/datasource/go/index.ts
+++ b/lib/datasource/go/index.ts
@@ -9,6 +9,7 @@ export const id = 'go';
 
 const http = new Http(id);
 const gitlabRegExp = /^(https:\/\/[^/]*gitlab.[^/]*)\/(.*)$/;
+const httpRegExp = /^(https:\/\/[^/]*)\/(.*)$/;
 
 interface DataSource {
   datasource: string;
@@ -35,6 +36,7 @@ async function getDatasource(goModule: string): Promise<DataSource | null> {
       lookupName,
     };
   }
+
   const pkgUrl = `https://${goModule}?go-get=1`;
   const res = (await http.get(pkgUrl)).body;
   const sourceMatch = regEx(
@@ -64,7 +66,32 @@ async function getDatasource(goModule: string): Promise<DataSource | null> {
       };
     }
   } else {
-    logger.trace({ goModule }, 'No go-source header found');
+    // GitHub Enterprise only returns a go-import meta
+    const importMatch = regEx(
+      `<meta\\s+name="go-import"\\s+content="([^\\s]+)\\s+([^\\s]+)\\s+([^\\s]+)">`
+    ).exec(res);
+    if (importMatch) {
+      const [, prefix, , goImportURL] = importMatch;
+      if (!goModule.startsWith(prefix)) {
+        logger.trace({ goModule }, 'go-import header prefix not match');
+        return null;
+      }
+      logger.debug({ goModule, goImportURL }, 'Go lookup import url');
+
+      // get server base url from import url
+      const httpMatch = httpRegExp.exec(goImportURL);
+
+      const split = goModule.split('/');
+      const lookupName = split[1] + '/' + split[2];
+
+      return {
+        datasource: github.id,
+        registryUrl: httpMatch[1],
+        lookupName,
+      };
+    }
+
+    logger.trace({ goModule }, 'No go-source or go-import header found');
   }
   return null;
 }


### PR DESCRIPTION
feat: support github enterprise for go datasource

* all go datasources that don't match gitlab rules but return the expected go-import from GHE will use the github-tags datasource with the GitHub enterprise instance set as the base url.

without this it is impossible to resolve dependencies in a private GitHub enterprise instance

This fixes #4741 and fixes #3498 (assuming the remote server exposes a go-source header).

I do not have experience with this code base so let me know if there are changes required.