### PR TITLE
refactor: datasource defaultVersioning

### DIFF
--- a/lib/datasource/common.ts
+++ b/lib/datasource/common.ts
@@ -75,6 +75,7 @@ export interface DatasourceApi {
   getDigest?(config: DigestConfig, newValue?: string): Promise<string | null>;
   getReleases(config: GetReleasesConfig): Promise<ReleaseResult | null>;
   defaultRegistryUrls?: string[];
+  defaultVersioning?: string;
   defaultConfig?: Record<string, unknown>;
   registryStrategy?: 'first' | 'hunt' | 'merge';
 }

--- a/lib/datasource/index.ts
+++ b/lib/datasource/index.ts
@@ -162,6 +162,11 @@ function resolveRegistryUrls(
   return registryUrls.filter(Boolean);
 }
 
+export function getDefaultVersioning(datasourceName: string): string {
+  const datasource = load(datasourceName);
+  return datasource.defaultVersioning || 'semver';
+}
+
 async function fetchReleases(
   config: GetReleasesInternalConfig
 ): Promise<ReleaseResult | null> {
@@ -273,8 +278,10 @@ export async function getPkgReleases(
       })
       .filter(Boolean);
   }
-  // Filter by versioning
-  const version = allVersioning.get(config.versioning);
+  // Use the datasource's default versioning if none is configured
+  const versioning =
+    config.versioning || getDefaultVersioning(config.datasource);
+  const version = allVersioning.get(versioning);
   // Return a sorted list of valid Versions
   function sortReleases(release1: Release, release2: Release): number {
     return version.sortVersions(release1.version, release2.version);

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -5,6 +5,7 @@ import {
 } from '../../../../config';
 import {
   Release,
+  getDefaultVersioning,
   getDigest,
   getPkgReleases,
   isGetPkgReleasesConfig,
@@ -139,7 +140,10 @@ export async function lookupUpdates(
   let config: LookupUpdateConfig = { ...inconfig };
   const { depName, currentValue, lockedVersion, vulnerabilityAlert } = config;
   logger.trace({ dependency: depName, currentValue }, 'lookupUpdates');
-  const version = allVersioning.get(config.versioning);
+  // Use the datasource's default versioning if none is configured
+  const version = allVersioning.get(
+    config.versioning || getDefaultVersioning(config.datasource)
+  );
   const res: UpdateResult = { updates: [], warnings: [] } as any;
 
   const isValid = currentValue && version.isValid(currentValue);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds field `defaultVersioning` to datasources, plus an accessor `getDefaultVersioning()` function to the datasource index.

## Context:

Most datasources can/should have a default versioning scheme, instead of needing to insert it in the manager step.

Currently this a no-op refactoring that shouldn't change any behavior at all.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
