### PR TITLE
feat: allow composer security patch versioning

### DIFF
--- a/lib/versioning/composer/index.spec.ts
+++ b/lib/versioning/composer/index.spec.ts
@@ -38,6 +38,10 @@ describe('semver.isStable(input)', () => {
   it('should pad short version', () => {
     expect(semver.isStable('v1.2')).toBeTruthy();
   });
+    it('should mark -p/-patch version as stable', () => {
+        expect(semver.isStable('1.2.3-p1')).toBeTruthy();
+        expect(semver.isStable('1.2.3-patch1')).toBeTruthy();
+    });
 });
 describe('semver.isValid(input)', () => {
   it('should support simple semver', () => {
@@ -448,7 +452,7 @@ describe('semver.getNewValue()', () => {
 describe('.sortVersions', () => {
   it('sorts versions in an ascending order', () => {
     expect(
-      ['1.2.3-beta', '2.0.1', '1.3.4', '1.2.3'].sort(semver.sortVersions)
-    ).toEqual(['1.2.3-beta', '1.2.3', '1.3.4', '2.0.1']);
+      ['1.2.3-beta', '1.2.3-p1', '2.0.1', '1.3.4', '1.3.4-patch1', '1.2.3'].sort(semver.sortVersions)
+    ).toEqual(['1.2.3-beta', '1.2.3', '1.2.3-p1', '1.3.4', '1.3.4-patch1', '2.0.1']);
   });
 });

--- a/lib/versioning/composer/index.ts
+++ b/lib/versioning/composer/index.ts
@@ -57,7 +57,7 @@ function normalizeVersion(input: string): string {
   return convertStabilityModifier(output);
 }
 
-function composer2npm(input: string): string {
+function composer2npm(input: string, allowPatchVersion = false): string {
   const cleanInput = normalizeVersion(input);
   if (npm.isVersion(cleanInput)) {
     return cleanInput;
@@ -72,6 +72,11 @@ function composer2npm(input: string): string {
   output = output.replace(/(?:^|\s)~([1-9][0-9]*(?:\.[0-9]*)?)(?: |$)/g, '^$1');
   // ~0.4 to >=0.4 <1
   output = output.replace(/(?:^|\s)~(0\.[1-9][0-9]*)(?: |$)/g, '>=$1 <1');
+
+  // allow security composer patch version 2.3.6-p1
+  if (allowPatchVersion && stability && /^-(p|patch)+[0-9]+$/.test(stability)) {
+    return output;
+  }
 
   return output + stability;
 }
@@ -98,7 +103,7 @@ const isSingleVersion = (input: string): string | boolean =>
   input && npm.isSingleVersion(composer2npm(input));
 
 const isStable = (version: string): boolean =>
-  version && npm.isStable(composer2npm(version));
+  version && npm.isStable(composer2npm(version, true));
 
 export const isValid = (input: string): string | boolean =>
   input && npm.isValid(composer2npm(input));
@@ -110,10 +115,16 @@ const matches = (version: string, range: string): boolean =>
   npm.matches(composer2npm(version), composer2npm(range));
 
 const getSatisfyingVersion = (versions: string[], range: string): string =>
-  npm.getSatisfyingVersion(versions.map(composer2npm), composer2npm(range));
+  npm.getSatisfyingVersion(
+    versions.map((version) => composer2npm(version)),
+    composer2npm(range)
+  );
 
 const minSatisfyingVersion = (versions: string[], range: string): string =>
-  npm.minSatisfyingVersion(versions.map(composer2npm), composer2npm(range));
+  npm.minSatisfyingVersion(
+    versions.map((version) => composer2npm(version)),
+    composer2npm(range)
+  );
 
 function getNewValue({
   currentValue,

--- a/lib/versioning/composer/index.ts
+++ b/lib/versioning/composer/index.ts
@@ -57,7 +57,7 @@ function normalizeVersion(input: string): string {
   return convertStabilityModifier(output);
 }
 
-function composer2npm(input: string, allowPatchVersion = false): string {
+function composer2npm(input: string): string {
   const cleanInput = normalizeVersion(input);
   if (npm.isVersion(cleanInput)) {
     return cleanInput;
@@ -72,11 +72,6 @@ function composer2npm(input: string, allowPatchVersion = false): string {
   output = output.replace(/(?:^|\s)~([1-9][0-9]*(?:\.[0-9]*)?)(?: |$)/g, '^$1');
   // ~0.4 to >=0.4 <1
   output = output.replace(/(?:^|\s)~(0\.[1-9][0-9]*)(?: |$)/g, '>=$1 <1');
-
-  // allow security composer patch version 2.3.6-p1
-  if (allowPatchVersion && stability && /^-(p|patch)+[0-9]+$/.test(stability)) {
-    return output;
-  }
 
   return output + stability;
 }
@@ -103,7 +98,7 @@ const isSingleVersion = (input: string): string | boolean =>
   input && npm.isSingleVersion(composer2npm(input));
 
 const isStable = (version: string): boolean =>
-  version && npm.isStable(composer2npm(version, true));
+  version && npm.isStable(composer2npm(version.replace(/^-(p|patch)+[0-9]+$/, '')));
 
 export const isValid = (input: string): string | boolean =>
   input && npm.isValid(composer2npm(input));
@@ -115,16 +110,10 @@ const matches = (version: string, range: string): boolean =>
   npm.matches(composer2npm(version), composer2npm(range));
 
 const getSatisfyingVersion = (versions: string[], range: string): string =>
-  npm.getSatisfyingVersion(
-    versions.map((version) => composer2npm(version)),
-    composer2npm(range)
-  );
+  npm.getSatisfyingVersion(versions.map(composer2npm), composer2npm(range));
 
 const minSatisfyingVersion = (versions: string[], range: string): string =>
-  npm.minSatisfyingVersion(
-    versions.map((version) => composer2npm(version)),
-    composer2npm(range)
-  );
+  npm.minSatisfyingVersion(versions.map(composer2npm), composer2npm(range));
 
 function getNewValue({
   currentValue,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:
<!-- Describe what behavior is changed by this PR. -->
Mark patch version as stable for composer versioning

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->
Composer versioning: -p suffixes should be considered stable and sort higher
https://github.com/renovatebot/renovate/issues/8849

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
