### PR TITLE
fix(git-submodules): correctly parse git submodule name

### DIFF
--- a/lib/manager/git-submodules/extract.ts
+++ b/lib/manager/git-submodules/extract.ts
@@ -106,7 +106,8 @@ export default async function extractPackageFile(
         try {
           const [currentValue] = (await git.subModule(['status', path]))
             .trim()
-            .split(/[+\s]/);
+            .replace(/^[-+]/, '')
+            .split(/\s/);
           const subModuleUrl = await getUrl(git, gitModulesPath, name);
           const submoduleBranch = await getBranch(
             gitModulesPath,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

This is part 3 of #7498, and includes:

- Correctly parse git submodule name
## Context:

#7472 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
