### PR TITLE
feat(monorepo): add aws-sdk-js-v3

### DIFF
--- a/lib/config/presets/internal/monorepo.ts
+++ b/lib/config/presets/internal/monorepo.ts
@@ -16,6 +16,7 @@ const repoGroups = {
   'aspnet AspNetWebStack': 'https://github.com/aspnet/AspNetWebStack',
   'aspnet Extensions': 'https://github.com/aspnet/Extensions',
   'aws-cdk': 'https://github.com/aws/aws-cdk',
+  'aws-sdk-js-v3': 'https://github.com/aws/aws-sdk-js-v3',
   'azure azure-libraries-for-net':
     'https://github.com/Azure/azure-libraries-for-net',
   'azure azure-sdk-for-net': 'https://github.com/Azure/azure-sdk-for-net',


### PR DESCRIPTION
## Changes:

This adds https://github.com/aws/aws-sdk-js-v3 as a monorepo.

## Context:

AWS SDK v3 is a rewrite and the significant change is that they are now providing one package per client: https://aws.amazon.com/blogs/developer/modular-aws-sdk-for-javascript-is-now-generally-available/

## Documentation

- [x] No documentation update is required

## How I've tested my work

I have verified these changes via:

- [x] Code inspection only