### PR TITLE
fix: rebase if automerging even if rebaseWhen=conflicted

### DIFF
--- a/lib/workers/branch/reuse.spec.ts
+++ b/lib/workers/branch/reuse.spec.ts
@@ -159,14 +159,15 @@ describe(getName(__filename), () => {
       expect(git.isBranchModified).not.toHaveBeenCalled();
     });
 
-    it('returns true if automerge, rebaseWhen=conflicted and stale', async () => {
+    it('returns false if automerge, rebaseWhen=conflicted and stale', async () => {
       config.rebaseWhen = 'conflicted';
       config.automerge = true;
       git.branchExists.mockReturnValueOnce(true);
+      git.isBranchStale.mockResolvedValueOnce(true);
       const res = await shouldReuseExistingBranch(config);
-      expect(res.reuseExistingBranch).toBe(true);
-      expect(git.isBranchStale).not.toHaveBeenCalled();
-      expect(git.isBranchModified).not.toHaveBeenCalled();
+      expect(res.reuseExistingBranch).toBe(false);
+      expect(git.isBranchStale).toHaveBeenCalled();
+      expect(git.isBranchModified).toHaveBeenCalled();
     });
   });
 });

--- a/lib/workers/branch/reuse.ts
+++ b/lib/workers/branch/reuse.ts
@@ -48,8 +48,8 @@ export async function shouldReuseExistingBranch(
 
   if (
     config.rebaseWhen === 'behind-base-branch' ||
-    (config.rebaseWhen === 'auto' &&
-      (config.automerge === true || (await platform.getRepoForceRebase())))
+    (config.rebaseWhen !== 'never' && config.automerge === true) ||
+    (config.rebaseWhen === 'auto' && (await platform.getRepoForceRebase()))
   ) {
     if (await isBranchStale(branchName)) {
       logger.debug(`Branch is stale and needs rebasing`);
@@ -61,6 +61,9 @@ export async function shouldReuseExistingBranch(
       }
       return { reuseExistingBranch: false };
     }
+    logger.debug('Branch is up-to-date');
+  } else {
+    logger.debug('Skipping stale branch check');
   }
 
   // Now check if PR is unmergeable. If so then we also rebase


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Changes behavior to rebase when automerge is enabled and `rebaseWhen=conflicted`.

## Context:

Currently we skip rebasing then fail to ff merge.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
