### PR TITLE
feat: Allow to specify pypi registry for other datasources

### DIFF
--- a/lib/manager/pip_requirements/extract.spec.ts
+++ b/lib/manager/pip_requirements/extract.spec.ts
@@ -45,8 +45,14 @@ describe('lib/manager/pip_requirements/extract', () => {
   });
   describe('extractPackageFile()', () => {
     let config;
+    const OLD_ENV = process.env;
     beforeEach(() => {
       config = { registryUrls: ['AnExistingDefaultUrl'] };
+      process.env = { ...OLD_ENV };
+      delete process.env.PIP_INDEX_URL;
+    });
+    afterEach(() => {
+      process.env = OLD_ENV;
     });
     it('returns null for empty', () => {
       expect(

--- a/lib/manager/pip_requirements/extract.ts
+++ b/lib/manager/pip_requirements/extract.ts
@@ -44,7 +44,7 @@ export function extractPackageFile(
     registryUrls = registryUrls.concat(config.registryUrls);
   } else if (extraUrls.length) {
     // Use default registry first if extra URLs are present and index URL is not
-    registryUrls.push('https://pypi.org/pypi/');
+    registryUrls.push(process.env.PIP_INDEX_URL || 'https://pypi.org/pypi/');
   }
   registryUrls = registryUrls.concat(extraUrls);
 

--- a/lib/manager/poetry/extract.spec.ts
+++ b/lib/manager/poetry/extract.spec.ts
@@ -49,8 +49,14 @@ const pyproject9toml = readFileSync(
 describe('lib/manager/poetry/extract', () => {
   describe('extractPackageFile()', () => {
     let filename: string;
+    const OLD_ENV = process.env;
     beforeEach(() => {
       filename = '';
+      process.env = { ...OLD_ENV };
+      delete process.env.PIP_INDEX_URL;
+    });
+    afterEach(() => {
+      process.env = OLD_ENV;
     });
     it('returns null for empty', () => {
       expect(extractPackageFile('nothing here', filename)).toBeNull();

--- a/lib/manager/poetry/extract.ts
+++ b/lib/manager/poetry/extract.ts
@@ -82,7 +82,7 @@ function extractRegistries(pyprojectfile: PoetryFile): string[] {
       registryUrls.add(source.url);
     }
   }
-  registryUrls.add('https://pypi.org/pypi/');
+  registryUrls.add( process.env.PIP_INDEX_URL || 'https://pypi.org/pypi/');
 
   return Array.from(registryUrls);
 }

--- a/lib/manager/poetry/extract.ts
+++ b/lib/manager/poetry/extract.ts
@@ -82,7 +82,7 @@ function extractRegistries(pyprojectfile: PoetryFile): string[] {
       registryUrls.add(source.url);
     }
   }
-  registryUrls.add( process.env.PIP_INDEX_URL || 'https://pypi.org/pypi/');
+  registryUrls.add(process.env.PIP_INDEX_URL || 'https://pypi.org/pypi/');
 
   return Array.from(registryUrls);
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

In https://github.com/renovatebot/renovate/blob/master/lib/datasource/pypi/index.ts#L13
it's possible to override the pypi index by specifying the environment variable `PIP_INDEX_URL`

However in the datasources `pip_requirements` and `poetry` those two are hardcoded.
This PRs add this possibility to those as well

## Context:

As some place document the possible usage of PIP_INDEX_URL I was surprised to see them not applied after changing.
A quick look at the datasource showed me that it didn't apply for all pip sources.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
