### PR TITLE
chore(datasource/metadata): Move `massageGithub|GitLabUrl()` functions out of `addMetaData()`

### DIFF
--- a/lib/datasource/metadata.ts
+++ b/lib/datasource/metadata.ts
@@ -76,6 +76,25 @@ const manualSourceUrls = {
   },
 };
 
+function massageGithubUrl(url: string): string {
+  return url
+    .replace('http:', 'https:')
+    .replace(/^git:\/?\/?/, 'https://')
+    .replace('www.github.com', 'github.com')
+    .split('/')
+    .slice(0, 5)
+    .join('/');
+}
+
+function massageGitlabUrl(url: string): string {
+  return url
+    .replace('http:', 'https:')
+    .replace(/^git:\/?\/?/, 'https://')
+    .replace(/\/tree\/.*$/i, '')
+    .replace(/\/$/i, '')
+    .replace('.git', '');
+}
+
 /* eslint-disable no-param-reassign */
 export function addMetaData(
   dep?: ReleaseResult,
@@ -92,30 +111,6 @@ export function addMetaData(
   if (manualSourceUrls[datasource]?.[lookupNameLowercase]) {
     dep.sourceUrl = manualSourceUrls[datasource][lookupNameLowercase];
   }
-
-  /**
-   * @param {string} url
-   */
-  const massageGithubUrl = (url: string): string => {
-    return url
-      .replace('http:', 'https:')
-      .replace(/^git:\/?\/?/, 'https://')
-      .replace('www.github.com', 'github.com')
-      .split('/')
-      .slice(0, 5)
-      .join('/');
-  };
-  /**
-   * @param {string} url
-   */
-  const massageGitlabUrl = (url: string): string => {
-    return url
-      .replace('http:', 'https:')
-      .replace(/^git:\/?\/?/, 'https://')
-      .replace(/\/tree\/.*$/i, '')
-      .replace(/\/$/i, '')
-      .replace('.git', '');
-  };
 
   if (
     dep.changelogUrl?.includes('github.com') && // lgtm [js/incomplete-url-substring-sanitization]


### PR DESCRIPTION

There is no need for these functions to be nested and redefined for every `addMetaData()` function call

<!-- Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App: https://cla-assistant.io/renovatebot/renovate -->

<!-- When creating this PR on GitHub, please ensure `Allow edits from maintainers.` checkbox is checked -->

<!-- Please use a conventional commit message (https://www.conventionalcommits.org/en/v1.0.0/) as your PR title -->

<!-- Ideally include at least one sentence saying what this PR achieves -->

<!-- Finish the PR with `Closes #` and then the issue number if it closes any associated issue -->
