### PR TITLE
docs: correct link for GitLab personal access tokens

### DIFF
--- a/docs/usage/self-hosting.md
+++ b/docs/usage/self-hosting.md
@@ -200,7 +200,7 @@ Configure it either as `token` in your `config.js` file, or in environment varia
 
 #### GitLab CE/EE
 
-First, [create a personal access token](https://docs.gitlab.com/ee/api/README.html#personal-access-tokens) for the bot account (select "api" scope).
+First, [create a personal access token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) for the bot account (select "api" scope).
 Configure it either as `token` in your `config.js` file, or in environment variable `RENOVATE_TOKEN`, or via CLI `--token=`.
 Don't forget to configure `platform=gitlab` somewhere in config.
 


### PR DESCRIPTION
## Changes:

Updates a link in the self-hosting documentation to go to the correct page.

## Context:

I discovered that the link was wrong when I tried to use it.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository
