### PR TITLE
feat(gitea): filter archived autodiscover repos

### DIFF
--- a/lib/platform/gitea/__snapshots__/gitea-helper.spec.ts.snap
+++ b/lib/platform/gitea/__snapshots__/gitea-helper.spec.ts.snap
@@ -694,7 +694,7 @@ Array [
       "user-agent": "https://github.com/renovatebot/renovate",
     },
     "method": "GET",
-    "url": "https://gitea.renovatebot.com/api/v1/repos/search?uid=13",
+    "url": "https://gitea.renovatebot.com/api/v1/repos/search?uid=13&archived=false",
   },
 ]
 `;

--- a/lib/platform/gitea/__snapshots__/index.spec.ts.snap
+++ b/lib/platform/gitea/__snapshots__/index.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`platform/gitea createPr should use base branch by default 1`] = `
+exports[`platform/gitea/index createPr should use base branch by default 1`] = `
 Object {
   "body": "pr-body",
   "canMerge": true,
@@ -18,7 +18,7 @@ Object {
 }
 `;
 
-exports[`platform/gitea createPr should use default branch if requested 1`] = `
+exports[`platform/gitea/index createPr should use default branch if requested 1`] = `
 Object {
   "body": "pr-body",
   "canMerge": true,
@@ -36,7 +36,7 @@ Object {
 }
 `;
 
-exports[`platform/gitea getPr should fallback to direct fetching if cache fails 1`] = `
+exports[`platform/gitea/index getPr should fallback to direct fetching if cache fails 1`] = `
 Object {
   "body": "some random pull request",
   "canMerge": true,
@@ -54,7 +54,7 @@ Object {
 }
 `;
 
-exports[`platform/gitea getPr should return enriched pull request which exists if open 1`] = `
+exports[`platform/gitea/index getPr should return enriched pull request which exists if open 1`] = `
 Object {
   "body": "some random pull request",
   "canMerge": true,
@@ -72,14 +72,14 @@ Object {
 }
 `;
 
-exports[`platform/gitea getPrList should filter list by creator 1`] = `
+exports[`platform/gitea/index getPrList should filter list by creator 1`] = `
 Object {
   "endpoint": "https://gitea.com/api/v1/",
   "gitAuthor": "Renovate Bot <renovate@example.com>",
 }
 `;
 
-exports[`platform/gitea getPrList should filter list by creator 2`] = `
+exports[`platform/gitea/index getPrList should filter list by creator 2`] = `
 Array [
   Object {
     "body": "some random pull request",
@@ -114,7 +114,7 @@ Array [
 ]
 `;
 
-exports[`platform/gitea getPrList should return list of pull requests 1`] = `
+exports[`platform/gitea/index getPrList should return list of pull requests 1`] = `
 Array [
   Object {
     "body": "some random pull request",
@@ -149,49 +149,49 @@ Array [
 ]
 `;
 
-exports[`platform/gitea getRepos should return an array of repos 1`] = `
+exports[`platform/gitea/index getRepos should return an array of repos 1`] = `
 Array [
   "a/b",
   "c/d",
 ]
 `;
 
-exports[`platform/gitea initPlatform() should support custom endpoint 1`] = `
+exports[`platform/gitea/index initPlatform() should support custom endpoint 1`] = `
 Object {
   "endpoint": "https://gitea.renovatebot.com/",
   "gitAuthor": "Renovate Bot <renovate@example.com>",
 }
 `;
 
-exports[`platform/gitea initPlatform() should support default endpoint 1`] = `
+exports[`platform/gitea/index initPlatform() should support default endpoint 1`] = `
 Object {
   "endpoint": "https://gitea.com/api/v1/",
   "gitAuthor": "Renovate Bot <renovate@example.com>",
 }
 `;
 
-exports[`platform/gitea initPlatform() should use username as author name if full name is missing 1`] = `
+exports[`platform/gitea/index initPlatform() should use username as author name if full name is missing 1`] = `
 Object {
   "endpoint": "https://gitea.com/api/v1/",
   "gitAuthor": "renovate <renovate@example.com>",
 }
 `;
 
-exports[`platform/gitea initRepo should fall back to merge method "merge" 1`] = `
+exports[`platform/gitea/index initRepo should fall back to merge method "merge" 1`] = `
 Object {
   "defaultBranch": "master",
   "isFork": false,
 }
 `;
 
-exports[`platform/gitea initRepo should fall back to merge method "rebase-merge" 1`] = `
+exports[`platform/gitea/index initRepo should fall back to merge method "rebase-merge" 1`] = `
 Object {
   "defaultBranch": "master",
   "isFork": false,
 }
 `;
 
-exports[`platform/gitea initRepo should fall back to merge method "squash" 1`] = `
+exports[`platform/gitea/index initRepo should fall back to merge method "squash" 1`] = `
 Object {
   "defaultBranch": "master",
   "isFork": false,

--- a/lib/platform/gitea/gitea-helper.spec.ts
+++ b/lib/platform/gitea/gitea-helper.spec.ts
@@ -1,9 +1,10 @@
 import * as httpMock from '../../../test/http-mock';
+import { getName } from '../../../test/util';
 import { PrState } from '../../types';
 import { setBaseUrl } from '../../util/http/gitea';
 import * as ght from './gitea-helper';
 
-describe('platform/gitea/gitea-helper', () => {
+describe(getName(__filename), () => {
   const baseUrl = 'https://gitea.renovatebot.com/api/v1';
 
   const mockCommitHash = '0d9c7726c3d628b7e28af234595cfd20febdbf8e';
@@ -186,7 +187,7 @@ describe('platform/gitea/gitea-helper', () => {
     it('should construct proper query parameters', async () => {
       httpMock
         .scope(baseUrl)
-        .get('/repos/search?uid=13')
+        .get('/repos/search?uid=13&archived=false')
         .reply(200, {
           ok: true,
           data: [otherMockRepo],
@@ -194,6 +195,7 @@ describe('platform/gitea/gitea-helper', () => {
 
       const res = await ght.searchRepos({
         uid: 13,
+        archived: false,
       });
       expect(res).toEqual([otherMockRepo]);
       expect(httpMock.getTrace()).toMatchSnapshot();

--- a/lib/platform/gitea/gitea-helper.ts
+++ b/lib/platform/gitea/gitea-helper.ts
@@ -132,6 +132,7 @@ export interface CombinedCommitStatus {
 
 export type RepoSearchParams = {
   uid?: number;
+  archived?: boolean;
 };
 
 export type IssueCreateParams = IssueUpdateParams;

--- a/lib/platform/gitea/index.spec.ts
+++ b/lib/platform/gitea/index.spec.ts
@@ -1,5 +1,5 @@
 import { BranchStatusConfig, Platform, RepoParams, RepoResult } from '..';
-import { partial } from '../../../test/util';
+import { getName, partial } from '../../../test/util';
 import {
   REPOSITORY_ACCESS_FORBIDDEN,
   REPOSITORY_ARCHIVED,
@@ -20,7 +20,7 @@ import * as ght from './gitea-helper';
  */
 const GITEA_VERSION = '1.14.0+dev-754-g5d2b7ba63';
 
-describe('platform/gitea', () => {
+describe(getName(__filename), () => {
   let gitea: Platform;
   let helper: jest.Mocked<typeof import('./gitea-helper')>;
   let logger: jest.Mocked<typeof _logger>;

--- a/lib/platform/gitea/index.ts
+++ b/lib/platform/gitea/index.ts
@@ -314,7 +314,10 @@ const platform: Platform = {
   async getRepos(): Promise<string[]> {
     logger.debug('Auto-discovering Gitea repositories');
     try {
-      const repos = await helper.searchRepos({ uid: botUserID });
+      const repos = await helper.searchRepos({
+        uid: botUserID,
+        archived: false,
+      });
       return repos.map((r) => r.full_name);
     } catch (err) {
       logger.error({ err }, 'Gitea getRepos() error');


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Filter archived repos on autodiscover, as they would be skipped anyways.

<!-- Describe what behavior is changed by this PR. -->

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
