### PR TITLE
docs: improve docker usage documentation

### DIFF
--- a/docs/usage/docker.md
+++ b/docs/usage/docker.md
@@ -209,7 +209,7 @@ module.exports = {
 #### ChartMuseum
 
 Maybe you're running your own ChartMuseum server to host your private Helm Charts.
-Here is how you would connect to a private Helm repository:
+This is how you connect to a private Helm repository:
 
 ```js
 module.exports = {

--- a/docs/usage/docker.md
+++ b/docs/usage/docker.md
@@ -165,6 +165,11 @@ If you want Renovate to commit directly to your base branch without opening a PR
 
 ### Registry authentication
 
+There are many different registries, and many ways to authenticate to those registries.
+We will explain how to authenticate for the most common registries.
+
+#### DockerHub
+
 Here is an example of configuring a default Docker username/password in `config.js`.
 The Docker Hub password is stored in a process environment variable.
 
@@ -181,6 +186,8 @@ module.exports = {
 ```
 
 You can add additional host rules, read the [hostrules documentation](https://docs.renovatebot.com/configuration-options/#hostrules) for more information.
+
+#### Self-hosted Docker registry
 
 Say you host some Docker images yourself, and use a password to access your self-hosted Docker images.
 In addition to self-hosting, you also pull images from Docker Hub, without a password.
@@ -199,7 +206,10 @@ module.exports = {
 };
 ```
 
-You might be hosting your own chartmuseum somewhere to manage your private Helm Charts. Here is how you would connect to a private Helm repository :
+#### ChartMuseum
+
+Maybe you're running your own ChartMuseum server to host your private Helm Charts.
+Here is how you would connect to a private Helm repository :
 
 ```js
 module.exports = {

--- a/docs/usage/docker.md
+++ b/docs/usage/docker.md
@@ -209,7 +209,7 @@ module.exports = {
 #### ChartMuseum
 
 Maybe you're running your own ChartMuseum server to host your private Helm Charts.
-Here is how you would connect to a private Helm repository :
+Here is how you would connect to a private Helm repository:
 
 ```js
 module.exports = {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what this pull request changes. -->

- Split up longer section into subsections with `h3` and `h4` headings
- Add introductory text to `h3` heading
- Capitalize noun ChartMuseum
- Use one sentence per line
- Explain what ChartMuseum is
- Remove unnecessary white space before `:` character
- Improve sentence style

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

PR #8316 added a section on authenticating to a ChartMuseum instance.
I noticed the new text wasn't following the one line per sentence standard.

While I was fixing the one sentence per line problem, I found some other things that can be improved. 😄 

There's no issue that I'm closing with this.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
