### PR TITLE
refactor: config warning/error fields

### DIFF
--- a/lib/config/__snapshots__/migrate-validate.spec.ts.snap
+++ b/lib/config/__snapshots__/migrate-validate.spec.ts.snap
@@ -11,8 +11,8 @@ exports[`config/migrate-validate migrateAndValidate() handles invalid 1`] = `
 Object {
   "errors": Array [
     Object {
-      "depName": "Configuration Error",
       "message": "Invalid configuration option: foo",
+      "topic": "Configuration Error",
     },
   ],
   "foo": "none",

--- a/lib/config/__snapshots__/validation.spec.ts.snap
+++ b/lib/config/__snapshots__/validation.spec.ts.snap
@@ -3,12 +3,12 @@
 exports[`config/validation validateConfig(config) catches invalid allowedVersions regex 1`] = `
 Array [
   Object {
-    "depName": "Configuration Error",
     "message": "Invalid regExp for packageRules[1].allowedVersions: \`/***$}{]][/\`",
+    "topic": "Configuration Error",
   },
   Object {
-    "depName": "Configuration Error",
     "message": "Invalid regExp for packageRules[3].allowedVersions: \`!/***$}{]][/\`",
+    "topic": "Configuration Error",
   },
 ]
 `;
@@ -16,12 +16,12 @@ Array [
 exports[`config/validation validateConfig(config) catches invalid matchCurrentVersion regex 1`] = `
 Array [
   Object {
-    "depName": "Configuration Error",
     "message": "Invalid regExp for packageRules[1].matchCurrentVersion: \`/***$}{]][/\`",
+    "topic": "Configuration Error",
   },
   Object {
-    "depName": "Configuration Error",
     "message": "Invalid regExp for packageRules[3].matchCurrentVersion: \`!/***$}{]][/\`",
+    "topic": "Configuration Error",
   },
 ]
 `;
@@ -29,8 +29,8 @@ Array [
 exports[`config/validation validateConfig(config) catches invalid templates 1`] = `
 Array [
   Object {
-    "depName": "Configuration Error",
     "message": "Invalid template in config path: commitMessage",
+    "topic": "Configuration Error",
   },
 ]
 `;
@@ -38,52 +38,52 @@ Array [
 exports[`config/validation validateConfig(config) errors for all types 1`] = `
 Array [
   Object {
-    "depName": "Configuration Error",
     "message": "Configuration option \`enabled\` should be boolean. Found: 1 (number)",
+    "topic": "Configuration Error",
   },
   Object {
-    "depName": "Configuration Error",
     "message": "Configuration option \`labels\` should be a list (Array)",
+    "topic": "Configuration Error",
   },
   Object {
-    "depName": "Configuration Error",
     "message": "Configuration option \`lockFileMaintenance\` should be a json object",
+    "topic": "Configuration Error",
   },
   Object {
-    "depName": "Configuration Error",
     "message": "Configuration option \`packageRules[3].matchPackagePatterns\` should be a list (Array)",
+    "topic": "Configuration Error",
   },
   Object {
-    "depName": "Configuration Error",
     "message": "Configuration option \`semanticCommitType\` should be a string",
+    "topic": "Configuration Error",
   },
   Object {
-    "depName": "Configuration Error",
     "message": "Invalid configuration option: packageRules[1].foo",
+    "topic": "Configuration Error",
   },
   Object {
-    "depName": "Configuration Error",
     "message": "Invalid regExp for packageRules[3].excludePackagePatterns: \`abc ([a-z]+) ([a-z]+))\`",
+    "topic": "Configuration Error",
   },
   Object {
-    "depName": "Configuration Error",
     "message": "Invalid schedule: \`Invalid schedule: \\"every 15 mins every weekday\\" should not specify minutes\`",
+    "topic": "Configuration Error",
   },
   Object {
-    "depName": "Configuration Error",
     "message": "extends: Invalid schedule: Unsupported timezone Europe/Brussel",
+    "topic": "Configuration Error",
   },
   Object {
-    "depName": "Configuration Error",
     "message": "packageRules must contain JSON objects",
+    "topic": "Configuration Error",
   },
   Object {
-    "depName": "Configuration Error",
     "message": "packageRules: Each packageRule must contain at least one selector (matchFiles, matchPaths, matchLanguages, matchBaseBranches, matchManagers, matchDatasources, matchDepTypes, matchPackageNames, matchPackagePatterns, excludePackageNames, excludePackagePatterns, matchCurrentVersion, matchSourceUrlPrefixes, matchUpdateTypes). If you wish for configuration to apply to all packages, it is not necessary to place it inside a packageRule at all.",
+    "topic": "Configuration Error",
   },
   Object {
-    "depName": "Configuration Error",
     "message": "timezone: Invalid schedule: Unsupported timezone Asia",
+    "topic": "Configuration Error",
   },
 ]
 `;
@@ -91,12 +91,12 @@ Array [
 exports[`config/validation validateConfig(config) errors for unsafe fileMatches 1`] = `
 Array [
   Object {
-    "depName": "Configuration Error",
     "message": "Invalid regExp for dockerfile.fileMatch: \`x?+\`",
+    "topic": "Configuration Error",
   },
   Object {
-    "depName": "Configuration Error",
     "message": "Invalid regExp for npm.fileMatch: \`abc ([a-z]+) ([a-z]+))\`",
+    "topic": "Configuration Error",
   },
 ]
 `;
@@ -104,8 +104,8 @@ Array [
 exports[`config/validation validateConfig(config) errors if aliases depth is more than 1 1`] = `
 Array [
   Object {
-    "depName": "Configuration Error",
     "message": "Invalid alias object configuration",
+    "topic": "Configuration Error",
   },
 ]
 `;
@@ -113,8 +113,8 @@ Array [
 exports[`config/validation validateConfig(config) errors if aliases have invalid url 1`] = `
 Array [
   Object {
-    "depName": "Configuration Error",
     "message": "Invalid alias object configuration",
+    "topic": "Configuration Error",
   },
 ]
 `;
@@ -122,8 +122,8 @@ Array [
 exports[`config/validation validateConfig(config) errors if fileMatch has wrong parent 1`] = `
 Array [
   Object {
-    "depName": "Config error",
     "message": "\\"fileMatch\\" may not be defined at the top level of a config and must instead be within a manager block",
+    "topic": "Config error",
   },
 ]
 `;
@@ -131,8 +131,8 @@ Array [
 exports[`config/validation validateConfig(config) errors if fileMatch has wrong parent 2`] = `
 Array [
   Object {
-    "depName": "Config warning",
     "message": "\\"fileMatch\\" must be configured in a manager block and not here: npm.gradle",
+    "topic": "Config warning",
   },
 ]
 `;
@@ -140,8 +140,8 @@ Array [
 exports[`config/validation validateConfig(config) errors if regexManager fields are missing 1`] = `
 Array [
   Object {
-    "depName": "Configuration Error",
     "message": "Regex Managers must contain currentValueTemplate configuration or regex group named currentValue",
+    "topic": "Configuration Error",
   },
 ]
 `;
@@ -151,12 +151,12 @@ exports[`config/validation validateConfig(config) ignore packageRule nesting val
 exports[`config/validation validateConfig(config) included managers of the wrong type 1`] = `
 Array [
   Object {
-    "depName": "Configuration Error",
     "message": "Configuration option \`packageRules[0].matchManagers\` should be a list (Array)",
+    "topic": "Configuration Error",
   },
   Object {
-    "depName": "Configuration Error",
     "message": "packageRules: Managers should be type of List. You have included string.",
+    "topic": "Configuration Error",
   },
 ]
 `;
