### PR TITLE
fix: remove docker setTimeout

### DIFF
--- a/lib/util/exec/index.ts
+++ b/lib/util/exec/index.ts
@@ -140,15 +140,8 @@ export async function exec(
   let res: ExecResult | null = null;
   for (const rawExecCommand of commands) {
     const startTime = Date.now();
-    let timer;
-    const { timeout } = rawExecOptions;
     if (useDocker) {
       await removeDockerContainer(docker.image);
-      // istanbul ignore next
-      timer = setTimeout(() => {
-        removeDockerContainer(docker.image); // eslint-disable-line
-        logger.info({ timeout, rawExecCommand }, 'Docker run timed out');
-      }, timeout);
     }
     logger.debug({ command: rawExecCommand }, 'Executing command');
     logger.trace({ commandOptions: rawExecOptions }, 'Command options');
@@ -156,7 +149,6 @@ export async function exec(
       res = await rawExec(rawExecCommand, rawExecOptions);
     } catch (err) {
       logger.trace({ err }, 'rawExec err');
-      clearTimeout(timer);
       if (useDocker) {
         await removeDockerContainer(docker.image).catch((removeErr: Error) => {
           const message: string = err.message;
@@ -167,7 +159,6 @@ export async function exec(
       }
       throw err;
     }
-    clearTimeout(timer);
     const durationMs = Math.round(Date.now() - startTime);
     if (res) {
       logger.debug(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Removes logic to remove Docker containers on timeout and instead rely on the child process's own `timeout` feature.

## Context:

When reviewing this due to #8903 I realized that the child process timeout and `docker rm` logic would be executing simultaneously. I would like to try with only CP doing the timing out for now because Docker containers are cleaned up prior to the next command anyway.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
