### PR TITLE
feat(internal): fixedRegistries

### DIFF
--- a/lib/datasource/cdnjs/index.ts
+++ b/lib/datasource/cdnjs/index.ts
@@ -3,6 +3,8 @@ import { Http } from '../../util/http';
 import type { GetReleasesConfig, ReleaseResult } from '../types';
 
 export const id = 'cdnjs';
+export const fixedRegistries = true;
+export const defaultRegistryUrls = ['https://api.cdnjs.com/'];
 export const caching = true;
 
 const http = new Http(id);
@@ -24,10 +26,11 @@ interface CdnjsResponse {
 
 export async function getReleases({
   lookupName,
+  registryUrl,
 }: GetReleasesConfig): Promise<ReleaseResult | null> {
   // Each library contains multiple assets, so we cache at the library level instead of per-asset
   const library = lookupName.split('/')[0];
-  const url = `https://api.cdnjs.com/libraries/${library}?fields=homepage,repository,assets`;
+  const url = `${registryUrl}libraries/${library}?fields=homepage,repository,assets`;
   try {
     const { assets, homepage, repository } = (
       await http.getJson<CdnjsResponse>(url)

--- a/lib/datasource/cdnjs/index.ts
+++ b/lib/datasource/cdnjs/index.ts
@@ -3,7 +3,7 @@ import { Http } from '../../util/http';
 import type { GetReleasesConfig, ReleaseResult } from '../types';
 
 export const id = 'cdnjs';
-export const fixedRegistries = true;
+export const registryUrlRestriction = 'fixed';
 export const defaultRegistryUrls = ['https://api.cdnjs.com/'];
 export const caching = true;
 

--- a/lib/datasource/dart/index.ts
+++ b/lib/datasource/dart/index.ts
@@ -3,14 +3,17 @@ import { Http, HttpResponse } from '../../util/http';
 import type { GetReleasesConfig, ReleaseResult } from '../types';
 
 export const id = 'dart';
+export const defaultRegistryUrls = ['https://pub.dartlang.org/'];
+export const fixedRegistries = true;
 
 const http = new Http(id);
 
 export async function getReleases({
   lookupName,
+  registryUrl,
 }: GetReleasesConfig): Promise<ReleaseResult | null> {
   let result: ReleaseResult = null;
-  const pkgUrl = `https://pub.dartlang.org/api/packages/${lookupName}`;
+  const pkgUrl = `${registryUrl}api/packages/${lookupName}`;
   interface DartResult {
     versions?: {
       version: string;

--- a/lib/datasource/dart/index.ts
+++ b/lib/datasource/dart/index.ts
@@ -4,7 +4,7 @@ import type { GetReleasesConfig, ReleaseResult } from '../types';
 
 export const id = 'dart';
 export const defaultRegistryUrls = ['https://pub.dartlang.org/'];
-export const fixedRegistries = true;
+export const registryUrlRestriction = 'fixed';
 
 const http = new Http(id);
 

--- a/lib/datasource/galaxy/index.spec.ts
+++ b/lib/datasource/galaxy/index.spec.ts
@@ -89,18 +89,6 @@ describe('datasource/galaxy', () => {
       expect(res).toBeDefined();
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
-    it('ignores and warns for registryUrls', async () => {
-      httpMock
-        .scope(baseUrl)
-        .get('/api/v1/roles/?owner__username=yatesr2&name=timezone')
-        .reply(200, res1);
-      const res = await getPkgReleases({
-        datasource,
-        depName: 'yatesr2.timezone',
-        registryUrls: ['https://google.com/'],
-      });
-      expect(res).not.toBeNull();
-    });
     it('return null if searching random username and project name', async () => {
       httpMock
         .scope(baseUrl)

--- a/lib/datasource/galaxy/index.spec.ts
+++ b/lib/datasource/galaxy/index.spec.ts
@@ -89,6 +89,18 @@ describe('datasource/galaxy', () => {
       expect(res).toBeDefined();
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
+    it('ignores and warns for registryUrls', async () => {
+      httpMock
+        .scope(baseUrl)
+        .get('/api/v1/roles/?owner__username=yatesr2&name=timezone')
+        .reply(200, res1);
+      const res = await getPkgReleases({
+        datasource,
+        depName: 'yatesr2.timezone',
+        registryUrls: ['https://google.com/'],
+      });
+      expect(res).not.toBeNull();
+    });
     it('return null if searching random username and project name', async () => {
       httpMock
         .scope(baseUrl)

--- a/lib/datasource/galaxy/index.ts
+++ b/lib/datasource/galaxy/index.ts
@@ -5,11 +5,14 @@ import { Http } from '../../util/http';
 import type { GetReleasesConfig, Release, ReleaseResult } from '../types';
 
 export const id = 'galaxy';
+export const defaultRegistryUrls = ['https://galaxy.ansible.com/'];
+export const fixedRegistries = true;
 
 const http = new Http(id);
 
 export async function getReleases({
   lookupName,
+  registryUrl,
 }: GetReleasesConfig): Promise<ReleaseResult | null> {
   const cacheNamespace = 'datasource-galaxy';
   const cacheKey = lookupName;
@@ -26,14 +29,13 @@ export async function getReleases({
   const userName = lookUp[0];
   const projectName = lookUp[1];
 
-  const baseUrl = 'https://galaxy.ansible.com/';
   const galaxyAPIUrl =
-    baseUrl +
+    registryUrl +
     'api/v1/roles/?owner__username=' +
     userName +
     '&name=' +
     projectName;
-  const galaxyProjectUrl = baseUrl + userName + '/' + projectName;
+  const galaxyProjectUrl = registryUrl + userName + '/' + projectName;
   try {
     let res: any = await http.get(galaxyAPIUrl);
     if (!res || !res.body) {

--- a/lib/datasource/galaxy/index.ts
+++ b/lib/datasource/galaxy/index.ts
@@ -6,7 +6,7 @@ import type { GetReleasesConfig, Release, ReleaseResult } from '../types';
 
 export const id = 'galaxy';
 export const defaultRegistryUrls = ['https://galaxy.ansible.com/'];
-export const fixedRegistries = true;
+export const registryUrlRestriction = 'fixed';
 
 const http = new Http(id);
 

--- a/lib/datasource/git-refs/index.ts
+++ b/lib/datasource/git-refs/index.ts
@@ -4,6 +4,7 @@ import * as semver from '../../versioning/semver';
 import type { DigestConfig, GetReleasesConfig, ReleaseResult } from '../types';
 
 export const id = 'git-refs';
+export const registryUrlRestriction = 'disallowed';
 
 const cacheMinutes = 10;
 

--- a/lib/datasource/git-tags/index.ts
+++ b/lib/datasource/git-tags/index.ts
@@ -3,6 +3,7 @@ import * as gitRefs from '../git-refs';
 import type { DigestConfig, GetReleasesConfig, ReleaseResult } from '../types';
 
 export const id = 'git-tags';
+export const registryUrlRestriction = 'disallowed';
 
 export async function getReleases({
   lookupName,

--- a/lib/datasource/go/index.ts
+++ b/lib/datasource/go/index.ts
@@ -11,6 +11,7 @@ import * as gitlab from '../gitlab-tags';
 import type { DigestConfig, GetReleasesConfig, ReleaseResult } from '../types';
 
 export const id = 'go';
+export const registryUrlRestriction = 'disallowed';
 
 const http = new Http(id);
 const gitlabRegExp = /^(https:\/\/[^/]*gitlab.[^/]*)\/(.*)$/;

--- a/lib/datasource/hex/index.ts
+++ b/lib/datasource/hex/index.ts
@@ -6,7 +6,7 @@ import type { GetReleasesConfig, ReleaseResult } from '../types';
 
 export const id = 'hex';
 export const defaultRegistryUrls = ['https://hex.pm/'];
-export const fixedRegistries = true;
+export const registryUrlRestriction = 'fixed';
 export const defaultVersioning = hexVersioning.id;
 
 const http = new Http(id);

--- a/lib/datasource/hex/index.ts
+++ b/lib/datasource/hex/index.ts
@@ -5,6 +5,8 @@ import * as hexVersioning from '../../versioning/hex';
 import type { GetReleasesConfig, ReleaseResult } from '../types';
 
 export const id = 'hex';
+export const defaultRegistryUrls = ['https://hex.pm/'];
+export const fixedRegistries = true;
 export const defaultVersioning = hexVersioning.id;
 
 const http = new Http(id);
@@ -20,6 +22,7 @@ interface HexRelease {
 
 export async function getReleases({
   lookupName,
+  registryUrl,
 }: GetReleasesConfig): Promise<ReleaseResult | null> {
   // Get dependency name from lookupName.
   // If the dependency is private lookupName contains organization name as following:
@@ -27,7 +30,7 @@ export async function getReleases({
   // hexPackageName is used to pass it in hex dep url
   // organizationName is used for accessing to private deps
   const hexPackageName = lookupName.split(':')[0];
-  const hexUrl = `https://hex.pm/api/packages/${hexPackageName}`;
+  const hexUrl = `${registryUrl}api/packages/${hexPackageName}`;
   try {
     const response = await http.getJson<HexRelease>(hexUrl);
 

--- a/lib/datasource/index.spec.ts
+++ b/lib/datasource/index.spec.ts
@@ -1,4 +1,4 @@
-import { getName, mocked } from '../../test/util';
+import { getName, logger, mocked } from '../../test/util';
 import {
   EXTERNAL_HOST_ERROR,
   HOST_DISABLED,
@@ -6,6 +6,7 @@ import {
 import { ExternalHostError } from '../types/errors/external-host-error';
 import { loadModules } from '../util/modules';
 import * as datasourceDocker from './docker';
+import * as datasourceGalaxy from './galaxy';
 import * as datasourceGithubTags from './github-tags';
 import * as datasourceMaven from './maven';
 import * as datasourceNpm from './npm';
@@ -14,11 +15,13 @@ import type { DatasourceApi } from './types';
 import * as datasource from '.';
 
 jest.mock('./docker');
+jest.mock('./galaxy');
 jest.mock('./maven');
 jest.mock('./npm');
 jest.mock('./packagist');
 
 const dockerDatasource = mocked(datasourceDocker);
+const galaxyDatasource = mocked(datasourceGalaxy);
 const mavenDatasource = mocked(datasourceMaven);
 const npmDatasource = mocked(datasourceNpm);
 const packagistDatasource = mocked(datasourcePackagist);
@@ -127,6 +130,15 @@ describe(getName(__filename), () => {
     });
     expect(res).toMatchSnapshot();
     expect(res.sourceUrl).toBeDefined();
+  });
+  it('ignores and warns for registryUrls', async () => {
+    galaxyDatasource.getReleases.mockResolvedValue(null);
+    await datasource.getPkgReleases({
+      datasource: datasourceGalaxy.id,
+      depName: 'some.dep',
+      registryUrls: ['https://google.com/'],
+    });
+    expect(logger.logger.warn).toHaveBeenCalled();
   });
   it('warns if multiple registryUrls for registryStrategy=first', async () => {
     dockerDatasource.getReleases.mockResolvedValue(null);

--- a/lib/datasource/index.ts
+++ b/lib/datasource/index.ts
@@ -171,8 +171,17 @@ function resolveRegistryUrls(
   datasource: DatasourceApi,
   extractedUrls: string[]
 ): string[] {
-  const { defaultRegistryUrls = [] } = datasource;
+  const { defaultRegistryUrls = [], fixedRegistries } = datasource;
   const customUrls = extractedUrls?.filter(Boolean);
+  if (fixedRegistries) {
+    if (is.nonEmptyArray(customUrls)) {
+      logger.warn(
+        { datasource: datasource.id, customUrls },
+        'Ignoring custom registryUrls as they cannot be overridden'
+      );
+    }
+    return defaultRegistryUrls;
+  }
   let registryUrls: string[];
   if (is.nonEmptyArray(customUrls)) {
     registryUrls = [...customUrls];
@@ -199,7 +208,7 @@ async function fetchReleases(
   const registryUrls = resolveRegistryUrls(datasource, config.registryUrls);
   let dep: ReleaseResult = null;
   try {
-    if (datasource.registryStrategy) {
+    if (datasource.registryStrategy || datasource.fixedRegistries) {
       // istanbul ignore if
       if (!registryUrls.length) {
         logger.warn(
@@ -214,6 +223,9 @@ async function fetchReleases(
         dep = await huntRegistries(config, datasource, registryUrls);
       } else if (datasource.registryStrategy === 'merge') {
         dep = await mergeRegistries(config, datasource, registryUrls);
+      } else if (datasource.fixedRegistries) {
+        // Default to hunting default registries if no rangeStrategy provided
+        dep = await huntRegistries(config, datasource, registryUrls);
       }
     } else {
       dep = await datasource.getReleases({

--- a/lib/datasource/index.ts
+++ b/lib/datasource/index.ts
@@ -171,9 +171,9 @@ function resolveRegistryUrls(
   datasource: DatasourceApi,
   extractedUrls: string[]
 ): string[] {
-  const { defaultRegistryUrls = [], fixedRegistries } = datasource;
+  const { defaultRegistryUrls = [], registryUrlRestriction } = datasource;
   const customUrls = extractedUrls?.filter(Boolean);
-  if (fixedRegistries) {
+  if (registryUrlRestriction) {
     if (is.nonEmptyArray(customUrls)) {
       logger.warn(
         { datasource: datasource.id, customUrls },
@@ -208,7 +208,10 @@ async function fetchReleases(
   const registryUrls = resolveRegistryUrls(datasource, config.registryUrls);
   let dep: ReleaseResult = null;
   try {
-    if (datasource.registryStrategy || datasource.fixedRegistries) {
+    if (
+      datasource.registryStrategy ||
+      datasource.registryUrlRestriction === 'fixed'
+    ) {
       // istanbul ignore if
       if (!registryUrls.length) {
         logger.warn(
@@ -223,7 +226,7 @@ async function fetchReleases(
         dep = await huntRegistries(config, datasource, registryUrls);
       } else if (datasource.registryStrategy === 'merge') {
         dep = await mergeRegistries(config, datasource, registryUrls);
-      } else if (datasource.fixedRegistries) {
+      } else {
         // Default to hunting default registries if no rangeStrategy provided
         dep = await huntRegistries(config, datasource, registryUrls);
       }

--- a/lib/datasource/npm/index.ts
+++ b/lib/datasource/npm/index.ts
@@ -5,3 +5,4 @@ export { getReleases } from './releases';
 export { getNpmrc, setNpmrc } from './npmrc';
 export { id } from './common';
 export const defaultVersioning = npmVersioning.id;
+export const registryUrlRestriction = 'disallowed';

--- a/lib/datasource/npm/index.ts
+++ b/lib/datasource/npm/index.ts
@@ -5,4 +5,3 @@ export { getReleases } from './releases';
 export { getNpmrc, setNpmrc } from './npmrc';
 export { id } from './common';
 export const defaultVersioning = npmVersioning.id;
-export const registryUrlRestriction = 'disallowed';

--- a/lib/datasource/orb/index.ts
+++ b/lib/datasource/orb/index.ts
@@ -5,7 +5,7 @@ import type { GetReleasesConfig, ReleaseResult } from '../types';
 
 export const id = 'orb';
 export const defaultRegistryUrls = ['https://circleci.com/'];
-export const fixedRegistries = true;
+export const registryUrlRestriction = 'fixed';
 
 const http = new Http(id);
 

--- a/lib/datasource/orb/index.ts
+++ b/lib/datasource/orb/index.ts
@@ -4,6 +4,8 @@ import { Http } from '../../util/http';
 import type { GetReleasesConfig, ReleaseResult } from '../types';
 
 export const id = 'orb';
+export const defaultRegistryUrls = ['https://circleci.com/'];
+export const fixedRegistries = true;
 
 const http = new Http(id);
 
@@ -22,6 +24,7 @@ interface OrbRelease {
  */
 export async function getReleases({
   lookupName,
+  registryUrl,
 }: GetReleasesConfig): Promise<ReleaseResult | null> {
   logger.debug({ lookupName }, 'orb.getReleases()');
   const cacheNamespace = 'orb';
@@ -34,7 +37,7 @@ export async function getReleases({
   if (cachedResult) {
     return cachedResult;
   }
-  const url = 'https://circleci.com/graphql-unstable';
+  const url = `${registryUrl}graphql-unstable`;
   const body = {
     query: `{orb(name:"${lookupName}"){name, homeUrl, versions {version, createdAt}}}`,
     variables: {},

--- a/lib/datasource/ruby-version/index.ts
+++ b/lib/datasource/ruby-version/index.ts
@@ -6,15 +6,15 @@ import { isVersion, id as rubyVersioningId } from '../../versioning/ruby';
 import type { GetReleasesConfig, ReleaseResult } from '../types';
 
 export const id = 'ruby-version';
+export const defaultRegistryUrls = ['https://www.ruby-lang.org/'];
+export const fixedRegistries = true;
 export const defaultVersioning = rubyVersioningId;
 
 const http = new Http(id);
 
-const rubyVersionsUrl = 'https://www.ruby-lang.org/en/downloads/releases/';
-
-export async function getReleases(
-  _config?: GetReleasesConfig
-): Promise<ReleaseResult> {
+export async function getReleases({
+  registryUrl,
+}: GetReleasesConfig): Promise<ReleaseResult | null> {
   // First check the persistent cache
   const cacheNamespace = 'datasource-ruby-version';
   const cachedResult = await packageCache.get<ReleaseResult>(
@@ -31,6 +31,7 @@ export async function getReleases(
       sourceUrl: 'https://github.com/ruby/ruby',
       releases: [],
     };
+    const rubyVersionsUrl = `${registryUrl}en/downloads/releases/`;
     const response = await http.get(rubyVersionsUrl);
     const root = parse(response.body);
     const rows = root.querySelector('.release-list').querySelectorAll('tr');

--- a/lib/datasource/ruby-version/index.ts
+++ b/lib/datasource/ruby-version/index.ts
@@ -7,7 +7,7 @@ import type { GetReleasesConfig, ReleaseResult } from '../types';
 
 export const id = 'ruby-version';
 export const defaultRegistryUrls = ['https://www.ruby-lang.org/'];
-export const fixedRegistries = true;
+export const registryUrlRestriction = 'fixed';
 export const defaultVersioning = rubyVersioningId;
 
 const http = new Http(id);

--- a/lib/datasource/types.ts
+++ b/lib/datasource/types.ts
@@ -63,7 +63,17 @@ export interface DatasourceApi {
   defaultRegistryUrls?: string[];
   defaultVersioning?: string;
   defaultConfig?: Record<string, unknown>;
+
+  // registryStrategy=first means only the first registryUrl will be tried and others ignored
+  // registryStrategy=hunt means registryUrls will be tried in order until one returns a result
+  // registryStrategy=merge means all registryUrls will be tried and the results merged if more than one returns a result
   registryStrategy?: 'first' | 'hunt' | 'merge';
-  registryUrlRestriction?: 'fixed' | 'none';
+
+  // registryUrlRestriction=fixed means the default registryUrl settings can't be overridden
+  // registryUrlRestriction=disallowed means that registryUrls are not applicable to this datasource
+  // If registryUrlRestriction is unspecified, it means custom registryUrls are allowed (no retriction)
+  registryUrlRestriction?: 'fixed' | 'disallowed';
+
+  // caching=true means caching will be performed by the datasource index instead of the datasource implementation
   caching?: boolean;
 }

--- a/lib/datasource/types.ts
+++ b/lib/datasource/types.ts
@@ -64,5 +64,6 @@ export interface DatasourceApi {
   defaultVersioning?: string;
   defaultConfig?: Record<string, unknown>;
   registryStrategy?: 'first' | 'hunt' | 'merge';
+  fixedRegistries?: boolean; // true = registryUrls are fixed to defaults and cannot be overridden
   caching?: boolean;
 }

--- a/lib/datasource/types.ts
+++ b/lib/datasource/types.ts
@@ -64,6 +64,6 @@ export interface DatasourceApi {
   defaultVersioning?: string;
   defaultConfig?: Record<string, unknown>;
   registryStrategy?: 'first' | 'hunt' | 'merge';
-  fixedRegistries?: boolean; // true = registryUrls are fixed to defaults and cannot be overridden
+  registryUrlRestriction?: 'fixed' | 'none';
   caching?: boolean;
 }

--- a/lib/datasource/types.ts
+++ b/lib/datasource/types.ts
@@ -64,16 +64,25 @@ export interface DatasourceApi {
   defaultVersioning?: string;
   defaultConfig?: Record<string, unknown>;
 
-  // registryStrategy=first means only the first registryUrl will be tried and others ignored
-  // registryStrategy=hunt means registryUrls will be tried in order until one returns a result
-  // registryStrategy=merge means all registryUrls will be tried and the results merged if more than one returns a result
+  /**
+   * Strategy to use when multiple registryUrls are available to the datasource.
+   * first: only the first registryUrl will be tried and others ignored
+   * hunt: registryUrls will be tried in order until one returns a result
+   * merge: all registryUrls will be tried and the results merged if more than one returns a result
+   */
   registryStrategy?: 'first' | 'hunt' | 'merge';
 
-  // registryUrlRestriction=fixed means the default registryUrl settings can't be overridden
-  // registryUrlRestriction=disallowed means that registryUrls are not applicable to this datasource
-  // If registryUrlRestriction is unspecified, it means custom registryUrls are allowed (no retriction)
+  /**
+   * Whether restrictions apply on custom registryUrls. If unspecified, it means custom registryUrls are allowed (no retriction).
+   * fixed: the default registryUrl settings can't be overridden
+   * disallowed: registryUrls are not applicable to this datasource
+   */
   registryUrlRestriction?: 'fixed' | 'disallowed';
 
-  // caching=true means caching will be performed by the datasource index instead of the datasource implementation
+  /**
+   * Whether to perform caching in the datasource index/wrapper or not.
+   * true: datasoure index wrapper should cache all results (based on registryUrl/lookupName)
+   * false: caching is not performed, or performed within the datasource implementation
+   */
   caching?: boolean;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Adds "fixed" registryUrls for multiple datasources
- Add explicit "disallowed" registryUrls so that attempts to override them can be warned about

## Context:

- Provide warning when `registryUrls` are used mistakenly
- Provide more transparency about fixed registryUrls
- Part of the steps necessary for datasource proxying and cache

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
