### PR TITLE
feat: workarounds presets

### DIFF
--- a/lib/config/presets/index.ts
+++ b/lib/config/presets/index.ts
@@ -95,6 +95,7 @@ export function parsePreset(input: string): ParsedPreset {
     'packages',
     'preview',
     'schedule',
+    'workarounds',
   ];
   if (
     presetsPackages.some((presetPackage) => str.startsWith(`${presetPackage}:`))

--- a/lib/config/presets/internal/config.ts
+++ b/lib/config/presets/internal/config.ts
@@ -18,6 +18,7 @@ export const presets: Record<string, Preset> = {
       'group:monorepos',
       'group:recommended',
       'helpers:disableTypesNodeMajor',
+      'workarounds:all',
     ],
   },
   'base-js': {

--- a/lib/config/presets/internal/index.ts
+++ b/lib/config/presets/internal/index.ts
@@ -8,6 +8,7 @@ import * as monorepoPreset from './monorepo';
 import * as packagesPreset from './packages';
 import * as previewPreset from './preview';
 import * as schedulePreset from './schedule';
+import * as workaroundsPreset from './workarounds';
 
 export const groups: Record<string, Record<string, Preset>> = {
   config: configPreset.presets,
@@ -19,6 +20,7 @@ export const groups: Record<string, Record<string, Preset>> = {
   packages: packagesPreset.presets,
   preview: previewPreset.presets,
   schedule: schedulePreset.presets,
+  workarounds: workaroundsPreset.presets,
 };
 
 export function getPreset({

--- a/lib/config/presets/internal/workarounds.ts
+++ b/lib/config/presets/internal/workarounds.ts
@@ -1,0 +1,20 @@
+import { Preset } from '../common';
+
+export const presets: Record<string, Preset> = {
+  all: {
+    description: [
+      'A collection of workarounds for known problems with packages',
+    ],
+    extends: ['workarounds:unstableV2SetupNodeActions'],
+  },
+  unstableV2SetupNodeActions: {
+    description: 'Ignore wrongly tagged actions/setup-node v2 releases',
+    packageRules: [
+      {
+        datasources: ['github-tags', 'github-releases'],
+        packageNames: ['actions/setup-node'],
+        allowedVersions: '<2.1.1 || > 2.1.1',
+      },
+    ],
+  },
+};


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds a new internal preset category `workarounds` which are included by default with `config:all`. 

## Context:

The aim of this new category is to add rules when we can "fix" problems in package naming or releasing and it would benefit the user base. Includes a fix for `actions/setup-node` initially which should result in autoclosing of most open PRs including in this repo.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

Documentation will be automatically generated.

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
