### PR TITLE
fix(helm): add support for "alias:" repositories

### DIFF
--- a/lib/manager/helm-requirements/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/helm-requirements/__snapshots__/extract.spec.ts.snap
@@ -33,6 +33,13 @@ Object {
         "https://my-registry.gcr.io/",
       ],
     },
+    Object {
+      "currentValue": "1.0.0",
+      "depName": "example",
+      "registryUrls": Array [
+        "https://registry.example.com/",
+      ],
+    },
   ],
 }
 `;

--- a/lib/manager/helm-requirements/extract.spec.ts
+++ b/lib/manager/helm-requirements/extract.spec.ts
@@ -93,11 +93,15 @@ describe('lib/manager/helm-requirements/extract', () => {
         - name: redis
           version: 0.9.0
           repository: '@placeholder'
+        - name: example
+          version: 1.0.0
+          repository: alias:longalias
       `;
       const fileName = 'requirements.yaml';
       const result = extractPackageFile(content, fileName, {
         aliases: {
           placeholder: 'https://my-registry.gcr.io/',
+          longalias: 'https://registry.example.com/',
         },
       });
       expect(result).not.toBeNull();

--- a/lib/manager/helm-requirements/extract.ts
+++ b/lib/manager/helm-requirements/extract.ts
@@ -44,9 +44,11 @@ export function extractPackageFile(
     }
 
     res.registryUrls = [dep.repository];
-    if (dep.repository.startsWith('@')) {
-      const repoWithAtRemoved = dep.repository.slice(1);
-      const alias = config.aliases[repoWithAtRemoved];
+    if (dep.repository.startsWith('@') || dep.repository.startsWith('alias:')) {
+      const repoWithPrefixRemoved = dep.repository.slice(
+        dep.repository[0] === '@' ? 1 : 6
+      );
+      const alias = config.aliases[repoWithPrefixRemoved];
       if (alias) {
         res.registryUrls = [alias];
         return res;

--- a/lib/manager/helmv3/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/helmv3/__snapshots__/extract.spec.ts.snap
@@ -34,6 +34,13 @@ Object {
         "https://my-registry.gcr.io/",
       ],
     },
+    Object {
+      "currentValue": "1.0.0",
+      "depName": "example",
+      "registryUrls": Array [
+        "https://registry.example.com/",
+      ],
+    },
   ],
   "packageFileVersion": "0.1.0",
 }

--- a/lib/manager/helmv3/extract.spec.ts
+++ b/lib/manager/helmv3/extract.spec.ts
@@ -73,11 +73,15 @@ describe('lib/manager/helm-requirements/extract', () => {
         - name: redis
           version: 0.9.0
           repository: '@placeholder'
+        - name: example
+          version: 1.0.0
+          repository: alias:longalias
       `;
       const fileName = 'Chart.yaml';
       const result = await extractPackageFile(content, fileName, {
         aliases: {
           placeholder: 'https://my-registry.gcr.io/',
+          longalias: 'https://registry.example.com/',
         },
       });
       expect(result).not.toBeNull();

--- a/lib/manager/helmv3/extract.ts
+++ b/lib/manager/helmv3/extract.ts
@@ -58,9 +58,14 @@ export async function extractPackageFile(
     };
     if (dep.repository) {
       res.registryUrls = [dep.repository];
-      if (dep.repository.startsWith('@')) {
-        const repoWithAtRemoved = dep.repository.slice(1);
-        const alias = config.aliases[repoWithAtRemoved];
+      if (
+        dep.repository.startsWith('@') ||
+        dep.repository.startsWith('alias:')
+      ) {
+        const repoWithPrefixRemoved = dep.repository.slice(
+          dep.repository[0] === '@' ? 1 : 6
+        );
+        const alias = config.aliases[repoWithPrefixRemoved];
         if (alias) {
           res.registryUrls = [alias];
           return res;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:
Helm repository aliases may alternatively also be specified using `alias:` as prefix instead of `@`. This MR adds support for that syntax
<!-- Describe what behavior is changed by this PR. -->

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
