### PR TITLE
docs: go into Composer authentication more clearly

### DIFF
--- a/docs/usage/php.md
+++ b/docs/usage/php.md
@@ -34,9 +34,9 @@ If you are using a [privately hosted Composer package](https://getcomposer.org/d
 }
 ```
 
-If you don't wish for all users of the repository to be able to see the unencrypted token, you can encrypt it with Renovate's public key instead, so that only Renovate can decrypt it.
+This host rule is best added to the bot's `config.js` config so that it is not visible to users of the repository. If you are using the hosted WhiteSource Renovate App then you can encrypt it with Renovate's public key instead, so that only Renovate can decrypt it.
 
-Go to [https://renovatebot.com/encrypt](https://renovatebot.com/encrypt), paste in your credentials, click _Encrypt_, then copy the encrypted result. You may encrypt your `password` only or even pass your `username` encrypted.
+Go to [https://renovatebot.com/encrypt](https://renovatebot.com/encrypt), paste in the secret string you wish to encrypt, click _Encrypt_, then copy the encrypted result. You may encrypt your `password` only or even pass your `username` encrypted.
 
 ```json
 {

--- a/docs/usage/php.md
+++ b/docs/usage/php.md
@@ -25,12 +25,14 @@ If you are using a [privately hosted Composer package](https://getcomposer.org/d
 
 ```json
 {
-    "hostRules": [{
-        "hostName": "some.vendor.com",
-        "hostType": "packagist",
-        "username": "<your-username>",
-        "password": "<your-password>"
-    }]
+  "hostRules": [
+    {
+      "hostName": "some.vendor.com",
+      "hostType": "packagist",
+      "username": "<your-username>",
+      "password": "<your-password>"
+    }
+  ]
 }
 ```
 
@@ -40,13 +42,15 @@ Go to [https://renovatebot.com/encrypt](https://renovatebot.com/encrypt), paste 
 
 ```json
 {
-    "hostRules": [{
-        "hostName": "some.vendor.com",
-        "hostType": "packagist",
-        "encrypted": {
-            "username": "<your-encrypted-password",
-            "password": "<your-encrypted-password"
-        }
-    }]
+  "hostRules": [
+    {
+      "hostName": "some.vendor.com",
+      "hostType": "packagist",
+      "encrypted": {
+        "username": "<your-encrypted-password",
+        "password": "<your-encrypted-password"
+      }
+    }
+  ]
 }
 ```

--- a/docs/usage/php.md
+++ b/docs/usage/php.md
@@ -18,3 +18,35 @@ Renovate supports upgrading dependencies in PHP's `composer.json` files and thei
 ## Enabling
 
 Either install the [Renovate App](https://github.com/apps/renovate) on GitHub, or check out [Renovate OSS](https://github.com/renovatebot/renovate) for self-hosted.
+
+## Private packages
+
+If you are using a [privately hosted Composer package](https://getcomposer.org/doc/articles/authentication-for-private-packages.md) you can pass the credentials via the [`hostRules`](https://docs.renovatebot.com/configuration-options/#hostrules) configuration.
+
+```json
+{
+    "hostRules": [{
+        "hostName": "some.vendor.com",
+        "hostType": "packagist",
+        "username": "<your-username>",
+        "password": "<your-password>"
+    }]
+}
+```
+
+If you don't wish for all users of the repository to be able to see the unencrypted token, you can encrypt it with Renovate's public key instead, so that only Renovate can decrypt it.
+
+Go to [https://renovatebot.com/encrypt](https://renovatebot.com/encrypt), paste in your credentials, click _Encrypt_, then copy the encrypted result. You may encrypt your `password` only or even pass your `username` encrypted.
+
+```json
+{
+    "hostRules": [{
+        "hostName": "some.vendor.com",
+        "hostType": "packagist",
+        "encrypted": {
+            "username": "<your-encrypted-password",
+            "password": "<your-encrypted-password"
+        }
+    }]
+}
+```


### PR DESCRIPTION
Clarify how Renovate may be authenticated for private Composer packages.