### PR TITLE
feat(config): delete after setting admin config

### DIFF
--- a/lib/config/admin.ts
+++ b/lib/config/admin.ts
@@ -2,17 +2,20 @@ import { RenovateConfig, RepoAdminConfig } from './common';
 
 let adminConfig: RepoAdminConfig = {};
 
-const derivedAdminOptions = ['localDir'];
+// TODO: once admin config work is complete, add a test to make sure this list includes all options with admin=true
+export const repoAdminOptions = [
+  'allowPostUpgradeCommandTemplating',
+  'allowedPostUpgradeCommands',
+  'dockerImagePrefix',
+  'dockerUser',
+  'trustLevel',
+];
 
-export function setAdminConfig(
-  config: RenovateConfig = {},
-  adminOptions = Object.keys(config)
-): void {
+export function setAdminConfig(config: RenovateConfig = {}): void {
   adminConfig = {};
-  const repoAdminOptions = adminOptions.concat(derivedAdminOptions);
   for (const option of repoAdminOptions) {
     adminConfig[option] = config[option];
-    // TODO: delete from config
+    delete config[option]; // eslint-disable-line no-param-reassign
   }
 }
 

--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -1920,10 +1920,6 @@ export function getOptions(): RenovateOptions[] {
   return options;
 }
 
-export function getAdminOptionNames(): string[] {
-  return options.filter((option) => option.admin).map((option) => option.name);
-}
-
 function loadManagerOptions(): void {
   for (const [name, config] of getManagers().entries()) {
     if (config.defaultConfig) {

--- a/lib/workers/global/index.ts
+++ b/lib/workers/global/index.ts
@@ -4,7 +4,6 @@ import fs from 'fs-extra';
 import upath from 'upath';
 import * as configParser from '../../config';
 import { GlobalConfig } from '../../config';
-import { setAdminConfig } from '../../config/admin';
 import { getProblems, logger, setMeta } from '../../logger';
 import { setUtilConfig } from '../../util';
 import * as hostRules from '../../util/host-rules';
@@ -60,7 +59,6 @@ export async function start(): Promise<number> {
         break;
       }
       const repoConfig = await getRepositoryConfig(config, repository);
-      setAdminConfig(repoConfig);
       await setUtilConfig(repoConfig);
       if (repoConfig.hostRules) {
         hostRules.clear();

--- a/lib/workers/global/index.ts
+++ b/lib/workers/global/index.ts
@@ -5,7 +5,6 @@ import upath from 'upath';
 import * as configParser from '../../config';
 import { GlobalConfig } from '../../config';
 import { setAdminConfig } from '../../config/admin';
-import { getAdminOptionNames } from '../../config/definitions';
 import { getProblems, logger, setMeta } from '../../logger';
 import { setUtilConfig } from '../../util';
 import * as hostRules from '../../util/host-rules';
@@ -61,7 +60,7 @@ export async function start(): Promise<number> {
         break;
       }
       const repoConfig = await getRepositoryConfig(config, repository);
-      setAdminConfig(repoConfig, getAdminOptionNames());
+      setAdminConfig(repoConfig);
       await setUtilConfig(repoConfig);
       if (repoConfig.hostRules) {
         hostRules.clear();

--- a/lib/workers/repository/index.ts
+++ b/lib/workers/repository/index.ts
@@ -1,5 +1,6 @@
 import fs from 'fs-extra';
 import { RenovateConfig } from '../../config';
+import { setAdminConfig } from '../../config/admin';
 import { logger, setMeta } from '../../logger';
 import { deleteLocalFile, privateCacheDir } from '../../util/fs';
 import * as queue from '../../util/http/queue';
@@ -28,6 +29,7 @@ export async function renovateRepository(
 ): Promise<ProcessResult> {
   splitInit();
   let config = { ...repoConfig };
+  setAdminConfig(config);
   setMeta({ repository: config.repository });
   logger.info({ renovateVersion }, 'Repository started');
   logger.trace({ config });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Config options saved to admin config are now deleted from the supplied config. Moves admin config setting inside `renovateRepository()`.

## Context:

#7574 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
