### PR TITLE
refactor(npm): More tests for 'replace' strategy

### DIFF
--- a/lib/versioning/npm/index.spec.ts
+++ b/lib/versioning/npm/index.spec.ts
@@ -71,14 +71,29 @@ describe('semver.getNewValue()', () => {
     ).toEqual('^1.0.7-prerelease.1');
   });
   it('replaces with newer', () => {
-    expect(
-      semver.getNewValue({
-        currentValue: '^1.0.0',
-        rangeStrategy: 'replace',
-        currentVersion: '1.0.0',
-        newVersion: '1.0.7',
-      })
-    ).toEqual('^1.0.7');
+    [
+      ['^0.0.3', '0.0.6', '^0.0.6'],
+      ['^0.0.3', '0.5.0', '^0.5.0'],
+      ['^0.0.3', '0.5.6', '^0.5.0'],
+      ['^0.0.3', '4.0.0', '^4.0.0'],
+      ['^0.0.3', '4.0.6', '^4.0.0'],
+      ['^0.0.3', '4.5.6', '^4.0.0'],
+      ['^0.2.0', '0.5.6', '^0.5.0'],
+      ['^0.2.3', '0.5.0', '^0.5.0'],
+      ['^0.2.3', '0.5.6', '^0.5.0'],
+      ['^1.2.3', '4.0.0', '^4.0.0'],
+      ['^1.2.3', '4.5.6', '^4.0.0'],
+      ['^1.0.0', '4.5.6', '^4.0.0'],
+    ].forEach(([currentValue, newVersion, expectedValue]) => {
+      expect(
+        semver.getNewValue({
+          currentValue,
+          rangeStrategy: 'replace',
+          currentVersion: currentValue.replace('^', ''),
+          newVersion,
+        })
+      ).toEqual(expectedValue);
+    });
   });
   it('supports tilde greater than', () => {
     expect(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

This PR documents the current behavior of `replace` strategy for `npm`.
It will be changed in upcoming PR.

## Context:

Ref: #4762

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
