### PR TITLE
feat(git-submodules): use checkout instead of submodule update

### DIFF
--- a/lib/manager/git-submodules/update.spec.ts
+++ b/lib/manager/git-submodules/update.spec.ts
@@ -1,5 +1,6 @@
 import _simpleGit from 'simple-git';
 import { dir } from 'tmp-promise';
+import { Upgrade } from '../common';
 
 import updateDependency from './update';
 
@@ -8,28 +9,35 @@ const simpleGit: any = _simpleGit;
 
 describe('manager/git-submodules/update', () => {
   describe('updateDependency', () => {
+    let upgrade: Upgrade;
+    beforeAll(async () => {
+      const tmpDir = await dir();
+      upgrade = { localDir: tmpDir.path, depName: 'renovate' };
+    });
     it('returns null on error', async () => {
       simpleGit.mockReturnValue({
-        raw() {
+        submoduleUpdate() {
           throw new Error();
         },
       });
       const update = await updateDependency({
         fileContent: '',
-        upgrade: {},
+        upgrade,
       });
       expect(update).toBeNull();
     });
     it('returns content on update', async () => {
-      const tmpDir = await dir();
       simpleGit.mockReturnValue({
-        raw() {
+        submoduleUpdate() {
+          return Promise.resolve();
+        },
+        checkout() {
           return Promise.resolve();
         },
       });
       const update = await updateDependency({
         fileContent: '',
-        upgrade: { localDir: tmpDir.path },
+        upgrade,
       });
       expect(update).toEqual('');
     });

--- a/lib/manager/git-submodules/update.ts
+++ b/lib/manager/git-submodules/update.ts
@@ -1,4 +1,5 @@
 import Git from 'simple-git';
+import upath from 'upath';
 
 import { UpdateDependencyConfig } from '../common';
 
@@ -7,15 +8,11 @@ export default async function updateDependency({
   upgrade,
 }: UpdateDependencyConfig): Promise<string | null> {
   const git = Git(upgrade.localDir);
+  const submoduleGit = Git(upath.join(upgrade.localDir, upgrade.depName));
 
   try {
-    await git.raw([
-      'submodule',
-      'update',
-      '--init',
-      '--remote',
-      upgrade.depName,
-    ]);
+    await git.submoduleUpdate(['--init', upgrade.depName]);
+    await submoduleGit.checkout([upgrade.newVersion]);
     return fileContent;
   } catch (err) {
     return null;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

This is part 2 of #7498, and includes:

- Update submodules using `checkout` instead of `submodule update`

## Context:

#7472 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
