### PR TITLE
fix(go): handle null

### DIFF
--- a/lib/datasource/go/index.spec.ts
+++ b/lib/datasource/go/index.spec.ts
@@ -1,5 +1,6 @@
 import { getPkgReleases } from '..';
 import * as httpMock from '../../../test/http-mock';
+import { logger } from '../../../test/util';
 import { id as datasource, getDigest } from '.';
 
 const res1 = `<!DOCTYPE html>
@@ -223,6 +224,12 @@ describe('datasource/go', () => {
       expect(res).toMatchSnapshot();
       expect(res).toBeNull();
       expect(httpMock.getTrace()).toMatchSnapshot();
+      expect(logger.logger.warn).toHaveBeenCalled();
+      expect(logger.logger.error).not.toHaveBeenCalledWith(
+        { lookupName: 'golang.org/foo/something' },
+        'Unsupported dependency.'
+      );
+      expect(logger.logger.fatal).not.toHaveBeenCalled();
     });
     it('support ghe', async () => {
       httpMock

--- a/lib/datasource/go/index.ts
+++ b/lib/datasource/go/index.ts
@@ -125,6 +125,11 @@ export async function getReleases({
   const source = await getDatasource(lookupName);
   let res = null;
 
+  if (!source) {
+    logger.warn({ lookupName }, 'Unsupported dependency.');
+    return null;
+  }
+
   switch (source.datasource) {
     case github.id: {
       res = await github.getReleases(source);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Check `getDatasource` result for null. Test doesn't fail before because datasource has catched the error.
<!-- Describe what behavior is changed by this PR. -->

## Context:
#8859
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
