### PR TITLE
feat: drop dockerMapDotFiles

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -156,17 +156,6 @@ You would use put this in your configuration file:
 
 If you pulled a new `node` image, the final image would be `ghcr.io/renovatebot/node` instead of `docker.io/renovate/node`.
 
-## dockerMapDotfiles
-
-This is used if you want to map "dotfiles" from your host computer home directory to containers that Renovate creates, e.g. for updating lock files.
-Currently applicable to `.npmrc` only.
-
-```json
-{
-  "dockerMapDotfiles": true
-}
-```
-
 ## dockerUser
 
 Override default user and group used by Docker-based binaries.

--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -244,14 +244,6 @@ const options: RenovateOptions[] = [
     default: false,
   },
   {
-    name: 'dockerMapDotfiles',
-    description:
-      'Map relevant home directory dotfiles into containers when binarySource=docker.',
-    admin: true,
-    type: 'boolean',
-    default: false,
-  },
-  {
     name: 'dockerImagePrefix',
     description:
       'Change this value in order to override the default Renovate Docker sidecar image name prefix.',

--- a/lib/manager/npm/post-update/__snapshots__/lerna.spec.ts.snap
+++ b/lib/manager/npm/post-update/__snapshots__/lerna.spec.ts.snap
@@ -1,4 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
+
 exports[`manager/npm/post-update/lerna generateLockFiles() allows scripts for trust level high 1`] = `
 Array [
   Object {
@@ -235,65 +236,6 @@ Array [
 ]
 `;
 
-exports[`manager/npm/post-update/lerna generateLockFiles() maps dot files 1`] = `
-Array [
-  Object {
-    "cmd": "lerna info",
-    "options": Object {
-      "cwd": "some-dir",
-      "encoding": "utf-8",
-      "env": Object {
-        "HOME": "/home/user",
-        "HTTPS_PROXY": "https://example.com",
-        "HTTP_PROXY": "http://example.com",
-        "LANG": "en_US.UTF-8",
-        "LC_ALL": "en_US",
-        "NO_PROXY": "localhost",
-        "PATH": "/tmp/path",
-      },
-      "maxBuffer": 10485760,
-      "timeout": 900000,
-    },
-  },
-  Object {
-    "cmd": "npm install --ignore-scripts  --no-audit --package-lock-only",
-    "options": Object {
-      "cwd": "some-dir",
-      "encoding": "utf-8",
-      "env": Object {
-        "HOME": "/home/user",
-        "HTTPS_PROXY": "https://example.com",
-        "HTTP_PROXY": "http://example.com",
-        "LANG": "en_US.UTF-8",
-        "LC_ALL": "en_US",
-        "NO_PROXY": "localhost",
-        "PATH": "/tmp/path",
-      },
-      "maxBuffer": 10485760,
-      "timeout": 900000,
-    },
-  },
-  Object {
-    "cmd": "lerna bootstrap --no-ci --ignore-scripts -- --ignore-scripts  --no-audit --package-lock-only",
-    "options": Object {
-      "cwd": "some-dir",
-      "encoding": "utf-8",
-      "env": Object {
-        "HOME": "/home/user",
-        "HTTPS_PROXY": "https://example.com",
-        "HTTP_PROXY": "http://example.com",
-        "LANG": "en_US.UTF-8",
-        "LC_ALL": "en_US",
-        "NO_PROXY": "localhost",
-        "PATH": "/tmp/path",
-      },
-      "maxBuffer": 10485760,
-      "timeout": 900000,
-    },
-  },
-]
-`;
-
 exports[`manager/npm/post-update/lerna generateLockFiles() performs full npm install 1`] = `
 Array [
   Object {
@@ -352,4 +294,3 @@ Array [
   },
 ]
 `;
-

--- a/lib/manager/npm/post-update/lerna.spec.ts
+++ b/lib/manager/npm/post-update/lerna.spec.ts
@@ -93,27 +93,13 @@ describe(getName(__filename), () => {
       expect(res.error).toBe(false);
       expect(execSnapshots).toMatchSnapshot();
     });
-    it('maps dot files', async () => {
-      const execSnapshots = mockExecAll(exec);
-      const res = await lernaHelper.generateLockFiles(
-        lernaPkgFile('npm'),
-        'some-dir',
-        {
-          dockerMapDotfiles: true,
-          constraints: { npm: '^6.0.0' },
-        },
-        {}
-      );
-      expect(res.error).toBe(false);
-      expect(execSnapshots).toMatchSnapshot();
-    });
     it('allows scripts for trust level high', async () => {
       const execSnapshots = mockExecAll(exec);
       setAdminConfig({ allowScripts: true });
       const res = await lernaHelper.generateLockFiles(
         lernaPkgFile('npm'),
         'some-dir',
-        {},
+        { constraints: { npm: '^6.0.0' } },
         {}
       );
       expect(res.error).toBe(false);

--- a/lib/manager/npm/post-update/lerna.ts
+++ b/lib/manager/npm/post-update/lerna.ts
@@ -1,6 +1,5 @@
 import semver, { validRange } from 'semver';
 import { quote } from 'shlex';
-import { join } from 'upath';
 import { getAdminConfig } from '../../../config/admin';
 import { TEMPORARY_ERROR } from '../../../constants/error-messages';
 import { logger } from '../../../logger';
@@ -96,12 +95,6 @@ export async function generateLockFiles(
     if (getAdminConfig().exposeAllEnv) {
       execOptions.extraEnv.NPM_AUTH = env.NPM_AUTH;
       execOptions.extraEnv.NPM_EMAIL = env.NPM_EMAIL;
-    }
-    if (config.dockerMapDotfiles) {
-      const homeDir =
-        process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE;
-      const homeNpmrc = join(homeDir, '.npmrc');
-      execOptions.docker.volumes = [[homeNpmrc, '/home/ubuntu/.npmrc']];
     }
     const lernaVersion = getLernaVersion(lernaPackageFile);
     logger.debug('Using lerna version ' + lernaVersion);

--- a/lib/manager/npm/post-update/npm.spec.ts
+++ b/lib/manager/npm/post-update/npm.spec.ts
@@ -27,7 +27,6 @@ describe('generateLockFile', () => {
     const execSnapshots = mockExecAll(exec);
     fs.readFile = jest.fn(() => 'package-lock-contents') as never;
     const artifactUpdateApproach = 'deep';
-    const dockerMapDotfiles = true;
     const postUpdateOptions = ['npmDedupe'];
     const updates = [
       { depName: 'some-dep', newVersion: '1.0.1', isLockfileUpdate: false },
@@ -36,7 +35,7 @@ describe('generateLockFile', () => {
       'some-dir',
       {},
       'package-lock.json',
-      { dockerMapDotfiles, artifactUpdateApproach, postUpdateOptions },
+      { artifactUpdateApproach, postUpdateOptions },
       updates
     );
     expect(fs.readFile).toHaveBeenCalledTimes(1);

--- a/lib/manager/npm/post-update/npm.ts
+++ b/lib/manager/npm/post-update/npm.ts
@@ -75,12 +75,6 @@ export async function generateLockFile(
       execOptions.extraEnv.NPM_AUTH = env.NPM_AUTH;
       execOptions.extraEnv.NPM_EMAIL = env.NPM_EMAIL;
     }
-    if (config.dockerMapDotfiles) {
-      const homeDir =
-        process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE;
-      const homeNpmrc = join(homeDir, '.npmrc');
-      execOptions.docker.volumes = [[homeNpmrc, '/home/ubuntu/.npmrc']];
-    }
 
     if (!upgrades.every((upgrade) => upgrade.isLockfileUpdate)) {
       // This command updates the lock file based on package.json

--- a/lib/manager/npm/post-update/pnpm.spec.ts
+++ b/lib/manager/npm/post-update/pnpm.spec.ts
@@ -24,7 +24,6 @@ describe('generateLockFile', () => {
     env.getChildProcessEnv.mockReturnValue(envMock.basic);
   });
   it('generates lock files', async () => {
-    config.dockerMapDotfiles = true;
     const execSnapshots = mockExecAll(exec);
     fs.readFile = jest.fn(() => 'package-lock-contents') as never;
     const res = await pnpmHelper.generateLockFile('some-dir', {}, config);

--- a/lib/manager/npm/post-update/pnpm.ts
+++ b/lib/manager/npm/post-update/pnpm.ts
@@ -54,12 +54,6 @@ export async function generateLockFile(
       execOptions.extraEnv.NPM_AUTH = env.NPM_AUTH;
       execOptions.extraEnv.NPM_EMAIL = env.NPM_EMAIL;
     }
-    if (config.dockerMapDotfiles) {
-      const homeDir =
-        process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE;
-      const homeNpmrc = join(homeDir, '.npmrc');
-      execOptions.docker.volumes = [[homeNpmrc, '/home/ubuntu/.npmrc']];
-    }
     cmd = 'pnpm';
     let args = 'install --recursive --lockfile-only';
     if (!getAdminConfig().allowScripts || config.ignoreScripts) {

--- a/lib/manager/npm/post-update/yarn.spec.ts
+++ b/lib/manager/npm/post-update/yarn.spec.ts
@@ -54,7 +54,6 @@ describe(getName(__filename), () => {
         );
       });
       const config = {
-        dockerMapDotfiles: true,
         constraints: {
           yarn: yarnCompatibility,
         },
@@ -140,7 +139,6 @@ describe(getName(__filename), () => {
         );
       });
       const config = {
-        dockerMapDotfiles: true,
         constraints: {
           yarn: yarnCompatibility,
         },

--- a/lib/manager/npm/post-update/yarn.ts
+++ b/lib/manager/npm/post-update/yarn.ts
@@ -124,12 +124,6 @@ export async function generateLockFile(
       execOptions.extraEnv.NPM_AUTH = env.NPM_AUTH;
       execOptions.extraEnv.NPM_EMAIL = env.NPM_EMAIL;
     }
-    if (config.dockerMapDotfiles) {
-      const homeDir =
-        process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE;
-      const homeNpmrc = join(homeDir, '.npmrc');
-      execOptions.docker.volumes = [[homeNpmrc, '/home/ubuntu/.npmrc']];
-    }
 
     // This command updates the lock file based on package.json
     commands.push(`yarn install ${cmdOptions}`.trim());


### PR DESCRIPTION


<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Drops support for dockerMapDotfiles

## Context:

BREAKING CHANGE: dockerMapDotfiles is no longer supported

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
