### PR TITLE
chore: redirect security vulnerabilities to email

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,6 +3,8 @@ name: Bug report
 about: You've found a bug with Renovate
 ---
 
+<!-- Do not use this form to report security vulnerabilities. Instead please send an email to renovate-disclosure@whitesourcesoftware.com describing what you have found. Please do not raise an issue in this repository or publicize your concern in any other forum without giving us adequate time to investigate first. -->
+
 **What Renovate type, platform and version are you using?**
 
 <!-- Tell us if you're using the hosted App, or if you are self-hosted Renovate yourself. Platform too (GitHub, GitLab, etc) plus which version of Renovate if you're self-hosted. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,10 @@ name: Bug report
 about: You've found a bug with Renovate
 ---
 
-<!-- Do not use this form to report security vulnerabilities. Instead please send an email to renovate-disclosure@whitesourcesoftware.com describing what you have found. Please do not raise an issue in this repository or publicize your concern in any other forum without giving us adequate time to investigate first. -->
+<!-- 
+      PLEASE DO NOT REPORT ANY SECURITY CONCERNS THIS WAY
+      Email renovate-disclosure@whitesourcesoftware.com instead.
+-->
 
 **What Renovate type, platform and version are you using?**
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: You've found a bug with Renovate
 ---
 
-<!-- 
+<!--
       PLEASE DO NOT REPORT ANY SECURITY CONCERNS THIS WAY
       Email renovate-disclosure@whitesourcesoftware.com instead.
 -->


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what this pull request changes. -->

- Add Markdown comment to redirect potential security bugs to email instead

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

I think it's good to make sure bug reporters know that they should not use the bug report template for security concerns.
A bug reporter might miss the section "Report a security vulnerability" from the New issue part of GitHub.

This PR adds a Markdown comment, but we can also use a checkbox or line like this in the visible text:

```markdown
- [ ] This is not a security concern, please read the [security policy](https://github.com/renovatebot/renovate/security/policy) for security concerns
```

Closes #8119.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
