### PR TITLE
chore: label incoming issues with a triage label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: You've found a bug with Renovate
-labels: 'type:bug, status:requirements'
+labels: 'type:bug, status:requirements, priority-5-triage'
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-labels: 'type:feature, status:requirements'
+labels: 'type:feature, status:requirements, priority-5-triage'
 ---
 
 **What would you like Renovate to be able to do?**

--- a/docs/development/issue-labeling.md
+++ b/docs/development/issue-labeling.md
@@ -63,10 +63,12 @@ Add the `breaking` label for Issues or PRs which contain changes that are not ba
     priority-2-important
     priority-3-normal
     priority-4-low
+    priority-5-triage
 
 </details>
 
 Use these to assign a priority level to an issue.
+Incoming issues are labeled `priority-5-triage` by default, this label should be replaced with a proper priority (low/normal/important/critical).
 Make a best-effort attempt to select a proper priority.
 Nothing bad will happen if you select a "wrong" priority.
 At a high level: critical = needs immediate fix, important = to be prioritized ahead of others, normal = default priority, low = trivial issue, or impacts a very small % of the user base.

--- a/docs/development/issue-labeling.md
+++ b/docs/development/issue-labeling.md
@@ -73,6 +73,8 @@ Make a best-effort attempt to select a proper priority.
 Nothing bad will happen if you select a "wrong" priority.
 At a high level: critical = needs immediate fix, important = to be prioritized ahead of others, normal = default priority, low = trivial issue, or impacts a very small % of the user base.
 
+Use [this search](https://github.com/renovatebot/renovate/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+-label%3Apriority-1-critical+-label%3Apriority-2-important+-label%3Apriority-3-normal+-label%3Apriority-4-low++-label%3Apriority-5-triage) to find any issues which are missing a priority label.
+
 ### Platform
 
 <details>


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

- Incoming issues will be labeled `priority-5-triage`
- Update "issue labeling" docs
- Add "search URL" to find issues which are missing any priority labels

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

Closes #8960.

@rarkins You will need to create the new `priority-5-label` before merging this, or GitHub will complain that it can't find the label on incoming issues. 👻 😱 

Marking this PR "draft" until we have the label present on the repository to prevent annoyances on new issues. 😉 

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
