### PR TITLE
fix(yarn): use major range for v2 constraint

### DIFF
--- a/lib/manager/npm/extract/__snapshots__/locked-versions.spec.ts.snap
+++ b/lib/manager/npm/extract/__snapshots__/locked-versions.spec.ts.snap
@@ -126,7 +126,7 @@ exports[`manager/npm/extract/locked-versions .getLockedVersions() uses yarn.lock
 Array [
   Object {
     "constraints": Object {
-      "yarn": ">= 2.0.0",
+      "yarn": "^2.0.0",
     },
     "deps": Array [
       Object {
@@ -153,7 +153,7 @@ exports[`manager/npm/extract/locked-versions .getLockedVersions() uses yarn.lock
 Array [
   Object {
     "constraints": Object {
-      "yarn": ">= 2.2.0",
+      "yarn": "^2.2.0",
     },
     "deps": Array [
       Object {

--- a/lib/manager/npm/extract/locked-versions.ts
+++ b/lib/manager/npm/extract/locked-versions.ts
@@ -24,9 +24,9 @@ export async function getLockedVersions(
       if (!isYarn1) {
         if (lockfileVersion >= 6) {
           // https://github.com/yarnpkg/berry/commit/f753790380cbda5b55d028ea84b199445129f9ba
-          packageFile.constraints.yarn = '>= 2.2.0';
+          packageFile.constraints.yarn = '^2.2.0';
         } else {
-          packageFile.constraints.yarn = '>= 2.0.0';
+          packageFile.constraints.yarn = '^2.0.0';
         }
       }
       for (const dep of packageFile.deps) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Uses `^2` not `>2` for Yarn Berry constraints we add. 

## Context:

Yarn v3 is already in progress.

Maybe relevant also to #9481

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