@@ -164,8 +164,8 @@ Array [
 exports[`config/validation validateConfig(config) returns deprecation warnings 1`] = `
 Array [
   Object {
-    "depName": "Deprecation Warning",
     "message": "Direct editing of prTitle is now deprecated. Please edit commitMessage subcomponents instead as they will be passed through to prTitle.",
+    "topic": "Deprecation Warning",
   },
 ]
 `;
@@ -173,16 +173,16 @@ Array [
 exports[`config/validation validateConfig(config) returns nested errors 1`] = `
 Array [
   Object {
-    "depName": "Configuration Error",
     "message": "Invalid configuration option: foo",
+    "topic": "Configuration Error",
   },
   Object {
-    "depName": "Configuration Error",
     "message": "Invalid configuration option: lockFileMaintenance.bar",
+    "topic": "Configuration Error",
   },
   Object {
-    "depName": "Configuration Error",
     "message": "Invalid regExp for packageRules[0].excludePackagePatterns: \`abc ([a-z]+) ([a-z]+))\`",
+    "topic": "Configuration Error",
   },
 ]
 `;
@@ -190,12 +190,12 @@ Array [
 exports[`config/validation validateConfig(config) selectors outside packageRules array trigger errors 1`] = `
 Array [
   Object {
-    "depName": "Configuration Error",
     "message": "docker.minor.matchPackageNames: matchPackageNames should be inside a \`packageRule\` only",
+    "topic": "Configuration Error",
   },
   Object {
-    "depName": "Configuration Error",
     "message": "matchPackageNames: matchPackageNames should be inside a \`packageRule\` only",
+    "topic": "Configuration Error",
   },
 ]
 `;
@@ -203,8 +203,8 @@ Array [
 exports[`config/validation validateConfig(config) validates regEx for each fileMatch 1`] = `
 Array [
   Object {
-    "depName": "Configuration Error",
     "message": "Invalid regExp for regexManagers[0].fileMatch: \`***$}{]][\`",
+    "topic": "Configuration Error",
   },
 ]
 `;

--- a/lib/config/presets/index.spec.ts
+++ b/lib/config/presets/index.spec.ts
@@ -56,7 +56,7 @@ describe('config/presets', () => {
         e = err;
       }
       expect(e).toBeDefined();
-      expect(e.configFile).toMatchSnapshot();
+      expect(e.location).toMatchSnapshot();
       expect(e.validationError).toMatchSnapshot();
       expect(e.validationMessage).toMatchSnapshot();
     });
@@ -70,7 +70,7 @@ describe('config/presets', () => {
         e = err;
       }
       expect(e).toBeDefined();
-      expect(e.configFile).toMatchSnapshot();
+      expect(e.location).toMatchSnapshot();
       expect(e.validationError).toMatchSnapshot();
       expect(e.validationMessage).toMatchSnapshot();
     });
@@ -85,7 +85,7 @@ describe('config/presets', () => {
         e = err;
       }
       expect(e).toBeDefined();
-      expect(e.configFile).toMatchSnapshot();
+      expect(e.location).toMatchSnapshot();
       expect(e.validationError).toMatchSnapshot();
       expect(e.validationMessage).toMatchSnapshot();
     });
@@ -100,7 +100,7 @@ describe('config/presets', () => {
         e = err;
       }
       expect(e).toBeDefined();
-      expect(e.configFile).toMatchSnapshot();
+      expect(e.location).toMatchSnapshot();
       expect(e.validationError).toMatchSnapshot();
       expect(e.validationMessage).toMatchSnapshot();
     });
