### PR TITLE
fix(gitlab): getBranchPr returned cached results

### DIFF
--- a/lib/platform/gitlab/__snapshots__/index.spec.ts.snap
+++ b/lib/platform/gitlab/__snapshots__/index.spec.ts.snap
@@ -961,7 +961,7 @@ Array [
       "user-agent": "https://github.com/renovatebot/renovate",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/some%2Frepo/merge_requests?per_page=100&state=opened&source_branch=some-branch",
+    "url": "https://gitlab.com/api/v4/projects/some%2Frepo/merge_requests?per_page=100",
   },
 ]
 `;
@@ -1011,7 +1011,7 @@ Array [
       "user-agent": "https://github.com/renovatebot/renovate",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/some%2Frepo/merge_requests?per_page=100&state=opened&source_branch=some-branch",
+    "url": "https://gitlab.com/api/v4/projects/some%2Frepo/merge_requests?per_page=100",
   },
   Object {
     "headers": Object {
@@ -1084,7 +1084,7 @@ Array [
       "user-agent": "https://github.com/renovatebot/renovate",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/some%2Frepo/merge_requests?per_page=100&state=opened&source_branch=some-branch",
+    "url": "https://gitlab.com/api/v4/projects/some%2Frepo/merge_requests?per_page=100",
   },
   Object {
     "headers": Object {
@@ -1157,7 +1157,7 @@ Array [
       "user-agent": "https://github.com/renovatebot/renovate",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/some%2Frepo/merge_requests?per_page=100&state=opened&source_branch=some-branch",
+    "url": "https://gitlab.com/api/v4/projects/some%2Frepo/merge_requests?per_page=100",
   },
   Object {
     "headers": Object {

--- a/lib/platform/gitlab/index.spec.ts
+++ b/lib/platform/gitlab/index.spec.ts
@@ -311,9 +311,7 @@ describe('platform/gitlab', () => {
     it('should return null if no PR exists', async () => {
       const scope = await initRepo();
       scope
-        .get(
-          '/api/v4/projects/some%2Frepo/merge_requests?per_page=100&state=opened&source_branch=some-branch'
-        )
+        .get('/api/v4/projects/some%2Frepo/merge_requests?per_page=100')
         .reply(200, []);
       const pr = await gitlab.getBranchPr('some-branch');
       expect(pr).toBeNull();
@@ -322,12 +320,11 @@ describe('platform/gitlab', () => {
     it('should return the PR object', async () => {
       const scope = await initRepo();
       scope
-        .get(
-          '/api/v4/projects/some%2Frepo/merge_requests?per_page=100&state=opened&source_branch=some-branch'
-        )
+        .get('/api/v4/projects/some%2Frepo/merge_requests?per_page=100')
         .reply(200, [
           {
             iid: 91,
+            title: 'some change',
             source_branch: 'some-branch',
             target_branch: 'master',
             state: 'opened',
@@ -360,12 +357,11 @@ describe('platform/gitlab', () => {
     it('should strip draft prefix from title', async () => {
       const scope = await initRepo();
       scope
-        .get(
-          '/api/v4/projects/some%2Frepo/merge_requests?per_page=100&state=opened&source_branch=some-branch'
-        )
+        .get('/api/v4/projects/some%2Frepo/merge_requests?per_page=100')
         .reply(200, [
           {
             iid: 91,
+            title: 'Draft: some change',
             source_branch: 'some-branch',
             target_branch: 'master',
             state: 'opened',
@@ -398,12 +394,11 @@ describe('platform/gitlab', () => {
     it('should strip deprecated draft prefix from title', async () => {
       const scope = await initRepo();
       scope
-        .get(
-          '/api/v4/projects/some%2Frepo/merge_requests?per_page=100&state=opened&source_branch=some-branch'
-        )
+        .get('/api/v4/projects/some%2Frepo/merge_requests?per_page=100')
         .reply(200, [
           {
             iid: 91,
+            title: 'WIP: some change',
             source_branch: 'some-branch',
             target_branch: 'master',
             state: 'opened',

--- a/lib/platform/gitlab/index.ts
+++ b/lib/platform/gitlab/index.ts
@@ -607,33 +607,39 @@ export function getPrBody(input: string): string {
 
 // Branch
 
+function matchesState(state: string, desiredState: string): boolean {
+  if (desiredState === PrState.All) {
+    return true;
+  }
+  if (desiredState.startsWith('!')) {
+    return state !== desiredState.substring(1);
+  }
+  return state === desiredState;
+}
+
+export async function findPr({
+  branchName,
+  prTitle,
+  state = PrState.All,
+}: FindPRConfig): Promise<Pr> {
+  logger.debug(`findPr(${branchName}, ${prTitle}, ${state})`);
+  const prList = await getPrList();
+  return prList.find(
+    (p: { sourceBranch: string; title: string; state: string }) =>
+      p.sourceBranch === branchName &&
+      (!prTitle || p.title === prTitle) &&
+      matchesState(p.state, state)
+  );
+}
+
 // Returns the Pull Request for a branch. Null if not exists.
 export async function getBranchPr(branchName: string): Promise<Pr> {
   logger.debug(`getBranchPr(${branchName})`);
-  // istanbul ignore if
-  if (!git.branchExists(branchName)) {
-    return null;
-  }
-  const query = new URLSearchParams({
-    per_page: '100',
-    state: 'opened',
-    source_branch: branchName,
-  }).toString();
-  const urlString = `projects/${config.repository}/merge_requests?${query}`;
-  const res = await gitlabApi.getJson<{ source_branch: string }[]>(urlString, {
-    paginate: true,
+  const existingPr = await findPr({
+    branchName,
+    state: PrState.Open,
   });
-  logger.debug(`Got res with ${res.body.length} results`);
-  let pr: any = null;
-  res.body.forEach((result) => {
-    if (result.source_branch === branchName) {
-      pr = result;
-    }
-  });
-  if (!pr) {
-    return null;
-  }
-  return getPr(pr.iid);
+  return existingPr ? getPr(existingPr.number) : null;
 }
 
 export async function getBranchStatusCheck(
@@ -997,31 +1003,6 @@ export async function ensureCommentRemoval({
   if (commentId) {
     await deleteComment(issueNo, commentId);
   }
-}
-
-function matchesState(state: string, desiredState: string): boolean {
-  if (desiredState === PrState.All) {
-    return true;
-  }
-  if (desiredState.startsWith('!')) {
-    return state !== desiredState.substring(1);
-  }
-  return state === desiredState;
-}
-
-export async function findPr({
-  branchName,
-  prTitle,
-  state = PrState.All,
-}: FindPRConfig): Promise<Pr> {
-  logger.debug(`findPr(${branchName}, ${prTitle}, ${state})`);
-  const prList = await getPrList();
-  return prList.find(
-    (p: { sourceBranch: string; title: string; state: string }) =>
-      p.sourceBranch === branchName &&
-      (!prTitle || p.title === prTitle) &&
-      matchesState(p.state, state)
-  );
 }
 
 export function getVulnerabilityAlerts(): Promise<VulnerabilityAlert[]> {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:
Use same `getBranchPr` implementation as on other platforms which fixes a caching issue.
<!-- Describe what this pull request changes. -->

## Context:

Before renovate used `getBranchPr` to check if an pr exists. so if the pr is cretaed after that call, the dashboard call would use the cached result and don't find the new created pr.

See #83 for initial implementation.
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
