### PR TITLE
feat: handle GitLab push rule violation

### DIFF
--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -93,6 +93,7 @@ function checkForPlatformFailure(err: Error): void {
       logger.debug({ err }, 'Converting git error to CONFIG_VALIDATION error');
       const error = new Error(CONFIG_VALIDATION);
       error.validationError = validationError;
+      error.validationMessage = err.message;
       throw error;
     }
   }

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -78,7 +78,7 @@ function checkForPlatformFailure(err: Error): void {
     }
   }
 
-  const gitLabPushRuleFailureStrings = [
+  const configErrorStrings = [
     [
       'GitLab: Branch name does not follow the pattern',
       "Cannot push because branch name does not follow project's push rules",
@@ -88,7 +88,7 @@ function checkForPlatformFailure(err: Error): void {
       "Cannot push because commit message does not follow project's push rules",
     ],
   ];
-  for (const [errorStr, validationError] of gitLabPushRuleFailureStrings) {
+  for (const [errorStr, validationError] of configErrorStrings) {
     if (err.message.includes(errorStr)) {
       logger.debug({ err }, 'Converting git error to CONFIG_VALIDATION error');
       const error = new Error(CONFIG_VALIDATION);

--- a/lib/workers/branch/index.ts
+++ b/lib/workers/branch/index.ts
@@ -3,6 +3,7 @@ import { DateTime } from 'luxon';
 import minimatch from 'minimatch';
 import { RenovateConfig } from '../../config';
 import {
+  CONFIG_VALIDATION,
   MANAGER_LOCKFILE_ERROR,
   PLATFORM_AUTHENTICATION_ERROR,
   PLATFORM_BAD_CREDENTIALS,
@@ -574,6 +575,9 @@ export async function processBranch(
     } else if (err.message?.includes('fatal: bad revision')) {
       logger.debug({ err }, 'Aborting job due to bad revision error');
       throw new Error(REPOSITORY_CHANGED);
+    } else if (err.message === CONFIG_VALIDATION) {
+      logger.debug('Passing config validation error up');
+      throw err;
     } else if (!(err instanceof ExternalHostError)) {
       logger.error({ err }, `Error updating branch: ${String(err.message)}`);
     }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Handle GitLab push rule violation error and convert it to config validation error to inform user that Renovate bot configuration does not match GitLab project configuration in terms of branch name and/or commit message.

## Context:

Closes #8414

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
