### PR TITLE
fix(helm-datasource): wrong commitMessageTopic template

### DIFF
--- a/lib/datasource/helm/index.ts
+++ b/lib/datasource/helm/index.ts
@@ -19,7 +19,7 @@ export const registryStrategy = 'first';
 
 export const defaultConfig = {
   additionalBranchPrefix: 'helm-',
-  commitMessageTopic: 'Helm release {{depNameShort}}',
+  commitMessageTopic: 'Helm release {{depName}}',
   group: {
     commitMessageTopic: '{{{groupName}}} Helm releases',
   },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:
Use `depName` instead of `depNameSort` for `commitMessageTopic` template.

<!-- Describe what this pull request changes. -->

## Context:
fixes #8071
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
