### PR TITLE
feat: update Batect bundle references

### DIFF
--- a/lib/manager/batect/__fixtures__/batect.yml
+++ b/lib/manager/batect/__fixtures__/batect.yml
@@ -13,3 +13,21 @@ containers:
 
   container-5:
     image: postgres:9.6.20@sha256:166179811e4c75f8a092367afed6091208c8ecf60b111c7e49f29af45ca05e08
+
+include:
+  - some/file/include.yml
+
+  - type: file
+    path: a/valid/file/include.yml
+
+  - type: file
+    repo: https://file.includes/should/not/have/repo.git
+    ref: this-isn't-valid
+
+  - type: git
+    repo: https://includes.com/my-repo.git
+    ref: 1.2.3
+
+  - type: git
+    repo: https://includes.com/my-other-repo.git
+    ref: 4.5.6

--- a/lib/manager/batect/extract.spec.ts
+++ b/lib/manager/batect/extract.spec.ts
@@ -1,5 +1,7 @@
 import { readFileSync } from 'fs';
+import { id as gitTagDatasource } from '../../datasource/git-tags';
 import { id as dockerVersioning } from '../../versioning/docker';
+import { id as semverVersioning } from '../../versioning/semver';
 import { PackageDependency } from '../common';
 import { getDep } from '../dockerfile/extract';
 import { extractPackageFile } from './extract';
@@ -13,6 +15,16 @@ function createDockerDependency(tag: string): PackageDependency {
   return {
     ...getDep(tag),
     versioning: dockerVersioning,
+  };
+}
+
+function createGitDependency(repo: string, version: string): PackageDependency {
+  return {
+    depName: repo,
+    currentValue: version,
+    versioning: semverVersioning,
+    datasource: gitTagDatasource,
+    commitMessageTopic: 'bundle {{depName}}',
   };
 }
 
@@ -44,6 +56,8 @@ describe('lib/manager/batect/extract', () => {
         createDockerDependency(
           'postgres:9.6.20@sha256:166179811e4c75f8a092367afed6091208c8ecf60b111c7e49f29af45ca05e08'
         ),
+        createGitDependency('https://includes.com/my-repo.git', '1.2.3'),
+        createGitDependency('https://includes.com/my-other-repo.git', '4.5.6'),
       ]);
     });
   });

--- a/lib/manager/batect/readme.md
+++ b/lib/manager/batect/readme.md
@@ -1,4 +1,8 @@
-Extracts all Docker images from Batect configuration files.
+Extracts all Docker images and Batect bundles from Batect configuration files.
+
+For updates to Batect itself, see [batect-wrapper](../batect-wrapper).
+
+## Files searched
 
 By default, the manager searches for files called `batect.yml` or `batect-bundle.yml`.
 
@@ -21,3 +25,9 @@ For example:
   }
 }
 ```
+
+## Bundle versioning
+
+This manager assumes that any bundles referenced use tags for versioning, and that these tags use [semver](../../versioning/semver).
+The implementation of semver is strict - versions must follow the `X.Y.Z` or `vX.Y.Z` format.
+Versions that don't match this format (eg. `X.Y`) will be ignored.

--- a/lib/manager/batect/readme.md
+++ b/lib/manager/batect/readme.md
@@ -2,7 +2,7 @@ Extracts all Docker images and Batect bundles from Batect configuration files.
 
 For updates to Batect itself, see [batect-wrapper](../batect-wrapper).
 
-## Files searched
+### Files searched
 
 By default, the manager searches for files called `batect.yml` or `batect-bundle.yml`.
 
@@ -26,7 +26,7 @@ For example:
 }
 ```
 
-## Bundle versioning
+### Bundle versioning
 
 This manager assumes that any bundles referenced use tags for versioning, and that these tags use [semver](../../versioning/semver).
 The implementation of semver is strict - versions must follow the `X.Y.Z` or `vX.Y.Z` format.

--- a/lib/manager/batect/types.ts
+++ b/lib/manager/batect/types.ts
@@ -1,7 +1,20 @@
 export interface BatectConfig {
   containers?: Record<string, BatectContainer>;
+  include?: BatectInclude[];
 }
 
 export interface BatectContainer {
   image?: string;
+}
+
+export type BatectInclude = string | BatectFileInclude | BatectGitInclude;
+
+export interface BatectFileInclude {
+  type: 'file';
+}
+
+export interface BatectGitInclude {
+  type: 'git';
+  repo: string;
+  ref: string;
 }


### PR DESCRIPTION
## Changes:

This PR adds support for updating bundle version references in Batect configuration files.

## Context:

This is the third and final PR to implement what is described in #7891. (See #7898 and #7939 for the other PRs.)

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] Unit tests + ran on a real repository

You can test this on [`charleskorn/golang-bundle`](https://github.com/charleskorn/golang-bundle) - it should detect that the `bundle-dev-bundle` and `node-bundle` references in [`batect.yml`](https://github.com/charleskorn/golang-bundle/blob/master/batect.yml) are out of date.