### PR TITLE
fix(pypi): ensure trailing slash for simple API endpoints

### DIFF
--- a/lib/datasource/pypi/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/pypi/__snapshots__/index.spec.ts.snap
@@ -60,7 +60,7 @@ Array [
       "user-agent": "https://github.com/renovatebot/renovate",
     },
     "method": "GET",
-    "url": "https://custom.pypi.net/foo/dj-database-url",
+    "url": "https://custom.pypi.net/foo/dj-database-url/",
   },
 ]
 `;
@@ -114,7 +114,7 @@ Array [
       "user-agent": "https://github.com/renovatebot/renovate",
     },
     "method": "GET",
-    "url": "https://pypi.org/simple/dj-database-url",
+    "url": "https://pypi.org/simple/dj-database-url/",
   },
 ]
 `;
@@ -169,7 +169,7 @@ Array [
       "user-agent": "https://github.com/renovatebot/renovate",
     },
     "method": "GET",
-    "url": "https://some.registry.org/+simple/dj-database-url",
+    "url": "https://some.registry.org/+simple/dj-database-url/",
   },
 ]
 `;
@@ -224,7 +224,7 @@ Array [
       "user-agent": "https://github.com/renovatebot/renovate",
     },
     "method": "GET",
-    "url": "https://pypi.org/simple/dj-database-url",
+    "url": "https://pypi.org/simple/dj-database-url/",
   },
 ]
 `;
@@ -248,7 +248,7 @@ Array [
       "user-agent": "https://github.com/renovatebot/renovate",
     },
     "method": "GET",
-    "url": "https://pypi.org/simple/image-collector",
+    "url": "https://pypi.org/simple/image-collector/",
   },
 ]
 `;
@@ -435,7 +435,7 @@ Array [
       "user-agent": "https://github.com/renovatebot/renovate",
     },
     "method": "GET",
-    "url": "https://pypi.org/pypi/something",
+    "url": "https://pypi.org/pypi/something/",
   },
 ]
 `;
@@ -449,7 +449,7 @@ Array [
       "user-agent": "https://github.com/renovatebot/renovate",
     },
     "method": "GET",
-    "url": "https://pypi.org/simple/dj-database-url",
+    "url": "https://pypi.org/simple/dj-database-url/",
   },
 ]
 `;
@@ -463,7 +463,7 @@ Array [
       "user-agent": "https://github.com/renovatebot/renovate",
     },
     "method": "GET",
-    "url": "https://pypi.org/simple/dj-database-url",
+    "url": "https://pypi.org/simple/dj-database-url/",
   },
 ]
 `;

--- a/lib/datasource/pypi/index.spec.ts
+++ b/lib/datasource/pypi/index.spec.ts
@@ -53,7 +53,7 @@ describe('datasource/pypi', () => {
     });
     it('returns null for 404', async () => {
       httpMock.scope(baseUrl).get('/something/json').reply(404);
-      httpMock.scope(baseUrl).get('/something').reply(404);
+      httpMock.scope(baseUrl).get('/something/').reply(404);
       expect(
         await getPkgReleases({
           datasource,
@@ -233,7 +233,7 @@ describe('datasource/pypi', () => {
     it('process data from simple endpoint', async () => {
       httpMock
         .scope('https://pypi.org/simple/')
-        .get('/dj-database-url')
+        .get('/dj-database-url/')
         .reply(200, htmlResponse);
       const config = {
         registryUrls: ['https://pypi.org/simple/'],
@@ -251,7 +251,7 @@ describe('datasource/pypi', () => {
     it('process data from +simple endpoint', async () => {
       httpMock
         .scope('https://some.registry.org/+simple/')
-        .get('/dj-database-url')
+        .get('/dj-database-url/')
         .reply(200, htmlResponse);
       const config = {
         registryUrls: ['https://some.registry.org/+simple/'],
@@ -270,7 +270,7 @@ describe('datasource/pypi', () => {
       hostRules.add({ hostName: 'some.private.registry.org', token: 'abc123' });
       httpMock
         .scope('https://some.private.registry.org/+simple/')
-        .get('/dj-database-url')
+        .get('/dj-database-url/')
         .reply(200, htmlResponse);
       const config = {
         registryUrls: ['https://some.private.registry.org/+simple/'],
@@ -286,7 +286,7 @@ describe('datasource/pypi', () => {
     it('process data from simple endpoint with hyphens replaced with underscores', async () => {
       httpMock
         .scope('https://pypi.org/simple/')
-        .get('/image-collector')
+        .get('/image-collector/')
         .reply(200, mixedHyphensResponse);
       const config = {
         registryUrls: ['https://pypi.org/simple/'],
@@ -304,7 +304,7 @@ describe('datasource/pypi', () => {
     it('returns null for empty response', async () => {
       httpMock
         .scope('https://pypi.org/simple/')
-        .get('/dj-database-url')
+        .get('/dj-database-url/')
         .reply(200);
       const config = {
         registryUrls: ['https://pypi.org/simple/'],
@@ -322,7 +322,7 @@ describe('datasource/pypi', () => {
     it('returns null for 404 response from simple endpoint', async () => {
       httpMock
         .scope('https://pypi.org/simple/')
-        .get('/dj-database-url')
+        .get('/dj-database-url/')
         .replyWithError('error');
       const config = {
         registryUrls: ['https://pypi.org/simple/'],
@@ -340,7 +340,7 @@ describe('datasource/pypi', () => {
     it('returns null for response with no versions', async () => {
       httpMock
         .scope('https://pypi.org/simple/')
-        .get('/dj-database-url')
+        .get('/dj-database-url/')
         .reply(200, badResponse);
       const config = {
         registryUrls: ['https://pypi.org/simple/'],
@@ -361,7 +361,7 @@ describe('datasource/pypi', () => {
         .reply(404);
       httpMock
         .scope('https://custom.pypi.net/foo')
-        .get('/dj-database-url')
+        .get('/dj-database-url/')
         .reply(200, htmlResponse);
       const config = {
         registryUrls: ['https://custom.pypi.net/foo'],
@@ -377,7 +377,7 @@ describe('datasource/pypi', () => {
     it('parses data-requires-python and respects constraints from simple endpoint', async () => {
       httpMock
         .scope('https://pypi.org/simple/')
-        .get('/dj-database-url')
+        .get('/dj-database-url/')
         .reply(200, dataRequiresPythonResponse);
       const config = {
         registryUrls: ['https://pypi.org/simple/'],

--- a/lib/datasource/pypi/index.ts
+++ b/lib/datasource/pypi/index.ts
@@ -175,7 +175,7 @@ async function getSimpleDependency(
   packageName: string,
   hostUrl: string
 ): Promise<ReleaseResult | null> {
-  const lookupUrl = url.resolve(hostUrl, `${packageName}`);
+  const lookupUrl = url.resolve(hostUrl, ensureTrailingSlash(packageName));
   const dependency: ReleaseResult = { releases: null };
   const response = await http.get(lookupUrl);
   const dep = response?.body;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Makes the pypi lookup URL PEP-compliant with a trailing slash. Closes https://github.com/renovatebot/renovate/issues/8817

## Context:

Related to Artifactory pypi redirects to http when no trailing slash is present. Possibly makes @dlouzan a very happy man.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
