### PR TITLE
fix(kustomize): lookup Github dependency using HTTP

### DIFF
--- a/lib/manager/kustomize/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/kustomize/__snapshots__/extract.spec.ts.snap
@@ -6,13 +6,11 @@ Array [
     "currentValue": "v0.0.1",
     "datasource": "github-tags",
     "depName": "user/repo",
-    "depType": "github",
   },
   Object {
     "currentValue": "1.19.0",
     "datasource": "github-tags",
     "depName": "fluxcd/flux",
-    "depType": "github",
   },
 ]
 `;
@@ -24,7 +22,6 @@ Array [
     "datasource": "git-tags",
     "depName": "moredhel/remote-kustomize",
     "depNameShort": "moredhel/remote-kustomize",
-    "depType": "gitTags",
     "lookupName": "https://moredhel/remote-kustomize.git",
   },
   Object {
@@ -32,7 +29,6 @@ Array [
     "datasource": "git-tags",
     "depName": "moredhel/remote-kustomize",
     "depNameShort": "moredhel/remote-kustomize",
-    "depType": "gitTags",
     "lookupName": "https://moredhel/remote-kustomize.git",
   },
 ]
@@ -44,7 +40,6 @@ Array [
     "currentValue": "v0.0.1",
     "datasource": "github-tags",
     "depName": "moredhel/remote-kustomize",
-    "depType": "github",
   },
 ]
 `;
@@ -55,7 +50,6 @@ Array [
     "currentValue": "v2.0.0",
     "datasource": "github-tags",
     "depName": "kubernetes-sigs/kustomize",
-    "depType": "github",
   },
 ]
 `;
@@ -66,13 +60,11 @@ Array [
     "currentValue": "v0.0.1",
     "datasource": "github-tags",
     "depName": "moredhel/remote-kustomize",
-    "depType": "github",
   },
   Object {
     "currentValue": "1.19.0",
     "datasource": "github-tags",
     "depName": "fluxcd/flux",
-    "depType": "github",
   },
 ]
 `;

