### PR TITLE
fix(nuget): don't fail when updating lockfiles with private registries

### DIFF
--- a/lib/manager/nuget/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/manager/nuget/__snapshots__/artifacts.spec.ts.snap
@@ -3,7 +3,25 @@
 exports[`updateArtifacts aborts if lock file is unchanged 1`] = `
 Array [
   Object {
-    "cmd": "dotnet restore project.csproj --force-evaluate",
+    "cmd": "dotnet new nugetconfig --output ./others/nuget/755461d51c07d4de",
+    "options": Object {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": Object {
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+  Object {
+    "cmd": "dotnet restore project.csproj --force-evaluate --configfile others/nuget/755461d51c07d4de/nuget.config",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -28,7 +46,7 @@ exports[`updateArtifacts aborts if no lock file found 1`] = `Array []`;
 exports[`updateArtifacts authenticates at registries 1`] = `
 Array [
   Object {
-    "cmd": "dotnet nuget update source myRegistry --username some-username --password some-password --store-password-in-clear-text",
+    "cmd": "dotnet new nugetconfig --output ./others/nuget/6d74034e601eb829",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -46,7 +64,7 @@ Array [
     },
   },
   Object {
-    "cmd": "dotnet restore project.csproj --force-evaluate",
+    "cmd": "dotnet nuget add source https://my-registry.example.org --name myRegistry --configfile others/nuget/6d74034e601eb829/nuget.config --username some-username --password some-password --store-password-in-clear-text",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -64,7 +82,7 @@ Array [
     },
   },
   Object {
-    "cmd": "dotnet nuget update source myRegistry --username '' --password '' --store-password-in-clear-text",
+    "cmd": "dotnet restore project.csproj --force-evaluate --configfile others/nuget/6d74034e601eb829/nuget.config",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -102,7 +120,25 @@ exports[`updateArtifacts does not update lock file when non-proj file is changed
 exports[`updateArtifacts performs lock file maintenance 1`] = `
 Array [
   Object {
-    "cmd": "dotnet restore project.csproj --force-evaluate",
+    "cmd": "dotnet new nugetconfig --output ./others/nuget/bee8338fa55930a3",
+    "options": Object {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": Object {
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+  Object {
+    "cmd": "dotnet restore project.csproj --force-evaluate --configfile others/nuget/bee8338fa55930a3/nuget.config",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -137,7 +173,7 @@ Array [
     },
   },
   Object {
-    "cmd": "docker run --rm --name=renovate_dotnet --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -w \\"/tmp/github/some/repo\\" renovate/dotnet bash -l -c \\"dotnet restore project.csproj --force-evaluate\\"",
+    "cmd": "docker run --rm --name=renovate_dotnet --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -w \\"/tmp/github/some/repo\\" renovate/dotnet bash -l -c \\"dotnet new nugetconfig --output ./others/nuget/b8683917cce215c9 && dotnet restore project.csproj --force-evaluate --configfile others/nuget/b8683917cce215c9/nuget.config\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -160,7 +196,25 @@ Array [
 exports[`updateArtifacts supports global mode 1`] = `
 Array [
   Object {
-    "cmd": "dotnet restore project.csproj --force-evaluate",
+    "cmd": "dotnet new nugetconfig --output ./others/nuget/2a78f82ffaf9f663",
+    "options": Object {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": Object {
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+  Object {
+    "cmd": "dotnet restore project.csproj --force-evaluate --configfile others/nuget/2a78f82ffaf9f663/nuget.config",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -183,7 +237,25 @@ Array [
 exports[`updateArtifacts updates lock file 1`] = `
 Array [
   Object {
-    "cmd": "dotnet restore project.csproj --force-evaluate",
+    "cmd": "dotnet new nugetconfig --output ./others/nuget/1286b7ff5b3196a7",
+    "options": Object {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": Object {
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+  Object {
+    "cmd": "dotnet restore project.csproj --force-evaluate --configfile others/nuget/1286b7ff5b3196a7/nuget.config",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",

--- a/lib/manager/nuget/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/manager/nuget/__snapshots__/artifacts.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`updateArtifacts aborts if lock file is unchanged 1`] = `
 Array [
   Object {
-    "cmd": "dotnet new nugetconfig --output ./others/nuget/755461d51c07d4de",
+    "cmd": "dotnet new nugetconfig --output ./others/nuget/not-so-random",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -21,7 +21,7 @@ Array [
     },
   },
   Object {
-    "cmd": "dotnet restore project.csproj --force-evaluate --configfile others/nuget/755461d51c07d4de/nuget.config",
+    "cmd": "dotnet restore project.csproj --force-evaluate --configfile others/nuget/not-so-random/nuget.config",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -46,7 +46,7 @@ exports[`updateArtifacts aborts if no lock file found 1`] = `Array []`;
 exports[`updateArtifacts authenticates at registries 1`] = `
 Array [
   Object {
-    "cmd": "dotnet new nugetconfig --output ./others/nuget/6d74034e601eb829",
+    "cmd": "dotnet new nugetconfig --output ./others/nuget/not-so-random",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -64,7 +64,7 @@ Array [
     },
   },
   Object {
-    "cmd": "dotnet nuget add source https://my-registry.example.org --name myRegistry --configfile others/nuget/6d74034e601eb829/nuget.config --username some-username --password some-password --store-password-in-clear-text",
+    "cmd": "dotnet nuget add source https://my-registry.example.org --name myRegistry --configfile others/nuget/not-so-random/nuget.config --username some-username --password some-password --store-password-in-clear-text",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -82,7 +82,7 @@ Array [
     },
   },
   Object {
-    "cmd": "dotnet restore project.csproj --force-evaluate --configfile others/nuget/6d74034e601eb829/nuget.config",
+    "cmd": "dotnet restore project.csproj --force-evaluate --configfile others/nuget/not-so-random/nuget.config",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -120,7 +120,7 @@ exports[`updateArtifacts does not update lock file when non-proj file is changed
 exports[`updateArtifacts performs lock file maintenance 1`] = `
 Array [
   Object {
-    "cmd": "dotnet new nugetconfig --output ./others/nuget/bee8338fa55930a3",
+    "cmd": "dotnet new nugetconfig --output ./others/nuget/not-so-random",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -138,7 +138,7 @@ Array [
     },
   },
   Object {
-    "cmd": "dotnet restore project.csproj --force-evaluate --configfile others/nuget/bee8338fa55930a3/nuget.config",
+    "cmd": "dotnet restore project.csproj --force-evaluate --configfile others/nuget/not-so-random/nuget.config",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -173,7 +173,7 @@ Array [
     },
   },
   Object {
-    "cmd": "docker run --rm --name=renovate_dotnet --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -w \\"/tmp/github/some/repo\\" renovate/dotnet bash -l -c \\"dotnet new nugetconfig --output ./others/nuget/b8683917cce215c9 && dotnet restore project.csproj --force-evaluate --configfile others/nuget/b8683917cce215c9/nuget.config\\"",
+    "cmd": "docker run --rm --name=renovate_dotnet --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -w \\"/tmp/github/some/repo\\" renovate/dotnet bash -l -c \\"dotnet new nugetconfig --output ./others/nuget/not-so-random && dotnet restore project.csproj --force-evaluate --configfile others/nuget/not-so-random/nuget.config\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -196,7 +196,7 @@ Array [
 exports[`updateArtifacts supports global mode 1`] = `
 Array [
   Object {
-    "cmd": "dotnet new nugetconfig --output ./others/nuget/2a78f82ffaf9f663",
+    "cmd": "dotnet new nugetconfig --output ./others/nuget/not-so-random",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -214,7 +214,7 @@ Array [
     },
   },
   Object {
-    "cmd": "dotnet restore project.csproj --force-evaluate --configfile others/nuget/2a78f82ffaf9f663/nuget.config",
+    "cmd": "dotnet restore project.csproj --force-evaluate --configfile others/nuget/not-so-random/nuget.config",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -237,7 +237,7 @@ Array [
 exports[`updateArtifacts updates lock file 1`] = `
 Array [
   Object {
-    "cmd": "dotnet new nugetconfig --output ./others/nuget/1286b7ff5b3196a7",
+    "cmd": "dotnet new nugetconfig --output ./others/nuget/not-so-random",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -255,7 +255,7 @@ Array [
     },
   },
   Object {
-    "cmd": "dotnet restore project.csproj --force-evaluate --configfile others/nuget/1286b7ff5b3196a7/nuget.config",
+    "cmd": "dotnet restore project.csproj --force-evaluate --configfile others/nuget/not-so-random/nuget.config",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",

--- a/lib/manager/nuget/artifacts.spec.ts
+++ b/lib/manager/nuget/artifacts.spec.ts
@@ -33,6 +33,9 @@ describe('updateArtifacts', () => {
     jest.resetAllMocks();
     jest.resetModules();
     env.getChildProcessEnv.mockReturnValue(envMock.basic);
+    fs.ensureCacheDir.mockImplementation((dirName: string) =>
+      Promise.resolve(dirName)
+    );
     await setUtilConfig(config);
     docker.resetPrefetchedImages();
   });

--- a/lib/manager/nuget/artifacts.spec.ts
+++ b/lib/manager/nuget/artifacts.spec.ts
@@ -8,7 +8,10 @@ import * as docker from '../../util/exec/docker';
 import * as _env from '../../util/exec/env';
 import * as _hostRules from '../../util/host-rules';
 import * as nuget from './artifacts';
-import { determineRegistries as _determineRegistries } from './util';
+import {
+  determineRegistries as _determineRegistries,
+  getRandomString as _getRandomString,
+} from './util';
 
 jest.mock('child_process');
 jest.mock('../../util/exec/env');
@@ -19,6 +22,7 @@ jest.mock('./util');
 const exec: jest.Mock<typeof _exec> = _exec as any;
 const env = mocked(_env);
 const determineRegistries: jest.Mock<typeof _determineRegistries> = _determineRegistries as any;
+const getRandomString: jest.Mock<typeof _getRandomString> = _getRandomString as any;
 const hostRules = mocked(_hostRules);
 
 const config = {
@@ -36,6 +40,7 @@ describe('updateArtifacts', () => {
     fs.ensureCacheDir.mockImplementation((dirName: string) =>
       Promise.resolve(dirName)
     );
+    getRandomString.mockReturnValue('not-so-random' as any);
     await setUtilConfig(config);
     docker.resetPrefetchedImages();
   });

--- a/lib/manager/nuget/artifacts.ts
+++ b/lib/manager/nuget/artifacts.ts
@@ -1,3 +1,6 @@
+import { join } from 'path';
+import cryptoRandomString from 'crypto-random-string';
+import { fs } from '../../../test/util';
 import { id } from '../../datasource/nuget';
 import { logger } from '../../logger';
 import { ExecOptions, exec } from '../../util/exec';
@@ -14,30 +17,28 @@ import {
 } from '../common';
 import { determineRegistries } from './util';
 
-async function authenticate(
+async function addSourceCmds(
   packageFileName: string,
   config: UpdateArtifactsConfig,
-  cmds: string[]
-): Promise<void> {
+  nugetConfigFile: string
+): Promise<string[]> {
   const registries = (
     (await determineRegistries(packageFileName, config.localDir)) || []
   ).filter((registry) => registry.name != null);
+  const result = [];
   for (const registry of registries) {
     const { username, password } = hostRules.find({
       hostType: id,
       url: registry.url,
     });
+    let addSourceCmd = `dotnet nuget add source ${registry.url} --name ${registry.name} --configfile ${nugetConfigFile}`;
     if (username && password) {
       // Add registry credentials from host rules.
-      cmds.unshift(
-        `dotnet nuget update source ${registry.name} --username ${username} --password ${password} --store-password-in-clear-text`
-      );
-      // Ensure that credentials are removed as soon as not necessary anymore.
-      cmds.push(
-        `dotnet nuget update source ${registry.name} --username '' --password '' --store-password-in-clear-text`
-      );
+      addSourceCmd += ` --username ${username} --password ${password} --store-password-in-clear-text`;
     }
+    result.push(addSourceCmd);
   }
+  return result;
 }
 
 async function runDotnetRestore(
@@ -49,10 +50,19 @@ async function runDotnetRestore(
       image: 'renovate/dotnet',
     },
   };
-  const cmds = [`dotnet restore ${packageFileName} --force-evaluate`];
-  await authenticate(packageFileName, config, cmds);
+
+  const nugetConfigDir = await fs.ensureCacheDir(
+    `./others/nuget/${cryptoRandomString({ length: 16 })}`
+  );
+  const nugetConfigFile = join(nugetConfigDir, 'nuget.config');
+  const cmds = [
+    `dotnet new nugetconfig --output ${nugetConfigDir}`,
+    ...(await addSourceCmds(packageFileName, config, nugetConfigFile)),
+    `dotnet restore ${packageFileName} --force-evaluate --configfile ${nugetConfigFile}`,
+  ];
   logger.debug({ cmd: cmds }, 'dotnet command');
   await exec(cmds, execOptions);
+  await fs.remove(nugetConfigDir);
 }
 
 export async function updateArtifacts({

--- a/lib/manager/nuget/artifacts.ts
+++ b/lib/manager/nuget/artifacts.ts
@@ -1,5 +1,4 @@
 import { join } from 'path';
-import cryptoRandomString from 'crypto-random-string';
 import { id } from '../../datasource/nuget';
 import { logger } from '../../logger';
 import { ExecOptions, exec } from '../../util/exec';
@@ -16,7 +15,7 @@ import {
   UpdateArtifactsConfig,
   UpdateArtifactsResult,
 } from '../common';
-import { determineRegistries } from './util';
+import { determineRegistries, getRandomString } from './util';
 
 async function addSourceCmds(
   packageFileName: string,
@@ -53,7 +52,7 @@ async function runDotnetRestore(
   };
 
   const nugetConfigDir = await ensureCacheDir(
-    `./others/nuget/${cryptoRandomString({ length: 16 })}`
+    `./others/nuget/${getRandomString()}`
   );
   const nugetConfigFile = join(nugetConfigDir, 'nuget.config');
   const cmds = [

--- a/lib/manager/nuget/artifacts.ts
+++ b/lib/manager/nuget/artifacts.ts
@@ -1,12 +1,13 @@
 import { join } from 'path';
 import cryptoRandomString from 'crypto-random-string';
-import { fs } from '../../../test/util';
 import { id } from '../../datasource/nuget';
 import { logger } from '../../logger';
 import { ExecOptions, exec } from '../../util/exec';
 import {
+  ensureCacheDir,
   getSiblingFileName,
   readLocalFile,
+  remove,
   writeLocalFile,
 } from '../../util/fs';
 import * as hostRules from '../../util/host-rules';
@@ -51,7 +52,7 @@ async function runDotnetRestore(
     },
   };
 
-  const nugetConfigDir = await fs.ensureCacheDir(
+  const nugetConfigDir = await ensureCacheDir(
     `./others/nuget/${cryptoRandomString({ length: 16 })}`
   );
   const nugetConfigFile = join(nugetConfigDir, 'nuget.config');
@@ -62,7 +63,7 @@ async function runDotnetRestore(
   ];
   logger.debug({ cmd: cmds }, 'dotnet command');
   await exec(cmds, execOptions);
-  await fs.remove(nugetConfigDir);
+  await remove(nugetConfigDir);
 }
 
 export async function updateArtifacts({

--- a/lib/manager/nuget/util.ts
+++ b/lib/manager/nuget/util.ts
@@ -1,3 +1,4 @@
+import cryptoRandomString from 'crypto-random-string';
 import findUp from 'find-up';
 import * as upath from 'upath';
 import { XmlDocument } from 'xmldoc';
@@ -17,6 +18,10 @@ async function readFileAsXmlDocument(file: string): Promise<XmlDocument> {
 export interface Registry {
   readonly url: string;
   readonly name?: string;
+}
+
+export function getRandomString(): string {
+  return cryptoRandomString({ length: 16 });
 }
 
 export async function determineRegistries(

--- a/lib/manager/nuget/util.ts
+++ b/lib/manager/nuget/util.ts
@@ -20,6 +20,7 @@ export interface Registry {
   readonly name?: string;
 }
 
+/* istanbul ignore next */
 export function getRandomString(): string {
   return cryptoRandomString({ length: 16 });
 }

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "clean-git-ref": "2.0.1",
     "commander": "6.2.0",
     "conventional-commits-detector": "1.0.3",
+    "crypto-random-string": "3.3.0",
     "deepmerge": "4.2.2",
     "delay": "4.4.0",
     "detect-indent": "6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3511,6 +3511,13 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
+crypto-random-string@3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-3.3.0.tgz#c7a4682b2a87146a1f8b7378ea2606f95775e7e6"
+  integrity sha512-teWAwfMb1d6brahYyKqcBEb5Yp8PJPvPOdOonXDnvaKOTmKDFNVE8E3Y2XQuzjNV/3XMwHbrX9fHWvrhRKt4Gg==
+  dependencies:
+    type-fest "^0.8.1"
+
 crypto-random-string@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
@@ -7751,7 +7758,6 @@ npm@^6.13.0:
     cmd-shim "^3.0.3"
     columnify "~1.5.4"
     config-chain "^1.1.12"
-    debuglog "*"
     detect-indent "~5.0.0"
     detect-newline "^2.1.0"
     dezalgo "~1.0.3"
@@ -7766,7 +7772,6 @@ npm@^6.13.0:
     has-unicode "~2.0.1"
     hosted-git-info "^2.8.8"
     iferr "^1.0.2"
-    imurmurhash "*"
     infer-owner "^1.0.4"
     inflight "~1.0.6"
     inherits "^2.0.4"
@@ -7785,14 +7790,8 @@ npm@^6.13.0:
     libnpx "^10.2.4"
     lock-verify "^2.1.0"
     lockfile "^1.0.4"
-    lodash._baseindexof "*"
     lodash._baseuniq "~4.6.0"
-    lodash._bindcallback "*"
-    lodash._cacheindexof "*"
-    lodash._createcache "*"
-    lodash._getnative "*"
     lodash.clonedeep "~4.5.0"
-    lodash.restparam "*"
     lodash.union "~4.6.0"
     lodash.uniq "~4.5.0"
     lodash.without "~4.4.0"


### PR DESCRIPTION
## Changes:

We now create a temporary NuGet.config files to authenticate at private registries during lock file update. 

## Context:

Closes #7769 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
