### PR TITLE
feat: Add bumpVersion to gradle manager

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -203,7 +203,7 @@ This is an advance field and it's recommend you seek a config review before appl
 
 ## bumpVersion
 
-Currently this setting supports `helmv3` and `npm` only, so raise a feature request if you have a use for it with other package managers.
+Currently this setting supports `helmv3`, `gradle`, and `npm` only, so raise a feature request if you have a use for it with other package managers.
 Its purpose is if you want Renovate to update the `version` field within your file's `package.json` any time it updates dependencies within.
 Usually this is for automatic release purposes, so that you don't need to add another step after Renovate before you can release a new version.
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -204,6 +204,7 @@ This is an advance field and it's recommend you seek a config review before appl
 ## bumpVersion
 
 Currently this setting supports `helmv3`, `gradle`, and `npm` only, so raise a feature request if you have a use for it with other package managers.
+
 Its purpose is if you want Renovate to update the `version` field within your file's `package.json` any time it updates dependencies within.
 Usually this is for automatic release purposes, so that you don't need to add another step after Renovate before you can release a new version.
 

--- a/lib/manager/gradle/__fixtures__/build.gradle.example2
+++ b/lib/manager/gradle/__fixtures__/build.gradle.example2
@@ -1,0 +1,90 @@
+buildscript {
+    ext {
+        springBootVersion = '1.5.2.RELEASE'
+    }
+    repositories {
+        maven {
+           url "https://plugins.gradle.org/m2/"
+        }
+        mavenCentral()
+        jcenter()
+    }
+    dependencies {
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
+        classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.3'
+        classpath 'com.fkorotkov:gradle-libraries-plugin:0.1'
+        classpath "gradle.plugin.se.patrikerdes:gradle-use-latest-versions-plugin:0.2.3"
+        classpath 'org.apache.openjpa:openjpa:3.1.1'
+    }
+}
+
+configurations {
+    integration
+    integrationCompile.extendsFrom testCompile
+    integrationRuntime.extendsFrom testRuntime
+}
+
+apply plugin: 'groovy'
+apply plugin: 'idea'
+apply plugin: 'eclipse'
+apply plugin: 'org.springframework.boot'
+apply plugin: "com.github.ben-manes.versions"
+apply plugin: 'com.fkorotkov.libraries'
+apply plugin: 'se.patrikerdes.use-latest-versions'
+
+jar {
+    baseName = 'base'
+}
+
+sourceCompatibility = 1.8
+
+version = '0.0.1'
+
+sourceSets {
+    integration {
+        compileClasspath += main.output + test.output
+        runtimeClasspath += main.output + test.output
+
+        groovy.srcDir file('src/test/integration/groovy')
+    }
+}
+
+idea {
+    module {
+        scopes.TEST.plus = [configurations.integration]
+    }
+}
+repositories {
+    mavenCentral()
+}
+
+
+dependencies {
+    compile('org.springframework.boot:spring-boot-starter-jersey') {
+        exclude module: "spring-boot-starter-tomcat"
+    }
+
+    compile("org.springframework.boot:spring-boot-starter-jetty")
+
+    //compile('org.codehaus.groovy:groovy:2.4.9')
+    testCompile('org.springframework.boot:spring-boot-starter-test')
+    compile("org.grails:gorm-hibernate5-spring-boot:6.0.9.RELEASE")
+    runtime('mysql:mysql-connector-java:6.0.5')
+
+    testCompile 'org.spockframework:spock-spring:1.0-groovy-2.4'
+    // optional dependencies for using Spock
+    testCompile "org.hamcrest:hamcrest-core:1.3" // only necessary if Hamcrest matchers are used
+    testRuntime "cglib:cglib-nodep:3.1" // allows mocking of classes (in addition to interfaces)
+
+    dependency 'org.apache.openjpa:openjpa:3.1.1'
+}
+
+task integration(type: Test) {
+    testClassesDir = sourceSets.integration.output.classesDir
+    classpath = sourceSets.integration.runtimeClasspath
+
+    // This is not needed, but I like to see which tests have run
+    testLogging {
+        events "passed", "skipped", "failed"
+    }
+}

