### PR TITLE
fix: migrate packageRules objects to array

### DIFF
--- a/lib/config/migration.spec.ts
+++ b/lib/config/migration.spec.ts
@@ -304,6 +304,23 @@ describe('config/migration', () => {
         migratedConfig.lockFileMaintenance.packageRules[0].respectLatest
       ).toBe(false);
     });
+
+    it('migrates packageRules objects', () => {
+      const config = {
+        packageRules: {
+          packageNames: ['typescript'],
+          updateTypes: ['major'],
+          commitMessage:
+            'fix(package): update peerDependency to accept typescript ^{{newVersion}}',
+        },
+      } as any;
+      const { isMigrated, migratedConfig } = configMigration.migrateConfig(
+        config,
+        defaultConfig
+      );
+      expect(isMigrated).toBe(true);
+      expect(migratedConfig.packageRules).toHaveLength(1);
+    });
     it('migrates node to travis', () => {
       const config: RenovateConfig = {
         node: {

--- a/lib/config/migration.ts
+++ b/lib/config/migration.ts
@@ -109,6 +109,8 @@ export function migrateConfig(
       } else if (parentKey === 'hostRules' && key === 'host') {
         migratedConfig.hostName = val;
         delete migratedConfig.host;
+      } else if (key === 'packageRules' && is.plainObject(val)) {
+        migratedConfig.packageRules = [val];
       } else if (key === 'packageFiles' && is.array(val)) {
         const fileList = [];
         for (const packageFile of val) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Migrates `packageRules` object to array

## Context:

It causes errors otherwise

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
