### PR TITLE
fix(docker): accept manifest lists for digests

### DIFF
--- a/lib/datasource/docker/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/docker/__snapshots__/index.spec.ts.snap
@@ -61,7 +61,7 @@ Array [
   },
   Object {
     "headers": Object {
-      "accept": "application/vnd.docker.distribution.manifest.v2+json",
+      "accept": "application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json",
       "accept-encoding": "gzip, deflate",
       "authorization": "Basic c29tZS11c2VybmFtZTpzb21lLXBhc3N3b3Jk",
       "host": "index.docker.io",
@@ -98,7 +98,7 @@ Array [
   },
   Object {
     "headers": Object {
-      "accept": "application/vnd.docker.distribution.manifest.v2+json",
+      "accept": "application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json",
       "accept-encoding": "gzip, deflate",
       "authorization": "Bearer some-token",
       "host": "index.docker.io",
@@ -133,7 +133,7 @@ Array [
   },
   Object {
     "headers": Object {
-      "accept": "application/vnd.docker.distribution.manifest.v2+json",
+      "accept": "application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json",
       "accept-encoding": "gzip, deflate",
       "authorization": "Bearer some-token",
       "host": "index.docker.io",
@@ -184,7 +184,7 @@ Array [
   },
   Object {
     "headers": Object {
-      "accept": "application/vnd.docker.distribution.manifest.v2+json",
+      "accept": "application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json",
       "accept-encoding": "gzip, deflate",
       "authorization": "Basic c29tZS11c2VybmFtZTpzb21lLXBhc3N3b3Jk",
       "host": "index.docker.io",
@@ -210,7 +210,7 @@ Array [
   },
   Object {
     "headers": Object {
-      "accept": "application/vnd.docker.distribution.manifest.v2+json",
+      "accept": "application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json",
       "accept-encoding": "gzip, deflate",
       "authorization": "Basic c29tZS11c2VybmFtZTpzb21lLXBhc3N3b3Jk",
       "host": "index.docker.io",
@@ -236,7 +236,7 @@ Array [
   },
   Object {
     "headers": Object {
-      "accept": "application/vnd.docker.distribution.manifest.v2+json",
+      "accept": "application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json",
       "accept-encoding": "gzip, deflate",
       "authorization": "Basic c29tZS11c2VybmFtZTpzb21lLXBhc3N3b3Jk",
       "host": "index.docker.io",
@@ -272,7 +272,7 @@ Array [
   },
   Object {
     "headers": Object {
-      "accept": "application/vnd.docker.distribution.manifest.v2+json",
+      "accept": "application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json",
       "accept-encoding": "gzip, deflate",
       "authorization": "Basic abcdef",
       "host": "123456789.dkr.ecr.us-east-1.amazonaws.com",
@@ -308,7 +308,7 @@ Array [
   },
   Object {
     "headers": Object {
-      "accept": "application/vnd.docker.distribution.manifest.v2+json",
+      "accept": "application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json",
       "accept-encoding": "gzip, deflate",
       "authorization": "Basic c29tZS11c2VybmFtZTpzb21lLXBhc3N3b3Jk",
       "host": "index.docker.io",
@@ -334,7 +334,7 @@ Array [
   },
   Object {
     "headers": Object {
-      "accept": "application/vnd.docker.distribution.manifest.v2+json",
+      "accept": "application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json",
       "accept-encoding": "gzip, deflate",
       "authorization": "Basic c29tZS11c2VybmFtZTpzb21lLXBhc3N3b3Jk",
       "host": "index.docker.io",
@@ -371,7 +371,7 @@ Array [
   },
   Object {
     "headers": Object {
-      "accept": "application/vnd.docker.distribution.manifest.v2+json",
+      "accept": "application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json",
       "accept-encoding": "gzip, deflate",
       "authorization": "Bearer some-token",
       "host": "index.docker.io",
@@ -442,7 +442,7 @@ Array [
   },
   Object {
     "headers": Object {
-      "accept": "application/vnd.docker.distribution.manifest.v2+json",
+      "accept": "application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json",
       "accept-encoding": "gzip, deflate",
       "host": "index.docker.io",
       "user-agent": "https://github.com/renovatebot/renovate",
@@ -498,7 +498,7 @@ Array [
   },
   Object {
     "headers": Object {
-      "accept": "application/vnd.docker.distribution.manifest.v2+json",
+      "accept": "application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json",
       "accept-encoding": "gzip, deflate",
       "host": "index.docker.io",
       "user-agent": "https://github.com/renovatebot/renovate",
@@ -554,7 +554,7 @@ Array [
   },
   Object {
     "headers": Object {
-      "accept": "application/vnd.docker.distribution.manifest.v2+json",
+      "accept": "application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json",
       "accept-encoding": "gzip, deflate",
       "host": "k8s.gcr.io",
       "user-agent": "https://github.com/renovatebot/renovate",
@@ -684,7 +684,7 @@ Array [
   },
   Object {
     "headers": Object {
-      "accept": "application/vnd.docker.distribution.manifest.v2+json",
+      "accept": "application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json",
       "accept-encoding": "gzip, deflate",
       "authorization": "Basic c29tZS11c2VybmFtZTpzb21lLXBhc3N3b3Jk",
       "host": "registry.company.com",
@@ -759,7 +759,7 @@ Array [
   },
   Object {
     "headers": Object {
-      "accept": "application/vnd.docker.distribution.manifest.v2+json",
+      "accept": "application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json",
       "accept-encoding": "gzip, deflate",
       "authorization": "Basic c29tZS11c2VybmFtZTpzb21lLXBhc3N3b3Jk",
       "host": "registry.company.com",
@@ -835,7 +835,7 @@ Array [
   },
   Object {
     "headers": Object {
-      "accept": "application/vnd.docker.distribution.manifest.v2+json",
+      "accept": "application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json",
       "accept-encoding": "gzip, deflate",
       "authorization": "Basic c29tZS11c2VybmFtZTpzb21lLXBhc3N3b3Jk",
       "host": "registry.company.com",
@@ -893,7 +893,7 @@ Array [
   },
   Object {
     "headers": Object {
-      "accept": "application/vnd.docker.distribution.manifest.v2+json",
+      "accept": "application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json",
       "accept-encoding": "gzip, deflate",
       "authorization": "Basic c29tZS11c2VybmFtZTpzb21lLXBhc3N3b3Jk",
       "host": "registry.company.com",
@@ -940,7 +940,7 @@ Array [
   },
   Object {
     "headers": Object {
-      "accept": "application/vnd.docker.distribution.manifest.v2+json",
+      "accept": "application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json",
       "accept-encoding": "gzip, deflate",
       "authorization": "Basic c29tZS11c2VybmFtZTpzb21lLXBhc3N3b3Jk",
       "host": "123456789.dkr.ecr.us-east-1.amazonaws.com",

--- a/lib/datasource/docker/index.ts
+++ b/lib/datasource/docker/index.ts
@@ -267,7 +267,8 @@ async function getManifestResponse(
       logger.debug('No docker auth found - returning');
       return null;
     }
-    headers.accept = 'application/vnd.docker.distribution.manifest.v2+json';
+    headers.accept =
+      'application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json';
     const url = `${registry}/v2/${repository}/manifests/${tag}`;
     const manifestResponse = await http.get(url, {
       headers,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Update docker registry header to accept manifest lists so renovate can update those digests instead of tagging first image in manifest list.

* https://docs.docker.com/registry/spec/api/#pulling-an-image-manifest
* https://docs.docker.com/registry/spec/manifest-v2-2/#media-types

<!-- Describe what this pull request changes. -->

## Context:
closes #8427
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
