### PR TITLE
docs: add duplicate label to issue labeling guide

### DIFF
--- a/docs/development/issue-labeling.md
+++ b/docs/development/issue-labeling.md
@@ -132,6 +132,7 @@ Apply these labels when somebody opens a `feature` type issue requesting a new d
     help wanted
     reproduced
     reproduction needed
+    duplicate
 
 </details>
 
@@ -142,6 +143,8 @@ Add the label `help wanted` to indicate that we need the original poster or some
 
 Add a label `reproduction needed` if nobody's reproduced it in a public repo yet and such a reproduction is necessary before further work can be done.
 Add the label `reproduced` once there is a public reproduction.
+
+Add a label `duplicate` to issues/PRs that are a duplicate of an earlier issue/PR.
 
 ### Self hosted
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what this pull request changes. -->

- Add `duplicate` label to issue labeling guide in the "housekeeping" section

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

@rarkins proposed adding a new `duplicate` label to the repository when we discussed the triage guide I'm making at PR #8268.
This PR adds the proposed label to the docs.

Somebody with the proper rights would still need to add the label, as I cannot create new labels on this repository. 😄 

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
