### PR TITLE
tests(go): Use http mocks for downstream datasources

### DIFF
--- a/lib/datasource/go/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/go/__snapshots__/index.spec.ts.snap
@@ -11,6 +11,16 @@ Array [
     "method": "GET",
     "url": "https://golang.org/x/text?go-get=1",
   },
+  Object {
+    "headers": Object {
+      "accept": "application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate",
+      "host": "api.github.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://api.github.com/repos/golang/text/commits?per_page=1",
+  },
 ]
 `;
 
@@ -42,16 +52,49 @@ Array [
 ]
 `;
 
+exports[`datasource/go getReleases falls back to old behaviour 1`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate",
+      "host": "api.github.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://api.github.com/repos/x/text/tags?per_page=100",
+  },
+]
+`;
+
+exports[`datasource/go getReleases falls back to old behaviour 2`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate",
+      "host": "api.github.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://api.github.com/repos/x/text/tags?per_page=100",
+  },
+]
+`;
+
 exports[`datasource/go getReleases processes real data 1`] = `
 Object {
   "releases": Array [
     Object {
+      "gitRef": "v1.0.0",
       "version": "v1.0.0",
     },
     Object {
+      "gitRef": "v2.0.0",
       "version": "v2.0.0",
     },
   ],
+  "sourceUrl": "https://github.com/golang/text",
 }
 `;
 
@@ -65,6 +108,16 @@ Array [
     },
     "method": "GET",
     "url": "https://golang.org/x/text?go-get=1",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate",
+      "host": "api.github.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://api.github.com/repos/golang/text/tags?per_page=100",
   },
 ]
 `;
@@ -93,6 +146,20 @@ Array [
     },
     "method": "GET",
     "url": "https://golang.org/foo/something?go-get=1",
+  },
+]
+`;
+
+exports[`datasource/go getReleases returns null for go-import prefix mismatch 1`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept-encoding": "gzip, deflate",
+      "host": "git.enterprise.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://git.enterprise.com/example/module?go-get=1",
   },
 ]
 `;
@@ -139,43 +206,19 @@ Array [
 ]
 `;
 
-exports[`datasource/go getReleases support gitlab 1`] = `
-Object {
-  "releases": Array [
-    Object {
-      "version": "v1.0.0",
-    },
-    Object {
-      "version": "v2.0.0",
-    },
-  ],
-}
-`;
-
-exports[`datasource/go getReleases support gitlab 2`] = `
-Array [
-  Object {
-    "headers": Object {
-      "accept-encoding": "gzip, deflate",
-      "host": "golang.org",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
-    "url": "https://golang.org/x/text?go-get=1",
-  },
-]
-`;
-
 exports[`datasource/go getReleases support ghe 1`] = `
 Object {
   "releases": Array [
     Object {
+      "gitRef": "v1.0.0",
       "version": "v1.0.0",
     },
     Object {
+      "gitRef": "v2.0.0",
       "version": "v2.0.0",
     },
   ],
+  "sourceUrl": "https://git.enterprise.com/example/module",
 }
 `;
 
@@ -190,45 +233,120 @@ Array [
     "method": "GET",
     "url": "https://git.enterprise.com/example/module?go-get=1",
   },
