### PR TITLE
refactor: remove unused ReleaseResult fields

### DIFF
--- a/lib/datasource/common.ts
+++ b/lib/datasource/common.ts
@@ -56,18 +56,10 @@ export interface ReleaseResult {
   changelogUrl?: string;
   dependencyUrl?: string;
   deprecationMessage?: string;
-  display?: string;
-  dockerRegistry?: string;
-  dockerRepository?: string;
-  group?: string;
   homepage?: string;
-  name?: string;
-  pkgName?: string;
   releases: Release[];
   sourceUrl?: string;
   tags?: Record<string, string>;
-  versions?: any;
-  registryUrl?: string;
   isPrivate?: boolean;
 }
 

--- a/lib/datasource/docker/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/docker/__snapshots__/index.spec.ts.snap
@@ -567,8 +567,6 @@ Array [
 
 exports[`datasource/docker/index getReleases ignores unsupported manifest 1`] = `
 Object {
-  "dockerRegistry": "https://registry.company.com",
-  "dockerRepository": "node",
   "releases": Array [],
 }
 `;
@@ -622,8 +620,6 @@ Array [
 
 exports[`datasource/docker/index getReleases ignores unsupported schema version 1`] = `
 Object {
-  "dockerRegistry": "https://registry.company.com",
-  "dockerRepository": "node",
   "releases": Array [],
 }
 `;
@@ -752,8 +748,6 @@ Array [
 
 exports[`datasource/docker/index getReleases supports labels 1`] = `
 Object {
-  "dockerRegistry": "https://registry.company.com",
-  "dockerRepository": "node",
   "releases": Array [],
   "sourceUrl": "https://github.com/renovatebot/renovate",
 }
@@ -828,8 +822,6 @@ Array [
 
 exports[`datasource/docker/index getReleases supports manifest lists 1`] = `
 Object {
-  "dockerRegistry": "https://registry.company.com",
-  "dockerRepository": "node",
   "releases": Array [],
   "sourceUrl": "https://github.com/renovatebot/renovate",
 }
@@ -925,8 +917,6 @@ Array [
 
 exports[`datasource/docker/index getReleases supports redirect 1`] = `
 Object {
-  "dockerRegistry": "https://registry.company.com",
-  "dockerRepository": "node",
   "releases": Array [],
 }
 `;

--- a/lib/datasource/docker/index.ts
+++ b/lib/datasource/docker/index.ts
@@ -66,13 +66,11 @@ export function getRegistryRepository(
   registryUrl: string
 ): RegistryRepository {
   if (registryUrl !== defaultRegistryUrls[0]) {
-    const dockerRegistry = registryUrl
-      .replace('https://', '')
-      .replace(/\/?$/, '/');
-    if (lookupName.startsWith(dockerRegistry)) {
+    const registry = registryUrl.replace('https://', '').replace(/\/?$/, '/');
+    if (lookupName.startsWith(registry)) {
       return {
-        registry: dockerRegistry,
-        repository: lookupName.replace(dockerRegistry, ''),
+        registry,
+        repository: lookupName.replace(registry, ''),
       };
     }
   }
@@ -623,8 +621,6 @@ export async function getReleases({
   }
   const releases = tags.map((version) => ({ version }));
   const ret: ReleaseResult = {
-    dockerRegistry: registry,
-    dockerRepository: repository,
     releases,
   };
 

--- a/lib/datasource/helm/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/helm/__snapshots__/index.spec.ts.snap
@@ -17,7 +17,6 @@ Array [
 exports[`datasource/helm getReleases returns list of versions for normal response 1`] = `
 Object {
   "homepage": "https://www.getambassador.io/",
-  "name": "ambassador",
   "releases": Array [
     Object {
       "releaseTimestamp": "2019-02-13T00:56:01.476Z",

--- a/lib/datasource/helm/index.ts
+++ b/lib/datasource/helm/index.ts
@@ -78,7 +78,6 @@ export async function getRepositoryData(
     const result: RepositoryData = {};
     for (const [name, releases] of Object.entries(doc.entries)) {
       result[name] = {
-        name,
         homepage: releases[0].home,
         sourceUrl: releases[0].sources ? releases[0].sources[0] : undefined,
         releases: releases.map((release) => ({

--- a/lib/datasource/jenkins-plugins/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/jenkins-plugins/__snapshots__/index.spec.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`datasource/jenkins-plugins/index getReleases returns package releases for a hit for info and miss for releases 1`] = `
 Object {
-  "name": "email-ext",
   "releases": Array [],
   "sourceUrl": "https://github.com/jenkinsci/email-ext-plugin",
 }
@@ -10,7 +9,6 @@ Object {
 
 exports[`datasource/jenkins-plugins/index getReleases returns package releases for a hit for info and releases 1`] = `
 Object {
-  "name": "email-ext",
   "releases": Array [
     Object {
       "downloadUrl": "http://updates.jenkins-ci.org/download/plugins/email-ext/2.10/email-ext.hpi",

--- a/lib/datasource/jenkins-plugins/get.ts
+++ b/lib/datasource/jenkins-plugins/get.ts
@@ -71,7 +71,6 @@ function updateJenkinsPluginInfoCacheCallback(
   for (const name of Object.keys(response.plugins || [])) {
     // eslint-disable-next-line no-param-reassign
     cache.cache[name] = {
-      name,
       releases: [], // releases are stored in another cache
       sourceUrl: response.plugins[name]?.scm,
     };

--- a/lib/datasource/jenkins-plugins/index.spec.ts
+++ b/lib/datasource/jenkins-plugins/index.spec.ts
@@ -68,7 +68,6 @@ describe(getName(__filename), () => {
       expect(res.sourceUrl).toBe(
         'https://github.com/jenkinsci/email-ext-plugin'
       );
-      expect(res.name).toBe('email-ext');
 
       expect(
         res.releases.find((release) => release.version === '2.69')
@@ -100,7 +99,6 @@ describe(getName(__filename), () => {
       expect(res.sourceUrl).toBe(
         'https://github.com/jenkinsci/email-ext-plugin'
       );
-      expect(res.name).toBe('email-ext');
     });
 
     it('returns null empty response', async () => {

--- a/lib/datasource/nuget/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/nuget/__snapshots__/index.spec.ts.snap
@@ -67,7 +67,6 @@ Array [
 
 exports[`datasource/nuget getReleases handles paginated results (v2) 1`] = `
 Object {
-  "pkgName": "nunit",
   "releases": Array [
     Object {
       "version": "1.0.0",
@@ -104,7 +103,6 @@ Array [
 
 exports[`datasource/nuget getReleases processes real data (v2) 1`] = `
 Object {
-  "pkgName": "nunit",
   "releases": Array [
     Object {
       "releaseTimestamp": "2011-01-07T07:57:55.387+00:00",
@@ -308,7 +306,6 @@ Array [
 exports[`datasource/nuget getReleases processes real data (v3) feed is a nuget.org 1`] = `
 Object {
   "homepage": "https://nunit.org/",
-  "pkgName": "nunit",
   "releases": Array [
     Object {
       "releaseTimestamp": "2011-01-07T07:57:55.387+00:00",
@@ -543,7 +540,6 @@ Array [
 exports[`datasource/nuget getReleases processes real data (v3) feed is not a nuget.org 1`] = `
 Object {
   "homepage": "https://nunit.org/",
-  "pkgName": "nunit",
   "releases": Array [
     Object {
       "releaseTimestamp": "2011-01-07T07:57:55.387+00:00",
@@ -777,7 +773,6 @@ Array [
 exports[`datasource/nuget getReleases processes real data (v3) for several catalog pages 1`] = `
 Object {
   "homepage": "https://nlog-project.org/",
-  "pkgName": "nlog",
   "releases": Array [
     Object {
       "releaseTimestamp": "2011-01-07T07:57:35.043+00:00",
@@ -1586,7 +1581,6 @@ Array [
 
 exports[`datasource/nuget getReleases processes real data with no github project url (v2) 1`] = `
 Object {
-  "pkgName": "nunit",
   "releases": Array [
     Object {
       "version": "3.11.0",
@@ -1612,7 +1606,6 @@ Array [
 
 exports[`datasource/nuget getReleases processes real data without project url (v2) 1`] = `
 Object {
-  "pkgName": "nunit",
   "releases": Array [
     Object {
       "version": "2.5.7.10213",
@@ -1764,7 +1757,6 @@ Array [
 exports[`datasource/nuget getReleases returns deduplicated results 1`] = `
 Object {
   "homepage": "https://nunit.org/",
-  "pkgName": "nunit",
   "releases": Array [
     Object {
       "releaseTimestamp": "2011-01-07T07:57:55.387+00:00",

--- a/lib/datasource/nuget/v2.ts
+++ b/lib/datasource/nuget/v2.ts
@@ -16,7 +16,6 @@ export async function getReleases(
   pkgName: string
 ): Promise<ReleaseResult | null> {
   const dep: ReleaseResult = {
-    pkgName,
     releases: [],
   };
   let pkgUrlList = `${feedUrl.replace(

--- a/lib/datasource/nuget/v3.ts
+++ b/lib/datasource/nuget/v3.ts
@@ -173,7 +173,6 @@ export async function getReleases(
   }
 
   const dep: ReleaseResult = {
-    pkgName,
     releases,
   };
 

--- a/lib/datasource/orb/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/orb/__snapshots__/index.spec.ts.snap
@@ -3,7 +3,6 @@
 exports[`datasource/orb getReleases processes homeUrl 1`] = `
 Object {
   "homepage": "https://google.com",
-  "name": "hyper-expanse/library-release-workflows",
   "releases": Array [
     Object {
       "releaseTimestamp": "2018-12-11T05:28:14.080Z",
@@ -46,7 +45,6 @@ Object {
       "version": "4.2.0",
     },
   ],
-  "versions": Object {},
 }
 `;
 
@@ -85,7 +83,6 @@ Array [
 exports[`datasource/orb getReleases processes real data 1`] = `
 Object {
   "homepage": "https://circleci.com/developer/orbs/orb/hyper-expanse/library-release-workflows",
-  "name": "hyper-expanse/library-release-workflows",
   "releases": Array [
     Object {
       "releaseTimestamp": "2018-12-11T05:28:14.080Z",
@@ -128,7 +125,6 @@ Object {
       "version": "4.2.0",
     },
   ],
-  "versions": Object {},
 }
 `;
 

--- a/lib/datasource/orb/index.ts
+++ b/lib/datasource/orb/index.ts
@@ -50,8 +50,6 @@ export async function getReleases({
   }
   // Simplify response before caching and returning
   const dep: ReleaseResult = {
-    name: lookupName,
-    versions: {},
     releases: null,
   };
   if (res.homeUrl?.length) {

--- a/lib/datasource/packagist/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/packagist/__snapshots__/index.spec.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`datasource/packagist getReleases adds packagist source implicitly 1`] = `
 Object {
-  "name": "drewm/mailchimp-api",
   "releases": Array [
     Object {
       "gitRef": "v1.0",
@@ -236,7 +235,6 @@ Array [
 
 exports[`datasource/packagist getReleases processes real versioned data 1`] = `
 Object {
-  "name": "drewm/mailchimp-api",
   "releases": Array [
     Object {
       "gitRef": "v1.0",
@@ -336,7 +334,6 @@ Array [
 exports[`datasource/packagist getReleases supports includes packages 1`] = `
 Object {
   "homepage": "http://guzzlephp.org/",
-  "name": "guzzlehttp/guzzle",
   "releases": Array [
     Object {
       "gitRef": "v3.0.0",
@@ -507,7 +504,6 @@ Array [
 
 exports[`datasource/packagist getReleases supports lazy repositories 1`] = `
 Object {
-  "name": "guzzlehttp/guzzle",
   "releases": Array [
     Object {
       "gitRef": "5.3.4",
@@ -548,7 +544,6 @@ Array [
 
 exports[`datasource/packagist getReleases supports plain packages 1`] = `
 Object {
-  "name": "vendor/package-name",
   "releases": Array [
     Object {
       "gitRef": "0.0.1",
@@ -584,7 +579,6 @@ Array [
 exports[`datasource/packagist getReleases supports provider-includes 1`] = `
 Object {
   "homepage": "https://wordpress.org/plugins/1beyt/",
-  "name": "wpackagist-plugin/1beyt",
   "releases": Array [
     Object {
       "gitRef": "1.0",
@@ -649,7 +643,6 @@ Array [
 exports[`datasource/packagist getReleases supports providers 1`] = `
 Object {
   "homepage": "https://wordpress.org/plugins/1beyt/",
-  "name": "wpackagist-plugin/1beyt",
   "releases": Array [
     Object {
       "gitRef": "1.0",

--- a/lib/datasource/packagist/index.ts
+++ b/lib/datasource/packagist/index.ts
@@ -188,7 +188,6 @@ async function getAllPackages(regUrl: string): Promise<AllPackages | null> {
       if (res.packages) {
         for (const [key, val] of Object.entries(res.packages)) {
           const dep = extractDepReleases(val);
-          dep.name = key;
           includesPackages[key] = dep;
         }
       }
@@ -233,7 +232,6 @@ async function packagistOrgLookup(name: string): Promise<ReleaseResult> {
   const res = (await http.getJson<any>(pkgUrl)).body.packages[name];
   if (res) {
     dep = extractDepReleases(res);
-    dep.name = name;
     logger.trace({ dep }, 'dep');
   }
   const cacheMinutes = 10;
@@ -260,7 +258,6 @@ async function packageLookup(
     } = allPackages;
     if (packages?.[name]) {
       const dep = extractDepReleases(packages[name]);
-      dep.name = name;
       return dep;
     }
     if (includesPackages?.[name]) {
@@ -285,7 +282,6 @@ async function packageLookup(
       name
     ];
     const dep = extractDepReleases(versions);
-    dep.name = name;
     logger.trace({ dep }, 'dep');
     return dep;
   } catch (err) /* istanbul ignore next */ {

--- a/lib/datasource/rubygems/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/rubygems/__snapshots__/index.spec.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`datasource/rubygems getReleases returns a dep for rubygems.org package hit 1`] = `
 Object {
-  "name": "1pass",
   "releases": Array [
     Object {
       "version": "0.1.0",
@@ -2520,7 +2519,6 @@ Array [
 
 exports[`datasource/rubygems getReleases uses rubygems.org if no registry urls were provided 1`] = `
 Object {
-  "name": "1pass",
   "releases": Array [
     Object {
       "version": "0.1.0",

--- a/lib/datasource/rubygems/get-rubygems-org.ts
+++ b/lib/datasource/rubygems/get-rubygems-org.ts
@@ -115,7 +115,6 @@ export async function getRubygemsOrgDependency(
     return null;
   }
   const dep: ReleaseResult = {
-    name: lookupName,
     releases: packageReleases[lookupName].map((version) => ({ version })),
   };
   return dep;

--- a/lib/datasource/sbt-package/index.spec.ts
+++ b/lib/datasource/sbt-package/index.spec.ts
@@ -180,9 +180,6 @@ describe('datasource/sbt', () => {
         })
       ).toEqual({
         dependencyUrl: 'https://repo.maven.apache.org/maven2/org/scalatest',
-        display: 'org.scalatest:scalatest',
-        group: 'org.scalatest',
-        name: 'scalatest',
         releases: [{ version: '1.2.0' }, { version: '1.2.3' }],
       });
       expect(
@@ -194,9 +191,6 @@ describe('datasource/sbt', () => {
         })
       ).toEqual({
         dependencyUrl: 'https://repo.maven.apache.org/maven2/org/scalatest',
-        display: 'org.scalatest:scalatest_2.12',
-        group: 'org.scalatest',
-        name: 'scalatest_2.12',
         releases: [{ version: '1.2.3' }],
       });
     });
@@ -211,9 +205,6 @@ describe('datasource/sbt', () => {
         })
       ).toEqual({
         dependencyUrl: 'https://repo.maven.apache.org/maven2/org/scalatest',
-        display: 'org.scalatest:scalatest-app_2.12',
-        group: 'org.scalatest',
-        name: 'scalatest-app_2.12',
         releases: [{ version: '6.5.4' }],
         homepage: 'http://www.scalatest.org',
         sourceUrl: 'https://github.com/scalatest/scalatest',
@@ -227,9 +218,6 @@ describe('datasource/sbt', () => {
         })
       ).toEqual({
         dependencyUrl: 'https://repo.maven.apache.org/maven2/org/scalatest',
-        display: 'org.scalatest:scalatest-flatspec_2.12',
-        group: 'org.scalatest',
-        name: 'scalatest-flatspec_2.12',
         releases: [{ version: '6.5.4' }],
         sourceUrl: 'https://github.com/scalatest/scalatest',
       });
@@ -242,9 +230,6 @@ describe('datasource/sbt', () => {
         })
       ).toEqual({
         dependencyUrl: 'https://repo.maven.apache.org/maven2/org/scalatest',
-        display: 'org.scalatest:scalatest-matchers-core_2.12',
-        group: 'org.scalatest',
-        name: 'scalatest-matchers-core_2.12',
         releases: [{ version: '6.5.4' }],
         homepage: 'http://www.scalatest.org',
       });

--- a/lib/datasource/sbt-package/index.ts
+++ b/lib/datasource/sbt-package/index.ts
@@ -167,9 +167,6 @@ export async function getReleases({
     if (versions) {
       return {
         ...urls,
-        display: lookupName,
-        group: groupId,
-        name: artifactId,
         dependencyUrl,
         releases: versions.map((v) => ({ version: v })),
       };

--- a/lib/datasource/sbt-plugin/index.spec.ts
+++ b/lib/datasource/sbt-plugin/index.spec.ts
@@ -157,9 +157,6 @@ describe('datasource/sbt', () => {
       ).toEqual({
         dependencyUrl:
           'https://dl.bintray.com/sbt/sbt-plugin-releases/org.foundweekends/sbt-bintray',
-        display: 'org.foundweekends:sbt-bintray',
-        group: 'org.foundweekends',
-        name: 'sbt-bintray',
         releases: [{ version: '0.5.5' }],
       });
       expect(
@@ -172,9 +169,6 @@ describe('datasource/sbt', () => {
       ).toEqual({
         dependencyUrl:
           'https://dl.bintray.com/sbt/sbt-plugin-releases/org.foundweekends/sbt-bintray',
-        display: 'org.foundweekends:sbt-bintray_2.12',
-        group: 'org.foundweekends',
-        name: 'sbt-bintray_2.12',
         releases: [{ version: '0.5.5' }],
       });
     });
@@ -190,9 +184,6 @@ describe('datasource/sbt', () => {
       ).toEqual({
         dependencyUrl:
           'https://repo.maven.apache.org/maven2/io/get-coursier/sbt-coursier',
-        display: 'io.get-coursier:sbt-coursier',
-        group: 'io.get-coursier',
-        name: 'sbt-coursier',
         releases: [
           { version: '2.0.0-RC2' },
           { version: '2.0.0-RC6-1' },

--- a/lib/datasource/sbt-plugin/index.ts
+++ b/lib/datasource/sbt-plugin/index.ts
@@ -107,9 +107,6 @@ export async function getReleases({
     if (versions) {
       return {
         ...urls,
-        display: lookupName,
-        group: groupId,
-        name: artifactId,
         dependencyUrl,
         releases: versions.map((v) => ({ version: v })),
       };

--- a/lib/datasource/terraform-module/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/terraform-module/__snapshots__/index.spec.ts.snap
@@ -3,7 +3,6 @@
 exports[`datasource/terraform-module getReleases processes real data 1`] = `
 Object {
   "homepage": "https://registry.terraform.io/modules/hashicorp/consul/aws",
-  "name": "hashicorp/consul/aws",
   "releases": Array [
     Object {
       "version": "0.0.1",
@@ -77,7 +76,6 @@ Object {
     },
   ],
   "sourceUrl": "https://github.com/hashicorp/terraform-aws-consul",
-  "versions": Object {},
 }
 `;
 
@@ -133,7 +131,6 @@ Array [
 
 exports[`datasource/terraform-module getReleases processes real data on changed subpath 2`] = `
 Object {
-  "name": "hashicorp/consul/aws",
   "releases": Array [
     Object {
       "version": "0.0.1",
@@ -207,14 +204,12 @@ Object {
     },
   ],
   "sourceUrl": "https://github.com/hashicorp/terraform-aws-consul",
-  "versions": Object {},
 }
 `;
 
 exports[`datasource/terraform-module getReleases processes with registry in name 1`] = `
 Object {
   "homepage": "https://registry.terraform.io/modules/hashicorp/consul/aws",
-  "name": "hashicorp/consul/aws",
   "releases": Array [
     Object {
       "version": "0.0.1",
@@ -288,7 +283,6 @@ Object {
     },
   ],
   "sourceUrl": "https://github.com/hashicorp/terraform-aws-consul",
-  "versions": Object {},
 }
 `;
 

--- a/lib/datasource/terraform-module/index.ts
+++ b/lib/datasource/terraform-module/index.ts
@@ -123,8 +123,6 @@ export async function getReleases({
     }
     // Simplify response before caching and returning
     const dep: ReleaseResult = {
-      name: repository,
-      versions: {},
       releases: null,
     };
     if (res.source) {

--- a/lib/datasource/terraform-provider/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/terraform-provider/__snapshots__/index.spec.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`datasource/terraform getReleases processes data with alternative backend 1`] = `
 Object {
-  "name": "hashicorp/google-beta",
   "releases": Array [
     Object {
       "version": "1.19.0",
@@ -15,7 +14,6 @@ Object {
     },
   ],
   "sourceUrl": "https://github.com/terraform-providers/terraform-provider-google-beta",
-  "versions": Object {},
 }
 `;
 
@@ -57,7 +55,6 @@ Array [
 exports[`datasource/terraform getReleases processes real data 1`] = `
 Object {
   "homepage": "https://registry.terraform.io/providers/hashicorp/azurerm",
-  "name": "hashicorp/azurerm",
   "releases": Array [
     Object {
       "version": "0.1.0",
@@ -257,7 +254,6 @@ Object {
     },
   ],
   "sourceUrl": "https://github.com/terraform-providers/terraform-provider-azurerm",
-  "versions": Object {},
 }
 `;
 
@@ -289,7 +285,6 @@ Array [
 exports[`datasource/terraform getReleases processes real data from lookupName 1`] = `
 Object {
   "homepage": "https://registry.company.com/providers/hashicorp/azurerm",
-  "name": "hashicorp/azurerm",
   "releases": Array [
     Object {
       "version": "0.1.0",
@@ -489,7 +484,6 @@ Object {
     },
   ],
   "sourceUrl": "https://github.com/terraform-providers/terraform-provider-azurerm",
-  "versions": Object {},
 }
 `;
 

--- a/lib/datasource/terraform-provider/index.ts
+++ b/lib/datasource/terraform-provider/index.ts
@@ -48,8 +48,6 @@ async function queryRegistry(
   const backendURL = `${registryURL}${serviceDiscovery['providers.v1']}${repository}`;
   const res = (await http.getJson<TerraformProvider>(backendURL)).body;
   const dep: ReleaseResult = {
-    name: repository,
-    versions: {},
     releases: null,
   };
   if (res.source) {
@@ -87,8 +85,6 @@ async function queryReleaseBackend(
   }
 
   const dep: ReleaseResult = {
-    name: repository,
-    versions: {},
     releases: null,
     sourceUrl: `https://github.com/terraform-providers/${backendLookUpName}`,
   };

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -24,8 +24,6 @@ import { RollbackConfig, getRollbackUpdate } from './rollback';
 
 export interface UpdateResult {
   sourceDirectory?: string;
-  dockerRepository?: string;
-  dockerRegistry?: string;
   changelogUrl?: string;
   dependencyUrl?: string;
   homepage?: string;
@@ -200,12 +198,6 @@ export async function lookupUpdates(
     res.homepage = dependency.homepage;
     res.changelogUrl = dependency.changelogUrl;
     res.dependencyUrl = dependency?.dependencyUrl;
-    // TODO: improve this
-    // istanbul ignore if
-    if (dependency.dockerRegistry) {
-      res.dockerRegistry = dependency.dockerRegistry;
-      res.dockerRepository = dependency.dockerRepository;
-    }
     const { latestVersion, releases } = dependency;
     // Filter out any results from datasource that don't comply with our versioning
     let allVersions = releases.filter((release) =>


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Removes unused fields from `ReleaseResult`.

## Context:

Merge before #8715 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
