### PR TITLE
feat: force node 15 for lerna when npm lockfileVersion=2

### DIFF
--- a/lib/manager/npm/post-update/lerna.ts
+++ b/lib/manager/npm/post-update/lerna.ts
@@ -79,7 +79,8 @@ export async function generateLockFiles(
       lernaCommand = lernaCommand.replace('--ignore-scripts ', '');
     }
     lernaCommand += cmdOptions;
-    const tagConstraint = await getNodeConstraint(config);
+    const allowUnstable = true; // lerna will pick the default installed npm@6 if we use node@<15
+    const tagConstraint = await getNodeConstraint(config, allowUnstable);
     const execOptions: ExecOptions = {
       cwd,
       extraEnv: {

--- a/lib/manager/npm/post-update/lerna.ts
+++ b/lib/manager/npm/post-update/lerna.ts
@@ -79,7 +79,7 @@ export async function generateLockFiles(
       lernaCommand = lernaCommand.replace('--ignore-scripts ', '');
     }
     lernaCommand += cmdOptions;
-    const allowUnstable = true; // lerna will pick the default installed npm@6 if we use node@<15
+    const allowUnstable = true; // lerna will pick the default installed npm@6 unless we use node@>=15
     const tagConstraint = await getNodeConstraint(config, allowUnstable);
     const execOptions: ExecOptions = {
       cwd,

--- a/lib/manager/npm/post-update/node-version.spec.ts
+++ b/lib/manager/npm/post-update/node-version.spec.ts
@@ -29,7 +29,6 @@ describe('getNodeConstraint', () => {
     expect(isAugmentedRange || node16IsStable).toBe(true);
   });
   it('forces node 15 if v2 lockfile detected and constraint allows', async () => {
-    fs.readLocalFile = jest.fn();
     fs.readLocalFile.mockResolvedValueOnce(null);
     fs.readLocalFile.mockResolvedValueOnce(null);
     fs.readLocalFile.mockResolvedValueOnce('{"lockfileVersion":2}');

--- a/lib/manager/npm/post-update/node-version.spec.ts
+++ b/lib/manager/npm/post-update/node-version.spec.ts
@@ -28,6 +28,35 @@ describe('getNodeConstraint', () => {
     const node16IsStable = isStable('16.100.0');
     expect(isAugmentedRange || node16IsStable).toBe(true);
   });
+  it('forces node 15 if v2 lockfile detected and constraint allows', async () => {
+    fs.readLocalFile = jest.fn();
+    fs.readLocalFile.mockResolvedValueOnce(null);
+    fs.readLocalFile.mockResolvedValueOnce(null);
+    fs.readLocalFile.mockResolvedValueOnce('{"lockfileVersion":2}');
+    const res = await getNodeConstraint({
+      ...config,
+      constraints: { node: '>= 12.16.0' },
+    });
+    const isAugmentedRange = res === '>=15';
+    const node16IsStable = isStable('16.100.0');
+    expect(isAugmentedRange || node16IsStable).toBe(true);
+  });
+  it('forces node 15 if v2 lockfile detected and no constraint', async () => {
+    fs.readLocalFile = jest.fn();
+    fs.readLocalFile.mockResolvedValueOnce(null);
+    fs.readLocalFile.mockResolvedValueOnce(null);
+    fs.readLocalFile.mockResolvedValueOnce('{"lockfileVersion":2}');
+    const res = await getNodeConstraint(
+      {
+        ...config,
+        constraints: {},
+      },
+      true
+    );
+    const isAugmentedRange = res === '>=15';
+    const node16IsStable = isStable('16.100.0');
+    expect(isAugmentedRange || node16IsStable).toBe(true);
+  });
   it('returns .node-version value', async () => {
     fs.readLocalFile = jest.fn();
     fs.readLocalFile.mockResolvedValueOnce(null);

--- a/lib/manager/npm/post-update/node-version.spec.ts
+++ b/lib/manager/npm/post-update/node-version.spec.ts
@@ -41,7 +41,6 @@ describe('getNodeConstraint', () => {
     expect(isAugmentedRange || node16IsStable).toBe(true);
   });
   it('forces node 15 if v2 lockfile detected and no constraint', async () => {
-    fs.readLocalFile = jest.fn();
     fs.readLocalFile.mockResolvedValueOnce(null);
     fs.readLocalFile.mockResolvedValueOnce(null);
     fs.readLocalFile.mockResolvedValueOnce('{"lockfileVersion":2}');

--- a/lib/manager/npm/post-update/node-version.ts
+++ b/lib/manager/npm/post-update/node-version.ts
@@ -29,13 +29,25 @@ function getPackageJsonConstraint(config: PostUpdateConfig): string | null {
 }
 
 export async function getNodeConstraint(
-  config: PostUpdateConfig
+  config: PostUpdateConfig,
+  allowUnstable = false
 ): Promise<string> | null {
   const { packageFile } = config;
   let constraint =
     (await getNodeFile(getSiblingFileName(packageFile, '.nvmrc'))) ||
     (await getNodeFile(getSiblingFileName(packageFile, '.node-version'))) ||
     getPackageJsonConstraint(config);
+  let lockfileVersion = 1;
+  try {
+    const lockFileName = getSiblingFileName(packageFile, 'package-lock.json');
+    lockfileVersion = JSON.parse(await readLocalFile(lockFileName, 'utf8'))
+      .lockfileVersion;
+  } catch (err) {
+    logger.debug(
+      { err },
+      'Could not read lockfileVersion from sibling lock file'
+    );
+  }
   // Avoid using node 15 if node 14 also satisfies the same constraint
   // Remove this once node 16 is LTS
   if (constraint) {
@@ -43,12 +55,19 @@ export async function getNodeConstraint(
       validRange(constraint) &&
       satisfies('14.100.0', constraint) &&
       satisfies('15.100.0', constraint) &&
-      !isStable('16.100.0') && // this should return false as soon as Node 16 is LTS
-      validRange(`${constraint} <15`)
+      !isStable('16.100.0')
     ) {
-      logger.debug('Augmenting constraint to avoid node 15');
-      constraint = `${constraint} <15`;
+      if (lockfileVersion === 2) {
+        logger.debug('Forcing node 15 to ensure lockfileVersion=2 is used');
+        constraint = '>=15';
+      } else if (validRange(`${constraint} <15`)) {
+        logger.debug('Augmenting constraint to avoid node 15');
+        constraint = `${constraint} <15`;
+      }
     }
+  } else if (allowUnstable && lockfileVersion === 2) {
+    logger.debug('Using node >=15 for lockfileVersion=2');
+    constraint = '>=15';
   } else {
     logger.debug('No node constraint found - using latest');
   }

--- a/lib/manager/npm/post-update/node-version.ts
+++ b/lib/manager/npm/post-update/node-version.ts
@@ -43,10 +43,7 @@ export async function getNodeConstraint(
     lockfileVersion = JSON.parse(await readLocalFile(lockFileName, 'utf8'))
       .lockfileVersion;
   } catch (err) {
-    logger.debug(
-      { err },
-      'Could not read lockfileVersion from sibling lock file'
-    );
+    // do nothing
   }
   // Avoid using node 15 if node 14 also satisfies the same constraint
   // Remove this once node 16 is LTS


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds logic to force node 15 when npm lockfileVersion=2 and either:
- the specified node constraint supports node@15, or
- lerna is being used

## Context:

https://github.com/renovatebot/renovate/discussions/8553#discussioncomment-424941

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
