### PR TITLE
fix(pip_setup): Allow setup.py to import from its own package

### DIFF
--- a/data/extract.py
+++ b/data/extract.py
@@ -33,6 +33,8 @@ except ImportError:
 @mock.patch.object(setuptools, 'setup')
 @mock.patch.object(distutils.core, 'setup')
 def invoke(mock1, mock2):
+  # Inserting the parent directory of the target setup.py in Python import path:
+  sys.path.append(os.getcwd())
   # This is setup.py which calls setuptools.setup
   load_source('_target_setup_', basename(sys.argv[-1]))
   # called arguments are in `mock_setup.call_args`


### PR DESCRIPTION
## Changes:

Allow setup.py to import modules from the same package, again. This issue is re-introduced in https://github.com/renovatebot/renovate/pull/8320.

## Context:

Closes https://github.com/renovatebot/renovate/issues/8415.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

Run Renovate against https://github.com/hisener/renovate-tests/tree/master/gh-8415.

I also have a WIP branch for tests, see https://github.com/PicnicSupermarket/renovate/compare/hsener/gh-8415...PicnicSupermarket:hsener/gh-8415-tests.