### PR TITLE
fix: extra space when adding autoclosed suffix

### DIFF
--- a/lib/workers/repository/finalise/prune.ts
+++ b/lib/workers/repository/finalise/prune.ts
@@ -51,7 +51,7 @@ async function cleanUpBranches(
             'Autoclosing PR'
           );
           let newPrTitle = pr.title;
-          if (!pr.title.endsWith(' - autoclosed')) {
+          if (!pr.title.endsWith('- autoclosed')) {
             newPrTitle += ' - autoclosed';
           }
           await platform.updatePr({

--- a/lib/workers/repository/finalise/prune.ts
+++ b/lib/workers/repository/finalise/prune.ts
@@ -51,8 +51,8 @@ async function cleanUpBranches(
             'Autoclosing PR'
           );
           let newPrTitle = pr.title;
-          if (!pr.title.endsWith('- autoclosed')) {
-            newPrTitle += '- autoclosed';
+          if (!pr.title.endsWith(' - autoclosed')) {
+            newPrTitle += ' - autoclosed';
           }
           await platform.updatePr({
             number: pr.number,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Provide space when adding autoclose suffix to make it more readable.

Today `Update dependency YamlDotNet to v9` will be renamed to `Update dependency YamlDotNet to v9- autoclosed`, but this PR changes it to `Update dependency YamlDotNet to v9 - autoclosed`

Example: https://github.com/tomkerkhove/promitor/pull/1357

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

This makes it more readable when going through PRs

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
