### PR TITLE
fix(github-actions): disable digest pinning

### DIFF
--- a/lib/manager/github-actions/index.ts
+++ b/lib/manager/github-actions/index.ts
@@ -7,5 +7,4 @@ export { extractPackageFile, language };
 
 export const defaultConfig = {
   fileMatch: ['^\\.github/workflows/[^/]+\\.ya?ml$'],
-  pinDigests: true,
 };


### PR DESCRIPTION
Maybe we can enable pinning for docker image actions?

ref #7509