### PR TITLE
feat(rust): Find and update Cargo.lock for cargo workspaces

### DIFF
--- a/lib/manager/cargo/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/manager/cargo/__snapshots__/artifacts.spec.ts.snap
@@ -114,3 +114,26 @@ Array [
   },
 ]
 `;
+
+exports[`.updateArtifacts() returns updated workspace Cargo.lock 1`] = `
+Array [
+  Object {
+    "cmd": "cargo update --manifest-path crates/one/Cargo.toml --package dep1",
+    "options": Object {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": Object {
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+]
+`;

--- a/lib/manager/cargo/artifacts.spec.ts
+++ b/lib/manager/cargo/artifacts.spec.ts
@@ -35,6 +35,7 @@ describe('.updateArtifacts()', () => {
     docker.resetPrefetchedImages();
   });
   it('returns null if no Cargo.lock found', async () => {
+    fs.stat.mockRejectedValue(new Error('not found!'));
     const updatedDeps = ['dep1'];
     expect(
       await cargo.updateArtifacts({
@@ -56,9 +57,11 @@ describe('.updateArtifacts()', () => {
     ).toBeNull();
   });
   it('returns null if unchanged', async () => {
+    fs.stat.mockResolvedValueOnce({ name: 'Cargo.lock' } as any);
     fs.readFile.mockResolvedValueOnce('Current Cargo.lock' as any);
     const execSnapshots = mockExecAll(exec);
     fs.readFile.mockResolvedValueOnce('Current Cargo.lock' as any);
+
     const updatedDeps = ['dep1'];
     expect(
       await cargo.updateArtifacts({
@@ -71,6 +74,7 @@ describe('.updateArtifacts()', () => {
     expect(execSnapshots).toMatchSnapshot();
   });
   it('returns updated Cargo.lock', async () => {
+    fs.stat.mockResolvedValueOnce({ name: 'Cargo.lock' } as any);
     git.getFile.mockResolvedValueOnce('Old Cargo.lock');
     const execSnapshots = mockExecAll(exec);
     fs.readFile.mockResolvedValueOnce('New Cargo.lock' as any);
@@ -86,7 +90,28 @@ describe('.updateArtifacts()', () => {
     expect(execSnapshots).toMatchSnapshot();
   });
 
+  it('returns updated workspace Cargo.lock', async () => {
+    fs.stat.mockRejectedValueOnce(new Error('crates/one/Cargo.lock not found'));
+    fs.stat.mockRejectedValueOnce(new Error('crates/Cargo.lock not found'));
+    fs.stat.mockResolvedValueOnce({ name: 'Cargo.lock' } as any);
+
+    git.getFile.mockResolvedValueOnce('Old Cargo.lock');
+    const execSnapshots = mockExecAll(exec);
+    fs.readFile.mockResolvedValueOnce('New Cargo.lock' as any);
+    const updatedDeps = ['dep1'];
+    expect(
+      await cargo.updateArtifacts({
+        packageFileName: 'crates/one/Cargo.toml',
+        updatedDeps,
+        newPackageFileContent: '{}',
+        config,
+      })
+    ).not.toBeNull();
+    expect(execSnapshots).toMatchSnapshot();
+  });
+
   it('returns updated Cargo.lock for lockfile maintenance', async () => {
+    fs.stat.mockResolvedValueOnce({ name: 'Cargo.lock' } as any);
     git.getFile.mockResolvedValueOnce('Old Cargo.lock');
     const execSnapshots = mockExecAll(exec);
     fs.readFile.mockResolvedValueOnce('New Cargo.lock' as any);
@@ -102,6 +127,7 @@ describe('.updateArtifacts()', () => {
   });
 
   it('returns updated Cargo.lock with docker', async () => {
+    fs.stat.mockResolvedValueOnce({ name: 'Cargo.lock' } as any);
     jest.spyOn(docker, 'removeDanglingContainers').mockResolvedValueOnce();
     await setExecConfig({ ...config, binarySource: BinarySource.Docker });
     git.getFile.mockResolvedValueOnce('Old Cargo.lock');
@@ -119,6 +145,7 @@ describe('.updateArtifacts()', () => {
     expect(execSnapshots).toMatchSnapshot();
   });
   it('catches errors', async () => {
+    fs.stat.mockResolvedValueOnce({ name: 'Cargo.lock' } as any);
     fs.readFile.mockResolvedValueOnce('Current Cargo.lock' as any);
     fs.outputFile.mockImplementationOnce(() => {
       throw new Error('not found');

--- a/lib/util/fs/index.spec.ts
+++ b/lib/util/fs/index.spec.ts
@@ -1,5 +1,13 @@
+import { dir } from 'tmp-promise';
 import { getName } from '../../../test/util';
-import { getSubDirectory, localPathExists, readLocalFile } from '.';
+import {
+  findLocalSiblingOrParent,
+  getSubDirectory,
+  localPathExists,
+  readLocalFile,
+  setFsConfig,
+  writeLocalFile,
+} from '.';
 
 describe(getName(__filename), () => {
   describe('readLocalFile', () => {
@@ -29,6 +37,40 @@ describe(getName(__filename), () => {
       expect(await localPathExists(__filename.replace('.ts', '.txt'))).toBe(
         false
       );
+    });
+  });
+});
+
+describe(getName(__filename), () => {
+  describe('findLocalSiblingOrParent', () => {
+    it('returns path for file', async () => {
+      const localDir = await dir();
+
+      setFsConfig({
+        localDir: localDir.path,
+      });
+
+      await writeLocalFile('crates/one/Cargo.toml', '');
+      await writeLocalFile('Cargo.lock', '');
+
+      expect(
+        await findLocalSiblingOrParent('crates/one/Cargo.toml', 'Cargo.lock')
+      ).toBe('Cargo.lock');
+      expect(
+        await findLocalSiblingOrParent('crates/one/Cargo.toml', 'Cargo.mock')
+      ).toBeNull();
+
+      await writeLocalFile('crates/one/Cargo.lock', '');
+
+      expect(
+        await findLocalSiblingOrParent('crates/one/Cargo.toml', 'Cargo.lock')
+      ).toBe('crates/one/Cargo.lock');
+      expect(await findLocalSiblingOrParent('crates/one', 'Cargo.lock')).toBe(
+        'Cargo.lock'
+      );
+      expect(
+        await findLocalSiblingOrParent('crates/one/Cargo.toml', 'Cargo.mock')
+      ).toBeNull();
     });
   });
 });

--- a/lib/util/fs/index.ts
+++ b/lib/util/fs/index.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs-extra';
-import { join, parse } from 'upath';
+import { isAbsolute, join, parse } from 'upath';
 import { RenovateConfig } from '../../config/common';
 import { logger } from '../../logger';
 
@@ -95,4 +95,33 @@ export function localPathExists(pathName: string): Promise<boolean> {
     .stat(join(localDir, pathName))
     .then((s) => !!s)
     .catch(() => false);
+}
+
+/**
+ * Tries to find `otherFileName` in the directory where
+ * `existingFileNameWithPath` is, then in its parent directory, then in the
+ * grandparent, until we reach the top-level directory. All paths
+ * must be relative to `localDir`.
+ */
+export async function findLocalSiblingOrParent(
+  existingFileNameWithPath: string,
+  otherFileName: string
+): Promise<string | null> {
+  if (isAbsolute(existingFileNameWithPath)) {
+    return null;
+  }
+  if (isAbsolute(otherFileName)) {
+    return null;
+  }
+
+  let current = existingFileNameWithPath;
+  while (current !== '') {
+    current = getSubDirectory(current);
+    const candidate = join(current, otherFileName);
+    if (await localPathExists(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
 }


### PR DESCRIPTION
## Changes:

Currently, renovate only looks for `Cargo.lock` files that are *siblings* of `Cargo.toml` files, ie. in the same directory.

This is only true for "standalone packages". In monorepos (which tend to be Cargo workspaces), there's a global `Cargo.lock` file at the top-level, and individual crates don't have their own `Cargo.lock` file.

This changes the `cargo` manager so that, if it doesn't find a "sibling" lockFile, it looks up to the parent folder until it reaches the top of `localDir`.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] Unit tests + ran on a real repository

Sample real repository: https://github.com/fasterthanlime/renovate-monorepo-test/pull/2/files (renovate@master updates only `crates/one/Cargo.toml`, this PR also updates the top-level `Cargo.lock`).