### PR TITLE
feat: updateInternalDeps

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2062,6 +2062,13 @@ Please see the above link for valid timezone names.
 
 If enabled emoji shortcodes (`:warning:`) are replaced with their unicode equivalents (`⚠️`)
 
+## updateInternalDeps
+
+Renovate defaults to skipping any internal package dependencies within monorepos.
+In such case dependency versions won't be updated by Renovate.
+
+To opt in to letting Renovate update internal package versions normally, set this configuration option to true.
+
 ## updateLockFiles
 
 ## updateNotScheduled

--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -768,6 +768,13 @@ const options: RenovateOptions[] = [
     mergeable: true,
   },
   {
+    name: 'updateInternalDeps',
+    description:
+      'Whether to update internal dep versions in a monorepo (Lerna or Yarn Workspaces).',
+    type: 'boolean',
+    stage: 'package',
+  },
+  {
     name: 'packageRules',
     description: 'Rules for matching package names.',
     type: 'array',

--- a/lib/manager/common.ts
+++ b/lib/manager/common.ts
@@ -27,6 +27,7 @@ export interface ExtractConfig extends ManagerConfig {
   yarnrc?: string;
   skipInstalls?: boolean;
   versioning?: string;
+  updateInternalDeps?: boolean;
 }
 
 export interface CustomExtractConfig extends ExtractConfig {
@@ -81,7 +82,6 @@ export interface PackageFile<T = Record<string, any>>
   extends NpmLockFiles,
     ManagerData<T> {
   hasYarnWorkspaces?: boolean;
-  internalPackages?: string[]; // TODO: remove
   constraints?: Record<string, string>;
   datasource?: string;
   registryUrls?: string[];

--- a/lib/manager/npm/extract/__snapshots__/monorepo.spec.ts.snap
+++ b/lib/manager/npm/extract/__snapshots__/monorepo.spec.ts.snap
@@ -1,5 +1,61 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`manager/npm/extract .extractPackageFile() updates internal packges 1`] = `
+Array [
+  Object {
+    "deps": Array [
+      Object {
+        "depName": "@org/a",
+      },
+      Object {
+        "depName": "@org/b",
+      },
+      Object {
+        "depName": "@org/c",
+      },
+      Object {
+        "depName": "foo",
+      },
+    ],
+    "lernaDir": ".",
+    "lernaPackages": Array [
+      "packages/*",
+    ],
+    "packageFile": "package.json",
+    "packages": Array [
+      "packages/*",
+    ],
+  },
+  Object {
+    "deps": Array [
+      Object {
+        "depName": "@org/b",
+      },
+      Object {
+        "depName": "@org/c",
+      },
+      Object {
+        "depName": "bar",
+      },
+    ],
+    "lernaClient": undefined,
+    "lernaDir": ".",
+    "npmLock": undefined,
+    "packageFile": "packages/a/package.json",
+    "packageJsonName": "@org/a",
+    "yarnLock": undefined,
+  },
+  Object {
+    "lernaClient": undefined,
+    "lernaDir": ".",
+    "npmLock": undefined,
+    "packageFile": "packages/b/package.json",
+    "packageJsonName": "@org/b",
+    "yarnLock": undefined,
+  },
+]
+`;
+
 exports[`manager/npm/extract .extractPackageFile() uses lerna package settings 1`] = `
 Array [
   Object {

--- a/lib/manager/npm/extract/__snapshots__/monorepo.spec.ts.snap
+++ b/lib/manager/npm/extract/__snapshots__/monorepo.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`manager/npm/extract .extractPackageFile() updates internal packges 1`] = `
+exports[`manager/npm/extract .extractPackageFile() updates internal packages 1`] = `
 Array [
   Object {
     "deps": Array [

--- a/lib/manager/npm/extract/index.spec.ts
+++ b/lib/manager/npm/extract/index.spec.ts
@@ -327,7 +327,7 @@ describe('manager/npm/extract', () => {
   });
   describe('.postExtract()', () => {
     it('runs', async () => {
-      await expect(npmExtract.postExtract([])).resolves.not.toThrow();
+      await expect(npmExtract.postExtract([], false)).resolves.not.toThrow();
     });
   });
 });

--- a/lib/manager/npm/extract/index.ts
+++ b/lib/manager/npm/extract/index.ts
@@ -375,8 +375,11 @@ export async function extractPackageFile(
   };
 }
 
-export async function postExtract(packageFiles: PackageFile[]): Promise<void> {
-  detectMonorepos(packageFiles);
+export async function postExtract(
+  packageFiles: PackageFile[],
+  updateInternalDeps: boolean
+): Promise<void> {
+  detectMonorepos(packageFiles, updateInternalDeps);
   await getLockedVersions(packageFiles);
 }
 
@@ -400,6 +403,6 @@ export async function extractAllPackageFiles(
       logger.debug({ packageFile }, 'packageFile has no content');
     }
   }
-  await postExtract(npmFiles);
+  await postExtract(npmFiles, config.updateInternalDeps);
   return npmFiles;
 }

--- a/lib/manager/npm/extract/monorepo.spec.ts
+++ b/lib/manager/npm/extract/monorepo.spec.ts
@@ -43,10 +43,66 @@ describe('manager/npm/extract', () => {
           packageFile: 'packages/b/package.json',
           packageJsonName: '@org/b',
         },
-      ];
-      detectMonorepos(packageFiles);
+      ] as any;
+      detectMonorepos(packageFiles, false);
       expect(packageFiles).toMatchSnapshot();
       expect(packageFiles[1].lernaDir).toEqual('.');
+      expect(
+        packageFiles.some((packageFile) =>
+          packageFile.deps?.some((dep) => dep.skipReason)
+        )
+      ).toBe(true);
+    });
+    it('updates internal packges', () => {
+      const packageFiles = [
+        {
+          packageFile: 'package.json',
+          lernaDir: '.',
+          lernaPackages: ['packages/*'],
+          packages: ['packages/*'],
+          deps: [
+            {
+              depName: '@org/a',
+            },
+            {
+              depName: '@org/b',
+            },
+            {
+              depName: '@org/c',
+            },
+            {
+              depName: 'foo',
+            },
+          ],
+        },
+        {
+          packageFile: 'packages/a/package.json',
+          packageJsonName: '@org/a',
+          deps: [
+            {
+              depName: '@org/b',
+            },
+            {
+              depName: '@org/c',
+            },
+            {
+              depName: 'bar',
+            },
+          ],
+        },
+        {
+          packageFile: 'packages/b/package.json',
+          packageJsonName: '@org/b',
+        },
+      ] as any;
+      detectMonorepos(packageFiles, true);
+      expect(packageFiles).toMatchSnapshot();
+      expect(packageFiles[1].lernaDir).toEqual('.');
+      expect(
+        packageFiles.some((packageFile) =>
+          packageFile.deps?.some((dep) => dep.skipReason)
+        )
+      ).toBe(false);
     });
     it('uses yarn workspaces package settings with lerna', () => {
       const packageFiles = [
@@ -66,7 +122,7 @@ describe('manager/npm/extract', () => {
           packageJsonName: '@org/b',
         },
       ];
-      detectMonorepos(packageFiles);
+      detectMonorepos(packageFiles, false);
       expect(packageFiles).toMatchSnapshot();
       expect(packageFiles[1].lernaDir).toEqual('.');
     });
@@ -86,7 +142,7 @@ describe('manager/npm/extract', () => {
           packageJsonName: '@org/b',
         },
       ];
-      detectMonorepos(packageFiles);
+      detectMonorepos(packageFiles, false);
       expect(packageFiles).toMatchSnapshot();
     });
   });

--- a/lib/manager/npm/extract/monorepo.spec.ts
+++ b/lib/manager/npm/extract/monorepo.spec.ts
@@ -53,7 +53,7 @@ describe('manager/npm/extract', () => {
         )
       ).toBe(true);
     });
-    it('updates internal packges', () => {
+    it('updates internal packages', () => {
       const packageFiles = [
         {
           packageFile: 'package.json',

--- a/lib/manager/npm/extract/monorepo.ts
+++ b/lib/manager/npm/extract/monorepo.ts
@@ -13,7 +13,10 @@ function matchesAnyPattern(val: string, patterns: string[]): boolean {
   return res;
 }
 
-export function detectMonorepos(packageFiles: Partial<PackageFile>[]): void {
+export function detectMonorepos(
+  packageFiles: Partial<PackageFile>[],
+  updateInternalDeps: boolean
+): void {
   logger.debug('Detecting Lerna and Yarn Workspaces');
   for (const p of packageFiles) {
     const {
@@ -45,11 +48,13 @@ export function detectMonorepos(packageFiles: Partial<PackageFile>[]): void {
       const internalPackageNames = internalPackageFiles
         .map((sp) => sp.packageJsonName)
         .filter(Boolean);
-      p.deps?.forEach((dep) => {
-        if (internalPackageNames.includes(dep.depName)) {
-          dep.skipReason = SkipReason.InternalPackage; // eslint-disable-line no-param-reassign
-        }
-      });
+      if (!updateInternalDeps) {
+        p.deps?.forEach((dep) => {
+          if (internalPackageNames.includes(dep.depName)) {
+            dep.skipReason = SkipReason.InternalPackage; // eslint-disable-line no-param-reassign
+          }
+        });
+      }
       for (const subPackage of internalPackageFiles) {
         subPackage.lernaDir = lernaDir;
         subPackage.lernaClient = lernaClient;
@@ -58,11 +63,13 @@ export function detectMonorepos(packageFiles: Partial<PackageFile>[]): void {
         if (subPackage.yarnLock) {
           subPackage.hasYarnWorkspaces = !!yarnWorkspacesPackages;
         }
-        subPackage.deps?.forEach((dep) => {
-          if (internalPackageNames.includes(dep.depName)) {
-            dep.skipReason = SkipReason.InternalPackage; // eslint-disable-line no-param-reassign
-          }
-        });
+        if (!updateInternalDeps) {
+          subPackage.deps?.forEach((dep) => {
+            if (internalPackageNames.includes(dep.depName)) {
+              dep.skipReason = SkipReason.InternalPackage; // eslint-disable-line no-param-reassign
+            }
+          });
+        }
       }
     }
   }

--- a/lib/workers/repository/process/fetch.ts
+++ b/lib/workers/repository/process/fetch.ts
@@ -34,9 +34,6 @@ async function fetchDepUpdates(
   if (depConfig.ignoreDeps.includes(depName)) {
     logger.debug({ dependency: dep.depName }, 'Dependency is ignored');
     dep.skipReason = SkipReason.Ignored;
-  } else if (depConfig.internalPackages?.includes(depName)) {
-    // istanbul ignore next
-    dep.skipReason = SkipReason.InternalPackage;
   } else if (depConfig.enabled === false) {
     logger.debug({ dependency: dep.depName }, 'Dependency is disabled');
     dep.skipReason = SkipReason.Disabled;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds new configuration option `updateInternalDeps`.

## Context:

Allows users to opt into updating internal dependencies in a monorepo (Lerna, Yarn Workspaces). See #8808

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
