### PR TITLE
fix: filter status checks when counting

### DIFF
--- a/lib/platform/azure/index.spec.ts
+++ b/lib/platform/azure/index.spec.ts
@@ -529,6 +529,23 @@ describe('platform/azure', () => {
       const res = await azure.getBranchStatus('somebranch', []);
       expect(res).toEqual(BranchStatus.yellow);
     });
+    it('should fall back to yellow if only renovate statuses returned', async () => {
+      await initRepo({ repository: 'some/repo' });
+      azureApi.gitApi.mockImplementationOnce(
+        () =>
+          ({
+            getBranch: jest.fn(() => ({ commit: { commitId: 'abcd1234' } })),
+            getStatuses: jest.fn(() => [
+              {
+                state: GitStatusState.Succeeded,
+                context: { genre: 'renovate', name: 'stability-days' },
+              },
+            ]),
+          } as any)
+      );
+      const res = await azure.getBranchStatus('somebranch', []);
+      expect(res).toEqual(BranchStatus.yellow);
+    });
   });
 
   describe('getPr(prNo)', () => {

--- a/lib/platform/azure/index.ts
+++ b/lib/platform/azure/index.ts
@@ -10,7 +10,7 @@ import {
 import { REPOSITORY_EMPTY } from '../../constants/error-messages';
 import { PLATFORM_TYPE_AZURE } from '../../constants/platforms';
 import { logger } from '../../logger';
-import { BranchStatus, PrState } from '../../types';
+import { BranchStatus, PrState, isStatusCheck } from '../../types';
 import * as git from '../../util/git';
 import * as hostRules from '../../util/host-rules';
 import { sanitize } from '../../util/sanitize';
@@ -328,7 +328,12 @@ export async function getBranchStatus(
   }
   const statuses = await getStatusCheck(branchName);
   logger.debug({ branch: branchName, statuses }, 'branch status check result');
-  if (!statuses.length) {
+  if (
+    statuses.filter(
+      (status: GitStatus) =>
+        !isStatusCheck(getGitStatusContextCombinedName(status.context))
+    ).length === 0
+  ) {
     logger.debug('empty branch status check result = returning "pending"');
     return BranchStatus.yellow;
   }

--- a/lib/platform/bitbucket/__snapshots__/index.spec.ts.snap
+++ b/lib/platform/bitbucket/__snapshots__/index.spec.ts.snap
@@ -692,6 +692,44 @@ Array [
 ]
 `;
 
+exports[`platform/bitbucket getBranchStatus() returns pending if only renovate checks pass 1`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "authorization": "Basic YWJjOjEyMw==",
+      "host": "api.bitbucket.org",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://api.bitbucket.org/2.0/repositories/some/repo",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "authorization": "Basic YWJjOjEyMw==",
+      "host": "api.bitbucket.org",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://api.bitbucket.org/2.0/repositories/some/repo/refs/branches/branch",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "authorization": "Basic YWJjOjEyMw==",
+      "host": "api.bitbucket.org",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://api.bitbucket.org/2.0/repositories/some/repo/commit/branch_hash/statuses?pagelen=100",
+  },
+]
+`;
+
 exports[`platform/bitbucket getBranchStatusCheck() getBranchStatusCheck 1 1`] = `
 Array [
   Object {

--- a/lib/platform/bitbucket/index.spec.ts
+++ b/lib/platform/bitbucket/index.spec.ts
@@ -306,6 +306,33 @@ describe('platform/bitbucket', () => {
       ).toBe(BranchStatus.yellow);
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
+    it('returns pending if only renovate checks pass', async () => {
+      const scope = await initRepoMock();
+      scope
+        .get('/2.0/repositories/some/repo/refs/branches/branch')
+        .reply(200, {
+          name: 'branch',
+          target: {
+            hash: 'branch_hash',
+            parents: [{ hash: 'master_hash' }],
+          },
+        })
+        .get(
+          '/2.0/repositories/some/repo/commit/branch_hash/statuses?pagelen=100'
+        )
+        .reply(200, {
+          values: [
+            {
+              key: 'renovate/stability-days',
+              state: 'SUCCESSFUL',
+            },
+          ],
+        });
+      expect(await bitbucket.getBranchStatus('branch', [])).toBe(
+        BranchStatus.yellow
+      );
+      expect(httpMock.getTrace()).toMatchSnapshot();
+    });
   });
 
   describe('getBranchStatusCheck()', () => {

--- a/lib/platform/bitbucket/index.ts
+++ b/lib/platform/bitbucket/index.ts
@@ -4,7 +4,7 @@ import parseDiff from 'parse-diff';
 import { REPOSITORY_NOT_FOUND } from '../../constants/error-messages';
 import { PLATFORM_TYPE_BITBUCKET } from '../../constants/platforms';
 import { logger } from '../../logger';
-import { BranchStatus, PrState } from '../../types';
+import { BranchStatus, PrState, isStatusCheck } from '../../types';
 import * as git from '../../util/git';
 import * as hostRules from '../../util/host-rules';
 import { BitbucketHttp, setBaseUrl } from '../../util/http/bitbucket';
@@ -344,7 +344,10 @@ export async function getBranchStatus(
   }
   const statuses = await getStatus(branchName);
   logger.debug({ branch: branchName, statuses }, 'branch status check result');
-  if (!statuses.length) {
+  if (
+    statuses.filter((status: { key: string }) => !isStatusCheck(status.key))
+      .length === 0
+  ) {
     logger.debug('empty branch status check result = returning "pending"');
     return BranchStatus.yellow;
   }

--- a/lib/platform/github/__snapshots__/index.spec.ts.snap
+++ b/lib/platform/github/__snapshots__/index.spec.ts.snap
@@ -2422,6 +2422,68 @@ Array [
 ]
 `;
 
+exports[`platform/github getBranchStatus() defaults to pending if only renovate status check passed 1`] = `
+Array [
+  Object {
+    "graphql": Object {
+      "query": Object {
+        "repository": Object {
+          "__args": Object {
+            "name": "repo",
+            "owner": "some",
+          },
+          "defaultBranchRef": Object {
+            "name": null,
+            "target": Object {
+              "oid": null,
+            },
+          },
+          "isArchived": null,
+          "isFork": null,
+          "mergeCommitAllowed": null,
+          "nameWithOwner": null,
+          "rebaseMergeAllowed": null,
+          "squashMergeAllowed": null,
+        },
+      },
+    },
+    "headers": Object {
+      "accept": "application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate",
+      "authorization": "token abc123",
+      "content-length": "330",
+      "content-type": "application/json",
+      "host": "api.github.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "POST",
+    "url": "https://api.github.com/graphql",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate",
+      "authorization": "token abc123",
+      "host": "api.github.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://api.github.com/repos/some/repo/commits/somebranch/status",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/vnd.github.antiope-preview+json, application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate",
+      "authorization": "token abc123",
+      "host": "api.github.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://api.github.com/repos/some/repo/commits/somebranch/check-runs",
+  },
+]
+`;
+
 exports[`platform/github getBranchStatus() return failed if unsupported requiredStatusChecks 1`] = `
 Array [
   Object {

--- a/lib/platform/github/index.spec.ts
+++ b/lib/platform/github/index.spec.ts
@@ -568,6 +568,7 @@ describe('platform/github', () => {
         .get('/repos/some/repo/commits/somebranch/status')
         .reply(200, {
           state: 'success',
+          statuses: [],
         })
         .get('/repos/some/repo/commits/somebranch/check-runs')
         .reply(200, []);
@@ -586,6 +587,7 @@ describe('platform/github', () => {
         .get('/repos/some/repo/commits/somebranch/status')
         .reply(200, {
           state: 'failure',
+          statuses: [],
         })
         .get('/repos/some/repo/commits/somebranch/check-runs')
         .reply(200, []);
@@ -604,6 +606,30 @@ describe('platform/github', () => {
         .get('/repos/some/repo/commits/somebranch/status')
         .reply(200, {
           state: 'unknown',
+          statuses: [],
+        })
+        .get('/repos/some/repo/commits/somebranch/check-runs')
+        .reply(200, []);
+      await github.initRepo({
+        repository: 'some/repo',
+      } as any);
+      const res = await github.getBranchStatus('somebranch', []);
+      expect(res).toEqual(BranchStatus.yellow);
+      expect(httpMock.getTrace()).toMatchSnapshot();
+    });
+    it('defaults to pending if only renovate status check passed', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      initRepoMock(scope, 'some/repo');
+      scope
+        .get('/repos/some/repo/commits/somebranch/status')
+        .reply(200, {
+          state: 'success',
+          statuses: [
+            {
+              context: 'renovate/stability-days',
+              state: 'success',
+            },
+          ],
         })
         .get('/repos/some/repo/commits/somebranch/check-runs')
         .reply(200, []);

--- a/lib/platform/github/index.ts
+++ b/lib/platform/github/index.ts
@@ -831,9 +831,12 @@ export async function getBranchStatus(
       logger.warn({ err }, 'Error retrieving check runs');
     }
   }
+  const filteredStatuses = commitStatus.statuses.filter(
+    (status: { context: string }) => !isStatusCheck(status.context)
+  );
   if (
-    checkRuns.filter((status: { name: string }) => !isStatusCheck(status.name))
-      .length === 0
+    checkRuns.length === 0 &&
+    (commitStatus.statuses.length === 0 || filteredStatuses.length > 0)
   ) {
     if (commitStatus.state === 'success') {
       return BranchStatus.green;
@@ -850,10 +853,8 @@ export async function getBranchStatus(
     return BranchStatus.red;
   }
   if (
-    (commitStatus.state === 'success' ||
-      commitStatus.statuses.filter(
-        (status: { context: string }) => !isStatusCheck(status.context)
-      ).length === 0) &&
+    ((commitStatus.state === 'success' && filteredStatuses.length > 0) ||
+      commitStatus.statuses.length === 0) &&
     checkRuns.every((run) =>
       ['skipped', 'neutral', 'success'].includes(run.conclusion)
     )

--- a/lib/platform/gitlab/__snapshots__/index.spec.ts.snap
+++ b/lib/platform/gitlab/__snapshots__/index.spec.ts.snap
@@ -1265,6 +1265,33 @@ Array [
 ]
 `;
 
+exports[`platform/gitlab getBranchStatus(branchName, requiredStatusChecks) returns pending if only renovate checks are success 1`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "authorization": "Bearer abc123",
+      "host": "gitlab.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitlab.com/api/v4/projects/some%2Frepo",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "authorization": "Bearer abc123",
+      "host": "gitlab.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitlab.com/api/v4/projects/some%2Frepo/repository/commits/0d9c7726c3d628b7e28af234595cfd20febdbf8e/statuses",
+  },
+]
+`;
+
 exports[`platform/gitlab getBranchStatus(branchName, requiredStatusChecks) returns success if all are optional 1`] = `
 Array [
   Object {

--- a/lib/platform/gitlab/index.spec.ts
+++ b/lib/platform/gitlab/index.spec.ts
@@ -454,6 +454,17 @@ describe('platform/gitlab', () => {
       expect(res).toEqual(BranchStatus.yellow);
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
+    it('returns pending if only renovate checks are success', async () => {
+      const scope = await initRepo();
+      scope
+        .get(
+          '/api/v4/projects/some%2Frepo/repository/commits/0d9c7726c3d628b7e28af234595cfd20febdbf8e/statuses'
+        )
+        .reply(200, [{ status: 'success', name: 'renovate/stability-days' }]);
+      const res = await gitlab.getBranchStatus('somebranch', []);
+      expect(res).toEqual(BranchStatus.yellow);
+      expect(httpMock.getTrace()).toMatchSnapshot();
+    });
     it('returns success if all are success', async () => {
       const scope = await initRepo();
       scope

--- a/lib/platform/gitlab/index.ts
+++ b/lib/platform/gitlab/index.ts
@@ -330,10 +330,10 @@ export async function getBranchStatus(
 
   const res = await getStatus(branchName);
   logger.debug(`Got res with ${res.length} results`);
-  if (
-    res.filter((status: GitlabBranchStatus) => !isStatusCheck(status.name))
-      .length === 0
-  ) {
+  const filteredStatuses = res.filter(
+    (status: GitlabBranchStatus) => !isStatusCheck(status.name)
+  );
+  if (filteredStatuses.length === 0) {
     // Return 'pending' if we have no status checks
     return BranchStatus.yellow;
   }

--- a/lib/platform/gitlab/index.ts
+++ b/lib/platform/gitlab/index.ts
@@ -15,7 +15,7 @@ import {
 } from '../../constants/error-messages';
 import { PLATFORM_TYPE_GITLAB } from '../../constants/platforms';
 import { logger } from '../../logger';
-import { BranchStatus, PrState } from '../../types';
+import { BranchStatus, PrState, isStatusCheck } from '../../types';
 import * as git from '../../util/git';
 import * as hostRules from '../../util/host-rules';
 import { HttpResponse } from '../../util/http';
@@ -330,7 +330,10 @@ export async function getBranchStatus(
 
   const res = await getStatus(branchName);
   logger.debug(`Got res with ${res.length} results`);
-  if (res.length === 0) {
+  if (
+    res.filter((status: GitlabBranchStatus) => !isStatusCheck(status.name))
+      .length === 0
+  ) {
     // Return 'pending' if we have no status checks
     return BranchStatus.yellow;
   }

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -2,5 +2,6 @@ export * from './host-rules';
 export * from './skip-reason';
 export * from './versioning';
 export * from './branch-status';
+export * from './status-check';
 export * from './vulnerability-alert';
 export * from './pr-state';

--- a/lib/types/status-check.ts
+++ b/lib/types/status-check.ts
@@ -1,0 +1,8 @@
+export enum StatusCheck {
+  stabilityDays = 'renovate/stability-days',
+  unpublishSafe = 'renovate/unpublish-safe',
+}
+
+export function isStatusCheck(status: string): status is StatusCheck {
+  return Object.values(StatusCheck).indexOf(status as StatusCheck) !== -1;
+}

--- a/lib/types/status-check.ts
+++ b/lib/types/status-check.ts
@@ -4,5 +4,5 @@ export enum StatusCheck {
 }
 
 export function isStatusCheck(status: string): status is StatusCheck {
-  return Object.values(StatusCheck).indexOf(status as StatusCheck) !== -1;
+  return Object.values(StatusCheck).includes(status as StatusCheck);
 }

--- a/lib/workers/branch/status-checks.ts
+++ b/lib/workers/branch/status-checks.ts
@@ -1,7 +1,7 @@
 import { RenovateConfig } from '../../config';
 import { logger } from '../../logger';
 import { platform } from '../../platform';
-import { BranchStatus } from '../../types';
+import { BranchStatus, StatusCheck } from '../../types';
 
 async function setStatusCheck(
   branchName: string,
@@ -38,7 +38,7 @@ export async function setStability(config: StabilityConfig): Promise<void> {
   if (!config.stabilityStatus) {
     return;
   }
-  const context = `renovate/stability-days`;
+  const context = StatusCheck.stabilityDays;
   const description =
     config.stabilityStatus === BranchStatus.green
       ? 'Updates have met stability days requirement'
@@ -64,7 +64,7 @@ export async function setUnpublishable(
   if (!config.unpublishSafe) {
     return;
   }
-  const context = `renovate/unpublish-safe`;
+  const context = StatusCheck.unpublishSafe;
   // Set canBeUnpublished status check
   const state = config.canBeUnpublished
     ? BranchStatus.yellow


### PR DESCRIPTION
## Changes:

Excludes `renovate/*` status checks when counting successful checks.

Platforms:

- [x] GitLab
- [x] GitHub
- [x] Azure
- [x] Bitbucket
- [ ] Bitbucket server
- [ ] Gitea

## Context:

Closes #7800

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository
