### PR TITLE
fix(npm): use compatibility from the packageFile in generateLockFile

### DIFF
--- a/lib/manager/npm/post-update/__snapshots__/npm.spec.ts.snap
+++ b/lib/manager/npm/post-update/__snapshots__/npm.spec.ts.snap
@@ -97,4 +97,27 @@ exports[`generateLockFile performs npm-shrinkwrap.json updates (no package-lock.
 
 exports[`generateLockFile performs npm-shrinkwrap.json updates 1`] = `Array []`;
 
+exports[`generateLockFile uses compatibility from the packageFile 1`] = `
+Array [
+  Object {
+    "cmd": "npm install --package-lock-only --ignore-scripts --no-audit",
+    "options": Object {
+      "cwd": "some-dir",
+      "encoding": "utf-8",
+      "env": Object {
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+]
+`;
+
 exports[`generateLockFile uses docker npm 1`] = `Array []`;

--- a/lib/manager/npm/post-update/__snapshots__/pnpm.spec.ts.snap
+++ b/lib/manager/npm/post-update/__snapshots__/pnpm.spec.ts.snap
@@ -91,3 +91,26 @@ Array [
   },
 ]
 `;
+
+exports[`generateLockFile uses compatibility from the packageFile 1`] = `
+Array [
+  Object {
+    "cmd": "pnpm install --recursive --lockfile-only --ignore-scripts --ignore-pnpmfile",
+    "options": Object {
+      "cwd": "some-dir",
+      "encoding": "utf-8",
+      "env": Object {
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+]
+`;

--- a/lib/manager/npm/post-update/__snapshots__/yarn.spec.ts.snap
+++ b/lib/manager/npm/post-update/__snapshots__/yarn.spec.ts.snap
@@ -502,3 +502,50 @@ Array [
   },
 ]
 `;
+
+exports[`manager/npm/post-update/yarn uses compatibility from the packageFile 1`] = `
+Array [
+  Object {
+    "cmd": "yarn install",
+    "options": Object {
+      "cwd": "some-dir",
+      "encoding": "utf-8",
+      "env": Object {
+        "CI": "true",
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+        "YARN_ENABLE_SCRIPTS": "0",
+        "YARN_HTTP_TIMEOUT": "100000",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+  Object {
+    "cmd": "yarn dedupe --strategy highest",
+    "options": Object {
+      "cwd": "some-dir",
+      "encoding": "utf-8",
+      "env": Object {
+        "CI": "true",
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+        "YARN_ENABLE_SCRIPTS": "0",
+        "YARN_HTTP_TIMEOUT": "100000",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+]
+`;

--- a/lib/manager/npm/post-update/index.ts
+++ b/lib/manager/npm/post-update/index.ts
@@ -501,7 +501,7 @@ export async function getAdditionalFiles(
       (upgrade) => upgrade.yarnLock === lockFile
     );
     const res = await yarn.generateLockFile(
-      upath.join(config.localDir, lockFileDir),
+      fullLockFileDir,
       env,
       config,
       upgrades,
@@ -607,7 +607,7 @@ export async function getAdditionalFiles(
       (upgrade) => upgrade.pnpmShrinkwrap === lockFile
     );
     const res = await pnpm.generateLockFile(
-      upath.join(config.localDir, lockFileDir),
+      fullLockFileDir,
       env,
       config,
       upgrades,

--- a/lib/manager/npm/post-update/index.ts
+++ b/lib/manager/npm/post-update/index.ts
@@ -419,6 +419,9 @@ export async function getAdditionalFiles(
   for (const lockFile of dirs.npmLockDirs) {
     const lockFileDir = path.dirname(lockFile);
     const fullLockFileDir = upath.join(config.localDir, lockFileDir);
+    const packageFile = packageFiles.npm.find(
+      (p) => path.dirname(p.packageFile) === lockFileDir
+    );
     const npmrcContent = await getNpmrcContent(fullLockFileDir);
     await updateNpmrcContent(
       fullLockFileDir,
@@ -435,7 +438,8 @@ export async function getAdditionalFiles(
       env,
       fileName,
       config,
-      upgrades
+      upgrades,
+      packageFile
     );
     if (res.error) {
       // istanbul ignore if
@@ -482,6 +486,9 @@ export async function getAdditionalFiles(
   for (const lockFile of dirs.yarnLockDirs) {
     const lockFileDir = path.dirname(lockFile);
     const fullLockFileDir = upath.join(config.localDir, lockFileDir);
+    const packageFile = packageFiles.npm.find(
+      (p) => path.dirname(p.packageFile) === lockFileDir
+    );
     const npmrcContent = await getNpmrcContent(fullLockFileDir);
     await updateNpmrcContent(
       fullLockFileDir,
@@ -497,7 +504,8 @@ export async function getAdditionalFiles(
       upath.join(config.localDir, lockFileDir),
       env,
       config,
-      upgrades
+      upgrades,
+      packageFile
     );
     if (res.error) {
       // istanbul ignore if
@@ -585,6 +593,9 @@ export async function getAdditionalFiles(
   for (const lockFile of dirs.pnpmShrinkwrapDirs) {
     const lockFileDir = path.dirname(lockFile);
     const fullLockFileDir = upath.join(config.localDir, lockFileDir);
+    const packageFile = packageFiles.npm.find(
+      (p) => path.dirname(p.packageFile) === lockFileDir
+    );
     const npmrcContent = await getNpmrcContent(fullLockFileDir);
     await updateNpmrcContent(
       fullLockFileDir,
@@ -599,7 +610,8 @@ export async function getAdditionalFiles(
       upath.join(config.localDir, lockFileDir),
       env,
       config,
-      upgrades
+      upgrades,
+      packageFile
     );
     if (res.error) {
       // istanbul ignore if

--- a/lib/manager/npm/post-update/lerna.spec.ts
+++ b/lib/manager/npm/post-update/lerna.spec.ts
@@ -12,10 +12,11 @@ const exec: jest.Mock<typeof _exec> = _exec as any;
 const env = mocked(_env);
 const lernaHelper = mocked(_lernaHelper);
 
-function lernaPkgFile(lernaClient: string) {
+function lernaPkgFile(lernaClient: string, config: Record<string, any> = {}) {
   return {
     lernaClient,
     deps: [{ depName: 'lerna', currentValue: '2.0.0' }],
+    ...config,
   };
 }
 
@@ -72,10 +73,11 @@ describe(getName(__filename), () => {
     });
     it('generates yarn.lock files', async () => {
       const execSnapshots = mockExecAll(exec);
+      const config = { compatibility: { yarn: '^1.10.0' } };
       const res = await lernaHelper.generateLockFiles(
-        lernaPkgFile('yarn'),
+        lernaPkgFile('yarn', config),
         'some-dir',
-        { compatibility: { yarn: '^1.10.0' } },
+        config,
         {}
       );
       expect(execSnapshots).toMatchSnapshot();
@@ -94,13 +96,14 @@ describe(getName(__filename), () => {
     });
     it('maps dot files', async () => {
       const execSnapshots = mockExecAll(exec);
+      const config = {
+        dockerMapDotfiles: true,
+        compatibility: { npm: '^6.0.0' },
+      };
       const res = await lernaHelper.generateLockFiles(
-        lernaPkgFile('npm'),
+        lernaPkgFile('npm', config),
         'some-dir',
-        {
-          dockerMapDotfiles: true,
-          compatibility: { npm: '^6.0.0' },
-        },
+        config,
         {}
       );
       expect(res.error).toBe(false);

--- a/lib/manager/npm/post-update/lerna.ts
+++ b/lib/manager/npm/post-update/lerna.ts
@@ -45,7 +45,7 @@ export async function generateLockFiles(
   try {
     if (lernaClient === 'yarn') {
       let installYarn = 'npm i -g yarn';
-      const yarnCompatibility = config.compatibility?.yarn;
+      const yarnCompatibility = lernaPackageFile.compatibility?.yarn;
       if (validRange(yarnCompatibility)) {
         installYarn += `@${quote(yarnCompatibility)}`;
       }
@@ -56,7 +56,7 @@ export async function generateLockFiles(
       cmdOptions = '--ignore-scripts --ignore-engines --ignore-platform';
     } else if (lernaClient === 'npm') {
       let installNpm = 'npm i -g npm';
-      const npmCompatibility = config.compatibility?.npm;
+      const npmCompatibility = lernaPackageFile.compatibility?.npm;
       if (validRange(npmCompatibility)) {
         installNpm += `@${quote(npmCompatibility)}`;
         preCommands.push(installNpm);

--- a/lib/manager/npm/post-update/node-version.ts
+++ b/lib/manager/npm/post-update/node-version.ts
@@ -1,7 +1,7 @@
 import { validRange } from 'semver';
 import { logger } from '../../../logger';
 import { getSiblingFileName, readLocalFile } from '../../../util/fs';
-import { PostUpdateConfig } from '../../common';
+import { PackageFile, PostUpdateConfig } from '../../common';
 
 async function getNodeFile(filename: string): Promise<string> | null {
   try {
@@ -18,7 +18,9 @@ async function getNodeFile(filename: string): Promise<string> | null {
   return null;
 }
 
-function getPackageJsonConstraint(config: PostUpdateConfig): string | null {
+function getPackageJsonConstraint(
+  config: PostUpdateConfig | Partial<PackageFile>
+): string | null {
   const constraint: string = config.compatibility?.node;
   if (constraint && validRange(constraint)) {
     logger.debug(`Using node constraint "${constraint}" from package.json`);
@@ -28,7 +30,7 @@ function getPackageJsonConstraint(config: PostUpdateConfig): string | null {
 }
 
 export async function getNodeConstraint(
-  config: PostUpdateConfig
+  config: PostUpdateConfig | Partial<PackageFile>
 ): Promise<string> | null {
   const { packageFile } = config;
   const constraint =

--- a/lib/manager/npm/post-update/npm.spec.ts
+++ b/lib/manager/npm/post-update/npm.spec.ts
@@ -187,4 +187,28 @@ describe('generateLockFile', () => {
     expect(res.lockFile).toEqual('package-lock-contents');
     expect(execSnapshots).toMatchSnapshot();
   });
+  it('uses compatibility from the packageFile', async () => {
+    const execSnapshots = mockExecAll(exec);
+    fs.readFile = jest.fn(() => 'package-lock-contents') as never;
+    const config = {
+      dockerMapDotfiles: true,
+      skipInstalls: true,
+      compatibility: { npm: '^6.0.0' },
+    };
+    const updates = [
+      { depName: 'some-dep', toVersion: '1.0.1', isLockfileUpdate: false },
+    ];
+    const res = await npmHelper.generateLockFile(
+      'some-dir',
+      {},
+      'package-lock.json',
+      config,
+      updates,
+      { ...config }
+    );
+    expect(fs.readFile).toHaveBeenCalledTimes(1);
+    expect(res.error).toBeUndefined();
+    expect(res.lockFile).toEqual('package-lock-contents');
+    expect(execSnapshots).toMatchSnapshot();
+  });
 });

--- a/lib/manager/npm/post-update/pnpm.spec.ts
+++ b/lib/manager/npm/post-update/pnpm.spec.ts
@@ -62,4 +62,14 @@ describe('generateLockFile', () => {
     expect(res.lockFile).toEqual('package-lock-contents');
     expect(execSnapshots).toMatchSnapshot();
   });
+  it('uses compatibility from the packageFile', async () => {
+    const execSnapshots = mockExecAll(exec);
+    fs.readFile = jest.fn(() => 'package-lock-contents') as never;
+    const res = await pnpmHelper.generateLockFile('some-dir', {}, config, [], {
+      ...config,
+    });
+    expect(fs.readFile).toHaveBeenCalledTimes(1);
+    expect(res.lockFile).toEqual('package-lock-contents');
+    expect(execSnapshots).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
This PR fixes #7285 by using the correct `compatibility` from the corresponding package file when available.