### PR TITLE
fix(git): add — after rev-parse

### DIFF
--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -393,7 +393,7 @@ export async function checkoutBranch(branchName: string): Promise<CommitSha> {
   try {
     config.currentBranch = branchName;
     config.currentBranchSha = (
-      await git.raw(['rev-parse', 'origin/' + branchName])
+      await git.raw(['rev-parse', 'origin/' + branchName, '--'])
     ).trim();
     await git.checkout([branchName, '-f']);
     const latestCommitDate = (await git.log({ n: 1 }))?.latest?.date;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Add `--` after `git rev-parse` to disambiguate.

## Context:

Attempt to solve:

```
err.message | fatal: ambiguous argument 'origin/main': unknown revision or path not in the working tree.Use '--' to separate paths from revisions, like this:'git <command> [<revision>...] -- [<file>...]'
-- | --
err.stack | Error: fatal: ambiguous argument 'origin/main': unknown revision or path not in the working tree.Use '--' to separate paths from revisions, like this:'git <command> [<revision>...] -- [<file>...]'at GitExecutorChain.onFatalException (/home/ubuntu/renovateapp/node_modules/simple-git/src/lib/runners/git-executor-chain.js:61:87)at GitExecutorChain.<anonymous> (/home/ubuntu/renovateapp/node_modules/simple-git/src/lib/runners/git-executor-chain.js:52:28)at Generator.throw (<anonymous>)at rejected (/home/ubuntu/renovateapp/node_modules/simple-git/src/lib/runners/git-executor-chain.js:6:65)at runMicrotasks (<anonymous>)at processTicksAndRejections (internal/process/task_queues.js:97:5)
err.task.commands.0 | rev-parse
err.task.commands.1 | origin/main
```

This happens in forkMode when the forked repo already exists and uses `master`.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
