### PR TITLE
refactor(bitbucket-server): Platform-wide getJsonFile

### DIFF
--- a/lib/platform/bitbucket-server/index.ts
+++ b/lib/platform/bitbucket-server/index.ts
@@ -118,15 +118,19 @@ export async function getRepos(): Promise<string[]> {
   }
 }
 
-export async function getJsonFile(fileName: string): Promise<any | null> {
+export async function getJsonFile(
+  fileName: string,
+  repo: string = config.repository
+): Promise<any | null> {
   try {
-    const { body } = await bitbucketServerHttp.getJson<FileData>(
-      `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/browse/${fileName}?limit=20000`
-    );
-    if (body.isLastPage) {
-      return JSON.parse(body.lines.map((l) => l.text).join(''));
+    const [project, slug] = repo.split('/');
+    const fileUrl = `./rest/api/1.0/projects/${project}/repos/${slug}/browse/${fileName}?limit=20000`;
+    const res = await bitbucketServerHttp.getJson<FileData>(fileUrl);
+    const { isLastPage, lines, size } = res.body;
+    if (isLastPage) {
+      return JSON.parse(lines.map(({ text }) => text).join(''));
     }
-    logger.warn({ size: body.size }, `The file is too big`);
+    logger.warn({ size }, `The file is too big`);
   } catch (err) {
     // no-op
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

New optional parameter for getJsonFile() allows to choose another repository to fetch JSON from.

## Context:

Ref: #9171

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
