### PR TITLE
fix(pep440): correct supportedRangeStrategies

### DIFF
--- a/lib/versioning/pep440/index.ts
+++ b/lib/versioning/pep440/index.ts
@@ -7,7 +7,7 @@ export const id = 'pep440';
 export const displayName = 'PEP440';
 export const urls = ['https://www.python.org/dev/peps/pep-0440/'];
 export const supportsRanges = true;
-export const supportedRangeStrategies = ['bump', 'extend', 'pin', 'replace'];
+export const supportedRangeStrategies = ['pin', 'replace'];
 
 const {
   compare: sortVersions,

--- a/lib/versioning/pep440/range.ts
+++ b/lib/versioning/pep440/range.ts
@@ -64,7 +64,7 @@ export function getNewValue({
       return currentValue;
     }
   }
-  if (!['replace', 'bump'].includes(rangeStrategy)) {
+  if (!['extend', 'bump'].includes(rangeStrategy)) {
     logger.debug(
       'Unsupported rangeStrategy: ' +
         rangeStrategy +


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Corrects the list of supported range strategies for pep440

## Context:

Discovered when testing why pep440 + bump doesn't work

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
