### PR TITLE
feat(datasource/crate): Fetch `sourceUrl` from crates.io API

### DIFF
--- a/lib/datasource/crate/__fixtures__/libc.api
+++ b/lib/datasource/crate/__fixtures__/libc.api
@@ -1,0 +1,3519 @@
+{
+  "crate": {
+    "id": "libc",
+    "name": "libc",
+    "updated_at": "2021-02-02T05:46:43.092194+00:00",
+    "versions": [
+      334406,
+      332879,
+      332554,
+      324283,
+      312506,
+      298941,
+      290425,
+      289223,
+      281962,
+      274412,
+      274397,
+      267249,
+      263935,
+      259963,
+      245683,
+      240656,
+      230996,
+      222203,
+      214297,
+      192983,
+      183459,
+      182828,
+      170724,
+      169588,
+      168916,
+      163049,
+      161737,
+      154074,
+      153833,
+      153802,
+      150885,
+      148107,
+      146965,
+      142012,
+      137368,
+      135409,
+      129695,
+      128162,
+      125335,
+      121714,
+      119061,
+      102589,
+      95089,
+      93661,
+      86416,
+      83417,
+      83347,
+      82661,
+      77227,
+      76325,
+      72807,
+      69615,
+      67575,
+      65812,
+      63743,
+      61242,
+      60588,
+      60383,
+      59067,
+      59046,
+      56839,
+      53711,
+      51450,
+      46700,
+      42535,
+      41598,
+      38948,
+      35816,
+      33357,
+      31311,
+      29868,
+      29286,
+      28414,
+      26549,
+      25536,
+      24776,
+      23609,
+      22138,
+      21365,
+      21096,
+      19509,
+      19469,
+      17958,
+      17638,
+      17572,
+      17355,
+      16916,
+      14628,
+      13021,
+      10384,
+      9938,
+      8437,
+      7842,
+      7408,
+      6260,
+      4732,
+      4106,
+      3006
+    ],
+    "keywords": [
+      "bindings",
+      "ffi",
+      "system",
+      "libc",
+      "operating"
+    ],
+    "categories": [
+      "no-std",
+      "os",
+      "external-ffi-bindings"
+    ],
+    "badges": [],
+    "created_at": "2015-01-15T20:22:13.100871+00:00",
+    "downloads": 44652915,
+    "recent_downloads": 6619692,
+    "max_version": "0.2.85",
+    "newest_version": "0.2.85",
+    "max_stable_version": "0.2.85",
+    "description": "Raw FFI bindings to platform libraries like libc.\n",
+    "homepage": "https://github.com/rust-lang/libc",
+    "documentation": "https://docs.rs/libc/",
+    "repository": "https://github.com/rust-lang/libc",
+    "links": {
+      "version_downloads": "/api/v1/crates/libc/downloads",
+      "versions": null,
+      "owners": "/api/v1/crates/libc/owners",
+      "owner_team": "/api/v1/crates/libc/owner_team",
+      "owner_user": "/api/v1/crates/libc/owner_user",
+      "reverse_dependencies": "/api/v1/crates/libc/reverse_dependencies"
+    },
+    "exact_match": false
+  },
+  "versions": [
+    {
+      "id": 334406,
+      "crate": "libc",
+      "num": "0.2.85",
+      "dl_path": "/api/v1/crates/libc/0.2.85/download",
+      "readme_path": "/api/v1/crates/libc/0.2.85/readme",
+      "updated_at": "2021-02-02T05:46:43.092194+00:00",
+      "created_at": "2021-02-02T05:46:43.092194+00:00",
+      "downloads": 220904,
+      "features": {
+        "align": [],
+        "const-extern-fn": [],
+        "default": [
+          "std"
+        ],
+        "extra_traits": [],
+        "rustc-dep-of-std": [
+          "align",
+          "rustc-std-workspace-core"
+        ],
+        "std": [],
+        "use_std": [
+          "std"
+        ]
+      },
+      "yanked": false,
+      "license": "MIT OR Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.85/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.85/downloads",
+        "authors": "/api/v1/crates/libc/0.2.85/authors"
+      },
+      "crate_size": 516872,
+      "published_by": {
+        "id": 2915,
+        "login": "Amanieu",
+        "name": "Amanieu d'Antras",
+        "avatar": "https://avatars0.githubusercontent.com/u/278509?v=4",
+        "url": "https://github.com/Amanieu"
+      },
+      "audit_actions": [
+        {
+          "action": "publish",
+          "user": {
+            "id": 2915,
+            "login": "Amanieu",
+            "name": "Amanieu d'Antras",
+            "avatar": "https://avatars0.githubusercontent.com/u/278509?v=4",
+            "url": "https://github.com/Amanieu"
+          },
+          "time": "2021-02-02T05:46:43.092194+00:00"
+        }
+      ]
+    },
+    {
+      "id": 332879,
+      "crate": "libc",
+      "num": "0.2.84",
+      "dl_path": "/api/v1/crates/libc/0.2.84/download",
+      "readme_path": "/api/v1/crates/libc/0.2.84/readme",
+      "updated_at": "2021-01-29T00:46:40.915083+00:00",
+      "created_at": "2021-01-29T00:46:40.915083+00:00",
+      "downloads": 206031,
+      "features": {
+        "align": [],
+        "const-extern-fn": [],
+        "default": [
+          "std"
+        ],
+        "extra_traits": [],
+        "rustc-dep-of-std": [
+          "align",
+          "rustc-std-workspace-core"
+        ],
+        "std": [],
+        "use_std": [
+          "std"
+        ]
+      },
+      "yanked": false,
+      "license": "MIT OR Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.84/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.84/downloads",
+        "authors": "/api/v1/crates/libc/0.2.84/authors"
+      },
+      "crate_size": 517732,
+      "published_by": {
+        "id": 4333,
+        "login": "joshtriplett",
+        "name": "Josh Triplett",
+        "avatar": "https://avatars2.githubusercontent.com/u/162737?v=4",
+        "url": "https://github.com/joshtriplett"
+      },
+      "audit_actions": [
+        {
+          "action": "publish",
+          "user": {
+            "id": 4333,
+            "login": "joshtriplett",
+            "name": "Josh Triplett",
+            "avatar": "https://avatars2.githubusercontent.com/u/162737?v=4",
+            "url": "https://github.com/joshtriplett"
+          },
+          "time": "2021-01-29T00:46:40.915083+00:00"
+        }
+      ]
+    },
+    {
+      "id": 332554,
+      "crate": "libc",
+      "num": "0.2.83",
+      "dl_path": "/api/v1/crates/libc/0.2.83/download",
+      "readme_path": "/api/v1/crates/libc/0.2.83/readme",
+      "updated_at": "2021-01-27T22:45:59.596615+00:00",
+      "created_at": "2021-01-27T22:45:59.596615+00:00",
+      "downloads": 64296,
+      "features": {
+        "align": [],
+        "const-extern-fn": [],
+        "default": [
+          "std"
+        ],
+        "extra_traits": [],
+        "rustc-dep-of-std": [
+          "align",
+          "rustc-std-workspace-core"
+        ],
+        "std": [],
+        "use_std": [
+          "std"
+        ]
+      },
+      "yanked": false,
+      "license": "MIT OR Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.83/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.83/downloads",
+        "authors": "/api/v1/crates/libc/0.2.83/authors"
+      },
+      "crate_size": 516762,
+      "published_by": {
+        "id": 2915,
+        "login": "Amanieu",
+        "name": "Amanieu d'Antras",
+        "avatar": "https://avatars0.githubusercontent.com/u/278509?v=4",
+        "url": "https://github.com/Amanieu"
+      },
+      "audit_actions": [
+        {
+          "action": "publish",
+          "user": {
+            "id": 2915,
+            "login": "Amanieu",
+            "name": "Amanieu d'Antras",
+            "avatar": "https://avatars0.githubusercontent.com/u/278509?v=4",
+            "url": "https://github.com/Amanieu"
+          },
+          "time": "2021-01-27T22:45:59.596615+00:00"
+        }
+      ]
+    },
+    {
+      "id": 324283,
+      "crate": "libc",
+      "num": "0.2.82",
+      "dl_path": "/api/v1/crates/libc/0.2.82/download",
+      "readme_path": "/api/v1/crates/libc/0.2.82/readme",
+      "updated_at": "2021-01-07T20:52:24.135640+00:00",
+      "created_at": "2021-01-07T20:52:24.135640+00:00",
+      "downloads": 1023551,
+      "features": {
+        "align": [],
+        "const-extern-fn": [],
+        "default": [
+          "std"
+        ],
+        "extra_traits": [],
+        "rustc-dep-of-std": [
+          "align",
+          "rustc-std-workspace-core"
+        ],
+        "std": [],
+        "use_std": [
+          "std"
+        ]
+      },
+      "yanked": false,
+      "license": "MIT OR Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.82/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.82/downloads",
+        "authors": "/api/v1/crates/libc/0.2.82/authors"
+      },
+      "crate_size": 515967,
+      "published_by": {
+        "id": 51017,
+        "login": "JohnTitor",
+        "name": "Yuki Okushi",
+        "avatar": "https://avatars3.githubusercontent.com/u/25030997?v=4",
+        "url": "https://github.com/JohnTitor"
+      },
+      "audit_actions": [
+        {
+          "action": "publish",
+          "user": {
+            "id": 51017,
+            "login": "JohnTitor",
+            "name": "Yuki Okushi",
+            "avatar": "https://avatars3.githubusercontent.com/u/25030997?v=4",
+            "url": "https://github.com/JohnTitor"
+          },
+          "time": "2021-01-07T20:52:24.135640+00:00"
+        }
+      ]
+    },
+    {
+      "id": 312506,
+      "crate": "libc",
+      "num": "0.2.81",
+      "dl_path": "/api/v1/crates/libc/0.2.81/download",
+      "readme_path": "/api/v1/crates/libc/0.2.81/readme",
+      "updated_at": "2020-12-06T18:54:53.493905+00:00",
+      "created_at": "2020-12-06T18:54:53.493905+00:00",
+      "downloads": 1526009,
+      "features": {
+        "align": [],
+        "const-extern-fn": [],
+        "default": [
+          "std"
+        ],
+        "extra_traits": [],
+        "rustc-dep-of-std": [
+          "align",
+          "rustc-std-workspace-core"
+        ],
+        "std": [],
+        "use_std": [
+          "std"
+        ]
+      },
+      "yanked": false,
+      "license": "MIT OR Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.81/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.81/downloads",
+        "authors": "/api/v1/crates/libc/0.2.81/authors"
+      },
+      "crate_size": 513105,
+      "published_by": {
+        "id": 51017,
+        "login": "JohnTitor",
+        "name": "Yuki Okushi",
+        "avatar": "https://avatars3.githubusercontent.com/u/25030997?v=4",
+        "url": "https://github.com/JohnTitor"
+      },
+      "audit_actions": [
+        {
+          "action": "publish",
+          "user": {
+            "id": 51017,
+            "login": "JohnTitor",
+            "name": "Yuki Okushi",
+            "avatar": "https://avatars3.githubusercontent.com/u/25030997?v=4",
+            "url": "https://github.com/JohnTitor"
+          },
+          "time": "2020-12-06T18:54:53.493905+00:00"
+        }
+      ]
+    },
+    {
+      "id": 298941,
+      "crate": "libc",
+      "num": "0.2.80",
+      "dl_path": "/api/v1/crates/libc/0.2.80/download",
+      "readme_path": "/api/v1/crates/libc/0.2.80/readme",
+      "updated_at": "2020-10-25T20:52:26.931032+00:00",
+      "created_at": "2020-10-25T20:52:26.931032+00:00",
+      "downloads": 2312654,
+      "features": {
+        "align": [],
+        "const-extern-fn": [],
+        "default": [
+          "std"
+        ],
+        "extra_traits": [],
+        "rustc-dep-of-std": [
+          "align",
+          "rustc-std-workspace-core"
+        ],
+        "std": [],
+        "use_std": [
+          "std"
+        ]
+      },
+      "yanked": false,
+      "license": "MIT OR Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.80/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.80/downloads",
+        "authors": "/api/v1/crates/libc/0.2.80/authors"
+      },
+      "crate_size": 513503,
+      "published_by": {
+        "id": 51017,
+        "login": "JohnTitor",
+        "name": "Yuki Okushi",
+        "avatar": "https://avatars3.githubusercontent.com/u/25030997?v=4",
+        "url": "https://github.com/JohnTitor"
+      },
+      "audit_actions": [
+        {
+          "action": "publish",
+          "user": {
+            "id": 51017,
+            "login": "JohnTitor",
+            "name": "Yuki Okushi",
+            "avatar": "https://avatars3.githubusercontent.com/u/25030997?v=4",
+            "url": "https://github.com/JohnTitor"
+          },
+          "time": "2020-10-25T20:52:26.931032+00:00"
+        }
+      ]
+    },
+    {
+      "id": 290425,
+      "crate": "libc",
+      "num": "0.2.79",
+      "dl_path": "/api/v1/crates/libc/0.2.79/download",
+      "readme_path": "/api/v1/crates/libc/0.2.79/readme",
+      "updated_at": "2020-10-05T05:09:40.185687+00:00",
+      "created_at": "2020-10-05T05:09:40.185687+00:00",
+      "downloads": 1328658,
+      "features": {
+        "align": [],
+        "const-extern-fn": [],
+        "default": [
+          "std"
+        ],
+        "extra_traits": [],
+        "rustc-dep-of-std": [
+          "align",
+          "rustc-std-workspace-core"
+        ],
+        "std": [],
+        "use_std": [
+          "std"
+        ]
+      },
+      "yanked": false,
+      "license": "MIT OR Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.79/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.79/downloads",
+        "authors": "/api/v1/crates/libc/0.2.79/authors"
+      },
+      "crate_size": 511752,
+      "published_by": {
+        "id": 4333,
+        "login": "joshtriplett",
+        "name": "Josh Triplett",
+        "avatar": "https://avatars2.githubusercontent.com/u/162737?v=4",
+        "url": "https://github.com/joshtriplett"
+      },
+      "audit_actions": [
+        {
+          "action": "publish",
+          "user": {
+            "id": 4333,
+            "login": "joshtriplett",
+            "name": "Josh Triplett",
+            "avatar": "https://avatars2.githubusercontent.com/u/162737?v=4",
+            "url": "https://github.com/joshtriplett"
+          },
+          "time": "2020-10-05T05:09:40.185687+00:00"
+        }
+      ]
+    },
+    {
+      "id": 289223,
+      "crate": "libc",
+      "num": "0.2.78",
+      "dl_path": "/api/v1/crates/libc/0.2.78/download",
+      "readme_path": "/api/v1/crates/libc/0.2.78/readme",
+      "updated_at": "2020-10-01T04:02:08.640863+00:00",
+      "created_at": "2020-10-01T04:02:08.640863+00:00",
+      "downloads": 228136,
+      "features": {
+        "align": [],
+        "const-extern-fn": [],
+        "default": [
+          "std"
+        ],
+        "extra_traits": [],
+        "rustc-dep-of-std": [
+          "align",
+          "rustc-std-workspace-core"
+        ],
+        "std": [],
+        "use_std": [
+          "std"
+        ]
+      },
+      "yanked": false,
+      "license": "MIT OR Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.78/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.78/downloads",
+        "authors": "/api/v1/crates/libc/0.2.78/authors"
+      },
+      "crate_size": 508428,
+      "published_by": {
+        "id": 4333,
+        "login": "joshtriplett",
+        "name": "Josh Triplett",
+        "avatar": "https://avatars2.githubusercontent.com/u/162737?v=4",
+        "url": "https://github.com/joshtriplett"
+      },
+      "audit_actions": [
+        {
+          "action": "publish",
+          "user": {
+            "id": 4333,
+            "login": "joshtriplett",
+            "name": "Josh Triplett",
+            "avatar": "https://avatars2.githubusercontent.com/u/162737?v=4",
+            "url": "https://github.com/joshtriplett"
+          },
+          "time": "2020-10-01T04:02:08.640863+00:00"
+        }
+      ]
+    },
+    {
+      "id": 281962,
+      "crate": "libc",
+      "num": "0.2.77",
+      "dl_path": "/api/v1/crates/libc/0.2.77/download",
+      "readme_path": "/api/v1/crates/libc/0.2.77/readme",
+      "updated_at": "2020-09-10T05:13:43.360156+00:00",
+      "created_at": "2020-09-10T05:13:43.360156+00:00",
+      "downloads": 1224045,
+      "features": {
+        "align": [],
+        "const-extern-fn": [],
+        "default": [
+          "std"
+        ],
+        "extra_traits": [],
+        "rustc-dep-of-std": [
+          "align",
+          "rustc-std-workspace-core"
+        ],
+        "std": [],
+        "use_std": [
+          "std"
+        ]
+      },
+      "yanked": false,
+      "license": "MIT OR Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.77/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.77/downloads",
+        "authors": "/api/v1/crates/libc/0.2.77/authors"
+      },
+      "crate_size": 507233,
+      "published_by": {
+        "id": 51017,
+        "login": "JohnTitor",
+        "name": "Yuki Okushi",
+        "avatar": "https://avatars3.githubusercontent.com/u/25030997?v=4",
+        "url": "https://github.com/JohnTitor"
+      },
+      "audit_actions": [
+        {
+          "action": "publish",
+          "user": {
+            "id": 51017,
+            "login": "JohnTitor",
+            "name": "Yuki Okushi",
+            "avatar": "https://avatars3.githubusercontent.com/u/25030997?v=4",
+            "url": "https://github.com/JohnTitor"
+          },
+          "time": "2020-09-10T05:13:43.360156+00:00"
+        }
+      ]
+    },
+    {
+      "id": 274412,
+      "crate": "libc",
+      "num": "0.2.76",
+      "dl_path": "/api/v1/crates/libc/0.2.76/download",
+      "readme_path": "/api/v1/crates/libc/0.2.76/readme",
+      "updated_at": "2020-08-20T07:06:38.704864+00:00",
+      "created_at": "2020-08-20T07:06:38.704864+00:00",
+      "downloads": 1108207,
+      "features": {
+        "align": [],
+        "const-extern-fn": [],
+        "default": [
+          "std"
+        ],
+        "extra_traits": [],
+        "rustc-dep-of-std": [
+          "align",
+          "rustc-std-workspace-core"
+        ],
+        "std": [],
+        "use_std": [
+          "std"
+        ]
+      },
+      "yanked": false,
+      "license": "MIT OR Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.76/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.76/downloads",
+        "authors": "/api/v1/crates/libc/0.2.76/authors"
+      },
+      "crate_size": 506496,
+      "published_by": {
+        "id": 51017,
+        "login": "JohnTitor",
+        "name": "Yuki Okushi",
+        "avatar": "https://avatars3.githubusercontent.com/u/25030997?v=4",
+        "url": "https://github.com/JohnTitor"
+      },
+      "audit_actions": [
+        {
+          "action": "publish",
+          "user": {
+            "id": 51017,
+            "login": "JohnTitor",
+            "name": "Yuki Okushi",
+            "avatar": "https://avatars3.githubusercontent.com/u/25030997?v=4",
+            "url": "https://github.com/JohnTitor"
+          },
+          "time": "2020-08-20T07:06:38.704864+00:00"
+        }
+      ]
+    },
+    {
+      "id": 274397,
+      "crate": "libc",
+      "num": "0.2.75",
+      "dl_path": "/api/v1/crates/libc/0.2.75/download",
+      "readme_path": "/api/v1/crates/libc/0.2.75/readme",
+      "updated_at": "2020-08-20T04:12:12.653219+00:00",
+      "created_at": "2020-08-20T04:12:12.653219+00:00",
+      "downloads": 4075,
+      "features": {
+        "align": [],
+        "const-extern-fn": [],
+        "default": [
+          "std"
+        ],
+        "extra_traits": [],
+        "rustc-dep-of-std": [
+          "align",
+          "rustc-std-workspace-core"
+        ],
+        "std": [],
+        "use_std": [
+          "std"
+        ]
+      },
+      "yanked": false,
+      "license": "MIT OR Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.75/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.75/downloads",
+        "authors": "/api/v1/crates/libc/0.2.75/authors"
+      },
+      "crate_size": 506460,
+      "published_by": {
+        "id": 51017,
+        "login": "JohnTitor",
+        "name": "Yuki Okushi",
+        "avatar": "https://avatars3.githubusercontent.com/u/25030997?v=4",
+        "url": "https://github.com/JohnTitor"
+      },
+      "audit_actions": [
+        {
+          "action": "publish",
+          "user": {
+            "id": 51017,
+            "login": "JohnTitor",
+            "name": "Yuki Okushi",
+            "avatar": "https://avatars3.githubusercontent.com/u/25030997?v=4",
+            "url": "https://github.com/JohnTitor"
+          },
+          "time": "2020-08-20T04:12:12.653219+00:00"
+        }
+      ]
+    },
+    {
+      "id": 267249,
+      "crate": "libc",
+      "num": "0.2.74",
+      "dl_path": "/api/v1/crates/libc/0.2.74/download",
+      "readme_path": "/api/v1/crates/libc/0.2.74/readme",
+      "updated_at": "2020-07-28T19:39:00.322775+00:00",
+      "created_at": "2020-07-28T19:39:00.322775+00:00",
+      "downloads": 1173398,
+      "features": {
+        "align": [],
+        "const-extern-fn": [],
+        "default": [
+          "std"
+        ],
+        "extra_traits": [],
+        "rustc-dep-of-std": [
+          "align",
+          "rustc-std-workspace-core"
+        ],
+        "std": [],
+        "use_std": [
+          "std"
+        ]
+      },
+      "yanked": false,
+      "license": "MIT OR Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.74/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.74/downloads",
+        "authors": "/api/v1/crates/libc/0.2.74/authors"
+      },
+      "crate_size": 503397,
+      "published_by": {
+        "id": 51017,
+        "login": "JohnTitor",
+        "name": "Yuki Okushi",
+        "avatar": "https://avatars3.githubusercontent.com/u/25030997?v=4",
+        "url": "https://github.com/JohnTitor"
+      },
+      "audit_actions": [
+        {
+          "action": "publish",
+          "user": {
+            "id": 51017,
+            "login": "JohnTitor",
+            "name": "Yuki Okushi",
+            "avatar": "https://avatars3.githubusercontent.com/u/25030997?v=4",
+            "url": "https://github.com/JohnTitor"
+          },
+          "time": "2020-07-28T19:39:00.322775+00:00"
+        }
+      ]
+    },
+    {
+      "id": 263935,
+      "crate": "libc",
+      "num": "0.2.73",
+      "dl_path": "/api/v1/crates/libc/0.2.73/download",
+      "readme_path": "/api/v1/crates/libc/0.2.73/readme",
+      "updated_at": "2020-07-19T20:40:52.896687+00:00",
+      "created_at": "2020-07-19T20:40:52.896687+00:00",
+      "downloads": 554406,
+      "features": {
+        "align": [],
+        "const-extern-fn": [],
+        "default": [
+          "std"
+        ],
+        "extra_traits": [],
+        "rustc-dep-of-std": [
+          "align",
+          "rustc-std-workspace-core"
+        ],
+        "std": [],
+        "use_std": [
+          "std"
+        ]
+      },
+      "yanked": false,
+      "license": "MIT OR Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.73/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.73/downloads",
+        "authors": "/api/v1/crates/libc/0.2.73/authors"
+      },
+      "crate_size": 502354,
+      "published_by": {
+        "id": 51017,
+        "login": "JohnTitor",
+        "name": "Yuki Okushi",
+        "avatar": "https://avatars3.githubusercontent.com/u/25030997?v=4",
+        "url": "https://github.com/JohnTitor"
+      },
+      "audit_actions": [
+        {
+          "action": "publish",
+          "user": {
+            "id": 51017,
+            "login": "JohnTitor",
+            "name": "Yuki Okushi",
+            "avatar": "https://avatars3.githubusercontent.com/u/25030997?v=4",
+            "url": "https://github.com/JohnTitor"
+          },
+          "time": "2020-07-19T20:40:52.896687+00:00"
+        }
+      ]
+    },
+    {
+      "id": 259963,
+      "crate": "libc",
+      "num": "0.2.72",
+      "dl_path": "/api/v1/crates/libc/0.2.72/download",
+      "readme_path": "/api/v1/crates/libc/0.2.72/readme",
+      "updated_at": "2020-07-07T23:23:14.200609+00:00",
+      "created_at": "2020-07-07T23:23:14.200609+00:00",
+      "downloads": 597916,
+      "features": {
+        "align": [],
+        "const-extern-fn": [],
+        "default": [
+          "std"
+        ],
+        "extra_traits": [],
+        "rustc-dep-of-std": [
+          "align",
+          "rustc-std-workspace-core"
+        ],
+        "std": [],
+        "use_std": [
+          "std"
+        ]
+      },
+      "yanked": false,
+      "license": "MIT OR Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.72/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.72/downloads",
+        "authors": "/api/v1/crates/libc/0.2.72/authors"
+      },
+      "crate_size": 478292,
+      "published_by": {
+        "id": 51017,
+        "login": "JohnTitor",
+        "name": "Yuki Okushi",
+        "avatar": "https://avatars3.githubusercontent.com/u/25030997?v=4",
+        "url": "https://github.com/JohnTitor"
+      },
+      "audit_actions": [
+        {
+          "action": "publish",
+          "user": {
+            "id": 51017,
+            "login": "JohnTitor",
+            "name": "Yuki Okushi",
+            "avatar": "https://avatars3.githubusercontent.com/u/25030997?v=4",
+            "url": "https://github.com/JohnTitor"
+          },
+          "time": "2020-07-07T23:23:14.200609+00:00"
+        }
+      ]
+    },
+    {
+      "id": 245683,
+      "crate": "libc",
+      "num": "0.2.71",
+      "dl_path": "/api/v1/crates/libc/0.2.71/download",
+      "readme_path": "/api/v1/crates/libc/0.2.71/readme",
+      "updated_at": "2020-05-26T15:42:25.610518+00:00",
+      "created_at": "2020-05-26T15:42:25.610518+00:00",
+      "downloads": 2085870,
+      "features": {
+        "align": [],
+        "const-extern-fn": [],
+        "default": [
+          "std"
+        ],
+        "extra_traits": [],
+        "rustc-dep-of-std": [
+          "align",
+          "rustc-std-workspace-core"
+        ],
+        "std": [],
+        "use_std": [
+          "std"
+        ]
+      },
+      "yanked": false,
+      "license": "MIT OR Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.71/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.71/downloads",
+        "authors": "/api/v1/crates/libc/0.2.71/authors"
+      },
+      "crate_size": 474209,
+      "published_by": {
+        "id": 51017,
+        "login": "JohnTitor",
+        "name": "Yuki Okushi",
+        "avatar": "https://avatars3.githubusercontent.com/u/25030997?v=4",
+        "url": "https://github.com/JohnTitor"
+      },
+      "audit_actions": [
+        {
+          "action": "publish",
+          "user": {
+            "id": 51017,
+            "login": "JohnTitor",
+            "name": "Yuki Okushi",
+            "avatar": "https://avatars3.githubusercontent.com/u/25030997?v=4",
+            "url": "https://github.com/JohnTitor"
+          },
+          "time": "2020-05-26T15:42:25.610518+00:00"
+        }
+      ]
+    },
+    {
+      "id": 240656,
+      "crate": "libc",
+      "num": "0.2.70",
+      "dl_path": "/api/v1/crates/libc/0.2.70/download",
+      "readme_path": "/api/v1/crates/libc/0.2.70/readme",
+      "updated_at": "2020-05-12T16:22:44.420976+00:00",
+      "created_at": "2020-05-12T16:22:44.420976+00:00",
+      "downloads": 576731,
+      "features": {
+        "align": [],
+        "const-extern-fn": [],
+        "default": [
+          "std"
+        ],
+        "extra_traits": [],
+        "rustc-dep-of-std": [
+          "align",
+          "rustc-std-workspace-core"
+        ],
+        "std": [],
+        "use_std": [
+          "std"
+        ]
+      },
+      "yanked": false,
+      "license": "MIT OR Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.70/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.70/downloads",
+        "authors": "/api/v1/crates/libc/0.2.70/authors"
+      },
+      "crate_size": 472909,
+      "published_by": {
+        "id": 51017,
+        "login": "JohnTitor",
+        "name": "Yuki Okushi",
+        "avatar": "https://avatars3.githubusercontent.com/u/25030997?v=4",
+        "url": "https://github.com/JohnTitor"
+      },
+      "audit_actions": [
+        {
+          "action": "publish",
+          "user": {
+            "id": 51017,
+            "login": "JohnTitor",
+            "name": "Yuki Okushi",
+            "avatar": "https://avatars3.githubusercontent.com/u/25030997?v=4",
+            "url": "https://github.com/JohnTitor"
+          },
+          "time": "2020-05-12T16:22:44.420976+00:00"
+        }
+      ]
+    },
+    {
+      "id": 230996,
+      "crate": "libc",
+      "num": "0.2.69",
+      "dl_path": "/api/v1/crates/libc/0.2.69/download",
+      "readme_path": "/api/v1/crates/libc/0.2.69/readme",
+      "updated_at": "2020-04-13T23:25:06.331888+00:00",
+      "created_at": "2020-04-13T23:25:06.331888+00:00",
+      "downloads": 1513671,
+      "features": {
+        "align": [],
+        "const-extern-fn": [],
+        "default": [
+          "std"
+        ],
+        "extra_traits": [],
+        "rustc-dep-of-std": [
+          "align",
+          "rustc-std-workspace-core"
+        ],
+        "std": [],
+        "use_std": [
+          "std"
+        ]
+      },
+      "yanked": false,
+      "license": "MIT OR Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.69/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.69/downloads",
+        "authors": "/api/v1/crates/libc/0.2.69/authors"
+      },
+      "crate_size": 472393,
+      "published_by": {
+        "id": 51017,
+        "login": "JohnTitor",
+        "name": "Yuki Okushi",
+        "avatar": "https://avatars3.githubusercontent.com/u/25030997?v=4",
+        "url": "https://github.com/JohnTitor"
+      },
+      "audit_actions": [
+        {
+          "action": "publish",
+          "user": {
+            "id": 51017,
+            "login": "JohnTitor",
+            "name": "Yuki Okushi",
+            "avatar": "https://avatars3.githubusercontent.com/u/25030997?v=4",
+            "url": "https://github.com/JohnTitor"
+          },
+          "time": "2020-04-13T23:25:06.331888+00:00"
+        }
+      ]
+    },
+    {
+      "id": 222203,
+      "crate": "libc",
+      "num": "0.2.68",
+      "dl_path": "/api/v1/crates/libc/0.2.68/download",
+      "readme_path": "/api/v1/crates/libc/0.2.68/readme",
+      "updated_at": "2020-03-17T20:36:42.630322+00:00",
+      "created_at": "2020-03-17T20:36:42.630322+00:00",
+      "downloads": 1137295,
+      "features": {
+        "align": [],
+        "const-extern-fn": [],
+        "default": [
+          "std"
+        ],
+        "extra_traits": [],
+        "rustc-dep-of-std": [
+          "align",
+          "rustc-std-workspace-core"
+        ],
+        "std": [],
+        "use_std": [
+          "std"
+        ]
+      },
+      "yanked": false,
+      "license": "MIT OR Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.68/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.68/downloads",
+        "authors": "/api/v1/crates/libc/0.2.68/authors"
+      },
+      "crate_size": 468882,
+      "published_by": {
+        "id": 51017,
+        "login": "JohnTitor",
+        "name": "Yuki Okushi",
+        "avatar": "https://avatars3.githubusercontent.com/u/25030997?v=4",
+        "url": "https://github.com/JohnTitor"
+      },
+      "audit_actions": [
+        {
+          "action": "publish",
+          "user": {
+            "id": 51017,
+            "login": "JohnTitor",
+            "name": "Yuki Okushi",
+            "avatar": "https://avatars3.githubusercontent.com/u/25030997?v=4",
+            "url": "https://github.com/JohnTitor"
+          },
+          "time": "2020-03-17T20:36:42.630322+00:00"
+        }
+      ]
+    },
+    {
+      "id": 214297,
+      "crate": "libc",
+      "num": "0.2.67",
+      "dl_path": "/api/v1/crates/libc/0.2.67/download",
+      "readme_path": "/api/v1/crates/libc/0.2.67/readme",
+      "updated_at": "2020-02-20T23:23:31.192298+00:00",
+      "created_at": "2020-02-20T23:23:31.192298+00:00",
+      "downloads": 1012549,
+      "features": {
+        "align": [],
+        "const-extern-fn": [],
+        "default": [
+          "std"
+        ],
+        "extra_traits": [],
+        "rustc-dep-of-std": [
+          "align",
+          "rustc-std-workspace-core"
+        ],
+        "std": [],
+        "use_std": [
+          "std"
+        ]
+      },
+      "yanked": false,
+      "license": "MIT OR Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.67/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.67/downloads",
+        "authors": "/api/v1/crates/libc/0.2.67/authors"
+      },
+      "crate_size": 458605,
+      "published_by": {
+        "id": 1,
+        "login": "alexcrichton",
+        "name": "Alex Crichton",
+        "avatar": "https://avatars.githubusercontent.com/u/64996?v=4",
+        "url": "https://github.com/alexcrichton"
+      },
+      "audit_actions": [
+        {
+          "action": "publish",
+          "user": {
+            "id": 1,
+            "login": "alexcrichton",
+            "name": "Alex Crichton",
+            "avatar": "https://avatars.githubusercontent.com/u/64996?v=4",
+            "url": "https://github.com/alexcrichton"
+          },
+          "time": "2020-02-20T23:23:31.192298+00:00"
+        }
+      ]
+    },
+    {
+      "id": 192983,
+      "crate": "libc",
+      "num": "0.2.66",
+      "dl_path": "/api/v1/crates/libc/0.2.66/download",
+      "readme_path": "/api/v1/crates/libc/0.2.66/readme",
+      "updated_at": "2019-11-29T12:21:47.053991+00:00",
+      "created_at": "2019-11-29T12:21:47.053991+00:00",
+      "downloads": 2650622,
+      "features": {
+        "align": [],
+        "const-extern-fn": [],
+        "default": [
+          "std"
+        ],
+        "extra_traits": [],
+        "rustc-dep-of-std": [
+          "align",
+          "rustc-std-workspace-core"
+        ],
+        "std": [],
+        "use_std": [
+          "std"
+        ]
+      },
+      "yanked": false,
+      "license": "MIT OR Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.66/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.66/downloads",
+        "authors": "/api/v1/crates/libc/0.2.66/authors"
+      },
+      "crate_size": 457815,
+      "published_by": {
+        "id": 5725,
+        "login": "gnzlbg",
+        "name": "gnzlbg",
+        "avatar": "https://avatars0.githubusercontent.com/u/904614?v=4",
+        "url": "https://github.com/gnzlbg"
+      },
+      "audit_actions": []
+    },
+    {
+      "id": 183459,
+      "crate": "libc",
+      "num": "0.2.65",
+      "dl_path": "/api/v1/crates/libc/0.2.65/download",
+      "readme_path": "/api/v1/crates/libc/0.2.65/readme",
+      "updated_at": "2019-10-18T08:17:25.326162+00:00",
+      "created_at": "2019-10-18T08:17:25.326162+00:00",
+      "downloads": 1552126,
+      "features": {
+        "align": [],
+        "default": [
+          "std"
+        ],
+        "extra_traits": [],
+        "rustc-dep-of-std": [
+          "align",
+          "rustc-std-workspace-core"
+        ],
+        "std": [],
+        "use_std": [
+          "std"
+        ]
+      },
+      "yanked": false,
+      "license": "MIT OR Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.65/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.65/downloads",
+        "authors": "/api/v1/crates/libc/0.2.65/authors"
+      },
+      "crate_size": 439610,
+      "published_by": {
+        "id": 5725,
+        "login": "gnzlbg",
+        "name": "gnzlbg",
+        "avatar": "https://avatars0.githubusercontent.com/u/904614?v=4",
+        "url": "https://github.com/gnzlbg"
+      },
+      "audit_actions": []
+    },
+    {
+      "id": 182828,
+      "crate": "libc",
+      "num": "0.2.64",
+      "dl_path": "/api/v1/crates/libc/0.2.64/download",
+      "readme_path": "/api/v1/crates/libc/0.2.64/readme",
+      "updated_at": "2019-10-15T17:30:37.828035+00:00",
+      "created_at": "2019-10-15T17:30:37.828035+00:00",
+      "downloads": 269229,
+      "features": {
+        "align": [],
+        "default": [
+          "std"
+        ],
+        "extra_traits": [],
+        "rustc-dep-of-std": [
+          "align",
+          "rustc-std-workspace-core"
+        ],
+        "std": [],
+        "use_std": [
+          "std"
+        ]
+      },
+      "yanked": false,
+      "license": "MIT OR Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.64/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.64/downloads",
+        "authors": "/api/v1/crates/libc/0.2.64/authors"
+      },
+      "crate_size": 439389,
+      "published_by": {
+        "id": 5725,
+        "login": "gnzlbg",
+        "name": "gnzlbg",
+        "avatar": "https://avatars0.githubusercontent.com/u/904614?v=4",
+        "url": "https://github.com/gnzlbg"
+      },
+      "audit_actions": []
+    },
+    {
+      "id": 170724,
+      "crate": "libc",
+      "num": "0.2.63",
+      "dl_path": "/api/v1/crates/libc/0.2.63/download",
+      "readme_path": "/api/v1/crates/libc/0.2.63/readme",
+      "updated_at": "2019-08-20T13:08:33.994751+00:00",
+      "created_at": "2019-08-20T11:13:40.910876+00:00",
+      "downloads": 2652,
+      "features": {
+        "align": [],
+        "default": [
+          "std"
+        ],
+        "extra_traits": [],
+        "rustc-dep-of-std": [
+          "align",
+          "rustc-std-workspace-core"
+        ],
+        "std": [],
+        "use_std": [
+          "std"
+        ]
+      },
+      "yanked": true,
+      "license": "MIT OR Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.63/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.63/downloads",
+        "authors": "/api/v1/crates/libc/0.2.63/authors"
+      },
+      "crate_size": 437880,
+      "published_by": {
+        "id": 5725,
+        "login": "gnzlbg",
+        "name": "gnzlbg",
+        "avatar": "https://avatars0.githubusercontent.com/u/904614?v=4",
+        "url": "https://github.com/gnzlbg"
+      },
+      "audit_actions": []
+    },
+    {
+      "id": 169588,
+      "crate": "libc",
+      "num": "0.2.62",
+      "dl_path": "/api/v1/crates/libc/0.2.62/download",
+      "readme_path": "/api/v1/crates/libc/0.2.62/readme",
+      "updated_at": "2019-08-15T08:45:37.666151+00:00",
+      "created_at": "2019-08-15T08:45:37.666151+00:00",
+      "downloads": 2008252,
+      "features": {
+        "align": [],
+        "default": [
+          "std"
+        ],
+        "extra_traits": [],
+        "rustc-dep-of-std": [
+          "align",
+          "rustc-std-workspace-core"
+        ],
+        "std": [],
+        "use_std": [
+          "std"
+        ]
+      },
+      "yanked": false,
+      "license": "MIT OR Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.62/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.62/downloads",
+        "authors": "/api/v1/crates/libc/0.2.62/authors"
+      },
+      "crate_size": 433193,
+      "published_by": {
+        "id": 5725,
+        "login": "gnzlbg",
+        "name": "gnzlbg",
+        "avatar": "https://avatars0.githubusercontent.com/u/904614?v=4",
+        "url": "https://github.com/gnzlbg"
+      },
+      "audit_actions": []
+    },
+    {
+      "id": 168916,
+      "crate": "libc",
+      "num": "0.2.61",
+      "dl_path": "/api/v1/crates/libc/0.2.61/download",
+      "readme_path": "/api/v1/crates/libc/0.2.61/readme",
+      "updated_at": "2019-08-12T12:08:21.939841+00:00",
+      "created_at": "2019-08-12T12:08:21.939841+00:00",
+      "downloads": 194503,
+      "features": {
+        "align": [],
+        "default": [
+          "std"
+        ],
+        "extra_traits": [],
+        "rustc-dep-of-std": [
+          "align",
+          "rustc-std-workspace-core"
+        ],
+        "std": [],
+        "use_std": [
+          "std"
+        ]
+      },
+      "yanked": false,
+      "license": "MIT OR Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.61/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.61/downloads",
+        "authors": "/api/v1/crates/libc/0.2.61/authors"
+      },
+      "crate_size": 433045,
+      "published_by": {
+        "id": 5725,
+        "login": "gnzlbg",
+        "name": "gnzlbg",
+        "avatar": "https://avatars0.githubusercontent.com/u/904614?v=4",
+        "url": "https://github.com/gnzlbg"
+      },
+      "audit_actions": []
+    },
+    {
+      "id": 163049,
+      "crate": "libc",
+      "num": "0.2.60",
+      "dl_path": "/api/v1/crates/libc/0.2.60/download",
+      "readme_path": "/api/v1/crates/libc/0.2.60/readme",
+      "updated_at": "2019-07-15T08:53:50.369368+00:00",
+      "created_at": "2019-07-15T08:53:50.369368+00:00",
+      "downloads": 1023458,
+      "features": {
+        "align": [],
+        "default": [
+          "std"
+        ],
+        "extra_traits": [],
+        "rustc-dep-of-std": [
+          "align",
+          "rustc-std-workspace-core"
+        ],
+        "std": [],
+        "use_std": [
+          "std"
+        ]
+      },
+      "yanked": false,
+      "license": "MIT OR Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.60/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.60/downloads",
+        "authors": "/api/v1/crates/libc/0.2.60/authors"
+      },
+      "crate_size": 409744,
+      "published_by": {
+        "id": 5725,
+        "login": "gnzlbg",
+        "name": "gnzlbg",
+        "avatar": "https://avatars0.githubusercontent.com/u/904614?v=4",
+        "url": "https://github.com/gnzlbg"
+      },
+      "audit_actions": []
+    },
+    {
+      "id": 161737,
+      "crate": "libc",
+      "num": "0.2.59",
+      "dl_path": "/api/v1/crates/libc/0.2.59/download",
+      "readme_path": "/api/v1/crates/libc/0.2.59/readme",
+      "updated_at": "2019-07-08T10:13:27.883487+00:00",
+      "created_at": "2019-07-08T10:13:27.883487+00:00",
+      "downloads": 254397,
+      "features": {
+        "align": [],
+        "default": [
+          "std"
+        ],
+        "extra_traits": [],
+        "rustc-dep-of-std": [
+          "align",
+          "rustc-std-workspace-core"
+        ],
+        "std": [],
+        "use_std": [
+          "std"
+        ]
+      },
+      "yanked": false,
+      "license": "MIT OR Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.59/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.59/downloads",
+        "authors": "/api/v1/crates/libc/0.2.59/authors"
+      },
+      "crate_size": 408668,
+      "published_by": {
+        "id": 5725,
+        "login": "gnzlbg",
+        "name": "gnzlbg",
+        "avatar": "https://avatars0.githubusercontent.com/u/904614?v=4",
+        "url": "https://github.com/gnzlbg"
+      },
+      "audit_actions": []
+    },
+    {
+      "id": 154074,
+      "crate": "libc",
+      "num": "0.2.58",
+      "dl_path": "/api/v1/crates/libc/0.2.58/download",
+      "readme_path": "/api/v1/crates/libc/0.2.58/readme",
+      "updated_at": "2019-06-02T11:48:10.298304+00:00",
+      "created_at": "2019-06-02T11:48:10.298304+00:00",
+      "downloads": 976636,
+      "features": {
+        "align": [],
+        "default": [
+          "std"
+        ],
+        "extra_traits": [],
+        "rustc-dep-of-std": [
+          "align",
+          "rustc-std-workspace-core"
+        ],
+        "std": [],
+        "use_std": [
+          "std"
+        ]
+      },
+      "yanked": false,
+      "license": "MIT OR Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.58/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.58/downloads",
+        "authors": "/api/v1/crates/libc/0.2.58/authors"
+      },
+      "crate_size": 409031,
+      "published_by": {
+        "id": 5725,
+        "login": "gnzlbg",
+        "name": "gnzlbg",
+        "avatar": "https://avatars0.githubusercontent.com/u/904614?v=4",
+        "url": "https://github.com/gnzlbg"
+      },
+      "audit_actions": []
+    },
+    {
+      "id": 153833,
+      "crate": "libc",
+      "num": "0.2.57",
+      "dl_path": "/api/v1/crates/libc/0.2.57/download",
+      "readme_path": "/api/v1/crates/libc/0.2.57/readme",
+      "updated_at": "2019-05-31T14:44:24.875772+00:00",
+      "created_at": "2019-05-31T14:44:24.875772+00:00",
+      "downloads": 40789,
+      "features": {
+        "align": [],
+        "default": [
+          "std"
+        ],
+        "extra_traits": [],
+        "rustc-dep-of-std": [
+          "align",
+          "rustc-std-workspace-core"
+        ],
+        "std": [],
+        "use_std": [
+          "std"
+        ]
+      },
+      "yanked": false,
+      "license": "MIT OR Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.57/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.57/downloads",
+        "authors": "/api/v1/crates/libc/0.2.57/authors"
+      },
+      "crate_size": 408902,
+      "published_by": {
+        "id": 5725,
+        "login": "gnzlbg",
+        "name": "gnzlbg",
+        "avatar": "https://avatars0.githubusercontent.com/u/904614?v=4",
+        "url": "https://github.com/gnzlbg"
+      },
+      "audit_actions": []
+    },
+    {
+      "id": 153802,
+      "crate": "libc",
+      "num": "0.2.56",
+      "dl_path": "/api/v1/crates/libc/0.2.56/download",
+      "readme_path": "/api/v1/crates/libc/0.2.56/readme",
+      "updated_at": "2019-05-31T10:38:25.863324+00:00",
+      "created_at": "2019-05-31T10:38:25.863324+00:00",
+      "downloads": 14188,
+      "features": {
+        "align": [],
+        "default": [
+          "std"
+        ],
+        "extra_traits": [],
+        "rustc-dep-of-std": [
+          "align",
+          "rustc-std-workspace-core"
+        ],
+        "std": [],
+        "use_std": [
+          "std"
+        ]
+      },
+      "yanked": false,
+      "license": "MIT OR Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.56/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.56/downloads",
+        "authors": "/api/v1/crates/libc/0.2.56/authors"
+      },
+      "crate_size": 408475,
+      "published_by": {
+        "id": 5725,
+        "login": "gnzlbg",
+        "name": "gnzlbg",
+        "avatar": "https://avatars0.githubusercontent.com/u/904614?v=4",
+        "url": "https://github.com/gnzlbg"
+      },
+      "audit_actions": []
+    },
+    {
+      "id": 150885,
+      "crate": "libc",
+      "num": "0.2.55",
+      "dl_path": "/api/v1/crates/libc/0.2.55/download",
+      "readme_path": "/api/v1/crates/libc/0.2.55/readme",
+      "updated_at": "2019-05-17T06:42:13.034356+00:00",
+      "created_at": "2019-05-17T06:42:13.034356+00:00",
+      "downloads": 330194,
+      "features": {
+        "align": [],
+        "default": [
+          "use_std"
+        ],
+        "extra_traits": [],
+        "rustc-dep-of-std": [
+          "align",
+          "rustc-std-workspace-core"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT OR Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.55/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.55/downloads",
+        "authors": "/api/v1/crates/libc/0.2.55/authors"
+      },
+      "crate_size": 400416,
+      "published_by": {
+        "id": 5725,
+        "login": "gnzlbg",
+        "name": "gnzlbg",
+        "avatar": "https://avatars0.githubusercontent.com/u/904614?v=4",
+        "url": "https://github.com/gnzlbg"
+      },
+      "audit_actions": []
+    },
+    {
+      "id": 148107,
+      "crate": "libc",
+      "num": "0.2.54",
+      "dl_path": "/api/v1/crates/libc/0.2.54/download",
+      "readme_path": "/api/v1/crates/libc/0.2.54/readme",
+      "updated_at": "2019-05-02T18:25:18.335275+00:00",
+      "created_at": "2019-05-02T18:25:18.335275+00:00",
+      "downloads": 561380,
+      "features": {
+        "align": [],
+        "default": [
+          "use_std"
+        ],
+        "extra_traits": [],
+        "rustc-dep-of-std": [
+          "align",
+          "rustc-std-workspace-core"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT OR Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.54/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.54/downloads",
+        "authors": "/api/v1/crates/libc/0.2.54/authors"
+      },
+      "crate_size": 401259,
+      "published_by": {
+        "id": 5725,
+        "login": "gnzlbg",
+        "name": "gnzlbg",
+        "avatar": "https://avatars0.githubusercontent.com/u/904614?v=4",
+        "url": "https://github.com/gnzlbg"
+      },
+      "audit_actions": []
+    },
+    {
+      "id": 146965,
+      "crate": "libc",
+      "num": "0.2.53",
+      "dl_path": "/api/v1/crates/libc/0.2.53/download",
+      "readme_path": "/api/v1/crates/libc/0.2.53/readme",
+      "updated_at": "2019-04-26T14:30:38.962189+00:00",
+      "created_at": "2019-04-26T14:30:38.962189+00:00",
+      "downloads": 142012,
+      "features": {
+        "align": [],
+        "default": [
+          "use_std"
+        ],
+        "extra_traits": [],
+        "rustc-dep-of-std": [
+          "align",
+          "rustc-std-workspace-core"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT OR Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.53/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.53/downloads",
+        "authors": "/api/v1/crates/libc/0.2.53/authors"
+      },
+      "crate_size": 401196,
+      "published_by": {
+        "id": 1,
+        "login": "alexcrichton",
+        "name": "Alex Crichton",
+        "avatar": "https://avatars.githubusercontent.com/u/64996?v=4",
+        "url": "https://github.com/alexcrichton"
+      },
+      "audit_actions": []
+    },
+    {
+      "id": 142012,
+      "crate": "libc",
+      "num": "0.2.51",
+      "dl_path": "/api/v1/crates/libc/0.2.51/download",
+      "readme_path": "/api/v1/crates/libc/0.2.51/readme",
+      "updated_at": "2019-03-29T02:31:51.111106+00:00",
+      "created_at": "2019-03-29T02:31:51.111106+00:00",
+      "downloads": 874132,
+      "features": {
+        "align": [],
+        "default": [
+          "use_std"
+        ],
+        "extra_traits": [],
+        "rustc-dep-of-std": [
+          "align",
+          "rustc-std-workspace-core"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT OR Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.51/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.51/downloads",
+        "authors": "/api/v1/crates/libc/0.2.51/authors"
+      },
+      "crate_size": 397323,
+      "published_by": {
+        "id": 1,
+        "login": "alexcrichton",
+        "name": "Alex Crichton",
+        "avatar": "https://avatars.githubusercontent.com/u/64996?v=4",
+        "url": "https://github.com/alexcrichton"
+      },
+      "audit_actions": []
+    },
+    {
+      "id": 137368,
+      "crate": "libc",
+      "num": "0.2.50",
+      "dl_path": "/api/v1/crates/libc/0.2.50/download",
+      "readme_path": "/api/v1/crates/libc/0.2.50/readme",
+      "updated_at": "2019-03-05T11:06:03.435987+00:00",
+      "created_at": "2019-03-05T11:06:03.435987+00:00",
+      "downloads": 500794,
+      "features": {
+        "align": [],
+        "default": [
+          "use_std"
+        ],
+        "extra_traits": [],
+        "rustc-dep-of-std": [
+          "align",
+          "rustc-std-workspace-core"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT OR Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.50/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.50/downloads",
+        "authors": "/api/v1/crates/libc/0.2.50/authors"
+      },
+      "crate_size": 392277,
+      "published_by": {
+        "id": 5725,
+        "login": "gnzlbg",
+        "name": "gnzlbg",
+        "avatar": "https://avatars0.githubusercontent.com/u/904614?v=4",
+        "url": "https://github.com/gnzlbg"
+      },
+      "audit_actions": []
+    },
+    {
+      "id": 135409,
+      "crate": "libc",
+      "num": "0.2.49",
+      "dl_path": "/api/v1/crates/libc/0.2.49/download",
+      "readme_path": "/api/v1/crates/libc/0.2.49/readme",
+      "updated_at": "2019-02-22T20:46:56.611254+00:00",
+      "created_at": "2019-02-22T20:46:56.611254+00:00",
+      "downloads": 224948,
+      "features": {
+        "align": [],
+        "default": [
+          "use_std"
+        ],
+        "extra_traits": [],
+        "rustc-dep-of-std": [
+          "align",
+          "rustc-std-workspace-core"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT OR Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.49/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.49/downloads",
+        "authors": "/api/v1/crates/libc/0.2.49/authors"
+      },
+      "crate_size": 375486,
+      "published_by": {
+        "id": 5725,
+        "login": "gnzlbg",
+        "name": "gnzlbg",
+        "avatar": "https://avatars0.githubusercontent.com/u/904614?v=4",
+        "url": "https://github.com/gnzlbg"
+      },
+      "audit_actions": []
+    },
+    {
+      "id": 129695,
+      "crate": "libc",
+      "num": "0.2.48",
+      "dl_path": "/api/v1/crates/libc/0.2.48/download",
+      "readme_path": "/api/v1/crates/libc/0.2.48/readme",
+      "updated_at": "2019-01-23T15:55:42.577086+00:00",
+      "created_at": "2019-01-23T15:55:42.577086+00:00",
+      "downloads": 728172,
+      "features": {
+        "align": [],
+        "default": [
+          "use_std"
+        ],
+        "rustc-dep-of-std": [
+          "align",
+          "rustc-std-workspace-core"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT OR Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.48/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.48/downloads",
+        "authors": "/api/v1/crates/libc/0.2.48/authors"
+      },
+      "crate_size": 353045,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 128162,
+      "crate": "libc",
+      "num": "0.2.47",
+      "dl_path": "/api/v1/crates/libc/0.2.47/download",
+      "readme_path": "/api/v1/crates/libc/0.2.47/readme",
+      "updated_at": "2019-01-14T20:33:01.729887+00:00",
+      "created_at": "2019-01-14T20:33:01.729887+00:00",
+      "downloads": 186579,
+      "features": {
+        "align": [],
+        "default": [
+          "use_std"
+        ],
+        "rustc-dep-of-std": [
+          "align",
+          "rustc-std-workspace-core"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT OR Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.47/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.47/downloads",
+        "authors": "/api/v1/crates/libc/0.2.47/authors"
+      },
+      "crate_size": 351491,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 125335,
+      "crate": "libc",
+      "num": "0.2.46",
+      "dl_path": "/api/v1/crates/libc/0.2.46/download",
+      "readme_path": "/api/v1/crates/libc/0.2.46/readme",
+      "updated_at": "2019-01-03T15:25:59.610479+00:00",
+      "created_at": "2019-01-03T15:25:59.610479+00:00",
+      "downloads": 320294,
+      "features": {
+        "align": [],
+        "default": [
+          "use_std"
+        ],
+        "rustc-dep-of-std": [
+          "align",
+          "rustc-std-workspace-core"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT OR Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.46/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.46/downloads",
+        "authors": "/api/v1/crates/libc/0.2.46/authors"
+      },
+      "crate_size": 350476,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 121714,
+      "crate": "libc",
+      "num": "0.2.45",
+      "dl_path": "/api/v1/crates/libc/0.2.45/download",
+      "readme_path": "/api/v1/crates/libc/0.2.45/readme",
+      "updated_at": "2018-12-10T16:35:24.539294+00:00",
+      "created_at": "2018-12-10T16:35:24.539294+00:00",
+      "downloads": 417358,
+      "features": {
+        "align": [],
+        "default": [
+          "use_std"
+        ],
+        "rustc-dep-of-std": [
+          "align",
+          "rustc-std-workspace-core"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT OR Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.45/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.45/downloads",
+        "authors": "/api/v1/crates/libc/0.2.45/authors"
+      },
+      "crate_size": 349425,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 119061,
+      "crate": "libc",
+      "num": "0.2.44",
+      "dl_path": "/api/v1/crates/libc/0.2.44/download",
+      "readme_path": "/api/v1/crates/libc/0.2.44/readme",
+      "updated_at": "2018-11-22T06:00:01.887655+00:00",
+      "created_at": "2018-11-22T06:00:01.887655+00:00",
+      "downloads": 322551,
+      "features": {
+        "align": [],
+        "default": [
+          "use_std"
+        ],
+        "rustc-dep-of-std": [
+          "align",
+          "rustc-std-workspace-core"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT OR Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.44/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.44/downloads",
+        "authors": "/api/v1/crates/libc/0.2.44/authors"
+      },
+      "crate_size": 347920,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 102589,
+      "crate": "libc",
+      "num": "0.2.43",
+      "dl_path": "/api/v1/crates/libc/0.2.43/download",
+      "readme_path": "/api/v1/crates/libc/0.2.43/readme",
+      "updated_at": "2018-08-06T13:58:01.547975+00:00",
+      "created_at": "2018-08-06T13:58:01.547975+00:00",
+      "downloads": 1765148,
+      "features": {
+        "align": [],
+        "default": [
+          "use_std"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.43/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.43/downloads",
+        "authors": "/api/v1/crates/libc/0.2.43/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 95089,
+      "crate": "libc",
+      "num": "0.2.42",
+      "dl_path": "/api/v1/crates/libc/0.2.42/download",
+      "readme_path": "/api/v1/crates/libc/0.2.42/readme",
+      "updated_at": "2018-06-01T21:41:57.990052+00:00",
+      "created_at": "2018-06-01T21:41:57.990052+00:00",
+      "downloads": 910928,
+      "features": {
+        "default": [
+          "use_std"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.42/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.42/downloads",
+        "authors": "/api/v1/crates/libc/0.2.42/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 93661,
+      "crate": "libc",
+      "num": "0.2.41",
+      "dl_path": "/api/v1/crates/libc/0.2.41/download",
+      "readme_path": "/api/v1/crates/libc/0.2.41/readme",
+      "updated_at": "2018-05-21T15:06:52.283653+00:00",
+      "created_at": "2018-05-21T15:06:52.283653+00:00",
+      "downloads": 226687,
+      "features": {
+        "default": [
+          "use_std"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.41/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.41/downloads",
+        "authors": "/api/v1/crates/libc/0.2.41/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 86416,
+      "crate": "libc",
+      "num": "0.2.40",
+      "dl_path": "/api/v1/crates/libc/0.2.40/download",
+      "readme_path": "/api/v1/crates/libc/0.2.40/readme",
+      "updated_at": "2018-03-26T06:55:01.045990+00:00",
+      "created_at": "2018-03-26T06:55:01.045990+00:00",
+      "downloads": 831320,
+      "features": {
+        "default": [
+          "use_std"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.40/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.40/downloads",
+        "authors": "/api/v1/crates/libc/0.2.40/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 83417,
+      "crate": "libc",
+      "num": "0.2.39",
+      "dl_path": "/api/v1/crates/libc/0.2.39/download",
+      "readme_path": "/api/v1/crates/libc/0.2.39/readme",
+      "updated_at": "2018-03-05T16:41:58.165278+00:00",
+      "created_at": "2018-03-05T16:41:58.165278+00:00",
+      "downloads": 334681,
+      "features": {
+        "default": [
+          "use_std"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.39/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.39/downloads",
+        "authors": "/api/v1/crates/libc/0.2.39/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 83347,
+      "crate": "libc",
+      "num": "0.2.38",
+      "dl_path": "/api/v1/crates/libc/0.2.38/download",
+      "readme_path": "/api/v1/crates/libc/0.2.38/readme",
+      "updated_at": "2018-03-05T02:37:48.373061+00:00",
+      "created_at": "2018-03-05T02:37:48.373061+00:00",
+      "downloads": 9745,
+      "features": {
+        "default": [
+          "use_std"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.38/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.38/downloads",
+        "authors": "/api/v1/crates/libc/0.2.38/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 82661,
+      "crate": "libc",
+      "num": "0.2.37",
+      "dl_path": "/api/v1/crates/libc/0.2.37/download",
+      "readme_path": "/api/v1/crates/libc/0.2.37/readme",
+      "updated_at": "2018-02-27T12:01:41.193552+00:00",
+      "created_at": "2018-02-27T12:01:41.193552+00:00",
+      "downloads": 66898,
+      "features": {
+        "default": [
+          "use_std"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.37/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.37/downloads",
+        "authors": "/api/v1/crates/libc/0.2.37/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 77227,
+      "crate": "libc",
+      "num": "0.2.36",
+      "dl_path": "/api/v1/crates/libc/0.2.36/download",
+      "readme_path": "/api/v1/crates/libc/0.2.36/readme",
+      "updated_at": "2018-01-12T15:57:05.925907+00:00",
+      "created_at": "2018-01-12T15:57:05.925907+00:00",
+      "downloads": 469610,
+      "features": {
+        "default": [
+          "use_std"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.36/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.36/downloads",
+        "authors": "/api/v1/crates/libc/0.2.36/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 76325,
+      "crate": "libc",
+      "num": "0.2.35",
+      "dl_path": "/api/v1/crates/libc/0.2.35/download",
+      "readme_path": "/api/v1/crates/libc/0.2.35/readme",
+      "updated_at": "2018-01-04T03:32:05.574245+00:00",
+      "created_at": "2018-01-04T03:32:05.574245+00:00",
+      "downloads": 83763,
+      "features": {
+        "default": [
+          "use_std"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.35/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.35/downloads",
+        "authors": "/api/v1/crates/libc/0.2.35/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 72807,
+      "crate": "libc",
+      "num": "0.2.34",
+      "dl_path": "/api/v1/crates/libc/0.2.34/download",
+      "readme_path": "/api/v1/crates/libc/0.2.34/readme",
+      "updated_at": "2017-11-30T15:47:00.179016+00:00",
+      "created_at": "2017-11-30T15:47:00.179016+00:00",
+      "downloads": 322143,
+      "features": {
+        "default": [
+          "use_std"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.34/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.34/downloads",
+        "authors": "/api/v1/crates/libc/0.2.34/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 69615,
+      "crate": "libc",
+      "num": "0.2.33",
+      "dl_path": "/api/v1/crates/libc/0.2.33/download",
+      "readme_path": "/api/v1/crates/libc/0.2.33/readme",
+      "updated_at": "2017-11-30T03:01:39.752229+00:00",
+      "created_at": "2017-10-28T20:20:15.081891+00:00",
+      "downloads": 317787,
+      "features": {
+        "default": [
+          "use_std"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.33/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.33/downloads",
+        "authors": "/api/v1/crates/libc/0.2.33/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 67575,
+      "crate": "libc",
+      "num": "0.2.32",
+      "dl_path": "/api/v1/crates/libc/0.2.32/download",
+      "readme_path": "/api/v1/crates/libc/0.2.32/readme",
+      "updated_at": "2017-11-30T03:52:06.751004+00:00",
+      "created_at": "2017-10-06T14:16:36.183976+00:00",
+      "downloads": 246581,
+      "features": {
+        "default": [
+          "use_std"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.32/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.32/downloads",
+        "authors": "/api/v1/crates/libc/0.2.32/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 65812,
+      "crate": "libc",
+      "num": "0.2.31",
+      "dl_path": "/api/v1/crates/libc/0.2.31/download",
+      "readme_path": "/api/v1/crates/libc/0.2.31/readme",
+      "updated_at": "2017-11-30T03:21:16.371491+00:00",
+      "created_at": "2017-09-20T03:45:25.228566+00:00",
+      "downloads": 194855,
+      "features": {
+        "default": [
+          "use_std"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.31/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.31/downloads",
+        "authors": "/api/v1/crates/libc/0.2.31/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 63743,
+      "crate": "libc",
+      "num": "0.2.30",
+      "dl_path": "/api/v1/crates/libc/0.2.30/download",
+      "readme_path": "/api/v1/crates/libc/0.2.30/readme",
+      "updated_at": "2017-11-30T02:38:31.047644+00:00",
+      "created_at": "2017-08-27T18:10:50.883879+00:00",
+      "downloads": 351122,
+      "features": {
+        "default": [
+          "use_std"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.30/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.30/downloads",
+        "authors": "/api/v1/crates/libc/0.2.30/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 61242,
+      "crate": "libc",
+      "num": "0.2.29",
+      "dl_path": "/api/v1/crates/libc/0.2.29/download",
+      "readme_path": "/api/v1/crates/libc/0.2.29/readme",
+      "updated_at": "2017-11-30T03:18:48.166855+00:00",
+      "created_at": "2017-08-01T01:19:13.341558+00:00",
+      "downloads": 215534,
+      "features": {
+        "default": [
+          "use_std"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.29/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.29/downloads",
+        "authors": "/api/v1/crates/libc/0.2.29/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 60588,
+      "crate": "libc",
+      "num": "0.2.28",
+      "dl_path": "/api/v1/crates/libc/0.2.28/download",
+      "readme_path": "/api/v1/crates/libc/0.2.28/readme",
+      "updated_at": "2017-11-30T02:22:38.354867+00:00",
+      "created_at": "2017-07-24T17:09:13.948619+00:00",
+      "downloads": 67389,
+      "features": {
+        "default": [
+          "use_std"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.28/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.28/downloads",
+        "authors": "/api/v1/crates/libc/0.2.28/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 60383,
+      "crate": "libc",
+      "num": "0.2.27",
+      "dl_path": "/api/v1/crates/libc/0.2.27/download",
+      "readme_path": "/api/v1/crates/libc/0.2.27/readme",
+      "updated_at": "2017-11-30T02:27:43.363802+00:00",
+      "created_at": "2017-07-22T17:15:02.416831+00:00",
+      "downloads": 21604,
+      "features": {
+        "default": [
+          "use_std"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.27/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.27/downloads",
+        "authors": "/api/v1/crates/libc/0.2.27/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 59067,
+      "crate": "libc",
+      "num": "0.2.26",
+      "dl_path": "/api/v1/crates/libc/0.2.26/download",
+      "readme_path": "/api/v1/crates/libc/0.2.26/readme",
+      "updated_at": "2017-11-30T03:11:12.480219+00:00",
+      "created_at": "2017-07-07T23:15:50.860753+00:00",
+      "downloads": 146767,
+      "features": {
+        "default": [
+          "use_std"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.26/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.26/downloads",
+        "authors": "/api/v1/crates/libc/0.2.26/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 59046,
+      "crate": "libc",
+      "num": "0.2.25",
+      "dl_path": "/api/v1/crates/libc/0.2.25/download",
+      "readme_path": "/api/v1/crates/libc/0.2.25/readme",
+      "updated_at": "2017-11-30T03:29:56.031391+00:00",
+      "created_at": "2017-07-07T17:20:26.072226+00:00",
+      "downloads": 27959,
+      "features": {
+        "default": [
+          "use_std"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.25/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.25/downloads",
+        "authors": "/api/v1/crates/libc/0.2.25/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 56839,
+      "crate": "libc",
+      "num": "0.2.24",
+      "dl_path": "/api/v1/crates/libc/0.2.24/download",
+      "readme_path": "/api/v1/crates/libc/0.2.24/readme",
+      "updated_at": "2017-11-30T03:40:54.602099+00:00",
+      "created_at": "2017-06-15T19:39:48.812470+00:00",
+      "downloads": 196008,
+      "features": {
+        "default": [
+          "use_std"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.24/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.24/downloads",
+        "authors": "/api/v1/crates/libc/0.2.24/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 53711,
+      "crate": "libc",
+      "num": "0.2.23",
+      "dl_path": "/api/v1/crates/libc/0.2.23/download",
+      "readme_path": "/api/v1/crates/libc/0.2.23/readme",
+      "updated_at": "2017-11-30T03:06:24.458020+00:00",
+      "created_at": "2017-05-19T03:34:16.804139+00:00",
+      "downloads": 329076,
+      "features": {
+        "default": [
+          "use_std"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.23/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.23/downloads",
+        "authors": "/api/v1/crates/libc/0.2.23/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 51450,
+      "crate": "libc",
+      "num": "0.2.22",
+      "dl_path": "/api/v1/crates/libc/0.2.22/download",
+      "readme_path": "/api/v1/crates/libc/0.2.22/readme",
+      "updated_at": "2017-11-30T03:52:13.978067+00:00",
+      "created_at": "2017-04-26T22:38:24.471289+00:00",
+      "downloads": 177030,
+      "features": {
+        "default": [
+          "use_std"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.22/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.22/downloads",
+        "authors": "/api/v1/crates/libc/0.2.22/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 46700,
+      "crate": "libc",
+      "num": "0.2.21",
+      "dl_path": "/api/v1/crates/libc/0.2.21/download",
+      "readme_path": "/api/v1/crates/libc/0.2.21/readme",
+      "updated_at": "2017-11-30T02:54:36.471869+00:00",
+      "created_at": "2017-03-02T02:47:02.806228+00:00",
+      "downloads": 625658,
+      "features": {
+        "default": [
+          "use_std"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.21/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.21/downloads",
+        "authors": "/api/v1/crates/libc/0.2.21/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 42535,
+      "crate": "libc",
+      "num": "0.2.20",
+      "dl_path": "/api/v1/crates/libc/0.2.20/download",
+      "readme_path": "/api/v1/crates/libc/0.2.20/readme",
+      "updated_at": "2017-11-30T03:02:12.823936+00:00",
+      "created_at": "2017-01-17T17:24:02.660081+00:00",
+      "downloads": 493141,
+      "features": {
+        "default": [
+          "use_std"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.20/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.20/downloads",
+        "authors": "/api/v1/crates/libc/0.2.20/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 41598,
+      "crate": "libc",
+      "num": "0.2.19",
+      "dl_path": "/api/v1/crates/libc/0.2.19/download",
+      "readme_path": "/api/v1/crates/libc/0.2.19/readme",
+      "updated_at": "2017-11-30T03:22:12.162153+00:00",
+      "created_at": "2017-01-04T22:37:52.728926+00:00",
+      "downloads": 121848,
+      "features": {
+        "default": [
+          "use_std"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.19/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.19/downloads",
+        "authors": "/api/v1/crates/libc/0.2.19/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 38948,
+      "crate": "libc",
+      "num": "0.2.18",
+      "dl_path": "/api/v1/crates/libc/0.2.18/download",
+      "readme_path": "/api/v1/crates/libc/0.2.18/readme",
+      "updated_at": "2017-11-30T02:48:23.076471+00:00",
+      "created_at": "2016-12-02T21:36:53.789601+00:00",
+      "downloads": 502573,
+      "features": {
+        "default": [
+          "use_std"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.18/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.18/downloads",
+        "authors": "/api/v1/crates/libc/0.2.18/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 35816,
+      "crate": "libc",
+      "num": "0.2.17",
+      "dl_path": "/api/v1/crates/libc/0.2.17/download",
+      "readme_path": "/api/v1/crates/libc/0.2.17/readme",
+      "updated_at": "2017-11-30T03:00:25.666845+00:00",
+      "created_at": "2016-10-15T07:47:24.133563+00:00",
+      "downloads": 426478,
+      "features": {
+        "default": [
+          "use_std"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.17/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.17/downloads",
+        "authors": "/api/v1/crates/libc/0.2.17/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 33357,
+      "crate": "libc",
+      "num": "0.2.16",
+      "dl_path": "/api/v1/crates/libc/0.2.16/download",
+      "readme_path": "/api/v1/crates/libc/0.2.16/readme",
+      "updated_at": "2017-11-30T03:44:41.088177+00:00",
+      "created_at": "2016-09-09T06:56:18.886090+00:00",
+      "downloads": 232318,
+      "features": {
+        "default": [
+          "use_std"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.16/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.16/downloads",
+        "authors": "/api/v1/crates/libc/0.2.16/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 31311,
+      "crate": "libc",
+      "num": "0.2.15",
+      "dl_path": "/api/v1/crates/libc/0.2.15/download",
+      "readme_path": "/api/v1/crates/libc/0.2.15/readme",
+      "updated_at": "2017-11-30T03:02:49.574754+00:00",
+      "created_at": "2016-08-05T01:54:20.962345+00:00",
+      "downloads": 285773,
+      "features": {
+        "default": [
+          "use_std"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.15/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.15/downloads",
+        "authors": "/api/v1/crates/libc/0.2.15/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 29868,
+      "crate": "libc",
+      "num": "0.2.14",
+      "dl_path": "/api/v1/crates/libc/0.2.14/download",
+      "readme_path": "/api/v1/crates/libc/0.2.14/readme",
+      "updated_at": "2017-11-30T02:26:29.634195+00:00",
+      "created_at": "2016-07-11T18:54:03.962781+00:00",
+      "downloads": 219998,
+      "features": {
+        "default": [
+          "use_std"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.14/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.14/downloads",
+        "authors": "/api/v1/crates/libc/0.2.14/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 29286,
+      "crate": "libc",
+      "num": "0.2.13",
+      "dl_path": "/api/v1/crates/libc/0.2.13/download",
+      "readme_path": "/api/v1/crates/libc/0.2.13/readme",
+      "updated_at": "2017-11-30T03:08:12.109385+00:00",
+      "created_at": "2016-06-28T19:40:27.264246+00:00",
+      "downloads": 140718,
+      "features": {
+        "default": [
+          "use_std"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.13/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.13/downloads",
+        "authors": "/api/v1/crates/libc/0.2.13/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 28414,
+      "crate": "libc",
+      "num": "0.2.12",
+      "dl_path": "/api/v1/crates/libc/0.2.12/download",
+      "readme_path": "/api/v1/crates/libc/0.2.12/readme",
+      "updated_at": "2017-11-30T02:26:50.765781+00:00",
+      "created_at": "2016-06-10T15:11:59.859394+00:00",
+      "downloads": 129593,
+      "features": {
+        "default": [
+          "use_std"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.12/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.12/downloads",
+        "authors": "/api/v1/crates/libc/0.2.12/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 26549,
+      "crate": "libc",
+      "num": "0.2.11",
+      "dl_path": "/api/v1/crates/libc/0.2.11/download",
+      "readme_path": "/api/v1/crates/libc/0.2.11/readme",
+      "updated_at": "2017-11-30T02:54:30.293252+00:00",
+      "created_at": "2016-05-03T20:19:50.829787+00:00",
+      "downloads": 281734,
+      "features": {
+        "default": [
+          "use_std"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.11/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.11/downloads",
+        "authors": "/api/v1/crates/libc/0.2.11/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 25536,
+      "crate": "libc",
+      "num": "0.2.10",
+      "dl_path": "/api/v1/crates/libc/0.2.10/download",
+      "readme_path": "/api/v1/crates/libc/0.2.10/readme",
+      "updated_at": "2017-11-30T04:00:24.731513+00:00",
+      "created_at": "2016-04-12T22:56:49.175130+00:00",
+      "downloads": 141809,
+      "features": {
+        "default": [
+          "use_std"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.10/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.10/downloads",
+        "authors": "/api/v1/crates/libc/0.2.10/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 24776,
+      "crate": "libc",
+      "num": "0.2.9",
+      "dl_path": "/api/v1/crates/libc/0.2.9/download",
+      "readme_path": "/api/v1/crates/libc/0.2.9/readme",
+      "updated_at": "2017-11-30T03:47:12.048321+00:00",
+      "created_at": "2016-03-31T04:45:51.223181+00:00",
+      "downloads": 86136,
+      "features": {
+        "default": [
+          "use_std"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.9/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.9/downloads",
+        "authors": "/api/v1/crates/libc/0.2.9/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 23609,
+      "crate": "libc",
+      "num": "0.2.8",
+      "dl_path": "/api/v1/crates/libc/0.2.8/download",
+      "readme_path": "/api/v1/crates/libc/0.2.8/readme",
+      "updated_at": "2017-11-30T02:31:10.014767+00:00",
+      "created_at": "2016-03-07T22:42:56.442340+00:00",
+      "downloads": 177716,
+      "features": {
+        "default": [
+          "use_std"
+        ],
+        "use_std": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.8/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.8/downloads",
+        "authors": "/api/v1/crates/libc/0.2.8/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 22138,
+      "crate": "libc",
+      "num": "0.2.7",
+      "dl_path": "/api/v1/crates/libc/0.2.7/download",
+      "readme_path": "/api/v1/crates/libc/0.2.7/readme",
+      "updated_at": "2017-11-30T02:26:14.801490+00:00",
+      "created_at": "2016-02-09T23:27:41.755788+00:00",
+      "downloads": 168980,
+      "features": {
+        "default": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.7/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.7/downloads",
+        "authors": "/api/v1/crates/libc/0.2.7/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 21365,
+      "crate": "libc",
+      "num": "0.2.6",
+      "dl_path": "/api/v1/crates/libc/0.2.6/download",
+      "readme_path": "/api/v1/crates/libc/0.2.6/readme",
+      "updated_at": "2017-11-30T03:50:08.394122+00:00",
+      "created_at": "2016-01-27T01:00:27.842917+00:00",
+      "downloads": 78160,
+      "features": {
+        "default": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.6/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.6/downloads",
+        "authors": "/api/v1/crates/libc/0.2.6/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 21096,
+      "crate": "libc",
+      "num": "0.2.5",
+      "dl_path": "/api/v1/crates/libc/0.2.5/download",
+      "readme_path": "/api/v1/crates/libc/0.2.5/readme",
+      "updated_at": "2017-11-30T04:00:24.708032+00:00",
+      "created_at": "2016-01-21T21:32:48.948442+00:00",
+      "downloads": 23347,
+      "features": {
+        "default": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.5/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.5/downloads",
+        "authors": "/api/v1/crates/libc/0.2.5/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 19509,
+      "crate": "libc",
+      "num": "0.2.4",
+      "dl_path": "/api/v1/crates/libc/0.2.4/download",
+      "readme_path": "/api/v1/crates/libc/0.2.4/readme",
+      "updated_at": "2017-11-30T04:20:50.966957+00:00",
+      "created_at": "2015-12-17T23:20:44.957419+00:00",
+      "downloads": 153474,
+      "features": {
+        "default": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.4/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.4/downloads",
+        "authors": "/api/v1/crates/libc/0.2.4/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 19469,
+      "crate": "libc",
+      "num": "0.2.3",
+      "dl_path": "/api/v1/crates/libc/0.2.3/download",
+      "readme_path": "/api/v1/crates/libc/0.2.3/readme",
+      "updated_at": "2017-11-30T03:05:29.856154+00:00",
+      "created_at": "2015-12-16T21:01:18.534146+00:00",
+      "downloads": 4566,
+      "features": {
+        "default": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.3/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.3/downloads",
+        "authors": "/api/v1/crates/libc/0.2.3/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 17958,
+      "crate": "libc",
+      "num": "0.2.2",
+      "dl_path": "/api/v1/crates/libc/0.2.2/download",
+      "readme_path": "/api/v1/crates/libc/0.2.2/readme",
+      "updated_at": "2017-11-30T03:10:31.178202+00:00",
+      "created_at": "2015-11-10T18:10:05.382010+00:00",
+      "downloads": 158762,
+      "features": {
+        "default": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.2/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.2/downloads",
+        "authors": "/api/v1/crates/libc/0.2.2/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 17638,
+      "crate": "libc",
+      "num": "0.2.1",
+      "dl_path": "/api/v1/crates/libc/0.2.1/download",
+      "readme_path": "/api/v1/crates/libc/0.2.1/readme",
+      "updated_at": "2017-11-30T04:04:16.047232+00:00",
+      "created_at": "2015-11-05T01:47:03.827924+00:00",
+      "downloads": 15048,
+      "features": {
+        "default": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.1/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.1/downloads",
+        "authors": "/api/v1/crates/libc/0.2.1/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 17572,
+      "crate": "libc",
+      "num": "0.2.0",
+      "dl_path": "/api/v1/crates/libc/0.2.0/download",
+      "readme_path": "/api/v1/crates/libc/0.2.0/readme",
+      "updated_at": "2017-11-30T03:30:03.255002+00:00",
+      "created_at": "2015-11-03T21:32:22.041055+00:00",
+      "downloads": 5573,
+      "features": {
+        "default": []
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.2.0/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.2.0/downloads",
+        "authors": "/api/v1/crates/libc/0.2.0/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 17355,
+      "crate": "libc",
+      "num": "0.1.12",
+      "dl_path": "/api/v1/crates/libc/0.1.12/download",
+      "readme_path": "/api/v1/crates/libc/0.1.12/readme",
+      "updated_at": "2017-11-30T03:53:57.332797+00:00",
+      "created_at": "2015-10-28T21:22:48.024978+00:00",
+      "downloads": 695010,
+      "features": {
+        "cargo-build": [],
+        "default": [
+          "cargo-build"
+        ]
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.1.12/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.1.12/downloads",
+        "authors": "/api/v1/crates/libc/0.1.12/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 16916,
+      "crate": "libc",
+      "num": "0.1.11",
+      "dl_path": "/api/v1/crates/libc/0.1.11/download",
+      "readme_path": "/api/v1/crates/libc/0.1.11/readme",
+      "updated_at": "2017-11-30T04:00:11.197225+00:00",
+      "created_at": "2015-10-19T20:51:19.038697+00:00",
+      "downloads": 534,
+      "features": {
+        "cargo-build": [],
+        "default": [
+          "cargo-build"
+        ]
+      },
+      "yanked": true,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.1.11/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.1.11/downloads",
+        "authors": "/api/v1/crates/libc/0.1.11/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 14628,
+      "crate": "libc",
+      "num": "0.1.10",
+      "dl_path": "/api/v1/crates/libc/0.1.10/download",
+      "readme_path": "/api/v1/crates/libc/0.1.10/readme",
+      "updated_at": "2017-11-30T02:36:03.506148+00:00",
+      "created_at": "2015-08-15T20:29:52.723609+00:00",
+      "downloads": 273129,
+      "features": {
+        "cargo-build": [],
+        "default": [
+          "cargo-build"
+        ]
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.1.10/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.1.10/downloads",
+        "authors": "/api/v1/crates/libc/0.1.10/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 13021,
+      "crate": "libc",
+      "num": "0.1.9",
+      "dl_path": "/api/v1/crates/libc/0.1.9/download",
+      "readme_path": "/api/v1/crates/libc/0.1.9/readme",
+      "updated_at": "2017-11-30T03:11:03.349653+00:00",
+      "created_at": "2015-07-11T20:51:59.562389+00:00",
+      "downloads": 7101,
+      "features": {
+        "cargo-build": [],
+        "default": [
+          "cargo-build"
+        ]
+      },
+      "yanked": true,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.1.9/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.1.9/downloads",
+        "authors": "/api/v1/crates/libc/0.1.9/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 10384,
+      "crate": "libc",
+      "num": "0.1.8",
+      "dl_path": "/api/v1/crates/libc/0.1.8/download",
+      "readme_path": "/api/v1/crates/libc/0.1.8/readme",
+      "updated_at": "2017-11-30T02:28:30.975602+00:00",
+      "created_at": "2015-05-17T19:46:43.744066+00:00",
+      "downloads": 240607,
+      "features": {
+        "cargo-build": [],
+        "default": [
+          "cargo-build"
+        ]
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.1.8/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.1.8/downloads",
+        "authors": "/api/v1/crates/libc/0.1.8/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 9938,
+      "crate": "libc",
+      "num": "0.1.7",
+      "dl_path": "/api/v1/crates/libc/0.1.7/download",
+      "readme_path": "/api/v1/crates/libc/0.1.7/readme",
+      "updated_at": "2017-11-30T02:57:45.661351+00:00",
+      "created_at": "2015-05-07T07:53:09.958093+00:00",
+      "downloads": 33269,
+      "features": {
+        "cargo-build": [],
+        "default": [
+          "cargo-build"
+        ]
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.1.7/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.1.7/downloads",
+        "authors": "/api/v1/crates/libc/0.1.7/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 8437,
+      "crate": "libc",
+      "num": "0.1.6",
+      "dl_path": "/api/v1/crates/libc/0.1.6/download",
+      "readme_path": "/api/v1/crates/libc/0.1.6/readme",
+      "updated_at": "2017-11-30T02:25:07.277378+00:00",
+      "created_at": "2015-04-07T17:10:55.631663+00:00",
+      "downloads": 48480,
+      "features": {
+        "cargo-build": [],
+        "default": [
+          "cargo-build"
+        ]
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.1.6/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.1.6/downloads",
+        "authors": "/api/v1/crates/libc/0.1.6/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 7842,
+      "crate": "libc",
+      "num": "0.1.5",
+      "dl_path": "/api/v1/crates/libc/0.1.5/download",
+      "readme_path": "/api/v1/crates/libc/0.1.5/readme",
+      "updated_at": "2017-11-30T03:21:15.827062+00:00",
+      "created_at": "2015-04-03T01:01:05.479603+00:00",
+      "downloads": 11482,
+      "features": {
+        "cargo-build": [],
+        "default": [
+          "cargo-build"
+        ]
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.1.5/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.1.5/downloads",
+        "authors": "/api/v1/crates/libc/0.1.5/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 7408,
+      "crate": "libc",
+      "num": "0.1.4",
+      "dl_path": "/api/v1/crates/libc/0.1.4/download",
+      "readme_path": "/api/v1/crates/libc/0.1.4/readme",
+      "updated_at": "2017-11-30T03:49:57.924961+00:00",
+      "created_at": "2015-03-28T17:51:19.880974+00:00",
+      "downloads": 10524,
+      "features": {
+        "cargo-build": [],
+        "default": [
+          "cargo-build"
+        ]
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.1.4/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.1.4/downloads",
+        "authors": "/api/v1/crates/libc/0.1.4/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 6260,
+      "crate": "libc",
+      "num": "0.1.3",
+      "dl_path": "/api/v1/crates/libc/0.1.3/download",
+      "readme_path": "/api/v1/crates/libc/0.1.3/readme",
+      "updated_at": "2017-11-30T04:04:15.866089+00:00",
+      "created_at": "2015-03-12T21:09:28.261382+00:00",
+      "downloads": 16979,
+      "features": {
+        "cargo-build": [],
+        "default": [
+          "cargo-build"
+        ]
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.1.3/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.1.3/downloads",
+        "authors": "/api/v1/crates/libc/0.1.3/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 4732,
+      "crate": "libc",
+      "num": "0.1.2",
+      "dl_path": "/api/v1/crates/libc/0.1.2/download",
+      "readme_path": "/api/v1/crates/libc/0.1.2/readme",
+      "updated_at": "2017-11-30T03:36:02.708097+00:00",
+      "created_at": "2015-02-08T14:03:43.901010+00:00",
+      "downloads": 25612,
+      "features": {
+        "cargo-build": [],
+        "default": [
+          "cargo-build"
+        ]
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.1.2/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.1.2/downloads",
+        "authors": "/api/v1/crates/libc/0.1.2/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 4106,
+      "crate": "libc",
+      "num": "0.1.1",
+      "dl_path": "/api/v1/crates/libc/0.1.1/download",
+      "readme_path": "/api/v1/crates/libc/0.1.1/readme",
+      "updated_at": "2017-11-30T03:53:57.315980+00:00",
+      "created_at": "2015-01-29T16:47:33.701342+00:00",
+      "downloads": 6362,
+      "features": {
+        "cargo-build": [],
+        "default": [
+          "cargo-build"
+        ]
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.1.1/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.1.1/downloads",
+        "authors": "/api/v1/crates/libc/0.1.1/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    },
+    {
+      "id": 3006,
+      "crate": "libc",
+      "num": "0.1.0",
+      "dl_path": "/api/v1/crates/libc/0.1.0/download",
+      "readme_path": "/api/v1/crates/libc/0.1.0/readme",
+      "updated_at": "2017-11-30T03:21:20.770945+00:00",
+      "created_at": "2015-01-15T20:22:13.116297+00:00",
+      "downloads": 4120,
+      "features": {
+        "cargo-build": [],
+        "default": [
+          "cargo-build"
+        ]
+      },
+      "yanked": false,
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "dependencies": "/api/v1/crates/libc/0.1.0/dependencies",
+        "version_downloads": "/api/v1/crates/libc/0.1.0/downloads",
+        "authors": "/api/v1/crates/libc/0.1.0/authors"
+      },
+      "crate_size": null,
+      "published_by": null,
+      "audit_actions": []
+    }
+  ],
+  "keywords": [
+    {
+      "id": "bindings",
+      "keyword": "bindings",
+      "created_at": "2014-11-20T21:45:18.916803+00:00",
+      "crates_cnt": 260
+    },
+    {
+      "id": "ffi",
+      "keyword": "ffi",
+      "created_at": "2014-11-21T14:53:31.372632+00:00",
+      "crates_cnt": 876
+    },
+    {
+      "id": "system",
+      "keyword": "system",
+      "created_at": "2014-11-21T22:48:22.309413+00:00",
+      "crates_cnt": 97
+    },
+    {
+      "id": "libc",
+      "keyword": "libc",
+      "created_at": "2015-11-21T13:17:16.903742+00:00",
+      "crates_cnt": 13
+    },
+    {
+      "id": "operating",
+      "keyword": "operating",
+      "created_at": "2018-12-10T16:35:24.539294+00:00",
+      "crates_cnt": 1
+    }
+  ],
+  "categories": [
+    {
+      "id": "no-std",
+      "category": "No standard library",
+      "slug": "no-std",
+      "description": "Crates that are able to function without the Rust standard library.\n",
+      "created_at": "2017-02-10T01:52:09.447906+00:00",
+      "crates_cnt": 2360
+    },
+    {
+      "id": "os",
+      "category": "Operating systems",
+      "slug": "os",
+      "description": "Bindings to operating system-specific APIs.",
+      "created_at": "2017-01-17T19:13:05.112025+00:00",
+      "crates_cnt": 344
+    },
+    {
+      "id": "external-ffi-bindings",
+      "category": "External FFI bindings",
+      "slug": "external-ffi-bindings",
+      "description": "Direct Rust FFI bindings to libraries written in other languages; often denoted by a -sys suffix. Safe and idiomatic wrappers are in the API bindings category.\n",
+      "created_at": "2017-01-17T19:13:05.112025+00:00",
+      "crates_cnt": 670
+    }
+  ]
+}

--- a/lib/datasource/crate/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/crate/__snapshots__/index.spec.ts.snap
@@ -105,6 +105,16 @@ Array [
     "method": "GET",
     "url": "https://raw.githubusercontent.com/rust-lang/crates.io-index/master/am/et/amethyst",
   },
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "crates.io",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://crates.io/api/v1/crates/amethyst",
+  },
 ]
 `;
 
@@ -310,6 +320,7 @@ Object {
       "version": "0.2.51",
     },
   ],
+  "sourceUrl": "https://github.com/rust-lang/libc",
 }
 `;
 
@@ -323,6 +334,16 @@ Array [
     },
     "method": "GET",
     "url": "https://raw.githubusercontent.com/rust-lang/crates.io-index/master/li/bc/libc",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "crates.io",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://crates.io/api/v1/crates/libc",
   },
 ]
 `;
@@ -354,6 +375,16 @@ Array [
     "method": "GET",
     "url": "https://raw.githubusercontent.com/rust-lang/crates.io-index/master/no/n_/non_existent_crate",
   },
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "crates.io",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://crates.io/api/v1/crates/non_existent_crate",
+  },
 ]
 `;
 
@@ -368,6 +399,16 @@ Array [
     "method": "GET",
     "url": "https://raw.githubusercontent.com/rust-lang/crates.io-index/master/no/n_/non_existent_crate",
   },
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "crates.io",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://crates.io/api/v1/crates/non_existent_crate",
+  },
 ]
 `;
 
@@ -381,6 +422,16 @@ Array [
     },
     "method": "GET",
     "url": "https://raw.githubusercontent.com/rust-lang/crates.io-index/master/no/n_/non_existent_crate",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "crates.io",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://crates.io/api/v1/crates/non_existent_crate",
   },
 ]
 `;

--- a/lib/datasource/crate/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/crate/__snapshots__/index.spec.ts.snap
@@ -118,6 +118,235 @@ Array [
 ]
 `;
 
+exports[`datasource/crate getReleases processes real data: libc (with failing API call) 1`] = `
+Object {
+  "dependencyUrl": "https://crates.io/crates/libc",
+  "releases": Array [
+    Object {
+      "version": "0.1.0",
+    },
+    Object {
+      "version": "0.1.1",
+    },
+    Object {
+      "version": "0.1.2",
+    },
+    Object {
+      "version": "0.1.3",
+    },
+    Object {
+      "version": "0.1.4",
+    },
+    Object {
+      "version": "0.1.5",
+    },
+    Object {
+      "version": "0.1.6",
+    },
+    Object {
+      "version": "0.1.7",
+    },
+    Object {
+      "version": "0.1.8",
+    },
+    Object {
+      "isDeprecated": true,
+      "version": "0.1.9",
+    },
+    Object {
+      "version": "0.1.10",
+    },
+    Object {
+      "isDeprecated": true,
+      "version": "0.1.11",
+    },
+    Object {
+      "version": "0.1.12",
+    },
+    Object {
+      "version": "0.2.0",
+    },
+    Object {
+      "version": "0.2.1",
+    },
+    Object {
+      "version": "0.2.2",
+    },
+    Object {
+      "version": "0.2.3",
+    },
+    Object {
+      "version": "0.2.4",
+    },
+    Object {
+      "version": "0.2.5",
+    },
+    Object {
+      "version": "0.2.6",
+    },
+    Object {
+      "version": "0.2.7",
+    },
+    Object {
+      "version": "0.2.8",
+    },
+    Object {
+      "version": "0.2.9",
+    },
+    Object {
+      "version": "0.2.10",
+    },
+    Object {
+      "version": "0.2.11",
+    },
+    Object {
+      "version": "0.2.12",
+    },
+    Object {
+      "version": "0.2.13",
+    },
+    Object {
+      "version": "0.2.14",
+    },
+    Object {
+      "version": "0.2.15",
+    },
+    Object {
+      "version": "0.2.16",
+    },
+    Object {
+      "version": "0.2.17",
+    },
+    Object {
+      "version": "0.2.18",
+    },
+    Object {
+      "version": "0.2.19",
+    },
+    Object {
+      "version": "0.2.20",
+    },
+    Object {
+      "version": "0.2.21",
+    },
+    Object {
+      "version": "0.2.22",
+    },
+    Object {
+      "version": "0.2.23",
+    },
+    Object {
+      "version": "0.2.24",
+    },
+    Object {
+      "version": "0.2.25",
+    },
+    Object {
+      "version": "0.2.26",
+    },
+    Object {
+      "version": "0.2.27",
+    },
+    Object {
+      "version": "0.2.28",
+    },
+    Object {
+      "version": "0.2.29",
+    },
+    Object {
+      "version": "0.2.30",
+    },
+    Object {
+      "version": "0.2.31",
+    },
+    Object {
+      "version": "0.2.32",
+    },
+    Object {
+      "version": "0.2.33",
+    },
+    Object {
+      "version": "0.2.34",
+    },
+    Object {
+      "version": "0.2.35",
+    },
+    Object {
+      "version": "0.2.36",
+    },
+    Object {
+      "version": "0.2.37",
+    },
+    Object {
+      "version": "0.2.38",
+    },
+    Object {
+      "version": "0.2.39",
+    },
+    Object {
+      "version": "0.2.40",
+    },
+    Object {
+      "version": "0.2.41",
+    },
+    Object {
+      "version": "0.2.42",
+    },
+    Object {
+      "version": "0.2.43",
+    },
+    Object {
+      "version": "0.2.44",
+    },
+    Object {
+      "version": "0.2.45",
+    },
+    Object {
+      "version": "0.2.46",
+    },
+    Object {
+      "version": "0.2.47",
+    },
+    Object {
+      "version": "0.2.48",
+    },
+    Object {
+      "version": "0.2.49",
+    },
+    Object {
+      "version": "0.2.50",
+    },
+    Object {
+      "version": "0.2.51",
+    },
+  ],
+}
+`;
+
+exports[`datasource/crate getReleases processes real data: libc (with failing API call) 2`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept-encoding": "gzip, deflate",
+      "host": "raw.githubusercontent.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://raw.githubusercontent.com/rust-lang/crates.io-index/master/li/bc/libc",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "crates.io",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://crates.io/api/v1/crates/libc",
+  },
+]
+`;
+
 exports[`datasource/crate getReleases processes real data: libc 1`] = `
 Object {
   "dependencyUrl": "https://crates.io/crates/libc",

--- a/lib/datasource/crate/index.spec.ts
+++ b/lib/datasource/crate/index.spec.ts
@@ -209,6 +209,7 @@ describe('datasource/crate', () => {
       ).toBeNull();
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
+
     it('processes real data: libc', async () => {
       httpMock.scope(baseUrl).get('/li/bc/libc').reply(200, res1);
       httpMock
@@ -226,6 +227,25 @@ describe('datasource/crate', () => {
       expect(res).toBeDefined();
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
+
+    it('processes real data: libc (with failing API call)', async () => {
+      httpMock.scope(baseUrl).get('/li/bc/libc').reply(200, res1);
+      httpMock
+        .scope('https://crates.io/')
+        .get('/api/v1/crates/libc')
+        .reply(500, '');
+
+      const res = await getPkgReleases({
+        datasource,
+        depName: 'libc',
+        registryUrls: ['https://crates.io'],
+      });
+      expect(res).toMatchSnapshot();
+      expect(res).not.toBeNull();
+      expect(res).toBeDefined();
+      expect(httpMock.getTrace()).toMatchSnapshot();
+    });
+
     it('processes real data: amethyst', async () => {
       httpMock.scope(baseUrl).get('/am/et/amethyst').reply(200, res2);
       httpMock

--- a/lib/datasource/crate/index.spec.ts
+++ b/lib/datasource/crate/index.spec.ts
@@ -4,9 +4,11 @@ import { DirectoryResult, dir } from 'tmp-promise';
 import { dirname, join } from 'upath';
 import { getPkgReleases } from '..';
 import * as httpMock from '../../../test/http-mock';
+import { mocked } from '../../../test/util';
 import { setAdminConfig } from '../../config/admin';
 import * as memCache from '../../util/cache/memory';
 import { setFsConfig } from '../../util/fs';
+import * as _hostRules from '../../util/http/host-rules';
 import {
   RegistryFlavor,
   RegistryInfo,
@@ -14,6 +16,9 @@ import {
   fetchCrateRecordsPayload,
   getIndexSuffix,
 } from '.';
+
+jest.mock('../../util/http/host-rules');
+const hostRules = mocked(_hostRules);
 
 jest.mock('simple-git');
 const simpleGit: any = _simpleGit;
@@ -76,6 +81,13 @@ describe('datasource/crate', () => {
       simpleGit.mockReset();
       memCache.init();
       setAdminConfig();
+
+      // run tests without rate limit
+      const { applyHostRules } = jest.requireActual(
+        '../../util/http/host-rules'
+      );
+      hostRules.applyHostRules.mockImplementation(applyHostRules);
+      hostRules.getQueueOptions.mockReturnValue({});
     });
 
     afterEach(() => {

--- a/lib/datasource/crate/index.spec.ts
+++ b/lib/datasource/crate/index.spec.ts
@@ -24,6 +24,10 @@ jest.mock('simple-git');
 const simpleGit: any = _simpleGit;
 
 const res1 = fs.readFileSync('lib/datasource/crate/__fixtures__/libc', 'utf8');
+const libcApiRes = fs.readFileSync(
+  'lib/datasource/crate/__fixtures__/libc.api',
+  'utf8'
+);
 const res2 = fs.readFileSync(
   'lib/datasource/crate/__fixtures__/amethyst',
   'utf8'
@@ -118,6 +122,11 @@ describe('datasource/crate', () => {
     });
     it('returns null for empty result', async () => {
       httpMock.scope(baseUrl).get('/no/n_/non_existent_crate').reply(200, {});
+      httpMock
+        .scope('https://crates.io/')
+        .get('/api/v1/crates/non_existent_crate')
+        .reply(200, undefined);
+
       expect(
         await getPkgReleases({
           datasource,
@@ -132,6 +141,11 @@ describe('datasource/crate', () => {
         .scope(baseUrl)
         .get('/no/n_/non_existent_crate')
         .reply(200, undefined);
+      httpMock
+        .scope('https://crates.io/')
+        .get('/api/v1/crates/non_existent_crate')
+        .reply(200, undefined);
+
       expect(
         await getPkgReleases({
           datasource,
@@ -143,6 +157,11 @@ describe('datasource/crate', () => {
     });
     it('returns null for empty list', async () => {
       httpMock.scope(baseUrl).get('/no/n_/non_existent_crate').reply(200, '\n');
+      httpMock
+        .scope('https://crates.io/')
+        .get('/api/v1/crates/non_existent_crate')
+        .reply(200, undefined);
+
       expect(
         await getPkgReleases({
           datasource,
@@ -192,6 +211,11 @@ describe('datasource/crate', () => {
     });
     it('processes real data: libc', async () => {
       httpMock.scope(baseUrl).get('/li/bc/libc').reply(200, res1);
+      httpMock
+        .scope('https://crates.io/')
+        .get('/api/v1/crates/libc')
+        .reply(200, libcApiRes);
+
       const res = await getPkgReleases({
         datasource,
         depName: 'libc',
@@ -204,6 +228,11 @@ describe('datasource/crate', () => {
     });
     it('processes real data: amethyst', async () => {
       httpMock.scope(baseUrl).get('/am/et/amethyst').reply(200, res2);
+      httpMock
+        .scope('https://crates.io/')
+        .get('/api/v1/crates/amethyst')
+        .reply(200, undefined);
+
       const res = await getPkgReleases({
         datasource,
         depName: 'amethyst',

--- a/lib/util/http/host-rules.ts
+++ b/lib/util/http/host-rules.ts
@@ -40,6 +40,8 @@ export function applyHostRules(url: string, inOptions: GotOptions): GotOptions {
 
 export interface QueueOptions {
   concurrency?: number;
+  interval?: number;
+  intervalCap?: number;
 }
 
 export function getQueueOptions(url: string): QueueOptions {
@@ -49,6 +51,12 @@ export function getQueueOptions(url: string): QueueOptions {
   const limit = hostRule.concurrentRequestLimit;
   if (typeof limit === 'number' && limit > 0) {
     options.concurrency = limit;
+  }
+
+  if (url.startsWith('https://crates.io/')) {
+    // see https://crates.io/policies#crawlers
+    options.interval = 1000;
+    options.intervalCap = 1;
   }
 
   return options;

--- a/lib/util/http/host-rules.ts
+++ b/lib/util/http/host-rules.ts
@@ -38,10 +38,18 @@ export function applyHostRules(url: string, inOptions: GotOptions): GotOptions {
   return options;
 }
 
-export function getRequestLimit(url: string): number | null {
-  const hostRule = hostRules.find({
-    url,
-  });
+export interface QueueOptions {
+  concurrency?: number;
+}
+
+export function getQueueOptions(url: string): QueueOptions {
+  const options: QueueOptions = {};
+
+  const hostRule = hostRules.find({ url });
   const limit = hostRule.concurrentRequestLimit;
-  return typeof limit === 'number' && limit > 0 ? limit : null;
+  if (typeof limit === 'number' && limit > 0) {
+    options.concurrency = limit;
+  }
+
+  return options;
 }

--- a/lib/util/http/queue.ts
+++ b/lib/util/http/queue.ts
@@ -1,6 +1,6 @@
 import URL from 'url';
 import PQueue from 'p-queue';
-import { getRequestLimit } from './host-rules';
+import { getQueueOptions } from './host-rules';
 
 const hostQueues = new Map<string | null, PQueue | null>();
 
@@ -21,9 +21,10 @@ export function getQueue(url: string): PQueue | null {
   let queue = hostQueues.get(host);
   if (queue === undefined) {
     queue = null; // null represents "no queue", as opposed to undefined
-    const concurrency = getRequestLimit(url);
-    if (concurrency) {
-      queue = new PQueue({ concurrency });
+
+    const options = getQueueOptions(url);
+    if (Object.keys(options).length !== 0) {
+      queue = new PQueue(options);
     }
 
     hostQueues.set(host, queue);

--- a/lib/util/http/queue.ts
+++ b/lib/util/http/queue.ts
@@ -25,8 +25,9 @@ export function getQueue(url: string): PQueue | null {
     if (concurrency) {
       queue = new PQueue({ concurrency });
     }
+
+    hostQueues.set(host, queue);
   }
-  hostQueues.set(host, queue);
 
   return queue;
 }


### PR DESCRIPTION
## Changes:

This PR changes the `crate` datasource to query the crates.io API for crate metadata. Specifically, it takes the `repository` fields as the `sourceUrl`. This allows the changelog code to retrieve changelogs when the crates are hosted on e.g. GitHub.

## Context:

Rust crate update PRs currently don't contain any changelogs, but they can be very valuable in knowing what you're updating. The repository URL is unfortunately not part of the crates.io registry index, so we need to query the crates.io API for that metadata. The crates.io has a rate limit of one request per second, which this PR adds to our `p-queue` options for any requests that are going to the crates.io domain.

## Documentation

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
