### PR TITLE
docs: fix capitalization/style errors

### DIFF
--- a/docs/development/adding-a-package-manager.md
+++ b/docs/development/adding-a-package-manager.md
@@ -39,7 +39,7 @@ Also, if a file is passed to `extractPackageFile` which is a "false match" (e.g.
 
 You can use this function instead of `extractPackageFile` if the package manager cannot parse/extract all package files in parallel.
 
-For example, npm/yarn needs to correlate package files together for features such as Lerna and Workspaces, so it's necessary to iterate through them all together after initial parsing.
+For example, npm/Yarn needs to correlate package files together for features such as Lerna and Workspaces, so it's necessary to iterate through them all together after initial parsing.
 
 As another example, gradle needs to call a command via child process in order to extract dependencies, so that must be done first.
 

--- a/docs/development/adding-a-package-manager.md
+++ b/docs/development/adding-a-package-manager.md
@@ -41,7 +41,7 @@ You can use this function instead of `extractPackageFile` if the package manager
 
 For example, npm/Yarn needs to correlate package files together for features such as Lerna and Workspaces, so it's necessary to iterate through them all together after initial parsing.
 
-As another example, gradle needs to call a command via child process in order to extract dependencies, so that must be done first.
+As another example, Gradle needs to call a command via child process in order to extract dependencies, so that must be done first.
 
 This function takes an array of filenames as input and returns an array of filenames and dependencies as a result.
 

--- a/docs/development/local-development.md
+++ b/docs/development/local-development.md
@@ -9,12 +9,12 @@ Please submit PRs to improve it if you think anything is unclear or you can thin
 
 For local development some dependencies are required:
 
-- git
-- nodejs `>=12`
-- yarn `^1.17.0`
-- c++ compiler
-- python `^3.7`
-- java between `8` and `12`
+- Git
+- Node.js `>=12`
+- Yarn `^1.17.0`
+- C++ compiler
+- Python `^3.7`
+- Java between `8` and `12`
 
 We support Node.js versions according to the [Node.js release schedule](https://github.com/nodejs/Release#release-schedule)
 
@@ -39,7 +39,7 @@ _Windows_
 
 The following steps work to set up a brand new Windows 10 installation for developing Renovate. If you already have some components installed, you can naturally skip them.
 
-- Install [git](https://git-scm.com/downloads). Make sure you've [configured your username and email](https://git-scm.com/book/en/v2/Getting-Started-First-Time-Git-Setup).
+- Install [Git](https://git-scm.com/downloads). Make sure you've [configured your username and email](https://git-scm.com/book/en/v2/Getting-Started-First-Time-Git-Setup).
 - Install [Node.js LTS](https://nodejs.org/en/download/)
 - In an Administrator PowerShell prompt, run `npm install -global npm` and then `npm --add-python-to-path='true' --debug install --global windows-build-tools`
 - Install [Yarn](https://yarnpkg.com/lang/en/docs/install/#windows-stable)
@@ -80,7 +80,7 @@ If you will contribute to the project, you should first "fork" the main project 
 
 #### Install dependencies
 
-We use [yarn](https://github.com/yarnpkg/yarn) so run `yarn install` to install dependencies instead of `npm install`.
+We use [Yarn](https://github.com/yarnpkg/yarn) so run `yarn install` to install dependencies instead of `npm install`.
 
 #### Build Renovate
 
@@ -129,7 +129,7 @@ You can run `yarn test` locally to test your code. We test all PRs using the sam
 
 ## Jest
 
-You can run just the Jest unit tests by running `yarn jest`. You can also run just a subset of the Jest tests using file matching, e.g. `yarn jest composer` or `yarn jest workers/branch`. If you get a test failure due to a "snapshot" mismatch, and you are sure that you need to update the snapshot, then you can append `-u` to the end. e.g. `yarn jest composer -u` would update the saved Snapshots for _all_ tests in `test/manager/composer/*`.
+You can run just the Jest unit tests by running `yarn jest`. You can also run just a subset of the Jest tests using file matching, e.g. `yarn jest composer` or `yarn jest workers/branch`. If you get a test failure due to a "snapshot" mismatch, and you are sure that you need to update the snapshot, then you can append `-u` to the end. e.g. `yarn jest composer -u` would update the saved snapshots for _all_ tests in `test/manager/composer/*`.
 
 #### Prerequisites
 
@@ -149,7 +149,7 @@ Also, it can be good to submit your PR as a work in progress (WIP) without tests
 
 #### Linting and formatting
 
-We use [Prettier](https://github.com/prettier/prettier) for code formatting. If your code fails `yarn test` due to a `prettier` rule then run `yarn lint-fix` to fix it or most `eslint` errors automatically before running `yarn test` again. You usually shouldn't need to fix any prettier errors manually.
+We use [Prettier](https://github.com/prettier/prettier) for code formatting. If your code fails `yarn test` due to a `prettier` rule then run `yarn lint-fix` to fix it or most `eslint` errors automatically before running `yarn test` again. You usually shouldn't need to fix any Prettier errors manually.
 
 ## Keeping your Renovate fork up to date
 

--- a/docs/development/shareable-configs.md
+++ b/docs/development/shareable-configs.md
@@ -1,7 +1,7 @@
 # Preset configs
 
 Renovate uses the term "presets" to refer to shareable config snippets, similar
-to eslint. Unlike eslint though:
+to ESLint. Unlike ESLint though:
 
 - Presets may be as small as a list of package names, or as large as a full
   config

--- a/docs/usage/bazel.md
+++ b/docs/usage/bazel.md
@@ -5,7 +5,7 @@ description: Bazel dependencies support in Renovate
 
 # Bazel
 
-Renovate supports upgrading dependencies in bazel `WORKSPACE` files.
+Renovate supports upgrading dependencies in Bazel `WORKSPACE` files.
 
 ## How It Works
 

--- a/docs/usage/config-presets.md
+++ b/docs/usage/config-presets.md
@@ -1,6 +1,6 @@
 ---
 title: Shareable Config Presets
-description: Renovate's support for eslint-like shareable configs
+description: Renovate's support for ESLint-like shareable configs
 ---
 
 # Shareable Config Presets

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -761,7 +761,7 @@ Use this configuration option for shared config across all java projects (Gradle
 
 ## js
 
-Use this configuration option for shared config across npm/yarn/pnpm and meteor package managers.
+Use this configuration option for shared config across npm/Yarn/pnpm and meteor package managers.
 
 ## labels
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -899,7 +899,7 @@ Important to know: Renovate will evaluate all `packageRules` and not stop once i
 
 ### allowedVersions
 
-Use this - usually within a packageRule - to limit how far to upgrade a dependency. For example, if you wish to upgrade to angular v1.5 but not to `angular` v1.6 or higher, you could define this to be `<= 1.5` or `< 1.6.0`:
+Use this - usually within a packageRule - to limit how far to upgrade a dependency. For example, if you wish to upgrade to Angular v1.5 but not to `angular` v1.6 or higher, you could define this to be `<= 1.5` or `< 1.6.0`:
 
 ```json
 {
@@ -1523,11 +1523,11 @@ Technical details: We mostly rely on the text parsing of the library [later](htt
 
 ## semanticCommitScope
 
-By default you will see angular-style commit prefixes like `"chore(deps):"`. If you wish to change it to something else like `"package"` then it will look like `"chore(package):"`. You can also use `parentDir` or `baseDir` to namespace your commits for monorepos e.g. `"{{parentDir}}"`.
+By default you will see Angular-style commit prefixes like `"chore(deps):"`. If you wish to change it to something else like `"package"` then it will look like `"chore(package):"`. You can also use `parentDir` or `baseDir` to namespace your commits for monorepos e.g. `"{{parentDir}}"`.
 
 ## semanticCommitType
 
-By default you will see angular-style commit prefixes like `"chore(deps):"`. If you wish to change it to something else like "ci" then it will look like `"ci(deps):"`.
+By default you will see Angular-style commit prefixes like `"chore(deps):"`. If you wish to change it to something else like "ci" then it will look like `"ci(deps):"`.
 
 ## semanticCommits
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -653,7 +653,7 @@ Enable got [http2](https://github.com/sindresorhus/got/blob/v11.5.2/readme.md#ht
 
 Warning: Advanced config, use at own risk.
 
-Enable this option to allow Renovate to connect to an [insecure docker registry](https://docs.docker.com/registry/insecure/) that is http only. This is insecure and is not recommended.
+Enable this option to allow Renovate to connect to an [insecure Docker registry](https://docs.docker.com/registry/insecure/) that is http only. This is insecure and is not recommended.
 
 Example:
 
@@ -1152,7 +1152,7 @@ Add to this object if you wish to define rules that apply only to PRs that pin d
 
 ## pinDigests
 
-If enabled Renovate will pin docker images by means of their sha256 digest and not only by tag so that they are immutable.
+If enabled Renovate will pin Docker images by means of their SHA256 digest and not only by tag so that they are immutable.
 
 ## postUpdateOptions
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -734,7 +734,7 @@ It would take the entire `"config:base"` preset - which contains a lot of sub-pr
 
 ## ignoreScripts
 
-Applicable for npm and composer only for now. Set this to `true` if running scripts causes problems.
+Applicable for npm and Composer only for now. Set this to `true` if running scripts causes problems.
 
 ## ignoreUnstable
 

--- a/docs/usage/configure-renovate.md
+++ b/docs/usage/configure-renovate.md
@@ -29,7 +29,7 @@ Alternatively, if you prefer to use "dot files" then you can add the same JSON c
 
 Most of the settings in the `renovate.json` onboarding configuration are defaults, however usually this configuration file will have some default overrides in it, such as:
 
-- Automatically enabling angular-style semantic commits if your repository uses them
+- Automatically enabling Angular-style semantic commits if your repository uses them
 - Determining whether to use dependency range pinning depending on the detected project type
 
 ## Common Overrides

--- a/docs/usage/dependency-pinning.md
+++ b/docs/usage/dependency-pinning.md
@@ -151,9 +151,9 @@ But certainly "does it give a false sense of security" is not a question we can 
 
 We recommend:
 
-1.  Any apps (web or node.js) that aren't `require()`'d by other packages should pin all types of dependencies for greatest reliability/predictability.
+1.  Any apps (web or Node.js) that aren't `require()`'d by other packages should pin all types of dependencies for greatest reliability/predictability.
 2.  Browser or dual browser/node.js libraries that are consumed/`required()`'d by others should keep using semver ranges for `dependencies` but can use pinned dependencies for `devDependencies`.
-3.  Node.js-only libraries can consider pinning all dependencies, because application size/duplicate dependencies are not as much a concern in node.js compared to the browser. Of course, don't do that if your library is a micro one likely to be consumed in disk-sensitive environments.
+3.  Node.js-only libraries can consider pinning all dependencies, because application size/duplicate dependencies are not as much a concern in Node.js compared to the browser. Of course, don't do that if your library is a micro one likely to be consumed in disk-sensitive environments.
 4.  Use a lock file.
 
 As noted earlier, when you pin dependencies then you will see an increase in the raw volume of dependency updates, compared to if you use ranges. If/when this starts bothering you, add Renovate rules to reduce the volume, such as scheduling updates, grouping them, or automerging "safe" ones.

--- a/docs/usage/docker.md
+++ b/docs/usage/docker.md
@@ -146,7 +146,7 @@ module.exports = {
 };
 ```
 
-It is possible to add additional host rules following the [documentation](https://docs.renovatebot.com/configuration-options/#hostrules). For example if you have some images you host yourself that are password protected and also some images you pull from Docker hub without authentication then you can configure for a specific Docker host like this:
+It is possible to add additional host rules following the [documentation](https://docs.renovatebot.com/configuration-options/#hostrules). For example if you have some images you host yourself that are password protected and also some images you pull from Docker Hub without authentication then you can configure for a specific Docker host like this:
 
 ```js
 module.exports = {

--- a/docs/usage/docker.md
+++ b/docs/usage/docker.md
@@ -61,11 +61,11 @@ Finally, if you use a Docker image that follows a versioning approach not captur
 
 ## Digest Pinning
 
-Pinning your docker images to an exact digest is recommended for reasons of **immutability**. In short: pin to digests so every time you `pull`, you get the same content.
+Pinning your Docker images to an exact digest is recommended for reasons of **immutability**. In short: pin to digests so every time you `pull`, you get the same content.
 
 If your experience with dependency versioning comes from a place like JavaScript/npm, you might be used to exact versions being immutable, e.g. if you specify a version like `2.0.1` then you and your colleagues will always get the exact same "code". What you may not expect is that Docker's tags are not immutable versions even if they look like a version. e.g. you probably expect that `node:8` and `node:8.9` will change over time, but you might incorrectly assume that `node:8.9.0` would never change. Although it probably _shouldn't_, the reality is that any Docker image tag _can_ change content, and potentially break.
 
-Using a docker digest as the image's primary identifier instead of docker tag will achieve immutability but as a human it's quite inconvenient to deal with strings like `FROM node@sha256:552348163f074034ae75643c01e0ba301af936a898d778bb4fc16062917d0430`. The good news is that, as a human you no longer need to manually update such digests once you have Renovate on the job.
+Using a Docker digest as the image's primary identifier instead of Docker tag will achieve immutability but as a human it's quite inconvenient to deal with strings like `FROM node@sha256:552348163f074034ae75643c01e0ba301af936a898d778bb4fc16062917d0430`. The good news is that, as a human you no longer need to manually update such digests once you have Renovate on the job.
 
 Also, to retain some human-friendliness, Renovate will actually retain the tag in the `FROM` line too, e.g. `FROM node:8@sha256:552348163f074034ae75643c01e0ba301af936a898d778bb4fc16062917d0430`. Read on to see how Renovate keeps it up-to-date.
 
@@ -85,7 +85,7 @@ Thanks to this, you may wish to change the way you tag your image dependencies t
 
 Currently, Renovate will upgrade minor/patch versions (e.g. from `8.9.0` to `8.9.1`) by default, but not upgrade major versions. If you wish to enable major versions then add the preset `docker:enableMajor` to your `extends` array in your `renovate.json`.
 
-Renovate has a some docker-specific intelligence when it comes to versions. For example:
+Renovate has a some Docker-specific intelligence when it comes to versions. For example:
 
 ## Configuring/Disabling
 
@@ -146,7 +146,7 @@ module.exports = {
 };
 ```
 
-It is possible to add additional host rules following the [documentation](https://docs.renovatebot.com/configuration-options/#hostrules). For example if you have some images you host yourself that are password protected and also some images you pull from docker hub without authentication then you can configure for a specific Docker host like this:
+It is possible to add additional host rules following the [documentation](https://docs.renovatebot.com/configuration-options/#hostrules). For example if you have some images you host yourself that are password protected and also some images you pull from Docker hub without authentication then you can configure for a specific Docker host like this:
 
 ```js
 module.exports = {

--- a/docs/usage/javascript.md
+++ b/docs/usage/javascript.md
@@ -1,6 +1,6 @@
 ---
 title: JavaScript
-description: JavaScript (npm/yarn) Package Manager Support in Renovate
+description: JavaScript (npm/Yarn) Package Manager Support in Renovate
 ---
 
 # JavaScript

--- a/docs/usage/modules/manager.md
+++ b/docs/usage/modules/manager.md
@@ -91,4 +91,4 @@ If you want to limit Renovate to only one or a small number of managers, you can
 }
 ```
 
-The above would then result in all other managers being disabled, including Bundler, Composer, Docker Composer, etc.
+The above would then result in all other managers being disabled, including Bundler, Composer, Docker Compose, etc.

--- a/docs/usage/node.md
+++ b/docs/usage/node.md
@@ -1,6 +1,6 @@
 ---
 title: Node.js Versions
-description: Node versions support in Renovate
+description: Node.js versions support in Renovate
 ---
 
 # Node.js Versions

--- a/docs/usage/noise-reduction.md
+++ b/docs/usage/noise-reduction.md
@@ -26,7 +26,7 @@ You may wish to take this further, for example you might want to group together 
   ]
 ```
 
-By setting `packagePatterns` to "eslint", it means that any package with eslint anywhere in its name will be grouped into a `renovate/eslint` branch and related PR.
+By setting `packagePatterns` to "eslint", it means that any package with ESLint anywhere in its name will be grouped into a `renovate/eslint` branch and related PR.
 
 **Caution**: Any time you group dependencies together, you naturally increase the chance that the branch will have an error ("break" your build). When you have more than one package upgrade in a PR, it's going to take you longer to work out which one broke than if they were all in separate PRs. Also, you will be held up upgrading all those dependencies until they all pass. If you weren't grouping, then you could keep upgrading all dependencies except the one that fails, instead of being held up. You will also have less flexibility about what to do when one or more in the group have a major upgrade and may break the others.
 

--- a/docs/usage/noise-reduction.md
+++ b/docs/usage/noise-reduction.md
@@ -32,7 +32,7 @@ By setting `packagePatterns` to "eslint", it means that any package with ESLint 
 
 ## Scheduling Renovate
 
-On its own, the Renovate cli tool runs once and then exits. Hence it only runs as often as its administrator sets it to (e.g. via `cron`). For the [Renovate app on GitHub](https://github.com/apps/renovate), it currently runs continuously using a job queue that gets refreshed hourly, or when you make relevant commits to your repository. Therefore, you can expect to get PRs at any time of the day, i.e. soon after versions are published to npm.
+On its own, the Renovate CLI tool runs once and then exits. Hence it only runs as often as its administrator sets it to (e.g. via `cron`). For the [Renovate app on GitHub](https://github.com/apps/renovate), it currently runs continuously using a job queue that gets refreshed hourly, or when you make relevant commits to your repository. Therefore, you can expect to get PRs at any time of the day, i.e. soon after versions are published to npm.
 
 Receiving PRs at any hour can increase the feeling of being "overwhelmed" by updates and possibly interrupt your flow during working hours, so many Renovate users also consider reducing Renovate's schedule to be outside their normal working hours, for example weeknights and weekends. This is achievable by configuring `schedule` in your Renovate config and optionally `timezone` (Renovate's default time zone is UTC, so you may find it easier to write schedules if you override `timezone` to your local one).
 

--- a/docs/usage/nuget.md
+++ b/docs/usage/nuget.md
@@ -26,7 +26,7 @@ To convert your .NET Framework `.csproj`/`.fsproj`/`.vbproj` into an SDK-style p
 
 ## Alternate feeds
 
-Renovate by default performs all lookups on `https://api.nuget.org/v3/index.json`, but it also supports alternative nuget feeds. Alternative feeds can be specified either [in a `NuGet.config` file](https://docs.microsoft.com/en-us/nuget/reference/nuget-config-file#package-source-sections) within your repository (Renovate will not search outside the repository) or in Renovate configuration options:
+Renovate by default performs all lookups on `https://api.nuget.org/v3/index.json`, but it also supports alternative NuGet feeds. Alternative feeds can be specified either [in a `NuGet.config` file](https://docs.microsoft.com/en-us/nuget/reference/nuget-config-file#package-source-sections) within your repository (Renovate will not search outside the repository) or in Renovate configuration options:
 
 ```json
 "nuget": {
@@ -38,7 +38,7 @@ Renovate by default performs all lookups on `https://api.nuget.org/v3/index.json
 }
 ```
 
-If this example we defined 3 nuget feeds. Packages resolving will process feeds consequentially. It means that if package will be resolved in second feed renovate won't look in last one.
+If this example we defined 3 NuGet feeds. Packages resolving will process feeds consequentially. It means that if package will be resolved in second feed renovate won't look in last one.
 
 ### Protocol versions
 

--- a/docs/usage/private-modules.md
+++ b/docs/usage/private-modules.md
@@ -17,9 +17,9 @@ Assuming the private module lookup succeeds (solutions for that are described la
 
 #### 2. Lock file generation
 
-If you are using a lock file (e.g. yarn's `yarn.lock` or npm's `package-lock.json`) then Renovate needs to update that lock file whenever _any_ package listed in your package file is updated to a new version.
+If you are using a lock file (e.g. Yarn's `yarn.lock` or npm's `package-lock.json`) then Renovate needs to update that lock file whenever _any_ package listed in your package file is updated to a new version.
 
-To do this, Renovate will run `npm install` or equivalent and save the resulting lock file. If a private module hasn't been updated, it _usually_ won't matter to npm/yarn because they won't attempt to update its lock file entry anyway. However it's possible that the install will fail if it attempts to look up that private module for some reason, even when that private module is not the main one being updated. It's therefore better to provide Renovate with all the credentials it needs to look up private packages.
+To do this, Renovate will run `npm install` or equivalent and save the resulting lock file. If a private module hasn't been updated, it _usually_ won't matter to npm/Yarn because they won't attempt to update its lock file entry anyway. However it's possible that the install will fail if it attempts to look up that private module for some reason, even when that private module is not the main one being updated. It's therefore better to provide Renovate with all the credentials it needs to look up private packages.
 
 ## Supported npm authentication approaches
 

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -42,7 +42,7 @@ Configure this directory if you want to change which directory Renovate uses for
 
 ## composerIgnorePlatformReqs
 
-Set to `false` to prevent usage of `--ignore-platform-reqs` in the composer package manager.
+Set to `false` to prevent usage of `--ignore-platform-reqs` in the Composer package manager.
 
 ## dockerImagePrefix
 

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -34,7 +34,7 @@ Configure this directory if you want to change which directory Renovate uses for
 ## binarySource
 
 Set this to `global` if you wish Renovate to use globally-installed binaries (`npm`, `yarn`, etc) instead of using its bundled versions.
-Set this to `docker` instead to use docker-based binaries.
+Set this to `docker` instead to use Docker-based binaries.
 
 ## cacheDir
 
@@ -46,7 +46,7 @@ Set to `false` to prevent usage of `--ignore-platform-reqs` in the composer pack
 
 ## dockerImagePrefix
 
-Override the default renovate sidecar docker containers image prefix from `docker.io/renovate` to a custom value, so renovate will pull images from a custom docker registry.
+Override the default renovate sidecar Docker containers image prefix from `docker.io/renovate` to a custom value, so renovate will pull images from a custom Docker registry.
 
 If this is set to `ghcr.io/renovatebot` the final image for `node` would become `ghcr.io/renovatebot/node` instead of currently used `docker.io/renovate/node`.
 
@@ -56,7 +56,7 @@ This is used if you want to map "dotfiles" from your host computer home director
 
 ## dockerUser
 
-Override default user and group used by docker-based binaries. UID and GID should match the user that executes renovate. See [Docker run reference](https://docs.docker.com/engine/reference/run/#user) for more information on user and group syntax.
+Override default user and group used by Docker-based binaries. UID and GID should match the user that executes renovate. See [Docker run reference](https://docs.docker.com/engine/reference/run/#user) for more information on user and group syntax.
 Set this to `1001:1002` to use UID 1001 and GID 1002.
 
 ## dryRun

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -79,9 +79,9 @@ You probably have no need for this option - it is an experimental setting for th
 
 ## gitAuthor
 
-RFC5322-compliant string if you wish to customise the git author for commits. If you need to transition from one git author to another, put the old gitAuthor into `RENOVATE_LEGACY_GIT_AUTHOR_EMAIL` in environment. Renovate will then check against it as well as the current git author value before deciding if a branch has been modified.
+RFC5322-compliant string if you wish to customise the Git author for commits. If you need to transition from one Git author to another, put the old gitAuthor into `RENOVATE_LEGACY_GIT_AUTHOR_EMAIL` in environment. Renovate will then check against it as well as the current Git author value before deciding if a branch has been modified.
 
-**Note** It is strongly recommended that the git author email you provide should be unique to Renovate. Otherwise, if another bot or human shares the same email and pushes to one of Renovate's branches then Renovate will mistake the branch as unmodified and potentially force push over the changes.
+**Note** It is strongly recommended that the Git author email you provide should be unique to Renovate. Otherwise, if another bot or human shares the same email and pushes to one of Renovate's branches then Renovate will mistake the branch as unmodified and potentially force push over the changes.
 
 ## gitPrivateKey
 
@@ -92,7 +92,7 @@ It will be loaded _lazily_. Before the first commit in a repository, Renovate wi
 - First, run `gpg import` if it hasn't been run before
 - Then, run `git config user.signingkey` and `git config commit.gpgsign true`
 
-The `git` commands are run locally in the cloned repo instead of globally to reduce the chance of causing unintended consequences with global git configs on shared systems.
+The `git` commands are run locally in the cloned repo instead of globally to reduce the chance of causing unintended consequences with global Git configs on shared systems.
 
 ## logContext
 

--- a/docs/usage/self-hosting.md
+++ b/docs/usage/self-hosting.md
@@ -256,7 +256,7 @@ You should save and test out this script manually first, and add it to cron once
 
 ## Kubernetes for Gitlab, using Git over SSH
 
-This section describes how to use git binary with SSH for Gitlab, to avoid API shortcomings.
+This section describes how to use Git binary with SSH for Gitlab, to avoid API shortcomings.
 
 You need to first create a SSH key, then add the public part to Gitlab (see this [guide](https://docs.gitlab.com/ee/ssh/))
 

--- a/docs/usage/self-hosting.md
+++ b/docs/usage/self-hosting.md
@@ -254,7 +254,7 @@ Note: the GitHub.com token in env is necessary in order to retrieve Release Note
 
 You should save and test out this script manually first, and add it to cron once you've verified it.
 
-## Kubernetes for Gitlab, using Git over SSH
+## Kubernetes for GitLab, using Git over SSH
 
 This section describes how to use Git binary with SSH for Gitlab, to avoid API shortcomings.
 

--- a/docs/usage/self-hosting.md
+++ b/docs/usage/self-hosting.md
@@ -195,7 +195,7 @@ Don't forget to configure `platform=gitea` somewhere in config.
 
 If you are running on any platform except github.com, it's important to also configure the environment variable `GITHUB_COM_TOKEN` containing a personal access token for github.com. This account can actually be _any_ account on GitHub, and needs only read-only access. It's used when fetching release notes for repositories in order to increase the hourly API limit. It's also OK to configure the same as a host rule instead, if you prefer that.
 
-**Note:** If you're using renovate in a project where dependencies are loaded from github.com (such as Go m=Modules hosted on GitHub) it is highly recommended to add a token as you will run in the rate limit from the github.com api, which will lead to renovate closing and reopening PRs because it could not get reliable info on updated dependencies.
+**Note:** If you're using renovate in a project where dependencies are loaded from github.com (such as Go m=Modules hosted on GitHub) it is highly recommended to add a token as you will run in the rate limit from the github.com API, which will lead to renovate closing and reopening PRs because it could not get reliable info on updated dependencies.
 
 ## File/directory usage
 

--- a/docs/usage/self-hosting.md
+++ b/docs/usage/self-hosting.md
@@ -230,9 +230,9 @@ module.exports = {
 };
 ```
 
-Here change the `logFile` and `repositories` to something appropriate. Also replace gitlab-token value with the one created during the previous step.
+Here change the `logFile` and `repositories` to something appropriate. Also replace `gitlab-token` value with the one created during the previous step.
 
-If running against GitHub Enterprise, change the above gitlab values to the equivalent GitHub ones.
+If running against GitHub Enterprise, change the above `gitlab` values to the equivalent GitHub ones.
 
 You can save this file as anything you want and then use `RENOVATE_CONFIG_FILE` env variable to tell Renovate where to find it.
 

--- a/docs/usage/self-hosting.md
+++ b/docs/usage/self-hosting.md
@@ -195,7 +195,7 @@ Don't forget to configure `platform=gitea` somewhere in config.
 
 If you are running on any platform except github.com, it's important to also configure the environment variable `GITHUB_COM_TOKEN` containing a personal access token for github.com. This account can actually be _any_ account on GitHub, and needs only read-only access. It's used when fetching release notes for repositories in order to increase the hourly API limit. It's also OK to configure the same as a host rule instead, if you prefer that.
 
-**Note:** If you're using renovate in a project where dependencies are loaded from github.com (such as Go m=Modules hosted on github) it is highly recommended to add a token as you will run in the rate limit from the github.com api, which will lead to renovate closing and reopening PRs because it could not get reliable info on updated dependencies.
+**Note:** If you're using renovate in a project where dependencies are loaded from github.com (such as Go m=Modules hosted on GitHub) it is highly recommended to add a token as you will run in the rate limit from the github.com api, which will lead to renovate closing and reopening PRs because it could not get reliable info on updated dependencies.
 
 ## File/directory usage
 
@@ -232,7 +232,7 @@ module.exports = {
 
 Here change the `logFile` and `repositories` to something appropriate. Also replace gitlab-token value with the one created during the previous step.
 
-If running against GitHub Enterprise, change the above gitlab values to the equivalent github ones.
+If running against GitHub Enterprise, change the above gitlab values to the equivalent GitHub ones.
 
 You can save this file as anything you want and then use `RENOVATE_CONFIG_FILE` env variable to tell Renovate where to find it.
 

--- a/docs/usage/self-hosting.md
+++ b/docs/usage/self-hosting.md
@@ -203,7 +203,7 @@ By default, Renovate will store all files within a `renovate/` subdirectory of t
 
 Repository data will be copied or cloned into unique subdirectories under `repos/`, e.g. `/tmp/renovate/repos/github/owner1/repo-a/`.
 
-Cache data - such as Renovate's own cache as well as that for npm, yarn, composer, etc - will be stored in `/tmp/renovate/cache`.
+Cache data - such as Renovate's own cache as well as that for npm, Yarn, composer, etc - will be stored in `/tmp/renovate/cache`.
 
 If you wish to override the base directory to be used (e.g. instead of `/tmp/renovate/`) then configure a value for `baseDir` in `config.js`, or via env (`RENOVATE_BASE_DIR`) or via CLI (`--base-dir=`).
 

--- a/docs/usage/self-hosting.md
+++ b/docs/usage/self-hosting.md
@@ -203,7 +203,7 @@ By default, Renovate will store all files within a `renovate/` subdirectory of t
 
 Repository data will be copied or cloned into unique subdirectories under `repos/`, e.g. `/tmp/renovate/repos/github/owner1/repo-a/`.
 
-Cache data - such as Renovate's own cache as well as that for npm, Yarn, composer, etc - will be stored in `/tmp/renovate/cache`.
+Cache data - such as Renovate's own cache as well as that for npm, Yarn, Composer, etc - will be stored in `/tmp/renovate/cache`.
 
 If you wish to override the base directory to be used (e.g. instead of `/tmp/renovate/`) then configure a value for `baseDir` in `config.js`, or via env (`RENOVATE_BASE_DIR`) or via CLI (`--base-dir=`).
 

--- a/docs/usage/self-hosting.md
+++ b/docs/usage/self-hosting.md
@@ -256,11 +256,11 @@ You should save and test out this script manually first, and add it to cron once
 
 ## Kubernetes for Gitlab, using Git over SSH
 
-This section describes how to use git binary with ssh for Gitlab, to avoid API shortcomings.
+This section describes how to use git binary with SSH for Gitlab, to avoid API shortcomings.
 
-You need to first create a ssh key, then add the public part to Gitlab (see this [guide](https://docs.gitlab.com/ee/ssh/))
+You need to first create a SSH key, then add the public part to Gitlab (see this [guide](https://docs.gitlab.com/ee/ssh/))
 
-Then, you need to create the secret to add the ssh key, and the following config to your container
+Then, you need to create the secret to add the SSH key, and the following config to your container
 
 ```
 host gitlab.com

--- a/docs/usage/semantic-commits.md
+++ b/docs/usage/semantic-commits.md
@@ -9,7 +9,7 @@ Renovate attempts to autodetect if your repository uses "semantic" commit messag
 
 Currently, Renovate ignores commit conventions apart from "angular".
 
-If angular-style commits are found then Renovate will structure its commit messages and PR titles to be like so:
+If Angular-style commits are found then Renovate will structure its commit messages and PR titles to be like so:
 
 - chore(deps): update eslint to v4.2.0
 - fix(deps): update express to v4.16.2

--- a/docs/usage/updating-rebasing.md
+++ b/docs/usage/updating-rebasing.md
@@ -7,7 +7,7 @@ description: How Renovate Updates and Rebases Branches
 
 There are many cases where Renovate will need to update a branch/PR after its initial creation, and this document will attempt to describe them.
 
-Note: Renovate doesn't technically do "rebasing" in the git sense. Instead, it manually recreates the same commit based off of the latest commit in base branch.
+Note: Renovate doesn't technically do "rebasing" in the Git sense. Instead, it manually recreates the same commit based off of the latest commit in base branch.
 
 ## If you have made edits
 


### PR DESCRIPTION
<!-- Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App: https://cla-assistant.io/renovatebot/renovate -->

<!-- When creating this PR on GitHub, please ensure `Allow edits from maintainers.` checkbox is checked -->

<!-- Please use a conventional commit message (https://www.conventionalcommits.org/en/v1.0.0/) as your PR title -->

<!-- Ideally include at least one sentence saying what this PR achieves -->

<!-- Finish the PR with `Closes #` and then the issue number if it closes any associated issue -->

## Changes:

- Fix a lot of capitalization inconsistencies.
- Fix spelling of Docker Composer -> Docker Compose.
- Add some monospaced text where I think it was missing.
- Use `Node.js` instead of `Node` in description field.

## Context:

I've tried to keep all changes organized into separate commits, so you can revert things you don't like easily.
The changes touch `docs/usage` and `docs/development`.

I hope I've done this right! :smile: