### PR TITLE
feat(preset): add the `formatjs` monorepo

### DIFF
--- a/lib/config/presets/internal/monorepo.ts
+++ b/lib/config/presets/internal/monorepo.ts
@@ -61,6 +61,7 @@ const repoGroups = {
   expo: 'https://github.com/expo/expo',
   fimbullinter: 'https://github.com/fimbullinter/wotan',
   flopflip: 'https://github.com/tdeekens/flopflip',
+  formatjs: 'https://github.com/formatjs/formatjs',
   framework7: 'https://github.com/framework7io/framework7',
   gatsby: 'https://github.com/gatsbyjs/gatsby',
   graphqlcodegenerator: [


### PR DESCRIPTION
Adds the [`formatjs` monorepo](https://github.com/formatjs/formatjs) to group `react-intl`, `@formatjs/*`, etc. together.

Closes #7292 

