### PR TITLE
fix(git-refs): insert token if found in host-rules

### DIFF
--- a/lib/datasource/git-refs/index.ts
+++ b/lib/datasource/git-refs/index.ts
@@ -1,5 +1,6 @@
 import simpleGit from 'simple-git';
 import * as packageCache from '../../util/cache/package';
+import { getRemoteUrlWithToken } from '../../util/git/url';
 import * as semver from '../../versioning/semver';
 import type { DigestConfig, GetReleasesConfig, ReleaseResult } from '../types';
 
@@ -33,7 +34,7 @@ export async function getRawRefs({
   }
 
   // fetch remote tags
-  const lsRemote = await git.listRemote([lookupName]);
+  const lsRemote = await git.listRemote([getRemoteUrlWithToken(lookupName)]);
   if (!lsRemote) {
     return null;
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds token to git-refs url if found in host-rules.

## Context:

#9532

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
