### PR TITLE
fix(bitbucket-server): remove / from url for local presets

### DIFF
--- a/lib/config/presets/bitbucket-server/index.ts
+++ b/lib/config/presets/bitbucket-server/index.ts
@@ -17,7 +17,7 @@ export async function fetchJSONFile(
 ): Promise<Preset> {
   const [projectKey, repositorySlug] = repo.split('/');
   setBaseUrl(endpoint);
-  const url = `/rest/api/1.0/projects/${projectKey}/repos/${repositorySlug}/browse/${fileName}?limit=20000`;
+  const url = `rest/api/1.0/projects/${projectKey}/repos/${repositorySlug}/browse/${fileName}?limit=20000`;
   let res: { body: FileData };
   try {
     res = await http.getJson(url);


### PR DESCRIPTION
<!-- Before submitting a Pull Request, please ensure you have signed the CLA using this GitHub App: https://cla-assistant.io/renovatebot/renovate -->

<!-- When creating this PR on GitHub, please ensure `Allow edits from maintainers.` checkbox is checked -->

<!-- Please use a conventional commit message (https://www.conventionalcommits.org/en/v1.0.0/) as your PR title -->

<!-- Ideally include at least one sentence saying what this PR achieves -->
The purpose of this PR is to fix the local presets for bitbucket-server. 
The issue was that the __endpoint__ (baseUrl) was used together with the __url__ inside the URL.resolve method that will append a second '/'
<!-- Finish the PR with `Closes #` and then the issue number if it closes any associated issue -->
renovatebot/config-help#941