### PR TITLE
ci: disable macos and use node v14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,9 +12,7 @@ env:
   YARN_MODULES_CACHE_KEY: v1
   YARN_PACKAGE_CACHE_KEY: v1
   YARN_CACHE_FOLDER: .cache/yarn
-  NODE_VERSION: 12
-  # https://github.com/chalk/supports-color/issues/106
-  FORCE_COLOR: true
+  NODE_VERSION: 14
 
 jobs:
   test:
@@ -25,16 +23,17 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [12, ^14.15.0]
+        # disable macos-latest: https://github.com/actions/virtual-environments/issues/2247
+        os: [ubuntu-latest, windows-latest] # macos-latest
+        node-version: [12, 14]
         python-version: [3.8]
         java-version: [8]
         exclude:
           - os: windows-latest
-            node-version: 10
+            node-version: 12
 
     env:
-      coverage: ${{ matrix.os == 'ubuntu-latest' && matrix.node-version == 12 }}
+      coverage: ${{ matrix.os == 'ubuntu-latest' && matrix.node-version == 14 }}
       NODE_VERSION: ${{ matrix.node-version }}
       PYTHON_VERSION: ${{ matrix.python-version }}
       JAVA_VERSION: ${{ matrix.java-version }}
@@ -51,13 +50,13 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Set up Java  ${{ env.JAVA_VERSION }}
-        if: env.NODE_VERSION == '12'
+        if: env.NODE_VERSION == '14'
         uses: actions/setup-java@v1.4.3
         with:
           java-version: ${{ env.JAVA_VERSION }}
 
       - name: Skip Java tests
-        if: env.NODE_VERSION != '12'
+        if: env.NODE_VERSION != '14'
         run: echo "SKIP_JAVA_TESTS=true" >> $GITHUB_ENV
 
       - name: Init platform

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         os: [ubuntu-latest, windows-latest] # macos-latest
         node-version: [12, 14]
         python-version: [3.8]
-        java-version: [8]
+        java-version: [11]
         exclude:
           - os: windows-latest
             node-version: 12

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -7,9 +7,7 @@ env:
   YARN_MODULES_CACHE_KEY: v1
   YARN_PACKAGE_CACHE_KEY: v1
   YARN_CACHE_FOLDER: .cache/yarn
-  NODE_VERSION: 12
-  # https://github.com/chalk/supports-color/issues/106
-  FORCE_COLOR: true
+  NODE_VERSION: 14
 
 jobs:
   release-npm:


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:
- Disable macos tests
- use node v14 by default
- exclude node v12 on windows
- use java v11 for tests
<!-- Describe what this pull request changes. -->

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
