### PR TITLE
chore: bump operations-per-run for stale action

### DIFF
--- a/.github/workflows/stale-action.yml
+++ b/.github/workflows/stale-action.yml
@@ -11,8 +11,8 @@ jobs:
     steps:
       - uses: actions/stale@v3.0.18
         with:
-          # Rate limit per run, defaults to 30.
-          operations-per-run: 30
+          # Rate limit per run, (defaults to 30, but we've increased it to 40 for now).
+          operations-per-run: 40
 
           # Only issues with both `reproduction:needed` and `type:bug` will be touched by the stale bot.
           only-issue-labels: 'reproduction:needed,type:bug'


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

- Bump `operations-per-run` from `30` -> `40`

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

This should give us a bit more room to grow in amount of open issues/PRs before the stale action runs out of operations again.
Right now `30` puts us right at the current limit of open issues/PRs, so it's likely the action will not complete properly next run.

I'm making a light bump from 30 to 40 as we need the GitHub CRUD operations for some or even all other actions as well, and I don't want to cause problems for the main process (making releases/testing PRs, etc.).

Closes #9194.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
