### PR TITLE
fix(github): pass up repo not found in init

### DIFF
--- a/lib/platform/github/index.ts
+++ b/lib/platform/github/index.ts
@@ -248,7 +248,8 @@ export async function initRepo({
     logger.debug('Caught initRepo error');
     if (
       err.message === REPOSITORY_ARCHIVED ||
-      err.message === REPOSITORY_RENAMED
+      err.message === REPOSITORY_RENAMED ||
+      err.message === REPOSITORY_NOT_FOUND
     ) {
       throw err;
     }

--- a/lib/workers/repository/result.ts
+++ b/lib/workers/repository/result.ts
@@ -11,6 +11,7 @@ import {
   REPOSITORY_EMPTY,
   REPOSITORY_FORKED,
   REPOSITORY_MIRRORED,
+  REPOSITORY_NOT_FOUND,
   REPOSITORY_RENAMED,
   REPOSITORY_UNINITIATED,
 } from '../../constants/error-messages';
@@ -40,6 +41,7 @@ export function processResult(
     REPOSITORY_RENAMED,
     REPOSITORY_UNINITIATED,
     REPOSITORY_EMPTY,
+    REPOSITORY_NOT_FOUND,
   ];
   const enabledStatuses = [CONFIG_SECRETS_EXPOSED, CONFIG_VALIDATION];
   let status: ProcessStatus;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Passes up `REPOSITORY_NOT_FOUND` from github initRepo() and classifies the repo as disabled.

## Context:

This seems to have been missed out once we switched to GraphQL.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
