### PR TITLE
refactor: vulnerability matchFiles

### DIFF
--- a/lib/workers/repository/init/__snapshots__/vulnerability.spec.ts.snap
+++ b/lib/workers/repository/init/__snapshots__/vulnerability.spec.ts.snap
@@ -20,7 +20,6 @@ Array [
     ],
     "matchFiles": Array [
       "backend/package-lock.json",
-      "backend/package.json",
     ],
     "matchPackageNames": Array [
       "electron",

--- a/lib/workers/repository/init/vulnerability.ts
+++ b/lib/workers/repository/init/vulnerability.ts
@@ -184,21 +184,6 @@ export async function detectVulnerabilityAlerts(
           },
         };
         matchRule.matchFiles = [fileName];
-        // The following list based off https://docs.github.com/en/github/visualizing-repository-data-with-graphs/about-the-dependency-graph#supported-package-ecosystems
-        const lockToPackageFile = {
-          'package-lock.json': 'package.json',
-          'composer.lock': 'composer.json',
-          'pipfile.lock': 'Pipfile',
-          'Gemfile.lock': 'Gemfile',
-          'yarn.lock': 'package.json',
-        };
-        for (const [lock, packageFile] of Object.entries(lockToPackageFile)) {
-          if (fileName.endsWith(lock)) {
-            matchRule.matchFiles.push(
-              fileName.replace(regEx(`${lock}$`), packageFile)
-            );
-          }
-        }
         alertPackageRules.push(matchRule);
       }
     }

--- a/lib/workers/repository/init/vulnerability.ts
+++ b/lib/workers/repository/init/vulnerability.ts
@@ -9,7 +9,6 @@ import { logger } from '../../../logger';
 import { platform } from '../../../platform';
 import { SecurityAdvisory } from '../../../types';
 import { sanitizeMarkdown } from '../../../util/markdown';
-import { regEx } from '../../../util/regex';
 import * as allVersioning from '../../../versioning';
 import * as mavenVersioning from '../../../versioning/maven';
 import * as npmVersioning from '../../../versioning/npm';


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Removes the lock file -> package file mapping workaround for vulnerability alerts.

## Context:

This is no longer necessary after #8783 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
