### PR TITLE
feat(maven): workaround for spring cloud numeric versions

### DIFF
--- a/lib/config/presets/internal/workarounds.ts
+++ b/lib/config/presets/internal/workarounds.ts
@@ -8,6 +8,7 @@ export const presets: Record<string, Preset> = {
     extends: [
       'workarounds:unstableV2SetupNodeActions',
       'workarounds:mavenCommonsCliAncientVersion',
+      'workarounds:ignoreSpringCloudNumeric',
     ],
   },
   unstableV2SetupNodeActions: {
@@ -26,6 +27,16 @@ export const presets: Record<string, Preset> = {
         datasources: ['maven'],
         packageNames: ['commons-cli:commons-cli'],
         allowedVersions: '!/20040117.000000/',
+      },
+    ],
+  },
+  ignoreSpringCloudNumeric: {
+    description: 'Ignore spring cloud 1.x releases',
+    packageRules: [
+      {
+        datasources: ['maven'],
+        packageNames: ['org.springframework.cloud:spring-cloud-starter-parent'],
+        allowedVersions: '/^[A-Z]/',
       },
     ],
   },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds a workaround to ignore spring cloud numeric versions.

## Context:

#7817

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
