### PR TITLE
feat: add the Resilience4j libraries as a package grouping

### DIFF
--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -46,6 +46,7 @@ const staticGroups = {
       'group:illuminate',
       'group:jekyllEcosystem',
       'group:polymer',
+      'group:resilience4j',
       'group:rubyOmniauth',
       'group:socketio',
       'group:springAmqp',
@@ -194,6 +195,15 @@ const staticGroups = {
       {
         packagePatterns: ['^org.hibernate.common:'],
         groupName: 'hibernate commons',
+      },
+    ],
+  },
+  resilience4j: {
+    description: 'Group Java Resilience4j packages',
+    packageRules: [
+      {
+        packagePatterns: ['^io.github.resilience4j:'],
+        groupName: 'resilience4j',
       },
     ],
   },


### PR DESCRIPTION
<!-- Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App: https://cla-assistant.io/renovatebot/renovate -->

<!-- When creating this PR on GitHub, please ensure `Allow edits from maintainers.` checkbox is checked -->

<!-- Please use a conventional commit message (https://www.conventionalcommits.org/en/v1.0.0/) as your PR title -->

<!-- Ideally include at least one sentence saying what this PR achieves -->

<!-- Finish the PR with `Closes #` and then the issue number if it closes any associated issue -->

This adds a grouping for the [Resilience4j](https://resilience4j.readme.io) Java libraries. This library is becoming quite popular and should be versioned together. 

I tried to follow the ordering conventions of the `group.ts` file, but if I got it wrong I'm happy to adjust it.


Closes #7427