### PR TITLE
feat(azure): implemented azure branch status checks for automerge

### DIFF
--- a/lib/platform/azure/index.spec.ts
+++ b/lib/platform/azure/index.spec.ts
@@ -526,6 +526,18 @@ describe('platform/azure', () => {
       const res = await azure.getBranchStatus('somebranch', []);
       expect(res).toEqual(BranchStatus.yellow);
     });
+    it('should fall back to yellow if no statuses returned', async () => {
+      await initRepo({ repository: 'some/repo' });
+      azureApi.gitApi.mockImplementationOnce(
+        () =>
+          ({
+            getBranch: jest.fn(() => ({ commit: { commitId: 'abcd1234' } })),
+            getStatuses: jest.fn(() => []),
+          } as any)
+      );
+      const res = await azure.getBranchStatus('somebranch', []);
+      expect(res).toEqual(BranchStatus.yellow);
+    });
   });
 
   describe('getPr(prNo)', () => {

--- a/lib/platform/azure/index.spec.ts
+++ b/lib/platform/azure/index.spec.ts
@@ -337,75 +337,146 @@ describe('platform/azure', () => {
     });
   });
   describe('getBranchStatusCheck(branchName, context)', () => {
-    it('should return success if no statuses on the branch', async () => {
-      await initRepo({ repository: 'some/repo' });
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            getBranch: jest.fn(() => ({ commit: { commitId: 'abcd1234' } })),
-            getStatuses: jest.fn(() => []),
-          } as any)
-      );
-      const res = await azure.getBranchStatusCheck('somebranch', 'context');
-      expect(res).toEqual(BranchStatus.green);
-    });
-    it('should return success if all statuses on the branch are succeeding', async () => {
-      await initRepo({ repository: 'some/repo' });
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            getBranch: jest.fn(() => ({ commit: { commitId: 'abcd1234' } })),
-            getStatuses: jest.fn(() => [{ state: GitStatusState.Succeeded }]),
-          } as any)
-      );
-      const res = await azure.getBranchStatusCheck('somebranch', 'context');
-      expect(res).toEqual(BranchStatus.green);
-    });
-    it('should return failed if any statuses on the branch are failing', async () => {
+    it('should return green if status is succeeded', async () => {
       await initRepo({ repository: 'some/repo' });
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
             getBranch: jest.fn(() => ({ commit: { commitId: 'abcd1234' } })),
             getStatuses: jest.fn(() => [
-              { state: GitStatusState.Succeeded },
-              { state: GitStatusState.Failed },
+              {
+                state: GitStatusState.Succeeded,
+                context: { genre: 'a-genre', name: 'a-name' },
+              },
             ]),
           } as any)
       );
-      const res = await azure.getBranchStatusCheck('somebranch', 'context');
+      const res = await azure.getBranchStatusCheck(
+        'somebranch',
+        'a-genre/a-name'
+      );
+      expect(res).toBe(BranchStatus.green);
+    });
+
+    it('should return green if status is not applicable', async () => {
+      await initRepo({ repository: 'some/repo' });
+      azureApi.gitApi.mockImplementationOnce(
+        () =>
+          ({
+            getBranch: jest.fn(() => ({ commit: { commitId: 'abcd1234' } })),
+            getStatuses: jest.fn(() => [
+              {
+                state: GitStatusState.NotApplicable,
+                context: { genre: 'a-genre', name: 'a-name' },
+              },
+            ]),
+          } as any)
+      );
+      const res = await azure.getBranchStatusCheck(
+        'somebranch',
+        'a-genre/a-name'
+      );
+      expect(res).toBe(BranchStatus.green);
+    });
+    it('should return red if status is failed', async () => {
+      await initRepo({ repository: 'some/repo' });
+      azureApi.gitApi.mockImplementationOnce(
+        () =>
+          ({
+            getBranch: jest.fn(() => ({ commit: { commitId: 'abcd1234' } })),
+            getStatuses: jest.fn(() => [
+              {
+                state: GitStatusState.Failed,
+                context: { genre: 'a-genre', name: 'a-name' },
+              },
+            ]),
+          } as any)
+      );
+      const res = await azure.getBranchStatusCheck(
+        'somebranch',
+        'a-genre/a-name'
+      );
+      expect(res).toBe(BranchStatus.red);
+    });
+    it('should return red if context status is error', async () => {
+      await initRepo({ repository: 'some/repo' });
+      azureApi.gitApi.mockImplementationOnce(
+        () =>
+          ({
+            getBranch: jest.fn(() => ({ commit: { commitId: 'abcd1234' } })),
+            getStatuses: jest.fn(() => [
+              {
+                state: GitStatusState.Error,
+                context: { genre: 'a-genre', name: 'a-name' },
+              },
+            ]),
+          } as any)
+      );
+      const res = await azure.getBranchStatusCheck(
+        'somebranch',
+        'a-genre/a-name'
+      );
       expect(res).toEqual(BranchStatus.red);
     });
