### PR TITLE
feat(http): support custom auth types

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -815,6 +815,26 @@ To abort Renovate for errors for a specific `docker` host:
 
 When this field is enabled, Renovate will abort its run if it encounters either (a) any low-level http error (e.g. `ETIMEDOUT`) or (b) receives a response _not_ matching any of the configured `abortIgnoreStatusCodes` (e.g. `500 Internal Error`);
 
+### authType
+
+This can be used with `token` to create a custom http `authorization` header.
+
+An example for npm basic auth with token:
+
+```json
+{
+  "hostRules": [
+    {
+      "domainName": "npm.custom.org",
+      "token": "<some-token>",
+      "authType": "Basic"
+    }
+  ]
+}
+```
+
+This will generate the following header: `authorization: Basic <some-token>`.
+
 ### baseUrl
 
 Use this instead of `domainName` or `hostName` if you need a rule to apply to a specific path on a host.

--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -1696,6 +1696,16 @@ const options: RenovateOptions[] = [
     env: false,
   },
   {
+    name: 'authType',
+    description:
+      'Authentication type for http header. e.g. "Bearer" or "Basic".',
+    type: 'string',
+    stage: 'repository',
+    parent: 'hostRules',
+    cli: false,
+    env: false,
+  },
+  {
     name: 'prBodyDefinitions',
     description: 'Table column definitions for use in PR tables.',
     type: 'object',

--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -1702,6 +1702,7 @@ const options: RenovateOptions[] = [
     type: 'string',
     stage: 'repository',
     parent: 'hostRules',
+    default: 'Bearer',
     cli: false,
     env: false,
   },

--- a/lib/datasource/npm/__snapshots__/get.spec.ts.snap
+++ b/lib/datasource/npm/__snapshots__/get.spec.ts.snap
@@ -500,6 +500,23 @@ Array [
 ]
 `;
 
+exports[`datasource/npm/get uses hostRules basic token auth 1`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate",
+      "authorization": "Basic XXX",
+      "cache-control": "no-cache",
+      "host": "registry.npmjs.org",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://registry.npmjs.org/renovate",
+  },
+]
+`;
+
 exports[`datasource/npm/get uses hostRules token auth 1`] = `
 Array [
   Object {

--- a/lib/datasource/npm/get.spec.ts
+++ b/lib/datasource/npm/get.spec.ts
@@ -153,6 +153,28 @@ describe(getName(__filename), () => {
     expect(httpMock.getTrace()).toMatchSnapshot();
   });
 
+  it('uses hostRules basic token auth', async () => {
+    expect.assertions(1);
+    const npmrc = ``;
+    hostRules.add({
+      baseUrl: 'https://registry.npmjs.org',
+      token: 'XXX',
+      authType: 'Basic',
+    });
+
+    httpMock
+      .scope('https://registry.npmjs.org', {
+        reqheaders: {
+          authorization: 'Basic XXX',
+        },
+      })
+      .get('/renovate')
+      .reply(200, { name: 'renovate' });
+    setNpmrc(npmrc);
+    await getDependency('renovate', 0);
+    expect(httpMock.getTrace()).toMatchSnapshot();
+  });
+
   it('cover all paths', async () => {
     expect.assertions(10);
 

--- a/lib/types/host-rules.ts
+++ b/lib/types/host-rules.ts
@@ -1,4 +1,5 @@
 export interface HostRule {
+  authType?: string;
   endpoint?: string;
   host?: string;
   hostType?: string;

--- a/lib/util/http/auth.spec.ts
+++ b/lib/util/http/auth.spec.ts
@@ -112,6 +112,32 @@ describe(getName(__filename), () => {
     });
   });
 
+  it(`npm basic token`, () => {
+    const opts: GotOptions = {
+      headers: {},
+      token: 'a40bdd925a0c0b9c4cdd19d101c0df3b2bcd063ab7ad6706f03bcffcec01e863',
+      hostType: 'npm',
+      context: {
+        authType: 'Basic',
+      },
+    };
+
+    applyAuthorization(opts);
+
+    expect(opts).toMatchInlineSnapshot(`
+      Object {
+        "context": Object {
+          "authType": "Basic",
+        },
+        "headers": Object {
+          "authorization": "Basic a40bdd925a0c0b9c4cdd19d101c0df3b2bcd063ab7ad6706f03bcffcec01e863",
+        },
+        "hostType": "npm",
+        "token": "a40bdd925a0c0b9c4cdd19d101c0df3b2bcd063ab7ad6706f03bcffcec01e863",
+      }
+    `);
+  });
+
   describe('removeAuthorization', () => {
     it('no authorization', () => {
       const opts = partial<NormalizedOptions>({

--- a/lib/util/http/auth.ts
+++ b/lib/util/http/auth.ts
@@ -36,7 +36,9 @@ export function applyAuthorization(inOptions: GotOptions): GotOptions {
         options.headers.authorization = `Bearer ${options.token}`;
       }
     } else {
-      options.headers.authorization = `Bearer ${options.token}`;
+      // Custom Auth type, eg `Basic XXXX_TOKEN`
+      const type = options.context?.authType ?? 'Bearer';
+      options.headers.authorization = `${type} ${options.token}`;
     }
     delete options.token;
   } else if (options.password !== undefined) {

--- a/lib/util/http/host-rules.spec.ts
+++ b/lib/util/http/host-rules.spec.ts
@@ -33,6 +33,12 @@ describe(getName(__filename), () => {
       password: 'password',
     });
 
+    hostRules.add({
+      hostType: 'npm',
+      authType: 'Basic',
+      token: 'XXX',
+    });
+
     httpMock.reset();
     httpMock.setup();
   });
@@ -45,6 +51,9 @@ describe(getName(__filename), () => {
   it('adds token', () => {
     expect(applyHostRules(url, { ...options })).toMatchInlineSnapshot(`
       Object {
+        "context": Object {
+          "authType": undefined,
+        },
         "hostType": "github",
         "token": "token",
       }
@@ -58,6 +67,18 @@ describe(getName(__filename), () => {
         "hostType": "gitea",
         "password": "password",
         "username": undefined,
+      }
+    `);
+  });
+
+  it('adds custom auth', () => {
+    expect(applyHostRules(url, { hostType: 'npm' })).toMatchInlineSnapshot(`
+      Object {
+        "context": Object {
+          "authType": "Basic",
+        },
+        "hostType": "npm",
+        "token": "XXX",
       }
     `);
   });

--- a/lib/util/http/host-rules.ts
+++ b/lib/util/http/host-rules.ts
@@ -12,7 +12,7 @@ export function applyHostRules(url: string, inOptions: GotOptions): GotOptions {
       hostType: options.hostType,
       url,
     }) || /* istanbul ignore next: can only happen in tests */ {};
-  const { username, password, token, enabled } = foundRules;
+  const { username, password, token, enabled, authType } = foundRules;
   if (options.headers?.authorization || options.password || options.token) {
     logger.trace({ url }, `Authorization already set`);
   } else if (password !== undefined) {
@@ -22,6 +22,7 @@ export function applyHostRules(url: string, inOptions: GotOptions): GotOptions {
   } else if (token) {
     logger.trace({ url }, `Applying Bearer authentication`);
     options.token = token;
+    options.context = { ...options.context, authType };
   } else if (enabled === false) {
     options.enabled = false;
   }

--- a/lib/util/http/types.ts
+++ b/lib/util/http/types.ts
@@ -1,5 +1,9 @@
 import { OptionsOfJSONResponseBody, RequestError as RequestError_ } from 'got';
 
+export type GotContextOptions = {
+  authType?: string;
+} & Record<string, unknown>;
+
 // TODO: Move options to context
 export type GotOptions = OptionsOfJSONResponseBody & {
   abortOnError?: boolean;
@@ -8,6 +12,7 @@ export type GotOptions = OptionsOfJSONResponseBody & {
   hostType?: string;
   enabled?: boolean;
   useCache?: boolean;
+  context?: GotContextOptions;
 };
 
 export { RequestError_ as HttpError };


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

This allows custom auth types like basic auth with token used by some legacy npm registries. eg: `Basic XXX_TOKEN`

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization
<!-- Describe what behavior is changed by this PR. -->

## Context:

Currently we have no alternate for legacy npmrc config: 

```ini
//registry.com/:_auth=dGVzdDp0ZXN0
_auth=dGVzdDp0ZXN0
```


With this pr we can do:

```js
  hostRules: [
  {
    hostType: 'npm',
    domainName: 'registry.com',
    authType: 'Basic',
    token: 'ABC',
  }
  ]
```
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
