### PR TITLE
fix(pip_setup): pick latest installed python version

### DIFF
--- a/data/extract.py
+++ b/data/extract.py
@@ -1,7 +1,6 @@
 import sys
 import json
 import os
-import distutils.core
 from os.path import basename
 
 if sys.version_info[:2] >= (3, 3):
@@ -23,6 +22,8 @@ except ImportError:
   class setuptools:
     def setup():
       pass
+
+import distutils.core
 
 try:
   from unittest import mock

--- a/lib/manager/pip_setup/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/pip_setup/__snapshots__/extract.spec.ts.snap
@@ -58,23 +58,5 @@ Array [
       "timeout": 900000,
     },
   },
-  Object {
-    "cmd": "python3.9 --version",
-    "options": Object {
-      "cwd": null,
-      "encoding": "utf-8",
-      "env": Object {
-        "HOME": "/home/user",
-        "HTTPS_PROXY": "https://example.com",
-        "HTTP_PROXY": "http://example.com",
-        "LANG": "en_US.UTF-8",
-        "LC_ALL": "en_US",
-        "NO_PROXY": "localhost",
-        "PATH": "/tmp/path",
-      },
-      "maxBuffer": 10485760,
-      "timeout": 900000,
-    },
-  },
 ]
 `;

--- a/lib/manager/pip_setup/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/pip_setup/__snapshots__/extract.spec.ts.snap
@@ -58,5 +58,23 @@ Array [
       "timeout": 900000,
     },
   },
+  Object {
+    "cmd": "python3.9 --version",
+    "options": Object {
+      "cwd": null,
+      "encoding": "utf-8",
+      "env": Object {
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
 ]
 `;

--- a/lib/manager/pip_setup/__snapshots__/index.spec.ts.snap
+++ b/lib/manager/pip_setup/__snapshots__/index.spec.ts.snap
@@ -390,42 +390,6 @@ Array [
     },
   },
   Object {
-    "cmd": "python3.8 --version",
-    "options": Object {
-      "cwd": "/tmp/github/some/repo",
-      "encoding": "utf-8",
-      "env": Object {
-        "HOME": "/home/user",
-        "HTTPS_PROXY": "https://example.com",
-        "HTTP_PROXY": "http://example.com",
-        "LANG": "en_US.UTF-8",
-        "LC_ALL": "en_US",
-        "NO_PROXY": "localhost",
-        "PATH": "/tmp/path",
-      },
-      "maxBuffer": 10485760,
-      "timeout": 900000,
-    },
-  },
-  Object {
-    "cmd": "python3.9 --version",
-    "options": Object {
-      "cwd": "/tmp/github/some/repo",
-      "encoding": "utf-8",
-      "env": Object {
-        "HOME": "/home/user",
-        "HTTPS_PROXY": "https://example.com",
-        "HTTP_PROXY": "http://example.com",
-        "LANG": "en_US.UTF-8",
-        "LC_ALL": "en_US",
-        "NO_PROXY": "localhost",
-        "PATH": "/tmp/path",
-      },
-      "maxBuffer": 10485760,
-      "timeout": 900000,
-    },
-  },
-  Object {
     "cmd": "<extract.py> \\"lib/manager/pip_setup/__fixtures__/setup.py\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo/lib/manager/pip_setup/__fixtures__",
@@ -485,42 +449,6 @@ Array [
     },
   },
   Object {
-    "cmd": "python3.8 --version",
-    "options": Object {
-      "cwd": "/tmp/github/some/repo",
-      "encoding": "utf-8",
-      "env": Object {
-        "HOME": "/home/user",
-        "HTTPS_PROXY": "https://example.com",
-        "HTTP_PROXY": "http://example.com",
-        "LANG": "en_US.UTF-8",
-        "LC_ALL": "en_US",
-        "NO_PROXY": "localhost",
-        "PATH": "/tmp/path",
-      },
-      "maxBuffer": 10485760,
-      "timeout": 900000,
-    },
-  },
-  Object {
-    "cmd": "python3.9 --version",
-    "options": Object {
-      "cwd": "/tmp/github/some/repo",
-      "encoding": "utf-8",
-      "env": Object {
-        "HOME": "/home/user",
-        "HTTPS_PROXY": "https://example.com",
-        "HTTP_PROXY": "http://example.com",
-        "LANG": "en_US.UTF-8",
-        "LC_ALL": "en_US",
-        "NO_PROXY": "localhost",
-        "PATH": "/tmp/path",
-      },
-      "maxBuffer": 10485760,
-      "timeout": 900000,
-    },
-  },
-  Object {
     "cmd": "<extract.py> \\"lib/manager/pip_setup/__fixtures__/setup.py\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo/lib/manager/pip_setup/__fixtures__",
@@ -563,42 +491,6 @@ Array [
   },
   Object {
     "cmd": "python3 --version",
-    "options": Object {
-      "cwd": "/tmp/github/some/repo",
-      "encoding": "utf-8",
-      "env": Object {
-        "HOME": "/home/user",
-        "HTTPS_PROXY": "https://example.com",
-        "HTTP_PROXY": "http://example.com",
-        "LANG": "en_US.UTF-8",
-        "LC_ALL": "en_US",
-        "NO_PROXY": "localhost",
-        "PATH": "/tmp/path",
-      },
-      "maxBuffer": 10485760,
-      "timeout": 900000,
-    },
-  },
-  Object {
-    "cmd": "python3.8 --version",
-    "options": Object {
-      "cwd": "/tmp/github/some/repo",
-      "encoding": "utf-8",
-      "env": Object {
-        "HOME": "/home/user",
-        "HTTPS_PROXY": "https://example.com",
-        "HTTP_PROXY": "http://example.com",
-        "LANG": "en_US.UTF-8",
-        "LC_ALL": "en_US",
-        "NO_PROXY": "localhost",
-        "PATH": "/tmp/path",
-      },
-      "maxBuffer": 10485760,
-      "timeout": 900000,
-    },
-  },
-  Object {
-    "cmd": "python3.9 --version",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",

--- a/lib/manager/pip_setup/__snapshots__/index.spec.ts.snap
+++ b/lib/manager/pip_setup/__snapshots__/index.spec.ts.snap
@@ -57,6 +57,24 @@ Array [
     },
   },
   Object {
+    "cmd": "python3.9 --version",
+    "options": Object {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": Object {
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+  Object {
     "cmd": "<extract.py> \\"folders/foobar.py\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo/folders",
@@ -390,6 +408,24 @@ Array [
     },
   },
   Object {
+    "cmd": "python3.9 --version",
+    "options": Object {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": Object {
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+  Object {
     "cmd": "<extract.py> \\"lib/manager/pip_setup/__fixtures__/setup.py\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo/lib/manager/pip_setup/__fixtures__",
@@ -467,6 +503,24 @@ Array [
     },
   },
   Object {
+    "cmd": "python3.9 --version",
+    "options": Object {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": Object {
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+  Object {
     "cmd": "<extract.py> \\"lib/manager/pip_setup/__fixtures__/setup.py\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo/lib/manager/pip_setup/__fixtures__",
@@ -527,6 +581,24 @@ Array [
   },
   Object {
     "cmd": "python3.8 --version",
+    "options": Object {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": Object {
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+  Object {
+    "cmd": "python3.9 --version",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",

--- a/lib/manager/pip_setup/extract.spec.ts
+++ b/lib/manager/pip_setup/extract.spec.ts
@@ -36,7 +36,7 @@ describe(getName(__filename), () => {
       expect(result).toMatchSnapshot();
       expect(await getPythonAlias()).toEqual(result);
       expect(execSnapshots).toMatchSnapshot();
-      expect(execSnapshots).toHaveLength(4);
+      expect(execSnapshots).toHaveLength(3);
     });
   });
 });

--- a/lib/manager/pip_setup/extract.spec.ts
+++ b/lib/manager/pip_setup/extract.spec.ts
@@ -29,13 +29,14 @@ describe(getName(__filename), () => {
         { stdout: '', stderr: 'Python 2.7.17\\n' },
         new Error(),
         { stdout: 'Python 3.8.0\\n', stderr: '' },
+        new Error(),
       ]);
       const result = await getPythonAlias();
       expect(pythonVersions).toContain(result);
       expect(result).toMatchSnapshot();
       expect(await getPythonAlias()).toEqual(result);
       expect(execSnapshots).toMatchSnapshot();
-      expect(execSnapshots).toHaveLength(3);
+      expect(execSnapshots).toHaveLength(4);
     });
   });
 });

--- a/lib/manager/pip_setup/extract.ts
+++ b/lib/manager/pip_setup/extract.ts
@@ -31,6 +31,7 @@ export async function getPythonAlias(): Promise<string> {
       const version = parsePythonVersion(stdout || stderr);
       if (version[0] >= 3 && version[1] >= 7) {
         pythonAlias = pythonVersion;
+        break;
       }
     } catch (err) {
       logger.debug(`${pythonVersion} alias not found`);

--- a/lib/manager/pip_setup/extract.ts
+++ b/lib/manager/pip_setup/extract.ts
@@ -8,7 +8,7 @@ import { ExtractConfig, PackageDependency, PackageFile } from '../common';
 import { dependencyPattern } from '../pip_requirements/extract';
 import { PythonSetup, getExtractFile, parseReport } from './util';
 
-export const pythonVersions = ['python', 'python3', 'python3.8'];
+export const pythonVersions = ['python', 'python3', 'python3.8', 'python3.9'];
 let pythonAlias: string | null = null;
 
 export function resetModule(): void {

--- a/lib/manager/pip_setup/index.spec.ts
+++ b/lib/manager/pip_setup/index.spec.ts
@@ -31,6 +31,7 @@ const pythonVersionCallResults = [
   { stdout: '', stderr: 'Python 2.7.17\\n' },
   { stdout: 'Python 3.7.5\\n', stderr: '' },
   new Error(),
+  new Error(),
 ];
 
 // TODO: figure out snapshot similarity for each CI platform
@@ -67,7 +68,7 @@ describe(getName(__filename), () => {
       expect(
         await extractPackageFile(content, packageFile, config)
       ).toMatchSnapshot();
-      expect(exec).toHaveBeenCalledTimes(4);
+      expect(exec).toHaveBeenCalledTimes(5);
       expect(fixSnapshots(execSnapshots)).toMatchSnapshot();
     });
 
@@ -96,7 +97,7 @@ describe(getName(__filename), () => {
       ]);
       jest.spyOn(fs, 'readLocalFile').mockResolvedValueOnce('{}');
       expect(await extractPackageFile(content, packageFile, config)).toBeNull();
-      expect(exec).toHaveBeenCalledTimes(4);
+      expect(exec).toHaveBeenCalledTimes(5);
       expect(fixSnapshots(execSnapshots)).toMatchSnapshot();
     });
 
@@ -112,7 +113,7 @@ describe(getName(__filename), () => {
           config
         )
       ).toBeNull();
-      expect(exec).toHaveBeenCalledTimes(4);
+      expect(exec).toHaveBeenCalledTimes(5);
       expect(fixSnapshots(execSnapshots)).toMatchSnapshot();
     });
     it('catches error', async () => {

--- a/lib/manager/pip_setup/index.spec.ts
+++ b/lib/manager/pip_setup/index.spec.ts
@@ -30,8 +30,6 @@ jest.mock('../../util/exec/env');
 const pythonVersionCallResults = [
   { stdout: '', stderr: 'Python 2.7.17\\n' },
   { stdout: 'Python 3.7.5\\n', stderr: '' },
-  new Error(),
-  new Error(),
 ];
 
 // TODO: figure out snapshot similarity for each CI platform
@@ -68,7 +66,7 @@ describe(getName(__filename), () => {
       expect(
         await extractPackageFile(content, packageFile, config)
       ).toMatchSnapshot();
-      expect(exec).toHaveBeenCalledTimes(5);
+      expect(exec).toHaveBeenCalledTimes(3);
       expect(fixSnapshots(execSnapshots)).toMatchSnapshot();
     });
 
@@ -97,7 +95,7 @@ describe(getName(__filename), () => {
       ]);
       jest.spyOn(fs, 'readLocalFile').mockResolvedValueOnce('{}');
       expect(await extractPackageFile(content, packageFile, config)).toBeNull();
-      expect(exec).toHaveBeenCalledTimes(5);
+      expect(exec).toHaveBeenCalledTimes(3);
       expect(fixSnapshots(execSnapshots)).toMatchSnapshot();
     });
 
@@ -113,7 +111,7 @@ describe(getName(__filename), () => {
           config
         )
       ).toBeNull();
-      expect(exec).toHaveBeenCalledTimes(5);
+      expect(exec).toHaveBeenCalledTimes(3);
       expect(fixSnapshots(execSnapshots)).toMatchSnapshot();
     });
     it('catches error', async () => {


### PR DESCRIPTION
## Changes:

fix(pip_setup): pick latest installed python version, in order python, python3, python3.8, python3.9

## Context:

system python3.8 installation was used instead of installed 3.9 which caused errors when parsing setup.py.
Also, python 3.9 discourages importing distutils.core before setuptools. The warning message was
```
UserWarning: Distutils was imported before Setuptools. This usage is discouraged and may exhibit undesirable behaviors or errors. Please use Setuptools' objects directly or at least import Setuptools first
```
Closes #8478

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

tested with py 3.8 and 3.9 installed locally using repo https://github.com/adamko147/renovate-python
