### PR TITLE
feat: fallback to info version when version endpoint fails

### DIFF
--- a/lib/datasource/rubygems/get.ts
+++ b/lib/datasource/rubygems/get.ts
@@ -52,7 +52,7 @@ export async function getDependency(
 
   const versions = (await fetch(dependency, registry, VERSIONS_PATH)) || [];
 
-  const releases = versions.map(
+  let releases = versions.map(
     ({
       number: version,
       platform: rubyPlatform,
@@ -67,6 +67,19 @@ export async function getDependency(
       rubyVersion,
     })
   );
+
+  if (versions.length === 0 && info.version) {
+    logger.warn('falling back to using the info version');
+    releases = [
+      {
+        version: info.version,
+        rubyPlatform: info.platform,
+        releaseTimestamp: null,
+        rubyVersion: null,
+        rubygemsVersion: '\u003e= 0',
+      },
+    ];
+  }
 
   return {
     releases,


### PR DESCRIPTION
when the version endpoint fails use the single version from the info endpoint.
This occurs for example when using artifactory.

<!-- Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App: https://cla-assistant.io/renovatebot/renovate -->

<!-- When creating this PR on GitHub, please ensure `Allow edits from maintainers.` checkbox is checked -->

<!-- Please use a conventional commit message (https://www.conventionalcommits.org/en/v1.0.0/) as your PR title -->

<!-- Ideally include at least one sentence saying what this PR achieves -->

<!-- Finish the PR with `Closes #` and then the issue number if it closes any associated issue -->

Closes #7320 