### PR TITLE
feat(internal): repository cache revision

### DIFF
--- a/lib/util/cache/repository/index.spec.ts
+++ b/lib/util/cache/repository/index.spec.ts
@@ -38,7 +38,9 @@ describe('lib/util/cache/repository', () => {
     });
   });
   it('reads from cache and finalizes', async () => {
-    fs.readFile.mockResolvedValueOnce('{"repository":"abc/def"}' as any);
+    fs.readFile.mockResolvedValueOnce(
+      `{"repository":"abc/def","revision":${repositoryCache.CACHE_REVISION}}` as any
+    );
     await repositoryCache.initialize({
       ...config,
       repositoryCache: 'enabled',
@@ -46,20 +48,6 @@ describe('lib/util/cache/repository', () => {
     await repositoryCache.finalize();
     expect(fs.readFile.mock.calls).toHaveLength(1);
     expect(fs.outputFile.mock.calls).toHaveLength(1);
-  });
-  it('migrates', async () => {
-    fs.readFile.mockResolvedValueOnce(
-      '{"repository":"abc/def","branches":[{"upgrades":[{"fromVersion":"1.0.0","toVersion":"1.0.1"}]}]}' as any
-    );
-    await repositoryCache.initialize({
-      ...config,
-      repositoryCache: 'enabled',
-    });
-    expect(repositoryCache.getCache().branches[0].upgrades[0]).toEqual({
-      currentVersion: '1.0.0',
-      newVersion: '1.0.1',
-    });
-    await repositoryCache.finalize();
   });
   it('gets', () => {
     expect(repositoryCache.getCache()).toEqual({ scan: {} });

--- a/lib/util/cache/repository/index.ts
+++ b/lib/util/cache/repository/index.ts
@@ -5,6 +5,9 @@ import { logger } from '../../../logger';
 import { PackageFile } from '../../../manager/common';
 import { RepoInitConfig } from '../../../workers/repository/init/common';
 
+// Increment this whenever there could be incompatibilities between old and new cache structure
+export const CACHE_REVISION = 1;
+
 export interface BaseBranchCache {
   sha: string; // branch commit sha
   configHash: string; // object hash of config
@@ -38,6 +41,7 @@ export interface BranchCache {
 export interface Cache {
   branches?: BranchCache[];
   repository?: string;
+  revision?: number;
   init?: RepoInitConfig;
   scan?: Record<string, BaseBranchCache>;
 }
@@ -56,7 +60,11 @@ export function getCacheFileName(config: RenovateConfig): string {
 }
 
 function validate(config: RenovateConfig, input: any): Cache | null {
-  if (input?.repository === config.repository) {
+  if (
+    input &&
+    input.repository === config.repository &&
+    input.revision === CACHE_REVISION
+  ) {
     logger.debug('Repository cache is valid');
     return input as Cache;
   }
@@ -79,27 +87,14 @@ export async function initialize(config: RenovateConfig): Promise<void> {
   } catch (err) {
     logger.debug({ cacheFileName }, 'Repository cache not found');
   }
-  cache = cache || Object.create({});
+  cache = cache || Object.create({ revision: CACHE_REVISION });
   cache.repository = config.repository;
 }
 
 export function getCache(): Cache {
-  cache = cache || Object.create({});
+  cache = cache || Object.create({ revision: CACHE_REVISION });
   delete cache.init;
   cache.scan = cache.scan || Object.create({});
-  for (const branch of cache.branches || []) {
-    for (const upgrade of (branch.upgrades || []) as any) {
-      // migrate fromVersion to currentVersion
-      if (upgrade.fromVersion) {
-        upgrade.currentVersion = upgrade.fromVersion;
-        delete upgrade.fromVersion;
-      }
-      if (upgrade.toVersion) {
-        upgrade.newVersion = upgrade.toVersion;
-        delete upgrade.toVersion;
-      }
-    }
-  }
   return cache;
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds a cache revision number which is part of validation.

## Context:

This gives us a lever to pull to invalidate existing caches whenever we make breaking internal changes to scan or branch cache.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
