### PR TITLE
refactor: remove currentVersion

### DIFF
--- a/lib/config/__snapshots__/migration.spec.ts.snap
+++ b/lib/config/__snapshots__/migration.spec.ts.snap
@@ -88,7 +88,6 @@ Object {
   "branchName": "{{{branchPrefix}}}{{{additionalBranchPrefix}}}{{{branchTopic}}}{{{packageFileDir}}}",
   "branchPrefix": "renovate/",
   "commitMessage": "{{#if semanticCommitType}}{{semanticCommitType}}{{#if semanticCommitScope}}({{semanticCommitScope}}){{/if}}: {{/if}}some commit message",
-  "commitMessageExtra": "{{currentValue}} something",
   "constraints": Object {
     "python": "3.7",
   },
@@ -318,6 +317,22 @@ Object {
         "other/package.json",
       ],
       "rangeStrategy": "pin",
+    },
+  ],
+}
+`;
+
+exports[`config/migration migrateConfig(config, parentConfig) migrates packageRules objects 1`] = `
+Object {
+  "packageRules": Array [
+    Object {
+      "commitMessage": "fix(package): update peerDependency to accept typescript ^{{newValue}} {{newValue}}",
+      "matchPackageNames": Array [
+        "typescript",
+      ],
+      "matchUpdateTypes": Array [
+        "major",
+      ],
     },
   ],
 }

