### PR TITLE
feat: check for dot platform org preset when onboarding

### DIFF
--- a/docs/usage/config-presets.md
+++ b/docs/usage/config-presets.md
@@ -180,6 +180,18 @@ The answer is to host your preset using GitHub or GitLab - not npmjs - and make 
 
 Have you configured a rule that you think others might benefit from? Please consider contributing it to the [Renovate](https://github.com/renovatebot/renovate) repository so that it gains higher visibility and saves others from reinventing the same thing.
 
-## Organisation level presets
+## Organization level presets
 
-When repository onboarding happens, if a repository called `renovate-config` exists under the same organization and contains a default Renovate preset, that repository will be suggested as the the sole extended preset, and any existing `onboardingConfig` config will be ignored/overriden. This allows for a seamless onboarding workflow with your own organization settings.
+Whenever repository onboarding happens, Renovate checks if the current user/group/org contains a default config to extend. It looks for:
+
+- A repository called `renovate-config` under the same user/group/org with either `default.json` or `renovate.json`, or
+- A repository named like `.{{platform}}` (e.g. `.github`) under the same user/group/org with `renovate-config.json`
+
+If found, that repository's preset will be suggested as the the sole extended preset, and any existing `onboardingConfig` config will be ignored/overriden. For example the result may be:
+
+```json
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["local>renovate-tests/.github:renovate-config"]
+}
+```

--- a/docs/usage/config-presets.md
+++ b/docs/usage/config-presets.md
@@ -192,6 +192,6 @@ If found, that repository's preset will be suggested as the the sole extended pr
 ```json
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>renovate-tests/.github:renovate-config"]
+  "extends": ["local>myorgname/.github:renovate-config"]
 }
 ```

--- a/lib/workers/repository/onboarding/branch/config.spec.ts
+++ b/lib/workers/repository/onboarding/branch/config.spec.ts
@@ -13,14 +13,27 @@ describe('workers/repository/onboarding/branch', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     config = getConfig();
+    config.platform = 'github';
     config.repository = 'some/repo';
   });
   describe('getOnboardingConfig', () => {
     it('handles finding an organization preset', async () => {
+      mockedPresets.getPreset.mockResolvedValueOnce({ enabled: true });
       onboardingConfig = await getOnboardingConfig(config);
       expect(mockedPresets.getPreset).toHaveBeenCalledTimes(1);
       expect(JSON.parse(onboardingConfig).extends[0]).toEqual(
         'local>some/renovate-config'
+      );
+    });
+    it('handles finding an organization dot platform preset', async () => {
+      mockedPresets.getPreset.mockRejectedValueOnce(
+        new Error(PRESET_DEP_NOT_FOUND)
+      );
+      mockedPresets.getPreset.mockResolvedValueOnce({ enabled: true });
+      onboardingConfig = await getOnboardingConfig(config);
+      expect(mockedPresets.getPreset).toHaveBeenCalledTimes(2);
+      expect(JSON.parse(onboardingConfig).extends[0]).toEqual(
+        'local>some/.github:renovate'
       );
     });
     it('handles not finding an organization preset', async () => {
@@ -28,7 +41,7 @@ describe('workers/repository/onboarding/branch', () => {
         new Error(PRESET_DEP_NOT_FOUND)
       );
       onboardingConfig = await getOnboardingConfig(config);
-      expect(mockedPresets.getPreset).toHaveBeenCalledTimes(1);
+      expect(mockedPresets.getPreset).toHaveBeenCalledTimes(2);
       expect(JSON.parse(onboardingConfig)).toEqual(config.onboardingConfig);
     });
     it('ignores an unknown error', async () => {
@@ -36,7 +49,7 @@ describe('workers/repository/onboarding/branch', () => {
         new Error('unknown error for test')
       );
       onboardingConfig = await getOnboardingConfig(config);
-      expect(mockedPresets.getPreset).toHaveBeenCalledTimes(1);
+      expect(mockedPresets.getPreset).toHaveBeenCalledTimes(2);
       expect(JSON.parse(onboardingConfig)).toEqual(config.onboardingConfig);
     });
   });

--- a/lib/workers/repository/onboarding/branch/config.spec.ts
+++ b/lib/workers/repository/onboarding/branch/config.spec.ts
@@ -33,7 +33,7 @@ describe('workers/repository/onboarding/branch', () => {
       onboardingConfig = await getOnboardingConfig(config);
       expect(mockedPresets.getPreset).toHaveBeenCalledTimes(2);
       expect(JSON.parse(onboardingConfig).extends[0]).toEqual(
-        'local>some/.github:renovate'
+        'local>some/.github:renovate-config'
       );
     });
     it('handles not finding an organization preset', async () => {

--- a/lib/workers/repository/onboarding/branch/config.ts
+++ b/lib/workers/repository/onboarding/branch/config.ts
@@ -28,6 +28,19 @@ export async function getOnboardingConfig(
     }
   }
 
+  if (!orgPreset) {
+    // Check for org/.{{platform}}
+    try {
+      const orgDotPlatformConfig = `local>${orgName}/.${config.platform}:renovate`;
+      await getPreset(orgDotPlatformConfig, config);
+      orgPreset = orgDotPlatformConfig;
+    } catch (err) {
+      if (err.message !== PRESET_DEP_NOT_FOUND) {
+        logger.warn({ err }, 'Unknown error fetching default owner preset');
+      }
+    }
+  }
+
   if (orgPreset) {
     onboardingConfig = {
       $schema: 'https://docs.renovatebot.com/renovate-schema.json',

--- a/lib/workers/repository/onboarding/branch/config.ts
+++ b/lib/workers/repository/onboarding/branch/config.ts
@@ -31,7 +31,7 @@ export async function getOnboardingConfig(
   if (!orgPreset) {
     // Check for org/.{{platform}}
     try {
-      const orgDotPlatformConfig = `local>${orgName}/.${config.platform}:renovate`;
+      const orgDotPlatformConfig = `local>${orgName}/.${config.platform}:renovate-config`;
       await getPreset(orgDotPlatformConfig, config);
       orgPreset = orgDotPlatformConfig;
     } catch (err) {


### PR DESCRIPTION
Checks for a renovate.json file in a repo like org/.github and uses it during onboarding if found.

Closes #7422