### PR TITLE
docs: Update error message in local dev instructions

### DIFF
--- a/docs/development/local-development.md
+++ b/docs/development/local-development.md
@@ -87,7 +87,7 @@ To ensure everything is working properly on your end, you must:
 1. Install all dependencies with `yarn install`
 1. Make a build with `yarn build`, which should pass with no errors
 1. Verify all tests pass and have 100% test coverage, by running `yarn test`
-1. Verify the installation by running `yarn start`. You must see this error: `Fatal error: No authentication found for platform https://api.github.com/ (github)`
+1. Verify the installation by running `yarn start`. You must see this error: `You must configure a GitHub personal access token`
 
 You only need to do these 5 steps this one time.
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Updates the error message in the local development instructions.

## Context:

When setting up my local copy of Renovate, I noticed that the error message on the instructions didn't match the message I got.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
