### PR TITLE
fix(gitlab): getJsonFile must URL encode filename

### DIFF
--- a/lib/platform/gitlab/__snapshots__/index.spec.ts.snap
+++ b/lib/platform/gitlab/__snapshots__/index.spec.ts.snap
@@ -1465,7 +1465,7 @@ Array [
       "user-agent": "https://github.com/renovatebot/renovate",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/some%2Frepo/repository/files/file.json?ref=master",
+    "url": "https://gitlab.com/api/v4/projects/some%2Frepo/repository/files/dir%2Ffile.json?ref=master",
   },
 ]
 `;

--- a/lib/platform/gitlab/index.spec.ts
+++ b/lib/platform/gitlab/index.spec.ts
@@ -1407,12 +1407,12 @@ These updates have all been created already. Click a checkbox below to force a r
       const scope = await initRepo();
       scope
         .get(
-          '/api/v4/projects/some%2Frepo/repository/files/file.json?ref=master'
+          '/api/v4/projects/some%2Frepo/repository/files/dir%2Ffile.json?ref=master'
         )
         .reply(200, {
           content: Buffer.from(JSON.stringify(data)).toString('base64'),
         });
-      const res = await gitlab.getJsonFile('file.json');
+      const res = await gitlab.getJsonFile('dir/file.json');
       expect(res).toEqual(data);
       expect(httpMock.getTrace()).toMatchSnapshot();
     });

--- a/lib/platform/gitlab/index.ts
+++ b/lib/platform/gitlab/index.ts
@@ -137,11 +137,12 @@ function urlEscape(str: string): string {
 
 export async function getJsonFile(fileName: string): Promise<any | null> {
   try {
+    const escapedFileName = urlEscape(fileName);
     return JSON.parse(
       Buffer.from(
         (
           await gitlabApi.getJson<{ content: string }>(
-            `projects/${config.repository}/repository/files/${fileName}?ref=${config.defaultBranch}`
+            `projects/${config.repository}/repository/files/${escapedFileName}?ref=${config.defaultBranch}`
           )
         ).body.content,
         'base64'


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Fix GitLab getJsonFile to URL encode file_name

## Context:

GitLab expect file_name to be URL encoded while getJsonFile doesn't.

https://docs.gitlab.com/ee/api/repository_files.html#get-file-from-repository

See #8032 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
