### PR TITLE
fix(kustomize): don’t pin digests

### DIFF
--- a/lib/manager/kustomize/index.ts
+++ b/lib/manager/kustomize/index.ts
@@ -2,4 +2,5 @@ export { extractPackageFile } from './extract';
 
 export const defaultConfig = {
   fileMatch: ['(^|/)kustomization\\.yaml'],
+  pinDigests: false,
 };


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Removes digests pinning from kustomize updates.

## Context:

This scenario currently fails. Also see #8089

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
