### PR TITLE
feat(config): Add mergeable `addLabels` option

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -29,8 +29,9 @@ If you have any questions about the below config options, or would like to get h
 
 ## addLabels
 
-The `labels` field is non-mergeable, meaning that any config setting a list of PR labels will replace any existing list that existed.
-If you want to append labels for matched rules, then define an `addLabels` array of one or more label strings to append to the PR so all matched `addLabels` will be attached to PR.
+The `labels` field is non-mergeable, meaning that any config setting a list of PR labels will replace any existing list.
+If you want to append labels for matched rules, then define an `addLabels` array with one (or more) label strings.
+All matched `addLabels` strings will be attached to the PR.
 
 Consider this example:
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -27,6 +27,31 @@ Also, be sure to check out Renovate's [shareable config presets](/config-presets
 
 If you have any questions about the below config options, or would like to get help/feedback about a config, please post it as an issue in [renovatebot/config-help](https://github.com/renovatebot/config-help) where we will do our best to answer your question.
 
+## addLabels
+
+Different sets of package matching `labels` are not appended to PRs, last matched rule just fully override labels to set.
+If you want to append labels for matched rules, then define an `addLabels` array of one or more label strings to append to the PR so all matched `addLabels` will be attached to PR.
+
+Consider this example:
+
+```json
+{
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "packagePatterns": ["eslint"],
+      "addLabels": ["linting"]
+    },
+    {
+      "depTypeList": ["optionalDependencies"],
+      "addLabels": ["optional"]
+    }
+  ]
+}
+```
+
+With the above config, every PR raised by Renovate will have the label `dependencies` while PRs containing `eslint`-related packages will instead have labels `dependencies` and `linting`, PRs for optional dependencies will have `dependencies` and `optional`, and so on for different combinations of matched rules.
+
 ## additionalBranchPrefix
 
 This value defaults to an empty string, and is typically not necessary.
@@ -898,30 +923,6 @@ Consider this example:
 ```
 
 With the above config, every PR raised by Renovate will have the label `dependencies` while PRs containing `eslint`-related packages will instead have the label `linting`.
-
-## addLabels
-
-Different sets of package matching `labels` are not appended to PRs, last matched rule just fully override labels to set.
-If you want to append labels for matched rules, then define an `addLabels` array of one or more label strings to append to the PR so all matched `addLabels` will be attached to PR.
-
-Consider this example:
-
-```json
-{
-  "labels": ["dependencies"],
-  "packageRules": [
-    {
-      "packagePatterns": ["eslint"],
-      "addLabels": ["linting"]
-    },
-    {
-      "depTypeList": ["optionalDependencies"],
-      "addLabels": ["optional"]
-    }
-  ]
-}
-```
-With the above config, every PR raised by Renovate will have the label `dependencies` while PRs containing `eslint`-related packages will instead have labels `dependencies` and `linting`, PRs for optional dependencies will have `dependencies` and `optional`, and so on for different combinations of matched rules.
 
 ## lockFileMaintenance
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -51,9 +51,10 @@ Consider this example:
 ```
 
 With the above config:
- - Optional dependencies will have the labels `dependencies` and `optional`
- - ESLint dependencies will have the label `linting`
- - All other dependencies will have the label `dependencies`
+
+- Optional dependencies will have the labels `dependencies` and `optional`
+- ESLint dependencies will have the label `linting`
+- All other dependencies will have the label `dependencies`
 
 ## additionalBranchPrefix
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -29,7 +29,7 @@ If you have any questions about the below config options, or would like to get h
 
 ## addLabels
 
-Different sets of package matching `labels` are not appended to PRs, last matched rule just fully override labels to set.
+The `labels` field is non-mergeable, meaning that any config setting a list of PR labels will replace any existing list that existed.
 If you want to append labels for matched rules, then define an `addLabels` array of one or more label strings to append to the PR so all matched `addLabels` will be attached to PR.
 
 Consider this example:
@@ -40,7 +40,7 @@ Consider this example:
   "packageRules": [
     {
       "packagePatterns": ["eslint"],
-      "addLabels": ["linting"]
+      "labels": ["linting"]
     },
     {
       "depTypeList": ["optionalDependencies"],
@@ -50,7 +50,10 @@ Consider this example:
 }
 ```
 
-With the above config, every PR raised by Renovate will have the label `dependencies` while PRs containing `eslint`-related packages will instead have labels `dependencies` and `linting`, PRs for optional dependencies will have `dependencies` and `optional`, and so on for different combinations of matched rules.
+With the above config:
+ - Optional dependencies will have the labels `dependencies` and `optional`
+ - ESLint dependencies will have the label `linting`
+ - All other dependencies will have the label `dependencies`
 
 ## additionalBranchPrefix
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -899,6 +899,30 @@ Consider this example:
 
 With the above config, every PR raised by Renovate will have the label `dependencies` while PRs containing `eslint`-related packages will instead have the label `linting`.
 
+## addLabels
+
+Different sets of package matching `labels` are not appended to PRs, last matched rule just fully override labels to set.
+If you want to append labels for matched rules, then define an `addLabels` array of one or more label strings to append to the PR so all matched `addLabels` will be attached to PR.
+
+Consider this example:
+
+```json
+{
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "packagePatterns": ["eslint"],
+      "addLabels": ["linting"]
+    },
+    {
+      "depTypeList": ["optionalDependencies"],
+      "addLabels": ["optional"]
+    }
+  ]
+}
+```
+With the above config, every PR raised by Renovate will have the label `dependencies` while PRs containing `eslint`-related packages will instead have labels `dependencies` and `linting`, PRs for optional dependencies will have `dependencies` and `optional`, and so on for different combinations of matched rules.
+
 ## lockFileMaintenance
 
 This feature can be used to refresh lock files and keep them up-to-date.

--- a/lib/config/common.ts
+++ b/lib/config/common.ts
@@ -37,6 +37,7 @@ export interface RenovateSharedConfig {
   ignoreDeps?: string[];
   ignorePaths?: string[];
   labels?: string[];
+  addLabels?: string[];
   managers?: string | string[];
   dependencyDashboardApproval?: boolean;
   npmrc?: string;

--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -1418,7 +1418,7 @@ const options: RenovateOptions[] = [
     description: 'Labels to add to Pull Request',
     type: 'array',
     subType: 'string',
-    mergeable: true
+    mergeable: true,
   },
   {
     name: 'assignees',

--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -1409,9 +1409,16 @@ const options: RenovateOptions[] = [
   // Pull Request options
   {
     name: 'labels',
+    description: 'Labels to set in Pull Request',
+    type: 'array',
+    subType: 'string',
+  },
+  {
+    name: 'addLabels',
     description: 'Labels to add to Pull Request',
     type: 'array',
     subType: 'string',
+    mergeable: true
   },
   {
     name: 'assignees',

--- a/lib/workers/pr/index.spec.ts
+++ b/lib/workers/pr/index.spec.ts
@@ -645,9 +645,9 @@ describe('workers/pr', () => {
     });
 
     it('should create a PR with set of labels and mergeable addLabels', async () => {
-      const { prResult } = await prWorker.ensurePr(
-        {...config, labels: ['deps', 'renovate'], addLabels: ['deps', 'js']}
-      );
+      config.labels = ['deps', 'renovate'];
+      config.addLabels = ['deps', 'js'];
+      const { prResult } = await prWorker.ensurePr(config);
       expect(prResult).toEqual(PrResult.Created);
       expect(platform.createPr.mock.calls[0][0]).toMatchObject({
         labels: ['deps', 'renovate', 'js'],

--- a/lib/workers/pr/index.spec.ts
+++ b/lib/workers/pr/index.spec.ts
@@ -645,8 +645,6 @@ describe('workers/pr', () => {
     });
 
     it('should create a PR with set of labels and mergeable addLabels', async () => {
-      config.labels = ['deps', 'renovate'];
-      config.addLabels = ['deps', 'js'];
       const { prResult } = await prWorker.ensurePr(
         {...config, labels: ['deps', 'renovate'], addLabels: ['deps', 'js']}
       );

--- a/lib/workers/pr/index.spec.ts
+++ b/lib/workers/pr/index.spec.ts
@@ -643,5 +643,17 @@ describe('workers/pr', () => {
         gitLabAutomerge: true,
       });
     });
+
+    it('should create a PR with set of labels and mergeable addLabels', async () => {
+      config.labels = ['deps', 'renovate'];
+      config.addLabels = ['deps', 'js'];
+      const { prResult } = await prWorker.ensurePr(
+        {...config, labels: ['deps', 'renovate'], addLabels: ['deps', 'js']}
+      );
+      expect(prResult).toEqual(PrResult.Created);
+      expect(platform.createPr.mock.calls[0][0]).toMatchObject({
+        labels: ['deps', 'renovate', 'js'],
+      });
+    });
   });
 });

--- a/lib/workers/pr/index.ts
+++ b/lib/workers/pr/index.ts
@@ -384,7 +384,7 @@ export async function ensurePr(
           targetBranch: config.baseBranch,
           prTitle,
           prBody,
-          labels: config.labels,
+          labels: [...new Set([...config.labels, ...config.addLabels])],
           platformOptions: getPlatformPrOptions(config),
           draftPR: config.draftPR,
         });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:
<!-- Describe what this pull request changes. -->
Adds a new `addLabels` configuration option that works in the same way than existing `labels` one but is has `mergeable` tag enable.
Current labels are fully overwritten by last matched rule and combining different rules to produce a set of combined labels produces a combinatorial explosion to manually combine them.
This will allow to append labels to PRs not manually writting a lot of combined rules and labels

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->
Closes #6503

## Documentation (please check one with an [x])

- [X] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [X] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
