### PR TITLE
fix: Deduplicate custom cargo registry clones

### DIFF
--- a/lib/datasource/crate/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/crate/__snapshots__/index.spec.ts.snap
@@ -399,6 +399,20 @@ Array [
 ]
 `;
 
+exports[`datasource/crate getReleases returns null when git clone fails 1`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept-encoding": "gzip, deflate",
+      "host": "raw.githubusercontent.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://raw.githubusercontent.com/rust-lang/crates.io-index/master/no/n_/non_existent_crate",
+  },
+]
+`;
+
 exports[`datasource/crate getReleases throws for 5xx 1`] = `[Error: external-host-error]`;
 
 exports[`datasource/crate getReleases throws for 5xx 2`] = `

--- a/lib/datasource/crate/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/crate/__snapshots__/index.spec.ts.snap
@@ -399,20 +399,6 @@ Array [
 ]
 `;
 
-exports[`datasource/crate getReleases returns null when git clone fails 1`] = `
-Array [
-  Object {
-    "headers": Object {
-      "accept-encoding": "gzip, deflate",
-      "host": "raw.githubusercontent.com",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
-    "url": "https://raw.githubusercontent.com/rust-lang/crates.io-index/master/no/n_/non_existent_crate",
-  },
-]
-`;
-
 exports[`datasource/crate getReleases throws for 5xx 1`] = `[Error: external-host-error]`;
 
 exports[`datasource/crate getReleases throws for 5xx 2`] = `

--- a/lib/datasource/crate/index.spec.ts
+++ b/lib/datasource/crate/index.spec.ts
@@ -317,8 +317,14 @@ describe('datasource/crate', () => {
         depName: 'mypkg',
         registryUrls: [url],
       });
+      const result2 = await getPkgReleases({
+        datasource,
+        depName: 'mypkg-2',
+        registryUrls: [url],
+      });
 
       expect(result).toBeNull();
+      expect(result2).toBeNull();
     });
   });
 

--- a/lib/datasource/crate/index.spec.ts
+++ b/lib/datasource/crate/index.spec.ts
@@ -294,14 +294,14 @@ describe('datasource/crate', () => {
         }),
         getPkgReleases({
           datasource,
-          depName: 'mypkg',
+          depName: 'mypkg-2',
           registryUrls: [url],
         }),
       ]);
 
       await getPkgReleases({
         datasource,
-        depName: 'mypkg',
+        depName: 'mypkg-3',
         registryUrls: [url],
       });
 

--- a/lib/datasource/crate/index.ts
+++ b/lib/datasource/crate/index.ts
@@ -178,6 +178,7 @@ async function fetchRegistryInfo(
     const clonePathPromise: Promise<string> | null = memCache.get(cacheKey);
     let clonePath: string;
 
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     if (clonePathPromise) {
       clonePath = await clonePathPromise;
     } else {

--- a/lib/datasource/crate/index.ts
+++ b/lib/datasource/crate/index.ts
@@ -195,7 +195,7 @@ async function fetchRegistryInfo(
       try {
         await clonePromise;
       } catch (err) {
-        logger.error(
+        logger.warn(
           { err, lookupName: config.lookupName, registryUrl },
           'failed cloning git registry'
         );

--- a/lib/datasource/crate/index.ts
+++ b/lib/datasource/crate/index.ts
@@ -183,17 +183,17 @@ async function fetchRegistryInfo(
       logger.info({ clonePath, registryUrl }, `Cloning private cargo registry`);
 
       const git = Git();
-      const promise = git.clone(registryUrl, clonePath, {
+      const clonePromise = git.clone(registryUrl, clonePath, {
         '--depth': 1,
       });
 
       memCache.set(
         cacheKey,
-        promise.then(() => clonePath).catch(() => null)
+        clonePromise.then(() => clonePath).catch(() => null)
       );
 
       try {
-        await promise;
+        await clonePromise;
       } catch (err) {
         logger.error(
           { err, lookupName: config.lookupName, registryUrl },

--- a/lib/datasource/crate/index.ts
+++ b/lib/datasource/crate/index.ts
@@ -178,7 +178,9 @@ async function fetchRegistryInfo(
     const clonePathPromise: Promise<string> | null = memCache.get(cacheKey);
     let clonePath: string;
 
-    if (clonePathPromise === null || clonePathPromise === undefined) {
+    if (clonePathPromise) {
+      clonePath = await clonePathPromise;
+    } else {
       clonePath = join(privateCacheDir(), cacheDirFromUrl(url));
       logger.info({ clonePath, registryUrl }, `Cloning private cargo registry`);
 
@@ -202,8 +204,6 @@ async function fetchRegistryInfo(
 
         return null;
       }
-    } else {
-      clonePath = await clonePathPromise;
     }
 
     if (!clonePath) {

--- a/lib/datasource/crate/index.ts
+++ b/lib/datasource/crate/index.ts
@@ -170,6 +170,7 @@ async function fetchRegistryInfo(
     }
 
     const cacheKey = `crate-datasource/registry-clone-path/${registryUrl}`;
+    const cacheKeyForError = `crate-datasource/registry-clone-path/${registryUrl}/error`;
 
     // We need to ensure we don't run `git clone` in parallel. Therefore we store
     // a promise of the running operation in the mem cache, which in the end resolves
@@ -202,14 +203,16 @@ async function fetchRegistryInfo(
           { err, lookupName: config.lookupName, registryUrl },
           'failed cloning git registry'
         );
+        memCache.set(cacheKeyForError, err);
 
         return null;
       }
     }
 
     if (!clonePath) {
+      const err = memCache.get(cacheKeyForError);
       logger.warn(
-        { lookupName: config.lookupName, registryUrl },
+        { err, lookupName: config.lookupName, registryUrl },
         'Previous git clone failed, bailing out.'
       );
 


### PR DESCRIPTION
## Changes:

<!-- Describe what behavior is changed by this PR. -->

When renovating repositories with multiple cargo dependencies hosted on custom registries (CloudSmith), renovate currently attempts to clone them in parallel, which leads to errors in git.

After this PR, renovate keeps track of the currently running `git clone`, avoiding duplicated clone processes.

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

We are using renovate to update in-house cargo dependencies, and seeing the following error in repositories with multiple custom dependencies:

<img width="2005" alt="screenshot of git clone errors" src="https://user-images.githubusercontent.com/1683034/109950434-cb46db80-7cdc-11eb-8922-6e2ea108224d.png">

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [X] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
