### PR TITLE
feat: regexManagers presets

### DIFF
--- a/lib/config/presets/index.ts
+++ b/lib/config/presets/index.ts
@@ -100,6 +100,7 @@ export function parsePreset(input: string): ParsedPreset {
     'npm',
     'packages',
     'preview',
+    'regexManagers',
     'schedule',
     'workarounds',
   ];

--- a/lib/config/presets/internal/index.ts
+++ b/lib/config/presets/internal/index.ts
@@ -8,6 +8,7 @@ import * as monorepoPreset from './monorepo';
 import * as npm from './npm';
 import * as packagesPreset from './packages';
 import * as previewPreset from './preview';
+import * as regexManagersPreset from './regex-managers';
 import * as schedulePreset from './schedule';
 import * as workaroundsPreset from './workarounds';
 
@@ -21,6 +22,7 @@ export const groups: Record<string, Record<string, Preset>> = {
   npm: npm.presets,
   packages: packagesPreset.presets,
   preview: previewPreset.presets,
+  regexManagers: regexManagersPreset.presets,
   schedule: schedulePreset.presets,
   workarounds: workaroundsPreset.presets,
 };

--- a/lib/config/presets/internal/regex-managers.ts
+++ b/lib/config/presets/internal/regex-managers.ts
@@ -1,0 +1,15 @@
+import { Preset } from '../common';
+
+export const presets: Record<string, Preset> = {
+  dockerfileVersions: {
+    description: 'Update _VERSION variables in Dockerfiles',
+    regexManagers: [
+      {
+        fileMatch: ['(^|/|\\.)Dockerfile$', '(^|/)Dockerfile\\.[^/]*$'],
+        matchStrings: [
+          '# renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>[^\\s]+?)(?: lookupName=(?<lookupName>[^\\s]+?))?(?: versioning=(?<versioning>[a-z-]+?))?\\s(?:ENV|ARG) .+?_VERSION=(?<currentValue>.+?)\\s',
+        ],
+      },
+    ],
+  },
+};


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds a new `regexManagers` category of internal presets, with `regexManagers:dockerfileVersions` as the first one.

## Context:

The approach we use for updating Dockerfile versions would be useful to many others.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] Ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
