### PR TITLE
docs: set unicodeEmoji to false if using MySQL/MariaDB on BitBucket Server

### DIFF
--- a/docs/usage/self-hosting.md
+++ b/docs/usage/self-hosting.md
@@ -232,6 +232,8 @@ Configure it as `password` in your `config.js` file, or in environment variable 
 Also configure the `username` for your bot account too, if you decided not to name it `@renovate-bot`.
 Don't forget to configure `platform=bitbucket-server` somewhere in config.
 
+If you use MySQL or MariaDB you must set `unicodeEmoji` to `false` in the bot config (`RENOVATE_CONFIG_FILE`) to prevent issues with emojis.
+
 ### Azure DevOps
 
 First, [create a personal access token](https://docs.microsoft.com/en-us/azure/devops/integrate/get-started/authentication/pats) for the bot account.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

- Explain that you need to set `unicodeEmoji` to `false` if you use MySQL/MariaDB on BitBucket Server

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

I don't know if this is fixed in the meantime though, by either MySQL and/or MariaDB supporting the default emojis that Renovate bot uses?

Maybe this new text should go in https://github.com/renovatebot/renovate/blob/master/lib/platform/bitbucket-server/index.md instead?

Closes #6424.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
