### PR TITLE
feat(helmfile): Parse multidoc yaml

### DIFF
--- a/lib/manager/helmfile/extract.ts
+++ b/lib/manager/helmfile/extract.ts
@@ -35,8 +35,7 @@ export function extractPackageFile(
   }
   for (const doc of docs) {
     if (!(doc && is.array(doc.releases))) {
-      logger.debug({ fileName }, 'helmfile.yaml has no releases');
-      return null;
+      continue;
     }
 
     if (doc.repositories) {
@@ -92,6 +91,11 @@ export function extractPackageFile(
 
       return res;
     });
+  }
+
+  if (deps.length == 0) {
+    logger.debug({ fileName }, 'helmfile.yaml has no releases');
+    return null;
   }
 
   return { deps, datasource: datasourceHelm.id } as PackageFile;

--- a/lib/manager/helmfile/extract.ts
+++ b/lib/manager/helmfile/extract.ts
@@ -93,7 +93,7 @@ export function extractPackageFile(
     });
   }
 
-  if (deps.length == 0) {
+  if (!deps.length) {
     logger.debug({ fileName }, 'helmfile.yaml has no releases');
     return null;
   }

--- a/lib/manager/helmfile/extract.ts
+++ b/lib/manager/helmfile/extract.ts
@@ -35,7 +35,7 @@ export function extractPackageFile(
   }
   for (const doc of docs) {
     if (!(doc && is.array(doc.releases))) {
-      continue;
+      continue; // eslint-disable-line no-continue
     }
 
     if (doc.repositories) {


### PR DESCRIPTION
We should skip empty docs to be able to parse last one with contains
releases map.

## Changes:

* Skip empty docs in multidoc yaml
* Return `null` in case of empty release map

## Context:

Closes #8682

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [X] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
