### PR TITLE
fix(gradle-lite): Use "url" and "uri" interchangeably for registryUrls

### DIFF
--- a/lib/manager/gradle-lite/parser.spec.ts
+++ b/lib/manager/gradle-lite/parser.spec.ts
@@ -41,6 +41,12 @@ describe('manager/gradle-lite/parser', () => {
 
     ({ urls } = parseGradle('url("https://example.com")'));
     expect(urls).toStrictEqual(['https://example.com']);
+
+    ({ urls } = parseGradle('uri "https://example.com"'));
+    expect(urls).toStrictEqual(['https://example.com']);
+
+    ({ urls } = parseGradle('uri("https://example.com")'));
+    expect(urls).toStrictEqual(['https://example.com']);
   });
   it('parses long form deps', () => {
     let deps;

--- a/lib/manager/gradle-lite/parser.ts
+++ b/lib/manager/gradle-lite/parser.ts
@@ -299,7 +299,7 @@ const matcherConfigs: SyntaxMatchConfig[] = [
   {
     // url 'https://repo.spring.io/snapshot/'
     matchers: [
-      { matchType: TokenType.Word, matchValue: 'url' },
+      { matchType: TokenType.Word, matchValue: ['uri', 'url'] },
       { matchType: TokenType.String, tokenMapKey: 'registryUrl' },
       endOfInstruction,
     ],
@@ -308,7 +308,7 @@ const matcherConfigs: SyntaxMatchConfig[] = [
   {
     // url('https://repo.spring.io/snapshot/')
     matchers: [
-      { matchType: TokenType.Word, matchValue: 'url' },
+      { matchType: TokenType.Word, matchValue: ['uri', 'url'] },
       { matchType: TokenType.LeftParen },
       { matchType: TokenType.String, tokenMapKey: 'registryUrl' },
       { matchType: TokenType.RightParen },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Extends `gradle-lite` parsing

## Context:

https://github.com/renovatebot/renovate/discussions/8104#discussioncomment-234517

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
