### PR TITLE
feat(pypi): Add more changelogUrls for python projects

### DIFF
--- a/lib/datasource/metadata.ts
+++ b/lib/datasource/metadata.ts
@@ -21,7 +21,8 @@ const manualChangelogUrls = {
   },
   pypi: {
     alembic: 'https://alembic.sqlalchemy.org/en/latest/changelog.html',
-    beautifulsoup4: 'https://bazaar.launchpad.net/~leonardr/beautifulsoup/bs4/view/head:/CHANGELOG',
+    beautifulsoup4:
+      'https://bazaar.launchpad.net/~leonardr/beautifulsoup/bs4/view/head:/CHANGELOG',
     django: 'https://github.com/django/django/tree/master/docs/releases',
     djangorestframework:
       'https://www.django-rest-framework.org/community/release-notes/',
@@ -36,7 +37,8 @@ const manualChangelogUrls = {
       'https://github.com/daviddrysdale/python-phonenumbers/blob/dev/python/HISTORY.md',
     psycopg2: 'http://initd.org/psycopg/articles/tag/release/',
     'psycopg2-binary': 'http://initd.org/psycopg/articles/tag/release/',
-    pycountry: 'https://github.com/flyingcircusio/pycountry/blob/master/HISTORY.txt',
+    pycountry:
+      'https://github.com/flyingcircusio/pycountry/blob/master/HISTORY.txt',
     'django-debug-toolbar':
       'https://django-debug-toolbar.readthedocs.io/en/latest/changes.html',
     'firebase-admin':

--- a/lib/datasource/metadata.ts
+++ b/lib/datasource/metadata.ts
@@ -20,20 +20,30 @@ const manualChangelogUrls = {
       'https://github.com/angular/angular/blob/master/packages/zone.js/CHANGELOG.md',
   },
   pypi: {
+    alembic: 'https://alembic.sqlalchemy.org/en/latest/changelog.html',
+    beautifulsoup4: 'https://bazaar.launchpad.net/~leonardr/beautifulsoup/bs4/view/head:/CHANGELOG',
     django: 'https://github.com/django/django/tree/master/docs/releases',
     djangorestframework:
       'https://www.django-rest-framework.org/community/release-notes/',
     flake8: 'http://flake8.pycqa.org/en/latest/release-notes/index.html',
     'django-storages':
       'https://github.com/jschneier/django-storages/blob/master/CHANGELOG.rst',
+    hypothesis:
+      'https://github.com/HypothesisWorks/hypothesis/blob/master/hypothesis-python/docs/changes.rst',
+    lxml: 'https://git.launchpad.net/lxml/plain/CHANGES.txt',
+    mypy: 'https://mypy-lang.blogspot.com/',
     phonenumbers:
       'https://github.com/daviddrysdale/python-phonenumbers/blob/dev/python/HISTORY.md',
+    psycopg2: 'http://initd.org/psycopg/articles/tag/release/',
     'psycopg2-binary': 'http://initd.org/psycopg/articles/tag/release/',
+    pycountry: 'https://github.com/flyingcircusio/pycountry/blob/master/HISTORY.txt',
     'django-debug-toolbar':
       'https://django-debug-toolbar.readthedocs.io/en/latest/changes.html',
     'firebase-admin':
       'https://firebase.google.com/support/release-notes/admin/python',
     requests: 'https://github.com/psf/requests/blob/master/HISTORY.md',
+    sqlalchemy: 'https://docs.sqlalchemy.org/en/latest/changelog/',
+    uwsgi: 'https://uwsgi-docs.readthedocs.io/en/latest/#release-notes'
     wagtail: 'https://github.com/wagtail/wagtail/tree/master/docs/releases',
   },
   docker: {

--- a/lib/datasource/metadata.ts
+++ b/lib/datasource/metadata.ts
@@ -43,7 +43,7 @@ const manualChangelogUrls = {
       'https://firebase.google.com/support/release-notes/admin/python',
     requests: 'https://github.com/psf/requests/blob/master/HISTORY.md',
     sqlalchemy: 'https://docs.sqlalchemy.org/en/latest/changelog/',
-    uwsgi: 'https://uwsgi-docs.readthedocs.io/en/latest/#release-notes'
+    uwsgi: 'https://uwsgi-docs.readthedocs.io/en/latest/#release-notes',
     wagtail: 'https://github.com/wagtail/wagtail/tree/master/docs/releases',
   },
   docker: {


### PR DESCRIPTION
Add more changelogUrls for python projects to make renovate MRs more informative.

Note that I haven't tested it. 

I don't know if for launchpad tracker (beautifulsoup4) the proposed link is the best one or if `https://bazaar.launchpad.net/~leonardr/beautifulsoup/bs4/download/head:/CHANGELOG` would be a better fit.

<!-- Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App: https://cla-assistant.io/renovatebot/renovate -->

<!-- When creating this PR on GitHub, please ensure `Allow edits from maintainers.` checkbox is checked -->

<!-- Please use a conventional commit message (https://www.conventionalcommits.org/en/v1.0.0/) as your PR title -->

<!-- Ideally include at least one sentence saying what this PR achieves -->

<!-- Finish the PR with `Closes #` and then the issue number if it closes any associated issue -->
