### PR TITLE
fix(hex): short range replace

### DIFF
--- a/lib/versioning/hex/index.spec.ts
+++ b/lib/versioning/hex/index.spec.ts
@@ -215,4 +215,14 @@ describe('lib/versioning/hex', () => {
       })
     ).toEqual('== 2.0.7');
   });
+  it('handles short range replace', () => {
+    expect(
+      hexScheme.getNewValue({
+        currentValue: '~> 0.4',
+        rangeStrategy: 'replace',
+        currentVersion: '0.4.2',
+        newVersion: '0.6.0',
+      })
+    ).toEqual('~> 0.6');
+  });
 });

--- a/lib/versioning/hex/index.ts
+++ b/lib/versioning/hex/index.ts
@@ -76,9 +76,8 @@ const getNewValue = ({
     );
   } else if (/~>\s*(\d+\.\d+)$/.test(currentValue)) {
     newSemver = newSemver.replace(
-      /\^\s*(\d+\.\d+)/,
-      (_str, p1: string) =>
-        `~> ${rangeStrategy === 'bump' ? p1 : p1.slice(0, -2)}`
+      /\^\s*(\d+\.\d+)(\.\d+)?/,
+      (_str, p1: string) => `~> ${p1}`
     );
   } else {
     newSemver = newSemver.replace(/~\s*(\d+\.\d+\.\d)/, '~> $1');


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Fixes hex versioning logic for short range updates

## Context:

Closes #9182

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
