### PR TITLE
fix(group/glimmer): Fix `glimmer` grouping config

### DIFF
--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -123,8 +123,14 @@ const staticGroups = {
     packagePatterns: ['^fusion-plugin-*', '^fusion-react*', '^fusion-apollo*'],
   },
   glimmer: {
-    description: 'Glimmer.js packages',
-    packageNames: ['@glimmer/component', '@glimmer/tracking'],
+    description: 'Group Glimmer.js packages together',
+    packageRules: [
+      {
+        groupName: 'Glimmer.js packages',
+        groupSlug: 'glimmer',
+        packageNames: ['@glimmer/component', '@glimmer/tracking'],
+      },
+    ],
   },
   illuminate: {
     description: 'Group PHP illuminate packages together',


### PR DESCRIPTION
I was confused by the potentially also broken `fusionjs` group when I first implemented this. As it turns out the config should include the `packageRules` key... 😅

<!-- Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App: https://cla-assistant.io/renovatebot/renovate -->

<!-- When creating this PR on GitHub, please ensure `Allow edits from maintainers.` checkbox is checked -->

<!-- Please use a conventional commit message (https://www.conventionalcommits.org/en/v1.0.0/) as your PR title -->

<!-- Ideally include at least one sentence saying what this PR achieves -->

<!-- Finish the PR with `Closes #` and then the issue number if it closes any associated issue -->
