### PR TITLE
fix: support constraints.node override

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -244,6 +244,18 @@ Constraints are also used to manually restrict which _datasource_ versions are p
 }
 ```
 
+If you need to _override_ constraints that Renovate detects from the repository, wrap it in the `force` object like so:
+
+```json
+{
+  "force": {
+    "constraints": {
+      "node": "< 15.0.0"
+    }
+  }
+}
+```
+
 Note: make sure not to mix this up with the term `compatibility`, which Renovate uses in the context of version releases, e.g. if a Docker image is `node:12.16.0-alpine` then the `-alpine` suffix represents `compatibility`.
 
 ## dependencyDashboard

--- a/lib/config/__snapshots__/index.spec.ts.snap
+++ b/lib/config/__snapshots__/index.spec.ts.snap
@@ -18,3 +18,10 @@ Object {
   ],
 }
 `;
+
+exports[`config/index mergeChildConfig(parentConfig, childConfig) merges constraints 1`] = `
+Object {
+  "node": "<15",
+  "npm": "^6.0.0",
+}
+`;

--- a/lib/config/index.spec.ts
+++ b/lib/config/index.spec.ts
@@ -153,6 +153,24 @@ describe('config/index', () => {
         4,
       ]);
     });
+    it('merges constraints', async () => {
+      const parentConfig = { ...defaultConfig };
+      Object.assign(parentConfig, {
+        constraints: {
+          node: '>=12',
+          npm: '^6.0.0',
+        },
+      });
+      const childConfig = {
+        constraints: {
+          node: '<15',
+        },
+      };
+      const configParser = await import('./index');
+      const config = configParser.mergeChildConfig(parentConfig, childConfig);
+      expect(config.constraints).toMatchSnapshot();
+      expect(config.constraints.node).toEqual('<15');
+    });
     it('handles null parent packageRules', async () => {
       const parentConfig = { ...defaultConfig };
       Object.assign(parentConfig, {

--- a/lib/config/utils.ts
+++ b/lib/config/utils.ts
@@ -21,7 +21,12 @@ export function mergeChildConfig<T, TChild>(
       parentConfig[option.name]
     ) {
       logger.trace(`mergeable option: ${option.name}`);
-      if (option.type === 'array') {
+      if (option.name === 'constraints') {
+        config[option.name] = Object.assign(
+          parentConfig[option.name],
+          childConfig[option.name]
+        );
+      } else if (option.type === 'array') {
         config[option.name] = (parentConfig[option.name] as unknown[]).concat(
           config[option.name]
         );


### PR DESCRIPTION
Currently, `mergeChildConfig` corrupts any `constraints.node` settings due to `node` being defined as a mergeable config object itself.