### PR TITLE
docs: Add trustLevel info to allowedPostUpgradeCommands

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -53,7 +53,8 @@ npx ng update @angular/core --from=9.0.0 --to=10.0.0 --migrateOnly --allowDirty 
 ## allowedPostUpgradeCommands
 
 A list of regular expressions that determine which commands in `postUpgradeTasks` are allowed to be executed.
-If this list is empty then no tasks will be executed. Also you need to have `"trustLevel": "high"`, otherwise option will be ignored.
+If this list is empty then no tasks will be executed.
+Also you need to have `"trustLevel": "high"`, otherwise these tasks will be ignored.
 
 e.g.
 

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -53,7 +53,7 @@ npx ng update @angular/core --from=9.0.0 --to=10.0.0 --migrateOnly --allowDirty 
 ## allowedPostUpgradeCommands
 
 A list of regular expressions that determine which commands in `postUpgradeTasks` are allowed to be executed.
-If this list is empty then no tasks will be executed.
+If this list is empty then no tasks will be executed. Also you need to have `"trustLevel": "high"`, otherwise option will be ignored.
 
 e.g.
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Added info about trustLevel into allowedPostUpgradeCommands section.

## Context:

I was not able to figure out why allowedPostUpgradeCommands does not work and I found in source code that `trustLevel` must be set to `high`. So this information may help other lost people :)

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
