### PR TITLE
refactor: HttpResponse.authorization

### DIFF
--- a/lib/util/http/__snapshots__/index.spec.ts.snap
+++ b/lib/util/http/__snapshots__/index.spec.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`util/http/index deleteJson 1`] = `
 Object {
+  "authorization": false,
   "body": Object {},
   "headers": Object {
     "content-type": "application/json",
@@ -12,6 +13,7 @@ Object {
 
 exports[`util/http/index get 1`] = `
 Object {
+  "authorization": false,
   "body": "",
   "headers": Object {},
   "statusCode": 200,
@@ -20,6 +22,7 @@ Object {
 
 exports[`util/http/index getJson 1`] = `
 Object {
+  "authorization": false,
   "body": Object {
     "test": true,
   },
@@ -30,6 +33,7 @@ Object {
 
 exports[`util/http/index headJson 1`] = `
 Object {
+  "authorization": false,
   "body": Object {},
   "headers": Object {
     "content-type": "application/json",
@@ -40,6 +44,7 @@ Object {
 
 exports[`util/http/index patchJson 1`] = `
 Object {
+  "authorization": false,
   "body": Object {},
   "headers": Object {
     "content-type": "application/json",
@@ -50,6 +55,7 @@ Object {
 
 exports[`util/http/index postJson 1`] = `
 Object {
+  "authorization": false,
   "body": Object {},
   "headers": Object {
     "content-type": "application/json",
@@ -60,6 +66,7 @@ Object {
 
 exports[`util/http/index putJson 1`] = `
 Object {
+  "authorization": false,
   "body": Object {},
   "headers": Object {
     "content-type": "application/json",
@@ -70,6 +77,7 @@ Object {
 
 exports[`util/http/index retries 1`] = `
 Object {
+  "authorization": false,
   "body": "",
   "headers": Object {
     "x-some-header": "abc",

--- a/lib/util/http/index.ts
+++ b/lib/util/http/index.ts
@@ -44,6 +44,7 @@ export interface HttpResponse<T = string> {
   statusCode: number;
   body: T;
   headers: any;
+  authorization?: boolean;
 }
 
 function cloneResponse<T>(response: any): HttpResponse<T> {
@@ -52,6 +53,7 @@ function cloneResponse<T>(response: any): HttpResponse<T> {
     statusCode: response.statusCode,
     body: clone<T>(response.body),
     headers: clone(response.headers),
+    authorization: response.authorization,
   };
 }
 
@@ -116,6 +118,7 @@ export class Http<GetOptions = HttpOptions, PostOptions = HttpPostOptions> {
       throw new Error(HOST_DISABLED);
     }
     options = applyAuthorization(options);
+    const authorization = !!options?.headers?.authorization;
 
     const cacheKey = crypto
       .createHash('md5')
@@ -148,6 +151,7 @@ export class Http<GetOptions = HttpOptions, PostOptions = HttpPostOptions> {
 
     try {
       const res = await resPromise;
+      res.authorization = authorization;
       return cloneResponse(res);
     } catch (err) {
       const { abortOnError, abortIgnoreStatusCodes } = options;

--- a/lib/util/http/index.ts
+++ b/lib/util/http/index.ts
@@ -118,7 +118,6 @@ export class Http<GetOptions = HttpOptions, PostOptions = HttpPostOptions> {
       throw new Error(HOST_DISABLED);
     }
     options = applyAuthorization(options);
-    const authorization = !!options?.headers?.authorization;
 
     const cacheKey = crypto
       .createHash('md5')
@@ -151,7 +150,7 @@ export class Http<GetOptions = HttpOptions, PostOptions = HttpPostOptions> {
 
     try {
       const res = await resPromise;
-      res.authorization = authorization;
+      res.authorization = !!options?.headers?.authorization;
       return cloneResponse(res);
     } catch (err) {
       const { abortOnError, abortIgnoreStatusCodes } = options;

--- a/lib/util/http/index.ts
+++ b/lib/util/http/index.ts
@@ -53,7 +53,7 @@ function cloneResponse<T>(response: any): HttpResponse<T> {
     statusCode: response.statusCode,
     body: clone<T>(response.body),
     headers: clone(response.headers),
-    authorization: response.authorization,
+    authorization: !!response.authorization,
   };
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds boolean field `authorization` to HttpResponse. It is `true` if the `authorization` header is set.

## Context:

This will soon be used by datasources to help determine if a package is private or not.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
