### PR TITLE
feat(npm): transitiveRemediation for v2 lockfiles

### DIFF
--- a/lib/manager/npm/update/locked-dependency/__fixtures__/package-lock.v2.json
+++ b/lib/manager/npm/update/locked-dependency/__fixtures__/package-lock.v2.json
@@ -1,0 +1,352 @@
+{
+  "name": "npm50",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "express": "4.0.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.0.0.tgz",
+      "integrity": "sha1-NgTHZVhsO5z3h3tpN829RYf5R9w=",
+      "dependencies": {
+        "mime": "~1.2.11",
+        "negotiator": "~0.3.0"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz",
+      "integrity": "sha1-vj5TgvwCttYySVasGvmKqYsIU0w=",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz",
+      "integrity": "sha1-kOtGndzpBchm3mh+/EMTHYgB+dA=",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.3.tgz",
+      "integrity": "sha1-kc2ZfMUftkFZVzjGnNoCAyj1D/k="
+    },
+    "node_modules/debug": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-0.8.1.tgz",
+      "integrity": "sha1-IP9NJvXkIstoobrLu2EDmtjBwTA=",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz",
+      "integrity": "sha1-GBoobq05ejmpKFfPsdQwUuNWv/A="
+    },
+    "node_modules/express": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.0.0.tgz",
+      "integrity": "sha1-J03IKTPJ9XTMOKDOXqgXK+nGsJQ=",
+      "dependencies": {
+        "accepts": "1.0.0",
+        "buffer-crc32": "0.2.1",
+        "cookie": "0.1.0",
+        "cookie-signature": "1.0.3",
+        "debug": ">= 0.7.3 < 1",
+        "escape-html": "1.0.1",
+        "fresh": "0.2.2",
+        "merge-descriptors": "0.0.2",
+        "methods": "0.1.0",
+        "parseurl": "1.0.1",
+        "path-to-regexp": "0.1.2",
+        "qs": "0.6.6",
+        "range-parser": "1.0.0",
+        "send": "0.2.0",
+        "serve-static": "1.0.1",
+        "type-is": "1.0.0",
+        "utils-merge": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.2.tgz",
+      "integrity": "sha1-lzHc9WeMf660T7kDxPct9VGH+nc="
+    },
+    "node_modules/merge-descriptors": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.2.tgz",
+      "integrity": "sha1-w2pSp4FDdRPFcnXzndnTF1FKyMc="
+    },
+    "node_modules/methods": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-0.1.0.tgz",
+      "integrity": "sha1-M11Cnu/SG3us8unJIqjSvRSjDk8="
+    },
+    "node_modules/mime": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+      "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA="
+    },
+    "node_modules/negotiator": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.3.0.tgz",
+      "integrity": "sha1-cG1pLv7d9XTVfqn7GriaT6fuj2A=",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.0.1.tgz",
+      "integrity": "sha1-Llfc5u/dN8NRhwEDCUTCK/OIt7Q="
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.2.tgz",
+      "integrity": "sha1-mysVH5zDAYye6lDKlXKeBXgXErQ="
+    },
+    "node_modules/qs": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
+      "integrity": "sha1-bgFQmP9RlouKPIGQAdXyyJvEsQc=",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.0.tgz",
+      "integrity": "sha1-pLJkz+C+XONqvjdlrJwqJIdG28A="
+    },
+    "node_modules/send": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.2.0.tgz",
+      "integrity": "sha1-Bnq/Rc/4v/spy9t0OXJbMjiKLFg=",
+      "dependencies": {
+        "debug": "*",
+        "fresh": "~0.2.1",
+        "mime": "~1.2.9",
+        "range-parser": "~1.0.0"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.0.1.tgz",
+      "integrity": "sha1-ENy/1Es+ApGhMfyatKslqfWnikI=",
+      "dependencies": {
+        "send": "0.1.4"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/serve-static/node_modules/fresh": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.0.tgz",
+      "integrity": "sha1-v9lALPPfEsSkwxDHn5mj3eE9NKc="
+    },
+    "node_modules/serve-static/node_modules/range-parser": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-0.0.4.tgz",
+      "integrity": "sha1-wEJ//vUcEKy6B4KkbJYC50T/Ygs="
+    },
+    "node_modules/serve-static/node_modules/send": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.1.4.tgz",
+      "integrity": "sha1-vnDY0b4B3mGCGvE3gLUDRaT3Gr0=",
+      "dependencies": {
+        "debug": "*",
+        "fresh": "0.2.0",
+        "mime": "~1.2.9",
+        "range-parser": "0.0.4"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.0.0.tgz",
+      "integrity": "sha1-T/Qk6XNJoe4ZELS/xIhZXs3EQ/w=",
+      "dependencies": {
+        "mime": "~1.2.11"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+      "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg=",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    }
+  },
+  "dependencies": {
+    "accepts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.0.0.tgz",
+      "integrity": "sha1-NgTHZVhsO5z3h3tpN829RYf5R9w=",
+      "requires": {
+        "mime": "~1.2.11",
+        "negotiator": "~0.3.0"
+      }
+    },
+    "buffer-crc32": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz",
+      "integrity": "sha1-vj5TgvwCttYySVasGvmKqYsIU0w="
+    },
+    "cookie": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz",
+      "integrity": "sha1-kOtGndzpBchm3mh+/EMTHYgB+dA="
+    },
+    "cookie-signature": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.3.tgz",
+      "integrity": "sha1-kc2ZfMUftkFZVzjGnNoCAyj1D/k="
+    },
+    "debug": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-0.8.1.tgz",
+      "integrity": "sha1-IP9NJvXkIstoobrLu2EDmtjBwTA="
+    },
+    "escape-html": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz",
+      "integrity": "sha1-GBoobq05ejmpKFfPsdQwUuNWv/A="
+    },
+    "express": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.0.0.tgz",
+      "integrity": "sha1-J03IKTPJ9XTMOKDOXqgXK+nGsJQ=",
+      "requires": {
+        "accepts": "1.0.0",
+        "buffer-crc32": "0.2.1",
+        "cookie": "0.1.0",
+        "cookie-signature": "1.0.3",
+        "debug": ">= 0.7.3 < 1",
+        "escape-html": "1.0.1",
+        "fresh": "0.2.2",
+        "merge-descriptors": "0.0.2",
+        "methods": "0.1.0",
+        "parseurl": "1.0.1",
+        "path-to-regexp": "0.1.2",
+        "qs": "0.6.6",
+        "range-parser": "1.0.0",
+        "send": "0.2.0",
+        "serve-static": "1.0.1",
+        "type-is": "1.0.0",
+        "utils-merge": "1.0.0"
+      }
+    },
+    "fresh": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.2.tgz",
+      "integrity": "sha1-lzHc9WeMf660T7kDxPct9VGH+nc="
+    },
+    "merge-descriptors": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.2.tgz",
+      "integrity": "sha1-w2pSp4FDdRPFcnXzndnTF1FKyMc="
+    },
+    "methods": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-0.1.0.tgz",
+      "integrity": "sha1-M11Cnu/SG3us8unJIqjSvRSjDk8="
+    },
+    "mime": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+      "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA="
+    },
+    "negotiator": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.3.0.tgz",
+      "integrity": "sha1-cG1pLv7d9XTVfqn7GriaT6fuj2A="
+    },
+    "parseurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.0.1.tgz",
+      "integrity": "sha1-Llfc5u/dN8NRhwEDCUTCK/OIt7Q="
+    },
+    "path-to-regexp": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.2.tgz",
+      "integrity": "sha1-mysVH5zDAYye6lDKlXKeBXgXErQ="
+    },
+    "qs": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
+      "integrity": "sha1-bgFQmP9RlouKPIGQAdXyyJvEsQc="
+    },
+    "range-parser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.0.tgz",
+      "integrity": "sha1-pLJkz+C+XONqvjdlrJwqJIdG28A="
+    },
+    "send": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.2.0.tgz",
+      "integrity": "sha1-Bnq/Rc/4v/spy9t0OXJbMjiKLFg=",
+      "requires": {
+        "debug": "*",
+        "fresh": "~0.2.1",
+        "mime": "~1.2.9",
+        "range-parser": "~1.0.0"
+      }
+    },
+    "serve-static": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.0.1.tgz",
+      "integrity": "sha1-ENy/1Es+ApGhMfyatKslqfWnikI=",
+      "requires": {
+        "send": "0.1.4"
+      },
+      "dependencies": {
+        "fresh": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.0.tgz",
+          "integrity": "sha1-v9lALPPfEsSkwxDHn5mj3eE9NKc="
+        },
+        "range-parser": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-0.0.4.tgz",
+          "integrity": "sha1-wEJ//vUcEKy6B4KkbJYC50T/Ygs="
+        },
+        "send": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.1.4.tgz",
+          "integrity": "sha1-vnDY0b4B3mGCGvE3gLUDRaT3Gr0=",
+          "requires": {
+            "debug": "*",
+            "fresh": "0.2.0",
+            "mime": "~1.2.9",
+            "range-parser": "0.0.4"
+          }
+        }
+      }
+    },
+    "type-is": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.0.0.tgz",
+      "integrity": "sha1-T/Qk6XNJoe4ZELS/xIhZXs3EQ/w=",
+      "requires": {
+        "mime": "~1.2.11"
+      }
+    },
+    "utils-merge": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+      "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
+    }
+  }
+}

