### PR TITLE
fix(nuget): normalize paths

### DIFF
--- a/lib/manager/nuget/extract.spec.ts
+++ b/lib/manager/nuget/extract.spec.ts
@@ -1,5 +1,4 @@
 import { readFileSync } from 'fs';
-import path from 'path';
 import * as upath from 'upath';
 import { ExtractConfig } from '../common';
 import { extractPackageFile } from './extract';
@@ -9,7 +8,7 @@ describe('lib/manager/nuget/extract', () => {
     let config: ExtractConfig;
     beforeEach(() => {
       config = {
-        localDir: path.resolve('lib/manager/nuget/__fixtures__'),
+        localDir: upath.resolve('lib/manager/nuget/__fixtures__'),
       };
     });
     it('returns empty for invalid csproj', async () => {

--- a/lib/manager/nuget/util.ts
+++ b/lib/manager/nuget/util.ts
@@ -25,12 +25,17 @@ export async function determineRegistries(
 ): Promise<Registry[] | undefined> {
   // Valid file names taken from https://github.com/NuGet/NuGet.Client/blob/f64621487c0b454eda4b98af853bf4a528bef72a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs#L34
   const nuGetConfigFileNames = ['nuget.config', 'NuGet.config', 'NuGet.Config'];
+  // normalize paths, otherwise startsWith can fail because of path delimitter mismatch
+  const baseDir = upath.normalizeSafe(localDir);
   const nuGetConfigPath = await findUp(nuGetConfigFileNames, {
-    cwd: upath.dirname(upath.join(localDir, packageFile)),
+    cwd: upath.dirname(upath.join(baseDir, packageFile)),
     type: 'file',
   });
 
-  if (nuGetConfigPath?.startsWith(localDir) !== true) {
+  if (
+    !nuGetConfigPath ||
+    upath.normalizeSafe(nuGetConfigPath).startsWith(baseDir) !== true
+  ) {
     return undefined;
   }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

normalize nuget config paths before comparing
<!-- Describe what this pull request changes. -->

## Context:

ref #7708
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

Also verified while debugging. 🙃 

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
