### PR TITLE
fix: Fix `semanticCommits` migration code

### DIFF
--- a/lib/config/migration.spec.ts
+++ b/lib/config/migration.spec.ts
@@ -421,6 +421,16 @@ describe('config/migration', () => {
       res = configMigration.migrateConfig(config);
       expect(res.isMigrated).toBe(true);
       expect(res.migratedConfig).toMatchObject({ semanticCommits: 'auto' });
+
+      config = { semanticCommits: 'enabled' };
+      res = configMigration.migrateConfig(config);
+      expect(res.isMigrated).toBe(true);
+      expect(res.migratedConfig).toMatchObject({ semanticCommits: 'enabled' });
+
+      config = { semanticCommits: 'disabled' };
+      res = configMigration.migrateConfig(config);
+      expect(res.isMigrated).toBe(true);
+      expect(res.migratedConfig).toMatchObject({ semanticCommits: 'disabled' });
     });
   });
 });

--- a/lib/config/migration.ts
+++ b/lib/config/migration.ts
@@ -107,7 +107,7 @@ export function migrateConfig(
           migratedConfig.semanticCommits = 'enabled';
         } else if (val === false) {
           migratedConfig.semanticCommits = 'disabled';
-        } else {
+        } else if (val !== 'enabled' && val !== 'disabled') {
           migratedConfig.semanticCommits = 'auto';
         }
       } else if (parentKey === 'hostRules' && key === 'platform') {


### PR DESCRIPTION
The code was overriding any non-boolean value with `auto`, even if `enabled` or `disabled` was set.

Looks like this was introduced by #7170 