### PR TITLE
fix(nuget): ignore build metadata

### DIFF
--- a/lib/datasource/nuget/__fixtures__/nlog/v3_catalog_1.json
+++ b/lib/datasource/nuget/__fixtures__/nlog/v3_catalog_1.json
@@ -237,7 +237,7 @@
           "NLog"
         ],
         "title": "NLog",
-        "version": "3.0.0"
+        "version": "3.0.0+build-632"
       },
       "packageContent": "https://api.nuget.org/v3-flatcontainer/nlog/3.0.0/nlog.3.0.0.nupkg",
       "registration": "https://api.nuget.org/v3/registration5-gz-semver2/nlog/index.json"

--- a/lib/datasource/nuget/common.ts
+++ b/lib/datasource/nuget/common.ts
@@ -2,6 +2,6 @@ export const id = 'nuget';
 
 const buildMetaRe = /\+.+$/g;
 
-export function replaceBuildMeta(version: string): string {
+export function removeBuildMeta(version: string): string {
   return version?.replace(buildMetaRe, '');
 }

--- a/lib/datasource/nuget/common.ts
+++ b/lib/datasource/nuget/common.ts
@@ -1,1 +1,7 @@
 export const id = 'nuget';
+
+const buildMetaRe = /\+.+$/g;
+
+export function replaceBuildMeta(version: string): string {
+  return version?.replace(buildMetaRe, '');
+}

--- a/lib/datasource/nuget/v2.ts
+++ b/lib/datasource/nuget/v2.ts
@@ -3,7 +3,7 @@ import { logger } from '../../logger';
 import { Http } from '../../util/http';
 import { ReleaseResult } from '../common';
 
-import { id, replaceBuildMeta } from './common';
+import { id, removeBuildMeta } from './common';
 
 const http = new Http(id);
 
@@ -33,7 +33,7 @@ export async function getReleases(
       const version = getPkgProp(pkgInfo, 'Version');
       const releaseTimestamp = getPkgProp(pkgInfo, 'Published');
       dep.releases.push({
-        version: replaceBuildMeta(version),
+        version: removeBuildMeta(version),
         releaseTimestamp,
       });
       try {

--- a/lib/datasource/nuget/v2.ts
+++ b/lib/datasource/nuget/v2.ts
@@ -3,7 +3,7 @@ import { logger } from '../../logger';
 import { Http } from '../../util/http';
 import { ReleaseResult } from '../common';
 
-import { id } from './common';
+import { id, replaceBuildMeta } from './common';
 
 const http = new Http(id);
 
@@ -32,7 +32,10 @@ export async function getReleases(
     for (const pkgInfo of pkgInfoList) {
       const version = getPkgProp(pkgInfo, 'Version');
       const releaseTimestamp = getPkgProp(pkgInfo, 'Published');
-      dep.releases.push({ version, releaseTimestamp });
+      dep.releases.push({
+        version: replaceBuildMeta(version),
+        releaseTimestamp,
+      });
       try {
         const pkgIsLatestVersion = getPkgProp(pkgInfo, 'IsLatestVersion');
         if (pkgIsLatestVersion === 'true') {

--- a/lib/datasource/nuget/v3.ts
+++ b/lib/datasource/nuget/v3.ts
@@ -9,7 +9,7 @@ import { Http } from '../../util/http';
 import { ensureTrailingSlash } from '../../util/url';
 import { Release, ReleaseResult } from '../common';
 
-import { id, replaceBuildMeta } from './common';
+import { id, removeBuildMeta } from './common';
 
 const http = new Http(id);
 
@@ -145,7 +145,7 @@ export async function getReleases(
   let latestStable: string = null;
   const releases = catalogEntries.map(
     ({ version, published: releaseTimestamp, projectUrl, listed }) => {
-      const release: Release = { version: replaceBuildMeta(version) };
+      const release: Release = { version: removeBuildMeta(version) };
       if (releaseTimestamp) {
         release.releaseTimestamp = releaseTimestamp;
       }

--- a/lib/datasource/nuget/v3.ts
+++ b/lib/datasource/nuget/v3.ts
@@ -9,7 +9,7 @@ import { Http } from '../../util/http';
 import { ensureTrailingSlash } from '../../util/url';
 import { Release, ReleaseResult } from '../common';
 
-import { id } from './common';
+import { id, replaceBuildMeta } from './common';
 
 const http = new Http(id);
 
@@ -145,7 +145,7 @@ export async function getReleases(
   let latestStable: string = null;
   const releases = catalogEntries.map(
     ({ version, published: releaseTimestamp, projectUrl, listed }) => {
-      const release: Release = { version };
+      const release: Release = { version: replaceBuildMeta(version) };
       if (releaseTimestamp) {
         release.releaseTimestamp = releaseTimestamp;
       }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Remove the semver v2 build metadata from version.

<!-- Describe what this pull request changes. -->

## Context:

closes #7659
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
