### PR TITLE
chore: label-actions comments when logs:problem label is applied

### DIFF
--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -62,7 +62,7 @@
     </details>
 
 
-    #### Finding logs on self-hosted app
+    #### Finding logs when self-hosting
 
     <details><summary>Click me to read instructions</summary>
 

--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -47,7 +47,7 @@
     <details><summary>Click me to read instructions</summary>
 
 
-    If you use the Renovate app (GitHub/GitLab/etc):
+    If you use the Renovate app (GitHub):
 
     1. Go to the affected PR, and search for "View repository job log here"
 

--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -67,7 +67,7 @@
     <details><summary>Click me to read instructions</summary>
 
 
-    If you're running self-hosted, run with `--log-level=debug` or LOG_LEVEL=debug and search for whatever dependency/branch/PR that is causing the problem.
+    If you're running self-hosted, run with `LOG_LEVEL=debug` in your environment variables and search for whatever dependency/branch/PR that is causing the problem.
 
     </details>
 

--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -44,6 +44,9 @@
 
     #### Finding logs on hosted app
 
+    <details><summary>Click me to read instructions</summary>
+
+
     If you use the Renovate app (GitHub/GitLab/etc):
 
     1. Go to the affected PR, and search for "View repository job log here"
@@ -56,18 +59,33 @@
 
     1. Follow the steps in the **formatting your logs** section
 
+    </details>
+
 
     #### Finding logs on self-hosted app
 
+    <details><summary>Click me to read instructions</summary>
+
+
     If you host Renovate bot yourself, go to .... to find the logging output.
+
+    </details>
 
 
     ### Insufficient logs
 
+    <details><summary>Click me to read instructions</summary>
+
+
     If you already provided logs, and the Renovate team said they are not enough, follow the instructions from the **No logs at all** section.
+
+    </details>
 
 
     ### Formatting your logs
+
+    <details><summary>Click me to read instructions</summary>
+
 
     Please put your logs in a `<details>` and `<summary>` element like this:
 
@@ -79,3 +97,5 @@
         ```
 
         </details>
+
+    </details>

--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -67,7 +67,7 @@
     <details><summary>Click me to read instructions</summary>
 
 
-    If you host Renovate bot yourself, go to .... to find the logging output.
+    If you're running self-hosted, run with `--log-level=debug` or LOG_LEVEL=debug and search for whatever dependency/branch/PR that is causing the problem.
 
     </details>
 

--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -93,7 +93,7 @@
         <details><summary>Click me to see logs</summary>
 
         ```
-        Copy/paste your log here
+        Copy/paste any log here, between the starting and ending backticks
         ```
 
         </details>

--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -28,15 +28,54 @@
     The Renovate team will take a look at the reproduction repository.
     Once we confirm the provided repository reproduces the problem, the label will be changed to `reproduction:confirmed`.
 
-'logs:formatting':
+'logs:problem':
   comment: >
-    Please put long logs into a `<details>` and `<summary>` element like this:
+    Hi there,
+
+
+    We have found that there's a problem with the logs.
+    Depending on which situation applies follow one, some or all of these instructions.
+
+
+    ### No logs at all
+
+    If there's no log posted yet, we need you to find and copy/paste the log into the issue template.
+
+
+    #### Finding logs on hosted app
+
+    If you use the Renovate app (GitHub/GitLab/etc):
+
+    1. Go to the affected PR, and search for "View repository job log here"
+
+    1. Click on the link to go to the "WhiteSource Renovate Dashboard" and log in
+
+    1. You are now in the correct repository log overview screen
+
+    1. Copy/paste the correct log
+
+    1. Follow the steps in the **formatting your logs** section
+
+
+    #### Finding logs on self-hosted app
+
+    If you host Renovate bot yourself, go to .... to find the logging output.
+
+
+    ### Insufficient logs
+
+    If you already provided logs, and the Renovate team said they are not enough, follow the instructions from the **No logs at all** section.
+
+
+    ### Formatting your logs
+
+    Please put your logs in a `<details>` and `<summary>` element like this:
 
 
         <details><summary>Click me to see logs</summary>
 
-        REPLACE THIS TEXT WITH 3 BACKTICKS
+        ```
         Copy/paste your log here
-        REPLACE THIS TEXT WITH 3 BACKTICKS
+        ```
 
         </details>

--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -27,3 +27,16 @@
 
     The Renovate team will take a look at the reproduction repository.
     Once we confirm the provided repository reproduces the problem, the label will be changed to `reproduction:confirmed`.
+
+'logs:formatting':
+  comment: >
+    Please put long logs into a `<details>` and `<summary>` element like this:
+
+
+        <details><summary>Click me to see logs</summary>
+
+        REPLACE THIS TEXT WITH 3 BACKTICKS
+        Copy/paste your log here
+        REPLACE THIS TEXT WITH 3 BACKTICKS
+
+        </details>

--- a/docs/development/issue-labeling.md
+++ b/docs/development/issue-labeling.md
@@ -138,6 +138,7 @@ Apply these labels when somebody opens a `feature` type issue requesting a new d
 
     good first issue
     help wanted
+    logs:problem
     reproduction:needed
     reproduction:provided
     reproduction:confirmed
@@ -149,6 +150,12 @@ Add a label `good first issue` to issues that are small, easy to fix, and do-abl
 This label is sometimes picked up by tools or websites that try to encourage people to contribute to open source.
 
 Add the label `help wanted` to indicate that we need the original poster or someone else to do some work or it is unlikely to get done.
+
+Add a label `logs:problem` to indicate that there's a problem with the logs, and the contributor needs to do one of these things:
+
+1. Provide logs (if there are none yet)
+1. Provide more logs (in case current log insufficient)
+1. Format their logs properly
 
 Add a label `reproduction:needed` if nobody's reproduced it in a public repo yet and such a reproduction is necessary before further work can be done.
 Add the label `reproduction:provided` once there is a public reproduction.

--- a/docs/development/issue-labeling.md
+++ b/docs/development/issue-labeling.md
@@ -154,7 +154,7 @@ Add the label `help wanted` to indicate that we need the original poster or some
 Add a label `logs:problem` to indicate that there's a problem with the logs, and the contributor needs to do one of these things:
 
 1. Provide logs (if there are none yet)
-1. Provide more logs (in case current log insufficient)
+1. Provide more logs (in case current logs are insufficient)
 1. Format their logs properly
 
 Add a label `reproduction:needed` if nobody's reproduced it in a public repo yet and such a reproduction is necessary before further work can be done.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

- `label-actions` will comment when `logs:problem` label is applied
- Explain `logs:problem` label usage in the `development/issue-labeling.md` docs

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

Originally this PR was just to add a `logs:formatting` label and comment.

We have decided to make a `logs:problem` label and capture all 3 things that can go wrong with the logs:

- No logs at all
- Logs insufficient
- Logs badly formatted (wall of text in issue or comment)

After this PR gets merged, @rarkins will need to create the new label, and add a description to the label.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
