### PR TITLE
refactor(azure): Platform-wide getJsonFile

### DIFF
--- a/lib/platform/azure/azure-helper.ts
+++ b/lib/platform/azure/azure-helper.ts
@@ -12,6 +12,7 @@ import {
   getBranchNameWithoutRefsPrefix,
   getBranchNameWithoutRefsheadsPrefix,
   getNewBranchName,
+  streamToString,
 } from './util';
 
 const mergePolicyGuid = 'fa4e907d-c16b-4a4c-9dfa-4916e5d171ab'; // Magic GUID for merge strategy policy configurations
@@ -76,20 +77,6 @@ export async function getAzureBranchObj(
     name: getNewBranchName(branchName),
     oldObjectId: refs[0].objectId,
   };
-}
-
-async function streamToString(stream: NodeJS.ReadableStream): Promise<string> {
-  const chunks: string[] = [];
-  /* eslint-disable promise/avoid-new */
-  const p = await new Promise<string>((resolve) => {
-    stream.on('data', (chunk: any) => {
-      chunks.push(chunk.toString());
-    });
-    stream.on('end', () => {
-      resolve(chunks.join(''));
-    });
-  });
-  return p;
 }
 
 // if no branchName, look globally

--- a/lib/platform/azure/index.spec.ts
+++ b/lib/platform/azure/index.spec.ts
@@ -1,3 +1,4 @@
+import { Readable } from 'stream';
 import is from '@sindresorhus/is';
 import {
   GitPullRequestMergeStrategy,
@@ -1184,18 +1185,24 @@ describe('platform/azure', () => {
   describe('getJsonFile()', () => {
     it('returns file content', async () => {
       const data = { foo: 'bar' };
-      azureHelper.getFile.mockResolvedValueOnce(JSON.stringify(data));
-      await initRepo({
-        repository: 'some-repo',
-      });
+      azureApi.gitApi.mockImplementationOnce(
+        () =>
+          ({
+            getItemContent: jest.fn(() =>
+              Promise.resolve(Readable.from(JSON.stringify(data)))
+            ),
+          } as any)
+      );
       const res = await azure.getJsonFile('file.json');
       expect(res).toEqual(data);
     });
     it('returns null on errors', async () => {
-      azureHelper.getFile.mockRejectedValueOnce('some error');
-      await initRepo({
-        repository: 'some-repo',
-      });
+      azureApi.gitApi.mockImplementationOnce(
+        () =>
+          ({
+            getItemContent: jest.fn(() => Promise.reject('some error')),
+          } as any)
+      );
       const res = await azure.getJsonFile('file.json');
       expect(res).toBeNull();
     });

--- a/lib/platform/azure/index.ts
+++ b/lib/platform/azure/index.ts
@@ -41,6 +41,7 @@ import {
   getGitStatusContextFromCombinedName,
   getNewBranchName,
   getRenovatePRFormat,
+  streamToString,
 } from './util';
 
 interface Config {
@@ -103,14 +104,15 @@ export async function getRepos(): Promise<string[]> {
   return repos.map((repo) => `${repo.project.name}/${repo.name}`);
 }
 
-export async function getJsonFile(fileName: string): Promise<any | null> {
+export async function getJsonFile(
+  fileName: string,
+  repo: string = config.repoId
+): Promise<any | null> {
   try {
-    const json = await azureHelper.getFile(
-      config.repoId,
-      fileName,
-      config.defaultBranch
-    );
-    return JSON.parse(json);
+    const azureApiGit = await azureApi.gitApi();
+    const buf = await azureApiGit.getItemContent(repo, fileName);
+    const str = await streamToString(buf);
+    return JSON.parse(str);
   } catch (err) {
     return null;
   }

--- a/lib/platform/azure/util.spec.ts
+++ b/lib/platform/azure/util.spec.ts
@@ -1,9 +1,11 @@
+import { Readable } from 'stream';
 import {
   getBranchNameWithoutRefsheadsPrefix,
   getGitStatusContextCombinedName,
   getGitStatusContextFromCombinedName,
   getNewBranchName,
   getRenovatePRFormat,
+  streamToString,
 } from './util';
 
 describe('platform/azure/helpers', () => {
@@ -105,6 +107,13 @@ describe('platform/azure/helpers', () => {
     it('should be formated (isConflicted)', () => {
       const res = getRenovatePRFormat({ mergeStatus: 2 } as any);
       expect(res).toMatchSnapshot();
+    });
+  });
+
+  describe('streamToString', () => {
+    it('converts Readable stream to string', async () => {
+      const res = await streamToString(Readable.from('foobar'));
+      expect(res).toEqual('foobar');
     });
   });
 });

--- a/lib/platform/azure/util.ts
+++ b/lib/platform/azure/util.ts
@@ -115,3 +115,19 @@ export function getRenovatePRFormat(azurePr: GitPullRequest): AzurePr {
     ...(isConflicted && { isConflicted }),
   } as AzurePr;
 }
+
+export async function streamToString(
+  stream: NodeJS.ReadableStream
+): Promise<string> {
+  const chunks: string[] = [];
+  /* eslint-disable promise/avoid-new */
+  const p = await new Promise<string>((resolve) => {
+    stream.on('data', (chunk: any) => {
+      chunks.push(chunk.toString());
+    });
+    stream.on('end', () => {
+      resolve(chunks.join(''));
+    });
+  });
+  return p;
+}


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

New optional for `getJsonFile()` allows to choose another repository to fetch JSON from.

## Context:

Ref: #9171

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
