### PR TITLE
fix(nuget): remove build meta from latest

### DIFF
--- a/lib/datasource/nuget/__fixtures__/nunit/v3_registration.json
+++ b/lib/datasource/nuget/__fixtures__/nunit/v3_registration.json
@@ -2649,7 +2649,7 @@
               "addin"
             ],
             "title": "NUnit",
-            "version": "3.12.0"
+            "version": "3.12.0+build-632"
           },
           "packageContent": "https://api.nuget.org/v3-flatcontainer/nunit/3.12.0/nunit.3.12.0.nupkg",
           "registration": "https://api.nuget.org/v3/registration5-gz-semver2/nunit/index.json"

--- a/lib/datasource/nuget/v3.ts
+++ b/lib/datasource/nuget/v3.ts
@@ -150,7 +150,7 @@ export async function getReleases(
         release.releaseTimestamp = releaseTimestamp;
       }
       if (semver.valid(version) && !semver.prerelease(version)) {
-        latestStable = version;
+        latestStable = removeBuildMeta(version);
         homepage = projectUrl || homepage;
       }
       if (listed === false) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Remove semver v2 build meta from latest version. Before this renovate tried to fetch the nupsec file from wrong url.
I've found it because i wondered why the changelog was missing. 🙃 
<!-- Describe what this pull request changes. -->

## Context:
see viceice-tests/renovate-nuget-buildmeta#2 for sample
ref #7781
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
