### PR TITLE
feat(repology): Support all repositories of repology

### DIFF
--- a/lib/datasource/repology/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/repology/__snapshots__/index.spec.ts.snap
@@ -20,7 +20,7 @@ Array [
       "user-agent": "https://github.com/renovatebot/renovate",
     },
     "method": "GET",
-    "url": "https://repology.org/tools/project-by?repo=debian_stable&name_type=binname&target_page=api_v1_project&noautoresolve=on&name=nginx",
+    "url": "https://repology.org/api/v1/project/nginx",
   },
 ]
 `;
@@ -45,7 +45,7 @@ Array [
       "user-agent": "https://github.com/renovatebot/renovate",
     },
     "method": "GET",
-    "url": "https://repology.org/tools/project-by?repo=debian_stable&name_type=binname&target_page=api_v1_project&noautoresolve=on&name=pulseaudio-utils",
+    "url": "https://repology.org/api/v1/project/pulseaudio-utils",
   },
 ]
 `;
@@ -70,7 +70,7 @@ Array [
       "user-agent": "https://github.com/renovatebot/renovate",
     },
     "method": "GET",
-    "url": "https://repology.org/tools/project-by?repo=alpine_3_12&name_type=binname&target_page=api_v1_project&noautoresolve=on&name=gcc",
+    "url": "https://repology.org/api/v1/project/gcc",
   },
 ]
 `;
@@ -95,17 +95,7 @@ Array [
       "user-agent": "https://github.com/renovatebot/renovate",
     },
     "method": "GET",
-    "url": "https://repology.org/tools/project-by?repo=debian_stable&name_type=binname&target_page=api_v1_project&noautoresolve=on&name=gcc-defaults",
-  },
-  Object {
-    "headers": Object {
-      "accept": "application/json",
-      "accept-encoding": "gzip, deflate",
-      "host": "repology.org",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
-    "url": "https://repology.org/tools/project-by?repo=debian_stable&name_type=srcname&target_page=api_v1_project&noautoresolve=on&name=gcc-defaults",
+    "url": "https://repology.org/api/v1/project/gcc-defaults",
   },
 ]
 `;
@@ -120,17 +110,7 @@ Array [
       "user-agent": "https://github.com/renovatebot/renovate",
     },
     "method": "GET",
-    "url": "https://repology.org/tools/project-by?repo=debian_stable&name_type=binname&target_page=api_v1_project&noautoresolve=on&name=nginx",
-  },
-  Object {
-    "headers": Object {
-      "accept": "application/json",
-      "accept-encoding": "gzip, deflate",
-      "host": "repology.org",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
-    "url": "https://repology.org/tools/project-by?repo=debian_stable&name_type=srcname&target_page=api_v1_project&noautoresolve=on&name=nginx",
+    "url": "https://repology.org/api/v1/project/nginx",
   },
 ]
 `;
@@ -145,42 +125,7 @@ Array [
       "user-agent": "https://github.com/renovatebot/renovate",
     },
     "method": "GET",
-    "url": "https://repology.org/tools/project-by?repo=this_should&name_type=binname&target_page=api_v1_project&noautoresolve=on&name=never-exist",
-  },
-  Object {
-    "headers": Object {
-      "accept": "application/json",
-      "accept-encoding": "gzip, deflate",
-      "host": "repology.org",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
-    "url": "https://repology.org/tools/project-by?repo=this_should&name_type=srcname&target_page=api_v1_project&noautoresolve=on&name=never-exist",
-  },
-]
-`;
-
-exports[`datasource/repology/index getReleases returns null for unsupported repository 1`] = `
-Array [
-  Object {
-    "headers": Object {
-      "accept": "application/json",
-      "accept-encoding": "gzip, deflate",
-      "host": "repology.org",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
-    "url": "https://repology.org/tools/project-by?repo=unsupported_repo&name_type=binname&target_page=api_v1_project&noautoresolve=on&name=nginx",
-  },
-  Object {
-    "headers": Object {
-      "accept": "application/json",
-      "accept-encoding": "gzip, deflate",
-      "host": "repology.org",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
-    "url": "https://repology.org/tools/project-by?repo=unsupported_repo&name_type=srcname&target_page=api_v1_project&noautoresolve=on&name=nginx",
+    "url": "https://repology.org/api/v1/project/never-exist",
   },
 ]
 `;
@@ -195,32 +140,7 @@ Array [
       "user-agent": "https://github.com/renovatebot/renovate",
     },
     "method": "GET",
