### PR TITLE
fix(regex-manager): copy templates for auto-replace

### DIFF
--- a/lib/manager/regex/__snapshots__/index.spec.ts.snap
+++ b/lib/manager/regex/__snapshots__/index.spec.ts.snap
@@ -90,6 +90,7 @@ Object {
   "matchStrings": Array [
     "ENV .*?_VERSION=(?<currentValue>.*) # (?<datasource>.*?)/(?<depName>[^&]*?)(\\\\&versioning=(?<versioning>[^&]*?))?\\\\s",
   ],
+  "versioningTemplate": "{{#if versioning}}{{versioning}}{{else}}semver{{/if}}",
 }
 `;
 
@@ -117,11 +118,13 @@ Object {
     "ENV GRADLE_VERSION=(?<currentValue>.*) # (?<datasource>.*?)/(?<depName>.*?)(\\\\&versioning=(?<versioning>.*?))?\\\\s",
     "ENV NODE_VERSION=(?<currentValue>.*) # (?<datasource>.*?)/(?<depName>.*?)(\\\\&versioning=(?<versioning>.*?))?\\\\s",
   ],
+  "versioningTemplate": "{{#if versioning}}{{versioning}}{{else}}semver{{/if}}",
 }
 `;
 
 exports[`manager/regex/index extracts registryUrl 1`] = `
 Object {
+  "datasourceTemplate": "helm",
   "deps": Array [
     Object {
       "currentValue": "8.12.13",
@@ -149,6 +152,7 @@ Object {
 
 exports[`manager/regex/index extracts with combination strategy 1`] = `
 Object {
+  "datasourceTemplate": "docker",
   "deps": Array [
     Object {
       "currentValue": "v2.21.0",
@@ -167,6 +171,7 @@ Object {
 
 exports[`manager/regex/index extracts with combination strategy and multiple matches 1`] = `
 Object {
+  "datasourceTemplate": "docker",
   "deps": Array [
     Object {
       "currentValue": "0.12.0",

--- a/lib/manager/regex/index.ts
+++ b/lib/manager/regex/index.ts
@@ -139,7 +139,7 @@ export function extractPackageFile(
   packageFile: string,
   config: CustomExtractConfig
 ): Result<PackageFile | null> {
-  let deps;
+  let deps: PackageDependency[];
   switch (config.matchStringsStrategy) {
     default:
     case 'any':
@@ -156,17 +156,17 @@ export function extractPackageFile(
   // filter all null values
   deps = deps.filter(Boolean);
   if (deps.length) {
+    const res: PackageFile = { deps, matchStrings: config.matchStrings };
     if (config.matchStringsStrategy) {
-      return {
-        deps,
-        matchStrings: config.matchStrings,
-        matchStringsStrategy: config.matchStringsStrategy,
-      };
+      res.matchStringsStrategy = config.matchStringsStrategy;
     }
-    return {
-      deps,
-      matchStrings: config.matchStrings,
-    };
+    // copy over templates for autoreplace
+    for (const field of validMatchFields.map((f) => `${f}Template`)) {
+      if (config[field]) {
+        res[field] = config[field];
+      }
+    }
+    return res;
   }
 
   return null;

--- a/lib/workers/branch/auto-replace.ts
+++ b/lib/workers/branch/auto-replace.ts
@@ -38,7 +38,7 @@ export async function confirmIfDepUpdated(
     return false;
   }
 
-  if (newUpgrade.depName && upgrade.depName !== newUpgrade.depName) {
+  if (upgrade.depName !== newUpgrade.depName) {
     logger.debug(
       {
         manager,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:
regression of #8062, regex manager templates needs to be preserved
<!-- Describe what this pull request changes. -->

## Context:
#8062, #8061
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
