### PR TITLE
docs: remove single quotes around process.env for Docker docs

### DIFF
--- a/docs/usage/docker.md
+++ b/docs/usage/docker.md
@@ -179,7 +179,7 @@ module.exports = {
     {
       hostType: 'docker',
       username: '<your-username>',
-      password: 'process.env.DOCKER_HUB_PASSWORD',
+      password: process.env.DOCKER_HUB_PASSWORD,
     },
   ],
 };
@@ -200,7 +200,7 @@ module.exports = {
       hostType: 'docker',
       hostName: 'your.host.io',
       username: '<your-username>',
-      password: 'process.env.SELF_HOSTED_DOCKER_IMAGES_PASSWORD',
+      password: process.env.SELF_HOSTED_DOCKER_IMAGES_PASSWORD,
     },
   ],
 };
@@ -217,7 +217,7 @@ module.exports = {
     {
       hostName: 'your.host.io',
       username: '<your-username>',
-      password: 'process.env.SELF_HOSTED_HELM_CHARTS_PASSWORD',
+      password: process.env.SELF_HOSTED_HELM_CHARTS_PASSWORD,
     },
   ],
 };


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what this pull request changes. -->

- Remove the single quotes that were around the process.env variable

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

You should now be able to copy/paste the example config and have it work when using Docker.

Closes #8376

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
