### PR TITLE
feat: ENV_PREFIX

### DIFF
--- a/docs/usage/self-hosting.md
+++ b/docs/usage/self-hosting.md
@@ -208,6 +208,8 @@ If you are configuring using environment variables, there are two possibilities:
 
 If you combine both of the above then any single config option in the environment variable will override what's in `RENOVATE_CONFIG`.
 
+Note: it's also possible to change the default prefix from `RENOVATE_` using `ENV_PREFIX`. e.g. `ENV_PREFIX=RNV_ RNV_TOKEN=abc123 renovate`.
+
 ## Authentication
 
 Regardless of platform, you need to select a user account for `renovate` to assume the identity of, and generate a Personal Access Token.

--- a/lib/config/env.ts
+++ b/lib/config/env.ts
@@ -6,6 +6,15 @@ import { logger } from '../logger';
 import { getOptions } from './definitions';
 import type { GlobalConfig, RenovateOptions } from './types';
 
+// istanbul ignore if
+if (process.env.ENV_PREFIX) {
+  for (const [key, val] of Object.entries(process.env)) {
+    if (key.startsWith(process.env.ENV_PREFIX)) {
+      process.env[key.replace(process.env.ENV_PREFIX, 'RENOVATE_')] = val;
+    }
+  }
+}
+
 export function getEnvName(option: Partial<RenovateOptions>): string {
   if (option.env === false) {
     return '';


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Add support to change the default env prefix using `ENV_PREFIX`.

## Context:

Useful for when using `RENOVATE_` is not suitable.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
