### PR TITLE
chore: use --check for Prettier command

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "prepare:generate": "run-s generate:*",
     "prestart": "run-s generate:* ",
     "pretest": "run-s generate:* ",
-    "prettier": "prettier --list-different \"**/*.{ts,js,mjs,json,md}\"",
+    "prettier": "prettier --check \"**/*.{ts,js,mjs,json,md}\"",
     "prettier-fix": "prettier --write \"**/*.{ts,js,mjs,json,md}\"",
     "release": "node --experimental-modules tools/release.mjs",
     "start": "babel-node --extensions \".ts,.js\" -- lib/renovate.ts",


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what this pull request changes. -->

- Use `--check` instead of `--list-different` for the Prettier lint command

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

@viceice noticed that the Prettier lint action does not say what files are borked, only that something is borked.
By using `--check`, Prettier prints what files are borked in the output.

Should help a bit with issue #8408, but doesn't close it.

`--check` does not give a full `diff` output though, so if we do want a proper diff we'd need to build something ourselves I think.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
