### PR TITLE
refactor: use object not array for helm cache

### DIFF
--- a/lib/datasource/helm/index.ts
+++ b/lib/datasource/helm/index.ts
@@ -23,12 +23,14 @@ export const defaultConfig = {
   },
 };
 
+export type RepositoryData = Record<string, ReleaseResult>;
+
 export async function getRepositoryData(
   repository: string
-): Promise<Record<string, ReleaseResult>> {
+): Promise<RepositoryData> {
   const cacheNamespace = 'datasource-helm';
   const cacheKey = repository;
-  const cachedIndex = await packageCache.get<Record<string, ReleaseResult>>(
+  const cachedIndex = await packageCache.get<RepositoryData>(
     cacheNamespace,
     cacheKey
   );
@@ -73,7 +75,7 @@ export async function getRepositoryData(
       logger.warn(`Failed to parse index.yaml from ${repository}`);
       return null;
     }
-    const result: Record<string, ReleaseResult> = {};
+    const result: RepositoryData = {};
     for (const [name, releases] of Object.entries(doc.entries)) {
       result[name] = {
         name,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Refactors helm caching to use an object instead of array.

## Context:

Makes #8715 simpler.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
