### PR TITLE
fix(github): fix `v3` stripping for graphql in GHE

### DIFF
--- a/lib/util/http/github.spec.ts
+++ b/lib/util/http/github.spec.ts
@@ -218,12 +218,12 @@ describe(getName(__filename), () => {
       const repository = { foo: 'foo', bar: 'bar' };
       httpMock
         .scope('https://ghe.mycompany.com')
-        .post('/graphql')
+        .post('/api/graphql')
         .reply(200, { data: { repository } });
       await githubApi.queryRepo(query);
       const [req] = httpMock.getTrace();
       expect(req).toBeDefined();
-      expect(req.url).toEqual('https://ghe.mycompany.com/graphql');
+      expect(req.url).toEqual('https://ghe.mycompany.com/api/graphql');
     });
     it('supports app mode', async () => {
       hostRules.add({ hostType: 'github', token: 'x-access-token:abc123' });

--- a/lib/util/http/github.ts
+++ b/lib/util/http/github.ts
@@ -220,10 +220,8 @@ export class GithubHttp extends Http<GithubHttpOptions, GithubHttpOptions> {
 
     const path = 'graphql';
 
-    const { origin } = new URL(baseUrl);
-
     const opts: HttpPostOptions = {
-      baseUrl: origin,
+      baseUrl: baseUrl.replace('/v3/', '/'), // GHE uses unversioned graphql path
       body: { query },
       headers: { accept: options?.acceptHeader },
     };


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Return older logic which just removed `/v3/` path segment from `baseUrl`

## Context:

Closes #7942
Ref: #7932

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
