### PR TITLE
fix(npm): merge compatibility in generateBranchConfig

### DIFF
--- a/lib/workers/repository/updates/__snapshots__/generate.spec.ts.snap
+++ b/lib/workers/repository/updates/__snapshots__/generate.spec.ts.snap
@@ -13,6 +13,7 @@ Object {
   "branchName": "some-branch",
   "canBeUnpublished": false,
   "commitMessage": "",
+  "compatibility": Object {},
   "depName": "some-dep",
   "dependencyDashboardApproval": false,
   "dependencyDashboardPrApproval": false,
@@ -73,6 +74,7 @@ Object {
 | ---------- | --------------- | ----- | ----- |
 | npm        | @types/some-dep | 0.5.7 | 0.5.8 |
 ",
+  "compatibility": Object {},
   "datasource": "npm",
   "depName": "some-dep",
   "dependencyDashboardApproval": false,

--- a/lib/workers/repository/updates/generate.spec.ts
+++ b/lib/workers/repository/updates/generate.spec.ts
@@ -74,6 +74,9 @@ describe('workers/repository/updates/generate', () => {
           releaseTimestamp: '2017-02-07T20:01:41+00:00',
           canBeUnpublished: false,
           automerge: true,
+          compatibility: {
+            foo: 'bar',
+          },
         },
         {
           depName: 'some-other-dep',
@@ -99,6 +102,7 @@ describe('workers/repository/updates/generate', () => {
       expect(res.releaseTimestamp).toEqual('2017-02-07T20:01:41+00:00');
       expect(res.canBeUnpublished).toBe(true);
       expect(res.automerge).toBe(false);
+      expect(res.compatibility).toEqual({ foo: 'bar' });
     });
     it('groups multiple upgrades different version', () => {
       const branch = [

--- a/lib/workers/repository/updates/generate.spec.ts
+++ b/lib/workers/repository/updates/generate.spec.ts
@@ -75,11 +75,32 @@ describe('workers/repository/updates/generate', () => {
           canBeUnpublished: false,
           automerge: true,
           compatibility: {
-            foo: 'bar',
+            foo: '1.0.0',
           },
         },
         {
           depName: 'some-other-dep',
+          groupName: 'some-group',
+          branchName: 'some-branch',
+          prTitle: 'some-title',
+          commitMessageExtra:
+            'to {{#if isMajor}}v{{newMajor}}{{else}}{{#unless isRange}}v{{/unless}}{{newValue}}{{/if}}',
+          foo: 1,
+          newValue: '5.1.2',
+          toVersion: '5.1.2',
+          group: {
+            foo: 2,
+          },
+          releaseTimestamp: '2017-02-06T20:01:41+00:00',
+          canBeUnpublished: true,
+          automerge: false,
+          compatibility: {
+            foo: '1.0.0',
+            bar: '2.0.0',
+          },
+        },
+        {
+          depName: 'another-dep',
           groupName: 'some-group',
           branchName: 'some-branch',
           prTitle: 'some-title',
@@ -102,7 +123,10 @@ describe('workers/repository/updates/generate', () => {
       expect(res.releaseTimestamp).toEqual('2017-02-07T20:01:41+00:00');
       expect(res.canBeUnpublished).toBe(true);
       expect(res.automerge).toBe(false);
-      expect(res.compatibility).toEqual({ foo: 'bar' });
+      expect(res.compatibility).toEqual({
+        foo: '1.0.0',
+        bar: '2.0.0',
+      });
     });
     it('groups multiple upgrades different version', () => {
       const branch = [

--- a/lib/workers/repository/updates/generate.ts
+++ b/lib/workers/repository/updates/generate.ts
@@ -304,6 +304,10 @@ export function generateBranchConfig(
   config.blockedByPin = config.upgrades.every(
     (upgrade) => upgrade.blockedByPin
   );
+  config.compatibility = Object.assign(
+    {},
+    ...config.upgrades.map((upgrade) => upgrade.compatibility)
+  );
   const tableRows = config.upgrades
     .map((upgrade) => getTableValues(upgrade))
     .filter(Boolean);


### PR DESCRIPTION
This PR fixes #7285 by merging `compatibility` in `generateBranchConfig`.

Example: https://github.com/ylemkimon/test-renovate/pull/21 -> https://github.com/ylemkimon/test-renovate/pull/29

Alternative to closes #7270.