### PR TITLE
feat: added flag toggle between force push and delete and push for br…

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -1978,6 +1978,12 @@ Configure this to `true` if you wish to receive one PR for every separate major 
 e.g. if you are on webpack@v1 currently then default behavior is a PR for upgrading to webpack@v3 and not for webpack@v2.
 If this setting is true then you would get one PR for webpack@v2 and one for webpack@v3.
 
+## shouldUseForcePush
+
+Configure this to `false` to change branch push behavior from using force push to deleting the branch (if it exists) and repushing.
+This is generally reserved for environments where force push has been disabled. This will cause open pull requests for
+the deleted branch to be closed.
+
 ## stabilityDays
 
 If this is configured to a non-zero value, and an update has a release date/timestamp available, then Renovate will check if the configured "stability days" have elapsed.

--- a/lib/config/common.ts
+++ b/lib/config/common.ts
@@ -178,6 +178,8 @@ export interface RenovateConfig
 
   repoIsOnboarded?: boolean;
 
+  shouldUseForcePush?: boolean;
+
   updateType?: UpdateType;
 
   warnings?: ValidationMessage[];

--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -987,6 +987,13 @@ const options: RenovateOptions[] = [
     default: false,
   },
   {
+    name: 'shouldUseForcePush',
+    description:
+      'If set to false, branches will be deleted and repushed in order to be updated. Open pull requests will be closed.',
+    type: 'boolean',
+    default: true,
+  },
+  {
     name: 'ignoreUnstable',
     description: 'Ignore versions with unstable semver',
     stage: 'package',

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -182,6 +182,7 @@ describe('platform/git', () => {
         branchName: 'renovate/branch_with_changes',
         files: [file],
         message: 'Create something',
+        shouldUseForcePush: true,
       });
       const branchFiles = await git.getBranchFiles(
         'renovate/branch_with_changes'
@@ -234,7 +235,7 @@ describe('platform/git', () => {
       expect(await git.getFile('some-path', 'some-branch')).toBeNull();
     });
   });
-  describe('commitFiles({branchName, files, message})', () => {
+  describe('commitFiles({branchName, files, message, shouldUseForcePush})', () => {
     it('creates file', async () => {
       const file = {
         name: 'some-new-file',
@@ -244,6 +245,20 @@ describe('platform/git', () => {
         branchName: 'renovate/past_branch',
         files: [file],
         message: 'Create something',
+        shouldUseForcePush: true,
+      });
+      expect(commit).not.toBeNull();
+    });
+    it('creates file when shouldUseForcePush is false', async () => {
+      const file = {
+        name: 'some-new-file',
+        contents: 'some new-contents',
+      };
+      const commit = await git.commitFiles({
+        branchName: 'renovate/past_branch',
+        files: [file],
+        message: 'Create something',
+        shouldUseForcePush: false,
       });
       expect(commit).not.toBeNull();
     });
@@ -256,6 +271,7 @@ describe('platform/git', () => {
         branchName: 'renovate/something',
         files: [file],
         message: 'Delete something',
+        shouldUseForcePush: true,
       });
       expect(commit).not.toBeNull();
     });
@@ -274,6 +290,7 @@ describe('platform/git', () => {
         branchName: 'renovate/something',
         files,
         message: 'Update something',
+        shouldUseForcePush: true,
       });
       expect(commit).not.toBeNull();
     });
@@ -288,6 +305,7 @@ describe('platform/git', () => {
         branchName: 'renovate/something',
         files,
         message: 'Update something',
+        shouldUseForcePush: true,
       });
       expect(commit).not.toBeNull();
     });
@@ -304,6 +322,7 @@ describe('platform/git', () => {
         branchName,
         files,
         message: 'Update something',
+        shouldUseForcePush: true,
       });
       expect(commit).toBeNull();
     });

--- a/lib/workers/branch/__snapshots__/commit.spec.ts.snap
+++ b/lib/workers/branch/__snapshots__/commit.spec.ts.snap
@@ -13,6 +13,7 @@ Array [
       ],
       "force": false,
       "message": "some commit message",
+      "shouldUseForcePush": true,
     },
   ],
 ]

--- a/lib/workers/branch/commit.ts
+++ b/lib/workers/branch/commit.ts
@@ -48,5 +48,6 @@ export function commitFilesToBranch(
     files: updatedFiles,
     message: config.commitMessage,
     force: !!config.forceCommit,
+    shouldUseForcePush: config.shouldUseForcePush,
   });
 }

--- a/lib/workers/common.ts
+++ b/lib/workers/common.ts
@@ -111,6 +111,8 @@ export interface BranchConfig
   forceCommit?: boolean;
   rebaseRequested?: boolean;
 
+  shouldUseForcePush?: boolean;
+
   res?: ProcessBranchResult;
   upgrades: BranchUpgradeConfig[];
   packageFiles?: Record<string, PackageFile[]>;

--- a/lib/workers/repository/onboarding/branch/create.spec.ts
+++ b/lib/workers/repository/onboarding/branch/create.spec.ts
@@ -23,6 +23,7 @@ const buildExpectedCommitFilesArgument = (
     },
   ],
   message,
+  shouldUseForcePush: true,
 });
 
 describe('workers/repository/onboarding/branch', () => {

--- a/lib/workers/repository/onboarding/branch/create.ts
+++ b/lib/workers/repository/onboarding/branch/create.ts
@@ -56,5 +56,6 @@ export async function createOnboardingBranch(
       },
     ],
     message: commitMessage,
+    shouldUseForcePush: config.shouldUseForcePush,
   });
 }

--- a/lib/workers/repository/onboarding/branch/rebase.ts
+++ b/lib/workers/repository/onboarding/branch/rebase.ts
@@ -67,5 +67,6 @@ export async function rebaseOnboardingBranch(
       },
     ],
     message: commitMessage,
+    shouldUseForcePush: config.shouldUseForcePush,
   });
 }

--- a/lib/workers/repository/process/write.ts
+++ b/lib/workers/repository/process/write.ts
@@ -46,6 +46,9 @@ export async function writeUpdates(
     addMeta({ branch: branch.branchName });
     const branchExisted = branchExists(branch.branchName);
     const prExisted = await prExists(branch.branchName);
+
+    branch.shouldUseForcePush = config.shouldUseForcePush;
+
     const res = await processBranch(branch);
     branch.res = res;
     if (


### PR DESCRIPTION
…anch updates (#5718)

## Changes:

Add a new config option to change branches uploads from force push to delete and push.

## Context:
Since force push can be blocked in many enterprises, this update enables a delete and push in lieu of a force push to mitigate that challenge. 

## Documentation (please check one with an [x])

- [X] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [X] Newly added unit tests, or
- [X] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
