### PR TITLE
feat(gitlab): support automerge on pr update

### DIFF
--- a/lib/platform/common.ts
+++ b/lib/platform/common.ts
@@ -94,6 +94,7 @@ export interface CreatePRConfig {
 }
 export interface UpdatePrConfig {
   number: number;
+  platformOptions?: PlatformPrOptions;
   prTitle: string;
   prBody?: string;
   state?: PrState.Open | PrState.Closed;

--- a/lib/platform/gitlab/index.ts
+++ b/lib/platform/gitlab/index.ts
@@ -31,6 +31,7 @@ import {
   FindPRConfig,
   Issue,
   PlatformParams,
+  PlatformPrOptions,
   PlatformResult,
   Pr,
   RepoParams,
@@ -419,6 +420,43 @@ export async function getPrList(): Promise<Pr[]> {
   return config.prList;
 }
 
+async function tryPrAutomerge(
+  pr: number,
+  platformOptions: PlatformPrOptions
+): Promise<void> {
+  if (platformOptions?.gitLabAutomerge) {
+    try {
+      const desiredStatus = 'can_be_merged';
+      const retryTimes = 5;
+
+      // Check for correct merge request status before setting `merge_when_pipeline_succeeds` to  `true`.
+      for (let attempt = 1; attempt <= retryTimes; attempt += 1) {
+        const { body } = await gitlabApi.getJson<{
+          merge_status: string;
+          pipeline: string;
+        }>(`projects/${config.repository}/merge_requests/${pr}`);
+        // Only continue if the merge request can be merged and has a pipeline.
+        if (body.merge_status === desiredStatus && body.pipeline !== null) {
+          break;
+        }
+        await delay(500 * attempt);
+      }
+
+      await gitlabApi.putJson(
+        `projects/${config.repository}/merge_requests/${pr}/merge`,
+        {
+          body: {
+            should_remove_source_branch: true,
+            merge_when_pipeline_succeeds: true,
+          },
+        }
+      );
+    } catch (err) /* istanbul ignore next */ {
+      logger.debug({ err }, 'Automerge on PR creation failed');
+    }
+  }
+}
+
 export async function createPr({
   sourceBranch,
   targetBranch,
@@ -455,37 +493,8 @@ export async function createPr({
   if (config.prList) {
     config.prList.push(pr);
   }
-  if (platformOptions?.gitLabAutomerge) {
-    try {
-      const desiredStatus = 'can_be_merged';
-      const retryTimes = 5;
 
-      // Check for correct merge request status before setting `merge_when_pipeline_succeeds` to  `true`.
-      for (let attempt = 1; attempt <= retryTimes; attempt += 1) {
-        const { body } = await gitlabApi.getJson<{
-          merge_status: string;
-          pipeline: string;
-        }>(`projects/${config.repository}/merge_requests/${pr.iid}`);
-        // Only continue if the merge request can be merged and has a pipeline.
-        if (body.merge_status === desiredStatus && body.pipeline !== null) {
-          break;
-        }
-        await delay(500 * attempt);
-      }
-
-      await gitlabApi.putJson(
-        `projects/${config.repository}/merge_requests/${pr.iid}/merge`,
-        {
-          body: {
-            should_remove_source_branch: true,
-            merge_when_pipeline_succeeds: true,
-          },
-        }
-      );
-    } catch (err) /* istanbul ignore next */ {
-      logger.debug({ err }, 'Automerge on PR creation failed');
-    }
-  }
+  await tryPrAutomerge(pr.iid, platformOptions);
 
   return massagePr(pr);
 }
@@ -536,6 +545,7 @@ export async function updatePr({
   prTitle,
   prBody: description,
   state,
+  platformOptions,
 }: UpdatePrConfig): Promise<void> {
   let title = prTitle;
   if ((await getPrList()).find((pr) => pr.number === iid)?.isDraft) {
@@ -555,6 +565,8 @@ export async function updatePr({
       },
     }
   );
+
+  await tryPrAutomerge(iid, platformOptions);
 }
 
 export async function mergePr(iid: number): Promise<boolean> {

--- a/lib/workers/branch/index.ts
+++ b/lib/workers/branch/index.ts
@@ -30,7 +30,7 @@ import {
 import { regEx } from '../../util/regex';
 import * as template from '../../util/template';
 import { BranchConfig, PrResult, ProcessBranchResult } from '../common';
-import { checkAutoMerge, ensurePr } from '../pr';
+import { checkAutoMerge, ensurePr, getPlatformPrOptions } from '../pr';
 import { tryBranchAutomerge } from './automerge';
 import { prAlreadyExisted } from './check-existing';
 import { commitFilesToBranch } from './commit';
@@ -200,6 +200,7 @@ export async function processBranch(
                 number: branchPr.number,
                 prTitle: branchPr.title,
                 prBody: newBody,
+                platformOptions: getPlatformPrOptions(config),
               });
             }
             return ProcessBranchResult.PrEdited;

--- a/lib/workers/pr/index.ts
+++ b/lib/workers/pr/index.ts
@@ -359,7 +359,12 @@ export async function ensurePr(
       if (config.dryRun) {
         logger.info(`DRY-RUN: Would update PR #${existingPr.number}`);
       } else {
-        await platform.updatePr({ number: existingPr.number, prTitle, prBody });
+        await platform.updatePr({
+          number: existingPr.number,
+          prTitle,
+          prBody,
+          platformOptions: getPlatformPrOptions(config),
+        });
         logger.info({ pr: existingPr.number, prTitle }, `PR updated`);
       }
       return { prResult: PrResult.Updated, pr: existingPr };


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:
Passing platform options to `updatePr` so `gitLabAutomerge` can work after pr update.
<!-- Describe what this pull request changes. -->

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
