### PR TITLE
fix(circleci): Expect whitespace/comments during CircleCI Orb parsing

### DIFF
--- a/lib/manager/circleci/__fixtures__/config2.yml
+++ b/lib/manager/circleci/__fixtures__/config2.yml
@@ -1,8 +1,14 @@
 version: 2.1
 
+# There are blank lines and comments in this orbs section intentionally!
 orbs:
   release-workflows: hutson/library-release-workflows@4.1.0
+  # Comments help me understand my work.
+  # The next line is intentionally just whitespace!
+  
   no-version: abc/def
+
+  # Comments help me understand my work.
   volatile: zzz/zzz@volatile
 
 test_plan: &test_plan

--- a/lib/manager/circleci/extract.ts
+++ b/lib/manager/circleci/extract.ts
@@ -23,7 +23,7 @@ export function extractPackageFile(content: string): PackageFile | null {
             logger.debug('orbNoop');
             foundOrbOrNoop = true;
             lineNumber += 1;
-            continue;
+            continue; // eslint-disable-line no-continue
           }
           const orbMatch = /^\s+([^:]+):\s(.+)$/.exec(orbLine);
           if (orbMatch) {

--- a/lib/manager/circleci/extract.ts
+++ b/lib/manager/circleci/extract.ts
@@ -13,15 +13,22 @@ export function extractPackageFile(content: string): PackageFile | null {
       const orbs = /^\s*orbs:\s*$/.exec(line);
       if (orbs) {
         logger.trace(`Matched orbs on line ${lineNumber}`);
-        let foundOrb: boolean;
+        let foundOrbOrNoop: boolean;
         do {
-          foundOrb = false;
+          foundOrbOrNoop = false;
           const orbLine = lines[lineNumber + 1];
           logger.trace(`orbLine: "${orbLine}"`);
+          const yamlNoop = /^\s*(#|$)/.exec(orbLine);
+          if (yamlNoop) {
+            logger.debug('orbNoop');
+            foundOrbOrNoop = true;
+            lineNumber += 1;
+            continue;
+          }
           const orbMatch = /^\s+([^:]+):\s(.+)$/.exec(orbLine);
           if (orbMatch) {
             logger.trace('orbMatch');
-            foundOrb = true;
+            foundOrbOrNoop = true;
             lineNumber += 1;
             const depName = orbMatch[1];
             const [orbName, currentValue] = orbMatch[2].split('@');
@@ -37,7 +44,7 @@ export function extractPackageFile(content: string): PackageFile | null {
             };
             deps.push(dep);
           }
-        } while (foundOrb);
+        } while (foundOrbOrNoop);
       }
       const match = /^\s*-? image:\s*'?"?([^\s'"]+)'?"?\s*$/.exec(line);
       if (match) {


### PR DESCRIPTION
## Changes:

This changes the parsing behavior that is used for the `orbs` section within the CircleCI orbs extraction logic to accommodate the presence of (YAML) comments and no-op content.  A far more defensive approach might change this entirely to use YAML parsing (looks like this repo occasionally uses `js-yaml`?), though this _should_ suffice.

Now, rather than stopping when an `orbMatch` is **not** encountered, we continue past lines that start with comments (`#`) or lines that are only whitespace (`\s`) — now indicated by `orbNoop` designation in the `trace` log-level output.

## Context:

Previously, the parser for CircleCI Orbs would necessitate that the `orbs` object have only key and value properties in it, e.g.:

```yaml
orbs:
  my_orb_ref1: org1/orb1@0.1.2
  my_orb_ref2: org2/orb2@0.3.4
  my_orb_ref3: org3/orb3@0.5.6
```

If there were any variations to this pattern (e.g., YAML comments, `^\n$`, whitespace-only lines, etc.), the search would stop.

I had been wondering for a while why the CircleCI manager wasn't bumping the Orbs we had listed in [our `.circleci/config.yml`](https://github.com/apollographql/federation/blob/d3fe1ed97d4cc109d10137f2cfb1d12878930d71/.circleci/config.yml#L1-L9) (snippet below):

```yaml
version: 2.1

# These "CircleCI Orbs" are reusable bits of configuration that can be shared
# across projects.  See https://circleci.com/orbs/ for more information.
orbs:
  # `oss` is a local reference to the package.  The source for Apollo Orbs can
  # be found at http://github.com/apollographql/CircleCI-Orbs/.
  # We could use Renovate to bump this version via PR, but that's not set up now.
  oss: apollo/oss-ci-cd-tooling@0.0.16

```

The above usage was resulting in _no_ orbs being found since looping would stop when a non-`orbMatch` line was encountered - e.g. ``   # `oss` is a local reference ``.., in this case)

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository


I believe the way I've altered tests is acceptable.  Happy to duplicate and introduce new ones, if that's desired.