### PR TITLE
docs: add hostrules example for private helm charts repo

### DIFF
--- a/docs/usage/docker.md
+++ b/docs/usage/docker.md
@@ -199,4 +199,18 @@ module.exports = {
 };
 ```
 
+You might be hosting your own chartmuseum somewhere to manage your private Helm Charts. Here is how you would connect to a private Helm repository :
+
+```js
+module.exports = {
+  hostRules: [
+    {
+      hostName: 'your.host.io',
+      username: '<your-username>',
+      password: 'process.env.SELF_HOSTED_HELM_CHARTS_PASSWORD',
+    },
+  ],
+};
+```
+
 If you need to configure per-repository credentials then you can also configure the above within a repository's Renovate config (e.g. `renovate.json`).


### PR DESCRIPTION
## Changes:

Just added one more example for authenticating against a private Helm repo.

## Context:

Fixes https://github.com/renovatebot/renovate/issues/8275

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository