### PR TITLE
feat: matchFiles

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -1286,14 +1286,14 @@ Use the syntax `!/ /` like the following:
 }
 ```
 
-### matchPackageFiles
+### matchFiles
 
-Renovate will match `matchPackageFiles` as an exact match against package files.
+Renovate will compare `matchFiles` for an exact match against the dependency's package file.
 
 For example the following would match `package.json` but not `package/frontend/package.json`:
 
 ```
-  "matchPackageFiles": ["package.json"],
+  "matchFiles": ["package.json"],
 ```
 
 Use `matchPaths` instead if you need more flexible matching.

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -1286,6 +1286,18 @@ Use the syntax `!/ /` like the following:
 }
 ```
 
+### matchPackageFiles
+
+Renovate will match `matchPackageFiles` as an exact match against package files.
+
+For example the following would match `package.json` but not `package/frontend/package.json`:
+
+```
+  "matchPackageFiles": ["package.json"],
+```
+
+Use `matchPaths` instead if you need more flexible matching.
+
 ### matchPackageNames
 
 Use this field if you want to have one or more exact name matches in your package rule.

--- a/lib/config/__snapshots__/validation.spec.ts.snap
+++ b/lib/config/__snapshots__/validation.spec.ts.snap
@@ -79,7 +79,7 @@ Array [
   },
   Object {
     "depName": "Configuration Error",
-    "message": "packageRules: Each packageRule must contain at least one selector (matchPaths, matchLanguages, matchBaseBranches, matchManagers, matchDatasources, matchDepTypes, matchPackageNames, matchPackagePatterns, excludePackageNames, excludePackagePatterns, matchCurrentVersion, matchSourceUrlPrefixes, matchUpdateTypes). If you wish for configuration to apply to all packages, it is not necessary to place it inside a packageRule at all.",
+    "message": "packageRules: Each packageRule must contain at least one selector (matchPackageRules, matchPaths, matchLanguages, matchBaseBranches, matchManagers, matchDatasources, matchDepTypes, matchPackageNames, matchPackagePatterns, excludePackageNames, excludePackagePatterns, matchCurrentVersion, matchSourceUrlPrefixes, matchUpdateTypes). If you wish for configuration to apply to all packages, it is not necessary to place it inside a packageRule at all.",
   },
   Object {
     "depName": "Configuration Error",

--- a/lib/config/common.ts
+++ b/lib/config/common.ts
@@ -220,6 +220,7 @@ export interface PackageRule
   extends RenovateSharedConfig,
     UpdateConfig,
     Record<string, any> {
+  matchPackageFiles?: string[];
   matchPaths?: string[];
   matchLanguages?: string[];
   matchBaseBranches?: string[];

--- a/lib/config/common.ts
+++ b/lib/config/common.ts
@@ -220,7 +220,7 @@ export interface PackageRule
   extends RenovateSharedConfig,
     UpdateConfig,
     Record<string, any> {
-  matchPackageFiles?: string[];
+  matchFiles?: string[];
   matchPaths?: string[];
   matchLanguages?: string[];
   matchBaseBranches?: string[];

--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -943,7 +943,7 @@ const options: RenovateOptions[] = [
     env: false,
   },
   {
-    name: 'matchPackageFiles',
+    name: 'matchFiles',
     description:
       'List of strings to do an exact match against package files with full path. Applicable inside packageRules only.',
     type: 'array',

--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -943,6 +943,17 @@ const options: RenovateOptions[] = [
     env: false,
   },
   {
+    name: 'matchPackageFiles',
+    description:
+      'List of strings to do an exact match against package files with full path. Applicable inside packageRules only.',
+    type: 'array',
+    subType: 'string',
+    stage: 'repository',
+    parent: 'packageRules',
+    cli: false,
+    env: false,
+  },
+  {
     name: 'matchPaths',
     description:
       'List of strings or glob patterns to match against package files. Applicable inside packageRules only.',

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -217,6 +217,7 @@ export async function validateConfig(
             }
 
             const selectors = [
+              'matchPackageRules',
               'matchPaths',
               'matchLanguages',
               'matchBaseBranches',

--- a/lib/util/package-rules.spec.ts
+++ b/lib/util/package-rules.spec.ts
@@ -610,7 +610,7 @@ describe('applyPackageRules()', () => {
       packageFile: 'examples/foo/package.json',
       packageRules: [
         {
-          matchPackageFiles: ['package.json'],
+          matchFiles: ['package.json'],
           x: 1,
         },
       ],

--- a/lib/util/package-rules.spec.ts
+++ b/lib/util/package-rules.spec.ts
@@ -605,6 +605,28 @@ describe('applyPackageRules()', () => {
     expect(res1.x).toBeUndefined();
     expect(res2.x).toBeDefined();
   });
+  it('matches packageFiles', () => {
+    const config: TestConfig = {
+      packageFile: 'examples/foo/package.json',
+      packageRules: [
+        {
+          matchPackageFiles: ['package.json'],
+          x: 1,
+        },
+      ],
+    };
+    const res1 = applyPackageRules({
+      ...config,
+      depName: 'test',
+    });
+    expect(res1.x).toBeUndefined();
+    config.packageFile = 'package.json';
+    const res2 = applyPackageRules({
+      ...config,
+      depName: 'test',
+    });
+    expect(res2.x).toBeDefined();
+  });
   it('matches paths', () => {
     const config: TestConfig = {
       packageFile: 'examples/foo/package.json',

--- a/lib/util/package-rules.ts
+++ b/lib/util/package-rules.ts
@@ -43,7 +43,7 @@ function matchesRule(inputConfig: Config, packageRule: PackageRule): boolean {
     datasource,
   } = inputConfig;
   // Setting empty arrays simplifies our logic later
-  const matchPackageFiles = packageRule.matchPackageFiles || [];
+  const matchFiles = packageRule.matchFiles || [];
   const matchPaths = packageRule.matchPaths || [];
   const matchLanguages = packageRule.matchLanguages || [];
   const matchBaseBranches = packageRule.matchBaseBranches || [];
@@ -65,10 +65,8 @@ function matchesRule(inputConfig: Config, packageRule: PackageRule): boolean {
   ) {
     matchPackagePatterns = ['.*'];
   }
-  if (matchPackageFiles.length) {
-    const isMatch = matchPackageFiles.some(
-      (fileName) => packageFile === fileName
-    );
+  if (matchFiles.length) {
+    const isMatch = matchFiles.some((fileName) => packageFile === fileName);
     if (!isMatch) {
       return false;
     }

--- a/lib/util/package-rules.ts
+++ b/lib/util/package-rules.ts
@@ -43,6 +43,7 @@ function matchesRule(inputConfig: Config, packageRule: PackageRule): boolean {
     datasource,
   } = inputConfig;
   // Setting empty arrays simplifies our logic later
+  const matchPackageFiles = packageRule.matchPackageFiles || [];
   const matchPaths = packageRule.matchPaths || [];
   const matchLanguages = packageRule.matchLanguages || [];
   const matchBaseBranches = packageRule.matchBaseBranches || [];
@@ -63,6 +64,15 @@ function matchesRule(inputConfig: Config, packageRule: PackageRule): boolean {
     !(matchPackageNames.length || matchPackagePatterns.length)
   ) {
     matchPackagePatterns = ['.*'];
+  }
+  if (matchPackageFiles.length) {
+    const isMatch = matchPackageFiles.some(
+      (fileName) => packageFile === fileName
+    );
+    if (!isMatch) {
+      return false;
+    }
+    positiveMatch = true;
   }
   if (matchPaths.length) {
     const isMatch = matchPaths.some(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds `matchFiles` to `packageRules`.

## Context:

The current "substring" support in `matchPaths` is too flexible for some situations and doing simple rules like match `package.json` but not `packages/backend/package.json` is too hard. `matchFiles` is exact match only.

I've chosen `matchFiles` instead of `matchPackageFiles` in case we find a use for matching against a lock file later.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
