### PR TITLE
feat: suppress onboarding preset warning

### DIFF
--- a/lib/workers/repository/onboarding/branch/config.spec.ts
+++ b/lib/workers/repository/onboarding/branch/config.spec.ts
@@ -1,9 +1,9 @@
 import { RenovateConfig, getConfig } from '../../../../../test/util';
-import * as presets from '../../../../config/presets';
+import * as presets from '../../../../config/presets/local';
 import { PRESET_DEP_NOT_FOUND } from '../../../../config/presets/util';
 import { getOnboardingConfig } from './config';
 
-jest.mock('../../../../config/presets');
+jest.mock('../../../../config/presets/local');
 
 const mockedPresets = presets as jest.Mocked<typeof presets>;
 
@@ -47,6 +47,14 @@ describe('workers/repository/onboarding/branch', () => {
     it('ignores an unknown error', async () => {
       mockedPresets.getPreset.mockRejectedValue(
         new Error('unknown error for test')
+      );
+      onboardingConfig = await getOnboardingConfig(config);
+      expect(mockedPresets.getPreset).toHaveBeenCalledTimes(2);
+      expect(JSON.parse(onboardingConfig)).toEqual(config.onboardingConfig);
+    });
+    it('ignores unsupported platform', async () => {
+      mockedPresets.getPreset.mockRejectedValue(
+        new Error(`Unsupported platform 'dummy' for local preset.`)
       );
       onboardingConfig = await getOnboardingConfig(config);
       expect(mockedPresets.getPreset).toHaveBeenCalledTimes(2);

--- a/lib/workers/repository/onboarding/branch/config.ts
+++ b/lib/workers/repository/onboarding/branch/config.ts
@@ -1,5 +1,5 @@
 import { RenovateConfig } from '../../../../config';
-import { getPreset } from '../../../../config/presets';
+import { getPreset } from '../../../../config/presets/local';
 import { PRESET_DEP_NOT_FOUND } from '../../../../config/presets/util';
 import { logger } from '../../../../logger';
 import { clone } from '../../../../util/clone';
@@ -19,11 +19,14 @@ export async function getOnboardingConfig(
 
   // Check for org/renovate-config
   try {
-    const orgRenovateConfig = `local>${orgName}/renovate-config`;
-    await getPreset(orgRenovateConfig, config);
-    orgPreset = orgRenovateConfig;
+    const packageName = `${orgName}/renovate-config`;
+    await getPreset({ packageName, baseConfig: config });
+    orgPreset = `local>${packageName}`;
   } catch (err) {
-    if (err.message !== PRESET_DEP_NOT_FOUND) {
+    if (
+      err.message !== PRESET_DEP_NOT_FOUND &&
+      !err.message.startsWith('Unsupported platform')
+    ) {
       logger.warn({ err }, 'Unknown error fetching default owner preset');
     }
   }
@@ -31,11 +34,19 @@ export async function getOnboardingConfig(
   if (!orgPreset) {
     // Check for org/.{{platform}}
     try {
-      const orgDotPlatformConfig = `local>${orgName}/.${config.platform}:renovate-config`;
-      await getPreset(orgDotPlatformConfig, config);
-      orgPreset = orgDotPlatformConfig;
+      const packageName = `${orgName}/.${config.platform}`;
+      const presetName = 'renovate-config';
+      await getPreset({
+        packageName,
+        presetName,
+        baseConfig: config,
+      });
+      orgPreset = `local>${packageName}:${presetName}`;
     } catch (err) {
-      if (err.message !== PRESET_DEP_NOT_FOUND) {
+      if (
+        err.message !== PRESET_DEP_NOT_FOUND &&
+        !err.message.startsWith('Unsupported platform')
+      ) {
         logger.warn({ err }, 'Unknown error fetching default owner preset');
       }
     }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Instead calling normal `getPreset` function renovate onboarding config now calls local `getPreset` function. So the unsupported platform warnings are now suppressed.
<!-- Describe what this pull request changes. -->

## Context:
closes #8213 

ref #7448
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