--- a/lib/manager/npm/update/locked-dependency/index.spec.ts
+++ b/lib/manager/npm/update/locked-dependency/index.spec.ts
@@ -14,6 +14,10 @@ const lockFileContent = readFileSync(
   resolve(__dirname, './__fixtures__/package-lock.json'),
   'utf8'
 );
+const lockFileV2Content = readFileSync(
+  resolve(__dirname, './__fixtures__/package-lock.v2.json'),
+  'utf8'
+);
 
 const acceptsJson = JSON.parse(
   readFileSync(resolve(__dirname, './__fixtures__/accepts.json'), 'utf8')
@@ -75,14 +79,6 @@ describe(getName(__filename), () => {
         await updateLockedDependency({ ...config, lockFileContent: 'not json' })
       ).toBeNull();
     });
-    it('rejects lockFileVersion 2', async () => {
-      expect(
-        await updateLockedDependency({
-          ...config,
-          lockFileContent: lockFileContent.replace(': 1,', ': 2,'),
-        })
-      ).toBeNull();
-    });
     it('returns null if no locked deps', async () => {
       expect(await updateLockedDependency(config)).toBeNull();
     });
@@ -100,6 +96,18 @@ describe(getName(__filename), () => {
     it('remediates in-range', async () => {
       const res = await updateLockedDependency({
         ...config,
+        depName: 'mime',
+        currentVersion: '1.2.11',
+        newVersion: '1.2.12',
+      });
+      expect(
+        JSON.parse(res['package-lock.json']).dependencies.mime.version
+      ).toEqual('1.2.12');
+    });
+    it('remediates v2 in-range', async () => {
+      const res = await updateLockedDependency({
+        ...config,
+        lockFileContent: lockFileV2Content,
         depName: 'mime',
         currentVersion: '1.2.11',
         newVersion: '1.2.12',
@@ -132,6 +140,18 @@ describe(getName(__filename), () => {
       config.currentVersion = '4.0.0';
       config.newVersion = '4.1.0';
       const res = await updateLockedDependency(config);
+      expect(res['package.json']).toContain('"express": "4.1.0"');
+      const packageLock = JSON.parse(res['package-lock.json']);
+      expect(packageLock.dependencies.express.version).toEqual('4.1.0');
+    });
+    it('remediates v2 express', async () => {
+      config.depName = 'express';
+      config.currentVersion = '4.0.0';
+      config.newVersion = '4.1.0';
+      const res = await updateLockedDependency({
+        ...config,
+        lockFileContent: lockFileV2Content,
+      });
       expect(res['package.json']).toContain('"express": "4.1.0"');
       const packageLock = JSON.parse(res['package-lock.json']);
       expect(packageLock.dependencies.express.version).toEqual('4.1.0');

--- a/lib/manager/npm/update/locked-dependency/index.ts
+++ b/lib/manager/npm/update/locked-dependency/index.ts
@@ -54,10 +54,6 @@ export async function updateLockedDependency(
       logger.warn({ err }, 'Failed to parse files');
       return null;
     }
-    if (packageLockJson.lockfileVersion === 2) {
-      logger.debug('Only lockfileVersion 1 is supported');
-      return null;
-    }
     const lockedDeps = getLockedDependencies(
       packageLockJson,
       depName,

--- a/lib/workers/repository/init/vulnerability.ts
+++ b/lib/workers/repository/init/vulnerability.ts
@@ -217,7 +217,10 @@ export async function detectVulnerabilityAlerts(
       }
     }
   }
-  logger.debug({ alertPackageRules }, 'alert package rules');
+  logger.debug(
+    { alertPackageRules, remediations: config.remediations },
+    'alert package rules'
+  );
   config.packageRules = (config.packageRules || []).concat(alertPackageRules);
   return config;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Removes code blocking nom's v2 lockfiles from being transitively remediated.

## Context:

Follow-on from #8883 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
