### PR TITLE
fix: add sbt latest.integration workaround

### DIFF
--- a/lib/config/presets/internal/workarounds.ts
+++ b/lib/config/presets/internal/workarounds.ts
@@ -7,6 +7,7 @@ export const presets: Record<string, Preset> = {
     ],
     extends: [
       'workarounds:mavenCommonsAncientVersion',
+      'workarounds:ignoreSbtLatestIntegration',
       'workarounds:ignoreSpringCloudNumeric',
     ],
   },
@@ -16,6 +17,16 @@ export const presets: Record<string, Preset> = {
         datasources: ['maven', 'sbt-package'],
         packagePatterns: ['^commons-'],
         allowedVersions: '!/^200\\d{5}(\\.\\d+)?/',
+      },
+    ],
+  },
+  ignoreSbtLatestIntegration: {
+    description: 'Do not upgrade sbt latest.integration',
+    packageRules: [
+      {
+        managers: ['sbt'],
+        matchCurrentVersion: '/^latest\\.integration$/',
+        enabled: false,
       },
     ],
   },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds a workaround to not update sbt `latest.integration`

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

#8208

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
