### PR TITLE
fix(hex): Preserve minor versions when in bump mode

### DIFF
--- a/lib/versioning/hex/index.spec.ts
+++ b/lib/versioning/hex/index.spec.ts
@@ -128,7 +128,7 @@ describe('lib/versioning/hex', () => {
           fromVersion: '1.2.3',
           toVersion: '2.0.7',
         })
-      ).toEqual('~> 2');
+      ).toEqual('~> 2.0');
       expect(
         hexScheme.getNewValue({
           currentValue: '~> 1.2.0',

--- a/lib/versioning/hex/index.spec.ts
+++ b/lib/versioning/hex/index.spec.ts
@@ -131,6 +131,14 @@ describe('lib/versioning/hex', () => {
       ).toEqual('~> 2.0');
       expect(
         hexScheme.getNewValue({
+          currentValue: '~> 1.2',
+          rangeStrategy: 'bump',
+          fromVersion: '1.2.3',
+          toVersion: '1.3.1',
+        })
+      ).toEqual('~> 1.3');
+      expect(
+        hexScheme.getNewValue({
           currentValue: '~> 1.2.0',
           rangeStrategy: 'replace',
           fromVersion: '1.2.3',

--- a/lib/versioning/hex/index.ts
+++ b/lib/versioning/hex/index.ts
@@ -77,7 +77,8 @@ const getNewValue = ({
   } else if (/~>\s*(\d+\.\d+)$/.test(currentValue)) {
     newSemver = newSemver.replace(
       /\^\s*(\d+\.\d+)/,
-      (_str, p1: string) => `~> ${rangeStrategy !== 'bump' ? p1.slice(0, -2) : p1}`
+      (_str, p1: string) =>
+        `~> ${rangeStrategy !== 'bump' ? p1.slice(0, -2) : p1}`
     );
   } else {
     newSemver = newSemver.replace(/~\s*(\d+\.\d+\.\d)/, '~> $1');

--- a/lib/versioning/hex/index.ts
+++ b/lib/versioning/hex/index.ts
@@ -69,10 +69,15 @@ const getNewValue = ({
     toVersion,
   });
   newSemver = npm2hex(newSemver);
-  if (/~>\s*(\d+\.\d+)$/.test(currentValue)) {
+  if (/~>\s*(\d+\.\d+\.\d+)$/.test(currentValue)) {
     newSemver = newSemver.replace(
-      /\^\s*(\d+\.\d+(\.\d)?)/,
-      (_str, p1: string) => `~> ${p1.slice(0, -2)}`
+      /[\^~]\s*(\d+\.\d+\.\d+)/,
+      (_str, p1: string) => `~> ${p1}`
+    );
+  } else if (/~>\s*(\d+\.\d+)$/.test(currentValue)) {
+    newSemver = newSemver.replace(
+      /\^\s*(\d+\.\d+)/,
+      (_str, p1: string) => `~> ${rangeStrategy !== 'bump' ? p1.slice(0, -2) : p1}`
     );
   } else {
     newSemver = newSemver.replace(/~\s*(\d+\.\d+\.\d)/, '~> $1');


### PR DESCRIPTION
## Changes:

Changes the way hex versioning resolves an update's new value to avoid losing the minor precision when bumping a dependency that was previously specified with the `~> X.Y` format.

## Context:

Currently, when a dependency is specified with the `~> X.Y` format (eg `~> 1.10`), the hex versioning module would resolve the new dependency specification as `~> 1`, losing the minimum minor version constraint (see https://hexdocs.pm/elixir/Version.html#module-requirements for more information about the `~>` specification format).

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] Unit tests + ran on a real repository

Test repository: https://github.com/Blond11516/Mobius
