### PR TITLE
fix(bitbucket): Return proper type for "createPr()"

### DIFF
--- a/lib/platform/bitbucket/__snapshots__/index.spec.ts.snap
+++ b/lib/platform/bitbucket/__snapshots__/index.spec.ts.snap
@@ -382,6 +382,7 @@ exports[`platform/bitbucket/index findPr() finds pr 1`] = `
 Object {
   "body": "summary",
   "createdAt": "2018-07-02T07:02:25.275030+00:00",
+  "displayNumber": "Pull Request #5",
   "number": 5,
   "sourceBranch": "branch",
   "state": "open",
@@ -1158,6 +1159,7 @@ Array [
   Object {
     "body": undefined,
     "createdAt": undefined,
+    "displayNumber": "Pull Request #1",
     "number": 1,
     "sourceBranch": "branch-a",
     "state": "open",

--- a/lib/platform/bitbucket/index.ts
+++ b/lib/platform/bitbucket/index.ts
@@ -696,7 +696,7 @@ export async function createPr({
   };
 
   try {
-    const prInfo = (
+    const prRes = (
       await bitbucketHttp.postJson<PrResponse>(
         `/2.0/repositories/${config.repository}/pullrequests`,
         {
@@ -704,11 +704,7 @@ export async function createPr({
         }
       )
     ).body;
-    // TODO: fix types
-    const pr: Pr = {
-      number: prInfo.id,
-      displayNumber: `Pull Request #${prInfo.id}`,
-    } as any;
+    const pr = utils.prInfo(prRes);
     // istanbul ignore if
     if (config.prList) {
       config.prList.push(pr);

--- a/lib/platform/bitbucket/utils.ts
+++ b/lib/platform/bitbucket/utils.ts
@@ -172,13 +172,14 @@ export interface PrResponse {
 export function prInfo(pr: PrResponse): Pr {
   return {
     number: pr.id,
-    body: pr.summary ? pr.summary.raw : /* istanbul ignore next */ undefined,
-    sourceBranch: pr.source.branch.name,
-    targetBranch: pr.destination.branch.name,
+    displayNumber: `Pull Request #${pr.id}`,
+    body: pr.summary?.raw,
+    sourceBranch: pr.source?.branch?.name,
+    targetBranch: pr.destination?.branch?.name,
     title: pr.title,
-    state: prStates.closed.includes(pr.state)
+    state: prStates.closed?.includes(pr.state)
       ? /* istanbul ignore next */ PrState.Closed
-      : pr.state.toLowerCase(),
+      : pr.state?.toLowerCase(),
     createdAt: pr.created_on,
   };
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Refactor helper and use it for result massaging.

## Context:

Closes #9619

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