-    it('should return failed if any statuses on the branch are error', async () => {
+    it('should return yellow if status is pending', async () => {
       await initRepo({ repository: 'some/repo' });
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
             getBranch: jest.fn(() => ({ commit: { commitId: 'abcd1234' } })),
             getStatuses: jest.fn(() => [
-              { state: GitStatusState.Succeeded },
-              { state: GitStatusState.Error },
+              {
+                state: GitStatusState.Pending,
+                context: { genre: 'a-genre', name: 'a-name' },
+              },
             ]),
           } as any)
       );
-      const res = await azure.getBranchStatusCheck('somebranch', 'context');
-      expect(res).toEqual(BranchStatus.red);
+      const res = await azure.getBranchStatusCheck(
+        'somebranch',
+        'a-genre/a-name'
+      );
+      expect(res).toBe(BranchStatus.yellow);
     });
-    it('should return pending if not all statuses on the branch are succeeding but no error or failures', async () => {
+    it('should return yellow if status is not set', async () => {
       await initRepo({ repository: 'some/repo' });
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
             getBranch: jest.fn(() => ({ commit: { commitId: 'abcd1234' } })),
             getStatuses: jest.fn(() => [
-              { state: GitStatusState.Succeeded },
-              { state: GitStatusState.Pending },
-              { state: GitStatusState.NotSet },
+              {
+                state: GitStatusState.NotSet,
+                context: { genre: 'a-genre', name: 'a-name' },
+              },
             ]),
           } as any)
       );
-      const res = await azure.getBranchStatusCheck('somebranch', 'context');
-      expect(res).toEqual(BranchStatus.yellow);
+      const res = await azure.getBranchStatusCheck(
+        'somebranch',
+        'a-genre/a-name'
+      );
+      expect(res).toBe(BranchStatus.yellow);
+    });
+    it('should return null if status not found', async () => {
+      await initRepo({ repository: 'some/repo' });
+      azureApi.gitApi.mockImplementationOnce(
+        () =>
+          ({
+            getBranch: jest.fn(() => ({ commit: { commitId: 'abcd1234' } })),
+            getStatuses: jest.fn(() => [
+              {
+                state: GitStatusState.Pending,
+                context: { genre: 'another-genre', name: 'a-name' },
+              },
+            ]),
+          } as any)
+      );
+      const res = await azure.getBranchStatusCheck(
+        'somebranch',
+        'a-genre/a-name'
+      );
+      expect(res).toBeNull();
     });
   });
   describe('getBranchStatus(branchName, requiredStatusChecks)', () => {
@@ -866,18 +937,71 @@ describe('platform/azure', () => {
     });
   });
 
