### PR TITLE
refactor(platform): getRawFile and getJsonFile throw instead of null

### DIFF
--- a/lib/platform/azure/index.spec.ts
+++ b/lib/platform/azure/index.spec.ts
@@ -1196,7 +1196,7 @@ describe('platform/azure', () => {
       const res = await azure.getJsonFile('file.json');
       expect(res).toEqual(data);
     });
-    it('returns null for malformed JSON', async () => {
+    it('throws on malformed JSON', async () => {
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
@@ -1205,18 +1205,18 @@ describe('platform/azure', () => {
             ),
           } as any)
       );
-      const res = await azure.getJsonFile('file.json');
-      expect(res).toBeNull();
+      await expect(azure.getJsonFile('file.json')).rejects.toThrow();
     });
-    it('returns null on errors', async () => {
+    it('throws on errors', async () => {
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
-            getItemContent: jest.fn(() => Promise.reject('some error')),
+            getItemContent: jest.fn(() => {
+              throw new Error('some error');
+            }),
           } as any)
       );
-      const res = await azure.getJsonFile('file.json');
-      expect(res).toBeNull();
+      await expect(azure.getJsonFile('file.json')).rejects.toThrow();
     });
   });
 });

--- a/lib/platform/azure/index.ts
+++ b/lib/platform/azure/index.ts
@@ -108,26 +108,18 @@ export async function getRawFile(
   fileName: string,
   repo: string = config.repoId
 ): Promise<string | null> {
-  try {
-    const azureApiGit = await azureApi.gitApi();
-    const buf = await azureApiGit.getItemContent(repo, fileName);
-    const str = await streamToString(buf);
-    return str;
-  } catch (err) {
-    return null;
-  }
+  const azureApiGit = await azureApi.gitApi();
+  const buf = await azureApiGit.getItemContent(repo, fileName);
+  const str = await streamToString(buf);
+  return str;
 }
 
 export async function getJsonFile(
   fileName: string,
   repo: string = config.repoId
 ): Promise<any | null> {
-  try {
-    const raw = await getRawFile(fileName, repo);
-    return raw && JSON.parse(raw);
-  } catch (err) {
-    return null;
-  }
+  const raw = await getRawFile(fileName, repo);
+  return JSON.parse(raw);
 }
 
 export async function initRepo({

--- a/lib/platform/bitbucket-server/__snapshots__/index.spec.ts.snap
+++ b/lib/platform/bitbucket-server/__snapshots__/index.spec.ts.snap
@@ -1931,7 +1931,7 @@ Array [
 ]
 `;
 
-exports[`platform/bitbucket-server/index endpoint with no path getJsonFile() returns null for long content 1`] = `
+exports[`platform/bitbucket-server/index endpoint with no path getJsonFile() throws on errors 1`] = `
 Array [
   Object {
     "headers": Object {
@@ -1972,7 +1972,7 @@ Array [
 ]
 `;
 
-exports[`platform/bitbucket-server/index endpoint with no path getJsonFile() returns null for malformed JSON 1`] = `
+exports[`platform/bitbucket-server/index endpoint with no path getJsonFile() throws on long content 1`] = `
 Array [
   Object {
     "headers": Object {
@@ -2013,7 +2013,7 @@ Array [
 ]
 `;
 
-exports[`platform/bitbucket-server/index endpoint with no path getJsonFile() returns null on errors 1`] = `
+exports[`platform/bitbucket-server/index endpoint with no path getJsonFile() throws on malformed JSON 1`] = `
 Array [
   Object {
     "headers": Object {
@@ -6062,7 +6062,7 @@ Array [
 ]
 `;
 
-exports[`platform/bitbucket-server/index endpoint with path getJsonFile() returns null for long content 1`] = `
+exports[`platform/bitbucket-server/index endpoint with path getJsonFile() throws on errors 1`] = `
 Array [
   Object {
     "headers": Object {
@@ -6103,7 +6103,7 @@ Array [
 ]
 `;
 
-exports[`platform/bitbucket-server/index endpoint with path getJsonFile() returns null for malformed JSON 1`] = `
+exports[`platform/bitbucket-server/index endpoint with path getJsonFile() throws on long content 1`] = `
 Array [
   Object {
     "headers": Object {
@@ -6144,7 +6144,7 @@ Array [
 ]
 `;
 
-exports[`platform/bitbucket-server/index endpoint with path getJsonFile() returns null on errors 1`] = `
+exports[`platform/bitbucket-server/index endpoint with path getJsonFile() throws on malformed JSON 1`] = `
 Array [
   Object {
     "headers": Object {

--- a/lib/platform/bitbucket-server/index.spec.ts
+++ b/lib/platform/bitbucket-server/index.spec.ts
@@ -2107,7 +2107,7 @@ Followed by some information.
           expect(res).toEqual(data);
           expect(httpMock.getTrace()).toMatchSnapshot();
         });
-        it('returns null for malformed JSON', async () => {
+        it('throws on malformed JSON', async () => {
           const scope = await initRepo();
           scope
             .get(
@@ -2117,11 +2117,10 @@ Followed by some information.
               isLastPage: true,
               lines: [{ text: '!@#' }],
             });
-          const res = await bitbucket.getJsonFile('file.json');
-          expect(res).toBeNull();
+          await expect(bitbucket.getJsonFile('file.json')).rejects.toThrow();
           expect(httpMock.getTrace()).toMatchSnapshot();
         });
-        it('returns null for long content', async () => {
+        it('throws on long content', async () => {
           const scope = await initRepo();
           scope
             .get(
@@ -2131,19 +2130,17 @@ Followed by some information.
               isLastPage: false,
               lines: [{ text: '{' }],
             });
-          const res = await bitbucket.getJsonFile('file.json');
-          expect(res).toBeNull();
+          await expect(bitbucket.getJsonFile('file.json')).rejects.toThrow();
           expect(httpMock.getTrace()).toMatchSnapshot();
         });
-        it('returns null on errors', async () => {
+        it('throws on errors', async () => {
           const scope = await initRepo();
           scope
             .get(
               `${urlPath}/rest/api/1.0/projects/SOME/repos/repo/browse/file.json?limit=20000`
             )
             .replyWithError('some error');
-          const res = await bitbucket.getJsonFile('file.json');
-          expect(res).toBeNull();
+          await expect(bitbucket.getJsonFile('file.json')).rejects.toThrow();
           expect(httpMock.getTrace()).toMatchSnapshot();
         });
       });

--- a/lib/platform/bitbucket/__snapshots__/index.spec.ts.snap
+++ b/lib/platform/bitbucket/__snapshots__/index.spec.ts.snap
@@ -921,7 +921,7 @@ Array [
 ]
 `;
 
-exports[`platform/bitbucket getJsonFile() returns null for malformed JSON 1`] = `
+exports[`platform/bitbucket getJsonFile() throws on errors 1`] = `
 Array [
   Object {
     "headers": Object {
@@ -947,7 +947,7 @@ Array [
 ]
 `;
 
-exports[`platform/bitbucket getJsonFile() returns null on errors 1`] = `
+exports[`platform/bitbucket getJsonFile() throws on malformed JSON 1`] = `
 Array [
   Object {
     "headers": Object {

--- a/lib/platform/bitbucket/index.spec.ts
+++ b/lib/platform/bitbucket/index.spec.ts
@@ -851,22 +851,20 @@ describe('platform/bitbucket', () => {
       expect(res).toEqual(data);
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
-    it('returns null for malformed JSON', async () => {
+    it('throws on malformed JSON', async () => {
       const scope = await initRepoMock();
       scope
         .get('/2.0/repositories/some/repo/src/HEAD/file.json')
         .reply(200, '!@#');
-      const res = await bitbucket.getJsonFile('file.json');
-      expect(res).toBeNull();
+      await expect(bitbucket.getJsonFile('file.json')).rejects.toThrow();
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
-    it('returns null on errors', async () => {
+    it('throws on errors', async () => {
       const scope = await initRepoMock();
       scope
         .get('/2.0/repositories/some/repo/src/HEAD/file.json')
         .replyWithError('some error');
-      const res = await bitbucket.getJsonFile('file.json');
-      expect(res).toBeNull();
+      await expect(bitbucket.getJsonFile('file.json')).rejects.toThrow();
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
   });

--- a/lib/platform/bitbucket/index.ts
+++ b/lib/platform/bitbucket/index.ts
@@ -103,27 +103,19 @@ export async function getRawFile(
   fileName: string,
   repo: string = config.repository
 ): Promise<string | null> {
-  try {
-    // See: https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Bworkspace%7D/%7Brepo_slug%7D/src/%7Bcommit%7D/%7Bpath%7D
-    const path = fileName;
-    const url = `/2.0/repositories/${repo}/src/HEAD/${path}`;
-    const res = await bitbucketHttp.get(url);
-    return res.body;
-  } catch (err) {
-    return null;
-  }
+  // See: https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Bworkspace%7D/%7Brepo_slug%7D/src/%7Bcommit%7D/%7Bpath%7D
+  const path = fileName;
+  const url = `/2.0/repositories/${repo}/src/HEAD/${path}`;
+  const res = await bitbucketHttp.get(url);
+  return res.body;
 }
 
 export async function getJsonFile(
   fileName: string,
   repo: string = config.repository
 ): Promise<any | null> {
-  try {
-    const raw = await getRawFile(fileName, repo);
-    return raw && JSON.parse(raw);
-  } catch (err) {
-    return null;
-  }
+  const raw = await getRawFile(fileName, repo);
+  return JSON.parse(raw);
 }
 
 // Initialize bitbucket by getting base branch and SHA

--- a/lib/platform/gitea/index.spec.ts
+++ b/lib/platform/gitea/index.spec.ts
@@ -1363,19 +1363,17 @@ describe(getName(__filename), () => {
       const res = await gitea.getJsonFile('file.json');
       expect(res).toEqual(data);
     });
-    it('returns null for malformed JSON', async () => {
+    it('throws on malformed JSON', async () => {
       helper.getRepoContents.mockResolvedValueOnce({
         contentString: '!@#',
       } as never);
       await initFakeRepo({ full_name: 'some/repo' });
-      const res = await gitea.getJsonFile('file.json');
-      expect(res).toBeNull();
+      await expect(gitea.getJsonFile('file.json')).rejects.toThrow();
     });
-    it('returns null on errors', async () => {
-      helper.getRepoContents.mockRejectedValueOnce('some error');
+    it('throws on errors', async () => {
+      helper.getRepoContents.mockRejectedValueOnce(new Error('some error'));
       await initFakeRepo({ full_name: 'some/repo' });
-      const res = await gitea.getJsonFile('file.json');
-      expect(res).toBeNull();
+      await expect(gitea.getJsonFile('file.json')).rejects.toThrow();
     });
   });
 });

--- a/lib/platform/gitea/index.ts
+++ b/lib/platform/gitea/index.ts
@@ -212,24 +212,16 @@ const platform: Platform = {
     fileName: string,
     repo: string = config.repository
   ): Promise<string | null> {
-    try {
-      const contents = await helper.getRepoContents(repo, fileName);
-      return contents.contentString;
-    } catch (err) /* istanbul ignore next */ {
-      return null;
-    }
+    const contents = await helper.getRepoContents(repo, fileName);
+    return contents.contentString;
   },
 
   async getJsonFile(
     fileName: string,
     repo: string = config.repository
   ): Promise<any | null> {
-    try {
-      const raw = await platform.getRawFile(fileName, repo);
-      return raw && JSON.parse(raw);
-    } catch (err) /* istanbul ignore next */ {
-      return null;
-    }
+    const raw = await platform.getRawFile(fileName, repo);
+    return JSON.parse(raw);
   },
 
   async initRepo({

--- a/lib/platform/github/__snapshots__/index.spec.ts.snap
+++ b/lib/platform/github/__snapshots__/index.spec.ts.snap
@@ -3454,7 +3454,7 @@ Array [
 ]
 `;
 
-exports[`platform/github getJsonFile() returns null for malformed JSON 1`] = `
+exports[`platform/github getJsonFile() throws on errors 1`] = `
 Array [
   Object {
     "graphql": Object {
@@ -3505,7 +3505,7 @@ Array [
 ]
 `;
 
-exports[`platform/github getJsonFile() returns null on errors 1`] = `
+exports[`platform/github getJsonFile() throws on malformed JSON 1`] = `
 Array [
   Object {
     "graphql": Object {

--- a/lib/platform/github/index.spec.ts
+++ b/lib/platform/github/index.spec.ts
@@ -2152,18 +2152,17 @@ describe('platform/github', () => {
       expect(res).toEqual(data);
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
-    it('returns null for malformed JSON', async () => {
+    it('throws on malformed JSON', async () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
       await github.initRepo({ repository: 'some/repo', token: 'token' } as any);
       scope.get('/repos/some/repo/contents/file.json').reply(200, {
         content: Buffer.from('!@#').toString('base64'),
       });
-      const res = await github.getJsonFile('file.json');
-      expect(res).toBeNull();
+      await expect(github.getJsonFile('file.json')).rejects.toThrow();
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
-    it('returns null on errors', async () => {
+    it('throws on errors', async () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
       await github.initRepo({ repository: 'some/repo', token: 'token' } as any);
@@ -2171,8 +2170,7 @@ describe('platform/github', () => {
         .get('/repos/some/repo/contents/file.json')
         .replyWithError('some error');
 
-      const res = await github.getJsonFile('file.json');
-      expect(res).toBeNull();
+      await expect(github.getJsonFile('file.json')).rejects.toThrow();
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
   });

--- a/lib/platform/github/index.ts
+++ b/lib/platform/github/index.ts
@@ -145,27 +145,19 @@ export async function getRawFile(
   fileName: string,
   repo: string = config.repository
 ): Promise<string | null> {
-  try {
-    const url = `repos/${repo}/contents/${fileName}`;
-    const res = await githubApi.getJson<{ content: string }>(url);
-    const buf = res.body.content;
-    const str = Buffer.from(buf, 'base64').toString();
-    return str;
-  } catch (err) {
-    return null;
-  }
+  const url = `repos/${repo}/contents/${fileName}`;
+  const res = await githubApi.getJson<{ content: string }>(url);
+  const buf = res.body.content;
+  const str = Buffer.from(buf, 'base64').toString();
+  return str;
 }
 
 export async function getJsonFile(
   fileName: string,
   repo: string = config.repository
 ): Promise<any | null> {
-  try {
-    const raw = await getRawFile(fileName, repo);
-    return raw && JSON.parse(raw);
-  } catch (err) {
-    return null;
-  }
+  const raw = await getRawFile(fileName, repo);
+  return JSON.parse(raw);
 }
 
 let existingRepos;

--- a/lib/platform/gitlab/__snapshots__/index.spec.ts.snap
+++ b/lib/platform/gitlab/__snapshots__/index.spec.ts.snap
@@ -1551,7 +1551,7 @@ Array [
 ]
 `;
 
-exports[`platform/gitlab getJsonFile() returns null for malformed JSON 1`] = `
+exports[`platform/gitlab getJsonFile() throws on errors 1`] = `
 Array [
   Object {
     "headers": Object {
@@ -1578,7 +1578,7 @@ Array [
 ]
 `;
 
-exports[`platform/gitlab getJsonFile() returns null on errors 1`] = `
+exports[`platform/gitlab getJsonFile() throws on malformed JSON 1`] = `
 Array [
   Object {
     "headers": Object {
@@ -1600,7 +1600,7 @@ Array [
       "user-agent": "https://github.com/renovatebot/renovate",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/some%2Frepo/repository/files/file.json?ref=HEAD",
+    "url": "https://gitlab.com/api/v4/projects/some%2Frepo/repository/files/dir%2Ffile.json?ref=HEAD",
   },
 ]
 `;

--- a/lib/platform/gitlab/index.spec.ts
+++ b/lib/platform/gitlab/index.spec.ts
@@ -1447,7 +1447,7 @@ These updates have all been created already. Click a checkbox below to force a r
       expect(res).toEqual(data);
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
-    it('returns null for malformed JSON', async () => {
+    it('throws on malformed JSON', async () => {
       const scope = await initRepo();
       scope
         .get(
@@ -1456,17 +1456,17 @@ These updates have all been created already. Click a checkbox below to force a r
         .reply(200, {
           content: Buffer.from('!@#').toString('base64'),
         });
-      const res = await gitlab.getJsonFile('dir/file.json');
-      expect(res).toBeNull();
+      await expect(gitlab.getJsonFile('dir/file.json')).rejects.toThrow();
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
-    it('returns null on errors', async () => {
+    it('throws on errors', async () => {
       const scope = await initRepo();
       scope
-        .get('/api/v4/projects/some%2Frepo/repository/files/file.json?ref=HEAD')
+        .get(
+          '/api/v4/projects/some%2Frepo/repository/files/dir%2Ffile.json?ref=HEAD'
+        )
         .replyWithError('some error');
-      const res = await gitlab.getJsonFile('file.json');
-      expect(res).toBeNull();
+      await expect(gitlab.getJsonFile('dir/file.json')).rejects.toThrow();
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
   });

--- a/lib/platform/gitlab/index.ts
+++ b/lib/platform/gitlab/index.ts
@@ -143,28 +143,20 @@ export async function getRawFile(
   fileName: string,
   repo: string = config.repository
 ): Promise<string | null> {
-  try {
-    const escapedFileName = urlEscape(fileName);
-    const url = `projects/${repo}/repository/files/${escapedFileName}?ref=HEAD`;
-    const res = await gitlabApi.getJson<{ content: string }>(url);
-    const buf = res.body.content;
-    const str = Buffer.from(buf, 'base64').toString();
-    return str;
-  } catch (err) {
-    return null;
-  }
+  const escapedFileName = urlEscape(fileName);
+  const url = `projects/${repo}/repository/files/${escapedFileName}?ref=HEAD`;
+  const res = await gitlabApi.getJson<{ content: string }>(url);
+  const buf = res.body.content;
+  const str = Buffer.from(buf, 'base64').toString();
+  return str;
 }
 
 export async function getJsonFile(
   fileName: string,
   repo: string = config.repository
 ): Promise<any | null> {
-  try {
-    const raw = await getRawFile(fileName, repo);
-    return raw && JSON.parse(raw);
-  } catch (err) {
-    return null;
-  }
+  const raw = await getRawFile(fileName, repo);
+  return JSON.parse(raw);
 }
 
 // Initialize GitLab by getting base branch

--- a/lib/workers/repository/init/apis.spec.ts
+++ b/lib/workers/repository/init/apis.spec.ts
@@ -59,7 +59,14 @@ describe('workers/repository/init/apis', () => {
         isFork: false,
       });
       platform.getJsonFile.mockRejectedValue(new Error());
-      await expect(initApis(config)).resolves.not.toThrow();
+      await expect(
+        initApis({
+          ...config,
+          optimizeForDisabled: true,
+          includeForks: false,
+          isFork: true,
+        })
+      ).resolves.not.toThrow();
     });
     it('uses the onboardingConfigFileName if set', async () => {
       platform.initRepo.mockResolvedValueOnce({

--- a/lib/workers/repository/init/apis.spec.ts
+++ b/lib/workers/repository/init/apis.spec.ts
@@ -53,6 +53,14 @@ describe('workers/repository/init/apis', () => {
         })
       ).rejects.toThrow(REPOSITORY_FORKED);
     });
+    it('ignores platform.getJsonFile() failures', async () => {
+      platform.initRepo.mockResolvedValueOnce({
+        defaultBranch: 'master',
+        isFork: false,
+      });
+      platform.getJsonFile.mockRejectedValue(new Error());
+      await expect(initApis(config)).resolves.not.toThrow();
+    });
     it('uses the onboardingConfigFileName if set', async () => {
       platform.initRepo.mockResolvedValueOnce({
         defaultBranch: 'master',

--- a/lib/workers/repository/init/apis.ts
+++ b/lib/workers/repository/init/apis.ts
@@ -17,13 +17,19 @@ const defaultConfigFile = (config: RenovateConfig): string =>
     ? config.onboardingConfigFileName
     : configFileNames[0];
 
+async function getJsonFile(file: string): Promise<any | null> {
+  try {
+    return await platform.getJsonFile(file);
+  } catch (err) {
+    return null;
+  }
+}
+
 async function validateOptimizeForDisabled(
   config: RenovateConfig
 ): Promise<void> {
   if (config.optimizeForDisabled) {
-    const renovateConfig = await platform.getJsonFile(
-      defaultConfigFile(config)
-    );
+    const renovateConfig = await getJsonFile(defaultConfigFile(config));
     if (renovateConfig?.enabled === false) {
       throw new Error(REPOSITORY_DISABLED_BY_CONFIG);
     }
@@ -32,9 +38,7 @@ async function validateOptimizeForDisabled(
 
 async function validateIncludeForks(config: RenovateConfig): Promise<void> {
   if (!config.includeForks && config.isFork) {
-    const renovateConfig = await platform.getJsonFile(
-      defaultConfigFile(config)
-    );
+    const renovateConfig = await getJsonFile(defaultConfigFile(config));
     if (!renovateConfig?.includeForks) {
       throw new Error(REPOSITORY_FORKED);
     }

--- a/lib/workers/repository/init/apis.ts
+++ b/lib/workers/repository/init/apis.ts
@@ -17,7 +17,7 @@ const defaultConfigFile = (config: RenovateConfig): string =>
     ? config.onboardingConfigFileName
     : configFileNames[0];
 
-async function getJsonFile(file: string): Promise<any | null> {
+async function getJsonFile(file: string): Promise<RenovateConfig | null> {
   try {
     return await platform.getJsonFile(file);
   } catch (err) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

In order to show good error messages, it would be better to throw + handle, instead of return `null` + logging

## Context:

Ref: #9171

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
