### PR TITLE
docs: update config help links

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -7,7 +7,7 @@ Instead, email security@renovatebot.com with as much details as possible so that
 
 ## Support
 
-If you have a **configuration question**, please create an issue in https://github.com/renovatebot/config-help
+If you want help with your Renovate configuration, go to the [discussions tab in the Renovate repository](https://github.com/renovatebot/renovate/discussions) and open a new "config help" discussion post.
 
 ## Bug Reports and Feature Requests
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -25,7 +25,8 @@ Renovate does not read/override the config from within each base branch if prese
 
 Also, be sure to check out Renovate's [shareable config presets](/config-presets/) to save yourself from reinventing any wheels.
 
-If you have any questions about the below config options, or would like to get help/feedback about a config, please post it as an issue in [renovatebot/config-help](https://github.com/renovatebot/config-help) where we will do our best to answer your question.
+If you have any questions about the config options, or want to get help/feedback about a config, go to the [discussions tab in the Renovate repository](https://github.com/renovatebot/renovate/discussions) and start a new "config help" discussion.
+We will do our best to answer your question(s).
 
 ## addLabels
 
@@ -211,7 +212,7 @@ Warning: it's strongly recommended not to configure this field directly.
 Use at your own risk.
 If you truly need to configure this then it probably means either:
 
-- You are hopefully mistaken, and there's a better approach you should use, so [ask here](https://github.com/renovatebot/config-help) or
+- You are hopefully mistaken, and there's a better approach you should use, so open a new "config help" discussion at the [Renovate discussions tab](https://github.com/renovatebot/renovate/discussions) or
 - You have a use case we didn't anticipate and we should have a feature request from you to add it to the project
 
 ## branchPrefix

--- a/docs/usage/configuration-templates.md
+++ b/docs/usage/configuration-templates.md
@@ -26,7 +26,7 @@ We use `docker-` for all Docker updates, branches will look like this: `renovate
 
 `branchTopic` depends on the package manager and upgrade type, so you will see a lot of variety.
 This is probably a setting you want to change yourself.
-Be careful, and consider posting your config to https://github.com/renovateapp/config-help first to get help from the Renovate team with your config.
+Be careful, and consider creating a new "config help" post at the [discussions tab in the Renovate repository](https://github.com/renovatebot/renovate/discussions) to get help from the Renovate team with your config.
 
 ## Commit Message
 

--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,7 @@ For Bitbucket Cloud, Bitbucket Server, Gitea and GitLab, use our self-hosting op
 
 Visit https://docs.renovatebot.com/ for documentation, and in particular https://docs.renovatebot.com/configuration-options/ for a list of configuration options.
 
-You can also raise an issue in https://github.com/renovatebot/config-help if you'd like to get your config reviewed or ask any questions.
+To get help and/or a review for your config, go to the [discussions tab in the Renovate repository](https://github.com/renovatebot/renovate/discussions) and open a new "config help" discussion post.
 
 ## Self-Hosting
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what this pull request changes. -->

- Update text and links to point to the Renovate discussions tab instead of the old `config-help` repository.

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

Closes #7973. (Note: I'm making a separate PR to update the issue templates 😉)

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
