### PR TITLE
feat(config): remove manager additionalBranchPrefix defaults

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -69,7 +69,7 @@ With the above config:
 ## additionalBranchPrefix
 
 This value defaults to an empty string, and is typically not necessary.
-Some managers previously populate this field, but they no longer do it by default.
+Some managers previously populated this field, but they no longer do so by default.
 You normally don't need to configure this, but one example where it can be useful is combining with `parentDir` in monorepos to split PRs based on where the package definition is located, e.g.
 
 ```json

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -69,7 +69,7 @@ With the above config:
 ## additionalBranchPrefix
 
 This value defaults to an empty string, and is typically not necessary.
-Some managers populate this field for historical reasons, for example we use `docker-` for Docker branches, so they may look like `renovate/docker-ubuntu-16.x`.
+Some managers previously populate this field, but they no longer do it by default.
 You normally don't need to configure this, but one example where it can be useful is combining with `parentDir` in monorepos to split PRs based on where the package definition is located, e.g.
 
 ```json

--- a/docs/usage/configuration-templates.md
+++ b/docs/usage/configuration-templates.md
@@ -21,8 +21,7 @@ Most users will be happy with the default `branchPrefix` of `renovate/`, but you
 Say you don't want the forward slashes, in that case you would use `renovate-` as your `branchPrefix`.
 The onboarding PR will always use `renovate/configure`.
 
-`additionalBranchPrefix` is optional and by default is empty for all JavaScript dependencies.
-We use `docker-` for all Docker updates, branches will look like this: `renovate/docker-ubuntu-16.x`.
+`additionalBranchPrefix` is optional and by default is empty.
 
 `branchTopic` depends on the package manager and upgrade type, so you will see a lot of variety.
 This is probably a setting you want to change yourself.

--- a/lib/config/presets/index.ts
+++ b/lib/config/presets/index.ts
@@ -93,6 +93,7 @@ export function parsePreset(input: string): ParsedPreset {
     str = str.slice(0, str.indexOf('('));
   }
   const presetsPackages = [
+    'compatibility',
     'config',
     'default',
     'docker',

--- a/lib/config/presets/internal/compatibility.ts
+++ b/lib/config/presets/internal/compatibility.ts
@@ -11,11 +11,14 @@ export const presets: Record<string, Preset> = {
     docker: {
       additionalBranchPrefix: 'docker-',
     },
-    helm: {
-      additionalBranchPrefix: 'helm-',
-    },
     homebrew: {
       additionalBranchPrefix: 'homebrew-',
     },
+    packageRules: [
+      {
+        matchDatasources: ['helm'],
+        additionalBranchPrefix: 'helm-',
+      },
+    ],
   },
 };

--- a/lib/config/presets/internal/compatibility.ts
+++ b/lib/config/presets/internal/compatibility.ts
@@ -1,0 +1,21 @@
+import { Preset } from '../types';
+
+export const presets: Record<string, Preset> = {
+  additionalBranchPrefix: {
+    buildkite: {
+      additionalBranchPrefix: 'buildkite-',
+    },
+    cargo: {
+      additionalBranchPrefix: 'rust-',
+    },
+    docker: {
+      additionalBranchPrefix: 'docker-',
+    },
+    helm: {
+      additionalBranchPrefix: 'helm-',
+    },
+    homebrew: {
+      additionalBranchPrefix: 'homebrew-',
+    },
+  },
+};

--- a/lib/config/presets/internal/index.ts
+++ b/lib/config/presets/internal/index.ts
@@ -1,4 +1,5 @@
 import type { Preset, PresetConfig } from '../types';
+import * as compatibilityPreset from './compatibility';
 import * as configPreset from './config';
 import * as defaultPreset from './default';
 import * as dockerPreset from './docker';
