### PR TITLE
fix: allow dash character in local preset path (#9283)

### DIFF
--- a/lib/config/presets/__snapshots__/index.spec.ts.snap
+++ b/lib/config/presets/__snapshots__/index.spec.ts.snap
@@ -172,6 +172,16 @@ Object {
 }
 `;
 
+exports[`config/presets parsePreset parses local with subdirectory 1`] = `
+Object {
+  "packageName": "some-group/some-repo",
+  "params": undefined,
+  "presetName": "some-file",
+  "presetPath": "some-dir",
+  "presetSource": "local",
+}
+`;
+
 exports[`config/presets parsePreset parses no prefix as local 1`] = `
 Object {
   "packageName": "some/repo",

--- a/lib/config/presets/index.spec.ts
+++ b/lib/config/presets/index.spec.ts
@@ -312,6 +312,11 @@ describe('config/presets', () => {
     it('parses local', () => {
       expect(presets.parsePreset('local>some/repo')).toMatchSnapshot();
     });
+    it('parses local with subdirectory', () => {
+      expect(
+        presets.parsePreset('local>some-group/some-repo//some-dir/some-file')
+      ).toMatchSnapshot();
+    });
     it('parses no prefix as local', () => {
       expect(presets.parsePreset('some/repo')).toMatchSnapshot();
     });

--- a/lib/config/presets/index.ts
+++ b/lib/config/presets/index.ts
@@ -130,7 +130,7 @@ export function parsePreset(input: string): ParsedPreset {
     }
   } else if (str.includes('//')) {
     // non-scoped namespace with a subdirectory preset
-    const re = /^([\w./]+?)\/\/(?:([\w./]+)\/)?([\w.]+)$/;
+    const re = /^([\w\-./]+?)\/\/(?:([\w\-./]+)\/)?([\w\-.]+)$/;
 
     // Validation
     if (str.includes(':')) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

This change fixes a parsing error when there is a dash in a path to local config preset.

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->
Closes #9283 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [X] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
