### PR TITLE
feat: kustomize: support `newName` in `image`

### DIFF
--- a/lib/manager/kustomize/__fixtures__/gitImages.yaml
+++ b/lib/manager/kustomize/__fixtures__/gitImages.yaml
@@ -15,3 +15,6 @@ images:
   newTag: v0.0.2
 - name: gitlab.com/org/suborg/image
   newTag: v0.0.3
+- name: this-lives/on-docker-hub
+  newName: but.this.lives.on.local/private-registry # and therefore we need to check the versions available here
+  newTag: v0.0.4

--- a/lib/manager/kustomize/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/kustomize/__snapshots__/extract.spec.ts.snap
@@ -99,5 +99,11 @@ Array [
     "depName": "gitlab.com/org/suborg/image",
     "lookupName": "gitlab.com/org/suborg/image",
   },
+  Object {
+    "currentValue": "v0.0.4",
+    "datasource": "docker",
+    "depName": "but.this.lives.on.local/private-registry",
+    "lookupName": "but.this.lives.on.local/private-registry",
+  },
 ]
 `;

--- a/lib/manager/kustomize/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/kustomize/__snapshots__/extract.spec.ts.snap
@@ -79,31 +79,26 @@ Array [
     "currentValue": "v0.1.0",
     "datasource": "docker",
     "depName": "node",
-    "lookupName": "node",
   },
   Object {
     "currentValue": "v0.0.1",
     "datasource": "docker",
     "depName": "group/instance",
-    "lookupName": "group/instance",
   },
   Object {
     "currentValue": "v0.0.2",
     "datasource": "docker",
     "depName": "quay.io/test/repo",
-    "lookupName": "quay.io/test/repo",
   },
   Object {
     "currentValue": "v0.0.3",
     "datasource": "docker",
     "depName": "gitlab.com/org/suborg/image",
-    "lookupName": "gitlab.com/org/suborg/image",
   },
   Object {
     "currentValue": "v0.0.4",
     "datasource": "docker",
     "depName": "but.this.lives.on.local/private-registry",
-    "lookupName": "but.this.lives.on.local/private-registry",
   },
 ]
 `;

--- a/lib/manager/kustomize/extract.spec.ts
+++ b/lib/manager/kustomize/extract.spec.ts
@@ -130,10 +130,9 @@ describe('manager/kustomize/extract', () => {
         currentValue: 'v1.0.0',
         datasource: datasourceDocker.id,
         depName: 'node',
-        lookupName: 'node',
       };
       const pkg = extractImage({
-        name: sample.lookupName,
+        name: sample.depName,
         newTag: sample.currentValue,
       });
       expect(pkg).toEqual(sample);
@@ -143,10 +142,9 @@ describe('manager/kustomize/extract', () => {
         currentValue: 'v1.0.0',
         datasource: datasourceDocker.id,
         depName: 'test/node',
-        lookupName: 'test/node',
       };
       const pkg = extractImage({
-        name: sample.lookupName,
+        name: sample.depName,
         newTag: sample.currentValue,
       });
       expect(pkg).toEqual(sample);
@@ -156,10 +154,9 @@ describe('manager/kustomize/extract', () => {
         currentValue: 'v1.0.0',
         datasource: datasourceDocker.id,
         depName: 'quay.io/repo/image',
-        lookupName: 'quay.io/repo/image',
       };
       const pkg = extractImage({
-        name: sample.lookupName,
+        name: sample.depName,
         newTag: sample.currentValue,
       });
       expect(pkg).toEqual(sample);
@@ -169,10 +166,9 @@ describe('manager/kustomize/extract', () => {
         currentValue: 'v1.0.0',
         datasource: datasourceDocker.id,
         depName: 'localhost:5000/repo/image',
-        lookupName: 'localhost:5000/repo/image',
       };
       const pkg = extractImage({
-        name: sample.lookupName,
+        name: sample.depName,
         newTag: sample.currentValue,
       });
       expect(pkg).toEqual(sample);
@@ -182,10 +178,9 @@ describe('manager/kustomize/extract', () => {
         currentValue: 'v1.0.0',
         datasource: datasourceDocker.id,
         depName: 'localhost:5000/repo/image/service',
-        lookupName: 'localhost:5000/repo/image/service',
       };
       const pkg = extractImage({
-        name: sample.lookupName,
+        name: sample.depName,
         newTag: sample.currentValue,
       });
       expect(pkg).toEqual(sample);

--- a/lib/manager/kustomize/extract.spec.ts
+++ b/lib/manager/kustomize/extract.spec.ts
@@ -222,7 +222,7 @@ describe('manager/kustomize/extract', () => {
     it('should extract out image versions', () => {
       const res = extractPackageFile(gitImages);
       expect(res.deps).toMatchSnapshot();
-      expect(res.deps).toHaveLength(4);
+      expect(res.deps).toHaveLength(5);
       expect(res.deps[0].currentValue).toEqual('v0.1.0');
       expect(res.deps[1].currentValue).toEqual('v0.0.1');
     });

--- a/lib/manager/kustomize/extract.ts
+++ b/lib/manager/kustomize/extract.ts
@@ -8,6 +8,7 @@ import { PackageDependency, PackageFile } from '../common';
 interface Image {
   name: string;
   newTag: string;
+  newName: string;
 }
 
 interface Kustomize {
@@ -65,8 +66,8 @@ export function extractImage(image: Image): PackageDependency | null {
   if (image?.name && image.newTag) {
     return {
       datasource: datasourceDocker.id,
-      depName: image.name,
-      lookupName: image.name,
+      depName: image.newName ?? image.name,
+      lookupName: image.newName ?? image.name,
       currentValue: image.newTag,
     };
   }

--- a/lib/manager/kustomize/extract.ts
+++ b/lib/manager/kustomize/extract.ts
@@ -8,7 +8,7 @@ import { PackageDependency, PackageFile } from '../common';
 interface Image {
   name: string;
   newTag: string;
-  newName: string;
+  newName?: string;
 }
 
 interface Kustomize {

--- a/lib/manager/kustomize/extract.ts
+++ b/lib/manager/kustomize/extract.ts
@@ -67,7 +67,6 @@ export function extractImage(image: Image): PackageDependency | null {
     return {
       datasource: datasourceDocker.id,
       depName: image.newName ?? image.name,
-      lookupName: image.newName ?? image.name,
       currentValue: image.newTag,
     };
   }


### PR DESCRIPTION
kustomize allows overriding not just the version (`newTag`), but also the registry via `newName`. When a `newName` is present, k8s will look for the image in the location defined. If the overridden registry follows a different release cycle (e.g. has a delay for newly released images) - things will fail, i.e. `newTag` must be available for the `newName`, not the old `name`.

---

I didn't create an issue for this, I hope that's OK.

Tested this with our local registry - seemed to do the right thing, but please let me know if there's any additional tests that need to be added.

Possible the docs need an update - but I'm not 100% sure what exactly was the intent of the note included at the moment.