### PR TITLE
feat(validation): warn if packageRules contain all selectors

### DIFF
--- a/lib/config/__snapshots__/validation.spec.ts.snap
+++ b/lib/config/__snapshots__/validation.spec.ts.snap
@@ -219,3 +219,12 @@ Array [
   },
 ]
 `;
+
+exports[`config/validation validateConfig(config) warns if only selectors in packageRules 1`] = `
+Array [
+  Object {
+    "message": "packageRules[0]: Each packageRule must contain at least one non-match* or non-exclude* field. Rule: {\\"matchDepTypes\\":[\\"foo\\"],\\"excludePackageNames\\":[\\"bar\\"]}",
+    "topic": "Configuration Error",
+  },
+]
+`;

--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -507,5 +507,20 @@ describe('config/validation', () => {
       expect(warnings).toHaveLength(0);
       expect(errors).toHaveLength(1);
     });
+
+    it('warns if only selectors in packageRules', async () => {
+      const config = {
+        packageRules: [
+          { matchDepTypes: ['foo'], excludePackageNames: ['bar'] },
+        ],
+      };
+      const { warnings, errors } = await configValidation.validateConfig(
+        config,
+        true
+      );
+      expect(warnings).toHaveLength(1);
+      expect(warnings).toMatchSnapshot();
+      expect(errors).toHaveLength(0);
+    });
   });
 });

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -289,6 +289,15 @@ export async function validateConfig(
                       message,
                     });
                   }
+                  if (selectorLength === Object.keys(resolvedRule).length) {
+                    const message = `${currentPath}[${subIndex}]: Each packageRule must contain at least one non-match* or non-exclude* field. Rule: ${JSON.stringify(
+                      packageRule
+                    )}`;
+                    warnings.push({
+                      topic: 'Configuration Error',
+                      message,
+                    });
+                  }
                 } else {
                   errors.push({
                     topic: 'Configuration Error',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds a config warning if any `packageRules` contain only selectors.

## Context:

I think WARN is safest because errors would cause the repo to stop, and I'm not 100% sure if there's any edge cases I've missed.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
