### PR TITLE
feat(github): reuse autoclosed PRs

### DIFF
--- a/lib/platform/github/__snapshots__/index.spec.ts.snap
+++ b/lib/platform/github/__snapshots__/index.spec.ts.snap
@@ -1873,6 +1873,400 @@ Array [
 ]
 `;
 
+exports[`platform/github getBranchPr(branchName) aborts reopening if PR reopening fails 1`] = `
+Array [
+  Object {
+    "graphql": Object {
+      "query": Object {
+        "repository": Object {
+          "__args": Object {
+            "name": "repo",
+            "owner": "some",
+          },
+          "defaultBranchRef": Object {
+            "name": null,
+            "target": Object {
+              "oid": null,
+            },
+          },
+          "isArchived": null,
+          "isFork": null,
+          "mergeCommitAllowed": null,
+          "nameWithOwner": null,
+          "rebaseMergeAllowed": null,
+          "squashMergeAllowed": null,
+        },
+      },
+    },
+    "headers": Object {
+      "accept": "application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate",
+      "authorization": "token abc123",
+      "content-length": "330",
+      "content-type": "application/json",
+      "host": "api.github.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "POST",
+    "url": "https://api.github.com/graphql",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate",
+      "authorization": "token abc123",
+      "host": "api.github.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://api.github.com/repos/some/repo/pulls?per_page=100&state=all",
+  },
+  Object {
+    "body": "{\\"ref\\":\\"refs/heads/somebranch\\"}",
+    "headers": Object {
+      "accept": "application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate",
+      "authorization": "token abc123",
+      "content-length": "31",
+      "content-type": "application/json",
+      "host": "api.github.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "POST",
+    "url": "https://api.github.com/repos/some/repo/git/refs",
+  },
+]
+`;
+
+exports[`platform/github getBranchPr(branchName) aborts reopening if branch recreation fails 1`] = `
+Array [
+  Object {
+    "graphql": Object {
+      "query": Object {
+        "repository": Object {
+          "__args": Object {
+            "name": "repo",
+            "owner": "some",
+          },
+          "defaultBranchRef": Object {
+            "name": null,
+            "target": Object {
+              "oid": null,
+            },
+          },
+          "isArchived": null,
+          "isFork": null,
+          "mergeCommitAllowed": null,
+          "nameWithOwner": null,
+          "rebaseMergeAllowed": null,
+          "squashMergeAllowed": null,
+        },
+      },
+    },
+    "headers": Object {
+      "accept": "application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate",
+      "authorization": "token abc123",
+      "content-length": "330",
+      "content-type": "application/json",
+      "host": "api.github.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "POST",
+    "url": "https://api.github.com/graphql",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate",
+      "authorization": "token abc123",
+      "host": "api.github.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://api.github.com/repos/some/repo/pulls?per_page=100&state=all",
+  },
+  Object {
+    "body": "{\\"ref\\":\\"refs/heads/somebranch\\"}",
+    "headers": Object {
+      "accept": "application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate",
+      "authorization": "token abc123",
+      "content-length": "31",
+      "content-type": "application/json",
+      "host": "api.github.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "POST",
+    "url": "https://api.github.com/repos/some/repo/git/refs",
+  },
+  Object {
+    "body": "{\\"state\\":\\"open\\",\\"title\\":\\"old title\\"}",
+    "headers": Object {
+      "accept": "application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate",
+      "authorization": "token abc123",
+      "content-length": "36",
+      "content-type": "application/json",
+      "host": "api.github.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "PATCH",
+    "url": "https://api.github.com/repos/some/repo/pulls/91",
+  },
+]
+`;
+
+exports[`platform/github getBranchPr(branchName) should reopen an autoclosed PR 1`] = `
+Object {
+  "additions": 1,
+  "base": Object {
+    "sha": "1234",
+  },
+  "canMerge": false,
+  "canMergeReason": "mergeable = undefined",
+  "commits": 1,
+  "deletions": 1,
+  "displayNumber": "Pull Request #91",
+  "head": Object {
+    "ref": "somebranch",
+    "repo": Object {
+      "full_name": "some/repo",
+    },
+  },
+  "number": 91,
+  "sha": undefined,
+  "sourceBranch": "somebranch",
+  "state": "open",
+}
+`;
+
+exports[`platform/github getBranchPr(branchName) should reopen an autoclosed PR 2`] = `
+Array [
+  Object {
+    "graphql": Object {
+      "query": Object {
+        "repository": Object {
+          "__args": Object {
+            "name": "repo",
+            "owner": "some",
+          },
+          "defaultBranchRef": Object {
+            "name": null,
+            "target": Object {
+              "oid": null,
+            },
+          },
+          "isArchived": null,
+          "isFork": null,
+          "mergeCommitAllowed": null,
+          "nameWithOwner": null,
+          "rebaseMergeAllowed": null,
+          "squashMergeAllowed": null,
+        },
+      },
+    },
+    "headers": Object {
+      "accept": "application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate",
+      "authorization": "token abc123",
+      "content-length": "330",
+      "content-type": "application/json",
+      "host": "api.github.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "POST",
+    "url": "https://api.github.com/graphql",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate",
+      "authorization": "token abc123",
+      "host": "api.github.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://api.github.com/repos/some/repo/pulls?per_page=100&state=all",
+  },
+  Object {
+    "body": "{\\"ref\\":\\"refs/heads/somebranch\\"}",
+    "headers": Object {
+      "accept": "application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate",
+      "authorization": "token abc123",
+      "content-length": "31",
+      "content-type": "application/json",
+      "host": "api.github.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "POST",
+    "url": "https://api.github.com/repos/some/repo/git/refs",
+  },
+  Object {
+    "body": "{\\"state\\":\\"open\\",\\"title\\":\\"old title\\"}",
+    "headers": Object {
+      "accept": "application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate",
+      "authorization": "token abc123",
+      "content-length": "36",
+      "content-type": "application/json",
+      "host": "api.github.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "PATCH",
+    "url": "https://api.github.com/repos/some/repo/pulls/91",
+  },
+  Object {
+    "graphql": Object {
+      "query": Object {
+        "repository": Object {
+          "__args": Object {
+            "name": "repo",
+            "owner": "some",
+          },
+          "pullRequests": Object {
+            "__args": Object {
+              "first": "100",
+            },
+            "nodes": Object {
+              "assignees": Object {
+                "totalCount": null,
+              },
+              "baseRefName": null,
+              "body": null,
+              "commits": Object {
+                "__args": Object {
+                  "first": "2",
+                },
+                "nodes": Object {
+                  "commit": Object {
+                    "author": Object {
+                      "email": null,
+                    },
+                    "committer": Object {
+                      "email": null,
+                    },
+                    "parents": Object {
+                      "__args": Object {
+                        "last": "1",
+                      },
+                      "edges": Object {
+                        "node": Object {
+                          "abbreviatedOid": null,
+                          "oid": null,
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+              "headRefName": null,
+              "labels": Object {
+                "__args": Object {
+                  "last": "100",
+                },
+                "nodes": Object {
+                  "name": null,
+                },
+              },
+              "mergeStateStatus": null,
+              "mergeable": null,
+              "number": null,
+              "reviewRequests": Object {
+                "totalCount": null,
+              },
+              "reviews": Object {
+                "__args": Object {
+                  "first": "1",
+                },
+                "nodes": Object {
+                  "state": null,
+                },
+              },
+              "title": null,
+            },
+            "pageInfo": Object {
+              "endCursor": null,
+              "hasNextPage": null,
+            },
+          },
+        },
+      },
+    },
+    "headers": Object {
+      "accept": "application/vnd.github.merge-info-preview+json, application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate",
+      "authorization": "token abc123",
+      "content-length": "1504",
+      "content-type": "application/json",
+      "host": "api.github.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "POST",
+    "url": "https://api.github.com/graphql",
+  },
+  Object {
+    "graphql": Object {
+      "query": Object {
+        "repository": Object {
+          "__args": Object {
+            "name": "repo",
+            "owner": "some",
+          },
+          "pullRequests": Object {
+            "__args": Object {
+              "first": "100",
+            },
+            "nodes": Object {
+              "comments": Object {
+                "__args": Object {
+                  "last": "100",
+                },
+                "nodes": Object {
+                  "body": null,
+                  "databaseId": null,
+                },
+              },
+              "headRefName": null,
+              "number": null,
+              "state": null,
+              "title": null,
+            },
+            "pageInfo": Object {
+              "endCursor": null,
+              "hasNextPage": null,
+            },
+          },
+        },
+      },
+    },
+    "headers": Object {
+      "accept": "application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate",
+      "authorization": "token abc123",
+      "content-length": "604",
+      "content-type": "application/json",
+      "host": "api.github.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "POST",
+    "url": "https://api.github.com/graphql",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate",
+      "authorization": "token abc123",
+      "host": "api.github.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://api.github.com/repos/some/repo/pulls/91",
+  },
+]
+`;
+
 exports[`platform/github getBranchPr(branchName) should return null if no PR exists 1`] = `
 Array [
   Object {
@@ -4199,70 +4593,6 @@ Array [
 ]
 `;
 
-exports[`platform/github massageMarkdown(input) returns not-updated pr body for GHE 1`] = `
-Array [
-  Object {
-    "headers": Object {
-      "accept": "application/vnd.github.v3+json",
-      "accept-encoding": "gzip, deflate",
-      "authorization": "token abc123",
-      "host": "github.company.com",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
-    "url": "https://github.company.com/user",
-  },
-  Object {
-    "headers": Object {
-      "accept": "application/vnd.github.v3+json",
-      "accept-encoding": "gzip, deflate",
-      "authorization": "token abc123",
-      "host": "github.company.com",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
-    "url": "https://github.company.com/user/emails",
-  },
-  Object {
-    "graphql": Object {
-      "query": Object {
-        "repository": Object {
-          "__args": Object {
-            "name": "repo",
-            "owner": "some",
-          },
-          "defaultBranchRef": Object {
-            "name": null,
-            "target": Object {
-              "oid": null,
-            },
-          },
-          "isArchived": null,
-          "isFork": null,
-          "mergeCommitAllowed": null,
-          "nameWithOwner": null,
-          "rebaseMergeAllowed": null,
-          "squashMergeAllowed": null,
-        },
-      },
-    },
-    "headers": Object {
-      "accept": "application/vnd.github.v3+json",
-      "accept-encoding": "gzip, deflate",
-      "authorization": "token abc123",
-      "content-length": "330",
-      "content-type": "application/json",
-      "host": "github.company.com",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "POST",
-    "url": "https://github.company.com/graphql",
-  },
-]
-`;
-
-exports[`platform/github massageMarkdown(input) returns updated pr body 1`] = `"https://github.com/foo/bar/issues/5 plus also [a link](https://togithub.com/foo/bar/issues/5)"`;
-
 exports[`platform/github getRepoForceRebase should detect repoForceRebase 1`] = `
 Array [
   Object {
@@ -5334,6 +5664,70 @@ Array [
   },
 ]
 `;
+
+exports[`platform/github massageMarkdown(input) returns not-updated pr body for GHE 1`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate",
+      "authorization": "token abc123",
+      "host": "github.company.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://github.company.com/user",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate",
+      "authorization": "token abc123",
+      "host": "github.company.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://github.company.com/user/emails",
+  },
+  Object {
+    "graphql": Object {
+      "query": Object {
+        "repository": Object {
+          "__args": Object {
+            "name": "repo",
+            "owner": "some",
+          },
+          "defaultBranchRef": Object {
+            "name": null,
+            "target": Object {
+              "oid": null,
+            },
+          },
+          "isArchived": null,
+          "isFork": null,
+          "mergeCommitAllowed": null,
+          "nameWithOwner": null,
+          "rebaseMergeAllowed": null,
+          "squashMergeAllowed": null,
+        },
+      },
+    },
+    "headers": Object {
+      "accept": "application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate",
+      "authorization": "token abc123",
+      "content-length": "330",
+      "content-type": "application/json",
+      "host": "github.company.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "POST",
+    "url": "https://github.company.com/graphql",
+  },
+]
+`;
+
+exports[`platform/github massageMarkdown(input) returns updated pr body 1`] = `"https://github.com/foo/bar/issues/5 plus also [a link](https://togithub.com/foo/bar/issues/5)"`;
 
 exports[`platform/github mergePr(prNo) - autodetection should give up 1`] = `
 Array [

--- a/lib/platform/github/index.ts
+++ b/lib/platform/github/index.ts
@@ -811,18 +811,8 @@ export async function getBranchPr(branchName: string): Promise<Pr | null> {
       });
       logger.debug({ branchName, sha }, 'Recreated autoclosed branch');
     } catch (err) {
-      if (
-        err.response?.statusCode === 422 &&
-        err.response?.body?.message === 'Reference already exists'
-      ) {
-        logger.debug(
-          { branchName },
-          'Branch already exists - no need to recreate'
-        );
-      } else {
-        logger.debug('Could not recreate autoclosed branch - skipping reopen');
-        return null;
-      }
+      logger.debug('Could not recreate autoclosed branch - skipping reopen');
+      return null;
     }
     try {
       const title = autoclosedPr.title.replace(/ - autoclosed$/, '');
@@ -840,7 +830,7 @@ export async function getBranchPr(branchName: string): Promise<Pr | null> {
       logger.debug('Could not reopen autoclosed PR');
       return null;
     }
-    delete config.closedPrList[number]; // So that it's no longer found in the closed list
+    delete config.closedPrList?.[number]; // So that it's no longer found in the closed list
     return getPr(number);
   }
   return null;

--- a/lib/platform/github/index.ts
+++ b/lib/platform/github/index.ts
@@ -822,7 +822,7 @@ export async function getBranchPr(branchName: string): Promise<Pr | null> {
           title,
         },
       });
-      logger.debug(
+      logger.info(
         { branchName, title, number },
         'Successfully reopened autoclosed PR'
       );

--- a/lib/platform/github/index.ts
+++ b/lib/platform/github/index.ts
@@ -791,11 +791,59 @@ export async function findPr({
 // Returns the Pull Request for a branch. Null if not exists.
 export async function getBranchPr(branchName: string): Promise<Pr | null> {
   logger.debug(`getBranchPr(${branchName})`);
-  const existingPr = await findPr({
+  const openPr = await findPr({
     branchName,
     state: PrState.Open,
   });
-  return existingPr ? getPr(existingPr.number) : null;
+  if (openPr) {
+    return getPr(openPr.number);
+  }
+  const autoclosedPr = await findPr({
+    branchName,
+    state: PrState.Closed,
+  });
+  if (autoclosedPr?.title?.endsWith(' - autoclosed')) {
+    logger.debug({ autoclosedPr }, 'Found autoclosed PR for branch');
+    const { sha, number } = autoclosedPr;
+    try {
+      await githubApi.postJson(`repos/${config.repository}/git/refs`, {
+        body: { ref: `refs/heads/${branchName}`, sha },
+      });
+      logger.debug({ branchName, sha }, 'Recreated autoclosed branch');
+    } catch (err) {
+      if (
+        err.response?.statusCode === 422 &&
+        err.response?.body?.message === 'Reference already exists'
+      ) {
+        logger.debug(
+          { branchName },
+          'Branch already exists - no need to recreate'
+        );
+      } else {
+        logger.debug('Could not recreate autoclosed branch - skipping reopen');
+        return null;
+      }
+    }
+    try {
+      const title = autoclosedPr.title.replace(/ - autoclosed$/, '');
+      await githubApi.patchJson(`repos/${config.repository}/pulls/${number}`, {
+        body: {
+          state: 'open',
+          title,
+        },
+      });
+      logger.debug(
+        { branchName, title, number },
+        'Successfully reopened autoclosed PR'
+      );
+    } catch (err) {
+      logger.debug('Could not reopen autoclosed PR');
+      return null;
+    }
+    delete config.closedPrList[number]; // So that it's no longer found in the closed list
+    return getPr(number);
+  }
+  return null;
 }
 
 async function getStatus(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds logic to look for an autoclosed PR for the same branch as called for `getBranchPr()`. If found then an attempt to restore the branch and reopen the PR is made, so that it can be reused.

## Context:

Closes #3982 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
