### PR TITLE
fix: don’t imply patch from automerge settings

### DIFF
--- a/lib/workers/repository/process/lookup/__snapshots__/index.spec.ts.snap
+++ b/lib/workers/repository/process/lookup/__snapshots__/index.spec.ts.snap
@@ -977,52 +977,6 @@ Array [
 ]
 `;
 
-exports[`workers/repository/process/lookup .lookupUpdates() returns patch update if automerging patch 1`] = `
-Array [
-  Object {
-    "bucket": "non-major",
-    "currentVersion": "0.9.0",
-    "isSingleVersion": true,
-    "newMajor": 0,
-    "newMinor": 9,
-    "newValue": "0.9.7",
-    "newVersion": "0.9.7",
-    "releaseTimestamp": "2013-09-04T17:07:22.948Z",
-    "skippedOverVersions": Array [
-      "0.9.1",
-      "0.9.2",
-      "0.9.3",
-      "0.9.4",
-      "0.9.5",
-      "0.9.6",
-    ],
-    "updateType": "patch",
-  },
-  Object {
-    "bucket": "major",
-    "currentVersion": "0.9.0",
-    "isSingleVersion": true,
-    "newMajor": 1,
-    "newMinor": 4,
-    "newValue": "1.4.1",
-    "newVersion": "1.4.1",
-    "releaseTimestamp": "2015-05-17T04:25:07.299Z",
-    "skippedOverVersions": Array [
-      "1.0.0",
-      "1.0.1",
-      "1.1.0",
-      "1.1.1",
-      "1.1.2",
-      "1.2.0",
-      "1.2.1",
-      "1.3.0",
-      "1.4.0",
-    ],
-    "updateType": "major",
-  },
-]
-`;
-
 exports[`workers/repository/process/lookup .lookupUpdates() returns patch update if separateMinorPatch 1`] = `
 Array [
   Object {

--- a/lib/workers/repository/process/lookup/index.spec.ts
+++ b/lib/workers/repository/process/lookup/index.spec.ts
@@ -193,19 +193,6 @@ describe('workers/repository/process/lookup', () => {
       expect(res.updates[0].updateType).not.toEqual('patch');
       expect(res.updates[1].updateType).not.toEqual('patch');
     });
-    it('returns patch update if automerging patch', async () => {
-      config.patch = {
-        automerge: true,
-      };
-      config.currentValue = '0.9.0';
-      config.rangeStrategy = 'pin';
-      config.depName = 'q';
-      config.datasource = datasourceNpmId;
-      nock('https://registry.npmjs.org').get('/q').reply(200, qJson);
-      const res = await lookup.lookupUpdates(config);
-      expect(res.updates).toMatchSnapshot();
-      expect(res.updates[0].updateType).toEqual('patch');
-    });
     it('returns minor update if automerging both patch and minor', async () => {
       config.patch = {
         automerge: true,

--- a/lib/workers/repository/process/lookup/update-type.ts
+++ b/lib/workers/repository/process/lookup/update-type.ts
@@ -18,8 +18,5 @@ export function getUpdateType(
   if (config.separateMinorPatch) {
     return 'patch';
   }
-  if (config.patch.automerge && !config.minor.automerge) {
-    return 'patch';
-  }
   return 'minor';
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Removes logic which implies `separateMinorPatch` if `patch` automerge is configured.

## Context:

Currently we have inconsistent behavior between whether patch settings are configured in package rules or within `patch {}`. This was undocumented voodoo code which I think is best to revert.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
