### PR TITLE
fix(github-actions): escape forward slash in fileMatch

### DIFF
--- a/lib/manager/github-actions/index.ts
+++ b/lib/manager/github-actions/index.ts
@@ -6,5 +6,5 @@ const language = LANGUAGE_DOCKER;
 export { extractPackageFile, language };
 
 export const defaultConfig = {
-  fileMatch: ['^\\.github/workflows/[^/]+\\.ya?ml$'],
+  fileMatch: ['^\\.github\\/workflows\\/[^/]+\\.ya?ml$'],
 };


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Simply escape forward slashed in `fileMatch`
<!-- Describe what this pull request changes. -->

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