--- a/lib/manager/gradle/__fixtures__/minimal-project-with-version/build.gradle
+++ b/lib/manager/gradle/__fixtures__/minimal-project-with-version/build.gradle
@@ -1,0 +1,13 @@
+plugins {
+  id 'java'
+}
+
+repositories {
+  jcenter()
+}
+
+version = '1.2.3'
+
+dependencies {
+  implementation 'org.apache.commons:commons-collections4:4.4'
+}

--- a/lib/manager/gradle/__fixtures__/minimal-project-with-version/settings.gradle
+++ b/lib/manager/gradle/__fixtures__/minimal-project-with-version/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'minimal-test-with-version'

--- a/lib/manager/gradle/__fixtures__/updatesReportWithVersion.json
+++ b/lib/manager/gradle/__fixtures__/updatesReportWithVersion.json
@@ -1,0 +1,47 @@
+[
+  {
+    "project": "telegram-images",
+    "version": "1.2.3",
+    "repositories": [
+      "https://repo.maven.apache.org/maven2/",
+      "https://jitpack.io"
+    ],
+    "dependencies": [
+      {
+        "name": "spring-boot-starter-jersey",
+        "group": "org.springframework.boot",
+        "version": null
+      },
+      {
+        "name": "spock-core",
+        "group": "org.spockframework",
+        "version": "1.0-groovy-2.4"
+      },
+      {
+        "name": "cglib-nodep",
+        "group": "cglib",
+        "version": "3.1"
+      },
+      {
+        "name": "scala-library",
+        "group": "org.scala-lang",
+        "version": "%scala-version%"
+      },
+      {
+        "name": "scala-logging_%%",
+        "group": "com.typesafe.scala-logging",
+        "version": "3.9.0"
+      },
+      {
+        "name": "foo",
+        "group": "foo",
+        "version": null
+      },
+      {
+        "name": "bar",
+        "group": "bar",
+        "version": null
+      }
+    ]
+  }
+]

