### PR TITLE
feat(npm): add support for npm 7 (package-lock v2)

### DIFF
--- a/lib/manager/npm/__fixtures__/npm7/package-lock.json
+++ b/lib/manager/npm/__fixtures__/npm7/package-lock.json
@@ -1,0 +1,130 @@
+{
+  "name": "npm7",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "chalk": "^2.4.1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dependencies": {
+        "color-convert": "1.9.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "dependencies": {
+        "ansi-styles": "3.2.1",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "5.4.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "dependencies": {
+        "has-flag": "3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    }
+  },
+  "dependencies": {
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "requires": {
+        "color-convert": "1.9.1"
+      }
+    },
+    "chalk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "requires": {
+        "ansi-styles": "3.2.1",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "5.4.0"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
+    "supports-color": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "requires": {
+        "has-flag": "3.0.0"
+      }
+    }
+  }
+}

--- a/lib/manager/npm/__fixtures__/npm7/package.json
+++ b/lib/manager/npm/__fixtures__/npm7/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "npm7",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "chalk": "^2.4.1"
+  }
+}

--- a/lib/manager/npm/extract/__snapshots__/locked-versions.spec.ts.snap
+++ b/lib/manager/npm/extract/__snapshots__/locked-versions.spec.ts.snap
@@ -18,9 +18,33 @@ Array [
 ]
 `;
 
-exports[`manager/npm/extract/locked-versions .getLockedVersions() uses package-lock.json 1`] = `
+exports[`manager/npm/extract/locked-versions .getLockedVersions() uses package-lock.json with npm v6.0.0 1`] = `
 Array [
   Object {
+    "constraints": Object {},
+    "deps": Array [
+      Object {
+        "currentValue": "1.0.0",
+        "depName": "a",
+        "lockedVersion": "1.0.0",
+      },
+      Object {
+        "currentValue": "2.0.0",
+        "depName": "b",
+        "lockedVersion": "2.0.0",
+      },
+    ],
+    "npmLock": "package-lock.json",
+  },
+]
+`;
+
+exports[`manager/npm/extract/locked-versions .getLockedVersions() uses package-lock.json with npm v7.0.0 1`] = `
+Array [
+  Object {
+    "constraints": Object {
+      "npm": ">= 7.0.0",
+    },
     "deps": Array [
       Object {
         "currentValue": "1.0.0",

--- a/lib/manager/npm/extract/__snapshots__/npm.spec.ts.snap
+++ b/lib/manager/npm/extract/__snapshots__/npm.spec.ts.snap
@@ -11,5 +11,21 @@ Object {
     "has-flag": "3.0.0",
     "supports-color": "5.4.0",
   },
+  "lockfileVersion": 1,
+}
+`;
+
+exports[`manager/npm/extract/npm .getNpmLock() extracts npm 7 lockfile 1`] = `
+Object {
+  "lockedVersions": Object {
+    "ansi-styles": "3.2.1",
+    "chalk": "2.4.1",
+    "color-convert": "1.9.1",
+    "color-name": "1.1.3",
+    "escape-string-regexp": "1.0.5",
+    "has-flag": "3.0.0",
+    "supports-color": "5.4.0",
+  },
+  "lockfileVersion": 2,
 }
 `;

--- a/lib/manager/npm/extract/locked-versions.spec.ts
+++ b/lib/manager/npm/extract/locked-versions.spec.ts
@@ -44,32 +44,37 @@ describe('manager/npm/extract/locked-versions', () => {
       }
     );
 
