### PR TITLE
fix(http): Throw ExternalHostError on ECONNRESET

### DIFF
--- a/lib/util/http/github.ts
+++ b/lib/util/http/github.ts
@@ -50,7 +50,8 @@ function handleGotError(
     err.name === 'RequestError' &&
     (err.code === 'ENOTFOUND' ||
       err.code === 'ETIMEDOUT' ||
-      err.code === 'EAI_AGAIN')
+      err.code === 'EAI_AGAIN' ||
+      err.code === 'ECONNRESET')
   ) {
     logger.debug({ err }, 'GitHub failure: RequestError');
     throw new ExternalHostError(err, PLATFORM_TYPE_GITHUB);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Throw ExternalHostError on ECONNRESET exception

## Context:

Closes #8894

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
