### PR TITLE
fix(config-validator): migrate and massage before validating

### DIFF
--- a/lib/config-validator.ts
+++ b/lib/config-validator.ts
@@ -22,7 +22,7 @@ async function validate(
 ): Promise<void> {
   const { isMigrated, migratedConfig } = migrateConfig(config);
   if (isMigrated) {
-    logger.info(
+    logger.warn(
       {
         oldConfig: config,
         newConfig: migratedConfig,
@@ -90,7 +90,7 @@ type PackageJson = {
   try {
     const fileConfig = getFileConfig(process.env);
     if (!equal(fileConfig, {})) {
-      logger.info(`Validating config.js`);
+      logger.info(`Validating ${process.env.RENOVATE_CONFIG_FILE ?? 'config.js'}`);
       try {
         await validate('config.js', fileConfig);
       } catch (err) {

--- a/lib/config-validator.ts
+++ b/lib/config-validator.ts
@@ -6,7 +6,9 @@ import { configFileNames } from './config/app-strings';
 import { RenovateConfig } from './config/common';
 import { getConfig } from './config/file';
 import { massageConfig } from './config/massage';
+import { migrateConfig } from './config/migration';
 import { validateConfig } from './config/validation';
+import { logger } from './logger';
 
 /* eslint-disable no-console */
 
@@ -17,7 +19,18 @@ async function validate(
   config: RenovateConfig,
   isPreset = false
 ): Promise<void> {
-  const res = await validateConfig(massageConfig(config), isPreset);
+  const { isMigrated, migratedConfig } = migrateConfig(config);
+  if (isMigrated) {
+    logger.info(
+      {
+        oldConfig: config,
+        newConfig: migratedConfig,
+      },
+      'Config migration necessary'
+    );
+  }
+  const massagedConfig = massageConfig(migratedConfig);
+  const res = await validateConfig(massagedConfig, isPreset);
   if (res.errors.length) {
     console.log(
       `${desc} contains errors:\n\n${JSON.stringify(res.errors, null, 2)}`

--- a/lib/config-validator.ts
+++ b/lib/config-validator.ts
@@ -90,7 +90,9 @@ type PackageJson = {
   try {
     const fileConfig = getFileConfig(process.env);
     if (!equal(fileConfig, {})) {
-      logger.info(`Validating ${process.env.RENOVATE_CONFIG_FILE ?? 'config.js'}`);
+      logger.info(
+        `Validating ${process.env.RENOVATE_CONFIG_FILE ?? 'config.js'}`
+      );
       try {
         await validate('config.js', fileConfig);
       } catch (err) {

--- a/lib/config-validator.ts
+++ b/lib/config-validator.ts
@@ -4,7 +4,7 @@ import { readFileSync } from 'fs-extra';
 import JSON5 from 'json5';
 import { configFileNames } from './config/app-strings';
 import { RenovateConfig } from './config/common';
-import { getConfig } from './config/file';
+import { getConfig as getFileConfig } from './config/file';
 import { massageConfig } from './config/massage';
 import { migrateConfig } from './config/migration';
 import { validateConfig } from './config/validation';
@@ -91,7 +91,7 @@ type PackageJson = {
     // ignore
   }
   try {
-    const fileConfig = getConfig(process.env);
+    const fileConfig = getFileConfig(process.env);
     console.log(`Validating config.js`);
     try {
       await validate('config.js', fileConfig);

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "clean-cache": "node bin/clean-cache.js",
     "compile:ts": "tsc -p tsconfig.app.json",
     "compile:dts": "tsc -p tsconfig.dts.json",
+    "config-validator": "babel-node --extensions \".ts,.js\" -- lib/config-validator.ts",
     "generate": "run-s generate:*",
     "generate:imports": "node tmp/tools/generate-imports.js",
     "create-json-schema": "babel-node --extensions \".ts,.js\" -- bin/create-json-schema.js && prettier --write \"renovate-schema.json\"",


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds migrate+massage step before validating. 
Switches to logger instead of console.

## Context:

The config validator is currently failing configs which renovate itself can happily migrate.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
