### PR TITLE
docs: remove list of labels for manager and datasource in labeling guide

### DIFF
--- a/docs/development/issue_labeling.md
+++ b/docs/development/issue_labeling.md
@@ -70,68 +70,11 @@ Keep in mind that an issue can be both affecting a platform and a self hosted in
 
 ### Manager
 
-<details>
-    <summary>Manager</summary>
-
-    manager:bazel
-    manager:buildkite
-    manager:bundler
-    manager:cargo
-    manager:circleci
-    manager:cocoapods
-    manager:composer
-    manager:docker-compose
-    manager:dockerfile
-    manager:github-actions
-    manager:gitlab-ci
-    manager:gomod
-    manager:gradle
-    manager:helm
-    manager:helm-values
-    manager:kubernetes
-    manager:kustomize
-    manager:maven
-    manager:meteor
-    manager:mix
-    manager:npm
-    manager:nuget
-    manager:pip_requirements
-    manager:pip_setup
-    manager:pipenv
-    manager:poetry
-    manager:ruby-version
-    manager:sbt
-    manager:swift
-    manager:terraform
-    manager:terragrunt
-    manager:travis
-
-</details>
-
 "manager" is short for "package manager".
-Add the relevant manager labels to the issue.
+Add the relevant `manager:` labels to the issue.
 If there are multiple managers affected, add labels for all of them.
 
 ### Datasource
-
-<details>
-    <summary>Datasource</summary>
-
-    datasource:docker
-    datasource:git-submodule
-    datasource:git-tags
-    datasource:github-tags
-    datasource:go
-    datasource:jenkins
-    datasource:maven
-    datasource:nuget
-    datasource:packagist
-    datasource:pypi
-    datasource:rubygems
-    datasource:terraform-module
-    datasource:terraform-provider
-
-</details>
 
 Use a `datasource:` label when it is applicable specifically to particular datasources (for example, as defined in the docs list of datasources).
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what this pull request changes. -->

- Removes the specific list of labels for `manager:` and `datasource:`
- Add backticks around label `manager:`

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

Closes #7718

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
