### PR TITLE
refactor: add depNameShort during flatten

### DIFF
--- a/lib/workers/repository/updates/flatten.spec.ts
+++ b/lib/workers/repository/updates/flatten.spec.ts
@@ -35,6 +35,7 @@ describe('workers/repository/updates/flatten', () => {
               { depName: '@org/a', updates: [{ newValue: '1.0.0' }] },
               { depName: 'foo', updates: [{ newValue: '2.0.0' }] },
               {
+                depName: 'a1',
                 updateTypes: ['pin'],
                 updates: [{ newValue: '2.0.0' }],
               },
@@ -77,6 +78,7 @@ describe('workers/repository/updates/flatten', () => {
       expect(
         res.filter((r) => r.updateType === 'lockFileMaintenance')
       ).toHaveLength(2);
+      expect(res.filter((r) => r.depNameShort)).toHaveLength(7); // lockFileMaintenance has no depName
     });
   });
 });

--- a/lib/workers/repository/updates/flatten.ts
+++ b/lib/workers/repository/updates/flatten.ts
@@ -77,6 +77,8 @@ export async function flattenUpdates(
             // Apply again in case any were added by the updateType config
             updateConfig = applyPackageRules(updateConfig);
             delete updateConfig.packageRules;
+            // TODO: Remove next line once #8075 is complete
+            updateConfig.depNameShort ||= updateConfig.depName;
             updateConfig.depNameSanitized = updateConfig.depName
               ? updateConfig.depName
                   .replace('@types/', '')


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds `depNameShort` to each update during flatten process

## Context:

#8075

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
