### PR TITLE
fix(go): Fix submodules releases behavior

### DIFF
--- a/lib/datasource/go/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/go/__snapshots__/index.spec.ts.snap
@@ -93,56 +93,6 @@ Array [
 ]
 `;
 
-exports[`datasource/go getReleases falls back to old behaviour 1`] = `
-Array [
-  Object {
-    "headers": Object {
-      "accept": "application/vnd.github.v3+json",
-      "accept-encoding": "gzip, deflate",
-      "host": "api.github.com",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
-    "url": "https://api.github.com/repos/x/text/tags?per_page=100",
-  },
-  Object {
-    "headers": Object {
-      "accept": "application/vnd.github.v3+json",
-      "accept-encoding": "gzip, deflate",
-      "host": "api.github.com",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
-    "url": "https://api.github.com/repos/x/text/releases?per_page=100",
-  },
-]
-`;
-
-exports[`datasource/go getReleases falls back to old behaviour 2`] = `
-Array [
-  Object {
-    "headers": Object {
-      "accept": "application/vnd.github.v3+json",
-      "accept-encoding": "gzip, deflate",
-      "host": "api.github.com",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
-    "url": "https://api.github.com/repos/x/text/tags?per_page=100",
-  },
-  Object {
-    "headers": Object {
-      "accept": "application/vnd.github.v3+json",
-      "accept-encoding": "gzip, deflate",
-      "host": "api.github.com",
-      "user-agent": "https://github.com/renovatebot/renovate",
-    },
-    "method": "GET",
-    "url": "https://api.github.com/repos/x/text/releases?per_page=100",
-  },
-]
-`;
-
 exports[`datasource/go getReleases handles fyne.io 1`] = `
 Object {
   "releases": Array [
@@ -239,6 +189,56 @@ Array [
     },
     "method": "GET",
     "url": "https://api.github.com/repos/golang/text/releases?per_page=100",
+  },
+]
+`;
+
+exports[`datasource/go getReleases returns none if no tags match submodules 1`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate",
+      "host": "api.github.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://api.github.com/repos/x/text/tags?per_page=100",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate",
+      "host": "api.github.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://api.github.com/repos/x/text/releases?per_page=100",
+  },
+]
+`;
+
+exports[`datasource/go getReleases returns none if no tags match submodules 2`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate",
+      "host": "api.github.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://api.github.com/repos/x/text/tags?per_page=100",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate",
+      "host": "api.github.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://api.github.com/repos/x/text/releases?per_page=100",
   },
 ]
 `;

--- a/lib/datasource/go/index.spec.ts
+++ b/lib/datasource/go/index.spec.ts
@@ -132,6 +132,7 @@ describe('datasource/go', () => {
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
   });
+
   describe('getReleases', () => {
     it('returns null for empty result', async () => {
       httpMock
@@ -391,7 +392,7 @@ describe('datasource/go', () => {
         httpMock.reset();
       }
     });
-    it('falls back to old behaviour', async () => {
+    it('returns none if no tags match submodules', async () => {
       const packages = [
         { datasource, depName: 'github.com/x/text/a' },
         { datasource, depName: 'github.com/x/text/b' },
@@ -408,10 +409,7 @@ describe('datasource/go', () => {
           .reply(200, []);
 
         const result = await getPkgReleases(pkg);
-        expect(result.releases).toHaveLength(2);
-        expect(result.releases.map(({ version }) => version)).toStrictEqual(
-          tags.map(({ name }) => name)
-        );
+        expect(result.releases).toHaveLength(0);
 
         const httpCalls = httpMock.getTrace();
         expect(httpCalls).toMatchSnapshot();
@@ -427,7 +425,6 @@ describe('datasource/go', () => {
         { name: 'b/v3.0.0' },
       ];
 
-      httpMock.setup();
       httpMock
         .scope('https://api.github.com/')
         .get('/repos/x/text/tags?per_page=100')
@@ -443,7 +440,6 @@ describe('datasource/go', () => {
 
       const httpCalls = httpMock.getTrace();
       expect(httpCalls).toMatchSnapshot();
-      httpMock.reset();
     });
     it('handles fyne.io', async () => {
       httpMock

--- a/lib/datasource/go/index.ts
+++ b/lib/datasource/go/index.ts
@@ -151,12 +151,13 @@ export async function getReleases({
 }: GetReleasesConfig): Promise<ReleaseResult | null> {
   logger.trace(`go.getReleases(${lookupName})`);
   const source = await getDatasource(lookupName);
-  let res = null;
 
   if (!source) {
     logger.warn({ lookupName }, 'Unsupported dependency.');
     return null;
   }
+
+  let res: ReleaseResult;
 
   switch (source.datasource) {
     case github.id: {
@@ -179,8 +180,9 @@ export async function getReleases({
 
   // istanbul ignore if
   if (!res) {
-    return res;
+    return null;
   }
+
   /**
    * github.com/org/mod/submodule should be tagged as submodule/va.b.c
    * and that tag should be used instead of just va.b.c, although for compatibility
@@ -188,9 +190,14 @@ export async function getReleases({
    */
   const nameParts = lookupName.replace(/\/v\d+$/, '').split('/');
   logger.trace({ nameParts, releases: res.releases }, 'go.getReleases');
+
+  // If it has more than 3 parts it's a submodule
   if (nameParts.length > 3) {
     const prefix = nameParts.slice(3, nameParts.length).join('/');
     logger.trace(`go.getReleases.prefix:${prefix}`);
+
+    // Filter the releases so that we only get the ones that are for this submodule
+    // Also trim the submodule prefix from the version number
     const submodReleases = res.releases
       .filter((release) => release.version?.startsWith(prefix))
       .map((release) => {
@@ -199,18 +206,19 @@ export async function getReleases({
         return r2;
       });
     logger.trace({ submodReleases }, 'go.getReleases');
-    if (submodReleases.length > 0) {
-      return {
-        sourceUrl: res.sourceUrl,
-        releases: submodReleases,
-      };
-    }
+
+    return {
+      sourceUrl: res.sourceUrl,
+      releases: submodReleases,
+    };
   }
-  if (res?.releases) {
+
+  if (res.releases) {
     res.releases = res.releases.filter((release) =>
       release.version?.startsWith('v')
     );
   }
+
   return res;
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

When dealing with a Go dependency that's a submodule, Renovate should always and only look for submodule-style release tags. Previously, it would fall back on regular tags if it couldn't find any submodule tags.

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

Closes #9370.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
