### PR TITLE
feat: RENOVATE_X_HARD_EXIT

### DIFF
--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -39,3 +39,8 @@ If set to "false" (string), Renovate will remove any existing `package-lock.json
 ## RENOVATE_USER_AGENT
 
 Configures the `user-agent` string to be sent with HTTP requests.
+
+## RENOVATE_X_HARD_EXIT
+
+If set to any value, Renovate will use a "hard" `process.exit()` once all work is done, even if a sub-process is otherwise delaying Node.js from exiting.
+See https://github.com/renovatebot/renovate/issues/8660 for background on why this was created.

--- a/lib/renovate.ts
+++ b/lib/renovate.ts
@@ -8,4 +8,8 @@ proxy.bootstrap();
 // eslint-disable-next-line @typescript-eslint/no-floating-promises
 (async (): Promise<void> => {
   process.exitCode = await globalWorker.start();
+  // istanbul ignore if
+  if (process.env.RENOVATE_X_HARD_EXIT) {
+    process.exit(process.exitCode);
+  }
 })();


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds an experimental env `RENOVATE_X_HARD_EXIT` which performs a `process.exit()` if set.

## Context:

Workaround for ECR problems in #8660.

Not sure where/how we should document this? We have some other similar env variables too, but this is the first time I am using the `RENOVATE_X_` naming convention. The idea is that these experimental options are not otherwise exposed to config or polluting our docs, and hopefully each will go away over time or be promoted to a first-class option if necessary. However should we add a new "experimental environment options" section or page in our docs?

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
