### PR TITLE
feat: pypi public package caching

### DIFF
--- a/lib/datasource/common.ts
+++ b/lib/datasource/common.ts
@@ -69,6 +69,7 @@ export interface ReleaseResult {
   tags?: Record<string, string>;
   versions?: any;
   registryUrl?: string;
+  isPrivate?: boolean;
 }
 
 export interface DatasourceApi {
@@ -79,6 +80,7 @@ export interface DatasourceApi {
   defaultVersioning?: string;
   defaultConfig?: Record<string, unknown>;
   registryStrategy?: 'first' | 'hunt' | 'merge';
+  caching?: boolean;
 }
 
 // TODO: remove, only for compatibility

--- a/lib/datasource/index.ts
+++ b/lib/datasource/index.ts
@@ -4,6 +4,7 @@ import { HOST_DISABLED } from '../constants/error-messages';
 import { logger } from '../logger';
 import { ExternalHostError } from '../types/errors/external-host-error';
 import * as memCache from '../util/cache/memory';
+import * as packageCache from '../util/cache/package';
 import { clone } from '../util/clone';
 import { regEx } from '../util/regex';
 import * as allVersioning from '../versioning';
@@ -52,7 +53,24 @@ async function getRegistryReleases(
   config: GetReleasesConfig,
   registryUrl: string
 ): Promise<ReleaseResult> {
+  const cacheKey = `${datasource.id} ${registryUrl} ${config.lookupName}`;
+  if (datasource.caching) {
+    const cachedResult = await packageCache.get<ReleaseResult>(
+      cacheNamespace,
+      cacheKey
+    );
+    if (cachedResult) {
+      logger.debug({ cacheKey }, 'Returning cached datasource response');
+      return cachedResult;
+    }
+  }
   const res = await datasource.getReleases({ ...config, registryUrl });
+  // cache non-null responses unless marked as private
+  if (datasource.caching && res && !res.isPrivate) {
+    logger.trace({ cacheKey }, 'Caching datasource response');
+    const cacheMinutes = 15;
+    await packageCache.set(cacheNamespace, cacheKey, res, cacheMinutes);
+  }
   return res;
 }
 

--- a/lib/datasource/index.ts
+++ b/lib/datasource/index.ts
@@ -59,6 +59,7 @@ async function getRegistryReleases(
       cacheNamespace,
       cacheKey
     );
+    // istanbul ignore if
     if (cachedResult) {
       logger.debug({ cacheKey }, 'Returning cached datasource response');
       return cachedResult;

--- a/lib/datasource/pypi/index.ts
+++ b/lib/datasource/pypi/index.ts
@@ -13,6 +13,7 @@ export const defaultRegistryUrls = [
 ];
 export const defaultVersioning = pep440.id;
 export const registryStrategy = 'merge';
+export const caching = true;
 
 const githubRepoPattern = /^https?:\/\/github\.com\/[^\\/]+\/[^\\/]+$/;
 const http = new Http(id);
@@ -49,6 +50,9 @@ async function getDependency(
   if (!dep) {
     logger.trace({ dependency: packageName }, 'pip package not found');
     return null;
+  }
+  if (rep.authorization) {
+    dependency.isPrivate = true;
   }
   logger.trace({ lookupUrl }, 'Got pypi api result');
   if (
@@ -178,6 +182,9 @@ async function getSimpleDependency(
   if (!dep) {
     logger.trace({ dependency: packageName }, 'pip package not found');
     return null;
+  }
+  if (response.authorization) {
+    dependency.isPrivate = true;
   }
   const root: HTMLElement = parse(cleanSimpleHtml(dep));
   const links = root.querySelectorAll('a');


### PR DESCRIPTION
## Changes:

Adds automated datasource caching, with PyPI as the first implementation.

## Context:

Part of #8473

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
