### PR TITLE
fix(nuget): use last version if no stable exists

### DIFF
--- a/lib/datasource/nuget/v3.ts
+++ b/lib/datasource/nuget/v3.ts
@@ -165,6 +165,13 @@ export async function getReleases(
     return null;
   }
 
+  // istanbul ignore if: only happens when no stable version exists
+  if (latestStable === null) {
+    const last = catalogEntries.pop();
+    latestStable = removeBuildMeta(last.version);
+    homepage ??= last.projectUrl;
+  }
+
   const dep: ReleaseResult = {
     pkgName,
     releases,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:
Use last version for metadata fetching when no stable version exists.
<!-- Describe what this pull request changes. -->

## Context:
See slack
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
