### PR TITLE
fix: don’t throw repository-changed from git layer

### DIFF
--- a/lib/platform/bitbucket-server/index.ts
+++ b/lib/platform/bitbucket-server/index.ts
@@ -408,6 +408,7 @@ export async function getBranchStatus(
   }
 
   if (!git.branchExists(branchName)) {
+    logger.debug('Branch does not exist - cannot fetch status');
     throw new Error(REPOSITORY_CHANGED);
   }
 
@@ -604,6 +605,9 @@ export async function addReviewers(
       err.statusCode === 409 &&
       !utils.isInvalidReviewersResponse(err)
     ) {
+      logger.debug(
+        '409 response to adding reviewers - has repository changed?'
+      );
       throw new Error(REPOSITORY_CHANGED);
     } else {
       throw err;

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -11,7 +11,6 @@ import { join } from 'upath';
 import { configFileNames } from '../../config/app-strings';
 import {
   CONFIG_VALIDATION,
-  REPOSITORY_CHANGED,
   REPOSITORY_DISABLED,
   REPOSITORY_EMPTY,
   SYSTEM_INSUFFICIENT_DISK_SPACE,
@@ -697,8 +696,9 @@ export async function commitFiles({
       logger.error({ err }, 'Error committing files.');
       return null;
     }
-    logger.debug({ err }, 'Error committing files');
-    throw new Error(REPOSITORY_CHANGED);
+    logger.debug({ err }, 'Unknown error committing files');
+    // We don't know why this happened, so this will cause bubble up to a branch error
+    throw err;
   }
 }
 

--- a/lib/util/http/github.ts
+++ b/lib/util/http/github.ts
@@ -109,6 +109,7 @@ function handleGotError(
     ) {
       throw err;
     } else if (err.body?.errors?.find((e: any) => e.code === 'invalid')) {
+      logger.debug({ err }, 'Received invalid response - aborting');
       throw new Error(REPOSITORY_CHANGED);
     }
     logger.debug({ err }, '422 Error thrown from GitHub');

--- a/lib/workers/branch/check-existing.ts
+++ b/lib/workers/branch/check-existing.ts
@@ -24,7 +24,7 @@ export async function prAlreadyExisted(
     const prDetails = await platform.getPr(pr.number);
     // istanbul ignore if
     if (prDetails.state === PrState.Open) {
-      logger.debug('PR reopened');
+      logger.debug('PR reopened - aborting run');
       throw new Error(REPOSITORY_CHANGED);
     }
     return pr;

--- a/lib/workers/branch/index.ts
+++ b/lib/workers/branch/index.ts
@@ -560,6 +560,7 @@ export async function processBranch(
     }
   } catch (err) /* istanbul ignore next */ {
     if (err.statusCode === 404) {
+      logger.debug({ err }, 'Received a 404 error - aborting run');
       throw new Error(REPOSITORY_CHANGED);
     }
     if (err.message === PLATFORM_RATE_LIMIT_EXCEEDED) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Removes `repository-changed` error throwing from git layer, instead passing the error up to the branch worker.

## Context:

Any unknown git error previously caused the repository run to be aborted, but there may be cases where the error affects the branch only and not the whole repo. We will see more branch errors now and can maybe push detection of some of them back down to git, but the goal is that we don't block repos unnecessarily.

Closes #8354

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
