### PR TITLE
refactor(workers): Use limiting API for PRs instead of in-place counters

### DIFF
--- a/lib/workers/branch/index.ts
+++ b/lib/workers/branch/index.ts
@@ -30,6 +30,7 @@ import {
 import { regEx } from '../../util/regex';
 import * as template from '../../util/template';
 import { BranchConfig, PrResult, ProcessBranchResult } from '../common';
+import { Limit, isLimitReached } from '../global/limits';
 import { checkAutoMerge, ensurePr, getPlatformPrOptions } from '../pr';
 import { tryBranchAutomerge } from './automerge';
 import { prAlreadyExisted } from './check-existing';
@@ -60,9 +61,7 @@ async function deleteBranchSilently(branchName: string): Promise<void> {
 }
 
 export async function processBranch(
-  branchConfig: BranchConfig,
-  prLimitReached?: boolean,
-  commitLimitReached?: boolean
+  branchConfig: BranchConfig
 ): Promise<ProcessBranchResult> {
   const config: BranchConfig = { ...branchConfig };
   const dependencies = config.upgrades
@@ -153,7 +152,7 @@ export async function processBranch(
     }
     if (
       !branchExists &&
-      prLimitReached &&
+      isLimitReached(Limit.PullRequests) &&
       !dependencyDashboardCheck &&
       !config.vulnerabilityAlert
     ) {
@@ -161,7 +160,7 @@ export async function processBranch(
       return ProcessBranchResult.PrLimitReached;
     }
     if (
-      commitLimitReached &&
+      isLimitReached(Limit.Commits) &&
       !dependencyDashboardCheck &&
       !config.vulnerabilityAlert
     ) {
@@ -583,7 +582,7 @@ export async function processBranch(
     logger.debug(
       `There are ${config.errors.length} errors and ${config.warnings.length} warnings`
     );
-    const { prResult: result, pr } = await ensurePr(config, prLimitReached);
+    const { prResult: result, pr } = await ensurePr(config);
     if (result === PrResult.LimitReached) {
       logger.debug('Reached PR limit - skipping PR creation');
       return ProcessBranchResult.PrLimitReached;

--- a/lib/workers/global/limits.ts
+++ b/lib/workers/global/limits.ts
@@ -2,6 +2,7 @@ import { logger } from '../../logger';
 
 export enum Limit {
   Commits = 'Commits',
+  PullRequests = 'PullRequests',
 }
 
 interface LimitValue {

--- a/lib/workers/pr/index.spec.ts
+++ b/lib/workers/pr/index.spec.ts
@@ -4,6 +4,7 @@ import { PLATFORM_TYPE_GITLAB } from '../../constants/platforms';
 import { Pr, platform as _platform } from '../../platform';
 import { BranchStatus } from '../../types';
 import { BranchConfig, PrResult } from '../common';
+import * as _limits from '../global/limits';
 import * as _changelogHelper from './changelog';
 import { getChangeLogJSON } from './changelog';
 import * as codeOwners from './code-owners';
@@ -14,10 +15,12 @@ const changelogHelper = mocked(_changelogHelper);
 const gitlabChangelogHelper = mocked(_changelogHelper);
 const platform = mocked(_platform);
 const defaultConfig = getConfig();
+const limits = mocked(_limits);
 
 jest.mock('../../util/git');
 jest.mock('./changelog');
 jest.mock('./code-owners');
+jest.mock('../global/limits');
 
 function setupChangelogMock() {
   changelogHelper.getChangeLogJSON = jest.fn();
@@ -268,7 +271,8 @@ describe('workers/pr', () => {
       config.prCreation = 'status-success';
       config.automerge = true;
       config.schedule = ['before 5am'];
-      const { prResult } = await prWorker.ensurePr(config, true);
+      limits.isLimitReached.mockReturnValueOnce(true);
+      const { prResult } = await prWorker.ensurePr(config);
       expect(prResult).toEqual(PrResult.LimitReached);
       expect(platform.createPr.mock.calls).toBeEmpty();
     });
@@ -278,13 +282,11 @@ describe('workers/pr', () => {
       config.prCreation = 'status-success';
       config.automerge = true;
       config.schedule = ['before 5am'];
-      const { prResult } = await prWorker.ensurePr(
-        {
-          ...config,
-          dependencyDashboardChecks: { 'renovate/dummy-1.x': 'true' },
-        },
-        true
-      );
+      limits.isLimitReached.mockReturnValueOnce(true);
+      const { prResult } = await prWorker.ensurePr({
+        ...config,
+        dependencyDashboardChecks: { 'renovate/dummy-1.x': 'true' },
+      });
       expect(prResult).toEqual(PrResult.Created);
       expect(platform.createPr).toHaveBeenCalled();
     });

--- a/lib/workers/pr/index.ts
+++ b/lib/workers/pr/index.ts
@@ -15,6 +15,7 @@ import {
   isBranchModified,
 } from '../../util/git';
 import { BranchConfig, PrResult } from '../common';
+import { Limit, isLimitReached } from '../global/limits';
 import { getPrBody } from './body';
 import { ChangeLogError } from './changelog';
 import { codeOwnersForPr } from './code-owners';
@@ -114,8 +115,7 @@ export function getPlatformPrOptions(
 
 // Ensures that PR exists with matching title/body
 export async function ensurePr(
-  prConfig: BranchConfig,
-  prLimitReached?: boolean
+  prConfig: BranchConfig
 ): Promise<{
   prResult: PrResult;
   pr?: Pr;
@@ -381,7 +381,7 @@ export async function ensurePr(
         logger.info('DRY-RUN: Would create PR: ' + prTitle);
         pr = { number: 0, displayNumber: 'Dry run PR' } as never;
       } else {
-        if (!dependencyDashboardCheck && prLimitReached) {
+        if (!dependencyDashboardCheck && isLimitReached(Limit.PullRequests)) {
           return { prResult: PrResult.LimitReached };
         }
         pr = await platform.createPr({

--- a/lib/workers/repository/process/write.ts
+++ b/lib/workers/repository/process/write.ts
@@ -59,14 +59,13 @@ export async function writeUpdates(
       incLimitedValue(Limit.PullRequests);
     }
     // istanbul ignore if
-    if (
+    else if (
       res === ProcessBranchResult.Automerged &&
       branch.automergeType === 'pr-comment' &&
       branch.requiredStatusChecks === null
     ) {
       incLimitedValue(Limit.PullRequests);
-    }
-    if (
+    } else if (
       res === ProcessBranchResult.Pending &&
       !branchExisted &&
       branchExists(branch.branchName)

--- a/lib/workers/repository/process/write.ts
+++ b/lib/workers/repository/process/write.ts
@@ -5,7 +5,7 @@ import { PrState } from '../../../types';
 import { branchExists } from '../../../util/git';
 import { processBranch } from '../../branch';
 import { BranchConfig, ProcessBranchResult } from '../../common';
-import { Limit, isLimitReached } from '../../global/limits';
+import { Limit, incLimitedValue, setMaxLimit } from '../../global/limits';
 import { getPrsRemaining } from './limits';
 
 export type WriteUpdateResult = 'done' | 'automerged';
@@ -39,15 +39,14 @@ export async function writeUpdates(
     }
     return true;
   });
-  let prsRemaining = await getPrsRemaining(config, branches);
+  const prsRemaining = await getPrsRemaining(config, branches);
   logger.debug({ prsRemaining }, 'Calculated maximum PRs remaining this run');
+  setMaxLimit(Limit.PullRequests, prsRemaining);
   for (const branch of branches) {
     addMeta({ branch: branch.branchName });
-    const prLimitReached = prsRemaining <= 0;
-    const commitLimitReached = isLimitReached(Limit.Commits);
     const branchExisted = branchExists(branch.branchName);
     const prExisted = await prExists(branch.branchName);
-    const res = await processBranch(branch, prLimitReached, commitLimitReached);
+    const res = await processBranch(branch);
     branch.res = res;
     if (
       res === ProcessBranchResult.Automerged &&
@@ -56,9 +55,8 @@ export async function writeUpdates(
       // Stop processing other branches because base branch has been changed
       return 'automerged';
     }
-    let deductPrRemainingCount = 0;
     if (res === ProcessBranchResult.PrCreated) {
-      deductPrRemainingCount = 1;
+      incLimitedValue(Limit.PullRequests);
     }
     // istanbul ignore if
     if (
@@ -66,24 +64,19 @@ export async function writeUpdates(
       branch.automergeType === 'pr-comment' &&
       branch.requiredStatusChecks === null
     ) {
-      deductPrRemainingCount = 1;
+      incLimitedValue(Limit.PullRequests);
     }
     if (
       res === ProcessBranchResult.Pending &&
       !branchExisted &&
       branchExists(branch.branchName)
     ) {
-      deductPrRemainingCount = 1;
+      incLimitedValue(Limit.PullRequests);
     }
     // istanbul ignore if
-    if (
-      deductPrRemainingCount === 0 &&
-      !prExisted &&
-      (await prExists(branch.branchName))
-    ) {
-      deductPrRemainingCount = 1;
+    else if (!prExisted && (await prExists(branch.branchName))) {
+      incLimitedValue(Limit.PullRequests);
     }
-    prsRemaining -= deductPrRemainingCount;
   }
   removeMeta(['branch']);
   return 'done';


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Use counter API from `workers/global/limits.ts` instead of ad-hoc counting.

## Context:

Part of #7198

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