@@ -13,6 +14,7 @@ import * as schedulePreset from './schedule';
 import * as workaroundsPreset from './workarounds';
 
 export const groups: Record<string, Record<string, Preset>> = {
+  compatibility: compatibilityPreset.presets,
   config: configPreset.presets,
   default: defaultPreset.presets,
   docker: dockerPreset.presets,

--- a/lib/datasource/docker/index.ts
+++ b/lib/datasource/docker/index.ts
@@ -26,7 +26,6 @@ export const defaultVersioning = dockerVersioning.id;
 export const registryStrategy = 'first';
 
 export const defaultConfig = {
-  additionalBranchPrefix: 'docker-',
   commitMessageTopic: '{{{depName}}} Docker tag',
   major: { enabled: false },
   commitMessageExtra:

--- a/lib/datasource/helm/index.ts
+++ b/lib/datasource/helm/index.ts
@@ -17,7 +17,6 @@ export const defaultRegistryUrls = ['https://charts.helm.sh/stable'];
 export const registryStrategy = 'first';
 
 export const defaultConfig = {
-  additionalBranchPrefix: 'helm-',
   commitMessageTopic: 'Helm release {{depName}}',
   group: {
     commitMessageTopic: '{{{groupName}}} Helm releases',

--- a/lib/manager/buildkite/index.ts
+++ b/lib/manager/buildkite/index.ts
@@ -7,5 +7,4 @@ export const defaultConfig = {
   commitMessageTopic: 'buildkite plugin {{depName}}',
   commitMessageExtra:
     'to {{#if isMajor}}v{{{newMajor}}}{{else}}{{{newValue}}}{{/if}}',
-  additionalBranchPrefix: 'buildkite-',
 };

--- a/lib/manager/cargo/index.ts
+++ b/lib/manager/cargo/index.ts
@@ -10,7 +10,6 @@ export { extractPackageFile, updateArtifacts, language };
 
 export const defaultConfig = {
   commitMessageTopic: 'Rust crate {{depName}}',
-  additionalBranchPrefix: 'rust-',
   fileMatch: ['(^|/)Cargo.toml$'],
   versioning: cargoVersioning.id,
   rangeStrategy: 'bump',

--- a/lib/manager/homebrew/index.ts
+++ b/lib/manager/homebrew/index.ts
@@ -3,6 +3,5 @@ export { updateDependency } from './update';
 
 export const defaultConfig = {
   commitMessageTopic: 'Homebrew Formula {{depName}}',
-  additionalBranchPrefix: 'homebrew-',
   fileMatch: ['^Formula/[^/]+[.]rb$'],
 };

--- a/lib/workers/repository/updates/flatten.ts
+++ b/lib/workers/repository/updates/flatten.ts
@@ -4,7 +4,6 @@ import {
   getManagerConfig,
   mergeChildConfig,
 } from '../../../config';
-import { LANGUAGE_DOCKER } from '../../../constants/languages';
 import { getDefaultConfig } from '../../../datasource';
 import { get } from '../../../manager';
 import { applyPackageRules } from '../../../util/package-rules';

--- a/lib/workers/repository/updates/flatten.ts
+++ b/lib/workers/repository/updates/flatten.ts
@@ -27,14 +27,6 @@ export function applyUpdateConfig(input: BranchUpgradeConfig): any {
         .replace(/-+/, '-')
         .toLowerCase()
     : undefined;
-  if (
-    updateConfig.language === LANGUAGE_DOCKER &&
-    /(^|\/)node$/.exec(updateConfig.depName) &&
-    updateConfig.depName !== 'calico/node'
-  ) {
-    updateConfig.additionalBranchPrefix = '';
-    updateConfig.depNameSanitized = 'node';
-  }
   generateBranchName(updateConfig);
   return updateConfig;
 }


### PR DESCRIPTION




<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Resets any language or manager additionalBranchPrefix values to empty string. Add the `compatibility:additionalBranchPrefix` prefix to restore previous behavior.

## Context:

BREAKING CHANGE: Removal of default additionalBranchPrefix values will cause branch names to change for docker/helm/buildkite/cargo/homebrew.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
