### PR TITLE
fix(pip_setup): Run pip setup extract in the correct directory

### DIFF
--- a/data/extract.py
+++ b/data/extract.py
@@ -2,7 +2,7 @@ import sys
 import json
 import os
 import distutils.core
-from os.path import dirname, realpath
+from os.path import basename, dirname, realpath
 
 if sys.version_info[:2] >= (3, 3):
   from importlib.machinery import SourceFileLoader
@@ -36,7 +36,7 @@ def invoke(mock1, mock2):
   # Inserting the parent directory of the target setup.py in Python import path:
   sys.path.append(dirname(realpath(sys.argv[-1])))
   # This is setup.py which calls setuptools.setup
-  load_source('_target_setup_', sys.argv[-1])
+  load_source('_target_setup_', basename(sys.argv[-1]))
   # called arguments are in `mock_setup.call_args`
   call_args = mock1.call_args or mock2.call_args
   args, kwargs = call_args

--- a/data/extract.py
+++ b/data/extract.py
@@ -2,7 +2,7 @@ import sys
 import json
 import os
 import distutils.core
-from os.path import basename, dirname, realpath
+from os.path import basename
 
 if sys.version_info[:2] >= (3, 3):
   from importlib.machinery import SourceFileLoader
@@ -33,8 +33,6 @@ except ImportError:
 @mock.patch.object(setuptools, 'setup')
 @mock.patch.object(distutils.core, 'setup')
 def invoke(mock1, mock2):
-  # Inserting the parent directory of the target setup.py in Python import path:
-  sys.path.append(dirname(realpath(sys.argv[-1])))
   # This is setup.py which calls setuptools.setup
   load_source('_target_setup_', basename(sys.argv[-1]))
   # called arguments are in `mock_setup.call_args`

