### PR TITLE
fix: Add registryTemplateUrl field to allowed fields for regexManager

### DIFF
--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -291,6 +291,7 @@ describe('config/validation', () => {
             matchStrings: ['ENV (?<currentValue>.*?)\\s'],
             depNameTemplate: 'foo',
             datasourceTemplate: 'bar',
+            registryUrlTemplate: 'foobar',
           },
         ],
       };

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -277,6 +277,7 @@ export async function validateConfig(
                 'lookupNameTemplate',
                 'datasourceTemplate',
                 'versioningTemplate',
+                'registryUrlTemplate',
               ];
               // TODO: fix types
               for (const regexManager of val as any[]) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

This adds the `registryTemplateUrl` field to the list of allowed fields in `regexManager`s.

## Context:

Support for this field was added in #8611, but as far as I can tell, it was never added to the list of allowed fields. This means that if you try and use this field, you get the following error:

```
File: renovate.json
Error type: The renovate configuration file contains some invalid settings
Message: Regex Manager contains disallowed fields: registryUrlTemplate
```

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
