### PR TITLE
fix(helm-values): set docker versioning

### DIFF
--- a/lib/manager/helm-values/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/helm-values/__snapshots__/extract.spec.ts.snap
@@ -9,6 +9,7 @@ Object {
       "datasource": "docker",
       "depName": "bitnami/postgresql",
       "replaceString": "11.6.0-debian-9-r0",
+      "versioning": "docker",
     },
     Object {
       "currentDigest": undefined,
@@ -16,6 +17,7 @@ Object {
       "datasource": "docker",
       "depName": "docker.io/bitnami/postgres-exporter",
       "replaceString": "0.7.0-debian-9-r12",
+      "versioning": "docker",
     },
     Object {
       "currentDigest": "sha256:4762726f1471ef048dd807afdc0e19265e95ffdcc7cb4a34891f680290022809",
@@ -23,6 +25,7 @@ Object {
       "datasource": "docker",
       "depName": "docker.io/bitnami/postgresql",
       "replaceString": "11.5.0-debian-9-r0@sha256:4762726f1471ef048dd807afdc0e19265e95ffdcc7cb4a34891f680290022809",
+      "versioning": "docker",
     },
   ],
 }
@@ -37,6 +40,7 @@ Object {
       "datasource": "docker",
       "depName": "nginx",
       "replaceString": "1.16.1",
+      "versioning": "docker",
     },
   ],
 }

--- a/lib/manager/helm-values/extract.ts
+++ b/lib/manager/helm-values/extract.ts
@@ -1,5 +1,6 @@
 import yaml from 'js-yaml';
 import { logger } from '../../logger';
+import { id as dockerVersioning } from '../../versioning/docker';
 import { PackageDependency, PackageFile } from '../common';
 import { getDep } from '../dockerfile/extract';
 
@@ -19,6 +20,7 @@ function getHelmDep({
 }): PackageDependency {
   const dep = getDep(`${registry}${repository}:${tag}`, false);
   dep.replaceString = tag;
+  dep.versioning = dockerVersioning;
   return dep;
 }
 

--- a/lib/manager/helm-values/index.ts
+++ b/lib/manager/helm-values/index.ts
@@ -1,4 +1,8 @@
+import { LANGUAGE_DOCKER } from '../../constants/languages';
+
 export { extractPackageFile } from './extract';
+
+export const language = LANGUAGE_DOCKER;
 
 export const defaultConfig = {
   commitMessageTopic: 'helm values {{depName}}',

--- a/lib/manager/helm-values/index.ts
+++ b/lib/manager/helm-values/index.ts
@@ -1,8 +1,4 @@
-import { LANGUAGE_DOCKER } from '../../constants/languages';
-
 export { extractPackageFile } from './extract';
-
-export const language = LANGUAGE_DOCKER;
 
 export const defaultConfig = {
   commitMessageTopic: 'helm values {{depName}}',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Add the docker language to `helm-values` manager,  so the `docker` versioning will be auto aqssigned to deps.
<!-- Describe what this pull request changes. -->

## Context:

renovatebot/config-help#990

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
