### PR TITLE
feat: admin config init

### DIFF
--- a/lib/config/admin.ts
+++ b/lib/config/admin.ts
@@ -9,9 +9,10 @@ export function setAdminConfig(
   adminOptions: string[]
 ): void {
   adminConfig = {};
-  const repoAdminOptions = adminOptions.concat(derivedAdminOptions).sort();
+  const repoAdminOptions = adminOptions.concat(derivedAdminOptions);
   for (const option of repoAdminOptions) {
     adminConfig[option] = config[option];
+    // TODO: delete from config
   }
 }
 

--- a/lib/config/admin.ts
+++ b/lib/config/admin.ts
@@ -1,0 +1,20 @@
+import { RenovateConfig, RepoAdminConfig } from './common';
+
+let adminConfig: RepoAdminConfig = {};
+
+const derivedAdminOptions = ['localDir'];
+
+export function setAdminConfig(
+  config: RenovateConfig,
+  adminOptions: string[]
+): void {
+  adminConfig = {};
+  const repoAdminOptions = adminOptions.concat(derivedAdminOptions).sort();
+  for (const option of repoAdminOptions) {
+    adminConfig[option] = config[option];
+  }
+}
+
+export function getAdminConfig(): RepoAdminConfig {
+  return adminConfig;
+}

