### PR TITLE
feat: remove logLevel support in config

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -225,18 +225,6 @@ If left as default (null), a random short ID will be selected.
 
 ## logFileLevel
 
-## logLevel
-
-We recommend that you run the Renovate bot at the debug level if you can.
-Use the environment variable `LOG_LEVEL=debug` to run Renovate at the debug level.
-
-When you use `LOG_LEVEL=debug`, debug logging starts from the beginning of the app.
-If you had configured debug logging in a file config, then the debug logging starts _after_ the file config is parsed.
-
-Additionally, if you configure `LOG_FORMAT=json` in env then logging will be done in JSON format instead of "pretty" format, which is usually better if you're doing any ingestion or parsing of the logs.
-
-Warning: Configuring `logLevel` config option or `--log-level` cli option is deprecated and will be removed in a major version.
-
 ## onboarding
 
 Set this to `false` only if all three statements are true:

--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -276,13 +276,6 @@ const options: RenovateOptions[] = [
   },
   // Log options
   {
-    name: 'logLevel',
-    description: 'Logging level. Deprecated, use `LOG_LEVEL` environment.',
-    stage: 'global',
-    type: 'string',
-    allowedValues: ['fatal', 'error', 'warn', 'info', 'debug', 'trace'],
-  },
-  {
     name: 'logFile',
     description: 'Log file path.',
     stage: 'global',

--- a/lib/config/index.ts
+++ b/lib/config/index.ts
@@ -84,15 +84,6 @@ export async function parseConfigs(
     delete config.privateKeyPath;
   }
 
-  // Deprecated set log level: https://github.com/renovatebot/renovate/issues/8291
-  // istanbul ignore if
-  if (config.logLevel) {
-    logger.warn(
-      'Configuring logLevel in CLI or file is deprecated. Use LOG_LEVEL environment variable instead'
-    );
-    levels('stdout', config.logLevel);
-  }
-
   if (config.logContext) {
     // This only has an effect if logContext was defined via file or CLI, otherwise it would already have been detected in env
     setContext(config.logContext);

--- a/lib/config/index.ts
+++ b/lib/config/index.ts
@@ -1,4 +1,4 @@
-import { addStream, levels, logger, setContext } from '../logger';
+import { addStream, logger, setContext } from '../logger';
 import { get, getLanguageList, getManagerList } from '../manager';
 import { ensureDir, getSubDirectory, readFile } from '../util/fs';
 import { ensureTrailingSlash } from '../util/url';

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -74,7 +74,6 @@ export interface GlobalOnlyConfig {
   gitPrivateKey?: string;
   logFile?: string;
   logFileLevel?: LogLevel;
-  logLevel?: LogLevel;
   prCommitsPerRunLimit?: number;
   privateKeyPath?: string;
   redisUrl?: string;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Remove support for logLevel in config. Must be configured using LOG_LEVEL instead.

## Context:

Closes #8291

BREAKING CHANGE: Configure LOG_LEVEL in env and not in config or CLI.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
