### PR TITLE
chore: automatically label incoming bugs/feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,7 @@
 ---
 name: Bug report
 about: You've found a bug with Renovate
+labels: 'type:bug, status:requirements'
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
+labels: 'type:feature, status:requirements'
 ---
 
 **What would you like Renovate to be able to do?**

--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -27,14 +27,3 @@
 
     The Renovate team will take a look at the reproduction repository.
     Once we confirm the provided repository reproduces the problem, the label will be changed to `reproduction:confirmed`.
-
-'status:requirements':
-  comment: >
-    This issue has been labeled with `status:requirements`. This indicates that we don't know enough to start work and further requirements or a reproduction are needed first.
-
-
-    This label will be replaced with `status:ready` once all requirements and reproductions necessary to start work have been met.
-
-
-    If it's not clear _what_ is missing to move this issue forward, ask for clarification in a new comment.
-    If you think we already have what we need to move forward, mention this in a new comment.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

- Automatically label incoming issues that come from a template
- Remove `status:requirements` auto-comment

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

We can use the front-matter property `labels` to specify what labels we want GitHub to automatically apply to incoming issues filled from the templates. This reduces the amount of busywork for maintainers.

EDIT: **rarkins** has chosen to remove the `status:requirements` part of the stale bot action.

~Also the `status:requirements` label automatically fires a message right after the issue is opened.
By merging this PR we change the context in which this label is applied, so maybe we should adjust this message as well with this PR?~

~The current `status:requirements` message says:~

> This issue has been labeled with `status:requirements`. This indicates that we don't know enough to start work and further requirements or a reproduction are needed first.

> This label will be replaced with `status:ready` once all requirements and reproductions necessary to start work have been met.
> If it's not clear _what_ is missing to move this issue forward, ask for clarification in a new comment.
> If you think we already have what we need to move forward, mention this in a new comment.


## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
