### PR TITLE
fix(pipenv): Specify `Pipfile` location while executing `pipenv lock`

### DIFF
--- a/lib/manager/pipenv/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/manager/pipenv/__snapshots__/artifacts.spec.ts.snap
@@ -27,6 +27,7 @@ Array [
         "NO_PROXY": "localhost",
         "PATH": "/tmp/path",
         "PIPENV_CACHE_DIR": "/tmp/renovate/cache/others/pipenv",
+        "PIPENV_PIPFILE": "Pipfile",
       },
       "maxBuffer": 10485760,
       "timeout": 900000,
@@ -51,6 +52,7 @@ Array [
         "NO_PROXY": "localhost",
         "PATH": "/tmp/path",
         "PIPENV_CACHE_DIR": "/tmp/renovate/cache/others/pipenv",
+        "PIPENV_PIPFILE": "Pipfile",
       },
       "maxBuffer": 10485760,
       "timeout": 900000,
@@ -75,6 +77,7 @@ Array [
         "NO_PROXY": "localhost",
         "PATH": "/tmp/path",
         "PIPENV_CACHE_DIR": "/tmp/renovate/cache/others/pipenv",
+        "PIPENV_PIPFILE": "Pipfile",
       },
       "maxBuffer": 10485760,
       "timeout": 900000,
@@ -99,6 +102,7 @@ Array [
         "NO_PROXY": "localhost",
         "PATH": "/tmp/path",
         "PIPENV_CACHE_DIR": "/tmp/renovate/cache/others/pipenv",
+        "PIPENV_PIPFILE": "Pipfile",
       },
       "maxBuffer": 10485760,
       "timeout": 900000,
