### PR TITLE
refactor(datasource): Unify registryUrl resolving

### DIFF
--- a/lib/datasource/index.ts
+++ b/lib/datasource/index.ts
@@ -1,4 +1,3 @@
-import is from '@sindresorhus/is';
 import equal from 'fast-deep-equal';
 import { HOST_DISABLED } from '../constants/error-messages';
 import { logger } from '../logger';
@@ -149,17 +148,14 @@ async function mergeRegistries(
 
 function resolveRegistryUrls(
   datasource: Datasource,
-  extractedUrls: string[]
+  extractedUrls: string[] = []
 ): string[] {
   const { defaultRegistryUrls = [], appendRegistryUrls = [] } = datasource;
-  const customUrls = extractedUrls?.filter(Boolean);
-  let registryUrls: string[];
-  if (is.nonEmptyArray(customUrls)) {
-    registryUrls = [...extractedUrls, ...appendRegistryUrls];
-  } else {
-    registryUrls = [...defaultRegistryUrls, ...appendRegistryUrls];
-  }
-  return registryUrls.filter(Boolean);
+  return [
+    ...defaultRegistryUrls,
+    ...extractedUrls,
+    ...appendRegistryUrls,
+  ].filter(Boolean);
 }
 
 async function fetchReleases(

--- a/lib/datasource/index.ts
+++ b/lib/datasource/index.ts
@@ -152,10 +152,12 @@ function resolveRegistryUrls(
 ): string[] {
   const { defaultRegistryUrls = [], appendRegistryUrls = [] } = datasource;
   return [
-    ...defaultRegistryUrls,
-    ...extractedUrls,
-    ...appendRegistryUrls,
-  ].filter(Boolean);
+    ...new Set(
+      [...defaultRegistryUrls, ...extractedUrls, ...appendRegistryUrls].filter(
+        Boolean
+      )
+    ),
+  ];
 }
 
 async function fetchReleases(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Make final `registryUrls` order and content not depend on whether we have extracted custom URLs or not.

## Context:

Ref: #3446 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
