### PR TITLE
feat(gitlabci): loosen file match

### DIFF
--- a/lib/manager/gitlabci/index.ts
+++ b/lib/manager/gitlabci/index.ts
@@ -6,5 +6,5 @@ const language = LANGUAGE_DOCKER;
 export { extractPackageFile, language };
 
 export const defaultConfig = {
-  fileMatch: ['^\\.gitlab-ci\\.yml$'],
+  fileMatch: ['\\.gitlab-ci\\.yml$'],
 };


### PR DESCRIPTION
There are cases which `.gitlab-ci.yml` file could be placed into a different directory
e.g. `.gitlab/.gitlab-ci.yml`
or it could be split into multiple files using `include:` key while having `.gitlab-ci.yml` suffix.

Loosen the file matching regex of gitlabci manager to accommodate for those cases.
