### PR TITLE
docs: document that updateTypes: ['patch'] only works/matches if separateMinorPatch is set to true

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -1152,9 +1152,12 @@ Use this field to match rules against types of updates. For example to apply a s
 }
 ```
 
+Update type `patch` only matches if `separateMinorPatch` is set to true.
+
 ## patch
 
 Add to this object if you wish to define rules that apply only to patch updates. See also `major` and `minor` configuration options.
+Only applies if `separateMinorPatch` is set to true.
 
 ## php
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -1268,8 +1268,6 @@ For example to apply a special label for Major updates:
 }
 ```
 
-Update type `patch` only matches if `separateMinorPatch` is set to true.
-
 ## patch
 
 Add to this object if you wish to define rules that apply only to patch updates.

--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -900,7 +900,7 @@ const options: RenovateOptions[] = [
   {
     name: 'updateTypes',
     description:
-      'Update types to match against (major, minor, pin, etc). Valid only within `packageRules` object. `patch` only matches if `separateMinorPatch` is set to true',
+      'Update types to match against (major, minor, pin, etc). Valid only within `packageRules` object.
     type: 'array',
     // TODO: add allowedValues
     subType: 'string',

--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -900,7 +900,7 @@ const options: RenovateOptions[] = [
   {
     name: 'updateTypes',
     description:
-      'Update types to match against (major, minor, pin, etc). Valid only within `packageRules` object.',
+      'Update types to match against (major, minor, pin, etc). Valid only within `packageRules` object. `patch` only matches if `separateMinorPatch` is set to true',
     type: 'array',
     // TODO: add allowedValues
     subType: 'string',

--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -900,7 +900,7 @@ const options: RenovateOptions[] = [
   {
     name: 'updateTypes',
     description:
-      'Update types to match against (major, minor, pin, etc). Valid only within `packageRules` object.
+      'Update types to match against (major, minor, pin, etc). Valid only within `packageRules` object.',
     type: 'array',
     // TODO: add allowedValues
     subType: 'string',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

update config definitions

## Context:

I noticed that `updateTypes: ['patch']` only matches patch updates if `separateMinorPatch` is set to true.
This comes somewhat unexpected and does not seem to be documented anywhere at the moment, as opposed to the documentation of the `patch` setting, where the docs correctly state `Only applies if separateMinorPatch is set to true`.

Maybe related to https://github.com/renovatebot/renovate/issues/2818

But without reading the docs, I would expect `updateTypes: ['patch']` to always match on patch updates (e.g. 1.0.0 to 1.0.1) anyway, regardless of the `separateMinorPatch` setting (which is only set if we want separate PRs or branches for patch AND minor updates)

Docs should be updated accordingly.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
