### PR TITLE
feat(gradle-lite): Support method-based variable assignment via "set()"

### DIFF
--- a/lib/manager/gradle-lite/parser.spec.ts
+++ b/lib/manager/gradle-lite/parser.spec.ts
@@ -16,7 +16,23 @@ describe('manager/gradle-lite/parser', () => {
     let deps;
 
     ({ deps } = parseGradle(
-      '\nversion = "1.2.3"\n"foo:bar:$version"\nversion = "3.2.1"'
+      ['version = "1.2.3"', '"foo:bar:$version"', 'version = "3.2.1"'].join(
+        '\n'
+      )
+    ));
+    expect(deps).toMatchObject([
+      {
+        depName: 'foo:bar',
+        currentValue: '1.2.3',
+      },
+    ]);
+
+    ({ deps } = parseGradle(
+      [
+        'set("version", "1.2.3")',
+        '"foo:bar:$version"',
+        'set("version", "3.2.1")',
+      ].join('\n')
     ));
     expect(deps).toMatchObject([
       {

--- a/lib/manager/gradle-lite/parser.ts
+++ b/lib/manager/gradle-lite/parser.ts
@@ -260,6 +260,19 @@ const matcherConfigs: SyntaxMatchConfig[] = [
     handler: handleAssignment,
   },
   {
+    // set('foo', 'bar')
+    matchers: [
+      { matchType: TokenType.Word, matchValue: 'set' },
+      { matchType: TokenType.LeftParen },
+      { matchType: TokenType.String, tokenMapKey: 'keyToken' },
+      { matchType: TokenType.Comma },
+      { matchType: TokenType.String, tokenMapKey: 'valToken' },
+      { matchType: TokenType.RightParen },
+      endOfInstruction,
+    ],
+    handler: handleAssignment,
+  },
+  {
     // 'foo.bar:baz:1.2.3'
     matchers: [
       {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Extend parser to support assignments like `set('foo', '1.2.3')`

## Context:

Ref: #8307

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
