### PR TITLE
fix(auto-replace): should fail on wrong replace

### DIFF
--- a/lib/workers/branch/auto-replace.spec.ts
+++ b/lib/workers/branch/auto-replace.spec.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'upath';
 import { defaultConfig } from '../../../test/util';
+import { WORKER_FILE_UPDATE_FAILED } from '../../constants/error-messages';
 import { extractPackageFile } from '../../manager/html';
 import { BranchUpgradeConfig } from '../common';
 import { doAutoReplace } from './auto-replace';
@@ -140,6 +141,24 @@ describe('workers/branch/auto-replace', () => {
         '{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}';
       const res = await doAutoReplace(upgrade, dockerfile, reuseExistingBranch);
       expect(res).toMatchSnapshot();
+    });
+    it('fails with oldversion in depname', async () => {
+      const yml =
+        'image: "1111111111.dkr.ecr.us-east-1.amazonaws.com/my-repository:1"\n\n';
+      upgrade.manager = 'regex';
+      upgrade.depName =
+        '1111111111.dkr.ecr.us-east-1.amazonaws.com/my-repository';
+      upgrade.currentValue = '1';
+      upgrade.newValue = '42';
+      upgrade.depIndex = 0;
+      upgrade.replaceString =
+        'image: "1111111111.dkr.ecr.us-east-1.amazonaws.com/my-repository:1"\n\n';
+      upgrade.packageFile = 'k8s/base/defaults.yaml';
+      upgrade.matchStrings = [
+        'image:\\s*\\\'?\\"?(?<depName>[^:]+):(?<currentValue>[^\\s\\\'\\"]+)\\\'?\\"?\\s*',
+      ];
+      const res = doAutoReplace(upgrade, yml, reuseExistingBranch);
+      await expect(res).rejects.toThrow(WORKER_FILE_UPDATE_FAILED);
     });
   });
 });

--- a/lib/workers/branch/auto-replace.ts
+++ b/lib/workers/branch/auto-replace.ts
@@ -37,7 +37,7 @@ export async function confirmIfDepUpdated(
     logger.debug({ manager, packageFile }, 'No newUpgrade');
     return false;
   }
-  // istanbul ignore if
+
   if (upgrade.depName !== newUpgrade.depName) {
     logger.debug(
       {
@@ -48,6 +48,7 @@ export async function confirmIfDepUpdated(
       },
       'depName mismatch'
     );
+    return false;
   }
   if (newUpgrade.currentValue !== newValue) {
     logger.debug(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

There was a missing return and a missing test, so renovate auto-replace suggested an invalid update if the `depName` contains the `currentValue`.
<!-- Describe what this pull request changes. -->

## Context:
ref #8061 (only partial fix)
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
