### PR TITLE
fix: rerun `applyPackageRules` after fetching sourceUrl from datasource

### DIFF
--- a/lib/workers/repository/process/lookup/__snapshots__/index.spec.ts.snap
+++ b/lib/workers/repository/process/lookup/__snapshots__/index.spec.ts.snap
@@ -205,6 +205,30 @@ exports[`workers/repository/process/lookup .lookupUpdates() handles packagist 1`
 
 exports[`workers/repository/process/lookup .lookupUpdates() handles pypi 404 1`] = `Array []`;
 
+exports[`workers/repository/process/lookup .lookupUpdates() handles sourceUrl packageRules with version restrictions 1`] = `
+Object {
+  "changelogUrl": undefined,
+  "dependencyUrl": undefined,
+  "fixedVersion": "0.9.99",
+  "homepage": undefined,
+  "sourceUrl": "https://github.com/kriskowal/q",
+  "updates": Array [
+    Object {
+      "canBeUnpublished": false,
+      "fromVersion": "0.9.99",
+      "isSingleVersion": true,
+      "newMajor": 1,
+      "newMinor": 3,
+      "newValue": "1.3.0",
+      "releaseTimestamp": "2015-04-26T16:42:11.311Z",
+      "toVersion": "1.3.0",
+      "updateType": "major",
+    },
+  ],
+  "warnings": Array [],
+}
+`;
+
 exports[`workers/repository/process/lookup .lookupUpdates() handles unknown datasource 1`] = `Array []`;
 
 exports[`workers/repository/process/lookup .lookupUpdates() ignores deprecated 1`] = `

--- a/lib/workers/repository/process/lookup/index.spec.ts
+++ b/lib/workers/repository/process/lookup/index.spec.ts
@@ -1163,5 +1163,19 @@ describe('workers/repository/process/lookup', () => {
       const res = await lookup.lookupUpdates(config);
       expect(res).toMatchSnapshot();
     });
+    it('handles sourceUrl packageRules with version restrictions', async () => {
+      config.currentValue = '0.9.99';
+      config.depName = 'q';
+      config.datasource = datasourceNpmId;
+      config.packageRules = [
+        {
+          sourceUrlPrefixes: ['https://github.com/kriskowal/q'],
+          allowedVersions: '< 1.4.0',
+        },
+      ];
+      nock('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      const res = await lookup.lookupUpdates(config);
+      expect(res).toMatchSnapshot();
+    });
   });
 });


### PR DESCRIPTION
## Changes:

In previous versions, when the config has a packageRule that have `sourceUrl` conditions and `allowedVersions` restrictions, it does not work. This is due to Renovate fetch the sourceUrl after it resolves the version to update to. This commit will make renovate fetch the package metadata from the datasource and apply only `sourceUrl` property to the dependency object before resolving the version to update to.

## Context:

This PR intends to resolve https://github.com/renovatebot/config-help/issues/532. (I procrastinate for a very long time there LOL.)

EDIT: this also fixes #4160

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [x] Unit tests + ran on a real repository

