### PR TITLE
fix: sampleSize: 0 does not add assignees/reviewers

### DIFF
--- a/lib/workers/pr/index.spec.ts
+++ b/lib/workers/pr/index.spec.ts
@@ -479,6 +479,17 @@ describe('workers/pr', () => {
       expect(reviewers).toHaveLength(2);
       expect(config.reviewers).toEqual(expect.arrayContaining(reviewers));
     });
+    it('should not add any assignees or reviewers to new PR', async () => {
+      config.assignees = ['foo', 'bar', 'baz'];
+      config.assigneesSampleSize = 0;
+      config.reviewers = ['baz', 'boo', 'bor'];
+      config.reviewersSampleSize = 0;
+      const { prResult, pr } = await prWorker.ensurePr(config);
+      expect(prResult).toEqual(PrResult.Created);
+      expect(pr).toMatchObject({ displayNumber: 'New Pull Request' });
+      expect(platform.addAssignees).toHaveBeenCalledTimes(0);
+      expect(platform.addReviewers).toHaveBeenCalledTimes(0);
+    });
     it('should add and deduplicate additionalReviewers on new PR', async () => {
       config.reviewers = ['@foo', 'bar'];
       config.additionalReviewers = ['bar', 'baz', '@boo'];

--- a/lib/workers/pr/index.ts
+++ b/lib/workers/pr/index.ts
@@ -48,12 +48,14 @@ export async function addAssigneesReviewers(
       if (config.assigneesSampleSize !== null) {
         assignees = sampleSize(assignees, config.assigneesSampleSize);
       }
-      // istanbul ignore if
-      if (config.dryRun) {
-        logger.info(`DRY-RUN: Would add assignees to PR #${pr.number}`);
-      } else {
-        await platform.addAssignees(pr.number, assignees);
-        logger.debug({ assignees }, 'Added assignees');
+      if (assignees.length > 0) {
+        // istanbul ignore if
+        if (config.dryRun) {
+          logger.info(`DRY-RUN: Would add assignees to PR #${pr.number}`);
+        } else {
+          await platform.addAssignees(pr.number, assignees);
+          logger.debug({ assignees }, 'Added assignees');
+        }
       }
     } catch (err) {
       logger.debug(
@@ -78,12 +80,14 @@ export async function addAssigneesReviewers(
       if (config.reviewersSampleSize !== null) {
         reviewers = sampleSize(reviewers, config.reviewersSampleSize);
       }
-      // istanbul ignore if
-      if (config.dryRun) {
-        logger.info(`DRY-RUN: Would add reviewers to PR #${pr.number}`);
-      } else {
-        await platform.addReviewers(pr.number, reviewers);
-        logger.debug({ reviewers }, 'Added reviewers');
+      if (reviewers.length > 0) {
+        // istanbul ignore if
+        if (config.dryRun) {
+          logger.info(`DRY-RUN: Would add reviewers to PR #${pr.number}`);
+        } else {
+          await platform.addReviewers(pr.number, reviewers);
+          logger.debug({ reviewers }, 'Added reviewers');
+        }
       }
     } catch (err) {
       logger.debug(


### PR DESCRIPTION
When having a `reviewersSampleSize: 0` or `assigneesSampleSize: 0` it can lead Renovate to update a PR with an empty list of reviewers/assignees.

This is fixed by having a separate check after evaluating the sampleSIze function.

config:
```
...
  "reviewers": ["@foo", "@bar", "@baz"],
  "reviewersSampleSize": 0,
...
```
log:
```
DEBUG: Adding reviewers '' to #72 (repository=my/repo, branch=renovate/node-14.x)
DEBUG: Added reviewers (repository=my/repo, branch=renovate/node-14.x)
       "reviewers": []
DEBUG: Created Pull Request #72 (repository=my/repo, branch=renovate/node-14.x)
```