### PR TITLE
Fix: re-add /api to the base url of a GHE request

### DIFF
--- a/lib/util/http/github.spec.ts
+++ b/lib/util/http/github.spec.ts
@@ -217,13 +217,13 @@ describe(getName(__filename), () => {
       setBaseUrl('https://ghe.mycompany.com/api/v3/');
       const repository = { foo: 'foo', bar: 'bar' };
       httpMock
-        .scope('https://ghe.mycompany.com')
+        .scope('https://ghe.mycompany.com/api')
         .post('/graphql')
         .reply(200, { data: { repository } });
       await githubApi.queryRepo(query);
       const [req] = httpMock.getTrace();
       expect(req).toBeDefined();
-      expect(req.url).toEqual('https://ghe.mycompany.com/graphql');
+      expect(req.url).toEqual('https://ghe.mycompany.com/api/graphql');
     });
     it('supports app mode', async () => {
       hostRules.add({ hostType: 'github', token: 'x-access-token:abc123' });

--- a/lib/util/http/github.ts
+++ b/lib/util/http/github.ts
@@ -220,8 +220,7 @@ export class GithubHttp extends Http<GithubHttpOptions, GithubHttpOptions> {
 
     const path = 'graphql';
 
-    const { origin } = new URL(baseUrl);
-
+    const origin = new URL('/api', baseUrl).toString();
     const opts: HttpPostOptions = {
       baseUrl: origin,
       body: { query },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what this pull request changes. -->
Fixes #7942, allowing GHE requests to (hopefully) start working again 😄 

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
