### PR TITLE
fix: support the latest docker-compose 1.27 spec

### DIFF
--- a/lib/manager/docker-compose/__fixtures__/docker-compose.3-no-version.yml
+++ b/lib/manager/docker-compose/__fixtures__/docker-compose.3-no-version.yml
@@ -1,0 +1,103 @@
+services:
+
+  redis:
+    image: quay.io/something/redis:alpine
+    ports:
+      - "6379"
+    networks:
+      - frontend
+    deploy:
+      replicas: 2
+      update_config:
+        parallelism: 2
+        delay: 10s
+      restart_policy:
+        condition: on-failure
+
+  worker:
+    image: "node:10.0.0"
+
+  db:
+    image: "postgres:9.4.0"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    networks:
+      - backend
+    deploy:
+      placement:
+        constraints: [node.role == manager]
+
+  vote:
+    image: dockersamples/examplevotingapp_vote:before
+    ports:
+      - 5000:80
+    networks:
+      - frontend
+    depends_on:
+      - redis
+    deploy:
+      replicas: 2
+      update_config:
+        parallelism: 2
+      restart_policy:
+        condition: on-failure
+
+  result:
+    image: 'dockersamples/examplevotingapp_result:before'
+    ports:
+      - 5001:80
+    networks:
+      - backend
+    depends_on:
+      - db
+    deploy:
+      replicas: 1
+      update_config:
+        parallelism: 2
+        delay: 10s
+      restart_policy:
+        condition: on-failure
+
+  votingworker:
+    image: dockersamples/examplevotingapp_worker
+    networks:
+      - frontend
+      - backend
+    deploy:
+      mode: replicated
+      replicas: 1
+      labels: [APP=VOTING]
+      restart_policy:
+        condition: on-failure
+        delay: 10s
+        max_attempts: 3
+        window: 120s
+      placement:
+        constraints: [node.role == manager]
+
+  visualizer:
+    image: dockersamples/visualizer:stable
+    ports:
+      - "8080:8080"
+    stop_grace_period: 1m30s
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    deploy:
+      placement:
+        constraints: [node.role == manager]
+
+  edplugins:
+    image: ${IMAGE:-synkodevelopers/edplugins}:${TAG:-latest}
+
+  debugapp:
+    image: app-local-debug
+    build:
+      context: .
+      dockerfile: Dockerfile.local
+
+networks:
+  frontend:
+  backend:
+
+volumes:
+  db-data:

--- a/lib/manager/docker-compose/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/docker-compose/__snapshots__/extract.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/manager/docker-compose/extract extractPackageFile() extracts multiple image lines for version 1 1`] = `
+exports[`manager/docker-compose/extract extractPackageFile() extracts multiple image lines for version 1 1`] = `
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
@@ -68,7 +68,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/docker-compose/extract extractPackageFile() extracts multiple image lines for version 3 1`] = `
+exports[`manager/docker-compose/extract extractPackageFile() extracts multiple image lines for version 3 1`] = `
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
@@ -136,7 +136,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/docker-compose/extract extractPackageFile() extracts multiple image lines for version 3 without set version key 1`] = `
+exports[`manager/docker-compose/extract extractPackageFile() extracts multiple image lines for version 3 without set version key 1`] = `
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",

--- a/lib/manager/docker-compose/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/docker-compose/__snapshots__/extract.spec.ts.snap
@@ -136,7 +136,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/docker-compose/extract extractPackageFile() extracts multiple image lines for version 3 without version key set 1`] = `
+exports[`lib/manager/docker-compose/extract extractPackageFile() extracts multiple image lines for version 3 without set version key 1`] = `
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",

