### PR TITLE
refactor: latestVersion -> tags.latest

### DIFF
--- a/lib/datasource/common.ts
+++ b/lib/datasource/common.ts
@@ -52,7 +52,6 @@ export interface Release {
 
 export interface ReleaseResult {
   sourceDirectory?: string;
-  latestVersion?: string;
   changelogUrl?: string;
   dependencyUrl?: string;
   deprecationMessage?: string;

--- a/lib/datasource/npm/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/npm/__snapshots__/index.spec.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`datasource/npm/index should fetch package info from custom registry 1`] = `
 Object {
-  "latestVersion": "0.0.1",
   "name": "foobar",
   "releases": Array [
     Object {
@@ -25,7 +24,6 @@ Object {
 
 exports[`datasource/npm/index should fetch package info from npm 1`] = `
 Object {
-  "latestVersion": "0.0.1",
   "name": "foobar",
   "releases": Array [
     Object {
@@ -48,7 +46,6 @@ Object {
 
 exports[`datasource/npm/index should handle foobar 1`] = `
 Object {
-  "latestVersion": "0.0.1",
   "name": "foobar",
   "releases": Array [
     Object {
@@ -71,7 +68,6 @@ Object {
 
 exports[`datasource/npm/index should handle no time 1`] = `
 Object {
-  "latestVersion": "0.0.1",
   "name": "foobar",
   "releases": Array [
     Object {
@@ -93,7 +89,6 @@ Object {
 
 exports[`datasource/npm/index should parse repo url (string) 1`] = `
 Object {
-  "latestVersion": "0.0.1",
   "name": "foobar",
   "releases": Array [
     Object {
@@ -111,7 +106,6 @@ Object {
 
 exports[`datasource/npm/index should parse repo url 1`] = `
 Object {
-  "latestVersion": "0.0.1",
   "name": "foobar",
   "releases": Array [
     Object {
@@ -129,7 +123,6 @@ Object {
 
 exports[`datasource/npm/index should replace any environment variable in npmrc 1`] = `
 Object {
-  "latestVersion": "0.0.1",
   "name": "foobar",
   "releases": Array [
     Object {
@@ -152,13 +145,12 @@ Object {
 
 exports[`datasource/npm/index should return deprecated 1`] = `
 Object {
-  "deprecationMessage": "On registry \`https://registry.npmjs.org/\`, the \\"latest\\" version (v0.0.2) of dependency \`foobar\` has the following deprecation notice:
+  "deprecationMessage": "On registry \`https://registry.npmjs.org/\`, the \\"latest\\" version of dependency \`foobar\` has the following deprecation notice:
 
 \`This is deprecated\`
 
 Marking the latest version of an npm package as deprecated results in the entire package being considered deprecated, so contact the package author you think this is a mistake.",
   "deprecationSource": "npm",
-  "latestVersion": "0.0.2",
   "name": "foobar",
   "releases": Array [
     Object {
@@ -180,7 +172,7 @@ Marking the latest version of an npm package as deprecated results in the entire
 `;
 
 exports[`datasource/npm/index should return deprecated 2`] = `
-"On registry \`https://registry.npmjs.org/\`, the \\"latest\\" version (v0.0.2) of dependency \`foobar\` has the following deprecation notice:
+"On registry \`https://registry.npmjs.org/\`, the \\"latest\\" version of dependency \`foobar\` has the following deprecation notice:
 
 \`This is deprecated\`
 
@@ -189,7 +181,6 @@ Marking the latest version of an npm package as deprecated results in the entire
 
 exports[`datasource/npm/index should send an authorization header if provided 1`] = `
 Object {
-  "latestVersion": "0.0.1",
   "name": "foobar",
   "releases": Array [
     Object {
@@ -212,7 +203,6 @@ Object {
 
 exports[`datasource/npm/index should use NPM_TOKEN if provided 1`] = `
 Object {
-  "latestVersion": "0.0.1",
   "name": "foobar",
   "releases": Array [
     Object {
@@ -235,7 +225,6 @@ Object {
 
 exports[`datasource/npm/index should use default registry if missing from npmrc 1`] = `
 Object {
-  "latestVersion": "0.0.1",
   "name": "foobar",
   "releases": Array [
     Object {
@@ -258,7 +247,6 @@ Object {
 
 exports[`datasource/npm/index should use host rules by baseUrl if provided 1`] = `
 Object {
-  "latestVersion": "0.0.1",
   "name": "foobar",
   "releases": Array [
     Object {
@@ -281,7 +269,6 @@ Object {
 
 exports[`datasource/npm/index should use host rules by hostName if provided 1`] = `
 Object {
-  "latestVersion": "0.0.1",
   "name": "foobar",
   "releases": Array [
     Object {

--- a/lib/datasource/npm/get.ts
+++ b/lib/datasource/npm/get.ts
@@ -35,7 +35,6 @@ export interface NpmDependency extends ReleaseResult {
   deprecationSource?: string;
   name: string;
   homepage: string;
-  latestVersion: string;
   sourceUrl: string;
   versions: Record<string, any>;
   'dist-tags': Record<string, string>;
@@ -194,7 +193,6 @@ export async function getDependency(
     const dep: NpmDependency = {
       name: res.name,
       homepage: res.homepage,
-      latestVersion: res['dist-tags'].latest,
       sourceUrl,
       versions: {},
       releases: null,
@@ -205,7 +203,7 @@ export async function getDependency(
       dep.sourceDirectory = res.repository.directory;
     }
     if (latestVersion.deprecated) {
-      dep.deprecationMessage = `On registry \`${regUrl}\`, the "latest" version (v${dep.latestVersion}) of dependency \`${packageName}\` has the following deprecation notice:\n\n\`${latestVersion.deprecated}\`\n\nMarking the latest version of an npm package as deprecated results in the entire package being considered deprecated, so contact the package author you think this is a mistake.`;
+      dep.deprecationMessage = `On registry \`${regUrl}\`, the "latest" version of dependency \`${packageName}\` has the following deprecation notice:\n\n\`${latestVersion.deprecated}\`\n\nMarking the latest version of an npm package as deprecated results in the entire package being considered deprecated, so contact the package author you think this is a mistake.`;
       dep.deprecationSource = id;
     }
     dep.releases = Object.keys(res.versions).map((version) => {

--- a/lib/workers/repository/process/lookup/__snapshots__/index.spec.ts.snap
+++ b/lib/workers/repository/process/lookup/__snapshots__/index.spec.ts.snap
@@ -310,7 +310,7 @@ exports[`workers/repository/process/lookup .lookupUpdates() ignores deprecated 1
 Object {
   "changelogUrl": undefined,
   "dependencyUrl": undefined,
-  "deprecationMessage": "On registry \`https://registry.npmjs.org/\`, the \\"latest\\" version (v1.4.1) of dependency \`q2\` has the following deprecation notice:
+  "deprecationMessage": "On registry \`https://registry.npmjs.org/\`, the \\"latest\\" version of dependency \`q2\` has the following deprecation notice:
 
 \`true\`
 

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -198,7 +198,8 @@ export async function lookupUpdates(
     res.homepage = dependency.homepage;
     res.changelogUrl = dependency.changelogUrl;
     res.dependencyUrl = dependency?.dependencyUrl;
-    const { latestVersion, releases } = dependency;
+    const { releases } = dependency;
+    const latestVersion = dependency.tags?.latest;
     // Filter out any results from datasource that don't comply with our versioning
     let allVersions = releases.filter((release) =>
       versioning.isVersion(release.version)
@@ -296,7 +297,7 @@ export async function lookupUpdates(
     let filteredVersions = filterVersions(
       config,
       filterStart,
-      dependency.latestVersion,
+      latestVersion,
       allVersions
     ).filter((v) =>
       // Leave only compatible versions


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Removes `latestVersion`, uses `tags.latest` instead.

## Context:

Types simplification.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
