### PR TITLE
fix: update-lockfile in-range updates

### DIFF
--- a/lib/workers/branch/__snapshots__/get-updated.spec.ts.snap
+++ b/lib/workers/branch/__snapshots__/get-updated.spec.ts.snap
@@ -1,14 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`workers/branch/get-updated getUpdatedPackageFiles()  does not update artifacts on update-lockfile if packageFile already updated 1`] = `
-Object {
-  "artifactErrors": Array [],
-  "reuseExistingBranch": undefined,
-  "updatedArtifacts": Array [],
-  "updatedPackageFiles": Array [],
-}
-`;
-
 exports[`workers/branch/get-updated getUpdatedPackageFiles() handles autoreplace base updated 1`] = `
 Object {
   "artifactErrors": Array [],

--- a/lib/workers/branch/get-updated.spec.ts
+++ b/lib/workers/branch/get-updated.spec.ts
@@ -168,28 +168,6 @@ describe('workers/branch/get-updated', () => {
       ]);
       const res = await getUpdatedPackageFiles(config);
       expect(res).toMatchSnapshot();
-      expect(res.updatedPackageFiles).toHaveLength(1);
-    });
-    it(' does not update artifacts on update-lockfile if packageFile already updated', async () => {
-      config.upgrades.push({
-        manager: 'composer',
-        branchName: undefined,
-        rangeStrategy: 'update-lockfile',
-        currentValue: '^1.0.0',
-        newValue: '^2.0.0',
-      });
-      autoReplace.doAutoReplace.mockResolvedValueOnce('existing content');
-      composer.updateArtifacts.mockResolvedValueOnce([
-        {
-          file: {
-            name: 'composer.lock',
-            contents: 'some contents',
-          },
-        },
-      ]);
-      const res = await getUpdatedPackageFiles(config);
-      expect(res).toMatchSnapshot();
-      expect(res.updatedPackageFiles).toHaveLength(0);
     });
   });
 });

--- a/lib/workers/branch/get-updated.ts
+++ b/lib/workers/branch/get-updated.ts
@@ -65,10 +65,7 @@ export async function getUpdatedPackageFiles(
         if (res) {
           if (res === existingContent) {
             logger.debug({ packageFile, depName }, 'No content changed');
-            if (
-              upgrade.currentValue === upgrade.newValue &&
-              upgrade.rangeStrategy === 'update-lockfile'
-            ) {
+            if (upgrade.rangeStrategy === 'update-lockfile') {
               logger.debug({ packageFile, depName }, 'update-lockfile add');
               updatedFileContents[packageFile] = res;
             }
@@ -122,18 +119,13 @@ export async function getUpdatedPackageFiles(
         logger.debug({ packageFile, depName }, 'Updating packageFile content');
         updatedFileContents[packageFile] = newContent;
       }
-      if (newContent === existingContent) {
-        if (upgrade.datasource === datasourceGitSubmodules.id) {
-          updatedFileContents[packageFile] = newContent;
-        }
-        // istanbul ignore next
-        if (
-          upgrade.rangeStrategy === 'update-lockfile' &&
-          upgrade.currentValue === upgrade.newValue
-        ) {
-          // Treat the file as modified because we need to update artifacts
-          updatedFileContents[packageFile] = newContent;
-        }
+      if (
+        newContent === existingContent &&
+        (upgrade.datasource ===
+          datasourceGitSubmodules.id /* istanbul ignore next: no manager to test this exists */ ||
+          upgrade.rangeStrategy === 'update-lockfile')
+      ) {
+        updatedFileContents[packageFile] = newContent;
       }
     }
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Fixes a bug with in-range update-lockfile updates which was caused when fixing an out-of-range bug. Reverts the previous change and addresses the problem by keeping updated and non-updated package files in separtae lists.

## Context:

Closes #7658

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
