### PR TITLE
fix(github): support default branch rename when forking

### DIFF
--- a/lib/platform/github/index.spec.ts
+++ b/lib/platform/github/index.spec.ts
@@ -209,10 +209,16 @@ describe('platform/github', () => {
       })
       // getRepos
       .get('/user/repos?per_page=100')
-      .reply(200, forkedRepo ? [{ full_name: forkedRepo }] : [])
+      .reply(
+        200,
+        forkedRepo ? [{ full_name: forkedRepo, default_branch: 'master' }] : []
+      )
       // getBranchCommit
       .post(`/repos/${repository}/forks`)
-      .reply(200, forkedRepo ? { full_name: forkedRepo } : {});
+      .reply(
+        200,
+        forkedRepo ? { full_name: forkedRepo, default_branch: 'master' } : {}
+      );
   }
 
   describe('initRepo', () => {

--- a/lib/platform/github/index.ts
+++ b/lib/platform/github/index.ts
@@ -300,14 +300,14 @@ export async function initRepo({
         )
       ).body.map((r) => r.full_name);
     try {
-      config.repository = (
-        await githubApi.postJson<{ full_name: string }>(
-          `repos/${repository}/forks`,
-          {
-            token: forkToken || opts.token,
-          }
-        )
-      ).body.full_name;
+      const forkedRepo = await githubApi.postJson<{
+        full_name: string;
+        default_branch: string;
+      }>(`repos/${repository}/forks`, {
+        token: forkToken || opts.token,
+      });
+      config.repository = forkedRepo.body.full_name;
+      config.forkDefaultBranch = forkedRepo.body.default_branch;
     } catch (err) /* istanbul ignore next */ {
       logger.debug({ err }, 'Error forking repository');
       throw new Error(REPOSITORY_CANNOT_FORK);
@@ -317,14 +317,14 @@ export async function initRepo({
         { repository_fork: config.repository },
         'Found existing fork'
       );
-      // This is a lovely "hack" by GitHub that lets us force update our fork's master
+      // This is a lovely "hack" by GitHub that lets us force update our fork's default branch
       // with the base commit from the parent repository
       try {
         logger.debug(
           'Updating forked repository default sha to match upstream'
         );
         await githubApi.patchJson(
-          `repos/${config.repository}/git/refs/heads/${config.defaultBranch}`,
+          `repos/${config.repository}/git/refs/heads/${config.forkDefaultBranch}`,
           {
             body: {
               sha: repo.defaultBranchRef.target.oid,

--- a/lib/platform/github/types.ts
+++ b/lib/platform/github/types.ts
@@ -67,6 +67,7 @@ export interface LocalRepoConfig {
   issueList: any[] | null;
   mergeMethod: string;
   defaultBranch: string;
+  forkDefaultBranch?: string;
   repositoryOwner: string;
   repository: string | null;
   localDir: string;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Detects the default branch of the forked repo, in case the parent has renamed their default while the fork remains on the old default.

## Context:

Forked Renovate repos fail currently if they rename from `master` to `main`. Also, if we were to delete our fork then and PRs were open, it would be messy.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