--- a/lib/manager/kustomize/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/kustomize/__snapshots__/extract.spec.ts.snap
@@ -22,16 +22,18 @@ Array [
   Object {
     "currentValue": "v0.0.1",
     "datasource": "git-tags",
-    "depName": "https://moredhel/remote-kustomize.git",
+    "depName": "moredhel/remote-kustomize",
+    "depNameShort": "moredhel/remote-kustomize",
     "depType": "gitTags",
     "lookupName": "https://moredhel/remote-kustomize.git",
   },
   Object {
     "currentValue": "v0.0.1",
     "datasource": "git-tags",
-    "depName": "https://moredhel/remote-kustomize.git//deploy",
+    "depName": "moredhel/remote-kustomize",
+    "depNameShort": "moredhel/remote-kustomize",
     "depType": "gitTags",
-    "lookupName": "https://moredhel/remote-kustomize.git//deploy",
+    "lookupName": "https://moredhel/remote-kustomize.git",
   },
 ]
 `;

--- a/lib/manager/kustomize/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/kustomize/__snapshots__/extract.spec.ts.snap
@@ -4,15 +4,15 @@ exports[`manager/kustomize/extract extractPackageFile() extracts http dependency
 Array [
   Object {
     "currentValue": "v0.0.1",
-    "datasource": "git-tags",
-    "depName": "github.com/user/repo//deploy",
-    "lookupName": "github.com/user/repo",
+    "datasource": "github-tags",
+    "depName": "user/repo",
+    "depType": "github",
   },
   Object {
     "currentValue": "1.19.0",
     "datasource": "github-tags",
-    "depName": "fluxcd/flux/deploy",
-    "lookupName": "fluxcd/flux",
+    "depName": "fluxcd/flux",
+    "depType": "github",
   },
 ]
 `;
@@ -23,12 +23,14 @@ Array [
     "currentValue": "v0.0.1",
     "datasource": "git-tags",
     "depName": "https://moredhel/remote-kustomize.git",
+    "depType": "gitTags",
     "lookupName": "https://moredhel/remote-kustomize.git",
   },
   Object {
     "currentValue": "v0.0.1",
     "datasource": "git-tags",
     "depName": "https://moredhel/remote-kustomize.git//deploy",
+    "depType": "gitTags",
     "lookupName": "https://moredhel/remote-kustomize.git//deploy",
   },
 ]
@@ -38,9 +40,9 @@ exports[`manager/kustomize/extract extractPackageFile() extracts ssh dependency 
 Array [
   Object {
     "currentValue": "v0.0.1",
-    "datasource": "git-tags",
-    "depName": "git@github.com:moredhel/remote-kustomize.git",
-    "lookupName": "git@github.com:moredhel/remote-kustomize.git",
+    "datasource": "github-tags",
+    "depName": "moredhel/remote-kustomize",
+    "depType": "github",
   },
 ]
 `;
@@ -49,9 +51,9 @@ exports[`manager/kustomize/extract extractPackageFile() extracts ssh dependency 
 Array [
   Object {
     "currentValue": "v2.0.0",
-    "datasource": "git-tags",
-    "depName": "git@github.com:kubernetes-sigs/kustomize.git//examples/helloWorld",
-    "lookupName": "git@github.com:kubernetes-sigs/kustomize.git",
+    "datasource": "github-tags",
+    "depName": "kubernetes-sigs/kustomize",
+    "depType": "github",
   },
 ]
 `;
@@ -60,15 +62,15 @@ exports[`manager/kustomize/extract extractPackageFile() should extract bases fro
 Array [
   Object {
     "currentValue": "v0.0.1",
-    "datasource": "git-tags",
-    "depName": "git@github.com:moredhel/remote-kustomize.git",
-    "lookupName": "git@github.com:moredhel/remote-kustomize.git",
+    "datasource": "github-tags",
+    "depName": "moredhel/remote-kustomize",
+    "depType": "github",
   },
   Object {
     "currentValue": "1.19.0",
     "datasource": "github-tags",
-    "depName": "fluxcd/flux/deploy",
-    "lookupName": "fluxcd/flux",
+    "depName": "fluxcd/flux",
+    "depType": "github",
   },
 ]
 `;

--- a/lib/manager/kustomize/extract.spec.ts
+++ b/lib/manager/kustomize/extract.spec.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'fs';
 import * as datasourceDocker from '../../datasource/docker';
+import * as datasourceGitTags from '../../datasource/git-tags';
 import * as datasourceGitHubTags from '../../datasource/github-tags';
 import * as dockerVersioning from '../../versioning/docker';
 import {
@@ -76,7 +77,32 @@ describe('manager/kustomize/extract', () => {
       const pkg = extractBase(`${base}?ref=${version}`);
       expect(pkg).toEqual(sample);
     });
-
+    it('should extract the version of a non http base', () => {
+      const pkg = extractBase(
+        'ssh://git@bitbucket.com/user/test-repo?ref=v1.2.3'
+      );
+      expect(pkg).toEqual({
+        currentValue: 'v1.2.3',
+        datasource: datasourceGitTags.id,
+        depName: 'bitbucket.com/user/test-repo',
+        depNameShort: 'user/test-repo',
+        depType: 'gitTags',
+        lookupName: 'ssh://git@bitbucket.com/user/test-repo',
+      });
+    });
+    it('should extract the version of a non http base with subdir', () => {
+      const pkg = extractBase(
+        'ssh://git@bitbucket.com/user/test-repo/subdir?ref=v1.2.3'
+      );
+      expect(pkg).toEqual({
+        currentValue: 'v1.2.3',
+        datasource: datasourceGitTags.id,
+        depName: 'bitbucket.com/user/test-repo',
+        depNameShort: 'user/test-repo',
+        depType: 'gitTags',
+        lookupName: 'ssh://git@bitbucket.com/user/test-repo',
+      });
+    });
     it('should extract out the version of an github base', () => {
       const base = 'github.com/fluxcd/flux/deploy';
       const version = 'v1.0.0';

--- a/lib/manager/kustomize/extract.spec.ts
+++ b/lib/manager/kustomize/extract.spec.ts
@@ -71,7 +71,6 @@ describe('manager/kustomize/extract', () => {
         currentValue: version,
         datasource: datasourceGitHubTags.id,
         depName: 'user/test-repo',
-        depType: 'github',
       };
 
       const pkg = extractBase(`${base}?ref=${version}`);
@@ -86,7 +85,6 @@ describe('manager/kustomize/extract', () => {
         datasource: datasourceGitTags.id,
         depName: 'bitbucket.com/user/test-repo',
         depNameShort: 'user/test-repo',
-        depType: 'gitTags',
         lookupName: 'ssh://git@bitbucket.com/user/test-repo',
       });
     });
@@ -99,7 +97,6 @@ describe('manager/kustomize/extract', () => {
         datasource: datasourceGitTags.id,
         depName: 'bitbucket.com/user/test-repo',
         depNameShort: 'user/test-repo',
-        depType: 'gitTags',
         lookupName: 'ssh://git@bitbucket.com/user/test-repo',
       });
     });
@@ -110,7 +107,6 @@ describe('manager/kustomize/extract', () => {
         currentValue: version,
         datasource: datasourceGitHubTags.id,
         depName: 'fluxcd/flux',
-        depType: 'github',
       };
 
       const pkg = extractBase(`${base}?ref=${version}`);
@@ -123,7 +119,6 @@ describe('manager/kustomize/extract', () => {
         currentValue: version,
         datasource: datasourceGitHubTags.id,
         depName: 'user/repo',
-        depType: 'github',
       };
 
       const pkg = extractBase(`${base}?ref=${version}`);
@@ -136,7 +131,6 @@ describe('manager/kustomize/extract', () => {
         currentValue: version,
         datasource: datasourceGitHubTags.id,
         depName: 'user/repo',
-        depType: 'github',
       };
 
       const pkg = extractBase(`${base}?ref=${version}`);

--- a/lib/manager/kustomize/extract.spec.ts
+++ b/lib/manager/kustomize/extract.spec.ts
@@ -1,6 +1,5 @@
 import { readFileSync } from 'fs';
 import * as datasourceDocker from '../../datasource/docker';
-import * as datasourceGitTags from '../../datasource/git-tags';
 import * as datasourceGitHubTags from '../../datasource/github-tags';
 import * as dockerVersioning from '../../versioning/docker';
 import {
@@ -69,9 +68,9 @@ describe('manager/kustomize/extract', () => {
       const version = 'v1.0.0';
       const sample = {
         currentValue: version,
-        datasource: datasourceGitTags.id,
-        depName: base,
-        lookupName: base,
+        datasource: datasourceGitHubTags.id,
+        depName: 'user/test-repo',
+        depType: 'github',
       };
 
       const pkg = extractBase(`${base}?ref=${version}`);
@@ -79,16 +78,16 @@ describe('manager/kustomize/extract', () => {
     });
 
     it('should extract out the version of an github base', () => {
-      const base = 'fluxcd/flux/deploy';
+      const base = 'github.com/fluxcd/flux/deploy';
       const version = 'v1.0.0';
       const sample = {
         currentValue: version,
         datasource: datasourceGitHubTags.id,
-        depName: base,
-        lookupName: 'fluxcd/flux',
+        depName: 'fluxcd/flux',
+        depType: 'github',
       };
 
-      const pkg = extractBase(`github.com/${base}?ref=${version}`);
+      const pkg = extractBase(`${base}?ref=${version}`);
       expect(pkg).toEqual(sample);
     });
     it('should extract out the version of a git base', () => {
@@ -96,25 +95,25 @@ describe('manager/kustomize/extract', () => {
       const version = 'v1.0.0';
       const sample = {
         currentValue: version,
-        datasource: datasourceGitTags.id,
-        depName: base,
-        lookupName: base,
+        datasource: datasourceGitHubTags.id,
+        depName: 'user/repo',
+        depType: 'github',
       };
 
       const pkg = extractBase(`${base}?ref=${version}`);
       expect(pkg).toEqual(sample);
     });
     it('should extract out the version of a git base with subdir', () => {
-      const base = 'git@github.com:user/repo.git';
+      const base = 'git@github.com:user/repo.git/subdir';
       const version = 'v1.0.0';
       const sample = {
         currentValue: version,
-        datasource: datasourceGitTags.id,
-        depName: `${base}//subdir`,
-        lookupName: base,
+        datasource: datasourceGitHubTags.id,
+        depName: 'user/repo',
+        depType: 'github',
       };
 
