### PR TITLE
feat: remove RENOVATE_LEGACY_GIT_AUTHOR_EMAIL

### DIFF
--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -27,11 +27,6 @@ If set to any integer, Renovate will use this integer instead of the default npm
 If set to any value, Renovate will skip its default artifacts filter check in the Maven datasource.
 Skiping the check will speed things up, but may result in versions being returned which don't properly exist on the server.
 
-## RENOVATE_LEGACY_GIT_AUTHOR_EMAIL
-
-An additional `gitAuthor` email to ignore.
-This variable is deprecated: use `ignoredAuthors` instead.
-
 ## RENOVATE_PAGINATE_ALL
 
 If set to any value, Renovate will always paginate requests to GitHub fully, instead of stopping after 10 pages.

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -489,7 +489,6 @@ export async function isBranchModified(branchName: string): Promise<boolean> {
   ).trim();
   const { gitAuthorEmail } = config;
   if (
-    lastAuthor === process.env.RENOVATE_LEGACY_GIT_AUTHOR_EMAIL || // remove in next major release
     lastAuthor === gitAuthorEmail ||
     config.ignoredAuthors.some((ignoredAuthor) => lastAuthor === ignoredAuthor)
   ) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Removes RENOVATE_LEGACY_GIT_AUTHOR_EMAIL support. Use `ignoredAuthors` in config isntead.

## Context:

BREAKING CHANGE: RENOVATE_LEGACY_GIT_AUTHOR_EMAIL is no longer supported.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