@@ -115,7 +115,7 @@ describe('config/presets', () => {
         e = err;
       }
       expect(e).toBeDefined();
-      expect(e.configFile).toMatchSnapshot();
+      expect(e.location).toMatchSnapshot();
       expect(e.validationError).toMatchSnapshot();
       expect(e.validationMessage).toMatchSnapshot();
     });
@@ -130,7 +130,7 @@ describe('config/presets', () => {
         e = err;
       }
       expect(e).toBeDefined();
-      expect(e.configFile).toMatchSnapshot();
+      expect(e.location).toMatchSnapshot();
       expect(e.validationError).toMatchSnapshot();
       expect(e.validationMessage).toMatchSnapshot();
     });
@@ -153,7 +153,7 @@ describe('config/presets', () => {
         e = err;
       }
       expect(e).toBeDefined();
-      expect(e.configFile).toMatchSnapshot();
+      expect(e.location).toMatchSnapshot();
       expect(e.validationError).toMatchSnapshot();
       expect(e.validationMessage).toMatchSnapshot();
     });
@@ -414,7 +414,7 @@ describe('config/presets', () => {
         e = err;
       }
       expect(e).toBeDefined();
-      expect(e.configFile).toMatchSnapshot();
+      expect(e.location).toMatchSnapshot();
       expect(e.validationError).toMatchSnapshot();
       expect(e.validationMessage).toMatchSnapshot();
     });
