### PR TITLE
fix: remove artifacts error comment whenever branch PR exists

### DIFF
--- a/lib/workers/branch/index.spec.ts
+++ b/lib/workers/branch/index.spec.ts
@@ -420,7 +420,7 @@ describe('workers/branch', () => {
       commit.commitFilesToBranch.mockResolvedValueOnce(null);
       await branchWorker.processBranch(config);
       expect(prWorker.ensurePr).toHaveBeenCalledTimes(1);
-      expect(platform.ensureCommentRemoval).toHaveBeenCalledTimes(1);
+      expect(platform.ensureCommentRemoval).toHaveBeenCalledTimes(0);
       expect(prWorker.checkAutoMerge).toHaveBeenCalledTimes(1);
     });
     it('ensures PR and adds lock file error comment if no releaseTimestamp', async () => {

--- a/lib/workers/branch/index.ts
+++ b/lib/workers/branch/index.ts
@@ -494,6 +494,20 @@ export async function processBranch(
       } else {
         logger.debug('PR has no releaseTimestamp');
       }
+    } else if (config.updatedArtifacts?.length && branchPr) {
+      // If there are artifacts, no errors, and an existing PR then ensure any artifacts error comment is removed
+      // istanbul ignore if
+      if (getAdminConfig().dryRun) {
+        logger.info(
+          `DRY-RUN: Would ensure comment removal in PR #${branchPr.number}`
+        );
+      } else {
+        // Remove artifacts error comment only if this run has successfully updated artifacts
+        await platform.ensureCommentRemoval({
+          number: branchPr.number,
+          topic: artifactErrorTopic,
+        });
+      }
     }
     config.forceCommit =
       !!dependencyDashboardCheck ||
@@ -705,20 +719,6 @@ export async function processBranch(
           }
         }
       } else {
-        if (config.updatedArtifacts?.length) {
-          // istanbul ignore if
-          if (getAdminConfig().dryRun) {
-            logger.info(
-              `DRY-RUN: Would ensure comment removal in PR #${pr.number}`
-            );
-          } else {
-            // Remove artifacts error comment only if this run has successfully updated artifacts
-            await platform.ensureCommentRemoval({
-              number: pr.number,
-              topic: artifactErrorTopic,
-            });
-          }
-        }
         const prAutomerged = await checkAutoMerge(pr, config);
         if (prAutomerged && config.automergeType !== 'pr-comment') {
           await deleteBranchSilently(config.branchName);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Moves the ensureCommentRemoval() call earlier so that any artifact error is always removed from an existing PR.

## Context:

Closes #7588

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
