### PR TITLE
feat(datasource): define defaultVersioning

### DIFF
--- a/lib/datasource/crate/index.ts
+++ b/lib/datasource/crate/index.ts
@@ -7,10 +7,12 @@ import * as memCache from '../../util/cache/memory';
 import * as packageCache from '../../util/cache/package';
 import { privateCacheDir, readFile } from '../../util/fs';
 import { Http } from '../../util/http';
+import * as cargoVersioning from '../../versioning/cargo';
 import { GetReleasesConfig, Release, ReleaseResult } from '../common';
 
 export const id = 'crate';
 export const defaultRegistryUrls = ['https://crates.io'];
+export const defaultVersioning = cargoVersioning.id;
 export const registryStrategy = 'first';
 
 const http = new Http(id);

--- a/lib/datasource/docker/index.ts
+++ b/lib/datasource/docker/index.ts
@@ -11,6 +11,7 @@ import { ExternalHostError } from '../../types/errors/external-host-error';
 import * as packageCache from '../../util/cache/package';
 import * as hostRules from '../../util/host-rules';
 import { Http, HttpResponse } from '../../util/http';
+import * as dockerVersioning from '../../versioning/docker';
 import { GetReleasesConfig, ReleaseResult } from '../common';
 
 // TODO: add got typings when available
@@ -18,6 +19,7 @@ import { GetReleasesConfig, ReleaseResult } from '../common';
 
 export const id = 'docker';
 export const defaultRegistryUrls = ['https://index.docker.io'];
+export const defaultVersioning = dockerVersioning.id;
 export const registryStrategy = 'first';
 
 export const defaultConfig = {

--- a/lib/datasource/gradle-version/index.ts
+++ b/lib/datasource/gradle-version/index.ts
@@ -1,10 +1,12 @@
 import { ExternalHostError } from '../../types/errors/external-host-error';
 import { Http } from '../../util/http';
 import { regEx } from '../../util/regex';
+import * as gradleVersioning from '../../versioning/gradle';
 import { GetReleasesConfig, ReleaseResult } from '../common';
 
 export const id = 'gradle-version';
 export const defaultRegistryUrls = ['https://services.gradle.org/versions/all'];
+export const defaultVersioning = gradleVersioning.id;
 export const registryStrategy = 'merge';
 
 const http = new Http(id);

--- a/lib/datasource/hex/index.ts
+++ b/lib/datasource/hex/index.ts
@@ -1,9 +1,11 @@
 import { logger } from '../../logger';
 import { ExternalHostError } from '../../types/errors/external-host-error';
 import { Http } from '../../util/http';
+import * as hexVersioning from '../../versioning/hex';
 import { GetReleasesConfig, ReleaseResult } from '../common';
 
 export const id = 'hex';
+export const defaultVersioning = hexVersioning.id;
 
 const http = new Http(id);
 

--- a/lib/datasource/maven/index.ts
+++ b/lib/datasource/maven/index.ts
@@ -5,6 +5,7 @@ import { XmlDocument } from 'xmldoc';
 import { logger } from '../../logger';
 import * as packageCache from '../../util/cache/package';
 import mavenVersion from '../../versioning/maven';
+import * as mavenVersioning from '../../versioning/maven';
 import { compare } from '../../versioning/maven/compare';
 import { GetReleasesConfig, Release, ReleaseResult } from '../common';
 import { MAVEN_REPO } from './common';
@@ -13,6 +14,7 @@ import { downloadHttpProtocol, isHttpResourceExists } from './util';
 export { id } from './common';
 
 export const defaultRegistryUrls = [MAVEN_REPO];
+export const defaultVersioning = mavenVersioning.id;
 export const registryStrategy = 'merge';
 
 function containsPlaceholder(str: string): boolean {

--- a/lib/datasource/npm/index.ts
+++ b/lib/datasource/npm/index.ts
@@ -1,4 +1,7 @@
+import * as npmVersioning from '../../versioning/npm';
+
 export { resetMemCache, resetCache } from './get';
 export { getReleases } from './releases';
 export { getNpmrc, setNpmrc } from './npmrc';
 export { id } from './common';
+export const defaultVersioning = npmVersioning.id;

--- a/lib/datasource/nuget/index.ts
+++ b/lib/datasource/nuget/index.ts
@@ -1,5 +1,6 @@
 import urlApi from 'url';
 import { logger } from '../../logger';
+import * as nugetVersioning from '../../versioning/nuget';
 import { GetReleasesConfig, ReleaseResult } from '../common';
 import * as v2 from './v2';
 import * as v3 from './v3';
@@ -7,6 +8,7 @@ import * as v3 from './v3';
 export { id } from './common';
 
 export const defaultRegistryUrls = [v3.getDefaultFeed()];
+export const defaultVersioning = nugetVersioning.id;
 export const registryStrategy = 'merge';
 
 function parseRegistryUrl(

--- a/lib/datasource/packagist/index.ts
+++ b/lib/datasource/packagist/index.ts
@@ -7,10 +7,12 @@ import * as memCache from '../../util/cache/memory';
 import * as packageCache from '../../util/cache/package';
 import * as hostRules from '../../util/host-rules';
 import { Http, HttpOptions } from '../../util/http';
+import * as composerVersioning from '../../versioning/composer';
 import { GetReleasesConfig, ReleaseResult } from '../common';
 
 export const id = 'packagist';
 export const defaultRegistryUrls = ['https://packagist.org'];
+export const defaultVersioning = composerVersioning.id;
 export const registryStrategy = 'hunt';
 
 const http = new Http(id);

--- a/lib/datasource/pypi/index.ts
+++ b/lib/datasource/pypi/index.ts
@@ -4,7 +4,6 @@ import { logger } from '../../logger';
 import { parse } from '../../util/html';
 import { Http } from '../../util/http';
 import { ensureTrailingSlash } from '../../util/url';
-import { matches } from '../../versioning/pep440';
 import * as pep440 from '../../versioning/pep440';
 import { GetReleasesConfig, Release, ReleaseResult } from '../common';
 
@@ -12,6 +11,7 @@ export const id = 'pypi';
 export const defaultRegistryUrls = [
   process.env.PIP_INDEX_URL || 'https://pypi.org/pypi/',
 ];
+export const defaultVersioning = pep440.id;
 export const registryStrategy = 'merge';
 
 const githubRepoPattern = /^https?:\/\/github\.com\/[^\\/]+\/[^\\/]+$/;
@@ -50,7 +50,7 @@ function compatibleVersions(
       if (!release.requires_python) {
         return true;
       }
-      return matches(constraints.python, release.requires_python);
+      return pep440.matches(constraints.python, release.requires_python);
     })
   );
 }

