### PR TITLE
fix(gradle-lite): Allow scala versions parsing in strings

### DIFF
--- a/lib/manager/gradle-lite/parser.spec.ts
+++ b/lib/manager/gradle-lite/parser.spec.ts
@@ -16,13 +16,15 @@ describe('manager/gradle-lite/parser', () => {
     let deps;
 
     ({ deps } = parseGradle(
-      ['version = "1.2.3"', '"foo:bar:$version"', 'version = "3.2.1"'].join(
-        '\n'
-      )
+      [
+        'version = "1.2.3"',
+        '"foo:bar_$version:$version"',
+        'version = "3.2.1"',
+      ].join('\n')
     ));
     expect(deps).toMatchObject([
       {
-        depName: 'foo:bar',
+        depName: 'foo:bar_1.2.3',
         currentValue: '1.2.3',
       },
     ]);

--- a/lib/manager/gradle-lite/utils.ts
+++ b/lib/manager/gradle-lite/utils.ts
@@ -10,7 +10,7 @@ import {
 } from './common';
 
 const artifactRegex = regEx(
-  '^[a-zA-Z][-_a-zA-Z0-9]*(?:.[a-zA-Z][-_a-zA-Z0-9]*)*$'
+  '^[a-zA-Z][-_a-zA-Z0-9]*(?:.[a-zA-Z0-9][-_a-zA-Z0-9]*)*$'
 );
 
 const versionLikeRegex = regEx('^(?<version>[-.\\[\\](),a-zA-Z0-9+]+)');


### PR DESCRIPTION
## Changes:

Slightly change to regex that allows parsing of artifacts with like `foo:bar_1.12:5.6.7`.

## Context:

Ref: #8418
If may cover all issues mentioned in the issue.
Probably we need to handle other places that parse artifact IDs (in further issues/PRs).

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
