### PR TITLE
feat: Allow multiple autodiscover filter

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -81,7 +81,7 @@ e.g.
 
 ```json
 {
-  "autodiscoverFilter": "project/*"
+  "autodiscoverFilter": ["project/*"]
 }
 ```
 

--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -579,7 +579,9 @@ const options: RenovateOptions[] = [
     name: 'autodiscoverFilter',
     description: 'Filter the list of autodiscovered repositories.',
     stage: 'global',
-    type: 'string',
+    type: 'array',
+    subType: 'string',
+    allowString: true,
     default: null,
   },
   {

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -68,7 +68,7 @@ export interface RenovateSharedConfig {
 // The below should contain config options where stage=global
 export interface GlobalOnlyConfig {
   autodiscover?: boolean;
-  autodiscoverFilter?: string;
+  autodiscoverFilter?: string[];
   baseDir?: string;
   forceCli?: boolean;
   gitPrivateKey?: string;

--- a/lib/workers/global/autodiscover.spec.ts
+++ b/lib/workers/global/autodiscover.spec.ts
@@ -49,18 +49,36 @@ describe(getName(__filename), () => {
   });
   it('filters autodiscovered github repos', async () => {
     config.autodiscover = true;
-    config.autodiscoverFilter = 'project/re*';
+    config.autodiscoverFilter = ['project/re*', 'new/prj*'];
     config.platform = PLATFORM_TYPE_GITHUB;
     hostRules.find = jest.fn(() => ({
       token: 'abc',
     }));
     ghApi.getRepos = jest.fn(() =>
-      Promise.resolve(['project/repo', 'project/another-repo'])
+      Promise.resolve([
+        'project/repo',
+        'project/another-repo',
+        'new/prj-test',
+        'new/not-matched',
+      ])
     );
     const res = await autodiscoverRepositories(config);
-    expect(res.repositories).toEqual(['project/repo']);
+    expect(res.repositories).toEqual(['project/repo', 'new/prj-test']);
   });
   it('filters autodiscovered github repos but nothing matches', async () => {
+    config.autodiscover = true;
+    config.autodiscoverFilter = ['project/re*'];
+    config.platform = 'github';
+    hostRules.find = jest.fn(() => ({
+      token: 'abc',
+    }));
+    ghApi.getRepos = jest.fn(() =>
+      Promise.resolve(['another-project/repo', 'another-project/another-repo'])
+    );
+    const res = await autodiscoverRepositories(config);
+    expect(res).toEqual(config);
+  });
+  it('filters autodiscovered github repos with string variable', async () => {
     config.autodiscover = true;
     config.autodiscoverFilter = 'project/re*';
     config.platform = 'github';

--- a/lib/workers/global/autodiscover.ts
+++ b/lib/workers/global/autodiscover.ts
@@ -30,7 +30,14 @@ export async function autodiscoverRepositories(
     return config;
   }
   if (config.autodiscoverFilter) {
-    discovered = discovered.filter(minimatch.filter(config.autodiscoverFilter));
+    const matched = new Set<string>();
+
+    for (const filter of config.autodiscoverFilter) {
+      const res = minimatch.match(discovered, filter);
+      res.forEach((e) => matched.add(e));
+    }
+
+    discovered = [...matched];
     if (!discovered.length) {
       // Soft fail (no error thrown) if no accessible repositories match the filter
       logger.debug('None of the discovered repositories matched the filter');


### PR DESCRIPTION
To support multiple filters when using the autodiscover feature, the
type of the configuration value is changed to an array.

Closes #8763

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Type of `autodiscoverFilter` configuration value changed to `string[]`.

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