-  describe('Not supported by Azure DevOps (yet!)', () => {
-    it('setBranchStatus', async () => {
-      const res = await azure.setBranchStatus({
+  describe('setBranchStatus', () => {
+    it('should build and call the create status api properly', async () => {
+      await initRepo({ repository: 'some/repo' });
+      const createCommitStatusMock = jest.fn();
+      azureApi.gitApi.mockImplementationOnce(
+        () =>
+          ({
+            getBranch: jest.fn(() => ({ commit: { commitId: 'abcd1234' } })),
+            createCommitStatus: createCommitStatusMock,
+          } as any)
+      );
+      await azure.setBranchStatus({
         branchName: 'test',
         context: 'test',
         description: 'test',
         state: BranchStatus.yellow,
-        url: 'test',
+        url: 'test.com',
       });
-      expect(res).toBeUndefined();
+      expect(createCommitStatusMock).toHaveBeenCalledWith(
+        {
+          context: {
+            genre: undefined,
+            name: 'test',
+          },
+          description: 'test',
+          state: GitStatusState.Pending,
+          targetUrl: 'test.com',
+        },
+        'abcd1234',
+        '1'
+      );
     });
-
+    it('should build and call the create status api properly with a complex context', async () => {
+      await initRepo({ repository: 'some/repo' });
+      const createCommitStatusMock = jest.fn();
+      azureApi.gitApi.mockImplementationOnce(
+        () =>
+          ({
+            getBranch: jest.fn(() => ({ commit: { commitId: 'abcd1234' } })),
+            createCommitStatus: createCommitStatusMock,
+          } as any)
+      );
+      await azure.setBranchStatus({
+        branchName: 'test',
+        context: 'renovate/artifact/test',
+        description: 'test',
+        state: BranchStatus.green,
+        url: 'test.com',
+      });
+      expect(createCommitStatusMock).toHaveBeenCalledWith(
+        {
+          context: {
+            genre: 'renovate/artifact',
+            name: 'test',
+          },
+          description: 'test',
+          state: GitStatusState.Succeeded,
+          targetUrl: 'test.com',
+        },
+        'abcd1234',
+        '1'
+      );
+    });
+  });
+  describe('Not supported by Azure DevOps (yet!)', () => {
     it('mergePr', async () => {
       const res = await azure.mergePr(0, undefined);
       expect(res).toBe(false);

--- a/lib/platform/azure/index.ts
+++ b/lib/platform/azure/index.ts
@@ -293,7 +293,7 @@ async function getStatusCheck(branchName: string): Promise<GitStatus[]> {
     getBranchNameWithoutRefsheadsPrefix(branchName)
   );
   // only grab the latest statuses, it will group any by context
-  const statuses = await azureApiGit.getStatuses(
+  return await azureApiGit.getStatuses(
     branch.commit.commitId,
     config.repoId,
     undefined,
@@ -301,7 +301,6 @@ async function getStatusCheck(branchName: string): Promise<GitStatus[]> {
     undefined,
     true
   );
-  return statuses;
 }
 
 const azureToRenovateStatusMapping: Record<GitStatusState, BranchStatus> = {

--- a/lib/platform/azure/index.ts
+++ b/lib/platform/azure/index.ts
@@ -567,6 +567,9 @@ export async function setBranchStatus({
   state,
   url: targetUrl,
 }: BranchStatusConfig): Promise<void> {
+  logger.debug(
+    `setBranchStatus(${branchName}, ${context}, ${description}, ${state}, ${targetUrl})`
+  );
   const azureApiGit = await azureApi.gitApi();
   const branch = await azureApiGit.getBranch(
     config.repoId,
@@ -583,9 +586,7 @@ export async function setBranchStatus({
     branch.commit.commitId,
     config.repoId
   );
-  logger.debug(
-    `setBranchStatus(${branchName}, ${context}, ${description}, ${state}, ${targetUrl}) - Not supported by Azure DevOps (yet!)`
-  );
+  logger.trace(`Created commit status of ${state} on branch ${branchName}`);
 }
 
 export function mergePr(pr: number, branchName: string): Promise<boolean> {

--- a/lib/platform/azure/index.ts
+++ b/lib/platform/azure/index.ts
@@ -278,7 +278,7 @@ async function getStatusCheck(branchName: string): Promise<GitStatus[]> {
     getBranchNameWithoutRefsheadsPrefix(branchName)
   );
   // only grab the latest statuses, it will group any by context
-  return await azureApiGit.getStatuses(
+  return azureApiGit.getStatuses(
     branch.commit.commitId,
     config.repoId,
     undefined,

--- a/lib/platform/azure/util.spec.ts
+++ b/lib/platform/azure/util.spec.ts
@@ -1,5 +1,7 @@
 import {
   getBranchNameWithoutRefsheadsPrefix,
+  getGitStatusContextCombinedName,
+  getGitStatusContextFromCombinedName,
   getNewBranchName,
   getRenovatePRFormat,
 } from './util';
@@ -13,6 +15,59 @@ describe('platform/azure/helpers', () => {
     it('should be the same', () => {
       const res = getNewBranchName('refs/heads/testBB');
       expect(res).toBe(`refs/heads/testBB`);
+    });
+  });
+
+  describe('getGitStatusContextCombinedName', () => {
+    it('should return undefined if null context passed', () => {
+      const contextName = getGitStatusContextCombinedName(null);
+      expect(contextName).toBeUndefined();
+    });
+    it('should combine valid genre and name with slash', () => {
+      const contextName = getGitStatusContextCombinedName({
+        genre: 'my-genre',
+        name: 'status-name',
+      });
+      expect(contextName).toMatch('my-genre/status-name');
+    });
+    it('should combine valid empty genre and name without a slash', () => {
+      const contextName = getGitStatusContextCombinedName({
+        genre: undefined,
+        name: 'status-name',
+      });
+      expect(contextName).toMatch('status-name');
+    });
+  });
+
+  describe('getGitStatusContextFromCombinedName', () => {
+    it('should return undefined if null context passed', () => {
+      const context = getGitStatusContextFromCombinedName(null);
+      expect(context).toBeUndefined();
+    });
+    it('should parse valid genre and name with slash', () => {
+      const context = getGitStatusContextFromCombinedName(
+        'my-genre/status-name'
+      );
+      expect(context).toEqual({
+        genre: 'my-genre',
+        name: 'status-name',
+      });
+    });
+    it('should parse valid genre and name with multiple slashes', () => {
+      const context = getGitStatusContextFromCombinedName(
+        'my-genre/sub-genre/status-name'
+      );
+      expect(context).toEqual({
+        genre: 'my-genre/sub-genre',
+        name: 'status-name',
+      });
+    });
+    it('should parse valid empty genre and name without a slash', () => {
+      const context = getGitStatusContextFromCombinedName('status-name');
+      expect(context).toEqual({
+        genre: undefined,
+        name: 'status-name',
+      });
     });
   });
 

--- a/lib/platform/azure/util.ts
+++ b/lib/platform/azure/util.ts
@@ -1,5 +1,6 @@
 import {
   GitPullRequest,
+  GitStatusContext,
   PullRequestAsyncStatus,
   PullRequestStatus,
 } from 'azure-devops-node-api/interfaces/GitInterfaces';
@@ -12,6 +13,38 @@ export function getNewBranchName(branchName?: string): string {
     return `refs/heads/${branchName}`;
   }
   return branchName;
+}
+
+export function getGitStatusContextCombinedName(
+  context: GitStatusContext
+): string | undefined {
+  if (!context) {
+    return undefined;
+  }
+  const combinedName = `${context.genre ? `${context.genre}/` : ''}${
+    context.name
+  }`;
+  logger.trace(`Got combined context name of ${combinedName}`);
+  return combinedName;
+}
+
+export function getGitStatusContextFromCombinedName(
+  context: string
+): GitStatusContext | undefined {
+  if (!context) {
+    return undefined;
+  }
+  let name = context;
+  let genre;
+  const lastSlash = context.lastIndexOf('/');
+  if (lastSlash > 0) {
+    name = context.substr(lastSlash + 1);
+    genre = context.substr(0, lastSlash);
+  }
+  return {
+    genre,
+    name,
+  };
 }
 
 export function getBranchNameWithoutRefsheadsPrefix(


### PR DESCRIPTION
Implemented checks for branch statuses for azure, using the latest branch gitStatusState to determine if it's pending, failing or successful. This is required to properly automerge, as it was always pending prior.
Added tests for scenarios with various results and updated relevant existing tests.

Closes #7392

<!-- Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App: https://cla-assistant.io/renovatebot/renovate -->

<!-- When creating this PR on GitHub, please ensure `Allow edits from maintainers.` checkbox is checked -->

<!-- Please use a conventional commit message (https://www.conventionalcommits.org/en/v1.0.0/) as your PR title -->

<!-- Ideally include at least one sentence saying what this PR achieves -->

<!-- Finish the PR with `Closes #` and then the issue number if it closes any associated issue -->
