### PR TITLE
chore(datasource/crate): Extract `getIndexSuffix()` function and add tests

### DIFF
--- a/lib/datasource/crate/index.spec.ts
+++ b/lib/datasource/crate/index.spec.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import { getPkgReleases } from '..';
 import * as httpMock from '../../../test/httpMock';
 
-import { id as datasource } from '.';
+import { id as datasource, getIndexSuffix } from '.';
 
 const res1 = fs.readFileSync('lib/datasource/crate/__fixtures__/libc', 'utf8');
 const res2 = fs.readFileSync(
@@ -14,6 +14,18 @@ const baseUrl =
   'https://raw.githubusercontent.com/rust-lang/crates.io-index/master/';
 
 describe('datasource/crate', () => {
+  describe('getIndexSuffix', () => {
+    it('returns correct suffixes', () => {
+      expect(getIndexSuffix('a')).toBe('1/a');
+      expect(getIndexSuffix('1')).toBe('1/1');
+      expect(getIndexSuffix('1234567')).toBe('12/34/1234567');
+      expect(getIndexSuffix('ab')).toBe('2/ab');
+      expect(getIndexSuffix('abc')).toBe('3/a/abc');
+      expect(getIndexSuffix('abcd')).toBe('ab/cd/abcd');
+      expect(getIndexSuffix('abcde')).toBe('ab/cd/abcde');
+    });
+  });
+
   describe('getReleases', () => {
     it('returns null for empty result', async () => {
       httpMock.scope(baseUrl).get('/no/n_/non_existent_crate').reply(200, {});

--- a/lib/datasource/crate/index.ts
+++ b/lib/datasource/crate/index.ts
@@ -7,6 +7,27 @@ export const id = 'crate';
 
 const http = new Http(id);
 
+const BASE_URL =
+  'https://raw.githubusercontent.com/rust-lang/crates.io-index/master/';
+
+export function getIndexSuffix(lookupName: string): string {
+  const len = lookupName.length;
+
+  if (len === 1) {
+    return '1/' + lookupName;
+  }
+  if (len === 2) {
+    return '2/' + lookupName;
+  }
+  if (len === 3) {
+    return '3/' + lookupName[0] + '/' + lookupName;
+  }
+
+  return (
+    lookupName.slice(0, 2) + '/' + lookupName.slice(2, 4) + '/' + lookupName
+  );
+}
+
 export async function getReleases({
   lookupName,
 }: GetReleasesConfig): Promise<ReleaseResult | null> {
@@ -21,23 +42,7 @@ export async function getReleases({
     return cachedResult;
   }
 
-  const len = lookupName.length;
-  let path: string;
-  // Ignored because there is no way to test this without hitting up GitHub API
-  /* istanbul ignore next */
-  if (len === 1) {
-    path = '1/' + lookupName;
-  } else if (len === 2) {
-    path = '2/' + lookupName;
-  } else if (len === 3) {
-    path = '3/' + lookupName[0] + '/' + lookupName;
-  } else {
-    path =
-      lookupName.slice(0, 2) + '/' + lookupName.slice(2, 4) + '/' + lookupName;
-  }
-  const baseUrl =
-    'https://raw.githubusercontent.com/rust-lang/crates.io-index/master/';
-  const crateUrl = baseUrl + path;
+  const crateUrl = BASE_URL + getIndexSuffix(lookupName);
   try {
     const lines = (await http.get(crateUrl)).body
       .split('\n') // break into lines


### PR DESCRIPTION
The code said that code coverage was disabled "because there is no way to test this without hitting up GitHub API", but at least the URL building part can be tested quite easily by extracting it into a dedicated function.