### PR TITLE
feat(npm): remove yarnrc config option

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2205,5 +2205,3 @@ To disable vulnerability alerts completely, configure like this:
   }
 }
 ```
-
-## yarnrc

--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -514,12 +514,6 @@ const options: RenovateOptions[] = [
     type: 'string',
   },
   {
-    name: 'yarnrc',
-    description: 'String copy of yarnrc file. Use \\n instead of line breaks.',
-    stage: 'branch',
-    type: 'string',
-  },
-  {
     name: 'updateLockFiles',
     description: 'Set to false to disable lock file updating.',
     type: 'boolean',

--- a/lib/config/migration.ts
+++ b/lib/config/migration.ts
@@ -25,6 +25,7 @@ const removedOptions = [
   'groupPrBody',
   'statusCheckVerify',
   'lazyGrouping',
+  'yarnrc',
 ];
 
 export interface MigratedConfig {

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -49,8 +49,6 @@ export async function validateConfig(
       branchName: `Direct editing of branchName is now deprecated. Please edit branchPrefix, additionalBranchPrefix, or branchTopic instead`,
       commitMessage: `Direct editing of commitMessage is now deprecated. Please edit commitMessage's subcomponents instead.`,
       prTitle: `Direct editing of prTitle is now deprecated. Please edit commitMessage subcomponents instead as they will be passed through to prTitle.`,
-      yarnrc:
-        'Use of `yarnrc` in config is deprecated. Please commit it to your repository instead.',
     };
     return deprecatedOptions[option];
   }

--- a/lib/manager/npm/extract/__snapshots__/index.spec.ts.snap
+++ b/lib/manager/npm/extract/__snapshots__/index.spec.ts.snap
@@ -26,7 +26,6 @@ Object {
   "skipInstalls": true,
   "yarnLock": undefined,
   "yarnWorkspacesPackages": undefined,
-  "yarnrc": undefined,
 }
 `;
 
@@ -150,7 +149,6 @@ Object {
   "skipInstalls": false,
   "yarnLock": undefined,
   "yarnWorkspacesPackages": undefined,
-  "yarnrc": undefined,
 }
 `;
 
@@ -314,7 +312,6 @@ Object {
   "skipInstalls": true,
   "yarnLock": undefined,
   "yarnWorkspacesPackages": undefined,
-  "yarnrc": undefined,
 }
 `;
 
@@ -364,7 +361,6 @@ Object {
   "skipInstalls": true,
   "yarnLock": undefined,
   "yarnWorkspacesPackages": undefined,
-  "yarnrc": undefined,
 }
 `;
 
@@ -425,7 +421,6 @@ Object {
   "skipInstalls": true,
   "yarnLock": undefined,
   "yarnWorkspacesPackages": undefined,
-  "yarnrc": undefined,
 }
 `;
 
@@ -480,7 +475,6 @@ Object {
   "skipInstalls": true,
   "yarnLock": undefined,
   "yarnWorkspacesPackages": undefined,
-  "yarnrc": undefined,
 }
 `;
 
@@ -617,7 +611,6 @@ Object {
   "skipInstalls": true,
   "yarnLock": undefined,
   "yarnWorkspacesPackages": undefined,
-  "yarnrc": undefined,
 }
 `;
 
@@ -754,7 +747,6 @@ Object {
   "skipInstalls": true,
   "yarnLock": undefined,
   "yarnWorkspacesPackages": undefined,
-  "yarnrc": undefined,
 }
 `;
 
@@ -891,7 +883,6 @@ Object {
   "skipInstalls": true,
   "yarnLock": "yarn.lock",
   "yarnWorkspacesPackages": undefined,
-  "yarnrc": undefined,
 }
 `;
 
@@ -916,7 +907,6 @@ Object {
   "yarnWorkspacesPackages": Array [
     "packages/*",
   ],
-  "yarnrc": undefined,
 }
 `;
 