--- a/lib/manager/gradle/__snapshots__/gradle-updates-report.spec.ts.snap
+++ b/lib/manager/gradle/__snapshots__/gradle-updates-report.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`manager/gradle/gradle-updates-report createRenovateGradlePlugin generates a report for Gradle version 5 1`] = `
+exports[`manager/gradle/gradle-updates-report createRenovateGradlePlugin generates a report for the project minimal-project, with Gradle version 5 1`] = `
 Array [
   Object {
     "dependencies": Array [
@@ -15,11 +15,12 @@ Array [
       "https://jcenter.bintray.com/",
       "https://plugins.gradle.org/m2",
     ],
+    "version": "unspecified",
   },
 ]
 `;
 
-exports[`manager/gradle/gradle-updates-report createRenovateGradlePlugin generates a report for Gradle version 6 1`] = `
+exports[`manager/gradle/gradle-updates-report createRenovateGradlePlugin generates a report for the project minimal-project, with Gradle version 6 1`] = `
 Array [
   Object {
     "dependencies": Array [
@@ -34,6 +35,47 @@ Array [
       "https://jcenter.bintray.com/",
       "https://plugins.gradle.org/m2",
     ],
+    "version": "unspecified",
+  },
+]
+`;
+
+exports[`manager/gradle/gradle-updates-report createRenovateGradlePlugin generates a report for the project minimal-project-with-version, with Gradle version 5 1`] = `
+Array [
+  Object {
+    "dependencies": Array [
+      Object {
+        "group": "org.apache.commons",
+        "name": "commons-collections4",
+        "version": "4.4",
+      },
+    ],
+    "project": "minimal-test-with-version",
+    "repositories": Array [
+      "https://jcenter.bintray.com/",
+      "https://plugins.gradle.org/m2",
+    ],
+    "version": "1.2.3",
+  },
+]
+`;
+
+exports[`manager/gradle/gradle-updates-report createRenovateGradlePlugin generates a report for the project minimal-project-with-version, with Gradle version 6 1`] = `
+Array [
+  Object {
+    "dependencies": Array [
+      Object {
+        "group": "org.apache.commons",
+        "name": "commons-collections4",
+        "version": "4.4",
+      },
+    ],
+    "project": "minimal-test-with-version",
+    "repositories": Array [
+      "https://jcenter.bintray.com/",
+      "https://plugins.gradle.org/m2",
+    ],
+    "version": "1.2.3",
   },
 ]
 `;

--- a/lib/manager/gradle/__snapshots__/index.spec.ts.snap
+++ b/lib/manager/gradle/__snapshots__/index.spec.ts.snap
@@ -96,6 +96,114 @@ Array [
 ]
 `;
 
+exports[`manager/gradle/index extractPackageFile should include version when in the project report 1`] = `
+Array [
+  Object {
+    "datasource": "maven",
+    "deps": Array [
+      Object {
+        "currentValue": null,
+        "depGroup": "org.springframework.boot",
+        "depName": "org.springframework.boot:spring-boot-starter-jersey",
+        "name": "spring-boot-starter-jersey",
+        "registryUrls": Array [
+          "https://repo.maven.apache.org/maven2/",
+          "https://jitpack.io",
+        ],
+      },
+      Object {
+        "currentValue": "1.0-groovy-2.4",
+        "depGroup": "org.spockframework",
+        "depName": "org.spockframework:spock-core",
+        "name": "spock-core",
+        "registryUrls": Array [
+          "https://repo.maven.apache.org/maven2/",
+          "https://jitpack.io",
+        ],
+      },
+      Object {
+        "currentValue": "3.1",
+        "depGroup": "cglib",
+        "depName": "cglib:cglib-nodep",
+        "name": "cglib-nodep",
+        "registryUrls": Array [
+          "https://repo.maven.apache.org/maven2/",
+          "https://jitpack.io",
+        ],
+      },
+      Object {
+        "currentValue": "%scala-version%",
+        "depGroup": "org.scala-lang",
+        "depName": "org.scala-lang:scala-library",
+        "name": "scala-library",
+        "registryUrls": Array [
+          "https://repo.maven.apache.org/maven2/",
+          "https://jitpack.io",
+        ],
+        "skipReason": "version-placeholder",
+      },
+      Object {
+        "currentValue": "3.9.0",
+        "datasource": "sbt-package",
+        "depGroup": "com.typesafe.scala-logging",
+        "depName": "com.typesafe.scala-logging:scala-logging",
+        "name": "scala-logging_%%",
+        "registryUrls": Array [
+          "https://repo.maven.apache.org/maven2/",
+          "https://jitpack.io",
+        ],
+      },
+      Object {
+        "currentValue": "1.2.3",
+        "depGroup": "foo",
+        "depName": "foo:foo",
+        "name": "foo",
+        "registryUrls": Array [
+          "https://repo.maven.apache.org/maven2/",
+          "https://jitpack.io",
+        ],
+      },
+      Object {
+        "currentValue": "3.4.5",
+        "depGroup": "bar",
+        "depName": "bar:bar",
+        "name": "bar",
+        "registryUrls": Array [
+          "https://repo.maven.apache.org/maven2/",
+          "https://jitpack.io",
+        ],
+      },
+    ],
+    "packageFile": "build.gradle",
+    "packageJsonVersion": "1.2.3",
+  },
+]
+`;
+
+exports[`manager/gradle/index extractPackageFile should include version when in the project report 2`] = `
+Array [
+  Object {
+    "cmd": "<gradlew> --init-script renovate-plugin.gradle renovate",
+    "options": Object {
+      "cwd": "localDir",
+      "encoding": "utf-8",
+      "env": Object {
+        "GRADLE_OPTS": "-Dorg.gradle.parallel=true -Dorg.gradle.configureondemand=true -Dorg.gradle.daemon=false -Dorg.gradle.caching=false",
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 60000,
+    },
+  },
+]
+`;
+
 exports[`manager/gradle/index extractPackageFile should return empty if renovate report is invalid 1`] = `
 Array [
   Object {

--- a/lib/manager/gradle/__snapshots__/index.spec.ts.snap
+++ b/lib/manager/gradle/__snapshots__/index.spec.ts.snap
@@ -175,7 +175,7 @@ Array [
       },
     ],
     "packageFile": "build.gradle",
-    "packageJsonVersion": "1.2.3",
+    "packageFileVersion": "1.2.3",
   },
 ]
 `;

--- a/lib/manager/gradle/gradle-updates-report.spec.ts
+++ b/lib/manager/gradle/gradle-updates-report.spec.ts
@@ -25,7 +25,7 @@ describe(getName(__filename), () => {
           let workingDir: DirectoryResult;
 
           beforeEach(async () => {
-            workingDir = await tmp.dir({unsafeCleanup: true});
+            workingDir = await tmp.dir({ unsafeCleanup: true });
           });
 
           it(`generates a report for the project ${projectName}, with Gradle version ${gradleVersion}`, async () => {

--- a/lib/manager/gradle/gradle-updates-report.spec.ts
+++ b/lib/manager/gradle/gradle-updates-report.spec.ts
@@ -14,36 +14,41 @@ import { GRADLE_DEPENDENCY_REPORT_OPTIONS } from '.';
 const fixtures = 'lib/manager/gradle/__fixtures__';
 
 describe(getName(__filename), () => {
-  for (const gradleVersion of [5, 6]) {
-    ifSystemSupportsGradle(gradleVersion).describe(
-      'createRenovateGradlePlugin',
-      () => {
-        let workingDir: DirectoryResult;
+  for (const projectName of [
+    'minimal-project',
+    'minimal-project-with-version',
+  ]) {
+    for (const gradleVersion of [5, 6]) {
+      ifSystemSupportsGradle(gradleVersion).describe(
+        'createRenovateGradlePlugin',
+        () => {
+          let workingDir: DirectoryResult;
 
-        beforeEach(async () => {
-          workingDir = await tmp.dir({ unsafeCleanup: true });
-        });
-
-        it(`generates a report for Gradle version ${gradleVersion}`, async () => {
-          await fs.copy(`${fixtures}/minimal-project`, workingDir.path);
-          await fs.copy(
-            `${fixtures}/gradle-wrappers/${gradleVersion}`,
-            workingDir.path
-          );
-          await createRenovateGradlePlugin(workingDir.path);
-
-          const gradlew = upath.join(workingDir.path, 'gradlew');
-          await exec(`${gradlew} ${GRADLE_DEPENDENCY_REPORT_OPTIONS}`, {
-            cwd: workingDir.path,
-            extraEnv,
+          beforeEach(async () => {
+            workingDir = await tmp.dir({unsafeCleanup: true});
           });
-          expect(
-            fs.readJSONSync(
-              `${workingDir.path}/${GRADLE_DEPENDENCY_REPORT_FILENAME}`
-            )
-          ).toMatchSnapshot();
-        }, 120000);
-      }
-    );
+
+          it(`generates a report for the project ${projectName}, with Gradle version ${gradleVersion}`, async () => {
+            await fs.copy(`${fixtures}/${projectName}`, workingDir.path);
+            await fs.copy(
+              `${fixtures}/gradle-wrappers/${gradleVersion}`,
+              workingDir.path
+            );
+            await createRenovateGradlePlugin(workingDir.path);
+
+            const gradlew = upath.join(workingDir.path, 'gradlew');
+            await exec(`${gradlew} ${GRADLE_DEPENDENCY_REPORT_OPTIONS}`, {
+              cwd: workingDir.path,
+              extraEnv,
+            });
+            expect(
+              fs.readJSONSync(
+                `${workingDir.path}/${GRADLE_DEPENDENCY_REPORT_FILENAME}`
+              )
+            ).toMatchSnapshot();
+          }, 120000);
+        }
+      );
+    }
   }
 });

--- a/lib/manager/gradle/index.spec.ts
+++ b/lib/manager/gradle/index.spec.ts
@@ -471,7 +471,7 @@ describe(getName(__filename), () => {
         name: 'openjpa',
         version: '3.1.1',
         newValue: '3.1.2',
-        packageJsonVersion: '0.0.1',
+        packageFileVersion: '0.0.1',
         bumpVersion: 'patch',
       };
 
@@ -481,7 +481,6 @@ describe(getName(__filename), () => {
       });
 
       expect(buildGradleContent).toContain("version = '0.0.1'");
-
       expect(buildGradleContentUpdated).toContain("version = '0.0.2'");
     });
 
@@ -498,7 +497,7 @@ describe(getName(__filename), () => {
         name: 'openjpa',
         version: '3.1.1',
         newValue: '3.1.2',
-        packageJsonVersion: '0.0.1',
+        packageFileVersion: '0.0.1',
       };
 
       const buildGradleContentUpdated = manager.updateDependency({
@@ -524,7 +523,7 @@ describe(getName(__filename), () => {
         name: 'openjpa',
         version: '3.1.1',
         newValue: '3.1.2',
-        packageJsonVersion: '0.0.1',
+        packageFileVersion: '0.0.1',
         bumpVersion: 'invalid-value',
       };
 
@@ -556,7 +555,7 @@ describe(getName(__filename), () => {
         name: 'openjpa',
         version: '3.1.1',
         newValue: '3.1.2',
-        packageJsonVersion: '0.0.1-SNAPSHOT',
+        packageFileVersion: '0.0.1-SNAPSHOT',
         bumpVersion: 'invalid-value',
       };
 
@@ -590,7 +589,7 @@ describe(getName(__filename), () => {
         name: 'openjpa',
         version: '3.1.1',
         newValue: '3.1.2',
-        packageJsonVersion: '0.0.1',
+        packageFileVersion: '0.0.1',
         bumpVersion: 'patch',
       };
 

--- a/lib/manager/gradle/index.ts
+++ b/lib/manager/gradle/index.ts
@@ -151,7 +151,7 @@ export async function extractAllPackageFiles(
       };
 
       if (gradleProjectVersion != null) {
-        gradleFileObject.packageJsonVersion = gradleProjectVersion;
+        gradleFileObject.packageFileVersion = gradleProjectVersion;
       }
 
       gradleFiles.push(gradleFileObject);
@@ -233,7 +233,7 @@ export function updateDependency({
   return bumpPackageVersion(
     content,
     // This is a holdover from the npm bumpVersion implementation. This should either stay the same with a slightly weird name or be renamed to be more generic.
-    upgrade.packageJsonVersion,
+    upgrade.packageFileVersion,
     upgrade.bumpVersion
   );
 }


### PR DESCRIPTION
Updates the gradle manager to work with the bumpVersion configuration option. 

Even though in gradle it is possible to have the project version be an object, this assumes that the version is only configured as a
string.

I made [this test repository](https://github.com/EricLemieux/renovate-gradle-sample/pulls) in which I was testing the changes, where it appears to be working as intended.

Open questions that I have, unsure if they are blockers
* The project version field is named packageJsonVersion, should that be renamed in both npm and gradle to something more generic?
* `mirror:x` is missing, due to not having the gradle report, should I be reading off the file system again?

Closes #7214 