### PR TITLE
feat(github-releases): use prerelease metadata in filtering

### DIFF
--- a/lib/datasource/common.ts
+++ b/lib/datasource/common.ts
@@ -44,7 +44,7 @@ export interface Release {
   downloadUrl?: string;
   gitRef?: string;
   isDeprecated?: boolean;
-
+  isStable?: boolean;
   releaseTimestamp?: any;
   version: string;
   newDigest?: string;

--- a/lib/datasource/github-releases/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/github-releases/__snapshots__/index.spec.ts.snap
@@ -13,6 +13,12 @@ Object {
       "releaseTimestamp": "2020-03-09T10:00:00Z",
       "version": "v1.1.0",
     },
+    Object {
+      "gitRef": "2.0.0",
+      "isStable": false,
+      "releaseTimestamp": "2020-04-09T10:00:00Z",
+      "version": "2.0.0",
+    },
   ],
   "sourceUrl": "https://github.com/some/dep",
 }

--- a/lib/datasource/github-releases/index.spec.ts
+++ b/lib/datasource/github-releases/index.spec.ts
@@ -31,6 +31,11 @@ describe('datasource/github-releases', () => {
           { tag_name: 'v', published_at: '2020-03-09T12:00:00Z' },
           { tag_name: '1.0.0', published_at: '2020-03-09T11:00:00Z' },
           { tag_name: 'v1.1.0', published_at: '2020-03-09T10:00:00Z' },
+          {
+            tag_name: '2.0.0',
+            published_at: '2020-04-09T10:00:00Z',
+            prerelease: true,
+          },
         ]);
 
       const res = await getPkgReleases({
@@ -38,10 +43,13 @@ describe('datasource/github-releases', () => {
         depName: 'some/dep',
       });
       expect(res).toMatchSnapshot();
-      expect(res.releases).toHaveLength(2);
+      expect(res.releases).toHaveLength(3);
       expect(
         res.releases.find((release) => release.version === 'v1.1.0')
       ).toBeDefined();
+      expect(
+        res.releases.find((release) => release.version === '2.0.0').isStable
+      ).toBe(false);
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
   });

--- a/lib/datasource/github-releases/index.ts
+++ b/lib/datasource/github-releases/index.ts
@@ -11,6 +11,7 @@ const http = new GithubHttp();
 type GithubRelease = {
   tag_name: string;
   published_at: string;
+  prerelease: boolean;
 };
 
 /**
@@ -43,11 +44,14 @@ export async function getReleases({
     sourceUrl: 'https://github.com/' + repo,
     releases: null,
   };
-  dependency.releases = githubReleases.map(({ tag_name, published_at }) => ({
-    version: tag_name,
-    gitRef: tag_name,
-    releaseTimestamp: published_at,
-  }));
+  dependency.releases = githubReleases.map(
+    ({ tag_name, published_at, prerelease }) => ({
+      version: tag_name,
+      gitRef: tag_name,
+      releaseTimestamp: published_at,
+      isStable: prerelease ? false : undefined,
+    })
+  );
   const cacheMinutes = 10;
   await packageCache.set(cacheNamespace, repo, dependency, cacheMinutes);
   return dependency;

--- a/lib/manager/github-actions/extract.ts
+++ b/lib/manager/github-actions/extract.ts
@@ -1,4 +1,4 @@
-import * as githubTagsDatasource from '../../datasource/github-tags';
+import * as githubTagsDatasource from '../../datasource/github-releases';
 import { logger } from '../../logger';
 import { SkipReason } from '../../types';
 import * as dockerVersioning from '../../versioning/docker';

--- a/lib/manager/github-actions/extract.ts
+++ b/lib/manager/github-actions/extract.ts
@@ -1,4 +1,4 @@
-import * as githubTagsDatasource from '../../datasource/github-releases';
+import * as githubTagsDatasource from '../../datasource/github-tags';
 import { logger } from '../../logger';
 import { SkipReason } from '../../types';
 import * as dockerVersioning from '../../versioning/docker';

--- a/lib/workers/repository/process/lookup/__snapshots__/index.spec.ts.snap
+++ b/lib/workers/repository/process/lookup/__snapshots__/index.spec.ts.snap
@@ -777,6 +777,20 @@ Array [
 ]
 `;
 
+exports[`workers/repository/process/lookup .lookupUpdates() should ignore unstable versions from datasource 1`] = `
+Array [
+  Object {
+    "fromVersion": "1.4.4",
+    "isSingleVersion": true,
+    "newMajor": 2,
+    "newMinor": 0,
+    "newValue": "2.0.0",
+    "toVersion": "2.0.0",
+    "updateType": "major",
+  },
+]
+`;
+
 exports[`workers/repository/process/lookup .lookupUpdates() should jump unstable versions if followTag 1`] = `
 Array [
   Object {

--- a/lib/workers/repository/process/lookup/filter.ts
+++ b/lib/workers/repository/process/lookup/filter.ts
@@ -37,6 +37,11 @@ export function filterVersions(
     if (!versioning.isStable(version)) {
       return false;
     }
+    // Check if the datasource returned isStable = false
+    const release = releases.find((r) => r.version === version);
+    if (release?.isStable === false) {
+      return false;
+    }
     return true;
   }
   versioning = allVersioning.get(config.versioning);


### PR DESCRIPTION
Marks releases as unstable if `prerelease` is set in a GitHub Release. Also adds additional stability filtering logic to evaluate this field.