### PR TITLE
docs: deprecate npmrc in home

### DIFF
--- a/docs/usage/private-modules.md
+++ b/docs/usage/private-modules.md
@@ -33,6 +33,8 @@ The recommended approaches in order of preference are:
 
 **If you are running your own Renovate bot**: copy an `.npmrc` file to the home dir of the bot and it will work for all repositories
 
+**NOTE:** This is considered deprecated and doesn't work out of the box with `binarySource=docker`.
+
 **Renovate App with private modules from npmjs.org**: Add an encrypted `npmToken` to your Renovate config
 
 **Renovate App with a private registry**: Add an unencrypted `npmrc` plus an encrypted `npmToken` in config


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Deprecate (docs only) `.npmrc` in bot home dir.

<!-- Describe what behavior is changed by this PR. -->

## Context:

#8748

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
