### PR TITLE
fix(worker): early exit if config can't parsed

### DIFF
--- a/lib/workers/global/index.ts
+++ b/lib/workers/global/index.ts
@@ -43,7 +43,7 @@ function haveReachedLimits(): boolean {
   return false;
 }
 
-export async function start(): Promise<0 | 1> {
+export async function start(): Promise<number> {
   let config: RenovateConfig;
   try {
     // read global config from file, env and cli args
@@ -72,6 +72,11 @@ export async function start(): Promise<0 | 1> {
       logger.fatal(err.message.substring(6));
     } else {
       logger.fatal({ err }, `Fatal error: ${String(err.message)}`);
+    }
+    if (!config) {
+      // return early if we can't parse config options
+      logger.debug(`Missing config`);
+      return 2;
     }
   } finally {
     globalFinalize(config);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:
Add early exit if config can't be parsed, otherwise we get an error.
<!-- Describe what this pull request changes. -->

## Context:
`TypeError: Cannot read property 'redisUrl' of undefined` is thrown here:
https://github.com/renovatebot/renovate/blob/95577ac01bbb5648e800dc6f8dd4669dfa6fd2b1/lib/workers/global/index.ts#L77

That will throw an unhandled promise rejection and causes a silent renovate exit (code 0)
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
