### PR TITLE
feat: warn about disallowed template variables

### DIFF
--- a/lib/util/template/index.spec.ts
+++ b/lib/util/template/index.spec.ts
@@ -10,8 +10,9 @@ describe('util/template', () => {
     expect(missingOptions).toEqual([]);
   });
   it('filters out disallowed fields', () => {
-    const userTemplate = '{{platform}} token = "{{token}}"';
-    const input = { platform: 'github', token: 'abc123 ' };
+    const userTemplate =
+      '{{#if isFoo}}foo{{/if}}{{platform}} token = "{{token}}"';
+    const input = { isFoo: true, platform: 'github', token: 'abc123 ' };
     const output = template.compile(userTemplate, input);
     expect(output).toMatchSnapshot();
     expect(output).toContain('github');

--- a/lib/util/template/index.ts
+++ b/lib/util/template/index.ts
@@ -87,6 +87,8 @@ export const allowedFields = {
   versions: 'An array of ChangeLogRelease objects in the upgrade',
 };
 
+const allowedFieldsList = Object.keys(allowedFields);
+
 type CompileInput = Record<string, unknown>;
 
 function getFilteredObject(input: CompileInput): any {
@@ -111,6 +113,8 @@ function getFilteredObject(input: CompileInput): any {
   return res;
 }
 
+const templateRegex = /{{(#(if|unless) )?([a-zA-Z]+)}}/g;
+
 export function compile(
   template: string,
   input: CompileInput,
@@ -118,5 +122,15 @@ export function compile(
 ): string {
   const filteredInput = filterFields ? getFilteredObject(input) : input;
   logger.trace({ template, filteredInput }, 'Compiling template');
+  const matches = template.matchAll(templateRegex);
+  for (const match of matches) {
+    const varName = match[3];
+    if (!allowedFieldsList.includes(varName)) {
+      logger.warn(
+        { varName, template },
+        'Disallowed variable name in template'
+      );
+    }
+  }
   return handlebars.compile(template)(filteredInput);
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Logs a warning if a simple check of template strings reveals a variable that is not allowed.

## Context:

This is to complement the recent template filtering so that there is less chance of it failing silently.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
