### PR TITLE
fix(gitea): check version for addReviewers

### DIFF
--- a/lib/platform/gitea/__snapshots__/gitea-helper.spec.ts.snap
+++ b/lib/platform/gitea/__snapshots__/gitea-helper.spec.ts.snap
@@ -561,6 +561,21 @@ Array [
 ]
 `;
 
+exports[`platform/gitea/gitea-helper getVersion should call /api/v1/version endpoint 1`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "host": "gitea.renovatebot.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://gitea.renovatebot.com/api/v1/version",
+  },
+]
+`;
+
 exports[`platform/gitea/gitea-helper mergePR should call /api/v1/repos/[repo]/pulls/[pull]/merge endpoint 1`] = `
 Array [
   Object {

--- a/lib/platform/gitea/gitea-helper.spec.ts
+++ b/lib/platform/gitea/gitea-helper.spec.ts
@@ -157,6 +157,17 @@ describe('platform/gitea/gitea-helper', () => {
     });
   });
 
+  describe('getVersion', () => {
+    it('should call /api/v1/version endpoint', async () => {
+      const version = '1.13.01.14.0+dev-754-g5d2b7ba63';
+      httpMock.scope(baseUrl).get('/version').reply(200, { version });
+
+      const res = await ght.getVersion();
+      expect(httpMock.getTrace()).toMatchSnapshot();
+      expect(res).toEqual(version);
+    });
+  });
+
   describe('searchRepos', () => {
     it('should call /api/v1/repos/search endpoint', async () => {
       httpMock

--- a/lib/platform/gitea/gitea-helper.ts
+++ b/lib/platform/gitea/gitea-helper.ts
@@ -200,6 +200,12 @@ export async function getCurrentUser(
   return res.body;
 }
 
+export async function getVersion(options?: GiteaHttpOptions): Promise<string> {
+  const url = 'version';
+  const res = await giteaHttp.getJson<{ version: string }>(url, options);
+  return res.body.version;
+}
+
 export async function searchRepos(
   params: RepoSearchParams,
   options?: GiteaHttpOptions

--- a/lib/platform/gitea/index.md
+++ b/lib/platform/gitea/index.md
@@ -2,4 +2,4 @@
 
 ## Unsupported platform features/concepts
 
-- **Adding reviewers to PRs not supported**: While Gitea supports a basic implementation for supporting PR reviews, no API support has been implemented so far.
+- **Adding reviewers to PRs not supported**: Gitea older that v1.14.0 doesn't have the required API to support this.

--- a/lib/platform/gitea/index.spec.ts
+++ b/lib/platform/gitea/index.spec.ts
@@ -12,7 +12,13 @@ import { logger as _logger } from '../../logger';
 import { BranchStatus, PrState } from '../../types';
 import * as _git from '../../util/git';
 import { setBaseUrl } from '../../util/http/gitea';
+import { PlatformResult } from '../types';
 import * as ght from './gitea-helper';
+
+/**
+ * latest tested gitea version.
+ */
+const GITEA_VERSION = '1.14.0+dev-754-g5d2b7ba63';
 
 describe('platform/gitea', () => {
   let gitea: Platform;
@@ -163,6 +169,12 @@ describe('platform/gitea', () => {
 
     setBaseUrl('https://gitea.renovatebot.com/api/v1');
   });
+
+  function initFakePlatform(version = GITEA_VERSION): Promise<PlatformResult> {
+    helper.getCurrentUser.mockResolvedValueOnce(mockUser);
+    helper.getVersion.mockResolvedValueOnce(version);
+    return gitea.initPlatform({ token: 'abc' });
+  }
 
   function initFakeRepo(
     repo?: Partial<ght.Repo>,
@@ -1295,21 +1307,35 @@ describe('platform/gitea', () => {
 
   describe('addReviewers', () => {
     it('should assign reviewers', async () => {
-      expect.assertions(2);
+      expect.assertions(3);
+      await initFakePlatform();
       const mockPR = mockPRs[0];
       await expect(
         gitea.addReviewers(mockPR.number, ['me', 'you'])
       ).resolves.not.toThrow();
 
       expect(helper.requestPrReviewers).toHaveBeenCalledTimes(1);
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+    it('should should do nothing if version to old', async () => {
+      expect.assertions(3);
+      const mockPR = mockPRs[0];
+      await expect(
+        gitea.addReviewers(mockPR.number, ['me', 'you'])
+      ).resolves.not.toThrow();
+
+      expect(helper.requestPrReviewers).not.toHaveBeenCalled();
+      expect(logger.warn).not.toHaveBeenCalled();
     });
     it('catches errors', async () => {
-      expect.assertions(1);
+      expect.assertions(2);
       const mockPR = mockPRs[0];
+      await initFakePlatform();
       helper.requestPrReviewers.mockRejectedValueOnce(null);
       await expect(
         gitea.addReviewers(mockPR.number, ['me', 'you'])
       ).resolves.not.toThrow();
+      expect(logger.warn).toHaveBeenCalled();
     });
   });
 

--- a/lib/platform/gitea/index.ts
+++ b/lib/platform/gitea/index.ts
@@ -1,5 +1,6 @@
 import URL from 'url';
 import is from '@sindresorhus/is';
+import { lt } from 'semver';
 import {
   REPOSITORY_ACCESS_FORBIDDEN,
   REPOSITORY_ARCHIVED,
@@ -51,6 +52,7 @@ interface GiteaRepoConfig {
 const defaults = {
   hostType: PLATFORM_TYPE_GITEA,
   endpoint: 'https://gitea.com/api/v1/',
+  version: '0.0.0',
 };
 
 let config: GiteaRepoConfig = {} as any;
@@ -191,6 +193,7 @@ const platform: Platform = {
       gitAuthor = `${user.full_name || user.username} <${user.email}>`;
       botUserID = user.id;
       botUserName = user.username;
+      defaults.version = await helper.getVersion({ token });
     } catch (err) {
       logger.debug(
         { err },
@@ -792,6 +795,13 @@ const platform: Platform = {
 
   async addReviewers(number: number, reviewers: string[]): Promise<void> {
     logger.debug(`Adding reviewers '${reviewers?.join(', ')}' to #${number}`);
+    if (lt(defaults.version, '1.14.0')) {
+      logger.debug(
+        { version: defaults.version },
+        'Adding reviewer not yet supported.'
+      );
+      return;
+    }
     try {
       await helper.requestPrReviewers(config.repository, number, { reviewers });
     } catch (err) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Check gitea version before trying to add reviewer. That api is only available from 1.14.0, current version is 1.13.2.
Otherwise we see unexpected warnings in logs and dashboard.

<!-- Describe what behavior is changed by this PR. -->

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
