### PR TITLE
fix: log git commit and push results

### DIFF
--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -666,6 +666,7 @@ export async function commitFiles({
       '-u': null,
       '--no-verify': null,
     });
+    delete pushRes.repo;
     logger.debug({ result: pushRes }, 'git push');
     // Fetch it after create
     const ref = `refs/heads/${branchName}:refs/remotes/origin/${branchName}`;

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -652,6 +652,7 @@ export async function commitFiles({
     const commitRes = await git.commit(message, [], {
       '--no-verify': null,
     });
+    logger.debug({ result: commitRes }, `git commit`);
     const commit = commitRes?.commit || 'unknown';
     if (!force && !(await hasDiff(`origin/${branchName}`))) {
       logger.debug(
@@ -660,11 +661,12 @@ export async function commitFiles({
       );
       return null;
     }
-    await git.push('origin', `${branchName}:${branchName}`, {
+    const pushRes = await git.push('origin', `${branchName}:${branchName}`, {
       '--force': null,
       '-u': null,
       '--no-verify': null,
     });
+    logger.debug({ result: pushRes }, 'git push');
     // Fetch it after create
     const ref = `refs/heads/${branchName}:refs/remotes/origin/${branchName}`;
     await git.fetch(['origin', ref, '--depth=2', '--force']);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Logs commit and push results for easier debugging.

## Context:

Debugging git from logs is hard without this.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
