### PR TITLE
feat(Terraform): renovate required_version blocks

### DIFF
--- a/lib/manager/terraform/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/terraform/__snapshots__/extract.spec.ts.snap
@@ -260,6 +260,13 @@ Object {
       "depType": "terraform",
     },
     Object {
+      "currentValue": ">= 0.13",
+      "datasource": "github-tags",
+      "depName": "hashicorp/terraform",
+      "extractVersion": "v(?<version>.*)$",
+      "lineNumber": 205,
+    },
+    Object {
       "currentValue": "2.7.2",
       "datasource": "terraform-provider",
       "depName": "docker",

--- a/lib/manager/terraform/extract.spec.ts
+++ b/lib/manager/terraform/extract.spec.ts
@@ -16,7 +16,7 @@ describe('lib/manager/terraform/extract', () => {
     it('extracts', () => {
       const res = extractPackageFile(tf1);
       expect(res).toMatchSnapshot();
-      expect(res.deps).toHaveLength(44);
+      expect(res.deps).toHaveLength(45);
       expect(res.deps.filter((dep) => dep.skipReason)).toHaveLength(8);
     });
     it('returns null if only local deps', () => {

--- a/lib/manager/terraform/extract.ts
+++ b/lib/manager/terraform/extract.ts
@@ -7,6 +7,10 @@ import {
 } from './providers';
 import { extractTerraformRequiredProviders } from './required-providers';
 import {
+  analyseTerraformVersion,
+  extractTerraformRequiredVersion,
+} from './required-version';
+import {
   analyseTerraformResource,
   extractTerraformResource,
 } from './resources';
@@ -70,6 +74,10 @@ export function extractPackageFile(content: string): PackageFile | null {
             result = extractTerraformResource(lineNumber, lines);
             break;
           }
+          case TerraformDependencyTypes.terraform_version: {
+            result = extractTerraformRequiredVersion(lineNumber, lines);
+            break;
+          }
           /* istanbul ignore next */
           default:
             logger.trace(
@@ -98,6 +106,9 @@ export function extractPackageFile(content: string): PackageFile | null {
         break;
       case TerraformDependencyTypes.resource:
         analyseTerraformResource(dep);
+        break;
+      case TerraformDependencyTypes.terraform_version:
+        analyseTerraformVersion(dep);
         break;
       /* istanbul ignore next */
       default:

--- a/lib/manager/terraform/required-version.ts
+++ b/lib/manager/terraform/required-version.ts
@@ -1,0 +1,55 @@
+import * as datasourceGithubTags from '../../datasource/github-tags';
+import { logger } from '../../logger';
+import { PackageDependency } from '../common';
+import {
+  ExtractionResult,
+  TerraformDependencyTypes,
+  keyValueExtractionRegex,
+} from './util';
+
+export function extractTerraformRequiredVersion(
+  startingLine: number,
+  lines: string[]
+): ExtractionResult {
+  const deps: PackageDependency[] = [];
+  let lineNumber = startingLine;
+  let braceCounter = 0;
+  do {
+    // istanbul ignore if
+    if (lineNumber > lines.length - 1) {
+      logger.debug(`Malformed Terraform file detected.`);
+    }
+
+    const line = lines[lineNumber];
+    // `{` will be counted wit +1 and `}` with -1. Therefore if we reach braceCounter == 0. We have found the end of the terraform block
+    const openBrackets = (line.match(/\{/g) || []).length;
+    const closedBrackets = (line.match(/\}/g) || []).length;
+    braceCounter = braceCounter + openBrackets - closedBrackets;
+
+    const kvMatch = keyValueExtractionRegex.exec(line);
+    if (kvMatch && kvMatch.groups.key === 'required_version') {
+      const dep: PackageDependency = {
+        currentValue: kvMatch.groups.value,
+        lineNumber,
+        managerData: {
+          terraformDependencyType: TerraformDependencyTypes.terraform_version,
+        },
+      };
+      deps.push(dep);
+      // returning starting line as required_providers are also in the terraform block
+      // if we would return the position of the required_version line we would potentially skip the providers
+      return { lineNumber: startingLine, dependencies: deps };
+    }
+
+    lineNumber += 1;
+  } while (braceCounter !== 0);
+  return null;
+}
+
+export function analyseTerraformVersion(dep: PackageDependency): void {
+  /* eslint-disable no-param-reassign */
+  dep.datasource = datasourceGithubTags.id;
+  dep.depName = 'hashicorp/terraform';
+  dep.extractVersion = 'v(?<version>.*)$';
+  /* eslint-enable no-param-reassign */
+}

--- a/lib/manager/terraform/util.ts
+++ b/lib/manager/terraform/util.ts
@@ -14,6 +14,7 @@ export enum TerraformDependencyTypes {
   provider = 'provider',
   required_providers = 'required_providers',
   resource = 'resource',
+  terraform_version = 'terraform_version',
 }
 
 export interface TerraformManagerData {
@@ -63,6 +64,9 @@ export function getTerraformDependencyType(
     }
     case 'resource': {
       return TerraformDependencyTypes.resource;
+    }
+    case 'terraform': {
+      return TerraformDependencyTypes.terraform_version;
     }
     default: {
       return TerraformDependencyTypes.unknown;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

This PR implements the renovating of the Terraform versions in `required_version`fields. 

## Context:

Closes #8746 
## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

https://github.com/secustor/renovate_test

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
