### PR TITLE
feat(util): Add resolveBaseUrl function

### DIFF
--- a/lib/util/url.spec.ts
+++ b/lib/util/url.spec.ts
@@ -4,33 +4,44 @@ describe('util/url', () => {
   test.each([
     ['http://foo.io', '', 'http://foo.io'],
     ['http://foo.io/', '', 'http://foo.io'],
-    ['http://foo.io', '/', 'http://foo.io'],
-    ['http://foo.io/', '/', 'http://foo.io'],
+    ['http://foo.io', '/', 'http://foo.io/'],
+    ['http://foo.io/', '/', 'http://foo.io/'],
 
     ['http://foo.io', '/aaa', 'http://foo.io/aaa'],
     ['http://foo.io', 'aaa', 'http://foo.io/aaa'],
     ['http://foo.io/', '/aaa', 'http://foo.io/aaa'],
     ['http://foo.io/', 'aaa', 'http://foo.io/aaa'],
+    ['http://foo.io', '/aaa/', 'http://foo.io/aaa/'],
+    ['http://foo.io', 'aaa/', 'http://foo.io/aaa/'],
+    ['http://foo.io/', '/aaa/', 'http://foo.io/aaa/'],
+    ['http://foo.io/', 'aaa/', 'http://foo.io/aaa/'],
 
     ['http://foo.io/aaa', '/bbb', 'http://foo.io/aaa/bbb'],
     ['http://foo.io/aaa', 'bbb', 'http://foo.io/aaa/bbb'],
     ['http://foo.io/aaa/', '/bbb', 'http://foo.io/aaa/bbb'],
     ['http://foo.io/aaa/', 'bbb', 'http://foo.io/aaa/bbb'],
 
-    ['http://foo.io/aaa', '/bbb/', 'http://foo.io/aaa/bbb'],
-    ['http://foo.io/aaa', 'bbb/', 'http://foo.io/aaa/bbb'],
-    ['http://foo.io/aaa/', '/bbb/', 'http://foo.io/aaa/bbb'],
-    ['http://foo.io/aaa/', 'bbb/', 'http://foo.io/aaa/bbb'],
+    ['http://foo.io/aaa', '/bbb/', 'http://foo.io/aaa/bbb/'],
+    ['http://foo.io/aaa', 'bbb/', 'http://foo.io/aaa/bbb/'],
+    ['http://foo.io/aaa/', '/bbb/', 'http://foo.io/aaa/bbb/'],
+    ['http://foo.io/aaa/', 'bbb/', 'http://foo.io/aaa/bbb/'],
 
     ['http://foo.io', 'http://bar.io/bbb', 'http://bar.io/bbb'],
     ['http://foo.io/', 'http://bar.io/bbb', 'http://bar.io/bbb'],
     ['http://foo.io/aaa', 'http://bar.io/bbb', 'http://bar.io/bbb'],
     ['http://foo.io/aaa/', 'http://bar.io/bbb', 'http://bar.io/bbb'],
 
+    ['http://foo.io', 'http://bar.io/bbb/', 'http://bar.io/bbb/'],
+    ['http://foo.io/', 'http://bar.io/bbb/', 'http://bar.io/bbb/'],
+    ['http://foo.io/aaa', 'http://bar.io/bbb/', 'http://bar.io/bbb/'],
+    ['http://foo.io/aaa/', 'http://bar.io/bbb/', 'http://bar.io/bbb/'],
+
     ['http://foo.io', 'aaa?bbb=z', 'http://foo.io/aaa?bbb=z'],
     ['http://foo.io', '/aaa?bbb=z', 'http://foo.io/aaa?bbb=z'],
     ['http://foo.io/', 'aaa?bbb=z', 'http://foo.io/aaa?bbb=z'],
     ['http://foo.io/', '/aaa?bbb=z', 'http://foo.io/aaa?bbb=z'],
+
+    ['http://foo.io', 'aaa/?bbb=z', 'http://foo.io/aaa?bbb=z'],
   ])('%s + %s => %s', (baseUrl, x, result) => {
     expect(resolveBaseUrl(baseUrl, x)).toBe(result);
   });

--- a/lib/util/url.spec.ts
+++ b/lib/util/url.spec.ts
@@ -1,0 +1,37 @@
+import { resolveBaseUrl } from './url';
+
+describe('util/url', () => {
+  test.each([
+    ['http://foo.io', '', 'http://foo.io'],
+    ['http://foo.io/', '', 'http://foo.io'],
+    ['http://foo.io', '/', 'http://foo.io'],
+    ['http://foo.io/', '/', 'http://foo.io'],
+
+    ['http://foo.io', '/aaa', 'http://foo.io/aaa'],
+    ['http://foo.io', 'aaa', 'http://foo.io/aaa'],
+    ['http://foo.io/', '/aaa', 'http://foo.io/aaa'],
+    ['http://foo.io/', 'aaa', 'http://foo.io/aaa'],
+
+    ['http://foo.io/aaa', '/bbb', 'http://foo.io/aaa/bbb'],
+    ['http://foo.io/aaa', 'bbb', 'http://foo.io/aaa/bbb'],
+    ['http://foo.io/aaa/', '/bbb', 'http://foo.io/aaa/bbb'],
+    ['http://foo.io/aaa/', 'bbb', 'http://foo.io/aaa/bbb'],
+
+    ['http://foo.io/aaa', '/bbb/', 'http://foo.io/aaa/bbb'],
+    ['http://foo.io/aaa', 'bbb/', 'http://foo.io/aaa/bbb'],
+    ['http://foo.io/aaa/', '/bbb/', 'http://foo.io/aaa/bbb'],
+    ['http://foo.io/aaa/', 'bbb/', 'http://foo.io/aaa/bbb'],
+
+    ['http://foo.io', 'http://bar.io/bbb', 'http://bar.io/bbb'],
+    ['http://foo.io/', 'http://bar.io/bbb', 'http://bar.io/bbb'],
+    ['http://foo.io/aaa', 'http://bar.io/bbb', 'http://bar.io/bbb'],
+    ['http://foo.io/aaa/', 'http://bar.io/bbb', 'http://bar.io/bbb'],
+
+    ['http://foo.io', 'aaa?bbb=z', 'http://foo.io/aaa?bbb=z'],
+    ['http://foo.io', '/aaa?bbb=z', 'http://foo.io/aaa?bbb=z'],
+    ['http://foo.io/', 'aaa?bbb=z', 'http://foo.io/aaa?bbb=z'],
+    ['http://foo.io/', '/aaa?bbb=z', 'http://foo.io/aaa?bbb=z'],
+  ])('%s + %s => %s', (baseUrl, x, result) => {
+    expect(resolveBaseUrl(baseUrl, x)).toBe(result);
+  });
+});

--- a/lib/util/url.ts
+++ b/lib/util/url.ts
@@ -1,3 +1,20 @@
+import urlJoin from 'url-join';
+
 export function ensureTrailingSlash(url: string): string {
   return url.replace(/\/?$/, '/');
+}
+
+export function resolveBaseUrl(baseUrl: string, input: string | URL): string {
+  const inputString = input.toString();
+
+  let host;
+  let pathname;
+  try {
+    ({ host, pathname } = new URL(inputString));
+  } catch (e) {
+    pathname = inputString;
+  }
+
+  const result = host ? inputString : urlJoin(baseUrl, pathname || '');
+  return result.replace(/\/+$/, '');
 }

--- a/lib/util/url.ts
+++ b/lib/util/url.ts
@@ -15,6 +15,5 @@ export function resolveBaseUrl(baseUrl: string, input: string | URL): string {
     pathname = inputString;
   }
 
-  const result = host ? inputString : urlJoin(baseUrl, pathname || '');
-  return result.replace(/\/+$/, '');
+  return host ? inputString : urlJoin(baseUrl, pathname || '');
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Added `resolveBaseUrl` function with behavior described in #7317.
Migrations from `URL.resolve()` will be made in separate PRs.

## Context:

Ref: #7317

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
