### PR TITLE
fix(poetry): poetry install constraints quoting

### DIFF
--- a/lib/manager/poetry/__fixtures__/pyproject.2.toml
+++ b/lib/manager/poetry/__fixtures__/pyproject.2.toml
@@ -14,3 +14,7 @@ dep4 = { path = "/some/path/" }
 extra_dep1 = "^0.8.3"
 extra_dep2 = "^0.9.4"
 extra_dep3 = '^0.4.0'
+
+[build-system]
+requires = ["poetry>=1.0", "wheel"]
+build-backend = "poetry.core.masonry.api"

--- a/lib/manager/poetry/__fixtures__/pyproject.4.toml
+++ b/lib/manager/poetry/__fixtures__/pyproject.4.toml
@@ -9,3 +9,7 @@ foo = [
     {version = "<=1.9", python = "^2.7"},
     {version = "^2.0", python = "^3.4"}
 ]
+
+[build-system]
+requires = ["poetry>=1.1.2", "setuptools", "poetry-dynamic-versioning"]
+build-backend = "poetry.masonry.api"

--- a/lib/manager/poetry/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/manager/poetry/__snapshots__/artifacts.spec.ts.snap
@@ -135,7 +135,7 @@ Array [
     },
   },
   Object {
-    "cmd": "docker run --rm --name=renovate_python --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -w \\"/tmp/github/some/repo\\" renovate/python:3.4.2 bash -l -c \\"pip install poetry && poetry update --lock --no-interaction dep1\\"",
+    "cmd": "docker run --rm --name=renovate_python --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -w \\"/tmp/github/some/repo\\" renovate/python:3.4.2 bash -l -c \\"pip install 'poetry>=1.1.2' setuptools 'poetry-dynamic-versioning>1' && poetry update --lock --no-interaction dep1\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",

--- a/lib/manager/poetry/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/poetry/__snapshots__/extract.spec.ts.snap
@@ -358,7 +358,9 @@ Object {
 
 exports[`lib/manager/poetry/extract extractPackageFile() extracts multiple dependencies (with dep = {version = "1.2.3"} case) 1`] = `
 Object {
-  "constraints": Object {},
+  "constraints": Object {
+    "poetry": "poetry>=1.0 wheel",
+  },
   "deps": Array [
     Object {
       "currentValue": "*",
@@ -540,7 +542,9 @@ Array [
 
 exports[`lib/manager/poetry/extract extractPackageFile() handles multiple constraint dependencies 1`] = `
 Object {
-  "constraints": Object {},
+  "constraints": Object {
+    "poetry": "poetry>=1.1.2 setuptools poetry-dynamic-versioning",
+  },
   "deps": Array [
     Object {
       "currentValue": "",

--- a/lib/manager/poetry/artifacts.spec.ts
+++ b/lib/manager/poetry/artifacts.spec.ts
@@ -150,7 +150,10 @@ describe('.updateArtifacts()', () => {
         newPackageFileContent: '{}',
         config: {
           ...config,
-          constraints: { python: '~2.7 || ^3.4' },
+          constraints: {
+            python: '~2.7 || ^3.4',
+            poetry: 'poetry>=1.1.2 setuptools poetry-dynamic-versioning>1',
+          },
         },
       })
     ).not.toBeNull();

--- a/lib/manager/poetry/artifacts.ts
+++ b/lib/manager/poetry/artifacts.ts
@@ -122,7 +122,8 @@ export async function updateArtifacts({
     }
     const tagConstraint = getPythonConstraint(existingLockFileContent, config);
     const poetryRequirement = config.constraints?.poetry || 'poetry';
-    const poetryInstall = 'pip install ' + quote(poetryRequirement);
+    const poetryInstall =
+      'pip install ' + poetryRequirement.split(' ').map(quote).join(' ');
     const extraEnv = getSourceCredentialVars(
       newPackageFileContent,
       packageFileName

--- a/lib/manager/poetry/extract.ts
+++ b/lib/manager/poetry/extract.ts
@@ -151,7 +151,9 @@ export async function extractPackageFile(
 
   // https://python-poetry.org/docs/pyproject/#poetry-and-pep-517
   if (
-    pyprojectfile['build-system']?.['build-backend'] === 'poetry.masonry.api'
+    pyprojectfile['build-system']?.['build-backend'] === 'poetry.masonry.api' ||
+    pyprojectfile['build-system']?.['build-backend'] ===
+      'poetry.core.masonry.api'
   ) {
     constraints.poetry = pyprojectfile['build-system']?.requires.join(' ');
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Extracts poetry version from core if found, and ensures multiple install requirements are quoted separately.

## Context:

Closes #7513

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