--- a/lib/config/migration.spec.ts
+++ b/lib/config/migration.spec.ts
@@ -76,7 +76,6 @@ describe('config/migration', () => {
         commitMessage: '{{semanticPrefix}}some commit message',
         prTitle: '{{semanticPrefix}}some pr title',
         semanticPrefix: 'fix(deps): ',
-        commitMessageExtra: '{{currentVersion}} something',
         pathRules: [
           {
             paths: ['examples/**'],
@@ -314,7 +313,7 @@ describe('config/migration', () => {
           packageNames: ['typescript'],
           updateTypes: ['major'],
           commitMessage:
-            'fix(package): update peerDependency to accept typescript ^{{newVersion}}',
+            'fix(package): update peerDependency to accept typescript ^{{newVersion}} {{newVersion}}',
         },
       } as any;
       const { isMigrated, migratedConfig } = configMigration.migrateConfig(
@@ -322,6 +321,7 @@ describe('config/migration', () => {
         defaultConfig
       );
       expect(isMigrated).toBe(true);
+      expect(migratedConfig).toMatchSnapshot();
       expect(migratedConfig.packageRules).toHaveLength(1);
     });
     it('migrates node to travis', () => {

--- a/lib/config/migration.ts
+++ b/lib/config/migration.ts
@@ -493,17 +493,6 @@ export function migrateConfig(
         if (subMigrate.isMigrated) {
           migratedConfig[key] = subMigrate.migratedConfig;
         }
-      } else if (
-        (key.startsWith('commitMessage') || key.startsWith('prTitle')) &&
-        is.string(val)
-      ) {
-        migratedConfig[key] = val
-          .replace(/currentVersion/g, 'currentValue')
-          .replace(/newVersion/g, 'newValue')
-          .replace(/newValueMajor/g, 'newMajor')
-          .replace(/newValueMinor/g, 'newMinor')
-          .replace(/newVersionMajor/g, 'newMajor')
-          .replace(/newVersionMinor/g, 'newMinor');
       } else if (key === 'raiseDeprecationWarnings') {
         delete migratedConfig.raiseDeprecationWarnings;
         if (val === false) {
@@ -513,6 +502,22 @@ export function migrateConfig(
         }
       } else if (key === 'binarySource' && val === 'auto') {
         migratedConfig.binarySource = 'global';
+      }
+      const migratedTemplates = {
+        newVersion: 'newValue',
+        newValueMajor: 'newMajor',
+        newValueMinor: 'newMinor',
+        newVersionMajor: 'newMajor',
+        newVersionMinor: 'newMinor',
+        fromVersion: 'currentVersion',
+      };
+      if (is.string(migratedConfig[key])) {
+        for (const [from, to] of Object.entries(migratedTemplates)) {
+          migratedConfig[key] = (migratedConfig[key] as string).replace(
+            new RegExp(from, 'g'),
+            to
+          );
+        }
       }
     }
     if (migratedConfig.endpoints) {

--- a/lib/datasource/terraform-module/index.ts
+++ b/lib/datasource/terraform-module/index.ts
@@ -137,11 +137,11 @@ export async function getReleases({
       dep.homepage = `https://registry.terraform.io/modules/${repository}`;
     }
     // set published date for latest release
-    const currentVersion = dep.releases.find(
+    const latestVersion = dep.releases.find(
       (release) => res.version === release.version
     );
-    if (currentVersion) {
-      currentVersion.releaseTimestamp = res.published_at;
+    if (latestVersion) {
+      latestVersion.releaseTimestamp = res.published_at;
     }
     logger.trace({ dep }, 'dep');
     const cacheMinutes = 30;

--- a/lib/datasource/terraform-provider/index.ts
+++ b/lib/datasource/terraform-provider/index.ts
@@ -59,12 +59,12 @@ async function queryRegistry(
     version,
   }));
   // set published date for latest release
-  const currentVersion = dep.releases.find(
+  const latestVersion = dep.releases.find(
     (release) => res.version === release.version
   );
   // istanbul ignore else
-  if (currentVersion) {
-    currentVersion.releaseTimestamp = res.published_at;
+  if (latestVersion) {
+    latestVersion.releaseTimestamp = res.published_at;
   }
   dep.homepage = `${registryURL}/providers/${repository}`;
   logger.trace({ dep }, 'dep');

--- a/lib/manager/bazel/update.ts
+++ b/lib/manager/bazel/update.ts
@@ -12,12 +12,12 @@ function updateWithNewVersion(
   currentValue: string,
   newValue: string
 ): string {
-  const currentVersion = currentValue.replace(/^v/, '');
-  const newVersion = newValue.replace(/^v/, '');
+  const replaceFrom = currentValue.replace(/^v/, '');
+  const replaceTo = newValue.replace(/^v/, '');
   let newContent = content;
   do {
-    newContent = newContent.replace(currentVersion, newVersion);
-  } while (newContent.includes(currentVersion));
+    newContent = newContent.replace(replaceFrom, replaceTo);
+  } while (newContent.includes(replaceFrom));
   return newContent;
 }
 

--- a/lib/manager/common.ts
+++ b/lib/manager/common.ts
@@ -187,7 +187,6 @@ export interface Upgrade<T = Record<string, any>>
     NpmLockFiles {
   isLockfileUpdate?: boolean;
   currentRawValue?: any;
-  currentVersion?: string;
   depGroup?: string;
   dockerRepository?: string;
   localDir?: string;

--- a/lib/manager/gomod/update.spec.ts
+++ b/lib/manager/gomod/update.spec.ts
@@ -153,7 +153,6 @@ describe('manager/gomod/update', () => {
       const upgrade = {
         depName: 'github.com/spf13/jwalterweatherman',
         managerData: { lineNumber: 43, multiLine: true },
-        currentVersion: 'v0.0.0',
         updateType: 'digest' as UpdateType,
         currentDigest: '14d3d4c51834',
         newDigest: '123456123456abcdef',
@@ -168,7 +167,6 @@ describe('manager/gomod/update', () => {
       const upgrade = {
         depName: 'github.com/spf13/jwalterweatherman',
         managerData: { lineNumber: 43, multiLine: true },
-        currentVersion: 'v0.0.0',
         updateType: 'digest' as UpdateType,
         currentDigest: 'abcdefabcdef',
         newDigest: '14d3d4c51834000000',

--- a/lib/util/template/index.ts
+++ b/lib/util/template/index.ts
@@ -40,7 +40,6 @@ export const allowedFields = {
   baseBranch: 'The baseBranch for this branch/PR',
   body: 'The body of the release notes',
   currentValue: 'The extracted current value of the dependency being updated',
-  currentVersion: 'The current version that is being updated',
   datasource: 'The datasource used to look up the upgrade',
   depName: 'The name of the dependency being updated',
   depNameLinked:
@@ -52,7 +51,7 @@ export const allowedFields = {
   displayFrom: 'The current value, formatted for display',
   displayTo: 'The to value, formatted for display',
   fromVersion:
-    'The version that would be currently installed. For example, if currentValue is ^3.0.0 then currentVersion might be 3.1.0.',
+    'The version that would be currently installed. For example, if currentValue is ^3.0.0 then fromVersion might be 3.1.0.',
   hasReleaseNotes: 'true if the upgrade has release notes',
   isLockfileUpdate: 'true if the branch is a lock file update',
   isMajor: 'true if the upgrade is major',

--- a/lib/workers/common.ts
+++ b/lib/workers/common.ts
@@ -31,7 +31,6 @@ export interface BranchUpgradeConfig
   currentDigest?: string;
   currentDigestShort?: string;
   currentValue?: string;
-  currentVersion?: string;
   endpoint?: string;
   excludeCommitPaths?: string[];
   githubName?: string;

--- a/lib/workers/repository/updates/flatten.ts
+++ b/lib/workers/repository/updates/flatten.ts
@@ -48,8 +48,6 @@ export async function flattenUpdates(
           for (const update of dep.updates) {
             let updateConfig = mergeChildConfig(depConfig, update);
             delete updateConfig.updates;
-            // Massage legacy vars just in case
-            updateConfig.currentVersion = updateConfig.currentValue;
             updateConfig.newVersion =
               updateConfig.newVersion || updateConfig.newValue;
             if (updateConfig.updateType) {

--- a/lib/workers/repository/updates/generate.ts
+++ b/lib/workers/repository/updates/generate.ts
@@ -120,8 +120,7 @@ export function generateBranchConfig(
     }
     if (!upgrade.displayFrom) {
       if (upgrade.currentValue === upgrade.newValue) {
-        upgrade.displayFrom =
-          upgrade.currentDigestShort || upgrade.currentVersion || '';
+        upgrade.displayFrom = upgrade.currentDigestShort || '';
         upgrade.displayTo =
           upgrade.displayTo ||
           upgrade.newDigestShort ||
@@ -129,10 +128,7 @@ export function generateBranchConfig(
           '';
       } else {
         upgrade.displayFrom =
-          upgrade.currentValue ||
-          upgrade.currentVersion ||
-          upgrade.currentDigestShort ||
-          '';
+          upgrade.currentValue || upgrade.currentDigestShort || '';
         upgrade.displayTo =
           upgrade.displayTo ||
           upgrade.newValue ||


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Removes use of `currentVersion`

## Context:

One step towards a reduced set of slimmed-down variables.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
