### PR TITLE
fix(git): gracefully handle remote ref lock error

### DIFF
--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -57,7 +57,6 @@ function checkForPlatformFailure(err: Error): void {
     return;
   }
   const platformFailureStrings = [
-    'remote: error: cannot lock ref',
     'remote: Invalid username or password',
     'gnutls_handshake() failed',
     'The requested URL returned error: 5',
@@ -658,6 +657,10 @@ export async function commitFiles({
       logger.warn(
         'App has not been granted permissions to update Workflows - aborting branch.'
       );
+      return null;
+    }
+    if (err.message.includes('remote: error: cannot lock ref')) {
+      logger.error({ err }, 'Error committing files.');
       return null;
     }
     logger.debug({ err }, 'Error committing files');

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -57,7 +57,7 @@ function checkForPlatformFailure(err: Error): void {
     return;
   }
   const platformFailureStrings = [
-    'error: cannot lock ref',
+    'remote: error: cannot lock ref',
     'remote: Invalid username or password',
     'gnutls_handshake() failed',
     'The requested URL returned error: 5',

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -57,6 +57,7 @@ function checkForPlatformFailure(err: Error): void {
     return;
   }
   const platformFailureStrings = [
+    'error: cannot lock ref',
     'remote: Invalid username or password',
     'gnutls_handshake() failed',
     'The requested URL returned error: 5',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

gracefully handle `remote: error: cannot lock ref` git errors as `ExternalHostError`
<!-- Describe what this pull request changes. -->

## Context:

I've had a corrupt git repo and renovate silently failed  to push an update

```
Pushing to https://git.some.org/some/repo.git
POST git-receive-pack (711 bytes)
remote: error: cannot lock ref  'refs/heads/renovate/docker-renovate-renovate-23.26.x': unable to resolve reference 'refs/heads/renovate/docker-renovate-renovate-23.26.x': reference broken        
    error: failed to push some refs to https://git.some.org/some/repo.git
```
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
