### PR TITLE
feat: Add `@embroider` monorepo

### DIFF
--- a/lib/config/presets/internal/monorepo.ts
+++ b/lib/config/presets/internal/monorepo.ts
@@ -130,6 +130,7 @@ const patternGroups = {
   wordpress: '^@wordpress/',
   angularmaterial: ['^@angular/material', '^@angular/cdk'],
   'aws-java-sdk': '^com.amazonaws:aws-java-sdk-',
+  embroider: '^@embroider/',
   fullcalendar: '^@fullcalendar/',
 };
 


### PR DESCRIPTION
see https://github.com/embroider-build/embroider/

unfortunately, adding it to `repoGroups` does not work, because the packages are currently lacking a `repository` field in their metadata