### PR TITLE
refactor: getQueryString

### DIFF
--- a/lib/datasource/repology/index.ts
+++ b/lib/datasource/repology/index.ts
@@ -3,6 +3,7 @@ import { logger } from '../../logger';
 import { ExternalHostError } from '../../types/errors/external-host-error';
 import * as packageCache from '../../util/cache/package';
 import { Http } from '../../util/http';
+import { getQueryString } from '../../util/url';
 import { GetReleasesConfig, ReleaseResult } from '../common';
 
 export const id = 'repology';
@@ -46,13 +47,13 @@ async function queryPackagesViaResolver(
   packageName: string,
   packageType: RepologyPackageType
 ): Promise<RepologyPackage[]> {
-  const query = new URLSearchParams({
+  const query = getQueryString({
     repo: repoName,
     name_type: packageType,
     target_page: 'api_v1_project',
     noautoresolve: 'on',
     name: packageName,
-  }).toString();
+  });
 
   // Retrieve list of packages by looking up Repology project
   const packages = await queryPackages(

--- a/lib/platform/bitbucket-server/index.ts
+++ b/lib/platform/bitbucket-server/index.ts
@@ -1,4 +1,4 @@
-import url, { URLSearchParams } from 'url';
+import url from 'url';
 import is from '@sindresorhus/is';
 import delay from 'delay';
 import type { PartialDeep } from 'type-fest';
@@ -21,7 +21,7 @@ import {
   setBaseUrl,
 } from '../../util/http/bitbucket-server';
 import { sanitize } from '../../util/sanitize';
-import { ensureTrailingSlash } from '../../util/url';
+import { ensureTrailingSlash, getQueryString } from '../../util/url';
 import {
   BranchStatusConfig,
   CreatePRConfig,
@@ -326,7 +326,7 @@ export async function getPrList(refreshCache?: boolean): Promise<Pr[]> {
       searchParams['role.1'] = 'AUTHOR';
       searchParams['username.1'] = config.username;
     }
-    const query = new URLSearchParams(searchParams).toString();
+    const query = getQueryString(searchParams);
     const values = await utils.accumulateValues(
       `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests?${query}`
     );

--- a/lib/platform/gitea/gitea-helper.ts
+++ b/lib/platform/gitea/gitea-helper.ts
@@ -1,6 +1,6 @@
-import { URLSearchParams } from 'url';
 import { BranchStatus, PrState } from '../../types';
 import { GiteaHttp, GiteaHttpOptions } from '../../util/http/gitea';
+import { getQueryString } from '../../util/url';
 import { PrReviewersParams } from './types';
 
 const giteaHttp = new GiteaHttp();
@@ -192,20 +192,6 @@ const commitStatusStates: CommitStatusType[] = [
   'error',
 ];
 
-function queryParams(params: Record<string, any>): URLSearchParams {
-  const usp = new URLSearchParams();
-  for (const [k, v] of Object.entries(params)) {
-    if (Array.isArray(v)) {
-      for (const item of v) {
-        usp.append(k, item.toString());
-      }
-    } else {
-      usp.append(k, v.toString());
-    }
-  }
-  return usp;
-}
-
 export async function getCurrentUser(
   options?: GiteaHttpOptions
 ): Promise<User> {
@@ -218,7 +204,7 @@ export async function searchRepos(
   params: RepoSearchParams,
   options?: GiteaHttpOptions
 ): Promise<Repo[]> {
-  const query = queryParams(params).toString();
+  const query = getQueryString(params);
   const url = `repos/search?${query}`;
   const res = await giteaHttp.getJson<RepoSearchResults>(url, {
     ...options,
@@ -249,7 +235,7 @@ export async function getRepoContents(
   ref?: string,
   options?: GiteaHttpOptions
 ): Promise<RepoContents> {
-  const query = queryParams(ref ? { ref } : {}).toString();
+  const query = getQueryString(ref ? { ref } : {});
   const url = `repos/${repoPath}/contents/${urlEscape(filePath)}?${query}`;
   const res = await giteaHttp.getJson<RepoContents>(url, options);
 
@@ -342,7 +328,7 @@ export async function searchPRs(
   params: PRSearchParams,
   options?: GiteaHttpOptions
 ): Promise<PR[]> {
-  const query = queryParams(params).toString();
+  const query = getQueryString(params);
   const url = `repos/${repoPath}/pulls?${query}`;
   const res = await giteaHttp.getJson<PR[]>(url, {
     ...options,
@@ -397,7 +383,7 @@ export async function searchIssues(
   params: IssueSearchParams,
   options?: GiteaHttpOptions
 ): Promise<Issue[]> {
-  const query = queryParams({ ...params, type: 'issues' }).toString();
+  const query = getQueryString({ ...params, type: 'issues' });
   const url = `repos/${repoPath}/issues?${query}`;
   const res = await giteaHttp.getJson<Issue[]>(url, {
     ...options,

--- a/lib/platform/gitlab/index.ts
+++ b/lib/platform/gitlab/index.ts
@@ -1,4 +1,4 @@
-import URL, { URLSearchParams } from 'url';
+import URL from 'url';
 import is from '@sindresorhus/is';
 import delay from 'delay';
 import semver from 'semver';
@@ -21,7 +21,7 @@ import * as hostRules from '../../util/host-rules';
 import { HttpResponse } from '../../util/http';
 import { GitlabHttp, setBaseUrl } from '../../util/http/gitlab';
 import { sanitize } from '../../util/sanitize';
-import { ensureTrailingSlash } from '../../util/url';
+import { ensureTrailingSlash, getQueryString } from '../../util/url';
 import {
   BranchStatusConfig,
   CreatePRConfig,
@@ -384,7 +384,7 @@ async function fetchPrList(): Promise<Pr[]> {
     // default: `scope=created_by_me`
     searchParams.scope = 'all';
   }
-  const query = new URLSearchParams(searchParams).toString();
+  const query = getQueryString(searchParams);
   const urlString = `projects/${config.repository}/merge_requests?${query}`;
   try {
     const res = await gitlabApi.getJson<
@@ -710,11 +710,11 @@ export async function setBranchStatus({
 
 export async function getIssueList(): Promise<GitlabIssue[]> {
   if (!config.issueList) {
-    const query = new URLSearchParams({
+    const query = getQueryString({
       per_page: '100',
       author_id: `${authorId}`,
       state: 'opened',
-    }).toString();
+    });
     const res = await gitlabApi.getJson<{ iid: number; title: string }[]>(
       `projects/${config.repository}/issues?${query}`,
       {

--- a/lib/util/url.ts
+++ b/lib/util/url.ts
@@ -17,3 +17,18 @@ export function resolveBaseUrl(baseUrl: string, input: string | URL): string {
 
   return host ? inputString : urlJoin(baseUrl, pathname || '');
 }
+
+export function getQueryString(params: Record<string, any>): string {
+  const usp = new URLSearchParams();
+  for (const [k, v] of Object.entries(params)) {
+    if (Array.isArray(v)) {
+      for (const item of v) {
+        usp.append(k, item.toString());
+      }
+    } else {
+      usp.append(k, v.toString());
+    }
+  }
+  const res = usp.toString();
+  return res;
+}


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Removes direct use of `URLSearchParams` and replaces with a url util function.

## Context:

Part of an attempt to address our jest memory leaks.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
