### PR TITLE
feat(onboarding): Onboard with autodetected semanticCommits option

### DIFF
--- a/lib/workers/repository/onboarding/branch/config.spec.ts
+++ b/lib/workers/repository/onboarding/branch/config.spec.ts
@@ -75,6 +75,8 @@ describe('workers/repository/onboarding/branch', () => {
       expect(JSON.parse(onboardingConfig).semanticCommits).toBeUndefined();
     });
     it('does not set semanticCommits if already enabled', async () => {
+      mockedSemantic.detectSemanticCommits.mockReset();
+      mockedSemantic.detectSemanticCommits.mockResolvedValueOnce('enabled');
       onboardingConfig = await getOnboardingConfig({
         ...config,
         semanticCommits: 'enabled',
@@ -82,16 +84,11 @@ describe('workers/repository/onboarding/branch', () => {
       expect(JSON.parse(onboardingConfig).semanticCommits).toBeUndefined();
     });
     it('does not set semanticCommits if already disabled', async () => {
+      mockedSemantic.detectSemanticCommits.mockReset();
+      mockedSemantic.detectSemanticCommits.mockResolvedValueOnce('enabled');
       onboardingConfig = await getOnboardingConfig({
         ...config,
         semanticCommits: 'disabled',
-      });
-      expect(JSON.parse(onboardingConfig).semanticCommits).toBeUndefined();
-    });
-    it('does not set semanticCommits if already set to auto', async () => {
-      onboardingConfig = await getOnboardingConfig({
-        ...config,
-        semanticCommits: 'auto',
       });
       expect(JSON.parse(onboardingConfig).semanticCommits).toBeUndefined();
     });

--- a/lib/workers/repository/onboarding/branch/config.ts
+++ b/lib/workers/repository/onboarding/branch/config.ts
@@ -11,7 +11,7 @@ export async function getOnboardingConfig(
   let onboardingConfig = clone(config.onboardingConfig);
 
   if (
-    typeof onboardingConfig.semanticCommits === 'undefined' &&
+    config.semanticCommits === 'auto' &&
     (await detectSemanticCommits()) === 'enabled'
   ) {
     onboardingConfig.semanticCommits = 'enabled';

--- a/lib/workers/repository/onboarding/branch/config.ts
+++ b/lib/workers/repository/onboarding/branch/config.ts
@@ -3,11 +3,19 @@ import { getPreset } from '../../../../config/presets/local';
 import { PRESET_DEP_NOT_FOUND } from '../../../../config/presets/util';
 import { logger } from '../../../../logger';
 import { clone } from '../../../../util/clone';
+import { detectSemanticCommits } from '../../init/semantic';
 
 export async function getOnboardingConfig(
   config: RenovateConfig
 ): Promise<string> {
   let onboardingConfig = clone(config.onboardingConfig);
+
+  if (
+    typeof onboardingConfig.semanticCommits === 'undefined' &&
+    (await detectSemanticCommits()) === 'enabled'
+  ) {
+    onboardingConfig.semanticCommits = 'enabled';
+  }
 
   let orgPreset: string;
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds `semanticCommits` option set to `enabled` in Onboarding PR when appropriate

## Context:

Closes #2591

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
