### PR TITLE
fix(bazel): use github-tags for http archives

### DIFF
--- a/lib/manager/bazel/__fixtures__/WORKSPACE2
+++ b/lib/manager/bazel/__fixtures__/WORKSPACE2
@@ -1,0 +1,17 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "GBDeviceInfo",
+    url = "https://github.com/lmirosevic/GBDeviceInfo/archive/6.3.0.tar.gz",
+    sha256 = "d7666275dff039407ea467c3083b83e24934101777c8b55b6b1b3b7e9a9e220b",
+    strip_prefix = "GBDeviceInfo-6.3.0/GBDeviceInfo"
+)
+
+http_archive(
+    name = "com_github_nelhage_rules_boost",
+    url = "https://github.com/nelhage/rules_boost/archive/135d46b4c9423ee7d494c78a21ff621bc73c12f3.tar.gz",
+    sha256 = "3651f5dda0f7296e4cecafacc7f9d1f274be0fd64e30bebd74e28ffba28fe77f",
+    strip_prefix = "rules_boost-135d46b4c9423ee7d494c78a21ff621bc73c12f3",
+)
+load("@com_github_nelhage_rules_boost//:boost/boost.bzl", "boost_deps")
+boost_deps()

--- a/lib/manager/bazel/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/bazel/__snapshots__/extract.spec.ts.snap
@@ -31,7 +31,7 @@ exports[`lib/manager/bazel/extract extractPackageFile() extracts dependencies fr
 Array [
   Object {
     "currentDigest": "0356bef3fbbabec5f0e196ecfacdeb6db62d48c0",
-    "datasource": "github-releases",
+    "datasource": "github-tags",
     "depName": "subpar",
     "depType": "http_archive",
     "lookupName": "google/subpar",
@@ -48,7 +48,7 @@ Array [
   },
   Object {
     "currentValue": "0.6.0",
-    "datasource": "github-releases",
+    "datasource": "github-tags",
     "depName": "bazel_skylib",
     "depType": "http_archive",
     "lookupName": "bazelbuild/bazel-skylib",
@@ -61,6 +61,43 @@ Array [
         )",
     },
     "repo": "bazelbuild/bazel-skylib",
+  },
+]
+`;
+
+exports[`lib/manager/bazel/extract extractPackageFile() extracts github tags 1`] = `
+Array [
+  Object {
+    "currentValue": "6.3.0",
+    "datasource": "github-tags",
+    "depName": "GBDeviceInfo",
+    "depType": "http_archive",
+    "lookupName": "lmirosevic/GBDeviceInfo",
+    "managerData": Object {
+      "def": "http_archive(
+    name = \\"GBDeviceInfo\\",
+    url = \\"https://github.com/lmirosevic/GBDeviceInfo/archive/6.3.0.tar.gz\\",
+    sha256 = \\"d7666275dff039407ea467c3083b83e24934101777c8b55b6b1b3b7e9a9e220b\\",
+    strip_prefix = \\"GBDeviceInfo-6.3.0/GBDeviceInfo\\"
+)",
+    },
+    "repo": "lmirosevic/GBDeviceInfo",
+  },
+  Object {
+    "currentDigest": "135d46b4c9423ee7d494c78a21ff621bc73c12f3",
+    "datasource": "github-tags",
+    "depName": "com_github_nelhage_rules_boost",
+    "depType": "http_archive",
+    "lookupName": "nelhage/rules_boost",
+    "managerData": Object {
+      "def": "http_archive(
+    name = \\"com_github_nelhage_rules_boost\\",
+    url = \\"https://github.com/nelhage/rules_boost/archive/135d46b4c9423ee7d494c78a21ff621bc73c12f3.tar.gz\\",
+    sha256 = \\"3651f5dda0f7296e4cecafacc7f9d1f274be0fd64e30bebd74e28ffba28fe77f\\",
+    strip_prefix = \\"rules_boost-135d46b4c9423ee7d494c78a21ff621bc73c12f3\\",
+)",
+    },
+    "repo": "nelhage/rules_boost",
   },
 ]
 `;
@@ -90,7 +127,7 @@ Array [
   },
   Object {
     "currentDigest": "446923c3756ceeaa75888f52fcbdd48bb314fbf8",
-    "datasource": "github-releases",
+    "datasource": "github-tags",
     "depName": "distroless",
     "depType": "http_archive",
     "lookupName": "GoogleContainerTools/distroless",
@@ -106,7 +143,7 @@ Array [
   },
   Object {
     "currentDigest": "d665ccfa3e9c90fa789671bf4ef5f7c19c5715c4",
-    "datasource": "github-releases",
+    "datasource": "github-tags",
     "depName": "bazel_toolchains",
     "depType": "http_archive",
     "lookupName": "bazelbuild/bazel-toolchains",
@@ -140,7 +177,7 @@ Array [
   },
   Object {
     "currentValue": "0.5.0",
-    "datasource": "github-releases",
+    "datasource": "github-tags",
     "depName": "bazel_skylib",
     "depType": "http_archive",
     "lookupName": "bazelbuild/bazel-skylib",
@@ -159,7 +196,7 @@ Array [
   },
   Object {
     "currentDigest": "446923c3756ceeaa75888f52fcbdd48bb314fbf8",
-    "datasource": "github-releases",
+    "datasource": "github-tags",
     "depName": "distroless",
     "depType": "http_archive",
     "lookupName": "GoogleContainerTools/distroless",
@@ -175,7 +212,7 @@ Array [
   },
   Object {
     "currentDigest": "446923c3756ceeaa75888f52fcbdd48bb314fbf8",
-    "datasource": "github-releases",
+    "datasource": "github-tags",
     "depName": "distroless",
     "depType": "http_file",
     "lookupName": "GoogleContainerTools/distroless",

--- a/lib/manager/bazel/extract.spec.ts
+++ b/lib/manager/bazel/extract.spec.ts
@@ -6,6 +6,11 @@ const workspaceFile = readFileSync(
   'utf8'
 );
 
+const workspace2File = readFileSync(
+  'lib/manager/bazel/__fixtures__/WORKSPACE2',
+  'utf8'
+);
+
 const fileWithBzlExtension = readFileSync(
   'lib/manager/bazel/__fixtures__/repositories.bzl',
   'utf8'
@@ -23,6 +28,10 @@ describe('lib/manager/bazel/extract', () => {
     });
     it('extracts multiple types of dependencies', () => {
       const res = extractPackageFile(workspaceFile);
+      expect(res.deps).toMatchSnapshot();
+    });
+    it('extracts github tags', () => {
+      const res = extractPackageFile(workspace2File);
       expect(res.deps).toMatchSnapshot();
     });
     it('extracts dependencies from *.bzl files', () => {

--- a/lib/manager/bazel/extract.ts
+++ b/lib/manager/bazel/extract.ts
@@ -3,6 +3,7 @@ import { parse as _parse } from 'url';
 import parse from 'github-url-from-git';
 import * as datasourceDocker from '../../datasource/docker';
 import * as datasourceGithubReleases from '../../datasource/github-releases';
+import * as datasourceGithubTags from '../../datasource/github-tags';
 import * as datasourceGo from '../../datasource/go';
 import { logger } from '../../logger';
 import { SkipReason } from '../../types';
@@ -11,6 +12,7 @@ import * as dockerVersioning from '../../versioning/docker';
 import { PackageDependency, PackageFile } from '../common';
 
 interface UrlParsedResult {
+  datasource: string;
   repo: string;
   currentValue: string;
 }
@@ -26,15 +28,18 @@ function parseUrl(urlString: string): UrlParsedResult | null {
   }
   const path = url.path.split('/').slice(1);
   const repo = path[0] + '/' + path[1];
+  let datasource: string;
   let currentValue: string = null;
   if (path[2] === 'releases' && path[3] === 'download') {
+    datasource = datasourceGithubReleases.id;
     currentValue = path[4];
   }
   if (path[2] === 'archive') {
+    datasource = datasourceGithubTags.id;
     currentValue = path[3].replace(/\.tar\.gz$/, '');
   }
   if (currentValue) {
-    return { repo, currentValue };
+    return { datasource, repo, currentValue };
   }
   // istanbul ignore next
   return null;
@@ -232,7 +237,7 @@ export function extractPackageFile(
       } else {
         dep.currentValue = parsedUrl.currentValue;
       }
-      dep.datasource = datasourceGithubReleases.id;
+      dep.datasource = parsedUrl.datasource;
       dep.lookupName = dep.repo;
       deps.push(dep);
     } else if (


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Uses `github-tags` as datasource when a github archive file pattern is detected in bazel.

## Context:

Closes #7852

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
