### PR TITLE
refactor(http): Remove URL functions from platform-specific wrappers

### DIFF
--- a/lib/util/http/bitbucket-server.ts
+++ b/lib/util/http/bitbucket-server.ts
@@ -1,5 +1,5 @@
-import URL from 'url';
 import { PLATFORM_TYPE_BITBUCKET_SERVER } from '../../constants/platforms';
+import { resolveBaseUrl } from '../url';
 import { Http, HttpOptions, HttpResponse, InternalHttpOptions } from '.';
 
 let baseUrl: string;
@@ -16,7 +16,7 @@ export class BitbucketServerHttp extends Http {
     path: string,
     options?: InternalHttpOptions
   ): Promise<HttpResponse<T> | null> {
-    const url = URL.resolve(baseUrl, path);
+    const url = resolveBaseUrl(baseUrl, path);
     const opts = {
       baseUrl,
       ...options,

--- a/lib/util/http/bitbucket.ts
+++ b/lib/util/http/bitbucket.ts
@@ -1,4 +1,3 @@
-import { URL } from 'url';
 import { PLATFORM_TYPE_BITBUCKET } from '../../constants/platforms';
 import { Http, HttpOptions, HttpResponse, InternalHttpOptions } from '.';
 

--- a/lib/util/http/gitea.ts
+++ b/lib/util/http/gitea.ts
@@ -1,5 +1,5 @@
-import url from 'url';
 import { PLATFORM_TYPE_GITEA } from '../../constants/platforms';
+import { resolveBaseUrl } from '../url';
 import { Http, HttpOptions, HttpResponse, InternalHttpOptions } from '.';
 
 let baseUrl;
@@ -24,8 +24,8 @@ function getPaginationContainer(body: any): any[] {
 }
 
 function resolveUrl(path: string, base: string): URL {
-  const resolvedUrlString = url.resolve(base, path);
-  return new url.URL(resolvedUrlString);
+  const resolvedUrlString = resolveBaseUrl(base, path);
+  return new URL(resolvedUrlString);
 }
 
 export class GiteaHttp extends Http<GiteaHttpOptions, GiteaHttpOptions> {

--- a/lib/util/http/gitlab.ts
+++ b/lib/util/http/gitlab.ts
@@ -1,4 +1,3 @@
-import { URL } from 'url';
 import parseLinkHeader from 'parse-link-header';
 import { PLATFORM_TYPE_GITLAB } from '../../constants/platforms';
 import { logger } from '../../logger';


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Remove obsolete URL functions from all platforms except Github.
Once this PR and #7932 are merged, we can safely refactor also `util/http/index.ts` too.
Thus, #7317 minimal requirement will be met.

## Context:

Ref: #7317, #7932

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
