### PR TITLE
fix: registry returned by getRegistryRepository must be a URL

### DIFF
--- a/lib/datasource/docker/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/docker/__snapshots__/index.spec.ts.snap
@@ -392,7 +392,21 @@ Object {
 
 exports[`datasource/docker/index getRegistryRepository supports registryUrls 1`] = `
 Object {
-  "registry": "my.local.registry/prefix",
+  "registry": "https://my.local.registry/prefix",
+  "repository": "image",
+}
+`;
+
+exports[`datasource/docker/index getRegistryRepository supports http registryUrls 1`] = `
+Object {
+  "registry": "http://my.local.registry/prefix",
+  "repository": "image",
+}
+`;
+
+exports[`datasource/docker/index getRegistryRepository supports schemeless registryUrls 1`] = `
+Object {
+  "registry": "https://my.local.registry/prefix",
   "repository": "image",
 }
 `;

--- a/lib/datasource/docker/index.spec.ts
+++ b/lib/datasource/docker/index.spec.ts
@@ -71,6 +71,20 @@ describe(getName(__filename), () => {
       );
       expect(res).toMatchSnapshot();
     });
+    it('supports http registryUrls', () => {
+      const res = docker.getRegistryRepository(
+        'my.local.registry/prefix/image',
+        'http://my.local.registry/prefix'
+      );
+      expect(res).toMatchSnapshot();
+    });
+    it('supports schemeless registryUrls', () => {
+      const res = docker.getRegistryRepository(
+        'my.local.registry/prefix/image',
+        'my.local.registry/prefix'
+      );
+      expect(res).toMatchSnapshot();
+    });
   });
   describe('getDigest', () => {
     it('returns null if no token', async () => {

--- a/lib/datasource/docker/index.ts
+++ b/lib/datasource/docker/index.ts
@@ -11,6 +11,7 @@ import { ExternalHostError } from '../../types/errors/external-host-error';
 import * as packageCache from '../../util/cache/package';
 import * as hostRules from '../../util/host-rules';
 import { Http, HttpResponse } from '../../util/http';
+import { ensureTrailingSlash, trimTrailingSlash } from '../../util/url';
 import * as dockerVersioning from '../../versioning/docker';
 import type { GetReleasesConfig, ReleaseResult } from '../types';
 import { Image, ImageList, MediaType } from './types';
@@ -66,9 +67,14 @@ export function getRegistryRepository(
   registryUrl: string
 ): RegistryRepository {
   if (registryUrl !== defaultRegistryUrls[0]) {
-    const registry = registryUrl.replace('https://', '');
-    const registryEndingWithSlash = registry.replace(/\/?$/, '/');
+    const registryEndingWithSlash = ensureTrailingSlash(
+      registryUrl.replace(/^https?:\/\//, '')
+    );
     if (lookupName.startsWith(registryEndingWithSlash)) {
+      let registry = trimTrailingSlash(registryUrl);
+      if (!/^https?:\/\//.test(registry)) {
+        registry = `https://${registry}`;
+      }
       return {
         registry,
         repository: lookupName.replace(registryEndingWithSlash, ''),

--- a/lib/util/url.ts
+++ b/lib/util/url.ts
@@ -4,6 +4,10 @@ export function ensureTrailingSlash(url: string): string {
   return url.replace(/\/?$/, '/');
 }
 
+export function trimTrailingSlash(url: string): string {
+  return url.replace(/\/?$/, '');
+}
+
 export function resolveBaseUrl(baseUrl: string, input: string | URL): string {
   const inputString = input.toString();
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:
The registry returned by `getRegistryRepository` must be a URL (including the scheme portion).

<!-- Describe what behavior is changed by this PR. -->

## Context:

Addresses another issue covered in #8649 - specifically https://github.com/renovatebot/renovate/issues/8649#issuecomment-787794610

I'm seeing this stack trace:
```
"stack": "TypeError [ERR_INVALID_URL]: Invalid URL: my.registry/v2/
    at onParseError (internal/url.js:259:9)
    at parse (<anonymous>)
    at new URL (internal/url.js:335:5)
    at Object.exports.default (/usr/src/app/node_modules/got/dist/source/core/utils/options-to-url.js:35:17)
    at normalizeArguments (/usr/src/app/node_modules/got/dist/source/core/index.js:480:51)
    at Function.got [as default] (/usr/src/app/node_modules/got/dist/source/create.js:112:39)
    at gotRoutine (/usr/src/app/node_modules/renovate/lib/util/http/index.ts:79:25)
    at queueTask (/usr/src/app/node_modules/renovate/lib/util/http/index.ts:138:16)
    at Http.request (/usr/src/app/node_modules/renovate/lib/util/http/index.ts:145:45)
    at Http.get (/usr/src/app/node_modules/renovate/lib/util/http/index.ts:165:17)
    at getAuthHeaders (/usr/src/app/node_modules/renovate/lib/datasource/docker/index.ts:139:41)
    at getTags (/usr/src/app/node_modules/renovate/lib/datasource/docker/index.ts:445:27)
    at Object.getReleases (/usr/src/app/node_modules/renovate/lib/datasource/docker/index.ts:624:16)
    at getRegistryReleases (/usr/src/app/node_modules/renovate/lib/datasource/index.ts:68:15)
    at fetchReleases (/usr/src/app/node_modules/renovate/lib/datasource/index.ts:211:15)
    at Object.getPkgReleases (/usr/src/app/node_modules/renovate/lib/datasource/index.ts:272:7)
    at Object.lookupUpdates (/usr/src/app/node_modules/renovate/lib/workers/repository/process/lookup/index.ts:55:30)
    at fetchDepUpdates (/usr/src/app/node_modules/renovate/lib/workers/repository/process/fetch.ts:42:26)
    at /usr/src/app/node_modules/p-map/index.js:57:22"
```
`my.registry/v2/` is an invalid URL - the correct value is `https://my.registry/v2/`
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [X] Code inspection only, or
- [X] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
