### PR TITLE
feat(azure): implement mergepr

### DIFF
--- a/lib/platform/azure/index.spec.ts
+++ b/lib/platform/azure/index.spec.ts
@@ -1004,10 +1004,32 @@ describe('platform/azure', () => {
       );
     });
   });
-  describe('Not supported by Azure DevOps (yet!)', () => {
-    it('mergePr', async () => {
-      const res = await azure.mergePr(0, undefined);
-      expect(res).toBe(false);
+  describe('mergePr', () => {
+    it('should complete the PR', async () => {
+      await initRepo({ repository: 'some/repo' });
+      const pullRequestIdMock = 12345;
+      const branchNameMock = 'test';
+      const lastMergeSourceCommitMock = { commitId: 'abcd1234' };
+      const updatePullRequestMock = jest.fn();
+      azureApi.gitApi.mockImplementationOnce(
+        () =>
+          ({
+            getPullRequestById: jest.fn(() => ({
+              lastMergeSourceCommit: lastMergeSourceCommitMock,
+            })),
+            updatePullRequest: updatePullRequestMock,
+          } as any)
+      );
+      const res = await azure.mergePr(pullRequestIdMock, branchNameMock);
+      expect(updatePullRequestMock).toHaveBeenCalledWith(
+        {
+          status: PullRequestStatus.Completed,
+          lastMergeSourceCommit: lastMergeSourceCommitMock,
+        },
+        '1',
+        pullRequestIdMock
+      );
+      expect(res).toBe(true);
     });
   });
 

--- a/lib/platform/azure/index.ts
+++ b/lib/platform/azure/index.ts
@@ -575,9 +575,35 @@ export async function setBranchStatus({
   logger.trace(`Created commit status of ${state} on branch ${branchName}`);
 }
 
-export function mergePr(pr: number, branchName: string): Promise<boolean> {
-  logger.debug(`mergePr(pr)(${pr}) - Not supported by Azure DevOps (yet!)`);
-  return Promise.resolve(false);
+export async function mergePr(
+  pullRequestId: number,
+  branchName: string
+): Promise<boolean> {
+  logger.debug(`mergePr(${pullRequestId}, ${branchName})`);
+  const azureApiGit = await azureApi.gitApi();
+
+  const pr = await azureApiGit.getPullRequestById(
+    pullRequestId,
+    config.project
+  );
+
+  const objToUpdate: GitPullRequest = {
+    status: PullRequestStatus.Completed,
+    lastMergeSourceCommit: pr.lastMergeSourceCommit,
+  };
+
+  logger.trace(
+    `Updating PR ${pullRequestId} to status ${PullRequestStatus.Completed} (${
+      PullRequestStatus[PullRequestStatus.Completed]
+    }) with lastMergeSourceCommit ${pr.lastMergeSourceCommit.commitId}`
+  );
+  await azureApiGit.updatePullRequest(
+    objToUpdate,
+    config.repoId,
+    pullRequestId
+  );
+
+  return Promise.resolve(true);
 }
 
 export function getPrBody(input: string): string {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate DONE -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. DONE -->

## Changes:

Implement the `mergePr` function for Azure DevOps. This updates a PR, setting the status to `Completed` and passing the required `lastMergeSourceCommit`.

This allows automerge to work end-to-end on Azure.

## Context:

#1149 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [X] Unit tests + ran on a real repository

Ran locally and pointed at my works AzureDevops repo.

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
