### PR TITLE
fix(terraform): do not abort search after a nested block

### DIFF
--- a/lib/manager/terraform/__fixtures__/1.tf
+++ b/lib/manager/terraform/__fixtures__/1.tf
@@ -79,6 +79,30 @@ module "vote_service_sg" {
   ]
 }
 
+module "addons_aws" {
+
+  providers = {
+    helm       = helm.core
+    kubectl    = kubectl.core
+    kubernetes = kubernetes.core
+  }
+
+  cluster-name = data.aws_eks_cluster.core_cluster.id
+
+  aws-ebs-csi-driver = {
+    enabled          = true
+    is_default_class = true
+  }
+
+
+  source  = "particuleio/addons/kubernetes//modules/aws"
+  version = "1.28.3"
+
+  aws-load-balancer-controller = {
+    enabled = true
+  }
+}
+
 module "consul" {
   source  = "app.terraform.io/example-corp/k8s-cluster/azurerm"
   version = "~> 1.1.0"

--- a/lib/manager/terraform/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/terraform/__snapshots__/extract.spec.ts.snap
@@ -138,6 +138,12 @@ Object {
       "depType": "terraform",
     },
     Object {
+      "currentValue": "1.28.3",
+      "datasource": "terraform-module",
+      "depName": "particuleio/addons/kubernetes",
+      "depType": "terraform",
+    },
+    Object {
       "currentValue": "~> 1.1.0",
       "datasource": "terraform-module",
       "depName": "app.terraform.io/example-corp/k8s-cluster/azurerm",
@@ -264,7 +270,7 @@ Object {
       "datasource": "github-tags",
       "depName": "hashicorp/terraform",
       "extractVersion": "v(?<version>.*)$",
-      "lineNumber": 205,
+      "lineNumber": 229,
     },
     Object {
       "currentValue": "2.7.2",

--- a/lib/manager/terraform/extract.spec.ts
+++ b/lib/manager/terraform/extract.spec.ts
@@ -16,7 +16,7 @@ describe('lib/manager/terraform/extract', () => {
     it('extracts', () => {
       const res = extractPackageFile(tf1);
       expect(res).toMatchSnapshot();
-      expect(res.deps).toHaveLength(45);
+      expect(res.deps).toHaveLength(46);
       expect(res.deps.filter((dep) => dep.skipReason)).toHaveLength(8);
     });
     it('returns null if only local deps', () => {

--- a/lib/manager/terraform/providers.ts
+++ b/lib/manager/terraform/providers.ts
@@ -1,5 +1,6 @@
 import is from '@sindresorhus/is';
 import * as datasourceTerraformProvider from '../../datasource/terraform-provider';
+import { logger } from '../../logger';
 import { SkipReason } from '../../types';
 import type { PackageDependency } from '../types';
 import {
@@ -16,7 +17,6 @@ export function extractTerraformProvider(
   moduleName: string
 ): ExtractionResult {
   let lineNumber = startingLine;
-  let line: string;
   const deps: PackageDependency[] = [];
   const dep: PackageDependency = {
     managerData: {
@@ -24,9 +24,19 @@ export function extractTerraformProvider(
       terraformDependencyType: TerraformDependencyTypes.provider,
     },
   };
+  let braceCounter = 0;
   do {
-    lineNumber += 1;
-    line = lines[lineNumber];
+    // istanbul ignore if
+    if (lineNumber > lines.length - 1) {
+      logger.debug(`Malformed Terraform file detected.`);
+    }
+
+    const line = lines[lineNumber];
+    // `{` will be counted wit +1 and `}` with -1. Therefore if we reach braceCounter == 0. We have found the end of the terraform block
+    const openBrackets = (line.match(/\{/g) || []).length;
+    const closedBrackets = (line.match(/\}/g) || []).length;
+    braceCounter = braceCounter + openBrackets - closedBrackets;
+
     const kvMatch = keyValueExtractionRegex.exec(line);
     if (kvMatch) {
       if (kvMatch.groups.key === 'version') {
@@ -36,8 +46,12 @@ export function extractTerraformProvider(
         dep.managerData.sourceLine = lineNumber;
       }
     }
-  } while (line.trim() !== '}');
+    lineNumber += 1;
+  } while (braceCounter !== 0);
   deps.push(dep);
+
+  // remove last lineNumber addition to not skip a line after the last bracket
+  lineNumber -= 1;
   return { lineNumber, dependencies: deps };
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

This changes the block extraction for modules and providers. 

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

Closes #9238

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
