### PR TITLE
feat(validation): language/manager top-level check

### DIFF
--- a/lib/config/__snapshots__/validation.spec.ts.snap
+++ b/lib/config/__snapshots__/validation.spec.ts.snap
@@ -137,6 +137,19 @@ Array [
 ]
 `;
 
+exports[`config/validation validateConfig(config) errors if language or manager objects are nested 1`] = `
+Array [
+  Object {
+    "message": "The \\"docker\\" object can only be configured at the top level of a config but was found inside \\"major.minor\\"",
+    "topic": "Configuration Error",
+  },
+  Object {
+    "message": "The \\"gradle\\" object can only be configured at the top level of a config but was found inside \\"java\\"",
+    "topic": "Configuration Error",
+  },
+]
+`;
+
 exports[`config/validation validateConfig(config) errors if regexManager fields are missing 1`] = `
 Array [
   Object {

--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -484,6 +484,32 @@ describe('config/validation', () => {
       expect(warnings).toMatchSnapshot();
     });
 
+    it('errors if language or manager objects are nested', async () => {
+      const config = {
+        python: {
+          enabled: false,
+        },
+        java: {
+          gradle: {
+            enabled: false,
+          },
+        },
+        major: {
+          minor: {
+            docker: {
+              automerge: true,
+            },
+          },
+        },
+      };
+      const { warnings, errors } = await configValidation.validateConfig(
+        config
+      );
+      expect(errors).toHaveLength(2);
+      expect(warnings).toHaveLength(0);
+      expect(errors).toMatchSnapshot();
+    });
+
     it('warns if hostType has the wrong parent', async () => {
       const config = {
         hostType: 'npm',

--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -501,7 +501,7 @@ describe('config/validation', () => {
             },
           },
         },
-      };
+      } as never;
       const { warnings, errors } = await configValidation.validateConfig(
         config
       );

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -1,5 +1,5 @@
 import is from '@sindresorhus/is';
-import { getManagerList } from '../manager';
+import { getLanguageList, getManagerList } from '../manager';
 import { configRegexPredicate, isConfigRegex, regEx } from '../util/regex';
 import * as template from '../util/template';
 import { hasValidSchedule, hasValidTimezone } from '../workers/branch/schedule';
@@ -40,6 +40,8 @@ export function getParentName(parentPath: string): string {
         .pop()
     : '.';
 }
+
+const topLevelObjects = getLanguageList().concat(getManagerList());
 
 export async function validateConfig(
   config: RenovateConfig,
@@ -114,6 +116,12 @@ export async function validateConfig(
         message: '__proto__',
       });
       continue; // eslint-disable-line
+    }
+    if (parentPath && topLevelObjects.includes(key)) {
+      errors.push({
+        topic: 'Configuration Error',
+        message: `The "${key}" object can only be configured at the top level of a config but was found inside "${parentPath}"`,
+      });
     }
     if (key === 'fileMatch') {
       if (parentPath === undefined) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds validation to ensure that any `language` or `manager` object is configured at the top level.

## Context:

Such config would not be applied if left as-is.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
