### PR TITLE
fix: always add additionalReviewers to new PR

### DIFF
--- a/lib/workers/pr/__snapshots__/index.spec.ts.snap
+++ b/lib/workers/pr/__snapshots__/index.spec.ts.snap
@@ -14,6 +14,20 @@ Array [
 ]
 `;
 
+exports[`workers/pr ensurePr should add and deduplicate additionalReviewers to empty reviewers on new PR 1`] = `
+Array [
+  Array [
+    undefined,
+    Array [
+      "bar",
+      "baz",
+      "boo",
+      "foo",
+    ],
+  ],
+]
+`;
+
 exports[`workers/pr ensurePr should add assignees and reviewers to new PR 1`] = `
 Array [
   Array [

--- a/lib/workers/pr/index.spec.ts
+++ b/lib/workers/pr/index.spec.ts
@@ -514,6 +514,15 @@ describe('workers/pr', () => {
       expect(platform.addReviewers).toHaveBeenCalledTimes(1);
       expect(platform.addReviewers.mock.calls).toMatchSnapshot();
     });
+    it('should add and deduplicate additionalReviewers to empty reviewers on new PR', async () => {
+      config.reviewers = [];
+      config.additionalReviewers = ['bar', 'baz', '@boo', '@foo', 'bar'];
+      const { prResult, pr } = await prWorker.ensurePr(config);
+      expect(prResult).toEqual(PrResult.Created);
+      expect(pr).toMatchObject({ displayNumber: 'New Pull Request' });
+      expect(platform.addReviewers).toHaveBeenCalledTimes(1);
+      expect(platform.addReviewers.mock.calls).toMatchSnapshot();
+    });
     it('should return unmodified existing PR', async () => {
       platform.getBranchPr.mockResolvedValueOnce(existingPr);
       config.semanticCommitScope = null;

--- a/lib/workers/pr/index.ts
+++ b/lib/workers/pr/index.ts
@@ -70,15 +70,12 @@ export async function addAssigneesReviewers(
   if (config.reviewersFromCodeOwners) {
     reviewers = await addCodeOwners(reviewers, pr);
   }
+  if (config.additionalReviewers.length > 0) {
+    reviewers = reviewers.concat(config.additionalReviewers);
+  }
   if (reviewers.length > 0) {
     try {
-      reviewers = reviewers.map(noLeadingAtSymbol);
-      if (config.additionalReviewers.length > 0) {
-        const additionalReviewers = config.additionalReviewers.map(
-          noLeadingAtSymbol
-        );
-        reviewers = [...new Set(reviewers.concat(additionalReviewers))];
-      }
+      reviewers = [...new Set(reviewers.map(noLeadingAtSymbol))];
       if (config.reviewersSampleSize !== null) {
         reviewers = sampleSize(reviewers, config.reviewersSampleSize);
       }


### PR DESCRIPTION
## Changes:

Always add additionalReviewers to PR

## Context:

Closes #8549 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository
