### PR TITLE
refactor: convert all path to upath

### DIFF
--- a/lib/config/file.spec.ts
+++ b/lib/config/file.spec.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import path from 'path';
+import upath from 'upath';
 import customConfig from './config/__fixtures__/file';
 import * as file from './file';
 
@@ -11,7 +11,7 @@ describe('config/file', () => {
       );
     });
     it('parses custom config file', () => {
-      const configFile = path.resolve(
+      const configFile = upath.resolve(
         __dirname,
         './config/__fixtures__/file.js'
       );
@@ -20,7 +20,7 @@ describe('config/file', () => {
       );
     });
     it('migrates', () => {
-      const configFile = path.resolve(
+      const configFile = upath.resolve(
         __dirname,
         './config/__fixtures__/file2.js'
       );
@@ -29,7 +29,7 @@ describe('config/file', () => {
       expect(res.rangeStrategy).toEqual('bump');
     });
     it('informs user when error in parsing config.js', () => {
-      const configFile = path.resolve(
+      const configFile = upath.resolve(
         __dirname,
         './config/__fixtures__/file3.ts'
       );
@@ -53,7 +53,7 @@ describe('config/file', () => {
     });
   });
   it('handles when invalid file location is provided', () => {
-    const configFile = path.resolve(
+    const configFile = upath.resolve(
       __dirname,
       './config/__fixtures__/file4.ts'
     );

--- a/lib/config/file.ts
+++ b/lib/config/file.ts
@@ -1,11 +1,11 @@
-import path from 'path';
+import upath from 'upath';
 import { logger } from '../logger';
 import { RenovateConfig } from './common';
 import { migrateConfig } from './migration';
 
 export function getConfig(env: NodeJS.ProcessEnv): RenovateConfig {
   let configFile = env.RENOVATE_CONFIG_FILE || 'config';
-  if (!path.isAbsolute(configFile)) {
+  if (!upath.isAbsolute(configFile)) {
     configFile = `${process.cwd()}/${configFile}`;
     logger.debug('Checking for config file in ' + configFile);
   }

--- a/lib/config/index.spec.ts
+++ b/lib/config/index.spec.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import upath from 'upath';
 import { readFile } from '../util/fs';
 import getArgv from './config/__fixtures__/argv';
 import { getConfig } from './defaults';
@@ -62,7 +62,7 @@ describe('config/index', () => {
       expect(parsedConfig).not.toContainKey('configFile');
     });
     it('supports config.force', async () => {
-      const configPath = path.join(
+      const configPath = upath.join(
         __dirname,
         'config/__fixtures__/withForce.js'
       );
@@ -82,7 +82,7 @@ describe('config/index', () => {
       ]);
     });
     it('reads private key from file', async () => {
-      const privateKeyPath = path.join(
+      const privateKeyPath = upath.join(
         __dirname,
         'keys/__fixtures__/private.pem'
       );

--- a/lib/datasource/maven/index.spec.ts
+++ b/lib/datasource/maven/index.spec.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
-import { resolve } from 'path';
 import nock from 'nock';
+import { resolve } from 'upath';
 import { Release, getPkgReleases } from '..';
 import { EXTERNAL_HOST_ERROR } from '../../constants/error-messages';
 import * as hostRules from '../../util/host-rules';

--- a/lib/datasource/sbt-package/index.spec.ts
+++ b/lib/datasource/sbt-package/index.spec.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
-import path from 'path';
 import nock from 'nock';
+import upath from 'upath';
 import { getPkgReleases } from '..';
 import * as mavenVersioning from '../../versioning/maven';
 import { MAVEN_REPO } from '../maven/common';
@@ -8,12 +8,12 @@ import { parseIndexDir } from '../sbt-plugin/util';
 import * as sbtPlugin from '.';
 
 const mavenIndexHtml = fs.readFileSync(
-  path.resolve(__dirname, `./__fixtures__/maven-index.html`),
+  upath.resolve(__dirname, `./__fixtures__/maven-index.html`),
   'utf8'
 );
 
 const sbtPluginIndex = fs.readFileSync(
-  path.resolve(__dirname, `./__fixtures__/sbt-plugins-index.html`),
+  upath.resolve(__dirname, `./__fixtures__/sbt-plugins-index.html`),
   'utf8'
 );
 

--- a/lib/datasource/sbt-plugin/index.spec.ts
+++ b/lib/datasource/sbt-plugin/index.spec.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
-import path from 'path';
 import nock from 'nock';
+import upath from 'upath';
 import { getPkgReleases } from '..';
 import * as mavenVersioning from '../../versioning/maven';
 import { MAVEN_REPO } from '../maven/common';
@@ -8,12 +8,12 @@ import { parseIndexDir } from './util';
 import * as sbtPlugin from '.';
 
 const mavenIndexHtml = fs.readFileSync(
-  path.resolve(__dirname, `./__fixtures__/maven-index.html`),
+  upath.resolve(__dirname, `./__fixtures__/maven-index.html`),
   'utf8'
 );
 
 const sbtPluginIndex = fs.readFileSync(
-  path.resolve(__dirname, `./__fixtures__/sbt-plugins-index.html`),
+  upath.resolve(__dirname, `./__fixtures__/sbt-plugins-index.html`),
   'utf8'
 );
 

--- a/lib/manager/bazel/update.spec.ts
+++ b/lib/manager/bazel/update.spec.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'fs';
-import { resolve } from 'path';
 import { Readable } from 'stream';
+import { resolve } from 'upath';
 import * as httpMock from '../../../test/httpMock';
 import { UpdateType } from '../../config';
 import { updateDependency } from './update';

--- a/lib/manager/cdnurl/extract.spec.ts
+++ b/lib/manager/cdnurl/extract.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { resolve } from 'path';
+import { resolve } from 'upath';
 import { extractPackageFile } from '.';
 
 const input = readFileSync(

--- a/lib/manager/cocoapods/extract.spec.ts
+++ b/lib/manager/cocoapods/extract.spec.ts
@@ -1,14 +1,15 @@
-import path from 'path';
 import fs from 'fs-extra';
+import upath from 'upath';
+
 import { extractPackageFile } from '.';
 
 const simplePodfile = fs.readFileSync(
-  path.resolve(__dirname, './__fixtures__/Podfile.simple'),
+  upath.resolve(__dirname, './__fixtures__/Podfile.simple'),
   'utf-8'
 );
 
 const complexPodfile = fs.readFileSync(
-  path.resolve(__dirname, './__fixtures__/Podfile.complex'),
+  upath.resolve(__dirname, './__fixtures__/Podfile.complex'),
   'utf-8'
 );
 

--- a/lib/manager/deps-edn/extract.spec.ts
+++ b/lib/manager/deps-edn/extract.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import { readFileSync } from 'fs';
-import { resolve } from 'path';
+import { resolve } from 'upath';
 import { extractPackageFile } from './extract';
 
 const depsEdn = readFileSync(

--- a/lib/manager/droneci/extract.spec.ts
+++ b/lib/manager/droneci/extract.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { resolve } from 'path';
+import { resolve } from 'upath';
 
 import { extractPackageFile } from './extract';
 

--- a/lib/manager/gradle-wrapper/artifacts-real.spec.ts
+++ b/lib/manager/gradle-wrapper/artifacts-real.spec.ts
@@ -1,6 +1,6 @@
-import { resolve } from 'path';
 import { readFile, readFileSync } from 'fs-extra';
 import Git from 'simple-git';
+import { resolve } from 'upath';
 import * as httpMock from '../../../test/httpMock';
 import { getName, git, partial } from '../../../test/util';
 import { setUtilConfig } from '../../util';

--- a/lib/manager/gradle-wrapper/artifacts.spec.ts
+++ b/lib/manager/gradle-wrapper/artifacts.spec.ts
@@ -1,7 +1,7 @@
 /* eslint jest/no-standalone-expect: 0 */
 import { exec as _exec } from 'child_process';
-import { resolve } from 'path';
 import { readFile } from 'fs-extra';
+import { resolve } from 'upath';
 import { envMock, mockExecAll } from '../../../test/execUtil';
 import * as httpMock from '../../../test/httpMock';
 import {

--- a/lib/manager/gradle-wrapper/artifacts.ts
+++ b/lib/manager/gradle-wrapper/artifacts.ts
@@ -1,5 +1,5 @@
-import { resolve } from 'path';
 import { stat } from 'fs-extra';
+import { resolve } from 'upath';
 import { logger } from '../../logger';
 import { ExecOptions, exec } from '../../util/exec';
 import { readLocalFile, writeLocalFile } from '../../util/fs';

--- a/lib/manager/gradle-wrapper/extract.spec.ts
+++ b/lib/manager/gradle-wrapper/extract.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { resolve } from 'path';
+import { resolve } from 'upath';
 import { extractPackageFile } from './extract';
 
 const propertiesFile1 = readFileSync(

--- a/lib/manager/gradle/gradle-updates-report.spec.ts
+++ b/lib/manager/gradle/gradle-updates-report.spec.ts
@@ -1,6 +1,6 @@
-import * as path from 'path';
 import * as fs from 'fs-extra';
 import tmp, { DirectoryResult } from 'tmp-promise';
+import * as path from 'upath';
 import { getName } from '../../../test/util';
 import { exec } from '../../util/exec';
 import { ifSystemSupportsGradle } from './__testutil__/gradle';

--- a/lib/manager/gradle/gradle-updates-report.spec.ts
+++ b/lib/manager/gradle/gradle-updates-report.spec.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs-extra';
 import tmp, { DirectoryResult } from 'tmp-promise';
-import * as path from 'upath';
+import * as upath from 'upath';
 import { getName } from '../../../test/util';
 import { exec } from '../../util/exec';
 import { ifSystemSupportsGradle } from './__testutil__/gradle';
@@ -32,7 +32,7 @@ describe(getName(__filename), () => {
           );
           await createRenovateGradlePlugin(workingDir.path);
 
-          const gradlew = path.join(workingDir.path, 'gradlew');
+          const gradlew = upath.join(workingDir.path, 'gradlew');
           await exec(`${gradlew} ${GRADLE_DEPENDENCY_REPORT_OPTIONS}`, {
             cwd: workingDir.path,
             extraEnv,

--- a/lib/manager/gradle/gradle-updates-report.ts
+++ b/lib/manager/gradle/gradle-updates-report.ts
@@ -1,5 +1,5 @@
-import { join } from 'path';
 import { exists, readFile, writeFile } from 'fs-extra';
+import { join } from 'upath';
 import * as datasourceSbtPackage from '../../datasource/sbt-package';
 import { logger } from '../../logger';
 

--- a/lib/manager/html/extract.spec.ts
+++ b/lib/manager/html/extract.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { resolve } from 'path';
+import { resolve } from 'upath';
 import { extractPackageFile } from '.';
 
 const sample = readFileSync(

--- a/lib/manager/leiningen/extract.spec.ts
+++ b/lib/manager/leiningen/extract.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import { readFileSync } from 'fs';
-import { resolve } from 'path';
+import { resolve } from 'upath';
 import * as datasourceClojure from '../../datasource/clojure';
 import { extractFromVectors, extractPackageFile, trimAtKey } from './extract';
 

--- a/lib/manager/maven/extract.spec.ts
+++ b/lib/manager/maven/extract.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import { readFileSync } from 'fs';
-import { resolve } from 'path';
+import { resolve } from 'upath';
 import { extractPackage } from './extract';
 
 const minimumContent = readFileSync(

--- a/lib/manager/maven/extract.ts
+++ b/lib/manager/maven/extract.ts
@@ -1,5 +1,5 @@
-import { basename, dirname, join, normalize } from 'path';
 import is from '@sindresorhus/is';
+import { basename, dirname, join, normalize } from 'upath';
 import { XmlDocument, XmlElement } from 'xmldoc';
 import * as datasourceMaven from '../../datasource/maven';
 import { MAVEN_REPO } from '../../datasource/maven/common';

--- a/lib/manager/meteor/extract.spec.ts
+++ b/lib/manager/meteor/extract.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { resolve } from 'path';
+import { resolve } from 'upath';
 import { extractPackageFile } from './extract';
 
 function readFixture(fixture: string) {

--- a/lib/manager/mix/extract.spec.ts
+++ b/lib/manager/mix/extract.spec.ts
@@ -1,9 +1,9 @@
-import path from 'path';
 import fs from 'fs-extra';
+import upath from 'upath';
 import { extractPackageFile } from '.';
 
 const sample = fs.readFileSync(
-  path.resolve(__dirname, './__fixtures__/mix.exs'),
+  upath.resolve(__dirname, './__fixtures__/mix.exs'),
   'utf-8'
 );
 

--- a/lib/manager/npm/extract/index.spec.ts
+++ b/lib/manager/npm/extract/index.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import path from 'path';
+import upath from 'upath';
 import { getConfig } from '../../../config/defaults';
 import * as _fs from '../../../util/fs';
 import * as npmExtract from '.';
@@ -11,7 +11,7 @@ const defaultConfig = getConfig();
 
 function readFixture(fixture: string) {
   return readFileSync(
-    path.resolve(__dirname, `../__fixtures__/${fixture}`),
+    upath.resolve(__dirname, `../__fixtures__/${fixture}`),
     'utf8'
   );
 }

--- a/lib/manager/npm/extract/index.ts
+++ b/lib/manager/npm/extract/index.ts
@@ -1,5 +1,5 @@
-import { dirname } from 'path';
 import is from '@sindresorhus/is';
+import { dirname } from 'upath';
 import validateNpmPackageName from 'validate-npm-package-name';
 import { CONFIG_VALIDATION } from '../../../constants/error-messages';
 import * as datasourceGithubTags from '../../../datasource/github-tags';

--- a/lib/manager/npm/extract/monorepo.ts
+++ b/lib/manager/npm/extract/monorepo.ts
@@ -1,6 +1,4 @@
-import path from 'path';
 import is from '@sindresorhus/is';
-
 import minimatch from 'minimatch';
 import upath from 'upath';
 import { logger } from '../../../logger';
@@ -27,7 +25,7 @@ export function detectMonorepos(packageFiles: Partial<PackageFile>[]): void {
       lernaPackages,
       yarnWorkspacesPackages,
     } = p;
-    const basePath = path.dirname(packageFile);
+    const basePath = upath.dirname(packageFile);
     const packages = yarnWorkspacesPackages || lernaPackages;
     if (packages?.length) {
       logger.debug(
@@ -39,7 +37,10 @@ export function detectMonorepos(packageFiles: Partial<PackageFile>[]): void {
         : [packages]
       ).map((pattern) => upath.join(basePath, pattern));
       const internalPackageFiles = packageFiles.filter((sp) =>
-        matchesAnyPattern(path.dirname(sp.packageFile), internalPackagePatterns)
+        matchesAnyPattern(
+          upath.dirname(sp.packageFile),
+          internalPackagePatterns
+        )
       );
       const internalPackageNames = internalPackageFiles
         .map((sp) => sp.packageJsonName)

--- a/lib/manager/npm/post-update/index.ts
+++ b/lib/manager/npm/post-update/index.ts
@@ -1,4 +1,3 @@
-import path from 'path';
 import is from '@sindresorhus/is';
 import { parseSyml } from '@yarnpkg/parsers';
 import upath from 'upath';
@@ -146,7 +145,7 @@ export async function writeExistingFiles(
   for (const packageFile of npmFiles) {
     const basedir = upath.join(
       config.localDir,
-      path.dirname(packageFile.packageFile)
+      upath.dirname(packageFile.packageFile)
     );
     const npmrc: string = packageFile.npmrc || config.npmrc;
     const npmrcFilename = upath.join(basedir, '.npmrc');
@@ -482,7 +481,7 @@ export async function getAdditionalFiles(
     logger.warn({ err }, 'Error getting token for packageFile');
   }
   for (const lockFile of dirs.npmLockDirs) {
-    const lockFileDir = path.dirname(lockFile);
+    const lockFileDir = upath.dirname(lockFile);
     const fullLockFileDir = upath.join(config.localDir, lockFileDir);
     const npmrcContent = await getNpmrcContent(fullLockFileDir);
     await updateNpmrcContent(
@@ -490,7 +489,7 @@ export async function getAdditionalFiles(
       npmrcContent,
       additionalNpmrcContent
     );
-    const fileName = path.basename(lockFile);
+    const fileName = upath.basename(lockFile);
     logger.debug(`Generating ${fileName} for ${lockFileDir}`);
     const upgrades = config.upgrades.filter(
       (upgrade) => upgrade.npmLock === lockFile
@@ -545,7 +544,7 @@ export async function getAdditionalFiles(
   }
 
   for (const lockFile of dirs.yarnLockDirs) {
-    const lockFileDir = path.dirname(lockFile);
+    const lockFileDir = upath.dirname(lockFile);
     const fullLockFileDir = upath.join(config.localDir, lockFileDir);
     const npmrcContent = await getNpmrcContent(fullLockFileDir);
     await updateNpmrcContent(
@@ -612,7 +611,7 @@ export async function getAdditionalFiles(
   }
 
   for (const lockFile of dirs.pnpmShrinkwrapDirs) {
-    const lockFileDir = path.dirname(lockFile);
+    const lockFileDir = upath.dirname(lockFile);
     const fullLockFileDir = upath.join(config.localDir, lockFileDir);
     const npmrcContent = await getNpmrcContent(fullLockFileDir);
     await updateNpmrcContent(
@@ -678,7 +677,7 @@ export async function getAdditionalFiles(
     let lockFile: string;
     logger.debug(`Finding package.json for lerna directory "${lernaDir}"`);
     const lernaPackageFile = packageFiles.npm.find(
-      (p) => path.dirname(p.packageFile) === lernaDir
+      (p) => upath.dirname(p.packageFile) === lernaDir
     );
     if (!lernaPackageFile) {
       logger.debug('No matching package.json found');

--- a/lib/manager/npm/post-update/npm.spec.ts
+++ b/lib/manager/npm/post-update/npm.spec.ts
@@ -1,5 +1,6 @@
 import { exec as _exec } from 'child_process';
-import path from 'path';
+import upath from 'upath';
+
 import { envMock, mockExecAll } from '../../../../test/execUtil';
 import { mocked } from '../../../../test/util';
 import { BinarySource } from '../../../util/exec/common';
@@ -75,16 +76,16 @@ describe('generateLockFile', () => {
       { skipInstalls }
     );
     expect(fs.pathExists).toHaveBeenCalledWith(
-      path.join('some-dir', 'package-lock.json')
+      upath.join('some-dir', 'package-lock.json')
     );
     expect(fs.move).toHaveBeenCalledTimes(1);
     expect(fs.move).toHaveBeenCalledWith(
-      path.join('some-dir', 'package-lock.json'),
-      path.join('some-dir', 'npm-shrinkwrap.json')
+      upath.join('some-dir', 'package-lock.json'),
+      upath.join('some-dir', 'npm-shrinkwrap.json')
     );
     expect(fs.readFile).toHaveBeenCalledTimes(1);
     expect(fs.readFile).toHaveBeenCalledWith(
-      path.join('some-dir', 'npm-shrinkwrap.json'),
+      upath.join('some-dir', 'npm-shrinkwrap.json'),
       'utf8'
     );
     expect(res.error).toBeUndefined();
@@ -104,12 +105,12 @@ describe('generateLockFile', () => {
       { skipInstalls }
     );
     expect(fs.pathExists).toHaveBeenCalledWith(
-      path.join('some-dir', 'package-lock.json')
+      upath.join('some-dir', 'package-lock.json')
     );
     expect(fs.move).toHaveBeenCalledTimes(0);
     expect(fs.readFile).toHaveBeenCalledTimes(1);
     expect(fs.readFile).toHaveBeenCalledWith(
-      path.join('some-dir', 'npm-shrinkwrap.json'),
+      upath.join('some-dir', 'npm-shrinkwrap.json'),
       'utf8'
     );
     expect(res.error).toBeUndefined();

--- a/lib/manager/npm/update.spec.ts
+++ b/lib/manager/npm/update.spec.ts
@@ -1,10 +1,11 @@
 import fs from 'fs';
-import path from 'path';
+import upath from 'upath';
+
 import * as npmUpdater from './update';
 
 function readFixture(fixture: string) {
   return fs.readFileSync(
-    path.resolve(__dirname, `./__fixtures__/${fixture}`),
+    upath.resolve(__dirname, `./__fixtures__/${fixture}`),
     'utf8'
   );
 }

--- a/lib/manager/nuget/extract.spec.ts
+++ b/lib/manager/nuget/extract.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import * as path from 'path';
+import * as path from 'upath';
 import { ExtractConfig } from '../common';
 import { extractPackageFile } from './extract';
 

--- a/lib/manager/nuget/extract.spec.ts
+++ b/lib/manager/nuget/extract.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import * as path from 'upath';
+import * as upath from 'upath';
 import { ExtractConfig } from '../common';
 import { extractPackageFile } from './extract';
 
@@ -8,7 +8,7 @@ describe('lib/manager/nuget/extract', () => {
     let config: ExtractConfig;
     beforeEach(() => {
       config = {
-        localDir: path.resolve('lib/manager/nuget/__fixtures__'),
+        localDir: upath.resolve('lib/manager/nuget/__fixtures__'),
       };
     });
     it('returns empty for invalid csproj', async () => {
@@ -20,7 +20,7 @@ describe('lib/manager/nuget/extract', () => {
       const packageFile =
         'with-centralized-package-versions/Directory.Packages.props';
       const sample = readFileSync(
-        path.join(config.localDir, packageFile),
+        upath.join(config.localDir, packageFile),
         'utf8'
       );
       const res = await extractPackageFile(sample, packageFile, config);
@@ -29,7 +29,7 @@ describe('lib/manager/nuget/extract', () => {
     it('extracts all dependencies', async () => {
       const packageFile = 'sample.csproj';
       const sample = readFileSync(
-        path.join(config.localDir, packageFile),
+        upath.join(config.localDir, packageFile),
         'utf8'
       );
       const res = await extractPackageFile(sample, packageFile, config);
@@ -38,7 +38,7 @@ describe('lib/manager/nuget/extract', () => {
     it('extracts all dependencies from global packages file', async () => {
       const packageFile = 'packages.props';
       const sample = readFileSync(
-        path.join(config.localDir, packageFile),
+        upath.join(config.localDir, packageFile),
         'utf8'
       );
       const res = await extractPackageFile(sample, packageFile, config);
@@ -47,7 +47,7 @@ describe('lib/manager/nuget/extract', () => {
     it('considers NuGet.config', async () => {
       const packageFile = 'with-config-file/with-config-file.csproj';
       const contents = readFileSync(
-        path.join(config.localDir, packageFile),
+        upath.join(config.localDir, packageFile),
         'utf8'
       );
 
@@ -59,7 +59,7 @@ describe('lib/manager/nuget/extract', () => {
       const packageFile =
         'with-lower-case-config-file/with-lower-case-config-file.csproj';
       const contents = readFileSync(
-        path.join(config.localDir, packageFile),
+        upath.join(config.localDir, packageFile),
         'utf8'
       );
 
@@ -71,7 +71,7 @@ describe('lib/manager/nuget/extract', () => {
       const packageFile =
         'with-pascal-case-config-file/with-pascal-case-config-file.csproj';
       const contents = readFileSync(
-        path.join(config.localDir, packageFile),
+        upath.join(config.localDir, packageFile),
         'utf8'
       );
 
@@ -83,7 +83,7 @@ describe('lib/manager/nuget/extract', () => {
       const packageFile =
         'with-malformed-config-file/with-malformed-config-file.csproj';
       const contents = readFileSync(
-        path.join(config.localDir, packageFile),
+        upath.join(config.localDir, packageFile),
         'utf8'
       );
 
@@ -95,7 +95,7 @@ describe('lib/manager/nuget/extract', () => {
       const packageFile =
         'without-package-sources/without-package-sources.csproj';
       const contents = readFileSync(
-        path.join(config.localDir, packageFile),
+        upath.join(config.localDir, packageFile),
         'utf8'
       );
 
@@ -107,7 +107,7 @@ describe('lib/manager/nuget/extract', () => {
       const packageFile =
         'with-local-feed-in-config-file/with-local-feed-in-config-file.csproj';
       const contents = readFileSync(
-        path.join(config.localDir, packageFile),
+        upath.join(config.localDir, packageFile),
         'utf8'
       );
 
@@ -118,12 +118,12 @@ describe('lib/manager/nuget/extract', () => {
     it('extracts registry URLs independently', async () => {
       const packageFile = 'multiple-package-files/one/one.csproj';
       const contents = readFileSync(
-        path.join(config.localDir, packageFile),
+        upath.join(config.localDir, packageFile),
         'utf8'
       );
       const otherPackageFile = 'multiple-package-files/two/two.csproj';
       const otherContents = readFileSync(
-        path.join(config.localDir, packageFile),
+        upath.join(config.localDir, packageFile),
         'utf8'
       );
       expect(

--- a/lib/manager/nuget/util.ts
+++ b/lib/manager/nuget/util.ts
@@ -1,5 +1,5 @@
-import * as path from 'path';
 import findUp from 'find-up';
+import * as path from 'upath';
 import { XmlDocument } from 'xmldoc';
 import * as datasourceNuget from '../../datasource/nuget';
 import { logger } from '../../logger';

--- a/lib/manager/nuget/util.ts
+++ b/lib/manager/nuget/util.ts
@@ -1,5 +1,5 @@
 import findUp from 'find-up';
-import * as path from 'upath';
+import * as upath from 'upath';
 import { XmlDocument } from 'xmldoc';
 import * as datasourceNuget from '../../datasource/nuget';
 import { logger } from '../../logger';
@@ -26,7 +26,7 @@ export async function determineRegistries(
   // Valid file names taken from https://github.com/NuGet/NuGet.Client/blob/f64621487c0b454eda4b98af853bf4a528bef72a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs#L34
   const nuGetConfigFileNames = ['nuget.config', 'NuGet.config', 'NuGet.Config'];
   const nuGetConfigPath = await findUp(nuGetConfigFileNames, {
-    cwd: path.dirname(path.join(localDir, packageFile)),
+    cwd: upath.dirname(upath.join(localDir, packageFile)),
     type: 'file',
   });
 

--- a/lib/manager/regex/index.spec.ts
+++ b/lib/manager/regex/index.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { resolve } from 'path';
+import { resolve } from 'upath';
 import { getName } from '../../../test/util';
 import { defaultConfig, extractPackageFile } from '.';
 

--- a/lib/manager/sbt/extract.spec.ts
+++ b/lib/manager/sbt/extract.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { resolve } from 'path';
+import { resolve } from 'upath';
 import { extractPackageFile } from './extract';
 
 const sbt = readFileSync(

--- a/lib/manager/swift/index.spec.ts
+++ b/lib/manager/swift/index.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { resolve } from 'path';
+import { resolve } from 'upath';
 import { extractPackageFile } from './extract';
 
 const pkgContent = readFileSync(

--- a/lib/manager/travis/extract.spec.ts
+++ b/lib/manager/travis/extract.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { resolve } from 'path';
+import { resolve } from 'upath';
 import { extractPackageFile } from './extract';
 
 const invalidYAML = readFileSync(

--- a/lib/manager/travis/update.spec.ts
+++ b/lib/manager/travis/update.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { resolve } from 'path';
+import { resolve } from 'upath';
 import { updateDependency } from './update';
 
 const content = readFileSync(

--- a/lib/util/cache/package/file.ts
+++ b/lib/util/cache/package/file.ts
@@ -1,6 +1,6 @@
-import path from 'path';
 import * as cacache from 'cacache';
 import { DateTime } from 'luxon';
+import upath from 'upath';
 import { logger } from '../../../logger';
 
 function getKey(namespace: string, key: string): string {
@@ -58,6 +58,6 @@ export async function set(
 }
 
 export function init(cacheDir: string): void {
-  cacheFileName = path.join(cacheDir, '/renovate/renovate-cache-v1');
+  cacheFileName = upath.join(cacheDir, '/renovate/renovate-cache-v1');
   logger.debug('Initializing Renovate internal cache into ' + cacheFileName);
 }

--- a/lib/util/exec/index.ts
+++ b/lib/util/exec/index.ts
@@ -1,5 +1,5 @@
 import { ExecOptions as ChildProcessExecOptions } from 'child_process';
-import { dirname, join } from 'path';
+import { dirname, join } from 'upath';
 import { RenovateConfig } from '../../config/common';
 import { logger } from '../../logger';
 import {

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -1,4 +1,3 @@
-import { join } from 'path';
 import URL from 'url';
 import fs from 'fs-extra';
 import Git, {
@@ -7,6 +6,7 @@ import Git, {
   SimpleGit,
   StatusResult as StatusResult_,
 } from 'simple-git';
+import { join } from 'upath';
 import {
   REPOSITORY_CHANGED,
   REPOSITORY_DISABLED,

--- a/lib/util/git/private-key.ts
+++ b/lib/util/git/private-key.ts
@@ -1,6 +1,6 @@
 import os from 'os';
-import path from 'path';
 import fs from 'fs-extra';
+import upath from 'upath';
 import { PLATFORM_GPG_FAILED } from '../../constants/error-messages';
 import { logger } from '../../logger';
 import { exec } from '../exec';
@@ -16,7 +16,7 @@ async function importKey(): Promise<void> {
   if (keyId) {
     return;
   }
-  const keyFileName = path.join(os.tmpdir() + '/git-private.key');
+  const keyFileName = upath.join(os.tmpdir() + '/git-private.key');
   await fs.outputFile(keyFileName, gitPrivateKey);
   const { stdout, stderr } = await exec(`gpg --import ${keyFileName}`);
   logger.debug({ stdout, stderr }, 'Private key import result');

--- a/lib/workers/branch/auto-replace.spec.ts
+++ b/lib/workers/branch/auto-replace.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { resolve } from 'path';
+import { resolve } from 'upath';
 import { defaultConfig } from '../../../test/util';
 import { extractPackageFile } from '../../manager/html';
 import { BranchUpgradeConfig } from '../common';

--- a/lib/workers/global/index.ts
+++ b/lib/workers/global/index.ts
@@ -1,7 +1,7 @@
-import path from 'path';
 import is from '@sindresorhus/is';
 import { ERROR } from 'bunyan';
 import fs from 'fs-extra';
+import upath from 'upath';
 import * as configParser from '../../config';
 import { getProblems, logger, setMeta } from '../../logger';
 import { setUtilConfig } from '../../util';
@@ -22,7 +22,7 @@ export async function getRepositoryConfig(
     globalConfig,
     is.string(repository) ? { repository } : repository
   );
-  repoConfig.localDir = path.join(
+  repoConfig.localDir = upath.join(
     repoConfig.baseDir,
     `./repos/${repoConfig.platform}/${repoConfig.repository}`
   );

--- a/lib/workers/global/initialize.ts
+++ b/lib/workers/global/initialize.ts
@@ -1,6 +1,6 @@
 import os from 'os';
-import path from 'path';
 import fs from 'fs-extra';
+import upath from 'upath';
 import { RenovateConfig } from '../../config/common';
 import { logger } from '../../logger';
 import { initPlatform } from '../../platform';
@@ -14,14 +14,14 @@ async function setDirectories(input: RenovateConfig): Promise<RenovateConfig> {
   if (config.baseDir) {
     logger.debug('Using configured baseDir: ' + config.baseDir);
   } else {
-    config.baseDir = path.join(process.env.TMPDIR, 'renovate');
+    config.baseDir = upath.join(process.env.TMPDIR, 'renovate');
     logger.debug('Using baseDir: ' + config.baseDir);
   }
   await fs.ensureDir(config.baseDir);
   if (config.cacheDir) {
     logger.debug('Using configured cacheDir: ' + config.cacheDir);
   } else {
-    config.cacheDir = path.join(config.baseDir, 'cache');
+    config.cacheDir = upath.join(config.baseDir, 'cache');
     logger.debug('Using cacheDir: ' + config.cacheDir);
   }
   await fs.ensureDir(config.cacheDir);

--- a/lib/workers/repository/init/config.ts
+++ b/lib/workers/repository/init/config.ts
@@ -1,7 +1,7 @@
-import path from 'path';
 import is from '@sindresorhus/is';
 import jsonValidator from 'json-dup-key-validator';
 import JSON5 from 'json5';
+import upath from 'upath';
 
 import { RenovateConfig, mergeChildConfig } from '../../../config';
 import { configFileNames } from '../../../config/app-strings';
@@ -66,7 +66,7 @@ export async function detectRepoFileConfig(): Promise<RepoFileConfig> {
       rawFileContents = '{}';
     }
 
-    const fileType = path.extname(configFileName);
+    const fileType = upath.extname(configFileName);
 
     if (fileType === '.json5') {
       try {


### PR DESCRIPTION
## Changes:

Changes all `path` imports to use `upath`.

## Context:

Trying to unbreak a weird `upath` upgrade in a separate PR.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