@@ -426,7 +426,7 @@ describe('config/presets', () => {
         e = err;
       }
       expect(e).toBeDefined();
-      expect(e.configFile).toMatchSnapshot();
+      expect(e.location).toMatchSnapshot();
       expect(e.validationError).toMatchSnapshot();
       expect(e.validationMessage).toMatchSnapshot();
     });
@@ -438,7 +438,7 @@ describe('config/presets', () => {
         e = err;
       }
       expect(e).toBeDefined();
-      expect(e.configFile).toMatchSnapshot();
+      expect(e.location).toMatchSnapshot();
       expect(e.validationError).toMatchSnapshot();
       expect(e.validationMessage).toMatchSnapshot();
     });
@@ -450,7 +450,7 @@ describe('config/presets', () => {
         e = err;
       }
       expect(e).toBeDefined();
-      expect(e.configFile).toMatchSnapshot();
+      expect(e.location).toMatchSnapshot();
       expect(e.validationError).toMatchSnapshot();
       expect(e.validationMessage).toMatchSnapshot();
     });

--- a/lib/config/secrets.ts
+++ b/lib/config/secrets.ts
@@ -64,7 +64,7 @@ function replaceSecretsInString(
   const disallowedPrefixes = ['branch', 'commit', 'group', 'pr', 'semantic'];
   if (disallowedPrefixes.some((prefix) => key.startsWith(prefix))) {
     const error = new Error(CONFIG_VALIDATION);
-    error.configFile = 'config';
+    error.location = 'config';
     error.validationError = 'Disallowed secret substitution';
     error.validationMessage = `The field ${key} may not use secret substitution`;
     throw error;
@@ -74,7 +74,7 @@ function replaceSecretsInString(
       return secrets[secretName];
     }
     const error = new Error(CONFIG_VALIDATION);
-    error.configFile = 'config';
+    error.location = 'config';
     error.validationError = 'Unknown secret name';
     error.validationMessage = `The following secret name was not found in config: ${String(
       secretName

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -240,7 +240,7 @@ export interface PackageRule
 }
 
 export interface ValidationMessage {
-  depName: string;
+  topic: string;
   message: string;
 }
 

--- a/lib/config/validation-helpers/managers.ts
+++ b/lib/config/validation-helpers/managers.ts
@@ -33,7 +33,7 @@ export function check({
   return managersErrMessage
     ? [
         {
-          depName: 'Configuration Error',
+          topic: 'Configuration Error',
           message: managersErrMessage,
         },
       ]

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -91,7 +91,7 @@ export async function validateConfig(
     // istanbul ignore if
     if (key === '__proto__') {
       errors.push({
-        depName: 'Config security error',
+        topic: 'Config security error',
         message: '__proto__',
       });
       continue; // eslint-disable-line
@@ -99,12 +99,12 @@ export async function validateConfig(
     if (key === 'fileMatch') {
       if (parentPath === undefined) {
         errors.push({
-          depName: 'Config error',
+          topic: 'Config error',
           message: `"fileMatch" may not be defined at the top level of a config and must instead be within a manager block`,
         });
       } else if (!isManagerPath(parentPath)) {
         warnings.push({
-          depName: 'Config warning',
+          topic: 'Config warning',
           message: `"fileMatch" must be configured in a manager block and not here: ${parentPath}`,
         });
       }
@@ -115,7 +115,7 @@ export async function validateConfig(
     ) {
       if (getDeprecationMessage(key)) {
         warnings.push({
-          depName: 'Deprecation Warning',
+          topic: 'Deprecation Warning',
           message: getDeprecationMessage(key),
         });
       }
@@ -133,21 +133,21 @@ export async function validateConfig(
           template.compile(res, config, false);
         } catch (err) {
           errors.push({
-            depName: 'Configuration Error',
+            topic: 'Configuration Error',
             message: `Invalid template in config path: ${currentPath}`,
           });
         }
       }
       if (!optionTypes[key]) {
         errors.push({
-          depName: 'Configuration Error',
+          topic: 'Configuration Error',
           message: `Invalid configuration option: ${currentPath}`,
         });
       } else if (key === 'schedule') {
         const [validSchedule, errorMessage] = hasValidSchedule(val as string[]);
         if (!validSchedule) {
           errors.push({
-            depName: 'Configuration Error',
+            topic: 'Configuration Error',
             message: `Invalid ${currentPath}: \`${errorMessage}\``,
           });
         }
