### PR TITLE
fix(yarn): incorrect logic around caching of locked versions

### DIFF
--- a/lib/manager/npm/extract/locked-versions.ts
+++ b/lib/manager/npm/extract/locked-versions.ts
@@ -7,7 +7,7 @@ import { getYarnLock } from './yarn';
 export async function getLockedVersions(
   packageFiles: PackageFile[]
 ): Promise<void> {
-  const lockFileCache: Record<string, Record<string, string>> = {};
+  const lockFileCache: Record<string, YarnLockCache> = {};
   logger.debug('Finding locked versions');
   for (const packageFile of packageFiles) {
     const { yarnLock, npmLock, pnpmShrinkwrap } = packageFile;
@@ -15,34 +15,42 @@ export async function getLockedVersions(
       logger.trace('Found yarnLock');
       if (!lockFileCache[yarnLock]) {
         logger.trace('Retrieving/parsing ' + yarnLock);
-        const { lockedVersions, cacheVersion, isYarn1 } = await getYarnLock(
-          yarnLock
-        );
-        lockFileCache[yarnLock] = lockedVersions;
-        if (!isYarn1) {
-          if (cacheVersion >= 6) {
-            // https://github.com/yarnpkg/berry/commit/f753790380cbda5b55d028ea84b199445129f9ba
-            packageFile.compatibility.yarn = '>= 2.2.0';
-          } else {
-            packageFile.compatibility.yarn = '>= 2.0.0';
-          }
+        lockFileCache[yarnLock] = await getYarnLock(yarnLock);
+      }
+      const { cacheVersion, isYarn1 } = lockFileCache[yarnLock];
+      if (!isYarn1) {
+        if (cacheVersion >= 6) {
+          // https://github.com/yarnpkg/berry/commit/f753790380cbda5b55d028ea84b199445129f9ba
+          packageFile.compatibility.yarn = '>= 2.2.0';
+        } else {
+          packageFile.compatibility.yarn = '>= 2.0.0';
         }
       }
       for (const dep of packageFile.deps) {
         dep.lockedVersion =
-          lockFileCache[yarnLock][`${dep.depName}@${dep.currentValue}`];
+          lockFileCache[yarnLock].lockedVersions[
+            `${dep.depName}@${dep.currentValue}`
+          ];
       }
     } else if (npmLock) {
       logger.debug('Found ' + npmLock + ' for ' + packageFile.packageFile);
       if (!lockFileCache[npmLock]) {
         logger.trace('Retrieving/parsing ' + npmLock);
-        lockFileCache[npmLock] = await getNpmLock(npmLock);
+        lockFileCache[npmLock] = { lockedVersions: await getNpmLock(npmLock) };
       }
       for (const dep of packageFile.deps) {
-        dep.lockedVersion = valid(lockFileCache[npmLock][dep.depName]);
+        dep.lockedVersion = valid(
+          lockFileCache[npmLock].lockedVersions[dep.depName]
+        );
       }
     } else if (pnpmShrinkwrap) {
       logger.debug('TODO: implement pnpm-lock.yaml parsing of lockVersion');
     }
   }
+}
+
+interface YarnLockCache {
+  lockedVersions: Record<string, string>;
+  cacheVersion?: number;
+  isYarn1?: boolean;
 }


### PR DESCRIPTION
The issue is that the compatibility was only being set for the first `package.json` that was detected, due to how this if/else statement was constructed. 
                                                   https://github.com/renovatebot/renovate/blob/1b99f4f0f7011f48b90250540c2b60cf2b1c9d20/lib/manager/npm/extract/locked-versions.ts#L16-L30

`isYarn1`, and the following logic, was only being executed if the lockfile was _not_ found in the cache.