### PR TITLE
feat: find release notes for lerna monorepos

### DIFF
--- a/lib/workers/pr/changelog/__snapshots__/release-notes.spec.ts.snap
+++ b/lib/workers/pr/changelog/__snapshots__/release-notes.spec.ts.snap
@@ -208,7 +208,16 @@ Array [
 ]
 `;
 
-exports[`workers/pr/changelog/release-notes getReleaseNotes() gets release notes with body 9`] = `null`;
+exports[`workers/pr/changelog/release-notes getReleaseNotes() gets release notes with body 9`] = `
+Object {
+  "body": "some body [#123](https://github.com/some/other-repository/issues/123), [#124](https://github.com/some/yet-other-repository/issues/124)
+",
+  "id": undefined,
+  "name": undefined,
+  "tag": "other@1.0.1",
+  "url": "https://github.com/some/other-repository/releases/other@1.0.1",
+}
+`;
 
 exports[`workers/pr/changelog/release-notes getReleaseNotes() gets release notes with body 10`] = `
 Array [

--- a/lib/workers/pr/changelog/__snapshots__/release-notes.spec.ts.snap
+++ b/lib/workers/pr/changelog/__snapshots__/release-notes.spec.ts.snap
@@ -208,6 +208,23 @@ Array [
 ]
 `;
 
+exports[`workers/pr/changelog/release-notes getReleaseNotes() gets release notes with body 9`] = `null`;
+
+exports[`workers/pr/changelog/release-notes getReleaseNotes() gets release notes with body 10`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate",
+      "host": "api.github.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://api.github.com/repos/some/other-repository/releases?per_page=100",
+  },
+]
+`;
+
 exports[`workers/pr/changelog/release-notes getReleaseNotes() gets release notes with body from gitlab repo  1`] = `null`;
 
 exports[`workers/pr/changelog/release-notes getReleaseNotes() gets release notes with body from gitlab repo  2`] = `

--- a/lib/workers/pr/changelog/release-notes.spec.ts
+++ b/lib/workers/pr/changelog/release-notes.spec.ts
@@ -146,7 +146,7 @@ describe(getName(__filename), () => {
       expect(res).toBeNull();
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
-    it.each([[''], ['v'], ['other-'], ['other_v']])(
+    it.each([[''], ['v'], ['other-'], ['other_v'], ['other@']])(
       'gets release notes with body',
       async (prefix) => {
         httpMock

--- a/lib/workers/pr/changelog/release-notes.ts
+++ b/lib/workers/pr/changelog/release-notes.ts
@@ -97,7 +97,8 @@ export async function getReleaseNotes(
       release.tag === version ||
       release.tag === `v${version}` ||
       release.tag === `${depName}-${version}` ||
-      release.tag === `${depName}_v${version}`
+      release.tag === `${depName}_v${version}` ||
+      release.tag === `${depName}@${version}`
     ) {
       releaseNotes = release;
       releaseNotes.url = baseUrl.includes('gitlab')


### PR DESCRIPTION
By default, `lerna publish` produces `my-pkg@1.2.3` tags. Example: https://github.com/mmkal/ts/releases/tag/expect-type%400.7.6

Fixes #6709 

Related: #7445 
