### PR TITLE
fix(composer): Fix wrong getNewValue results for 'update-lockfile'

### DIFF
--- a/lib/versioning/composer/index.spec.ts
+++ b/lib/versioning/composer/index.spec.ts
@@ -392,6 +392,58 @@ describe('semver.getNewValue()', () => {
       })
     ).toEqual('v3.2.*'); // #5388
   });
+  it('handles update-lockfile strategy', () => {
+    expect(
+      semver.getNewValue({
+        currentValue: '^0.1',
+        rangeStrategy: 'update-lockfile',
+        fromVersion: '0.1.0',
+        toVersion: '0.1.1',
+      })
+    ).toEqual('^0.1');
+    expect(
+      semver.getNewValue({
+        currentValue: '^0.1',
+        rangeStrategy: 'update-lockfile',
+        fromVersion: '0.1.0',
+        toVersion: '0.2.0',
+      })
+    ).toEqual('^0.2');
+
+    expect(
+      semver.getNewValue({
+        currentValue: '^5.1',
+        rangeStrategy: 'update-lockfile',
+        fromVersion: '5.1.0',
+        toVersion: '5.2.0',
+      })
+    ).toEqual('^5.1');
+    expect(
+      semver.getNewValue({
+        currentValue: '^5.1',
+        rangeStrategy: 'update-lockfile',
+        fromVersion: '5.1.0',
+        toVersion: '6.0.0',
+      })
+    ).toEqual('^6.0');
+
+    expect(
+      semver.getNewValue({
+        currentValue: '^5',
+        rangeStrategy: 'update-lockfile',
+        fromVersion: '5.1.0',
+        toVersion: '5.2.0',
+      })
+    ).toEqual('^5');
+    expect(
+      semver.getNewValue({
+        currentValue: '^5',
+        rangeStrategy: 'update-lockfile',
+        fromVersion: '5.1.0',
+        toVersion: '6.0.0',
+      })
+    ).toEqual('^6');
+  });
 });
 describe('.sortVersions', () => {
   it('sorts versions in an ascending order', () => {

--- a/lib/versioning/composer/index.ts
+++ b/lib/versioning/composer/index.ts
@@ -124,6 +124,17 @@ function getNewValue({
   if (rangeStrategy === 'pin') {
     return toVersion;
   }
+  if (rangeStrategy === 'update-lockfile') {
+    if (matches(toVersion, currentValue)) {
+      return currentValue;
+    }
+    return getNewValue({
+      currentValue,
+      rangeStrategy: 'replace',
+      fromVersion,
+      toVersion,
+    });
+  }
   const toMajor = getMajor(toVersion);
   const toMinor = getMinor(toVersion);
   let newValue: string;


### PR DESCRIPTION
## Changes:

Apply same principle we use in `npm` versioning when dealing with `update-lockfile` strategy.

## Context:

Closes #8250

Example: https://github.com/renovate-testing/test-8250-update-lockfile/pulls

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] Unit tests + ran on a real repository