--- a/lib/config/common.ts
+++ b/lib/config/common.ts
@@ -64,6 +64,7 @@ export interface RenovateSharedConfig {
 }
 
 export interface RepoAdminConfig {
+  dockerUser?: string;
 }
 
 export interface RenovateAdminConfig {
@@ -78,7 +79,6 @@ export interface RenovateAdminConfig {
 
   customEnvVariables?: Record<string, string>;
   dockerImagePrefix?: string;
-  dockerUser?: string;
 
   dryRun?: boolean;
 

--- a/lib/config/common.ts
+++ b/lib/config/common.ts
@@ -1,7 +1,6 @@
 import { LogLevel } from 'bunyan';
 import { Range } from 'semver';
 import { HostRule } from '../types';
-import { Opt } from '../util/exec/common';
 
 export type RenovateConfigStage =
   | 'global'
@@ -65,7 +64,7 @@ export interface RenovateSharedConfig {
 }
 
 export interface RepoAdminConfig {
-  dockerImagePrefix?: Opt<string>;
+  dockerImagePrefix?: string;
   dockerUser?: string;
 }
 

--- a/lib/config/common.ts
+++ b/lib/config/common.ts
@@ -63,6 +63,9 @@ export interface RenovateSharedConfig {
   unicodeEmoji?: boolean;
 }
 
+export interface RepoAdminConfig {
+}
+
 export interface RenovateAdminConfig {
   allowPostUpgradeCommandTemplating?: boolean;
   allowedPostUpgradeCommands?: string[];

--- a/lib/config/common.ts
+++ b/lib/config/common.ts
@@ -1,6 +1,7 @@
 import { LogLevel } from 'bunyan';
 import { Range } from 'semver';
 import { HostRule } from '../types';
+import { Opt } from '../util/exec/common';
 
 export type RenovateConfigStage =
   | 'global'
@@ -64,6 +65,7 @@ export interface RenovateSharedConfig {
 }
 
 export interface RepoAdminConfig {
+  dockerImagePrefix?: Opt<string>;
   dockerUser?: string;
 }
 
@@ -78,7 +80,6 @@ export interface RenovateAdminConfig {
   configWarningReuseIssue?: boolean;
 
   customEnvVariables?: Record<string, string>;
-  dockerImagePrefix?: string;
 
   dryRun?: boolean;
 

--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -1920,6 +1920,10 @@ export function getOptions(): RenovateOptions[] {
   return options;
 }
 
+export function getAdminOptionNames(): string[] {
+  return options.filter((option) => option.admin).map((option) => option.name);
+}
+
 function loadManagerOptions(): void {
   for (const [name, config] of getManagers().entries()) {
     if (config.defaultConfig) {

--- a/lib/manager/bundler/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/manager/bundler/__snapshots__/artifacts.spec.ts.snap
@@ -26,7 +26,7 @@ Array [
     },
   },
   Object {
-    "cmd": "docker run --rm --name=renovate_ruby --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/cache\\":\\"/tmp/cache\\" -e GEM_HOME -w \\"/tmp/github/some/repo\\" renovate/ruby:1.2.0 bash -l -c \\"ruby --version && gem install bundler && bundle lock --update foo bar\\"",
+    "cmd": "docker run --rm --name=renovate_ruby --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/cache\\":\\"/tmp/cache\\" -e GEM_HOME -w \\"/tmp/github/some/repo\\" renovate/ruby:1.2.0 bash -l -c \\"ruby --version && gem install bundler && bundle lock --update foo bar\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -73,7 +73,7 @@ Array [
     },
   },
   Object {
-    "cmd": "docker run --rm --name=renovate_ruby --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/cache\\":\\"/tmp/cache\\" -e GEM_HOME -w \\"/tmp/github/some/repo\\" renovate/ruby:latest bash -l -c \\"ruby --version && gem install bundler -v 3.2.1 && bundle lock --update foo bar\\"",
+    "cmd": "docker run --rm --name=renovate_ruby --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/cache\\":\\"/tmp/cache\\" -e GEM_HOME -w \\"/tmp/github/some/repo\\" renovate/ruby:latest bash -l -c \\"ruby --version && gem install bundler -v 3.2.1 && bundle lock --update foo bar\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -120,7 +120,7 @@ Array [
     },
   },
   Object {
-    "cmd": "docker run --rm --name=renovate_ruby --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/cache\\":\\"/tmp/cache\\" -e BUNDLE_GEMS__PRIVATE__COM -e GEM_HOME -w \\"/tmp/github/some/repo\\" renovate/ruby:1.2.0 bash -l -c \\"ruby --version && gem install bundler && bundle lock --update foo bar\\"",
+    "cmd": "docker run --rm --name=renovate_ruby --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/cache\\":\\"/tmp/cache\\" -e BUNDLE_GEMS__PRIVATE__COM -e GEM_HOME -w \\"/tmp/github/some/repo\\" renovate/ruby:1.2.0 bash -l -c \\"ruby --version && gem install bundler && bundle lock --update foo bar\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -168,7 +168,7 @@ Array [
     },
   },
   Object {
-    "cmd": "docker run --rm --name=renovate_ruby --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/cache\\":\\"/tmp/cache\\" -e GEM_HOME -w \\"/tmp/github/some/repo\\" renovate/ruby:latest bash -l -c \\"ruby --version && gem install bundler && bundle lock --update foo bar\\"",
+    "cmd": "docker run --rm --name=renovate_ruby --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/cache\\":\\"/tmp/cache\\" -e GEM_HOME -w \\"/tmp/github/some/repo\\" renovate/ruby:latest bash -l -c \\"ruby --version && gem install bundler && bundle lock --update foo bar\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",

--- a/lib/manager/bundler/artifacts.spec.ts
+++ b/lib/manager/bundler/artifacts.spec.ts
@@ -38,7 +38,6 @@ describe('bundler.updateArtifacts()', () => {
       // `join` fixes Windows CI
       localDir: join('/tmp/github/some/repo'),
       cacheDir: join('/tmp/cache'),
-      dockerUser: 'foobar',
     };
 
     env.getChildProcessEnv.mockReturnValue(envMock.basic);
@@ -173,7 +172,6 @@ describe('bundler.updateArtifacts()', () => {
           config: {
             ...config,
             binarySource: BinarySource.Docker,
-            dockerUser: 'foobar',
             constraints: {
               ruby: '1.2.5',
               bundler: '3.2.1',
@@ -206,7 +204,6 @@ describe('bundler.updateArtifacts()', () => {
           config: {
             ...config,
             binarySource: BinarySource.Docker,
-            dockerUser: 'foobar',
             constraints: {
               ruby: 'foo',
               bundler: 'bar',

--- a/lib/manager/cargo/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/manager/cargo/__snapshots__/artifacts.spec.ts.snap
@@ -95,7 +95,7 @@ Array [
     },
   },
   Object {
-    "cmd": "docker run --rm --name=renovate_rust --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -w \\"/tmp/github/some/repo\\" renovate/rust bash -l -c \\"cargo update --manifest-path Cargo.toml --package dep1\\"",
+    "cmd": "docker run --rm --name=renovate_rust --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -w \\"/tmp/github/some/repo\\" renovate/rust bash -l -c \\"cargo update --manifest-path Cargo.toml --package dep1\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",

--- a/lib/manager/cargo/artifacts.spec.ts
+++ b/lib/manager/cargo/artifacts.spec.ts
@@ -22,7 +22,6 @@ const env = mocked(_env);
 const config = {
   // `join` fixes Windows CI
   localDir: join('/tmp/github/some/repo'),
-  dockerUser: 'foobar',
 };
 
 describe('.updateArtifacts()', () => {

--- a/lib/manager/cocoapods/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/manager/cocoapods/__snapshots__/artifacts.spec.ts.snap
@@ -34,7 +34,7 @@ Array [
     },
   },
   Object {
-    "cmd": "docker run --rm --name=renovate_cocoapods --label=renovate_child --user=ubuntu -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/cache\\":\\"/tmp/cache\\" -e CP_HOME_DIR -w \\"/tmp/github/some/repo\\" renovate/cocoapods:1.2.4 bash -l -c \\"pod install\\"",
+    "cmd": "docker run --rm --name=renovate_cocoapods --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/cache\\":\\"/tmp/cache\\" -e CP_HOME_DIR -w \\"/tmp/github/some/repo\\" renovate/cocoapods:1.2.4 bash -l -c \\"pod install\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -76,7 +76,7 @@ Array [
     },
   },
   Object {
-    "cmd": "docker run --rm --name=renovate_cocoapods --label=renovate_child --user=ubuntu -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/cache\\":\\"/tmp/cache\\" -e CP_HOME_DIR -w \\"/tmp/github/some/repo\\" renovate/cocoapods:latest bash -l -c \\"pod install\\"",
+    "cmd": "docker run --rm --name=renovate_cocoapods --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/cache\\":\\"/tmp/cache\\" -e CP_HOME_DIR -w \\"/tmp/github/some/repo\\" renovate/cocoapods:latest bash -l -c \\"pod install\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",

--- a/lib/manager/cocoapods/artifacts.spec.ts
+++ b/lib/manager/cocoapods/artifacts.spec.ts
@@ -190,7 +190,6 @@ describe('.updateArtifacts()', () => {
     await setExecConfig({
       ...config,
       binarySource: 'docker',
-      dockerUser: 'ubuntu',
     });
 
     fs.readFile.mockResolvedValueOnce('COCOAPODS: 1.2.4' as any);
@@ -215,7 +214,6 @@ describe('.updateArtifacts()', () => {
     await setExecConfig({
       ...config,
       binarySource: 'docker',
-      dockerUser: 'ubuntu',
     });
 
     fs.readFile.mockResolvedValueOnce('COCOAPODS: 1.2.4' as any);

--- a/lib/manager/common.ts
+++ b/lib/manager/common.ts
@@ -11,7 +11,6 @@ export type Result<T> = T | Promise<T>;
 
 export interface ManagerConfig {
   binarySource?: string;
-  dockerUser?: string;
   localDir?: string;
   registryUrls?: string[];
 }

--- a/lib/manager/composer/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/manager/composer/__snapshots__/artifacts.spec.ts.snap
@@ -133,7 +133,7 @@ Array [
     },
   },
   Object {
-    "cmd": "docker run --rm --name=renovate_composer --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -e COMPOSER_CACHE_DIR -w \\"/tmp/github/some/repo\\" renovate/composer:1.10.17 bash -l -c \\"composer update --with-dependencies --ignore-platform-reqs --no-ansi --no-interaction --no-scripts --no-autoloader\\"",
+    "cmd": "docker run --rm --name=renovate_composer --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -e COMPOSER_CACHE_DIR -w \\"/tmp/github/some/repo\\" renovate/composer:1.10.17 bash -l -c \\"composer update --with-dependencies --ignore-platform-reqs --no-ansi --no-interaction --no-scripts --no-autoloader\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",

--- a/lib/manager/composer/artifacts.spec.ts
+++ b/lib/manager/composer/artifacts.spec.ts
@@ -28,7 +28,6 @@ const config = {
   // `join` fixes Windows CI
   localDir: join('/tmp/github/some/repo'),
   cacheDir: join('/tmp/renovate/cache'),
-  dockerUser: 'foobar',
   composerIgnorePlatformReqs: true,
 };
 

--- a/lib/manager/gomod/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/manager/gomod/__snapshots__/artifacts.spec.ts.snap
@@ -84,7 +84,7 @@ Array [
     },
   },
   Object {
-    "cmd": "docker run --rm --name=renovate_go --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -v \\"/tmp/renovate/cache/others/go\\":\\"/tmp/renovate/cache/others/go\\" -e GOPATH -e GOPROXY -e GONOSUMDB -e CGO_ENABLED -w \\"/tmp/github/some/repo\\" renovate/go:latest bash -l -c \\"git config --global url.\\\\\\"https://some-token@github.com/\\\\\\".insteadOf \\\\\\"https://github.com/\\\\\\" && go get -d ./...\\"",
+    "cmd": "docker run --rm --name=renovate_go --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -v \\"/tmp/renovate/cache/others/go\\":\\"/tmp/renovate/cache/others/go\\" -e GOPATH -e GOPROXY -e GONOSUMDB -e CGO_ENABLED -w \\"/tmp/github/some/repo\\" renovate/go:latest bash -l -c \\"git config --global url.\\\\\\"https://some-token@github.com/\\\\\\".insteadOf \\\\\\"https://github.com/\\\\\\" && go get -d ./...\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -123,7 +123,7 @@ Array [
     },
   },
   Object {
-    "cmd": "docker run --rm --name=renovate_go --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -v \\"/tmp/renovate/cache/others/go\\":\\"/tmp/renovate/cache/others/go\\" -e GOPATH -e GOPROXY -e GONOSUMDB -e CGO_ENABLED -w \\"/tmp/github/some/repo\\" renovate/go:latest bash -l -c \\"go get -d ./... && go mod tidy && go mod tidy\\"",
+    "cmd": "docker run --rm --name=renovate_go --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -v \\"/tmp/renovate/cache/others/go\\":\\"/tmp/renovate/cache/others/go\\" -e GOPATH -e GOPROXY -e GONOSUMDB -e CGO_ENABLED -w \\"/tmp/github/some/repo\\" renovate/go:latest bash -l -c \\"go get -d ./... && go mod tidy && go mod tidy\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -162,7 +162,7 @@ Array [
     },
   },
   Object {
-    "cmd": "docker run --rm --name=renovate_go --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -v \\"/tmp/renovate/cache/others/go\\":\\"/tmp/renovate/cache/others/go\\" -e GOPATH -e GOPROXY -e GONOSUMDB -e CGO_ENABLED -w \\"/tmp/github/some/repo\\" renovate/go:latest bash -l -c \\"go get -d ./...\\"",
+    "cmd": "docker run --rm --name=renovate_go --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -v \\"/tmp/renovate/cache/others/go\\":\\"/tmp/renovate/cache/others/go\\" -e GOPATH -e GOPROXY -e GONOSUMDB -e CGO_ENABLED -w \\"/tmp/github/some/repo\\" renovate/go:latest bash -l -c \\"go get -d ./...\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",

--- a/lib/manager/gomod/artifacts.spec.ts
+++ b/lib/manager/gomod/artifacts.spec.ts
@@ -39,7 +39,6 @@ const config = {
   // `join` fixes Windows CI
   localDir: join('/tmp/github/some/repo'),
   cacheDir: join('/tmp/renovate/cache'),
-  dockerUser: 'foobar',
   constraints: { go: '1.14' },
 };
 

--- a/lib/manager/helmv3/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/manager/helmv3/__snapshots__/artifacts.spec.ts.snap
@@ -95,7 +95,7 @@ Array [
     },
   },
   Object {
-    "cmd": "docker run --rm --name=renovate_helm --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -w \\"/tmp/github/some/repo\\" renovate/helm bash -l -c \\"helm dependency update ''\\"",
+    "cmd": "docker run --rm --name=renovate_helm --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -w \\"/tmp/github/some/repo\\" renovate/helm bash -l -c \\"helm dependency update ''\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",

--- a/lib/manager/helmv3/artifacts.spec.ts
+++ b/lib/manager/helmv3/artifacts.spec.ts
@@ -22,7 +22,6 @@ const env = mocked(_env);
 const config = {
   // `join` fixes Windows CI
   localDir: join('/tmp/github/some/repo'),
-  dockerUser: 'foobar',
 };
 
 describe('.updateArtifacts()', () => {

--- a/lib/manager/nuget/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/manager/nuget/__snapshots__/artifacts.spec.ts.snap
@@ -119,7 +119,7 @@ Array [
     },
   },
   Object {
-    "cmd": "docker run --rm --name=renovate_dotnet --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -w \\"/tmp/github/some/repo\\" renovate/dotnet bash -l -c \\"dotnet restore project.csproj --force-evaluate --configfile others/nuget/not-so-random/nuget.config\\"",
+    "cmd": "docker run --rm --name=renovate_dotnet --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -w \\"/tmp/github/some/repo\\" renovate/dotnet bash -l -c \\"dotnet restore project.csproj --force-evaluate --configfile others/nuget/not-so-random/nuget.config\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",

--- a/lib/manager/nuget/artifacts.spec.ts
+++ b/lib/manager/nuget/artifacts.spec.ts
@@ -37,7 +37,6 @@ const config = {
   // `join` fixes Windows CI
   localDir: join('/tmp/github/some/repo'),
   cacheDir: join('/tmp/renovate/cache'),
-  dockerUser: 'foobar',
 };
 
 describe('updateArtifacts', () => {

--- a/lib/manager/pipenv/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/manager/pipenv/__snapshots__/artifacts.spec.ts.snap
@@ -122,7 +122,7 @@ Array [
     },
   },
   Object {
-    "cmd": "docker run --rm --name=renovate_python --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -v \\"/tmp/renovate/cache/others/pipenv\\":\\"/tmp/renovate/cache/others/pipenv\\" -e PIPENV_CACHE_DIR -w \\"/tmp/github/some/repo\\" renovate/python:latest bash -l -c \\"pip install --user pipenv && pipenv lock\\"",
+    "cmd": "docker run --rm --name=renovate_python --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -v \\"/tmp/renovate/cache/others/pipenv\\":\\"/tmp/renovate/cache/others/pipenv\\" -e PIPENV_CACHE_DIR -w \\"/tmp/github/some/repo\\" renovate/python:latest bash -l -c \\"pip install --user pipenv && pipenv lock\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -158,7 +158,7 @@ Array [
     },
   },
   Object {
-    "cmd": "docker run --rm --name=renovate_python --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -v \\"/tmp/renovate/cache/others/pipenv\\":\\"/tmp/renovate/cache/others/pipenv\\" -e PIPENV_CACHE_DIR -w \\"/tmp/github/some/repo\\" renovate/python bash -l -c \\"pip install --user pipenv==2020.8.13 && pipenv lock\\"",
+    "cmd": "docker run --rm --name=renovate_python --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -v \\"/tmp/renovate/cache/others/pipenv\\":\\"/tmp/renovate/cache/others/pipenv\\" -e PIPENV_CACHE_DIR -w \\"/tmp/github/some/repo\\" renovate/python bash -l -c \\"pip install --user pipenv==2020.8.13 && pipenv lock\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -194,7 +194,7 @@ Array [
     },
   },
   Object {
-    "cmd": "docker run --rm --name=renovate_python --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -v \\"/tmp/renovate/cache/others/pipenv\\":\\"/tmp/renovate/cache/others/pipenv\\" -e PIPENV_CACHE_DIR -w \\"/tmp/github/some/repo\\" renovate/python bash -l -c \\"pip install --user pipenv==2020.8.13 && pipenv lock\\"",
+    "cmd": "docker run --rm --name=renovate_python --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -v \\"/tmp/renovate/cache/others/pipenv\\":\\"/tmp/renovate/cache/others/pipenv\\" -e PIPENV_CACHE_DIR -w \\"/tmp/github/some/repo\\" renovate/python bash -l -c \\"pip install --user pipenv==2020.8.13 && pipenv lock\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -230,7 +230,7 @@ Array [
     },
   },
   Object {
-    "cmd": "docker run --rm --name=renovate_python --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -v \\"/tmp/renovate/cache/others/pipenv\\":\\"/tmp/renovate/cache/others/pipenv\\" -e PIPENV_CACHE_DIR -w \\"/tmp/github/some/repo\\" renovate/python bash -l -c \\"pip install --user pipenv==2020.1.1 && pipenv lock\\"",
+    "cmd": "docker run --rm --name=renovate_python --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -v \\"/tmp/renovate/cache/others/pipenv\\":\\"/tmp/renovate/cache/others/pipenv\\" -e PIPENV_CACHE_DIR -w \\"/tmp/github/some/repo\\" renovate/python bash -l -c \\"pip install --user pipenv==2020.1.1 && pipenv lock\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",

--- a/lib/manager/pipenv/artifacts.spec.ts
+++ b/lib/manager/pipenv/artifacts.spec.ts
@@ -25,7 +25,6 @@ const config = {
   // `join` fixes Windows CI
   localDir: join('/tmp/github/some/repo'),
   cacheDir: join('/tmp/renovate/cache'),
-  dockerUser: 'foobar',
 };
 
 const dockerConfig = { ...config, binarySource: BinarySource.Docker };

--- a/lib/manager/poetry/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/manager/poetry/__snapshots__/artifacts.spec.ts.snap
@@ -100,7 +100,7 @@ Array [
     },
   },
   Object {
-    "cmd": "docker run --rm --name=renovate_python --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -w \\"/tmp/github/some/repo\\" renovate/python:2.7.5 bash -l -c \\"pip install 'poetry>=1.0' && poetry update --lock --no-interaction dep1\\"",
+    "cmd": "docker run --rm --name=renovate_python --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -w \\"/tmp/github/some/repo\\" renovate/python:2.7.5 bash -l -c \\"pip install 'poetry>=1.0' && poetry update --lock --no-interaction dep1\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -135,7 +135,7 @@ Array [
     },
   },
   Object {
-    "cmd": "docker run --rm --name=renovate_python --label=renovate_child --user=foobar -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -w \\"/tmp/github/some/repo\\" renovate/python:3.4.2 bash -l -c \\"pip install poetry && poetry update --lock --no-interaction dep1\\"",
+    "cmd": "docker run --rm --name=renovate_python --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -w \\"/tmp/github/some/repo\\" renovate/python:3.4.2 bash -l -c \\"pip install poetry && poetry update --lock --no-interaction dep1\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",

--- a/lib/manager/poetry/artifacts.spec.ts
+++ b/lib/manager/poetry/artifacts.spec.ts
@@ -135,7 +135,6 @@ describe('.updateArtifacts()', () => {
     await setExecConfig({
       ...config,
       binarySource: BinarySource.Docker,
-      dockerUser: 'foobar',
     });
     fs.readFile.mockResolvedValueOnce('[metadata]\n' as any);
     const execSnapshots = mockExecAll(exec);
@@ -162,7 +161,6 @@ describe('.updateArtifacts()', () => {
     await setExecConfig({
       ...config,
       binarySource: BinarySource.Docker,
-      dockerUser: 'foobar',
     });
     fs.readFile.mockResolvedValueOnce(
       '[metadata]\npython-versions = "~2.7 || ^3.4"' as any

--- a/lib/util/exec/common.ts
+++ b/lib/util/exec/common.ts
@@ -15,7 +15,6 @@ export interface ExecConfig {
   binarySource: Opt<BinarySource>;
   customEnvVariables: Opt<Record<string, string>>;
   dockerImagePrefix: Opt<string>;
-  dockerUser: Opt<string>;
   localDir: Opt<string>;
   cacheDir: Opt<string>;
 }

--- a/lib/util/exec/common.ts
+++ b/lib/util/exec/common.ts
@@ -14,7 +14,6 @@ export enum BinarySource {
 export interface ExecConfig {
   binarySource: Opt<BinarySource>;
   customEnvVariables: Opt<Record<string, string>>;
-  dockerImagePrefix: Opt<string>;
   localDir: Opt<string>;
   cacheDir: Opt<string>;
 }

--- a/lib/util/exec/docker/index.ts
+++ b/lib/util/exec/docker/index.ts
@@ -1,3 +1,4 @@
+import { getAdminConfig } from '../../../config/admin';
 import { SYSTEM_INSUFFICIENT_MEMORY } from '../../../constants/error-messages';
 import { getPkgReleases } from '../../../datasource';
 import { logger } from '../../../logger';
@@ -186,8 +187,8 @@ export async function generateDockerCommand(
   const volumes = options.volumes || [];
   const preCommands = options.preCommands || [];
   const postCommands = options.postCommands || [];
-  const { localDir, cacheDir, dockerUser } = config;
-
+  const { localDir, cacheDir } = config;
+  const { dockerUser } = getAdminConfig();
   const result = ['docker run --rm'];
   const containerName = getContainerName(image);
   result.push(`--name=${containerName}`);

--- a/lib/util/exec/docker/index.ts
+++ b/lib/util/exec/docker/index.ts
@@ -188,7 +188,7 @@ export async function generateDockerCommand(
   const preCommands = options.preCommands || [];
   const postCommands = options.postCommands || [];
   const { localDir, cacheDir } = config;
-  const { dockerUser } = getAdminConfig();
+  const { dockerUser, dockerImagePrefix } = getAdminConfig();
   const result = ['docker run --rm'];
   const containerName = getContainerName(image);
   result.push(`--name=${containerName}`);
@@ -211,10 +211,10 @@ export async function generateDockerCommand(
     result.push(`-w "${cwd}"`);
   }
 
-  if (config.dockerImagePrefix) {
+  if (dockerImagePrefix) {
     image = image.replace(
       /^renovate\//,
-      ensureTrailingSlash(config.dockerImagePrefix)
+      ensureTrailingSlash(dockerImagePrefix)
     );
   }
 

--- a/lib/util/exec/exec.spec.ts
+++ b/lib/util/exec/exec.spec.ts
@@ -423,7 +423,6 @@ describe(`Child process execution wrapper`, () => {
         execConfig: {
           ...execConfig,
           binarySource: BinarySource.Docker,
-          dockerImagePrefix: 'ghcr.io/renovatebot',
         },
         processEnv,
         inCmd,
@@ -444,6 +443,7 @@ describe(`Child process execution wrapper`, () => {
             maxBuffer: 10485760,
           },
         ],
+        adminConfig: { dockerImagePrefix: 'ghcr.io/renovatebot' },
       },
     ],
 

--- a/lib/util/exec/exec.spec.ts
+++ b/lib/util/exec/exec.spec.ts
@@ -5,6 +5,7 @@ import {
 } from 'child_process';
 import { envMock } from '../../../test/exec-util';
 import { setAdminConfig } from '../../config/admin';
+import { RepoAdminConfig } from '../../config/common';
 import {
   BinarySource,
   ExecConfig,
@@ -26,7 +27,7 @@ interface TestInput {
   outCmd: string[];
   outOpts: RawExecOptions[];
   trustLevel?: 'high' | 'low';
-  dockerUser?: string;
+  adminConfig?: RepoAdminConfig;
 }
 
 describe(`Child process execution wrapper`, () => {
@@ -412,7 +413,7 @@ describe(`Child process execution wrapper`, () => {
             maxBuffer: 10485760,
           },
         ],
-        dockerUser: 'foobar',
+        adminConfig: { dockerUser: 'foobar' },
       },
     ],
 
@@ -662,7 +663,7 @@ describe(`Child process execution wrapper`, () => {
       outCmd: outCommand,
       outOpts,
       trustLevel,
-      dockerUser,
+      adminConfig = {},
     } = testOpts;
 
     process.env = procEnv;
@@ -685,7 +686,7 @@ describe(`Child process execution wrapper`, () => {
       callback(null, { stdout: '', stderr: '' });
       return undefined;
     });
-    setAdminConfig({ dockerUser }, ['dockerUser']);
+    setAdminConfig(adminConfig as any, Object.keys(adminConfig));
     await exec(cmd as string, inOpts);
 
     expect(actualCmd).toEqual(outCommand);

--- a/lib/util/exec/exec.spec.ts
+++ b/lib/util/exec/exec.spec.ts
@@ -4,6 +4,7 @@ import {
   exec as _cpExec,
 } from 'child_process';
 import { envMock } from '../../../test/exec-util';
+import { setAdminConfig } from '../../config/admin';
 import {
   BinarySource,
   ExecConfig,
@@ -25,6 +26,7 @@ interface TestInput {
   outCmd: string[];
   outOpts: RawExecOptions[];
   trustLevel?: 'high' | 'low';
+  dockerUser?: string;
 }
 
 describe(`Child process execution wrapper`, () => {
@@ -390,7 +392,6 @@ describe(`Child process execution wrapper`, () => {
         execConfig: {
           ...execConfig,
           binarySource: BinarySource.Docker,
-          dockerUser: 'foobar',
         },
         processEnv,
         inCmd,
@@ -411,6 +412,7 @@ describe(`Child process execution wrapper`, () => {
             maxBuffer: 10485760,
           },
         ],
+        dockerUser: 'foobar',
       },
     ],
 
@@ -660,6 +662,7 @@ describe(`Child process execution wrapper`, () => {
       outCmd: outCommand,
       outOpts,
       trustLevel,
+      dockerUser,
     } = testOpts;
 
     process.env = procEnv;
@@ -682,7 +685,7 @@ describe(`Child process execution wrapper`, () => {
       callback(null, { stdout: '', stderr: '' });
       return undefined;
     });
-
+    setAdminConfig({ dockerUser }, ['dockerUser']);
     await exec(cmd as string, inOpts);
 
     expect(actualCmd).toEqual(outCommand);

--- a/lib/util/exec/index.ts
+++ b/lib/util/exec/index.ts
@@ -21,7 +21,6 @@ import { getChildProcessEnv } from './env';
 const execConfig: ExecConfig = {
   binarySource: null,
   customEnvVariables: null,
-  dockerImagePrefix: null,
   localDir: null,
   cacheDir: null,
 };

--- a/lib/util/exec/index.ts
+++ b/lib/util/exec/index.ts
@@ -22,7 +22,6 @@ const execConfig: ExecConfig = {
   binarySource: null,
   customEnvVariables: null,
   dockerImagePrefix: null,
-  dockerUser: null,
   localDir: null,
   cacheDir: null,
 };

--- a/lib/util/template/index.ts
+++ b/lib/util/template/index.ts
@@ -1,5 +1,6 @@
 import is from '@sindresorhus/is';
 import * as handlebars from 'handlebars';
+import { getAdminConfig } from '../../config/admin';
 import { logger } from '../../logger';
 import { clone } from '../clone';
 
@@ -144,7 +145,8 @@ export function compile(
   input: CompileInput,
   filterFields = true
 ): string {
-  const filteredInput = filterFields ? getFilteredObject(input) : input;
+  const data = { ...getAdminConfig(), ...input };
+  const filteredInput = filterFields ? getFilteredObject(data) : data;
   logger.trace({ template, filteredInput }, 'Compiling template');
   if (filterFields) {
     const matches = template.matchAll(templateRegex);

--- a/lib/workers/global/index.ts
+++ b/lib/workers/global/index.ts
@@ -3,6 +3,8 @@ import { ERROR } from 'bunyan';
 import fs from 'fs-extra';
 import upath from 'upath';
 import * as configParser from '../../config';
+import { setAdminConfig } from '../../config/admin';
+import { getAdminOptionNames } from '../../config/definitions';
 import { getProblems, logger, setMeta } from '../../logger';
 import { setUtilConfig } from '../../util';
 import * as hostRules from '../../util/host-rules';
@@ -58,6 +60,7 @@ export async function start(): Promise<number> {
         break;
       }
       const repoConfig = await getRepositoryConfig(config, repository);
+      setAdminConfig(repoConfig, getAdminOptionNames());
       await setUtilConfig(repoConfig);
       if (repoConfig.hostRules) {
         hostRules.clear();


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Refactors multiple admin-only fields into a new "admin" config.

## Context:

We want complete separation of options which users can change and those they can't.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