--- a/lib/manager/pip_setup/__snapshots__/index.spec.ts.snap
+++ b/lib/manager/pip_setup/__snapshots__/index.spec.ts.snap
@@ -57,9 +57,9 @@ Array [
     },
   },
   Object {
-    "cmd": "<extract.py> \\"foobar.py\\"",
+    "cmd": "<extract.py> \\"folders/foobar.py\\"",
     "options": Object {
-      "cwd": "/tmp/github/some/repo/tmp/folders",
+      "cwd": "/tmp/github/some/repo/folders",
       "encoding": "utf-8",
       "env": Object {
         "HOME": "/home/user",
@@ -390,7 +390,7 @@ Array [
     },
   },
   Object {
-    "cmd": "<extract.py> \\"setup.py\\"",
+    "cmd": "<extract.py> \\"lib/manager/pip_setup/__fixtures__/setup.py\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo/lib/manager/pip_setup/__fixtures__",
       "encoding": "utf-8",
@@ -467,7 +467,7 @@ Array [
     },
   },
   Object {
-    "cmd": "<extract.py> \\"setup.py\\"",
+    "cmd": "<extract.py> \\"lib/manager/pip_setup/__fixtures__/setup.py\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo/lib/manager/pip_setup/__fixtures__",
       "encoding": "utf-8",
@@ -544,9 +544,9 @@ Array [
     },
   },
   Object {
-    "cmd": "<extract.py> \\"foobar.py\\"",
+    "cmd": "<extract.py> \\"folders/foobar.py\\"",
     "options": Object {
-      "cwd": "/tmp/github/some/repo/tmp/folders",
+      "cwd": "/tmp/github/some/repo/folders",
       "encoding": "utf-8",
       "env": Object {
         "HOME": "/home/user",

--- a/lib/manager/pip_setup/__snapshots__/index.spec.ts.snap
+++ b/lib/manager/pip_setup/__snapshots__/index.spec.ts.snap
@@ -5,7 +5,7 @@ Array [
   Object {
     "cmd": "python --version",
     "options": Object {
-      "cwd": null,
+      "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
       "env": Object {
         "HOME": "/home/user",
@@ -23,7 +23,7 @@ Array [
   Object {
     "cmd": "python3 --version",
     "options": Object {
-      "cwd": null,
+      "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
       "env": Object {
         "HOME": "/home/user",
@@ -41,7 +41,7 @@ Array [
   Object {
     "cmd": "python3.8 --version",
     "options": Object {
-      "cwd": null,
+      "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
       "env": Object {
         "HOME": "/home/user",
@@ -57,9 +57,9 @@ Array [
     },
   },
   Object {
-    "cmd": "<extract.py> \\"/tmp/folders/foobar.py\\"",
+    "cmd": "<extract.py> \\"foobar.py\\"",
     "options": Object {
-      "cwd": "/tmp/github/some/repo",
+      "cwd": "/tmp/github/some/repo/tmp/folders",
       "encoding": "utf-8",
       "env": Object {
         "HOME": "/home/user",
@@ -338,7 +338,7 @@ Array [
   Object {
     "cmd": "python --version",
     "options": Object {
-      "cwd": null,
+      "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
       "env": Object {
         "HOME": "/home/user",
@@ -356,7 +356,7 @@ Array [
   Object {
     "cmd": "python3 --version",
     "options": Object {
-      "cwd": null,
+      "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
       "env": Object {
         "HOME": "/home/user",
@@ -374,7 +374,7 @@ Array [
   Object {
     "cmd": "python3.8 --version",
     "options": Object {
-      "cwd": null,
+      "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
       "env": Object {
         "HOME": "/home/user",
@@ -390,9 +390,9 @@ Array [
     },
   },
   Object {
-    "cmd": "<extract.py> \\"lib/manager/pip_setup/__fixtures__/setup.py\\"",
+    "cmd": "<extract.py> \\"setup.py\\"",
     "options": Object {
-      "cwd": "/tmp/github/some/repo",
+      "cwd": "/tmp/github/some/repo/lib/manager/pip_setup/__fixtures__",
       "encoding": "utf-8",
       "env": Object {
         "HOME": "/home/user",
@@ -415,7 +415,7 @@ Array [
   Object {
     "cmd": "python --version",
     "options": Object {
-      "cwd": null,
+      "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
       "env": Object {
         "HOME": "/home/user",
@@ -433,7 +433,7 @@ Array [
   Object {
     "cmd": "python3 --version",
     "options": Object {
-      "cwd": null,
+      "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
       "env": Object {
         "HOME": "/home/user",
@@ -451,7 +451,7 @@ Array [
   Object {
     "cmd": "python3.8 --version",
     "options": Object {
-      "cwd": null,
+      "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
       "env": Object {
         "HOME": "/home/user",
@@ -467,9 +467,9 @@ Array [
     },
   },
   Object {
-    "cmd": "<extract.py> \\"lib/manager/pip_setup/__fixtures__/setup.py\\"",
+    "cmd": "<extract.py> \\"setup.py\\"",
     "options": Object {
-      "cwd": "/tmp/github/some/repo",
+      "cwd": "/tmp/github/some/repo/lib/manager/pip_setup/__fixtures__",
       "encoding": "utf-8",
       "env": Object {
         "HOME": "/home/user",
@@ -492,7 +492,7 @@ Array [
   Object {
     "cmd": "python --version",
     "options": Object {
-      "cwd": null,
+      "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
       "env": Object {
         "HOME": "/home/user",
@@ -510,7 +510,7 @@ Array [
   Object {
     "cmd": "python3 --version",
     "options": Object {
-      "cwd": null,
+      "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
       "env": Object {
         "HOME": "/home/user",
@@ -528,7 +528,7 @@ Array [
   Object {
     "cmd": "python3.8 --version",
     "options": Object {
-      "cwd": null,
+      "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
       "env": Object {
         "HOME": "/home/user",
@@ -544,9 +544,9 @@ Array [
     },
   },
   Object {
-    "cmd": "<extract.py> \\"/tmp/folders/foobar.py\\"",
+    "cmd": "<extract.py> \\"foobar.py\\"",
     "options": Object {
-      "cwd": "/tmp/github/some/repo",
+      "cwd": "/tmp/github/some/repo/tmp/folders",
       "encoding": "utf-8",
       "env": Object {
         "HOME": "/home/user",

--- a/lib/manager/pip_setup/extract.ts
+++ b/lib/manager/pip_setup/extract.ts
@@ -1,4 +1,3 @@
-import { basename } from 'upath';
 import * as datasourcePypi from '../../datasource/pypi';
 import { logger } from '../../logger';
 import { SkipReason } from '../../types';

--- a/lib/manager/pip_setup/extract.ts
+++ b/lib/manager/pip_setup/extract.ts
@@ -1,4 +1,4 @@
-import { basename, dirname } from 'upath';
+import { basename } from 'upath';
 import * as datasourcePypi from '../../datasource/pypi';
 import { logger } from '../../logger';
 import { SkipReason } from '../../types';
@@ -7,7 +7,7 @@ import { BinarySource } from '../../util/exec/common';
 import { isSkipComment } from '../../util/ignore';
 import { ExtractConfig, PackageDependency, PackageFile } from '../common';
 import { dependencyPattern } from '../pip_requirements/extract';
-import { PythonSetup, copyExtractFile, parseReport } from './util';
+import { PythonSetup, getExtractFile, parseReport } from './util';
 
 export const pythonVersions = ['python', 'python3', 'python3.8'];
 let pythonAlias: string | null = null;
@@ -46,9 +46,8 @@ export async function extractSetupFile(
   config: ExtractConfig
 ): Promise<PythonSetup> {
   let cmd = 'python';
-  const packageDirectory = dirname(packageFile);
-  const extractPy = await copyExtractFile(packageDirectory);
-  const args = [`"${extractPy}"`, `"${basename(packageFile)}"`];
+  const extractPy = await getExtractFile();
+  const args = [`"${extractPy}"`, `"${packageFile}"`];
   if (config.binarySource !== BinarySource.Docker) {
     logger.debug('Running python via global command');
     cmd = await getPythonAlias();
@@ -70,7 +69,7 @@ export async function extractSetupFile(
       logger.warn({ stdout: res.stdout, stderr }, 'Error in read setup file');
     }
   }
-  return parseReport(packageDirectory);
+  return parseReport(packageFile);
 }
 
 export async function extractPackageFile(

--- a/lib/manager/pip_setup/index.spec.ts
+++ b/lib/manager/pip_setup/index.spec.ts
@@ -21,6 +21,7 @@ const jsonContent = readFileSync(packageFileJson, 'utf8');
 
 const config = {
   localDir: '/tmp/github/some/repo',
+  cacheDir: '/tmp/renovate/cache',
 };
 
 jest.mock('child_process');
@@ -107,7 +108,7 @@ describe(getName(__filename), () => {
       expect(
         await extractPackageFile(
           'raise Exception()',
-          '/tmp/folders/foobar.py',
+          'folders/foobar.py',
           config
         )
       ).toBeNull();
@@ -119,7 +120,7 @@ describe(getName(__filename), () => {
       expect(
         await extractPackageFile(
           'raise Exception()',
-          '/tmp/folders/foobar.py',
+          'folders/foobar.py',
           config
         )
       ).toBeNull();

--- a/lib/manager/pip_setup/index.spec.ts
+++ b/lib/manager/pip_setup/index.spec.ts
@@ -7,6 +7,7 @@ import {
   mockExecSequence,
 } from '../../../test/exec-util';
 import { env, getName } from '../../../test/util';
+import { setUtilConfig } from '../../util';
 import { BinarySource } from '../../util/exec/common';
 import * as fs from '../../util/fs';
 import * as extract from './extract';
@@ -40,11 +41,12 @@ const fixSnapshots = (snapshots: ExecSnapshots): ExecSnapshots =>
 
 describe(getName(__filename), () => {
   describe('extractPackageFile()', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       jest.resetAllMocks();
       jest.resetModules();
       extract.resetModule();
 
+      await setUtilConfig(config);
       env.getChildProcessEnv.mockReturnValue(envMock.basic);
 
       // do not copy extract.py

--- a/lib/manager/pip_setup/util.ts
+++ b/lib/manager/pip_setup/util.ts
@@ -1,3 +1,4 @@
+import { join } from 'upath';
 import dataFiles from '../../data-files.generated';
 import { readLocalFile, writeLocalFile } from '../../util/fs';
 
@@ -7,12 +8,12 @@ const EXTRACT = 'renovate-pip_setup-extract.py';
 
 let extractPy: string | undefined;
 
-export async function copyExtractFile(): Promise<string> {
+export async function copyExtractFile(directory: string): Promise<string> {
   if (extractPy === undefined) {
     extractPy = dataFiles.get('extract.py');
   }
 
-  await writeLocalFile(EXTRACT, extractPy);
+  await writeLocalFile(join(directory, EXTRACT), extractPy);
 
   return EXTRACT;
 }
@@ -22,7 +23,7 @@ export interface PythonSetup {
   install_requires: string[];
 }
 
-export async function parseReport(): Promise<PythonSetup> {
-  const data = await readLocalFile(REPORT, 'utf8');
+export async function parseReport(directory: string): Promise<PythonSetup> {
+  const data = await readLocalFile(join(directory, REPORT), 'utf8');
   return JSON.parse(data);
 }


### PR DESCRIPTION
## Changes:

Changes pip setup extract script's working directory to "dirname" of `setup.py`.

## Context:

Fixes https://github.com/renovatebot/renovate/issues/8319.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] Unit tests + ran on a real repository

I run it against [`hisener/renovate-tests`](https://github.com/hisener/renovate-tests/), see https://github.com/hisener/renovate-tests/pull/32. The hosted app closes the PR because it fails to extract (See the issue for the error message).

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
