### PR TITLE
feat: `hashedBranchLength` option

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -1376,16 +1376,10 @@ For example to apply a special label for Major updates:
 
 ### maxBranchLength
 
-Some code hosting systems have restrictions on the branch name lengths,
-this option lets you get around these restrictions. You can set the
-`maxBranchLength` option to a number of characters that works for your
-system and then Renovate will generate branch names with the appropriate length
-by hashing `additionalBranchPrefix` and `branchTopic`, and then truncating the
-hash so that the full branch name (including `branchPrefix`) has the right
-number of characters.
+Some code hosting systems have restrictions on the branch name lengths, this option lets you get around these restrictions.
+You can set the `maxBranchLength` option to a number of characters that works for your system and then Renovate will generate branch names with the appropriate length by hashing `additionalBranchPrefix` and `branchTopic`, and then truncating the hash so that the full branch name (including `branchPrefix`) has the right number of characters.
 
-Example: If you have set `branchPrefix: "deps-"` and `maxBranchLength: 10` it
-will result in a branch name like `deps-5bf36`
+Example: If you have set `branchPrefix: "deps-"` and `maxBranchLength: 10` it will result in a branch name like `deps-5bf36`
 
 ## patch
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -1374,7 +1374,7 @@ For example to apply a special label for Major updates:
 }
 ```
 
-### hashedBranchLength
+## hashedBranchLength
 
 Some code hosting systems have restrictions on the branch name lengths, this option lets you get around these restrictions.
 You can set the `hashedBranchLength` option to a number of characters that works for your system and then Renovate will generate branch names with the appropriate length by hashing `additionalBranchPrefix` and `branchTopic`, and then truncating the hash so that the full branch name (including `branchPrefix`) has the right number of characters.

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -661,7 +661,7 @@ Note: you shouldn't usually need to configure this unless you really care about 
 Some code hosting systems have restrictions on the branch name lengths, this option lets you get around these restrictions.
 You can set the `hashedBranchLength` option to a number of characters that works for your system and then Renovate will generate branch names with the appropriate length by hashing `additionalBranchPrefix` and `branchTopic`, and then truncating the hash so that the full branch name (including `branchPrefix`) has the right number of characters.
 
-Example: If you have set `branchPrefix: "deps-"` and `hashedBranchLength: 10` it will result in a branch name like `deps-5bf36`
+Example: If you have set `branchPrefix: "deps-"` and `hashedBranchLength: 12` it will result in a branch name like `deps-5bf36ec` instead of the traditional pretty branch name like `deps-react-17.x`.
 
 ## hostRules
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -656,6 +656,13 @@ As a result of the above, the branchName would be `renovate/dev-dependencies` in
 
 Note: you shouldn't usually need to configure this unless you really care about your branch names.
 
+## hashedBranchLength
+
+Some code hosting systems have restrictions on the branch name lengths, this option lets you get around these restrictions.
+You can set the `hashedBranchLength` option to a number of characters that works for your system and then Renovate will generate branch names with the appropriate length by hashing `additionalBranchPrefix` and `branchTopic`, and then truncating the hash so that the full branch name (including `branchPrefix`) has the right number of characters.
+
+Example: If you have set `branchPrefix: "deps-"` and `hashedBranchLength: 10` it will result in a branch name like `deps-5bf36`
+
 ## hostRules
 
 Currently the purpose of `hostRules` is to configure credentials for host authentication.
@@ -1373,13 +1380,6 @@ For example to apply a special label for Major updates:
   ]
 }
 ```
-
-## hashedBranchLength
-
-Some code hosting systems have restrictions on the branch name lengths, this option lets you get around these restrictions.
-You can set the `hashedBranchLength` option to a number of characters that works for your system and then Renovate will generate branch names with the appropriate length by hashing `additionalBranchPrefix` and `branchTopic`, and then truncating the hash so that the full branch name (including `branchPrefix`) has the right number of characters.
-
-Example: If you have set `branchPrefix: "deps-"` and `hashedBranchLength: 10` it will result in a branch name like `deps-5bf36`
 
 ## patch
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -1374,6 +1374,19 @@ For example to apply a special label for Major updates:
 }
 ```
 
+### maxBranchLength
+
+Some code hosting systems have restrictions on the branch name lengths,
+this option lets you get around these restrictions. You can set the
+`maxBranchLength` option to a number of characters that works for your
+system and then Renovate will generate branch names with the appropriate length
+by hashing `additionalBranchPrefix` and `branchTopic`, and then truncating the
+hash so that the full branch name (including `branchPrefix`) has the right
+number of characters.
+
+Example: If you have set `branchPrefix: "deps-"` and `maxBranchLength: 10` it
+will result in a branch name like `deps-5bf36`
+
 ## patch
 
 Add to this object if you wish to define rules that apply only to patch updates.

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -1374,12 +1374,12 @@ For example to apply a special label for Major updates:
 }
 ```
 
-### maxBranchLength
+### hashedBranchLength
 
 Some code hosting systems have restrictions on the branch name lengths, this option lets you get around these restrictions.
-You can set the `maxBranchLength` option to a number of characters that works for your system and then Renovate will generate branch names with the appropriate length by hashing `additionalBranchPrefix` and `branchTopic`, and then truncating the hash so that the full branch name (including `branchPrefix`) has the right number of characters.
+You can set the `hashedBranchLength` option to a number of characters that works for your system and then Renovate will generate branch names with the appropriate length by hashing `additionalBranchPrefix` and `branchTopic`, and then truncating the hash so that the full branch name (including `branchPrefix`) has the right number of characters.
 
-Example: If you have set `branchPrefix: "deps-"` and `maxBranchLength: 10` it will result in a branch name like `deps-5bf36`
+Example: If you have set `branchPrefix: "deps-"` and `hashedBranchLength: 10` it will result in a branch name like `deps-5bf36`
 
 ## patch
 

--- a/lib/config/common.ts
+++ b/lib/config/common.ts
@@ -39,6 +39,7 @@ export interface RenovateSharedConfig {
   labels?: string[];
   addLabels?: string[];
   dependencyDashboardApproval?: boolean;
+  maxBranchLength?: number;
   npmrc?: string;
   platform?: string;
   postUpgradeTasks?: PostUpgradeTasks;

--- a/lib/config/common.ts
+++ b/lib/config/common.ts
@@ -39,7 +39,7 @@ export interface RenovateSharedConfig {
   labels?: string[];
   addLabels?: string[];
   dependencyDashboardApproval?: boolean;
-  maxBranchLength?: number;
+  hashedBranchLength?: number;
   npmrc?: string;
   platform?: string;
   postUpgradeTasks?: PostUpgradeTasks;

--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -1394,8 +1394,9 @@ const options: RenovateOptions[] = [
     mergeable: true,
   },
   {
-    name: 'maxBranchLength',
-    description: 'If enabled, branch names will use a hashing function to ensure each branch has that length.',
+    name: 'hashedBranchLength',
+    description:
+      'If enabled, branch names will use a hashing function to ensure each branch has that length.',
     type: 'integer',
     default: null,
     cli: false,

--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -1395,7 +1395,7 @@ const options: RenovateOptions[] = [
   },
   {
     name: 'maxBranchLength',
-    description: 'Maximum number of characters in the branch name.',
+    description: 'If enabled, branch names will use a hashing function to ensure each branch has that length.',
     type: 'integer',
     default: null,
     cli: false,

--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -1393,6 +1393,13 @@ const options: RenovateOptions[] = [
     cli: false,
     mergeable: true,
   },
+  {
+    name: 'maxBranchLength',
+    description: 'Maximum number of characters in the branch name.',
+    type: 'integer',
+    default: null,
+    cli: false,
+  },
   // Dependency Groups
   {
     name: 'groupName',

--- a/lib/workers/repository/updates/branch-name.spec.ts
+++ b/lib/workers/repository/updates/branch-name.spec.ts
@@ -100,13 +100,13 @@ describe('workers/repository/updates/branch-name', () => {
       expect(upgrade.branchName).toEqual('renovate/jest-42.x');
     });
 
-    it('maxBranchLength hashing', () => {
+    it('hashedBranchLength hashing', () => {
       const upgrade: RenovateConfig = {
         branchName:
           '{{{branchPrefix}}}{{{additionalBranchPrefix}}}{{{branchTopic}}}',
         branchTopic:
           '{{{depNameSanitized}}}-{{{newMajor}}}{{#if isPatch}}.{{{newMinor}}}{{/if}}.x{{#if isLockfileUpdate}}-lockfile{{/if}}',
-        maxBranchLength: 14,
+        hashedBranchLength: 14,
         branchPrefix: 'dep-',
         depNameSanitized: 'jest',
         newMajor: '42',
@@ -116,9 +116,9 @@ describe('workers/repository/updates/branch-name', () => {
       expect(upgrade.branchName).toEqual('dep-df9ca0f348');
     });
 
-    it('maxBranchLength hashing with group name', () => {
+    it('hashedBranchLength hashing with group name', () => {
       const upgrade: RenovateConfig = {
-        maxBranchLength: 20,
+        hashedBranchLength: 20,
         branchPrefix: 'dep-',
         depNameSanitized: 'jest',
         newMajor: '42',

--- a/lib/workers/repository/updates/branch-name.spec.ts
+++ b/lib/workers/repository/updates/branch-name.spec.ts
@@ -84,6 +84,56 @@ describe('workers/repository/updates/branch-name', () => {
       generateBranchName(upgrade);
       expect(upgrade.branchName).toEqual('dep');
     });
+
+    it('realistic defaults', () => {
+      const upgrade: RenovateConfig = {
+        branchName:
+          '{{{branchPrefix}}}{{{additionalBranchPrefix}}}{{{branchTopic}}}',
+        branchTopic:
+          '{{{depNameSanitized}}}-{{{newMajor}}}{{#if isPatch}}.{{{newMinor}}}{{/if}}.x{{#if isLockfileUpdate}}-lockfile{{/if}}',
+        branchPrefix: 'renovate/',
+        depNameSanitized: 'jest',
+        newMajor: '42',
+        group: {},
+      };
+      generateBranchName(upgrade);
+      expect(upgrade.branchName).toEqual('renovate/jest-42.x');
+    });
+
+    it('maxBranchLength hashing', () => {
+      const upgrade: RenovateConfig = {
+        branchName:
+          '{{{branchPrefix}}}{{{additionalBranchPrefix}}}{{{branchTopic}}}',
+        branchTopic:
+          '{{{depNameSanitized}}}-{{{newMajor}}}{{#if isPatch}}.{{{newMinor}}}{{/if}}.x{{#if isLockfileUpdate}}-lockfile{{/if}}',
+        maxBranchLength: 14,
+        branchPrefix: 'dep-',
+        depNameSanitized: 'jest',
+        newMajor: '42',
+        group: {},
+      };
+      generateBranchName(upgrade);
+      expect(upgrade.branchName).toEqual('dep-df9ca0f348');
+    });
+
+    it('maxBranchLength hashing with group name', () => {
+      const upgrade: RenovateConfig = {
+        maxBranchLength: 20,
+        branchPrefix: 'dep-',
+        depNameSanitized: 'jest',
+        newMajor: '42',
+        groupName: 'some group name',
+        group: {
+          branchName:
+            '{{{branchPrefix}}}{{{additionalBranchPrefix}}}{{{branchTopic}}}',
+          branchTopic:
+            '{{{depNameSanitized}}}-{{{newMajor}}}{{#if isPatch}}.{{{newMinor}}}{{/if}}.x{{#if isLockfileUpdate}}-lockfile{{/if}}',
+        },
+      };
+      generateBranchName(upgrade);
+      expect(upgrade.branchName).toEqual('dep-df9ca0f34833f3e0');
+    });
+
     it('enforces valid git branch name', () => {
       const fixtures = [
         {

--- a/lib/workers/repository/updates/branch-name.spec.ts
+++ b/lib/workers/repository/updates/branch-name.spec.ts
@@ -134,6 +134,24 @@ describe('workers/repository/updates/branch-name', () => {
       expect(upgrade.branchName).toEqual('dep-df9ca0f34833f3e0');
     });
 
+    it('hashedBranchLength too short', () => {
+      const upgrade: RenovateConfig = {
+        hashedBranchLength: 3,
+        branchPrefix: 'dep-',
+        depNameSanitized: 'jest',
+        newMajor: '42',
+        groupName: 'some group name',
+        group: {
+          branchName:
+            '{{{branchPrefix}}}{{{additionalBranchPrefix}}}{{{branchTopic}}}',
+          branchTopic:
+            '{{{depNameSanitized}}}-{{{newMajor}}}{{#if isPatch}}.{{{newMinor}}}{{/if}}.x{{#if isLockfileUpdate}}-lockfile{{/if}}',
+        },
+      };
+      generateBranchName(upgrade);
+      expect(upgrade.branchName).toEqual('dep-df9ca0');
+    });
+
     it('enforces valid git branch name', () => {
       const fixtures = [
         {

--- a/lib/workers/repository/updates/branch-name.ts
+++ b/lib/workers/repository/updates/branch-name.ts
@@ -5,6 +5,8 @@ import { RenovateConfig } from '../../../config/common';
 import { logger } from '../../../logger';
 import * as template from '../../../util/template';
 
+const MIN_HASH_LENGTH = 6;
+
 /**
  * Clean git branch name
  *
@@ -48,11 +50,11 @@ export function generateBranchName(update: RenovateConfig): void {
 
   if (update.hashedBranchLength) {
     let hashLength = update.hashedBranchLength - update.branchPrefix.length;
-    if (hashLength <= 10) {
+    if (hashLength <= MIN_HASH_LENGTH) {
       logger.warn(
-        '`hashedBranchLength` must allow for at least 10 characters hashing in addition to `branchPrefix`. Using 10 character hash instead.'
+        `\`hashedBranchLength\` must allow for at least 6 characters hashing in addition to \`branchPrefix\`. Using ${MIN_HASH_LENGTH} character hash instead.`
       );
-      hashLength = 10;
+      hashLength = MIN_HASH_LENGTH;
     }
 
     const additionalBranchPrefix = update.additionalBranchPrefix

--- a/lib/workers/repository/updates/branch-name.ts
+++ b/lib/workers/repository/updates/branch-name.ts
@@ -65,7 +65,13 @@ export function generateBranchName(update: RenovateConfig): void {
       ? template.compile(String(update.branchTopic), update)
       : '';
 
-    const hash = hasha(additionalBranchPrefix + branchTopic);
+    let hashInput = additionalBranchPrefix + branchTopic;
+
+    // Compile extra times in case of nested templates
+    hashInput = template.compile(hashInput, update);
+    hashInput = template.compile(hashInput, update);
+
+    const hash = hasha(hashInput);
 
     update.branchName = update.branchPrefix + hash.slice(0, hashLength);
   } else {

--- a/lib/workers/repository/updates/branch-name.ts
+++ b/lib/workers/repository/updates/branch-name.ts
@@ -52,7 +52,7 @@ export function generateBranchName(update: RenovateConfig): void {
     let hashLength = update.hashedBranchLength - update.branchPrefix.length;
     if (hashLength <= MIN_HASH_LENGTH) {
       logger.warn(
-        `\`hashedBranchLength\` must allow for at least 6 characters hashing in addition to \`branchPrefix\`. Using ${MIN_HASH_LENGTH} character hash instead.`
+        `\`hashedBranchLength\` must allow for at least ${MIN_HASH_LENGTH} characters hashing in addition to \`branchPrefix\`. Using ${MIN_HASH_LENGTH} character hash instead.`
       );
       hashLength = MIN_HASH_LENGTH;
     }

--- a/lib/workers/repository/updates/branch-name.ts
+++ b/lib/workers/repository/updates/branch-name.ts
@@ -46,11 +46,11 @@ export function generateBranchName(update: RenovateConfig): void {
     update.branchName = update.group.branchName || update.branchName;
   }
 
-  if (update.maxBranchLength) {
-    let hashLength = update.maxBranchLength - update.branchPrefix.length;
+  if (update.hashedBranchLength) {
+    let hashLength = update.hashedBranchLength - update.branchPrefix.length;
     if (hashLength <= 10) {
       logger.warn(
-        '`maxBranchLength` must allow for at least 10 characters hashing in addition to `branchPrefix`. Using 10 character hash instead.'
+        '`hashedBranchLength` must allow for at least 10 characters hashing in addition to `branchPrefix`. Using 10 character hash instead.'
       );
       hashLength = 10;
     }

--- a/lib/workers/repository/updates/branch-name.ts
+++ b/lib/workers/repository/updates/branch-name.ts
@@ -48,9 +48,9 @@ export function generateBranchName(update: RenovateConfig): void {
 
   if (update.maxBranchLength) {
     let hashLength = update.maxBranchLength - update.branchPrefix.length;
-    if (hashLength <= 0) {
+    if (hashLength <= 10) {
       logger.warn(
-        '`maxBranchLength` must be larger than the length of `branchPrefix`. using 10 character hash instead.'
+        '`maxBranchLength` must allow for at least 10 characters hashing in addition to `branchPrefix`. Using 10 character hash instead.'
       );
       hashLength = 10;
     }

--- a/lib/workers/repository/updates/branch-name.ts
+++ b/lib/workers/repository/updates/branch-name.ts
@@ -42,13 +42,11 @@ export function generateBranchName(update: RenovateConfig): void {
       update.groupSlug = `patch-${update.groupSlug}`;
     }
     update.branchTopic = update.group.branchTopic || update.branchTopic;
-    update.branchName = template.compile(
-      update.group.branchName || update.branchName,
-      update
-    );
-  } else {
-    update.branchName = template.compile(update.branchName, update);
+    update.branchName = update.group.branchName || update.branchName;
   }
+
+  update.branchName = template.compile(update.branchName, update);
+
   // Compile extra times in case of nested templates
   update.branchName = template.compile(update.branchName, update);
   update.branchName = cleanBranchName(


### PR DESCRIPTION
## Changes:

As suggested in https://github.com/renovatebot/renovate/issues/5390, this PR implements a `hashedBranchLength ` option, which causes the branch name to include a hash of `additionalBranchPrefix` and `branchTopic`, cut off at the right length.

## Context:

As the linked issue describes, this option is introduced to fix compatibility with systems that impose a maximum branch name length on the developers. More details on this are described in the issue.

Closes https://github.com/renovatebot/renovate/issues/5390

This is an alternative proposal to #8496 and closes #8496, if merged.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository
