### PR TITLE
feat: customEnvVariables

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -92,6 +92,10 @@ If you configure this to be different to the `baseDir`, it means you can have on
 
 Set to `false` to prevent usage of `--ignore-platform-reqs` in the Composer package manager.
 
+## customEnvForChild
+
+Custom environment variables for sidecar Docker containers. This configuration will be applied after all other environment variables so that it can be used to override defaults.
+
 ## dockerImagePrefix
 
 Override the default renovate sidecar Docker containers image prefix from `docker.io/renovate` to a custom value, so renovate will pull images from a custom Docker registry.

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -94,7 +94,7 @@ Set to `false` to prevent usage of `--ignore-platform-reqs` in the Composer pack
 
 ## customEnvVariables
 
-Custom environment variables for child processes and sidecar Docker containers. This configuration will be applied after all other environment variables so that it can be used to override defaults.
+This configuration will be applied after all other environment variables so that it can be used to override defaults.
 
 ## dockerImagePrefix
 

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -92,9 +92,9 @@ If you configure this to be different to the `baseDir`, it means you can have on
 
 Set to `false` to prevent usage of `--ignore-platform-reqs` in the Composer package manager.
 
-## customEnvForChild
+## customEnvVariables
 
-Custom environment variables for sidecar Docker containers. This configuration will be applied after all other environment variables so that it can be used to override defaults.
+Custom environment variables for child processes and sidecar Docker containers. This configuration will be applied after all other environment variables so that it can be used to override defaults.
 
 ## dockerImagePrefix
 

--- a/lib/config/common.ts
+++ b/lib/config/common.ts
@@ -78,6 +78,7 @@ export interface RenovateAdminConfig {
   cacheDir?: string;
   configWarningReuseIssue?: boolean;
 
+  customEnvForChild?: Record<string, string>;
   dockerImagePrefix?: string;
   dockerUser?: string;
 

--- a/lib/config/common.ts
+++ b/lib/config/common.ts
@@ -78,7 +78,7 @@ export interface RenovateAdminConfig {
   cacheDir?: string;
   configWarningReuseIssue?: boolean;
 
-  customEnvForChild?: Record<string, string>;
+  customEnvVariables?: Record<string, string>;
   dockerImagePrefix?: string;
   dockerUser?: string;
 

--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -309,9 +309,9 @@ const options: RenovateOptions[] = [
     type: 'string',
   },
   {
-    name: 'customEnvForChild',
+    name: 'customEnvVariables',
     description:
-      'Custom environment variables for sidecar Docker containers. This configuration will be applied after all other environment variables so that it can be used to override defaults.',
+      'Custom environment variables for child processes and sidecar Docker containers. This configuration will be applied after all other environment variables so that it can be used to override defaults.',
     admin: true,
     type: 'object',
     default: false,

--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -309,6 +309,14 @@ const options: RenovateOptions[] = [
     type: 'string',
   },
   {
+    name: 'customEnvForChild',
+    description:
+      'Custom environment variables for sidecar Docker containers. This configuration will be applied after all other environment variables so that it can be used to override defaults.',
+    admin: true,
+    type: 'object',
+    default: false,
+  },
+  {
     name: 'dockerMapDotfiles',
     description:
       'Map relevant home directory dotfiles into containers when binarySource=docker.',

--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -311,7 +311,7 @@ const options: RenovateOptions[] = [
   {
     name: 'customEnvVariables',
     description:
-      'Custom environment variables for child processes and sidecar Docker containers. This configuration will be applied after all other environment variables so that it can be used to override defaults.',
+      'Custom environment variables for child processes and sidecar Docker containers.',
     admin: true,
     type: 'object',
     default: false,

--- a/lib/util/exec/common.ts
+++ b/lib/util/exec/common.ts
@@ -14,7 +14,7 @@ export enum BinarySource {
 
 export interface ExecConfig {
   binarySource: Opt<BinarySource>;
-  customEnvForChild: Opt<Record<string, string>>;
+  customEnvVariables: Opt<Record<string, string>>;
   dockerImagePrefix: Opt<string>;
   dockerUser: Opt<string>;
   localDir: Opt<string>;

--- a/lib/util/exec/common.ts
+++ b/lib/util/exec/common.ts
@@ -14,6 +14,7 @@ export enum BinarySource {
 
 export interface ExecConfig {
   binarySource: Opt<BinarySource>;
+  customEnvForChild: Opt<Record<string, string>>;
   dockerImagePrefix: Opt<string>;
   dockerUser: Opt<string>;
   localDir: Opt<string>;

--- a/lib/util/exec/docker/index.ts
+++ b/lib/util/exec/docker/index.ts
@@ -202,7 +202,9 @@ export async function generateDockerCommand(
   if (envVars) {
     result.push(
       ...uniq(envVars)
-        .filter((x) => typeof x === 'string' && !customEnvVariables[x])
+        .filter(
+          (x) => typeof x === 'string' && customEnvVariables[x] === undefined
+        )
         .map((e) => `-e ${e}`)
     );
   }

--- a/lib/util/exec/docker/index.ts
+++ b/lib/util/exec/docker/index.ts
@@ -198,19 +198,13 @@ export async function generateDockerCommand(
 
   result.push(...prepareVolumes([localDir, cacheDir, ...volumes]));
 
-  const customEnvVariables = config.customEnvVariables || {};
   if (envVars) {
     result.push(
       ...uniq(envVars)
-        .filter(
-          (x) => typeof x === 'string' && customEnvVariables[x] === undefined
-        )
+        .filter((x) => typeof x === 'string')
         .map((e) => `-e ${e}`)
     );
   }
-  Object.entries(customEnvVariables).forEach(([key, val]) => {
-    result.push(`-e ${key}=${val}`);
-  });
 
   if (cwd) {
     result.push(`-w "${cwd}"`);

--- a/lib/util/exec/docker/index.ts
+++ b/lib/util/exec/docker/index.ts
@@ -198,13 +198,17 @@ export async function generateDockerCommand(
 
   result.push(...prepareVolumes([localDir, cacheDir, ...volumes]));
 
+  const customEnvForChild = config.customEnvForChild || {};
   if (envVars) {
     result.push(
       ...uniq(envVars)
-        .filter((x) => typeof x === 'string')
+        .filter((x) => typeof x === 'string' && !customEnvForChild[x])
         .map((e) => `-e ${e}`)
     );
   }
+  Object.entries(customEnvForChild).forEach(([key, val]) => {
+    result.push(`-e ${key}=${val}`);
+  });
 
   if (cwd) {
     result.push(`-w "${cwd}"`);

--- a/lib/util/exec/docker/index.ts
+++ b/lib/util/exec/docker/index.ts
@@ -198,15 +198,15 @@ export async function generateDockerCommand(
 
   result.push(...prepareVolumes([localDir, cacheDir, ...volumes]));
 
-  const customEnvForChild = config.customEnvForChild || {};
+  const customEnvVariables = config.customEnvVariables || {};
   if (envVars) {
     result.push(
       ...uniq(envVars)
-        .filter((x) => typeof x === 'string' && !customEnvForChild[x])
+        .filter((x) => typeof x === 'string' && !customEnvVariables[x])
         .map((e) => `-e ${e}`)
     );
   }
-  Object.entries(customEnvForChild).forEach(([key, val]) => {
+  Object.entries(customEnvVariables).forEach(([key, val]) => {
     result.push(`-e ${key}=${val}`);
   });
 

--- a/lib/util/exec/exec.spec.ts
+++ b/lib/util/exec/exec.spec.ts
@@ -602,7 +602,7 @@ describe(`Child process execution wrapper`, () => {
         outCmd: [
           dockerPullCmd,
           dockerRemoveCmd,
-          `docker run --rm --name=${name} --label=renovate_child ${defaultVolumes} -e CUSTOM_KEY=CUSTOM_VALUE ${defaultCwd} ${image} bash -l -c "${inCmd}"`,
+          `docker run --rm --name=${name} --label=renovate_child ${defaultVolumes} -e CUSTOM_KEY ${defaultCwd} ${image} bash -l -c "${inCmd}"`,
         ],
         outOpts: [
           dockerPullOpts,
@@ -634,7 +634,7 @@ describe(`Child process execution wrapper`, () => {
         outCmd: [
           dockerPullCmd,
           dockerRemoveCmd,
-          `docker run --rm --name=${name} --label=renovate_child ${defaultVolumes} -e CUSTOM_KEY=CUSTOM_OVERRIDEN_VALUE ${defaultCwd} ${image} bash -l -c "${inCmd}"`,
+          `docker run --rm --name=${name} --label=renovate_child ${defaultVolumes} -e CUSTOM_KEY ${defaultCwd} ${image} bash -l -c "${inCmd}"`,
         ],
         outOpts: [
           dockerPullOpts,

--- a/lib/util/exec/exec.spec.ts
+++ b/lib/util/exec/exec.spec.ts
@@ -541,7 +541,7 @@ describe(`Child process execution wrapper`, () => {
       {
         execConfig: {
           ...execConfig,
-          customEnvForChild: {
+          customEnvVariables: {
             CUSTOM_KEY: 'CUSTOM_VALUE',
           },
         },
@@ -566,7 +566,7 @@ describe(`Child process execution wrapper`, () => {
       {
         execConfig: {
           ...execConfig,
-          customEnvForChild: {
+          customEnvVariables: {
             CUSTOM_KEY: 'CUSTOM_OVERRIDEN_VALUE',
           },
         },
@@ -592,7 +592,7 @@ describe(`Child process execution wrapper`, () => {
         execConfig: {
           ...execConfig,
           binarySource: BinarySource.Docker,
-          customEnvForChild: {
+          customEnvVariables: {
             CUSTOM_KEY: 'CUSTOM_VALUE',
           },
         },
@@ -624,7 +624,7 @@ describe(`Child process execution wrapper`, () => {
         execConfig: {
           ...execConfig,
           binarySource: BinarySource.Docker,
-          customEnvForChild: {
+          customEnvVariables: {
             CUSTOM_KEY: 'CUSTOM_OVERRIDEN_VALUE',
           },
         },

--- a/lib/util/exec/exec.spec.ts
+++ b/lib/util/exec/exec.spec.ts
@@ -535,6 +535,120 @@ describe(`Child process execution wrapper`, () => {
         ],
       },
     ],
+
+    [
+      'Custom environment variables for child',
+      {
+        execConfig: {
+          ...execConfig,
+          customEnvForChild: {
+            CUSTOM_KEY: 'CUSTOM_VALUE',
+          },
+        },
+        processEnv: envMock.basic,
+        inCmd,
+        inOpts: {},
+        outCmd,
+        outOpts: [
+          {
+            cwd,
+            encoding,
+            env: { ...envMock.basic, CUSTOM_KEY: 'CUSTOM_VALUE' },
+            timeout: 900000,
+            maxBuffer: 10485760,
+          },
+        ],
+      },
+    ],
+
+    [
+      'Custom environment variables for child should override',
+      {
+        execConfig: {
+          ...execConfig,
+          customEnvForChild: {
+            CUSTOM_KEY: 'CUSTOM_OVERRIDEN_VALUE',
+          },
+        },
+        processEnv: { ...envMock.basic, CUSTOM_KEY: 'CUSTOM_VALUE' },
+        inCmd,
+        inOpts: {},
+        outCmd,
+        outOpts: [
+          {
+            cwd,
+            encoding,
+            env: { ...envMock.basic, CUSTOM_KEY: 'CUSTOM_OVERRIDEN_VALUE' },
+            timeout: 900000,
+            maxBuffer: 10485760,
+          },
+        ],
+      },
+    ],
+
+    [
+      'Custom environment variables for child (Docker)',
+      {
+        execConfig: {
+          ...execConfig,
+          binarySource: BinarySource.Docker,
+          customEnvForChild: {
+            CUSTOM_KEY: 'CUSTOM_VALUE',
+          },
+        },
+        processEnv,
+        inCmd,
+        inOpts: { docker, cwd },
+        outCmd: [
+          dockerPullCmd,
+          dockerRemoveCmd,
+          `docker run --rm --name=${name} --label=renovate_child ${defaultVolumes} -e CUSTOM_KEY=CUSTOM_VALUE ${defaultCwd} ${image} bash -l -c "${inCmd}"`,
+        ],
+        outOpts: [
+          dockerPullOpts,
+          dockerRemoveOpts,
+          {
+            cwd,
+            encoding,
+            env: { ...envMock.basic, CUSTOM_KEY: 'CUSTOM_VALUE' },
+            timeout: 900000,
+            maxBuffer: 10485760,
+          },
+        ],
+      },
+    ],
+
+    [
+      'Custom environment variables for child should override (Docker)',
+      {
+        execConfig: {
+          ...execConfig,
+          binarySource: BinarySource.Docker,
+          customEnvForChild: {
+            CUSTOM_KEY: 'CUSTOM_OVERRIDEN_VALUE',
+          },
+        },
+        processEnv: { ...envMock.basic, CUSTOM_KEY: 'CUSTOM_VALUE' },
+        inCmd,
+        inOpts: { docker, cwd },
+        outCmd: [
+          dockerPullCmd,
+          dockerRemoveCmd,
+          `docker run --rm --name=${name} --label=renovate_child ${defaultVolumes} -e CUSTOM_KEY=CUSTOM_OVERRIDEN_VALUE ${defaultCwd} ${image} bash -l -c "${inCmd}"`,
+        ],
+        outOpts: [
+          dockerPullOpts,
+          dockerRemoveOpts,
+          {
+            cwd,
+            encoding,
+            env: { ...envMock.basic, CUSTOM_KEY: 'CUSTOM_OVERRIDEN_VALUE' },
+            timeout: 900000,
+            maxBuffer: 10485760,
+          },
+        ],
+      },
+    ],
   ];
 
   test.each(testInputs)('%s', async (_msg, testOpts) => {

--- a/lib/util/exec/index.ts
+++ b/lib/util/exec/index.ts
@@ -62,7 +62,7 @@ function createChildEnv(
   });
   const extraEnvKeys = Object.keys(extraEnvEntries);
 
-  let childEnv =
+  const childEnv =
     env || extraEnv
       ? {
           ...extraEnv,
@@ -70,7 +70,6 @@ function createChildEnv(
           ...env,
         }
       : getChildProcessEnv();
-  childEnv = { ...childEnv, ...execConfig.customEnvVariables };
 
   const result: ExtraEnv<string> = {};
   Object.entries(childEnv).forEach(([key, val]) => {
@@ -99,7 +98,8 @@ export async function exec(
   cmd: string | string[],
   opts: ExecOptions = {}
 ): Promise<ExecResult> {
-  const { env, extraEnv, docker, cwdFile } = opts;
+  const { env, docker, cwdFile } = opts;
+  const extraEnv = { ...opts.extraEnv, ...execConfig.customEnvVariables };
   let cwd;
   // istanbul ignore if
   if (cwdFile) {

--- a/lib/util/exec/index.ts
+++ b/lib/util/exec/index.ts
@@ -20,7 +20,7 @@ import { getChildProcessEnv } from './env';
 
 const execConfig: ExecConfig = {
   binarySource: null,
-  customEnvForChild: null,
+  customEnvVariables: null,
   dockerImagePrefix: null,
   dockerUser: null,
   localDir: null,
@@ -70,7 +70,7 @@ function createChildEnv(
           ...env,
         }
       : getChildProcessEnv();
-  childEnv = { ...childEnv, ...execConfig.customEnvForChild };
+  childEnv = { ...childEnv, ...execConfig.customEnvVariables };
 
   const result: ExtraEnv<string> = {};
   Object.entries(childEnv).forEach(([key, val]) => {

--- a/lib/util/exec/index.ts
+++ b/lib/util/exec/index.ts
@@ -20,6 +20,7 @@ import { getChildProcessEnv } from './env';
 
 const execConfig: ExecConfig = {
   binarySource: null,
+  customEnvForChild: null,
   dockerImagePrefix: null,
   dockerUser: null,
   localDir: null,
@@ -61,7 +62,7 @@ function createChildEnv(
   });
   const extraEnvKeys = Object.keys(extraEnvEntries);
 
-  const childEnv =
+  let childEnv =
     env || extraEnv
       ? {
           ...extraEnv,
@@ -69,6 +70,7 @@ function createChildEnv(
           ...env,
         }
       : getChildProcessEnv();
+  childEnv = { ...childEnv, ...execConfig.customEnvForChild };
 
   const result: ExtraEnv<string> = {};
   Object.entries(childEnv).forEach(([key, val]) => {


### PR DESCRIPTION
## Changes:

Introduces a new option to pass custom environment variables to child processes. So that users can provide/override environment variables to influence executions, e.g. setting `MAVEN_OPTS` or passing credentials for private registries for the locking process.

## Context:

Closes https://github.com/renovatebot/renovate/issues/6758.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