-    it('uses package-lock.json', async () => {
-      npm.getNpmLock.mockReturnValue({
-        lockedVersions: {
-          a: '1.0.0',
-          b: '2.0.0',
-          c: '3.0.0',
-        },
-      });
-      const packageFiles = [
-        {
-          npmLock: 'package-lock.json',
-          deps: [
-            {
-              depName: 'a',
-              currentValue: '1.0.0',
-            },
-            {
-              depName: 'b',
-              currentValue: '2.0.0',
-            },
-          ],
-        },
-      ];
-      await getLockedVersions(packageFiles);
-      expect(packageFiles).toMatchSnapshot();
-    });
+    it.each([['6.0.0'], ['7.0.0']])(
+      'uses package-lock.json with npm v%s',
+      async (npmVersion) => {
+        npm.getNpmLock.mockReturnValue({
+          lockedVersions: {
+            a: '1.0.0',
+            b: '2.0.0',
+            c: '3.0.0',
+          },
+          lockfileVersion: npmVersion === '7.0.0' ? 2 : 1,
+        });
+        const packageFiles = [
+          {
+            npmLock: 'package-lock.json',
+            constraints: {},
+            deps: [
+              {
+                depName: 'a',
+                currentValue: '1.0.0',
+              },
+              {
+                depName: 'b',
+                currentValue: '2.0.0',
+              },
+            ],
+          },
+        ];
+        await getLockedVersions(packageFiles);
+        expect(packageFiles).toMatchSnapshot();
+      }
+    );
     it('ignores pnpm', async () => {
       const packageFiles = [
         {

--- a/lib/manager/npm/extract/locked-versions.ts
+++ b/lib/manager/npm/extract/locked-versions.ts
@@ -39,9 +39,12 @@ export async function getLockedVersions(
         logger.trace('Retrieving/parsing ' + npmLock);
         lockFileCache[npmLock] = await getNpmLock(npmLock);
       }
-      const { lockfileVersion } = lockFileCache[npmLock];
-      if (lockfileVersion >= 2) {
-        packageFile.constraints.npm = '>= 7.0.0';
+      if (!packageFile.constraints.npm) {
+        // do not override if already set
+        const { lockfileVersion } = lockFileCache[npmLock];
+        if (lockfileVersion >= 2) {
+          packageFile.constraints.npm = '>= 7.0.0';
+        }
       }
       for (const dep of packageFile.deps) {
         dep.lockedVersion = valid(

--- a/lib/manager/npm/extract/locked-versions.ts
+++ b/lib/manager/npm/extract/locked-versions.ts
@@ -39,6 +39,10 @@ export async function getLockedVersions(
         logger.trace('Retrieving/parsing ' + npmLock);
         lockFileCache[npmLock] = await getNpmLock(npmLock);
       }
+      const { lockfileVersion } = lockFileCache[npmLock];
+      if (lockfileVersion >= 2) {
+        packageFile.constraints.npm = '>= 7.0.0';
+      }
       for (const dep of packageFile.deps) {
         dep.lockedVersion = valid(
           lockFileCache[npmLock].lockedVersions[dep.depName]

--- a/lib/manager/npm/extract/npm.spec.ts
+++ b/lib/manager/npm/extract/npm.spec.ts
@@ -20,6 +20,16 @@ describe('manager/npm/extract/npm', () => {
       expect(res).toMatchSnapshot();
       expect(Object.keys(res.lockedVersions)).toHaveLength(7);
     });
+    it('extracts npm 7 lockfile', async () => {
+      const npm7Lock = readFileSync(
+        'lib/manager/npm/__fixtures__/npm7/package-lock.json'
+      );
+      fs.readLocalFile.mockResolvedValueOnce(npm7Lock as never);
+      const res = await getNpmLock('package.json');
+      expect(res).toMatchSnapshot();
+      expect(Object.keys(res.lockedVersions)).toHaveLength(7);
+      expect(res.lockfileVersion).toEqual(2);
+    });
     it('returns empty if no deps', async () => {
       fs.readLocalFile.mockResolvedValueOnce('{}');
       const res = await getNpmLock('package.json');

--- a/lib/manager/npm/extract/npm.ts
+++ b/lib/manager/npm/extract/npm.ts
@@ -13,7 +13,7 @@ export async function getNpmLock(filePath: string): Promise<LockFile> {
       logger.trace({ entry, version: val.version });
       lockedVersions[entry] = val.version;
     }
-    return { lockedVersions };
+    return { lockedVersions, lockfileVersion: lockParsed.lockfileVersion };
   } catch (err) {
     logger.debug({ filePath, err }, 'Warning: Exception parsing npm lock file');
     return { lockedVersions: {} };

--- a/lib/manager/npm/post-update/npm.ts
+++ b/lib/manager/npm/post-update/npm.ts
@@ -31,7 +31,7 @@ export async function generateLockFile(
     if (validRange(npmCompatibility)) {
       installNpm += `@${quote(npmCompatibility)}`;
     }
-    const preCommands = [installNpm];
+    const preCommands = [installNpm, 'hash -d npm'];
     const commands = [];
     let cmdOptions = '';
     if (postUpdateOptions?.includes('npmDedupe') || skipInstalls === false) {


### PR DESCRIPTION
## Changes:
This PR installs npm@7, if the new `package-lock.json` format (`lockfileVersion: 2`) is detected.

Note https://github.com/renovatebot/renovate/pull/7700/commits/0586d45ecf4a16411185669c531f078c455d161d?diff=split&w=1 is only relevant changes, other changes are just refactoring.

## Context:

npm 7 [has been released last month and has a new lockfile format](https://github.blog/2020-10-13-presenting-v7-0-0-of-the-npm-cli/), which old versions of npm revert.

Related: #7474.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [x] Unit tests + ran on a real repository: https://github.com/ylemkimon/test-renovate/pull/38
