### PR TITLE
feat(internal): return registryUrl from datasources

### DIFF
--- a/lib/datasource/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/__snapshots__/index.spec.ts.snap
@@ -25,6 +25,7 @@ Object {
 
 exports[`datasource/index merges registries and returns success 1`] = `
 Object {
+  "registryUrl": "https://reg1.com",
   "releases": Array [
     Object {
       "version": "1.0.0",

--- a/lib/datasource/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/__snapshots__/index.spec.ts.snap
@@ -25,12 +25,13 @@ Object {
 
 exports[`datasource/index merges registries and returns success 1`] = `
 Object {
-  "registryUrl": "https://reg1.com",
   "releases": Array [
     Object {
+      "registryUrl": "https://reg1.com",
       "version": "1.0.0",
     },
     Object {
+      "registryUrl": "https://reg1.com",
       "version": "1.1.0",
     },
   ],

--- a/lib/datasource/bitbucket-tags/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/bitbucket-tags/__snapshots__/index.spec.ts.snap
@@ -56,6 +56,7 @@ Array [
 
 exports[`datasource/bitbucket-tags/index getReleases returns tags from bitbucket cloud 1`] = `
 Object {
+  "registryUrl": "https://bitbucket.org",
   "releases": Array [
     Object {
       "gitRef": "v1.0.0",

--- a/lib/datasource/cdnjs/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/cdnjs/__snapshots__/index.spec.ts.snap
@@ -3,6 +3,7 @@
 exports[`datasource/cdnjs getReleases filters releases by asset presence 1`] = `
 Object {
   "homepage": "http://bulma.io",
+  "registryUrl": "https://api.cdnjs.com/",
   "releases": Array [
     Object {
       "version": "0.7.5",
@@ -30,6 +31,7 @@ Array [
 exports[`datasource/cdnjs getReleases processes real data 1`] = `
 Object {
   "homepage": "https://d3js.org/d3-force/",
+  "registryUrl": "https://api.cdnjs.com/",
   "releases": Array [
     Object {
       "newDigest": "sha256-DNKhvPNPQByxMloPGL2GfmxYsbWDcrznYp+/r4eXs+o=",

--- a/lib/datasource/crate/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/crate/__snapshots__/index.spec.ts.snap
@@ -3,6 +3,7 @@
 exports[`datasource/crate getReleases clones cloudsmith private registry 1`] = `
 Object {
   "dependencyUrl": "https://cloudsmith.io/~myorg/repos/myrepo/packages/detail/cargo/mypkg",
+  "registryUrl": "https://dl.cloudsmith.io/basic/myorg/myrepo/cargo/index.git",
   "releases": Array [
     Object {
       "version": "0.1.0",
@@ -17,6 +18,7 @@ Object {
 exports[`datasource/crate getReleases clones other private registry 1`] = `
 Object {
   "dependencyUrl": "https://github.com/mcorbin/testregistry/mypkg",
+  "registryUrl": "https://github.com/mcorbin/testregistry",
   "releases": Array [
     Object {
       "version": "0.1.0",
@@ -31,6 +33,7 @@ Object {
 exports[`datasource/crate getReleases processes real data: amethyst 1`] = `
 Object {
   "dependencyUrl": "https://crates.io/crates/amethyst",
+  "registryUrl": "https://crates.io",
   "releases": Array [
     Object {
       "version": "0.1.0",
@@ -111,6 +114,7 @@ Array [
 exports[`datasource/crate getReleases processes real data: libc 1`] = `
 Object {
   "dependencyUrl": "https://crates.io/crates/libc",
+  "registryUrl": "https://crates.io",
   "releases": Array [
     Object {
       "version": "0.1.0",

--- a/lib/datasource/dart/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/dart/__snapshots__/index.spec.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`datasource/dart getReleases processes real data 1`] = `
 Object {
+  "registryUrl": "https://pub.dartlang.org/",
   "releases": Array [
     Object {
       "releaseTimestamp": "2017-05-09T18:25:24.268Z",

--- a/lib/datasource/docker/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/docker/__snapshots__/index.spec.ts.snap
@@ -390,16 +390,16 @@ Object {
 }
 `;
 
-exports[`datasource/docker/index getRegistryRepository supports registryUrls 1`] = `
+exports[`datasource/docker/index getRegistryRepository supports http registryUrls 1`] = `
 Object {
-  "registry": "https://my.local.registry/prefix",
+  "registry": "http://my.local.registry/prefix",
   "repository": "image",
 }
 `;
 
-exports[`datasource/docker/index getRegistryRepository supports http registryUrls 1`] = `
+exports[`datasource/docker/index getRegistryRepository supports registryUrls 1`] = `
 Object {
-  "registry": "http://my.local.registry/prefix",
+  "registry": "https://my.local.registry/prefix",
   "repository": "image",
 }
 `;
@@ -581,6 +581,7 @@ Array [
 
 exports[`datasource/docker/index getReleases ignores unsupported manifest 1`] = `
 Object {
+  "registryUrl": "https://index.docker.io",
   "releases": Array [],
 }
 `;
@@ -634,6 +635,7 @@ Array [
 
 exports[`datasource/docker/index getReleases ignores unsupported schema version 1`] = `
 Object {
+  "registryUrl": "https://index.docker.io",
   "releases": Array [],
 }
 `;
@@ -762,6 +764,7 @@ Array [
 
 exports[`datasource/docker/index getReleases supports labels 1`] = `
 Object {
+  "registryUrl": "https://index.docker.io",
   "releases": Array [],
   "sourceUrl": "https://github.com/renovatebot/renovate",
 }
@@ -836,6 +839,7 @@ Array [
 
 exports[`datasource/docker/index getReleases supports manifest lists 1`] = `
 Object {
+  "registryUrl": "https://index.docker.io",
   "releases": Array [],
   "sourceUrl": "https://github.com/renovatebot/renovate",
 }
@@ -931,6 +935,7 @@ Array [
 
 exports[`datasource/docker/index getReleases supports redirect 1`] = `
 Object {
+  "registryUrl": "https://index.docker.io",
   "releases": Array [],
 }
 `;

--- a/lib/datasource/galaxy/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/galaxy/__snapshots__/index.spec.ts.snap
@@ -3,6 +3,7 @@
 exports[`datasource/galaxy getReleases processes real data 1`] = `
 Object {
   "dependencyUrl": "https://galaxy.ansible.com/yatesr/timezone",
+  "registryUrl": "https://galaxy.ansible.com/",
   "releases": Array [
     Object {
       "releaseTimestamp": "2015-11-17T00:43:42.000Z",

--- a/lib/datasource/github-releases/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/github-releases/__snapshots__/index.spec.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`datasource/github-releases getReleases returns releases 1`] = `
 Object {
+  "registryUrl": "https://github.com",
   "releases": Array [
     Object {
       "gitRef": "1.0.0",

--- a/lib/datasource/github-tags/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/github-tags/__snapshots__/index.spec.ts.snap
@@ -136,6 +136,7 @@ Array [
 
 exports[`datasource/github-tags getReleases returns tags 1`] = `
 Object {
+  "registryUrl": "https://github.com",
   "releases": Array [
     Object {
       "gitRef": "v1.0.0",

--- a/lib/datasource/gitlab-tags/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/gitlab-tags/__snapshots__/index.spec.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`datasource/gitlab-tags getReleases returns tags from custom registry 1`] = `
 Object {
+  "registryUrl": "https://gitlab.company.com/api/v4/",
   "releases": Array [
     Object {
       "gitRef": "v1.0.0",
@@ -38,6 +39,7 @@ Array [
 
 exports[`datasource/gitlab-tags getReleases returns tags with default registry 1`] = `
 Object {
+  "registryUrl": "https://gitlab.com",
   "releases": Array [
     Object {
       "gitRef": "v1.0.0",

--- a/lib/datasource/gradle-version/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/gradle-version/__snapshots__/index.spec.ts.snap
@@ -3,268 +3,333 @@
 exports[`datasource/gradle-version getReleases calls configured registryUrls 1`] = `
 Object {
   "homepage": "https://gradle.org",
-  "registryUrl": "https://foo.bar",
   "releases": Array [
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2009-07-20T06:50:13.000Z",
       "version": "0.7",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2009-09-28T12:01:59.000Z",
       "version": "0.8",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2010-12-19T01:50:06.000Z",
       "version": "0.9",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2011-01-02T00:40:57.000Z",
       "version": "0.9.1",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2011-01-23T02:34:21.000Z",
       "version": "0.9.2",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2012-06-12T00:56:21.000Z",
       "version": "1.0",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2012-07-31T13:24:32.000Z",
       "version": "1.1",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2012-09-12T10:46:02.000Z",
       "version": "1.2",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2012-11-20T11:37:38.000Z",
       "version": "1.3",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2013-01-28T03:42:46.000Z",
       "version": "1.4",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2013-03-27T14:09:35.000Z",
       "version": "1.5",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2013-05-07T09:12:14.000Z",
       "version": "1.6",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2013-08-06T11:19:56.000Z",
       "version": "1.7",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2013-09-24T07:32:33.000Z",
       "version": "1.8",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2013-11-19T08:20:02.000Z",
       "version": "1.9",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2013-12-17T09:28:15.000Z",
       "version": "1.10",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2014-02-11T11:34:39.000Z",
       "version": "1.11",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2014-04-29T09:24:31.000Z",
       "version": "1.12",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2014-07-01T07:45:34.000Z",
       "version": "2.0",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2014-09-08T10:40:39.000Z",
       "version": "2.1",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2014-11-10T13:31:44.000Z",
       "version": "2.2",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2014-11-24T09:45:35.000Z",
       "version": "2.2.1",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2015-02-16T05:09:33.000Z",
       "version": "2.3",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2015-05-05T08:09:24.000Z",
       "version": "2.4",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2015-07-08T07:38:37.000Z",
       "version": "2.5",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2015-08-10T13:15:06.000Z",
       "version": "2.6",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2015-09-14T07:26:16.000Z",
       "version": "2.7",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2015-10-20T03:46:36.000Z",
       "version": "2.8",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2015-11-17T07:02:17.000Z",
       "version": "2.9",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2015-12-21T21:15:04.000Z",
       "version": "2.10",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2016-02-08T07:59:16.000Z",
       "version": "2.11",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2016-03-14T08:32:03.000Z",
       "version": "2.12",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2016-04-25T04:10:10.000Z",
       "version": "2.13",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2016-06-14T07:16:37.000Z",
       "version": "2.14",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2016-07-18T06:38:37.000Z",
       "version": "2.14.1",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2016-08-15T13:15:01.000Z",
       "version": "3.0",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2016-09-19T10:53:53.000Z",
       "version": "3.1",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2016-11-14T12:32:59.000Z",
       "version": "3.2",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2016-11-22T15:19:54.000Z",
       "version": "3.2.1",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2017-01-03T15:31:04.000Z",
       "version": "3.3",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2017-02-20T14:49:26.000Z",
       "version": "3.4",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2017-03-03T19:45:41.000Z",
       "version": "3.4.1",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2017-04-10T13:37:25.000Z",
       "version": "3.5",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2017-06-16T14:36:27.000Z",
       "version": "3.5.1",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2017-06-14T15:11:08.000Z",
       "version": "4.0",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2017-07-07T14:02:41.000Z",
       "version": "4.0.1",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2017-07-26T16:19:18.000Z",
       "version": "4.0.2",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2017-08-07T14:38:48.000Z",
       "version": "4.1",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2017-09-20T14:48:23.000Z",
       "version": "4.2",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2017-10-02T15:36:21.000Z",
       "version": "4.2.1",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2017-10-30T15:43:29.000Z",
       "version": "4.3",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2017-11-08T08:59:45.000Z",
       "version": "4.3.1",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2017-12-06T09:05:06.000Z",
       "version": "4.4",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2017-12-20T15:45:23.000Z",
       "version": "4.4.1",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2018-01-24T17:04:52.000Z",
       "version": "4.5",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2018-02-05T13:22:49.000Z",
       "version": "4.5.1",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2018-02-28T13:36:36.000Z",
       "version": "4.6",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2018-04-18T09:09:12.000Z",
       "version": "4.7",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2018-06-04T10:39:58.000Z",
       "version": "4.8",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2018-06-21T07:53:06.000Z",
       "version": "4.8.1",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2018-07-16T08:14:03.000Z",
       "version": "4.9",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2018-08-27T18:35:06.000Z",
       "version": "4.10",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2018-09-12T11:33:27.000Z",
       "version": "4.10.1",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "releaseTimestamp": "2018-09-19T18:10:15.000Z",
       "version": "4.10.2",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "version": "4.10.3",
     },
     Object {
+      "registryUrl": "https://foo.bar",
       "version": "5.0",
     },
   ],

--- a/lib/datasource/gradle-version/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/gradle-version/__snapshots__/index.spec.ts.snap
@@ -3,6 +3,7 @@
 exports[`datasource/gradle-version getReleases calls configured registryUrls 1`] = `
 Object {
   "homepage": "https://gradle.org",
+  "registryUrl": "https://foo.bar",
   "releases": Array [
     Object {
       "releaseTimestamp": "2009-07-20T06:50:13.000Z",
@@ -299,6 +300,7 @@ Array [
 exports[`datasource/gradle-version getReleases processes real data 1`] = `
 Object {
   "homepage": "https://gradle.org",
+  "registryUrl": "https://services.gradle.org/versions/all",
   "releases": Array [
     Object {
       "releaseTimestamp": "2009-07-20T06:50:13.000Z",

--- a/lib/datasource/helm/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/helm/__snapshots__/index.spec.ts.snap
@@ -17,6 +17,7 @@ Array [
 exports[`datasource/helm getReleases returns list of versions for normal response 1`] = `
 Object {
   "homepage": "https://www.getambassador.io/",
+  "registryUrl": "https://example-repository.com",
   "releases": Array [
     Object {
       "releaseTimestamp": "2019-02-13T00:56:01.476Z",

--- a/lib/datasource/hex/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/hex/__snapshots__/index.spec.ts.snap
@@ -3,6 +3,7 @@
 exports[`datasource/hex getReleases process public repo without auth 1`] = `
 Object {
   "homepage": "https://hex.pm/packages/certifi",
+  "registryUrl": "https://hex.pm/",
   "releases": Array [
     Object {
       "releaseTimestamp": "2015-09-10T13:58:55.620Z",
@@ -106,6 +107,7 @@ Array [
 exports[`datasource/hex getReleases processes real data 1`] = `
 Object {
   "homepage": "https://hex.pm/packages/certifi",
+  "registryUrl": "https://hex.pm/",
   "releases": Array [
     Object {
       "releaseTimestamp": "2015-09-10T13:58:55.620Z",

--- a/lib/datasource/index.ts
+++ b/lib/datasource/index.ts
@@ -68,7 +68,7 @@ async function getRegistryReleases(
   }
   const res = await datasource.getReleases({ ...config, registryUrl });
   if (res?.releases.length) {
-    res.registryUrl ||= registryUrl;
+    res.registryUrl ??= registryUrl;
   }
   // cache non-null responses unless marked as private
   if (datasource.caching && res && !res.isPrivate) {

--- a/lib/datasource/index.ts
+++ b/lib/datasource/index.ts
@@ -1,6 +1,5 @@
 import is from '@sindresorhus/is';
 import { dequal } from 'dequal';
-import { release } from 'node:os';
 import { HOST_DISABLED } from '../constants/error-messages';
 import { logger } from '../logger';
 import { ExternalHostError } from '../types/errors/external-host-error';

--- a/lib/datasource/index.ts
+++ b/lib/datasource/index.ts
@@ -67,6 +67,9 @@ async function getRegistryReleases(
     }
   }
   const res = await datasource.getReleases({ ...config, registryUrl });
+  if (res?.releases.length) {
+    res.registryUrl ||= registryUrl;
+  }
   // cache non-null responses unless marked as private
   if (datasource.caching && res && !res.isPrivate) {
     logger.trace({ cacheKey }, 'Caching datasource response');

--- a/lib/datasource/jenkins-plugins/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/jenkins-plugins/__snapshots__/index.spec.ts.snap
@@ -9,6 +9,7 @@ Object {
 
 exports[`datasource/jenkins-plugins/index getReleases returns package releases for a hit for info and releases 1`] = `
 Object {
+  "registryUrl": "https://updates.jenkins.io/",
   "releases": Array [
     Object {
       "downloadUrl": "http://updates.jenkins-ci.org/download/plugins/email-ext/2.10/email-ext.hpi",

--- a/lib/datasource/maven/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/maven/__snapshots__/index.spec.ts.snap
@@ -64,6 +64,7 @@ Object {
   "display": "mysql:mysql-connector-java",
   "group": "mysql",
   "name": "mysql-connector-java",
+  "registryUrl": "https://repo.maven.apache.org/maven2/",
   "releases": Array [
     Object {
       "releaseTimestamp": "2020-01-01T00:00:00.650Z",
@@ -122,27 +123,35 @@ Object {
   "name": "mysql-connector-java",
   "releases": Array [
     Object {
+      "registryUrl": "file://lib/datasource/maven/__fixtures__/custom_maven_repo/maven2/",
       "version": "6.0.4",
     },
     Object {
+      "registryUrl": "file://lib/datasource/maven/__fixtures__/repo1.maven.org/maven2/",
       "version": "6.0.5",
     },
     Object {
+      "registryUrl": "file://lib/datasource/maven/__fixtures__/repo1.maven.org/maven2/",
       "version": "6.0.6",
     },
     Object {
+      "registryUrl": "file://lib/datasource/maven/__fixtures__/repo1.maven.org/maven2/",
       "version": "8.0.7",
     },
     Object {
+      "registryUrl": "file://lib/datasource/maven/__fixtures__/repo1.maven.org/maven2/",
       "version": "8.0.8",
     },
     Object {
+      "registryUrl": "file://lib/datasource/maven/__fixtures__/repo1.maven.org/maven2/",
       "version": "8.0.9",
     },
     Object {
+      "registryUrl": "file://lib/datasource/maven/__fixtures__/repo1.maven.org/maven2/",
       "version": "8.0.11",
     },
     Object {
+      "registryUrl": "file://lib/datasource/maven/__fixtures__/repo1.maven.org/maven2/",
       "version": "8.0.12",
     },
   ],

--- a/lib/datasource/maven/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/maven/__snapshots__/index.spec.ts.snap
@@ -6,6 +6,7 @@ Object {
   "group": "mysql",
   "homepage": "http://dev.mysql.com/doc/connector-j/en/",
   "name": "mysql-connector-java",
+  "registryUrl": "https://custom.registry.renovatebot.com",
   "releases": Array [
     Object {
       "version": "6.0.5",

--- a/lib/datasource/npm/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/npm/__snapshots__/index.spec.ts.snap
@@ -19,6 +19,7 @@ Array [
 exports[`datasource/npm/index should fetch package info from custom registry 1`] = `
 Object {
   "name": "foobar",
+  "registryUrl": "https://npm.mycustomregistry.com/",
   "releases": Array [
     Object {
       "releaseTimestamp": "2018-05-06T05:21:53.000Z",
@@ -57,6 +58,7 @@ Array [
 exports[`datasource/npm/index should fetch package info from npm 1`] = `
 Object {
   "name": "foobar",
+  "registryUrl": "https://registry.npmjs.org/",
   "releases": Array [
     Object {
       "releaseTimestamp": "2018-05-06T05:21:53.000Z",
@@ -95,6 +97,7 @@ Array [
 exports[`datasource/npm/index should handle foobar 1`] = `
 Object {
   "name": "foobar",
+  "registryUrl": "https://registry.npmjs.org/",
   "releases": Array [
     Object {
       "releaseTimestamp": "2018-05-06T05:21:53.000Z",
@@ -133,6 +136,7 @@ Array [
 exports[`datasource/npm/index should handle no time 1`] = `
 Object {
   "name": "foobar",
+  "registryUrl": "https://registry.npmjs.org/",
   "releases": Array [
     Object {
       "releaseTimestamp": "2018-05-06T05:21:53.000Z",
@@ -170,6 +174,7 @@ Array [
 exports[`datasource/npm/index should not send an authorization header if public package 1`] = `
 Object {
   "name": "foobar",
+  "registryUrl": "https://registry.npmjs.org/",
   "releases": Array [
     Object {
       "releaseTimestamp": "2018-05-06T05:21:53.000Z",
@@ -208,6 +213,7 @@ Array [
 exports[`datasource/npm/index should parse repo url (string) 1`] = `
 Object {
   "name": "foobar",
+  "registryUrl": "https://registry.npmjs.org/",
   "releases": Array [
     Object {
       "releaseTimestamp": "2018-05-06T05:21:53.000Z",
@@ -241,6 +247,7 @@ Array [
 exports[`datasource/npm/index should parse repo url 1`] = `
 Object {
   "name": "foobar",
+  "registryUrl": "https://registry.npmjs.org/",
   "releases": Array [
     Object {
       "releaseTimestamp": "2018-05-06T05:21:53.000Z",
@@ -290,6 +297,7 @@ Array [
 exports[`datasource/npm/index should replace any environment variable in npmrc 1`] = `
 Object {
   "name": "foobar",
+  "registryUrl": "https://registry.from-env.com/",
   "releases": Array [
     Object {
       "releaseTimestamp": "2018-05-06T05:21:53.000Z",
@@ -334,6 +342,7 @@ Object {
 Marking the latest version of an npm package as deprecated results in the entire package being considered deprecated, so contact the package author you think this is a mistake.",
   "deprecationSource": "npm",
   "name": "foobar",
+  "registryUrl": "https://registry.npmjs.org/",
   "releases": Array [
     Object {
       "releaseTimestamp": "2018-05-06T05:21:53.000Z",
@@ -428,6 +437,7 @@ Array [
 exports[`datasource/npm/index should send an authorization header if provided 1`] = `
 Object {
   "name": "@foobar/core",
+  "registryUrl": "https://registry.npmjs.org/",
   "releases": Array [
     Object {
       "releaseTimestamp": "2018-05-06T05:21:53.000Z",
@@ -580,6 +590,7 @@ Array [
 exports[`datasource/npm/index should use NPM_TOKEN if provided 1`] = `
 Object {
   "name": "@foobar/core",
+  "registryUrl": "https://registry.npmjs.org/",
   "releases": Array [
     Object {
       "releaseTimestamp": "2018-05-06T05:21:53.000Z",
@@ -619,6 +630,7 @@ Array [
 exports[`datasource/npm/index should use default registry if missing from npmrc 1`] = `
 Object {
   "name": "foobar",
+  "registryUrl": "https://registry.npmjs.org",
   "releases": Array [
     Object {
       "releaseTimestamp": "2018-05-06T05:21:53.000Z",
@@ -657,6 +669,7 @@ Array [
 exports[`datasource/npm/index should use host rules by baseUrl if provided 1`] = `
 Object {
   "name": "foobar",
+  "registryUrl": "https://npm.mycustomregistry.com/_packaging/mycustomregistry/npm/registry/",
   "releases": Array [
     Object {
       "releaseTimestamp": "2018-05-06T05:21:53.000Z",
@@ -696,6 +709,7 @@ Array [
 exports[`datasource/npm/index should use host rules by hostName if provided 1`] = `
 Object {
   "name": "foobar",
+  "registryUrl": "https://npm.mycustomregistry.com/",
   "releases": Array [
     Object {
       "releaseTimestamp": "2018-05-06T05:21:53.000Z",

--- a/lib/datasource/npm/get.ts
+++ b/lib/datasource/npm/get.ts
@@ -187,6 +187,7 @@ export async function getDependency(
       releases: null,
       'dist-tags': res['dist-tags'],
       'renovate-config': latestVersion['renovate-config'],
+      registryUrl: regUrl,
     };
     if (res.repository?.directory) {
       dep.sourceDirectory = res.repository.directory;

--- a/lib/datasource/nuget/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/nuget/__snapshots__/index.spec.ts.snap
@@ -1764,186 +1764,230 @@ Array [
 exports[`datasource/nuget getReleases returns deduplicated results 1`] = `
 Object {
   "homepage": "https://nunit.org/",
-  "registryUrl": "https://api.nuget.org/v3/index.json",
   "releases": Array [
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2011-01-07T07:57:55.387Z",
       "version": "2.5.7.10213",
     },
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2011-02-09T07:26:34.347Z",
       "version": "2.5.9.10348",
     },
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2011-04-25T20:20:34.397Z",
       "version": "2.5.10.11092",
     },
     Object {
       "isDeprecated": true,
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "1900-01-01T00:00:00.000Z",
       "version": "2.6.0.12051",
     },
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2012-02-24T04:03:05.290Z",
       "version": "2.6.0.12054",
     },
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2012-08-05T03:08:28.403Z",
       "version": "2.6.1",
     },
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2012-10-23T15:37:48.000Z",
       "version": "2.6.2",
     },
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2013-10-11T01:52:53.417Z",
       "version": "2.6.3",
     },
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2014-12-17T17:30:47.607Z",
       "version": "2.6.4",
     },
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2018-04-20T04:23:59.217Z",
       "version": "2.6.5",
     },
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2018-06-07T15:24:16.807Z",
       "version": "2.6.6",
     },
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2018-07-07T15:41:32.657Z",
       "version": "2.6.7",
     },
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2018-08-10T20:45:24.080Z",
       "version": "2.7.0",
     },
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2019-08-21T07:08:49.360Z",
       "version": "2.7.1",
     },
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2014-09-23T03:11:33.430Z",
       "version": "3.0.0-alpha",
     },
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2014-11-03T06:24:59.217Z",
       "version": "3.0.0-alpha-2",
     },
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2014-11-29T22:38:18.493Z",
       "version": "3.0.0-alpha-3",
     },
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2014-12-31T04:47:39.507Z",
       "version": "3.0.0-alpha-4",
     },
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2015-01-31T22:13:01.997Z",
       "version": "3.0.0-alpha-5",
     },
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2015-03-26T11:33:22.173Z",
       "version": "3.0.0-beta-1",
     },
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2015-05-13T00:51:22.430Z",
       "version": "3.0.0-beta-2",
     },
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2015-07-15T23:44:47.403Z",
       "version": "3.0.0-beta-3",
     },
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2015-08-25T23:24:11.473Z",
       "version": "3.0.0-beta-4",
     },
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2015-10-17T03:39:18.100Z",
       "version": "3.0.0-beta-5",
     },
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2015-11-01T21:56:49.637Z",
       "version": "3.0.0-rc",
     },
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2015-11-08T16:27:15.110Z",
       "version": "3.0.0-rc-2",
     },
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2015-11-14T05:30:57.323Z",
       "version": "3.0.0-rc-3",
     },
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2015-11-16T00:02:51.807Z",
       "version": "3.0.0",
     },
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2015-12-02T03:52:57.997Z",
       "version": "3.0.1",
     },
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2016-03-05T21:12:58.990Z",
       "version": "3.2.0",
     },
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2016-04-19T15:31:13.390Z",
       "version": "3.2.1",
     },
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2016-06-25T17:44:56.253Z",
       "version": "3.4.0",
     },
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2016-06-30T21:20:49.497Z",
       "version": "3.4.1",
     },
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2016-10-04T01:19:19.447Z",
       "version": "3.5.0",
     },
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2017-01-10T02:17:19.187Z",
       "version": "3.6.0",
     },
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2017-02-26T14:56:04.407Z",
       "version": "3.6.1",
     },
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2017-05-30T00:07:36.707Z",
       "version": "3.7.0",
     },
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2017-06-06T01:59:11.787Z",
       "version": "3.7.1",
     },
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2017-08-28T00:08:29.500Z",
       "version": "3.8.0",
     },
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2017-08-29T01:11:58.860Z",
       "version": "3.8.1",
     },
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2017-11-10T23:35:19.670Z",
       "version": "3.9.0",
     },
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2018-03-13T00:29:56.400Z",
       "version": "3.10.0",
     },
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2018-03-13T03:13:09.930Z",
       "version": "3.10.1",
     },
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2018-10-07T01:17:31.310Z",
       "version": "3.11.0",
     },
     Object {
+      "registryUrl": "https://api.nuget.org/v3/index.json",
       "releaseTimestamp": "2019-05-15T00:24:28.390Z",
       "version": "3.12.0",
     },

--- a/lib/datasource/nuget/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/nuget/__snapshots__/index.spec.ts.snap
@@ -67,6 +67,7 @@ Array [
 
 exports[`datasource/nuget getReleases handles paginated results (v2) 1`] = `
 Object {
+  "registryUrl": "https://www.nuget.org/api/v2/",
   "releases": Array [
     Object {
       "version": "1.0.0",
@@ -103,6 +104,7 @@ Array [
 
 exports[`datasource/nuget getReleases processes real data (v2) 1`] = `
 Object {
+  "registryUrl": "https://www.nuget.org/api/v2/",
   "releases": Array [
     Object {
       "releaseTimestamp": "2011-01-07T07:57:55.387Z",
@@ -306,6 +308,7 @@ Array [
 exports[`datasource/nuget getReleases processes real data (v3) feed is a nuget.org 1`] = `
 Object {
   "homepage": "https://nunit.org/",
+  "registryUrl": "https://api.nuget.org/v3/index.json",
   "releases": Array [
     Object {
       "releaseTimestamp": "2011-01-07T07:57:55.387Z",
@@ -540,6 +543,7 @@ Array [
 exports[`datasource/nuget getReleases processes real data (v3) feed is not a nuget.org 1`] = `
 Object {
   "homepage": "https://nunit.org/",
+  "registryUrl": "https://myprivatefeed/index.json",
   "releases": Array [
     Object {
       "releaseTimestamp": "2011-01-07T07:57:55.387Z",
@@ -773,6 +777,7 @@ Array [
 exports[`datasource/nuget getReleases processes real data (v3) for several catalog pages 1`] = `
 Object {
   "homepage": "https://nlog-project.org/",
+  "registryUrl": "https://api.nuget.org/v3/index.json",
   "releases": Array [
     Object {
       "releaseTimestamp": "2011-01-07T07:57:35.043Z",
@@ -1581,6 +1586,7 @@ Array [
 
 exports[`datasource/nuget getReleases processes real data with no github project url (v2) 1`] = `
 Object {
+  "registryUrl": "https://www.nuget.org/api/v2/",
   "releases": Array [
     Object {
       "version": "3.11.0",
@@ -1606,6 +1612,7 @@ Array [
 
 exports[`datasource/nuget getReleases processes real data without project url (v2) 1`] = `
 Object {
+  "registryUrl": "https://www.nuget.org/api/v2/",
   "releases": Array [
     Object {
       "version": "2.5.7.10213",
@@ -1757,6 +1764,7 @@ Array [
 exports[`datasource/nuget getReleases returns deduplicated results 1`] = `
 Object {
   "homepage": "https://nunit.org/",
+  "registryUrl": "https://api.nuget.org/v3/index.json",
   "releases": Array [
     Object {
       "releaseTimestamp": "2011-01-07T07:57:55.387Z",

--- a/lib/datasource/orb/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/orb/__snapshots__/index.spec.ts.snap
@@ -3,6 +3,7 @@
 exports[`datasource/orb getReleases processes homeUrl 1`] = `
 Object {
   "homepage": "https://google.com",
+  "registryUrl": "https://circleci.com/",
   "releases": Array [
     Object {
       "releaseTimestamp": "2018-12-11T05:28:14.080Z",
@@ -83,6 +84,7 @@ Array [
 exports[`datasource/orb getReleases processes real data 1`] = `
 Object {
   "homepage": "https://circleci.com/developer/orbs/orb/hyper-expanse/library-release-workflows",
+  "registryUrl": "https://circleci.com/",
   "releases": Array [
     Object {
       "releaseTimestamp": "2018-12-11T05:28:14.080Z",

--- a/lib/datasource/packagist/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/packagist/__snapshots__/index.spec.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`datasource/packagist getReleases adds packagist source implicitly 1`] = `
 Object {
+  "registryUrl": "https://packagist.org",
   "releases": Array [
     Object {
       "gitRef": "v1.0",
@@ -235,6 +236,7 @@ Array [
 
 exports[`datasource/packagist getReleases processes real versioned data 1`] = `
 Object {
+  "registryUrl": "https://packagist.org",
   "releases": Array [
     Object {
       "gitRef": "v1.0",
@@ -334,6 +336,7 @@ Array [
 exports[`datasource/packagist getReleases supports includes packages 1`] = `
 Object {
   "homepage": "http://guzzlephp.org/",
+  "registryUrl": "https://composer.renovatebot.com",
   "releases": Array [
     Object {
       "gitRef": "v3.0.0",
@@ -504,6 +507,7 @@ Array [
 
 exports[`datasource/packagist getReleases supports lazy repositories 1`] = `
 Object {
+  "registryUrl": "https://composer.renovatebot.com/composer/lazy",
   "releases": Array [
     Object {
       "gitRef": "5.3.4",
@@ -544,6 +548,7 @@ Array [
 
 exports[`datasource/packagist getReleases supports plain packages 1`] = `
 Object {
+  "registryUrl": "https://composer.renovatebot.com",
   "releases": Array [
     Object {
       "gitRef": "0.0.1",
@@ -579,6 +584,7 @@ Array [
 exports[`datasource/packagist getReleases supports provider-includes 1`] = `
 Object {
   "homepage": "https://wordpress.org/plugins/1beyt/",
+  "registryUrl": "https://composer.renovatebot.com",
   "releases": Array [
     Object {
       "gitRef": "1.0",
@@ -643,6 +649,7 @@ Array [
 exports[`datasource/packagist getReleases supports providers 1`] = `
 Object {
   "homepage": "https://wordpress.org/plugins/1beyt/",
+  "registryUrl": "https://composer.renovatebot.com",
   "releases": Array [
     Object {
       "gitRef": "1.0",

--- a/lib/datasource/pod/index.spec.ts
+++ b/lib/datasource/pod/index.spec.ts
@@ -86,6 +86,7 @@ describe('datasource/cocoapods', () => {
           registryUrls: ['https://github.com/CocoaPods/Specs'],
         })
       ).toEqual({
+        registryUrl: 'https://github.com/CocoaPods/Specs',
         releases: [
           {
             version: '1.2.3',
@@ -106,6 +107,7 @@ describe('datasource/cocoapods', () => {
         registryUrls: ['https://github.com/Artsy/Specs'],
       });
       expect(res).toEqual({
+        registryUrl: 'https://github.com/Artsy/Specs',
         releases: [
           {
             version: '1.2.3',

--- a/lib/datasource/pypi/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/pypi/__snapshots__/index.spec.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`datasource/pypi getReleases fall back from json and process data from simple endpoint 1`] = `
 Object {
+  "registryUrl": "https://custom.pypi.net/foo",
   "releases": Array [
     Object {
       "version": "0.1.2",
@@ -82,6 +83,7 @@ Array [
 
 exports[`datasource/pypi getReleases parses data-requires-python and respects constraints from simple endpoint 1`] = `
 Object {
+  "registryUrl": "https://pypi.org/simple/",
   "releases": Array [
     Object {
       "version": "0.1.2",
@@ -121,6 +123,7 @@ Array [
 
 exports[`datasource/pypi getReleases process data from +simple endpoint 1`] = `
 Object {
+  "registryUrl": "https://some.registry.org/+simple/",
   "releases": Array [
     Object {
       "version": "0.1.2",
@@ -176,6 +179,7 @@ Array [
 
 exports[`datasource/pypi getReleases process data from simple endpoint 1`] = `
 Object {
+  "registryUrl": "https://pypi.org/simple/",
   "releases": Array [
     Object {
       "version": "0.1.2",
@@ -231,6 +235,7 @@ Array [
 
 exports[`datasource/pypi getReleases process data from simple endpoint with hyphens replaced with underscores 1`] = `
 Object {
+  "registryUrl": "https://pypi.org/simple/",
   "releases": Array [
     Object {
       "version": "0.0.5",
@@ -255,6 +260,7 @@ Array [
 
 exports[`datasource/pypi getReleases processes real data 1`] = `
 Object {
+  "registryUrl": "https://pypi.org/pypi/",
   "releases": Array [
     Object {
       "releaseTimestamp": "2017-04-03T16:55:14.000Z",
@@ -367,6 +373,7 @@ Array [
 
 exports[`datasource/pypi getReleases respects constraints 1`] = `
 Object {
+  "registryUrl": "https://pypi.org/pypi/",
   "releases": Array [
     Object {
       "version": "0.4.0",

--- a/lib/datasource/repology/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/repology/__snapshots__/index.spec.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`datasource/repology/index getReleases returns correct version for api package 1`] = `
 Object {
+  "registryUrl": "https://repology.org/",
   "releases": Array [
     Object {
       "version": "1.181",
@@ -37,6 +38,7 @@ Array [
 
 exports[`datasource/repology/index getReleases returns correct version for binary package 1`] = `
 Object {
+  "registryUrl": "https://repology.org/",
   "releases": Array [
     Object {
       "version": "1.14.2-2+deb10u1",
@@ -62,6 +64,7 @@ Array [
 
 exports[`datasource/repology/index getReleases returns correct version for multi-package project with different name 1`] = `
 Object {
+  "registryUrl": "https://repology.org/",
   "releases": Array [
     Object {
       "version": "12.2-4+deb10u1",
@@ -87,6 +90,7 @@ Array [
 
 exports[`datasource/repology/index getReleases returns correct version for multi-package project with same name 1`] = `
 Object {
+  "registryUrl": "https://repology.org/",
   "releases": Array [
     Object {
       "version": "9.3.0-r2",
@@ -112,6 +116,7 @@ Array [
 
 exports[`datasource/repology/index getReleases returns correct version for source package 1`] = `
 Object {
+  "registryUrl": "https://repology.org/",
   "releases": Array [
     Object {
       "version": "1.181",
@@ -147,6 +152,7 @@ Array [
 
 exports[`datasource/repology/index getReleases returns multiple versions if they are present in repository 1`] = `
 Object {
+  "registryUrl": "https://repology.org/",
   "releases": Array [
     Object {
       "version": "1:11.0.7.10-1.el8_1",

--- a/lib/datasource/ruby-version/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/ruby-version/__snapshots__/index.spec.ts.snap
@@ -3,6 +3,7 @@
 exports[`datasource/gradle getReleases parses real data 1`] = `
 Object {
   "homepage": "https://www.ruby-lang.org",
+  "registryUrl": "https://www.ruby-lang.org/",
   "releases": Array [
     Object {
       "changelogUrl": "https://www.ruby-lang.org/en/news/2002/03/01/167-is-released/",

--- a/lib/datasource/rubygems/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/rubygems/__snapshots__/index.spec.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`datasource/rubygems getReleases returns a dep for rubygems.org package hit 1`] = `
 Object {
+  "registryUrl": "https://rubygems.org",
   "releases": Array [
     Object {
       "version": "0.1.0",
@@ -100,6 +101,7 @@ Array [
 exports[`datasource/rubygems getReleases uses multiple source urls 1`] = `
 Object {
   "homepage": "http://rubyonrails.org",
+  "registryUrl": "https://firstparty.com/basepath/",
   "releases": Array [
     Object {
       "releaseTimestamp": "2009-07-25T18:01:56.000Z",
@@ -2519,6 +2521,7 @@ Array [
 
 exports[`datasource/rubygems getReleases uses rubygems.org if no registry urls were provided 1`] = `
 Object {
+  "registryUrl": "https://rubygems.org",
   "releases": Array [
     Object {
       "version": "0.1.0",
@@ -2548,6 +2551,7 @@ Array [
 exports[`datasource/rubygems getReleases works with real data 1`] = `
 Object {
   "homepage": "http://rubyonrails.org",
+  "registryUrl": "https://thirdparty.com",
   "releases": Array [
     Object {
       "releaseTimestamp": "2009-07-25T18:01:56.000Z",

--- a/lib/datasource/sbt-package/index.spec.ts
+++ b/lib/datasource/sbt-package/index.spec.ts
@@ -180,6 +180,7 @@ describe('datasource/sbt', () => {
         })
       ).toEqual({
         dependencyUrl: 'https://repo.maven.apache.org/maven2/org/scalatest',
+        registryUrl: 'https://repo.maven.apache.org/maven2',
         releases: [{ version: '1.2.0' }, { version: '1.2.3' }],
       });
       expect(
@@ -191,6 +192,7 @@ describe('datasource/sbt', () => {
         })
       ).toEqual({
         dependencyUrl: 'https://repo.maven.apache.org/maven2/org/scalatest',
+        registryUrl: 'https://repo.maven.apache.org/maven2',
         releases: [{ version: '1.2.3' }],
       });
     });
@@ -205,6 +207,7 @@ describe('datasource/sbt', () => {
         })
       ).toEqual({
         dependencyUrl: 'https://repo.maven.apache.org/maven2/org/scalatest',
+        registryUrl: 'https://repo.maven.apache.org/maven2',
         releases: [{ version: '6.5.4' }],
         homepage: 'http://www.scalatest.org',
         sourceUrl: 'https://github.com/scalatest/scalatest',
@@ -218,6 +221,7 @@ describe('datasource/sbt', () => {
         })
       ).toEqual({
         dependencyUrl: 'https://repo.maven.apache.org/maven2/org/scalatest',
+        registryUrl: 'https://repo.maven.apache.org/maven2',
         releases: [{ version: '6.5.4' }],
         sourceUrl: 'https://github.com/scalatest/scalatest',
       });
@@ -230,6 +234,7 @@ describe('datasource/sbt', () => {
         })
       ).toEqual({
         dependencyUrl: 'https://repo.maven.apache.org/maven2/org/scalatest',
+        registryUrl: 'https://repo.maven.apache.org/maven2',
         releases: [{ version: '6.5.4' }],
         homepage: 'http://www.scalatest.org',
       });

--- a/lib/datasource/sbt-plugin/index.spec.ts
+++ b/lib/datasource/sbt-plugin/index.spec.ts
@@ -157,6 +157,7 @@ describe('datasource/sbt', () => {
       ).toEqual({
         dependencyUrl:
           'https://dl.bintray.com/sbt/sbt-plugin-releases/org.foundweekends/sbt-bintray',
+        registryUrl: 'https://dl.bintray.com/sbt/sbt-plugin-releases',
         releases: [{ version: '0.5.5' }],
       });
       expect(
@@ -169,6 +170,7 @@ describe('datasource/sbt', () => {
       ).toEqual({
         dependencyUrl:
           'https://dl.bintray.com/sbt/sbt-plugin-releases/org.foundweekends/sbt-bintray',
+        registryUrl: 'https://dl.bintray.com/sbt/sbt-plugin-releases',
         releases: [{ version: '0.5.5' }],
       });
     });
@@ -184,6 +186,7 @@ describe('datasource/sbt', () => {
       ).toEqual({
         dependencyUrl:
           'https://repo.maven.apache.org/maven2/io/get-coursier/sbt-coursier',
+        registryUrl: 'https://repo.maven.apache.org/maven2',
         releases: [
           { version: '2.0.0-RC2' },
           { version: '2.0.0-RC6-1' },

--- a/lib/datasource/terraform-module/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/terraform-module/__snapshots__/index.spec.ts.snap
@@ -3,6 +3,7 @@
 exports[`datasource/terraform-module getReleases processes real data 1`] = `
 Object {
   "homepage": "https://registry.terraform.io/modules/hashicorp/consul/aws",
+  "registryUrl": "https://registry.terraform.io",
   "releases": Array [
     Object {
       "version": "0.0.1",
@@ -131,6 +132,7 @@ Array [
 
 exports[`datasource/terraform-module getReleases processes real data on changed subpath 2`] = `
 Object {
+  "registryUrl": "https://terraform.foo.bar",
   "releases": Array [
     Object {
       "version": "0.0.1",
@@ -210,6 +212,7 @@ Object {
 exports[`datasource/terraform-module getReleases processes with registry in name 1`] = `
 Object {
   "homepage": "https://registry.terraform.io/modules/hashicorp/consul/aws",
+  "registryUrl": "https://registry.terraform.io",
   "releases": Array [
     Object {
       "version": "0.0.1",

--- a/lib/datasource/terraform-provider/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/terraform-provider/__snapshots__/index.spec.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`datasource/terraform getReleases processes data with alternative backend 1`] = `
 Object {
+  "registryUrl": "https://releases.hashicorp.com",
   "releases": Array [
     Object {
       "version": "1.19.0",
@@ -55,6 +56,7 @@ Array [
 exports[`datasource/terraform getReleases processes real data 1`] = `
 Object {
   "homepage": "https://registry.terraform.io/providers/hashicorp/azurerm",
+  "registryUrl": "https://registry.terraform.io",
   "releases": Array [
     Object {
       "version": "0.1.0",
@@ -285,6 +287,7 @@ Array [
 exports[`datasource/terraform getReleases processes real data from lookupName 1`] = `
 Object {
   "homepage": "https://registry.company.com/providers/hashicorp/azurerm",
+  "registryUrl": "https://registry.company.com",
   "releases": Array [
     Object {
       "version": "0.1.0",

--- a/lib/datasource/types.ts
+++ b/lib/datasource/types.ts
@@ -41,6 +41,7 @@ export interface Release {
   constraints?: Record<string, string[]>;
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
+  registryUrl?: string;
 }
 
 export interface ReleaseResult {

--- a/lib/datasource/types.ts
+++ b/lib/datasource/types.ts
@@ -54,6 +54,7 @@ export interface ReleaseResult {
   homepage?: string;
   sourceUrl?: string;
   sourceDirectory?: string;
+  registryUrl?: string;
 }
 
 export interface DatasourceApi {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds `registryUrl` to returned datasource data.

## Context:

This will be useful for future tasks, including knowing if npm presets are fetched from non-default registries or not.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
