### PR TITLE
test: add missing httpMock.reset

### DIFF
--- a/lib/datasource/bitbucket-tags/index.spec.ts
+++ b/lib/datasource/bitbucket-tags/index.spec.ts
@@ -8,6 +8,9 @@ describe(getName(__filename), () => {
     httpMock.reset();
     httpMock.setup();
   });
+  afterEach(() => {
+    httpMock.reset();
+  });
   describe('getReleases', () => {
     it('returns tags from bitbucket cloud', async () => {
       const body = {

--- a/lib/datasource/github-tags/index.spec.ts
+++ b/lib/datasource/github-tags/index.spec.ts
@@ -19,6 +19,9 @@ describe('datasource/github-tags', () => {
       token: 'some-token',
     });
   });
+  afterEach(() => {
+    httpMock.reset();
+  });
 
   describe('getDigest', () => {
     const lookupName = 'some/dep';
@@ -113,6 +116,9 @@ describe('datasource/github-tags', () => {
       hostRules.find.mockReturnValue({
         token: 'some-token',
       });
+    });
+    afterEach(() => {
+      httpMock.reset();
     });
 
     const depName = 'some/dep2';

--- a/lib/datasource/gitlab-tags/index.spec.ts
+++ b/lib/datasource/gitlab-tags/index.spec.ts
@@ -7,6 +7,9 @@ describe('datasource/gitlab-tags', () => {
     httpMock.reset();
     httpMock.setup();
   });
+  afterEach(() => {
+    httpMock.reset();
+  });
   describe('getReleases', () => {
     it('returns tags from custom registry', async () => {
       const body = [

--- a/lib/platform/bitbucket-server/index.spec.ts
+++ b/lib/platform/bitbucket-server/index.spec.ts
@@ -231,6 +231,9 @@ describe(getName(__filename), () => {
           password,
         });
       });
+      afterEach(() => {
+        httpMock.reset();
+      });
 
       describe('initPlatform()', () => {
         it('should throw if no endpoint', () => {

--- a/lib/platform/bitbucket/comments.spec.ts
+++ b/lib/platform/bitbucket/comments.spec.ts
@@ -16,6 +16,9 @@ describe(getName(__filename), () => {
 
     setBaseUrl(baseUrl);
   });
+  afterEach(() => {
+    httpMock.reset();
+  });
 
   describe('ensureComment()', () => {
     it('does not throw', async () => {

--- a/lib/platform/bitbucket/index.spec.ts
+++ b/lib/platform/bitbucket/index.spec.ts
@@ -62,6 +62,9 @@ describe('platform/bitbucket', () => {
 
     setBaseUrl(baseUrl);
   });
+  afterEach(() => {
+    httpMock.reset();
+  });
 
   async function initRepoMock(
     config?: Partial<RepoParams>,

--- a/lib/platform/bitbucket/utils.spec.ts
+++ b/lib/platform/bitbucket/utils.spec.ts
@@ -35,5 +35,6 @@ describe('accumulateValues()', () => {
     expect(res).toHaveLength(25);
     expect(httpMock.getTrace()).toHaveLength(3);
     expect(httpMock.getTrace()).toMatchSnapshot();
+    httpMock.reset();
   });
 });

--- a/lib/platform/gitea/gitea-helper.spec.ts
+++ b/lib/platform/gitea/gitea-helper.spec.ts
@@ -143,6 +143,9 @@ describe('platform/gitea/gitea-helper', () => {
     httpMock.setup();
     setBaseUrl(baseUrl);
   });
+  afterEach(() => {
+    httpMock.reset();
+  });
 
   describe('getCurrentUser', () => {
     it('should call /api/v1/user endpoint', async () => {

--- a/lib/platform/gitlab/index.spec.ts
+++ b/lib/platform/gitlab/index.spec.ts
@@ -40,6 +40,9 @@ describe('platform/gitlab', () => {
     httpMock.reset();
     httpMock.setup();
   });
+  afterEach(() => {
+    httpMock.reset();
+  });
 
   describe('initPlatform()', () => {
     it(`should throw if no token`, async () => {

--- a/lib/util/http/bitbucket-server.spec.ts
+++ b/lib/util/http/bitbucket-server.spec.ts
@@ -27,6 +27,9 @@ describe(getName(__filename), () => {
 
     setBaseUrl(baseUrl);
   });
+  afterEach(() => {
+    httpMock.reset();
+  });
   it('posts', async () => {
     const body = ['a', 'b'];
     httpMock.scope(baseUrl).post('/some-url').reply(200, body);

--- a/lib/util/http/bitbucket.spec.ts
+++ b/lib/util/http/bitbucket.spec.ts
@@ -27,6 +27,9 @@ describe(getName(__filename), () => {
 
     setBaseUrl(baseUrl);
   });
+  afterEach(() => {
+    httpMock.reset();
+  });
   it('posts', async () => {
     const body = ['a', 'b'];
     httpMock.scope(baseUrl).post('/some-url').reply(200, body);

--- a/lib/util/http/gitea.spec.ts
+++ b/lib/util/http/gitea.spec.ts
@@ -18,6 +18,10 @@ describe(getName(__filename), () => {
     setBaseUrl(baseUrl);
   });
 
+  afterEach(() => {
+    httpMock.reset();
+  });
+
   it('supports responses without pagination when enabled', async () => {
     httpMock
       .scope(baseUrl)

--- a/lib/util/http/host-rules.spec.ts
+++ b/lib/util/http/host-rules.spec.ts
@@ -39,6 +39,7 @@ describe(getName(__filename), () => {
 
   afterEach(() => {
     delete process.env.HTTP_PROXY;
+    httpMock.reset();
   });
 
   it('adds token', () => {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds missing `httpMock.reset()` calls to `afterAll()`

## Context:

`nock` can be a source of memory leaks

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
