### PR TITLE
fix(go): Improve go-import content parsing

### DIFF
--- a/lib/datasource/go/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/go/__snapshots__/index.spec.ts.snap
@@ -143,6 +143,56 @@ Array [
 ]
 `;
 
+exports[`datasource/go getReleases handles fyne.io 1`] = `
+Object {
+  "releases": Array [
+    Object {
+      "gitRef": "v1.0.0",
+      "version": "v1.0.0",
+    },
+    Object {
+      "gitRef": "v2.0.0",
+      "version": "v2.0.0",
+    },
+  ],
+  "sourceUrl": "https://github.com/fyne-io/fyne",
+}
+`;
+
+exports[`datasource/go getReleases handles fyne.io 2`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept-encoding": "gzip, deflate",
+      "host": "fyne.io",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://fyne.io/fyne?go-get=1",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate",
+      "host": "api.github.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://api.github.com/repos/fyne-io/fyne/tags?per_page=100",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate",
+      "host": "api.github.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://api.github.com/repos/fyne-io/fyne/releases?per_page=100",
+  },
+]
+`;
+
 exports[`datasource/go getReleases processes real data 1`] = `
 Object {
   "releases": Array [

--- a/lib/datasource/go/index.spec.ts
+++ b/lib/datasource/go/index.spec.ts
@@ -418,5 +418,28 @@ describe('datasource/go', () => {
         httpMock.reset();
       }
     });
+    it('handles fyne.io', async () => {
+      httpMock
+        .scope('https://fyne.io/')
+        .get('/fyne?go-get=1')
+        .reply(
+          200,
+          '<meta name="go-import" content="fyne.io/fyne git https://github.com/fyne-io/fyne">'
+        );
+      httpMock
+        .scope('https://api.github.com/')
+        .get('/repos/fyne-io/fyne/tags?per_page=100')
+        .reply(200, [{ name: 'v1.0.0' }, { name: 'v2.0.0' }])
+        .get('/repos/fyne-io/fyne/releases?per_page=100')
+        .reply(200, []);
+      const res = await getPkgReleases({
+        datasource,
+        depName: 'fyne.io/fyne',
+      });
+      expect(res).toMatchSnapshot();
+      expect(res).not.toBeNull();
+      expect(res).toBeDefined();
+      expect(httpMock.getTrace()).toMatchSnapshot();
+    });
   });
 });

--- a/lib/datasource/go/index.ts
+++ b/lib/datasource/go/index.ts
@@ -115,8 +115,12 @@ async function getDatasource(goModule: string): Promise<DataSource | null> {
       const parsedUrl = URL.parse(goImportURL);
 
       // split the go module from the URL: host/go/module -> go/module
-      const split = goModule.split('/');
-      const lookupName = split[1] + '/' + split[2];
+      const lookupName = parsedUrl.pathname
+        .replace(/\.git$/, '')
+        .replace(/\/$/, '')
+        .split('/')
+        .slice(-2)
+        .join('/');
 
       return {
         datasource: github.id,

--- a/lib/datasource/go/index.ts
+++ b/lib/datasource/go/index.ts
@@ -4,6 +4,7 @@ import { logger } from '../../logger';
 import * as hostRules from '../../util/host-rules';
 import { Http } from '../../util/http';
 import { regEx } from '../../util/regex';
+import { trimTrailingSlash } from '../../util/url';
 import * as bitbucket from '../bitbucket-tags';
 import * as github from '../github-tags';
 import * as gitlab from '../gitlab-tags';
@@ -115,9 +116,8 @@ async function getDatasource(goModule: string): Promise<DataSource | null> {
       const parsedUrl = URL.parse(goImportURL);
 
       // split the go module from the URL: host/go/module -> go/module
-      const lookupName = parsedUrl.pathname
+      const lookupName = trimTrailingSlash(parsedUrl.pathname)
         .replace(/\.git$/, '')
-        .replace(/\/$/, '')
         .split('/')
         .slice(-2)
         .join('/');

--- a/lib/util/url.spec.ts
+++ b/lib/util/url.spec.ts
@@ -1,4 +1,4 @@
-import { resolveBaseUrl, validateUrl } from './url';
+import { resolveBaseUrl, trimTrailingSlash, validateUrl } from './url';
 
 describe('util/url', () => {
   test.each([
@@ -52,5 +52,11 @@ describe('util/url', () => {
     expect(validateUrl('ssh://github.com')).toBe(false);
     expect(validateUrl('http://github.com')).toBe(true);
     expect(validateUrl('https://github.com')).toBe(true);
+  });
+  it('trimTrailingSlash', () => {
+    expect(trimTrailingSlash('foo')).toBe('foo');
+    expect(trimTrailingSlash('/foo/bar')).toBe('/foo/bar');
+    expect(trimTrailingSlash('foo/')).toBe('foo');
+    expect(trimTrailingSlash('foo//////')).toBe('foo');
   });
 });

--- a/lib/util/url.ts
+++ b/lib/util/url.ts
@@ -4,6 +4,10 @@ export function ensureTrailingSlash(url: string): string {
   return url.replace(/\/?$/, '/');
 }
 
+export function trimTrailingSlash(url: string): string {
+  return url.replace(/\/+$/, '');
+}
+
 export function resolveBaseUrl(baseUrl: string, input: string | URL): string {
   const inputString = input.toString();
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Given that we already assume `github` datasource in the conditional branch, let's rely on `goImportUrl` string instead of `goModule` argument.

## Context:

Closes #7663
Example: https://github.com/renovate-testing/test-7663-gomod-deps-404/pulls

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
