### PR TITLE
fix(gradle-lite): Upgrade deps in reverse order for grouped dependencies

### DIFF
--- a/lib/manager/gradle-lite/extract.ts
+++ b/lib/manager/gradle-lite/extract.ts
@@ -13,6 +13,21 @@ import {
   toAbsolutePath,
 } from './utils';
 
+// Enables reverse sorting in generateBranchConfig()
+//
+// Required for grouped dependencies to be upgraded
+// correctly in single branch.
+//
+// https://github.com/renovatebot/renovate/issues/8224
+function elevateFileReplacePositionField(
+  deps: PackageDependency<ManagerData>[]
+): PackageDependency<ManagerData>[] {
+  return deps.map((dep) => ({
+    ...dep,
+    fileReplacePosition: dep?.managerData?.fileReplacePosition,
+  }));
+}
+
 export async function extractAllPackageFiles(
   config: ExtractConfig,
   packageFiles: string[]
@@ -57,7 +72,7 @@ export async function extractAllPackageFiles(
     return null;
   }
 
-  extractedDeps.forEach((dep) => {
+  elevateFileReplacePositionField(extractedDeps).forEach((dep) => {
     const key = dep.managerData.packageFile;
     const pkgFile: PackageFile = packageFilesByName[key];
     const { deps } = pkgFile;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Copy `fileReplacePosition` from `managerData`, so it will be recognized by mechanism we recently used for this problem in other Maven-based managers.

## Context:

Closes #8224

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] ~~Unit tests~~ + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
