### PR TITLE
feat: add require to semanticPrefixFixDepsChoreOthers

### DIFF
--- a/lib/config/presets/__snapshots__/index.spec.ts.snap
+++ b/lib/config/presets/__snapshots__/index.spec.ts.snap
@@ -374,6 +374,7 @@ Object {
     Object {
       "matchDepTypes": Array [
         "dependencies",
+        "require",
       ],
       "semanticCommitType": "fix",
     },

--- a/lib/config/presets/internal/default.ts
+++ b/lib/config/presets/internal/default.ts
@@ -190,7 +190,7 @@ export const presets: Record<string, Preset> = {
         semanticCommitType: 'chore',
       },
       {
-        matchDepTypes: ['dependencies'],
+        matchDepTypes: ['dependencies', 'require'],
         semanticCommitType: 'fix',
       },
     ],


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

This PR changes `config:base` so that composer production dependencies (`require`) use semantic commit prefix `fix` when previously they used `chore`. This matches the default behavior of `semanticCommits: true` under the npm package manager.

## Context:

Closes #8736 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
