### PR TITLE
fix(gradle-wrapper): parse prerelease and milestones

### DIFF
--- a/lib/manager/gradle-wrapper/__fixtures__/gradle-wrapper-3.properties
+++ b/lib/manager/gradle-wrapper/__fixtures__/gradle-wrapper-3.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-milestone-1-bin.zip

--- a/lib/manager/gradle-wrapper/__fixtures__/gradle-wrapper-4.properties
+++ b/lib/manager/gradle-wrapper/__fixtures__/gradle-wrapper-4.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7-rc-1-bin.zip

--- a/lib/manager/gradle-wrapper/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/gradle-wrapper/__snapshots__/extract.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/manager/gradle-wrapper/extract extractPackageFile() extracts all version line 1`] = `
+exports[`manager/gradle-wrapper/extract extractPackageFile() extracts all version line 1`] = `
 Array [
   Object {
     "currentValue": "4.10.3",
@@ -11,7 +11,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/gradle-wrapper/extract extractPackageFile() extracts bin version line 1`] = `
+exports[`manager/gradle-wrapper/extract extractPackageFile() extracts bin version line 1`] = `
 Array [
   Object {
     "currentValue": "4.8",
@@ -22,7 +22,18 @@ Array [
 ]
 `;
 
-exports[`lib/manager/gradle-wrapper/extract extractPackageFile() handles whitespace 1`] = `
+exports[`manager/gradle-wrapper/extract extractPackageFile() extracts prerelease version line 1`] = `
+Array [
+  Object {
+    "currentValue": "7.0-milestone-1",
+    "datasource": "gradle-version",
+    "depName": "gradle",
+    "versioning": "gradle",
+  },
+]
+`;
+
+exports[`manager/gradle-wrapper/extract extractPackageFile() handles whitespace 1`] = `
 Array [
   Object {
     "currentValue": "4.10.3",

--- a/lib/manager/gradle-wrapper/extract.spec.ts
+++ b/lib/manager/gradle-wrapper/extract.spec.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'upath';
+import { getName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 const propertiesFile1 = readFileSync(
@@ -10,12 +11,20 @@ const propertiesFile2 = readFileSync(
   resolve(__dirname, './__fixtures__/gradle-wrapper-2.properties'),
   'utf8'
 );
+const propertiesFile3 = readFileSync(
+  resolve(__dirname, './__fixtures__/gradle-wrapper-3.properties'),
+  'utf8'
+);
+const propertiesFile4 = readFileSync(
+  resolve(__dirname, './__fixtures__/gradle-wrapper-4.properties'),
+  'utf8'
+);
 const whitespacePropertiesFile = readFileSync(
   resolve(__dirname, './__fixtures__/gradle-wrapper-whitespace.properties'),
   'utf8'
 );
 
-describe('lib/manager/gradle-wrapper/extract', () => {
+describe(getName(__filename), () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty', () => {
       expect(extractPackageFile('nothing here')).toBeNull();
@@ -30,6 +39,18 @@ describe('lib/manager/gradle-wrapper/extract', () => {
       const res = extractPackageFile(propertiesFile2);
       expect(res.deps).toMatchSnapshot();
     });
+
+    it('extracts prerelease version line', () => {
+      const res = extractPackageFile(propertiesFile3);
+      expect(res.deps).toMatchSnapshot();
+      expect(res.deps[0].currentValue).toBe('7.0-milestone-1');
+    });
+
+    it('ignores invalid', () => {
+      const res = extractPackageFile(propertiesFile4);
+      expect(res).toBeNull();
+    });
+
     it('handles whitespace', () => {
       const res = extractPackageFile(whitespacePropertiesFile);
       expect(res.deps).toMatchSnapshot();

--- a/lib/manager/gradle-wrapper/extract.ts
+++ b/lib/manager/gradle-wrapper/extract.ts
@@ -3,7 +3,7 @@ import { logger } from '../../logger';
 import * as gradleVersioning from '../../versioning/gradle';
 import type { PackageDependency, PackageFile } from '../types';
 
-const DISTRIBUTION_URL_REGEX = /^(?<assignment>distributionUrl\s*=\s*)\S*-(?<version>(\d|\.)+)-(?<type>bin|all)\.zip\s*$/;
+const DISTRIBUTION_URL_REGEX = /^(?:distributionUrl\s*=\s*)\S*-(?<version>\d+\.\d+(?:\.\d+)?(?:-\w+)*)-(?<type>bin|all)\.zip\s*$/;
 
 export function extractPackageFile(fileContent: string): PackageFile | null {
   logger.debug('gradle-wrapper.extractPackageFile()');

--- a/lib/manager/gradle-wrapper/extract.ts
+++ b/lib/manager/gradle-wrapper/extract.ts
@@ -1,10 +1,13 @@
 import * as datasourceGradleVersion from '../../datasource/gradle-version';
 import { logger } from '../../logger';
+import { regEx } from '../../util/regex';
 import * as gradleVersioning from '../../versioning/gradle';
 import type { PackageDependency, PackageFile } from '../types';
 
 // https://regex101.com/r/1GaQ2X/1
-const DISTRIBUTION_URL_REGEX = /^(?:distributionUrl\s*=\s*)\S*-(?<version>\d+\.\d+(?:\.\d+)?(?:-\w+)*)-(?<type>bin|all)\.zip\s*$/;
+const DISTRIBUTION_URL_REGEX = regEx(
+  '^(?:distributionUrl\\s*=\\s*)\\S*-(?<version>\\d+\\.\\d+(?:\\.\\d+)?(?:-\\w+)*)-(?<type>bin|all)\\.zip\\s*$'
+);
 
 export function extractPackageFile(fileContent: string): PackageFile | null {
   logger.debug('gradle-wrapper.extractPackageFile()');

--- a/lib/manager/gradle-wrapper/extract.ts
+++ b/lib/manager/gradle-wrapper/extract.ts
@@ -3,6 +3,7 @@ import { logger } from '../../logger';
 import * as gradleVersioning from '../../versioning/gradle';
 import type { PackageDependency, PackageFile } from '../types';
 
+// https://regex101.com/r/1GaQ2X/1
 const DISTRIBUTION_URL_REGEX = /^(?:distributionUrl\s*=\s*)\S*-(?<version>\d+\.\d+(?:\.\d+)?(?:-\w+)*)-(?<type>bin|all)\.zip\s*$/;
 
 export function extractPackageFile(fileContent: string): PackageFile | null {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Update regex to parse all gradle versions (excerpt nighly like `gradle-7.0-20210324011254+0000-bin.zip`)

<!-- Describe what behavior is changed by this PR. -->

## Context:

fixes #9234
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
