### PR TITLE
fix(maven): Treat LATEST and RELEASE as non-version values

### DIFF
--- a/lib/versioning/maven/compare.ts
+++ b/lib/versioning/maven/compare.ts
@@ -285,6 +285,9 @@ function isVersion(version: string): boolean {
   if (/[.-]$/.test(version)) {
     return false;
   }
+  if (['latest', 'release'].includes(version.toLowerCase())) {
+    return false;
+  }
   const tokens = tokenize(version);
   return !!tokens.length;
 }

--- a/lib/versioning/maven/index.spec.ts
+++ b/lib/versioning/maven/index.spec.ts
@@ -307,6 +307,11 @@ describe('versioning/maven/index', () => {
     expect(isVersion('-1')).toBe(false);
     expect(isVersion('1-')).toBe(false);
     expect(isVersion('[1.12.6,1.18.6]')).toBe(false);
+    expect(isVersion('RELEASE')).toBe(false);
+    expect(isVersion('release')).toBe(false);
+    expect(isVersion('LATEST')).toBe(false);
+    expect(isVersion('latest')).toBe(false);
+    expect(isVersion('foobar')).toBe(true);
   });
   it('checks if version is stable', () => {
     expect(isStable('')).toBeNull();


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Return `false` for `isVersion('RELEASE')` and `isVersion('LATEST')` (Maven versioning)

## Context:

Closes #7798

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [x] Unit tests + ran on a real repository

Example: https://github.com/zharinov/release-new-test-group/pull/1
It's identical to: https://github.com/zbyufei/release-new-test-group/pull/2