### PR TITLE
fix: wrong code quoting

### DIFF
--- a/lib/workers/repository/error-config.ts
+++ b/lib/workers/repository/error-config.ts
@@ -14,7 +14,7 @@ export async function raiseConfigWarningIssue(
   }
   body += `Error type: ${error.validationError}\n`;
   if (error.validationMessage) {
-    body += `Message: \`${error.validationMessage?.replaceAll('`', "'")}\`\n`;
+    body += `Message: \`${error.validationMessage.replace(/`/g, "'")}\`\n`;
   }
   const pr = await platform.getBranchPr(config.onboardingBranch);
   if (pr?.state === PrState.Open) {

--- a/lib/workers/repository/error-config.ts
+++ b/lib/workers/repository/error-config.ts
@@ -14,7 +14,7 @@ export async function raiseConfigWarningIssue(
   }
   body += `Error type: ${error.validationError}\n`;
   if (error.validationMessage) {
-    body += `Message: \`${error.validationMessage}\`\n`;
+    body += `Message: \`${error.validationMessage.replaceAll('`', "'")}\`\n`;
   }
   const pr = await platform.getBranchPr(config.onboardingBranch);
   if (pr?.state === PrState.Open) {

--- a/lib/workers/repository/error-config.ts
+++ b/lib/workers/repository/error-config.ts
@@ -14,7 +14,7 @@ export async function raiseConfigWarningIssue(
   }
   body += `Error type: ${error.validationError}\n`;
   if (error.validationMessage) {
-    body += `Message: \`${error.validationMessage.replaceAll('`', "'")}\`\n`;
+    body += `Message: \`${error.validationMessage?.replaceAll('`', "'")}\`\n`;
   }
   const pr = await platform.getBranchPr(config.onboardingBranch);
   if (pr?.state === PrState.Open) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:
Replace  backtick with single quote in error issue body, otherwise the formating is wrong:
![image](https://user-images.githubusercontent.com/1798109/103981614-74ac9d80-5182-11eb-8692-2b6518864b46.png)

<!-- Describe what this pull request changes. -->

## Context:
renovatebot/helm-charts#94
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