-    "url": "https://repology.org/tools/project-by?repo=debian_stable&name_type=binname&target_page=api_v1_project&noautoresolve=on&name=nginx",
-  },
-]
-`;
-
-exports[`datasource/repology/index getReleases throws error on unexpected response during source package lookup 1`] = `
-Array [
-  Object {
-    "headers": Object {
-      "accept": "application/json",
-      "accept-encoding": "gzip, deflate",
-      "host": "repology.org",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
-    "url": "https://repology.org/tools/project-by?repo=debian_stable&name_type=binname&target_page=api_v1_project&noautoresolve=on&name=nginx",
-  },
-  Object {
-    "headers": Object {
-      "accept": "application/json",
-      "accept-encoding": "gzip, deflate",
-      "host": "repology.org",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
-    "url": "https://repology.org/tools/project-by?repo=debian_stable&name_type=srcname&target_page=api_v1_project&noautoresolve=on&name=nginx",
+    "url": "https://repology.org/api/v1/project/nginx",
   },
 ]
 `;

--- a/lib/datasource/repology/index.spec.ts
+++ b/lib/datasource/repology/index.spec.ts
@@ -6,37 +6,15 @@ import { EXTERNAL_HOST_ERROR } from '../../constants/error-messages';
 import { id as versioning } from '../../versioning/loose';
 import { RepologyPackage, id as datasource } from '.';
 
-const repologyApiHost = 'https://repology.org/';
+const repologyApiHost = 'https://repology.org/api/v1/';
 
 type ResponseMock = { status: number; body?: string };
 
-const mockProjectBy = (
-  repo: string,
-  name: string,
-  binary: ResponseMock,
-  source: ResponseMock
-) => {
-  const endpoint = '/tools/project-by';
-  const defaultParams = {
-    target_page: 'api_v1_project',
-    noautoresolve: 'on',
-  };
-
-  if (binary) {
-    httpMock
-      .scope(repologyApiHost)
-      .get(endpoint)
-      .query({ ...defaultParams, repo, name, name_type: 'binname' })
-      .reply(binary.status, binary.body);
-  }
-
-  if (source) {
-    httpMock
-      .scope(repologyApiHost)
-      .get(endpoint)
-      .query({ ...defaultParams, repo, name, name_type: 'srcname' })
-      .reply(source.status, source.body);
-  }
+const mockProjectBy = (name: string, response: ResponseMock) => {
+  httpMock
+    .scope(repologyApiHost)
+    .get(`/project/${name}`)
+    .reply(response.status, response.body);
 };
 
 const fixtureNginx = fs.readFileSync(
@@ -65,12 +43,7 @@ describe(getName(__filename), () => {
     afterEach(() => httpMock.reset());
 
     it('returns null for empty result', async () => {
-      mockProjectBy(
-        'debian_stable',
-        'nginx',
-        { status: 200, body: '[]' },
-        { status: 200, body: '[]' }
-      );
+      mockProjectBy('nginx', { status: 200, body: '[]' });
 
       expect(
         await getPkgReleases({
@@ -83,12 +56,7 @@ describe(getName(__filename), () => {
     });
 
     it('returns null for missing repository or package', async () => {
-      mockProjectBy(
-        'this_should',
-        'never-exist',
-        { status: 404 },
-        { status: 404 }
-      );
+      mockProjectBy('never-exist', { status: 404 });
 
       expect(
         await getPkgReleases({
@@ -100,39 +68,8 @@ describe(getName(__filename), () => {
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
 
-    it('returns null for unsupported repository', async () => {
-      mockProjectBy(
-        'unsupported_repo',
-        'nginx',
-        { status: 403 },
-        { status: 403 }
-      );
-
-      expect(
-        await getPkgReleases({
-          datasource,
-          versioning,
-          depName: 'unsupported_repo/nginx',
-        })
-      ).toBeNull();
-      expect(httpMock.getTrace()).toMatchSnapshot();
-    });
-
     it('throws error on unexpected response during binary package lookup', async () => {
-      mockProjectBy('debian_stable', 'nginx', { status: 500 }, null);
-
-      await expect(
-        getPkgReleases({
-          datasource,
-          versioning,
-          depName: 'debian_stable/nginx',
-        })
-      ).rejects.toThrow(EXTERNAL_HOST_ERROR);
-      expect(httpMock.getTrace()).toMatchSnapshot();
-    });
-
-    it('throws error on unexpected response during source package lookup', async () => {
-      mockProjectBy('debian_stable', 'nginx', { status: 404 }, { status: 500 });
+      mockProjectBy('nginx', { status: 500 });
 
       await expect(
         getPkgReleases({
@@ -156,12 +93,7 @@ describe(getName(__filename), () => {
     });
 
     it('returns correct version for binary package', async () => {
-      mockProjectBy(
-        'debian_stable',
-        'nginx',
-        { status: 200, body: fixtureNginx },
-        null
-      );
+      mockProjectBy('nginx', { status: 200, body: fixtureNginx });
 
       const res = await getPkgReleases({
         datasource,
@@ -175,12 +107,7 @@ describe(getName(__filename), () => {
     });
 
     it('returns correct version for source package', async () => {
-      mockProjectBy(
-        'debian_stable',
-        'gcc-defaults',
-        { status: 404 },
-        { status: 200, body: fixtureGccDefaults }
-      );
+      mockProjectBy('gcc-defaults', { status: 200, body: fixtureGccDefaults });
 
       const res = await getPkgReleases({
         datasource,
@@ -194,12 +121,7 @@ describe(getName(__filename), () => {
     });
 
     it('returns correct version for multi-package project with same name', async () => {
-      mockProjectBy(
-        'alpine_3_12',
-        'gcc',
-        { status: 200, body: fixtureGcc },
-        null
-      );
+      mockProjectBy('gcc', { status: 200, body: fixtureGcc });
 
       const res = await getPkgReleases({
         datasource,
@@ -213,12 +135,10 @@ describe(getName(__filename), () => {
     });
 
     it('returns correct version for multi-package project with different name', async () => {
-      mockProjectBy(
-        'debian_stable',
-        'pulseaudio-utils',
-        { status: 200, body: fixturePulseaudio },
-        null
-      );
+      mockProjectBy('pulseaudio-utils', {
+        status: 200,
+        body: fixturePulseaudio,
+      });
 
       const res = await getPkgReleases({
         datasource,
@@ -238,12 +158,7 @@ describe(getName(__filename), () => {
       ];
       const pkgsJSON = JSON.stringify(pkgs);
 
-      mockProjectBy(
-        'dummy',
-        'example',
-        { status: 200, body: pkgsJSON },
-        { status: 200, body: pkgsJSON }
-      );
+      mockProjectBy('example', { status: 200, body: pkgsJSON });
 
       expect(
         await getPkgReleases({

--- a/lib/datasource/repology/readme.md
+++ b/lib/datasource/repology/readme.md
@@ -6,8 +6,6 @@ A [list of all supported repositories](https://repology.org/repositories/statist
 
 As an example, the `Alpine Linux 3.12` repository points to `https://repology.org/repository/alpine_3_12` and therefor has the repository identifier `alpine_3_12`.
 
-Please note that as of today, the Repology API endpoint `/tools/project-by` does not support a small subset of repositories. You can manually double-check [on their website](https://repology.org/tools/project-by) if your desired repository is supported and otherwise raise a request on their side. This datasource will also print a debug message `Repology does not support tools/project-by lookups for repository` if the given repository is unsupported.
-
 **Usage Example**
 
 A real world example for this specific datasource would be maintaining system packages within a Dockerfile, as this allows to specifically pin each dependency without having to manually keep the versions up-to-date. This can be achieved by configuring a generic regex manager in `renovate.json` for files named `Dockerfile`:


### PR DESCRIPTION
## Context:

I was running into the issue that renovate-bot wasn't able to use the repository `homebrew_cask` from repology because it is not available in https://repology.org/tools/project-by. I was curios though why renovate-bot isn't using the normal API (which supports everything) and instead this helper tool. After looking through the code it didn't really make sense to use this tool, because all this tool does is a HTTP redirect to the API, so why no use it in the first place and save one redirect and as it turns out also one request to the API in some cases. After a successful local test (log attached) I though I might open a PR directly and not an issue.

## Changes:

The changes include:
- Instead of calling `https://repology.org/tools/project-by?name=pkgName` directly call `https://repology.org/api/v1/project/pkgName` (which the first one redirectes to anyway)

```
> GET /tools/project-by?repo=debian_stable&name_type=binname&target_page=api_v1_project&noautoresolve=on&name=fontconfig HTTP/2
> Host: repology.org
> user-agent: insomnia/2020.4.2
> accept: application/json

< HTTP/2 302 
< ...
< location: https://repology.org/api/v1/project/fontconfig
  ```

- The whole "first request binary packages and then source packages" was unnecessary as both requests returned the same result (because all that matters for the redirect is the package name). So got rid of that and saved one request in these cases.
- The logic for ambiguous packages was left intact with the only difference that now that we only ever do one request to repology we can check `binname` and `srcname` directly afterwards if we still have more than one package. The tests also proved that this still works.
- Update the README and removed the part about invalid repositories (This is what is used on the website? Or is there somewhere else more docs?)
- Fixed tests and removed obsolete tests

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] Unit tests + ran on a real repository from devcontainer

<details>
  <summary>Log of successful run with repo `homebrew_cask` (previously unsupported)</summary>
  
  ```
DEBUG: File config
       "config": {
         "logLevel": "DEBUG",
         "platform": "github",
         "token": "***********",
         "repositories": ["danez/renovate-repology"]
       }
DEBUG: CLI config
       "config": {}
DEBUG: Env config
       "config": {"hostRules": []}
DEBUG: Combined config
       "config": {
         "logLevel": "DEBUG",
         "platform": "github",
         "token": "***********",
         "repositories": ["danez/renovate-repology"],
         "hostRules": []
       }
DEBUG: Using default github endpoint: https://api.github.com/
DEBUG: GitHub 404
       "url": "https://api.github.com/user/emails"
DEBUG: Cannot read user/emails endpoint on GitHub to retrieve gitAuthor
DEBUG: Authenticated as GitHub user: danez
DEBUG: Using default gitAuthor: Renovate Bot <renovate@whitesourcesoftware.com>
DEBUG: Using baseDir: /tmp/renovate
DEBUG: Using cacheDir: /tmp/renovate/cache
DEBUG: Initializing Renovate internal cache into /tmp/renovate/cache/renovate/renovate-cache-v1
DEBUG: Commits limit = null
 INFO: Repository started (repository=danez/renovate-repology)
       "renovateVersion": "0.0.0-semantic-release"
DEBUG: Using localDir: /tmp/renovate/repos/github/danez/renovate-repology (repository=danez/renovate-repology)
DEBUG: initRepo("danez/renovate-repology") (repository=danez/renovate-repology)
DEBUG: Overriding default GitHub endpoint (repository=danez/renovate-repology)
       "endpoint": "https://api.github.com/"
DEBUG: danez/renovate-repology default branch = main (repository=danez/renovate-repology)
DEBUG: Using personal access token for git init (repository=danez/renovate-repology)
(node:2078) DeprecationWarning: Instance method `debug.destroy()` is deprecated and no longer does anything. It will be removed in the next major version of `debug`.
(Use `node --trace-deprecation ...` to show where the warning was created)
DEBUG: resetMemCache() (repository=danez/renovate-repology)
DEBUG: checkOnboarding() (repository=danez/renovate-repology)
DEBUG: isOnboarded() (repository=danez/renovate-repology)
DEBUG: findFile(renovate.json) (repository=danez/renovate-repology)
DEBUG: Initializing git repository into /tmp/renovate/repos/github/danez/renovate-repology (repository=danez/renovate-repology)
DEBUG: git clone completed (repository=danez/renovate-repology)
       "durationMs": 1435
DEBUG: latest commit (repository=danez/renovate-repology)
       "latestCommitDate": "2020-11-28T16:16:11+01:00"
DEBUG: Setting git author name (repository=danez/renovate-repology)
       "gitAuthorName": "Renovate Bot"
DEBUG: Setting git author email (repository=danez/renovate-repology)
       "gitAuthorEmail": "renovate@whitesourcesoftware.com"
DEBUG: config file exists (repository=danez/renovate-repology)
DEBUG: Retrieving issueList (repository=danez/renovate-repology)
DEBUG: Retrieved 0 issues (repository=danez/renovate-repology)
DEBUG: Repo is onboarded (repository=danez/renovate-repology)
DEBUG: Found renovate.json config file (repository=danez/renovate-repology)
DEBUG: Repository config (repository=danez/renovate-repology)
       "fileName": "renovate.json",
       "config": {
         "$schema": "https://docs.renovatebot.com/renovate-schema.json",
         "extends": ["config:base"],
         "prHourlyLimit": 100,
         "regexManagers": [
           {
             "fileMatch": ["(^|/)Dockerfile(\\.[^/]+|)$"],
             "matchStrings": [
               "datasource=(?<datasource>.+?) depName=(?<depName>.+?)( versioning=(?<versioning>.+?))?\\sENV .+?_VERSION=\"(?<currentValue>[^\"]+)\"\\s"
             ],
             "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
           }
         ]
       }
DEBUG: migrateAndValidate() (repository=danez/renovate-repology)
DEBUG: No config migration necessary (repository=danez/renovate-repology)
DEBUG: massaged config (repository=danez/renovate-repology)
       "config": {
         "$schema": "https://docs.renovatebot.com/renovate-schema.json",
         "extends": ["config:base"],
         "prHourlyLimit": 100,
         "regexManagers": [
           {
             "fileMatch": ["(^|/)Dockerfile(\\.[^/]+|)$"],
             "matchStrings": [
               "datasource=(?<datasource>.+?) depName=(?<depName>.+?)( versioning=(?<versioning>.+?))?\\sENV .+?_VERSION=\"(?<currentValue>[^\"]+)\"\\s"
             ],
             "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
           }
         ]
       }
DEBUG: migrated config (repository=danez/renovate-repology)
       "config": {
         "$schema": "https://docs.renovatebot.com/renovate-schema.json",
         "extends": ["config:base"],
         "prHourlyLimit": 100,
         "regexManagers": [
           {
             "fileMatch": ["(^|/)Dockerfile(\\.[^/]+|)$"],
             "matchStrings": [
               "datasource=(?<datasource>.+?) depName=(?<depName>.+?)( versioning=(?<versioning>.+?))?\\sENV .+?_VERSION=\"(?<currentValue>[^\"]+)\"\\s"
             ],
             "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
           }
         ]
       }
DEBUG: Found repo ignorePaths (repository=danez/renovate-repology)
       "ignorePaths": [
         "**/node_modules/**",
         "**/bower_components/**",
         "**/vendor/**",
         "**/examples/**",
         "**/__tests__/**",
         "**/test/**",
         "**/tests/**",
         "**/__fixtures__/**"
       ]
DEBUG: detectSemanticCommits() (repository=danez/renovate-repology)
DEBUG: getCommitMessages (repository=danez/renovate-repology)
DEBUG: Semantic commits detection: unknown (repository=danez/renovate-repology)
DEBUG: No semantic commits detected (repository=danez/renovate-repology)
DEBUG: Setting branchPrefix: renovate/ (repository=danez/renovate-repology)
DEBUG: Cannot read vulnerability alerts (repository=danez/renovate-repology)
DEBUG: No vulnerability alerts found (repository=danez/renovate-repology)
DEBUG: processRepo() (repository=danez/renovate-repology)
DEBUG: No baseBranches (repository=danez/renovate-repology)
DEBUG: extract() (repository=danez/renovate-repology)
DEBUG: Setting current branch to main (repository=danez/renovate-repology)
DEBUG: latest commit (repository=danez/renovate-repology)
       "branchName": "main",
       "latestCommitDate": "2020-11-28T16:16:11+01:00"
DEBUG: Using file match: (^|/)tasks/[^/]+\.ya?ml$ for manager ansible (repository=danez/renovate-repology)
DEBUG: Using file match: (^|/)requirements\.ya?ml$ for manager ansible-galaxy (repository=danez/renovate-repology)
DEBUG: Using file match: azure.*pipelines?.*\.ya?ml$ for manager azure-pipelines (repository=danez/renovate-repology)
DEBUG: Using file match: (^|/)WORKSPACE(|\.bazel)$ for manager bazel (repository=danez/renovate-repology)
DEBUG: Using file match: \.bzl$ for manager bazel (repository=danez/renovate-repology)
DEBUG: Using file match: buildkite\.ya?ml for manager buildkite (repository=danez/renovate-repology)
DEBUG: Using file match: \.buildkite/.+\.ya?ml$ for manager buildkite (repository=danez/renovate-repology)
DEBUG: Using file match: (^|/)Gemfile$ for manager bundler (repository=danez/renovate-repology)
DEBUG: Using file match: (^|/)Cargo.toml$ for manager cargo (repository=danez/renovate-repology)
DEBUG: Using file match: (^|/).circleci/config.yml$ for manager circleci (repository=danez/renovate-repology)
DEBUG: Using file match: (^|/)Podfile$ for manager cocoapods (repository=danez/renovate-repology)
DEBUG: Using file match: (^|/)([\w-]*)composer.json$ for manager composer (repository=danez/renovate-repology)
DEBUG: Using file match: (^|/)deps\.edn$ for manager deps-edn (repository=danez/renovate-repology)
DEBUG: Using file match: (^|/)docker-compose[^/]*\.ya?ml$ for manager docker-compose (repository=danez/renovate-repology)
DEBUG: Using file match: (^|/|\.)Dockerfile$ for manager dockerfile (repository=danez/renovate-repology)
DEBUG: Using file match: (^|/)Dockerfile\.[^/]*$ for manager dockerfile (repository=danez/renovate-repology)
DEBUG: Using file match: (^|/).drone.yml$ for manager droneci (repository=danez/renovate-repology)
DEBUG: Using file match: (^|/).gitmodules$ for manager git-submodules (repository=danez/renovate-repology)
DEBUG: Using file match: ^\.github/workflows/[^/]+\.ya?ml$ for manager github-actions (repository=danez/renovate-repology)
DEBUG: Using file match: ^\.gitlab-ci\.yml$ for manager gitlabci (repository=danez/renovate-repology)
DEBUG: Using file match: ^\.gitlab-ci\.yml$ for manager gitlabci-include (repository=danez/renovate-repology)
DEBUG: Using file match: (^|/)go.mod$ for manager gomod (repository=danez/renovate-repology)
DEBUG: Using file match: \.gradle(\.kts)?$ for manager gradle (repository=danez/renovate-repology)
DEBUG: Using file match: (^|/)gradle.properties$ for manager gradle (repository=danez/renovate-repology)
DEBUG: Using file match: (^|/)gradle/wrapper/gradle-wrapper.properties$ for manager gradle-wrapper (repository=danez/renovate-repology)
DEBUG: Using file match: (^|/)requirements\.yaml$ for manager helm-requirements (repository=danez/renovate-repology)
DEBUG: Using file match: (^|/)values.yaml$ for manager helm-values (repository=danez/renovate-repology)
DEBUG: Using file match: (^|/)helmfile.yaml$ for manager helmfile (repository=danez/renovate-repology)
DEBUG: Using file match: (^|/)Chart.yaml$ for manager helmv3 (repository=danez/renovate-repology)
DEBUG: Using file match: ^Formula/[^/]+[.]rb$ for manager homebrew (repository=danez/renovate-repology)
DEBUG: Using file match: \.html?$ for manager html (repository=danez/renovate-repology)
DEBUG: Using file match: (^|/)plugins\.txt for manager jenkins (repository=danez/renovate-repology)
DEBUG: Using file match: (^|/)kustomization\.yaml for manager kustomize (repository=danez/renovate-repology)
DEBUG: Using file match: (^|/)project\.clj$ for manager leiningen (repository=danez/renovate-repology)
DEBUG: Using file match: \.pom\.xml$ for manager maven (repository=danez/renovate-repology)
DEBUG: Using file match: (^|/)pom\.xml$ for manager maven (repository=danez/renovate-repology)
DEBUG: Using file match: (^|/)package.js$ for manager meteor (repository=danez/renovate-repology)
DEBUG: Using file match: (^|/)mix\.exs$ for manager mix (repository=danez/renovate-repology)
DEBUG: Using file match: ^.node-version$ for manager nodenv (repository=danez/renovate-repology)
DEBUG: Using file match: (^|/)package.json$ for manager npm (repository=danez/renovate-repology)
DEBUG: Using file match: \.(?:cs|fs|vb)proj$ for manager nuget (repository=danez/renovate-repology)
DEBUG: Using file match: \.(?:props|targets)$ for manager nuget (repository=danez/renovate-repology)
DEBUG: Using file match: \.config\/dotnet-tools\.json$ for manager nuget (repository=danez/renovate-repology)
DEBUG: Using file match: (^|/)\.nvmrc$ for manager nvm (repository=danez/renovate-repology)
DEBUG: Using file match: (^|/)([\w-]*)requirements.(txt|pip)$ for manager pip_requirements (repository=danez/renovate-repology)
DEBUG: Using file match: (^|/)setup.py$ for manager pip_setup (repository=danez/renovate-repology)
DEBUG: Using file match: (^|/)Pipfile$ for manager pipenv (repository=danez/renovate-repology)
DEBUG: Using file match: (^|/)pyproject\.toml$ for manager poetry (repository=danez/renovate-repology)
DEBUG: Using file match: (^|/)\.pre-commit-config\.yaml$ for manager pre-commit (repository=danez/renovate-repology)
DEBUG: Using file match: (^|/)pubspec\.ya?ml$ for manager pub (repository=danez/renovate-repology)
DEBUG: Using file match: (^|/)Dockerfile(\.[^/]+|)$ for manager regex (repository=danez/renovate-repology)
DEBUG: Using file match: (^|/)\.ruby-version$ for manager ruby-version (repository=danez/renovate-repology)
DEBUG: Using file match: \.sbt$ for manager sbt (repository=danez/renovate-repology)
DEBUG: Using file match: project/[^/]*.scala$ for manager sbt (repository=danez/renovate-repology)
DEBUG: Using file match: (^|/)setup\.cfg$ for manager setup-cfg (repository=danez/renovate-repology)
DEBUG: Using file match: (^|/)Package\.swift for manager swift (repository=danez/renovate-repology)
DEBUG: Using file match: \.tf$ for manager terraform (repository=danez/renovate-repology)
DEBUG: Using file match: (^|/)terragrunt\.hcl$ for manager terragrunt (repository=danez/renovate-repology)
DEBUG: Using file match: ^.travis.yml$ for manager travis (repository=danez/renovate-repology)
DEBUG: Matched 1 file(s) for manager dockerfile: Dockerfile (repository=danez/renovate-repology)
DEBUG: Matched 1 file(s) for manager regex: Dockerfile (repository=danez/renovate-repology)
DEBUG: Found dockerfile package files (repository=danez/renovate-repology)
DEBUG: Found regex package files (repository=danez/renovate-repology)
DEBUG: Found 2 package file(s) (repository=danez/renovate-repology)
 INFO: Dependency extraction complete (repository=danez/renovate-repology)
       "baseBranch": "main",
       "stats": {
         "managers": {
           "dockerfile": {"fileCount": 1, "depCount": 1},
           "regex": {"fileCount": 1, "depCount": 2}
         },
         "total": {"fileCount": 2, "depCount": 3}
       }
DEBUG: getLabels(https://index.docker.io, library/php, latest) (repository=danez/renovate-repology)
DEBUG: getManifestResponse(https://index.docker.io, library/php, latest) (repository=danez/renovate-repology)
DEBUG: Package releases lookups complete (repository=danez/renovate-repology)
       "baseBranch": "main"
DEBUG: packageFiles with updates (repository=danez/renovate-repology)
       "config": {
         "dockerfile": [
           {
             "packageFile": "Dockerfile",
             "manager": "dockerfile",
             "deps": [
               {
                 "depName": "php",
                 "currentValue": "7.4.11",
                 "replaceString": "php:7.4.11",
                 "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
                 "datasource": "docker",
                 "depType": "final",
                 "depIndex": 0,
                 "updates": [
                   {
                     "fromVersion": "7.4.11",
                     "toVersion": "7.4.12",
                     "newValue": "7.4.12",
                     "newMajor": 7,
                     "newMinor": 4,
                     "updateType": "minor",
                     "isSingleVersion": true,
                     "newVersion": "7.4.12"
                   }
                 ],
                 "warnings": [],
                 "fixedVersion": "7.4.11",
                 "dockerRegistry": "https://index.docker.io",
                 "dockerRepository": "library/php"
               }
             ]
           }
         ],
         "regex": [
           {
             "packageFile": "Dockerfile",
             "manager": "regex",
             "deps": [
               {
                 "depName": "debian_stable/fontconfig",
                 "currentValue": "2.13.1-2",
                 "datasource": "repology",
                 "versioning": "loose",
                 "replaceString": "datasource=repology depName=debian_stable/fontconfig versioning=loose\nENV FONTCONFIG_VERSION=\"2.13.1-2\"\n",
                 "depIndex": 0,
                 "updates": [],
                 "warnings": [],
                 "fixedVersion": "2.13.1-2"
               },
               {
                 "depName": "homebrew_casks/phpstorm",
                 "currentValue": "2020.2.3",
                 "datasource": "repology",
                 "versioning": "loose",
                 "replaceString": "datasource=repology depName=homebrew_casks/phpstorm versioning=loose\nENV PHPSTORM_VERSION=\"2020.2.3\"\n",
                 "depIndex": 1,
                 "updates": [
                   {
                     "fromVersion": "2020.2.3",
                     "toVersion": "2020.2.4",
                     "newValue": "2020.2.4",
                     "newMajor": 2020,
                     "newMinor": 2,
                     "updateType": "minor",
                     "isSingleVersion": true
                   }
                 ],
                 "warnings": [],
                 "fixedVersion": "2020.2.3"
               }
             ],
             "matchStrings": [
               "datasource=(?<datasource>.+?) depName=(?<depName>.+?)( versioning=(?<versioning>.+?))?\\sENV .+?_VERSION=\"(?<currentValue>[^\"]+)\"\\s"
             ]
           }
         ]
       }
DEBUG: branchifyUpgrades (repository=danez/renovate-repology)
DEBUG: 2 flattened updates found: php, homebrew_casks/phpstorm (repository=danez/renovate-repology)
DEBUG: Returning 2 branch(es) (repository=danez/renovate-repology)
DEBUG: config.repoIsOnboarded=true (repository=danez/renovate-repology)
DEBUG: processRepo() (repository=danez/renovate-repology)
DEBUG: Processing 2 branches: renovate/docker-php-7.x, renovate/homebrew_casks-phpstorm-2020.x (repository=danez/renovate-repology)
DEBUG: Calculating hourly PRs remaining (repository=danez/renovate-repology)
DEBUG: Retrieving PR list (repository=danez/renovate-repology)
DEBUG: Retrieved 2 Pull Requests (repository=danez/renovate-repology)
DEBUG: currentHourStart=2020-11-28T15:00:00.000+00:00 (repository=danez/renovate-repology)
DEBUG: PR hourly limit remaining: 98 (repository=danez/renovate-repology)
DEBUG: Calculating prConcurrentLimit (20) (repository=danez/renovate-repology)
DEBUG: getBranchPr(renovate/homebrew_casks-phpstorm-2020.x) (repository=danez/renovate-repology)
DEBUG: findPr(renovate/homebrew_casks-phpstorm-2020.x, undefined, open) (repository=danez/renovate-repology)
DEBUG: getBranchPr(renovate/docker-php-7.x) (repository=danez/renovate-repology)
DEBUG: findPr(renovate/docker-php-7.x, undefined, open) (repository=danez/renovate-repology)
DEBUG: 0 PRs are currently open (repository=danez/renovate-repology)
DEBUG: PR concurrent limit remaining: 20 (repository=danez/renovate-repology)
DEBUG: Calculated maximum PRs remaining this run (repository=danez/renovate-repology)
       "prsRemaining": 20
DEBUG: getBranchPr(renovate/homebrew_casks-phpstorm-2020.x) (repository=danez/renovate-repology, branch=renovate/homebrew_casks-phpstorm-2020.x)
DEBUG: findPr(renovate/homebrew_casks-phpstorm-2020.x, undefined, open) (repository=danez/renovate-repology, branch=renovate/homebrew_casks-phpstorm-2020.x)
DEBUG: processBranch with 1 upgrades (repository=danez/renovate-repology, dependencies=homebrew_casks/phpstorm, branch=renovate/homebrew_casks-phpstorm-2020.x)
DEBUG: Setting current branch to main (repository=danez/renovate-repology, branch=renovate/homebrew_casks-phpstorm-2020.x)
DEBUG: latest commit (repository=danez/renovate-repology, branch=renovate/homebrew_casks-phpstorm-2020.x)
       "branchName": "main",
       "latestCommitDate": "2020-11-28T16:16:11+01:00"
DEBUG: getBranchPr(renovate/homebrew_casks-phpstorm-2020.x) (repository=danez/renovate-repology, branch=renovate/homebrew_casks-phpstorm-2020.x)
DEBUG: findPr(renovate/homebrew_casks-phpstorm-2020.x, undefined, open) (repository=danez/renovate-repology, branch=renovate/homebrew_casks-phpstorm-2020.x)
DEBUG: branchExists=false (repository=danez/renovate-repology, branch=renovate/homebrew_casks-phpstorm-2020.x)
DEBUG: Branch has 1 upgrade(s) (repository=danez/renovate-repology, branch=renovate/homebrew_casks-phpstorm-2020.x)
DEBUG: recreateClosed is false (repository=danez/renovate-repology, branch=renovate/homebrew_casks-phpstorm-2020.x)
DEBUG: findPr(renovate/homebrew_casks-phpstorm-2020.x, Update dependency homebrew_casks/phpstorm to v2020.2.4, !open) (repository=danez/renovate-repology, branch=renovate/homebrew_casks-phpstorm-2020.x)
DEBUG: prAlreadyExisted=false (repository=danez/renovate-repology, branch=renovate/homebrew_casks-phpstorm-2020.x)
DEBUG: Checking schedule(at any time, null) (repository=danez/renovate-repology, branch=renovate/homebrew_casks-phpstorm-2020.x)
DEBUG: No schedule defined (repository=danez/renovate-repology, branch=renovate/homebrew_casks-phpstorm-2020.x)
DEBUG: Branch needs creating (repository=danez/renovate-repology, branch=renovate/homebrew_casks-phpstorm-2020.x)
DEBUG: Using reuseExistingBranch: false (repository=danez/renovate-repology, branch=renovate/homebrew_casks-phpstorm-2020.x)
DEBUG: manager.getUpdatedPackageFiles() (repository=danez/renovate-repology, branch=renovate/homebrew_casks-phpstorm-2020.x)
       "reuseExistingBranch": false,
       "branchName": "renovate/homebrew_casks-phpstorm-2020.x"
DEBUG: Starting search at index 287 (repository=danez/renovate-repology, packageFile=Dockerfile, branch=renovate/homebrew_casks-phpstorm-2020.x)
       "depName": "homebrew_casks/phpstorm"
DEBUG: Found match at index 287 (repository=danez/renovate-repology, packageFile=Dockerfile, branch=renovate/homebrew_casks-phpstorm-2020.x)
       "depName": "homebrew_casks/phpstorm"
DEBUG: Contents updated (repository=danez/renovate-repology, packageFile=Dockerfile, branch=renovate/homebrew_casks-phpstorm-2020.x)
       "depName": "homebrew_casks/phpstorm"
DEBUG: Updated 1 package files (repository=danez/renovate-repology, branch=renovate/homebrew_casks-phpstorm-2020.x)
DEBUG: No updated lock files in branch (repository=danez/renovate-repology, branch=renovate/homebrew_casks-phpstorm-2020.x)
DEBUG: 1 file(s) to commit (repository=danez/renovate-repology, branch=renovate/homebrew_casks-phpstorm-2020.x)
DEBUG: Committing files to branch renovate/homebrew_casks-phpstorm-2020.x (repository=danez/renovate-repology, branch=renovate/homebrew_casks-phpstorm-2020.x)
 INFO: Branch created (repository=danez/renovate-repology, branch=renovate/homebrew_casks-phpstorm-2020.x)
       "commitSha": "d5267fa"
DEBUG: Ensuring PR (repository=danez/renovate-repology, branch=renovate/homebrew_casks-phpstorm-2020.x)
DEBUG: There are 0 errors and 0 warnings (repository=danez/renovate-repology, branch=renovate/homebrew_casks-phpstorm-2020.x)
DEBUG: getBranchPr(renovate/homebrew_casks-phpstorm-2020.x) (repository=danez/renovate-repology, branch=renovate/homebrew_casks-phpstorm-2020.x)
DEBUG: findPr(renovate/homebrew_casks-phpstorm-2020.x, undefined, open) (repository=danez/renovate-repology, branch=renovate/homebrew_casks-phpstorm-2020.x)
DEBUG: Creating PR (repository=danez/renovate-repology, branch=renovate/homebrew_casks-phpstorm-2020.x)
       "prTitle": "Update dependency homebrew_casks/phpstorm to v2020.2.4"
DEBUG: Creating PR (repository=danez/renovate-repology, branch=renovate/homebrew_casks-phpstorm-2020.x)
       "title": "Update dependency homebrew_casks/phpstorm to v2020.2.4",
       "head": "danez:renovate/homebrew_casks-phpstorm-2020.x",
       "base": "main",
       "draft": false
DEBUG: PR created (repository=danez/renovate-repology, branch=renovate/homebrew_casks-phpstorm-2020.x)
       "pr": 5,
       "draft": false
DEBUG: Adding labels '' to #5 (repository=danez/renovate-repology, branch=renovate/homebrew_casks-phpstorm-2020.x)
 INFO: PR created (repository=danez/renovate-repology, branch=renovate/homebrew_casks-phpstorm-2020.x)
       "pr": 5,
       "prTitle": "Update dependency homebrew_casks/phpstorm to v2020.2.4"
DEBUG: Created Pull Request #5 (repository=danez/renovate-repology, branch=renovate/homebrew_casks-phpstorm-2020.x)
DEBUG: Checking #5 for automerge (repository=danez/renovate-repology, branch=renovate/homebrew_casks-phpstorm-2020.x)
       "automerge": false,
       "automergeType": "pr",
       "automergeComment": "automergeComment"
DEBUG: No automerge (repository=danez/renovate-repology, branch=renovate/homebrew_casks-phpstorm-2020.x)
DEBUG: getBranchPr(renovate/docker-php-7.x) (repository=danez/renovate-repology, branch=renovate/docker-php-7.x)
DEBUG: findPr(renovate/docker-php-7.x, undefined, open) (repository=danez/renovate-repology, branch=renovate/docker-php-7.x)
DEBUG: processBranch with 1 upgrades (repository=danez/renovate-repology, dependencies=php, branch=renovate/docker-php-7.x)
DEBUG: Setting current branch to main (repository=danez/renovate-repology, branch=renovate/docker-php-7.x)
DEBUG: latest commit (repository=danez/renovate-repology, branch=renovate/docker-php-7.x)
       "branchName": "main",
       "latestCommitDate": "2020-11-28T16:16:11+01:00"
DEBUG: getBranchPr(renovate/docker-php-7.x) (repository=danez/renovate-repology, branch=renovate/docker-php-7.x)
DEBUG: findPr(renovate/docker-php-7.x, undefined, open) (repository=danez/renovate-repology, branch=renovate/docker-php-7.x)
DEBUG: branchExists=false (repository=danez/renovate-repology, branch=renovate/docker-php-7.x)
DEBUG: Branch has 1 upgrade(s) (repository=danez/renovate-repology, branch=renovate/docker-php-7.x)
DEBUG: recreateClosed is false (repository=danez/renovate-repology, branch=renovate/docker-php-7.x)
DEBUG: findPr(renovate/docker-php-7.x, Update php Docker tag to v7.4.12, !open) (repository=danez/renovate-repology, branch=renovate/docker-php-7.x)
DEBUG: prAlreadyExisted=false (repository=danez/renovate-repology, branch=renovate/docker-php-7.x)
DEBUG: Checking schedule(at any time, null) (repository=danez/renovate-repology, branch=renovate/docker-php-7.x)
DEBUG: No schedule defined (repository=danez/renovate-repology, branch=renovate/docker-php-7.x)
DEBUG: Branch needs creating (repository=danez/renovate-repology, branch=renovate/docker-php-7.x)
DEBUG: Using reuseExistingBranch: false (repository=danez/renovate-repology, branch=renovate/docker-php-7.x)
DEBUG: manager.getUpdatedPackageFiles() (repository=danez/renovate-repology, branch=renovate/docker-php-7.x)
       "reuseExistingBranch": false,
       "branchName": "renovate/docker-php-7.x"
DEBUG: Starting search at index 5 (repository=danez/renovate-repology, packageFile=Dockerfile, branch=renovate/docker-php-7.x)
       "depName": "php"
DEBUG: Found match at index 5 (repository=danez/renovate-repology, packageFile=Dockerfile, branch=renovate/docker-php-7.x)
       "depName": "php"
DEBUG: Contents updated (repository=danez/renovate-repology, packageFile=Dockerfile, branch=renovate/docker-php-7.x)
       "depName": "php"
DEBUG: Updated 1 package files (repository=danez/renovate-repology, branch=renovate/docker-php-7.x)
DEBUG: No updated lock files in branch (repository=danez/renovate-repology, branch=renovate/docker-php-7.x)
DEBUG: 1 file(s) to commit (repository=danez/renovate-repology, branch=renovate/docker-php-7.x)
DEBUG: Committing files to branch renovate/docker-php-7.x (repository=danez/renovate-repology, branch=renovate/docker-php-7.x)
 INFO: Branch created (repository=danez/renovate-repology, branch=renovate/docker-php-7.x)
       "commitSha": "fe2f6dd"
DEBUG: Ensuring PR (repository=danez/renovate-repology, branch=renovate/docker-php-7.x)
DEBUG: There are 0 errors and 0 warnings (repository=danez/renovate-repology, branch=renovate/docker-php-7.x)
DEBUG: getBranchPr(renovate/docker-php-7.x) (repository=danez/renovate-repology, branch=renovate/docker-php-7.x)
DEBUG: findPr(renovate/docker-php-7.x, undefined, open) (repository=danez/renovate-repology, branch=renovate/docker-php-7.x)
DEBUG: Creating PR (repository=danez/renovate-repology, branch=renovate/docker-php-7.x)
       "prTitle": "Update php Docker tag to v7.4.12"
DEBUG: Creating PR (repository=danez/renovate-repology, branch=renovate/docker-php-7.x)
       "title": "Update php Docker tag to v7.4.12",
       "head": "danez:renovate/docker-php-7.x",
       "base": "main",
       "draft": false
DEBUG: PR created (repository=danez/renovate-repology, branch=renovate/docker-php-7.x)
       "pr": 6,
       "draft": false
DEBUG: Adding labels '' to #6 (repository=danez/renovate-repology, branch=renovate/docker-php-7.x)
 INFO: PR created (repository=danez/renovate-repology, branch=renovate/docker-php-7.x)
       "pr": 6,
       "prTitle": "Update php Docker tag to v7.4.12"
DEBUG: Created Pull Request #6 (repository=danez/renovate-repology, branch=renovate/docker-php-7.x)
DEBUG: Checking #6 for automerge (repository=danez/renovate-repology, branch=renovate/docker-php-7.x)
       "automerge": false,
       "automergeType": "pr",
       "automergeComment": "automergeComment"
DEBUG: No automerge (repository=danez/renovate-repology, branch=renovate/docker-php-7.x)
DEBUG: getBranchPr(renovate/homebrew_casks-phpstorm-2020.x) (repository=danez/renovate-repology)
DEBUG: findPr(renovate/homebrew_casks-phpstorm-2020.x, undefined, open) (repository=danez/renovate-repology)
DEBUG: Found PR #5 (repository=danez/renovate-repology)
DEBUG: Returning from graphql open PR list (repository=danez/renovate-repology)
DEBUG: getBranchPr(renovate/docker-php-7.x) (repository=danez/renovate-repology)
DEBUG: findPr(renovate/docker-php-7.x, undefined, open) (repository=danez/renovate-repology)
DEBUG: Found PR #6 (repository=danez/renovate-repology)
DEBUG: Returning from graphql open PR list (repository=danez/renovate-repology)
DEBUG: Removing any stale branches (repository=danez/renovate-repology)
DEBUG: config.repoIsOnboarded=true (repository=danez/renovate-repology)
DEBUG: Branch lists (repository=danez/renovate-repology)
       "branchList": ["renovate/docker-php-7.x", "renovate/homebrew_casks-phpstorm-2020.x"],
       "renovateBranches": ["renovate/homebrew_casks-phpstorm-2020.x", "renovate/docker-php-7.x"]
DEBUG: remainingBranches= (repository=danez/renovate-repology)
DEBUG: No branches to clean up (repository=danez/renovate-repology)
DEBUG: Repository timing splits (milliseconds) (repository=danez/renovate-repology)
       "splits": {"init": 3791, "extract": 1621, "lookup": 4421, "update": 16337},
       "total": 26785
DEBUG: http statistics (repository=danez/renovate-repology)
       "hostStats": [
         "api.github.com, 7 requests, 610ms request average, 0ms queue average",
         "auth.docker.io, 1 request, 490ms request average, 0ms queue average",
         "index.docker.io, 4 requests, 806ms request average, 0ms queue average",
         "repology.org, 2 requests, 378ms request average, 0ms queue average"
       ],
       "totalRequests": 14
 INFO: Repository finished (repository=danez/renovate-repology)
       "durationMs": 26785
DEBUG: Renovate exiting
  ```
</details>