### PR TITLE
feat: add disableTypesVSCode preset

### DIFF
--- a/lib/config/presets/internal/helpers.ts
+++ b/lib/config/presets/internal/helpers.ts
@@ -11,6 +11,15 @@ export const presets: Record<string, Preset> = {
       },
     ],
   },
+  disableTypesVSCode: {
+    description: 'Disable Renovate for <code>@types/vscode</code>.',
+    packageRules: [
+      {
+        packageNames: ['@types/vscode'],
+        enabled: false,
+      },
+    ],
+  },
   oddIsUnstable: {
     description: 'DEPRECATED: Odd version numbers are classified as unstable',
   },


### PR DESCRIPTION
Updating `@types/vscode`  alone usually doesn't make sense for VS Code extensions because it needs to be changed along with `engines/vscode`.
