### PR TITLE
refactor(github): Remove obsolete URL functions from HTTP wrapper

### DIFF
--- a/lib/util/http/github.spec.ts
+++ b/lib/util/http/github.spec.ts
@@ -40,19 +40,6 @@ describe(getName(__filename), () => {
         'some-accept, application/vnd.github.machine-man-preview+json'
       );
     });
-    it('strips v3 for graphql', async () => {
-      httpMock
-        .scope('https://ghe.mycompany.com')
-        .post('/graphql')
-        .reply(200, {});
-      setBaseUrl('https://ghe.mycompany.com/api/v3/');
-      await githubApi.postJson('/graphql', {
-        body: {},
-      });
-      const [req] = httpMock.getTrace();
-      expect(req).toBeDefined();
-      expect(req.url).not.toContain('/v3');
-    });
     it('paginates', async () => {
       const url = '/some-url';
       httpMock
@@ -226,6 +213,18 @@ describe(getName(__filename), () => {
         }
       }`;
 
+    it('strips path from baseUrl', async () => {
+      setBaseUrl('https://ghe.mycompany.com/api/v3/');
+      const repository = { foo: 'foo', bar: 'bar' };
+      httpMock
+        .scope('https://ghe.mycompany.com')
+        .post('/graphql')
+        .reply(200, { data: { repository } });
+      await githubApi.queryRepo(query);
+      const [req] = httpMock.getTrace();
+      expect(req).toBeDefined();
+      expect(req.url).toEqual('https://ghe.mycompany.com/graphql');
+    });
     it('supports app mode', async () => {
       hostRules.add({ hostType: 'github', token: 'x-access-token:abc123' });
       httpMock


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

We need refactor it prior to `URL.resolve()` being removed from `util/http`.

## Context:

Ref: #7317

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
