### PR TITLE
perf: increase dry-run verboseness

### DIFF
--- a/lib/workers/branch/__snapshots__/commit.spec.ts.snap
+++ b/lib/workers/branch/__snapshots__/commit.spec.ts.snap
@@ -17,3 +17,23 @@ Array [
   ],
 ]
 `;
+
+exports[`workers/branch/automerge commitFilesToBranch dry runs 1`] = `
+Array [
+  Array [
+    "DRY-RUN: Would commit files to branch renovate/some-branch",
+  ],
+  Array [
+    "DRY-RUN: Commit message would be:
+some commit message",
+  ],
+  Array [
+    "DRY-RUN: Committed files would be:
+package.json
+<<<
+some contents
+>>>
+",
+  ],
+]
+`;

--- a/lib/workers/branch/__snapshots__/commit.spec.ts.snap
+++ b/lib/workers/branch/__snapshots__/commit.spec.ts.snap
@@ -21,19 +21,17 @@ Array [
 exports[`workers/branch/automerge commitFilesToBranch dry runs 1`] = `
 Array [
   Array [
-    "DRY-RUN: Would commit files to branch renovate/some-branch",
-  ],
-  Array [
-    "DRY-RUN: Commit message would be:
-some commit message",
-  ],
-  Array [
-    "DRY-RUN: Committed files would be:
+    Object {
+      "commitMessage": "some commit message",
+      "updatedFiles": "
 package.json
 <<<
 some contents
 >>>
+
 ",
+    },
+    "DRY-RUN: Would commit files to branch renovate/some-branch",
   ],
 ]
 `;

--- a/lib/workers/branch/commit.spec.ts
+++ b/lib/workers/branch/commit.spec.ts
@@ -1,5 +1,6 @@
 import { defaultConfig, git, partial } from '../../../test/util';
 import { setAdminConfig } from '../../config/admin';
+import { logger } from '../../logger';
 import type { BranchConfig } from '../types';
 import { commitFilesToBranch } from './commit';
 
@@ -42,8 +43,10 @@ describe('workers/branch/automerge', () => {
         name: 'package.json',
         contents: 'some contents',
       });
+      const infoLog = jest.spyOn(logger, 'info');
       await commitFilesToBranch(config);
       expect(git.commitFiles).toHaveBeenCalledTimes(0);
+      expect(infoLog.mock.calls).toMatchSnapshot();
     });
   });
 });

--- a/lib/workers/branch/commit.ts
+++ b/lib/workers/branch/commit.ts
@@ -32,18 +32,18 @@ export function commitFilesToBranch(
   const fileLength = [...new Set(updatedFiles.map((file) => file.name))].length;
   logger.debug(`${fileLength} file(s) to commit`);
   if (getAdminConfig().dryRun) {
-    logger.info('DRY-RUN: Would commit files to branch ' + config.branchName);
-    logger.info('DRY-RUN: Commit message would be:\n' + config.commitMessage);
     logger.info(
-      [
-        'DRY-RUN: Committed files would be:',
+      {
+        commitMessage: config.commitMessage,
+
         // Piping f.contents to
         // git diff -- ${f.name} -
         // would be much better, but this seems to be impossible with simple-git
-        ...updatedFiles.map(
-          (f) => `${f.name}\n<<<\n${String(f.contents)}\n>>>\n`
-        ),
-      ].join('\n')
+        updatedFiles: `\n${updatedFiles
+          .map((f) => `${f.name}\n<<<\n${String(f.contents)}\n>>>\n`)
+          .join('\n')}\n`,
+      },
+      'DRY-RUN: Would commit files to branch ' + config.branchName
     );
     return null;
   }

--- a/lib/workers/branch/commit.ts
+++ b/lib/workers/branch/commit.ts
@@ -31,7 +31,6 @@ export function commitFilesToBranch(
   }
   const fileLength = [...new Set(updatedFiles.map((file) => file.name))].length;
   logger.debug(`${fileLength} file(s) to commit`);
-  // istanbul ignore if
   if (getAdminConfig().dryRun) {
     logger.info('DRY-RUN: Would commit files to branch ' + config.branchName);
     logger.info('DRY-RUN: Commit message would be:\n' + config.commitMessage);

--- a/lib/workers/branch/commit.ts
+++ b/lib/workers/branch/commit.ts
@@ -34,6 +34,18 @@ export function commitFilesToBranch(
   // istanbul ignore if
   if (getAdminConfig().dryRun) {
     logger.info('DRY-RUN: Would commit files to branch ' + config.branchName);
+    logger.info('DRY-RUN: Commit message would be:\n' + config.commitMessage);
+    logger.info(
+      [
+        'DRY-RUN: Committed files would be:',
+        // Piping f.contents to
+        // git diff -- ${f.name} -
+        // would be much better, but this seems to be impossible with simple-git
+        ...updatedFiles.map(
+          (f) => `${f.name}\n<<<\n${String(f.contents)}\n>>>\n`
+        ),
+      ].join('\n')
+    );
     return null;
   }
   // istanbul ignore if


### PR DESCRIPTION
## Changes:

Add `INFO` level log messages to the dry run.

## Context:

See: https://github.com/renovatebot/renovate/discussions/8882#discussioncomment-433629

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added* unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

*) added snapshot

---
## Additional info

As mentioned in the code comment logging the `git diff` would be a much better solution than logging full file contents, but piping `contents` doesn't seem to be possible with `simple-git`.
There are two workarounds worth to be considered although not optimal:
a) Spawning `git` directly without using `simple-git` here.
b) Writing temporary files to the system's temp file directory although we're in `dry-run`.