### PR TITLE
refactor(manager): Enforce getName usage

### DIFF
--- a/lib/manager/ansible/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/ansible/__snapshots__/extract.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/manager/ansible/extract extractPackageFile() extracts multiple image lines from docker_container 1`] = `
+exports[`manager/ansible/extract extractPackageFile() extracts multiple image lines from docker_container 1`] = `
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
@@ -86,7 +86,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/ansible/extract extractPackageFile() extracts multiple image lines from docker_service 1`] = `
+exports[`manager/ansible/extract extractPackageFile() extracts multiple image lines from docker_service 1`] = `
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",

--- a/lib/manager/ansible/extract.spec.ts
+++ b/lib/manager/ansible/extract.spec.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'fs';
+import { getName } from '../../../test/util';
 import extractPackageFile from './extract';
 
 const yamlFile1 = readFileSync(
@@ -10,7 +11,7 @@ const yamlFile2 = readFileSync(
   'utf8'
 );
 
-describe('lib/manager/ansible/extract', () => {
+describe(getName(__filename), () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty', () => {
       expect(extractPackageFile('nothing here')).toBeNull();

--- a/lib/manager/azure-pipelines/extract.spec.ts
+++ b/lib/manager/azure-pipelines/extract.spec.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'fs';
+import { getName } from '../../../test/util';
 import {
   extractContainer,
   extractPackageFile,
@@ -21,7 +22,7 @@ const azurePipelinesNoDependency = readFileSync(
   'utf8'
 );
 
-describe('manager/azure-pipelines/extract', () => {
+describe(getName(__filename), () => {
   it('should parse a valid azure-pipelines file', () => {
     const file = parseAzurePipelines(azurePipelines, 'some-file');
     expect(file).not.toBeNull();

--- a/lib/manager/batect-wrapper/artifacts.spec.ts
+++ b/lib/manager/batect-wrapper/artifacts.spec.ts
@@ -1,4 +1,5 @@
 import * as httpMock from '../../../test/http-mock';
+import { getName } from '../../../test/util';
 import type { UpdateArtifact } from '../types';
 import { updateArtifacts } from './artifacts';
 
@@ -20,7 +21,7 @@ function artifactForPath(
   };
 }
 
-describe('lib/manager/batect-wrapper/artifacts', () => {
+describe(getName(__filename), () => {
   beforeEach(() => {
     httpMock.setup();
 

--- a/lib/manager/batect-wrapper/extract.spec.ts
+++ b/lib/manager/batect-wrapper/extract.spec.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'fs';
+import { getName } from '../../../test/util';
 import { id as githubReleaseDatasource } from '../../datasource/github-releases';
 import { id as semverVersioning } from '../../versioning/semver';
 import type { PackageDependency } from '../types';
@@ -14,7 +15,7 @@ const malformedWrapperContent = readFileSync(
   'utf8'
 );
 
-describe('lib/manager/batect-wrapper/extract', () => {
+describe(getName(__filename), () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty wrapper file', () => {
       expect(extractPackageFile('')).toBeNull();

--- a/lib/manager/batect/extract.spec.ts
+++ b/lib/manager/batect/extract.spec.ts
@@ -1,3 +1,4 @@
+import { getName } from '../../../test/util';
 import { id as gitTagDatasource } from '../../datasource/git-tags';
 import { id as dockerVersioning } from '../../versioning/docker';
 import { id as semverVersioning } from '../../versioning/semver';
@@ -24,7 +25,7 @@ function createGitDependency(repo: string, version: string): PackageDependency {
   };
 }
 
-describe('lib/manager/batect/extract', () => {
+describe(getName(__filename), () => {
   describe('extractPackageFile()', () => {
     it('returns empty array for empty configuration file', async () => {
       expect(

--- a/lib/manager/bazel/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/bazel/__snapshots__/extract.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/manager/bazel/extract extractPackageFile() extracts dependencies for container_pull deptype 1`] = `
+exports[`manager/bazel/extract extractPackageFile() extracts dependencies for container_pull deptype 1`] = `
 Array [
   Object {
     "currentDigest": "sha256:a4e8d8c444ca04fe706649e82263c9f4c2a4229bc30d2a64561b5e1d20cc8548",
@@ -27,7 +27,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/bazel/extract extractPackageFile() extracts dependencies from *.bzl files 1`] = `
+exports[`manager/bazel/extract extractPackageFile() extracts dependencies from *.bzl files 1`] = `
 Array [
   Object {
     "currentDigest": "0356bef3fbbabec5f0e196ecfacdeb6db62d48c0",
@@ -65,7 +65,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/bazel/extract extractPackageFile() extracts github tags 1`] = `
+exports[`manager/bazel/extract extractPackageFile() extracts github tags 1`] = `
 Array [
   Object {
     "currentValue": "6.3.0",
@@ -134,7 +134,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/bazel/extract extractPackageFile() extracts multiple types of dependencies 1`] = `
+exports[`manager/bazel/extract extractPackageFile() extracts multiple types of dependencies 1`] = `
 Array [
   Object {
     "currentValue": "v1.0.5",
@@ -363,7 +363,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/bazel/extract extractPackageFile() handle comments and strings 1`] = `
+exports[`manager/bazel/extract extractPackageFile() handle comments and strings 1`] = `
 Array [
   Object {
     "currentDigest": "98495a618246683c9058dd87c2c78a2c06087999",

--- a/lib/manager/bazel/extract.spec.ts
+++ b/lib/manager/bazel/extract.spec.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'fs';
+import { getName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 const workspaceFile = readFileSync(
@@ -21,7 +22,7 @@ const fileWithBzlExtension = readFileSync(
   'utf8'
 );
 
-describe('lib/manager/bazel/extract', () => {
+describe(getName(__filename), () => {
   describe('extractPackageFile()', () => {
     it('returns empty if fails to parse', () => {
       const res = extractPackageFile('blahhhhh:foo:@what\n');

--- a/lib/manager/bazel/update.spec.ts
+++ b/lib/manager/bazel/update.spec.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'fs';
 import { Readable } from 'stream';
 import { resolve } from 'upath';
 import * as httpMock from '../../../test/http-mock';
+import { getName } from '../../../test/util';
 import { UpdateType } from '../../config';
 import { updateDependency } from './update';
 
@@ -28,7 +29,7 @@ git_repository(
 )
 */
 
-describe('manager/bazel/update', () => {
+describe(getName(__filename), () => {
   describe('updateDependency', () => {
     beforeEach(() => {
       jest.resetAllMocks();

--- a/lib/manager/buildkite/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/buildkite/__snapshots__/extract.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/manager/buildkite/extract extractPackageFile() adds skipReason 1`] = `
+exports[`manager/buildkite/extract extractPackageFile() adds skipReason 1`] = `
 Array [
   Object {
     "currentValue": "v1.3.2.5",
@@ -20,7 +20,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/buildkite/extract extractPackageFile() extracts arrays of plugins 1`] = `
+exports[`manager/buildkite/extract extractPackageFile() extracts arrays of plugins 1`] = `
 Array [
   Object {
     "currentValue": "v2.0.1",
@@ -53,7 +53,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/buildkite/extract extractPackageFile() extracts multiple plugins in same file 1`] = `
+exports[`manager/buildkite/extract extractPackageFile() extracts multiple plugins in same file 1`] = `
 Array [
   Object {
     "currentValue": "v1.3.2",
@@ -72,7 +72,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/buildkite/extract extractPackageFile() extracts simple single plugin 1`] = `
+exports[`manager/buildkite/extract extractPackageFile() extracts simple single plugin 1`] = `
 Array [
   Object {
     "currentValue": "v2.0.0",

--- a/lib/manager/buildkite/extract.spec.ts
+++ b/lib/manager/buildkite/extract.spec.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'fs';
+import { getName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 const pipeline1 = readFileSync(
@@ -18,7 +19,7 @@ const pipeline4 = readFileSync(
   'utf8'
 );
 
-describe('lib/manager/buildkite/extract', () => {
+describe(getName(__filename), () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty', () => {
       expect(extractPackageFile('nothing here')).toBeNull();

--- a/lib/manager/bundler/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/bundler/__snapshots__/extract.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/manager/bundler/extract extractPackageFile() parse Ruby CI Gemfile 1`] = `
+exports[`manager/bundler/extract extractPackageFile() parse Ruby CI Gemfile 1`] = `
 Object {
   "constraints": Object {
     "bundler": "2.0.2",
@@ -152,7 +152,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/bundler/extract extractPackageFile() parse mastodon Gemfile 1`] = `
+exports[`manager/bundler/extract extractPackageFile() parse mastodon Gemfile 1`] = `
 Object {
   "constraints": Object {
     "ruby": ">= 2.4.0",
@@ -1391,7 +1391,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/bundler/extract extractPackageFile() parse webpacker Gemfile 1`] = `
+exports[`manager/bundler/extract extractPackageFile() parse webpacker Gemfile 1`] = `
 Object {
   "constraints": Object {
     "bundler": "1.17.3",
@@ -1455,7 +1455,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/bundler/extract extractPackageFile() parses rails Gemfile 1`] = `
+exports[`manager/bundler/extract extractPackageFile() parses rails Gemfile 1`] = `
 Object {
   "constraints": Object {
     "bundler": "1.17.2",
@@ -2156,7 +2156,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/bundler/extract extractPackageFile() parses sourceGroups 1`] = `
+exports[`manager/bundler/extract extractPackageFile() parses sourceGroups 1`] = `
 Object {
   "constraints": Object {
     "ruby": "~> 1.5.3",
@@ -2226,7 +2226,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/bundler/extract parse Gitlab Foss Gemfile 1`] = `
+exports[`manager/bundler/extract parse Gitlab Foss Gemfile 1`] = `
 Object {
   "constraints": Object {
     "bundler": "1.17.3",
@@ -4705,7 +4705,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/bundler/extract parse source blocks in Gemfile 1`] = `
+exports[`manager/bundler/extract parse source blocks in Gemfile 1`] = `
 Object {
   "deps": Array [
     Object {
@@ -4738,7 +4738,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/bundler/extract parse source blocks with spaces in Gemfile 1`] = `
+exports[`manager/bundler/extract parse source blocks with spaces in Gemfile 1`] = `
 Object {
   "constraints": Object {
     "bundler": "1.16.6",

--- a/lib/manager/bundler/extract.spec.ts
+++ b/lib/manager/bundler/extract.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { fs } from '../../../test/util';
+import { fs, getName } from '../../../test/util';
 import { isValid } from '../../versioning/ruby';
 import { extractPackageFile } from './extract';
 
@@ -70,7 +70,7 @@ function validateGems(raw, parsed) {
   expect(gemfileGemCount).toEqual(parsedGemCount);
 }
 
-describe('lib/manager/bundler/extract', () => {
+describe(getName(__filename), () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty', async () => {
       expect(await extractPackageFile('nothing here', 'Gemfile')).toBeNull();

--- a/lib/manager/bundler/host-rules.spec.ts
+++ b/lib/manager/bundler/host-rules.spec.ts
@@ -1,3 +1,4 @@
+import { getName } from '../../../test/util';
 import { HostRule } from '../../types';
 import { add, clear } from '../../util/host-rules';
 
@@ -7,7 +8,7 @@ import {
   getDomain,
 } from './host-rules';
 
-describe('lib/manager/bundler/host-rules', () => {
+describe(getName(__filename), () => {
   beforeEach(() => {
     clear();
   });

--- a/lib/manager/bundler/range.spec.ts
+++ b/lib/manager/bundler/range.spec.ts
@@ -1,7 +1,8 @@
+import { getName } from '../../../test/util';
 import type { RangeConfig } from '../types';
 import { getRangeStrategy } from '.';
 
-describe('lib/manager/bundler/range', () => {
+describe(getName(__filename), () => {
   describe('getRangeStrategy()', () => {
     it('returns replace when rangeStrategy is auto', () => {
       const config: RangeConfig = { rangeStrategy: 'auto' };

--- a/lib/manager/cargo/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/cargo/__snapshots__/extract.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/manager/cargo/extract extractPackageFile() extracts multiple dependencies advanced 1`] = `
+exports[`manager/cargo/extract extractPackageFile() extracts multiple dependencies advanced 1`] = `
 Array [
   Object {
     "currentValue": "0.2.0",
@@ -242,7 +242,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/cargo/extract extractPackageFile() extracts multiple dependencies simple 1`] = `
+exports[`manager/cargo/extract extractPackageFile() extracts multiple dependencies simple 1`] = `
 Array [
   Object {
     "currentValue": "=0.2.43",
@@ -391,7 +391,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/cargo/extract extractPackageFile() extracts platform specific dependencies 1`] = `
+exports[`manager/cargo/extract extractPackageFile() extracts platform specific dependencies 1`] = `
 Array [
   Object {
     "currentValue": "0.2.37",
@@ -437,7 +437,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/cargo/extract extractPackageFile() extracts registry urls from .cargo/config (legacy path) 1`] = `
+exports[`manager/cargo/extract extractPackageFile() extracts registry urls from .cargo/config (legacy path) 1`] = `
 Array [
   Object {
     "currentValue": "0.1.0",
@@ -475,7 +475,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/cargo/extract extractPackageFile() extracts registry urls from .cargo/config.toml 1`] = `
+exports[`manager/cargo/extract extractPackageFile() extracts registry urls from .cargo/config.toml 1`] = `
 Array [
   Object {
     "currentValue": "0.1.0",
@@ -513,7 +513,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/cargo/extract extractPackageFile() fails to parse cargo config with invalid TOML 1`] = `
+exports[`manager/cargo/extract extractPackageFile() fails to parse cargo config with invalid TOML 1`] = `
 Array [
   Object {
     "currentValue": "0.1.0",
@@ -547,7 +547,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/cargo/extract extractPackageFile() handles inline tables 1`] = `
+exports[`manager/cargo/extract extractPackageFile() handles inline tables 1`] = `
 Array [
   Object {
     "currentValue": "0.1",
@@ -629,7 +629,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/cargo/extract extractPackageFile() handles standard tables 1`] = `
+exports[`manager/cargo/extract extractPackageFile() handles standard tables 1`] = `
 Array [
   Object {
     "currentValue": "1.2",
@@ -694,7 +694,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/cargo/extract extractPackageFile() ignore cargo config registries with missing index 1`] = `
+exports[`manager/cargo/extract extractPackageFile() ignore cargo config registries with missing index 1`] = `
 Array [
   Object {
     "currentValue": "0.1.0",
@@ -728,7 +728,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/cargo/extract extractPackageFile() skips unknown registries 1`] = `
+exports[`manager/cargo/extract extractPackageFile() skips unknown registries 1`] = `
 Array [
   Object {
     "currentValue": "0.1.0",

--- a/lib/manager/cargo/extract.spec.ts
+++ b/lib/manager/cargo/extract.spec.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'fs';
 import { dir } from 'tmp-promise';
 import { join } from 'upath';
+import { getName } from '../../../test/util';
 import { setFsConfig, writeLocalFile } from '../../util/fs';
 import { extractPackageFile } from './extract';
 
@@ -34,7 +35,7 @@ const cargo6toml = readFileSync(
   'utf8'
 );
 
-describe('lib/manager/cargo/extract', () => {
+describe(getName(__filename), () => {
   describe('extractPackageFile()', () => {
     let config;
     beforeEach(() => {

--- a/lib/manager/cdnurl/extract.spec.ts
+++ b/lib/manager/cdnurl/extract.spec.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'upath';
+import { getName } from '../../../test/util';
 import { extractPackageFile } from '.';
 
 const input = readFileSync(
@@ -7,7 +8,7 @@ const input = readFileSync(
   'utf8'
 );
 
-describe('manager/cdnurl/extract', () => {
+describe(getName(__filename), () => {
   it('extractPackageFile', () => {
     expect(extractPackageFile(input)).toMatchSnapshot();
   });

--- a/lib/manager/circleci/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/circleci/__snapshots__/extract.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/manager/circleci/extract extractPackageFile() extracts image without leading dash 1`] = `
+exports[`manager/circleci/extract extractPackageFile() extracts image without leading dash 1`] = `
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
@@ -16,7 +16,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/circleci/extract extractPackageFile() extracts multiple image lines 1`] = `
+exports[`manager/circleci/extract extractPackageFile() extracts multiple image lines 1`] = `
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
@@ -65,7 +65,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/circleci/extract extractPackageFile() extracts orbs too 1`] = `
+exports[`manager/circleci/extract extractPackageFile() extracts orbs too 1`] = `
 Array [
   Object {
     "commitMessageTopic": "{{{depName}}} orb",

--- a/lib/manager/circleci/extract.spec.ts
+++ b/lib/manager/circleci/extract.spec.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'fs';
+import { getName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 const file1 = readFileSync(
@@ -14,7 +15,7 @@ const file3 = readFileSync(
   'utf8'
 );
 
-describe('lib/manager/circleci/extract', () => {
+describe(getName(__filename), () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty', () => {
       expect(extractPackageFile('nothing here')).toBeNull();

--- a/lib/manager/cloudbuild/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/cloudbuild/__snapshots__/extract.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/manager/cloudbuild/extract extractPackageFile() extracts multiple image lines 1`] = `
+exports[`manager/cloudbuild/extract extractPackageFile() extracts multiple image lines 1`] = `
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",

--- a/lib/manager/cloudbuild/extract.spec.ts
+++ b/lib/manager/cloudbuild/extract.spec.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'fs';
+import { getName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 const file1 = readFileSync(
@@ -6,7 +7,7 @@ const file1 = readFileSync(
   'utf8'
 );
 
-describe('lib/manager/cloudbuild/extract', () => {
+describe(getName(__filename), () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty', () => {
       expect(extractPackageFile('nothing here')).toBeNull();

--- a/lib/manager/cocoapods/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/cocoapods/__snapshots__/extract.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/manager/cocoapods/extract extractPackageFile() extracts all dependencies 1`] = `
+exports[`manager/cocoapods/extract extractPackageFile() extracts all dependencies 1`] = `
 Array [
   Object {
     "depName": "a",
@@ -68,7 +68,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/cocoapods/extract extractPackageFile() extracts all dependencies 2`] = `
+exports[`manager/cocoapods/extract extractPackageFile() extracts all dependencies 2`] = `
 Array [
   Object {
     "currentValue": "~> 6.5.0",

--- a/lib/manager/cocoapods/extract.spec.ts
+++ b/lib/manager/cocoapods/extract.spec.ts
@@ -1,6 +1,7 @@
 import fs from 'fs-extra';
 import upath from 'upath';
 
+import { getName } from '../../../test/util';
 import { extractPackageFile } from '.';
 
 const simplePodfile = fs.readFileSync(
@@ -13,7 +14,7 @@ const complexPodfile = fs.readFileSync(
   'utf-8'
 );
 
-describe('lib/manager/cocoapods/extract', () => {
+describe(getName(__filename), () => {
   describe('extractPackageFile()', () => {
     it('extracts all dependencies', async () => {
       const simpleResult = (await extractPackageFile(simplePodfile, 'Podfile'))

--- a/lib/manager/composer/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/composer/__snapshots__/extract.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/manager/composer/extract extractPackageFile() extracts dependencies with lock file 1`] = `
+exports[`manager/composer/extract extractPackageFile() extracts dependencies with lock file 1`] = `
 Object {
   "constraints": Object {
     "composer": "^1.10.0",
@@ -214,7 +214,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/composer/extract extractPackageFile() extracts dependencies with no lock file 1`] = `
+exports[`manager/composer/extract extractPackageFile() extracts dependencies with no lock file 1`] = `
 Object {
   "constraints": Object {
     "composer": "^1.10.0",
@@ -425,7 +425,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/composer/extract extractPackageFile() extracts object registryUrls 1`] = `
+exports[`manager/composer/extract extractPackageFile() extracts object registryUrls 1`] = `
 Object {
   "constraints": Object {
     "composer": "1.*",
@@ -530,7 +530,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/composer/extract extractPackageFile() extracts object repositories and registryUrls with lock file 1`] = `
+exports[`manager/composer/extract extractPackageFile() extracts object repositories and registryUrls with lock file 1`] = `
 Object {
   "constraints": Object {
     "composer": "1.*",
@@ -570,7 +570,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/composer/extract extractPackageFile() extracts registryUrls 1`] = `
+exports[`manager/composer/extract extractPackageFile() extracts registryUrls 1`] = `
 Object {
   "constraints": Object {
     "composer": "^1.10.0",
@@ -615,7 +615,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/composer/extract extractPackageFile() extracts repositories and registryUrls 1`] = `
+exports[`manager/composer/extract extractPackageFile() extracts repositories and registryUrls 1`] = `
 Object {
   "constraints": Object {
     "composer": "1.*",

--- a/lib/manager/composer/extract.spec.ts
+++ b/lib/manager/composer/extract.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { fs } from '../../../test/util';
+import { fs, getName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 jest.mock('../../util/fs');
@@ -29,7 +29,7 @@ const requirements5Lock = readFileSync(
   'utf8'
 );
 
-describe('lib/manager/composer/extract', () => {
+describe(getName(__filename), () => {
   describe('extractPackageFile()', () => {
     let packageFile;
     beforeEach(() => {

--- a/lib/manager/deps-edn/extract.spec.ts
+++ b/lib/manager/deps-edn/extract.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-template-curly-in-string */
 import { readFileSync } from 'fs';
 import { resolve } from 'upath';
+import { getName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 const depsEdn = readFileSync(
@@ -8,7 +9,7 @@ const depsEdn = readFileSync(
   'utf8'
 );
 
-describe('manager/deps-edn/extract', () => {
+describe(getName(__filename), () => {
   it('extractPackageFile', () => {
     expect(extractPackageFile(depsEdn)).toMatchSnapshot();
   });

--- a/lib/manager/dockerfile/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/dockerfile/__snapshots__/extract.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/manager/dockerfile/extract extractPackageFile() detects ["stage"] and ["final"] deps of docker multi-stage build. 1`] = `
+exports[`manager/dockerfile/extract extractPackageFile() detects ["stage"] and ["final"] deps of docker multi-stage build. 1`] = `
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
@@ -33,7 +33,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/dockerfile/extract extractPackageFile() extracts images from all sorts of (maybe multiline) FROM and COPY --from statements 1`] = `
+exports[`manager/dockerfile/extract extractPackageFile() extracts images from all sorts of (maybe multiline) FROM and COPY --from statements 1`] = `
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
@@ -119,7 +119,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/dockerfile/extract extractPackageFile() extracts images on adjacent lines 1`] = `
+exports[`manager/dockerfile/extract extractPackageFile() extracts images on adjacent lines 1`] = `
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
@@ -143,7 +143,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/dockerfile/extract extractPackageFile() extracts multiple FROM tags 1`] = `
+exports[`manager/dockerfile/extract extractPackageFile() extracts multiple FROM tags 1`] = `
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
@@ -167,7 +167,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/dockerfile/extract extractPackageFile() handles COPY --from 1`] = `
+exports[`manager/dockerfile/extract extractPackageFile() handles COPY --from 1`] = `
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
@@ -181,7 +181,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/dockerfile/extract extractPackageFile() handles abnormal spacing 1`] = `
+exports[`manager/dockerfile/extract extractPackageFile() handles abnormal spacing 1`] = `
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
@@ -196,7 +196,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/dockerfile/extract extractPackageFile() handles calico/node 1`] = `
+exports[`manager/dockerfile/extract extractPackageFile() handles calico/node 1`] = `
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
@@ -210,7 +210,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/dockerfile/extract extractPackageFile() handles comments 1`] = `
+exports[`manager/dockerfile/extract extractPackageFile() handles comments 1`] = `
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
@@ -225,7 +225,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/dockerfile/extract extractPackageFile() handles custom hosts 1`] = `
+exports[`manager/dockerfile/extract extractPackageFile() handles custom hosts 1`] = `
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
@@ -240,7 +240,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/dockerfile/extract extractPackageFile() handles custom hosts and suffix 1`] = `
+exports[`manager/dockerfile/extract extractPackageFile() handles custom hosts and suffix 1`] = `
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
@@ -255,7 +255,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/dockerfile/extract extractPackageFile() handles custom hosts with namespace 1`] = `
+exports[`manager/dockerfile/extract extractPackageFile() handles custom hosts with namespace 1`] = `
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
@@ -270,7 +270,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/dockerfile/extract extractPackageFile() handles custom hosts with port 1`] = `
+exports[`manager/dockerfile/extract extractPackageFile() handles custom hosts with port 1`] = `
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
@@ -285,7 +285,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/dockerfile/extract extractPackageFile() handles custom hosts with port without tag 1`] = `
+exports[`manager/dockerfile/extract extractPackageFile() handles custom hosts with port without tag 1`] = `
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
@@ -300,7 +300,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/dockerfile/extract extractPackageFile() handles digest 1`] = `
+exports[`manager/dockerfile/extract extractPackageFile() handles digest 1`] = `
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
@@ -315,7 +315,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/dockerfile/extract extractPackageFile() handles from as 1`] = `
+exports[`manager/dockerfile/extract extractPackageFile() handles from as 1`] = `
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
@@ -330,7 +330,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/dockerfile/extract extractPackageFile() handles naked dep 1`] = `
+exports[`manager/dockerfile/extract extractPackageFile() handles naked dep 1`] = `
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
@@ -345,7 +345,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/dockerfile/extract extractPackageFile() handles namespaced images 1`] = `
+exports[`manager/dockerfile/extract extractPackageFile() handles namespaced images 1`] = `
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
@@ -360,7 +360,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/dockerfile/extract extractPackageFile() handles tag 1`] = `
+exports[`manager/dockerfile/extract extractPackageFile() handles tag 1`] = `
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
@@ -375,7 +375,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/dockerfile/extract extractPackageFile() handles tag and digest 1`] = `
+exports[`manager/dockerfile/extract extractPackageFile() handles tag and digest 1`] = `
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
@@ -390,7 +390,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/dockerfile/extract extractPackageFile() handles ubuntu 1`] = `
+exports[`manager/dockerfile/extract extractPackageFile() handles ubuntu 1`] = `
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
@@ -405,7 +405,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/dockerfile/extract extractPackageFile() is case insensitive 1`] = `
+exports[`manager/dockerfile/extract extractPackageFile() is case insensitive 1`] = `
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
@@ -420,7 +420,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/dockerfile/extract extractPackageFile() skips index reference COPY --from tags 1`] = `
+exports[`manager/dockerfile/extract extractPackageFile() skips index reference COPY --from tags 1`] = `
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
@@ -435,7 +435,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/dockerfile/extract extractPackageFile() skips named multistage COPY --from tags 1`] = `
+exports[`manager/dockerfile/extract extractPackageFile() skips named multistage COPY --from tags 1`] = `
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
@@ -450,7 +450,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/dockerfile/extract extractPackageFile() skips named multistage FROM tags 1`] = `
+exports[`manager/dockerfile/extract extractPackageFile() skips named multistage FROM tags 1`] = `
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
@@ -465,7 +465,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/dockerfile/extract getDep() rejects null 1`] = `
+exports[`manager/dockerfile/extract getDep() rejects null 1`] = `
 Object {
   "skipReason": "invalid-value",
 }

--- a/lib/manager/dockerfile/extract.spec.ts
+++ b/lib/manager/dockerfile/extract.spec.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'fs';
+import { getName } from '../../../test/util';
 import { extractPackageFile, getDep } from './extract';
 
 const d1 = readFileSync(
@@ -11,7 +12,7 @@ const d2 = readFileSync(
   'utf8'
 );
 
-describe('lib/manager/dockerfile/extract', () => {
+describe(getName(__filename), () => {
   describe('extractPackageFile()', () => {
     it('handles no FROM', () => {
       const res = extractPackageFile('no from!');

--- a/lib/manager/droneci/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/droneci/__snapshots__/extract.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/manager/droneci/extract extractPackageFile() extracts multiple image lines 1`] = `
+exports[`manager/droneci/extract extractPackageFile() extracts multiple image lines 1`] = `
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",

--- a/lib/manager/droneci/extract.spec.ts
+++ b/lib/manager/droneci/extract.spec.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'upath';
+import { getName } from '../../../test/util';
 
 import { extractPackageFile } from './extract';
 
@@ -8,7 +9,7 @@ const droneYAML = readFileSync(
   'utf8'
 );
 
-describe('lib/manager/droneci/extract', () => {
+describe(getName(__filename), () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty', () => {
       expect(extractPackageFile('nothing here')).toBeNull();

--- a/lib/manager/git-submodules/__snapshots__/artifact.spec.ts.snap
+++ b/lib/manager/git-submodules/__snapshots__/artifact.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/manager/gitsubmodules/artifacts updateArtifacts() returns empty content 1`] = `
+exports[`manager/git-submodules/artifact updateArtifacts() returns empty content 1`] = `
 Array [
   Object {
     "file": Object {
@@ -11,7 +11,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/gitsubmodules/artifacts updateArtifacts() returns two modules 1`] = `
+exports[`manager/git-submodules/artifact updateArtifacts() returns two modules 1`] = `
 Array [
   Object {
     "file": Object {

--- a/lib/manager/git-submodules/artifact.spec.ts
+++ b/lib/manager/git-submodules/artifact.spec.ts
@@ -1,6 +1,7 @@
+import { getName } from '../../../test/util';
 import updateArtifacts from './artifacts';
 
-describe('lib/manager/gitsubmodules/artifacts', () => {
+describe(getName(__filename), () => {
   describe('updateArtifacts()', () => {
     it('returns empty content', () => {
       expect(

--- a/lib/manager/git-submodules/extract.spec.ts
+++ b/lib/manager/git-submodules/extract.spec.ts
@@ -1,6 +1,6 @@
 import { mock } from 'jest-mock-extended';
 import _simpleGit, { Response, SimpleGit } from 'simple-git';
-import { partial } from '../../../test/util';
+import { getName, partial } from '../../../test/util';
 import type { PackageFile } from '../types';
 import extractPackageFile from './extract';
 
@@ -10,7 +10,7 @@ const Git: typeof _simpleGit = jest.requireActual('simple-git');
 
 const localDir = `${__dirname}/__fixtures__`;
 
-describe('lib/manager/gitsubmodules/extract', () => {
+describe(getName(__filename), () => {
   // flaky ci tests
   jest.setTimeout(10 * 1000);
 

--- a/lib/manager/git-submodules/update.spec.ts
+++ b/lib/manager/git-submodules/update.spec.ts
@@ -1,12 +1,13 @@
 import _simpleGit from 'simple-git';
 import { dir } from 'tmp-promise';
+import { getName } from '../../../test/util';
 import type { Upgrade } from '../types';
 import updateDependency from './update';
 
 jest.mock('simple-git');
 const simpleGit: any = _simpleGit;
 
-describe('manager/git-submodules/update', () => {
+describe(getName(__filename), () => {
   describe('updateDependency', () => {
     let upgrade: Upgrade;
     beforeAll(async () => {

--- a/lib/manager/github-actions/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/github-actions/__snapshots__/extract.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/manager/github-actions/extract extractPackageFile() extracts multiple action tag lines from yaml configuration file 1`] = `
+exports[`manager/github-actions/extract extractPackageFile() extracts multiple action tag lines from yaml configuration file 1`] = `
 Array [
   Object {
     "commitMessageTopic": "{{{depName}}} action",
@@ -33,7 +33,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/github-actions/extract extractPackageFile() extracts multiple docker image lines from yaml configuration file 1`] = `
+exports[`manager/github-actions/extract extractPackageFile() extracts multiple docker image lines from yaml configuration file 1`] = `
 Array [
   Object {
     "commitMessageTopic": "{{{depName}}} action",

--- a/lib/manager/github-actions/extract.spec.ts
+++ b/lib/manager/github-actions/extract.spec.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'fs';
+import { getName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 const workflow1 = readFileSync(
@@ -11,7 +12,7 @@ const workflow2 = readFileSync(
   'utf8'
 );
 
-describe('lib/manager/github-actions/extract', () => {
+describe(getName(__filename), () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty', () => {
       expect(extractPackageFile('nothing here')).toBeNull();

--- a/lib/manager/gitlabci-include/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/gitlabci-include/__snapshots__/extract.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/manager/gitlabci-include/extract extractPackageFile() extracts multiple include blocks 1`] = `
+exports[`manager/gitlabci-include/extract extractPackageFile() extracts multiple include blocks 1`] = `
 Array [
   Object {
     "currentValue": "1.0.0",

--- a/lib/manager/gitlabci-include/extract.spec.ts
+++ b/lib/manager/gitlabci-include/extract.spec.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { getName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 const yamlFile = fs.readFileSync(
@@ -6,7 +7,7 @@ const yamlFile = fs.readFileSync(
   'utf8'
 );
 
-describe('lib/manager/gitlabci-include/extract', () => {
+describe(getName(__filename), () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty', () => {
       expect(

--- a/lib/manager/gomod/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/gomod/__snapshots__/extract.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/manager/gomod/extract extractPackageFile() extracts constraints 1`] = `
+exports[`manager/gomod/extract extractPackageFile() extracts constraints 1`] = `
 Object {
   "constraints": Object {
     "go": "1.13",
@@ -602,7 +602,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/gomod/extract extractPackageFile() extracts multi-line requires 1`] = `
+exports[`manager/gomod/extract extractPackageFile() extracts multi-line requires 1`] = `
 Array [
   Object {
     "currentValue": "v1.15.21",
@@ -1239,7 +1239,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/gomod/extract extractPackageFile() extracts single-line requires 1`] = `
+exports[`manager/gomod/extract extractPackageFile() extracts single-line requires 1`] = `
 Array [
   Object {
     "currentValue": "v0.7.0",

--- a/lib/manager/gomod/extract.spec.ts
+++ b/lib/manager/gomod/extract.spec.ts
@@ -1,11 +1,12 @@
 import { readFileSync } from 'fs';
+import { getName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 const gomod1 = readFileSync('lib/manager/gomod/__fixtures__/1/go.mod', 'utf8');
 const gomod2 = readFileSync('lib/manager/gomod/__fixtures__/2/go.mod', 'utf8');
 const gomod3 = readFileSync('lib/manager/gomod/__fixtures__/3/go.mod', 'utf8');
 
-describe('lib/manager/gomod/extract', () => {
+describe(getName(__filename), () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty', () => {
       expect(extractPackageFile('nothing here')).toBeNull();

--- a/lib/manager/gomod/update.spec.ts
+++ b/lib/manager/gomod/update.spec.ts
@@ -1,11 +1,12 @@
 import { readFileSync } from 'fs';
+import { getName } from '../../../test/util';
 import { UpdateType } from '../../config';
 import { updateDependency } from './update';
 
 const gomod1 = readFileSync('lib/manager/gomod/__fixtures__/1/go.mod', 'utf8');
 const gomod2 = readFileSync('lib/manager/gomod/__fixtures__/2/go.mod', 'utf8');
 
-describe('manager/gomod/update', () => {
+describe(getName(__filename), () => {
   describe('updateDependency', () => {
     it('replaces existing value', () => {
       const upgrade = {

--- a/lib/manager/gradle-lite/extract.spec.ts
+++ b/lib/manager/gradle-lite/extract.spec.ts
@@ -1,4 +1,4 @@
-import { fs } from '../../../test/util';
+import { fs, getName } from '../../../test/util';
 import { extractAllPackageFiles } from '.';
 
 jest.mock('../../util/fs');
@@ -14,7 +14,7 @@ function mockFs(files: Record<string, string>): void {
   );
 }
 
-describe('manager/gradle-lite/extract', () => {
+describe(getName(__filename), () => {
   beforeAll(() => {});
   afterAll(() => {
     jest.resetAllMocks();

--- a/lib/manager/gradle-lite/parser.spec.ts
+++ b/lib/manager/gradle-lite/parser.spec.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'fs';
 import path from 'path';
+import { getName } from '../../../test/util';
 import { GOOGLE_REPO, JCENTER_REPO, MAVEN_REPO } from './common';
 import { parseGradle, parseProps } from './parser';
 
@@ -7,7 +8,7 @@ function getGradleFile(fileName: string): string {
   return readFileSync(path.resolve(__dirname, fileName), 'utf8');
 }
 
-describe('manager/gradle-lite/parser', () => {
+describe(getName(__filename), () => {
   it('handles end of input', () => {
     expect(parseGradle('version = ').deps).toBeEmpty();
     expect(parseGradle('id "foo.bar" version').deps).toBeEmpty();

--- a/lib/manager/gradle-lite/tokenizer.spec.ts
+++ b/lib/manager/gradle-lite/tokenizer.spec.ts
@@ -1,3 +1,4 @@
+import { getName } from '../../../test/util';
 import { TokenType } from './common';
 import { extractRawTokens, tokenize } from './tokenizer';
 
@@ -5,7 +6,7 @@ function tokenTypes(input): string[] {
   return extractRawTokens(input).map((token) => token.type);
 }
 
-describe('manager/gradle-lite/tokenizer', () => {
+describe(getName(__filename), () => {
   it('extractTokens', () => {
     const samples = {
       ' ': [TokenType.Space],

--- a/lib/manager/gradle-lite/update.spec.ts
+++ b/lib/manager/gradle-lite/update.spec.ts
@@ -1,6 +1,7 @@
+import { getName } from '../../../test/util';
 import { updateDependency } from './update';
 
-describe('manager/gradle-lite/update', () => {
+describe(getName(__filename), () => {
   it('replaces', () => {
     expect(
       updateDependency({

--- a/lib/manager/gradle-lite/utils.spec.ts
+++ b/lib/manager/gradle-lite/utils.spec.ts
@@ -1,3 +1,4 @@
+import { getName } from '../../../test/util';
 import { TokenType } from './common';
 import {
   getVars,
@@ -9,7 +10,7 @@ import {
   versionLikeSubstring,
 } from './utils';
 
-describe('manager/gradle-lite/utils', () => {
+describe(getName(__filename), () => {
   it('versionLikeSubstring', () => {
     [
       '1.2.3',

--- a/lib/manager/gradle/build-gradle.spec.ts
+++ b/lib/manager/gradle/build-gradle.spec.ts
@@ -1,10 +1,11 @@
+import { getName } from '../../../test/util';
 import {
   collectVersionVariables,
   init,
   updateGradleVersion,
 } from './build-gradle';
 
-describe('lib/manager/gradle/updateGradleVersion', () => {
+describe(getName(__filename), () => {
   beforeEach(() => {
     init();
   });

--- a/lib/manager/helm-requirements/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/helm-requirements/__snapshots__/extract.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/manager/helm-requirements/extract extractPackageFile() parses simple requirements.yaml correctly 1`] = `
+exports[`manager/helm-requirements/extract extractPackageFile() parses simple requirements.yaml correctly 1`] = `
 Object {
   "datasource": "helm",
   "deps": Array [
@@ -22,7 +22,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/helm-requirements/extract extractPackageFile() resolves aliased registry urls 1`] = `
+exports[`manager/helm-requirements/extract extractPackageFile() resolves aliased registry urls 1`] = `
 Object {
   "datasource": "helm",
   "deps": Array [
@@ -44,7 +44,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/helm-requirements/extract extractPackageFile() skips invalid registry urls 1`] = `
+exports[`manager/helm-requirements/extract extractPackageFile() skips invalid registry urls 1`] = `
 Object {
   "datasource": "helm",
   "deps": Array [
@@ -73,7 +73,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/helm-requirements/extract extractPackageFile() skips local dependencies 1`] = `
+exports[`manager/helm-requirements/extract extractPackageFile() skips local dependencies 1`] = `
 Object {
   "datasource": "helm",
   "deps": Array [

--- a/lib/manager/helm-requirements/extract.spec.ts
+++ b/lib/manager/helm-requirements/extract.spec.ts
@@ -1,10 +1,10 @@
-import { fs } from '../../../test/util';
+import { fs, getName } from '../../../test/util';
 import { SkipReason } from '../../types';
 import { extractPackageFile } from './extract';
 
 jest.mock('../../util/fs');
 
-describe('lib/manager/helm-requirements/extract', () => {
+describe(getName(__filename), () => {
   describe('extractPackageFile()', () => {
     beforeEach(() => {
       jest.resetAllMocks();

--- a/lib/manager/helm-values/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/helm-values/__snapshots__/extract.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/manager/helm-values/extract extractPackageFile() extracts from complex values file correctly" 1`] = `
+exports[`manager/helm-values/extract extractPackageFile() extracts from complex values file correctly" 1`] = `
 Object {
   "deps": Array [
     Object {
@@ -43,7 +43,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/helm-values/extract extractPackageFile() extracts from values.yaml correctly with same structure as "helm create" 1`] = `
+exports[`manager/helm-values/extract extractPackageFile() extracts from values.yaml correctly with same structure as "helm create" 1`] = `
 Object {
   "deps": Array [
     Object {

--- a/lib/manager/helm-values/extract.spec.ts
+++ b/lib/manager/helm-values/extract.spec.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'fs';
+import { getName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 const helmDefaultChartInitValues = readFileSync(
@@ -11,7 +12,7 @@ const helmMultiAndNestedImageValues = readFileSync(
   'utf8'
 );
 
-describe('lib/manager/helm-values/extract', () => {
+describe(getName(__filename), () => {
   describe('extractPackageFile()', () => {
     beforeEach(() => {
       jest.resetAllMocks();

--- a/lib/manager/helmfile/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/helmfile/__snapshots__/extract.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/manager/helmfile/extract extractPackageFile() parses multidoc yaml 1`] = `
+exports[`manager/helmfile/extract extractPackageFile() parses multidoc yaml 1`] = `
 Object {
   "datasource": "helm",
   "deps": Array [
@@ -26,7 +26,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/helmfile/extract extractPackageFile() skip chart that does not have specified version 1`] = `
+exports[`manager/helmfile/extract extractPackageFile() skip chart that does not have specified version 1`] = `
 Object {
   "datasource": "helm",
   "deps": Array [
@@ -42,7 +42,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/helmfile/extract extractPackageFile() skip chart with special character in the name 1`] = `
+exports[`manager/helmfile/extract extractPackageFile() skip chart with special character in the name 1`] = `
 Object {
   "datasource": "helm",
   "deps": Array [
@@ -66,7 +66,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/helmfile/extract extractPackageFile() skip chart with unknown repository 1`] = `
+exports[`manager/helmfile/extract extractPackageFile() skip chart with unknown repository 1`] = `
 Object {
   "datasource": "helm",
   "deps": Array [
@@ -80,7 +80,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/helmfile/extract extractPackageFile() skip if repository details are not specified 1`] = `
+exports[`manager/helmfile/extract extractPackageFile() skip if repository details are not specified 1`] = `
 Object {
   "datasource": "helm",
   "deps": Array [
@@ -94,7 +94,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/helmfile/extract extractPackageFile() skip local charts 1`] = `
+exports[`manager/helmfile/extract extractPackageFile() skip local charts 1`] = `
 Object {
   "datasource": "helm",
   "deps": Array [
@@ -106,7 +106,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/helmfile/extract extractPackageFile() skip templetized release with invalid characters 1`] = `
+exports[`manager/helmfile/extract extractPackageFile() skip templetized release with invalid characters 1`] = `
 Object {
   "datasource": "helm",
   "deps": Array [

--- a/lib/manager/helmfile/extract.spec.ts
+++ b/lib/manager/helmfile/extract.spec.ts
@@ -1,11 +1,12 @@
 import { readFileSync } from 'fs';
+import { getName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 const multidocYaml = readFileSync(
   'lib/manager/helmfile/__fixtures__/multidoc.yaml',
   'utf8'
 );
-describe('lib/manager/helmfile/extract', () => {
+describe(getName(__filename), () => {
   describe('extractPackageFile()', () => {
     beforeEach(() => {
       jest.resetAllMocks();

--- a/lib/manager/helmv3/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/helmv3/__snapshots__/extract.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/manager/helm-requirements/extract extractPackageFile() parses simple Chart.yaml correctly 1`] = `
+exports[`manager/helmv3/extract extractPackageFile() parses simple Chart.yaml correctly 1`] = `
 Object {
   "datasource": "helm",
   "deps": Array [
@@ -23,7 +23,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/helm-requirements/extract extractPackageFile() resolves aliased registry urls 1`] = `
+exports[`manager/helmv3/extract extractPackageFile() resolves aliased registry urls 1`] = `
 Object {
   "datasource": "helm",
   "deps": Array [
@@ -46,7 +46,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/helm-requirements/extract extractPackageFile() skips invalid registry urls 1`] = `
+exports[`manager/helmv3/extract extractPackageFile() skips invalid registry urls 1`] = `
 Object {
   "datasource": "helm",
   "deps": Array [
@@ -76,7 +76,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/helm-requirements/extract extractPackageFile() skips local dependencies 1`] = `
+exports[`manager/helmv3/extract extractPackageFile() skips local dependencies 1`] = `
 Object {
   "datasource": "helm",
   "deps": Array [

--- a/lib/manager/helmv3/__snapshots__/update.spec.ts.snap
+++ b/lib/manager/helmv3/__snapshots__/update.spec.ts.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/manager/helmv3/update .bumpPackageVersion() increments 1`] = `
+exports[`manager/helmv3/update .bumpPackageVersion() increments 1`] = `
 "apiVersion: v2
 name: test
 version: 0.0.3
 "
 `;
 
-exports[`lib/manager/helmv3/update .bumpPackageVersion() updates 1`] = `
+exports[`manager/helmv3/update .bumpPackageVersion() updates 1`] = `
 "apiVersion: v2
 name: test
 version: 0.1.0

--- a/lib/manager/helmv3/extract.spec.ts
+++ b/lib/manager/helmv3/extract.spec.ts
@@ -1,9 +1,9 @@
-import { fs } from '../../../test/util';
+import { fs, getName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 jest.mock('../../util/fs');
 
-describe('lib/manager/helm-requirements/extract', () => {
+describe(getName(__filename), () => {
   describe('extractPackageFile()', () => {
     beforeEach(() => {
       jest.resetAllMocks();

--- a/lib/manager/helmv3/update.spec.ts
+++ b/lib/manager/helmv3/update.spec.ts
@@ -1,7 +1,8 @@
 import yaml from 'js-yaml';
+import { getName } from '../../../test/util';
 import * as helmv3Updater from './update';
 
-describe('lib/manager/helmv3/update', () => {
+describe(getName(__filename), () => {
   describe('.bumpPackageVersion()', () => {
     const content = yaml.safeDump({
       apiVersion: 'v2',

--- a/lib/manager/homebrew/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/homebrew/__snapshots__/extract.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/manager/homebrew/extract extractPackageFile() extracts "archive" github dependency 1`] = `
+exports[`manager/homebrew/extract extractPackageFile() extracts "archive" github dependency 1`] = `
 Object {
   "deps": Array [
     Object {
@@ -18,7 +18,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/homebrew/extract extractPackageFile() extracts "releases" github dependency 1`] = `
+exports[`manager/homebrew/extract extractPackageFile() extracts "releases" github dependency 1`] = `
 Object {
   "deps": Array [
     Object {
@@ -36,7 +36,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/homebrew/extract extractPackageFile() handles no space before class header 1`] = `
+exports[`manager/homebrew/extract extractPackageFile() handles no space before class header 1`] = `
 Object {
   "deps": Array [
     Object {
@@ -54,7 +54,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/homebrew/extract extractPackageFile() skips github dependency with wrong format 1`] = `
+exports[`manager/homebrew/extract extractPackageFile() skips github dependency with wrong format 1`] = `
 Object {
   "deps": Array [
     Object {
@@ -73,7 +73,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/homebrew/extract extractPackageFile() skips if invalid url 1`] = `
+exports[`manager/homebrew/extract extractPackageFile() skips if invalid url 1`] = `
 Object {
   "deps": Array [
     Object {
@@ -92,7 +92,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/homebrew/extract extractPackageFile() skips if invalid url extension 1`] = `
+exports[`manager/homebrew/extract extractPackageFile() skips if invalid url extension 1`] = `
 Object {
   "deps": Array [
     Object {
@@ -110,7 +110,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/homebrew/extract extractPackageFile() skips if invalid url protocol 1`] = `
+exports[`manager/homebrew/extract extractPackageFile() skips if invalid url protocol 1`] = `
 Object {
   "deps": Array [
     Object {
@@ -129,7 +129,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/homebrew/extract extractPackageFile() skips if invalid url version 1`] = `
+exports[`manager/homebrew/extract extractPackageFile() skips if invalid url version 1`] = `
 Object {
   "deps": Array [
     Object {
@@ -147,7 +147,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/homebrew/extract extractPackageFile() skips if sha256 field is invalid 1`] = `
+exports[`manager/homebrew/extract extractPackageFile() skips if sha256 field is invalid 1`] = `
 Object {
   "deps": Array [
     Object {
@@ -166,7 +166,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/homebrew/extract extractPackageFile() skips if there is no sha256 field 1`] = `
+exports[`manager/homebrew/extract extractPackageFile() skips if there is no sha256 field 1`] = `
 Object {
   "deps": Array [
     Object {
@@ -185,7 +185,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/homebrew/extract extractPackageFile() skips if there is no url field 1`] = `
+exports[`manager/homebrew/extract extractPackageFile() skips if there is no url field 1`] = `
 Object {
   "deps": Array [
     Object {
@@ -204,7 +204,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/homebrew/extract extractPackageFile() skips sourceforge dependency 1 1`] = `
+exports[`manager/homebrew/extract extractPackageFile() skips sourceforge dependency 1 1`] = `
 Object {
   "deps": Array [
     Object {
@@ -223,7 +223,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/homebrew/extract extractPackageFile() skips sourceforge dependency 2 1`] = `
+exports[`manager/homebrew/extract extractPackageFile() skips sourceforge dependency 2 1`] = `
 Object {
   "deps": Array [
     Object {

--- a/lib/manager/homebrew/extract.spec.ts
+++ b/lib/manager/homebrew/extract.spec.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { getName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 const aalib = fs.readFileSync(
@@ -19,7 +20,7 @@ const ibazel = fs.readFileSync(
   'utf8'
 );
 
-describe('lib/manager/homebrew/extract', () => {
+describe(getName(__filename), () => {
   describe('extractPackageFile()', () => {
     it('skips sourceforge dependency 1', () => {
       const res = extractPackageFile(aalib);

--- a/lib/manager/homebrew/update.spec.ts
+++ b/lib/manager/homebrew/update.spec.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import { Readable } from 'stream';
 import * as httpMock from '../../../test/http-mock';
+import { getName } from '../../../test/util';
 import { updateDependency } from './update';
 
 const aide = fs.readFileSync(
@@ -14,7 +15,7 @@ const ibazel = fs.readFileSync(
 
 const baseUrl = 'https://github.com';
 
-describe('manager/homebrew/update', () => {
+describe(getName(__filename), () => {
   beforeEach(() => {
     jest.resetAllMocks();
     jest.resetModules();

--- a/lib/manager/homebrew/util.spec.ts
+++ b/lib/manager/homebrew/util.spec.ts
@@ -1,6 +1,7 @@
+import { getName } from '../../../test/util';
 import { skip } from './util';
 
-describe('lib/manager/homebrew/util', () => {
+describe(getName(__filename), () => {
   describe('skip()', () => {
     it('handles out of bounds case', () => {
       const content = 'some content';

--- a/lib/manager/html/extract.spec.ts
+++ b/lib/manager/html/extract.spec.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'upath';
+import { getName } from '../../../test/util';
 import { extractPackageFile } from '.';
 
 const sample = readFileSync(
@@ -11,7 +12,7 @@ const nothing = readFileSync(
   'utf8'
 );
 
-describe('manager/html/extract', () => {
+describe(getName(__filename), () => {
   it('extractPackageFile', () => {
     expect(extractPackageFile(sample)).toMatchSnapshot();
   });

--- a/lib/manager/kubernetes/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/kubernetes/__snapshots__/extract.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/manager/kubernetes/extract extractPackageFile() extracts image line in a YAML array 1`] = `
+exports[`manager/kubernetes/extract extractPackageFile() extracts image line in a YAML array 1`] = `
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
@@ -13,7 +13,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/kubernetes/extract extractPackageFile() extracts multiple image lines 1`] = `
+exports[`manager/kubernetes/extract extractPackageFile() extracts multiple image lines 1`] = `
 Array [
   Object {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",

--- a/lib/manager/kubernetes/extract.spec.ts
+++ b/lib/manager/kubernetes/extract.spec.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'fs';
+import { getName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 const kubernetesImagesFile = readFileSync(
@@ -21,7 +22,7 @@ const otherYamlFile = readFileSync(
   'utf8'
 );
 
-describe('lib/manager/kubernetes/extract', () => {
+describe(getName(__filename), () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty', () => {
       expect(extractPackageFile(kubernetesConfigMapFile)).toBeNull();

--- a/lib/manager/kustomize/extract.spec.ts
+++ b/lib/manager/kustomize/extract.spec.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'fs';
+import { getName } from '../../../test/util';
 import * as datasourceDocker from '../../datasource/docker';
 import * as datasourceGitTags from '../../datasource/git-tags';
 import * as datasourceGitHubTags from '../../datasource/github-tags';
@@ -52,7 +53,7 @@ const kustomizeDepsInResources = readFileSync(
 
 const sha = readFileSync('lib/manager/kustomize/__fixtures__/sha.yaml', 'utf8');
 
-describe('manager/kustomize/extract', () => {
+describe(getName(__filename), () => {
   it('should successfully parse a valid kustomize file', () => {
     const file = parseKustomize(kustomizeGitSSHBase);
     expect(file).not.toBeNull();

--- a/lib/manager/leiningen/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/leiningen/__snapshots__/extract.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`manager/clojure/extract extractPackageFile 1`] = `
+exports[`manager/leiningen/extract extractPackageFile 1`] = `
 Object {
   "deps": Array [
     Object {

--- a/lib/manager/leiningen/extract.spec.ts
+++ b/lib/manager/leiningen/extract.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-template-curly-in-string */
 import { readFileSync } from 'fs';
 import { resolve } from 'upath';
+import { getName } from '../../../test/util';
 import * as datasourceClojure from '../../datasource/clojure';
 import { extractFromVectors, extractPackageFile, trimAtKey } from './extract';
 
@@ -9,7 +10,7 @@ const leinProjectClj = readFileSync(
   'utf8'
 );
 
-describe('manager/clojure/extract', () => {
+describe(getName(__filename), () => {
   it('trimAtKey', () => {
     expect(trimAtKey('foo', 'bar')).toBeNull();
     expect(trimAtKey(':dependencies    ', 'dependencies')).toBeNull();

--- a/lib/manager/maven/__snapshots__/index.spec.ts.snap
+++ b/lib/manager/maven/__snapshots__/index.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`manager/maven extractAllPackageFiles should return package files info 1`] = `
+exports[`manager/maven/index extractAllPackageFiles should return package files info 1`] = `
 Array [
   Object {
     "datasource": "maven",
@@ -158,7 +158,7 @@ Array [
 ]
 `;
 
-exports[`manager/maven updateDependency should include registryUrls from parent pom files 1`] = `
+exports[`manager/maven/index updateDependency should include registryUrls from parent pom files 1`] = `
 Array [
   Object {
     "datasource": "maven",

--- a/lib/manager/maven/extract.spec.ts
+++ b/lib/manager/maven/extract.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-template-curly-in-string */
 import { readFileSync } from 'fs';
 import { resolve } from 'upath';
+import { getName } from '../../../test/util';
 import { extractPackage } from './extract';
 
 const minimumContent = readFileSync(
@@ -13,7 +14,7 @@ const simpleContent = readFileSync(
   'utf8'
 );
 
-describe('manager/maven/extract', () => {
+describe(getName(__filename), () => {
   describe('extractDependencies', () => {
     it('returns null for invalid XML', () => {
       expect(extractPackage(undefined)).toBeNull();

--- a/lib/manager/maven/index.spec.ts
+++ b/lib/manager/maven/index.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { fs } from '../../../test/util';
+import { fs, getName } from '../../../test/util';
 import type { PackageDependency, PackageFile } from '../types';
 import { extractPackage, resolveParents } from './extract';
 import { extractAllPackageFiles, updateDependency } from '.';
@@ -27,7 +27,7 @@ function selectDep(deps: PackageDependency[], name = 'org.example:quuz') {
   return deps.find((dep) => dep.depName === name);
 }
 
-describe('manager/maven', () => {
+describe(getName(__filename), () => {
   describe('extractAllPackageFiles', () => {
     it('should return empty if package has no content', async () => {
       fs.readLocalFile.mockResolvedValueOnce(null);

--- a/lib/manager/meteor/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/meteor/__snapshots__/extract.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/manager/meteor/extract extractPackageFile() returns results 1`] = `
+exports[`manager/meteor/extract extractPackageFile() returns results 1`] = `
 Object {
   "deps": Array [
     Object {

--- a/lib/manager/meteor/extract.spec.ts
+++ b/lib/manager/meteor/extract.spec.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'upath';
+import { getName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 function readFixture(fixture: string) {
@@ -8,7 +9,7 @@ function readFixture(fixture: string) {
 
 const input01Content = readFixture('package-1.js');
 
-describe('lib/manager/meteor/extract', () => {
+describe(getName(__filename), () => {
   describe('extractPackageFile()', () => {
     it('returns empty if fails to parse', () => {
       const res = extractPackageFile('blahhhhh:foo:@what\n');

--- a/lib/manager/mix/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/mix/__snapshots__/extract.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/manager/mix/extract extractPackageFile() extracts all dependencies 1`] = `
+exports[`manager/mix/extract extractPackageFile() extracts all dependencies 1`] = `
 Object {
   "deps": Array [
     Object {
@@ -70,7 +70,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/mix/extract extractPackageFile() returns empty for invalid dependency file 1`] = `
+exports[`manager/mix/extract extractPackageFile() returns empty for invalid dependency file 1`] = `
 Object {
   "deps": Array [],
 }

--- a/lib/manager/mix/extract.spec.ts
+++ b/lib/manager/mix/extract.spec.ts
@@ -1,5 +1,6 @@
 import fs from 'fs-extra';
 import upath from 'upath';
+import { getName } from '../../../test/util';
 import { extractPackageFile } from '.';
 
 const sample = fs.readFileSync(
@@ -7,7 +8,7 @@ const sample = fs.readFileSync(
   'utf-8'
 );
 
-describe('lib/manager/mix/extract', () => {
+describe(getName(__filename), () => {
   describe('extractPackageFile()', () => {
     it('returns empty for invalid dependency file', async () => {
       expect(

--- a/lib/manager/nodenv/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/nodenv/__snapshots__/extract.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/manager/nvm/extract extractPackageFile() returns a result 1`] = `
+exports[`manager/nodenv/extract extractPackageFile() returns a result 1`] = `
 Array [
   Object {
     "currentValue": "8.4.0",
@@ -11,7 +11,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/nvm/extract extractPackageFile() skips non ranges 1`] = `
+exports[`manager/nodenv/extract extractPackageFile() skips non ranges 1`] = `
 Array [
   Object {
     "currentValue": "latestn",
@@ -22,7 +22,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/nvm/extract extractPackageFile() supports ranges 1`] = `
+exports[`manager/nodenv/extract extractPackageFile() supports ranges 1`] = `
 Array [
   Object {
     "currentValue": "8.4",

--- a/lib/manager/nodenv/extract.spec.ts
+++ b/lib/manager/nodenv/extract.spec.ts
@@ -1,6 +1,7 @@
+import { getName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
-describe('lib/manager/nvm/extract', () => {
+describe(getName(__filename), () => {
   describe('extractPackageFile()', () => {
     it('returns a result', () => {
       const res = extractPackageFile('8.4.0\n');

--- a/lib/manager/npm/extract/__snapshots__/index.spec.ts.snap
+++ b/lib/manager/npm/extract/__snapshots__/index.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`manager/npm/extract .extractPackageFile() catches invalid names 1`] = `
+exports[`manager/npm/extract/index .extractPackageFile() catches invalid names 1`] = `
 Object {
   "constraints": Object {},
   "deps": Array [
@@ -30,7 +30,7 @@ Object {
 }
 `;
 
-exports[`manager/npm/extract .extractPackageFile() extracts engines 1`] = `
+exports[`manager/npm/extract/index .extractPackageFile() extracts engines 1`] = `
 Object {
   "constraints": Object {
     "node": ">= 8.9.2",
@@ -154,7 +154,7 @@ Object {
 }
 `;
 
-exports[`manager/npm/extract .extractPackageFile() extracts non-npmjs 1`] = `
+exports[`manager/npm/extract/index .extractPackageFile() extracts non-npmjs 1`] = `
 Object {
   "constraints": Object {},
   "deps": Array [
@@ -318,7 +318,7 @@ Object {
 }
 `;
 
-exports[`manager/npm/extract .extractPackageFile() extracts npm package alias 1`] = `
+exports[`manager/npm/extract/index .extractPackageFile() extracts npm package alias 1`] = `
 Object {
   "constraints": Object {},
   "deps": Array [
@@ -368,7 +368,7 @@ Object {
 }
 `;
 
-exports[`manager/npm/extract .extractPackageFile() extracts volta 1`] = `
+exports[`manager/npm/extract/index .extractPackageFile() extracts volta 1`] = `
 Object {
   "constraints": Object {
     "node": "8.9.2",
@@ -429,7 +429,7 @@ Object {
 }
 `;
 
-exports[`manager/npm/extract .extractPackageFile() extracts volta yarn unknown-version 1`] = `
+exports[`manager/npm/extract/index .extractPackageFile() extracts volta yarn unknown-version 1`] = `
 Object {
   "constraints": Object {
     "node": "8.9.2",
@@ -484,7 +484,7 @@ Object {
 }
 `;
 
-exports[`manager/npm/extract .extractPackageFile() finds "npmClient":"npm" in lerna.json 1`] = `
+exports[`manager/npm/extract/index .extractPackageFile() finds "npmClient":"npm" in lerna.json 1`] = `
 Object {
   "constraints": Object {},
   "deps": Array [
@@ -621,7 +621,7 @@ Object {
 }
 `;
 
-exports[`manager/npm/extract .extractPackageFile() finds "npmClient":"yarn" in lerna.json 1`] = `
+exports[`manager/npm/extract/index .extractPackageFile() finds "npmClient":"yarn" in lerna.json 1`] = `
 Object {
   "constraints": Object {},
   "deps": Array [
@@ -758,7 +758,7 @@ Object {
 }
 `;
 
-exports[`manager/npm/extract .extractPackageFile() finds a lock file 1`] = `
+exports[`manager/npm/extract/index .extractPackageFile() finds a lock file 1`] = `
 Object {
   "constraints": Object {},
   "deps": Array [
@@ -895,7 +895,7 @@ Object {
 }
 `;
 
-exports[`manager/npm/extract .extractPackageFile() finds complex yarn workspaces 1`] = `
+exports[`manager/npm/extract/index .extractPackageFile() finds complex yarn workspaces 1`] = `
 Object {
   "constraints": Object {},
   "deps": Array [],
@@ -920,7 +920,7 @@ Object {
 }
 `;
 
-exports[`manager/npm/extract .extractPackageFile() finds lerna 1`] = `
+exports[`manager/npm/extract/index .extractPackageFile() finds lerna 1`] = `
 Object {
   "constraints": Object {},
   "deps": Array [
@@ -1057,7 +1057,7 @@ Object {
 }
 `;
 
-exports[`manager/npm/extract .extractPackageFile() finds simple yarn workspaces 1`] = `
+exports[`manager/npm/extract/index .extractPackageFile() finds simple yarn workspaces 1`] = `
 Object {
   "constraints": Object {},
   "deps": Array [],
@@ -1082,7 +1082,7 @@ Object {
 }
 `;
 
-exports[`manager/npm/extract .extractPackageFile() finds simple yarn workspaces with lerna.json and useWorkspaces: true 1`] = `
+exports[`manager/npm/extract/index .extractPackageFile() finds simple yarn workspaces with lerna.json and useWorkspaces: true 1`] = `
 Object {
   "constraints": Object {},
   "deps": Array [],
@@ -1107,7 +1107,7 @@ Object {
 }
 `;
 
-exports[`manager/npm/extract .extractPackageFile() returns an array of dependencies 1`] = `
+exports[`manager/npm/extract/index .extractPackageFile() returns an array of dependencies 1`] = `
 Object {
   "constraints": Object {},
   "deps": Array [

--- a/lib/manager/npm/extract/__snapshots__/monorepo.spec.ts.snap
+++ b/lib/manager/npm/extract/__snapshots__/monorepo.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`manager/npm/extract .extractPackageFile() updates internal packages 1`] = `
+exports[`manager/npm/extract/monorepo .extractPackageFile() updates internal packages 1`] = `
 Array [
   Object {
     "deps": Array [
@@ -62,7 +62,7 @@ Array [
 ]
 `;
 
-exports[`manager/npm/extract .extractPackageFile() uses lerna package settings 1`] = `
+exports[`manager/npm/extract/monorepo .extractPackageFile() uses lerna package settings 1`] = `
 Array [
   Object {
     "deps": Array [
@@ -127,7 +127,7 @@ Array [
 ]
 `;
 
-exports[`manager/npm/extract .extractPackageFile() uses yarn workspaces package settings with lerna 1`] = `
+exports[`manager/npm/extract/monorepo .extractPackageFile() uses yarn workspaces package settings with lerna 1`] = `
 Array [
   Object {
     "lernaClient": "yarn",
@@ -165,7 +165,7 @@ Array [
 ]
 `;
 
-exports[`manager/npm/extract .extractPackageFile() uses yarn workspaces package settings without lerna 1`] = `
+exports[`manager/npm/extract/monorepo .extractPackageFile() uses yarn workspaces package settings without lerna 1`] = `
 Array [
   Object {
     "packageFile": "package.json",

--- a/lib/manager/npm/extract/index.spec.ts
+++ b/lib/manager/npm/extract/index.spec.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'fs';
 import upath from 'upath';
+import { getName } from '../../../../test/util';
 import { getConfig } from '../../../config/defaults';
 import * as _fs from '../../../util/fs';
 import * as npmExtract from '.';
@@ -22,7 +23,7 @@ const workspacesSimpleContent = readFixture('inputs/workspaces-simple.json');
 const vendorisedContent = readFixture('is-object.json');
 const invalidNameContent = readFixture('invalid-name.json');
 
-describe('manager/npm/extract', () => {
+describe(getName(__filename), () => {
   describe('.extractPackageFile()', () => {
     beforeEach(() => {
       fs.readLocalFile = jest.fn(() => null);

--- a/lib/manager/npm/extract/locked-versions.spec.ts
+++ b/lib/manager/npm/extract/locked-versions.spec.ts
@@ -1,3 +1,4 @@
+import { getName } from '../../../../test/util';
 import { getLockedVersions } from './locked-versions';
 
 /** @type any */
@@ -8,7 +9,7 @@ const yarn = require('./yarn');
 jest.mock('./npm');
 jest.mock('./yarn');
 
-describe('manager/npm/extract/locked-versions', () => {
+describe(getName(__filename), () => {
   describe('.getLockedVersions()', () => {
     it.each([['1.22.0'], ['2.1.0'], ['2.2.0']])(
       'uses yarn.lock with yarn v%s',

--- a/lib/manager/npm/extract/monorepo.spec.ts
+++ b/lib/manager/npm/extract/monorepo.spec.ts
@@ -1,6 +1,7 @@
+import { getName } from '../../../../test/util';
 import { detectMonorepos } from './monorepo';
 
-describe('manager/npm/extract', () => {
+describe(getName(__filename), () => {
   describe('.extractPackageFile()', () => {
     it('uses lerna package settings', () => {
       const packageFiles = [

--- a/lib/manager/npm/extract/npm.spec.ts
+++ b/lib/manager/npm/extract/npm.spec.ts
@@ -1,10 +1,10 @@
 import { readFileSync } from 'fs';
-import { fs } from '../../../../test/util';
+import { fs, getName } from '../../../../test/util';
 import { getNpmLock } from './npm';
 
 jest.mock('../../../util/fs');
 
-describe('manager/npm/extract/npm', () => {
+describe(getName(__filename), () => {
   describe('.getNpmLock()', () => {
     it('returns empty if failed to parse', async () => {
       fs.readLocalFile.mockResolvedValueOnce('abcd');

--- a/lib/manager/npm/extract/type.spec.ts
+++ b/lib/manager/npm/extract/type.spec.ts
@@ -1,6 +1,7 @@
+import { getName } from '../../../../test/util';
 import { mightBeABrowserLibrary } from './type';
 
-describe('manager/npm/extract/type', () => {
+describe(getName(__filename), () => {
   describe('.mightBeABrowserLibrary()', () => {
     it('is not a library if private', () => {
       const isLibrary = mightBeABrowserLibrary({ private: true });

--- a/lib/manager/npm/extract/yarn.spec.ts
+++ b/lib/manager/npm/extract/yarn.spec.ts
@@ -1,10 +1,10 @@
 import { readFileSync } from 'fs';
-import { fs } from '../../../../test/util';
+import { fs, getName } from '../../../../test/util';
 import { getYarnLock } from './yarn';
 
 jest.mock('../../../util/fs');
 
-describe('manager/npm/extract/yarn', () => {
+describe(getName(__filename), () => {
   describe('.getYarnLock()', () => {
     it('returns empty if exception parsing', async () => {
       fs.readLocalFile.mockResolvedValueOnce('abcd');

--- a/lib/manager/nvm/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/nvm/__snapshots__/extract.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/manager/nvm/extract extractPackageFile() returns a result 1`] = `
+exports[`manager/nvm/extract extractPackageFile() returns a result 1`] = `
 Array [
   Object {
     "currentValue": "8.4.0",
@@ -11,7 +11,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/nvm/extract extractPackageFile() skips non ranges 1`] = `
+exports[`manager/nvm/extract extractPackageFile() skips non ranges 1`] = `
 Array [
   Object {
     "currentValue": "latestn",
@@ -22,7 +22,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/nvm/extract extractPackageFile() supports ranges 1`] = `
+exports[`manager/nvm/extract extractPackageFile() supports ranges 1`] = `
 Array [
   Object {
     "currentValue": "8.4",

--- a/lib/manager/nvm/extract.spec.ts
+++ b/lib/manager/nvm/extract.spec.ts
@@ -1,6 +1,7 @@
+import { getName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
-describe('lib/manager/nvm/extract', () => {
+describe(getName(__filename), () => {
   describe('extractPackageFile()', () => {
     it('returns a result', () => {
       const res = extractPackageFile('8.4.0\n');

--- a/lib/manager/pip_requirements/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/pip_requirements/__snapshots__/extract.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/manager/pip_requirements/extract extractPackageFile() extracts dependencies 1`] = `
+exports[`manager/pip_requirements/extract extractPackageFile() extracts dependencies 1`] = `
 Object {
   "deps": Array [
     Object {
@@ -28,7 +28,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/pip_requirements/extract extractPackageFile() extracts multiple dependencies 1`] = `
+exports[`manager/pip_requirements/extract extractPackageFile() extracts multiple dependencies 1`] = `
 Array [
   Object {
     "currentValue": "==1",
@@ -63,7 +63,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/pip_requirements/extract extractPackageFile() handles comments and commands 1`] = `
+exports[`manager/pip_requirements/extract extractPackageFile() handles comments and commands 1`] = `
 Array [
   Object {
     "currentValue": "==1.11.23",
@@ -99,7 +99,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/pip_requirements/extract extractPackageFile() handles extra index url 1`] = `
+exports[`manager/pip_requirements/extract extractPackageFile() handles extra index url 1`] = `
 Object {
   "deps": Array [
     Object {
@@ -145,7 +145,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/pip_requirements/extract extractPackageFile() handles extra index url and defaults without index to config 1`] = `
+exports[`manager/pip_requirements/extract extractPackageFile() handles extra index url and defaults without index to config 1`] = `
 Object {
   "deps": Array [
     Object {
@@ -191,7 +191,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/pip_requirements/extract extractPackageFile() handles extra index url and defaults without index to pypi 1`] = `
+exports[`manager/pip_requirements/extract extractPackageFile() handles extra index url and defaults without index to pypi 1`] = `
 Object {
   "deps": Array [
     Object {
@@ -237,7 +237,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/pip_requirements/extract extractPackageFile() handles extras and complex index url 1`] = `
+exports[`manager/pip_requirements/extract extractPackageFile() handles extras and complex index url 1`] = `
 Object {
   "deps": Array [
     Object {

--- a/lib/manager/pip_requirements/extract.spec.ts
+++ b/lib/manager/pip_requirements/extract.spec.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'fs';
+import { getName } from '../../../test/util';
 import { setAdminConfig } from '../../config/admin';
 import { extractPackageFile } from './extract';
 
@@ -35,7 +36,7 @@ const requirements7 = readFileSync(
   'utf8'
 );
 
-describe('lib/manager/pip_requirements/extract', () => {
+describe(getName(__filename), () => {
   beforeEach(() => {
     delete process.env.PIP_TEST_TOKEN;
     setAdminConfig();

--- a/lib/manager/pipenv/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/pipenv/__snapshots__/extract.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/manager/pipenv/extract extractPackageFile() extracts dependencies 1`] = `
+exports[`manager/pipenv/extract extractPackageFile() extracts dependencies 1`] = `
 Object {
   "constraints": Object {
     "python": "== 3.6.*",
@@ -61,7 +61,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/pipenv/extract extractPackageFile() extracts example pipfile 1`] = `
+exports[`manager/pipenv/extract extractPackageFile() extracts example pipfile 1`] = `
 Object {
   "constraints": Object {
     "python": "== 2.7.*",
@@ -136,7 +136,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/pipenv/extract extractPackageFile() extracts multiple dependencies 1`] = `
+exports[`manager/pipenv/extract extractPackageFile() extracts multiple dependencies 1`] = `
 Object {
   "constraints": Object {
     "python": "== 3.6.*",
@@ -187,7 +187,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/pipenv/extract extractPackageFile() supports custom index 1`] = `
+exports[`manager/pipenv/extract extractPackageFile() supports custom index 1`] = `
 Object {
   "constraints": Object {},
   "deps": Array [

--- a/lib/manager/pipenv/extract.spec.ts
+++ b/lib/manager/pipenv/extract.spec.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { fs as fsutil } from '../../../test/util';
+import { fs as fsutil, getName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 jest.mock('../../util/fs');
@@ -25,7 +25,7 @@ const pipfile5 = fs.readFileSync(
   'utf8'
 );
 
-describe('lib/manager/pipenv/extract', () => {
+describe(getName(__filename), () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty', async () => {
       expect(await extractPackageFile('[packages]\r\n', 'Pipfile')).toBeNull();

--- a/lib/manager/poetry/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/poetry/__snapshots__/extract.spec.ts.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/manager/poetry/extract extractPackageFile() dedupes registries 1`] = `
+exports[`manager/poetry/extract extractPackageFile() dedupes registries 1`] = `
 Array [
   "https://pypi.org/pypi/",
   "https://bar.baz/+simple/",
 ]
 `;
 
-exports[`lib/manager/poetry/extract extractPackageFile() extracts mixed versioning types 1`] = `
+exports[`manager/poetry/extract extractPackageFile() extracts mixed versioning types 1`] = `
 Object {
   "constraints": Object {},
   "deps": Array [
@@ -356,7 +356,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/poetry/extract extractPackageFile() extracts multiple dependencies (with dep = {version = "1.2.3"} case) 1`] = `
+exports[`manager/poetry/extract extractPackageFile() extracts multiple dependencies (with dep = {version = "1.2.3"} case) 1`] = `
 Object {
   "constraints": Object {},
   "deps": Array [
@@ -435,7 +435,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/poetry/extract extractPackageFile() extracts multiple dependencies 1`] = `
+exports[`manager/poetry/extract extractPackageFile() extracts multiple dependencies 1`] = `
 Array [
   Object {
     "currentValue": "0.0.0",
@@ -530,7 +530,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/poetry/extract extractPackageFile() extracts registries 1`] = `
+exports[`manager/poetry/extract extractPackageFile() extracts registries 1`] = `
 Array [
   "https://foo.bar/simple/",
   "https://bar.baz/+simple/",
@@ -538,7 +538,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/poetry/extract extractPackageFile() handles multiple constraint dependencies 1`] = `
+exports[`manager/poetry/extract extractPackageFile() handles multiple constraint dependencies 1`] = `
 Object {
   "constraints": Object {
     "poetry": "poetry>=1.1.2 setuptools poetry-dynamic-versioning",
@@ -559,7 +559,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/poetry/extract extractPackageFile() resolves lockedVersions from the lockfile 1`] = `
+exports[`manager/poetry/extract extractPackageFile() resolves lockedVersions from the lockfile 1`] = `
 Object {
   "constraints": Object {
     "python": "^3.9",

--- a/lib/manager/poetry/extract.spec.ts
+++ b/lib/manager/poetry/extract.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { fs } from '../../../test/util';
+import { fs, getName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 jest.mock('../../util/fs');
@@ -61,7 +61,7 @@ const pyproject11tomlLock = readFileSync(
   'utf8'
 );
 
-describe('lib/manager/poetry/extract', () => {
+describe(getName(__filename), () => {
   describe('extractPackageFile()', () => {
     let filename: string;
     const OLD_ENV = process.env;

--- a/lib/manager/pre-commit/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/pre-commit/__snapshots__/extract.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/manager/precommit/extract extractPackageFile() can handle invalid private git repos 1`] = `
+exports[`manager/pre-commit/extract extractPackageFile() can handle invalid private git repos 1`] = `
 Object {
   "deps": Array [
     Object {
@@ -17,7 +17,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/precommit/extract extractPackageFile() can handle private git repos 1`] = `
+exports[`manager/pre-commit/extract extractPackageFile() can handle private git repos 1`] = `
 Object {
   "deps": Array [
     Object {
@@ -34,7 +34,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/precommit/extract extractPackageFile() can handle unknown private git repos 1`] = `
+exports[`manager/pre-commit/extract extractPackageFile() can handle unknown private git repos 1`] = `
 Object {
   "deps": Array [
     Object {
@@ -51,7 +51,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/precommit/extract extractPackageFile() extracts from complex config file correctly 1`] = `
+exports[`manager/pre-commit/extract extractPackageFile() extracts from complex config file correctly 1`] = `
 Object {
   "deps": Array [
     Object {
@@ -108,7 +108,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/precommit/extract extractPackageFile() extracts from values.yaml correctly with same structure as "pre-commit sample-config" 1`] = `
+exports[`manager/pre-commit/extract extractPackageFile() extracts from values.yaml correctly with same structure as "pre-commit sample-config" 1`] = `
 Object {
   "deps": Array [
     Object {

--- a/lib/manager/pre-commit/extract.spec.ts
+++ b/lib/manager/pre-commit/extract.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { mocked } from '../../../test/util';
+import { getName, mocked } from '../../../test/util';
 import * as _hostRules from '../../util/host-rules';
 import { extractPackageFile } from './extract';
 
@@ -38,7 +38,7 @@ const enterpriseGitPrecommitConfig = readFileSync(
   'utf8'
 );
 
-describe('lib/manager/precommit/extract', () => {
+describe(getName(__filename), () => {
   describe('extractPackageFile()', () => {
     beforeEach(() => {
       jest.resetAllMocks();

--- a/lib/manager/pub/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/pub/__snapshots__/extract.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`manager/pub extractPackageFile should return valid dependencies 1`] = `
+exports[`manager/pub/extract extractPackageFile should return valid dependencies 1`] = `
 Object {
   "datasource": "dart",
   "deps": Array [

--- a/lib/manager/pub/extract.spec.ts
+++ b/lib/manager/pub/extract.spec.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'fs';
+import { getName } from '../../../test/util';
 import { extractPackageFile } from '.';
 
 const brokenYaml = readFileSync(
@@ -11,7 +12,7 @@ const packageFile = readFileSync(
   'utf8'
 );
 
-describe('manager/pub', () => {
+describe(getName(__filename), () => {
   describe('extractPackageFile', () => {
     it('should return null if package does not contain any deps', () => {
       const res = extractPackageFile('foo: bar', 'pubspec.yaml');

--- a/lib/manager/ruby-version/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/ruby-version/__snapshots__/extract.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/manager/ruby-version/extract extractPackageFile() returns a result 1`] = `
+exports[`manager/ruby-version/extract extractPackageFile() returns a result 1`] = `
 Array [
   Object {
     "currentValue": "8.4.0",
@@ -10,7 +10,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/ruby-version/extract extractPackageFile() skips non ranges 1`] = `
+exports[`manager/ruby-version/extract extractPackageFile() skips non ranges 1`] = `
 Array [
   Object {
     "currentValue": "latestn",
@@ -20,7 +20,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/ruby-version/extract extractPackageFile() supports ranges 1`] = `
+exports[`manager/ruby-version/extract extractPackageFile() supports ranges 1`] = `
 Array [
   Object {
     "currentValue": "8.4",

--- a/lib/manager/ruby-version/extract.spec.ts
+++ b/lib/manager/ruby-version/extract.spec.ts
@@ -1,6 +1,7 @@
+import { getName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
-describe('lib/manager/ruby-version/extract', () => {
+describe(getName(__filename), () => {
   describe('extractPackageFile()', () => {
     it('returns a result', () => {
       const res = extractPackageFile('8.4.0\n');

--- a/lib/manager/sbt/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/sbt/__snapshots__/extract.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/manager/sbt/extract extractPackageFile() extract deps from native scala file with private variables 1`] = `
+exports[`manager/sbt/extract extractPackageFile() extract deps from native scala file with private variables 1`] = `
 Object {
   "deps": Array [
     Object {
@@ -37,7 +37,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/sbt/extract extractPackageFile() extract deps from native scala file with variables 1`] = `
+exports[`manager/sbt/extract extractPackageFile() extract deps from native scala file with variables 1`] = `
 Object {
   "deps": Array [
     Object {
@@ -74,7 +74,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/sbt/extract extractPackageFile() extracts deps for generic use-cases 1`] = `
+exports[`manager/sbt/extract extractPackageFile() extracts deps for generic use-cases 1`] = `
 Object {
   "deps": Array [
     Object {
@@ -258,7 +258,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/sbt/extract extractPackageFile() extracts deps when scala version is defined in a variable 1`] = `
+exports[`manager/sbt/extract extractPackageFile() extracts deps when scala version is defined in a variable 1`] = `
 Object {
   "deps": Array [
     Object {
@@ -398,7 +398,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/sbt/extract extractPackageFile() extracts deps when scala version is defined in a variable with a trailing comma 1`] = `
+exports[`manager/sbt/extract extractPackageFile() extracts deps when scala version is defined in a variable with a trailing comma 1`] = `
 Object {
   "deps": Array [
     Object {
@@ -415,7 +415,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/sbt/extract extractPackageFile() extracts deps when scala version is defined with a trailing comma 1`] = `
+exports[`manager/sbt/extract extractPackageFile() extracts deps when scala version is defined with a trailing comma 1`] = `
 Object {
   "deps": Array [
     Object {
@@ -442,7 +442,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/sbt/extract extractPackageFile() skips deps when scala version is missing 1`] = `
+exports[`manager/sbt/extract extractPackageFile() skips deps when scala version is missing 1`] = `
 Object {
   "deps": Array [
     Object {

--- a/lib/manager/sbt/__snapshots__/update.spec.ts.snap
+++ b/lib/manager/sbt/__snapshots__/update.spec.ts.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/manager/sbt/update .bumpPackageVersion() increments 1`] = `
+exports[`manager/sbt/update .bumpPackageVersion() increments 1`] = `
 "name := \\"test\\"
 organization := \\"test-org\\"
 version := \\"0.0.3\\"
 "
 `;
 
-exports[`lib/manager/sbt/update .bumpPackageVersion() updates 1`] = `
+exports[`manager/sbt/update .bumpPackageVersion() updates 1`] = `
 "name := \\"test\\"
 organization := \\"test-org\\"
 version := \\"0.1.0\\"

--- a/lib/manager/sbt/extract.spec.ts
+++ b/lib/manager/sbt/extract.spec.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'upath';
+import { getName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 const sbt = readFileSync(
@@ -25,7 +26,7 @@ const sbtPrivateVariableDependencyFile = readFileSync(
   'utf8'
 );
 
-describe('lib/manager/sbt/extract', () => {
+describe(getName(__filename), () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty', () => {
       expect(extractPackageFile(null)).toBeNull();

--- a/lib/manager/sbt/update.spec.ts
+++ b/lib/manager/sbt/update.spec.ts
@@ -1,6 +1,7 @@
+import { getName } from '../../../test/util';
 import * as sbtUpdater from './update';
 
-describe('lib/manager/sbt/update', () => {
+describe(getName(__filename), () => {
   describe('.bumpPackageVersion()', () => {
     const content =
       'name := "test"\n' +

--- a/lib/manager/setup-cfg/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/setup-cfg/__snapshots__/extract.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/manager/pip_requirements/extract extractPackageFile() extracts dependencies 1`] = `
+exports[`manager/setup-cfg/extract extractPackageFile() extracts dependencies 1`] = `
 Object {
   "deps": Array [
     Object {

--- a/lib/manager/setup-cfg/extract.spec.ts
+++ b/lib/manager/setup-cfg/extract.spec.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'fs';
+import { getName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 const content = readFileSync(
@@ -6,7 +7,7 @@ const content = readFileSync(
   'utf8'
 );
 
-describe('lib/manager/pip_requirements/extract', () => {
+describe(getName(__filename), () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty', () => {
       expect(extractPackageFile('nothing here')).toBeNull();

--- a/lib/manager/swift/__snapshots__/index.spec.ts.snap
+++ b/lib/manager/swift/__snapshots__/index.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/manager/swift extractPackageFile() parses multiple packages 1`] = `
+exports[`manager/swift/index extractPackageFile() parses multiple packages 1`] = `
 Object {
   "deps": Array [
     Object {
@@ -59,7 +59,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/swift extractPackageFile() parses package descriptions 1`] = `
+exports[`manager/swift/index extractPackageFile() parses package descriptions 1`] = `
 Object {
   "deps": Array [
     Object {
@@ -73,7 +73,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/swift extractPackageFile() parses package descriptions 2`] = `
+exports[`manager/swift/index extractPackageFile() parses package descriptions 2`] = `
 Object {
   "deps": Array [
     Object {
@@ -87,7 +87,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/swift extractPackageFile() parses package descriptions 3`] = `
+exports[`manager/swift/index extractPackageFile() parses package descriptions 3`] = `
 Object {
   "deps": Array [
     Object {
@@ -101,7 +101,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/swift extractPackageFile() parses package descriptions 4`] = `
+exports[`manager/swift/index extractPackageFile() parses package descriptions 4`] = `
 Object {
   "deps": Array [
     Object {
@@ -115,7 +115,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/swift extractPackageFile() parses package descriptions 5`] = `
+exports[`manager/swift/index extractPackageFile() parses package descriptions 5`] = `
 Object {
   "deps": Array [
     Object {
@@ -129,7 +129,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/swift extractPackageFile() parses package descriptions 6`] = `
+exports[`manager/swift/index extractPackageFile() parses package descriptions 6`] = `
 Object {
   "deps": Array [
     Object {

--- a/lib/manager/swift/index.spec.ts
+++ b/lib/manager/swift/index.spec.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'upath';
+import { getName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 const pkgContent = readFileSync(
@@ -7,7 +8,7 @@ const pkgContent = readFileSync(
   'utf8'
 );
 
-describe('lib/manager/swift', () => {
+describe(getName(__filename), () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty content', () => {
       expect(extractPackageFile(null)).toBeNull();

--- a/lib/manager/terraform-version/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/terraform-version/__snapshots__/extract.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/manager/terraform-version/extract extractPackageFile() returns a result 1`] = `
+exports[`manager/terraform-version/extract extractPackageFile() returns a result 1`] = `
 Array [
   Object {
     "currentValue": "12.0.0",
@@ -10,7 +10,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/terraform-version/extract extractPackageFile() skips non ranges 1`] = `
+exports[`manager/terraform-version/extract extractPackageFile() skips non ranges 1`] = `
 Array [
   Object {
     "currentValue": "latest",

--- a/lib/manager/terraform-version/extract.spec.ts
+++ b/lib/manager/terraform-version/extract.spec.ts
@@ -1,6 +1,7 @@
+import { getName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
-describe('lib/manager/terraform-version/extract', () => {
+describe(getName(__filename), () => {
   describe('extractPackageFile()', () => {
     it('returns a result', () => {
       const res = extractPackageFile('12.0.0\n');

--- a/lib/manager/terraform/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/terraform/__snapshots__/extract.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/manager/terraform/extract extractPackageFile() extract helm releases 1`] = `
+exports[`manager/terraform/extract extractPackageFile() extract helm releases 1`] = `
 Object {
   "deps": Array [
     Object {
@@ -61,7 +61,7 @@ Object {
 }
 `;
 
-exports[`lib/manager/terraform/extract extractPackageFile() extracts 1`] = `
+exports[`manager/terraform/extract extractPackageFile() extracts 1`] = `
 Object {
   "deps": Array [
     Object {

--- a/lib/manager/terraform/extract.spec.ts
+++ b/lib/manager/terraform/extract.spec.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'fs';
+import { getName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 const tf1 = readFileSync('lib/manager/terraform/__fixtures__/1.tf', 'utf8');
@@ -8,7 +9,7 @@ const tf2 = `module "relative" {
 `;
 const helm = readFileSync('lib/manager/terraform/__fixtures__/helm.tf', 'utf8');
 
-describe('lib/manager/terraform/extract', () => {
+describe(getName(__filename), () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty', () => {
       expect(extractPackageFile('nothing here')).toBeNull();

--- a/lib/manager/terraform/util.spec.ts
+++ b/lib/manager/terraform/util.spec.ts
@@ -1,6 +1,7 @@
+import { getName } from '../../../test/util';
 import { TerraformDependencyTypes, getTerraformDependencyType } from './util';
 
-describe('lib/manager/terraform/extract', () => {
+describe(getName(__filename), () => {
   describe('getTerraformDependencyType()', () => {
     it('returns TerraformDependencyTypes.module', () => {
       expect(getTerraformDependencyType('module')).toBe(

--- a/lib/manager/terragrunt/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/terragrunt/__snapshots__/extract.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/manager/terragrunt/extract extractPackageFile() extracts terragrunt sources 1`] = `
+exports[`manager/terragrunt/extract extractPackageFile() extracts terragrunt sources 1`] = `
 Object {
   "deps": Array [
     Object {

--- a/lib/manager/terragrunt/extract.spec.ts
+++ b/lib/manager/terragrunt/extract.spec.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'fs';
+import { getName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 const tg1 = readFileSync('lib/manager/terragrunt/__fixtures__/2.hcl', 'utf8');
@@ -7,7 +8,7 @@ const tg2 = `terragrunt {
 }
 `;
 
-describe('lib/manager/terragrunt/extract', () => {
+describe(getName(__filename), () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty', () => {
       expect(extractPackageFile('nothing here')).toBeNull();

--- a/lib/manager/terragrunt/util.spec.ts
+++ b/lib/manager/terragrunt/util.spec.ts
@@ -1,6 +1,7 @@
+import { getName } from '../../../test/util';
 import { TerragruntDependencyTypes, getTerragruntDependencyType } from './util';
 
-describe('lib/manager/terragrunt/extract', () => {
+describe(getName(__filename), () => {
   describe('getTerragruntDependencyType()', () => {
     it('returns TerragruntDependencyTypes.terragrunt', () => {
       expect(getTerragruntDependencyType('terraform')).toBe(

--- a/lib/manager/travis/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/travis/__snapshots__/extract.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/manager/travis/extract extractPackageFile() returns results 1`] = `
+exports[`manager/travis/extract extractPackageFile() returns results 1`] = `
 Object {
   "deps": Array [
     Object {

--- a/lib/manager/travis/__snapshots__/package.spec.ts.snap
+++ b/lib/manager/travis/__snapshots__/package.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lib/manager/travis/package getPackageUpdates detects pinning 1`] = `
+exports[`manager/travis/package getPackageUpdates detects pinning 1`] = `
 Array [
   Object {
     "isRange": true,
@@ -11,7 +11,7 @@ Array [
 ]
 `;
 
-exports[`lib/manager/travis/package getPackageUpdates returns result if needing updates 1`] = `
+exports[`manager/travis/package getPackageUpdates returns result if needing updates 1`] = `
 Array [
   Object {
     "isRange": true,

--- a/lib/manager/travis/extract.spec.ts
+++ b/lib/manager/travis/extract.spec.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'upath';
+import { getName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 const invalidYAML = readFileSync(
@@ -7,7 +8,7 @@ const invalidYAML = readFileSync(
   'utf8'
 );
 
-describe('lib/manager/travis/extract', () => {
+describe(getName(__filename), () => {
   describe('extractPackageFile()', () => {
     it('returns empty if fails to parse', () => {
       const res = extractPackageFile('blahhhhh:foo:@what\n');

--- a/lib/manager/travis/package.spec.ts
+++ b/lib/manager/travis/package.spec.ts
@@ -1,3 +1,4 @@
+import { getName } from '../../../test/util';
 import { getConfig } from '../../config/defaults';
 import { getPkgReleases as _getPkgReleases } from '../../datasource';
 import { getPackageUpdates } from './package';
@@ -7,7 +8,7 @@ const getPkgReleases: any = _getPkgReleases;
 
 jest.mock('../../datasource');
 
-describe('lib/manager/travis/package', () => {
+describe(getName(__filename), () => {
   describe('getPackageUpdates', () => {
     // TODO: should be `PackageUpdateConfig`
     let config: any;

--- a/lib/manager/travis/update.spec.ts
+++ b/lib/manager/travis/update.spec.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'upath';
+import { getName } from '../../../test/util';
 import { updateDependency } from './update';
 
 const content = readFileSync(
@@ -7,7 +8,7 @@ const content = readFileSync(
   'utf8'
 );
 
-describe('manager/travis/update', () => {
+describe(getName(__filename), () => {
   describe('updateDependency', () => {
     it('updates values', () => {
       // TODO: should be `Upgrade`

--- a/lib/versioning/gradle/index.spec.ts
+++ b/lib/versioning/gradle/index.spec.ts
@@ -1,7 +1,8 @@
+import { getName } from '../../../test/util';
 import { compare, parseMavenBasedRange, parsePrefixRange } from './compare';
 import { api } from '.';
 
-describe('versioning/gradle/compare', () => {
+describe(getName(__filename), () => {
   it('returns equality', () => {
     expect(compare('1', '1')).toEqual(0);
     expect(compare('a', 'a')).toEqual(0);
@@ -112,7 +113,7 @@ describe('versioning/gradle/compare', () => {
   });
 });
 
-describe('versioning/gradle', () => {
+describe(getName(__filename), () => {
   it('isValid', () => {
     expect(api.isValid('1.0.0')).toBe(true);
     expect(api.isValid('[1.12.6,1.18.6]')).toBe(true);

--- a/lib/versioning/hex/index.spec.ts
+++ b/lib/versioning/hex/index.spec.ts
@@ -1,6 +1,7 @@
+import { getName } from '../../../test/util';
 import { api as hexScheme } from '.';
 
-describe('lib/versioning/hex', () => {
+describe(getName(__filename), () => {
   describe('hexScheme.matches()', () => {
     it('handles tilde greater than', () => {
       expect(hexScheme.matches('4.2.0', '~> 4.0')).toBe(true);

--- a/lib/versioning/ivy/index.spec.ts
+++ b/lib/versioning/ivy/index.spec.ts
@@ -1,3 +1,4 @@
+import { getName } from '../../../test/util';
 import {
   REV_TYPE_LATEST,
   REV_TYPE_RANGE,
@@ -8,7 +9,7 @@ import ivy from '.';
 
 const { getNewValue, isValid, isVersion, matches } = ivy;
 
-describe('versioning/ivy/match', () => {
+describe(getName(__filename), () => {
   it('parses dynamic revisions', () => {
     expect(parseDynamicRevision(null)).toBeNull();
     expect(parseDynamicRevision('')).toBeNull();
@@ -60,7 +61,7 @@ describe('versioning/ivy/match', () => {
   });
 });
 
-describe('versioning/ivy/index', () => {
+describe(getName(__filename), () => {
   it('isValid', () => {
     expect(isValid('')).toBe(false);
     expect(isValid('1.0.0')).toBe(true);

--- a/lib/versioning/loose/__snapshots__/utils.spec.ts.snap
+++ b/lib/versioning/loose/__snapshots__/utils.spec.ts.snap
@@ -1,27 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`loose/utils GenericVersioningApi equals 1`] = `true`;
+exports[`versioning/loose/utils GenericVersioningApi equals 1`] = `true`;
 
-exports[`loose/utils GenericVersioningApi getMajor 1`] = `1`;
+exports[`versioning/loose/utils GenericVersioningApi getMajor 1`] = `1`;
 
-exports[`loose/utils GenericVersioningApi getMinor 1`] = `0`;
+exports[`versioning/loose/utils GenericVersioningApi getMinor 1`] = `0`;
 
-exports[`loose/utils GenericVersioningApi getNewValue 1`] = `undefined`;
+exports[`versioning/loose/utils GenericVersioningApi getNewValue 1`] = `undefined`;
 
-exports[`loose/utils GenericVersioningApi getPatch 1`] = `0`;
+exports[`versioning/loose/utils GenericVersioningApi getPatch 1`] = `0`;
 
-exports[`loose/utils GenericVersioningApi isCompatible 1`] = `true`;
+exports[`versioning/loose/utils GenericVersioningApi isCompatible 1`] = `true`;
 
-exports[`loose/utils GenericVersioningApi isGreaterThan 1`] = `false`;
+exports[`versioning/loose/utils GenericVersioningApi isGreaterThan 1`] = `false`;
 
-exports[`loose/utils GenericVersioningApi isSingleVersion 1`] = `true`;
+exports[`versioning/loose/utils GenericVersioningApi isSingleVersion 1`] = `true`;
 
-exports[`loose/utils GenericVersioningApi isStable 1`] = `true`;
+exports[`versioning/loose/utils GenericVersioningApi isStable 1`] = `true`;
 
-exports[`loose/utils GenericVersioningApi isValid 1`] = `true`;
+exports[`versioning/loose/utils GenericVersioningApi isValid 1`] = `true`;
 
-exports[`loose/utils GenericVersioningApi isVersion 1`] = `true`;
+exports[`versioning/loose/utils GenericVersioningApi isVersion 1`] = `true`;
 
-exports[`loose/utils GenericVersioningApi matches 1`] = `true`;
+exports[`versioning/loose/utils GenericVersioningApi matches 1`] = `true`;
 
-exports[`loose/utils GenericVersioningApi sortVersions 1`] = `0`;
+exports[`versioning/loose/utils GenericVersioningApi sortVersions 1`] = `0`;

--- a/lib/versioning/loose/utils.spec.ts
+++ b/lib/versioning/loose/utils.spec.ts
@@ -1,6 +1,7 @@
+import { getName } from '../../../test/util';
 import { GenericVersion, GenericVersioningApi } from './generic';
 
-describe('loose/utils', () => {
+describe(getName(__filename), () => {
   const optionalFunctions = [
     'isLessThanRange',
     'valueToVersion',

--- a/lib/versioning/maven/index.spec.ts
+++ b/lib/versioning/maven/index.spec.ts
@@ -1,3 +1,4 @@
+import { getName } from '../../../test/util';
 import {
   autoExtendMavenRange,
   compare,
@@ -17,7 +18,7 @@ const {
   getNewValue,
 } = maven;
 
-describe('versioning/maven/compare', () => {
+describe(getName(__filename), () => {
   it('returns equality', () => {
     expect(compare('1.0.0', '1')).toEqual(0);
     expect(compare('1-a1', '1-alpha-1')).toEqual(0);
@@ -285,7 +286,7 @@ describe('versioning/maven/compare', () => {
   });
 });
 
-describe('versioning/maven/index', () => {
+describe(getName(__filename), () => {
   it('returns valid', () => {
     expect(isValid('1.0.0')).toBe(true);
     expect(isValid('[1.12.6,1.18.6]')).toBe(true);

--- a/lib/versioning/ubuntu/index.spec.ts
+++ b/lib/versioning/ubuntu/index.spec.ts
@@ -1,6 +1,7 @@
+import { getName } from '../../../test/util';
 import { api as ubuntu } from '.';
 
-describe('versioning/ubuntu', () => {
+describe(getName(__filename), () => {
   // validation
 
   it('isValid', () => {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Enforce the convention for `manager` and `versioning` directories

## Context:

`getName` usage is required in code reviews, while there are a lot of copy-paste sources that don't follow this convention.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
