### PR TITLE
docs: Add binarySource requirement note for global .npmrc usage

### DIFF
--- a/docs/usage/private-modules.md
+++ b/docs/usage/private-modules.md
@@ -31,7 +31,7 @@ It's therefore better to provide Renovate with all the credentials it needs to l
 
 The recommended approaches in order of preference are:
 
-**If you are running your own Renovate bot**: copy an `.npmrc` file to the home dir of the bot and it will work for all repositories
+**If you are running your own Renovate bot**: copy an `.npmrc` file to the home dir of the bot and it will work for all repositories. Note that this will only work when using `binarySource=global`.
 
 **Renovate App with private modules from npmjs.org**: Add an encrypted `npmToken` to your Renovate config
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

Small docs update to reflect the pitfall as described in https://github.com/renovatebot/renovate/discussions/8748
