### PR TITLE
refactor: move post upgrade commands to repo admin config

### DIFF
--- a/lib/config/common.ts
+++ b/lib/config/common.ts
@@ -64,13 +64,13 @@ export interface RenovateSharedConfig {
 }
 
 export interface RepoAdminConfig {
+  allowPostUpgradeCommandTemplating?: boolean;
+  allowedPostUpgradeCommands?: string[];
   dockerImagePrefix?: string;
   dockerUser?: string;
 }
 
 export interface RenovateAdminConfig {
-  allowPostUpgradeCommandTemplating?: boolean;
-  allowedPostUpgradeCommands?: string[];
   autodiscover?: boolean;
   autodiscoverFilter?: string;
 

--- a/lib/workers/branch/index.spec.ts
+++ b/lib/workers/branch/index.spec.ts
@@ -1,5 +1,6 @@
 import * as _fs from 'fs-extra';
 import { defaultConfig, git, mocked, platform } from '../../../test/util';
+import { setAdminConfig } from '../../config/admin';
 import {
   MANAGER_LOCKFILE_ERROR,
   REPOSITORY_CHANGED,
@@ -64,6 +65,7 @@ describe('workers/branch', () => {
       } as never;
       schedule.isScheduledNow.mockReturnValue(true);
       commit.commitFilesToBranch.mockResolvedValue('abc123');
+      setAdminConfig({}, []);
     });
     afterEach(() => {
       platform.ensureComment.mockClear();
@@ -693,6 +695,12 @@ describe('workers/branch', () => {
       schedule.isScheduledNow.mockReturnValueOnce(false);
       commit.commitFilesToBranch.mockResolvedValueOnce(null);
 
+      const adminConfig = {
+        allowedPostUpgradeCommands: ['^echo {{{versioning}}}$'],
+        allowPostUpgradeCommandTemplating: true,
+      };
+      setAdminConfig(adminConfig, Object.keys(adminConfig));
+
       const result = await branchWorker.processBranch({
         ...config,
         postUpgradeTasks: {
@@ -700,8 +708,6 @@ describe('workers/branch', () => {
           fileFilters: ['modified_file', 'deleted_file'],
         },
         localDir: '/localDir',
-        allowedPostUpgradeCommands: ['^echo {{{versioning}}}$'],
-        allowPostUpgradeCommandTemplating: true,
         upgrades: [
           {
             ...defaultConfig,
@@ -757,7 +763,11 @@ describe('workers/branch', () => {
 
       schedule.isScheduledNow.mockReturnValueOnce(false);
       commit.commitFilesToBranch.mockResolvedValueOnce(null);
-
+      const adminConfig = {
+        allowedPostUpgradeCommands: ['^echo {{{versioning}}}$'],
+        allowPostUpgradeCommandTemplating: false,
+      };
+      setAdminConfig(adminConfig, Object.keys(adminConfig));
       const result = await branchWorker.processBranch({
         ...config,
         postUpgradeTasks: {
@@ -765,8 +775,6 @@ describe('workers/branch', () => {
           fileFilters: ['modified_file', 'deleted_file'],
         },
         localDir: '/localDir',
-        allowedPostUpgradeCommands: ['^echo {{{versioning}}}$'],
-        allowPostUpgradeCommandTemplating: false,
         upgrades: [
           {
             ...defaultConfig,
@@ -833,6 +841,12 @@ describe('workers/branch', () => {
       schedule.isScheduledNow.mockReturnValueOnce(false);
       commit.commitFilesToBranch.mockResolvedValueOnce(null);
 
+      const adminConfig = {
+        allowedPostUpgradeCommands: ['^echo {{{depName}}}$'],
+        allowPostUpgradeCommandTemplating: true,
+      };
+      setAdminConfig(adminConfig, Object.keys(adminConfig));
+
       const inconfig = {
         ...config,
         postUpgradeTasks: {
@@ -845,8 +859,6 @@ describe('workers/branch', () => {
           ],
         },
         localDir: '/localDir',
-        allowedPostUpgradeCommands: ['^echo {{{depName}}}$'],
-        allowPostUpgradeCommandTemplating: true,
         upgrades: [
           {
             ...defaultConfig,

--- a/lib/workers/branch/index.ts
+++ b/lib/workers/branch/index.ts
@@ -2,6 +2,7 @@ import is from '@sindresorhus/is';
 import { DateTime } from 'luxon';
 import minimatch from 'minimatch';
 import { RenovateConfig } from '../../config';
+import { getAdminConfig } from '../../config/admin';
 import {
   CONFIG_VALIDATION,
   MANAGER_LOCKFILE_ERROR,
@@ -325,20 +326,25 @@ export async function processBranch(
       logger.debug('No updated lock files in branch');
     }
 
+    const {
+      allowedPostUpgradeCommands,
+      allowPostUpgradeCommandTemplating,
+    } = getAdminConfig();
+
     if (
       /* Only run post-upgrade tasks if there are changes to package files... */
       (config.updatedPackageFiles?.length > 0 ||
         /* ... or changes to artifacts */
         config.updatedArtifacts?.length > 0) &&
       global.trustLevel === 'high' &&
-      is.nonEmptyArray(config.allowedPostUpgradeCommands)
+      is.nonEmptyArray(allowedPostUpgradeCommands)
     ) {
       for (const upgrade of config.upgrades) {
         addMeta({ dep: upgrade.depName });
         logger.trace(
           {
             tasks: upgrade.postUpgradeTasks,
-            allowedCommands: config.allowedPostUpgradeCommands,
+            allowedCommands: allowedPostUpgradeCommands,
           },
           'Checking for post-upgrade tasks'
         );
@@ -363,19 +369,19 @@ export async function processBranch(
 
           for (const cmd of commands) {
             if (
-              !config.allowedPostUpgradeCommands.some((pattern) =>
+              !allowedPostUpgradeCommands.some((pattern) =>
                 regEx(pattern).test(cmd)
               )
             ) {
               logger.warn(
                 {
                   cmd,
-                  allowedPostUpgradeCommands: config.allowedPostUpgradeCommands,
+                  allowedPostUpgradeCommands,
                 },
                 'Post-upgrade task did not match any on allowed list'
               );
             } else {
-              const compiledCmd = config.allowPostUpgradeCommandTemplating
+              const compiledCmd = allowPostUpgradeCommandTemplating
                 ? template.compile(cmd, upgrade)
                 : cmd;
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Moves postUpgradeCommands admin logic to RepoAdminConfig.

## Context:

Part of #7574 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
