### PR TITLE
fix(sbt): Ignore http4s digest-based milestone releases

### DIFF
--- a/lib/config/presets/internal/workarounds.ts
+++ b/lib/config/presets/internal/workarounds.ts
@@ -9,6 +9,7 @@ export const presets: Record<string, Preset> = {
       'workarounds:mavenCommonsAncientVersion',
       'workarounds:ignoreSbtLatestIntegration',
       'workarounds:ignoreSpringCloudNumeric',
+      'workarounds:ignoreHttp4sDigestMilestones',
     ],
   },
   mavenCommonsAncientVersion: {
@@ -37,6 +38,16 @@ export const presets: Record<string, Preset> = {
         datasources: ['maven'],
         packageNames: ['org.springframework.cloud:spring-cloud-starter-parent'],
         allowedVersions: '/^[A-Z]/',
+      },
+    ],
+  },
+  ignoreHttp4sDigestMilestones: {
+    description: 'Ignore http4s digest-based 1.x milestones',
+    packageRules: [
+      {
+        managers: ['sbt'],
+        packagePatterns: ['^org\\.http4s:'],
+        allowedVersions: `!/^1\\.0-\\d+-[a-fA-F0-9]{7}$/`,
       },
     ],
   },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Add workaround preset which ignores versions like `1.0-2-1e49ccf`.

I'm not sure, maybe it's standard feature for `Ivy` versioning. In this case, we may want to extend the whole versioning scheme. But I found nothing about this in documentation.

## Context:

Closes #8162

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] ~~Unit tests~~ + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
