### PR TITLE
feat: add preset to opt-out of rebase checkbox within PRs

### DIFF
--- a/lib/config/presets/internal/default.ts
+++ b/lib/config/presets/internal/default.ts
@@ -584,4 +584,10 @@ export const presets: Record<string, Preset> = {
     description: 'deprecated alias for config:js-lib',
     extends: ['config:js-lib'],
   },
+  disableRebaseCheckboxInPRs: {
+    description:
+      'Remove the checkbox to rebase the PR, this can help when your CI checks if all checkboxes are ticked.',
+    prBodyTemplate:
+      '{{{header}}}{{{table}}}{{{notes}}}{{{changelogs}}}{{{configDescription}}}{{{footer}}}',
+  },
 };

--- a/lib/config/presets/internal/default.ts
+++ b/lib/config/presets/internal/default.ts
@@ -584,7 +584,7 @@ export const presets: Record<string, Preset> = {
     description: 'deprecated alias for config:js-lib',
     extends: ['config:js-lib'],
   },
-  disableControls: {
+  disablePrControls: {
     description: 'Remove the checkbox controls from PRs',
     prBodyTemplate:
       '{{{header}}}{{{table}}}{{{notes}}}{{{changelogs}}}{{{configDescription}}}{{{footer}}}',

--- a/lib/config/presets/internal/default.ts
+++ b/lib/config/presets/internal/default.ts
@@ -584,9 +584,9 @@ export const presets: Record<string, Preset> = {
     description: 'deprecated alias for config:js-lib',
     extends: ['config:js-lib'],
   },
-  disableRebaseCheckboxInPRs: {
+  disableControls: {
     description:
-      'Remove the checkbox to rebase the PR, this can help when your CI checks if all checkboxes are ticked.',
+      'Remove the checkbox controls from PRs',
     prBodyTemplate:
       '{{{header}}}{{{table}}}{{{notes}}}{{{changelogs}}}{{{configDescription}}}{{{footer}}}',
   },

--- a/lib/config/presets/internal/default.ts
+++ b/lib/config/presets/internal/default.ts
@@ -585,8 +585,7 @@ export const presets: Record<string, Preset> = {
     extends: ['config:js-lib'],
   },
   disableControls: {
-    description:
-      'Remove the checkbox controls from PRs',
+    description: 'Remove the checkbox controls from PRs',
     prBodyTemplate:
       '{{{header}}}{{{table}}}{{{notes}}}{{{changelogs}}}{{{configDescription}}}{{{footer}}}',
   },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what this pull request changes. -->

Adds a preset that removes the `{{{control}}}` template from the PR.
This in essence removes the checkbox to "rebase this pr".
This can help when a user has CI that checks if all checkboxes within a PR are ticked.

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

Inspired by #8387.

I'd feel better if we had a unit test to check that this preset actually works, and keeps working in the future.
We are migrating away from the rebase term, so a unit test would alert us if we're breaking the new preset.

Also please check if this preset is added to the right document.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
