### PR TITLE
feat: reduced artifact error threshold to 2 hours

### DIFF
--- a/lib/workers/branch/index.ts
+++ b/lib/workers/branch/index.ts
@@ -422,16 +422,18 @@ export async function processBranch(
       if (config.releaseTimestamp) {
         logger.debug(`Branch timestamp: ` + config.releaseTimestamp);
         const releaseTimestamp = DateTime.fromISO(config.releaseTimestamp);
-        if (releaseTimestamp.plus({ days: 1 }) < DateTime.local()) {
+        if (releaseTimestamp.plus({ hours: 2 }) < DateTime.local()) {
           logger.debug(
-            'PR is older than a day, raise PR with lock file errors'
+            'PR is older than 2 hours, raise PR with lock file errors'
           );
         } else if (branchExists) {
           logger.debug(
-            'PR is less than a day old but branchExists so updating anyway'
+            'PR is less than 2 hours old but branchExists so updating anyway'
           );
         } else {
-          logger.debug('PR is less than a day old - raise error instead of PR');
+          logger.debug(
+            'PR is less than 2 hours old - raise error instead of PR'
+          );
           throw new Error(MANAGER_LOCKFILE_ERROR);
         }
       } else {


### PR DESCRIPTION
<!-- Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App: https://cla-assistant.io/renovatebot/renovate -->

<!-- When creating this PR on GitHub, please ensure `Allow edits from maintainers.` checkbox is checked -->

<!-- Please use a conventional commit message (https://www.conventionalcommits.org/en/v1.0.0/) as your PR title -->

<!-- Ideally include at least one sentence saying what this PR achieves -->

As discussed on the below issue, this PR reduces the time to wait before opening a failed dependency from 1 day to 2 hours. This alleviates an issue where updates to other dependencies are blocked when the failing dependency releases every day.

<!-- Finish the PR with `Closes #` and then the issue number if it closes any associated issue -->

Closes #7340 