### PR TITLE
fix(hashicorp): update pre-1.0 short tilde ranges

### DIFF
--- a/lib/versioning/hashicorp/index.spec.ts
+++ b/lib/versioning/hashicorp/index.spec.ts
@@ -78,4 +78,22 @@ describe('semver.getNewValue()', () => {
       })
     ).toEqual('>= 1.0.0, <= 2.0.7');
   });
+  it('updates short ranges', () => {
+    expect(
+      semver.getNewValue({
+        currentValue: '0.14',
+        rangeStrategy: 'replace',
+        currentVersion: '0.14.2',
+        newVersion: '0.15.0',
+      })
+    ).toEqual('0.15');
+    expect(
+      semver.getNewValue({
+        currentValue: '~> 0.14',
+        rangeStrategy: 'replace',
+        currentVersion: '0.14.2',
+        newVersion: '0.15.0',
+      })
+    ).toEqual('~> 0.15');
+  });
 });

--- a/lib/versioning/hashicorp/index.ts
+++ b/lib/versioning/hashicorp/index.ts
@@ -35,7 +35,13 @@ function getNewValue({
   currentVersion,
   newVersion,
 }: NewValueConfig): string {
-  // handle specia. ~> 1.2 case
+  if (/~>\s*0\.\d+/.test(currentValue) && npm.getMajor(newVersion) === 0) {
+    return currentValue.replace(
+      /(~>\s*0\.).*$/,
+      `$1${npm.getMinor(newVersion)}`
+    );
+  }
+  // handle special ~> 1.2 case
   if (/(~>\s*)\d+\.\d+$/.test(currentValue)) {
     return currentValue.replace(
       /(~>\s*)\d+\.\d+$/,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds special case for pre-1.0 short tilde updating in hashicorp versioning.

## Context:

Closes #9558

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
