### PR TITLE
fix(nuget): fix error logging

### DIFF
--- a/lib/datasource/nuget/index.ts
+++ b/lib/datasource/nuget/index.ts
@@ -24,8 +24,8 @@ function parseRegistryUrl(
       protocolVersion = 3;
     }
     return { feedUrl: urlApi.format(parsedUrl), protocolVersion };
-  } catch (e) {
-    logger.debug({ e }, `nuget registry failure: can't parse ${registryUrl}`);
+  } catch (err) {
+    logger.debug({ err }, `nuget registry failure: can't parse ${registryUrl}`);
     return { feedUrl: registryUrl, protocolVersion: null };
   }
 }

--- a/lib/datasource/nuget/v3.ts
+++ b/lib/datasource/nuget/v3.ts
@@ -79,9 +79,9 @@ export async function getResourceUrl(
 
     await packageCache.set(cacheNamespace, resultCacheKey, serviceId, 60);
     return serviceId;
-  } catch (e) {
+  } catch (err) {
     logger.debug(
-      { e },
+      { err },
       `nuget registry failure: can't get ${resourceType} form ${url}`
     );
     return null;


### PR DESCRIPTION
just renamed the catched error from `e` to `err` to allow our error serializer do it's work.