### PR TITLE
refactor: remove manager from PackageFile

### DIFF
--- a/lib/manager/common.ts
+++ b/lib/manager/common.ts
@@ -90,7 +90,6 @@ export interface PackageFile<T = Record<string, any>>
   ignoreNpmrcFile?: boolean;
   lernaClient?: string;
   lernaPackages?: string[];
-  manager?: string;
   mavenProps?: Record<string, any>;
   npmrc?: string;
   packageFile?: string;

--- a/lib/workers/repository/extract/__snapshots__/manager-files.spec.ts.snap
+++ b/lib/workers/repository/extract/__snapshots__/manager-files.spec.ts.snap
@@ -45,7 +45,6 @@ Array [
         "replaceString": "abc",
       },
     ],
-    "manager": "html",
     "packageFile": "Dockerfile",
   },
 ]

--- a/lib/workers/repository/extract/manager-files.ts
+++ b/lib/workers/repository/extract/manager-files.ts
@@ -60,7 +60,6 @@ export async function getManagerPackageFiles(
         }
         packageFiles.push({
           packageFile,
-          manager,
           ...res,
         });
       }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Removes `manager` from `PackageFile` interface.

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
