### PR TITLE
fix: pypi vulnerabilities mapping

### DIFF
--- a/lib/workers/repository/init/__snapshots__/vulnerability.spec.ts.snap
+++ b/lib/workers/repository/init/__snapshots__/vulnerability.spec.ts.snap
@@ -27,7 +27,7 @@ Array [
       "schedule": Array [],
     },
     "isVulnerabilityAlert": true,
-    "matchCurrentVersion": "= 1.6.7",
+    "matchCurrentVersion": "== 1.6.7",
     "matchDatasources": Array [
       "pypi",
     ],

--- a/lib/workers/repository/init/__snapshots__/vulnerability.spec.ts.snap
+++ b/lib/workers/repository/init/__snapshots__/vulnerability.spec.ts.snap
@@ -16,7 +16,7 @@ Array [
     ],
   },
   Object {
-    "allowedVersions": "==2.2.0",
+    "allowedVersions": "==2.2.1.0",
     "force": Object {
       "branchTopic": "{{{datasource}}}-{{{depName}}}-vulnerability",
       "commitMessageSuffix": "[SECURITY]",

--- a/lib/workers/repository/init/vulnerability.ts
+++ b/lib/workers/repository/init/vulnerability.ts
@@ -62,7 +62,7 @@ export async function detectVulnerabilityAlerts(
     maven: mavenVersioning.id,
     npm: npmVersioning.id,
     nuget: semverVersioning.id,
-    pip_requirements: pep440Versioning.id,
+    pypi: pep440Versioning.id,
     rubygems: rubyVersioning.id,
   };
   const combinedAlerts: CombinedAlert = {};

--- a/lib/workers/repository/init/vulnerability.ts
+++ b/lib/workers/repository/init/vulnerability.ts
@@ -102,6 +102,9 @@ export async function detectVulnerabilityAlerts(
           vulnerableRequirements = `< ${firstPatchedVersion}`;
         }
       }
+      if (datasource === datasourcePypi.id) {
+        vulnerableRequirements = vulnerableRequirements.replace(/^= /, '== ');
+      }
       combinedAlerts[fileName] ||= {};
       combinedAlerts[fileName][datasource] ||= {};
       combinedAlerts[fileName][datasource][depName] ||= {};


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Fixes versioning and vulnerable matching for pypi.

## Context:

Fixes #8126

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
