### PR TITLE
feat(config): delay global config preset resolution

### DIFF
--- a/lib/config/index.ts
+++ b/lib/config/index.ts
@@ -7,7 +7,6 @@ import * as defaultsParser from './defaults';
 import * as definitions from './definitions';
 import * as envParser from './env';
 import * as fileParser from './file';
-import { resolveConfigPresets } from './presets';
 import type {
   GlobalConfig,
   RenovateConfig,
@@ -52,10 +51,10 @@ export async function parseConfigs(
   logger.debug('Parsing configs');
 
   // Get configs
-  const defaultConfig = await resolveConfigPresets(defaultsParser.getConfig());
-  const fileConfig = await resolveConfigPresets(fileParser.getConfig(env));
-  const cliConfig = await resolveConfigPresets(cliParser.getConfig(argv));
-  const envConfig = await resolveConfigPresets(envParser.getConfig(env));
+  const defaultConfig = defaultsParser.getConfig();
+  const fileConfig = fileParser.getConfig(env);
+  const cliConfig = cliParser.getConfig(argv);
+  const envConfig = envParser.getConfig(env);
 
   let config: GlobalConfig = mergeChildConfig(fileConfig, envConfig);
   config = mergeChildConfig(config, cliConfig);

--- a/lib/constants/error-messages.ts
+++ b/lib/constants/error-messages.ts
@@ -12,6 +12,7 @@ export const PLATFORM_RATE_LIMIT_EXCEEDED = 'rate-limit-exceeded';
 
 // Config Error
 export const CONFIG_VALIDATION = 'config-validation';
+export const CONFIG_PRESETS_INVALID = 'config-presets-invalid';
 export const CONFIG_SECRETS_EXPOSED = 'config-secrets-exposed';
 export const CONFIG_SECRETS_INVALID = 'config-secrets-invalid';
 

--- a/lib/workers/global/index.ts
+++ b/lib/workers/global/index.ts
@@ -6,7 +6,9 @@ import upath from 'upath';
 import * as pkg from '../../../package.json';
 import * as configParser from '../../config';
 import { GlobalConfig } from '../../config';
+import { resolveConfigPresets } from '../../config/presets';
 import { validateConfigSecrets } from '../../config/secrets';
+import { CONFIG_PRESETS_INVALID } from '../../constants/error-messages';
 import { getProblems, logger, setMeta } from '../../logger';
 import { setUtilConfig } from '../../util';
 import * as hostRules from '../../util/host-rules';
@@ -69,6 +71,14 @@ function checkEnv(): void {
   }
 }
 
+export async function validatePresets(config: GlobalConfig): Promise<void> {
+  try {
+    await resolveConfigPresets(config);
+  } catch (err) /* istanbul ignore next */ {
+    throw new Error(CONFIG_PRESETS_INVALID);
+  }
+}
+
 export async function start(): Promise<number> {
   let config: GlobalConfig;
   try {
@@ -76,6 +86,8 @@ export async function start(): Promise<number> {
     config = await getGlobalConfig();
     // initialize all submodules
     config = await globalInitialize(config);
+
+    await validatePresets(config);
 
     checkEnv();
 


### PR DESCRIPTION
## Changes:

Delay config preset resolution in admin config until after platform initialization. This will enable resolution of private “local>…” presets to work.

## Context:

BREAKING CHANGE: Config presets will be resolved after platform initialization, so platform credentials cannot be placed in presets.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
