### PR TITLE
feat: pnpm workspaces

### DIFF
--- a/lib/manager/npm/extract/index.spec.ts
+++ b/lib/manager/npm/extract/index.spec.ts
@@ -8,6 +8,7 @@ const fs: any = _fs;
 
 // TODO: fix types
 const defaultConfig = getConfig();
+defaultConfig.localDir = upath.resolve('lib/manager/npm/__fixtures__');
 
 function readFixture(fixture: string) {
   return readFileSync(
@@ -327,7 +328,9 @@ describe('manager/npm/extract', () => {
   });
   describe('.postExtract()', () => {
     it('runs', async () => {
-      await expect(npmExtract.postExtract([])).resolves.not.toThrow();
+      await expect(
+        npmExtract.postExtract(defaultConfig, [])
+      ).resolves.not.toThrow();
     });
   });
 });

--- a/lib/manager/npm/extract/index.ts
+++ b/lib/manager/npm/extract/index.ts
@@ -376,8 +376,11 @@ export async function extractPackageFile(
   };
 }
 
-export async function postExtract(packageFiles: PackageFile[]): Promise<void> {
-  detectMonorepos(packageFiles);
+export async function postExtract(
+  config: ExtractConfig,
+  packageFiles: PackageFile[]
+): Promise<void> {
+  await detectMonorepos(config, packageFiles);
   await getLockedVersions(packageFiles);
 }
 
@@ -401,6 +404,6 @@ export async function extractAllPackageFiles(
       logger.debug({ packageFile }, 'packageFile has no content');
     }
   }
-  await postExtract(npmFiles);
+  await postExtract(config, npmFiles);
   return npmFiles;
 }

--- a/lib/manager/npm/extract/monorepo.spec.ts
+++ b/lib/manager/npm/extract/monorepo.spec.ts
@@ -1,8 +1,14 @@
+import upath from 'upath';
+import { getConfig } from '../../../config/defaults';
 import { detectMonorepos } from './monorepo';