@@ -1053,7 +1043,6 @@ Object {
   "skipInstalls": true,
   "yarnLock": undefined,
   "yarnWorkspacesPackages": undefined,
-  "yarnrc": undefined,
 }
 `;
 
@@ -1078,7 +1067,6 @@ Object {
   "yarnWorkspacesPackages": Array [
     "packages/*",
   ],
-  "yarnrc": undefined,
 }
 `;
 
@@ -1103,7 +1091,6 @@ Object {
   "yarnWorkspacesPackages": Array [
     "packages/*",
   ],
-  "yarnrc": undefined,
 }
 `;
 
@@ -1240,6 +1227,5 @@ Object {
   "skipInstalls": true,
   "yarnLock": undefined,
   "yarnWorkspacesPackages": undefined,
-  "yarnrc": undefined,
 }
 `;

--- a/lib/manager/npm/extract/index.ts
+++ b/lib/manager/npm/extract/index.ts
@@ -117,11 +117,6 @@ export async function extractPackageFile(
       npmrc = undefined;
     }
   }
-  const yarnrcFileName = getSiblingFileName(fileName, '.yarnrc');
-  let yarnrc;
-  if (!is.string(config.yarnrc)) {
-    yarnrc = (await readLocalFile(yarnrcFileName, 'utf8')) || undefined;
-  }
 
   let lernaJsonFile: string;
   let lernaPackages: string[];
@@ -364,7 +359,6 @@ export async function extractPackageFile(
     packageJsonType,
     npmrc,
     ignoreNpmrcFile,
-    yarnrc,
     ...lockFiles,
     managerData: {
       lernaJsonFile,

--- a/lib/manager/npm/post-update/index.ts
+++ b/lib/manager/npm/post-update/index.ts
@@ -145,20 +145,6 @@ export async function writeExistingFiles(
         logger.warn({ npmrcFilename, err }, 'Error writing .npmrc');
       }
     }
-    if (packageFile.yarnrc) {
-      logger.debug(`Writing .yarnrc to ${basedir}`);
-      const yarnrcFilename = upath.join(basedir, '.yarnrc');
-      try {
-        await outputFile(
-          yarnrcFilename,
-          packageFile.yarnrc
-            .replace('--install.pure-lockfile true', '')
-            .replace('--install.frozen-lockfile true', '')
-        );
-      } catch (err) /* istanbul ignore next */ {
-        logger.warn({ yarnrcFilename, err }, 'Error writing .yarnrc');
-      }
-    }
     const { npmLock } = packageFile;
     if (npmLock) {
       const npmLockPath = upath.join(config.localDir, npmLock);

--- a/lib/manager/types.ts
+++ b/lib/manager/types.ts
@@ -24,7 +24,6 @@ export interface ExtractConfig extends ManagerConfig {
   gradle?: { timeout?: number };
   aliases?: Record<string, string>;
   ignoreNpmrcFile?: boolean;
-  yarnrc?: string;
   skipInstalls?: boolean;
   versioning?: string;
   updateInternalDeps?: boolean;
@@ -95,7 +94,6 @@ export interface PackageFile<T = Record<string, any>>
   packageFileVersion?: string;
   parent?: string;
   skipInstalls?: boolean;
-  yarnrc?: string;
   yarnWorkspacesPackages?: string[] | string;
   matchStrings?: string[];
   matchStringsStrategy?: MatchStringsStrategy;

--- a/lib/workers/repository/extract/__snapshots__/manager-files.spec.ts.snap
+++ b/lib/workers/repository/extract/__snapshots__/manager-files.spec.ts.snap
@@ -30,7 +30,6 @@ Array [
     "skipInstalls": undefined,
     "yarnLock": undefined,
     "yarnWorkspacesPackages": undefined,
-    "yarnrc": undefined,
   },
 ]
 `;


### PR DESCRIPTION
## Changes:

Removes the `yarnrc` configuration option.

## Context:

This probably shouldn't have been added in the first place, but I had assumed it might be needed for credentials like `.npmrc`.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

BREAKING CHANGE: yarnrc configuration option is no longer supported.