@@ -157,7 +157,7 @@ export async function validateConfig(
       ) {
         if (!configRegexPredicate(val)) {
           errors.push({
-            depName: 'Configuration Error',
+            topic: 'Configuration Error',
             message: `Invalid regExp for ${currentPath}: \`${val}\``,
           });
         }
@@ -165,7 +165,7 @@ export async function validateConfig(
         const [validTimezone, errorMessage] = hasValidTimezone(val as string);
         if (!validTimezone) {
           errors.push({
-            depName: 'Configuration Error',
+            topic: 'Configuration Error',
             message: `${currentPath}: ${errorMessage}`,
           });
         }
@@ -174,7 +174,7 @@ export async function validateConfig(
         if (type === 'boolean') {
           if (val !== true && val !== false) {
             errors.push({
-              depName: 'Configuration Error',
+              topic: 'Configuration Error',
               message: `Configuration option \`${currentPath}\` should be boolean. Found: ${JSON.stringify(
                 val
               )} (${typeof val})`,
@@ -204,14 +204,14 @@ export async function validateConfig(
                     );
                     if (!validTimezone) {
                       errors.push({
-                        depName: 'Configuration Error',
+                        topic: 'Configuration Error',
                         message: `${currentPath}: ${errorMessage}`,
                       });
                     }
                   }
                 } else {
                   errors.push({
-                    depName: 'Configuration Warning',
+                    topic: 'Configuration Warning',
                     message: `${currentPath}: preset value is not a string`,
                   });
                 }
@@ -255,13 +255,13 @@ export async function validateConfig(
                       ', '
                     )}). If you wish for configuration to apply to all packages, it is not necessary to place it inside a packageRule at all.`;
                     errors.push({
-                      depName: 'Configuration Error',
+                      topic: 'Configuration Error',
                       message,
                     });
                   }
                 } else {
                   errors.push({
-                    depName: 'Configuration Error',
+                    topic: 'Configuration Error',
                     message: `${currentPath} must contain JSON objects`,
                   });
                 }
@@ -290,7 +290,7 @@ export async function validateConfig(
                     (k) => !allowedKeys.includes(k)
                   );
                   errors.push({
-                    depName: 'Configuration Error',
+                    topic: 'Configuration Error',
                     message: `Regex Manager contains disallowed fields: ${disallowedKeys.join(
                       ', '
                     )}`,
@@ -303,7 +303,7 @@ export async function validateConfig(
                       validRegex = true;
                     } catch (e) {
                       errors.push({
-                        depName: 'Configuration Error',
+                        topic: 'Configuration Error',
                         message: `Invalid regExp for ${currentPath}: \`${String(
                           matchString
                         )}\``,
@@ -324,7 +324,7 @@ export async function validateConfig(
                         )
                       ) {
                         errors.push({
-                          depName: 'Configuration Error',
+                          topic: 'Configuration Error',
                           message: `Regex Managers must contain ${field}Template configuration or regex group named ${field}`,
                         });
                       }
@@ -332,7 +332,7 @@ export async function validateConfig(
                   }
                 } else {
                   errors.push({
-                    depName: 'Configuration Error',
+                    topic: 'Configuration Error',
                     message: `Each Regex Manager must contain a fileMatch array`,
                   });
                 }
@@ -348,7 +348,7 @@ export async function validateConfig(
                     regEx(pattern);
                   } catch (e) {
                     errors.push({
-                      depName: 'Configuration Error',
+                      topic: 'Configuration Error',
                       message: `Invalid regExp for ${currentPath}: \`${pattern}\``,
                     });
                   }
@@ -361,7 +361,7 @@ export async function validateConfig(
                   regEx(fileMatch);
                 } catch (e) {
                   errors.push({
-                    depName: 'Configuration Error',
+                    topic: 'Configuration Error',
                     message: `Invalid regExp for ${currentPath}: \`${fileMatch}\``,
                   });
                 }
@@ -373,20 +373,20 @@ export async function validateConfig(
               (parentPath || !isPreset) // top level in a preset
             ) {
               errors.push({
-                depName: 'Configuration Error',
+                topic: 'Configuration Error',
                 message: `${currentPath}: ${key} should be inside a \`packageRule\` only`,
               });
             }
           } else {
             errors.push({
-              depName: 'Configuration Error',
+              topic: 'Configuration Error',
               message: `Configuration option \`${currentPath}\` should be a list (Array)`,
             });
           }
         } else if (type === 'string') {
           if (!is.string(val)) {
             errors.push({
-              depName: 'Configuration Error',
+              topic: 'Configuration Error',
               message: `Configuration option \`${currentPath}\` should be a string`,
             });
           }
@@ -400,7 +400,7 @@ export async function validateConfig(
             if (key === 'aliases') {
               if (!validateAliasObject(key, val)) {
                 errors.push({
-                  depName: 'Configuration Error',
+                  topic: 'Configuration Error',
                   message: `Invalid alias object configuration`,
                 });
               }
@@ -420,7 +420,7 @@ export async function validateConfig(
             }
           } else {
             errors.push({
-              depName: 'Configuration Error',
+              topic: 'Configuration Error',
               message: `Configuration option \`${currentPath}\` should be a json object`,
             });
           }
@@ -430,11 +430,11 @@ export async function validateConfig(
   }
   function sortAll(a: ValidationMessage, b: ValidationMessage): number {
     // istanbul ignore else: currently never happen
-    if (a.depName === b.depName) {
+    if (a.topic === b.topic) {
       return a.message > b.message ? 1 : -1;
     }
     // istanbul ignore next: currently never happen
-    return a.depName > b.depName ? 1 : -1;
+    return a.topic > b.topic ? 1 : -1;
   }
   errors.sort(sortAll);
   warnings.sort(sortAll);

--- a/lib/globals.d.ts
+++ b/lib/globals.d.ts
@@ -3,7 +3,7 @@
  */
 
 declare interface Error {
-  configFile?: string;
+  location?: string;
 
   validationError?: string;
   validationMessage?: string;

--- a/lib/manager/npm/extract/index.ts
+++ b/lib/manager/npm/extract/index.ts
@@ -55,7 +55,7 @@ export async function extractPackageFile(
   }
   if (fileName !== 'package.json' && packageJson.renovate) {
     const error = new Error(CONFIG_VALIDATION);
-    error.configFile = fileName;
+    error.location = fileName;
     error.validationError =
       'Nested package.json must not contain renovate configuration. Please use `packageRules` with `matchPaths` in your main config instead.';
     throw error;

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -705,7 +705,7 @@ export async function commitFiles({
     checkForPlatformFailure(err);
     if (err.message.includes(`'refs/heads/renovate' exists`)) {
       const error = new Error(CONFIG_VALIDATION);
-      error.configFile = 'None';
+      error.location = 'None';
       error.validationError = 'An existing branch is blocking Renovate';
       error.validationMessage = `Renovate needs to create the branch "${branchName}" but is blocked from doing so because of an existing branch called "renovate". Please remove it so that Renovate can proceed.`;
       throw error;
@@ -722,7 +722,7 @@ export async function commitFiles({
     }
     if (err.message.includes('protected branch hook declined')) {
       const error = new Error(CONFIG_VALIDATION);
-      error.configFile = branchName;
+      error.location = branchName;
       error.validationError = 'Renovate branch is protected';
       error.validationMessage = `Renovate cannot push to its branch because branch protection has been enabled.`;
       throw error;

--- a/lib/util/regex.ts
+++ b/lib/util/regex.ts
@@ -21,7 +21,7 @@ export function regEx(pattern: string, flags?: string): RegExp {
     return new RegEx(pattern, flags);
   } catch (err) {
     const error = new Error(CONFIG_VALIDATION);
-    error.configFile = pattern;
+    error.location = pattern;
     error.validationError = `Invalid regular expression: ${pattern}`;
     throw error;
   }

--- a/lib/versioning/regex/index.ts
+++ b/lib/versioning/regex/index.ts
@@ -55,7 +55,7 @@ export class RegExpVersioningApi extends GenericVersioningApi<RegExpVersion> {
       !new_config.includes('<patch>')
     ) {
       const error = new Error(CONFIG_VALIDATION);
-      error.configFile = new_config;
+      error.location = new_config;
       error.validationError =
         'regex versioning needs at least one major, minor or patch group defined';
       throw error;

--- a/lib/workers/repository/error-config.spec.ts
+++ b/lib/workers/repository/error-config.spec.ts
@@ -21,7 +21,7 @@ describe('workers/repository/error-config', () => {
     });
     it('creates issues', async () => {
       const error = new Error(CONFIG_VALIDATION);
-      error.configFile = 'package.json';
+      error.location = 'package.json';
       error.validationMessage = 'some-message';
       platform.ensureIssue.mockResolvedValueOnce('created');
       const res = await raiseConfigWarningIssue(config, error);
@@ -29,7 +29,7 @@ describe('workers/repository/error-config', () => {
     });
     it('creates issues (dryRun)', async () => {
       const error = new Error(CONFIG_VALIDATION);
-      error.configFile = 'package.json';
+      error.location = 'package.json';
       error.validationMessage = 'some-message';
       platform.ensureIssue.mockResolvedValueOnce('created');
       setAdminConfig({ dryRun: true });
@@ -38,7 +38,7 @@ describe('workers/repository/error-config', () => {
     });
     it('handles onboarding', async () => {
       const error = new Error(CONFIG_VALIDATION);
-      error.configFile = 'package.json';
+      error.location = 'package.json';
       error.validationMessage = 'some-message';
       platform.getBranchPr.mockResolvedValue({
         ...mock<Pr>(),
@@ -50,7 +50,7 @@ describe('workers/repository/error-config', () => {
     });
     it('handles onboarding (dryRun)', async () => {
       const error = new Error(CONFIG_VALIDATION);
-      error.configFile = 'package.json';
+      error.location = 'package.json';
       error.validationMessage = 'some-message';
       platform.getBranchPr.mockResolvedValue({
         ...mock<Pr>(),

--- a/lib/workers/repository/error-config.ts
+++ b/lib/workers/repository/error-config.ts
@@ -10,8 +10,8 @@ export async function raiseConfigWarningIssue(
 ): Promise<void> {
   logger.debug('raiseConfigWarningIssue()');
   let body = `There is an error with this repository's Renovate configuration that needs to be fixed. As a precaution, Renovate will stop PRs until it is resolved.\n\n`;
-  if (error.configFile) {
-    body += `File: \`${error.configFile}\`\n`;
+  if (error.location) {
+    body += `Location: \`${error.location}\`\n`;
   }
   body += `Error type: ${error.validationError}\n`;
   if (error.validationMessage) {

--- a/lib/workers/repository/init/config.spec.ts
+++ b/lib/workers/repository/init/config.spec.ts
@@ -103,7 +103,7 @@ describe('workers/repository/init/config', () => {
       git.getFileList.mockResolvedValue(['package.json', '.renovaterc.json']);
       fs.readLocalFile.mockResolvedValue('{}');
       migrateAndValidate.migrateAndValidate.mockResolvedValueOnce({
-        errors: [{ depName: 'dep', message: 'test error' }],
+        errors: [{ topic: 'dep', message: 'test error' }],
       });
       let e: Error;
       try {

--- a/lib/workers/repository/init/config.ts
+++ b/lib/workers/repository/init/config.ts
@@ -138,7 +138,7 @@ export function checkForRepoConfigError(repoConfig: RepoFileConfig): void {
     return;
   }
   const error = new Error(CONFIG_VALIDATION);
-  error.configFile = repoConfig.configFileName;
+  error.location = repoConfig.configFileName;
   error.validationError = repoConfig.configFileParseError.validationError;
   error.validationMessage = repoConfig.configFileParseError.validationMessage;
   throw error;
@@ -162,7 +162,7 @@ export async function mergeRenovateConfig(
   const migratedConfig = await migrateAndValidate(config, configFileParsed);
   if (migratedConfig.errors.length) {
     const error = new Error(CONFIG_VALIDATION);
-    error.configFile = repoConfig.configFileName;
+    error.location = repoConfig.configFileName;
     error.validationError =
       'The renovate configuration file contains some invalid settings';
     error.validationMessage = migratedConfig.errors

--- a/lib/workers/repository/onboarding/pr/errors-warnings.spec.ts
+++ b/lib/workers/repository/onboarding/pr/errors-warnings.spec.ts
@@ -12,7 +12,7 @@ describe('workers/repository/onboarding/pr/errors-warnings', () => {
     it('returns warning text', () => {
       config.warnings = [
         {
-          depName: 'foo',
+          topic: 'foo',
           message: 'Failed to look up dependency',
         },
       ];
@@ -31,7 +31,7 @@ describe('workers/repository/onboarding/pr/errors-warnings', () => {
             packageFile: 'package.json',
             deps: [
               {
-                warnings: [{ message: 'Warning 1', depName: undefined }],
+                warnings: [{ message: 'Warning 1', topic: undefined }],
               },
               {},
             ],
@@ -40,7 +40,7 @@ describe('workers/repository/onboarding/pr/errors-warnings', () => {
             packageFile: 'backend/package.json',
             deps: [
               {
-                warnings: [{ message: 'Warning 1', depName: undefined }],
+                warnings: [{ message: 'Warning 1', topic: undefined }],
               },
             ],
           },
@@ -50,7 +50,7 @@ describe('workers/repository/onboarding/pr/errors-warnings', () => {
             packageFile: 'Dockerfile',
             deps: [
               {
-                warnings: [{ message: 'Warning 2', depName: undefined }],
+                warnings: [{ message: 'Warning 2', topic: undefined }],
               },
             ],
           },
@@ -69,7 +69,7 @@ describe('workers/repository/onboarding/pr/errors-warnings', () => {
     it('returns error text', () => {
       config.errors = [
         {
-          depName: 'renovate.json',
+          topic: 'renovate.json',
           message: 'Failed to parse',
         },
       ];

--- a/lib/workers/repository/onboarding/pr/errors-warnings.ts
+++ b/lib/workers/repository/onboarding/pr/errors-warnings.ts
@@ -10,7 +10,7 @@ export function getWarnings(config: RenovateConfig): string {
   let warningText = `\n# Warnings (${config.warnings.length})\n\n`;
   warningText += `Please correct - or verify that you can safely ignore - these warnings before you merge this PR.\n\n`;
   config.warnings.forEach((w) => {
-    warningText += `-   \`${w.depName}\`: ${w.message}\n`;
+    warningText += `-   \`${w.topic}\`: ${w.message}\n`;
   });
   warningText += '\n---\n';
   return warningText;
@@ -24,7 +24,7 @@ export function getErrors(config: RenovateConfig): string {
   errorText = `\n# Errors (${config.errors.length})\n\n`;
   errorText += `Renovate has found errors that you should fix (in this branch) before finishing this PR.\n\n`;
   config.errors.forEach((e) => {
-    errorText += `-   \`${e.depName}\`: ${e.message}\n`;
+    errorText += `-   \`${e.topic}\`: ${e.message}\n`;
   });
   errorText += '\n---\n';
   return errorText;

--- a/lib/workers/repository/process/lookup/filter.ts
+++ b/lib/workers/repository/process/lookup/filter.ts
@@ -96,7 +96,7 @@ export function filterVersions(
       );
     } else {
       const error = new Error(CONFIG_VALIDATION);
-      error.configFile = 'config';
+      error.location = 'config';
       error.validationError = 'Invalid `allowedVersions`';
       error.validationMessage =
         'The following allowedVersions does not parse as a valid version or range: ' +

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -59,7 +59,7 @@ export async function lookupUpdates(
     if (!dependency) {
       // If dependency lookup fails then warn and return
       const warning: ValidationMessage = {
-        depName,
+        topic: depName,
         message: `Failed to look up dependency ${depName}`,
       };
       logger.debug({ dependency: depName, packageFile }, warning.message);
@@ -98,7 +98,7 @@ export async function lookupUpdates(
       const taggedVersion = dependency.tags[followTag];
       if (!taggedVersion) {
         res.warnings.push({
-          depName,
+          topic: depName,
           message: `Can't find version with tag ${followTag} for ${depName}`,
         });
         return res;
@@ -119,7 +119,7 @@ export async function lookupUpdates(
       // istanbul ignore if
       if (!rollback) {
         res.warnings.push({
-          depName,
+          topic: depName,
           message: `Can't find version matching ${currentValue} for ${depName}`,
         });
         return res;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Refactors two fields in errors/warnings.

## Context:

They were named that way for legacy reasons and became unintuitive.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
