### PR TITLE
refactor(gitlab): Platform-wide getJsonFile

### DIFF
--- a/lib/platform/gitlab/__snapshots__/index.spec.ts.snap
+++ b/lib/platform/gitlab/__snapshots__/index.spec.ts.snap
@@ -1546,7 +1546,7 @@ Array [
       "user-agent": "https://github.com/renovatebot/renovate",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/some%2Frepo/repository/files/dir%2Ffile.json?ref=master",
+    "url": "https://gitlab.com/api/v4/projects/some%2Frepo/repository/files/dir%2Ffile.json?ref=HEAD",
   },
 ]
 `;
@@ -1573,7 +1573,7 @@ Array [
       "user-agent": "https://github.com/renovatebot/renovate",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/some%2Frepo/repository/files/file.json?ref=master",
+    "url": "https://gitlab.com/api/v4/projects/some%2Frepo/repository/files/file.json?ref=HEAD",
   },
 ]
 `;

--- a/lib/platform/gitlab/index.spec.ts
+++ b/lib/platform/gitlab/index.spec.ts
@@ -1438,7 +1438,7 @@ These updates have all been created already. Click a checkbox below to force a r
       const scope = await initRepo();
       scope
         .get(
-          '/api/v4/projects/some%2Frepo/repository/files/dir%2Ffile.json?ref=master'
+          '/api/v4/projects/some%2Frepo/repository/files/dir%2Ffile.json?ref=HEAD'
         )
         .reply(200, {
           content: Buffer.from(JSON.stringify(data)).toString('base64'),
@@ -1450,9 +1450,7 @@ These updates have all been created already. Click a checkbox below to force a r
     it('returns null on errors', async () => {
       const scope = await initRepo();
       scope
-        .get(
-          '/api/v4/projects/some%2Frepo/repository/files/file.json?ref=master'
-        )
+        .get('/api/v4/projects/some%2Frepo/repository/files/file.json?ref=HEAD')
         .replyWithError('some error');
       const res = await gitlab.getJsonFile('file.json');
       expect(res).toBeNull();

--- a/lib/platform/gitlab/index.ts
+++ b/lib/platform/gitlab/index.ts
@@ -139,19 +139,18 @@ function urlEscape(str: string): string {
   return str ? str.replace(/\//g, '%2F') : str;
 }
 
-export async function getJsonFile(fileName: string): Promise<any | null> {
+export async function getJsonFile(
+  fileName: string,
+  repo: string = config.repository
+): Promise<any | null> {
   try {
     const escapedFileName = urlEscape(fileName);
-    return JSON.parse(
-      Buffer.from(
-        (
-          await gitlabApi.getJson<{ content: string }>(
-            `projects/${config.repository}/repository/files/${escapedFileName}?ref=${config.defaultBranch}`
-          )
-        ).body.content,
-        'base64'
-      ).toString()
-    );
+    const url = `projects/${repo}/repository/files/${escapedFileName}?ref=HEAD`;
+    const res = await gitlabApi.getJson<{ content: string }>(url);
+    const buf = res.body.content;
+    const str = Buffer.from(buf, 'base64').toString();
+    const result = JSON.parse(str);
+    return result;
   } catch (err) {
     return null;
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

New optional parameter for getJsonFile() allows to choose another repository to fetch JSON from.

## Context:

Ref: #9171

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