-      const pkg = extractBase(`${sample.depName}?ref=${version}`);
+      const pkg = extractBase(`${base}?ref=${version}`);
       expect(pkg).toEqual(sample);
     });
   });
@@ -217,8 +216,7 @@ describe('manager/kustomize/extract', () => {
       expect(res.deps).toHaveLength(2);
       expect(res.deps[0].currentValue).toEqual('v0.0.1');
       expect(res.deps[1].currentValue).toEqual('1.19.0');
-      expect(res.deps[1].depName).toEqual('fluxcd/flux/deploy');
-      expect(res.deps[1].lookupName).toEqual('fluxcd/flux');
+      expect(res.deps[1].depName).toEqual('fluxcd/flux');
     });
     it('should extract out image versions', () => {
       const res = extractPackageFile(gitImages);
@@ -240,8 +238,7 @@ describe('manager/kustomize/extract', () => {
       expect(res.deps).toHaveLength(2);
       expect(res.deps[0].currentValue).toEqual('v0.0.1');
       expect(res.deps[1].currentValue).toEqual('1.19.0');
-      expect(res.deps[1].depName).toEqual('fluxcd/flux/deploy');
-      expect(res.deps[1].lookupName).toEqual('fluxcd/flux');
+      expect(res.deps[1].depName).toEqual('fluxcd/flux');
     });
   });
 });