+
+// TODO: fix types
+const defaultConfig = getConfig();
+defaultConfig.localDir = upath.resolve('lib/manager/npm/__fixtures__');
 
 describe('manager/npm/extract', () => {
   describe('.extractPackageFile()', () => {
-    it('uses lerna package settings', () => {
+    it('uses lerna package settings', async () => {
       const packageFiles = [
         {
           packageFile: 'package.json',
@@ -44,11 +50,11 @@ describe('manager/npm/extract', () => {
           packageJsonName: '@org/b',
         },
       ];
-      detectMonorepos(packageFiles);
+      await detectMonorepos(defaultConfig, packageFiles);
       expect(packageFiles).toMatchSnapshot();
       expect(packageFiles[1].lernaDir).toEqual('.');
     });
-    it('uses yarn workspaces package settings with lerna', () => {
+    it('uses yarn workspaces package settings with lerna', async () => {
       const packageFiles = [
         {
           packageFile: 'package.json',
@@ -66,11 +72,11 @@ describe('manager/npm/extract', () => {
           packageJsonName: '@org/b',
         },
       ];
-      detectMonorepos(packageFiles);
+      await detectMonorepos(defaultConfig, packageFiles);
       expect(packageFiles).toMatchSnapshot();
       expect(packageFiles[1].lernaDir).toEqual('.');
     });
-    it('uses yarn workspaces package settings without lerna', () => {
+    it('uses yarn workspaces package settings without lerna', async () => {
       const packageFiles = [
         {
           packageFile: 'package.json',
@@ -86,7 +92,7 @@ describe('manager/npm/extract', () => {
           packageJsonName: '@org/b',
         },
       ];
-      detectMonorepos(packageFiles);
+      await detectMonorepos(defaultConfig, packageFiles);
       expect(packageFiles).toMatchSnapshot();
     });
   });

--- a/lib/manager/npm/extract/monorepo.ts
+++ b/lib/manager/npm/extract/monorepo.ts
@@ -1,9 +1,16 @@
 import is from '@sindresorhus/is';
+import findUp from 'find-up';
+import yaml from 'js-yaml';
 import minimatch from 'minimatch';
 import upath from 'upath';
 import { logger } from '../../../logger';
 import { SkipReason } from '../../../types';
-import { PackageFile } from '../../common';
+import {
+  getSiblingFileName,
+  localPathExists,
+  readLocalFile,
+} from '../../../util/fs';
+import { ExtractConfig, PackageFile } from '../../common';
 
 function matchesAnyPattern(val: string, patterns: string[]): boolean {
   const res = patterns.some(
@@ -13,7 +20,115 @@ function matchesAnyPattern(val: string, patterns: string[]): boolean {
   return res;
 }
 
-export function detectMonorepos(packageFiles: Partial<PackageFile>[]): void {
+export async function extractPnpmFilters(
+  fileName: string
+): Promise<string[] | null> {
+  try {
+    const contents = yaml.safeLoad(await readLocalFile(fileName, 'utf8'), {
+      json: true,
+    }) as any;
+    if (
+      !Array.isArray(contents?.packages) ||
+      !contents.packages.every((item) => typeof item === 'string')
+    ) {
+      logger.debug(
+        { fileName },
+        'Failed to find required "packages" array in pnpm-workspace.yaml'
+      );
+      return null;
+    }
+    return contents.packages;
+  } catch (error) {
+    logger.debug({ fileName }, 'Failed to parse pnpm-workspace.yaml');
+    return null;
+  }
+}
+
+export async function findPnpmWorkspace(
+  packageFile: string,
+  normalizedLocalDir: string
+): Promise<{ lockFilePath: string; workspaceYamlPath: string } | null> {
+  const workspaceYamlPath = await findUp('pnpm-workspace.yaml', {
+    cwd: upath.dirname(upath.join(normalizedLocalDir, packageFile)),
+    type: 'file',
+  });
+  if (
+    !workspaceYamlPath ||
+    !upath.normalizeSafe(workspaceYamlPath).startsWith(normalizedLocalDir)
+  ) {
+    logger.trace(
+      { packageFile },
+      'Failed to locate pnpm-workspace.yaml in a parent directory.'
+    );
+    return null;
+  }
+  const normalizedWorkspaceYamlPath = upath
+    .normalizeSafe(workspaceYamlPath)
+    .slice(normalizedLocalDir.length + 1);
+  const pnpmLockfilePath = getSiblingFileName(
+    normalizedWorkspaceYamlPath,
+    'pnpm-lock.yaml'
+  );
+  if (!(await localPathExists(pnpmLockfilePath))) {
+    logger.trace(
+      { normalizedWorkspaceYamlPath, packageFile },
+      'Failed to find a pnpm-lock.yaml sibling for the workspace.'
+    );
+    return null;
+  }
+  return {
+    lockFilePath: pnpmLockfilePath,
+    workspaceYamlPath: normalizedWorkspaceYamlPath,
+  };
+}
+
+export async function detectPnpm(
+  config: ExtractConfig,
+  packageFiles: Partial<PackageFile>[]
+): Promise<void> {
+  logger.debug(`Detecting pnpm Workspaces`);
+  const packageFilterCache = new Map<string, string[] | null>();
+  const normalizedLocalDir = upath.normalizeSafe(config.localDir);
+  for (const p of packageFiles) {
+    const { packageFile, pnpmShrinkwrap } = p;
+    if (pnpmShrinkwrap) {
+      logger.debug(
+        { packageFile, pnpmShrinkwrap },
+        'Found an existing pnpm shrinkwrap file; skipping pnpm monorepo check.'
+      );
+      continue; // eslint-disable-line no-continue
+    }
+    const pnpmWorkspace = await findPnpmWorkspace(
+      packageFile,
+      normalizedLocalDir
+    );
+    if (pnpmWorkspace === null) {
+      continue; // eslint-disable-line no-continue
+    }
+    const { workspaceYamlPath, lockFilePath } = pnpmWorkspace;
+    if (!packageFilterCache.has(workspaceYamlPath)) {
+      const filters = await extractPnpmFilters(workspaceYamlPath);
+      packageFilterCache.set(workspaceYamlPath, filters);
+    }
+    const packageFilters = packageFilterCache.get(workspaceYamlPath);
+    const isPackageInWorkspace =
+      packageFilters !== null && matchesAnyPattern(packageFile, packageFilters);
+    if (isPackageInWorkspace) {
+      p.pnpmShrinkwrap = lockFilePath;
+    } else {
+      logger.debug(
+        { packageFile, workspaceYamlPath },
+        `Didn't find the package in the pnpm workspace`
+      );
+    }
+  }
+}
+
+export async function detectMonorepos(
+  config: ExtractConfig,
+  packageFiles: Partial<PackageFile>[]
+): Promise<void> {
+  await detectPnpm(config, packageFiles);
   logger.debug('Detecting Lerna and Yarn Workspaces');
   for (const p of packageFiles) {
     const {

--- a/lib/workers/repository/extract/manager-files.spec.ts
+++ b/lib/workers/repository/extract/manager-files.spec.ts
@@ -54,6 +54,7 @@ describe('workers/repository/extract/manager-files', () => {
         manager: 'npm',
         enabled: true,
         fileList: ['package.json'],
+        localDir: '/localDir',
       };
       fileMatch.getMatchingFiles.mockReturnValue(['package.json']);
       fs.readLocalFile.mockResolvedValueOnce(

--- a/lib/workers/repository/onboarding/branch/index.spec.ts
+++ b/lib/workers/repository/onboarding/branch/index.spec.ts
@@ -34,6 +34,7 @@ describe('workers/repository/onboarding/branch', () => {
       await expect(checkOnboardingBranch(config)).rejects.toThrow();
     });
     it('has default onboarding config', async () => {
+      config.localDir = '/localDir';
       git.getFileList.mockResolvedValue(['package.json']);
       fs.readLocalFile.mockResolvedValue('{}');
       await checkOnboardingBranch(config);


### PR DESCRIPTION
## Changes:

By default, [pnpm workspaces](https://pnpm.js.org/en/workspaces) keep a [single lockfile](https://pnpm.js.org/en/3.3/pnpm-recursive#shared-workspace-lockfile) at the root of the workspace. (Individual packages retain their own package.json files, but not individual lockfiles.)

If no existing `pnpmShrinkwrap` is found for a package, this code:
1. walks up the parent directories looking for a _workspace root_: a directory with a `pnpm-workspace.yaml` alongside a `pnp-lock.yaml`
2. if found, parses the `pnpm-workspace.yaml` for workspace _filters_
3. if the current `packageFile` falls into the filters, sets `package.pnpmShrinkwrap` to point to the `pnpm-lock.yaml` in the workspace root

_**This still needs tests which I'll add to `monorepo.spec.ts`.**_ I'm looking for feedback before doing so. Is it reasonable to model them after the fixture tests of [`managers/nuget/extract.spec.ts`](https://github.com/renovatebot/renovate/blob/master/lib/manager/nuget/extract.spec.ts)?

## Context:

Closes #6782

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

Example PR: https://github.com/kyle-johnson/rollup-plugin-optimize-lodash-imports/pull/26/files