--- a/lib/datasource/ruby-version/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/ruby-version/__snapshots__/index.spec.ts.snap
@@ -75,6 +75,11 @@ Object {
       "version": "1.8.6",
     },
     Object {
+      "changelogUrl": "https://www.ruby-lang.org/en/news/2008/08/11/ruby-1-8-7-p72-and-1-8-6-p287-released/",
+      "releaseTimestamp": "2008-08-11",
+      "version": "1.8.7-p72",
+    },
+    Object {
       "changelogUrl": "https://www.ruby-lang.org/en/news/2009/04/18/ruby-1-8-7-p160-and-1-8-6-p368-released/",
       "releaseTimestamp": "2009-04-18",
       "version": "1.8.7-p160",
@@ -113,11 +118,6 @@ Object {
       "changelogUrl": "https://www.ruby-lang.org/en/news/2013/06/27/ruby-1-8-7-p374-is-released/",
       "releaseTimestamp": "2013-06-27",
       "version": "1.8.7-p374",
-    },
-    Object {
-      "changelogUrl": "https://www.ruby-lang.org/en/news/2008/08/11/ruby-1-8-7-p72-and-1-8-6-p287-released/",
-      "releaseTimestamp": "2008-08-11",
-      "version": "1.8.7-p72",
     },
     Object {
       "changelogUrl": "https://www.ruby-lang.org/en/news/2008/05/31/ruby-1-8-7-has-been-released/",

--- a/lib/datasource/ruby-version/index.ts
+++ b/lib/datasource/ruby-version/index.ts
@@ -2,10 +2,11 @@ import { ExternalHostError } from '../../types/errors/external-host-error';
 import * as packageCache from '../../util/cache/package';
 import { parse } from '../../util/html';
 import { Http } from '../../util/http';
-import { isVersion } from '../../versioning/ruby';
+import { isVersion, id as rubyVersioningId } from '../../versioning/ruby';
 import { GetReleasesConfig, ReleaseResult } from '../common';
 
 export const id = 'ruby-version';
+export const defaultVersioning = rubyVersioningId;
 
 const http = new Http(id);
 

--- a/lib/datasource/rubygems/index.ts
+++ b/lib/datasource/rubygems/index.ts
@@ -1,4 +1,7 @@
+import * as rubyVersioning from '../../versioning/ruby';
+
 export { getReleases } from './releases';
 export { id } from './common';
 export const defaultRegistryUrls = ['https://rubygems.org'];
+export const defaultVersioning = rubyVersioning.id;
 export const registryStrategy = 'hunt';

--- a/lib/datasource/sbt-package/index.ts
+++ b/lib/datasource/sbt-package/index.ts
@@ -1,5 +1,6 @@
 import { XmlDocument } from 'xmldoc';
 import { logger } from '../../logger';
+import * as ivyVersioning from '../../versioning/ivy';
 import { compare } from '../../versioning/maven/compare';
 import { GetReleasesConfig, ReleaseResult } from '../common';
 import { MAVEN_REPO } from '../maven/common';
@@ -7,8 +8,8 @@ import { downloadHttpProtocol } from '../maven/util';
 import { parseIndexDir } from '../sbt-plugin/util';
 
 export const id = 'sbt-package';
-
 export const defaultRegistryUrls = [MAVEN_REPO];
+export const defaultVersioning = ivyVersioning.id;
 export const registryStrategy = 'hunt';
 
 const ensureTrailingSlash = (str: string): string => str.replace(/\/?$/, '/');

--- a/lib/datasource/sbt-plugin/index.ts
+++ b/lib/datasource/sbt-plugin/index.ts
@@ -1,4 +1,5 @@
 import { logger } from '../../logger';
+import * as ivyVersioning from '../../versioning/ivy';
 import { compare } from '../../versioning/maven/compare';
 import { GetReleasesConfig, ReleaseResult } from '../common';
 import { downloadHttpProtocol } from '../maven/util';
@@ -11,8 +12,8 @@ import {
 import { SBT_PLUGINS_REPO, parseIndexDir } from './util';
 
 export const id = 'sbt-plugin';
-
 export const defaultRegistryUrls = [SBT_PLUGINS_REPO];
+export const defaultVersioning = ivyVersioning.id;
 export const registryStrategy = 'hunt';
 
 const ensureTrailingSlash = (str: string): string => str.replace(/\/?$/, '/');

--- a/lib/datasource/terraform-module/index.ts
+++ b/lib/datasource/terraform-module/index.ts
@@ -2,10 +2,12 @@ import { logger } from '../../logger';
 import { ExternalHostError } from '../../types/errors/external-host-error';
 import * as packageCache from '../../util/cache/package';
 import { Http } from '../../util/http';
+import * as hashicorpVersioning from '../../versioning/hashicorp';
 import { GetReleasesConfig, ReleaseResult } from '../common';
 
 export const id = 'terraform-module';
 export const defaultRegistryUrls = ['https://registry.terraform.io'];
+export const defaultVersioning = hashicorpVersioning.id;
 export const registryStrategy = 'first';
 
 const http = new Http(id);

--- a/lib/datasource/terraform-provider/index.ts
+++ b/lib/datasource/terraform-provider/index.ts
@@ -2,6 +2,7 @@ import URL from 'url';
 import { logger } from '../../logger';
 import * as packageCache from '../../util/cache/package';
 import { Http } from '../../util/http';
+import * as hashicorpVersioning from '../../versioning/hashicorp';
 import { GetReleasesConfig, ReleaseResult } from '../common';
 import { getTerraformServiceDiscoveryResult } from '../terraform-module';
 
@@ -10,6 +11,7 @@ export const defaultRegistryUrls = [
   'https://registry.terraform.io',
   'https://releases.hashicorp.com',
 ];
+export const defaultVersioning = hashicorpVersioning.id;
 export const registryStrategy = 'hunt';
 
 const http = new Http(id);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds `defaultVersioning` values to applicable datasources.

## Context:

This should simplify managers by not making them specify `versioning` unless it differs from the datasource's default.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
