### PR TITLE
fix: don’t evaluate versions during extract

### DIFF
--- a/lib/manager/nuget/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/nuget/__snapshots__/extract.spec.ts.snap
@@ -154,7 +154,6 @@ Array [
     "datasource": "nuget",
     "depName": "Stateless",
     "depType": "nuget",
-    "skipReason": "not-a-version",
   },
   Object {
     "currentValue": "1.2.3",
@@ -181,51 +180,6 @@ Array [
     "depType": "nuget",
   },
 ]
-`;
-
-exports[`lib/manager/nuget/extract extractPackageFile() extracts package version dependency 1`] = `
-Array [
-  Object {
-    "currentValue": "4.5.0",
-    "datasource": "nuget",
-    "depName": "Autofac",
-    "depType": "nuget",
-  },
-]
-`;
-
-exports[`lib/manager/nuget/extract extractPackageFile() extracts registry URLs independently 1`] = `
-Object {
-  "deps": Array [
-    Object {
-      "currentValue": "4.5.0",
-      "datasource": "nuget",
-      "depName": "Autofac",
-      "depType": "nuget",
-      "registryUrls": Array [
-        "https://api.nuget.org/v3/index.json",
-        "https://example.org/one",
-      ],
-    },
-  ],
-}
-`;
-
-exports[`lib/manager/nuget/extract extractPackageFile() extracts registry URLs independently 2`] = `
-Object {
-  "deps": Array [
-    Object {
-      "currentValue": "4.5.0",
-      "datasource": "nuget",
-      "depName": "Autofac",
-      "depType": "nuget",
-      "registryUrls": Array [
-        "https://api.nuget.org/v3/index.json",
-        "https://example.org/two",
-      ],
-    },
-  ],
-}
 `;
 
 exports[`lib/manager/nuget/extract extractPackageFile() extracts all dependencies from global packages file 1`] = `
@@ -307,7 +261,6 @@ Array [
     "datasource": "nuget",
     "depName": "Stateless",
     "depType": "nuget",
-    "skipReason": "not-a-version",
   },
   Object {
     "currentValue": "1.2.3",
@@ -334,6 +287,51 @@ Array [
     "depType": "nuget",
   },
 ]
+`;
+
+exports[`lib/manager/nuget/extract extractPackageFile() extracts package version dependency 1`] = `
+Array [
+  Object {
+    "currentValue": "4.5.0",
+    "datasource": "nuget",
+    "depName": "Autofac",
+    "depType": "nuget",
+  },
+]
+`;
+
+exports[`lib/manager/nuget/extract extractPackageFile() extracts registry URLs independently 1`] = `
+Object {
+  "deps": Array [
+    Object {
+      "currentValue": "4.5.0",
+      "datasource": "nuget",
+      "depName": "Autofac",
+      "depType": "nuget",
+      "registryUrls": Array [
+        "https://api.nuget.org/v3/index.json",
+        "https://example.org/one",
+      ],
+    },
+  ],
+}
+`;
+
+exports[`lib/manager/nuget/extract extractPackageFile() extracts registry URLs independently 2`] = `
+Object {
+  "deps": Array [
+    Object {
+      "currentValue": "4.5.0",
+      "datasource": "nuget",
+      "depName": "Autofac",
+      "depType": "nuget",
+      "registryUrls": Array [
+        "https://api.nuget.org/v3/index.json",
+        "https://example.org/two",
+      ],
+    },
+  ],
+}
 `;
 
 exports[`lib/manager/nuget/extract extractPackageFile() handles NuGet.config without package sources 1`] = `

--- a/lib/manager/nuget/extract.ts
+++ b/lib/manager/nuget/extract.ts
@@ -109,9 +109,6 @@ export async function extractPackageFile(
     deps = extractDepsFromXml(parsedXml).map((dep) => ({
       ...dep,
       ...(registryUrls && { registryUrls }),
-      ...(!versioning.isVersion(dep.currentValue) && {
-        skipReason: SkipReason.NotAVersion,
-      }),
     }));
     return { deps };
   } catch (err) {

--- a/lib/manager/nuget/extract.ts
+++ b/lib/manager/nuget/extract.ts
@@ -1,9 +1,6 @@
 import { XmlDocument } from 'xmldoc';
 import * as datasourceNuget from '../../datasource/nuget';
 import { logger } from '../../logger';
-import { SkipReason } from '../../types';
-import { get } from '../../versioning';
-import * as semverVersioning from '../../versioning/semver';
 import { ExtractConfig, PackageDependency, PackageFile } from '../common';
 import { DotnetToolsManifest } from './types';
 import { determineRegistries } from './util';
@@ -61,7 +58,6 @@ export async function extractPackageFile(
   config: ExtractConfig
 ): Promise<PackageFile | null> {
   logger.trace({ packageFile }, 'nuget.extractPackageFile()');
-  const versioning = get(config.versioning || semverVersioning.id);
 
   const registries = await determineRegistries(packageFile, config.localDir);
   const registryUrls = registries

--- a/lib/manager/pub/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/pub/__snapshots__/extract.spec.ts.snap
@@ -18,13 +18,11 @@ Object {
       "currentValue": null,
       "depName": "baz",
       "depType": "dependencies",
-      "skipReason": "not-a-version",
     },
     Object {
       "currentValue": null,
       "depName": "qux",
       "depType": "dependencies",
-      "skipReason": "not-a-version",
     },
     Object {
       "currentValue": "^0.1",

--- a/lib/manager/pub/extract.ts
+++ b/lib/manager/pub/extract.ts
@@ -1,7 +1,6 @@
 import { safeLoad } from 'js-yaml';
 import * as datasourceDart from '../../datasource/dart';
 import { logger } from '../../logger';
-import { SkipReason } from '../../types';
 import { PackageDependency, PackageFile } from '../common';
 
 function getDeps(

--- a/lib/manager/pub/extract.ts
+++ b/lib/manager/pub/extract.ts
@@ -31,9 +31,6 @@ function getDeps(
     }
 
     const dep: PackageDependency = { ...preset, depName, currentValue };
-    if (!currentValue) {
-      dep.skipReason = SkipReason.NotAVersion;
-    }
 
     return [...acc, dep];
   }, []);


### PR DESCRIPTION


<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Postpone validation until the lookup, so that users can apply custom versioning after extraction.

## Context:

Closes #7801


<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
