### PR TITLE
fix(github): Propagate PR already exists up

### DIFF
--- a/lib/util/http/github.spec.ts
+++ b/lib/util/http/github.spec.ts
@@ -187,6 +187,14 @@ describe(getName(__filename), () => {
           'Review cannot be requested from pull request author.'
         );
       });
+      it('should throw original error when pull requests aleady existed', async () => {
+        await expect(
+          fail(422, {
+            message: 'Validation error',
+            errors: [{ message: 'A pull request already exists' }],
+          })
+        ).rejects.toThrow('Validation error');
+      });
       it('should throw original error of unknown type', async () => {
         await expect(
           fail(418, {

--- a/lib/util/http/github.ts
+++ b/lib/util/http/github.ts
@@ -111,6 +111,12 @@ function handleGotError(
     } else if (err.body?.errors?.find((e: any) => e.code === 'invalid')) {
       logger.debug({ err }, 'Received invalid response - aborting');
       throw new Error(REPOSITORY_CHANGED);
+    } else if (
+      err.body?.errors?.find((e: any) =>
+        e.message?.startsWith('A pull request already exists')
+      )
+    ) {
+      throw err;
     }
     logger.debug({ err }, '422 Error thrown from GitHub');
     throw new ExternalHostError(err, PLATFORM_TYPE_GITHUB);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Fixes github http layer to pass "Pull request already exists" instead of eagerly converting to an ExternalHost Error.

## Context:

Closes #9079

Checks already existed for this error higher up, but are not getting triggered because the error was transformed at the http layer.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
