### PR TITLE
refactor: rollback config

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -443,7 +443,7 @@ They are then collated as part of the onboarding description.
 
 ## digest
 
-Add to this object if you wish to define rules that apply only to PRs that update Docker digests.
+Add to this object if you wish to define rules that apply only to PRs that update digests.
 
 ## docker
 
@@ -2052,6 +2052,10 @@ See [GitHub](https://help.github.com/en/github/creating-cloning-and-archiving-re
 ## reviewersSampleSize
 
 Take a random sample of given size from reviewers.
+
+## rollback
+
+Add to this object if you wish to define rules that apply only to PRs that roll back versions.
 
 ## rollbackPrs
 

--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -1109,6 +1109,19 @@ const options: RenovateOptions[] = [
     cli: false,
     mergeable: true,
   },
+  {
+    name: 'rollback',
+    description: 'Configuration to apply when rolling back a version.',
+    stage: 'package',
+    type: 'object',
+    default: {
+      branchTopic: '{{{depNameSanitized}}}-rollback',
+      commitMessageAction: 'Roll back',
+      semanticCommitType: 'fix',
+    },
+    cli: false,
+    mergeable: true,
+  },
   // Semantic commit / Semantic release
   {
     name: 'semanticCommits',

--- a/lib/workers/repository/process/lookup/__snapshots__/index.spec.ts.snap
+++ b/lib/workers/repository/process/lookup/__snapshots__/index.spec.ts.snap
@@ -979,12 +979,10 @@ Array [
 exports[`workers/repository/process/lookup/index .lookupUpdates() returns rollback for pinned version 1`] = `
 Array [
   Object {
-    "branchName": "{{{branchPrefix}}}rollback-{{{depNameSanitized}}}-{{{newMajor}}}.x",
-    "commitMessageAction": "Roll back",
-    "isRollback": true,
+    "bucket": "rollback",
     "newMajor": 0,
     "newValue": "0.9.7",
-    "semanticCommitType": "fix",
+    "newVersion": "0.9.7",
     "updateType": "rollback",
   },
   Object {
@@ -1013,12 +1011,10 @@ Array [
 exports[`workers/repository/process/lookup/index .lookupUpdates() returns rollback for ranged version 1`] = `
 Array [
   Object {
-    "branchName": "{{{branchPrefix}}}rollback-{{{depNameSanitized}}}-{{{newMajor}}}.x",
-    "commitMessageAction": "Roll back",
-    "isRollback": true,
+    "bucket": "rollback",
     "newMajor": 0,
     "newValue": "^0.9.7",
-    "semanticCommitType": "fix",
+    "newVersion": "0.9.7",
     "updateType": "rollback",
   },
 ]
@@ -1064,12 +1060,10 @@ Array [
 
 exports[`workers/repository/process/lookup/index .lookupUpdates() should downgrade from missing versions 1`] = `
 Object {
-  "branchName": "{{{branchPrefix}}}rollback-{{{depNameSanitized}}}-{{{newMajor}}}.x",
-  "commitMessageAction": "Roll back",
-  "isRollback": true,
+  "bucket": "rollback",
   "newMajor": 1,
   "newValue": "1.16.0",
-  "semanticCommitType": "fix",
+  "newVersion": "1.16.0",
   "updateType": "rollback",
 }
 `;
@@ -1132,12 +1126,10 @@ Array [
 exports[`workers/repository/process/lookup/index .lookupUpdates() should roll back to dist-tag if current version is higher 1`] = `
 Array [
   Object {
-    "branchName": "{{{branchPrefix}}}rollback-{{{depNameSanitized}}}-{{{newMajor}}}.x",
-    "commitMessageAction": "Roll back",
-    "isRollback": true,
+    "bucket": "rollback",
     "newMajor": 3,
     "newValue": "3.0.1-insiders.20180726",
-    "semanticCommitType": "fix",
+    "newVersion": "3.0.1-insiders.20180726",
     "updateType": "rollback",
   },
 ]

--- a/lib/workers/repository/process/lookup/rollback.ts
+++ b/lib/workers/repository/process/lookup/rollback.ts
@@ -50,13 +50,10 @@ export function getRollbackUpdate(
     newVersion,
   });
   return {
-    updateType: 'rollback',
-    branchName:
-      '{{{branchPrefix}}}rollback-{{{depNameSanitized}}}-{{{newMajor}}}.x',
-    commitMessageAction: 'Roll back',
-    isRollback: true,
-    newValue,
+    bucket: 'rollback',
     newMajor: version.getMajor(newVersion),
-    semanticCommitType: 'fix',
+    newValue,
+    newVersion,
+    updateType: 'rollback',
   };
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Refactors `rollback` update types to be more config-based.

## Context:

Technical debt

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