--- a/lib/manager/kustomize/extract.ts
+++ b/lib/manager/kustomize/extract.ts
@@ -20,7 +20,7 @@ interface Kustomize {
 
 // URL specifications should follow the hashicorp URL format
 // https://github.com/hashicorp/go-getter#url-format
-const gitUrl = /^(?:git::)?(?<url>((?:http|https|ssh):\/\/(?:.*@)?)?(?<path>([^:/]+[:/])?(?<project>[^/]+\/[^/]+)))(?<subdir>[^?]*)\?ref=(?<currentValue>.+)$/;
+const gitUrl = /^(?:git::)?(?<url>(?:(?:(?:http|https|ssh):\/\/)?(?:.*@)?)?(?<path>(?:[^:/]+[:/])?(?<project>[^/]+\/[^/]+)))(?<subdir>[^?]*)\?ref=(?<currentValue>.+)$/;
 
 export function extractBase(base: string): PackageDependency | null {
   const match = gitUrl.exec(base);
@@ -29,7 +29,7 @@ export function extractBase(base: string): PackageDependency | null {
     return null;
   }
 
-  if (match?.groups.path.includes('github.com')) {
+  if (match?.groups.path.startsWith('github.com')) {
     return {
       currentValue: match.groups.currentValue,
       datasource: datasourceGitHubTags.id,

--- a/lib/manager/kustomize/extract.ts
+++ b/lib/manager/kustomize/extract.ts
@@ -24,19 +24,20 @@ const versionMatch = /(?<basename>.*)\?ref=(?<version>.*)\s*$/;
 // extract the url from the base of a url with a subdir
 const extractUrl = /^(?<url>.*)(?:\/\/.*)$/;
 
-const githubUrl = /^github\.com\/(?<depName>(?<lookupName>[^/]+?\/[^/]+?)(?:\/[^/]+?)*)\?ref=(?<currentValue>.+)$/;
+// extract github repository information
+const githubUrl = /^.*github\.com[:/](?<project>[^/]+\/[^/]+)[^?]*\?ref=(?<currentValue>.+)$/;
 
 export function extractBase(base: string): PackageDependency | null {
   const githubMatch = githubUrl.exec(base);
 
   if (githubMatch?.groups) {
-    const { currentValue, depName, lookupName } = githubMatch.groups;
+    const project = githubMatch.groups.project.replace('.git', '').split('/');
 
     return {
+      currentValue: githubMatch.groups.currentValue,
       datasource: datasourceGitHubTags.id,
-      depName,
-      lookupName,
-      currentValue,
+      depName: `${project[0]}/${project[1]}`,
+      depType: 'github',
     };
   }
 
@@ -55,6 +56,7 @@ export function extractBase(base: string): PackageDependency | null {
     return {
       datasource: datasourceGitTags.id,
       depName: root,
+      depType: 'gitTags',
       lookupName: url,
       currentValue,
     };

--- a/lib/manager/kustomize/extract.ts
+++ b/lib/manager/kustomize/extract.ts
@@ -34,7 +34,6 @@ export function extractBase(base: string): PackageDependency | null {
       currentValue: match.groups.currentValue,
       datasource: datasourceGitHubTags.id,
       depName: match.groups.project.replace('.git', ''),
-      depType: 'github',
     };
   }
 
@@ -42,7 +41,6 @@ export function extractBase(base: string): PackageDependency | null {
     datasource: datasourceGitTags.id,
     depName: match.groups.path.replace('.git', ''),
     depNameShort: match.groups.project.replace('.git', ''),
-    depType: 'gitTags',
     lookupName: match.groups.url,
     currentValue: match.groups.currentValue,
   };


### PR DESCRIPTION
- use github-tags when the base contains github.com
- refactor to make the extractBase function more readable and adjust the regular expression to match git url

close #7455
close https://github.com/whitesource/renovate-on-prem/issues/121