### PR TITLE
fix(gradle-lite): Inherit variables from parent build.gradle

### DIFF
--- a/lib/manager/gradle-lite/extract.ts
+++ b/lib/manager/gradle-lite/extract.ts
@@ -3,7 +3,7 @@ import * as datasourceMaven from '../../datasource/maven';
 import { logger } from '../../logger';
 import { readLocalFile } from '../../util/fs';
 import { ExtractConfig, PackageDependency, PackageFile } from '../common';
-import { ManagerData, VariableRegistry } from './common';
+import { ManagerData, PackageVariables, VariableRegistry } from './common';
 import { parseGradle, parseProps } from './parser';
 import {
   getVars,
@@ -46,18 +46,30 @@ export async function extractAllPackageFiles(
     try {
       const content = await readLocalFile(packageFile, 'utf8');
       const dir = upath.dirname(toAbsolutePath(packageFile));
+
+      const updateVars = (newVars: PackageVariables): void => {
+        const oldVars = registry[dir] || {};
+        registry[dir] = { ...oldVars, ...newVars };
+      };
+
       if (isPropsFile(packageFile)) {
         const { vars, deps } = parseProps(content, packageFile);
-        registry[dir] = vars;
+        updateVars(vars);
         extractedDeps.push(...deps);
       } else if (isGradleFile(packageFile)) {
         const vars = getVars(registry, dir);
-        const { deps, urls } = parseGradle(content, vars, packageFile);
+        const { deps, urls, vars: gradleVars } = parseGradle(
+          content,
+          vars,
+          packageFile
+        );
         urls.forEach((url) => {
           if (!registryUrls.includes(url)) {
             registryUrls.push(url);
           }
         });
+        registry[dir] = { ...registry[dir], ...gradleVars };
+        updateVars(gradleVars);
         extractedDeps.push(...deps);
       }
     } catch (e) {

--- a/lib/manager/gradle-lite/parser.ts
+++ b/lib/manager/gradle-lite/parser.ts
@@ -458,12 +458,18 @@ function tryMatch({
   return null;
 }
 
+interface ParseGradleResult {
+  deps: PackageDependency<ManagerData>[];
+  urls: string[];
+  vars: PackageVariables;
+}
+
 export function parseGradle(
   input: string,
   initVars: PackageVariables = {},
   packageFile?: string
-): { deps: PackageDependency<ManagerData>[]; urls: string[] } {
-  const vars = { ...initVars };
+): ParseGradleResult {
+  const vars: PackageVariables = { ...initVars };
   const deps: PackageDependency<ManagerData>[] = [];
   const urls = [];
 
@@ -493,7 +499,7 @@ export function parseGradle(
     prevTokensLength = tokens.length;
   }
 
-  return { deps, urls };
+  return { deps, urls, vars };
 }
 
 const propWord = '[a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)*';


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Allows top-level variables defined in `build.gradle` to be reused in subprojects.

## Context:

Closes #8418

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] Unit tests + ran on a real repository

For [the real repo](https://github.com/renovate-testing/test-8418-gradle-child-directories), I've checked just the the fact it's extracted fine some foobar dep.