### PR TITLE
test(datasource/crate): Add missing `httpMock.setup/reset()` calls

### DIFF
--- a/lib/datasource/crate/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/crate/__snapshots__/index.spec.ts.snap
@@ -103,69 +103,6 @@ Array [
       "user-agent": "https://github.com/renovatebot/renovate",
     },
     "method": "GET",
-    "url": "https://raw.githubusercontent.com/rust-lang/crates.io-index/master/no/n_/non_existent_crate",
-  },
-  Object {
-    "headers": Object {
-      "accept-encoding": "gzip, deflate",
-      "host": "raw.githubusercontent.com",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
-    "url": "https://raw.githubusercontent.com/rust-lang/crates.io-index/master/no/n_/non_existent_crate",
-  },
-  Object {
-    "headers": Object {
-      "accept-encoding": "gzip, deflate",
-      "host": "raw.githubusercontent.com",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
-    "url": "https://raw.githubusercontent.com/rust-lang/crates.io-index/master/no/n_/non_existent_crate",
-  },
-  Object {
-    "headers": Object {
-      "accept-encoding": "gzip, deflate",
-      "host": "raw.githubusercontent.com",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
-    "url": "https://raw.githubusercontent.com/rust-lang/crates.io-index/master/so/me/some_crate",
-  },
-  Object {
-    "headers": Object {
-      "accept-encoding": "gzip, deflate",
-      "host": "raw.githubusercontent.com",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
-    "url": "https://raw.githubusercontent.com/rust-lang/crates.io-index/master/so/me/some_crate",
-  },
-  Object {
-    "headers": Object {
-      "accept-encoding": "gzip, deflate",
-      "host": "raw.githubusercontent.com",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
-    "url": "https://raw.githubusercontent.com/rust-lang/crates.io-index/master/so/me/some_crate",
-  },
-  Object {
-    "headers": Object {
-      "accept-encoding": "gzip, deflate",
-      "host": "raw.githubusercontent.com",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
-    "url": "https://raw.githubusercontent.com/rust-lang/crates.io-index/master/li/bc/libc",
-  },
-  Object {
-    "headers": Object {
-      "accept-encoding": "gzip, deflate",
-      "host": "raw.githubusercontent.com",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
     "url": "https://raw.githubusercontent.com/rust-lang/crates.io-index/master/am/et/amethyst",
   },
 ]
@@ -385,60 +322,6 @@ Array [
       "user-agent": "https://github.com/renovatebot/renovate",
     },
     "method": "GET",
-    "url": "https://raw.githubusercontent.com/rust-lang/crates.io-index/master/no/n_/non_existent_crate",
-  },
-  Object {
-    "headers": Object {
-      "accept-encoding": "gzip, deflate",
-      "host": "raw.githubusercontent.com",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
-    "url": "https://raw.githubusercontent.com/rust-lang/crates.io-index/master/no/n_/non_existent_crate",
-  },
-  Object {
-    "headers": Object {
-      "accept-encoding": "gzip, deflate",
-      "host": "raw.githubusercontent.com",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
-    "url": "https://raw.githubusercontent.com/rust-lang/crates.io-index/master/no/n_/non_existent_crate",
-  },
-  Object {
-    "headers": Object {
-      "accept-encoding": "gzip, deflate",
-      "host": "raw.githubusercontent.com",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
-    "url": "https://raw.githubusercontent.com/rust-lang/crates.io-index/master/so/me/some_crate",
-  },
-  Object {
-    "headers": Object {
-      "accept-encoding": "gzip, deflate",
-      "host": "raw.githubusercontent.com",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
-    "url": "https://raw.githubusercontent.com/rust-lang/crates.io-index/master/so/me/some_crate",
-  },
-  Object {
-    "headers": Object {
-      "accept-encoding": "gzip, deflate",
-      "host": "raw.githubusercontent.com",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
-    "url": "https://raw.githubusercontent.com/rust-lang/crates.io-index/master/so/me/some_crate",
-  },
-  Object {
-    "headers": Object {
-      "accept-encoding": "gzip, deflate",
-      "host": "raw.githubusercontent.com",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
     "url": "https://raw.githubusercontent.com/rust-lang/crates.io-index/master/li/bc/libc",
   },
 ]
@@ -455,33 +338,6 @@ Array [
       "user-agent": "https://github.com/renovatebot/renovate",
     },
     "method": "GET",
-    "url": "https://raw.githubusercontent.com/rust-lang/crates.io-index/master/no/n_/non_existent_crate",
-  },
-  Object {
-    "headers": Object {
-      "accept-encoding": "gzip, deflate",
-      "host": "raw.githubusercontent.com",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
-    "url": "https://raw.githubusercontent.com/rust-lang/crates.io-index/master/no/n_/non_existent_crate",
-  },
-  Object {
-    "headers": Object {
-      "accept-encoding": "gzip, deflate",
-      "host": "raw.githubusercontent.com",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
-    "url": "https://raw.githubusercontent.com/rust-lang/crates.io-index/master/no/n_/non_existent_crate",
-  },
-  Object {
-    "headers": Object {
-      "accept-encoding": "gzip, deflate",
-      "host": "raw.githubusercontent.com",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
     "url": "https://raw.githubusercontent.com/rust-lang/crates.io-index/master/so/me/some_crate",
   },
 ]
@@ -489,24 +345,6 @@ Array [
 
 exports[`datasource/crate getReleases returns null for empty list 1`] = `
 Array [
-  Object {
-    "headers": Object {
-      "accept-encoding": "gzip, deflate",
-      "host": "raw.githubusercontent.com",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
-    "url": "https://raw.githubusercontent.com/rust-lang/crates.io-index/master/no/n_/non_existent_crate",
-  },
-  Object {
-    "headers": Object {
-      "accept-encoding": "gzip, deflate",
-      "host": "raw.githubusercontent.com",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
-    "url": "https://raw.githubusercontent.com/rust-lang/crates.io-index/master/no/n_/non_existent_crate",
-  },
   Object {
     "headers": Object {
       "accept-encoding": "gzip, deflate",
@@ -544,65 +382,11 @@ Array [
     "method": "GET",
     "url": "https://raw.githubusercontent.com/rust-lang/crates.io-index/master/no/n_/non_existent_crate",
   },
-  Object {
-    "headers": Object {
-      "accept-encoding": "gzip, deflate",
-      "host": "raw.githubusercontent.com",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
-    "url": "https://raw.githubusercontent.com/rust-lang/crates.io-index/master/no/n_/non_existent_crate",
-  },
 ]
 `;
 
 exports[`datasource/crate getReleases returns null for unknown error 1`] = `
 Array [
-  Object {
-    "headers": Object {
-      "accept-encoding": "gzip, deflate",
-      "host": "raw.githubusercontent.com",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
-    "url": "https://raw.githubusercontent.com/rust-lang/crates.io-index/master/no/n_/non_existent_crate",
-  },
-  Object {
-    "headers": Object {
-      "accept-encoding": "gzip, deflate",
-      "host": "raw.githubusercontent.com",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
-    "url": "https://raw.githubusercontent.com/rust-lang/crates.io-index/master/no/n_/non_existent_crate",
-  },
-  Object {
-    "headers": Object {
-      "accept-encoding": "gzip, deflate",
-      "host": "raw.githubusercontent.com",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
-    "url": "https://raw.githubusercontent.com/rust-lang/crates.io-index/master/no/n_/non_existent_crate",
-  },
-  Object {
-    "headers": Object {
-      "accept-encoding": "gzip, deflate",
-      "host": "raw.githubusercontent.com",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
-    "url": "https://raw.githubusercontent.com/rust-lang/crates.io-index/master/so/me/some_crate",
-  },
-  Object {
-    "headers": Object {
-      "accept-encoding": "gzip, deflate",
-      "host": "raw.githubusercontent.com",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
-    "url": "https://raw.githubusercontent.com/rust-lang/crates.io-index/master/so/me/some_crate",
-  },
   Object {
     "headers": Object {
       "accept-encoding": "gzip, deflate",
@@ -619,42 +403,6 @@ exports[`datasource/crate getReleases throws for 5xx 1`] = `[Error: external-hos
 
 exports[`datasource/crate getReleases throws for 5xx 2`] = `
 Array [
-  Object {
-    "headers": Object {
-      "accept-encoding": "gzip, deflate",
-      "host": "raw.githubusercontent.com",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
-    "url": "https://raw.githubusercontent.com/rust-lang/crates.io-index/master/no/n_/non_existent_crate",
-  },
-  Object {
-    "headers": Object {
-      "accept-encoding": "gzip, deflate",
-      "host": "raw.githubusercontent.com",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
-    "url": "https://raw.githubusercontent.com/rust-lang/crates.io-index/master/no/n_/non_existent_crate",
-  },
-  Object {
-    "headers": Object {
-      "accept-encoding": "gzip, deflate",
-      "host": "raw.githubusercontent.com",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
-    "url": "https://raw.githubusercontent.com/rust-lang/crates.io-index/master/no/n_/non_existent_crate",
-  },
-  Object {
-    "headers": Object {
-      "accept-encoding": "gzip, deflate",
-      "host": "raw.githubusercontent.com",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
-    "url": "https://raw.githubusercontent.com/rust-lang/crates.io-index/master/so/me/some_crate",
-  },
   Object {
     "headers": Object {
       "accept-encoding": "gzip, deflate",

--- a/lib/datasource/crate/index.spec.ts
+++ b/lib/datasource/crate/index.spec.ts
@@ -62,7 +62,10 @@ describe('datasource/crate', () => {
     let tmpDir: DirectoryResult | null;
     let localDir: string | null;
     let cacheDir: string | null;
+
     beforeEach(async () => {
+      httpMock.setup();
+
       tmpDir = await dir();
       localDir = join(tmpDir.path, 'local');
       cacheDir = join(tmpDir.path, 'cache');
@@ -74,11 +77,15 @@ describe('datasource/crate', () => {
       memCache.init();
       setAdminConfig();
     });
+
     afterEach(() => {
       fs.rmdirSync(tmpDir.path, { recursive: true });
       tmpDir = null;
       setAdminConfig();
+
+      httpMock.reset();
     });
+
     it('returns null for missing registry url', async () => {
       expect(
         await getPkgReleases({


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

This PR adds `httpMock.setup/reset()` calls to the test suite of the crates.io datasource.

## Context:

All other tests suites that use the `httpMock` are calling `setup()` at the start of the test, and `reset()` afterwards. In the current state, the snapshots of the tests for this datasource are wrong, because they include the request traces of the previous tests since the HTTP mock is never reset. This PR fixes the issue and updates the snapshots.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

