### PR TITLE
feat: updateType=patch

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -1517,7 +1517,6 @@ For example to apply a special label for Major updates:
 ## patch
 
 Add to this object if you wish to define rules that apply only to patch updates.
-Only applies if `separateMinorPatch` is set to true.
 
 ## php
 

--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -208,10 +208,7 @@ To learn more read the section below.
 
 You can see in the example above that Renovate won't normally open a PR for the `snorgleborf` patch release.
 
-There are 2 ways to tell Renovate to open a separate PR for the patch release:
-
-- Set `separateMinorPatch` to `true`
-- Set `automerge` to the value: `"patch"`
+You can tell Renovate to open a separate PR for the patch release by setting `separateMinorPatch` to `true`.
 
 In both cases, Renovate will open 3 PRs:
 

--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -1049,8 +1049,7 @@ const options: RenovateOptions[] = [
   },
   {
     name: 'patch',
-    description:
-      'Configuration to apply when an update type is patch. Only applies if `separateMinorPatch` is set to true.',
+    description: 'Configuration to apply when an update type is patch.',
     stage: 'package',
     type: 'object',
     default: {},

--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -499,6 +499,9 @@ const staticGroups = {
         minor: {
           groupName: 'JS unit test packages',
         },
+        patch: {
+          groupName: 'JS unit test packages',
+        },
       },
     ],
   },
@@ -517,6 +520,9 @@ const staticGroups = {
       {
         extends: 'packages:unitTest',
         minor: {
+          groupName: 'unit test packages',
+        },
+        patch: {
           groupName: 'unit test packages',
         },
       },
@@ -539,6 +545,9 @@ const staticGroups = {
         minor: {
           groupName: 'JS test packages',
         },
+        patch: {
+          groupName: 'JS test packages',
+        },
       },
     ],
   },
@@ -557,6 +566,9 @@ const staticGroups = {
       {
         extends: 'packages:test',
         minor: {
+          groupName: 'test packages',
+        },
+        patch: {
           groupName: 'test packages',
         },
       },

--- a/lib/workers/repository/process/lookup/__snapshots__/index.spec.ts.snap
+++ b/lib/workers/repository/process/lookup/__snapshots__/index.spec.ts.snap
@@ -112,7 +112,7 @@ Array [
       "0.9.5",
       "0.9.6",
     ],
-    "updateType": "minor",
+    "updateType": "patch",
   },
   Object {
     "blockedByPin": true,
@@ -705,53 +705,7 @@ Array [
       "0.9.5",
       "0.9.6",
     ],
-    "updateType": "minor",
-  },
-  Object {
-    "bucket": "major",
-    "currentVersion": "0.9.0",
-    "isSingleVersion": true,
-    "newMajor": 1,
-    "newMinor": 4,
-    "newValue": "1.4.1",
-    "newVersion": "1.4.1",
-    "releaseTimestamp": "2015-05-17T04:25:07.299Z",
-    "skippedOverVersions": Array [
-      "1.0.0",
-      "1.0.1",
-      "1.1.0",
-      "1.1.1",
-      "1.1.2",
-      "1.2.0",
-      "1.2.1",
-      "1.3.0",
-      "1.4.0",
-    ],
-    "updateType": "major",
-  },
-]
-`;
-
-exports[`workers/repository/process/lookup .lookupUpdates() returns minor update if separate patches not configured 1`] = `
-Array [
-  Object {
-    "bucket": "non-major",
-    "currentVersion": "0.9.0",
-    "isSingleVersion": true,
-    "newMajor": 0,
-    "newMinor": 9,
-    "newValue": "0.9.7",
-    "newVersion": "0.9.7",
-    "releaseTimestamp": "2013-09-04T17:07:22.948Z",
-    "skippedOverVersions": Array [
-      "0.9.1",
-      "0.9.2",
-      "0.9.3",
-      "0.9.4",
-      "0.9.5",
-      "0.9.6",
-    ],
-    "updateType": "minor",
+    "updateType": "patch",
   },
   Object {
     "bucket": "major",
@@ -979,6 +933,52 @@ Array [
 ]
 `;
 
+exports[`workers/repository/process/lookup .lookupUpdates() returns patch update even if separate patches not configured 1`] = `
+Array [
+  Object {
+    "bucket": "non-major",
+    "currentVersion": "0.9.0",
+    "isSingleVersion": true,
+    "newMajor": 0,
+    "newMinor": 9,
+    "newValue": "0.9.7",
+    "newVersion": "0.9.7",
+    "releaseTimestamp": "2013-09-04T17:07:22.948Z",
+    "skippedOverVersions": Array [
+      "0.9.1",
+      "0.9.2",
+      "0.9.3",
+      "0.9.4",
+      "0.9.5",
+      "0.9.6",
+    ],
+    "updateType": "patch",
+  },
+  Object {
+    "bucket": "major",
+    "currentVersion": "0.9.0",
+    "isSingleVersion": true,
+    "newMajor": 1,
+    "newMinor": 4,
+    "newValue": "1.4.1",
+    "newVersion": "1.4.1",
+    "releaseTimestamp": "2015-05-17T04:25:07.299Z",
+    "skippedOverVersions": Array [
+      "1.0.0",
+      "1.0.1",
+      "1.1.0",
+      "1.1.1",
+      "1.1.2",
+      "1.2.0",
+      "1.2.1",
+      "1.3.0",
+      "1.4.0",
+    ],
+    "updateType": "major",
+  },
+]
+`;
+
 exports[`workers/repository/process/lookup .lookupUpdates() returns patch update if separateMinorPatch 1`] = `
 Array [
   Object {
@@ -1096,7 +1096,7 @@ Array [
       "3.1.0-dev.20180809",
       "3.1.0-dev.20180810",
     ],
-    "updateType": "minor",
+    "updateType": "patch",
   },
 ]
 `;
@@ -1112,7 +1112,7 @@ Array [
     "newValue": "2.5.17-beta.0",
     "newVersion": "2.5.17-beta.0",
     "releaseTimestamp": "2018-03-23T23:29:13.819Z",
-    "updateType": "minor",
+    "updateType": "patch",
   },
 ]
 `;
@@ -1140,7 +1140,7 @@ Array [
     "newValue": "3.0.1-insiders.20180726",
     "newVersion": "3.0.1-insiders.20180726",
     "releaseTimestamp": "2018-07-26T18:20:51.679Z",
-    "updateType": "minor",
+    "updateType": "patch",
   },
 ]
 `;
@@ -1171,7 +1171,7 @@ Array [
     "newValue": "3.0.1-insiders.20180726",
     "newVersion": "3.0.1-insiders.20180726",
     "releaseTimestamp": "2018-07-26T18:20:51.679Z",
-    "updateType": "minor",
+    "updateType": "patch",
   },
 ]
 `;
@@ -1187,7 +1187,7 @@ Array [
     "newValue": "3.0.1",
     "newVersion": "3.0.1",
     "releaseTimestamp": "2018-07-30T16:21:13.150Z",
-    "updateType": "minor",
+    "updateType": "patch",
   },
 ]
 `;
@@ -1218,7 +1218,7 @@ Array [
     "newValue": "^0.0.35",
     "newVersion": "0.0.35",
     "releaseTimestamp": "2017-04-27T16:59:06.479Z",
-    "updateType": "minor",
+    "updateType": "patch",
   },
 ]
 `;
