### PR TITLE
fix: cleanSimpleHtml function regexp greedyness (issue #8285)

### DIFF
--- a/lib/datasource/pypi/index.ts
+++ b/lib/datasource/pypi/index.ts
@@ -172,11 +172,11 @@ function cleanSimpleHtml(html: string): string {
       .replace(/<\/?pre>/, '')
       // Certain simple repositories like artifactory don't escape > and <
       .replace(
-        /data-requires-python="(.*?)>(.*?)"/g,
+        /data-requires-python="([^\"]*?)>([^\"]*?)"/g,
         'data-requires-python="$1&gt;$2"'
       )
       .replace(
-        /data-requires-python="(.*?)<(.*?)"/g,
+        /data-requires-python="([^\"]*?)<([^\"]*?)"/g,
         'data-requires-python="$1&lt;$2"'
       )
   );

--- a/lib/datasource/pypi/index.ts
+++ b/lib/datasource/pypi/index.ts
@@ -172,11 +172,11 @@ function cleanSimpleHtml(html: string): string {
       .replace(/<\/?pre>/, '')
       // Certain simple repositories like artifactory don't escape > and <
       .replace(
-        /data-requires-python="([^\"]*?)>([^\"]*?)"/g,
+        /data-requires-python="([^"]*?)>([^"]*?)"/g,
         'data-requires-python="$1&gt;$2"'
       )
       .replace(
-        /data-requires-python="([^\"]*?)<([^\"]*?)"/g,
+        /data-requires-python="([^"]*?)<([^"]*?)"/g,
         'data-requires-python="$1&lt;$2"'
       )
   );


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Replace the regular expression on `cleanSimpleHtml` so it works with Gitlab's package registry

## Context:

See issue #8285 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [X] Code inspection only, or (tested using the debugger)
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