--- a/lib/manager/docker-compose/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/docker-compose/__snapshots__/extract.spec.ts.snap
@@ -135,3 +135,71 @@ Array [
   },
 ]
 `;
+
+exports[`lib/manager/docker-compose/extract extractPackageFile() extracts multiple image lines for version 3 without version key set 1`] = `
+Array [
+  Object {
+    "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
+    "currentDigest": undefined,
+    "currentValue": "alpine",
+    "datasource": "docker",
+    "depName": "quay.io/something/redis",
+    "replaceString": "quay.io/something/redis:alpine",
+  },
+  Object {
+    "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
+    "commitMessageTopic": "Node.js",
+    "currentDigest": undefined,
+    "currentValue": "10.0.0",
+    "datasource": "docker",
+    "depName": "node",
+    "replaceString": "node:10.0.0",
+  },
+  Object {
+    "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
+    "currentDigest": undefined,
+    "currentValue": "9.4.0",
+    "datasource": "docker",
+    "depName": "postgres",
+    "replaceString": "postgres:9.4.0",
+  },
+  Object {
+    "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
+    "currentDigest": undefined,
+    "currentValue": "before",
+    "datasource": "docker",
+    "depName": "dockersamples/examplevotingapp_vote",
+    "replaceString": "dockersamples/examplevotingapp_vote:before",
+  },
+  Object {
+    "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
+    "currentDigest": undefined,
+    "currentValue": "before",
+    "datasource": "docker",
+    "depName": "dockersamples/examplevotingapp_result",
+    "replaceString": "dockersamples/examplevotingapp_result:before",
+  },
+  Object {
+    "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
+    "currentDigest": undefined,
+    "currentValue": undefined,
+    "datasource": "docker",
+    "depName": "dockersamples/examplevotingapp_worker",
+    "replaceString": "dockersamples/examplevotingapp_worker",
+  },
+  Object {
+    "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
+    "currentDigest": undefined,
+    "currentValue": "stable",
+    "datasource": "docker",
+    "depName": "dockersamples/visualizer",
+    "replaceString": "dockersamples/visualizer:stable",
+  },
+  Object {
+    "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
+    "datasource": "docker",
+    "replaceString": "\${IMAGE:-synkodevelopers/edplugins}:\${TAG:-latest}",
+    "skipReason": "contains-variable",
+  },
+]
+`;

--- a/lib/manager/docker-compose/extract.spec.ts
+++ b/lib/manager/docker-compose/extract.spec.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'fs';
+import { getName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 const yamlFile1 = readFileSync(
@@ -16,7 +17,7 @@ const yamlFile3NoVersion = readFileSync(
   'utf8'
 );
 
-describe('lib/manager/docker-compose/extract', () => {
+describe(getName(__filename), () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty', () => {
       expect(extractPackageFile('')).toBeNull();

--- a/lib/manager/docker-compose/extract.spec.ts
+++ b/lib/manager/docker-compose/extract.spec.ts
@@ -11,6 +11,11 @@ const yamlFile3 = readFileSync(
   'utf8'
 );
 
+const yamlFile3NoVersion = readFileSync(
+  'lib/manager/docker-compose/__fixtures__/docker-compose.3-no-version.yml',
+  'utf8'
+);
+
 describe('lib/manager/docker-compose/extract', () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty', () => {
@@ -29,6 +34,11 @@ describe('lib/manager/docker-compose/extract', () => {
     });
     it('extracts multiple image lines for version 3', () => {
       const res = extractPackageFile(yamlFile3);
+      expect(res.deps).toMatchSnapshot();
+      expect(res.deps).toHaveLength(8);
+    });
+    it('extracts multiple image lines for version 3 without set version key', () => {
+      const res = extractPackageFile(yamlFile3NoVersion);
       expect(res.deps).toMatchSnapshot();
       expect(res.deps).toHaveLength(8);
     });

--- a/lib/manager/docker-compose/extract.ts
+++ b/lib/manager/docker-compose/extract.ts
@@ -70,10 +70,12 @@ export function extractPackageFile(
   try {
     const lineMapper = new LineMapper(content, /^\s*image:/);
 
-    const services =
-      'version' in config
-        ? config.services // docker-compose version 2+
-        : config; // docker-compose version 1 (services at top level)
+    // docker-compose v1 places the services at the top level,
+    // docker-compose v2+ places the services within a 'services' key
+    // since docker-compose spec version 1.27, the 'version' key has
+    // become optional and can no longer be used to differentiate
+    // between v1 and v2.
+    const services = config.services || config;
 
     // Image name/tags for services are only eligible for update if they don't
     // use variables and if the image is not built locally


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

This changes the way the list of services in a docker-compose.yaml file are retrieved. Previously the presence of the `version:` key was used to determine whether the services are part of the top-level file or are within a `services:` key. Since `version` is optional since docker-compose spec v1.27, this now simply uses `document.services` if set, or `document` if not.

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

Closes #9269

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository (see https://github.com/chgl/renovate-docker-compose-v127/pull/2/files)

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
