### PR TITLE
feat: Implement `hashBranchTopic` option

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -656,6 +656,24 @@ As a result of the above, the branchName would be `renovate/dev-dependencies` in
 
 Note: you shouldn't usually need to configure this unless you really care about your branch names.
 
+## hashBranchTopic
+
+This option allows you to replace the `branchTopic` with a SHA512 hashed version
+of itself. Some code hosting systems have restrictions on the branch name
+lengths and using the `hashBranchTopic` option in combination with `length: 10`
+lets you get around these restrictions.
+
+Example configuration:
+
+```json
+{
+  "hashBranchTopic": {
+    "enabled": true,
+    "length": 42
+  }
+}
+```
+
 ## hostRules
 
 Currently the purpose of `hostRules` is to configure credentials for host authentication.

--- a/lib/config/common.ts
+++ b/lib/config/common.ts
@@ -11,6 +11,11 @@ export type RenovateConfigStage =
 
 export type RepositoryCacheConfig = 'disabled' | 'enabled' | 'reset';
 
+export interface HashBranchTopicConfig {
+  enabled?: boolean;
+  length?: number;
+}
+
 export interface GroupConfig extends Record<string, unknown> {
   branchName?: string;
   branchTopic?: string;
@@ -33,6 +38,7 @@ export interface RenovateSharedConfig {
   group?: GroupConfig;
   groupName?: string;
   groupSlug?: string;
+  hashBranchTopic?: HashBranchTopicConfig;
   includePaths?: string[];
   ignoreDeps?: string[];
   ignorePaths?: string[];

--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -1284,6 +1284,14 @@ const options: RenovateOptions[] = [
     cli: false,
   },
   {
+    name: 'hashBranchTopic',
+    description: 'Branch topic hashing configuration.',
+    type: 'object',
+    default: { enabled: false },
+    cli: false,
+    mergeable: true,
+  },
+  {
     name: 'commitMessage',
     description: 'Message to use for commit messages and pull request titles.',
     type: 'string',

--- a/lib/workers/repository/updates/branch-name.spec.ts
+++ b/lib/workers/repository/updates/branch-name.spec.ts
@@ -84,6 +84,58 @@ describe('workers/repository/updates/branch-name', () => {
       generateBranchName(upgrade);
       expect(upgrade.branchName).toEqual('dep');
     });
+
+    it('realistic defaults', () => {
+      const upgrade: RenovateConfig = {
+        branchName:
+          '{{{branchPrefix}}}{{{additionalBranchPrefix}}}{{{branchTopic}}}',
+        branchTopic:
+          '{{{depNameSanitized}}}-{{{newMajor}}}{{#if isPatch}}.{{{newMinor}}}{{/if}}.x{{#if isLockfileUpdate}}-lockfile{{/if}}',
+        branchPrefix: 'renovate/',
+        depNameSanitized: 'jest',
+        newMajor: '42',
+        group: {},
+      };
+      generateBranchName(upgrade);
+      expect(upgrade.branchName).toEqual('renovate/jest-42.x');
+    });
+
+    it('branch topic hashing', () => {
+      const upgrade: RenovateConfig = {
+        branchName:
+          '{{{branchPrefix}}}{{{additionalBranchPrefix}}}{{{branchTopic}}}',
+        branchTopic:
+          '{{{depNameSanitized}}}-{{{newMajor}}}{{#if isPatch}}.{{{newMinor}}}{{/if}}.x{{#if isLockfileUpdate}}-lockfile{{/if}}',
+        hashBranchTopic: { enabled: true, length: 10 },
+        branchPrefix: 'dep-',
+        depNameSanitized: 'jest',
+        newMajor: '42',
+        group: {},
+      };
+      generateBranchName(upgrade);
+      expect(upgrade.branchName).toEqual('dep-df9ca0f348');
+    });
+
+    it('branch topic hashing with group name', () => {
+      const upgrade: RenovateConfig = {
+        hashBranchTopic: { enabled: true },
+        branchPrefix: 'dep-',
+        depNameSanitized: 'jest',
+        newMajor: '42',
+        groupName: 'some group name',
+        group: {
+          branchName:
+            '{{{branchPrefix}}}{{{additionalBranchPrefix}}}{{{branchTopic}}}',
+          branchTopic:
+            '{{{depNameSanitized}}}-{{{newMajor}}}{{#if isPatch}}.{{{newMinor}}}{{/if}}.x{{#if isLockfileUpdate}}-lockfile{{/if}}',
+        },
+      };
+      generateBranchName(upgrade);
+      expect(upgrade.branchName).toEqual(
+        'dep-df9ca0f34833f3e0fa78e343965936ad59530c431f7c676538dfce7be3a6b16d00aaa55d1ed101e17427e8e0375ae0578a266c4549aec830b5ed49b6fe3b4204'
+      );
+    });
+
     it('enforces valid git branch name', () => {
       const fixtures = [
         {


### PR DESCRIPTION
## Changes:

This PR introduces a new `hashBranchTopic` option, that allows users to replace the `branchTopic` with a hashed version of itself.

## Context:

The system that we use to create preview branches of our backend systems only limits our branch names to a certain length. Unfortunately we are using a few dependencies with longer names, which means we the renovatebot PRs will then fail because of the branch name length.

This PR solves the problem by allowing us to use a hashed and truncated variant of the branch name instead.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository
