### PR TITLE
fix(gradle-lite): Parse default registry urls configured explicitly

### DIFF
--- a/lib/manager/gradle-lite/common.ts
+++ b/lib/manager/gradle-lite/common.ts
@@ -1,5 +1,9 @@
 import { PackageDependency } from '../common';
 
+export { MAVEN_REPO } from '../../datasource/maven/common';
+
+export const JCENTER_REPO = 'https://jcenter.bintray.com/';
+
 export interface ManagerData {
   fileReplacePosition: number;
   packageFile?: string;

--- a/lib/manager/gradle-lite/common.ts
+++ b/lib/manager/gradle-lite/common.ts
@@ -3,6 +3,7 @@ import { PackageDependency } from '../common';
 export { MAVEN_REPO } from '../../datasource/maven/common';
 
 export const JCENTER_REPO = 'https://jcenter.bintray.com/';
+export const GOOGLE_REPO = 'https://dl.google.com/android/maven2/';
 
 export interface ManagerData {
   fileReplacePosition: number;

--- a/lib/manager/gradle-lite/parser.spec.ts
+++ b/lib/manager/gradle-lite/parser.spec.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'fs';
 import path from 'path';
-import { JCENTER_REPO, MAVEN_REPO } from './common';
+import { GOOGLE_REPO, JCENTER_REPO, MAVEN_REPO } from './common';
 import { parseGradle, parseProps } from './parser';
 
 function getGradleFile(fileName: string): string {
@@ -47,12 +47,13 @@ describe('manager/gradle-lite/parser', () => {
     expect(urls).toStrictEqual(['https://example.com']);
 
     ({ urls } = parseGradle(
-      'mavenCentral(); uri("https://example.com"); jcenter();'
+      'mavenCentral(); uri("https://example.com"); jcenter(); google();'
     ));
     expect(urls).toStrictEqual([
       MAVEN_REPO,
       'https://example.com',
       JCENTER_REPO,
+      GOOGLE_REPO,
     ]);
   });
   it('parses long form deps', () => {

--- a/lib/manager/gradle-lite/parser.spec.ts
+++ b/lib/manager/gradle-lite/parser.spec.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'fs';
 import path from 'path';
+import { JCENTER_REPO, MAVEN_REPO } from './common';
 import { parseGradle, parseProps } from './parser';
 
 function getGradleFile(fileName: string): string {
@@ -45,8 +46,14 @@ describe('manager/gradle-lite/parser', () => {
     ({ urls } = parseGradle('uri "https://example.com"'));
     expect(urls).toStrictEqual(['https://example.com']);
 
-    ({ urls } = parseGradle('uri("https://example.com")'));
-    expect(urls).toStrictEqual(['https://example.com']);
+    ({ urls } = parseGradle(
+      'mavenCentral(); uri("https://example.com"); jcenter();'
+    ));
+    expect(urls).toStrictEqual([
+      MAVEN_REPO,
+      'https://example.com',
+      JCENTER_REPO,
+    ]);
   });
   it('parses long form deps', () => {
     let deps;

--- a/lib/manager/gradle-lite/parser.ts
+++ b/lib/manager/gradle-lite/parser.ts
@@ -4,6 +4,8 @@ import { logger } from '../../logger';
 import { regEx } from '../../util/regex';
 import { PackageDependency } from '../common';
 import {
+  JCENTER_REPO,
+  MAVEN_REPO,
   ManagerData,
   PackageVariables,
   StringInterpolation,
@@ -295,6 +297,26 @@ const matcherConfigs: SyntaxMatchConfig[] = [
       endOfInstruction,
     ],
     handler: processPlugin,
+  },
+  {
+    // mavenCentral()
+    matchers: [
+      { matchType: TokenType.Word, matchValue: 'mavenCentral' },
+      { matchType: TokenType.LeftParen },
+      { matchType: TokenType.RightParen },
+      endOfInstruction,
+    ],
+    handler: () => ({ urls: [MAVEN_REPO] }),
+  },
+  {
+    // jcenter()
+    matchers: [
+      { matchType: TokenType.Word, matchValue: 'jcenter' },
+      { matchType: TokenType.LeftParen },
+      { matchType: TokenType.RightParen },
+      endOfInstruction,
+    ],
+    handler: () => ({ urls: [JCENTER_REPO] }),
   },
   {
     // url 'https://repo.spring.io/snapshot/'


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Parse `mavenCentral()`, `jcenter()` and `google()` as well as custom registry urls.

## Context:

Closes #8128

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
