### PR TITLE
chore(docs): add exceptions for force pushing a PR

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -32,6 +32,7 @@ PRs will always be squashed by us when we merge your work.
 Commit as many times as you need in your pull request branch.
 
 Force pushing a PR is OK when:
+
 - you need to make large changes on a PR which require a full review anyway
 - you need to bring the branch up-to-date with the default branch and incorporating the changes is more work than to create a new PR
 

--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -26,9 +26,14 @@ Pull Requests can only be merged once all status checks are green, which means `
 
 ## Do not force push to your pull request branch
 
-Please do not force push to your PR's branch after you have created your PR, as doing so makes it harder for us to review your work.
+Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again.
+This makes it harder for us to review your work because we don't know what has changed.
 PRs will always be squashed by us when we merge your work.
 Commit as many times as you need in your pull request branch.
+
+Force pushing a PR is OK when:
+* you need to make large changes on a PR which require a full review anyway.
+* you need to bring the branch up to date with the default branch and incorporating the changes is more work than to create a new PR.
 
 ## Re-requesting a review
 

--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -32,8 +32,8 @@ PRs will always be squashed by us when we merge your work.
 Commit as many times as you need in your pull request branch.
 
 Force pushing a PR is OK when:
-* you need to make large changes on a PR which require a full review anyway.
-* you need to bring the branch up to date with the default branch and incorporating the changes is more work than to create a new PR.
+- you need to make large changes on a PR which require a full review anyway
+- you need to bring the branch up-to-date with the default branch and incorporating the changes is more work than to create a new PR
 
 ## Re-requesting a review
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,5 +26,5 @@ I have verified these changes via:
 
 <!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->
 
-<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
+<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
 <!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Makes clear why force pushing a PR is discouraged and when it is OK to do so.

## Context:

I created a new PR instead of force pushing the old one, because I took the documentation too literally

## Documentation

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work

I have verified these changes via:

- [x] Documentation update only, or
- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to this PR's branch after you have created this PR, as doing so makes it harder for us to review your work. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
