### PR TITLE
fix(kustomize): handle sha256 digests

### DIFF
--- a/lib/manager/kustomize/__fixtures__/sha.yaml
+++ b/lib/manager/kustomize/__fixtures__/sha.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: hasura
+
+commonLabels:
+  app.kubernetes.io/name: hasura
+
+bases:
+  - ../base/
+
+patchesStrategicMerge:
+  - patches/deployment.yaml
+
+images:
+  - name: postgres
+    newTag: sha256:b0cfe264cb1143c7c660ddfd5c482464997d62d6bc9f97f8fdf3deefce881a8c

--- a/lib/manager/kustomize/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/kustomize/__snapshots__/extract.spec.ts.snap
@@ -42,6 +42,7 @@ Object {
       "currentValue": undefined,
       "datasource": "docker",
       "depName": "postgres",
+      "replaceString": "sha256:b0cfe264cb1143c7c660ddfd5c482464997d62d6bc9f97f8fdf3deefce881a8c",
       "versioning": "docker",
     },
   ],
@@ -90,6 +91,7 @@ Array [
     "currentValue": "v0.1.0",
     "datasource": "docker",
     "depName": "node",
+    "replaceString": "v0.1.0",
     "versioning": "docker",
   },
   Object {
@@ -97,6 +99,7 @@ Array [
     "currentValue": "v0.0.1",
     "datasource": "docker",
     "depName": "group/instance",
+    "replaceString": "v0.0.1",
     "versioning": "docker",
   },
   Object {
@@ -104,6 +107,7 @@ Array [
     "currentValue": "v0.0.2",
     "datasource": "docker",
     "depName": "quay.io/test/repo",
+    "replaceString": "v0.0.2",
     "versioning": "docker",
   },
   Object {
@@ -111,6 +115,7 @@ Array [
     "currentValue": "v0.0.3",
     "datasource": "docker",
     "depName": "gitlab.com/org/suborg/image",
+    "replaceString": "v0.0.3",
     "versioning": "docker",
   },
   Object {
@@ -118,6 +123,7 @@ Array [
     "currentValue": "v0.0.4",
     "datasource": "docker",
     "depName": "but.this.lives.on.local/private-registry",
+    "replaceString": "v0.0.4",
     "versioning": "docker",
   },
 ]

--- a/lib/manager/kustomize/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/kustomize/__snapshots__/extract.spec.ts.snap
@@ -34,6 +34,20 @@ Array [
 ]
 `;
 
+exports[`manager/kustomize/extract extractPackageFile() extracts sha256 instead of tag 1`] = `
+Object {
+  "deps": Array [
+    Object {
+      "currentDigest": "sha256:b0cfe264cb1143c7c660ddfd5c482464997d62d6bc9f97f8fdf3deefce881a8c",
+      "currentValue": undefined,
+      "datasource": "docker",
+      "depName": "postgres",
+      "versioning": "docker",
+    },
+  ],
+}
+`;
+
 exports[`manager/kustomize/extract extractPackageFile() extracts ssh dependency 1`] = `
 Array [
   Object {
@@ -72,30 +86,35 @@ Array [
 exports[`manager/kustomize/extract extractPackageFile() should extract out image versions 1`] = `
 Array [
   Object {
+    "currentDigest": undefined,
     "currentValue": "v0.1.0",
     "datasource": "docker",
     "depName": "node",
     "versioning": "docker",
   },
   Object {
+    "currentDigest": undefined,
     "currentValue": "v0.0.1",
     "datasource": "docker",
     "depName": "group/instance",
     "versioning": "docker",
   },
   Object {
+    "currentDigest": undefined,
     "currentValue": "v0.0.2",
     "datasource": "docker",
     "depName": "quay.io/test/repo",
     "versioning": "docker",
   },
   Object {
+    "currentDigest": undefined,
     "currentValue": "v0.0.3",
     "datasource": "docker",
     "depName": "gitlab.com/org/suborg/image",
     "versioning": "docker",
   },
   Object {
+    "currentDigest": undefined,
     "currentValue": "v0.0.4",
     "datasource": "docker",
     "depName": "but.this.lives.on.local/private-registry",

--- a/lib/manager/kustomize/extract.spec.ts
+++ b/lib/manager/kustomize/extract.spec.ts
@@ -149,8 +149,10 @@ describe('manager/kustomize/extract', () => {
     });
     it('should correctly extract a default image', () => {
       const sample = {
+        currentDigest: undefined,
         currentValue: 'v1.0.0',
         datasource: datasourceDocker.id,
+        replaceString: 'v1.0.0',
         versioning: dockerVersioning.id,
         depName: 'node',
       };
@@ -162,8 +164,10 @@ describe('manager/kustomize/extract', () => {
     });
     it('should correctly extract an image in a repo', () => {
       const sample = {
+        currentDigest: undefined,
         currentValue: 'v1.0.0',
         datasource: datasourceDocker.id,
+        replaceString: 'v1.0.0',
         versioning: dockerVersioning.id,
         depName: 'test/node',
       };
@@ -175,8 +179,10 @@ describe('manager/kustomize/extract', () => {
     });
     it('should correctly extract from a different registry', () => {
       const sample = {
+        currentDigest: undefined,
         currentValue: 'v1.0.0',
         datasource: datasourceDocker.id,
+        replaceString: 'v1.0.0',
         versioning: dockerVersioning.id,
         depName: 'quay.io/repo/image',
       };
@@ -188,9 +194,11 @@ describe('manager/kustomize/extract', () => {
     });
     it('should correctly extract from a different port', () => {
       const sample = {
+        currentDigest: undefined,
         currentValue: 'v1.0.0',
         datasource: datasourceDocker.id,
         versioning: dockerVersioning.id,
+        replaceString: 'v1.0.0',
         depName: 'localhost:5000/repo/image',
       };
       const pkg = extractImage({
@@ -201,7 +209,9 @@ describe('manager/kustomize/extract', () => {
     });
     it('should correctly extract from a multi-depth registry', () => {
       const sample = {
+        currentDigest: undefined,
         currentValue: 'v1.0.0',
+        replaceString: 'v1.0.0',
         datasource: datasourceDocker.id,
         versioning: dockerVersioning.id,
         depName: 'localhost:5000/repo/image/service',

--- a/lib/manager/kustomize/extract.spec.ts
+++ b/lib/manager/kustomize/extract.spec.ts
@@ -50,6 +50,8 @@ const kustomizeDepsInResources = readFileSync(
   'utf8'
 );
 
+const sha = readFileSync('lib/manager/kustomize/__fixtures__/sha.yaml', 'utf8');
+
 describe('manager/kustomize/extract', () => {
   it('should successfully parse a valid kustomize file', () => {
     const file = parseKustomize(kustomizeGitSSHBase);
@@ -259,6 +261,9 @@ describe('manager/kustomize/extract', () => {
       expect(res.deps[0].currentValue).toEqual('v0.0.1');
       expect(res.deps[1].currentValue).toEqual('1.19.0');
       expect(res.deps[1].depName).toEqual('fluxcd/flux');
+    });
+    it('extracts sha256 instead of tag', () => {
+      expect(extractPackageFile(sha)).toMatchSnapshot();
     });
   });
 });

--- a/lib/manager/kustomize/extract.ts
+++ b/lib/manager/kustomize/extract.ts
@@ -48,11 +48,22 @@ export function extractBase(base: string): PackageDependency | null {
 
 export function extractImage(image: Image): PackageDependency | null {
   if (image?.name && image.newTag) {
+    const replaceString = image.newTag;
+    let currentValue;
+    let currentDigest;
+    if (replaceString.startsWith('sha256:')) {
+      currentDigest = replaceString;
+      currentValue = undefined;
+    } else {
+      currentValue = replaceString;
+    }
     return {
       datasource: datasourceDocker.id,
       versioning: dockerVersioning.id,
       depName: image.newName ?? image.name,
-      currentValue: image.newTag,
+      currentValue,
+      currentDigest,
+      replaceString,
     };
   }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds sha256 digest support when extracting kustomize dependencies

## Context:

This scenario would previously cause an error.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
