### PR TITLE
fix: catch unknown datasource early

### DIFF
--- a/lib/workers/repository/process/lookup/index.spec.ts
+++ b/lib/workers/repository/process/lookup/index.spec.ts
@@ -51,6 +51,11 @@ describe('workers/repository/process/lookup', () => {
   });
 
   describe('.lookupUpdates()', () => {
+    it('returns null if unknown datasource', async () => {
+      config.depName = 'some-dep';
+      config.datasource = 'does not exist';
+      expect((await lookup.lookupUpdates(config)).updates).toEqual([]);
+    });
     it('returns rollback for pinned version', async () => {
       config.currentValue = '0.9.99';
       config.depName = 'q';

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -1,6 +1,7 @@
 import type { ValidationMessage } from '../../../../config/types';
 import {
   Release,
+  getDatasourceList,
   getDefaultVersioning,
   getDigest,
   getPkgReleases,
@@ -45,7 +46,10 @@ export async function lookupUpdates(
   );
   const res: UpdateResult = { updates: [], warnings: [] } as any;
   // istanbul ignore if
-  if (!isGetPkgReleasesConfig(config)) {
+  if (
+    !isGetPkgReleasesConfig(config) ||
+    !getDatasourceList().includes(datasource)
+  ) {
     res.skipReason = SkipReason.InvalidConfig;
     return res;
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Checks the datasource value early to check if it is valid.

## Context:

A regex manager template can produce an invalid datasource. Without this check, it gets caught much later on as an unhandled error.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