@@ -2648,7 +2648,7 @@ Array [
     "newValue": "1.0.1",
     "newVersion": "1.0.1",
     "releaseTimestamp": "2014-03-11T18:47:17.560Z",
-    "updateType": "minor",
+    "updateType": "patch",
   },
 ]
 `;

--- a/lib/workers/repository/process/lookup/index.spec.ts
+++ b/lib/workers/repository/process/lookup/index.spec.ts
@@ -186,7 +186,7 @@ describe('workers/repository/process/lookup', () => {
         Error(CONFIG_VALIDATION)
       );
     });
-    it('returns minor update if separate patches not configured', async () => {
+    it('returns patch update even if separate patches not configured', async () => {
       config.currentValue = '0.9.0';
       config.rangeStrategy = 'pin';
       config.depName = 'q';
@@ -195,8 +195,8 @@ describe('workers/repository/process/lookup', () => {
       const res = await lookup.lookupUpdates(config);
       expect(res.updates).toMatchSnapshot();
       expect(res.updates).toHaveLength(2);
-      expect(res.updates[0].updateType).not.toEqual('patch');
-      expect(res.updates[1].updateType).not.toEqual('patch');
+      expect(res.updates[0].updateType).toEqual('patch');
+      expect(res.updates[1].updateType).toEqual('major');
     });
     it('returns minor update if automerging both patch and minor', async () => {
       config.patch = {
@@ -212,7 +212,7 @@ describe('workers/repository/process/lookup', () => {
       nock('https://registry.npmjs.org').get('/q').reply(200, qJson);
       const res = await lookup.lookupUpdates(config);
       expect(res.updates).toMatchSnapshot();
-      expect(res.updates[0].updateType).toEqual('minor');
+      expect(res.updates[0].updateType).toEqual('patch');
     });
     it('returns patch update if separateMinorPatch', async () => {
       config.separateMinorPatch = true;

--- a/lib/workers/repository/process/lookup/update-type.ts
+++ b/lib/workers/repository/process/lookup/update-type.ts
@@ -19,8 +19,5 @@ export function getUpdateType(
   if (versioning.getMinor(newVersion) > versioning.getMinor(currentVersion)) {
     return 'minor';
   }
-  if (config.separateMinorPatch) {
-    return 'patch';
-  }
-  return 'minor';
+  return 'patch';
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Changes behavior so that patch updateType is not rewritten to minor by default.

## Context:

Closes #2818

BREAKING CHANGE: patch updates are not considered updateType=minor by default. Any config or packageRules which refers to only `minor` should add `patch` too.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
