### PR TITLE
refactor(azure): Extract more utils from platform helper

### DIFF
--- a/lib/platform/azure/__snapshots__/azure-helper.spec.ts.snap
+++ b/lib/platform/azure/__snapshots__/azure-helper.spec.ts.snap
@@ -24,20 +24,6 @@ Object {
 
 exports[`platform/azure/helpers getFile should return the file content because it is not a json 1`] = `"{\\"hello\\"= \\"test\\"}"`;
 
-exports[`platform/azure/helpers getProjectAndRepo should return the object with project and repo 1`] = `
-Object {
-  "project": "prjName",
-  "repo": "myRepoName",
-}
-`;
-
-exports[`platform/azure/helpers getProjectAndRepo should return the object with same strings 1`] = `
-Object {
-  "project": "myRepoName",
-  "repo": "myRepoName",
-}
-`;
-
 exports[`platform/azure/helpers getRef should get the ref with full ref name 1`] = `
 Array [
   Object {
@@ -53,23 +39,3 @@ Array [
   },
 ]
 `;
-
-exports[`platform/azure/helpers getStorageExtraCloneOpts should configure basic auth 1`] = `
-Object {
-  "-c": "http.extraheader=AUTHORIZATION: basic dXNlcjpwYXNz",
-}
-`;
-
-exports[`platform/azure/helpers getStorageExtraCloneOpts should configure bearer token 1`] = `
-Object {
-  "-c": "http.extraheader=AUTHORIZATION: bearer token",
-}
-`;
-
-exports[`platform/azure/helpers getStorageExtraCloneOpts should configure personal access token 1`] = `
-Object {
-  "-c": "http.extraheader=AUTHORIZATION: basic OjEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=",
-}
-`;
-
-exports[`platform/azure/helpers max4000Chars should be the same 1`] = `"Hello"`;

--- a/lib/platform/azure/__snapshots__/index.spec.ts.snap
+++ b/lib/platform/azure/__snapshots__/index.spec.ts.snap
@@ -199,8 +199,6 @@ Object {
 }
 `;
 
-exports[`platform/azure massageMarkdown(input) returns updated pr body 1`] = `"https://github.com/foo/bar/issues/5 plus also [a link](https://github.com/foo/bar/issues/5)"`;
-
 exports[`platform/azure getRepos() should return an array of repos 1`] = `
 Array [
   Array [],
@@ -233,11 +231,13 @@ Object {
 }
 `;
 
+exports[`platform/azure massageMarkdown(input) returns updated pr body 1`] = `"https://github.com/foo/bar/issues/5 plus also [a link](https://github.com/foo/bar/issues/5)"`;
+
 exports[`platform/azure updatePr(prNo, title, body) should close the PR 1`] = `
 Array [
   Array [
     Object {
-      "description": undefined,
+      "description": "Hello world again",
       "status": 2,
       "title": "The New Title",
     },
@@ -258,7 +258,7 @@ Array [
   ],
   Array [
     Object {
-      "description": undefined,
+      "description": "Hello world again",
       "title": "The New Title",
     },
     "1",
@@ -271,7 +271,7 @@ exports[`platform/azure updatePr(prNo, title, body) should update the PR 1`] = `
 Array [
   Array [
     Object {
-      "description": undefined,
+      "description": "Hello world again",
       "title": "The New Title",
     },
     "1",

--- a/lib/platform/azure/__snapshots__/util.spec.ts.snap
+++ b/lib/platform/azure/__snapshots__/util.spec.ts.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`platform/azure/helpers getProjectAndRepo should return the object with project and repo 1`] = `
+Object {
+  "project": "prjName",
+  "repo": "myRepoName",
+}
+`;
+
+exports[`platform/azure/helpers getProjectAndRepo should return the object with same strings 1`] = `
+Object {
+  "project": "myRepoName",
+  "repo": "myRepoName",
+}
+`;
+
 exports[`platform/azure/helpers getRenovatePRFormat should be formated (closed v2) 1`] = `
 Object {
   "body": undefined,
@@ -56,3 +70,23 @@ Object {
   "targetBranch": undefined,
 }
 `;
+
+exports[`platform/azure/helpers getStorageExtraCloneOpts should configure basic auth 1`] = `
+Object {
+  "-c": "http.extraheader=AUTHORIZATION: basic dXNlcjpwYXNz",
+}
+`;
+
+exports[`platform/azure/helpers getStorageExtraCloneOpts should configure bearer token 1`] = `
+Object {
+  "-c": "http.extraheader=AUTHORIZATION: bearer token",
+}
+`;
+
+exports[`platform/azure/helpers getStorageExtraCloneOpts should configure personal access token 1`] = `
+Object {
+  "-c": "http.extraheader=AUTHORIZATION: basic OjEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=",
+}
+`;
+
+exports[`platform/azure/helpers max4000Chars should be the same 1`] = `"Hello"`;

--- a/lib/platform/azure/azure-helper.spec.ts
+++ b/lib/platform/azure/azure-helper.spec.ts
@@ -13,26 +13,6 @@ describe('platform/azure/helpers', () => {
     azureApi = require('./azure-got-wrapper');
   });
 
-  describe('getStorageExtraCloneOpts', () => {
-    it('should configure basic auth', () => {
-      const res = azureHelper.getStorageExtraCloneOpts({
-        username: 'user',
-        password: 'pass',
-      });
-      expect(res).toMatchSnapshot();
-    });
-    it('should configure personal access token', () => {
-      const res = azureHelper.getStorageExtraCloneOpts({
-        token: '1234567890123456789012345678901234567890123456789012',
-      });
-      expect(res).toMatchSnapshot();
-    });
-    it('should configure bearer token', () => {
-      const res = azureHelper.getStorageExtraCloneOpts({ token: 'token' });
-      expect(res).toMatchSnapshot();
-    });
-  });
-
   describe('getRef', () => {
     it('should get the ref with short ref name', async () => {
       azureApi.gitApi.mockImplementationOnce(
@@ -203,21 +183,6 @@ describe('platform/azure/helpers', () => {
     });
   });
 
-  describe('max4000Chars', () => {
-    it('should be the same', () => {
-      const res = azureHelper.max4000Chars('Hello');
-      expect(res).toMatchSnapshot();
-    });
-    it('should be truncated', () => {
-      let str = '';
-      for (let i = 0; i < 5000; i += 1) {
-        str += 'a';
-      }
-      const res = azureHelper.max4000Chars(str);
-      expect(res).toHaveLength(3999);
-    });
-  });
-
   describe('getCommitDetails', () => {
     it('should get commit details', async () => {
       azureApi.gitApi.mockImplementationOnce(
@@ -230,26 +195,6 @@ describe('platform/azure/helpers', () => {
       );
       const res = await azureHelper.getCommitDetails('123', '123456');
       expect(res).toMatchSnapshot();
-    });
-  });
-
-  describe('getProjectAndRepo', () => {
-    it('should return the object with same strings', () => {
-      const res = azureHelper.getProjectAndRepo('myRepoName');
-      expect(res).toMatchSnapshot();
-    });
-    it('should return the object with project and repo', () => {
-      const res = azureHelper.getProjectAndRepo('prjName/myRepoName');
-      expect(res).toMatchSnapshot();
-    });
-    it('should return an error', () => {
-      expect(() =>
-        azureHelper.getProjectAndRepo('prjName/myRepoName/blalba')
-      ).toThrow(
-        Error(
-          `prjName/myRepoName/blalba can be only structured this way : 'repository' or 'projectName/repository'!`
-        )
-      );
     });
   });
 

--- a/lib/platform/azure/index.spec.ts
+++ b/lib/platform/azure/index.spec.ts
@@ -128,13 +128,13 @@ describe('platform/azure', () => {
         ({
           getRepositories: jest.fn(() => [
             {
-              name: 'some-repo',
+              name: 'repo',
               id: '1',
               privateRepo: true,
               isFork: false,
               defaultBranch: 'defBr',
               project: {
-                name: 'some-repo',
+                name: 'some',
               },
             },
             {
@@ -146,10 +146,6 @@ describe('platform/azure', () => {
           ]),
         } as any)
     );
-    azureHelper.getProjectAndRepo.mockImplementationOnce(() => ({
-      project: 'some-repo',
-      repo: 'some-repo',
-    }));
 
     if (is.string(args)) {
       return azure.initRepo({
@@ -166,7 +162,7 @@ describe('platform/azure', () => {
   describe('initRepo', () => {
     it(`should initialise the config for a repo`, async () => {
       const config = await initRepo({
-        repository: 'some-repo',
+        repository: 'some/repo',
       });
       expect(azureApi.gitApi.mock.calls).toMatchSnapshot();
       expect(config).toMatchSnapshot();
@@ -479,12 +475,12 @@ describe('platform/azure', () => {
   });
   describe('getBranchStatus(branchName, requiredStatusChecks)', () => {
     it('return success if requiredStatusChecks null', async () => {
-      await initRepo('some-repo');
+      await initRepo('some/repo');
       const res = await azure.getBranchStatus('somebranch', null);
       expect(res).toEqual(BranchStatus.green);
     });
     it('return failed if unsupported requiredStatusChecks', async () => {
-      await initRepo('some-repo');
+      await initRepo('some/repo');
       const res = await azure.getBranchStatus('somebranch', ['foo']);
       expect(res).toEqual(BranchStatus.red);
     });

--- a/lib/platform/azure/index.ts
+++ b/lib/platform/azure/index.ts
@@ -40,7 +40,10 @@ import {
   getGitStatusContextCombinedName,
   getGitStatusContextFromCombinedName,
   getNewBranchName,
+  getProjectAndRepo,
   getRenovatePRFormat,
+  getStorageExtraCloneOpts,
+  max4000Chars,
   streamToString,
 } from './util';
 
@@ -131,7 +134,7 @@ export async function initRepo({
   config = { repository } as Config;
   const azureApiGit = await azureApi.gitApi();
   const repos = await azureApiGit.getRepositories();
-  const names = azureHelper.getProjectAndRepo(repository);
+  const names = getProjectAndRepo(repository);
   const repo = repos.filter(
     (c) =>
       c.name.toLowerCase() === names.repo.toLowerCase() &&
@@ -170,7 +173,7 @@ export async function initRepo({
     ...config,
     localDir,
     url,
-    extraCloneOpts: azureHelper.getStorageExtraCloneOpts(opts),
+    extraCloneOpts: getStorageExtraCloneOpts(opts),
     gitAuthorName: global.gitAuthor?.name,
     gitAuthorEmail: global.gitAuthor?.email,
     cloneSubmodules,
@@ -373,7 +376,7 @@ export async function createPr({
 }: CreatePRConfig): Promise<Pr> {
   const sourceRefName = getNewBranchName(sourceBranch);
   const targetRefName = getNewBranchName(targetBranch);
-  const description = azureHelper.max4000Chars(sanitize(body));
+  const description = max4000Chars(sanitize(body));
   const azureApiGit = await azureApi.gitApi();
   const workItemRefs = [
     {
@@ -434,7 +437,7 @@ export async function updatePr({
   };
 
   if (body) {
-    objToUpdate.description = azureHelper.max4000Chars(sanitize(body));
+    objToUpdate.description = max4000Chars(sanitize(body));
   }
 
   if (state === PrState.Open) {

--- a/lib/platform/azure/util.spec.ts
+++ b/lib/platform/azure/util.spec.ts
@@ -4,7 +4,10 @@ import {
   getGitStatusContextCombinedName,
   getGitStatusContextFromCombinedName,
   getNewBranchName,
+  getProjectAndRepo,
   getRenovatePRFormat,
+  getStorageExtraCloneOpts,
+  max4000Chars,
   streamToString,
 } from './util';
 
@@ -120,6 +123,59 @@ describe('platform/azure/helpers', () => {
       const res = streamToString(stream);
       stream.destroy(new Error('some unknown error'));
       await expect(res).rejects.toThrow('some unknown error');
+    });
+  });
+
+  describe('getStorageExtraCloneOpts', () => {
+    it('should configure basic auth', () => {
+      const res = getStorageExtraCloneOpts({
+        username: 'user',
+        password: 'pass',
+      });
+      expect(res).toMatchSnapshot();
+    });
+    it('should configure personal access token', () => {
+      const res = getStorageExtraCloneOpts({
+        token: '1234567890123456789012345678901234567890123456789012',
+      });
+      expect(res).toMatchSnapshot();
+    });
+    it('should configure bearer token', () => {
+      const res = getStorageExtraCloneOpts({ token: 'token' });
+      expect(res).toMatchSnapshot();
+    });
+  });
+
+  describe('max4000Chars', () => {
+    it('should be the same', () => {
+      const res = max4000Chars('Hello');
+      expect(res).toMatchSnapshot();
+    });
+    it('should be truncated', () => {
+      let str = '';
+      for (let i = 0; i < 5000; i += 1) {
+        str += 'a';
+      }
+      const res = max4000Chars(str);
+      expect(res).toHaveLength(3999);
+    });
+  });
+
+  describe('getProjectAndRepo', () => {
+    it('should return the object with same strings', () => {
+      const res = getProjectAndRepo('myRepoName');
+      expect(res).toMatchSnapshot();
+    });
+    it('should return the object with project and repo', () => {
+      const res = getProjectAndRepo('prjName/myRepoName');
+      expect(res).toMatchSnapshot();
+    });
+    it('should return an error', () => {
+      expect(() => getProjectAndRepo('prjName/myRepoName/blalba')).toThrow(
+        Error(
+          `prjName/myRepoName/blalba can be only structured this way : 'repository' or 'projectName/repository'!`
+        )
+      );
     });
   });
 });

--- a/lib/platform/azure/util.ts
+++ b/lib/platform/azure/util.ts
@@ -5,7 +5,9 @@ import {
   PullRequestStatus,
 } from 'azure-devops-node-api/interfaces/GitInterfaces';
 import { logger } from '../../logger';
-import { PrState } from '../../types';
+import { HostRule, PrState } from '../../types';
+import { GitOptions } from '../../types/git';
+import { add } from '../../util/sanitize';
 import { AzurePr } from './types';
 
 export function getNewBranchName(branchName?: string): string {
@@ -127,4 +129,56 @@ export async function streamToString(
     stream.on('error', (err) => reject(err));
   });
   return p;
+}
+
+function toBase64(from: string): string {
+  return Buffer.from(from).toString('base64');
+}
+
+export function getStorageExtraCloneOpts(config: HostRule): GitOptions {
+  let authType: string;
+  let authValue: string;
+  if (!config.token && config.username && config.password) {
+    authType = 'basic';
+    authValue = toBase64(`${config.username}:${config.password}`);
+  } else if (config.token.length === 52) {
+    authType = 'basic';
+    authValue = toBase64(`:${config.token}`);
+  } else {
+    authType = 'bearer';
+    authValue = config.token;
+  }
+  add(authValue);
+  return {
+    '-c': `http.extraheader=AUTHORIZATION: ${authType} ${authValue}`,
+  };
+}
+
+export function max4000Chars(str: string): string {
+  if (str && str.length >= 4000) {
+    return str.substring(0, 3999);
+  }
+  return str;
+}
+
+export function getProjectAndRepo(
+  str: string
+): { project: string; repo: string } {
+  logger.trace(`getProjectAndRepo(${str})`);
+  const strSplit = str.split(`/`);
+  if (strSplit.length === 1) {
+    return {
+      project: str,
+      repo: str,
+    };
+  }
+  if (strSplit.length === 2) {
+    return {
+      project: strSplit[0],
+      repo: strSplit[1],
+    };
+  }
+  const msg = `${str} can be only structured this way : 'repository' or 'projectName/repository'!`;
+  logger.error(msg);
+  throw new Error(msg);
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Extract more utils from `azure-helper.ts` so that we don't have to mock them.

## Context:

It's the first of tests refactoring aiming to simplify other platform changes to come (ref #9171 )

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
