### PR TITLE
fix: packageRules don’t match undefined depName

### DIFF
--- a/lib/util/package-rules.spec.ts
+++ b/lib/util/package-rules.spec.ts
@@ -109,6 +109,23 @@ describe('applyPackageRules()', () => {
     expect(res.x).toBeUndefined();
     expect(res.y).toBeUndefined();
   });
+  it('ignores patterns if lock file maintenance', () => {
+    const dep = {
+      enabled: true,
+      packagePatterns: ['.*'],
+      updateType: 'lockFileMaintenance' as UpdateType,
+      packageRules: [
+        {
+          excludePackagePatterns: ['^foo'],
+          enabled: false,
+        },
+      ],
+    };
+    const res = applyPackageRules(dep);
+    expect(res.enabled).toBe(true);
+    const res2 = applyPackageRules({ ...dep, depName: 'anything' });
+    expect(res2.enabled).toBe(false);
+  });
   it('matches anything if missing inclusive rules', () => {
     const config: TestConfig = {
       packageRules: [

--- a/lib/util/package-rules.ts
+++ b/lib/util/package-rules.ts
@@ -136,7 +136,7 @@ function matchesRule(inputConfig: Config, packageRule: PackageRule): boolean {
     }
     positiveMatch = true;
   }
-  if (packageNames.length || packagePatterns.length) {
+  if (depName && (packageNames.length || packagePatterns.length)) {
     let isMatch = packageNames.includes(depName);
     // name match is "or" so we check patterns if we didn't match names
     if (!isMatch) {
@@ -164,7 +164,7 @@ function matchesRule(inputConfig: Config, packageRule: PackageRule): boolean {
     }
     positiveMatch = true;
   }
-  if (excludePackagePatterns.length) {
+  if (depName && excludePackagePatterns.length) {
     let isMatch = false;
     for (const pattern of excludePackagePatterns) {
       const packageRegex = regEx(


### PR DESCRIPTION
The empty `depName` in a lockFileMaintenance update was being matched positively against packagePatterns/excludePackagePatterns

Closes #7461 

