### PR TITLE
feat(cli): support --package-rules

### DIFF
--- a/lib/config/cli.spec.ts
+++ b/lib/config/cli.spec.ts
@@ -103,6 +103,35 @@ describe('config/cli', () => {
         hostRules: [],
       });
     });
+    it('parses json lists correctly as a list of packageRules', () => {
+      argv.push(
+        `--package-rules=[{"excludePackageNames":["react"],"enabled":false},{"matchPackageNames":["angular"],"rangeStrategy":"pin"}]`
+      );
+      expect(cli.getConfig(argv)).toEqual({
+        packageRules: [
+          {
+            excludePackageNames: ['react'],
+            enabled: false,
+          },
+          {
+            matchPackageNames: ['angular'],
+            rangeStrategy: 'pin',
+          },
+        ],
+      });
+    });
+    it('parses [] correctly as empty list of packageRules', () => {
+      argv.push(`--package-rules=[]`);
+      expect(cli.getConfig(argv)).toEqual({
+        packageRules: [],
+      });
+    });
+    it('parses an empty string correctly as empty list of packageRules', () => {
+      argv.push(`--package-rules=`);
+      expect(cli.getConfig(argv)).toEqual({
+        packageRules: [],
+      });
+    });
     it('migrates --endpoints', () => {
       argv.push(`--endpoints=`);
       expect(cli.getConfig(argv)).toEqual({

--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -735,7 +735,7 @@ const options: RenovateOptions[] = [
     type: 'array',
     stage: 'package',
     mergeable: true,
-    cli: false,
+    cli: true,
     env: false,
   },
   {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

support `--package-rules` in cli options

## Context:

I would like to dynamically set package rules via CLI option and see no reason why this should not be possible, as e.g. hostRules is also available via CLI.
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
