### PR TITLE
chore: remove no reproduction needed checkbox from bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -39,7 +39,6 @@ Copy/paste any log here, between the starting and ending backticks
 
 Please read the [minimal reproductions documentation](https://github.com/renovatebot/renovate/blob/master/docs/development/minimal-reproductions.md) to learn how to make a good minimal reproduction repository.
 
-- [ ] This is a really small bug, it does not need a reproduction (think small typo)
 - [ ] I have provided a minimal reproduction repository
 - [ ] I don't have time for that, but it happens in a public repository I have linked to
 - [ ] I don't have time for that, and cannot share my private repository


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

- Remove checkbox "This is a really small bug, it does not need a reproduction"

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

When we created the checkboxes for this bug report template we worried that users would click the "no reproduction needed" checkbox too much https://github.com/renovatebot/renovate/pull/8118#discussion_r547297368.

Renovate bot is complex software, with many configuration options, and moving parts. I don't think it's do-able for a bug reporter to determine whether a bug is caused by a small typo or not... 😄 

Maybe we should ask for a reproduction for each bug report. That way the Renovate developers can see what's causing the problem (configuration/confusing docs/platform problems/manager/datasource/etc.).

Let me know what you Renovate code-wizards think of this checkbox. 😉 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
