### PR TITLE
fix(github): catch branch protection and raise config error

### DIFF
--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -713,6 +713,13 @@ export async function commitFiles({
       );
       return null;
     }
+    if (err.message.includes('protected branch hook declined')) {
+      const error = new Error(CONFIG_VALIDATION);
+      error.configFile = branchName;
+      error.validationError = 'Renovate branch is protected';
+      error.validationMessage = `Renovate cannot push to its branch because branch protection has been enabled.`;
+      throw error;
+    }
     if (err.message.includes('remote: error: cannot lock ref')) {
       logger.error({ err }, 'Error committing files.');
       return null;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Catches when Renovate fails to push to a branch because of (mistaken) branch protection. Raises a config warning instead.

## Context:

Seeing the occasional error like this in the app:

```
To https://github.com/something/overlay.git
! refs/heads/renovate/configure:refs/heads/renovate/configure [remote rejected] (protected branch hook declined)
Done
Pushing to https://github.com/something/overlay.git
POST git-receive-pack (954 bytes)
remote: error: GH006: Protected branch update failed for refs/heads/renovate/configure. 
remote: error: 4 of 4 required status checks are expected. At least 2 approving reviews are required by reviewers with write access. 
error: failed to push some refs to 'https://github.com/something/overlay.git'
```

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
