### PR TITLE
fix(git-submodules): don’t include token in lookupName

### DIFF
--- a/lib/manager/git-submodules/extract.spec.ts
+++ b/lib/manager/git-submodules/extract.spec.ts
@@ -1,6 +1,7 @@
 import { mock } from 'jest-mock-extended';
 import _simpleGit, { Response, SimpleGit } from 'simple-git';
 import { getName, partial } from '../../../test/util';
+import * as hostRules from '../../util/host-rules';
 import type { PackageFile } from '../types';
 import extractPackageFile from './extract';
 
@@ -44,6 +45,7 @@ describe(getName(__filename), () => {
   });
   describe('extractPackageFile()', () => {
     it('extracts submodules', async () => {
+      hostRules.add({ hostName: 'github.com', token: 'abc123' });
       let res: PackageFile;
       expect(
         await extractPackageFile('', '.gitmodules.1', { localDir })

--- a/lib/manager/git-submodules/extract.ts
+++ b/lib/manager/git-submodules/extract.ts
@@ -114,7 +114,13 @@ export default async function extractPackageFile(
           // Find HTTP URL, then apply token
           let httpSubModuleUrl = getHttpUrl(subModuleUrl);
           const hostRule = hostRules.find({ url: httpSubModuleUrl });
-          httpSubModuleUrl = getHttpUrl(subModuleUrl, hostRule?.token);
+          if (hostRule?.token) {
+            logger.debug(
+              { httpSubModuleUrl },
+              'Found hostRules token for submodule'
+            );
+            httpSubModuleUrl = getHttpUrl(subModuleUrl, hostRule.token);
+          }
           const currentValue = await getBranch(
             gitModulesPath,
             name,
@@ -122,7 +128,7 @@ export default async function extractPackageFile(
           );
           return {
             depName: path,
-            lookupName: httpSubModuleUrl,
+            lookupName: getHttpUrl(subModuleUrl),
             currentValue,
             currentDigest,
           };


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Removes token from submodule lookupName, adds logging.

## Context:

Useful for debugging private module failures.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
