### PR TITLE
docs: explain rollbackPrs default behavior better

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2051,7 +2051,7 @@ Take a random sample of given size from reviewers.
 
 There are times when a dependency version in use by a project gets removed from the registry.
 For some registries, existing releases or even whole packages can be removed or "yanked" at any time, while for some registries only very new or unused releases can be removed.
-Renovate's "rollback" feature exists to propose a downgrade to the next-highest release if the current release is no longer found in the registry. 
+Renovate's "rollback" feature exists to propose a downgrade to the next-highest release if the current release is no longer found in the registry.
 
 Renovate does not create these rollback PRs by default, with one exception: npm packages get a rollback PR if needed.
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2049,7 +2049,11 @@ Take a random sample of given size from reviewers.
 
 ## rollbackPrs
 
-Renovate does not create rollback PRs by default, with one exception: npm packages get a rollback PR if needed.
+There are times when a dependency version in use by a project gets removed from the registry.
+For some registries, existing releases or even whole packages can be removed or "yanked" at any time, while for some registries only very new or unused releases can be removed.
+Renovate's "rollback" feature exists to propose a downgrade to the next-highest release if the current release is no longer found in the registry. 
+
+Renovate does not create these rollback PRs by default, with one exception: npm packages get a rollback PR if needed.
 
 You can configure the `rollbackPrs` property globally, per-lanuage, or per-package to override the default behavior.
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2049,7 +2049,9 @@ Take a random sample of given size from reviewers.
 
 ## rollbackPrs
 
-Configure this to `false` either globally, per-language, or per-package if you want to disable Renovate's behavior of generating rollback PRs when it can't find the current version on the registry anymore.
+Renovate does not create rollback PRs by default, with one exception: npm packages get a rollback PR if needed.
+
+You can configure the `rollbackPrs` property globally, per-lanuage, or per-package to override the default behavior.
 
 ## ruby
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

- Explain better that Renovate does not create rollback PRs by default, **except** for npm packages.
- Adjust sentence that previously duplicated part of the text provided by: https://github.com/renovatebot/renovate/blob/60eba68eb3724a718e030589ed84aaf4c466a58b/lib/config/definitions.ts#L1136

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

See discussion #9490.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
