### PR TITLE
feat: Remove 20 page limit when fetching repo tags

### DIFF
--- a/lib/datasource/docker/index.ts
+++ b/lib/datasource/docker/index.ts
@@ -454,14 +454,12 @@ async function getTags(
       logger.debug('Failed to get authHeaders for getTags lookup');
       return null;
     }
-    let page = 1;
     do {
       const res = await http.getJson<{ tags: string[] }>(url, { headers });
       tags = tags.concat(res.body.tags);
       const linkHeader = parseLinkHeader(res.headers.link as string);
       url = linkHeader?.next ? URL.resolve(url, linkHeader.next.url) : null;
-      page += 1;
-    } while (url && page < 20);
+    } while (url);
     const cacheMinutes = 30;
     await packageCache.set(cacheNamespace, cacheKey, tags, cacheMinutes);
     return tags;


### PR DESCRIPTION
## Changes:

- pagination for docker registries is not limited by 20 pages anymore

## Context:
On certain custom docker registries (`quay`..) each response will contain 50 results and will require looping and fetching the next pages.
Currently the loop is limited to 20 pages, this means that only 1000 tags at most can be returned. This has the potential to break when a repo has more than that. More info in https://github.com/renovatebot/renovate/discussions/9159

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

(`yarn install && yarn build && yarn test`)

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