+  Object {
+    "headers": Object {
+      "accept": "application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate",
+      "host": "git.enterprise.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://git.enterprise.com/api/v3/repos/example/module/tags?per_page=100",
+  },
+]
+`;
+
+exports[`datasource/go getReleases support gitlab 1`] = `
+Object {
+  "releases": Array [
+    Object {
+      "gitRef": "v1.0.0",
+      "version": "v1.0.0",
+    },
+    Object {
+      "gitRef": "v2.0.0",
+      "version": "v2.0.0",
+    },
+  ],
+  "sourceUrl": "https://gitlab.com/golang/text",
+}
+`;
+
+exports[`datasource/go getReleases support gitlab 2`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept-encoding": "gzip, deflate",
+      "host": "golang.org",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://golang.org/x/text?go-get=1",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitlab.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitlab.com/api/v4/projects/golang%2Ftext/repository/tags?per_page=100",
+  },
 ]
 `;
 
 exports[`datasource/go getReleases works for known servers 1`] = `
 Array [
-  Array [
-    Object {
-      "datasource": "github-tags",
-      "lookupName": "x/text",
+  Object {
+    "headers": Object {
+      "accept": "application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate",
+      "host": "api.github.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
     },
-  ],
-  Array [
-    Object {
-      "datasource": "github-tags",
-      "lookupName": "x/text",
+    "method": "GET",
+    "url": "https://api.github.com/repos/x/text/tags?per_page=100",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate",
+      "host": "api.github.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
     },
-  ],
-  Array [
-    Object {
-      "datasource": "github-tags",
-      "lookupName": "go-x/x",
+    "method": "GET",
+    "url": "https://api.github.com/repos/x/text/tags?per_page=100",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate",
+      "host": "api.github.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
     },
-  ],
+    "method": "GET",
+    "url": "https://api.github.com/repos/go-x/x/tags?per_page=100",
+  },
 ]
 `;
 
 exports[`datasource/go getReleases works for nested modules on github 1`] = `
 Array [
-  Array [
-    Object {
-      "datasource": "github-tags",
-      "lookupName": "x/text",
+  Object {
+    "headers": Object {
+      "accept": "application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate",
+      "host": "api.github.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
     },
-  ],
-  Array [
-    Object {
-      "datasource": "github-tags",
-      "lookupName": "x/text",
+    "method": "GET",
+    "url": "https://api.github.com/repos/x/text/tags?per_page=100",
+  },
+]
+`;
+
+exports[`datasource/go getReleases works for nested modules on github 2`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate",
+      "host": "api.github.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
     },
-  ],
+    "method": "GET",
+    "url": "https://api.github.com/repos/x/text/tags?per_page=100",
+  },
 ]
 `;

--- a/lib/datasource/go/index.spec.ts
+++ b/lib/datasource/go/index.spec.ts
@@ -1,15 +1,6 @@
-import { ReleaseResult, getPkgReleases } from '..';
+import { getPkgReleases } from '..';
 import * as httpMock from '../../../test/httpMock';
-import { mocked, partial } from '../../../test/util';
-import * as _github from '../github-tags';
-import * as _gitlab from '../gitlab-tags';
 import { id as datasource, getDigest } from '.';
-
-jest.mock('../github-tags');
-jest.mock('../gitlab-tags');
-
-const github = mocked(_github);
-const gitlab = mocked(_gitlab);
 
 const res1 = `<!DOCTYPE html>
 <html>
@@ -53,7 +44,6 @@ describe('datasource/go', () => {
         .scope('https://golang.org/')
         .get('/y/text?go-get=1')
         .reply(200, '');
-      github.getDigest.mockResolvedValueOnce('abcdefabcdefabcdefabcdef');
       const res = await getDigest({ lookupName: 'golang.org/y/text' }, null);
       expect(res).toBeNull();
       expect(httpMock.getTrace()).toMatchSnapshot();
@@ -63,7 +53,6 @@ describe('datasource/go', () => {
         .scope('https://golang.org/')
         .get('/y/text?go-get=1')
         .reply(200, res1);
-      github.getDigest.mockResolvedValueOnce('abcdefabcdefabcdefabcdef');
       const res = await getDigest({ lookupName: 'golang.org/y/text' }, null);
       expect(res).toBeNull();
       expect(httpMock.getTrace()).toMatchSnapshot();
@@ -73,7 +62,10 @@ describe('datasource/go', () => {
         .scope('https://golang.org/')
         .get('/x/text?go-get=1')
         .reply(200, res1);
-      github.getDigest.mockResolvedValueOnce('abcdefabcdefabcdefabcdef');
+      httpMock
+        .scope('https://api.github.com/')
+        .get('/repos/golang/text/commits?per_page=1')
+        .reply(200, [{ sha: 'abcdefabcdefabcdefabcdef' }]);
       const res = await getDigest({ lookupName: 'golang.org/x/text' }, null);
       expect(res).toBe('abcdefabcdefabcdefabcdef');
       expect(httpMock.getTrace()).toMatchSnapshot();
@@ -85,12 +77,11 @@ describe('datasource/go', () => {
         .scope('https://golang.org/')
         .get('/foo/something?go-get=1')
         .reply(200, res1);
-      expect(
-        await getPkgReleases({
-          datasource,
-          depName: 'golang.org/foo/something',
-        })
-      ).toBeNull();
+      const res = await getPkgReleases({
+        datasource,
+        depName: 'golang.org/foo/something',
+      });
+      expect(res).toBeNull();
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
     it('returns null for 404', async () => {
@@ -98,12 +89,11 @@ describe('datasource/go', () => {
         .scope('https://golang.org/')
         .get('/foo/something?go-get=1')
         .reply(404);
-      expect(
-        await getPkgReleases({
-          datasource,
-          depName: 'golang.org/foo/something',
-        })
-      ).toBeNull();
+      const res = await getPkgReleases({
+        datasource,
+        depName: 'golang.org/foo/something',
+      });
+      expect(res).toBeNull();
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
     it('returns null for unknown error', async () => {
@@ -111,12 +101,11 @@ describe('datasource/go', () => {
         .scope('https://golang.org/')
         .get('/foo/something?go-get=1')
         .replyWithError('error');
-      expect(
-        await getPkgReleases({
-          datasource,
-          depName: 'golang.org/foo/something',
-        })
-      ).toBeNull();
+      const res = await getPkgReleases({
+        datasource,
+        depName: 'golang.org/foo/something',
+      });
+      expect(res).toBeNull();
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
     it('processes real data', async () => {
@@ -124,9 +113,10 @@ describe('datasource/go', () => {
         .scope('https://golang.org/')
         .get('/x/text?go-get=1')
         .reply(200, res1);
-      github.getReleases.mockResolvedValueOnce({
-        releases: [{ version: 'v1.0.0' }, { version: 'v2.0.0' }],
-      });
+      httpMock
+        .scope('https://api.github.com/')
+        .get('/repos/golang/text/tags?per_page=100')
+        .reply(200, [{ name: 'v1.0.0' }, { name: 'v2.0.0' }]);
       const res = await getPkgReleases({
         datasource,
         depName: 'golang.org/x/text',
@@ -147,9 +137,10 @@ describe('datasource/go', () => {
             'https://gitlab.com/golang/text/'
           )
         );
-      gitlab.getReleases.mockResolvedValueOnce({
-        releases: [{ version: 'v1.0.0' }, { version: 'v2.0.0' }],
-      });
+      httpMock
+        .scope('https://gitlab.com/')
+        .get('/api/v4/projects/golang%2Ftext/repository/tags?per_page=100')
+        .reply(200, [{ name: 'v1.0.0' }, { name: 'v2.0.0' }]);
       const res = await getPkgReleases({
         datasource,
         depName: 'golang.org/x/text',
@@ -164,9 +155,10 @@ describe('datasource/go', () => {
         .scope('https://git.enterprise.com/')
         .get('/example/module?go-get=1')
         .reply(200, resGitHubEnterprise);
-      github.getReleases.mockResolvedValueOnce({
-        releases: [{ version: 'v1.0.0' }, { version: 'v2.0.0' }],
-      });
+      httpMock
+        .scope('https://git.enterprise.com/')
+        .get('/api/v3/repos/example/module/tags?per_page=100')
+        .reply(200, [{ name: 'v1.0.0' }, { name: 'v2.0.0' }]);
       const res = await getPkgReleases({
         datasource,
         depName: 'git.enterprise.com/example/module',
@@ -192,6 +184,7 @@ describe('datasource/go', () => {
         depName: 'git.enterprise.com/example/module',
       });
       expect(res).toBeNull();
+      expect(httpMock.getTrace()).toMatchSnapshot();
     });
     it('skips wrong package', async () => {
       httpMock
@@ -224,54 +217,74 @@ describe('datasource/go', () => {
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
     it('works for known servers', async () => {
-      github.getReleases.mockClear();
+      httpMock
+        .scope('https://api.github.com/')
+        .get('/repos/x/text/tags?per_page=100')
+        .reply(200, [])
+        .get('/repos/x/text/tags?per_page=100')
+        .reply(200, [])
+        .get('/repos/go-x/x/tags?per_page=100')
+        .reply(200, []);
       const packages = [
         { datasource, depName: 'github.com/x/text' },
         { datasource, depName: 'gopkg.in/x/text' },
         { datasource, depName: 'gopkg.in/x' },
       ];
-      const githubRes = {
-        releases: [],
-      } as any;
       for (const pkg of packages) {
-        github.getReleases.mockResolvedValueOnce(
-          partial<ReleaseResult>(githubRes)
-        );
-        expect(await getPkgReleases(pkg)).toBeNull();
+        const res = await getPkgReleases(pkg);
+        expect(res.releases).toBeEmpty();
       }
-      expect(github.getReleases.mock.calls).toMatchSnapshot();
+      const httpCalls = httpMock.getTrace();
+      expect(httpCalls).toHaveLength(3);
+      expect(httpCalls).toMatchSnapshot();
     });
     it('works for nested modules on github', async () => {
-      github.getReleases.mockClear();
       const packages = [
         { datasource, depName: 'github.com/x/text/a' },
         { datasource, depName: 'github.com/x/text/b' },
       ];
+      const tags = [{ name: 'a/v1.0.0' }, { name: 'b/v2.0.0' }];
 
       for (const pkg of packages) {
-        github.getReleases.mockResolvedValueOnce({
-          releases: [{ version: 'a/v1.0.0' }, { version: 'b/v2.0.0' }],
-        });
+        httpMock.setup();
+        httpMock
+          .scope('https://api.github.com/')
+          .get('/repos/x/text/tags?per_page=100')
+          .reply(200, tags);
+
         const prefix = pkg.depName.split('/')[3];
         const result = await getPkgReleases(pkg);
         expect(result.releases).toHaveLength(1);
         expect(result.releases[0].version.startsWith(prefix)).toBeFalse();
+
+        const httpCalls = httpMock.getTrace();
+        expect(httpCalls).toMatchSnapshot();
+        httpMock.reset();
       }
-      expect(github.getReleases.mock.calls).toMatchSnapshot();
     });
     it('falls back to old behaviour', async () => {
-      github.getReleases.mockClear();
       const packages = [
         { datasource, depName: 'github.com/x/text/a' },
         { datasource, depName: 'github.com/x/text/b' },
       ];
+      const tags = [{ name: 'v1.0.0' }, { name: 'v2.0.0' }];
 
-      const releases = {
-        releases: [{ version: 'v1.0.0' }, { version: 'v2.0.0' }],
-      };
       for (const pkg of packages) {
-        github.getReleases.mockResolvedValueOnce(releases);
-        expect(await getPkgReleases(pkg)).toStrictEqual(releases);
+        httpMock.setup();
+        httpMock
+          .scope('https://api.github.com/')
+          .get('/repos/x/text/tags?per_page=100')
+          .reply(200, tags);
+
+        const result = await getPkgReleases(pkg);
+        expect(result.releases).toHaveLength(2);
+        expect(result.releases.map(({ version }) => version)).toStrictEqual(
+          tags.map(({ name }) => name)
+        );
+
+        const httpCalls = httpMock.getTrace();
+        expect(httpCalls).toMatchSnapshot();
+        httpMock.reset();
       }
     });
   });


### PR DESCRIPTION
Ref: #7252, #7652

Before `github-tags` behavior will change, we need more confidence for this datasource