### PR TITLE
fix(rubygems): support base paths in registryUrls

### DIFF
--- a/lib/datasource/rubygems/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/rubygems/__snapshots__/index.spec.ts.snap
@@ -51,7 +51,7 @@ Array [
       "user-agent": "https://github.com/renovatebot/renovate",
     },
     "method": "GET",
-    "url": "https://firstparty.com/api/v1/gems/rails.json",
+    "url": "https://firstparty.com/basepath/api/v1/gems/rails.json",
   },
 ]
 `;
@@ -93,7 +93,7 @@ Array [
       "user-agent": "https://github.com/renovatebot/renovate",
     },
     "method": "GET",
-    "url": "https://firstparty.com/api/v1/gems/rails.json",
+    "url": "https://firstparty.com/basepath/api/v1/gems/rails.json",
   },
 ]
 `;
@@ -2502,7 +2502,7 @@ Array [
       "user-agent": "https://github.com/renovatebot/renovate",
     },
     "method": "GET",
-    "url": "https://firstparty.com/api/v1/gems/rails.json",
+    "url": "https://firstparty.com/basepath/api/v1/gems/rails.json",
   },
   Object {
     "headers": Object {
@@ -2513,7 +2513,7 @@ Array [
       "user-agent": "https://github.com/renovatebot/renovate",
     },
     "method": "GET",
-    "url": "https://firstparty.com/api/v1/versions/rails.json",
+    "url": "https://firstparty.com/basepath/api/v1/versions/rails.json",
   },
 ]
 `;

--- a/lib/datasource/rubygems/get.ts
+++ b/lib/datasource/rubygems/get.ts
@@ -1,7 +1,7 @@
 import { OutgoingHttpHeaders } from 'http';
+import urlJoin from 'url-join';
 import { logger } from '../../logger';
 import { Http } from '../../util/http';
-import { ensureTrailingSlash } from '../../util/url';
 import { ReleaseResult } from '../common';
 import { id } from './common';
 
@@ -21,11 +21,10 @@ export async function fetch(
 ): Promise<any> {
   const headers = getHeaders();
 
-  const name = `${path}/${dependency}.json`;
-  const baseUrl = ensureTrailingSlash(registry);
+  const url = urlJoin(registry, path, `${dependency}.json`);
 
-  logger.trace({ dependency }, `RubyGems lookup request: ${baseUrl} ${name}`);
-  const response = (await http.getJson(name, { baseUrl, headers })) || {
+  logger.trace({ dependency }, `RubyGems lookup request: ${url}`);
+  const response = (await http.getJson(url, { headers })) || {
     body: undefined,
   };
 

--- a/lib/datasource/rubygems/index.spec.ts
+++ b/lib/datasource/rubygems/index.spec.ts
@@ -33,7 +33,10 @@ describe('datasource/rubygems', () => {
       versioning: rubyVersioning.id,
       datasource: rubygems.id,
       depName: 'rails',
-      registryUrls: ['https://thirdparty.com', 'https://firstparty.com'],
+      registryUrls: [
+        'https://thirdparty.com',
+        'https://firstparty.com/basepath/',
+      ],
     };
 
     beforeEach(() => {
@@ -51,7 +54,7 @@ describe('datasource/rubygems', () => {
     it('returns null for missing pkg', async () => {
       httpMock
         .scope('https://firstparty.com')
-        .get('/api/v1/gems/rails.json')
+        .get('/basepath/api/v1/gems/rails.json')
         .reply(200, null);
       httpMock
         .scope('https://thirdparty.com')
@@ -141,9 +144,9 @@ describe('datasource/rubygems', () => {
         .reply(401);
       httpMock
         .scope('https://firstparty.com/')
-        .get('/api/v1/gems/rails.json')
+        .get('/basepath/api/v1/gems/rails.json')
         .reply(200, railsInfo)
-        .get('/api/v1/versions/rails.json')
+        .get('/basepath/api/v1/versions/rails.json')
         .reply(200, railsVersions);
 
       const res = await getPkgReleases(params);
@@ -159,7 +162,7 @@ describe('datasource/rubygems', () => {
         .reply(200, { ...railsInfo, name: 'oooops' });
       httpMock
         .scope('https://firstparty.com/')
-        .get('/api/v1/gems/rails.json')
+        .get('/basepath/api/v1/gems/rails.json')
         .reply(200, null);
       expect(await getPkgReleases(params)).toBeNull();
       expect(httpMock.getTrace()).toMatchSnapshot();

--- a/package.json
+++ b/package.json
@@ -167,6 +167,7 @@
     "toml": "3.0.0",
     "traverse": "0.6.6",
     "upath": "1.2.0",
+    "url-join": "4.0.1",
     "validate-npm-package-name": "3.0.0",
     "www-authenticate": "0.6.2",
     "xmldoc": "1.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7708,7 +7708,6 @@ npm@^6.13.0:
     cmd-shim "^3.0.3"
     columnify "~1.5.4"
     config-chain "^1.1.12"
-    debuglog "*"
     detect-indent "~5.0.0"
     detect-newline "^2.1.0"
     dezalgo "~1.0.3"
@@ -7723,7 +7722,6 @@ npm@^6.13.0:
     has-unicode "~2.0.1"
     hosted-git-info "^2.8.8"
     iferr "^1.0.2"
-    imurmurhash "*"
     infer-owner "^1.0.4"
     inflight "~1.0.6"
     inherits "^2.0.4"
@@ -7742,14 +7740,8 @@ npm@^6.13.0:
     libnpx "^10.2.4"
     lock-verify "^2.1.0"
     lockfile "^1.0.4"
-    lodash._baseindexof "*"
     lodash._baseuniq "~4.6.0"
-    lodash._bindcallback "*"
-    lodash._cacheindexof "*"
-    lodash._createcache "*"
-    lodash._getnative "*"
     lodash.clonedeep "~4.5.0"
-    lodash.restparam "*"
     lodash.union "~4.6.0"
     lodash.uniq "~4.5.0"
     lodash.without "~4.4.0"
@@ -10625,7 +10617,7 @@ urix@^0.1.0:
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
-url-join@^4.0.0:
+url-join@4.0.1, url-join@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/url-join/-/url-join-4.0.1.tgz#b642e21a2646808ffa178c4c5fda39844e12cde7"
   integrity sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==


### PR DESCRIPTION
Uses `url-join` package for joining baseUrl with path because Node's `URL.join` ignores paths in the baseUrl.

Closes #7315
