### PR TITLE
docs: improve self-hosted experimental environment variables documentation

### DIFF
--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -1,18 +1,18 @@
-# Self-hosted experimental options
+# Self-hosted experimental environment variables
 
-The following options are "experimental" because:
+The following enironment variables are "experimental" because:
 
 - They are not commonly needed
 - They are typically an effort to work around some other service's or platform's problem
 - They can be removed at any time
-- They are options for Renovate's internal use to validate they work as intended
+- They are variables for Renovate's internal use to validate they work as intended
 
-Experimental options which are commonly used and for which there is no external solution in sight can be converted to a official configuration option by the Renovate bot developers.
+Experimental variables which are commonly used and for which there is no external solution in sight can be converted to a official configuration option by the Renovate bot developers.
 
-Use experimental options at your own risk.
-We do not follow Semantic Versioning for any experimental option.
-These options may be removed or have their behavior changed in **any** version.
-We will try to keep breakage to a minimum, but make no guarantees that a experimental option will keep working.
+Use these experimental variables at your own risk.
+We do not follow Semantic Versioning for any experimental variables.
+These variables may be removed or have their behavior changed in **any** version.
+We will try to keep breakage to a minimum, but make no guarantees that a experimental variable will keep working.
 
 ## GITLAB_IGNORE_REPO_URL
 
@@ -30,7 +30,7 @@ Skiping the check will speed things up, but may result in versions being returne
 ## RENOVATE_LEGACY_GIT_AUTHOR_EMAIL
 
 An additional `gitAuthor` email to ignore.
-This option is deprecated: use `ignoredAuthors` instead.
+This variable is deprecated: use `ignoredAuthors` instead.
 
 ## RENOVATE_PAGINATE_ALL
 

--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -1,6 +1,6 @@
 # Self-hosted experimental environment variables
 
-The following enironment variables are "experimental" because:
+The following environment variables are "experimental" because:
 
 - They are not commonly needed
 - They are typically an effort to work around some other service's or platform's problem

--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -1,22 +1,23 @@
-# Self-Hosted Experimental Options
+# Self-hosted experimental options
 
-The following options are considered "experimental" in that:
+The following options are "experimental" because:
 
-- They should not commonly be needed
-- They are typically an effort to work around some other service or platform's problem
-- We hope they can each be removed one day, or we are waiting to be sure they work as intended
+- They are not commonly needed
+- They are typically an effort to work around some other service's or platform's problem
+- They can be removed at any time
+- They are options for Renovate's internal use to validate they work as intended
 
-Experimental options which are commonly used and for which there is no external solution in sight should be replaced with official options.
+Experimental options which are commonly used and for which there is no external solution in sight should be replaced with official options ("Who is doing the replacing here? Renovate bot team or end-user?").
 
-Please use experimental options at your own risk - they may be removed or behavior changed in any release, not just major, however all attempts will be made not to inconvenience anyone.
+Use experimental options at your own risk - they may be removed or behavior changed in any release, not just major, however all attempts will be made not to inconvenience anyone. (Aren't we breaking our "We always follow SemVer promise here?")
 
 ## GITLAB_IGNORE_REPO_URL
 
-If set to any value, Renovate will ignore the Project's `http_url_to_repo` value and instead construct the git URL manually.
+If set to any value, Renovate will ignore the Project's `http_url_to_repo` value and instead construct the Git URL manually.
 
 ## RENOVATE_CACHE_NPM_MINUTES
 
-This must be a number, and would override Renovate's default npm cache time of 15 minutes for the npm datasource.
+If set to any integer, Renovate will use this integer instead of the default npm cache time (15 minutes) for the npm datasource.
 
 ## RENOVATE_EXPERIMENTAL_NO_MAVEN_POM_CHECK
 
@@ -26,7 +27,7 @@ Skiping the check will speed things up, but may result in versions being returne
 ## RENOVATE_LEGACY_GIT_AUTHOR_EMAIL
 
 An additional `gitAuthor` email to ignore.
-Deprecated: use `ignoredAuthors` instead.
+This option is deprecated: use `ignoredAuthors` instead.
 
 ## RENOVATE_PAGINATE_ALL
 
@@ -38,4 +39,4 @@ If set to "false" (string), Renovate will remove any existing `package-lock.json
 
 ## RENOVATE_USER_AGENT
 
-Configures the `user-agent` string to be sent with HTTP requests.
+If set to any string, Renovate will use this as the `user-agent` it sends with HTTP requests.

--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -9,7 +9,10 @@ The following options are "experimental" because:
 
 Experimental options which are commonly used and for which there is no external solution in sight should be replaced with official options ("Who is doing the replacing here? Renovate bot team or end-user?").
 
-Use experimental options at your own risk - they may be removed or behavior changed in any release, not just major, however all attempts will be made not to inconvenience anyone. (Aren't we breaking our "We always follow SemVer promise here?")
+Use experimental options at your own risk.
+We do not follow Semantic Versioning for any experimental option.
+These options may be removed or have their behavior changed in **any** version.
+We will try to keep breakage to a minimum, but make no guarantees that a experimental option will keep working.
 
 ## GITLAB_IGNORE_REPO_URL
 

--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -7,7 +7,7 @@ The following options are "experimental" because:
 - They can be removed at any time
 - They are options for Renovate's internal use to validate they work as intended
 
-Experimental options which are commonly used and for which there is no external solution in sight should be replaced with official options ("Who is doing the replacing here? Renovate bot team or end-user?").
+Experimental options which are commonly used and for which there is no external solution in sight can be converted to a official configuration option by the Renovate bot developers.
 
 Use experimental options at your own risk.
 We do not follow Semantic Versioning for any experimental option.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

- Reduce `h1` capitalization
- Rewrite text to follow the same style (if possible): "If set to x, Renovate will..."
- Use simpler words where possible
- Be really clear that we're not following SemVer at all for the experimental stuff
- Explain that experimental options can be converted to official options if they turn out to be useful

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

I'm not closing any issues here.
Related to PR #9152 and #9156.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
