### PR TITLE
feat(npm): deprecate ignoreNpmrcFile

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -969,13 +969,6 @@ The above is the same as if you wrote this package rule:
 }
 ```
 
-## ignoreNpmrcFile
-
-By default, Renovate will look for and use any `.npmrc` file it finds in a repository.
-Additionally, it will be read in by `npm` or `yarn` at the time of lock file generation.
-Sometimes this causes problems, for example if the file contains placeholder values, so you can configure this to `true` and Renovate will ignore any `.npmrc` files it finds and temporarily remove the file before running `npm install` or `yarn install`.
-Renovate will try to configure this to `true` also if you have configured any `npmrc` string within your config file.
-
 ## ignorePaths
 
 Using this setting, you can selectively ignore package files that you don't want Renovate autodiscovering.

--- a/lib/config/__snapshots__/migration.spec.ts.snap
+++ b/lib/config/__snapshots__/migration.spec.ts.snap
@@ -120,6 +120,7 @@ Object {
   "minor": Object {
     "automerge": true,
   },
+  "npmrc": "",
   "nvmrc": Object {
     "packageRules": Array [
       Object {

--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -544,12 +544,6 @@ const options: RenovateOptions[] = [
     admin: true,
   },
   {
-    name: 'ignoreNpmrcFile',
-    description: 'Whether to ignore any .npmrc file found in repository.',
-    type: 'boolean',
-    default: false,
-  },
-  {
     name: 'autodiscover',
     description: 'Autodiscover all repositories.',
     stage: 'global',

--- a/lib/config/migration.spec.ts
+++ b/lib/config/migration.spec.ts
@@ -34,6 +34,7 @@ describe('config/migration', () => {
         onboarding: 'false' as never,
         multipleMajorPrs: true,
         gitFs: false,
+        ignoreNpmrcFile: true,
         separateMajorReleases: true,
         separatePatchReleases: true,
         suppressNotifications: ['lockFileErrors', 'prEditNotification'],

--- a/lib/config/migration.ts
+++ b/lib/config/migration.ts
@@ -195,6 +195,9 @@ export function migrateConfig(
         } else if (val === false) {
           migratedConfig.trustLevel = 'low';
         }
+      } else if (key === 'ignoreNpmrcFile') {
+        delete migratedConfig.ignoreNpmrcFile;
+        migratedConfig.npmrc ||= '';
       } else if (
         key === 'branchName' &&
         is.string(val) &&

--- a/lib/manager/npm/extract/__snapshots__/index.spec.ts.snap
+++ b/lib/manager/npm/extract/__snapshots__/index.spec.ts.snap
@@ -882,7 +882,7 @@ Object {
     "lernaJsonFile": undefined,
   },
   "npmLock": undefined,
-  "npmrc": "",
+  "npmrc": undefined,
   "packageFile": "package.json",
   "packageFileVersion": "1.0.0",
   "packageJsonName": "renovate",

--- a/lib/manager/npm/extract/index.spec.ts
+++ b/lib/manager/npm/extract/index.spec.ts
@@ -94,7 +94,7 @@ describe('manager/npm/extract', () => {
       const res = await npmExtract.extractPackageFile(
         input01Content,
         'package.json',
-        { ...defaultConfig, ignoreNpmrcFile: true }
+        defaultConfig
       );
       expect(res).toMatchSnapshot();
     });
@@ -111,20 +111,6 @@ describe('manager/npm/extract', () => {
         {}
       );
       expect(res.npmrc).toBeDefined();
-    });
-    it('ignores .npmrc when ignoreNpmrcFile', async () => {
-      fs.readLocalFile = jest.fn((fileName) => {
-        if (fileName === '.npmrc') {
-          return 'some-npmrc\n';
-        }
-        return null;
-      });
-      const res = await npmExtract.extractPackageFile(
-        input01Content,
-        'package.json',
-        { ignoreNpmrcFile: true }
-      );
-      expect(res.npmrc).toEqual('');
     });
     it('ignores .npmrc when config.npmrc is defined', async () => {
       fs.readLocalFile = jest.fn((fileName) => {

--- a/lib/manager/npm/extract/index.spec.ts
+++ b/lib/manager/npm/extract/index.spec.ts
@@ -112,6 +112,34 @@ describe('manager/npm/extract', () => {
       );
       expect(res.npmrc).toBeDefined();
     });
+    it('ignores .npmrc when ignoreNpmrcFile', async () => {
+      fs.readLocalFile = jest.fn((fileName) => {
+        if (fileName === '.npmrc') {
+          return 'some-npmrc\n';
+        }
+        return null;
+      });
+      const res = await npmExtract.extractPackageFile(
+        input01Content,
+        'package.json',
+        { ignoreNpmrcFile: true }
+      );
+      expect(res.npmrc).toEqual('');
+    });
+    it('ignores .npmrc when config.npmrc is defined', async () => {
+      fs.readLocalFile = jest.fn((fileName) => {
+        if (fileName === '.npmrc') {
+          return 'some-npmrc\n';
+        }
+        return null;
+      });
+      const res = await npmExtract.extractPackageFile(
+        input01Content,
+        'package.json',
+        { npmrc: 'some-configured-npmrc' }
+      );
+      expect(res.npmrc).toBeUndefined();
+    });
     it('finds and discards .npmrc', async () => {
       fs.readLocalFile = jest.fn((fileName) => {
         if (fileName === '.npmrc') {

--- a/lib/manager/npm/extract/index.ts
+++ b/lib/manager/npm/extract/index.ts
@@ -94,10 +94,7 @@ export async function extractPackageFile(
   const npmrcFileName = getSiblingFileName(fileName, '.npmrc');
   const npmrcFileContent = await readLocalFile(npmrcFileName, 'utf8');
   if (is.string(npmrcFileContent)) {
-    if (config.ignoreNpmrcFile) {
-      logger.debug({ npmrcFileName }, 'Ignoring .npmrc file in repository');
-      npmrc = '';
-    } else if (is.string(config.npmrc)) {
+    if (is.string(config.npmrc)) {
       // configured npmrc takes precedence over repository .npmrc
       // This could include an empty string used to blank the .npmrc
       logger.debug(
@@ -124,8 +121,6 @@ export async function extractPackageFile(
           .join('\n');
       }
     }
-  } else if (config.ignoreNpmrcFile) {
-    npmrc = '';
   }
   const yarnrcFileName = getSiblingFileName(fileName, '.yarnrc');
   let yarnrc;

--- a/lib/manager/types.ts
+++ b/lib/manager/types.ts
@@ -23,7 +23,6 @@ export interface ExtractConfig extends ManagerConfig {
   endpoint?: string;
   gradle?: { timeout?: number };
   aliases?: Record<string, string>;
-  ignoreNpmrcFile?: boolean;
   npmrc?: string;
   yarnrc?: string;
   skipInstalls?: boolean;

--- a/lib/workers/repository/init/config.ts
+++ b/lib/workers/repository/init/config.ts
@@ -196,7 +196,6 @@ export async function mergeRenovateConfig(
       'Ignoring any .npmrc files in repository due to configured npmrc'
     );
     npmApi.setNpmrc(resolvedConfig.npmrc);
-    resolvedConfig.ignoreNpmrcFile = true;
   }
   // istanbul ignore if
   if (resolvedConfig.hostRules) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Deprecates ignoreNpmrcFile option. Instead, an empty string for `npmrc` can be used.

## Context:

Technical debt refactoring.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
