### PR TITLE
fix(npm): detect npm6/7 for npm install

### DIFF
--- a/lib/manager/npm/extract/__snapshots__/locked-versions.spec.ts.snap
+++ b/lib/manager/npm/extract/__snapshots__/locked-versions.spec.ts.snap
@@ -1,28 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`manager/npm/extract/locked-versions .getLockedVersions() appends <7 to npm constraints 1`] = `
-Array [
-  Object {
-    "constraints": Object {
-      "npm": ">=6.0.0 <7",
-    },
-    "deps": Array [
-      Object {
-        "currentValue": "1.0.0",
-        "depName": "a",
-        "lockedVersion": "1.0.0",
-      },
-      Object {
-        "currentValue": "2.0.0",
-        "depName": "b",
-        "lockedVersion": "2.0.0",
-      },
-    ],
-    "npmLock": "package-lock.json",
-  },
-]
-`;
-
 exports[`manager/npm/extract/locked-versions .getLockedVersions() ignores pnpm 1`] = `
 Array [
   Object {
@@ -45,7 +22,7 @@ exports[`manager/npm/extract/locked-versions .getLockedVersions() uses package-l
 Array [
   Object {
     "constraints": Object {
-      "npm": "<7",
+      "npm": ">=6.0.0 <7",
     },
     "deps": Array [
       Object {
@@ -67,7 +44,9 @@ Array [
 exports[`manager/npm/extract/locked-versions .getLockedVersions() uses package-lock.json with npm v7.0.0 1`] = `
 Array [
   Object {
-    "constraints": Object {},
+    "constraints": Object {
+      "npm": ">=6.0.0",
+    },
     "deps": Array [
       Object {
         "currentValue": "1.0.0",

--- a/lib/manager/npm/extract/__snapshots__/locked-versions.spec.ts.snap
+++ b/lib/manager/npm/extract/__snapshots__/locked-versions.spec.ts.snap
@@ -1,5 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`manager/npm/extract/locked-versions .getLockedVersions() appends <7 to npm constraints 1`] = `
+Array [
+  Object {
+    "constraints": Object {
+      "npm": ">=6.0.0 <7",
+    },
+    "deps": Array [
+      Object {
+        "currentValue": "1.0.0",
+        "depName": "a",
+        "lockedVersion": "1.0.0",
+      },
+      Object {
+        "currentValue": "2.0.0",
+        "depName": "b",
+        "lockedVersion": "2.0.0",
+      },
+    ],
+    "npmLock": "package-lock.json",
+  },
+]
+`;
+
 exports[`manager/npm/extract/locked-versions .getLockedVersions() ignores pnpm 1`] = `
 Array [
   Object {
@@ -21,7 +44,9 @@ Array [
 exports[`manager/npm/extract/locked-versions .getLockedVersions() uses package-lock.json with npm v6.0.0 1`] = `
 Array [
   Object {
-    "constraints": Object {},
+    "constraints": Object {
+      "npm": "<7",
+    },
     "deps": Array [
       Object {
         "currentValue": "1.0.0",
@@ -42,9 +67,7 @@ Array [
 exports[`manager/npm/extract/locked-versions .getLockedVersions() uses package-lock.json with npm v7.0.0 1`] = `
 Array [
   Object {
-    "constraints": Object {
-      "npm": ">= 7.0.0",
-    },
+    "constraints": Object {},
     "deps": Array [
       Object {
         "currentValue": "1.0.0",

--- a/lib/manager/npm/extract/__snapshots__/locked-versions.spec.ts.snap
+++ b/lib/manager/npm/extract/__snapshots__/locked-versions.spec.ts.snap
@@ -1,24 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`manager/npm/extract/locked-versions .getLockedVersions() ignores pnpm 1`] = `
-Array [
-  Object {
-    "deps": Array [
-      Object {
-        "currentValue": "1.0.0",
-        "depName": "a",
-      },
-      Object {
-        "currentValue": "2.0.0",
-        "depName": "b",
-      },
-    ],
-    "pnpmShrinkwrap": "pnpm-lock.yaml",
-  },
-]
-`;
-
-exports[`manager/npm/extract/locked-versions .getLockedVersions() uses package-lock.json with npm v6.0.0 1`] = `
+exports[`manager/npm/extract/locked-versions .getLockedVersions() appends <7 to npm constraints 1`] = `
 Array [
   Object {
     "constraints": Object {
@@ -41,12 +23,51 @@ Array [
 ]
 `;
 
-exports[`manager/npm/extract/locked-versions .getLockedVersions() uses package-lock.json with npm v7.0.0 1`] = `
+exports[`manager/npm/extract/locked-versions .getLockedVersions() ignores pnpm 1`] = `
+Array [
+  Object {
+    "deps": Array [
+      Object {
+        "currentValue": "1.0.0",
+        "depName": "a",
+      },
+      Object {
+        "currentValue": "2.0.0",
+        "depName": "b",
+      },
+    ],
+    "pnpmShrinkwrap": "pnpm-lock.yaml",
+  },
+]
+`;
+
+exports[`manager/npm/extract/locked-versions .getLockedVersions() uses package-lock.json with npm v6.0.0 1`] = `
 Array [
   Object {
     "constraints": Object {
-      "npm": ">=6.0.0",
+      "npm": "<7",
     },
+    "deps": Array [
+      Object {
+        "currentValue": "1.0.0",
+        "depName": "a",
+        "lockedVersion": "1.0.0",
+      },
+      Object {
+        "currentValue": "2.0.0",
+        "depName": "b",
+        "lockedVersion": "2.0.0",
+      },
+    ],
+    "npmLock": "package-lock.json",
+  },
+]
+`;
+
+exports[`manager/npm/extract/locked-versions .getLockedVersions() uses package-lock.json with npm v7.0.0 1`] = `
+Array [
+  Object {
+    "constraints": Object {},
     "deps": Array [
       Object {
         "currentValue": "1.0.0",

--- a/lib/manager/npm/extract/locked-versions.spec.ts
+++ b/lib/manager/npm/extract/locked-versions.spec.ts
@@ -58,7 +58,7 @@ describe('manager/npm/extract/locked-versions', () => {
         const packageFiles = [
           {
             npmLock: 'package-lock.json',
-            constraints: { npm: '>=6.0.0' },
+            constraints: {},
             deps: [
               {
                 depName: 'a',
@@ -75,6 +75,36 @@ describe('manager/npm/extract/locked-versions', () => {
         expect(packageFiles).toMatchSnapshot();
       }
     );
+    it('appends <7 to npm constraints', async () => {
+      npm.getNpmLock.mockReturnValue({
+        lockedVersions: {
+          a: '1.0.0',
+          b: '2.0.0',
+          c: '3.0.0',
+        },
+        lockfileVersion: 1,
+      });
+      const packageFiles = [
+        {
+          npmLock: 'package-lock.json',
+          constraints: {
+            npm: '>=6.0.0',
+          },
+          deps: [
+            {
+              depName: 'a',
+              currentValue: '1.0.0',
+            },
+            {
+              depName: 'b',
+              currentValue: '2.0.0',
+            },
+          ],
+        },
+      ];
+      await getLockedVersions(packageFiles);
+      expect(packageFiles).toMatchSnapshot();
+    });
     it('ignores pnpm', async () => {
       const packageFiles = [
         {

--- a/lib/manager/npm/extract/locked-versions.spec.ts
+++ b/lib/manager/npm/extract/locked-versions.spec.ts
@@ -58,7 +58,7 @@ describe('manager/npm/extract/locked-versions', () => {
         const packageFiles = [
           {
             npmLock: 'package-lock.json',
-            constraints: {},
+            constraints: { npm: '>=6.0.0' },
             deps: [
               {
                 depName: 'a',
@@ -75,36 +75,6 @@ describe('manager/npm/extract/locked-versions', () => {
         expect(packageFiles).toMatchSnapshot();
       }
     );
-    it('appends <7 to npm constraints', async () => {
-      npm.getNpmLock.mockReturnValue({
-        lockedVersions: {
-          a: '1.0.0',
-          b: '2.0.0',
-          c: '3.0.0',
-        },
-        lockfileVersion: 1,
-      });
-      const packageFiles = [
-        {
-          npmLock: 'package-lock.json',
-          constraints: {
-            npm: '>=6.0.0',
-          },
-          deps: [
-            {
-              depName: 'a',
-              currentValue: '1.0.0',
-            },
-            {
-              depName: 'b',
-              currentValue: '2.0.0',
-            },
-          ],
-        },
-      ];
-      await getLockedVersions(packageFiles);
-      expect(packageFiles).toMatchSnapshot();
-    });
     it('ignores pnpm', async () => {
       const packageFiles = [
         {

--- a/lib/manager/npm/extract/locked-versions.spec.ts
+++ b/lib/manager/npm/extract/locked-versions.spec.ts
@@ -75,6 +75,36 @@ describe('manager/npm/extract/locked-versions', () => {
         expect(packageFiles).toMatchSnapshot();
       }
     );
+    it('appends <7 to npm constraints', async () => {
+      npm.getNpmLock.mockReturnValue({
+        lockedVersions: {
+          a: '1.0.0',
+          b: '2.0.0',
+          c: '3.0.0',
+        },
+        lockfileVersion: 1,
+      });
+      const packageFiles = [
+        {
+          npmLock: 'package-lock.json',
+          constraints: {
+            npm: '>=6.0.0',
+          },
+          deps: [
+            {
+              depName: 'a',
+              currentValue: '1.0.0',
+            },
+            {
+              depName: 'b',
+              currentValue: '2.0.0',
+            },
+          ],
+        },
+      ];
+      await getLockedVersions(packageFiles);
+      expect(packageFiles).toMatchSnapshot();
+    });
     it('ignores pnpm', async () => {
       const packageFiles = [
         {

--- a/lib/manager/npm/extract/locked-versions.ts
+++ b/lib/manager/npm/extract/locked-versions.ts
@@ -39,11 +39,12 @@ export async function getLockedVersions(
         logger.trace('Retrieving/parsing ' + npmLock);
         lockFileCache[npmLock] = await getNpmLock(npmLock);
       }
-      if (!packageFile.constraints.npm) {
-        // do not override if already set
-        const { lockfileVersion } = lockFileCache[npmLock];
-        if (lockfileVersion >= 2) {
-          packageFile.constraints.npm = '>= 7.0.0';
+      const { lockfileVersion } = lockFileCache[npmLock];
+      if (lockfileVersion === 1) {
+        if (packageFile.constraints.npm) {
+          packageFile.constraints.npm += ' <7';
+        } else {
+          packageFile.constraints.npm = '<7';
         }
       }
       for (const dep of packageFile.deps) {

--- a/lib/manager/npm/post-update/npm.ts
+++ b/lib/manager/npm/post-update/npm.ts
@@ -27,9 +27,9 @@ export async function generateLockFile(
   let lockFile = null;
   try {
     let installNpm = 'npm i -g npm';
-    const npmCompatibility = config.constraints?.npm;
+    const npmCompatibility = config.constraints?.npm as string;
     if (validRange(npmCompatibility)) {
-      installNpm += `@${quote(npmCompatibility)}`;
+      installNpm = `npm i -g ${quote(`npm@${npmCompatibility}`)}`;
     }
     const preCommands = [installNpm, 'hash -d npm'];
     const commands = [];


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds detection for npm 6 vs 7 when binarySource=docker

## Context:

npm@7 just became `latest` and we should install npm@6 for any repo with a v1 lockFile

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] Ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
