### PR TITLE
feat(node): remove hard-coded docker grouping

### DIFF
--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -29,10 +29,24 @@ const staticGroups = {
       },
     ],
   },
+  nodeJs: {
+    description:
+      "Group anything that looks like Node.js together so that it's updated together",
+    packageRules: [
+      {
+        matchDatasources: ['docker'],
+        matchPackageNames: ['node'],
+        matchPackagePatterns: ['/node$'],
+        excludePackageNames: ['calico/node'],
+        commitMessageTopic: 'Node.js',
+      },
+    ],
+  },
   recommended: {
     description:
       'Use curated list of recommended non-monorepo package groupings',
     extends: [
+      'group:nodeJs',
       'group:allApollographql',
       'group:fortawesome',
       'group:fusionjs',

--- a/lib/manager/circleci/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/circleci/__snapshots__/extract.spec.ts.snap
@@ -4,7 +4,6 @@ exports[`lib/manager/circleci/extract extractPackageFile() extracts image withou
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
-    "commitMessageTopic": "Node.js",
     "currentDigest": undefined,
     "currentValue": "14.8.0",
     "datasource": "docker",
@@ -20,7 +19,6 @@ exports[`lib/manager/circleci/extract extractPackageFile() extracts multiple ima
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
-    "commitMessageTopic": "Node.js",
     "currentDigest": undefined,
     "currentValue": undefined,
     "datasource": "docker",
@@ -31,7 +29,6 @@ Array [
   },
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
-    "commitMessageTopic": "Node.js",
     "currentDigest": undefined,
     "currentValue": "4",
     "datasource": "docker",
@@ -42,7 +39,6 @@ Array [
   },
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
-    "commitMessageTopic": "Node.js",
     "currentDigest": undefined,
     "currentValue": "6",
     "datasource": "docker",
@@ -53,7 +49,6 @@ Array [
   },
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
-    "commitMessageTopic": "Node.js",
     "currentDigest": undefined,
     "currentValue": "8.9.0",
     "datasource": "docker",

--- a/lib/manager/cloudbuild/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/cloudbuild/__snapshots__/extract.spec.ts.snap
@@ -12,7 +12,6 @@ Array [
   },
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
-    "commitMessageTopic": "Node.js",
     "currentDigest": undefined,
     "currentValue": "12",
     "datasource": "docker",

--- a/lib/manager/docker-compose/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/docker-compose/__snapshots__/extract.spec.ts.snap
@@ -12,7 +12,6 @@ Array [
   },
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
-    "commitMessageTopic": "Node.js",
     "currentDigest": undefined,
     "currentValue": "10.0.0",
     "datasource": "docker",
@@ -80,7 +79,6 @@ Array [
   },
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
-    "commitMessageTopic": "Node.js",
     "currentDigest": undefined,
     "currentValue": "10.0.0",
     "datasource": "docker",

--- a/lib/manager/dockerfile/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/dockerfile/__snapshots__/extract.spec.ts.snap
@@ -4,7 +4,6 @@ exports[`lib/manager/dockerfile/extract extractPackageFile() detects ["stage"] a
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
-    "commitMessageTopic": "Node.js",
     "currentDigest": undefined,
     "currentValue": "8.15.1-alpine",
     "datasource": "docker",
@@ -123,7 +122,6 @@ exports[`lib/manager/dockerfile/extract extractPackageFile() extracts images on 
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
-    "commitMessageTopic": "Node.js",
     "currentDigest": "sha256:d743b4141b02fcfb8beb68f92b4cd164f60ee457bf2d053f36785bf86de16b0d",
     "currentValue": "8.11.3-alpine",
     "datasource": "docker",
@@ -147,7 +145,6 @@ exports[`lib/manager/dockerfile/extract extractPackageFile() extracts multiple F
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
-    "commitMessageTopic": "Node.js",
     "currentDigest": undefined,
     "currentValue": "6.12.3",
     "datasource": "docker",
@@ -185,7 +182,6 @@ exports[`lib/manager/dockerfile/extract extractPackageFile() handles abnormal sp
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
-    "commitMessageTopic": "Node.js",
     "currentDigest": undefined,
     "currentValue": "8.7.0",
     "datasource": "docker",
@@ -214,7 +210,6 @@ exports[`lib/manager/dockerfile/extract extractPackageFile() handles comments 1`
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
-    "commitMessageTopic": "Node.js",
     "currentDigest": undefined,
     "currentValue": undefined,
     "datasource": "docker",
@@ -229,7 +224,6 @@ exports[`lib/manager/dockerfile/extract extractPackageFile() handles custom host
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
-    "commitMessageTopic": "Node.js",
     "currentDigest": undefined,
     "currentValue": "8",
     "datasource": "docker",
@@ -244,7 +238,6 @@ exports[`lib/manager/dockerfile/extract extractPackageFile() handles custom host
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
-    "commitMessageTopic": "Node.js",
     "currentDigest": undefined,
     "currentValue": "8-alpine",
     "datasource": "docker",
@@ -259,7 +252,6 @@ exports[`lib/manager/dockerfile/extract extractPackageFile() handles custom host
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
-    "commitMessageTopic": "Node.js",
     "currentDigest": undefined,
     "currentValue": "8",
     "datasource": "docker",
@@ -274,7 +266,6 @@ exports[`lib/manager/dockerfile/extract extractPackageFile() handles custom host
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
-    "commitMessageTopic": "Node.js",
     "currentDigest": undefined,
     "currentValue": "8",
     "datasource": "docker",
@@ -289,7 +280,6 @@ exports[`lib/manager/dockerfile/extract extractPackageFile() handles custom host
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
-    "commitMessageTopic": "Node.js",
     "currentDigest": undefined,
     "currentValue": undefined,
     "datasource": "docker",
@@ -304,7 +294,6 @@ exports[`lib/manager/dockerfile/extract extractPackageFile() handles digest 1`] 
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
-    "commitMessageTopic": "Node.js",
     "currentDigest": "sha256:eb85fc5b1198f5e1ec025ea07586bdbbf397e7d82df66c90d7511f533517e063",
     "currentValue": undefined,
     "datasource": "docker",
@@ -319,7 +308,6 @@ exports[`lib/manager/dockerfile/extract extractPackageFile() handles from as 1`]
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
-    "commitMessageTopic": "Node.js",
     "currentDigest": undefined,
     "currentValue": "8.9.0-alpine",
     "datasource": "docker",
@@ -334,7 +322,6 @@ exports[`lib/manager/dockerfile/extract extractPackageFile() handles naked dep 1
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
-    "commitMessageTopic": "Node.js",
     "currentDigest": undefined,
     "currentValue": undefined,
     "datasource": "docker",
@@ -349,7 +336,6 @@ exports[`lib/manager/dockerfile/extract extractPackageFile() handles namespaced 
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
-    "commitMessageTopic": "Node.js",
     "currentDigest": undefined,
     "currentValue": "8",
     "datasource": "docker",
@@ -364,7 +350,6 @@ exports[`lib/manager/dockerfile/extract extractPackageFile() handles tag 1`] = `
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
-    "commitMessageTopic": "Node.js",
     "currentDigest": undefined,
     "currentValue": "8.9.0-alpine",
     "datasource": "docker",
@@ -379,7 +364,6 @@ exports[`lib/manager/dockerfile/extract extractPackageFile() handles tag and dig
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
-    "commitMessageTopic": "Node.js",
     "currentDigest": "sha256:eb85fc5b1198f5e1ec025ea07586bdbbf397e7d82df66c90d7511f533517e063",
     "currentValue": "8.9.0",
     "datasource": "docker",
@@ -409,7 +393,6 @@ exports[`lib/manager/dockerfile/extract extractPackageFile() is case insensitive
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
-    "commitMessageTopic": "Node.js",
     "currentDigest": undefined,
     "currentValue": undefined,
     "datasource": "docker",
@@ -424,7 +407,6 @@ exports[`lib/manager/dockerfile/extract extractPackageFile() skips index referen
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
-    "commitMessageTopic": "Node.js",
     "currentDigest": undefined,
     "currentValue": "6.12.3",
     "datasource": "docker",
@@ -439,7 +421,6 @@ exports[`lib/manager/dockerfile/extract extractPackageFile() skips named multist
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
-    "commitMessageTopic": "Node.js",
     "currentDigest": undefined,
     "currentValue": "6.12.3",
     "datasource": "docker",
@@ -454,7 +435,6 @@ exports[`lib/manager/dockerfile/extract extractPackageFile() skips named multist
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
-    "commitMessageTopic": "Node.js",
     "currentDigest": undefined,
     "currentValue": "6.12.3",
     "datasource": "docker",

--- a/lib/manager/dockerfile/extract.ts
+++ b/lib/manager/dockerfile/extract.ts
@@ -48,14 +48,6 @@ export function getDep(
       '{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}';
   }
   dep.datasource = datasourceDocker.id;
-  if (
-    dep.depName &&
-    (dep.depName === 'node' || dep.depName.endsWith('/node')) &&
-    dep.depName !== 'calico/node'
-  ) {
-    dep.commitMessageTopic = 'Node.js';
-  }
-
   if (dep.depName === 'ubuntu') {
     dep.versioning = ubuntuVersioning.id;
   }

--- a/lib/manager/droneci/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/droneci/__snapshots__/extract.spec.ts.snap
@@ -13,7 +13,6 @@ Array [
   },
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
-    "commitMessageTopic": "Node.js",
     "currentDigest": "sha256:36adc17e9cceab32179d3314da9cb9c737ffb11f0de4e688f407ad6d9ca32201",
     "currentValue": "10.0.0",
     "datasource": "docker",

--- a/lib/manager/github-actions/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/github-actions/__snapshots__/extract.spec.ts.snap
@@ -67,7 +67,6 @@ Array [
   },
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
-    "commitMessageTopic": "Node.js",
     "currentDigest": "sha256:7b65413af120ec5328077775022c78101f103258a1876ec2f83890bce416e896",
     "currentValue": "6",
     "datasource": "docker",

--- a/lib/manager/gitlabci/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/gitlabci/__snapshots__/extract.spec.ts.snap
@@ -148,7 +148,6 @@ Array [
     "deps": Array [
       Object {
         "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
-        "commitMessageTopic": "Node.js",
         "currentDigest": undefined,
         "currentValue": "12",
         "datasource": "docker",


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Removes hardcoded rule for changing node commit message in Docker extractions, and instead replaces it with a preset.

## Context:

BREAKING CHANGE: node images founds in Dockerfiles will no longer have hardcoded commitMessageTopic. Add group:Nodejs or config:base to extends for backwards compatibility.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
