### PR TITLE
fix: description to string type

### DIFF
--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -213,8 +213,7 @@ const options: RenovateOptions[] = [
   {
     name: 'description',
     description: 'Plain text description for a config or preset.',
-    type: 'array',
-    subType: 'string',
+    type: 'string',
     stage: 'repository',
     allowString: true,
     mergeable: true,


### PR DESCRIPTION
According to the description of the field "description", it should be plain text.

## Changes:

This fixes the description data type to be string

## Context:

Couldn't find a responding issue

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] Unit tests + ran on a real repository
