### PR TITLE
fix: abort branch if child process receives SIGTERM

### DIFF
--- a/lib/constants/error-messages.ts
+++ b/lib/constants/error-messages.ts
@@ -35,6 +35,7 @@ export const REPOSITORY_UNINITIATED = 'uninitiated';
 export const REPOSITORY_CHANGED = 'repository-changed';
 export const TEMPORARY_ERROR = 'temporary-error';
 export const NO_VULNERABILITY_ALERTS = 'no-vulnerability-alerts';
+export const INTERRUPTED = 'interrupted';
 
 // Manager Error
 export const MANAGER_LOCKFILE_ERROR = 'lockfile-error';

--- a/lib/manager/bundler/artifacts.ts
+++ b/lib/manager/bundler/artifacts.ts
@@ -1,5 +1,8 @@
 import { quote } from 'shlex';
-import { BUNDLER_INVALID_CREDENTIALS } from '../../constants/error-messages';
+import {
+  BUNDLER_INVALID_CREDENTIALS,
+  INTERRUPTED,
+} from '../../constants/error-messages';
 import { logger } from '../../logger';
 import { HostRule } from '../../types';
 import * as memCache from '../../util/cache/memory';
@@ -158,6 +161,9 @@ export async function updateArtifacts(
       },
     ];
   } catch (err) /* istanbul ignore next */ {
+    if (err.message === INTERRUPTED) {
+      throw err;
+    }
     const output = `${String(err.stdout)}\n${String(err.stderr)}`;
     if (
       err.message.includes('fatal: Could not parse object') ||

--- a/lib/manager/cargo/artifacts.ts
+++ b/lib/manager/cargo/artifacts.ts
@@ -1,4 +1,5 @@
 import { quote } from 'shlex';
+import { INTERRUPTED } from '../../constants/error-messages';
 import { logger } from '../../logger';
 import { ExecOptions, exec } from '../../util/exec';
 import {
@@ -105,6 +106,10 @@ export async function updateArtifacts({
       },
     ];
   } catch (err) {
+    // istanbul ignore if
+    if (err.message === INTERRUPTED) {
+      throw err;
+    }
     logger.warn({ err }, 'Failed to update Cargo lock file');
     return [
       {

--- a/lib/manager/cocoapods/artifacts.ts
+++ b/lib/manager/cocoapods/artifacts.ts
@@ -1,5 +1,6 @@
 import { quote } from 'shlex';
 import { dirname, join } from 'upath';
+import { INTERRUPTED } from '../../constants/error-messages';
 import { logger } from '../../logger';
 import { ExecOptions, exec } from '../../util/exec';
 import {
@@ -82,6 +83,10 @@ export async function updateArtifacts({
   try {
     await exec(cmd, execOptions);
   } catch (err) {
+    // istanbul ignore if
+    if (err.message === INTERRUPTED) {
+      throw err;
+    }
     return [
       {
         artifactError: {

--- a/lib/manager/composer/artifacts.ts
+++ b/lib/manager/composer/artifacts.ts
@@ -3,7 +3,10 @@ import is from '@sindresorhus/is';
 import { quote } from 'shlex';
 import upath from 'upath';
 import { getAdminConfig } from '../../config/admin';
-import { SYSTEM_INSUFFICIENT_DISK_SPACE } from '../../constants/error-messages';
+import {
+  INTERRUPTED,
+  SYSTEM_INSUFFICIENT_DISK_SPACE,
+} from '../../constants/error-messages';
 import {
   PLATFORM_TYPE_GITHUB,
   PLATFORM_TYPE_GITLAB,
@@ -193,6 +196,10 @@ export async function updateArtifacts({
 
     return res;
   } catch (err) {
+    // istanbul ignore if
+    if (err.message === INTERRUPTED) {
+      throw err;
+    }
     if (
       err.message?.includes(
         'Your requirements could not be resolved to an installable set of packages.'

--- a/lib/manager/gomod/artifacts.ts
+++ b/lib/manager/gomod/artifacts.ts
@@ -1,5 +1,6 @@
 import { quote } from 'shlex';
 import { dirname, join } from 'upath';
+import { INTERRUPTED } from '../../constants/error-messages';
 import { PLATFORM_TYPE_GITHUB } from '../../constants/platforms';
 import { logger } from '../../logger';
 import { ExecOptions, exec } from '../../util/exec';
@@ -154,6 +155,10 @@ export async function updateArtifacts({
     }
     return res;
   } catch (err) {
+    // istanbul ignore if
+    if (err.message === INTERRUPTED) {
+      throw err;
+    }
     logger.debug({ err }, 'Failed to update go.sum');
     return [
       {

--- a/lib/manager/gradle-wrapper/artifacts.ts
+++ b/lib/manager/gradle-wrapper/artifacts.ts
@@ -1,5 +1,6 @@
 import { stat } from 'fs-extra';
 import { resolve } from 'upath';
+import { INTERRUPTED } from '../../constants/error-messages';
 import { logger } from '../../logger';
 import { ExecOptions, exec } from '../../util/exec';
 import { readLocalFile, writeLocalFile } from '../../util/fs';
@@ -92,6 +93,10 @@ export async function updateArtifacts({
     try {
       await exec(cmd, execOptions);
     } catch (err) {
+      // istanbul ignore if
+      if (err.message === INTERRUPTED) {
+        throw err;
+      }
       logger.warn(
         { err },
         'Error executing gradle wrapper update command. It can be not a critical one though.'

--- a/lib/manager/gradle/index.ts
+++ b/lib/manager/gradle/index.ts
@@ -1,6 +1,7 @@
 import { Stats } from 'fs';
 import { stat } from 'fs-extra';
 import upath from 'upath';
+import { INTERRUPTED } from '../../constants/error-messages';
 import { LANGUAGE_JAVA } from '../../constants/languages';
 import * as datasourceMaven from '../../datasource/maven';
 import { logger } from '../../logger';
@@ -72,6 +73,9 @@ export async function executeGradle(
     logger.debug({ cmd }, 'Start gradle command');
     ({ stdout, stderr } = await exec(cmd, execOptions));
   } catch (err) /* istanbul ignore next */ {
+    if (err.message === INTERRUPTED) {
+      throw err;
+    }
     if (err.code === TIMEOUT_CODE) {
       throw new ExternalHostError(err, 'gradle');
     }

--- a/lib/manager/helmv3/artifacts.ts
+++ b/lib/manager/helmv3/artifacts.ts
@@ -1,4 +1,5 @@
 import { quote } from 'shlex';
+import { INTERRUPTED } from '../../constants/error-messages';
 import { logger } from '../../logger';
 import { ExecOptions, exec } from '../../util/exec';
 import {
@@ -63,6 +64,10 @@ export async function updateArtifacts({
       },
     ];
   } catch (err) {
+    // istanbul ignore if
+    if (err.message === INTERRUPTED) {
+      throw err;
+    }
     logger.warn({ err }, 'Failed to update Helm lock file');
     return [
       {

--- a/lib/manager/mix/artifacts.ts
+++ b/lib/manager/mix/artifacts.ts
@@ -1,4 +1,5 @@
 import { quote } from 'shlex';
+import { INTERRUPTED } from '../../constants/error-messages';
 import { logger } from '../../logger';
 import { exec } from '../../util/exec';
 import { BinarySource } from '../../util/exec/common';
@@ -62,6 +63,10 @@ export async function updateArtifacts({
     const command = [...cmdParts, ...updatedDeps.map(quote)].join(' ');
     await exec(command, { cwd });
   } catch (err) {
+    // istanbul ignore if
+    if (err.message === INTERRUPTED) {
+      throw err;
+    }
     logger.warn(
       { err, message: err.message },
       'Failed to update Mix lock file'

--- a/lib/manager/npm/post-update/lerna.ts
+++ b/lib/manager/npm/post-update/lerna.ts
@@ -2,6 +2,7 @@ import semver, { validRange } from 'semver';
 import { quote } from 'shlex';
 import { join } from 'upath';
 import { getAdminConfig } from '../../../config/admin';
+import { INTERRUPTED } from '../../../constants/error-messages';
 import { logger } from '../../../logger';
 import { ExecOptions, exec } from '../../../util/exec';
 import type { PackageFile, PostUpdateConfig } from '../../types';
@@ -113,6 +114,9 @@ export async function generateLockFiles(
     cmd.push(lernaCommand);
     await exec(cmd, execOptions);
   } catch (err) /* istanbul ignore next */ {
+    if (err.message === INTERRUPTED) {
+      throw err;
+    }
     logger.debug(
       {
         cmd,

--- a/lib/manager/npm/post-update/npm.ts
+++ b/lib/manager/npm/post-update/npm.ts
@@ -2,7 +2,10 @@ import { validRange } from 'semver';
 import { quote } from 'shlex';
 import { join } from 'upath';
 import { getAdminConfig } from '../../../config/admin';
-import { SYSTEM_INSUFFICIENT_DISK_SPACE } from '../../../constants/error-messages';
+import {
+  INTERRUPTED,
+  SYSTEM_INSUFFICIENT_DISK_SPACE,
+} from '../../../constants/error-messages';
 import { logger } from '../../../logger';
 import { ExecOptions, exec } from '../../../util/exec';
 import { move, pathExists, readFile, remove } from '../../../util/fs';
@@ -135,6 +138,9 @@ export async function generateLockFile(
     // Read the result
     lockFile = await readFile(join(cwd, filename), 'utf8');
   } catch (err) /* istanbul ignore next */ {
+    if (err.message === INTERRUPTED) {
+      throw err;
+    }
     logger.debug(
       {
         err,

--- a/lib/manager/npm/post-update/pnpm.ts
+++ b/lib/manager/npm/post-update/pnpm.ts
@@ -2,6 +2,7 @@ import { validRange } from 'semver';
 import { quote } from 'shlex';
 import { join } from 'upath';
 import { getAdminConfig } from '../../../config/admin';
+import { INTERRUPTED } from '../../../constants/error-messages';
 import { logger } from '../../../logger';
 import { ExecOptions, exec } from '../../../util/exec';
 import { readFile, remove } from '../../../util/fs';
@@ -85,6 +86,9 @@ export async function generateLockFile(
     await exec(`${cmd} ${args}`, execOptions);
     lockFile = await readFile(lockFileName, 'utf8');
   } catch (err) /* istanbul ignore next */ {
+    if (err.message === INTERRUPTED) {
+      throw err;
+    }
     logger.debug(
       {
         cmd,

--- a/lib/manager/npm/post-update/yarn.ts
+++ b/lib/manager/npm/post-update/yarn.ts
@@ -3,7 +3,10 @@ import { gte, minVersion, validRange } from 'semver';
 import { quote } from 'shlex';
 import { join } from 'upath';
 import { getAdminConfig } from '../../../config/admin';
-import { SYSTEM_INSUFFICIENT_DISK_SPACE } from '../../../constants/error-messages';
+import {
+  INTERRUPTED,
+  SYSTEM_INSUFFICIENT_DISK_SPACE,
+} from '../../../constants/error-messages';
 import { id as npmId } from '../../../datasource/npm';
 import { logger } from '../../../logger';
 import { ExternalHostError } from '../../../types/errors/external-host-error';
@@ -182,6 +185,9 @@ export async function generateLockFile(
     // Read the result
     lockFile = await readFile(lockFileName, 'utf8');
   } catch (err) /* istanbul ignore next */ {
+    if (err.message === INTERRUPTED) {
+      throw err;
+    }
     logger.debug(
       {
         err,

--- a/lib/manager/nuget/artifacts.ts
+++ b/lib/manager/nuget/artifacts.ts
@@ -1,4 +1,5 @@
 import { join } from 'path';
+import { INTERRUPTED } from '../../constants/error-messages';
 import { id } from '../../datasource/nuget';
 import { logger } from '../../logger';
 import { ExecOptions, exec } from '../../util/exec';
@@ -137,6 +138,10 @@ export async function updateArtifacts({
       },
     ];
   } catch (err) {
+    // istanbul ignore if
+    if (err.message === INTERRUPTED) {
+      throw err;
+    }
     logger.debug({ err }, 'Failed to generate lock file');
     return [
       {

--- a/lib/manager/pip_requirements/artifacts.ts
+++ b/lib/manager/pip_requirements/artifacts.ts
@@ -1,4 +1,5 @@
 import is from '@sindresorhus/is';
+import { INTERRUPTED } from '../../constants/error-messages';
 import { logger } from '../../logger';
 import { ExecOptions, exec } from '../../util/exec';
 import { readLocalFile } from '../../util/fs';
@@ -52,6 +53,10 @@ export async function updateArtifacts({
       },
     ];
   } catch (err) {
+    // istanbul ignore if
+    if (err.message === INTERRUPTED) {
+      throw err;
+    }
     logger.debug({ err }, `Failed to update ${packageFileName} file`);
     return [
       {

--- a/lib/manager/pipenv/artifacts.ts
+++ b/lib/manager/pipenv/artifacts.ts
@@ -1,4 +1,5 @@
 import { quote } from 'shlex';
+import { INTERRUPTED } from '../../constants/error-messages';
 import { logger } from '../../logger';
 import { ExecOptions, exec } from '../../util/exec';
 import {
@@ -127,6 +128,10 @@ export async function updateArtifacts({
       },
     ];
   } catch (err) {
+    // istanbul ignore if
+    if (err.message === INTERRUPTED) {
+      throw err;
+    }
     logger.debug({ err }, 'Failed to update Pipfile.lock');
     return [
       {

--- a/lib/manager/poetry/artifacts.ts
+++ b/lib/manager/poetry/artifacts.ts
@@ -1,6 +1,7 @@
 import { parse } from '@iarna/toml';
 import is from '@sindresorhus/is';
 import { quote } from 'shlex';
+import { INTERRUPTED } from '../../constants/error-messages';
 import { logger } from '../../logger';
 import { ExecOptions, exec } from '../../util/exec';
 import {
@@ -153,6 +154,10 @@ export async function updateArtifacts({
       },
     ];
   } catch (err) {
+    // istanbul ignore if
+    if (err.message === INTERRUPTED) {
+      throw err;
+    }
     logger.debug({ err }, `Failed to update ${lockFileName} file`);
     return [
       {

--- a/lib/util/exec/exec.spec.ts
+++ b/lib/util/exec/exec.spec.ts
@@ -6,6 +6,7 @@ import {
 import { envMock } from '../../../test/exec-util';
 import { setAdminConfig } from '../../config/admin';
 import type { RepoAdminConfig } from '../../config/types';
+import { INTERRUPTED } from '../../constants/error-messages';
 import {
   BinarySource,
   ExecConfig,
@@ -774,5 +775,22 @@ describe(`Child process execution wrapper`, () => {
       )
     );
     expect(removeDockerContainerSpy).toHaveBeenCalledTimes(2);
+  });
+  it('converts to INTERRUPTED', async () => {
+    cpExec.mockImplementation(() => {
+      class ErrorSignal extends Error {
+        signal?: string;
+      }
+      const error = new ErrorSignal();
+      error.signal = 'SIGTERM';
+      throw error;
+    });
+    const removeDockerContainerSpy = jest.spyOn(
+      dockerModule,
+      'removeDockerContainer'
+    );
+    const promise = exec('foobar', {});
+    await expect(promise).rejects.toThrow(INTERRUPTED);
+    expect(removeDockerContainerSpy).toHaveBeenCalledTimes(0);
   });
 });

--- a/lib/util/exec/index.ts
+++ b/lib/util/exec/index.ts
@@ -2,6 +2,7 @@ import type { ExecOptions as ChildProcessExecOptions } from 'child_process';
 import { dirname, join } from 'upath';
 import { getAdminConfig } from '../../config/admin';
 import type { RenovateConfig } from '../../config/types';
+import { INTERRUPTED } from '../../constants/error-messages';
 import { logger } from '../../logger';
 import {
   BinarySource,
@@ -156,6 +157,10 @@ export async function exec(
             `Error: "${removeErr.message}" - Original Error: "${message}"`
           );
         });
+      }
+      if (err.signal === `SIGTERM`) {
+        logger.debug({ err }, 'exec interrupted by SIGTERM');
+        throw new Error(INTERRUPTED);
       }
       throw err;
     }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Detects when child process fails due to SIGTERM and aborts the branch.

## Context:

Trying to handle this gracefully as an alternative to:

```
{
  "level": 20,
  "branch": "renovate/npm-lodash-vulnerability",
  "err": {
    "killed": false,
    "code": null,
    "signal": "SIGTERM",
    "cmd": "docker pull docker.io/renovate/node:latest",
    "stdout": "latest: Pulling from renovate/node\n5d3b2c2d21bb: Pulling fs layer\n3fc2062ea667: Pulling fs layer\n75adf526d75b: Pulling fs layer\n8fac8f7ae834: Pulling fs layer\nbd2f495a6dc9: Pulling fs layer\n5cb6cb04bade: Pulling fs layer\na0d68e40d167: Pulling fs layer\n9bfa22e90d01: Pulling fs layer\n7b5f4722109c: Pulling fs layer\n8fac8f7ae834: Waiting\nbd2f495a6dc9: Waiting\n5cb6cb04bade: Waiting\na0d68e40d167: Waiting\n9bfa22e90d01: Waiting\n7b5f4722109c: Waiting\n3fc2062ea667: Verifying Checksum\n3fc2062ea667: Download complete\n75adf526d75b: Verifying Checksum\n75adf526d75b: Download complete\nbd2f495a6dc9: Verifying Checksum\nbd2f495a6dc9: Download complete\n8fac8f7ae834: Verifying Checksum\n8fac8f7ae834: Download complete\n5d3b2c2d21bb: Verifying Checksum\n5d3b2c2d21bb: Download complete\n9bfa22e90d01: Verifying Checksum\n9bfa22e90d01: Download complete\n",
    "stderr": "",
    "message": "Command failed: docker pull docker.io/renovate/node:latest\n",
    "stack": "Error: Command failed: docker pull docker.io/renovate/node:latest\n\n    at ChildProcess.exithandler (child_process.js:308:12)\n    at ChildProcess.emit (events.js:315:20)\n    at ChildProcess.EventEmitter.emit (domain.js:467:12)\n    at maybeClose (internal/child_process.js:1048:16)\n    at Socket.<anonymous> (internal/child_process.js:439:11)\n    at Socket.emit (events.js:315:20)\n    at Socket.EventEmitter.emit (domain.js:467:12)\n    at Pipe.<anonymous> (net.js:673:12)"
  },
  "type": "npm",
  "msg": "lock file error",
  "time": "2021-03-04T16:41:19.441Z"
}
```


## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
