### PR TITLE
feat: extractVersion

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -387,6 +387,51 @@ The above would mean Renovate would not include files matching the above glob pa
 
 See [shareable config presets](https://docs.renovatebot.com/config-presets) for details.
 
+## extractVersion
+
+Use this only when the raw version strings from the datasource do not match the expected format that you need in your package file. You must defined a "named capture group" called `version` as shown in the below examples.
+
+For example, to extract only the major.minor precision from a GitHub release, the following would work:
+
+```json
+{
+  "packageRules": [
+    {
+      "packageNames": ["foo"],
+      "extractVersion": "^(?<version>v\\d+\\.\\d+)"
+    }
+  ]
+}
+```
+
+The above will change a raw version of `v1.31.5` to `v1.31`, for example.
+
+Alternatively, to strip a `release-` prefix:
+
+```json
+{
+  "packageRules": [
+    {
+      "packageNames": ["bar"],
+      "extractVersion": "^release-(?<version>.*)$"
+    }
+  ]
+}
+```
+
+The above will change a raw version of `release-2.0.0` to `2.0.0`, for example. A similar one could strip leading `v` prefixes:
+
+```json
+{
+  "packageRules": [
+    {
+      "packageNames": ["baz"],
+      "extractVersion": "^v(?<version>.*)$"
+    }
+  ]
+}
+```
+
 ## fileMatch
 
 `fileMatch` is used by Renovate to know which files in a repository to parse and extract, and it is possible to override defaults values to customize for your project's needs.

--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -705,6 +705,15 @@ const options: RenovateOptions[] = [
     env: false,
   },
   {
+    name: 'extractVersion',
+    description:
+      "A regex (re2) to extract a version from a datasource's raw version string",
+    type: 'string',
+    format: 'regex',
+    cli: false,
+    env: false,
+  },
+  {
     name: 'versioning',
     description: 'versioning to use for filtering and comparisons',
     type: 'string',

--- a/lib/datasource/common.ts
+++ b/lib/datasource/common.ts
@@ -25,6 +25,7 @@ export interface GetPkgReleasesConfig extends ReleasesConfigBase {
   depName: string;
   lookupName?: string;
   versioning?: string;
+  extractVersion?: string;
 }
 
 export function isGetPkgReleasesConfig(

--- a/lib/datasource/index.spec.ts
+++ b/lib/datasource/index.spec.ts
@@ -102,6 +102,19 @@ describe('datasource/index', () => {
     expect(res.changelogUrl).toBeDefined();
     expect(res.sourceUrl).toBeDefined();
   });
+  it('applies extractVersion', async () => {
+    npmDatasource.getReleases.mockResolvedValue({
+      releases: [{ version: 'v1.0.0' }, { version: 'v1.0.1' }],
+    });
+    const res = await datasource.getPkgReleases({
+      datasource: datasourceNpm.id,
+      depName: 'react-native',
+      extractVersion: '^(?<version>v\\d+\\.\\d+)',
+      versioning: 'loose',
+    });
+    expect(res.releases).toHaveLength(1);
+    expect(res.releases[0].version).toEqual('v1.0');
+  });
   it('adds sourceUrl', async () => {
     npmDatasource.getReleases.mockResolvedValue({
       releases: [{ version: '1.0.0' }],

--- a/lib/datasource/index.spec.ts
+++ b/lib/datasource/index.spec.ts
@@ -104,7 +104,11 @@ describe('datasource/index', () => {
   });
   it('applies extractVersion', async () => {
     npmDatasource.getReleases.mockResolvedValue({
-      releases: [{ version: 'v1.0.0' }, { version: 'v1.0.1' }],
+      releases: [
+        { version: 'v1.0.0' },
+        { version: 'v1.0.1' },
+        { version: 'v2' },
+      ],
     });
     const res = await datasource.getPkgReleases({
       datasource: datasourceNpm.id,


### PR DESCRIPTION
Adds a new option extractVersion which allows for extracting a substring of raw versions from datasources, to be used as the actual version.

Closes #7297, Closes #6793