### PR TITLE
fix(terraform): skip interpretation of nested blocks

### DIFF
--- a/lib/manager/terraform/__fixtures__/1.tf
+++ b/lib/manager/terraform/__fixtures__/1.tf
@@ -92,6 +92,7 @@ module "addons_aws" {
   aws-ebs-csi-driver = {
     enabled          = true
     is_default_class = true
+    version = "1.0.0"
   }
 
 

--- a/lib/manager/terraform/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/terraform/__snapshots__/extract.spec.ts.snap
@@ -270,7 +270,7 @@ Object {
       "datasource": "github-tags",
       "depName": "hashicorp/terraform",
       "extractVersion": "v(?<version>.*)$",
-      "lineNumber": 229,
+      "lineNumber": 230,
     },
     Object {
       "currentValue": "2.7.2",

--- a/lib/manager/terraform/providers.ts
+++ b/lib/manager/terraform/providers.ts
@@ -37,15 +37,19 @@ export function extractTerraformProvider(
     const closedBrackets = (line.match(/\}/g) || []).length;
     braceCounter = braceCounter + openBrackets - closedBrackets;
 
-    const kvMatch = keyValueExtractionRegex.exec(line);
-    if (kvMatch) {
-      if (kvMatch.groups.key === 'version') {
-        dep.currentValue = kvMatch.groups.value;
-      } else if (kvMatch.groups.key === 'source') {
-        dep.managerData.source = kvMatch.groups.value;
-        dep.managerData.sourceLine = lineNumber;
+    // only update fields inside the root block
+    if (braceCounter === 1) {
+      const kvMatch = keyValueExtractionRegex.exec(line);
+      if (kvMatch) {
+        if (kvMatch.groups.key === 'version') {
+          dep.currentValue = kvMatch.groups.value;
+        } else if (kvMatch.groups.key === 'source') {
+          dep.managerData.source = kvMatch.groups.value;
+          dep.managerData.sourceLine = lineNumber;
+        }
       }
     }
+
     lineNumber += 1;
   } while (braceCounter !== 0);
   deps.push(dep);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:
Only interpret source and version fields of providers and modules if they are in the root block 
## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->


Closes #9238

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
