### PR TITLE
refactor(presets): Reuse PRESET_INVALID_JSON variable

### DIFF
--- a/lib/config/presets/bitbucket-server/index.spec.ts
+++ b/lib/config/presets/bitbucket-server/index.spec.ts
@@ -1,7 +1,7 @@
 import * as httpMock from '../../../../test/http-mock';
 import { getName, mocked } from '../../../../test/util';
 import * as _hostRules from '../../../util/host-rules';
-import { PRESET_DEP_NOT_FOUND } from '../util';
+import { PRESET_DEP_NOT_FOUND, PRESET_INVALID_JSON } from '../util';
 import * as bitbucketServer from '.';
 
 jest.mock('../../../util/host-rules');
@@ -73,7 +73,7 @@ describe(getName(__filename), () => {
           'some-filename.json',
           bitbucketApiHost
         )
-      ).rejects.toThrow('invalid preset JSON');
+      ).rejects.toThrow(PRESET_INVALID_JSON);
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
 
@@ -93,7 +93,7 @@ describe(getName(__filename), () => {
           'some-filename.json',
           bitbucketApiHost
         )
-      ).rejects.toThrow('invalid preset JSON');
+      ).rejects.toThrow(PRESET_INVALID_JSON);
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
   });

--- a/lib/config/presets/bitbucket-server/index.ts
+++ b/lib/config/presets/bitbucket-server/index.ts
@@ -6,7 +6,11 @@ import {
   setBaseUrl,
 } from '../../../util/http/bitbucket-server';
 import type { Preset } from '../types';
-import { PRESET_DEP_NOT_FOUND, fetchPreset } from '../util';
+import {
+  PRESET_DEP_NOT_FOUND,
+  PRESET_INVALID_JSON,
+  fetchPreset,
+} from '../util';
 
 const http = new BitbucketServerHttp();
 
@@ -34,14 +38,14 @@ export async function fetchJSONFile(
   }
   if (!res.body.isLastPage) {
     logger.warn({ size: res.body.size }, 'Renovate config to big');
-    throw new Error('invalid preset JSON');
+    throw new Error(PRESET_INVALID_JSON);
   }
   try {
     const content = res.body.lines.map((l) => l.text).join('');
     const parsed = JSON.parse(content);
     return parsed;
   } catch (err) {
-    throw new Error('invalid preset JSON');
+    throw new Error(PRESET_INVALID_JSON);
   }
 }
 

--- a/lib/config/presets/gitea/index.spec.ts
+++ b/lib/config/presets/gitea/index.spec.ts
@@ -2,7 +2,7 @@ import * as httpMock from '../../../../test/http-mock';
 import { getName, mocked } from '../../../../test/util';
 import * as _hostRules from '../../../util/host-rules';
 import { setBaseUrl } from '../../../util/http/gitea';
-import { PRESET_NOT_FOUND } from '../util';
+import { PRESET_INVALID_JSON, PRESET_NOT_FOUND } from '../util';
 import * as gitea from '.';
 
 jest.mock('../../../util/host-rules');
@@ -63,7 +63,7 @@ describe(getName(__filename), () => {
 
       await expect(
         gitea.getPreset({ packageName: 'some/repo' })
-      ).rejects.toThrow('invalid preset JSON');
+      ).rejects.toThrow(PRESET_INVALID_JSON);
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
 
@@ -77,7 +77,7 @@ describe(getName(__filename), () => {
 
       await expect(
         gitea.getPreset({ packageName: 'some/repo' })
-      ).rejects.toThrow('invalid preset JSON');
+      ).rejects.toThrow(PRESET_INVALID_JSON);
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
 

--- a/lib/config/presets/gitea/index.ts
+++ b/lib/config/presets/gitea/index.ts
@@ -5,7 +5,11 @@ import {
 } from '../../../platform/gitea/gitea-helper';
 import { ExternalHostError } from '../../../types/errors/external-host-error';
 import type { Preset, PresetConfig } from '../types';
-import { PRESET_DEP_NOT_FOUND, fetchPreset } from '../util';
+import {
+  PRESET_DEP_NOT_FOUND,
+  PRESET_INVALID_JSON,
+  fetchPreset,
+} from '../util';
 
 export const Endpoint = 'https://gitea.com/api/v1/';
 
@@ -33,7 +37,7 @@ export async function fetchJSONFile(
     const parsed = JSON.parse(content);
     return parsed;
   } catch (err) {
-    throw new Error('invalid preset JSON');
+    throw new Error(PRESET_INVALID_JSON);
   }
 }
 

--- a/lib/config/presets/github/index.spec.ts
+++ b/lib/config/presets/github/index.spec.ts
@@ -1,7 +1,7 @@
 import * as httpMock from '../../../../test/http-mock';
 import { getName, mocked } from '../../../../test/util';
 import * as _hostRules from '../../../util/host-rules';
-import { PRESET_NOT_FOUND } from '../util';
+import { PRESET_INVALID_JSON, PRESET_NOT_FOUND } from '../util';
 import * as github from '.';
 
 jest.mock('../../../util/host-rules');
@@ -61,7 +61,7 @@ describe(getName(__filename), () => {
 
       await expect(
         github.getPreset({ packageName: 'some/repo' })
-      ).rejects.toThrow('invalid preset JSON');
+      ).rejects.toThrow(PRESET_INVALID_JSON);
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
 
@@ -75,7 +75,7 @@ describe(getName(__filename), () => {
 
       await expect(
         github.getPreset({ packageName: 'some/repo' })
-      ).rejects.toThrow('invalid preset JSON');
+      ).rejects.toThrow(PRESET_INVALID_JSON);
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
 

--- a/lib/config/presets/github/index.ts
+++ b/lib/config/presets/github/index.ts
@@ -2,7 +2,11 @@ import { logger } from '../../../logger';
 import { ExternalHostError } from '../../../types/errors/external-host-error';
 import { GithubHttp } from '../../../util/http/github';
 import type { Preset, PresetConfig } from '../types';
-import { PRESET_DEP_NOT_FOUND, fetchPreset } from '../util';
+import {
+  PRESET_DEP_NOT_FOUND,
+  PRESET_INVALID_JSON,
+  fetchPreset,
+} from '../util';
 
 export const Endpoint = 'https://api.github.com/';
 
@@ -33,7 +37,7 @@ export async function fetchJSONFile(
     const parsed = JSON.parse(content);
     return parsed;
   } catch (err) {
-    throw new Error('invalid preset JSON');
+    throw new Error(PRESET_INVALID_JSON);
   }
 }
 

--- a/lib/config/presets/util.ts
+++ b/lib/config/presets/util.ts
@@ -4,6 +4,7 @@ import type { Preset } from './types';
 
 export const PRESET_DEP_NOT_FOUND = 'dep not found';
 export const PRESET_NOT_FOUND = 'preset not found';
+export const PRESET_INVALID_JSON = 'invalid preset JSON';
 
 export type PresetFetcher = (
   repo: string,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

One more error message defined as the constant

## Context:

Ref: #9171

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
