### PR TITLE
fix(poetry): don’t extract poetry.masonry.core.api requirements

### DIFF
--- a/lib/manager/poetry/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/poetry/__snapshots__/extract.spec.ts.snap
@@ -358,9 +358,7 @@ Object {
 
 exports[`lib/manager/poetry/extract extractPackageFile() extracts multiple dependencies (with dep = {version = "1.2.3"} case) 1`] = `
 Object {
-  "constraints": Object {
-    "poetry": "poetry>=1.0 wheel",
-  },
+  "constraints": Object {},
   "deps": Array [
     Object {
       "currentValue": "*",

--- a/lib/manager/poetry/extract.ts
+++ b/lib/manager/poetry/extract.ts
@@ -151,9 +151,7 @@ export async function extractPackageFile(
 
   // https://python-poetry.org/docs/pyproject/#poetry-and-pep-517
   if (
-    pyprojectfile['build-system']?.['build-backend'] === 'poetry.masonry.api' ||
-    pyprojectfile['build-system']?.['build-backend'] ===
-      'poetry.core.masonry.api'
+    pyprojectfile['build-system']?.['build-backend'] === 'poetry.masonry.api'
   ) {
     constraints.poetry = pyprojectfile['build-system']?.requires.join(' ');
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

No longer extracts poetry install requirements from core.masonry.api

## Context:

Closes #9025

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
