### PR TITLE
fix(poetry): better getNewValue replace

### DIFF
--- a/lib/versioning/poetry/index.spec.ts
+++ b/lib/versioning/poetry/index.spec.ts
@@ -300,6 +300,16 @@ describe(getName(__filename), () => {
         })
       ).toEqual('^2.0.0');
     });
+    it('handles precision change caret', () => {
+      expect(
+        versionig.getNewValue({
+          currentValue: '^5.0.3',
+          rangeStrategy: 'replace',
+          currentVersion: '5.3.1',
+          newVersion: '5.5',
+        })
+      ).toEqual('^5.0.3');
+    });
     it('replaces naked version', () => {
       expect(
         versionig.getNewValue({

--- a/lib/versioning/poetry/index.ts
+++ b/lib/versioning/poetry/index.ts
@@ -1,4 +1,5 @@
 import { parseRange } from 'semver-utils';
+import { logger } from '../../logger';
 import { api as npm } from '../npm';
 import type { NewValueConfig, VersioningApi } from '../types';
 
@@ -130,6 +131,16 @@ function getNewValue({
 }: NewValueConfig): string {
   if (rangeStrategy === 'replace') {
     const npmCurrentValue = poetry2npm(currentValue);
+    try {
+      if (npm.matches(padZeroes(newVersion), npmCurrentValue)) {
+        return currentValue;
+      }
+    } catch (err) /* istanbul ignore next */ {
+      logger.info(
+        { err },
+        'Poetry versioning: Error caught checking if newVersion satisfies currentValue'
+      );
+    }
     const parsedRange = parseRange(npmCurrentValue);
     const element = parsedRange[parsedRange.length - 1];
     if (parsedRange.length === 1 && element.operator) {

--- a/lib/versioning/poetry/index.ts
+++ b/lib/versioning/poetry/index.ts
@@ -132,7 +132,11 @@ function getNewValue({
   if (rangeStrategy === 'replace') {
     const npmCurrentValue = poetry2npm(currentValue);
     try {
-      if (npm.matches(padZeroes(newVersion), npmCurrentValue)) {
+      const massagedNewVersion = padZeroes(newVersion);
+      if (
+        npm.isVersion(massagedNewVersion) &&
+        npm.matches(massagedNewVersion, npmCurrentValue)
+      ) {
         return currentValue;
       }
     } catch (err) /* istanbul ignore next */ {


### PR DESCRIPTION
## Changes:

Adds logic to check if a massaged new version satisfies the existing range, and returns the range if so before doing other evaluation.

## Context:

Fixes #9256

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
