### PR TITLE
refactor: customRegistrySupport

### DIFF
--- a/lib/datasource/bitbucket-tags/index.ts
+++ b/lib/datasource/bitbucket-tags/index.ts
@@ -8,6 +8,7 @@ import { BitbucketCommit, BitbucketTag } from './types';
 const bitbucketHttp = new BitbucketHttp();
 
 export const id = 'bitbucket-tags';
+export const customRegistrySupport = true;
 export const registryStrategy = 'first';
 export const defaultRegistryUrls = ['https://bitbucket.org'];
 

--- a/lib/datasource/cdnjs/index.ts
+++ b/lib/datasource/cdnjs/index.ts
@@ -3,7 +3,7 @@ import { Http } from '../../util/http';
 import type { GetReleasesConfig, ReleaseResult } from '../types';
 
 export const id = 'cdnjs';
-export const registryUrlRestriction = 'fixed';
+export const customRegistrySupport = false;
 export const defaultRegistryUrls = ['https://api.cdnjs.com/'];
 export const caching = true;
 

--- a/lib/datasource/clojure/index.ts
+++ b/lib/datasource/clojure/index.ts
@@ -1,7 +1,7 @@
 import { MAVEN_REPO } from '../maven/common';
 
 export const id = 'clojure';
-
+export const customRegistrySupport = true;
 export const defaultRegistryUrls = ['https://clojars.org/repo', MAVEN_REPO];
 export const registryStrategy = 'merge';
 

--- a/lib/datasource/crate/index.ts
+++ b/lib/datasource/crate/index.ts
@@ -12,6 +12,7 @@ import * as cargoVersioning from '../../versioning/cargo';
 import type { GetReleasesConfig, Release, ReleaseResult } from '../types';
 
 export const id = 'crate';
+export const customRegistrySupport = true;
 export const defaultRegistryUrls = ['https://crates.io'];
 export const defaultVersioning = cargoVersioning.id;
 export const registryStrategy = 'first';

--- a/lib/datasource/dart/index.ts
+++ b/lib/datasource/dart/index.ts
@@ -4,7 +4,7 @@ import type { GetReleasesConfig, ReleaseResult } from '../types';
 
 export const id = 'dart';
 export const defaultRegistryUrls = ['https://pub.dartlang.org/'];
-export const registryUrlRestriction = 'fixed';
+export const customRegistrySupport = false;
 
 const http = new Http(id);
 

--- a/lib/datasource/docker/index.ts
+++ b/lib/datasource/docker/index.ts
@@ -20,6 +20,7 @@ import { Image, ImageList, MediaType } from './types';
 // TODO: replace www-authenticate with https://www.npmjs.com/package/auth-header ?
 
 export const id = 'docker';
+export const customRegistrySupport = true;
 export const defaultRegistryUrls = ['https://index.docker.io'];
 export const defaultVersioning = dockerVersioning.id;
 export const registryStrategy = 'first';

--- a/lib/datasource/galaxy/index.ts
+++ b/lib/datasource/galaxy/index.ts
@@ -6,7 +6,7 @@ import type { GetReleasesConfig, Release, ReleaseResult } from '../types';
 
 export const id = 'galaxy';
 export const defaultRegistryUrls = ['https://galaxy.ansible.com/'];
-export const registryUrlRestriction = 'fixed';
+export const customRegistrySupport = false;
 
 const http = new Http(id);
 

--- a/lib/datasource/git-refs/index.ts
+++ b/lib/datasource/git-refs/index.ts
@@ -4,7 +4,7 @@ import * as semver from '../../versioning/semver';
 import type { DigestConfig, GetReleasesConfig, ReleaseResult } from '../types';
 
 export const id = 'git-refs';
-export const registryUrlRestriction = 'disallowed';
+export const customRegistrySupport = false;
 
 const cacheMinutes = 10;
 

--- a/lib/datasource/git-tags/index.ts
+++ b/lib/datasource/git-tags/index.ts
@@ -3,7 +3,7 @@ import * as gitRefs from '../git-refs';
 import type { DigestConfig, GetReleasesConfig, ReleaseResult } from '../types';
 
 export const id = 'git-tags';
-export const registryUrlRestriction = 'disallowed';
+export const customRegistrySupport = false;
 
 export async function getReleases({
   lookupName,

--- a/lib/datasource/github-releases/index.ts
+++ b/lib/datasource/github-releases/index.ts
@@ -4,6 +4,7 @@ import { ensureTrailingSlash } from '../../util/url';
 import type { GetReleasesConfig, ReleaseResult } from '../types';
 
 export const id = 'github-releases';
+export const customRegistrySupport = true;
 export const defaultRegistryUrls = ['https://github.com'];
 export const registryStrategy = 'first';
 

--- a/lib/datasource/github-tags/index.ts
+++ b/lib/datasource/github-tags/index.ts
@@ -6,6 +6,7 @@ import * as githubReleases from '../github-releases';
 import type { DigestConfig, GetReleasesConfig, ReleaseResult } from '../types';
 
 export const id = 'github-tags';
+export const customRegistrySupport = true;
 export const defaultRegistryUrls = ['https://github.com'];
 export const registryStrategy = 'first';
 

--- a/lib/datasource/gitlab-tags/index.ts
+++ b/lib/datasource/gitlab-tags/index.ts
@@ -6,6 +6,7 @@ import type { GetReleasesConfig, ReleaseResult } from '../types';
 const gitlabApi = new GitlabHttp();
 
 export const id = 'gitlab-tags';
+export const customRegistrySupport = true;
 export const defaultRegistryUrls = ['https://gitlab.com'];
 export const registryStrategy = 'first';
 

--- a/lib/datasource/go/index.ts
+++ b/lib/datasource/go/index.ts
@@ -11,7 +11,7 @@ import * as gitlab from '../gitlab-tags';
 import type { DigestConfig, GetReleasesConfig, ReleaseResult } from '../types';
 
 export const id = 'go';
-export const registryUrlRestriction = 'disallowed';
+export const customRegistrySupport = false;
 
 const http = new Http(id);
 const gitlabRegExp = /^(https:\/\/[^/]*gitlab.[^/]*)\/(.*)$/;

--- a/lib/datasource/gradle-version/index.ts
+++ b/lib/datasource/gradle-version/index.ts
@@ -5,6 +5,7 @@ import * as gradleVersioning from '../../versioning/gradle';
 import type { GetReleasesConfig, ReleaseResult } from '../types';
 
 export const id = 'gradle-version';
+export const customRegistrySupport = true;
 export const defaultRegistryUrls = ['https://services.gradle.org/versions/all'];
 export const defaultVersioning = gradleVersioning.id;
 export const registryStrategy = 'merge';

--- a/lib/datasource/helm/index.ts
+++ b/lib/datasource/helm/index.ts
@@ -12,6 +12,7 @@ export const id = 'helm';
 
 const http = new Http(id);
 
+export const customRegistrySupport = true;
 export const defaultRegistryUrls = ['https://charts.helm.sh/stable'];
 export const registryStrategy = 'first';
 

--- a/lib/datasource/hex/index.ts
+++ b/lib/datasource/hex/index.ts
@@ -6,7 +6,7 @@ import type { GetReleasesConfig, ReleaseResult } from '../types';
 
 export const id = 'hex';
 export const defaultRegistryUrls = ['https://hex.pm/'];
-export const registryUrlRestriction = 'fixed';
+export const customRegistrySupport = false;
 export const defaultVersioning = hexVersioning.id;
 
 const http = new Http(id);

--- a/lib/datasource/jenkins-plugins/index.ts
+++ b/lib/datasource/jenkins-plugins/index.ts
@@ -1,3 +1,5 @@
 export { id } from './common';
 export { getReleases } from './get';
+export const customRegistrySupport = true;
 export const defaultRegistryUrls = ['https://updates.jenkins.io'];
+export const registryStrategy = 'hunt';

--- a/lib/datasource/maven/index.ts
+++ b/lib/datasource/maven/index.ts
@@ -13,6 +13,7 @@ import { downloadHttpProtocol, isHttpResourceExists } from './util';
 
 export { id } from './common';
 
+export const customRegistrySupport = true;
 export const defaultRegistryUrls = [MAVEN_REPO];
 export const defaultVersioning = mavenVersioning.id;
 export const registryStrategy = 'merge';

--- a/lib/datasource/npm/index.ts
+++ b/lib/datasource/npm/index.ts
@@ -5,4 +5,4 @@ export { getReleases } from './releases';
 export { getNpmrc, setNpmrc } from './npmrc';
 export { id } from './common';
 export const defaultVersioning = npmVersioning.id;
-export const registryUrlRestriction = 'disallowed';
+export const customRegistrySupport = false;

--- a/lib/datasource/nuget/index.ts
+++ b/lib/datasource/nuget/index.ts
@@ -7,6 +7,7 @@ import * as v3 from './v3';
 
 export { id } from './common';
 
+export const customRegistrySupport = true;
 export const defaultRegistryUrls = [v3.getDefaultFeed()];
 export const defaultVersioning = nugetVersioning.id;
 export const registryStrategy = 'merge';

--- a/lib/datasource/orb/index.ts
+++ b/lib/datasource/orb/index.ts
@@ -5,7 +5,7 @@ import type { GetReleasesConfig, ReleaseResult } from '../types';
 
 export const id = 'orb';
 export const defaultRegistryUrls = ['https://circleci.com/'];
-export const registryUrlRestriction = 'fixed';
+export const customRegistrySupport = false;
 
 const http = new Http(id);
 

--- a/lib/datasource/packagist/index.ts
+++ b/lib/datasource/packagist/index.ts
@@ -11,6 +11,7 @@ import * as composerVersioning from '../../versioning/composer';
 import type { GetReleasesConfig, ReleaseResult } from '../types';
 
 export const id = 'packagist';
+export const customRegistrySupport = true;
 export const defaultRegistryUrls = ['https://packagist.org'];
 export const defaultVersioning = composerVersioning.id;
 export const registryStrategy = 'hunt';

--- a/lib/datasource/pod/index.ts
+++ b/lib/datasource/pod/index.ts
@@ -9,6 +9,7 @@ import type { GetReleasesConfig, ReleaseResult } from '../types';
 
 export const id = 'pod';
 
+export const customRegistrySupport = true;
 export const defaultRegistryUrls = ['https://cdn.cocoapods.org'];
 export const registryStrategy = 'hunt';
 

--- a/lib/datasource/pypi/index.ts
+++ b/lib/datasource/pypi/index.ts
@@ -8,6 +8,7 @@ import * as pep440 from '../../versioning/pep440';
 import type { GetReleasesConfig, Release, ReleaseResult } from '../types';
 
 export const id = 'pypi';
+export const customRegistrySupport = true;
 export const defaultRegistryUrls = [
   process.env.PIP_INDEX_URL || 'https://pypi.org/pypi/',
 ];

--- a/lib/datasource/repology/index.ts
+++ b/lib/datasource/repology/index.ts
@@ -7,6 +7,7 @@ import { getQueryString } from '../../util/url';
 import type { GetReleasesConfig, ReleaseResult } from '../types';
 
 export const id = 'repology';
+export const customRegistrySupport = true;
 export const defaultRegistryUrls = ['https://repology.org/'];
 export const registryStrategy = 'hunt';
 

--- a/lib/datasource/ruby-version/index.ts
+++ b/lib/datasource/ruby-version/index.ts
@@ -7,7 +7,7 @@ import type { GetReleasesConfig, ReleaseResult } from '../types';
 
 export const id = 'ruby-version';
 export const defaultRegistryUrls = ['https://www.ruby-lang.org/'];
-export const registryUrlRestriction = 'fixed';
+export const customRegistrySupport = false;
 export const defaultVersioning = rubyVersioningId;
 
 const http = new Http(id);

--- a/lib/datasource/rubygems/index.ts
+++ b/lib/datasource/rubygems/index.ts
@@ -2,6 +2,7 @@ import * as rubyVersioning from '../../versioning/ruby';
 
 export { getReleases } from './releases';
 export { id } from './common';
+export const customRegistrySupport = true;
 export const defaultRegistryUrls = ['https://rubygems.org'];
 export const defaultVersioning = rubyVersioning.id;
 export const registryStrategy = 'hunt';

--- a/lib/datasource/sbt-package/index.ts
+++ b/lib/datasource/sbt-package/index.ts
@@ -8,6 +8,7 @@ import { parseIndexDir } from '../sbt-plugin/util';
 import type { GetReleasesConfig, ReleaseResult } from '../types';
 
 export const id = 'sbt-package';
+export const customRegistrySupport = true;
 export const defaultRegistryUrls = [MAVEN_REPO];
 export const defaultVersioning = ivyVersioning.id;
 export const registryStrategy = 'hunt';

--- a/lib/datasource/sbt-plugin/index.ts
+++ b/lib/datasource/sbt-plugin/index.ts
@@ -12,6 +12,7 @@ import type { GetReleasesConfig, ReleaseResult } from '../types';
 import { SBT_PLUGINS_REPO, parseIndexDir } from './util';
 
 export const id = 'sbt-plugin';
+export const customRegistrySupport = true;
 export const defaultRegistryUrls = [SBT_PLUGINS_REPO];
 export const defaultVersioning = ivyVersioning.id;
 export const registryStrategy = 'hunt';

--- a/lib/datasource/terraform-module/index.ts
+++ b/lib/datasource/terraform-module/index.ts
@@ -6,6 +6,7 @@ import * as hashicorpVersioning from '../../versioning/hashicorp';
 import type { GetReleasesConfig, ReleaseResult } from '../types';
 
 export const id = 'terraform-module';
+export const customRegistrySupport = true;
 export const defaultRegistryUrls = ['https://registry.terraform.io'];
 export const defaultVersioning = hashicorpVersioning.id;
 export const registryStrategy = 'first';

--- a/lib/datasource/terraform-provider/index.ts
+++ b/lib/datasource/terraform-provider/index.ts
@@ -7,6 +7,7 @@ import { getTerraformServiceDiscoveryResult } from '../terraform-module';
 import type { GetReleasesConfig, ReleaseResult } from '../types';
 
 export const id = 'terraform-provider';
+export const customRegistrySupport = true;
 export const defaultRegistryUrls = [
   'https://registry.terraform.io',
   'https://releases.hashicorp.com',

--- a/lib/datasource/types.ts
+++ b/lib/datasource/types.ts
@@ -73,11 +73,9 @@ export interface DatasourceApi {
   registryStrategy?: 'first' | 'hunt' | 'merge';
 
   /**
-   * Whether restrictions apply on custom registryUrls. If unspecified, it means custom registryUrls are allowed (no retriction).
-   * fixed: the default registryUrl settings can't be overridden
-   * disallowed: registryUrls are not applicable to this datasource
+   * Whether custom registryUrls are allowed.
    */
-  registryUrlRestriction?: 'fixed' | 'disallowed';
+  customRegistrySupport: boolean;
 
   /**
    * Whether to perform caching in the datasource index/wrapper or not.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Refactors internal datasource types to use new field `customRegistrySupport`.

## Context:

Replaces `registryUrlRestriction` and is better because:
- The most important information is whether custom registryUrls are allowed
- fixed vs disallowed can be derived

Since #9128 we no longer need to pass `registryUrls` to any datasource implementations.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
