### PR TITLE
fix(npm): delete hashed location after installing npm

### DIFF
--- a/lib/manager/npm/post-update/lerna.ts
+++ b/lib/manager/npm/post-update/lerna.ts
@@ -59,7 +59,7 @@ export async function generateLockFiles(
       const npmCompatibility = config.constraints?.npm;
       if (validRange(npmCompatibility)) {
         installNpm += `@${quote(npmCompatibility)}`;
-        preCommands.push(installNpm);
+        preCommands.push(installNpm, 'hash -d npm');
       }
       cmdOptions = '--ignore-scripts  --no-audit';
       if (skipInstalls !== false) {


### PR DESCRIPTION
## Changes:
Delete hashed location of `npm` after installing `npm` via `npm i -g npm`.

## Context:
The npm bundled with node.js is used to install npm, so the path is changed after `npm i -g npm` but npm is still based to the old location (https://github.com/renovatebot/renovate/pull/7700#discussion_r522898204):

```
ubuntu@ebe6a367a56e:/usr/src/app$ which npm
/usr/local/node/14.15.0/bin/npm
ubuntu@ebe6a367a56e:/usr/src/app$ type npm
npm is /usr/local/node/14.15.0/bin/npm
ubuntu@ebe6a367a56e:/usr/src/app$ npm -v
6.14.8
ubuntu@ebe6a367a56e:/usr/src/app$ npm i -g npm@7
/home/ubuntu/.npm-global/bin/npm -> /home/ubuntu/.npm-global/lib/node_modules/npm/bin/npm-cli.js
/home/ubuntu/.npm-global/bin/npx -> /home/ubuntu/.npm-global/lib/node_modules/npm/bin/npx-cli.js
+ npm@7.0.10
added 247 packages from 867 contributors in 2.328s
ubuntu@ebe6a367a56e:/usr/src/app$ which npm
/home/ubuntu/.npm-global/bin/npm
ubuntu@ebe6a367a56e:/usr/src/app$ type npm
npm is hashed (/usr/local/node/14.15.0/bin/npm)
ubuntu@ebe6a367a56e:/usr/src/app$ npm -v
6.14.8
ubuntu@ebe6a367a56e:/usr/src/app$ hash -d npm
ubuntu@ebe6a367a56e:/usr/src/app$ npm -v
7.0.10
```

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] Unit tests + ran on a real repository: https://github.com/ylemkimon/npm-workspace/pulls
