### PR TITLE
fix(yarn): avoid yarn v2 rollback

### DIFF
--- a/lib/manager/npm/extract/__snapshots__/locked-versions.spec.ts.snap
+++ b/lib/manager/npm/extract/__snapshots__/locked-versions.spec.ts.snap
@@ -112,6 +112,12 @@ Array [
         "depName": "b",
         "lockedVersion": "2.0.0",
       },
+      Object {
+        "currentValue": "^1.22.0",
+        "depName": "yarn",
+        "depType": "engines",
+        "lockedVersion": undefined,
+      },
     ],
     "lockFiles": Array [
       "yarn.lock",
@@ -139,6 +145,13 @@ Array [
         "depName": "b",
         "lockedVersion": "2.0.0",
       },
+      Object {
+        "currentValue": "^2.1.0",
+        "depName": "yarn",
+        "depType": "engines",
+        "lockedVersion": undefined,
+        "lookupName": "@yarnpkg/cli",
+      },
     ],
     "lockFiles": Array [
       "yarn.lock",
@@ -165,6 +178,13 @@ Array [
         "currentValue": "2.0.0",
         "depName": "b",
         "lockedVersion": "2.0.0",
+      },
+      Object {
+        "currentValue": "^2.2.0",
+        "depName": "yarn",
+        "depType": "engines",
+        "lockedVersion": undefined,
+        "lookupName": "@yarnpkg/cli",
       },
     ],
     "lockFiles": Array [

--- a/lib/manager/npm/extract/locked-versions.spec.ts
+++ b/lib/manager/npm/extract/locked-versions.spec.ts
@@ -36,6 +36,11 @@ describe('manager/npm/extract/locked-versions', () => {
                 depName: 'b',
                 currentValue: '2.0.0',
               },
+              {
+                depType: 'engines',
+                depName: 'yarn',
+                currentValue: `^${yarnVersion}`,
+              },
             ],
           },
         ];

--- a/lib/manager/npm/extract/locked-versions.ts
+++ b/lib/manager/npm/extract/locked-versions.ts
@@ -34,6 +34,9 @@ export async function getLockedVersions(
           lockFileCache[yarnLock].lockedVersions[
             `${dep.depName}@${dep.currentValue}`
           ];
+        if (dep.depType === 'engines' && dep.depName === 'yarn' && !isYarn1) {
+          dep.lookupName = '@yarnpkg/cli';
+        }
       }
     } else if (npmLock) {
       logger.debug('Found ' + npmLock + ' for ' + packageFile.packageFile);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Changes `lookupName` to `@yarnpkg/cli` when Yarn v2 is used.

## Context:

Closes #9483

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
