### PR TITLE
feat(helmv3): lock file support

### DIFF
--- a/lib/manager/helmv3/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/manager/helmv3/__snapshots__/artifacts.spec.ts.snap
@@ -83,19 +83,19 @@ Array [
 exports[`.updateArtifacts() returns updated Chart.lock with docker 1`] = `
 Array [
   Object {
-    "cmd": "docker pull renovate/helmv3",
+    "cmd": "docker pull renovate/helm",
     "options": Object {
       "encoding": "utf-8",
     },
   },
   Object {
-    "cmd": "docker ps --filter name=renovate_helmv3 -aq",
+    "cmd": "docker ps --filter name=renovate_helm -aq",
     "options": Object {
       "encoding": "utf-8",
     },
   },
   Object {
-    "cmd": "docker run --rm --name=renovate_helmv3 --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -w \\"/tmp/github/some/repo\\" renovate/helmv3 bash -l -c \\"helm dependency update ''\\"",
+    "cmd": "docker run --rm --name=renovate_helm --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -w \\"/tmp/github/some/repo\\" renovate/helm bash -l -c \\"helm dependency update ''\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",

--- a/lib/manager/helmv3/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/manager/helmv3/__snapshots__/artifacts.spec.ts.snap
@@ -1,0 +1,116 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`.updateArtifacts() catches errors 1`] = `
+Array [
+  Object {
+    "artifactError": Object {
+      "lockFile": "Chart.lock",
+      "stderr": "not found",
+    },
+  },
+]
+`;
+
+exports[`.updateArtifacts() returns null if unchanged 1`] = `
+Array [
+  Object {
+    "cmd": "helm dependency update ''",
+    "options": Object {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": Object {
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+]
+`;
+
+exports[`.updateArtifacts() returns updated Chart.lock 1`] = `
+Array [
+  Object {
+    "cmd": "helm dependency update ''",
+    "options": Object {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": Object {
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+]
+`;
+
+exports[`.updateArtifacts() returns updated Chart.lock for lockfile maintenance 1`] = `
+Array [
+  Object {
+    "cmd": "helm dependency update ''",
+    "options": Object {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": Object {
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+]
+`;
+
+exports[`.updateArtifacts() returns updated Chart.lock with docker 1`] = `
+Array [
+  Object {
+    "cmd": "docker pull renovate/helmv3",
+    "options": Object {
+      "encoding": "utf-8",
+    },
+  },
+  Object {
+    "cmd": "docker ps --filter name=renovate_helmv3 -aq",
+    "options": Object {
+      "encoding": "utf-8",
+    },
+  },
+  Object {
+    "cmd": "docker run --rm --name=renovate_helmv3 --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -w \\"/tmp/github/some/repo\\" renovate/helmv3 bash -l -c \\"helm dependency update ''\\"",
+    "options": Object {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": Object {
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+]
+`;

--- a/lib/manager/helmv3/artifacts.spec.ts
+++ b/lib/manager/helmv3/artifacts.spec.ts
@@ -1,0 +1,136 @@
+import { exec as _exec } from 'child_process';
+import _fs from 'fs-extra';
+import { join } from 'upath';
+import { envMock, mockExecAll } from '../../../test/execUtil';
+import { git, mocked } from '../../../test/util';
+import { setExecConfig } from '../../util/exec';
+import { BinarySource } from '../../util/exec/common';
+import * as docker from '../../util/exec/docker';
+import * as _env from '../../util/exec/env';
+import * as helmv3 from './artifacts';
+
+jest.mock('fs-extra');
+jest.mock('child_process');
+jest.mock('../../util/exec/env');
+jest.mock('../../util/git');
+jest.mock('../../util/http');
+
+const fs: jest.Mocked<typeof _fs> = _fs as any;
+const exec: jest.Mock<typeof _exec> = _exec as any;
+const env = mocked(_env);
+
+const config = {
+  // `join` fixes Windows CI
+  localDir: join('/tmp/github/some/repo'),
+  dockerUser: 'foobar',
+};
+
+describe('.updateArtifacts()', () => {
+  beforeEach(async () => {
+    jest.resetAllMocks();
+    jest.resetModules();
+
+    env.getChildProcessEnv.mockReturnValue(envMock.basic);
+    await setExecConfig(config);
+    docker.resetPrefetchedImages();
+  });
+  it('returns null if no Chart.lock found', async () => {
+    const updatedDeps = ['dep1'];
+    expect(
+      await helmv3.updateArtifacts({
+        packageFileName: 'Chart.yaml',
+        updatedDeps,
+        newPackageFileContent: '',
+        config,
+      })
+    ).toBeNull();
+  });
+  it('returns null if updatedDeps is empty', async () => {
+    expect(
+      await helmv3.updateArtifacts({
+        packageFileName: 'Chart.yaml',
+        updatedDeps: [],
+        newPackageFileContent: '',
+        config,
+      })
+    ).toBeNull();
+  });
+  it('returns null if unchanged', async () => {
+    fs.readFile.mockResolvedValueOnce('Current Chart.lock' as any);
+    const execSnapshots = mockExecAll(exec);
+    fs.readFile.mockResolvedValueOnce('Current Chart.lock' as any);
+    const updatedDeps = ['dep1'];
+    expect(
+      await helmv3.updateArtifacts({
+        packageFileName: 'Chart.yaml',
+        updatedDeps,
+        newPackageFileContent: '',
+        config,
+      })
+    ).toBeNull();
+    expect(execSnapshots).toMatchSnapshot();
+  });
+  it('returns updated Chart.lock', async () => {
+    git.getFile.mockResolvedValueOnce('Old Chart.lock');
+    const execSnapshots = mockExecAll(exec);
+    fs.readFile.mockResolvedValueOnce('New Chart.lock' as any);
+    const updatedDeps = ['dep1'];
+    expect(
+      await helmv3.updateArtifacts({
+        packageFileName: 'Chart.yaml',
+        updatedDeps,
+        newPackageFileContent: '{}',
+        config,
+      })
+    ).not.toBeNull();
+    expect(execSnapshots).toMatchSnapshot();
+  });
+
+  it('returns updated Chart.lock for lockfile maintenance', async () => {
+    git.getFile.mockResolvedValueOnce('Old Chart.lock');
+    const execSnapshots = mockExecAll(exec);
+    fs.readFile.mockResolvedValueOnce('New Chart.lock' as any);
+    expect(
+      await helmv3.updateArtifacts({
+        packageFileName: 'Chart.yaml',
+        updatedDeps: [],
+        newPackageFileContent: '{}',
+        config: { ...config, updateType: 'lockFileMaintenance' },
+      })
+    ).not.toBeNull();
+    expect(execSnapshots).toMatchSnapshot();
+  });
+
+  it('returns updated Chart.lock with docker', async () => {
+    jest.spyOn(docker, 'removeDanglingContainers').mockResolvedValueOnce();
+    await setExecConfig({ ...config, binarySource: BinarySource.Docker });
+    git.getFile.mockResolvedValueOnce('Old Chart.lock');
+    const execSnapshots = mockExecAll(exec);
+    fs.readFile.mockResolvedValueOnce('New Chart.lock' as any);
+    const updatedDeps = ['dep1'];
+    expect(
+      await helmv3.updateArtifacts({
+        packageFileName: 'Chart.yaml',
+        updatedDeps,
+        newPackageFileContent: '{}',
+        config,
+      })
+    ).not.toBeNull();
+    expect(execSnapshots).toMatchSnapshot();
+  });
+  it('catches errors', async () => {
+    fs.readFile.mockResolvedValueOnce('Current Chart.lock' as any);
+    fs.outputFile.mockImplementationOnce(() => {
+      throw new Error('not found');
+    });
+    const updatedDeps = ['dep1'];
+    expect(
+      await helmv3.updateArtifacts({
+        packageFileName: 'Chart.yaml',
+        updatedDeps,
+        newPackageFileContent: '{}',
+        config,
+      })
+    ).toMatchSnapshot();
+  });
+});

--- a/lib/manager/helmv3/artifacts.ts
+++ b/lib/manager/helmv3/artifacts.ts
@@ -1,0 +1,76 @@
+import { quote } from 'shlex';
+import { logger } from '../../logger';
+import { ExecOptions, exec } from '../../util/exec';
+import {
+  getSiblingFileName,
+  getSubDirectory,
+  readLocalFile,
+  writeLocalFile,
+} from '../../util/fs';
+import { UpdateArtifact, UpdateArtifactsResult } from '../common';
+
+async function helmUpdate(manifestPath: string): Promise<void> {
+  const cmd = `helm dependency update ${quote(getSubDirectory(manifestPath))}`;
+
+  const execOptions: ExecOptions = {
+    docker: {
+      image: 'renovate/helmv3',
+    },
+  };
+  await exec(cmd, execOptions);
+}
+
+export async function updateArtifacts({
+  packageFileName,
+  updatedDeps,
+  newPackageFileContent,
+  config,
+}: UpdateArtifact): Promise<UpdateArtifactsResult[] | null> {
+  logger.debug(`helmv3.updateArtifacts(${packageFileName})`);
+
+  const isLockFileMaintenance = config.updateType === 'lockFileMaintenance';
+
+  if (
+    !isLockFileMaintenance &&
+    (updatedDeps === undefined || updatedDeps.length < 1)
+  ) {
+    logger.debug('No updated helmv3 deps - returning null');
+    return null;
+  }
+
+  const lockFileName = getSiblingFileName(packageFileName, 'Chart.lock');
+  const existingLockFileContent = await readLocalFile(lockFileName);
+  if (!existingLockFileContent) {
+    logger.debug('No Chart.lock found');
+    return null;
+  }
+  try {
+    await writeLocalFile(packageFileName, newPackageFileContent);
+    logger.debug('Updating ' + lockFileName);
+    await helmUpdate(packageFileName);
+    logger.debug('Returning updated Chart.lock');
+    const newHelmLockContent = await readLocalFile(lockFileName);
+    if (existingLockFileContent === newHelmLockContent) {
+      logger.debug('Chart.lock is unchanged');
+      return null;
+    }
+    return [
+      {
+        file: {
+          name: lockFileName,
+          contents: newHelmLockContent,
+        },
+      },
+    ];
+  } catch (err) {
+    logger.warn({ err }, 'Failed to update Helm lock file');
+    return [
+      {
+        artifactError: {
+          lockFile: lockFileName,
+          stderr: err.message,
+        },
+      },
+    ];
+  }
+}

--- a/lib/manager/helmv3/artifacts.ts
+++ b/lib/manager/helmv3/artifacts.ts
@@ -14,7 +14,7 @@ async function helmUpdate(manifestPath: string): Promise<void> {
 
   const execOptions: ExecOptions = {
     docker: {
-      image: 'renovate/helmv3',
+      image: 'renovate/helm',
     },
   };
   await exec(cmd, execOptions);

--- a/lib/manager/helmv3/index.ts
+++ b/lib/manager/helmv3/index.ts
@@ -1,4 +1,7 @@
+export { updateArtifacts } from './artifacts';
 export { extractPackageFile } from './extract';
+
+export const supportsLockFileMaintenance = true;
 
 export const defaultConfig = {
   aliases: {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- helmv3: Adds support for updating the Chart.lock file when packages are updated
- helmv3: Adds lock file maintenance support

<!-- Describe what this pull request changes. -->

## Context:

Closes #6877 

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] Unit tests + ran on a real repository: https://github.com/mikebryant/renovate-test-helm-lock/pulls

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
