### PR TITLE
ci: split pr workflow

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,6 +1,9 @@
 name: build-pr
 
 on:
+  push:
+    branches:
+      - 'renovate/**'
   pull_request:
 
 env:

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,9 +1,6 @@
 name: build-pr
 
 on:
-  push:
-    branches:
-      - 'renovate/**'
   pull_request:
 
 env:

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -61,18 +61,11 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Unit tests
-        run: yarn jest --maxWorkers=2 --ci
-
-      - name: Upload coverage
-        uses: actions/upload-artifact@v2.2.2
-        with:
-          name: coverage
-          path: coverage
+        run: yarn jest --logHeapUsage --maxWorkers=2 --ci
 
       - name: Codecov
-        shell: bash
-        continue-on-error: true
-        run: bash <(curl -s https://codecov.io/bash)
+        uses: codecov/codecov-action@v1.2.1
+        if: always() && env.coverage == 'true'
 
       # build after tests to exclude files
       - name: Build

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,42 +1,22 @@
-name: build
+name: build-pr
 
 on:
-  push:
-    branches:
-      - master
-
-  workflow_dispatch:
+  pull_request:
 
 env:
   YARN_MODULES_CACHE_KEY: v1
   YARN_PACKAGE_CACHE_KEY: v1
   YARN_CACHE_FOLDER: .cache/yarn
   NODE_VERSION: 14
+  PYTHON_VERSION: 3.8
+  SKIP_JAVA_TESTS: true
 
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     # tests shouldn't need more time
     timeout-minutes: 30
-
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [12, 14]
-        python-version: [3.8]
-        java-version: [11]
-        exclude:
-          - os: windows-latest
-            node-version: 12
-          - os: macos-latest
-            node-version: 12
-
-    env:
-      coverage: ${{ matrix.os == 'ubuntu-latest' && matrix.node-version == 14 }}
-      NODE_VERSION: ${{ matrix.node-version }}
-      PYTHON_VERSION: ${{ matrix.python-version }}
-      JAVA_VERSION: ${{ matrix.java-version }}
 
     steps:
       - name: Set up Node.js ${{ env.NODE_VERSION }}
@@ -48,16 +28,6 @@ jobs:
         uses: actions/setup-python@v2.2.1
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Set up Java  ${{ env.JAVA_VERSION }}
-        if: env.NODE_VERSION == '14'
-        uses: actions/setup-java@v1.4.3
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-
-      - name: Skip Java tests
-        if: env.NODE_VERSION != '14'
-        run: echo "SKIP_JAVA_TESTS=true" >> $GITHUB_ENV
 
       - name: Init platform
         shell: bash
@@ -90,26 +60,23 @@ jobs:
       - name: Installing dependencies
         run: yarn install --frozen-lockfile
 
-      - name: Build
-        run: yarn build
-
       - name: Unit tests
-        run: yarn jest --maxWorkers=2 --ci --coverage ${{ env.coverage }}
+        run: yarn jest --maxWorkers=2 --ci
 
       - name: Upload coverage
         uses: actions/upload-artifact@v2.2.2
-        if: always() && env.coverage == 'true'
         with:
           name: coverage
           path: coverage
 
       - name: Codecov
         shell: bash
-        if: always() && env.coverage == 'true'
         continue-on-error: true
         run: bash <(curl -s https://codecov.io/bash)
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+      # build after tests to exclude files
+      - name: Build
+        run: yarn build
 
       - name: E2E Test
         run: yarn test-e2e
@@ -157,7 +124,7 @@ jobs:
 
       - name: Lint
         run: |
-          yarn eslint -f ./tmp/tools/eslint-gh-reporter.js
+          yarn eslint
           yarn prettier
 
       - name: Test schema
@@ -165,47 +132,3 @@ jobs:
 
       - name: Type check
         run: yarn type-check
-
-  release:
-    needs: [lint, test]
-    runs-on: ubuntu-latest
-    # release shouldn't need more than 5 min
-    timeout-minutes: 15
-
-    steps:
-      - name: Set up Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v2.1.5
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-
-      - name: Init platform
-        run: |
-          git config --global core.autocrlf false
-          git config --global core.symlinks true
-          git config --global user.email 'renovate@whitesourcesoftware.com'
-          git config --global user.name  'Renovate Bot'
-          yarn config set version-git-tag false
-          npm config set scripts-prepend-node-path true
-
-      # full checkout for semantic-release
-      - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
-
-      - name: Cache Yarn packages
-        uses: actions/cache@v2.1.4
-        with:
-          path: ${{ env.YARN_CACHE_FOLDER }}
-          key: ${{ env.YARN_PACKAGE_CACHE_KEY }}-${{ runner.os }}-yarn_cache-${{ hashFiles('**/yarn.lock') }}
-
-      - name: Installing dependencies
-        run: yarn install --frozen-lockfile
-
-      - name: semantic-release
-        if: github.ref == 'refs/heads/master'
-        run: |
-          echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> ~/.npmrc
-          npx semantic-release --dry-run ${{github.ref != 'refs/heads/master'}} --ci ${{github.ref == 'refs/heads/master'}}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,26 +90,16 @@ jobs:
       - name: Installing dependencies
         run: yarn install --frozen-lockfile
 
-      - name: Build
-        run: yarn build
-
       - name: Unit tests
-        run: yarn jest --maxWorkers=2 --ci --coverage ${{ env.coverage }}
-
-      - name: Upload coverage
-        uses: actions/upload-artifact@v2.2.2
-        if: always() && env.coverage == 'true'
-        with:
-          name: coverage
-          path: coverage
+        run: yarn jest --logHeapUsage --maxWorkers=2 --ci --coverage ${{ env.coverage }}
 
       - name: Codecov
-        shell: bash
+        uses: codecov/codecov-action@v1.2.1
         if: always() && env.coverage == 'true'
-        continue-on-error: true
-        run: bash <(curl -s https://codecov.io/bash)
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+      # build after tests to exclude files
+      - name: Build
+        run: yarn build
 
       - name: E2E Test
         run: yarn test-e2e

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "assignees": ["rarkins", "viceice"],
   "semanticCommitScope": "deps",
   "automergeType": "pr",
+  "prCreation": "immediate",
   "dockerfile": {
     "semanticCommitType": "build"
   },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Use separate smaller workflow for pr's
- Immediate create renovate pr, as we use pr automerge anyways. Also reduces ci builds.
<!-- Describe what behavior is changed by this PR. -->

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
