### PR TITLE
feat(cache): extend release notes cache TTL

### DIFF
--- a/lib/workers/pr/changelog/release-notes.spec.ts
+++ b/lib/workers/pr/changelog/release-notes.spec.ts
@@ -69,8 +69,8 @@ describe(getName(__filename), () => {
       [now, 55],
       [now.minus({ week: 2 }), 1435],
       [now.minus({ year: 1 }), 14495],
-    ])('works with string date (%s, %i)', (date, days) => {
-      expect(releaseNotesCacheMinutes(date?.toISO())).toEqual(days);
+    ])('works with string date (%s, %i)', (date, minutes) => {
+      expect(releaseNotesCacheMinutes(date?.toISO())).toEqual(minutes);
     });
 
     it('handles date object', () => {

--- a/lib/workers/pr/changelog/release-notes.spec.ts
+++ b/lib/workers/pr/changelog/release-notes.spec.ts
@@ -1,4 +1,5 @@
 import fs from 'fs-extra';
+import { DateTime } from 'luxon';
 import * as httpMock from '../../../../test/httpMock';
 import { getName } from '../../../../test/util';
 import { ChangeLogNotes } from './common';
@@ -7,6 +8,7 @@ import {
   getReleaseList,
   getReleaseNotes,
   getReleaseNotesMd,
+  releaseNotesCacheMinutes,
 } from './release-notes';
 
 const angularJsChangelogMd = fs.readFileSync(
@@ -59,6 +61,24 @@ describe(getName(__filename), () => {
 
   afterEach(() => {
     httpMock.reset();
+  });
+
+  describe('releaseNotesCacheMinutes', () => {
+    const now = DateTime.local();
+    it.each([
+      [now, 55],
+      [now.minus({ week: 2 }), 1435],
+      [now.minus({ year: 1 }), 14495],
+    ])('works with string date (%s, %i)', (date, days) => {
+      expect(releaseNotesCacheMinutes(date?.toISO())).toEqual(days);
+    });
+
+    it('handles date object', () => {
+      expect(releaseNotesCacheMinutes(new Date())).toEqual(55);
+    });
+    it.each([null, undefined, 'fake', 123])('handles invalid: %s', (date) => {
+      expect(releaseNotesCacheMinutes(date as never)).toEqual(55);
+    });
   });
 
   describe('addReleaseNotes()', () => {

--- a/lib/workers/pr/changelog/release-notes.ts
+++ b/lib/workers/pr/changelog/release-notes.ts
@@ -1,4 +1,5 @@
 import * as URL from 'url';
+import is from '@sindresorhus/is';
 import { linkify } from 'linkify-markdown';
 import { DateTime } from 'luxon';
 import MarkdownIt from 'markdown-it';
@@ -268,14 +269,17 @@ export async function getReleaseNotesMd(
  * so only cache for about an hour when the release is less than a week old. Otherwise,
  * cache for days.
  */
-function releaseNotesCacheMinutes(releaseDate?: string | Date): number {
-  const dt = DateTime.fromJSDate(new Date(releaseDate));
+export function releaseNotesCacheMinutes(releaseDate?: string | Date): number {
+  // for an invalid or missing release date, default to "now"
+  const dt = is.date(releaseDate)
+    ? DateTime.fromJSDate(releaseDate)
+    : DateTime.fromISO(releaseDate);
 
-  if (!dt.isValid || dt.diffNow('days').days < 7) {
+  if (!dt.isValid || dt.diffNow('days').days < -7) {
     return 55;
   }
 
-  if (dt.diffNow('months').months < 6) {
+  if (dt.diffNow('months').months < -6) {
     return 1435; // 5 minutes shy of one day
   }
 

--- a/lib/workers/pr/changelog/release-notes.ts
+++ b/lib/workers/pr/changelog/release-notes.ts
@@ -111,6 +111,7 @@ export async function getReleaseNotes(
         releaseNotes = null;
       } else {
         try {
+          // istanbul ignore else: not tested
           if (baseUrl !== 'https://gitlab.com/') {
             releaseNotes.body = linkify(releaseNotes.body, {
               repository: `${baseUrl}${repository}`,
@@ -236,6 +237,7 @@ export async function getReleaseNotesMd(
               let url = `${baseUrl}${repository}/blob/master/${changelogFile}#`;
               url += title.join('-').replace(/[^A-Za-z0-9-]/g, '');
               body = massageBody(body, baseUrl);
+              // istanbul ignore else: not tested
               if (body?.length) {
                 try {
                   body = linkify(body, {
@@ -270,16 +272,17 @@ export async function getReleaseNotesMd(
  * cache for days.
  */
 export function releaseNotesCacheMinutes(releaseDate?: string | Date): number {
-  // for an invalid or missing release date, default to "now"
   const dt = is.date(releaseDate)
     ? DateTime.fromJSDate(releaseDate)
     : DateTime.fromISO(releaseDate);
 
-  if (!dt.isValid || dt.diffNow('days').days < -7) {
+  const now = DateTime.local();
+
+  if (!dt.isValid || now.diff(dt, 'days').days < 7) {
     return 55;
   }
 
-  if (dt.diffNow('months').months < -6) {
+  if (now.diff(dt, 'months').months < 6) {
     return 1435; // 5 minutes shy of one day
   }
 
@@ -311,6 +314,7 @@ export async function addReleaseNotes(
     let releaseNotes: ChangeLogNotes;
     const cacheKey = getCacheKey(v.version);
     releaseNotes = await packageCache.get(cacheNamespace, cacheKey);
+    // istanbul ignore else: no cache tests
     if (!releaseNotes) {
       releaseNotes = await getReleaseNotesMd(
         repository,
@@ -318,6 +322,7 @@ export async function addReleaseNotes(
         input.project.baseUrl,
         input.project.apiBaseUrl
       );
+      // istanbul ignore else: should be tested
       if (!releaseNotes) {
         releaseNotes = await getReleaseNotes(
           repository,

--- a/lib/workers/pr/changelog/release-notes.ts
+++ b/lib/workers/pr/changelog/release-notes.ts
@@ -111,7 +111,6 @@ export async function getReleaseNotes(
         releaseNotes = null;
       } else {
         try {
-          // istanbul ignore else: not tested
           if (baseUrl !== 'https://gitlab.com/') {
             releaseNotes.body = linkify(releaseNotes.body, {
               repository: `${baseUrl}${repository}`,
@@ -237,7 +236,6 @@ export async function getReleaseNotesMd(
               let url = `${baseUrl}${repository}/blob/master/${changelogFile}#`;
               url += title.join('-').replace(/[^A-Za-z0-9-]/g, '');
               body = massageBody(body, baseUrl);
-              // istanbul ignore else: not tested
               if (body?.length) {
                 try {
                   body = linkify(body, {

--- a/lib/workers/pr/changelog/release-notes.ts
+++ b/lib/workers/pr/changelog/release-notes.ts
@@ -1,5 +1,6 @@
 import * as URL from 'url';
 import { linkify } from 'linkify-markdown';
+import { DateTime } from 'luxon';
 import MarkdownIt from 'markdown-it';
 
 import { logger } from '../../../logger';
@@ -268,15 +269,13 @@ export async function getReleaseNotesMd(
  * cache for days.
  */
 function releaseNotesCacheMinutes(releaseDate?: string | Date): number {
-  // for an invalid or missing release date, default to "now"
-  const releaseTS = new Date(releaseDate || '').valueOf() || Date.now();
-  const ageInDays = (Date.now() - releaseTS) / 86400000;
+  const dt = DateTime.fromJSDate(new Date(releaseDate));
 
-  if (ageInDays < 7) {
+  if (!dt.isValid || dt.diffNow('days').days < 7) {
     return 55;
   }
 
-  if (ageInDays < 180) {
+  if (dt.diffNow('months').months < 6) {
     return 1435; // 5 minutes shy of one day
   }
 

--- a/lib/workers/pr/changelog/release-notes.ts
+++ b/lib/workers/pr/changelog/release-notes.ts
@@ -260,6 +260,29 @@ export async function getReleaseNotesMd(
   return null;
 }
 
+/**
+ * Determine how long to cache release notes based on when the version was released.
+ *
+ * It's not uncommon for release notes to be updated shortly after the release itself,
+ * so only cache for about an hour when the release is less than a week old. Otherwise,
+ * cache for days.
+ */
+function releaseNotesCacheMinutes(releaseDate?: string | Date): number {
+  // for an invalid or missing release date, default to "now"
+  const releaseTS = new Date(releaseDate || '').valueOf() || Date.now();
+  const ageInDays = (Date.now() - releaseTS) / 86400000;
+
+  if (ageInDays < 7) {
+    return 55;
+  }
+
+  if (ageInDays < 180) {
+    return 1435; // 5 minutes shy of one day
+  }
+
+  return 14495; // 5 minutes shy of 10 days
+}
+
 export async function addReleaseNotes(
   input: ChangeLogResult
 ): Promise<ChangeLogResult> {
@@ -286,21 +309,12 @@ export async function addReleaseNotes(
     const cacheKey = getCacheKey(v.version);
     releaseNotes = await packageCache.get(cacheNamespace, cacheKey);
     if (!releaseNotes) {
-      if (input.project.github != null) {
-        releaseNotes = await getReleaseNotesMd(
-          repository,
-          v.version,
-          input.project.baseUrl,
-          input.project.apiBaseUrl
-        );
-      } else {
-        releaseNotes = await getReleaseNotesMd(
-          repository,
-          v.version,
-          input.project.baseUrl,
-          input.project.apiBaseUrl
-        );
-      }
+      releaseNotes = await getReleaseNotesMd(
+        repository,
+        v.version,
+        input.project.baseUrl,
+        input.project.apiBaseUrl
+      );
       if (!releaseNotes) {
         releaseNotes = await getReleaseNotes(
           repository,
@@ -314,7 +328,7 @@ export async function addReleaseNotes(
       if (!releaseNotes && v.compare.url) {
         releaseNotes = { url: v.compare.url };
       }
-      const cacheMinutes = 55;
+      const cacheMinutes = releaseNotesCacheMinutes(v.date);
       await packageCache.set(
         cacheNamespace,
         cacheKey,


### PR DESCRIPTION
## Changes:

Varies the TTL based on the age of the release. 
Releases less than a week old will not see a difference and will continue to cache for 55 minutes. Whereas older releases will cache for a day, or 10 days if older than six months.

## Context:

ref: https://github.com/renovatebot/config-help/issues/947
The hope is reduce the traffic to github.com for those with a large number of repos and thus avoiding rate limiting. 

No documentation or test updates have been provided as I wasn't sure what would be required for this type of change.
I'm happy to add them, with some guidance, if desired. 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository


