### PR TITLE
feat(npm): remove ignoreNpmrcFile support

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -969,13 +969,6 @@ The above is the same as if you wrote this package rule:
 }
 ```
 
-## ignoreNpmrcFile
-
-By default, Renovate will look for and use any `.npmrc` file it finds in a repository.
-Additionally, it will be read in by `npm` or `yarn` at the time of lock file generation.
-Sometimes this causes problems, for example if the file contains placeholder values, so you can configure this to `true` and Renovate will ignore any `.npmrc` files it finds and temporarily remove the file before running `npm install` or `yarn install`.
-Renovate will try to configure this to `true` also if you have configured any `npmrc` string within your config file.
-
 ## ignorePaths
 
 Using this setting, you can selectively ignore package files that you don't want Renovate autodiscovering.

--- a/lib/config/__snapshots__/migration.spec.ts.snap
+++ b/lib/config/__snapshots__/migration.spec.ts.snap
@@ -123,6 +123,7 @@ Object {
   "minor": Object {
     "automerge": true,
   },
+  "npmrc": "",
   "nvmrc": Object {
     "packageRules": Array [
       Object {

--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -553,12 +553,6 @@ const options: RenovateOptions[] = [
     admin: true,
   },
   {
-    name: 'ignoreNpmrcFile',
-    description: 'Whether to ignore any .npmrc file found in repository.',
-    type: 'boolean',
-    default: false,
-  },
-  {
     name: 'autodiscover',
     description: 'Autodiscover all repositories.',
     stage: 'global',

--- a/lib/config/migration.spec.ts
+++ b/lib/config/migration.spec.ts
@@ -34,6 +34,7 @@ describe('config/migration', () => {
         onboarding: 'false' as never,
         multipleMajorPrs: true,
         gitFs: false,
+        ignoreNpmrcFile: true,
         separateMajorReleases: true,
         separatePatchReleases: true,
         suppressNotifications: ['lockFileErrors', 'prEditNotification'],

--- a/lib/config/migration.ts
+++ b/lib/config/migration.ts
@@ -198,6 +198,9 @@ export function migrateConfig(
           migratedConfig.allowScripts ??= true;
           migratedConfig.exposeAllEnv ??= true;
         }
+      } else if (key === 'ignoreNpmrcFile') {
+        delete migratedConfig.ignoreNpmrcFile;
+        migratedConfig.npmrc ||= '';
       } else if (
         key === 'branchName' &&
         is.string(val) &&

--- a/lib/manager/npm/extract/__snapshots__/index.spec.ts.snap
+++ b/lib/manager/npm/extract/__snapshots__/index.spec.ts.snap
@@ -11,7 +11,6 @@ Object {
       "skipReason": "invalid-name",
     },
   ],
-  "ignoreNpmrcFile": undefined,
   "lernaClient": undefined,
   "lernaPackages": undefined,
   "managerData": Object {
@@ -135,7 +134,6 @@ Object {
       "prettyDepType": "engine",
     },
   ],
-  "ignoreNpmrcFile": undefined,
   "lernaClient": undefined,
   "lernaPackages": undefined,
   "managerData": Object {
@@ -299,7 +297,6 @@ Object {
       "sourceUrl": "https://github.com/owner/n",
     },
   ],
-  "ignoreNpmrcFile": undefined,
   "lernaClient": undefined,
   "lernaPackages": undefined,
   "managerData": Object {
@@ -349,7 +346,6 @@ Object {
       "skipReason": "unknown-version",
     },
   ],
-  "ignoreNpmrcFile": undefined,
   "lernaClient": undefined,
   "lernaPackages": undefined,
   "managerData": Object {
@@ -410,7 +406,6 @@ Object {
       "skipReason": "unknown-volta",
     },
   ],
-  "ignoreNpmrcFile": undefined,
   "lernaClient": undefined,
   "lernaPackages": undefined,
   "managerData": Object {
@@ -465,7 +460,6 @@ Object {
       "skipReason": "unknown-version",
     },
   ],
-  "ignoreNpmrcFile": undefined,
   "lernaClient": undefined,
   "lernaPackages": undefined,
   "managerData": Object {
@@ -602,7 +596,6 @@ Object {
       "prettyDepType": "resolutions",
     },
   ],
-  "ignoreNpmrcFile": undefined,
   "lernaClient": "npm",
   "lernaPackages": undefined,
   "managerData": Object {
@@ -739,7 +732,6 @@ Object {
       "prettyDepType": "resolutions",
     },
   ],
-  "ignoreNpmrcFile": undefined,
   "lernaClient": "yarn",
   "lernaPackages": undefined,
   "managerData": Object {
@@ -876,7 +868,6 @@ Object {
       "prettyDepType": "resolutions",
     },
   ],
-  "ignoreNpmrcFile": undefined,
   "lernaClient": undefined,
   "lernaPackages": undefined,
   "managerData": Object {
@@ -899,7 +890,6 @@ exports[`manager/npm/extract .extractPackageFile() finds complex yarn workspaces
 Object {
   "constraints": Object {},
   "deps": Array [],
-  "ignoreNpmrcFile": undefined,
   "lernaClient": "npm",
   "lernaPackages": undefined,
   "managerData": Object {
@@ -1038,7 +1028,6 @@ Object {
       "prettyDepType": "resolutions",
     },
   ],
-  "ignoreNpmrcFile": undefined,
   "lernaClient": "npm",
   "lernaPackages": undefined,
   "managerData": Object {
@@ -1061,7 +1050,6 @@ exports[`manager/npm/extract .extractPackageFile() finds simple yarn workspaces 
 Object {
   "constraints": Object {},
   "deps": Array [],
-  "ignoreNpmrcFile": undefined,
   "lernaClient": "npm",
   "lernaPackages": undefined,
   "managerData": Object {
@@ -1086,7 +1074,6 @@ exports[`manager/npm/extract .extractPackageFile() finds simple yarn workspaces 
 Object {
   "constraints": Object {},
   "deps": Array [],
-  "ignoreNpmrcFile": undefined,
   "lernaClient": undefined,
   "lernaPackages": undefined,
   "managerData": Object {
@@ -1225,7 +1212,6 @@ Object {
       "prettyDepType": "resolutions",
     },
   ],
-  "ignoreNpmrcFile": undefined,
   "lernaClient": undefined,
   "lernaPackages": undefined,
   "managerData": Object {

--- a/lib/manager/npm/extract/index.spec.ts
+++ b/lib/manager/npm/extract/index.spec.ts
@@ -112,6 +112,20 @@ describe('manager/npm/extract', () => {
       );
       expect(res.npmrc).toBeDefined();
     });
+    it('ignores .npmrc when config.npmrc is defined', async () => {
+      fs.readLocalFile = jest.fn((fileName) => {
+        if (fileName === '.npmrc') {
+          return 'some-npmrc\n';
+        }
+        return null;
+      });
+      const res = await npmExtract.extractPackageFile(
+        input01Content,
+        'package.json',
+        { npmrc: 'some-configured-npmrc' }
+      );
+      expect(res.npmrc).toBeUndefined();
+    });
     it('finds and discards .npmrc', async () => {
       fs.readLocalFile = jest.fn((fileName) => {
         if (fileName === '.npmrc') {
@@ -125,7 +139,7 @@ describe('manager/npm/extract', () => {
         'package.json',
         {}
       );
-      expect(res.npmrc).toBeUndefined();
+      expect(res.npmrc).toEqual('');
     });
     it('finds lerna', async () => {
       fs.readLocalFile = jest.fn((fileName) => {

--- a/lib/manager/npm/extract/index.ts
+++ b/lib/manager/npm/extract/index.ts
@@ -6,11 +6,7 @@ import * as datasourceGithubTags from '../../../datasource/github-tags';
 import { id as npmId } from '../../../datasource/npm';
 import { logger } from '../../../logger';
 import { SkipReason } from '../../../types';
-import {
-  deleteLocalFile,
-  getSiblingFileName,
-  readLocalFile,
-} from '../../../util/fs';
+import { getSiblingFileName, readLocalFile } from '../../../util/fs';
 import * as nodeVersioning from '../../../versioning/node';
 import { isValid, isVersion } from '../../../versioning/npm';
 import type {
@@ -95,26 +91,24 @@ export async function extractPackageFile(
   delete lockFiles.shrinkwrapJson;
 
   let npmrc: string;
-  let ignoreNpmrcFile: boolean;
   const npmrcFileName = getSiblingFileName(fileName, '.npmrc');
-  // istanbul ignore if
-  if (config.ignoreNpmrcFile) {
-    await deleteLocalFile(npmrcFileName);
-  } else {
-    npmrc = await readLocalFile(npmrcFileName, 'utf8');
-    if (npmrc?.includes('package-lock')) {
-      logger.debug('Stripping package-lock setting from npmrc');
-      npmrc = npmrc.replace(/(^|\n)package-lock.*?(\n|$)/g, '\n');
-    }
-    if (is.string(npmrc)) {
-      if (npmrc.includes('=${') && !getAdminConfig().exposeAllEnv) {
-        logger.debug('Discarding .npmrc file with variables');
-        ignoreNpmrcFile = true;
-        npmrc = undefined;
-        await deleteLocalFile(npmrcFileName);
-      }
+  const npmrcContent = await readLocalFile(npmrcFileName, 'utf8');
+  if (is.string(npmrcContent)) {
+    if (is.string(config.npmrc)) {
+      logger.debug(
+        { npmrcFileName },
+        'Repo .npmrc file is ignored due to presence of config.npmrc'
+      );
     } else {
-      npmrc = undefined;
+      npmrc = npmrcContent;
+      if (npmrc?.includes('package-lock')) {
+        logger.debug('Stripping package-lock setting from npmrc');
+        npmrc = npmrc.replace(/(^|\n)package-lock.*?(\n|$)/g, '\n');
+      }
+      if (npmrc.includes('=${') && !getAdminConfig().exposeAllEnv) {
+        logger.debug('Overriding .npmrc file with variables');
+        npmrc = '';
+      }
     }
   }
   const yarnrcFileName = getSiblingFileName(fileName, '.yarnrc');
@@ -363,7 +357,6 @@ export async function extractPackageFile(
     packageFileVersion,
     packageJsonType,
     npmrc,
-    ignoreNpmrcFile,
     yarnrc,
     ...lockFiles,
     managerData: {

--- a/lib/manager/npm/extract/index.ts
+++ b/lib/manager/npm/extract/index.ts
@@ -102,7 +102,7 @@ export async function extractPackageFile(
     } else {
       npmrc = npmrcContent;
       if (npmrc?.includes('package-lock')) {
-        logger.debug('Stripping package-lock setting from npmrc');
+        logger.debug('Stripping package-lock setting from .npmrc');
         npmrc = npmrc.replace(/(^|\n)package-lock.*?(\n|$)/g, '\n');
       }
       if (npmrc.includes('=${') && !getAdminConfig().exposeAllEnv) {

--- a/lib/manager/npm/post-update/index.ts
+++ b/lib/manager/npm/post-update/index.ts
@@ -144,9 +144,6 @@ export async function writeExistingFiles(
       } catch (err) /* istanbul ignore next */ {
         logger.warn({ npmrcFilename, err }, 'Error writing .npmrc');
       }
-    } else if (config.ignoreNpmrcFile) {
-      logger.debug('Removing ignored .npmrc file before artifact generation');
-      await remove(npmrcFilename);
     }
     if (packageFile.yarnrc) {
       logger.debug(`Writing .yarnrc to ${basedir}`);

--- a/lib/manager/types.ts
+++ b/lib/manager/types.ts
@@ -23,7 +23,7 @@ export interface ExtractConfig extends ManagerConfig {
   endpoint?: string;
   gradle?: { timeout?: number };
   aliases?: Record<string, string>;
-  ignoreNpmrcFile?: boolean;
+  npmrc?: string;
   yarnrc?: string;
   skipInstalls?: boolean;
   versioning?: string;
@@ -85,7 +85,6 @@ export interface PackageFile<T = Record<string, any>>
   datasource?: string;
   registryUrls?: string[];
   deps: PackageDependency[];
-  ignoreNpmrcFile?: boolean;
   lernaClient?: string;
   lernaPackages?: string[];
   mavenProps?: Record<string, any>;

--- a/lib/workers/repository/extract/__snapshots__/manager-files.spec.ts.snap
+++ b/lib/workers/repository/extract/__snapshots__/manager-files.spec.ts.snap
@@ -14,7 +14,6 @@ Array [
         "prettyDepType": "dependency",
       },
     ],
-    "ignoreNpmrcFile": undefined,
     "lernaClient": undefined,
     "lernaPackages": undefined,
     "managerData": Object {

--- a/lib/workers/repository/init/config.ts
+++ b/lib/workers/repository/init/config.ts
@@ -196,7 +196,6 @@ export async function mergeRenovateConfig(
       'Ignoring any .npmrc files in repository due to configured npmrc'
     );
     npmApi.setNpmrc(resolvedConfig.npmrc);
-    resolvedConfig.ignoreNpmrcFile = true;
   }
   // istanbul ignore if
   if (resolvedConfig.hostRules) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Removes support for the ignoreNpmrcFile config option.

## Context:

BREAKING CHANGE: ignoreNpmrcFile is no longer supported. Use an empty string for config.npmrc instead.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
