### PR TITLE
chore: improve label bot messages

### DIFF
--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -28,5 +28,5 @@
 
     This label will be replaced with `status:ready` once all requirements and reproductions necessary to start work have been met.
 
-    If it's not clear _what_ is missing to move this issue forward, ask for clarifacation in a new comment.
+    If it's not clear _what_ is missing to move this issue forward, ask for clarification in a new comment.
     If you think we already have what we need to move forward, mention this in a new comment.

--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -1,21 +1,31 @@
 'reproduction:needed':
   comment: >
-    This issue needs to be reproduced in order to continue.
+    Hi there,
 
-    Please consult our guide on [minimal reproductions](https://github.com/renovatebot/renovate/blob/master/docs/development/minimal-reproductions.md) to understand what is needed.
+    The Renovate team needs your help!
+    To fix the problem, we first need to know exactly what's causing the bug.
+    A minimal reproduction help us to pinpoint the exact cause of the bug.
 
-    Issues requiring reproductions may be closed if no reproduction can be provided within two weeks.
+    To get started, please read our guide on [minimal reproductions](https://github.com/renovatebot/renovate/blob/master/docs/development/minimal-reproductions.md) to understand what is needed.
+
+    We may close the issue if you have not provided a minimal reproduction within two weeks.
+    If you need more time, or are stuck, please ask for help or more time in a comment.
+
+    Good luck,
+
+    The Renovate team
 
 'reproduction:provided':
   comment: >
-    Thank you for providing a reproduction.
+    Thank you for providing a reproduction! :tada: :rocket:
 
-    The label will be updated to `reproduction:confirmed` once someone else has confirmed they can reproduce the problem with it.
+    The Renovate team will take a look at the reproduction repository.
+    Once we confirm the provided repository reproduces the problem, the label will be changed to `reproduction:confirmed`.
 
 'status:requirements':
   comment: >
-    This issue has been labeled with `status:requirements`. This indicates that the issue is not ready to start and further requirements or reproduction are needed first.
+    This issue has been labeled with `status:requirements`. This indicates that we don't know enough to start work and further requirements or a reproduction are needed first.
 
-    This label should be removed and replaced with `status:ready` once all requirements and reproductions necessary to start have been met.
+    This label will be replaced with `status:ready` once all requirements and reproductions necessary to start work have been met.
 
-    If it's *unclear* as to what is missing to move this issue forward, or you think it has already been provided, feel free to nudge a maintainer to take a look and clarify.
+    If it's *unclear* as to _what_ is missing to move this issue forward, or if you think it has already been provided, feel free to nudge a maintainer (how????) to take a look and clarify.

--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -28,4 +28,5 @@
 
     This label will be replaced with `status:ready` once all requirements and reproductions necessary to start work have been met.
 
-    If it's *unclear* as to _what_ is missing to move this issue forward, or if you think it has already been provided, feel free to nudge a maintainer (how????) to take a look and clarify.
+    If it's not clear _what_ is missing to move this issue forward, ask for clarifacation in a new comment.
+    If you think we already have what we need to move forward, mention this in a new comment.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

- Try to make the label bot messages more friendly and helpful

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

See the discussion at issue #8684.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
