### PR TITLE
fix: validate datasource URLs

### DIFF
--- a/lib/datasource/metadata.ts
+++ b/lib/datasource/metadata.ts
@@ -1,8 +1,8 @@
 import URL from 'url';
-import is from '@sindresorhus/is';
 import parse from 'github-url-from-git';
 import { DateTime } from 'luxon';
 import * as hostRules from '../util/host-rules';
+import { validateUrl } from '../util/url';
 import type { ReleaseResult } from './types';
 
 // Use this object to define changelog URLs for packages
@@ -226,16 +226,12 @@ export function addMetaData(
   }
 
   // Clean up any empty urls
-  const urls = ['homepage', 'sourceUrl', 'changelogUrl'];
+  const urls = ['homepage', 'sourceUrl', 'changelogUrl', 'dependencyUrl'];
   for (const url of urls) {
-    if (is.nonEmptyString(dep[url])) {
-      dep[url] = dep[url].trim();
-      // istanbul ignore if
-      if (!dep[url].match(/^https?:\/\//)) {
-        delete dep[url];
-      }
-    } else {
+    if (!validateUrl(dep[url]?.trim())) {
       delete dep[url];
+    } else {
+      dep[url] = dep[url].trim();
     }
   }
 }

--- a/lib/datasource/metadata.ts
+++ b/lib/datasource/metadata.ts
@@ -228,10 +228,10 @@ export function addMetaData(
   // Clean up any empty urls
   const urls = ['homepage', 'sourceUrl', 'changelogUrl', 'dependencyUrl'];
   for (const url of urls) {
-    if (!validateUrl(dep[url]?.trim())) {
-      delete dep[url];
-    } else {
+    if (validateUrl(dep[url]?.trim())) {
       dep[url] = dep[url].trim();
+    } else {
+      delete dep[url];
     }
   }
 }

--- a/lib/util/url.spec.ts
+++ b/lib/util/url.spec.ts
@@ -1,4 +1,4 @@
-import { resolveBaseUrl } from './url';
+import { resolveBaseUrl, validateUrl } from './url';
 
 describe('util/url', () => {
   test.each([
@@ -44,5 +44,13 @@ describe('util/url', () => {
     ['http://foo.io', 'aaa/?bbb=z', 'http://foo.io/aaa?bbb=z'],
   ])('%s + %s => %s', (baseUrl, x, result) => {
     expect(resolveBaseUrl(baseUrl, x)).toBe(result);
+  });
+  it('validates URLs', () => {
+    expect(validateUrl()).toBe(false);
+    expect(validateUrl(null)).toBe(false);
+    expect(validateUrl('foo')).toBe(false);
+    expect(validateUrl('ssh://github.com')).toBe(false);
+    expect(validateUrl('http://github.com')).toBe(true);
+    expect(validateUrl('https://github.com')).toBe(true);
   });
 });

--- a/lib/util/url.ts
+++ b/lib/util/url.ts
@@ -32,3 +32,15 @@ export function getQueryString(params: Record<string, any>): string {
   const res = usp.toString();
   return res;
 }
+
+export function validateUrl(url?: string, httpOnly = true): boolean {
+  if (!url) {
+    return false;
+  }
+  try {
+    const { protocol } = new URL(url);
+    return httpOnly ? !!protocol.startsWith('http') : !!protocol;
+  } catch (err) {
+    return false;
+  }
+}


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds missing `dependencyUrl` to validations, and does it using URL.

## Context:

`dependencyUrl` wasn't being validated at all, and a stronger validation is necessary.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