@@ -122,7 +126,7 @@ Array [
     },
   },
   Object {
-    "cmd": "docker run --rm --name=renovate_python --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -v \\"/tmp/renovate/cache/others/pipenv\\":\\"/tmp/renovate/cache/others/pipenv\\" -e PIPENV_CACHE_DIR -w \\"/tmp/github/some/repo\\" renovate/python:latest bash -l -c \\"pip install --user pipenv && pipenv lock\\"",
+    "cmd": "docker run --rm --name=renovate_python --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -v \\"/tmp/renovate/cache/others/pipenv\\":\\"/tmp/renovate/cache/others/pipenv\\" -e PIPENV_CACHE_DIR -e PIPENV_PIPFILE -w \\"/tmp/github/some/repo\\" renovate/python:latest bash -l -c \\"pip install --user pipenv && pipenv lock\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -135,6 +139,7 @@ Array [
         "NO_PROXY": "localhost",
         "PATH": "/tmp/path",
         "PIPENV_CACHE_DIR": "/tmp/renovate/cache/others/pipenv",
+        "PIPENV_PIPFILE": "Pipfile",
       },
       "maxBuffer": 10485760,
       "timeout": 900000,
@@ -142,6 +147,7 @@ Array [
   },
 ]
 `;
+
 exports[`.updateArtifacts() uses pipenv version from Pipfile 1`] = `
 Array [
   Object {
@@ -157,7 +163,7 @@ Array [
     },
   },
   Object {
-    "cmd": "docker run --rm --name=renovate_python --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -v \\"/tmp/renovate/cache/others/pipenv\\":\\"/tmp/renovate/cache/others/pipenv\\" -e PIPENV_CACHE_DIR -w \\"/tmp/github/some/repo\\" renovate/python bash -l -c \\"pip install --user pipenv==2020.8.13 && pipenv lock\\"",
+    "cmd": "docker run --rm --name=renovate_python --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -v \\"/tmp/renovate/cache/others/pipenv\\":\\"/tmp/renovate/cache/others/pipenv\\" -e PIPENV_CACHE_DIR -e PIPENV_PIPFILE -w \\"/tmp/github/some/repo\\" renovate/python bash -l -c \\"pip install --user pipenv==2020.8.13 && pipenv lock\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -170,6 +176,7 @@ Array [
         "NO_PROXY": "localhost",
         "PATH": "/tmp/path",
         "PIPENV_CACHE_DIR": "/tmp/renovate/cache/others/pipenv",
+        "PIPENV_PIPFILE": "Pipfile",
       },
       "maxBuffer": 10485760,
       "timeout": 900000,
@@ -177,6 +184,7 @@ Array [
   },
 ]
 `;
+
 exports[`.updateArtifacts() uses pipenv version from Pipfile dev packages 1`] = `
 Array [
   Object {
@@ -192,7 +200,7 @@ Array [
     },
   },
   Object {
-    "cmd": "docker run --rm --name=renovate_python --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -v \\"/tmp/renovate/cache/others/pipenv\\":\\"/tmp/renovate/cache/others/pipenv\\" -e PIPENV_CACHE_DIR -w \\"/tmp/github/some/repo\\" renovate/python bash -l -c \\"pip install --user pipenv==2020.8.13 && pipenv lock\\"",
+    "cmd": "docker run --rm --name=renovate_python --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -v \\"/tmp/renovate/cache/others/pipenv\\":\\"/tmp/renovate/cache/others/pipenv\\" -e PIPENV_CACHE_DIR -e PIPENV_PIPFILE -w \\"/tmp/github/some/repo\\" renovate/python bash -l -c \\"pip install --user pipenv==2020.8.13 && pipenv lock\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -205,6 +213,7 @@ Array [
         "NO_PROXY": "localhost",
         "PATH": "/tmp/path",
         "PIPENV_CACHE_DIR": "/tmp/renovate/cache/others/pipenv",
+        "PIPENV_PIPFILE": "Pipfile",
       },
       "maxBuffer": 10485760,
       "timeout": 900000,
@@ -212,6 +221,7 @@ Array [
   },
 ]
 `;
+
 exports[`.updateArtifacts() uses pipenv version from config 1`] = `
 Array [
   Object {
@@ -227,7 +237,7 @@ Array [
     },
   },
   Object {
-    "cmd": "docker run --rm --name=renovate_python --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -v \\"/tmp/renovate/cache/others/pipenv\\":\\"/tmp/renovate/cache/others/pipenv\\" -e PIPENV_CACHE_DIR -w \\"/tmp/github/some/repo\\" renovate/python bash -l -c \\"pip install --user pipenv==2020.1.1 && pipenv lock\\"",
+    "cmd": "docker run --rm --name=renovate_python --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -v \\"/tmp/renovate/cache/others/pipenv\\":\\"/tmp/renovate/cache/others/pipenv\\" -e PIPENV_CACHE_DIR -e PIPENV_PIPFILE -w \\"/tmp/github/some/repo\\" renovate/python bash -l -c \\"pip install --user pipenv==2020.1.1 && pipenv lock\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -240,6 +250,7 @@ Array [
         "NO_PROXY": "localhost",
         "PATH": "/tmp/path",
         "PIPENV_CACHE_DIR": "/tmp/renovate/cache/others/pipenv",
+        "PIPENV_PIPFILE": "Pipfile",
       },
       "maxBuffer": 10485760,
       "timeout": 900000,

--- a/lib/manager/pipenv/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/manager/pipenv/__snapshots__/artifacts.spec.ts.snap
@@ -27,7 +27,6 @@ Array [
         "NO_PROXY": "localhost",
         "PATH": "/tmp/path",
         "PIPENV_CACHE_DIR": "/tmp/renovate/cache/others/pipenv",
-        "PIPENV_PIPFILE": "Pipfile",
       },
       "maxBuffer": 10485760,
       "timeout": 900000,
@@ -52,7 +51,6 @@ Array [
         "NO_PROXY": "localhost",
         "PATH": "/tmp/path",
         "PIPENV_CACHE_DIR": "/tmp/renovate/cache/others/pipenv",
-        "PIPENV_PIPFILE": "Pipfile",
       },
       "maxBuffer": 10485760,
       "timeout": 900000,
@@ -77,7 +75,6 @@ Array [
         "NO_PROXY": "localhost",
         "PATH": "/tmp/path",
         "PIPENV_CACHE_DIR": "/tmp/renovate/cache/others/pipenv",
-        "PIPENV_PIPFILE": "Pipfile",
       },
       "maxBuffer": 10485760,
       "timeout": 900000,
@@ -102,7 +99,6 @@ Array [
         "NO_PROXY": "localhost",
         "PATH": "/tmp/path",
         "PIPENV_CACHE_DIR": "/tmp/renovate/cache/others/pipenv",
-        "PIPENV_PIPFILE": "Pipfile",
       },
       "maxBuffer": 10485760,
       "timeout": 900000,
@@ -126,7 +122,7 @@ Array [
     },
   },
   Object {
-    "cmd": "docker run --rm --name=renovate_python --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -v \\"/tmp/renovate/cache/others/pipenv\\":\\"/tmp/renovate/cache/others/pipenv\\" -e PIPENV_CACHE_DIR -e PIPENV_PIPFILE -w \\"/tmp/github/some/repo\\" renovate/python:latest bash -l -c \\"pip install --user pipenv && pipenv lock\\"",
+    "cmd": "docker run --rm --name=renovate_python --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -v \\"/tmp/renovate/cache/others/pipenv\\":\\"/tmp/renovate/cache/others/pipenv\\" -e PIPENV_CACHE_DIR -w \\"/tmp/github/some/repo\\" renovate/python:latest bash -l -c \\"pip install --user pipenv && pipenv lock\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -139,7 +135,6 @@ Array [
         "NO_PROXY": "localhost",
         "PATH": "/tmp/path",
         "PIPENV_CACHE_DIR": "/tmp/renovate/cache/others/pipenv",
-        "PIPENV_PIPFILE": "Pipfile",
       },
       "maxBuffer": 10485760,
       "timeout": 900000,
@@ -163,7 +158,7 @@ Array [
     },
   },
   Object {
-    "cmd": "docker run --rm --name=renovate_python --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -v \\"/tmp/renovate/cache/others/pipenv\\":\\"/tmp/renovate/cache/others/pipenv\\" -e PIPENV_CACHE_DIR -e PIPENV_PIPFILE -w \\"/tmp/github/some/repo\\" renovate/python bash -l -c \\"pip install --user pipenv==2020.8.13 && pipenv lock\\"",
+    "cmd": "docker run --rm --name=renovate_python --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -v \\"/tmp/renovate/cache/others/pipenv\\":\\"/tmp/renovate/cache/others/pipenv\\" -e PIPENV_CACHE_DIR -w \\"/tmp/github/some/repo\\" renovate/python bash -l -c \\"pip install --user pipenv==2020.8.13 && pipenv lock\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -176,7 +171,6 @@ Array [
         "NO_PROXY": "localhost",
         "PATH": "/tmp/path",
         "PIPENV_CACHE_DIR": "/tmp/renovate/cache/others/pipenv",
-        "PIPENV_PIPFILE": "Pipfile",
       },
       "maxBuffer": 10485760,
       "timeout": 900000,
@@ -200,7 +194,7 @@ Array [
     },
   },
   Object {
-    "cmd": "docker run --rm --name=renovate_python --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -v \\"/tmp/renovate/cache/others/pipenv\\":\\"/tmp/renovate/cache/others/pipenv\\" -e PIPENV_CACHE_DIR -e PIPENV_PIPFILE -w \\"/tmp/github/some/repo\\" renovate/python bash -l -c \\"pip install --user pipenv==2020.8.13 && pipenv lock\\"",
+    "cmd": "docker run --rm --name=renovate_python --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -v \\"/tmp/renovate/cache/others/pipenv\\":\\"/tmp/renovate/cache/others/pipenv\\" -e PIPENV_CACHE_DIR -w \\"/tmp/github/some/repo\\" renovate/python bash -l -c \\"pip install --user pipenv==2020.8.13 && pipenv lock\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -213,7 +207,6 @@ Array [
         "NO_PROXY": "localhost",
         "PATH": "/tmp/path",
         "PIPENV_CACHE_DIR": "/tmp/renovate/cache/others/pipenv",
-        "PIPENV_PIPFILE": "Pipfile",
       },
       "maxBuffer": 10485760,
       "timeout": 900000,
@@ -237,7 +230,7 @@ Array [
     },
   },
   Object {
-    "cmd": "docker run --rm --name=renovate_python --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -v \\"/tmp/renovate/cache/others/pipenv\\":\\"/tmp/renovate/cache/others/pipenv\\" -e PIPENV_CACHE_DIR -e PIPENV_PIPFILE -w \\"/tmp/github/some/repo\\" renovate/python bash -l -c \\"pip install --user pipenv==2020.1.1 && pipenv lock\\"",
+    "cmd": "docker run --rm --name=renovate_python --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -v \\"/tmp/renovate/cache/others/pipenv\\":\\"/tmp/renovate/cache/others/pipenv\\" -e PIPENV_CACHE_DIR -w \\"/tmp/github/some/repo\\" renovate/python bash -l -c \\"pip install --user pipenv==2020.1.1 && pipenv lock\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -250,7 +243,6 @@ Array [
         "NO_PROXY": "localhost",
         "PATH": "/tmp/path",
         "PIPENV_CACHE_DIR": "/tmp/renovate/cache/others/pipenv",
-        "PIPENV_PIPFILE": "Pipfile",
       },
       "maxBuffer": 10485760,
       "timeout": 900000,

--- a/lib/manager/pipenv/artifacts.ts
+++ b/lib/manager/pipenv/artifacts.ts
@@ -90,7 +90,7 @@ export async function updateArtifacts({
     if (config.isLockFileMaintenance) {
       await deleteLocalFile(lockFileName);
     }
-    const cmd = 'pipenv lock';
+    const cmd = `PIPENV_PIPFILE=${pipfileName} pipenv lock`;
     const tagConstraint = getPythonConstraint(existingLockFileContent, config);
     const pipenvConstraint = getPipenvConstraint(
       existingLockFileContent,

--- a/lib/manager/pipenv/artifacts.ts
+++ b/lib/manager/pipenv/artifacts.ts
@@ -90,7 +90,7 @@ export async function updateArtifacts({
     if (config.isLockFileMaintenance) {
       await deleteLocalFile(lockFileName);
     }
-    const cmd = `PIPENV_PIPFILE=${pipfileName} pipenv lock`;
+    const cmd = 'pipenv lock';
     const tagConstraint = getPythonConstraint(existingLockFileContent, config);
     const pipenvConstraint = getPipenvConstraint(
       existingLockFileContent,
@@ -99,6 +99,7 @@ export async function updateArtifacts({
     const execOptions: ExecOptions = {
       extraEnv: {
         PIPENV_CACHE_DIR: cacheDir,
+        PIPENV_PIPFILE: pipfileName,
       },
       docker: {
         image: 'renovate/python',

--- a/lib/manager/pipenv/artifacts.ts
+++ b/lib/manager/pipenv/artifacts.ts
@@ -97,9 +97,9 @@ export async function updateArtifacts({
       config
     );
     const execOptions: ExecOptions = {
+      cwdFile: pipfileName,
       extraEnv: {
         PIPENV_CACHE_DIR: cacheDir,
-        PIPENV_PIPFILE: pipfileName,
       },
       docker: {
         image: 'renovate/python',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

As the summary says, this change adds the `PIPENV_PIPFILE` environment variable to specify `Pipfile` location while executing `pipenv lock`. So that Renovate can update `Pipfile.lock` files under sub-directories.

<!-- Describe what this pull request changes. -->

## Context:

Fixes https://github.com/renovatebot/renovate/issues/8134.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

I haven't added a new unit test because I am not familiar with jest. Will have a look at it later if this change makes sense to reviewers.

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
