### PR TITLE
feat: Add `group:glimmer`

### DIFF
--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -38,6 +38,7 @@ const staticGroups = {
       'group:fortawesome',
       'group:goOpenapi',
       'group:fusionjs',
+      'group:glimmer',
       'group:hibernateCore',
       'group:hibernateValidator',
       'group:hibernateOgm',
@@ -120,6 +121,10 @@ const staticGroups = {
       'fusion-tokens',
     ],
     packagePatterns: ['^fusion-plugin-*', '^fusion-react*', '^fusion-apollo*'],
+  },
+  glimmer: {
+    description: 'Glimmer.js packages',
+    packageNames: ['@glimmer/component', '@glimmer/tracking'],
   },
   illuminate: {
     description: 'Group PHP illuminate packages together',


### PR DESCRIPTION
from https://github.com/glimmerjs/glimmer.js/tree/master/packages/%40glimmer

Note that not all packages should be included since these two are the only ones that are currently considered stable and officially used in Ember.js
