### PR TITLE
fix: fetch changelog from self-hosted gitlab independent from url

### DIFF
--- a/lib/workers/pr/changelog/__snapshots__/gitlab.spec.ts.snap
+++ b/lib/workers/pr/changelog/__snapshots__/gitlab.spec.ts.snap
@@ -190,6 +190,49 @@ Object {
 }
 `;
 
+exports[`workers/pr/changelog/gitlab getChangeLogJSON supports self-hosted gitlab changelog 1`] = `
+Object {
+  "hasReleaseNotes": false,
+  "project": Object {
+    "apiBaseUrl": "https://git.test.com/api/v4/",
+    "baseUrl": "https://git.test.com/",
+    "depName": "renovate",
+    "gitlab": "meno/dropzone",
+    "repository": "https://git.test.com/meno/dropzone/",
+  },
+  "versions": Array [
+    Object {
+      "changes": Array [],
+      "compare": Object {},
+      "date": undefined,
+      "releaseNotes": null,
+      "version": "5.6.1",
+    },
+    Object {
+      "changes": Array [],
+      "compare": Object {},
+      "date": "2020-02-13T15:37:00.000Z",
+      "releaseNotes": null,
+      "version": "5.6.0",
+    },
+    Object {
+      "changes": Array [],
+      "compare": Object {},
+      "date": undefined,
+      "releaseNotes": null,
+      "version": "5.5.0",
+    },
+    Object {
+      "changes": Array [],
+      "compare": Object {},
+      "date": "2018-08-24T14:23:00.000Z",
+      "releaseNotes": null,
+      "version": "5.4.0",
+    },
+  ],
+}
+`;
+
 exports[`workers/pr/changelog/gitlab getChangeLogJSON uses GitLab tags 1`] = `
 Object {
   "hasReleaseNotes": true,

--- a/lib/workers/pr/changelog/gitlab.spec.ts
+++ b/lib/workers/pr/changelog/gitlab.spec.ts
@@ -189,5 +189,26 @@ describe(getName(__filename), () => {
         })
       ).toMatchSnapshot();
     });
+    it('supports self-hosted gitlab changelog', async () => {
+        httpMock
+          .scope('https://git.test.com')
+          .persist()
+          .get(/.*/)
+          .reply(200, []);
+        hostRules.add({
+          hostType: PLATFORM_TYPE_GITLAB,
+          baseUrl: 'https://git.test.com/',
+          token: 'abc',
+        });
+        process.env.GITHUB_ENDPOINT = '';
+        expect(
+          await getChangeLogJSON({
+            ...upgrade,
+            platform: PLATFORM_TYPE_GITLAB,
+            sourceUrl: 'https://git.test.com/meno/dropzone/',
+            endpoint: 'https://git.test.com/api/v4/',
+          })
+        ).toMatchSnapshot();
+      });
   });
 });

--- a/lib/workers/pr/changelog/gitlab.spec.ts
+++ b/lib/workers/pr/changelog/gitlab.spec.ts
@@ -190,25 +190,21 @@ describe(getName(__filename), () => {
       ).toMatchSnapshot();
     });
     it('supports self-hosted gitlab changelog', async () => {
-        httpMock
-          .scope('https://git.test.com')
-          .persist()
-          .get(/.*/)
-          .reply(200, []);
-        hostRules.add({
-          hostType: PLATFORM_TYPE_GITLAB,
-          baseUrl: 'https://git.test.com/',
-          token: 'abc',
-        });
-        process.env.GITHUB_ENDPOINT = '';
-        expect(
-          await getChangeLogJSON({
-            ...upgrade,
-            platform: PLATFORM_TYPE_GITLAB,
-            sourceUrl: 'https://git.test.com/meno/dropzone/',
-            endpoint: 'https://git.test.com/api/v4/',
-          })
-        ).toMatchSnapshot();
+      httpMock.scope('https://git.test.com').persist().get(/.*/).reply(200, []);
+      hostRules.add({
+        hostType: PLATFORM_TYPE_GITLAB,
+        baseUrl: 'https://git.test.com/',
+        token: 'abc',
       });
+      process.env.GITHUB_ENDPOINT = '';
+      expect(
+        await getChangeLogJSON({
+          ...upgrade,
+          platform: PLATFORM_TYPE_GITLAB,
+          sourceUrl: 'https://git.test.com/meno/dropzone/',
+          endpoint: 'https://git.test.com/api/v4/',
+        })
+      ).toMatchSnapshot();
+    });
   });
 });

--- a/lib/workers/pr/changelog/index.ts
+++ b/lib/workers/pr/changelog/index.ts
@@ -1,5 +1,3 @@
-import URL from 'url';
-
 import { logger } from '../../../logger';
 import * as allVersioning from '../../../versioning';
 import { BranchUpgradeConfig } from '../../common';
@@ -32,8 +30,7 @@ export async function getChangeLogJSON(
     if (
       args.sourceUrl?.includes('gitlab') ||
       (args.platform === 'gitlab' &&
-        URL.parse(args.sourceUrl).hostname ===
-          URL.parse(args.endpoint).hostname)
+        new URL(args.sourceUrl).hostname === new URL(args.endpoint).hostname)
     ) {
       res = await sourceGitlab.getChangeLogJSON({ ...args, releases });
     } else {

--- a/lib/workers/pr/changelog/index.ts
+++ b/lib/workers/pr/changelog/index.ts
@@ -1,3 +1,5 @@
+import URL from 'url';
+
 import { logger } from '../../../logger';
 import * as allVersioning from '../../../versioning';
 import { BranchUpgradeConfig } from '../../common';
@@ -27,7 +29,12 @@ export async function getChangeLogJSON(
 
     let res: ChangeLogResult | null = null;
 
-    if (args.sourceUrl?.includes('gitlab')) {
+    if (
+      args.sourceUrl?.includes('gitlab') ||
+      (args.platform === 'gitlab' &&
+        URL.parse(args.sourceUrl).hostname ===
+          URL.parse(args.endpoint).hostname)
+    ) {
       res = await sourceGitlab.getChangeLogJSON({ ...args, releases });
     } else {
       res = await sourceGithub.getChangeLogJSON({ ...args, releases });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

fetches changelog from self-hosted Gitlab instance even if its url does not contain the word "gitlab"

## Context:

Closes #6704

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
