### PR TITLE
docs: document that 'setup.cfg' file is supported for Python package managers

### DIFF
--- a/docs/usage/python.md
+++ b/docs/usage/python.md
@@ -9,7 +9,8 @@ Renovate supports the following Python package managers:
 
 - `pip` (e.g. `requirements.txt`, `requirements.pip`) files
 - `pipenv` (e.g. `Pipfile`)
-- `setup.py`
+- `setup.py` file
+- `setup.cfg` file
 
 ## Versioning support
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Add `setup.cfg` to supported Python package managers in documentation.
- Document explicitly that `setup.py` and `setup.cfg` are files (not package managers).

## Context:

Reading [the documentation for Python language](https://docs.renovatebot.com/python/) I thought the file `setup.cfg` was not supported, but I have found that #7058 implemented it.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required
