### PR TITLE
feat(datasource/crate): Assign `dependencyUrl` property

### DIFF
--- a/lib/datasource/crate/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/crate/__snapshots__/index.spec.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`datasource/crate getReleases processes real data: amethyst 1`] = `
 Object {
+  "dependencyUrl": "https://crates.io/crates/amethyst",
   "releases": Array [
     Object {
       "version": "0.1.0",
@@ -144,6 +145,7 @@ Array [
 
 exports[`datasource/crate getReleases processes real data: libc 1`] = `
 Object {
+  "dependencyUrl": "https://crates.io/crates/libc",
   "releases": Array [
     Object {
       "version": "0.1.0",

--- a/lib/datasource/crate/index.ts
+++ b/lib/datasource/crate/index.ts
@@ -38,6 +38,7 @@ export async function getReleases({
   const baseUrl =
     'https://raw.githubusercontent.com/rust-lang/crates.io-index/master/';
   const crateUrl = baseUrl + path;
+  const dependencyUrl = `https://crates.io/crates/${lookupName}`;
   try {
     const lines = (await http.get(crateUrl)).body
       .split('\n') // break into lines
@@ -45,6 +46,7 @@ export async function getReleases({
       .filter((line) => line.length !== 0) // remove empty lines
       .map((line) => JSON.parse(line)); // parse
     const result: ReleaseResult = {
+      dependencyUrl,
       releases: [],
     };
     result.releases = lines


### PR DESCRIPTION
If I understand correctly the `dependencyUrl` property is supposed to link to the package on the package registry, which is crates.io in this case. 

This could be used in the PR description if no homepage or source URL is available and would be a short-term workaround for https://github.com/renovatebot/renovate/issues/3486.
