### PR TITLE
feat(docker): enable major updates by default

### DIFF
--- a/lib/datasource/docker/index.ts
+++ b/lib/datasource/docker/index.ts
@@ -27,7 +27,6 @@ export const registryStrategy = 'first';
 
 export const defaultConfig = {
   commitMessageTopic: '{{{depName}}} Docker tag',
-  major: { enabled: false },
   commitMessageExtra:
     'to v{{#if isMajor}}{{{newMajor}}}{{else}}{{{newVersion}}}{{/if}}',
   digest: {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Removes default settings which disabled docker major updates by default.

## Context:

BREAKING CHANGE: Major updates for docker will now be enabled by default.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
