### PR TITLE
feat(pr/body): Fall back to `dependencyUrl` property

### DIFF
--- a/lib/workers/common.ts
+++ b/lib/workers/common.ts
@@ -63,6 +63,7 @@ export interface BranchUpgradeConfig
 
   homepage?: string;
   changelogUrl?: string;
+  dependencyUrl?: string;
   sourceUrl?: string;
 }
 

--- a/lib/workers/pr/body/index.ts
+++ b/lib/workers/pr/body/index.ts
@@ -13,9 +13,15 @@ import { getPrUpdatesTable } from './updates-table';
 function massageUpdateMetadata(config: BranchConfig): void {
   config.upgrades.forEach((upgrade) => {
     /* eslint-disable no-param-reassign */
-    const { homepage, sourceUrl, sourceDirectory, changelogUrl } = upgrade;
+    const {
+      homepage,
+      sourceUrl,
+      sourceDirectory,
+      changelogUrl,
+      dependencyUrl,
+    } = upgrade;
     let depNameLinked = upgrade.depName;
-    const primaryLink = homepage || sourceUrl;
+    const primaryLink = homepage || sourceUrl || dependencyUrl;
     if (primaryLink) {
       depNameLinked = `[${depNameLinked}](${primaryLink})`;
     }

--- a/lib/workers/repository/process/lookup/__snapshots__/index.spec.ts.snap
+++ b/lib/workers/repository/process/lookup/__snapshots__/index.spec.ts.snap
@@ -79,6 +79,7 @@ Array [
 exports[`workers/repository/process/lookup .lookupUpdates() handles digest pin 1`] = `
 Object {
   "changelogUrl": undefined,
+  "dependencyUrl": undefined,
   "homepage": undefined,
   "sourceUrl": "https://github.com/nodejs/node",
   "updates": Array [
@@ -122,6 +123,7 @@ Object {
 exports[`workers/repository/process/lookup .lookupUpdates() handles digest pin for up to date version 1`] = `
 Object {
   "changelogUrl": undefined,
+  "dependencyUrl": undefined,
   "homepage": undefined,
   "sourceUrl": "https://github.com/nodejs/node",
   "updates": Array [
@@ -139,6 +141,7 @@ Object {
 exports[`workers/repository/process/lookup .lookupUpdates() handles digest update 1`] = `
 Object {
   "changelogUrl": undefined,
+  "dependencyUrl": undefined,
   "homepage": undefined,
   "sourceUrl": "https://github.com/nodejs/node",
   "updates": Array [
@@ -204,6 +207,7 @@ exports[`workers/repository/process/lookup .lookupUpdates() handles unknown data
 exports[`workers/repository/process/lookup .lookupUpdates() ignores deprecated 1`] = `
 Object {
   "changelogUrl": undefined,
+  "dependencyUrl": undefined,
   "deprecationMessage": "On registry \`https://registry.npmjs.org/\`, the \\"latest\\" version (v1.4.1) of dependency \`q2\` has the following deprecation notice:
 
 \`true\`
@@ -254,6 +258,7 @@ Array [
 exports[`workers/repository/process/lookup .lookupUpdates() is deprecated 1`] = `
 Object {
   "changelogUrl": undefined,
+  "dependencyUrl": undefined,
   "homepage": undefined,
   "sourceDirectory": "test",
   "sourceUrl": "https://github.com/kriskowal/q",
@@ -419,6 +424,7 @@ Array [
 exports[`workers/repository/process/lookup .lookupUpdates() returns complex object 1`] = `
 Object {
   "changelogUrl": undefined,
+  "dependencyUrl": undefined,
   "homepage": undefined,
   "sourceUrl": "https://github.com/kriskowal/q",
   "updates": Array [
@@ -833,6 +839,7 @@ exports[`workers/repository/process/lookup .lookupUpdates() should warn if no ve
 exports[`workers/repository/process/lookup .lookupUpdates() skips uncompatible versions for 8 1`] = `
 Object {
   "changelogUrl": undefined,
+  "dependencyUrl": undefined,
   "homepage": undefined,
   "sourceUrl": "https://github.com/nodejs/node",
   "updates": Array [
@@ -854,6 +861,7 @@ Object {
 exports[`workers/repository/process/lookup .lookupUpdates() skips uncompatible versions for 8.1 1`] = `
 Object {
   "changelogUrl": undefined,
+  "dependencyUrl": undefined,
   "homepage": undefined,
   "sourceUrl": "https://github.com/nodejs/node",
   "updates": Array [
@@ -885,6 +893,7 @@ Object {
 exports[`workers/repository/process/lookup .lookupUpdates() skips uncompatible versions for 8.1.0 1`] = `
 Object {
   "changelogUrl": undefined,
+  "dependencyUrl": undefined,
   "homepage": undefined,
   "sourceUrl": "https://github.com/nodejs/node",
   "updates": Array [

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -25,6 +25,7 @@ export interface UpdateResult {
   dockerRepository?: string;
   dockerRegistry?: string;
   changelogUrl?: string;
+  dependencyUrl?: string;
   homepage?: string;
   deprecationMessage?: string;
   sourceUrl?: string;
@@ -174,6 +175,7 @@ export async function lookupUpdates(
     }
     res.homepage = dependency.homepage;
     res.changelogUrl = dependency.changelogUrl;
+    res.dependencyUrl = dependency?.dependencyUrl;
     // TODO: improve this
     // istanbul ignore if
     if (dependency.dockerRegistry) {


### PR DESCRIPTION
... if no `homepage` or `sourceUrl` is available

This is relevant for the `crate` datasource where both are currently not available due to the API rate limiting.

Closes #7265