### PR TITLE
fix(batect): "Failed to parse newContent"

### DIFF
--- a/lib/manager/batect/extract.ts
+++ b/lib/manager/batect/extract.ts
@@ -121,7 +121,7 @@ interface ExtractionResult {
   referencedConfigFiles: string[];
 }
 
-function extractPackageFile(
+export function extractPackageFile(
   content: string,
   fileName: string
 ): ExtractionResult | null {

--- a/lib/manager/batect/index.ts
+++ b/lib/manager/batect/index.ts
@@ -1,6 +1,6 @@
-import { extractAllPackageFiles } from './extract';
+import { extractAllPackageFiles, extractPackageFile } from './extract';
 
-export { extractAllPackageFiles };
+export { extractAllPackageFiles, extractPackageFile };
 
 export const defaultConfig = {
   fileMatch: ['(^|/)batect(-bundle)?\\.yml$'],

--- a/lib/workers/branch/auto-replace.ts
+++ b/lib/workers/branch/auto-replace.ts
@@ -31,7 +31,7 @@ export async function confirmIfDepUpdated(
     );
     newUpgrade = newExtract.deps[depIndex];
   } catch (err) /* istanbul ignore next */ {
-    logger.debug({ manager, packageFile }, 'Failed to parse newContent');
+    logger.debug({ manager, packageFile, err }, 'Failed to parse newContent');
   }
   if (!newUpgrade) {
     logger.debug({ manager, packageFile }, 'No newUpgrade');


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

This fixes an issue where all updates with the `batect` manager would fail.
It also adds logging for errors like this so that they're easier to diagnose in the future.

## Context:

Updates to Batect configuration files (either Docker image references or bundle versions) were broken. Logs would contain messages like this:

```
DEBUG: prAlreadyExisted=false(branch="renovate/docker-golang-1.x")
DEBUG: Checking schedule(at any time, null)(branch="renovate/docker-golang-1.x")
DEBUG: No schedule defined(branch="renovate/docker-golang-1.x")
DEBUG: Branch needs creating(branch="renovate/docker-golang-1.x")
DEBUG: Using reuseExistingBranch: false(branch="renovate/docker-golang-1.x")
DEBUG: manager.getUpdatedPackageFiles()(branch="renovate/docker-golang-1.x")
{
  "reuseExistingBranch": false,
  "branchName": "renovate/docker-golang-1.x"
}
DEBUG: Starting search at index 43(packageFile="batect-bundle.yml", branch="renovate/docker-golang-1.x")
{
  "depName": "golang"
}
DEBUG: Found match at index 43(packageFile="batect-bundle.yml", branch="renovate/docker-golang-1.x")
{
  "depName": "golang"
}
DEBUG: Failed to parse newContent(packageFile="batect-bundle.yml", branch="renovate/docker-golang-1.x")
{
  "manager": "batect"
}
DEBUG: No newUpgrade(packageFile="batect-bundle.yml", branch="renovate/docker-golang-1.x")
{
  "manager": "batect"
}
WARN: Error updating branch: update failure(branch="renovate/docker-golang-1.x")
```

The error parsing `newContent` is due to [`auto-replace.ts` expecting the manager to implement `extractPackageFile`](https://github.com/renovatebot/renovate/blob/e91191c/lib/workers/branch/auto-replace.ts#L24), but the Batect manager doesn't implement this, and instead provided only `extractAllPackageFiles` (see #8091 for more details).

I haven't added a unit test for this, but if there's an existing pattern for tests that would catch this kind of problem, please let me know and I can add one.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository