### PR TITLE
fix(docker): Fix support for docker list manifests

### DIFF
--- a/lib/datasource/docker/types.ts
+++ b/lib/datasource/docker/types.ts
@@ -5,7 +5,7 @@
 export enum MediaType {
   manifestV1 = 'pplication/vnd.docker.distribution.manifest.v1+json',
   manifestV2 = 'application/vnd.docker.distribution.manifest.v2+json',
-  manifestListV2 = 'application/vnd.docker.distribution.manifest.list.v2+jso',
+  manifestListV2 = 'application/vnd.docker.distribution.manifest.list.v2+json',
 }
 
 export interface MediaObject {


### PR DESCRIPTION
## Changes:

Add a missing `n`.

## Context:

I guess the tests work as they are both (test+code) using this constant, but the actual runs don't work and fail with:
```
DEBUG: Invalid manifest - returning (repository=INFRASTRUCTURE/security-checker-job)
"manifest": {
"manifests": [
{
"digest": "sha256:3747d4eb5e7f0825d54c8e80452f1e245e24bd715972c919d189a62da97af2ae",
"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
"platform": {"architecture": "amd64", "os": "linux"},
"size": 528
},
...
],
"mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
"schemaVersion": 2
}
```

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
