### PR TITLE
fix(nvm): do not attempt to pin node digest for nvm

### DIFF
--- a/lib/manager/nvm/index.ts
+++ b/lib/manager/nvm/index.ts
@@ -8,4 +8,5 @@ export const language = LANGUAGE_NODE;
 export const defaultConfig = {
   fileMatch: ['(^|/)\\.nvmrc$'],
   versioning: nodeVersioning.id,
+  pinDigests: false,
 };


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

* Adds `pinDigests:false` to default configuration for the nvm manager. This option was failing for nvm because `getDigest` for git-tags datasource assumes that the tags will be in the same format as the version string, but nvm allows for the node version to be specified _with or without_ the preceding `v` character (and the node versioning will always strip the `v` character regardless). The `pinDigests` option is never required for nvm since the `.nvmrc` file does not use a digest for version locking.

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

Closes #8206 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
