### PR TITLE
fix(azure): Fix additional argument for getRawFile

### DIFF
--- a/lib/platform/azure/__snapshots__/index.spec.ts.snap
+++ b/lib/platform/azure/__snapshots__/index.spec.ts.snap
@@ -181,6 +181,15 @@ Object {
 
 exports[`platform/azure getBranchPr(branchName) should return the pr 1`] = `null`;
 
+exports[`platform/azure getJsonFile() supports fetch from another repo 1`] = `
+Array [
+  Array [
+    "123456",
+    "file.json",
+  ],
+]
+`;
+
 exports[`platform/azure getPr(prNo) should return a pr in the right format 1`] = `
 Object {
   "body": undefined,

--- a/lib/platform/azure/index.spec.ts
+++ b/lib/platform/azure/index.spec.ts
@@ -1214,5 +1214,22 @@ describe('platform/azure', () => {
       );
       await expect(azure.getJsonFile('file.json')).rejects.toThrow();
     });
+    it('supports fetch from another repo', async () => {
+      const data = { foo: 'bar' };
+      const gitApiMock = {
+        getItemContent: jest.fn(() =>
+          Promise.resolve(Readable.from(JSON.stringify(data)))
+        ),
+        getRepositories: jest.fn(() =>
+          Promise.resolve([
+            { id: '123456', name: 'bar', project: { name: 'foo' } },
+          ])
+        ),
+      };
+      azureApi.gitApi.mockImplementationOnce(() => gitApiMock as any);
+      const res = await azure.getJsonFile('file.json', 'foo/bar');
+      expect(res).toEqual(data);
+      expect(gitApiMock.getItemContent.mock.calls).toMatchSnapshot();
+    });
   });
 });

--- a/lib/platform/azure/util.ts
+++ b/lib/platform/azure/util.ts
@@ -1,5 +1,6 @@
 import {
   GitPullRequest,
+  GitRepository,
   GitStatusContext,
   PullRequestAsyncStatus,
   PullRequestStatus,
@@ -181,4 +182,23 @@ export function getProjectAndRepo(
   const msg = `${str} can be only structured this way : 'repository' or 'projectName/repository'!`;
   logger.error(msg);
   throw new Error(msg);
+}
+
+export function getRepoByName(
+  name: string,
+  repos: GitRepository[]
+): GitRepository | null {
+  logger.trace(`getRepoByName(${name})`);
+
+  let { project, repo } = getProjectAndRepo(name);
+  project = project.toLowerCase();
+  repo = repo.toLowerCase();
+
+  return (
+    repos?.find(
+      (r) =>
+        project === r?.project?.name?.toLowerCase() &&
+        repo === r?.name?.toLowerCase()
+    ) || null
+  );
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Current behavior worked just because of `config.repoId` default parameter. In the case when the second parameter of `getRawFile` is actually used, we need discover this repo ID first.

## Context:

Probably, the better way is to call `azureGitApi.getRepositories()` in the `initPlatform()` and store result locally instead of 2–3 more occasional calls from other platform methods. Moreover, it's desirable to check the credentials somehow in the `initPlatform()` phase, which can be done via repo discovery. Hovewer, it requires pretty substantial refactoring of tests that would block #9171. So, this PR is *good enough* kind of solution allowing us to release local plugins support first.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
