### PR TITLE
chore: fix paragraphs label-actions comments

### DIFF
--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -17,6 +17,7 @@
 
     Good luck,
 
+
     The Renovate team
 
 'reproduction:provided':

--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -2,14 +2,18 @@
   comment: >
     Hi there,
 
+
     The Renovate team needs your help!
     To fix the problem, we first need to know exactly what's causing the bug.
     A minimal reproduction help us to pinpoint the exact cause of the bug.
 
+
     To get started, please read our guide on [minimal reproductions](https://github.com/renovatebot/renovate/blob/master/docs/development/minimal-reproductions.md) to understand what is needed.
+
 
     We may close the issue if you have not provided a minimal reproduction within two weeks.
     If you need more time, or are stuck, please ask for help or more time in a comment.
+
 
     Good luck,
 
@@ -19,6 +23,7 @@
   comment: >
     Thank you for providing a reproduction! :tada: :rocket:
 
+
     The Renovate team will take a look at the reproduction repository.
     Once we confirm the provided repository reproduces the problem, the label will be changed to `reproduction:confirmed`.
 
@@ -26,7 +31,9 @@
   comment: >
     This issue has been labeled with `status:requirements`. This indicates that we don't know enough to start work and further requirements or a reproduction are needed first.
 
+
     This label will be replaced with `status:ready` once all requirements and reproductions necessary to start work have been met.
+
 
     If it's not clear _what_ is missing to move this issue forward, ask for clarification in a new comment.
     If you think we already have what we need to move forward, mention this in a new comment.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

- Add extra newlines

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

This should make it so that the bot uses paragraphs in its comments instead of a wall of text.
According to https://github.com/dessant/label-actions/issues/1 we need to use 2 newlines to get the bot to format its text nicely.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
