### PR TITLE
docs: fix example for matchCurrentVersion config option

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -1280,7 +1280,7 @@ Use the syntax `!/ /` like the following:
   "packageRules": [
     {
       "matchPackagePatterns": ["io.github.resilience4j"],
-      "allowedVersions": "!/^0\\./"
+      "matchCurrentVersion": "!/^0\\./"
     }
   ]
 }


### PR DESCRIPTION
## Changes:

Noticed a tiny typo while looking at the examples for `matchCurrentVersion`. Probably a copy/paste error from the `allowedVersions` section.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
