### PR TITLE
feat: don’t block updates due to pinning

### DIFF
--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -1082,7 +1082,6 @@ const options: RenovateOptions[] = [
     stage: 'package',
     type: 'object',
     default: {
-      recreateClosed: true,
       rebaseWhen: 'behind-base-branch',
       groupName: 'Pin Dependencies',
       groupSlug: 'pin-dependencies',

--- a/lib/manager/types.ts
+++ b/lib/manager/types.ts
@@ -135,7 +135,6 @@ export interface Package<T> extends ManagerData<T> {
 
 export interface LookupUpdate {
   bucket?: string;
-  blockedByPin?: boolean;
   branchName?: string;
   commitMessageAction?: string;
   isBump?: boolean;

--- a/lib/workers/repository/process/lookup/__snapshots__/index.spec.ts.snap
+++ b/lib/workers/repository/process/lookup/__snapshots__/index.spec.ts.snap
@@ -9,7 +9,6 @@ Array [
     "updateType": "pin",
   },
   Object {
-    "blockedByPin": true,
     "bucket": "latest",
     "newMajor": 1,
     "newMinor": 4,
@@ -94,7 +93,6 @@ Array [
     "updateType": "pin",
   },
   Object {
-    "blockedByPin": true,
     "bucket": "non-major",
     "isRange": true,
     "newMajor": 0,
@@ -109,7 +107,6 @@ Array [
     "updateType": "minor",
   },
   Object {
-    "blockedByPin": true,
     "bucket": "major",
     "isRange": true,
     "newMajor": 1,
@@ -144,7 +141,6 @@ Object {
   "sourceUrl": "https://github.com/nodejs/node",
   "updates": Array [
     Object {
-      "blockedByPin": true,
       "bucket": "non-major",
       "newDigest": "sha256:abcdef1234567890",
       "newMajor": 8,
@@ -331,7 +327,6 @@ Array [
     "updateType": "pin",
   },
   Object {
-    "blockedByPin": true,
     "bucket": "major",
     "newMajor": 1,
     "newMinor": 4,
@@ -563,7 +558,6 @@ Array [
     "updateType": "pin",
   },
   Object {
-    "blockedByPin": true,
     "bucket": "non-major",
     "newMajor": 0,
     "newMinor": 9,
@@ -603,7 +597,6 @@ Array [
     "updateType": "minor",
   },
   Object {
-    "blockedByPin": true,
     "bucket": "major",
     "newMajor": 1,
     "newMinor": 4,
@@ -1614,7 +1607,6 @@ Array [
     "updateType": "pin",
   },
   Object {
-    "blockedByPin": true,
     "bucket": "non-major",
     "newMajor": 0,
     "newMinor": 9,
@@ -1654,7 +1646,6 @@ Array [
     "updateType": "minor",
   },
   Object {
-    "blockedByPin": true,
     "bucket": "major",
     "newMajor": 1,
     "newMinor": 4,
@@ -1686,7 +1677,6 @@ Array [
     "updateType": "pin",
   },
   Object {
-    "blockedByPin": true,
     "bucket": "non-major",
     "newMajor": 0,
     "newMinor": 9,
@@ -1726,7 +1716,6 @@ Array [
     "updateType": "minor",
   },
   Object {
-    "blockedByPin": true,
     "bucket": "major",
     "newMajor": 1,
     "newMinor": 4,
@@ -1802,7 +1791,6 @@ Array [
     "updateType": "pin",
   },
   Object {
-    "blockedByPin": true,
     "bucket": "non-major",
     "newMajor": 1,
     "newMinor": 4,
@@ -2235,7 +2223,6 @@ Array [
     "updateType": "pin",
   },
   Object {
-    "blockedByPin": true,
     "bucket": "non-major",
     "newMajor": 1,
     "newMinor": 4,
@@ -2425,7 +2412,6 @@ Array [
     "updateType": "pin",
   },
   Object {
-    "blockedByPin": true,
     "bucket": "non-major",
     "newMajor": 1,
     "newMinor": 4,
@@ -2481,7 +2467,6 @@ Array [
     "updateType": "pin",
   },
   Object {
-    "blockedByPin": true,
     "bucket": "non-major",
     "newMajor": 1,
     "newMinor": 4,

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -343,16 +343,5 @@ export async function lookupUpdates(
         update.isLockfileUpdate ||
         (update.newDigest && !update.newDigest.startsWith(currentDigest))
     );
-  if (res.updates.some((update) => update.updateType === 'pin')) {
-    for (const update of res.updates) {
-      if (
-        update.updateType !== 'pin' &&
-        update.updateType !== 'rollback' &&
-        !isVulnerabilityAlert
-      ) {
-        update.blockedByPin = true;
-      }
-    }
-  }
   return res;
 }

--- a/lib/workers/repository/process/write.spec.ts
+++ b/lib/workers/repository/process/write.spec.ts
@@ -29,17 +29,6 @@ beforeEach(() => {
 
 describe(getName(__filename), () => {
   describe('writeUpdates()', () => {
-    it('skips branches blocked by pin', async () => {
-      const branches: BranchConfig[] = [
-        { updateType: 'pin' },
-        { blockedByPin: true },
-        {},
-      ] as never;
-      git.branchExists.mockReturnValueOnce(false);
-      const res = await writeUpdates(config, branches);
-      expect(res).toEqual('done');
-      expect(branchWorker.processBranch).toHaveBeenCalledTimes(2);
-    });
     it('stops after automerge', async () => {
       const branches: BranchConfig[] = [
         {},

--- a/lib/workers/repository/process/write.ts
+++ b/lib/workers/repository/process/write.ts
@@ -12,7 +12,7 @@ export async function writeUpdates(
   config: RenovateConfig,
   allBranches: BranchConfig[]
 ): Promise<WriteUpdateResult> {
-  let branches = allBranches;
+  const branches = allBranches;
   logger.debug(
     `Processing ${branches.length} branch${
       branches.length === 1 ? '' : 'es'
@@ -21,14 +21,6 @@ export async function writeUpdates(
       .sort()
       .join(', ')}`
   );
-  branches = branches.filter((branchConfig) => {
-    if (branchConfig.blockedByPin) {
-      logger.debug(`Branch ${branchConfig.branchName} is blocked by a Pin PR`);
-      return false;
-    }
-    return true;
-  });
-
   const prsRemaining = await getPrsRemaining(config, branches);
   logger.debug({ prsRemaining }, 'Calculated maximum PRs remaining this run');
   setMaxLimit(Limit.PullRequests, prsRemaining);

--- a/lib/workers/repository/updates/__snapshots__/generate.spec.ts.snap
+++ b/lib/workers/repository/updates/__snapshots__/generate.spec.ts.snap
@@ -6,7 +6,6 @@ exports[`workers/repository/updates/generate generateBranchConfig() handles @typ
 Object {
   "addLabels": Array [],
   "automerge": false,
-  "blockedByPin": false,
   "branchName": "some-branch",
   "commitMessage": "",
   "constraints": Object {},
@@ -77,7 +76,6 @@ exports[`workers/repository/updates/generate generateBranchConfig() handles @typ
 Object {
   "addLabels": Array [],
   "automerge": false,
-  "blockedByPin": false,
   "branchName": "some-branch",
   "commitBodyTable": true,
   "commitMessage": "\\n\\n| datasource | package         | from  | to    |\\n| ---------- | --------------- | ----- | ----- |\\n| npm        | @types/some-dep | 0.5.7 | 0.5.8 |\\n",

--- a/lib/workers/repository/updates/__snapshots__/generate.spec.ts.snap
+++ b/lib/workers/repository/updates/__snapshots__/generate.spec.ts.snap
@@ -147,7 +147,6 @@ exports[`workers/repository/updates/generate generateBranchConfig() handles lock
 Object {
   "addLabels": Array [],
   "automerge": false,
-  "blockedByPin": false,
   "branchName": "some-branch",
   "commitMessage": "",
   "constraints": Object {},
@@ -179,7 +178,6 @@ exports[`workers/repository/updates/generate generateBranchConfig() handles lock
 Object {
   "addLabels": Array [],
   "automerge": false,
-  "blockedByPin": false,
   "branchName": "some-branch",
   "commitMessage": "",
   "constraints": Object {},

--- a/lib/workers/repository/updates/generate.ts
+++ b/lib/workers/repository/updates/generate.ts
@@ -302,9 +302,6 @@ export function generateBranchConfig(
   if (config.upgrades.some((upgrade) => upgrade.updateType === 'major')) {
     config.updateType = 'major';
   }
-  config.blockedByPin = config.upgrades.every(
-    (upgrade) => upgrade.blockedByPin
-  );
   config.constraints = {};
   for (const upgrade of config.upgrades || []) {
     if (upgrade.constraints) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Removes previously opinionated behavior which suppressed updates if a dependency was to be pinned first.

## Context:

I don't think we gain much from this, while many people over time were confused. If PRs are created to update ranges, they'll still be needed afterwards even if they'll be updated to be exact versions. i.e. no autoclosing caused by this.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
