### PR TITLE
feat: Use v1 registry for tags from `quay.io`

### DIFF
--- a/lib/datasource/docker/index.ts
+++ b/lib/datasource/docker/index.ts
@@ -453,7 +453,7 @@ async function getTags(
     let page = 1;
 
     // quay registry returns unordered tags using v2, let's use v1 for now
-    const isQuay = registry.endsWith('.quay.io');
+    const isQuay = registry.endsWith('quay.io');
     if (isQuay) {
       url = `${registry}/api/v1/repository/${repository}/tag/?limit=${limit}&page=${page}`;
     } else {


### PR DESCRIPTION
Since on v2 it returns unordered tags which breaks in certain cases

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Switch to using v1 registry when fetching tags from `quay.io`.

## Context:

Fetching tags from quay using v2 returns tags in an unordered fashion. This means that in large repositories it's possible to never actually get the "latest" tag available. Using v1 in case the registry is quay should mitigate this issue. Relevant issue https://github.com/renovatebot/renovate/issues/9176
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
