### PR TITLE
feat: drop NPM_TOKEN support

### DIFF
--- a/docs/usage/private-modules.md
+++ b/docs/usage/private-modules.md
@@ -64,7 +64,7 @@ module.exports = {
 };
 ```
 
-**NOTE:** Do not use `NPM_TOKEN` as an environment variable, it's incompatible with `hostRules` and will be deprecated soon.
+**NOTE:** Do not use `NPM_TOKEN` as an environment variable.
 
 ### Commit .npmrc file into repository
 

--- a/lib/config/presets/npm/index.spec.ts
+++ b/lib/config/presets/npm/index.spec.ts
@@ -6,7 +6,6 @@ jest.mock('registry-auth-token');
 jest.mock('delay');
 
 describe('config/presets/npm', () => {
-  delete process.env.NPM_TOKEN;
   beforeEach(() => {
     jest.resetAllMocks();
     setAdminConfig();

--- a/lib/datasource/npm/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/npm/__snapshots__/index.spec.ts.snap
@@ -519,45 +519,6 @@ Array [
 ]
 `;
 
-exports[`datasource/npm/index should use NPM_TOKEN if provided 1`] = `
-Object {
-  "name": "@foobar/core",
-  "registryUrl": "https://registry.npmjs.org/",
-  "releases": Array [
-    Object {
-      "releaseTimestamp": "2018-05-06T05:21:53.000Z",
-      "version": "0.0.1",
-    },
-    Object {
-      "releaseTimestamp": "2018-05-07T05:21:53.000Z",
-      "version": "0.0.2",
-    },
-  ],
-  "sourceDirectory": "src/a",
-  "sourceUrl": "https://github.com/renovateapp/dummy",
-  "tags": Object {
-    "latest": "0.0.1",
-  },
-  "versions": Object {},
-}
-`;
-
-exports[`datasource/npm/index should use NPM_TOKEN if provided 2`] = `
-Array [
-  Object {
-    "headers": Object {
-      "accept": "application/json",
-      "accept-encoding": "gzip, deflate",
-      "authorization": "Bearer some-token",
-      "host": "registry.npmjs.org",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
-    "url": "https://registry.npmjs.org/@foobar%2Fcore",
-  },
-]
-`;
-
 exports[`datasource/npm/index should use default registry if missing from npmrc 1`] = `
 Object {
   "name": "foobar",

--- a/lib/datasource/npm/index.spec.ts
+++ b/lib/datasource/npm/index.spec.ts
@@ -15,7 +15,6 @@ const registryAuthToken: jest.Mock<_registryAuthToken.NpmCredentials> = _registr
 let npmResponse: any;
 
 describe(getName(__filename), () => {
-  delete process.env.NPM_TOKEN;
   beforeEach(() => {
     jest.resetAllMocks();
     httpMock.setup();
@@ -265,21 +264,6 @@ describe(getName(__filename), () => {
       .get('/@foobar%2Fcore')
       .reply(200, { ...npmResponse, name: '@foobar/core' });
     const res = await getPkgReleases({ datasource, depName: '@foobar/core' });
-    expect(res).toMatchSnapshot();
-    expect(httpMock.getTrace()).toMatchSnapshot();
-  });
-
-  it('should use NPM_TOKEN if provided', async () => {
-    httpMock
-      .scope('https://registry.npmjs.org', {
-        reqheaders: { authorization: 'Bearer some-token' },
-      })
-      .get('/@foobar%2Fcore')
-      .reply(200, { ...npmResponse, name: '@foobar/core' });
-    const oldToken = process.env.NPM_TOKEN;
-    process.env.NPM_TOKEN = 'some-token';
-    const res = await getPkgReleases({ datasource, depName: '@foobar/core' });
-    process.env.NPM_TOKEN = oldToken;
     expect(res).toMatchSnapshot();
     expect(httpMock.getTrace()).toMatchSnapshot();
   });

--- a/lib/datasource/npm/npmrc.spec.ts
+++ b/lib/datasource/npm/npmrc.spec.ts
@@ -9,7 +9,6 @@ const sanitize = mocked(_sanitize);
 
 describe(getName(__filename), () => {
   beforeEach(() => {
-    delete process.env.NPM_TOKEN;
     setNpmrc('');
     setAdminConfig();
     jest.resetAllMocks();

--- a/lib/datasource/npm/npmrc.ts
+++ b/lib/datasource/npm/npmrc.ts
@@ -129,12 +129,6 @@ export function resolvePackage(packageName: string): PackageResolution {
       { token: maskToken(authInfo.token), npmName: packageName },
       'Using auth (via npmrc) for npm lookup'
     );
-  } else if (process.env.NPM_TOKEN && process.env.NPM_TOKEN !== 'undefined') {
-    logger.trace(
-      { token: maskToken(process.env.NPM_TOKEN), npmName: packageName },
-      'Using auth (via process.env.NPM_TOKEN) for npm lookup'
-    );
-    headers.authorization = `Bearer ${process.env.NPM_TOKEN}`;
   }
   return { headers, packageUrl, registryUrl };
 }

--- a/lib/manager/npm/post-update/lerna.ts
+++ b/lib/manager/npm/post-update/lerna.ts
@@ -99,7 +99,6 @@ export async function generateLockFiles(
     if (getAdminConfig().trustLevel === 'high') {
       execOptions.extraEnv.NPM_AUTH = env.NPM_AUTH;
       execOptions.extraEnv.NPM_EMAIL = env.NPM_EMAIL;
-      execOptions.extraEnv.NPM_TOKEN = env.NPM_TOKEN;
     }
     if (config.dockerMapDotfiles) {
       const homeDir =

--- a/lib/manager/npm/post-update/npm.ts
+++ b/lib/manager/npm/post-update/npm.ts
@@ -74,7 +74,6 @@ export async function generateLockFile(
     if (getAdminConfig().trustLevel === 'high') {
       execOptions.extraEnv.NPM_AUTH = env.NPM_AUTH;
       execOptions.extraEnv.NPM_EMAIL = env.NPM_EMAIL;
-      execOptions.extraEnv.NPM_TOKEN = env.NPM_TOKEN;
     }
     if (config.dockerMapDotfiles) {
       const homeDir =

--- a/lib/manager/npm/post-update/pnpm.ts
+++ b/lib/manager/npm/post-update/pnpm.ts
@@ -53,7 +53,6 @@ export async function generateLockFile(
     if (getAdminConfig().trustLevel === 'high') {
       execOptions.extraEnv.NPM_AUTH = env.NPM_AUTH;
       execOptions.extraEnv.NPM_EMAIL = env.NPM_EMAIL;
-      execOptions.extraEnv.NPM_TOKEN = env.NPM_TOKEN;
     }
     if (config.dockerMapDotfiles) {
       const homeDir =

--- a/lib/manager/npm/post-update/yarn.ts
+++ b/lib/manager/npm/post-update/yarn.ts
@@ -123,7 +123,6 @@ export async function generateLockFile(
     if (getAdminConfig().trustLevel === 'high') {
       execOptions.extraEnv.NPM_AUTH = env.NPM_AUTH;
       execOptions.extraEnv.NPM_EMAIL = env.NPM_EMAIL;
-      execOptions.extraEnv.NPM_TOKEN = env.NPM_TOKEN;
     }
     if (config.dockerMapDotfiles) {
       const homeDir =


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Removes support for NPM_TOKEN.

## Context:

BREAKING CHANGE: Do not use NPM_TOKEN in env to configure npm authentication. Configure hostRules instead.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
