### PR TITLE
fix(maven): Add workaround for ancient commons-cli version

### DIFF
--- a/lib/config/presets/internal/workarounds.ts
+++ b/lib/config/presets/internal/workarounds.ts
@@ -5,7 +5,10 @@ export const presets: Record<string, Preset> = {
     description: [
       'A collection of workarounds for known problems with packages',
     ],
-    extends: ['workarounds:unstableV2SetupNodeActions'],
+    extends: [
+      'workarounds:unstableV2SetupNodeActions',
+      'workarounds:mavenCommonsCliAncientVersion',
+    ],
   },
   unstableV2SetupNodeActions: {
     description: 'Ignore wrongly tagged actions/setup-node v2 releases',
@@ -14,6 +17,15 @@ export const presets: Record<string, Preset> = {
         datasources: ['github-tags', 'github-releases'],
         packageNames: ['actions/setup-node'],
         allowedVersions: '<2.1.1 || > 2.1.1',
+      },
+    ],
+  },
+  mavenCommonsCliAncientVersion: {
+    packageRules: [
+      {
+        datasources: ['maven'],
+        packageNames: ['commons-cli:commons-cli'],
+        allowedVersions: '!/20040117.000000/',
       },
     ],
   },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Add one more case to `workarounds.ts`

## Context:

Original: https://github.com/INRIA/spoon/pull/3703
Fixed: https://github.com/zharinov/spoon/pull/5

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] ~~Unit tests~~ + ran on a real repository

