### PR TITLE
docs: tell Yarn users to match baseUrl of registry

### DIFF
--- a/docs/usage/setup-azure-devops.md
+++ b/docs/usage/setup-azure-devops.md
@@ -79,6 +79,32 @@ module.exports = {
 For the `endpoint` key, replace `YOUR-ORG` with your Azure DevOps organization.
 For the `repositories` key, replace `YOUR-PROJECT/YOUR-REPO` with your Azure DevOps project and repository.
 
+### Yarn users
+
+To do a succesfull `yarn install` you need to match the URL of the registry fully.
+Use the `baseUrl` config option to specify the full path to the registry.
+
+```javascript
+module.exports = {
+  platform: 'azure',
+  endpoint: 'https://<redacted>.visualstudio.com/',
+  token: process.env.TOKEN,
+  hostRules: [
+    {
+      baseUrl:
+        'https://<redacted>.pkgs.visualstudio.com/_packaging/<redacted>/npm/registry/',
+      token: process.env.TOKEN,
+      hostType: 'npm',
+    },
+    {
+      domainName: 'github.com',
+      token: process.env.GITHUB_COM_TOKEN,
+    },
+  ],
+  repositories: ['YOUR-PROJECT/YOUR-REPO'],
+};
+```
+
 ### Add renovate.json file
 
 Additionally, you can create a `renovate.json` file which holds the Renovate configuration, in the root of the repo.

--- a/docs/usage/setup-azure-devops.md
+++ b/docs/usage/setup-azure-devops.md
@@ -87,12 +87,12 @@ Use the `baseUrl` config option to specify the full path to the registry.
 ```javascript
 module.exports = {
   platform: 'azure',
-  endpoint: 'https://<redacted>.visualstudio.com/',
+  endpoint: 'https://myorg.visualstudio.com/',
   token: process.env.TOKEN,
   hostRules: [
     {
       baseUrl:
-        'https://<redacted>.pkgs.visualstudio.com/_packaging/<redacted>/npm/registry/',
+        'https://myorg.pkgs.visualstudio.com/_packaging/myorg/npm/registry/',
       token: process.env.TOKEN,
       hostType: 'npm',
     },
@@ -108,7 +108,7 @@ module.exports = {
 Put this in your repository's `.npmrc` file:
 
 ```ini
-registry=https://<redacted>.pkgs.visualstudio.com/_packaging/<redacted>/npm/registry/
+registry=https://myorg.pkgs.visualstudio.com/_packaging/myorg/npm/registry/
 always-auth=true
 ```
 

--- a/docs/usage/setup-azure-devops.md
+++ b/docs/usage/setup-azure-devops.md
@@ -105,6 +105,13 @@ module.exports = {
 };
 ```
 
+Put this in your repository's `.npmrc` file:
+
+```ini
+registry=https://<redacted>.pkgs.visualstudio.com/_packaging/<redacted>/npm/registry/
+always-auth=true
+```
+
 ### Add renovate.json file
 
 Additionally, you can create a `renovate.json` file which holds the Renovate configuration, in the root of the repo.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

- Improve Azure devops docs with Yarn instructions

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

@viceice asked me to put their working example in the Azure devops docs in https://github.com/renovatebot/renovate/discussions/9310#discussioncomment-546589.

I've put the config example plus some text in a new section for Yarn users, but maybe this is meant to be a general instruction?

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
