### PR TITLE
fix(npm): Migrate unpublishSafe presets

### DIFF
--- a/lib/config/migration.spec.ts
+++ b/lib/config/migration.spec.ts
@@ -497,7 +497,7 @@ describe('config/migration', () => {
       res = configMigration.migrateConfig(config);
       expect(res.isMigrated).toBe(true);
       expect(res.migratedConfig).toMatchObject({
-        extends: ['foo', 'npm:unpublishSafe', 'bar', 'npm:unpublishSafe'],
+        extends: ['foo', 'npm:unpublishSafe', 'bar'],
       });
 
       config = {
@@ -507,7 +507,7 @@ describe('config/migration', () => {
       res = configMigration.migrateConfig(config);
       expect(res.isMigrated).toBe(true);
       expect(res.migratedConfig).toMatchObject({
-        extends: ['foo', 'npm:unpublishSafe', 'bar', 'npm:unpublishSafe'],
+        extends: ['foo', 'npm:unpublishSafe', 'bar'],
       });
 
       config = {

--- a/lib/config/migration.spec.ts
+++ b/lib/config/migration.spec.ts
@@ -497,7 +497,7 @@ describe('config/migration', () => {
       res = configMigration.migrateConfig(config);
       expect(res.isMigrated).toBe(true);
       expect(res.migratedConfig).toMatchObject({
-        extends: ['foo', ':unpublishSafe', 'bar', 'npm:unpublishSafe'],
+        extends: ['foo', 'npm:unpublishSafe', 'bar', 'npm:unpublishSafe'],
       });
 
       config = {
@@ -507,7 +507,7 @@ describe('config/migration', () => {
       res = configMigration.migrateConfig(config);
       expect(res.isMigrated).toBe(true);
       expect(res.migratedConfig).toMatchObject({
-        extends: ['foo', 'default:unpublishSafe', 'bar', 'npm:unpublishSafe'],
+        extends: ['foo', 'npm:unpublishSafe', 'bar', 'npm:unpublishSafe'],
       });
 
       config = {

--- a/lib/config/migration.ts
+++ b/lib/config/migration.ts
@@ -241,7 +241,13 @@ export function migrateConfig(
           if (is.string(migratedConfig.extends)) {
             migratedConfig.extends = [migratedConfig.extends];
           }
-          if (!migratedConfig.extends.includes('npm:unpublishSafe')) {
+          if (
+            ![
+              ':unpublishSafe',
+              'default:unpublishSafe',
+              'npm:unpublishSafe',
+            ].some((x) => migratedConfig.extends.includes(x))
+          ) {
             migratedConfig.extends.push('npm:unpublishSafe');
           }
         }

--- a/lib/config/migration.ts
+++ b/lib/config/migration.ts
@@ -227,6 +227,10 @@ export function migrateConfig(
               preset = 'config:js-lib';
             } else if (preset.startsWith(':masterIssue')) {
               preset = preset.replace('masterIssue', 'dependencyDashboard');
+            } else if (
+              [':unpublishSafe', 'default:unpublishSafe'].includes(preset)
+            ) {
+              preset = 'npm:unpublishSafe';
             }
             presets[i] = preset;
           }

--- a/lib/config/presets/internal/default.ts
+++ b/lib/config/presets/internal/default.ts
@@ -584,7 +584,4 @@ export const presets: Record<string, Preset> = {
     description: 'deprecated alias for config:js-lib',
     extends: ['config:js-lib'],
   },
-  unpublishSafe: {
-    extends: ['npm:unpublishSafe'],
-  },
 };


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Migrate presets as well

## Context:

Closes #7982

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
