### PR TITLE
fix: rangeStrategy=replace with lockedVersion

### DIFF
--- a/lib/workers/repository/process/lookup/index.spec.ts
+++ b/lib/workers/repository/process/lookup/index.spec.ts
@@ -347,6 +347,15 @@ describe(getName(__filename), () => {
       nock('https://registry.npmjs.org').get('/q').reply(200, qJson);
       expect((await lookup.lookupUpdates(config)).updates).toHaveLength(0);
     });
+    it('ignores minor ranged versions when locked', async () => {
+      config.rangeStrategy = 'replace';
+      config.currentValue = '^1.0.0';
+      config.lockedVersion = '1.1.0';
+      config.depName = 'q';
+      config.datasource = datasourceNpmId;
+      nock('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      expect((await lookup.lookupUpdates(config)).updates).toHaveLength(0);
+    });
     it('upgrades tilde ranges', async () => {
       config.rangeStrategy = 'pin';
       config.currentValue = '~1.3.0';

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -138,7 +138,6 @@ export async function lookupUpdates(
       .filter((release) => !release.isDeprecated)
       .map((release) => release.version);
     const currentVersion =
-      lockedVersion ||
       getCurrentVersion(
         config,
         versioning,
@@ -290,6 +289,7 @@ export async function lookupUpdates(
 
   // Record if the dep is fixed to a version
   if (lockedVersion) {
+    res.currentVersion = lockedVersion;
     res.fixedVersion = lockedVersion;
   } else if (currentValue && versioning.isSingleVersion(currentValue)) {
     res.fixedVersion = currentValue.replace(/^=+/, '');


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Fixes an edge case where:
- rangeStrategy=replace
- A range is in use
- A lock file is in use
- The locked version is not the highest version matching the range, or the same version as the range

In such scenarios the incorrect result was a PR which essentially "bumped" the range to start with the current locked version.

## Context:

Closes #9627

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
