### PR TITLE
chore: update issue template to point to discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config_help.md
+++ b/.github/ISSUE_TEMPLATE/config_help.md
@@ -1,10 +1,13 @@
 ---
 name: Configuration help
-about: Please create an issue in renovatebot/config-help instead
+about: Please open an new config help post in the discussions tab
 ---
 
 Stop!
 
-Configuration help questions for Renovate are very welcome! However, please raise them in the https://github.com/renovatebot/config-help repository instead.
+Configuration help questions for Renovate are very welcome!
+However, please don't create a new issue.
+Instead use the [discussions tab](https://github.com/renovatebot/renovate/discussions).
 
-Maybe you might already find your question answered there by a past issue. If not, please [create a new issue](https://github.com/renovatebot/config-help/issues/new).
+Search the discussions forum to see if your config question is already answered.
+If not, create a new "config help" discussions post to get help from the Renovate team.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what this pull request changes. -->

- Update the issue template so that it points to the new discussions forum instead of the old `config-help` repository.

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

Closes #7974.

Note: there's a separate PR to update the rest of the docs. 😉 

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
