### PR TITLE
fix(composer): don’t add vendor directory

### DIFF
--- a/lib/manager/composer/artifacts.spec.ts
+++ b/lib/manager/composer/artifacts.spec.ts
@@ -142,7 +142,7 @@ describe('.updateArtifacts()', () => {
     const foo = join('vendor/foo/Foo.php');
     const bar = join('vendor/bar/Bar.php');
     const baz = join('vendor/baz/Baz.php');
-
+    fs.localPathExists.mockResolvedValueOnce(true);
     fs.readLocalFile.mockResolvedValueOnce('Current composer.lock' as any);
     const execSnapshots = mockExecAll(exec);
     git.getRepoStatus.mockResolvedValueOnce({

--- a/lib/manager/composer/artifacts.ts
+++ b/lib/manager/composer/artifacts.ts
@@ -16,6 +16,7 @@ import {
   ensureDir,
   ensureLocalDir,
   getSiblingFileName,
+  localPathExists,
   readLocalFile,
   writeLocalFile,
 } from '../../util/fs';
@@ -113,6 +114,7 @@ export async function updateArtifacts({
   }
 
   const vendorDir = getSiblingFileName(packageFileName, 'vendor');
+  const commitVendorFiles = await localPathExists(vendorDir);
   await ensureLocalDir(vendorDir);
   try {
     await writeLocalFile(packageFileName, newPackageFileContent);
@@ -164,6 +166,11 @@ export async function updateArtifacts({
       },
     ];
 
+    if (!commitVendorFiles) {
+      return res;
+    }
+
+    logger.debug(`Commiting vendor files in ${vendorDir}`);
     for (const f of [...status.modified, ...status.not_added]) {
       if (f.startsWith(vendorDir)) {
         res.push({

--- a/lib/util/fs/index.spec.ts
+++ b/lib/util/fs/index.spec.ts
@@ -1,5 +1,5 @@
 import { getName } from '../../../test/util';
-import { readLocalFile } from '.';
+import { getSubDirectory, localPathExists, readLocalFile } from '.';
 
 describe(getName(__filename), () => {
   describe('readLocalFile', () => {
@@ -13,6 +13,22 @@ describe(getName(__filename), () => {
     it('does not throw', async () => {
       // Does not work on FreeBSD: https://nodejs.org/docs/latest-v10.x/api/fs.html#fs_fs_readfile_path_options_callback
       expect(await readLocalFile(__dirname)).toBeNull();
+    });
+  });
+});
+
+describe(getName(__filename), () => {
+  describe('localPathExists', () => {
+    it('returns true for file', async () => {
+      expect(await localPathExists(__filename)).toBe(true);
+    });
+    it('returns true for directory', async () => {
+      expect(await localPathExists(getSubDirectory(__filename))).toBe(true);
+    });
+    it('returns false', async () => {
+      expect(await localPathExists(__filename.replace('.ts', '.txt'))).toBe(
+        false
+      );
     });
   });
 });

--- a/lib/util/fs/index.ts
+++ b/lib/util/fs/index.ts
@@ -82,9 +82,6 @@ export async function ensureCacheDir(
 
 export function localPathExists(pathName: string): Promise<boolean> {
   // Works for both files as well as directories
-  return new Promise<boolean>((resolve) => {
-    fs.stat(join(localDir, pathName), (err) => {
-      resolve(!err);
-    });
+  return fs.stat(join(localDir, pathName).then(s=> !!s).catch(() => false);
   });
 }

--- a/lib/util/fs/index.ts
+++ b/lib/util/fs/index.ts
@@ -79,3 +79,12 @@ export async function ensureCacheDir(
   await fs.ensureDir(cacheDirName);
   return cacheDirName;
 }
+
+export function localPathExists(pathName: string): Promise<boolean> {
+  // Works for both files as well as directories
+  return new Promise<boolean>((resolve) => {
+    fs.stat(join(localDir, pathName), (err) => {
+      resolve(!err);
+    });
+  });
+}

--- a/lib/util/fs/index.ts
+++ b/lib/util/fs/index.ts
@@ -82,6 +82,8 @@ export async function ensureCacheDir(
 
 export function localPathExists(pathName: string): Promise<boolean> {
   // Works for both files as well as directories
-  return fs.stat(join(localDir, pathName).then(s=> !!s).catch(() => false);
-  });
+  return fs
+    .stat(join(localDir, pathName))
+    .then((s) => !!s)
+    .catch(() => false);
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Fixes Composer Artifacts updating so that vendor files are only checked and added if the vendor folder previous existed.

## Context:

#7935 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
