### PR TITLE
fix(lerna): swallow lerna info failure

### DIFF
--- a/lib/manager/npm/post-update/__snapshots__/lerna.spec.ts.snap
+++ b/lib/manager/npm/post-update/__snapshots__/lerna.spec.ts.snap
@@ -1,8 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
+
 exports[`manager/npm/post-update/lerna generateLockFiles() allows scripts for trust level high 1`] = `
 Array [
   Object {
-    "cmd": "lerna info",
+    "cmd": "lerna info || echo \\"Ignoring lerna info failure\\"",
     "options": Object {
       "cwd": "some-dir",
       "encoding": "utf-8",
@@ -61,7 +62,7 @@ Array [
 exports[`manager/npm/post-update/lerna generateLockFiles() defaults to latest if lerna version unspecified 1`] = `
 Array [
   Object {
-    "cmd": "lerna info",
+    "cmd": "lerna info || echo \\"Ignoring lerna info failure\\"",
     "options": Object {
       "cwd": "some-dir",
       "encoding": "utf-8",
@@ -120,7 +121,7 @@ Array [
 exports[`manager/npm/post-update/lerna generateLockFiles() generates package-lock.json files 1`] = `
 Array [
   Object {
-    "cmd": "lerna info",
+    "cmd": "lerna info || echo \\"Ignoring lerna info failure\\"",
     "options": Object {
       "cwd": "some-dir",
       "encoding": "utf-8",
@@ -179,7 +180,7 @@ Array [
 exports[`manager/npm/post-update/lerna generateLockFiles() generates yarn.lock files 1`] = `
 Array [
   Object {
-    "cmd": "lerna info",
+    "cmd": "lerna info || echo \\"Ignoring lerna info failure\\"",
     "options": Object {
       "cwd": "some-dir",
       "encoding": "utf-8",
@@ -238,7 +239,7 @@ Array [
 exports[`manager/npm/post-update/lerna generateLockFiles() maps dot files 1`] = `
 Array [
   Object {
-    "cmd": "lerna info",
+    "cmd": "lerna info || echo \\"Ignoring lerna info failure\\"",
     "options": Object {
       "cwd": "some-dir",
       "encoding": "utf-8",
@@ -297,7 +298,7 @@ Array [
 exports[`manager/npm/post-update/lerna generateLockFiles() performs full npm install 1`] = `
 Array [
   Object {
-    "cmd": "lerna info",
+    "cmd": "lerna info || echo \\"Ignoring lerna info failure\\"",
     "options": Object {
       "cwd": "some-dir",
       "encoding": "utf-8",
@@ -352,4 +353,3 @@ Array [
   },
 ]
 `;
-

--- a/lib/manager/npm/post-update/lerna.ts
+++ b/lib/manager/npm/post-update/lerna.ts
@@ -110,7 +110,7 @@ export async function generateLockFiles(
     const lernaVersion = getLernaVersion(lernaPackageFile);
     logger.debug('Using lerna version ' + lernaVersion);
     preCommands.push(`npm i -g lerna@${quote(lernaVersion)}`);
-    cmd.push('lerna info');
+    cmd.push('lerna info || echo "Ignoring lerna info failure"');
     cmd.push(`${lernaClient} install ${cmdOptions}`);
     cmd.push(lernaCommand);
     await exec(cmd, execOptions);


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds an `||` after `lerna info` to swallow if it can't be run.

## Context:

Closes #9357

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
