### PR TITLE
docs: add label manager:terragrunt to issue labeling guide

### DIFF
--- a/docs/development/issue_labeling.md
+++ b/docs/development/issue_labeling.md
@@ -103,6 +103,7 @@ Keep in mind that an issue can be both affecting a platform and a self hosted in
     manager:sbt
     manager:swift
     manager:terraform
+    manager:terragrunt
     manager:travis
 
 </details>


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what this pull request changes. -->

- Add label `manager:terragrunt` to issue labeling documentation

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

PR #7653 added a new manager: `terragrunt`, we don't yet have a label for that in our repository.

Do we want a new label `manager:terragrunt` in this repository?
I don't have rights to create the label, but I can at least add it to the docs.
If we don't need a new label, feel free to close this PR.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
