### PR TITLE
fix(gradle-lite): Always use Maven registry url

### DIFF
--- a/lib/manager/gradle-lite/extract.spec.ts
+++ b/lib/manager/gradle-lite/extract.spec.ts
@@ -54,7 +54,10 @@ describe('manager/gradle-lite/extract', () => {
           {
             depName: 'foo:bar',
             currentValue: '1.2.3',
-            registryUrls: ['https://example.com'],
+            registryUrls: [
+              'https://repo.maven.apache.org/maven2',
+              'https://example.com',
+            ],
           },
         ],
       },

--- a/lib/manager/gradle-lite/extract.ts
+++ b/lib/manager/gradle-lite/extract.ts
@@ -1,5 +1,5 @@
 import * as upath from 'upath';
-import * as datasourceMaven from '../../datasource/maven';
+import { id as datasource, defaultRegistryUrls } from '../../datasource/maven';
 import { logger } from '../../logger';
 import { readLocalFile } from '../../util/fs';
 import { ExtractConfig, PackageDependency, PackageFile } from '../common';
@@ -39,7 +39,7 @@ export async function extractAllPackageFiles(
   for (const packageFile of reorderFiles(packageFiles)) {
     packageFilesByName[packageFile] = {
       packageFile,
-      datasource: datasourceMaven.id,
+      datasource,
       deps: [],
     };
 
@@ -90,7 +90,11 @@ export async function extractAllPackageFiles(
     const { deps } = pkgFile;
     deps.push({
       ...dep,
-      registryUrls: [...(dep.registryUrls || []), ...registryUrls],
+      registryUrls: [
+        ...defaultRegistryUrls,
+        ...(dep.registryUrls || []),
+        ...registryUrls,
+      ],
     });
     packageFilesByName[key] = pkgFile;
   });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Always prepend with Maven default registry URLs no matter what values are parsed, empty or not

## Context:

Closes #8701

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
