### PR TITLE
fix(maven): don't cache private

### DIFF
--- a/lib/datasource/maven/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/maven/__snapshots__/index.spec.ts.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`datasource/maven getReleases should return all versions from a custom repository 1`] = `
+Object {
+  "display": "mysql:mysql-connector-java",
+  "group": "mysql",
+  "homepage": "http://dev.mysql.com/doc/connector-j/en/",
+  "name": "mysql-connector-java",
+  "releases": Array [
+    Object {
+      "version": "6.0.5",
+    },
+    Object {
+      "version": "6.0.6",
+    },
+    Object {
+      "version": "8.0.7",
+    },
+    Object {
+      "version": "8.0.8",
+    },
+    Object {
+      "version": "8.0.9",
+    },
+    Object {
+      "version": "8.0.11",
+    },
+    Object {
+      "version": "8.0.12",
+    },
+  ],
+  "sourceUrl": "https://github.com/mysql/mysql-connector-j",
+}
+`;

--- a/lib/datasource/maven/index.spec.ts
+++ b/lib/datasource/maven/index.spec.ts
@@ -130,6 +130,7 @@ describe('datasource/maven', () => {
 
   afterEach(() => {
     nock.enableNetConnect();
+    delete process.env.RENOVATE_EXPERIMENTAL_NO_MAVEN_POM_CHECK;
   });
 
   describe('getReleases', () => {
@@ -198,7 +199,6 @@ describe('datasource/maven', () => {
         depName: 'mysql:mysql-connector-java',
         registryUrls: ['https://custom.registry.renovatebot.com'],
       });
-      delete process.env.RENOVATE_EXPERIMENTAL_NO_MAVEN_POM_CHECK;
       expect(releases).toMatchSnapshot();
     });
 

--- a/lib/datasource/maven/index.ts
+++ b/lib/datasource/maven/index.ts
@@ -57,7 +57,8 @@ async function downloadMavenXml(
       break;
     case 'http:':
     case 'https:':
-      ({ body: rawContent } = (await downloadHttpProtocol(pkgUrl)) || {});
+      ({ authorization, body: rawContent } =
+        (await downloadHttpProtocol(pkgUrl)) || {});
       break;
     case 's3:':
       logger.debug('Skipping s3 dependency');

--- a/lib/datasource/maven/index.ts
+++ b/lib/datasource/maven/index.ts
@@ -37,14 +37,20 @@ function getMavenUrl(
   return new url.URL(`${dependency.dependencyUrl}/${path}`, repoUrl);
 }
 
+interface MavenXml {
+  authorization?: boolean;
+  xml: XmlDocument;
+}
+
 async function downloadMavenXml(
   pkgUrl: url.URL | null
-): Promise<XmlDocument | null> {
+): Promise<MavenXml | null> {
   /* istanbul ignore if */
   if (!pkgUrl) {
     return null;
   }
   let rawContent: string;
+  let authorization: boolean;
   switch (pkgUrl.protocol) {
     case 'file:':
       rawContent = await downloadFileProtocol(pkgUrl);
@@ -66,7 +72,7 @@ async function downloadMavenXml(
     return null;
   }
 
-  return new XmlDocument(rawContent);
+  return { authorization, xml: new XmlDocument(rawContent) };
 }
 
 async function getDependencyInfo(
@@ -78,7 +84,7 @@ async function getDependencyInfo(
   const path = `${version}/${dependency.name}-${version}.pom`;
 
   const pomUrl = getMavenUrl(dependency, repoUrl, path);
-  const pomContent = await downloadMavenXml(pomUrl);
+  const { xml: pomContent } = (await downloadMavenXml(pomUrl)) || {};
   if (!pomContent) {
     return result;
   }
@@ -156,13 +162,16 @@ async function getVersionsFromMetadata(
     return cachedVersions;
   }
 
-  const mavenMetadata = await downloadMavenXml(metadataUrl);
+  const { authorization, xml: mavenMetadata } =
+    (await downloadMavenXml(metadataUrl)) || {};
   if (!mavenMetadata) {
     return null;
   }
 
   const versions = extractVersions(mavenMetadata);
-  await packageCache.set(cacheNamespace, cacheKey, versions, 30);
+  if (!authorization) {
+    await packageCache.set(cacheNamespace, cacheKey, versions, 30);
+  }
   return versions;
 }
 

--- a/lib/datasource/maven/index.ts
+++ b/lib/datasource/maven/index.ts
@@ -51,7 +51,7 @@ async function downloadMavenXml(
       break;
     case 'http:':
     case 'https:':
-      rawContent = await downloadHttpProtocol(pkgUrl);
+      ({ body: rawContent } = (await downloadHttpProtocol(pkgUrl)) || {});
       break;
     case 's3:':
       logger.debug('Skipping s3 dependency');

--- a/lib/datasource/maven/index.ts
+++ b/lib/datasource/maven/index.ts
@@ -57,8 +57,9 @@ async function downloadMavenXml(
       break;
     case 'http:':
     case 'https:':
-      ({ authorization, body: rawContent } =
-        (await downloadHttpProtocol(pkgUrl)) || {});
+      ({ authorization, body: rawContent } = await downloadHttpProtocol(
+        pkgUrl
+      ));
       break;
     case 's3:':
       logger.debug('Skipping s3 dependency');

--- a/lib/datasource/maven/util.ts
+++ b/lib/datasource/maven/util.ts
@@ -2,7 +2,7 @@ import url from 'url';
 import { HOST_DISABLED } from '../../constants/error-messages';
 import { logger } from '../../logger';
 import { ExternalHostError } from '../../types/errors/external-host-error';
-import { Http } from '../../util/http';
+import { Http, HttpResponse } from '../../util/http';
 
 import { MAVEN_REPO, id } from './common';
 
@@ -57,12 +57,12 @@ function isUnsupportedHostError(err: { name: string }): boolean {
 export async function downloadHttpProtocol(
   pkgUrl: url.URL | string,
   hostType = id
-): Promise<string | null> {
-  let raw: { body: string };
+): Promise<HttpResponse | null> {
+  let raw: HttpResponse;
   try {
     const httpClient = httpByHostType(hostType);
     raw = await httpClient.get(pkgUrl.toString());
-    return raw.body;
+    return raw;
   } catch (err) {
     const failedUrl = pkgUrl.toString();
     if (err.message === HOST_DISABLED) {

--- a/lib/datasource/maven/util.ts
+++ b/lib/datasource/maven/util.ts
@@ -57,7 +57,7 @@ function isUnsupportedHostError(err: { name: string }): boolean {
 export async function downloadHttpProtocol(
   pkgUrl: url.URL | string,
   hostType = id
-): Promise<HttpResponse | null> {
+): Promise<Partial<HttpResponse>> {
   let raw: HttpResponse;
   try {
     const httpClient = httpByHostType(hostType);
@@ -92,7 +92,7 @@ export async function downloadHttpProtocol(
     } else {
       logger.info({ failedUrl, err }, 'Unknown error');
     }
-    return null;
+    return {};
   }
 }
 

--- a/lib/datasource/sbt-package/index.ts
+++ b/lib/datasource/sbt-package/index.ts
@@ -19,8 +19,10 @@ export async function getArtifactSubdirs(
   artifact: string,
   scalaVersion: string
 ): Promise<string[]> {
-  const { body: indexContent } =
-    (await downloadHttpProtocol(ensureTrailingSlash(searchRoot), 'sbt')) || {};
+  const { body: indexContent } = await downloadHttpProtocol(
+    ensureTrailingSlash(searchRoot),
+    'sbt'
+  );
   if (indexContent) {
     const parseSubdirs = (content: string): string[] =>
       parseIndexDir(content, (x) => {
@@ -57,11 +59,10 @@ export async function getPackageReleases(
     const parseReleases = (content: string): string[] =>
       parseIndexDir(content, (x) => !/^\.+$/.test(x));
     for (const searchSubdir of artifactSubdirs) {
-      const { body: content } =
-        (await downloadHttpProtocol(
-          ensureTrailingSlash(`${searchRoot}/${searchSubdir}`),
-          'sbt'
-        )) || {};
+      const { body: content } = await downloadHttpProtocol(
+        ensureTrailingSlash(`${searchRoot}/${searchSubdir}`),
+        'sbt'
+      );
       if (content) {
         const subdirReleases = parseReleases(content);
         subdirReleases.forEach((x) => releases.push(x));
@@ -108,8 +109,7 @@ export async function getUrls(
 
     for (const pomFileName of pomFileNames) {
       const pomUrl = `${searchRoot}/${artifactDir}/${version}/${pomFileName}`;
-      const { body: content } =
-        (await downloadHttpProtocol(pomUrl, 'sbt')) || {};
+      const { body: content } = await downloadHttpProtocol(pomUrl, 'sbt');
 
       if (content) {
         const pomXml = new XmlDocument(content);

--- a/lib/datasource/sbt-package/index.ts
+++ b/lib/datasource/sbt-package/index.ts
@@ -19,10 +19,8 @@ export async function getArtifactSubdirs(
   artifact: string,
   scalaVersion: string
 ): Promise<string[]> {
-  const indexContent = await downloadHttpProtocol(
-    ensureTrailingSlash(searchRoot),
-    'sbt'
-  );
+  const { body: indexContent } =
+    (await downloadHttpProtocol(ensureTrailingSlash(searchRoot), 'sbt')) || {};
   if (indexContent) {
     const parseSubdirs = (content: string): string[] =>
       parseIndexDir(content, (x) => {
@@ -59,10 +57,11 @@ export async function getPackageReleases(
     const parseReleases = (content: string): string[] =>
       parseIndexDir(content, (x) => !/^\.+$/.test(x));
     for (const searchSubdir of artifactSubdirs) {
-      const content = await downloadHttpProtocol(
-        ensureTrailingSlash(`${searchRoot}/${searchSubdir}`),
-        'sbt'
-      );
+      const { body: content } =
+        (await downloadHttpProtocol(
+          ensureTrailingSlash(`${searchRoot}/${searchSubdir}`),
+          'sbt'
+        )) || {};
       if (content) {
         const subdirReleases = parseReleases(content);
         subdirReleases.forEach((x) => releases.push(x));
@@ -109,7 +108,8 @@ export async function getUrls(
 
     for (const pomFileName of pomFileNames) {
       const pomUrl = `${searchRoot}/${artifactDir}/${version}/${pomFileName}`;
-      const content = await downloadHttpProtocol(pomUrl, 'sbt');
+      const { body: content } =
+        (await downloadHttpProtocol(pomUrl, 'sbt')) || {};
 
       if (content) {
         const pomXml = new XmlDocument(content);

--- a/lib/datasource/sbt-plugin/index.ts
+++ b/lib/datasource/sbt-plugin/index.ts
@@ -26,10 +26,8 @@ async function resolvePluginReleases(
   const searchRoot = `${rootUrl}/${artifact}`;
   const parse = (content: string): string[] =>
     parseIndexDir(content, (x) => !/^\.+$/.test(x));
-  const indexContent = await downloadHttpProtocol(
-    ensureTrailingSlash(searchRoot),
-    'sbt'
-  );
+  const { body: indexContent } =
+    (await downloadHttpProtocol(ensureTrailingSlash(searchRoot), 'sbt')) || {};
   if (indexContent) {
     const releases: string[] = [];
     const scalaVersionItems = parse(indexContent);
@@ -41,18 +39,20 @@ async function resolvePluginReleases(
       : scalaVersions;
     for (const searchVersion of searchVersions) {
       const searchSubRoot = `${searchRoot}/scala_${searchVersion}`;
-      const subRootContent = await downloadHttpProtocol(
-        ensureTrailingSlash(searchSubRoot),
-        'sbt'
-      );
+      const { body: subRootContent } =
+        (await downloadHttpProtocol(
+          ensureTrailingSlash(searchSubRoot),
+          'sbt'
+        )) || {};
       if (subRootContent) {
         const sbtVersionItems = parse(subRootContent);
         for (const sbtItem of sbtVersionItems) {
           const releasesRoot = `${searchSubRoot}/${sbtItem}`;
-          const releasesIndexContent = await downloadHttpProtocol(
-            ensureTrailingSlash(releasesRoot),
-            'sbt'
-          );
+          const { body: releasesIndexContent } =
+            (await downloadHttpProtocol(
+              ensureTrailingSlash(releasesRoot),
+              'sbt'
+            )) || {};
           if (releasesIndexContent) {
             const releasesParsed = parse(releasesIndexContent);
             releasesParsed.forEach((x) => releases.push(x));

--- a/lib/datasource/sbt-plugin/index.ts
+++ b/lib/datasource/sbt-plugin/index.ts
@@ -26,8 +26,10 @@ async function resolvePluginReleases(
   const searchRoot = `${rootUrl}/${artifact}`;
   const parse = (content: string): string[] =>
     parseIndexDir(content, (x) => !/^\.+$/.test(x));
-  const { body: indexContent } =
-    (await downloadHttpProtocol(ensureTrailingSlash(searchRoot), 'sbt')) || {};
+  const { body: indexContent } = await downloadHttpProtocol(
+    ensureTrailingSlash(searchRoot),
+    'sbt'
+  );
   if (indexContent) {
     const releases: string[] = [];
     const scalaVersionItems = parse(indexContent);
@@ -39,20 +41,18 @@ async function resolvePluginReleases(
       : scalaVersions;
     for (const searchVersion of searchVersions) {
       const searchSubRoot = `${searchRoot}/scala_${searchVersion}`;
-      const { body: subRootContent } =
-        (await downloadHttpProtocol(
-          ensureTrailingSlash(searchSubRoot),
-          'sbt'
-        )) || {};
+      const { body: subRootContent } = await downloadHttpProtocol(
+        ensureTrailingSlash(searchSubRoot),
+        'sbt'
+      );
       if (subRootContent) {
         const sbtVersionItems = parse(subRootContent);
         for (const sbtItem of sbtVersionItems) {
           const releasesRoot = `${searchSubRoot}/${sbtItem}`;
-          const { body: releasesIndexContent } =
-            (await downloadHttpProtocol(
-              ensureTrailingSlash(releasesRoot),
-              'sbt'
-            )) || {};
+          const { body: releasesIndexContent } = await downloadHttpProtocol(
+            ensureTrailingSlash(releasesRoot),
+            'sbt'
+          );
           if (releasesIndexContent) {
             const releasesParsed = parse(releasesIndexContent);
             releasesParsed.forEach((x) => releases.push(x));


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Restricts maven caching for public packages only.

## Context:

We shouldn't cache private packages until we can be properly support it.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
