### PR TITLE
feat(nuget): add support for centralized PackageVersion

### DIFF
--- a/docs/usage/nuget.md
+++ b/docs/usage/nuget.md
@@ -20,7 +20,7 @@ To convert your .NET Framework `.csproj`/`.fsproj`/`.vbproj` into an SDK-style p
 ## How It Works
 
 1.  Renovate will search each repository for any files with a `.csproj`, `.fsproj`, or `.vbproj` extension.
-2.  Existing dependencies will be extracted from `<PackageReference>` tags
+2.  Existing dependencies will be extracted from `<PackageReference>` adn `<PackageVersion>` tags
 3.  Renovate will look up the latest version on [nuget.org](https://nuget.org) (or on [alternate feeds](#Alternate%20feeds)) to determine if any upgrades are available
 4.  If the source package includes a GitHub URL as its source, and has either a "changelog" file or uses GitHub releases, then Release Notes for each version will be embedded in the generated PR.
 

--- a/docs/usage/nuget.md
+++ b/docs/usage/nuget.md
@@ -20,7 +20,7 @@ To convert your .NET Framework `.csproj`/`.fsproj`/`.vbproj` into an SDK-style p
 ## How It Works
 
 1.  Renovate will search each repository for any files with a `.csproj`, `.fsproj`, or `.vbproj` extension.
-2.  Existing dependencies will be extracted from `<PackageReference>` adn `<PackageVersion>` tags
+2.  Existing dependencies will be extracted from `<PackageReference>` and `<PackageVersion>` tags
 3.  Renovate will look up the latest version on [nuget.org](https://nuget.org) (or on [alternate feeds](#Alternate%20feeds)) to determine if any upgrades are available
 4.  If the source package includes a GitHub URL as its source, and has either a "changelog" file or uses GitHub releases, then Release Notes for each version will be embedded in the generated PR.
 

--- a/lib/manager/nuget/__fixtures__/with-centralized-package-versions/Directory.Packages.props
+++ b/lib/manager/nuget/__fixtures__/with-centralized-package-versions/Directory.Packages.props
@@ -1,0 +1,5 @@
+<Project>
+  <ItemGroup>
+    <PackageVersion Include="Autofac" Version="4.5.0" />
+  </ItemGroup>
+</Project>

--- a/lib/manager/nuget/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/nuget/__snapshots__/extract.spec.ts.snap
@@ -183,6 +183,17 @@ Array [
 ]
 `;
 
+exports[`lib/manager/nuget/extract extractPackageFile() extracts package version dependency 1`] = `
+Array [
+  Object {
+    "currentValue": "4.5.0",
+    "datasource": "nuget",
+    "depName": "Autofac",
+    "depType": "nuget",
+  },
+]
+`;
+
 exports[`lib/manager/nuget/extract extractPackageFile() extracts registry URLs independently 1`] = `
 Object {
   "deps": Array [

--- a/lib/manager/nuget/extract.spec.ts
+++ b/lib/manager/nuget/extract.spec.ts
@@ -16,6 +16,16 @@ describe('lib/manager/nuget/extract', () => {
         await extractPackageFile('nothing here', 'bogus', config)
       ).toMatchSnapshot();
     });
+    it('extracts package version dependency', async () => {
+      const packageFile =
+        'with-centralized-package-versions/Directory.Packages.props';
+      const sample = readFileSync(
+        path.join(config.localDir, packageFile),
+        'utf8'
+      );
+      const res = await extractPackageFile(sample, packageFile, config);
+      expect(res.deps).toMatchSnapshot();
+    });
     it('extracts all dependencies', async () => {
       const packageFile = 'sample.csproj';
       const sample = readFileSync(

--- a/lib/manager/nuget/extract.ts
+++ b/lib/manager/nuget/extract.ts
@@ -27,6 +27,7 @@ function extractDepsFromXml(xmlNode: XmlDocument): PackageDependency[] {
   for (const itemGroup of itemGroups) {
     const relevantChildren = [
       ...itemGroup.childrenNamed('PackageReference'),
+      ...itemGroup.childrenNamed('PackageVersion'),
       ...itemGroup.childrenNamed('DotNetCliToolReference'),
       ...itemGroup.childrenNamed('GlobalPackageReference'),
     ];


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Add support for centralized nuget `PackageVersion` property name.
New dotnet feature, described e.g. here https://stu.dev/managing-package-versions-centrally/, allows easier nuget dependencies versions management.
However this feature uses new property name in config files.

So I added parsing of new property name into nuget manager.

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
