### PR TITLE
refactor: remove packageRules nesting from internal presets

### DIFF
--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -23,10 +23,9 @@ const staticGroups = {
     packageRules: [
       {
         packagePatterns: ['*'],
-        minor: {
-          groupName: 'all non-major dependencies',
-          groupSlug: 'all-minor-patch',
-        },
+        updateTypes: ['minor', 'patch'],
+        groupName: 'all non-major dependencies',
+        groupSlug: 'all-minor-patch',
       },
     ],
   },

--- a/lib/config/presets/internal/helpers.ts
+++ b/lib/config/presets/internal/helpers.ts
@@ -5,9 +5,8 @@ export const presets: Record<string, Preset> = {
     packageRules: [
       {
         packageNames: ['@types/node'],
-        major: {
-          enabled: false,
-        },
+        updateTypes: ['major'],
+        enabled: false,
       },
     ],
   },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Removes nested objects from internal presets

## Context:

We should aim to have flat packageRules

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
