### PR TITLE
feat(pipenv): allow to inject custom env variables

### DIFF
--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -48,3 +48,9 @@ If set to any string, Renovate will use this as the `user-agent` it sends with H
 
 If set to any value, Renovate will use a "hard" `process.exit()` once all work is done, even if a sub-process is otherwise delaying Node.js from exiting.
 See <https://github.com/renovatebot/renovate/issues/8660> for background on why this was created.
+
+## PIPENV*ENV*{ENVIRONMENT_KEY}
+
+If set to any value, Renovate will pass whatever the variables is behind `PIPENV_ENV_` for calls to `pipenv lock` for maintaining
+the `Pipfile.lock` file.
+See <https://github.com/renovatebot/renovate/issues/4487> for background on why this exists.

--- a/lib/manager/pipenv/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/manager/pipenv/__snapshots__/artifacts.spec.ts.snap
@@ -35,6 +35,31 @@ Array [
 ]
 `;
 
+exports[`.updateArtifacts() injects environment variables 1`] = `
+Array [
+  Object {
+    "cmd": "pipenv lock",
+    "options": Object {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": Object {
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+        "PIPENV_CACHE_DIR": "/tmp/renovate/cache/others/pipenv",
+        "TEST_VALUE": "this is a test",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+]
+`;
+
 exports[`.updateArtifacts() returns null if unchanged 1`] = `
 Array [
   Object {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

This PR allows to inject custom environment variables for the `pipenv lock` run. As the `pipenv` tool uses environment variables to handle secrets for private registries. It is used for self hosted runners and includes all environment variables which are prefixed with `PIPENV_ENV_`.

## Context:

This handles for self hosted configuration the support for private configuration in pipenv https://github.com/renovatebot/renovate/issues/4487 

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
