### PR TITLE
feat: split trustLevel into separate options

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -9,6 +9,8 @@ The configuration options listed in this document are applicable to self-hosted 
 
 Please also see [Self-Hosted Experimental Options](./self-hosted-experimental.md).
 
+## allowCustomCrateRegistries
+
 ## allowPostUpgradeCommandTemplating
 
 Set to true to allow templating of post-upgrade commands.
@@ -51,6 +53,8 @@ With this configuration, the executable command for `@angular/core` looks like t
 npm ci --ignore-scripts
 npx ng update @angular/core --from=9.0.0 --to=10.0.0 --migrateOnly --allowDirty --force
 ```
+
+## allowScripts
 
 ## allowedPostUpgradeCommands
 
@@ -177,6 +181,13 @@ e.g.
 ## dryRun
 
 ## endpoint
+
+## exposeAllEnv
+
+By default, Renovate will only pass a limited set of environment variables to package managers.
+Potentially, there could be leaks of confidential data if a script you don't trust enumerates all values in env, so set this to true only if you trust the repositories which the bot runs against.
+
+Setting this to true will also allow for variable substitution in `.npmrc` files.
 
 ## force
 
@@ -378,14 +389,5 @@ If this is set to false, then a full install of modules will be done.
 This is currently applicable to `npm` and `lerna`/`npm` only, and only used in cases where bugs in `npm` result in incorrect lock files being updated.
 
 ## token
-
-## trustLevel
-
-Setting trustLevel to `"high"` can make sense in many self-hosted cases where the bot operator trusts the content in each repository.
-
-Setting trustLevel=high means:
-
-- Child processes are run with full access to `env`
-- `.npmrc` files can have environment variable substitution performed
 
 ## username

--- a/lib/config/__snapshots__/migration.spec.ts.snap
+++ b/lib/config/__snapshots__/migration.spec.ts.snap
@@ -78,6 +78,8 @@ Array [
 exports[`config/migration migrateConfig(config, parentConfig) migrates config 1`] = `
 Object {
   "additionalBranchPrefix": "{{parentDir}}-",
+  "allowCustomCrateRegistries": true,
+  "allowScripts": true,
   "autodiscover": true,
   "automerge": false,
   "automergeType": "branch",
@@ -94,6 +96,7 @@ Object {
   "dependencyDashboard": true,
   "dependencyDashboardTitle": "foo",
   "enabled": true,
+  "exposeAllEnv": true,
   "extends": Array [
     "config:js-app",
     "config:js-lib",
@@ -108,8 +111,8 @@ Object {
   "includeForks": true,
   "lockFileMaintenance": Object {
     "automerge": true,
+    "exposeAllEnv": false,
     "schedule": "before 5am",
-    "trustLevel": "low",
   },
   "major": Object {
     "automerge": false,
@@ -233,7 +236,6 @@ Object {
   "travis": Object {
     "enabled": true,
   },
-  "trustLevel": "high",
 }
 `;
 

--- a/lib/config/admin.ts
+++ b/lib/config/admin.ts
@@ -4,14 +4,16 @@ let adminConfig: RepoAdminConfig = {};
 
 // TODO: once admin config work is complete, add a test to make sure this list includes all options with admin=true
 export const repoAdminOptions = [
+  'allowCustomCrateRegistries',
   'allowPostUpgradeCommandTemplating',
+  'allowScripts',
   'allowedPostUpgradeCommands',
   'customEnvVariables',
   'dockerImagePrefix',
   'dockerUser',
   'dryRun',
+  'exposeAllEnv',
   'privateKey',
-  'trustLevel',
 ];
 
 export function setAdminConfig(config: RenovateConfig = {}): void {

--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -461,17 +461,33 @@ const options: RenovateOptions[] = [
     default: false,
   },
   {
-    name: 'trustLevel',
+    name: 'exposeAllEnv',
     description:
-      'Set this to "high" if the bot should trust the repository owners/contents.',
+      'Configure this to true to allow passing of all env variables to package managers.',
     admin: true,
-    type: 'string',
-    default: 'low',
+    type: 'boolean',
+    default: false,
+  },
+  {
+    name: 'allowScripts',
+    description:
+      'Configure this to true if repositories are allowed to run install scripts.',
+    admin: true,
+    type: 'boolean',
+    default: false,
+  },
+  {
+    name: 'allowCustomCrateRegistries',
+    description:
+      'Configure this to true if custom crate registries are allowed.',
+    admin: true,
+    type: 'boolean',
+    default: false,
   },
   {
     name: 'ignoreScripts',
     description:
-      'Configure this to true if trustLevel is high but you wish to skip running scripts when updating lock files.',
+      'Configure this to true if allowScripts=true but you wish to skip running scripts when updating lock files.',
     type: 'boolean',
     default: false,
   },

--- a/lib/config/migration.spec.ts
+++ b/lib/config/migration.spec.ts
@@ -46,6 +46,7 @@ describe('config/migration', () => {
         masterIssueTitle: 'foo',
         gomodTidy: true,
         upgradeInRange: true,
+        trustLevel: 'high',
         automergeType: 'branch-push',
         branchName:
           '{{{branchPrefix}}}{{{managerBranchPrefix}}}{{{branchTopic}}}{{{baseDir}}}',

--- a/lib/config/migration.ts
+++ b/lib/config/migration.ts
@@ -189,11 +189,14 @@ export function migrateConfig(
           migratedConfig.rebaseWhen = 'never';
         }
       } else if (key === 'exposeEnv') {
+        migratedConfig.exposeAllEnv = val;
         delete migratedConfig.exposeEnv;
-        if (val === true) {
-          migratedConfig.trustLevel = 'high';
-        } else if (val === false) {
-          migratedConfig.trustLevel = 'low';
+      } else if (key === 'trustLevel') {
+        delete migratedConfig.trustLevel;
+        if (val === 'high') {
+          migratedConfig.allowCustomCrateRegistries ??= true;
+          migratedConfig.allowScripts ??= true;
+          migratedConfig.exposeAllEnv ??= true;
         }
       } else if (
         key === 'branchName' &&

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -84,14 +84,16 @@ export interface GlobalOnlyConfig {
 // Config options used within the repository worker, but not user configurable
 // The below should contain config options where admin=true
 export interface RepoAdminConfig {
+  allowCustomCrateRegistries?: boolean;
   allowPostUpgradeCommandTemplating?: boolean;
+  allowScripts?: boolean;
   allowedPostUpgradeCommands?: string[];
   customEnvVariables?: Record<string, string>;
   dockerImagePrefix?: string;
   dockerUser?: string;
   dryRun?: boolean;
+  exposeAllEnv?: boolean;
   privateKey?: string | Buffer;
-  trustLevel?: 'low' | 'high';
 }
 
 export interface LegacyAdminConfig {

--- a/lib/datasource/crate/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/crate/__snapshots__/index.spec.ts.snap
@@ -331,7 +331,7 @@ Array [
 ]
 `;
 
-exports[`datasource/crate getReleases refuses to clone if trustLevel is not high 1`] = `null`;
+exports[`datasource/crate getReleases refuses to clone if allowCustomCrateRegistries is not true 1`] = `null`;
 
 exports[`datasource/crate getReleases returns null for 404 1`] = `
 Array [

--- a/lib/datasource/crate/index.spec.ts
+++ b/lib/datasource/crate/index.spec.ts
@@ -224,7 +224,7 @@ describe('datasource/crate', () => {
       expect(res).toBeDefined();
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
-    it('refuses to clone if trustLevel is not high', async () => {
+    it('refuses to clone if allowCustomCrateRegistries is not true', async () => {
       const { mockClone } = setupGitMocks();
 
       const url = 'https://dl.cloudsmith.io/basic/myorg/myrepo/cargo/index.git';
@@ -239,7 +239,7 @@ describe('datasource/crate', () => {
     });
     it('clones cloudsmith private registry', async () => {
       const { mockClone } = setupGitMocks();
-      setAdminConfig({ trustLevel: 'high' });
+      setAdminConfig({ allowCustomCrateRegistries: true });
       const url = 'https://dl.cloudsmith.io/basic/myorg/myrepo/cargo/index.git';
       const res = await getPkgReleases({
         datasource,
@@ -253,7 +253,7 @@ describe('datasource/crate', () => {
     });
     it('clones other private registry', async () => {
       const { mockClone } = setupGitMocks();
-      setAdminConfig({ trustLevel: 'high' });
+      setAdminConfig({ allowCustomCrateRegistries: true });
       const url = 'https://github.com/mcorbin/testregistry';
       const res = await getPkgReleases({
         datasource,
@@ -267,7 +267,7 @@ describe('datasource/crate', () => {
     });
     it('clones once then reuses the cache', async () => {
       const { mockClone } = setupGitMocks();
-      setAdminConfig({ trustLevel: 'high' });
+      setAdminConfig({ allowCustomCrateRegistries: true });
       const url = 'https://github.com/mcorbin/othertestregistry';
       await getPkgReleases({
         datasource,
@@ -283,7 +283,7 @@ describe('datasource/crate', () => {
     });
     it('guards against race conditions while cloning', async () => {
       const { mockClone } = setupGitMocks(250);
-      setAdminConfig({ trustLevel: 'high' });
+      setAdminConfig({ allowCustomCrateRegistries: true });
       const url = 'https://github.com/mcorbin/othertestregistry';
 
       await Promise.all([
@@ -309,7 +309,7 @@ describe('datasource/crate', () => {
     });
     it('returns null when git clone fails', async () => {
       setupErrorGitMock();
-      setAdminConfig({ trustLevel: 'high' });
+      setAdminConfig({ allowCustomCrateRegistries: true });
       const url = 'https://github.com/mcorbin/othertestregistry';
 
       const result = await getPkgReleases({

--- a/lib/datasource/crate/index.ts
+++ b/lib/datasource/crate/index.ts
@@ -163,9 +163,9 @@ async function fetchRegistryInfo(
   };
 
   if (flavor !== RegistryFlavor.CratesIo) {
-    if (getAdminConfig().trustLevel !== 'high') {
+    if (!getAdminConfig().allowCustomCrateRegistries) {
       logger.warn(
-        'crate datasource: trustLevel=high is required for registries other than crates.io, bailing out'
+        'crate datasource: allowCustomCrateRegistries=true is required for registries other than crates.io, bailing out'
       );
       return null;
     }

--- a/lib/datasource/npm/index.spec.ts
+++ b/lib/datasource/npm/index.spec.ts
@@ -375,7 +375,7 @@ describe(getName(__filename), () => {
       .reply(200, npmResponse);
     process.env.REGISTRY = 'https://registry.from-env.com';
     process.env.RENOVATE_CACHE_NPM_MINUTES = '15';
-    setAdminConfig({ trustLevel: 'high' });
+    setAdminConfig({ exposeAllEnv: true });
     // eslint-disable-next-line no-template-curly-in-string
     const npmrc = 'registry=${REGISTRY}';
     const res = await getPkgReleases({ datasource, depName: 'foobar', npmrc });
@@ -384,7 +384,7 @@ describe(getName(__filename), () => {
   });
 
   it('should throw error if necessary env var is not present', () => {
-    setAdminConfig({ trustLevel: 'high' });
+    setAdminConfig({ exposeAllEnv: true });
     // eslint-disable-next-line no-template-curly-in-string
     expect(() => setNpmrc('registry=${REGISTRY_MISSING}')).toThrow(
       Error('env-replace')

--- a/lib/datasource/npm/npmrc.spec.ts
+++ b/lib/datasource/npm/npmrc.spec.ts
@@ -39,7 +39,7 @@ describe(getName(__filename), () => {
   });
 
   it('sanitize _authtoken with high trust', () => {
-    setAdminConfig({ trustLevel: 'high' });
+    setAdminConfig({ exposeAllEnv: true });
     process.env.TEST_TOKEN = 'test';
     setNpmrc(
       // eslint-disable-next-line no-template-curly-in-string

--- a/lib/datasource/npm/npmrc.ts
+++ b/lib/datasource/npm/npmrc.ts
@@ -61,13 +61,13 @@ export function setNpmrc(input?: string): void {
     npmrcRaw = input;
     logger.debug('Setting npmrc');
     npmrc = ini.parse(input.replace(/\\n/g, '\n'));
-    const { trustLevel } = getAdminConfig();
+    const { exposeAllEnv } = getAdminConfig();
     for (const [key, val] of Object.entries(npmrc)) {
-      if (trustLevel !== 'high') {
+      if (!exposeAllEnv) {
         sanitize(key, val);
       }
       if (
-        trustLevel !== 'high' &&
+        !exposeAllEnv &&
         key.endsWith('registry') &&
         val &&
         val.includes('localhost')
@@ -80,7 +80,7 @@ export function setNpmrc(input?: string): void {
         return;
       }
     }
-    if (trustLevel !== 'high') {
+    if (!exposeAllEnv) {
       return;
     }
     for (const key of Object.keys(npmrc)) {

--- a/lib/manager/composer/artifacts.spec.ts
+++ b/lib/manager/composer/artifacts.spec.ts
@@ -30,6 +30,7 @@ const config = {
   localDir: join('/tmp/github/some/repo'),
   cacheDir: join('/tmp/renovate/cache'),
   composerIgnorePlatformReqs: true,
+  ignoreScripts: false,
 };
 
 const repoStatus = partial<StatusResult>({
@@ -46,7 +47,7 @@ describe('.updateArtifacts()', () => {
     await setUtilConfig(config);
     docker.resetPrefetchedImages();
     hostRules.clear();
-    setAdminConfig();
+    setAdminConfig({ allowScripts: false });
   });
   it('returns if no composer.lock found', async () => {
     expect(
@@ -63,7 +64,7 @@ describe('.updateArtifacts()', () => {
     const execSnapshots = mockExecAll(exec);
     fs.readLocalFile.mockReturnValueOnce('Current composer.lock' as any);
     git.getRepoStatus.mockResolvedValue(repoStatus);
-    setAdminConfig({ trustLevel: 'high' });
+    setAdminConfig({ allowScripts: true });
     expect(
       await composer.updateArtifacts({
         packageFileName: 'composer.json',

--- a/lib/manager/composer/artifacts.ts
+++ b/lib/manager/composer/artifacts.ts
@@ -151,7 +151,7 @@ export async function updateArtifacts({
       args += ' --ignore-platform-reqs';
     }
     args += ' --no-ansi --no-interaction';
-    if (getAdminConfig().trustLevel !== 'high' || config.ignoreScripts) {
+    if (!getAdminConfig().allowScripts || config.ignoreScripts) {
       args += ' --no-scripts --no-autoloader';
     }
     logger.debug({ cmd, args }, 'composer command');

--- a/lib/manager/npm/extract/index.ts
+++ b/lib/manager/npm/extract/index.ts
@@ -107,7 +107,7 @@ export async function extractPackageFile(
       npmrc = npmrc.replace(/(^|\n)package-lock.*?(\n|$)/g, '\n');
     }
     if (is.string(npmrc)) {
-      if (npmrc.includes('=${') && getAdminConfig().trustLevel !== 'high') {
+      if (npmrc.includes('=${') && !getAdminConfig().exposeAllEnv) {
         logger.debug('Discarding .npmrc file with variables');
         ignoreNpmrcFile = true;
         npmrc = undefined;

--- a/lib/manager/npm/post-update/lerna.spec.ts
+++ b/lib/manager/npm/post-update/lerna.spec.ts
@@ -109,7 +109,7 @@ describe(getName(__filename), () => {
     });
     it('allows scripts for trust level high', async () => {
       const execSnapshots = mockExecAll(exec);
-      setAdminConfig({ trustLevel: 'high' });
+      setAdminConfig({ allowScripts: true });
       const res = await lernaHelper.generateLockFiles(
         lernaPkgFile('npm'),
         'some-dir',

--- a/lib/manager/npm/post-update/lerna.ts
+++ b/lib/manager/npm/post-update/lerna.ts
@@ -72,10 +72,7 @@ export async function generateLockFiles(
       return { error: false };
     }
     let lernaCommand = `lerna bootstrap --no-ci --ignore-scripts -- `;
-    if (
-      getAdminConfig().trustLevel === 'high' &&
-      config.ignoreScripts !== false
-    ) {
+    if (getAdminConfig().allowScripts && config.ignoreScripts !== false) {
       cmdOptions = cmdOptions.replace('--ignore-scripts ', '');
       lernaCommand = lernaCommand.replace('--ignore-scripts ', '');
     }
@@ -96,7 +93,7 @@ export async function generateLockFiles(
       },
     };
     // istanbul ignore if
-    if (getAdminConfig().trustLevel === 'high') {
+    if (getAdminConfig().exposeAllEnv) {
       execOptions.extraEnv.NPM_AUTH = env.NPM_AUTH;
       execOptions.extraEnv.NPM_EMAIL = env.NPM_EMAIL;
       execOptions.extraEnv.NPM_TOKEN = env.NPM_TOKEN;

--- a/lib/manager/npm/post-update/npm.ts
+++ b/lib/manager/npm/post-update/npm.ts
@@ -71,7 +71,7 @@ export async function generateLockFile(
       },
     };
     // istanbul ignore if
-    if (getAdminConfig().trustLevel === 'high') {
+    if (getAdminConfig().exposeAllEnv) {
       execOptions.extraEnv.NPM_AUTH = env.NPM_AUTH;
       execOptions.extraEnv.NPM_EMAIL = env.NPM_EMAIL;
       execOptions.extraEnv.NPM_TOKEN = env.NPM_TOKEN;

--- a/lib/manager/npm/post-update/pnpm.ts
+++ b/lib/manager/npm/post-update/pnpm.ts
@@ -50,7 +50,7 @@ export async function generateLockFile(
       },
     };
     // istanbul ignore if
-    if (getAdminConfig().trustLevel === 'high') {
+    if (getAdminConfig().exposeAllEnv) {
       execOptions.extraEnv.NPM_AUTH = env.NPM_AUTH;
       execOptions.extraEnv.NPM_EMAIL = env.NPM_EMAIL;
       execOptions.extraEnv.NPM_TOKEN = env.NPM_TOKEN;
@@ -63,7 +63,7 @@ export async function generateLockFile(
     }
     cmd = 'pnpm';
     let args = 'install --recursive --lockfile-only';
-    if (getAdminConfig().trustLevel !== 'high' || config.ignoreScripts) {
+    if (!getAdminConfig().allowScripts || config.ignoreScripts) {
       args += ' --ignore-scripts';
       args += ' --ignore-pnpmfile';
     }

--- a/lib/manager/npm/post-update/yarn.ts
+++ b/lib/manager/npm/post-update/yarn.ts
@@ -101,7 +101,7 @@ export async function generateLockFile(
     } else {
       extraEnv.YARN_HTTP_TIMEOUT = '100000';
     }
-    if (getAdminConfig().trustLevel !== 'high' || config.ignoreScripts) {
+    if (!getAdminConfig().allowScripts || config.ignoreScripts) {
       if (isYarn1) {
         cmdOptions += ' --ignore-scripts';
       } else {
@@ -120,7 +120,7 @@ export async function generateLockFile(
       },
     };
     // istanbul ignore if
-    if (getAdminConfig().trustLevel === 'high') {
+    if (getAdminConfig().exposeAllEnv) {
       execOptions.extraEnv.NPM_AUTH = env.NPM_AUTH;
       execOptions.extraEnv.NPM_EMAIL = env.NPM_EMAIL;
       execOptions.extraEnv.NPM_TOKEN = env.NPM_TOKEN;

--- a/lib/manager/pip_requirements/extract.spec.ts
+++ b/lib/manager/pip_requirements/extract.spec.ts
@@ -128,7 +128,7 @@ describe('lib/manager/pip_requirements/extract', () => {
     });
     it('should replace env vars in high trust mode', () => {
       process.env.PIP_TEST_TOKEN = 'its-a-secret';
-      setAdminConfig({ trustLevel: 'high' });
+      setAdminConfig({ exposeAllEnv: true });
       const res = extractPackageFile(requirements7, 'unused_file_name', {});
       expect(res.registryUrls).toEqual([
         'https://pypi.org/pypi/',

--- a/lib/manager/pip_requirements/extract.ts
+++ b/lib/manager/pip_requirements/extract.ts
@@ -84,7 +84,7 @@ export function extractPackageFile(
     res.registryUrls = registryUrls.map((url) => {
       // handle the optional quotes in eg. `--extra-index-url "https://foo.bar"`
       const cleaned = url.replace(/^"/, '').replace(/"$/, '');
-      if (getAdminConfig().trustLevel !== 'high') {
+      if (!getAdminConfig().exposeAllEnv) {
         return cleaned;
       }
       // interpolate any environment variables

--- a/lib/util/exec/env.spec.ts
+++ b/lib/util/exec/env.spec.ts
@@ -58,7 +58,7 @@ describe('getChildProcess environment when trustlevel set to low', () => {
 
   describe('getChildProcessEnv when trustlevel set to high', () => {
     it('returns process.env if trustlevel set to high', () => {
-      setAdminConfig({ trustLevel: 'high' });
+      setAdminConfig({ exposeAllEnv: true });
       expect(getChildProcessEnv()).toMatchObject(process.env);
     });
   });

--- a/lib/util/exec/env.ts
+++ b/lib/util/exec/env.ts
@@ -17,7 +17,7 @@ export function getChildProcessEnv(
   customEnvVars: string[] = []
 ): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = {};
-  if (getAdminConfig().trustLevel === 'high') {
+  if (getAdminConfig().exposeAllEnv) {
     return { ...env, ...process.env };
   }
   const envVars = [...basicEnvVars, ...customEnvVars];

--- a/lib/util/exec/exec.spec.ts
+++ b/lib/util/exec/exec.spec.ts
@@ -194,7 +194,7 @@ describe(getName(__filename), () => {
             maxBuffer: 10485760,
           },
         ],
-        adminConfig: { trustLevel: 'high' },
+        adminConfig: { exposeAllEnv: true },
       },
     ],
 

--- a/lib/workers/branch/index.spec.ts
+++ b/lib/workers/branch/index.spec.ts
@@ -731,7 +731,7 @@ describe('workers/branch', () => {
       const adminConfig = {
         allowedPostUpgradeCommands: ['^echo {{{versioning}}}$'],
         allowPostUpgradeCommandTemplating: true,
-        trustLevel: 'high',
+        exposeAllEnv: true,
       };
       setAdminConfig(adminConfig);
 
@@ -809,7 +809,7 @@ describe('workers/branch', () => {
       const adminConfig = {
         allowedPostUpgradeCommands: ['^exit 1$'],
         allowPostUpgradeCommandTemplating: true,
-        trustLevel: 'high',
+        exposeAllEnv: true,
       };
       setAdminConfig(adminConfig);
 
@@ -878,7 +878,7 @@ describe('workers/branch', () => {
       const adminConfig = {
         allowedPostUpgradeCommands: ['^echo {{{versioning}}}$'],
         allowPostUpgradeCommandTemplating: false,
-        trustLevel: 'high',
+        exposeAllEnv: true,
       };
       setAdminConfig(adminConfig);
       const result = await branchWorker.processBranch({
@@ -956,7 +956,7 @@ describe('workers/branch', () => {
       const adminConfig = {
         allowedPostUpgradeCommands: ['^echo {{{depName}}}$'],
         allowPostUpgradeCommandTemplating: true,
-        trustLevel: 'high',
+        exposeAllEnv: true,
       };
       setAdminConfig(adminConfig);
 

--- a/lib/workers/branch/index.ts
+++ b/lib/workers/branch/index.ts
@@ -360,7 +360,6 @@ export async function processBranch(
       (config.updatedPackageFiles?.length > 0 ||
         /* ... or changes to artifacts */
         config.updatedArtifacts?.length > 0) &&
-      getAdminConfig().trustLevel === 'high' &&
       is.nonEmptyArray(allowedPostUpgradeCommands)
     ) {
       for (const upgrade of config.upgrades) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Removes `trustLevel` and replaces it with 3 other options instead.

## Context:

We shouldn't need it to be "all or nothing".

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

BREAKING CHANGE: trustLevel is no longer supported and instead broken into `allowCustomCrateRegistries `, `allowScripts `, and `exposeAllEnv`. 
