### PR TITLE
feat: find release notes for rush repos

### DIFF
--- a/lib/workers/pr/changelog/__snapshots__/release-notes.spec.ts.snap
+++ b/lib/workers/pr/changelog/__snapshots__/release-notes.spec.ts.snap
@@ -182,6 +182,32 @@ Array [
 ]
 `;
 
+exports[`workers/pr/changelog/release-notes getReleaseNotes() gets release notes with body 7`] = `
+Object {
+  "body": "some body [#123](https://github.com/some/other-repository/issues/123), [#124](https://github.com/some/yet-other-repository/issues/124)
+",
+  "id": undefined,
+  "name": undefined,
+  "tag": "other_v1.0.1",
+  "url": "https://github.com/some/other-repository/releases/other_v1.0.1",
+}
+`;
+
+exports[`workers/pr/changelog/release-notes getReleaseNotes() gets release notes with body 8`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate",
+      "host": "api.github.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://api.github.com/repos/some/other-repository/releases?per_page=100",
+  },
+]
+`;
+
 exports[`workers/pr/changelog/release-notes getReleaseNotes() gets release notes with body from gitlab repo  1`] = `null`;
 
 exports[`workers/pr/changelog/release-notes getReleaseNotes() gets release notes with body from gitlab repo  2`] = `

--- a/lib/workers/pr/changelog/release-notes.spec.ts
+++ b/lib/workers/pr/changelog/release-notes.spec.ts
@@ -146,7 +146,7 @@ describe(getName(__filename), () => {
       expect(res).toBeNull();
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
-    it.each([[''], ['v'], ['other-']])(
+    it.each([[''], ['v'], ['other-'], ['other_v']])(
       'gets release notes with body',
       async (prefix) => {
         httpMock

--- a/lib/workers/pr/changelog/release-notes.ts
+++ b/lib/workers/pr/changelog/release-notes.ts
@@ -96,7 +96,8 @@ export async function getReleaseNotes(
     if (
       release.tag === version ||
       release.tag === `v${version}` ||
-      release.tag === `${depName}-${version}`
+      release.tag === `${depName}-${version}` ||
+      release.tag === `${depName}_v${version}`
     ) {
       releaseNotes = release;
       releaseNotes.url = baseUrl.includes('gitlab')


### PR DESCRIPTION
Rush generates a tag in the form `my-pkg_v1.2.3` rather than `my-pkg-1.2.3`: https://github.com/microsoft/rushstack/blob/8bc97947fb607eb9c109fbc4789183493eda5f17/apps/rush-lib/src/logic/PublishUtilities.ts#L168

Example: https://github.com/mmkal/ts/releases/tag/fs-syncer_v0.2.7

So this should pick up releases generated off tags created by rush.