### PR TITLE
feat(nuget): fetch sourceUrl from all v3 registries

### DIFF
--- a/lib/datasource/nuget/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/nuget/__snapshots__/index.spec.ts.snap
@@ -520,6 +520,16 @@ Array [
   },
   Object {
     "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "api.nuget.org",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://api.nuget.org/v3/index.json",
+  },
+  Object {
+    "headers": Object {
       "accept-encoding": "gzip, deflate",
       "host": "api.nuget.org",
       "user-agent": "https://github.com/renovatebot/renovate",
@@ -561,7 +571,6 @@ Object {
       "version": "2.6.1",
     },
     Object {
-      "releaseTimestamp": "2012-10-23T15:37:48+00:00",
       "version": "2.6.2",
     },
     Object {
@@ -742,6 +751,25 @@ Array [
     },
     "method": "GET",
     "url": "https://api.nuget.org/v3/registration5-gz-semver2/nunit/index.json",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "myprivatefeed",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://myprivatefeed/index.json",
+  },
+  Object {
+    "headers": Object {
+      "accept-encoding": "gzip, deflate",
+      "host": "api.nuget.org",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://api.nuget.org/v3-flatcontainer/nunit/3.12.0/nunit.nuspec",
   },
 ]
 `;
@@ -1522,6 +1550,16 @@ Array [
   },
   Object {
     "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "api.nuget.org",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://api.nuget.org/v3/index.json",
+  },
+  Object {
+    "headers": Object {
       "accept-encoding": "gzip, deflate",
       "host": "api.nuget.org",
       "user-agent": "https://github.com/renovatebot/renovate",
@@ -1938,6 +1976,16 @@ Array [
   },
   Object {
     "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "api.nuget.org",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://api.nuget.org/v3/index.json",
+  },
+  Object {
+    "headers": Object {
       "accept-encoding": "gzip, deflate",
       "host": "api.nuget.org",
       "user-agent": "https://github.com/renovatebot/renovate",
@@ -1964,6 +2012,25 @@ Array [
     },
     "method": "GET",
     "url": "https://api.nuget.org/v3/registration5-gz-semver2/nunit/index.json",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "myprivatefeed",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://myprivatefeed/index.json",
+  },
+  Object {
+    "headers": Object {
+      "accept-encoding": "gzip, deflate",
+      "host": "api.nuget.org",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://api.nuget.org/v3-flatcontainer/nunit/3.12.0/nunit.nuspec",
   },
 ]
 `;

--- a/lib/datasource/nuget/index.spec.ts
+++ b/lib/datasource/nuget/index.spec.ts
@@ -307,8 +307,10 @@ describe('datasource/nuget', () => {
       httpMock
         .scope('https://api.nuget.org')
         .get('/v3/index.json')
+        .twice()
         .reply(200, JSON.parse(nugetIndexV3))
         .get('/v3-flatcontainer/nunit/3.12.0/nunit.nuspec')
+        .twice()
         .reply(200, pkgInfoV3FromNuget)
         .get('/v3/registration5-gz-semver2/nunit/index.json')
         .twice()
@@ -316,6 +318,7 @@ describe('datasource/nuget', () => {
       httpMock
         .scope('https://myprivatefeed')
         .get('/index.json')
+        .twice()
         .reply(200, JSON.parse(nugetIndexV3));
 
       const res = await getPkgReleases({
@@ -370,6 +373,7 @@ describe('datasource/nuget', () => {
       httpMock
         .scope('https://api.nuget.org')
         .get('/v3/index.json')
+        .twice()
         .reply(200, JSON.parse(nugetIndexV3))
         .get('/v3/registration5-gz-semver2/nunit/index.json')
         .reply(200, pkgListV3Registration)
@@ -387,6 +391,7 @@ describe('datasource/nuget', () => {
       const scope = httpMock
         .scope('https://api.nuget.org')
         .get('/v3/index.json')
+        .twice()
         .reply(200, JSON.parse(nugetIndexV3));
       nlogMocks.forEach(({ url, result }) => {
         scope.get(url).reply(200, result);
@@ -404,10 +409,21 @@ describe('datasource/nuget', () => {
       httpMock
         .scope('https://api.nuget.org')
         .get('/v3/registration5-gz-semver2/nunit/index.json')
-        .reply(200, pkgListV3Registration);
+        .reply(
+          200,
+          pkgListV3Registration
+            .replace(/"http:\/\/nunit\.org"/g, '""')
+            .replace('"published": "2012-10-23T15:37:48+00:00",', '')
+        )
+        .get('/v3-flatcontainer/nunit/3.12.0/nunit.nuspec')
+        .reply(
+          200,
+          pkgInfoV3FromNuget.replace('https://github.com/nunit/nunit', '')
+        );
       httpMock
         .scope('https://myprivatefeed')
         .get('/index.json')
+        .twice()
         .reply(200, JSON.parse(nugetIndexV3));
 
       const res = await getPkgReleases({
@@ -415,8 +431,8 @@ describe('datasource/nuget', () => {
       });
       expect(res).not.toBeNull();
       expect(res).toMatchSnapshot();
-      expect(res.sourceUrl).toBeDefined();
       expect(httpMock.getTrace()).toMatchSnapshot();
+      expect(res.sourceUrl).toBeDefined();
     });
     it('processes real data (v2)', async () => {
       httpMock

--- a/lib/datasource/nuget/v3.ts
+++ b/lib/datasource/nuget/v3.ts
@@ -1,9 +1,11 @@
+import is from '@sindresorhus/is';
 import pAll from 'p-all';
 import * as semver from 'semver';
 import { XmlDocument } from 'xmldoc';
 import { logger } from '../../logger';
 import * as packageCache from '../../util/cache/package';
 import { Http } from '../../util/http';
+import { ensureTrailingSlash } from '../../util/url';
 import { Release, ReleaseResult } from '../common';
 
 import { id } from './common';
@@ -47,6 +49,7 @@ export async function getResourceUrl(
       cacheNamespace,
       responseCacheKey
     );
+    // istanbul ignore else: currently not testable
     if (!servicesIndexRaw) {
       servicesIndexRaw = (await http.getJson<ServicesIndexRaw>(url)).body;
       await packageCache.set(
@@ -165,26 +168,35 @@ export async function getReleases(
     releases,
   };
 
-  if (registryUrl.toLowerCase() === defaultNugetFeed.toLowerCase()) {
-    try {
-      const nuspecUrl = `https://api.nuget.org/v3-flatcontainer/${pkgName.toLowerCase()}/${latestStable}/${pkgName.toLowerCase()}.nuspec`;
+  try {
+    const packageBaseAddress = await getResourceUrl(
+      registryUrl,
+      'PackageBaseAddress'
+    );
+    // istanbul ignore else: this is a required v3 api
+    if (is.nonEmptyString(packageBaseAddress)) {
+      const nuspecUrl = `${ensureTrailingSlash(
+        packageBaseAddress
+      )}${pkgName.toLowerCase()}/${latestStable}/${pkgName.toLowerCase()}.nuspec`;
       const metaresult = await http.get(nuspecUrl);
       const nuspec = new XmlDocument(metaresult.body);
       const sourceUrl = nuspec.valueWithPath('metadata.repository@url');
       if (sourceUrl) {
         dep.sourceUrl = sourceUrl;
       }
-    } catch (err) /* istanbul ignore next */ {
-      logger.debug(
-        `Cannot obtain sourceUrl for ${pkgName} using version ${latestStable}`
-      );
-      return dep;
     }
-  } else if (homepage) {
-    dep.sourceUrl = homepage;
+  } catch (err) /* istanbul ignore next */ {
+    logger.debug(
+      { err, registryUrl, pkgName, pkgVersion: latestStable },
+      `Cannot obtain sourceUrl`
+    );
+    return dep;
   }
 
+  // istanbul ignore else: not easy testable
   if (homepage) {
+    // only assign if not assigned
+    dep.sourceUrl ??= homepage;
     dep.homepage = homepage;
   }
 

--- a/lib/datasource/nuget/v3.ts
+++ b/lib/datasource/nuget/v3.ts
@@ -1,4 +1,5 @@
 import is from '@sindresorhus/is';
+import { RequestError } from 'got';
 import pAll from 'p-all';
 import * as semver from 'semver';
 import { XmlDocument } from 'xmldoc';
@@ -186,6 +187,14 @@ export async function getReleases(
       }
     }
   } catch (err) /* istanbul ignore next */ {
+    // ignore / silence 404. Seen on proget, if remote connector is used and package is not yet cached
+    if (err instanceof RequestError && err.response?.statusCode === 404) {
+      logger.debug(
+        { registryUrl, pkgName, pkgVersion: latestStable },
+        `package manifest (.nuspec) not found`
+      );
+      return dep;
+    }
     logger.debug(
       { err, registryUrl, pkgName, pkgVersion: latestStable },
       `Cannot obtain sourceUrl`

--- a/lib/datasource/nuget/v3.ts
+++ b/lib/datasource/nuget/v3.ts
@@ -206,7 +206,7 @@ export async function getReleases(
   if (homepage) {
     // only assign if not assigned
     dep.sourceUrl ??= homepage;
-    dep.homepage = homepage;
+    dep.homepage ??= homepage;
   }
 
   return dep;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Try to fetch sourceUrl from nuspec file for all v3 registries

## Context:

Currently we only fetch it from official nuget v3 registry.
`sourceUrl` is required to group packages by `sourceUrlPrefixes`
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->
