### PR TITLE
feat(release-notes): running unemojify on release notes

### DIFF
--- a/lib/util/emoji.spec.ts
+++ b/lib/util/emoji.spec.ts
@@ -1,0 +1,22 @@
+import { getName } from '../../test/util';
+import { setEmojiConfig, unemojify } from './emoji';
+
+describe(getName(__filename), () => {
+  it('strips emojis when the config has been set accordingly', () => {
+    const emoji = '🚀💎';
+    const otherText = 'regular text';
+    const text = `${emoji} ${otherText}`;
+    setEmojiConfig({ unicodeEmoji: false });
+    const result = unemojify(text);
+    expect(result).not.toContain(emoji);
+  });
+
+  it('does not strip emojis when the config demands it', () => {
+    const emoji = '🚀💎';
+    const otherText = 'regular text';
+    const text = `${emoji} ${otherText}`;
+    setEmojiConfig({ unicodeEmoji: true });
+    const result = unemojify(text);
+    expect(result).toEqual(text);
+  });
+});

--- a/lib/util/emoji.ts
+++ b/lib/util/emoji.ts
@@ -10,3 +10,7 @@ export function setEmojiConfig(_config: RenovateConfig): void {
 export function emojify(text: string): string {
   return unicodeEmoji ? emoji.emojify(text) : text;
 }
+
+export function unemojify(text: string): string {
+  return unicodeEmoji ? text : emoji.unemojify(text);
+}

--- a/lib/workers/pr/body/changelogs.ts
+++ b/lib/workers/pr/body/changelogs.ts
@@ -1,3 +1,4 @@
+import { unemojify } from '../../../util/emoji';
 import { sanitizeMarkdown } from '../../../util/markdown';
 import * as template from '../../../util/template';
 import type { BranchConfig } from '../../types';
@@ -13,5 +14,7 @@ export function getChangelogs(config: BranchConfig): string {
     '\n\n---\n\n' + template.compile(releaseNotesHbs, config, false) + '\n\n';
   releaseNotes = releaseNotes.replace(/### \[`vv/g, '### [`v');
   releaseNotes = sanitizeMarkdown(releaseNotes);
+  releaseNotes = unemojify(releaseNotes);
+
   return releaseNotes;
 }


### PR DESCRIPTION
## Changes:

This invokes the new `unemojify` function on the fetched release notes. This PR is basically the result of https://github.com/renovatebot/renovate/issues/9219

## Context:

Bitbucket (depending on the database in the background) is really allergic to emojis and crashes silently when using them. While this can already be configured for renovate itself, the contents of the changelog of a project might still contain some.

Closes #9219 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or 
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

I have added a unit test for `emoji.ts`. If there is some place where you recommend testing the actual change that I have made, then I'll gladly add this. This is after all my first PR to renovate. 