### PR TITLE
fix(npm): use configured npmrc

### DIFF
--- a/lib/manager/npm/extract/__snapshots__/index.spec.ts.snap
+++ b/lib/manager/npm/extract/__snapshots__/index.spec.ts.snap
@@ -882,7 +882,7 @@ Object {
     "lernaJsonFile": undefined,
   },
   "npmLock": undefined,
-  "npmrc": undefined,
+  "npmrc": "",
   "packageFile": "package.json",
   "packageFileVersion": "1.0.0",
   "packageJsonName": "renovate",

--- a/lib/manager/npm/extract/index.spec.ts
+++ b/lib/manager/npm/extract/index.spec.ts
@@ -80,7 +80,7 @@ describe('manager/npm/extract', () => {
       const res = await npmExtract.extractPackageFile(
         input01Content,
         'package.json',
-        defaultConfig
+        { ...defaultConfig, npmrc: 'some-npmrc' }
       );
       expect(res).toMatchSnapshot();
     });
@@ -94,7 +94,7 @@ describe('manager/npm/extract', () => {
       const res = await npmExtract.extractPackageFile(
         input01Content,
         'package.json',
-        defaultConfig
+        { ...defaultConfig, ignoreNpmrcFile: true }
       );
       expect(res).toMatchSnapshot();
     });

--- a/lib/manager/npm/extract/index.ts
+++ b/lib/manager/npm/extract/index.ts
@@ -92,8 +92,9 @@ export async function extractPackageFile(
 
   let npmrc: string;
   const npmrcFileName = getSiblingFileName(fileName, '.npmrc');
-  // istanbul ignore if
-  if (config.ignoreNpmrcFile) {
+  if (is.string(config.npmrc)) {
+    logger.debug('Using configured npmrc');
+  } else if (config.ignoreNpmrcFile) {
     npmrc = '';
   } else {
     npmrc = await readLocalFile(npmrcFileName, 'utf8');

--- a/lib/manager/types.ts
+++ b/lib/manager/types.ts
@@ -24,6 +24,7 @@ export interface ExtractConfig extends ManagerConfig {
   gradle?: { timeout?: number };
   aliases?: Record<string, string>;
   ignoreNpmrcFile?: boolean;
+  npmrc?: string;
   yarnrc?: string;
   skipInstalls?: boolean;
   versioning?: string;

--- a/lib/util/cache/repository/index.ts
+++ b/lib/util/cache/repository/index.ts
@@ -9,7 +9,7 @@ import type { PackageFile } from '../../../manager/types';
 import type { RepoInitConfig } from '../../../workers/repository/init/common';
 
 // Increment this whenever there could be incompatibilities between old and new cache structure
-export const CACHE_REVISION = 6;
+export const CACHE_REVISION = 7;
 
 export interface BaseBranchCache {
   sha: string; // branch commit sha


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Does not set `npmrc` to `""` if it already has a value.

## Context:

Fixes npmrc regression problem

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
