### PR TITLE
refactor(test): Detect test caller file

### DIFF
--- a/lib/config/cli.spec.ts
+++ b/lib/config/cli.spec.ts
@@ -1,10 +1,10 @@
-import { getName } from '../../test/util';
+import { testName } from '../../test/util';
 import * as datasourceDocker from '../datasource/docker';
 import * as cli from './cli';
 import getArgv from './config/__fixtures__/argv';
 import type { RenovateOptions } from './types';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   let argv: string[];
   beforeEach(() => {
     argv = getArgv();

--- a/lib/config/decrypt.spec.ts
+++ b/lib/config/decrypt.spec.ts
@@ -1,12 +1,12 @@
 import fs from 'fs';
-import { getName } from '../../test/util';
+import { testName } from '../../test/util';
 import { setAdminConfig } from './admin';
 import { decryptConfig } from './decrypt';
 import type { RenovateConfig } from './types';
 
 const privateKey = fs.readFileSync('lib/config/keys/__fixtures__/private.pem');
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('decryptConfig()', () => {
     let config: RenovateConfig;
     beforeEach(() => {

--- a/lib/config/definitions.spec.ts
+++ b/lib/config/definitions.spec.ts
@@ -1,11 +1,11 @@
-import { getName } from '../../test/util';
+import { testName } from '../../test/util';
 import { getOptions } from './definitions';
 
 jest.mock('../manager', () => ({
   getManagers: jest.fn(() => new Map().set('testManager', {})),
 }));
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   it('test manager should have no defaultConfig', () => {
     const opts = getOptions();
     expect(opts.filter((o) => o.name === 'testManager')).toEqual([]);

--- a/lib/config/env.spec.ts
+++ b/lib/config/env.spec.ts
@@ -1,4 +1,4 @@
-import { getName } from '../../test/util';
+import { testName } from '../../test/util';
 import {
   PLATFORM_TYPE_BITBUCKET,
   PLATFORM_TYPE_GITLAB,
@@ -6,7 +6,7 @@ import {
 import * as env from './env';
 import type { RenovateOptions } from './types';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('.getConfig(env)', () => {
     it('returns empty env', () => {
       expect(env.getConfig({})).toEqual({ hostRules: [] });

--- a/lib/config/file.spec.ts
+++ b/lib/config/file.spec.ts
@@ -1,11 +1,11 @@
 import fs from 'fs';
 import { DirectoryResult, dir } from 'tmp-promise';
 import upath from 'upath';
-import { getName } from '../../test/util';
+import { testName } from '../../test/util';
 import customConfig from './config/__fixtures__/file';
 import * as file from './file';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   let tmp: DirectoryResult;
 
   beforeAll(async () => {

--- a/lib/config/index.spec.ts
+++ b/lib/config/index.spec.ts
@@ -1,5 +1,5 @@
 import upath from 'upath';
-import { getName } from '../../test/util';
+import { testName } from '../../test/util';
 import { readFile } from '../util/fs';
 import getArgv from './config/__fixtures__/argv';
 import { getConfig } from './defaults';
@@ -13,7 +13,7 @@ try {
 
 const defaultConfig = getConfig();
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('.parseConfigs(env, defaultArgv)', () => {
     let configParser: typeof import('.');
     let defaultArgv: string[];

--- a/lib/config/massage.spec.ts
+++ b/lib/config/massage.spec.ts
@@ -1,8 +1,8 @@
-import { getName } from '../../test/util';
+import { testName } from '../../test/util';
 import * as massage from './massage';
 import type { RenovateConfig } from './types';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('massageConfig', () => {
     it('returns empty', () => {
       const config: RenovateConfig = {};

--- a/lib/config/migrate-validate.spec.ts
+++ b/lib/config/migrate-validate.spec.ts
@@ -1,4 +1,4 @@
-import { RenovateConfig, getConfig, getName } from '../../test/util';
+import { RenovateConfig, getConfig, testName } from '../../test/util';
 import { migrateAndValidate } from './migrate-validate';
 
 let config: RenovateConfig;
@@ -7,7 +7,7 @@ beforeEach(() => {
   config = getConfig();
 });
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('migrateAndValidate()', () => {
     it('handles empty', async () => {
       const res = await migrateAndValidate(config, {});

--- a/lib/config/migration.spec.ts
+++ b/lib/config/migration.spec.ts
@@ -1,4 +1,4 @@
-import { getName } from '../../test/util';
+import { testName } from '../../test/util';
 import { PLATFORM_TYPE_GITHUB } from '../constants/platforms';
 import { getConfig } from './defaults';
 import * as configMigration from './migration';
@@ -14,7 +14,7 @@ interface RenovateConfig extends _RenovateConfig {
   node?: RenovateSharedConfig & { supportPolicy?: unknown };
 }
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('migrateConfig(config, parentConfig)', () => {
     it('migrates config', () => {
       const config: RenovateConfig = {

--- a/lib/config/presets/azure/index.spec.ts
+++ b/lib/config/presets/azure/index.spec.ts
@@ -1,5 +1,5 @@
 import { Readable } from 'stream';
-import { getName, mocked } from '../../../../test/util';
+import { mocked, testName } from '../../../../test/util';
 import { setPlatformApi } from '../../../platform';
 import * as _azureApi from '../../../platform/azure/azure-got-wrapper';
 import { PRESET_DEP_NOT_FOUND, PRESET_INVALID_JSON } from '../util';
@@ -10,7 +10,7 @@ jest.mock('../../../platform/azure/azure-got-wrapper');
 
 const azureApi = mocked(_azureApi);
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   beforeAll(() => {
     setPlatformApi('azure');
   });

--- a/lib/config/presets/bitbucket-server/index.spec.ts
+++ b/lib/config/presets/bitbucket-server/index.spec.ts
@@ -1,5 +1,5 @@
 import * as httpMock from '../../../../test/http-mock';
-import { getName, mocked } from '../../../../test/util';
+import { mocked, testName } from '../../../../test/util';
 import * as _hostRules from '../../../util/host-rules';
 import { PRESET_DEP_NOT_FOUND, PRESET_INVALID_JSON } from '../util';
 import * as bitbucketServer from '.';
@@ -11,7 +11,7 @@ const hostRules = mocked(_hostRules);
 const bitbucketApiHost = 'https://git.company.org';
 const basePath = '/rest/api/1.0/projects/some/repos/repo/browse';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   beforeEach(() => {
     httpMock.setup();
     hostRules.find.mockReturnValue({ token: 'abc' });

--- a/lib/config/presets/bitbucket/index.spec.ts
+++ b/lib/config/presets/bitbucket/index.spec.ts
@@ -1,5 +1,5 @@
 import * as httpMock from '../../../../test/http-mock';
-import { getName } from '../../../../test/util';
+import { testName } from '../../../../test/util';
 import { setPlatformApi } from '../../../platform';
 import { PRESET_DEP_NOT_FOUND, PRESET_INVALID_JSON } from '../util';
 import * as bitbucket from '.';
@@ -9,7 +9,7 @@ jest.unmock('../../../platform');
 const baseUrl = 'https://api.bitbucket.org';
 const basePath = '/2.0/repositories/some/repo/src/HEAD';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   beforeAll(() => {
     setPlatformApi('bitbucket');
   });

--- a/lib/config/presets/gitea/index.spec.ts
+++ b/lib/config/presets/gitea/index.spec.ts
@@ -1,5 +1,5 @@
 import * as httpMock from '../../../../test/http-mock';
-import { getName, mocked } from '../../../../test/util';
+import { mocked, testName } from '../../../../test/util';
 import * as _hostRules from '../../../util/host-rules';
 import { setBaseUrl } from '../../../util/http/gitea';
 import { PRESET_INVALID_JSON, PRESET_NOT_FOUND } from '../util';
@@ -12,7 +12,7 @@ const hostRules = mocked(_hostRules);
 const giteaApiHost = gitea.Endpoint;
 const basePath = '/repos/some/repo/contents';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   beforeEach(() => {
     httpMock.setup();
     hostRules.find.mockReturnValue({ token: 'abc' });

--- a/lib/config/presets/github/index.spec.ts
+++ b/lib/config/presets/github/index.spec.ts
@@ -1,5 +1,5 @@
 import * as httpMock from '../../../../test/http-mock';
-import { getName, mocked } from '../../../../test/util';
+import { mocked, testName } from '../../../../test/util';
 import * as _hostRules from '../../../util/host-rules';
 import { PRESET_INVALID_JSON, PRESET_NOT_FOUND } from '../util';
 import * as github from '.';
@@ -11,7 +11,7 @@ const hostRules = mocked(_hostRules);
 const githubApiHost = github.Endpoint;
 const basePath = '/repos/some/repo/contents';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   beforeEach(() => {
     httpMock.setup();
     hostRules.find.mockReturnValue({ token: 'abc' });

--- a/lib/config/presets/gitlab/index.spec.ts
+++ b/lib/config/presets/gitlab/index.spec.ts
@@ -1,5 +1,5 @@
 import * as httpMock from '../../../../test/http-mock';
-import { getName } from '../../../../test/util';
+import { testName } from '../../../../test/util';
 import { EXTERNAL_HOST_ERROR } from '../../../constants/error-messages';
 import { PRESET_DEP_NOT_FOUND } from '../util';
 import * as gitlab from '.';
@@ -7,7 +7,7 @@ import * as gitlab from '.';
 const gitlabApiHost = 'https://gitlab.com';
 const basePath = '/api/v4/projects/some%2Frepo/repository';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   beforeEach(() => {
     jest.resetAllMocks();
     httpMock.setup();

--- a/lib/config/presets/index.spec.ts
+++ b/lib/config/presets/index.spec.ts
@@ -1,4 +1,4 @@
-import { getName, mocked } from '../../../test/util';
+import { mocked, testName } from '../../../test/util';
 import type { RenovateConfig } from '../types';
 import presetIkatyang from './__fixtures__/renovate-config-ikatyang.json';
 import * as _local from './local';
@@ -38,7 +38,7 @@ npm.getPreset = jest.fn(({ packageName, presetName }) => {
   return null;
 });
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('resolvePreset', () => {
     let config: RenovateConfig;
     beforeEach(() => {

--- a/lib/config/presets/internal/index.spec.ts
+++ b/lib/config/presets/internal/index.spec.ts
@@ -1,4 +1,4 @@
-import { getName, mocked } from '../../../../test/util';
+import { mocked, testName } from '../../../../test/util';
 import { CONFIG_VALIDATION } from '../../../constants/error-messages';
 import { massageConfig } from '../../massage';
 import { validateConfig } from '../../validation';
@@ -14,7 +14,7 @@ npm.getPreset = jest.fn((_) => null);
 
 const ignoredPresets = ['default:group', 'default:timezone'];
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   it('fails for undefined internal preset', async () => {
     const preset = 'foo:bar';
     const presetConfig = { extends: [preset] };

--- a/lib/config/presets/local/index.spec.ts
+++ b/lib/config/presets/local/index.spec.ts
@@ -1,4 +1,4 @@
-import { getName, mocked } from '../../../../test/util';
+import { mocked, testName } from '../../../../test/util';
 import * as _azure from '../azure';
 import * as _bitbucket from '../bitbucket';
 import * as _bitbucketServer from '../bitbucket-server';
@@ -21,7 +21,7 @@ const gitea = mocked(_gitea);
 const github = mocked(_github);
 const gitlab = mocked(_gitlab);
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   beforeEach(() => {
     jest.resetAllMocks();
     const preset = { resolved: 'preset' };

--- a/lib/config/presets/npm/index.spec.ts
+++ b/lib/config/presets/npm/index.spec.ts
@@ -1,12 +1,12 @@
 import nock from 'nock';
-import { getName } from '../../../../test/util';
+import { testName } from '../../../../test/util';
 import { setAdminConfig } from '../../admin';
 import * as npm from '.';
 
 jest.mock('registry-auth-token');
 jest.mock('delay');
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   beforeEach(() => {
     jest.resetAllMocks();
     setAdminConfig();

--- a/lib/config/presets/util.spec.ts
+++ b/lib/config/presets/util.spec.ts
@@ -1,4 +1,4 @@
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import type { Preset } from './types';
 import {
   FetchPresetConfig,
@@ -16,7 +16,7 @@ const config: FetchPresetConfig = {
 
 const fetch = jest.fn(() => Promise.resolve<Preset>({}));
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   beforeEach(() => {
     fetch.mockReset();
   });

--- a/lib/config/secrets.spec.ts
+++ b/lib/config/secrets.spec.ts
@@ -1,11 +1,11 @@
-import { defaultConfig, getName } from '../../test/util';
+import { defaultConfig, testName } from '../../test/util';
 import {
   CONFIG_SECRETS_INVALID,
   CONFIG_VALIDATION,
 } from '../constants/error-messages';
 import { applySecretsToConfig, validateConfigSecrets } from './secrets';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('validateConfigSecrets(config)', () => {
     it('works with default config', () => {
       expect(() => validateConfigSecrets(defaultConfig)).not.toThrow();

--- a/lib/config/validation-helpers/managers.spec.ts
+++ b/lib/config/validation-helpers/managers.spec.ts
@@ -1,7 +1,7 @@
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { check } from './managers';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   it('should have no errors', () => {
     const res = check({
       resolvedRule: { matchManagers: ['npm'] },

--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -1,8 +1,8 @@
-import { getName } from '../../test/util';
+import { testName } from '../../test/util';
 import type { RenovateConfig } from './types';
 import * as configValidation from './validation';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('getParentName()', () => {
     it('ignores encrypted in root', () => {
       expect(configValidation.getParentName('encrypted')).toEqual('');

--- a/lib/datasource/bitbucket-tags/index.spec.ts
+++ b/lib/datasource/bitbucket-tags/index.spec.ts
@@ -1,9 +1,9 @@
 import { getDigest, getPkgReleases } from '..';
 import * as httpMock from '../../../test/http-mock';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { id as datasource } from '.';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   beforeEach(() => {
     httpMock.reset();
     httpMock.setup();

--- a/lib/datasource/cdnjs/index.spec.ts
+++ b/lib/datasource/cdnjs/index.spec.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { getPkgReleases } from '..';
 import * as httpMock from '../../../test/http-mock';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { EXTERNAL_HOST_ERROR } from '../../constants/error-messages';
 import { id as datasource } from '.';
 
@@ -22,7 +22,7 @@ const baseUrl = 'https://api.cdnjs.com/';
 const pathFor = (s: string): string =>
   `/libraries/${s.split('/').shift()}?fields=homepage,repository,assets`;
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('getReleases', () => {
     beforeEach(() => {
       jest.clearAllMocks();

--- a/lib/datasource/crate/index.spec.ts
+++ b/lib/datasource/crate/index.spec.ts
@@ -5,7 +5,7 @@ import { DirectoryResult, dir } from 'tmp-promise';
 import { dirname, join } from 'upath';
 import { getPkgReleases } from '..';
 import * as httpMock from '../../../test/http-mock';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { setAdminConfig } from '../../config/admin';
 import * as memCache from '../../util/cache/memory';
 import { setFsConfig } from '../../util/fs';
@@ -68,7 +68,7 @@ function setupErrorGitMock(): { mockClone: jest.Mock<any, any> } {
   return { mockClone };
 }
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('getIndexSuffix', () => {
     it('returns correct suffixes', () => {
       expect(getIndexSuffix('a')).toStrictEqual(['1', 'a']);

--- a/lib/datasource/dart/index.spec.ts
+++ b/lib/datasource/dart/index.spec.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { getPkgReleases } from '..';
 import * as httpMock from '../../../test/http-mock';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { id as datasource } from '.';
 
 const body: any = JSON.parse(
@@ -13,7 +13,7 @@ const body: any = JSON.parse(
 
 const baseUrl = 'https://pub.dartlang.org/api/packages/';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   beforeEach(() => {
     httpMock.setup();
   });

--- a/lib/datasource/docker/index.spec.ts
+++ b/lib/datasource/docker/index.spec.ts
@@ -1,7 +1,7 @@
 import * as _AWS from '@aws-sdk/client-ecr';
 import { getDigest, getPkgReleases } from '..';
 import * as httpMock from '../../../test/http-mock';
-import { getName, mocked, partial } from '../../../test/util';
+import { mocked, partial, testName } from '../../../test/util';
 import { EXTERNAL_HOST_ERROR } from '../../constants/error-messages';
 import * as _hostRules from '../../util/host-rules';
 import { MediaType } from './types';
@@ -41,7 +41,7 @@ function mockEcrAuthReject(msg: string) {
   );
 }
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   beforeEach(() => {
     httpMock.setup();
     hostRules.find.mockReturnValue({

--- a/lib/datasource/galaxy-collection/index.spec.ts
+++ b/lib/datasource/galaxy-collection/index.spec.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { getPkgReleases } from '..';
 import * as httpMock from '../../../test/http-mock';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 
 import { id as datasource } from '.';
 
@@ -28,7 +28,7 @@ const communityKubernetesDetails0111 = fs.readFileSync(
 
 const baseUrl = 'https://galaxy.ansible.com';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('getReleases', () => {
     beforeEach(() => {
       httpMock.setup();

--- a/lib/datasource/galaxy/index.spec.ts
+++ b/lib/datasource/galaxy/index.spec.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { getPkgReleases } from '..';
 import * as httpMock from '../../../test/http-mock';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 
 import { id as datasource } from '.';
 
@@ -16,7 +16,7 @@ const empty = fs.readFileSync(
 
 const baseUrl = 'https://galaxy.ansible.com/';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('getReleases', () => {
     beforeEach(() => {
       httpMock.setup();

--- a/lib/datasource/git-refs/index.spec.ts
+++ b/lib/datasource/git-refs/index.spec.ts
@@ -1,7 +1,7 @@
 import fs from 'fs-extra';
 import _simpleGit from 'simple-git';
 import { getPkgReleases } from '..';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { id as datasource, getDigest } from '.';
 
 jest.mock('simple-git');
@@ -14,7 +14,7 @@ const lsRemote1 = fs.readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('getReleases', () => {
     it('returns nil if response is wrong', async () => {
       simpleGit.mockReturnValue({

--- a/lib/datasource/git-tags/index.spec.ts
+++ b/lib/datasource/git-tags/index.spec.ts
@@ -1,7 +1,7 @@
 import fs from 'fs-extra';
 import _simpleGit from 'simple-git';
 import { getPkgReleases } from '..';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { id as datasource, getDigest } from '.';
 
 jest.mock('simple-git');
@@ -14,7 +14,7 @@ const lsRemote1 = fs.readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('getReleases', () => {
     it('returns nil if response is wrong', async () => {
       simpleGit.mockReturnValue({

--- a/lib/datasource/github-releases/index.spec.ts
+++ b/lib/datasource/github-releases/index.spec.ts
@@ -1,6 +1,6 @@
 import { getPkgReleases } from '..';
 import * as httpMock from '../../../test/http-mock';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import * as _hostRules from '../../util/host-rules';
 import { id as datasource } from '.';
 import * as github from '.';
@@ -23,7 +23,7 @@ const responseBody = [
   },
 ];
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   beforeEach(() => {
     hostRules.hosts.mockReturnValue([]);
     hostRules.find.mockReturnValue({

--- a/lib/datasource/github-tags/index.spec.ts
+++ b/lib/datasource/github-tags/index.spec.ts
@@ -1,6 +1,6 @@
 import { getPkgReleases } from '..';
 import * as httpMock from '../../../test/http-mock';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import * as _hostRules from '../../util/host-rules';
 import * as github from '.';
 
@@ -10,7 +10,7 @@ const hostRules: any = _hostRules;
 const githubApiHost = 'https://api.github.com';
 const githubEnterpriseApiHost = 'https://git.enterprise.com';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   beforeEach(() => {
     httpMock.reset();
     httpMock.setup();

--- a/lib/datasource/gitlab-tags/index.spec.ts
+++ b/lib/datasource/gitlab-tags/index.spec.ts
@@ -1,9 +1,9 @@
 import { getPkgReleases } from '..';
 import * as httpMock from '../../../test/http-mock';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { id as datasource } from '.';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   beforeEach(() => {
     httpMock.reset();
     httpMock.setup();

--- a/lib/datasource/go/index.spec.ts
+++ b/lib/datasource/go/index.spec.ts
@@ -1,6 +1,6 @@
 import { getPkgReleases } from '..';
 import * as httpMock from '../../../test/http-mock';
-import { getName, logger, mocked } from '../../../test/util';
+import { logger, mocked, testName } from '../../../test/util';
 import * as _hostRules from '../../util/host-rules';
 import { id as datasource, getDigest } from '.';
 
@@ -46,7 +46,7 @@ const resGitHubEnterprise = `<!DOCTYPE html>
 </body>
 </html>`;
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   beforeEach(() => {
     httpMock.setup();
     hostRules.find.mockReturnValue({});

--- a/lib/datasource/gradle-version/index.spec.ts
+++ b/lib/datasource/gradle-version/index.spec.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { GetPkgReleasesConfig, GetReleasesConfig, getPkgReleases } from '..';
 import * as httpMock from '../../../test/http-mock';
-import { getName, partial } from '../../../test/util';
+import { partial, testName } from '../../../test/util';
 import { ExternalHostError } from '../../types/errors/external-host-error';
 import { id as versioning } from '../../versioning/gradle';
 import { id as datasource, getReleases } from '.';
@@ -12,7 +12,7 @@ const allResponse: any = fs.readFileSync(
 
 let config: GetPkgReleasesConfig;
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('getReleases', () => {
     beforeEach(() => {
       config = {

--- a/lib/datasource/helm/index.spec.ts
+++ b/lib/datasource/helm/index.spec.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { getPkgReleases } from '..';
 import * as httpMock from '../../../test/http-mock';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { id as datasource } from '.';
 
 // Truncated index.yaml file
@@ -10,7 +10,7 @@ const indexYaml = fs.readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('getReleases', () => {
     beforeEach(() => {
       jest.resetAllMocks();

--- a/lib/datasource/hex/index.spec.ts
+++ b/lib/datasource/hex/index.spec.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { getPkgReleases } from '..';
 import * as httpMock from '../../../test/http-mock';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { EXTERNAL_HOST_ERROR } from '../../constants/error-messages';
 import * as _hostRules from '../../util/host-rules';
 import { id as datasource } from '.';
@@ -18,7 +18,7 @@ jest.mock('../../util/host-rules');
 
 const baseUrl = 'https://hex.pm/api/packages/';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   beforeEach(() => {
     hostRules.hosts.mockReturnValue([]);
     hostRules.find.mockReturnValue({});

--- a/lib/datasource/index.spec.ts
+++ b/lib/datasource/index.spec.ts
@@ -1,4 +1,4 @@
-import { getName, logger, mocked } from '../../test/util';
+import { logger, mocked, testName } from '../../test/util';
 import {
   EXTERNAL_HOST_ERROR,
   HOST_DISABLED,
@@ -26,7 +26,7 @@ const mavenDatasource = mocked(datasourceMaven);
 const npmDatasource = mocked(datasourceNpm);
 const packagistDatasource = mocked(datasourcePackagist);
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   beforeEach(() => {
     jest.resetAllMocks();
   });

--- a/lib/datasource/jenkins-plugins/index.spec.ts
+++ b/lib/datasource/jenkins-plugins/index.spec.ts
@@ -1,13 +1,13 @@
 import { getPkgReleases } from '..';
 import * as httpMock from '../../../test/http-mock';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import * as versioning from '../../versioning/docker';
 import jenkinsPluginsVersions from './__fixtures__/plugin-versions.json';
 import jenkinsPluginsInfo from './__fixtures__/update-center.actual.json';
 import { resetCache } from './get';
 import * as jenkins from '.';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('getReleases', () => {
     const SKIP_CACHE = process.env.RENOVATE_SKIP_CACHE;
 

--- a/lib/datasource/maven/index.spec.ts
+++ b/lib/datasource/maven/index.spec.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import nock from 'nock';
 import { resolve } from 'upath';
 import { Release, getPkgReleases } from '..';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { EXTERNAL_HOST_ERROR } from '../../constants/error-messages';
 import * as hostRules from '../../util/host-rules';
 import * as mavenVersioning from '../../versioning/maven';
@@ -46,7 +46,7 @@ function generateReleases(versions: string[], ts = false): Release[] {
   });
 }
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   beforeEach(() => {
     hostRules.add({
       hostType: datasource,

--- a/lib/datasource/metadata.spec.ts
+++ b/lib/datasource/metadata.spec.ts
@@ -1,10 +1,10 @@
-import { getName } from '../../test/util';
+import { testName } from '../../test/util';
 import * as datasourceMaven from './maven';
 import { addMetaData } from './metadata';
 import * as datasourceNpm from './npm';
 import * as datasourcePypi from './pypi';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   it('Should do nothing if dep is not specified', () => {
     expect(addMetaData()).toBeUndefined();
   });

--- a/lib/datasource/npm/get.spec.ts
+++ b/lib/datasource/npm/get.spec.ts
@@ -1,5 +1,5 @@
 import * as httpMock from '../../../test/http-mock';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { ExternalHostError } from '../../types/errors/external-host-error';
 import * as hostRules from '../../util/host-rules';
 import { getDependency, resetMemCache } from './get';
@@ -11,7 +11,7 @@ function getPath(s = ''): string {
   return `${prePath}/@myco%2Ftest`;
 }
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   beforeEach(() => {
     jest.clearAllMocks();
     resetMemCache();

--- a/lib/datasource/npm/index.spec.ts
+++ b/lib/datasource/npm/index.spec.ts
@@ -2,7 +2,7 @@ import mockDate from 'mockdate';
 import _registryAuthToken from 'registry-auth-token';
 import { getPkgReleases } from '..';
 import * as httpMock from '../../../test/http-mock';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { setAdminConfig } from '../../config/admin';
 import { EXTERNAL_HOST_ERROR } from '../../constants/error-messages';
 import * as hostRules from '../../util/host-rules';
@@ -14,7 +14,7 @@ jest.mock('delay');
 const registryAuthToken: jest.Mock<_registryAuthToken.NpmCredentials> = _registryAuthToken as never;
 let npmResponse: any;
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   beforeEach(() => {
     jest.resetAllMocks();
     httpMock.setup();

--- a/lib/datasource/npm/npmrc.spec.ts
+++ b/lib/datasource/npm/npmrc.spec.ts
@@ -1,4 +1,4 @@
-import { getName, mocked } from '../../../test/util';
+import { mocked, testName } from '../../../test/util';
 import { setAdminConfig } from '../../config/admin';
 import * as _sanitize from '../../util/sanitize';
 import { getNpmrc, setNpmrc } from './npmrc';
@@ -7,7 +7,7 @@ jest.mock('../../util/sanitize');
 
 const sanitize = mocked(_sanitize);
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   beforeEach(() => {
     setNpmrc('');
     setAdminConfig();

--- a/lib/datasource/nuget/index.spec.ts
+++ b/lib/datasource/nuget/index.spec.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { getPkgReleases } from '..';
 import * as httpMock from '../../../test/http-mock';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import * as _hostRules from '../../util/host-rules';
 import { id as versioning } from '../../versioning/nuget';
 import { id as datasource, parseRegistryUrl } from '.';
@@ -129,7 +129,7 @@ const configV3Multiple = {
   ],
 };
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('parseRegistryUrl', () => {
     beforeEach(() => {
       jest.resetAllMocks();

--- a/lib/datasource/orb/index.spec.ts
+++ b/lib/datasource/orb/index.spec.ts
@@ -1,6 +1,6 @@
 import { getPkgReleases } from '..';
 import * as httpMock from '../../../test/http-mock';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { id as datasource } from '.';
 
 const orbData = {
@@ -26,7 +26,7 @@ const orbData = {
 
 const baseUrl = 'https://circleci.com';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('getReleases', () => {
     beforeEach(() => {
       jest.clearAllMocks();

--- a/lib/datasource/packagist/index.spec.ts
+++ b/lib/datasource/packagist/index.spec.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { getPkgReleases } from '..';
 import * as httpMock from '../../../test/http-mock';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import * as _hostRules from '../../util/host-rules';
 import * as composerVersioning from '../../versioning/composer';
 import { id as versioning } from '../../versioning/loose';
@@ -23,7 +23,7 @@ const mailchimpJson: any = fs.readFileSync(
 
 const baseUrl = 'https://packagist.org';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('getReleases', () => {
     let config: any;
     beforeEach(() => {

--- a/lib/datasource/pod/index.spec.ts
+++ b/lib/datasource/pod/index.spec.ts
@@ -1,6 +1,6 @@
 import { getPkgReleases } from '..';
 import * as httpMock from '../../../test/http-mock';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { EXTERNAL_HOST_ERROR } from '../../constants/error-messages';
 import * as rubyVersioning from '../../versioning/ruby';
 import * as pod from '.';
@@ -15,7 +15,7 @@ const config = {
 const githubApiHost = 'https://api.github.com';
 const cocoapodsHost = 'https://cdn.cocoapods.org';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('getReleases', () => {
     beforeEach(() => {
       jest.resetAllMocks();

--- a/lib/datasource/pypi/index.spec.ts
+++ b/lib/datasource/pypi/index.spec.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { getPkgReleases } from '..';
 import * as httpMock from '../../../test/http-mock';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import * as hostRules from '../../util/host-rules';
 import { id as datasource } from '.';
 
@@ -26,7 +26,7 @@ const mixedHyphensResponse = fs.readFileSync(
 
 const baseUrl = 'https://pypi.org/pypi';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('getReleases', () => {
     const OLD_ENV = process.env;
 

--- a/lib/datasource/repology/index.spec.ts
+++ b/lib/datasource/repology/index.spec.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { getPkgReleases } from '..';
 import * as httpMock from '../../../test/http-mock';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { EXTERNAL_HOST_ERROR } from '../../constants/error-messages';
 import { id as versioning } from '../../versioning/loose';
 import { RepologyPackage, id as datasource } from '.';
@@ -67,7 +67,7 @@ const fixtureJdk = fs.readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('getReleases', () => {
     beforeEach(() => {
       httpMock.setup();

--- a/lib/datasource/ruby-version/index.spec.ts
+++ b/lib/datasource/ruby-version/index.spec.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { getPkgReleases } from '..';
 import * as httpMock from '../../../test/http-mock';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { id as datasource } from '.';
 
 const rubyReleasesHtml = fs.readFileSync(
@@ -9,7 +9,7 @@ const rubyReleasesHtml = fs.readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('getReleases', () => {
     beforeEach(() => {
       httpMock.setup();

--- a/lib/datasource/rubygems/index.spec.ts
+++ b/lib/datasource/rubygems/index.spec.ts
@@ -1,6 +1,6 @@
 import { getPkgReleases } from '..';
 import * as httpMock from '../../../test/http-mock';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import * as rubyVersioning from '../../versioning/ruby';
 import railsInfo from './__fixtures__/rails/info.json';
 import railsVersions from './__fixtures__/rails/versions.json';
@@ -26,7 +26,7 @@ const rubygemsOrgVersions = `created_at: 2017-03-27T04:38:13+00:00
 1pass -0.1.2 abcdef
 21-day-challenge-countdown 0.1.0,0.1.1,0.1.2 57e8873fe713063f4e54e85bbbd709bb`;
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('getReleases', () => {
     const SKIP_CACHE = process.env.RENOVATE_SKIP_CACHE;
 

--- a/lib/datasource/sbt-package/index.spec.ts
+++ b/lib/datasource/sbt-package/index.spec.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import nock from 'nock';
 import upath from 'upath';
 import { getPkgReleases } from '..';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import * as mavenVersioning from '../../versioning/maven';
 import { MAVEN_REPO } from '../maven/common';
 import { parseIndexDir } from '../sbt-plugin/util';
@@ -18,7 +18,7 @@ const sbtPluginIndex = fs.readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   it('parses Maven index directory', () => {
     expect(parseIndexDir(mavenIndexHtml)).toMatchSnapshot();
   });

--- a/lib/datasource/sbt-plugin/index.spec.ts
+++ b/lib/datasource/sbt-plugin/index.spec.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import nock from 'nock';
 import upath from 'upath';
 import { getPkgReleases } from '..';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import * as mavenVersioning from '../../versioning/maven';
 import { MAVEN_REPO } from '../maven/common';
 import { parseIndexDir } from './util';
@@ -18,7 +18,7 @@ const sbtPluginIndex = fs.readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   it('parses Maven index directory', () => {
     expect(parseIndexDir(mavenIndexHtml)).toMatchSnapshot();
   });

--- a/lib/datasource/terraform-module/index.spec.ts
+++ b/lib/datasource/terraform-module/index.spec.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { getPkgReleases } from '..';
 import * as httpMock from '../../../test/http-mock';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { id as datasource } from '.';
 
 const consulData: any = fs.readFileSync(
@@ -17,7 +17,7 @@ const serviceDiscoveryCustomResult: any = fs.readFileSync(
 const baseUrl = 'https://registry.terraform.io';
 const localTerraformEnterprisebaseUrl = 'https://terraform.foo.bar';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('getReleases', () => {
     beforeEach(() => {
       jest.clearAllMocks();

--- a/lib/datasource/terraform-provider/index.spec.ts
+++ b/lib/datasource/terraform-provider/index.spec.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { getPkgReleases } from '..';
 import * as httpMock from '../../../test/http-mock';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { id as datasource, defaultRegistryUrls } from '.';
 
 const consulData: any = fs.readFileSync(
@@ -17,7 +17,7 @@ const serviceDiscoveryResult: any = fs.readFileSync(
 const primaryUrl = defaultRegistryUrls[0];
 const secondaryUrl = defaultRegistryUrls[1];
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('getReleases', () => {
     beforeEach(() => {
       jest.clearAllMocks();

--- a/lib/logger/config-serializer.spec.ts
+++ b/lib/logger/config-serializer.spec.ts
@@ -1,7 +1,7 @@
-import { getName } from '../../test/util';
+import { testName } from '../../test/util';
 import configSerializer from './config-serializer';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   it('squashes templates', () => {
     const config = {
       nottoken: 'b',

--- a/lib/logger/err-serializer.spec.ts
+++ b/lib/logger/err-serializer.spec.ts
@@ -1,11 +1,11 @@
 import * as httpMock from '../../test/http-mock';
-import { getName, partial } from '../../test/util';
+import { partial, testName } from '../../test/util';
 import * as hostRules from '../util/host-rules';
 import { Http } from '../util/http';
 import errSerializer from './err-serializer';
 import { sanitizeValue } from './utils';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   it('expands errors', () => {
     const err = partial<Error & Record<string, unknown>>({
       a: 1,

--- a/lib/logger/pretty-stdout.spec.ts
+++ b/lib/logger/pretty-stdout.spec.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import { getName } from '../../test/util';
+import { testName } from '../../test/util';
 import * as prettyStdout from './pretty-stdout';
 import type { BunyanRecord } from './utils';
 
@@ -10,7 +10,7 @@ jest.mock('chalk', () =>
   )
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('getMeta(rec)', () => {
     it('returns empty string if null rec', () => {
       expect(prettyStdout.getMeta(null as any)).toEqual('');

--- a/lib/manager/ansible-galaxy/extract.spec.ts
+++ b/lib/manager/ansible-galaxy/extract.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import extractPackageFile, { getSliceEndNumber } from './extract';
 
 const yamlFile1 = readFileSync(
@@ -27,7 +27,7 @@ const galaxy = readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty', () => {
       expect(extractPackageFile('nothing here', 'requirements.yml')).toBeNull();

--- a/lib/manager/ansible/extract.spec.ts
+++ b/lib/manager/ansible/extract.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import extractPackageFile from './extract';
 
 const yamlFile1 = readFileSync(
@@ -11,7 +11,7 @@ const yamlFile2 = readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty', () => {
       expect(extractPackageFile('nothing here')).toBeNull();

--- a/lib/manager/azure-pipelines/extract.spec.ts
+++ b/lib/manager/azure-pipelines/extract.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import {
   extractContainer,
   extractPackageFile,
@@ -22,7 +22,7 @@ const azurePipelinesNoDependency = readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   it('should parse a valid azure-pipelines file', () => {
     const file = parseAzurePipelines(azurePipelines, 'some-file');
     expect(file).not.toBeNull();

--- a/lib/manager/batect-wrapper/artifacts.spec.ts
+++ b/lib/manager/batect-wrapper/artifacts.spec.ts
@@ -1,5 +1,5 @@
 import * as httpMock from '../../../test/http-mock';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import type { UpdateArtifact } from '../types';
 import { updateArtifacts } from './artifacts';
 
@@ -21,7 +21,7 @@ function artifactForPath(
   };
 }
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   beforeEach(() => {
     httpMock.setup();
 

--- a/lib/manager/batect-wrapper/extract.spec.ts
+++ b/lib/manager/batect-wrapper/extract.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { id as githubReleaseDatasource } from '../../datasource/github-releases';
 import { id as semverVersioning } from '../../versioning/semver';
 import type { PackageDependency } from '../types';
@@ -15,7 +15,7 @@ const malformedWrapperContent = readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty wrapper file', () => {
       expect(extractPackageFile('')).toBeNull();

--- a/lib/manager/batect/extract.spec.ts
+++ b/lib/manager/batect/extract.spec.ts
@@ -1,4 +1,4 @@
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { id as gitTagDatasource } from '../../datasource/git-tags';
 import { id as dockerVersioning } from '../../versioning/docker';
 import { id as semverVersioning } from '../../versioning/semver';
@@ -25,7 +25,7 @@ function createGitDependency(repo: string, version: string): PackageDependency {
   };
 }
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     it('returns empty array for empty configuration file', async () => {
       expect(

--- a/lib/manager/bazel/extract.spec.ts
+++ b/lib/manager/bazel/extract.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 const workspaceFile = readFileSync(
@@ -22,7 +22,7 @@ const fileWithBzlExtension = readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     it('returns empty if fails to parse', () => {
       const res = extractPackageFile('blahhhhh:foo:@what\n');

--- a/lib/manager/bazel/update.spec.ts
+++ b/lib/manager/bazel/update.spec.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'fs';
 import { Readable } from 'stream';
 import { resolve } from 'upath';
 import * as httpMock from '../../../test/http-mock';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import type { UpdateType } from '../../config/types';
 import { updateDependency } from './update';
 
@@ -29,7 +29,7 @@ git_repository(
 )
 */
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('updateDependency', () => {
     beforeEach(() => {
       jest.resetAllMocks();

--- a/lib/manager/buildkite/extract.spec.ts
+++ b/lib/manager/buildkite/extract.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 const pipeline1 = readFileSync(
@@ -19,7 +19,7 @@ const pipeline4 = readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty', () => {
       expect(extractPackageFile('nothing here')).toBeNull();

--- a/lib/manager/bundler/extract.spec.ts
+++ b/lib/manager/bundler/extract.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { fs, getName } from '../../../test/util';
+import { fs, testName } from '../../../test/util';
 import { isValid } from '../../versioning/ruby';
 import { extractPackageFile } from './extract';
 
@@ -70,7 +70,7 @@ function validateGems(raw, parsed) {
   expect(gemfileGemCount).toEqual(parsedGemCount);
 }
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty', async () => {
       expect(await extractPackageFile('nothing here', 'Gemfile')).toBeNull();

--- a/lib/manager/bundler/host-rules.spec.ts
+++ b/lib/manager/bundler/host-rules.spec.ts
@@ -1,4 +1,4 @@
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { HostRule } from '../../types';
 import { add, clear } from '../../util/host-rules';
 
@@ -8,7 +8,7 @@ import {
   getDomain,
 } from './host-rules';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   beforeEach(() => {
     clear();
   });

--- a/lib/manager/bundler/range.spec.ts
+++ b/lib/manager/bundler/range.spec.ts
@@ -1,8 +1,8 @@
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import type { RangeConfig } from '../types';
 import { getRangeStrategy } from '.';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('getRangeStrategy()', () => {
     it('returns replace when rangeStrategy is auto', () => {
       const config: RangeConfig = { rangeStrategy: 'auto' };

--- a/lib/manager/cake/index.spec.ts
+++ b/lib/manager/cake/index.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { extractPackageFile } from '.';
 
 const content = readFileSync(
@@ -7,7 +7,7 @@ const content = readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   it('extracts', () => {
     expect(extractPackageFile(content)).toMatchSnapshot();
   });

--- a/lib/manager/cargo/extract.spec.ts
+++ b/lib/manager/cargo/extract.spec.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'fs';
 import { dir } from 'tmp-promise';
 import { join } from 'upath';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { setFsConfig, writeLocalFile } from '../../util/fs';
 import { extractPackageFile } from './extract';
 
@@ -35,7 +35,7 @@ const cargo6toml = readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     let config;
     beforeEach(() => {

--- a/lib/manager/cdnurl/extract.spec.ts
+++ b/lib/manager/cdnurl/extract.spec.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'upath';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { extractPackageFile } from '.';
 
 const input = readFileSync(
@@ -8,7 +8,7 @@ const input = readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   it('extractPackageFile', () => {
     expect(extractPackageFile(input)).toMatchSnapshot();
   });

--- a/lib/manager/circleci/extract.spec.ts
+++ b/lib/manager/circleci/extract.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 const file1 = readFileSync(
@@ -15,7 +15,7 @@ const file3 = readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty', () => {
       expect(extractPackageFile('nothing here')).toBeNull();

--- a/lib/manager/cloudbuild/extract.spec.ts
+++ b/lib/manager/cloudbuild/extract.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 const file1 = readFileSync(
@@ -7,7 +7,7 @@ const file1 = readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty', () => {
       expect(extractPackageFile('nothing here')).toBeNull();

--- a/lib/manager/cocoapods/extract.spec.ts
+++ b/lib/manager/cocoapods/extract.spec.ts
@@ -1,7 +1,7 @@
 import fs from 'fs-extra';
 import upath from 'upath';
 
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { extractPackageFile } from '.';
 
 const simplePodfile = fs.readFileSync(
@@ -14,7 +14,7 @@ const complexPodfile = fs.readFileSync(
   'utf-8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     it('extracts all dependencies', async () => {
       const simpleResult = (await extractPackageFile(simplePodfile, 'Podfile'))

--- a/lib/manager/composer/extract.spec.ts
+++ b/lib/manager/composer/extract.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { fs, getName } from '../../../test/util';
+import { fs, testName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 jest.mock('../../util/fs');
@@ -29,7 +29,7 @@ const requirements5Lock = readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     let packageFile;
     beforeEach(() => {

--- a/lib/manager/composer/utils.spec.ts
+++ b/lib/manager/composer/utils.spec.ts
@@ -1,7 +1,7 @@
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { extractContraints, getConstraint } from './utils';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('getConstraint', () => {
     it('returns from config', () => {
       expect(getConstraint({ constraints: { composer: '1.1.0' } })).toEqual(

--- a/lib/manager/deps-edn/extract.spec.ts
+++ b/lib/manager/deps-edn/extract.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-template-curly-in-string */
 import { readFileSync } from 'fs';
 import { resolve } from 'upath';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 const depsEdn = readFileSync(
@@ -9,7 +9,7 @@ const depsEdn = readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   it('extractPackageFile', () => {
     expect(extractPackageFile(depsEdn)).toMatchSnapshot();
   });

--- a/lib/manager/docker-compose/extract.spec.ts
+++ b/lib/manager/docker-compose/extract.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 const yamlFile1 = readFileSync(
@@ -17,7 +17,7 @@ const yamlFile3NoVersion = readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty', () => {
       expect(extractPackageFile('')).toBeNull();

--- a/lib/manager/dockerfile/extract.spec.ts
+++ b/lib/manager/dockerfile/extract.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { extractPackageFile, getDep } from './extract';
 
 const d1 = readFileSync(
@@ -12,7 +12,7 @@ const d2 = readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     it('handles no FROM', () => {
       const res = extractPackageFile('no from!');

--- a/lib/manager/droneci/extract.spec.ts
+++ b/lib/manager/droneci/extract.spec.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'upath';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 
 import { extractPackageFile } from './extract';
 
@@ -9,7 +9,7 @@ const droneYAML = readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty', () => {
       expect(extractPackageFile('nothing here')).toBeNull();

--- a/lib/manager/git-submodules/artifact.spec.ts
+++ b/lib/manager/git-submodules/artifact.spec.ts
@@ -1,7 +1,7 @@
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import updateArtifacts from './artifacts';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('updateArtifacts()', () => {
     it('returns empty content', () => {
       expect(

--- a/lib/manager/git-submodules/extract.spec.ts
+++ b/lib/manager/git-submodules/extract.spec.ts
@@ -1,6 +1,6 @@
 import { mock } from 'jest-mock-extended';
 import _simpleGit, { Response, SimpleGit } from 'simple-git';
-import { getName, partial } from '../../../test/util';
+import { partial, testName } from '../../../test/util';
 import * as hostRules from '../../util/host-rules';
 import type { PackageFile } from '../types';
 import extractPackageFile from './extract';
@@ -11,7 +11,7 @@ const Git: typeof _simpleGit = jest.requireActual('simple-git');
 
 const localDir = `${__dirname}/__fixtures__`;
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   // flaky ci tests
   jest.setTimeout(10 * 1000);
 

--- a/lib/manager/git-submodules/update.spec.ts
+++ b/lib/manager/git-submodules/update.spec.ts
@@ -1,13 +1,13 @@
 import _simpleGit from 'simple-git';
 import { dir } from 'tmp-promise';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import type { Upgrade } from '../types';
 import updateDependency from './update';
 
 jest.mock('simple-git');
 const simpleGit: any = _simpleGit;
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('updateDependency', () => {
     let upgrade: Upgrade;
     beforeAll(async () => {

--- a/lib/manager/github-actions/extract.spec.ts
+++ b/lib/manager/github-actions/extract.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 const workflow1 = readFileSync(
@@ -12,7 +12,7 @@ const workflow2 = readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty', () => {
       expect(extractPackageFile('nothing here')).toBeNull();

--- a/lib/manager/gitlabci-include/extract.spec.ts
+++ b/lib/manager/gitlabci-include/extract.spec.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 const yamlFile = fs.readFileSync(
@@ -7,7 +7,7 @@ const yamlFile = fs.readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty', () => {
       expect(

--- a/lib/manager/gitlabci/extract.spec.ts
+++ b/lib/manager/gitlabci/extract.spec.ts
@@ -1,8 +1,8 @@
-import { getName, logger } from '../../../test/util';
+import { logger, testName } from '../../../test/util';
 import type { PackageDependency } from '../types';
 import { extractAllPackageFiles } from './extract';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractAllPackageFiles()', () => {
     it('returns null for empty', async () => {
       expect(

--- a/lib/manager/gomod/extract.spec.ts
+++ b/lib/manager/gomod/extract.spec.ts
@@ -1,12 +1,12 @@
 import { readFileSync } from 'fs';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 const gomod1 = readFileSync('lib/manager/gomod/__fixtures__/1/go.mod', 'utf8');
 const gomod2 = readFileSync('lib/manager/gomod/__fixtures__/2/go.mod', 'utf8');
 const gomod3 = readFileSync('lib/manager/gomod/__fixtures__/3/go.mod', 'utf8');
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty', () => {
       expect(extractPackageFile('nothing here')).toBeNull();

--- a/lib/manager/gomod/update.spec.ts
+++ b/lib/manager/gomod/update.spec.ts
@@ -1,12 +1,12 @@
 import { readFileSync } from 'fs';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import type { UpdateType } from '../../config/types';
 import { updateDependency } from './update';
 
 const gomod1 = readFileSync('lib/manager/gomod/__fixtures__/1/go.mod', 'utf8');
 const gomod2 = readFileSync('lib/manager/gomod/__fixtures__/2/go.mod', 'utf8');
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('updateDependency', () => {
     it('replaces existing value', () => {
       const upgrade = {

--- a/lib/manager/gradle-lite/extract.spec.ts
+++ b/lib/manager/gradle-lite/extract.spec.ts
@@ -1,4 +1,4 @@
-import { fs, getName } from '../../../test/util';
+import { fs, testName } from '../../../test/util';
 import { extractAllPackageFiles } from '.';
 
 jest.mock('../../util/fs');
@@ -14,7 +14,7 @@ function mockFs(files: Record<string, string>): void {
   );
 }
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   beforeAll(() => {});
   afterAll(() => {
     jest.resetAllMocks();

--- a/lib/manager/gradle-lite/parser.spec.ts
+++ b/lib/manager/gradle-lite/parser.spec.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'fs';
 import path from 'path';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { GOOGLE_REPO, JCENTER_REPO, MAVEN_REPO } from './common';
 import { parseGradle, parseProps } from './parser';
 
@@ -8,7 +8,7 @@ function getGradleFile(fileName: string): string {
   return readFileSync(path.resolve(__dirname, fileName), 'utf8');
 }
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   it('handles end of input', () => {
     expect(parseGradle('version = ').deps).toBeEmpty();
     expect(parseGradle('id "foo.bar" version').deps).toBeEmpty();

--- a/lib/manager/gradle-lite/tokenizer.spec.ts
+++ b/lib/manager/gradle-lite/tokenizer.spec.ts
@@ -1,4 +1,4 @@
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { TokenType } from './common';
 import { extractRawTokens, tokenize } from './tokenizer';
 
@@ -6,7 +6,7 @@ function tokenTypes(input): string[] {
   return extractRawTokens(input).map((token) => token.type);
 }
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   it('extractTokens', () => {
     const samples = {
       ' ': [TokenType.Space],

--- a/lib/manager/gradle-lite/update.spec.ts
+++ b/lib/manager/gradle-lite/update.spec.ts
@@ -1,7 +1,7 @@
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { updateDependency } from './update';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   it('replaces', () => {
     expect(
       updateDependency({

--- a/lib/manager/gradle-lite/utils.spec.ts
+++ b/lib/manager/gradle-lite/utils.spec.ts
@@ -1,4 +1,4 @@
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { TokenType } from './common';
 import {
   getVars,
@@ -10,7 +10,7 @@ import {
   versionLikeSubstring,
 } from './utils';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   it('versionLikeSubstring', () => {
     [
       '1.2.3',

--- a/lib/manager/gradle-wrapper/artifacts-real.spec.ts
+++ b/lib/manager/gradle-wrapper/artifacts-real.spec.ts
@@ -2,7 +2,7 @@ import { readFile, readFileSync } from 'fs-extra';
 import Git from 'simple-git';
 import { resolve } from 'upath';
 import * as httpMock from '../../../test/http-mock';
-import { getName, git, partial } from '../../../test/util';
+import { git, partial, testName } from '../../../test/util';
 import { setUtilConfig } from '../../util';
 import { StatusResult } from '../../util/git';
 import { ifSystemSupportsGradle } from '../gradle/__testutil__/gradle';
@@ -30,7 +30,7 @@ function compareFile(file: string, path: string) {
   );
 }
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   ifSystemSupportsGradle(6).describe('real tests', () => {
     jest.setTimeout(60 * 1000);
 

--- a/lib/manager/gradle-wrapper/artifacts.spec.ts
+++ b/lib/manager/gradle-wrapper/artifacts.spec.ts
@@ -8,9 +8,9 @@ import {
   addReplacingSerializer,
   env,
   fs,
-  getName,
   git,
   partial,
+  testName,
 } from '../../../test/util';
 import { setUtilConfig } from '../../util';
 import { BinarySource } from '../../util/exec/common';
@@ -38,7 +38,7 @@ function readString(...paths: string[]): Promise<string> {
   return readFile(resolve(fixtures, ...paths), 'utf8');
 }
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   beforeEach(async () => {
     jest.resetAllMocks();
     httpMock.setup();

--- a/lib/manager/gradle-wrapper/extract.spec.ts
+++ b/lib/manager/gradle-wrapper/extract.spec.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'upath';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 const propertiesFile1 = readFileSync(
@@ -24,7 +24,7 @@ const whitespacePropertiesFile = readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty', () => {
       expect(extractPackageFile('nothing here')).toBeNull();

--- a/lib/manager/gradle/build-gradle.spec.ts
+++ b/lib/manager/gradle/build-gradle.spec.ts
@@ -1,11 +1,11 @@
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import {
   collectVersionVariables,
   init,
   updateGradleVersion,
 } from './build-gradle';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   beforeEach(() => {
     init();
   });

--- a/lib/manager/gradle/gradle-updates-report.spec.ts
+++ b/lib/manager/gradle/gradle-updates-report.spec.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs-extra';
 import tmp, { DirectoryResult } from 'tmp-promise';
 import * as upath from 'upath';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { exec } from '../../util/exec';
 import { ifSystemSupportsGradle } from './__testutil__/gradle';
 import {
@@ -13,7 +13,7 @@ import { GRADLE_DEPENDENCY_REPORT_OPTIONS } from '.';
 
 const fixtures = 'lib/manager/gradle/__fixtures__';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   for (const gradleVersion of [5, 6]) {
     ifSystemSupportsGradle(gradleVersion).describe(
       'createRenovateGradlePlugin',

--- a/lib/manager/gradle/index-real.spec.ts
+++ b/lib/manager/gradle/index-real.spec.ts
@@ -1,6 +1,6 @@
 import fsExtra from 'fs-extra';
 import tmp, { DirectoryResult } from 'tmp-promise';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import type { ExtractConfig } from '../types';
 import { ifSystemSupportsGradle } from './__testutil__/gradle';
 import * as manager from '.';
@@ -13,7 +13,7 @@ const baseConfig = {
   },
 };
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   ifSystemSupportsGradle(6).describe('executeGradle integration', () => {
     const SUCCESS_FILE_NAME = 'success.indicator';
     let workingDir: DirectoryResult;

--- a/lib/manager/gradle/index.spec.ts
+++ b/lib/manager/gradle/index.spec.ts
@@ -6,8 +6,8 @@ import * as upath from 'upath';
 import { envMock, mockExecAll } from '../../../test/exec-util';
 import {
   addReplacingSerializer,
-  getName,
   replacingSerializer,
+  testName,
 } from '../../../test/util';
 import * as _util from '../../util';
 import { BinarySource } from '../../util/exec/common';
@@ -68,7 +68,7 @@ async function setupMocks() {
   return [require('.'), exec, util];
 }
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile', () => {
     let manager: typeof _manager;
     let exec: jest.Mock<typeof _exec>;

--- a/lib/manager/helm-requirements/extract.spec.ts
+++ b/lib/manager/helm-requirements/extract.spec.ts
@@ -1,10 +1,10 @@
-import { fs, getName } from '../../../test/util';
+import { fs, testName } from '../../../test/util';
 import { SkipReason } from '../../types';
 import { extractPackageFile } from './extract';
 
 jest.mock('../../util/fs');
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     beforeEach(() => {
       jest.resetAllMocks();

--- a/lib/manager/helm-values/extract.spec.ts
+++ b/lib/manager/helm-values/extract.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 const helmDefaultChartInitValues = readFileSync(
@@ -12,7 +12,7 @@ const helmMultiAndNestedImageValues = readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     beforeEach(() => {
       jest.resetAllMocks();

--- a/lib/manager/helmfile/extract.spec.ts
+++ b/lib/manager/helmfile/extract.spec.ts
@@ -1,12 +1,12 @@
 import { readFileSync } from 'fs';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 const multidocYaml = readFileSync(
   'lib/manager/helmfile/__fixtures__/multidoc.yaml',
   'utf8'
 );
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     beforeEach(() => {
       jest.resetAllMocks();

--- a/lib/manager/helmv3/extract.spec.ts
+++ b/lib/manager/helmv3/extract.spec.ts
@@ -1,9 +1,9 @@
-import { fs, getName } from '../../../test/util';
+import { fs, testName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 jest.mock('../../util/fs');
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     beforeEach(() => {
       jest.resetAllMocks();

--- a/lib/manager/helmv3/update.spec.ts
+++ b/lib/manager/helmv3/update.spec.ts
@@ -1,8 +1,8 @@
 import yaml from 'js-yaml';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import * as helmv3Updater from './update';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('.bumpPackageVersion()', () => {
     const content = yaml.safeDump({
       apiVersion: 'v2',

--- a/lib/manager/homebrew/extract.spec.ts
+++ b/lib/manager/homebrew/extract.spec.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 const aalib = fs.readFileSync(
@@ -20,7 +20,7 @@ const ibazel = fs.readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     it('skips sourceforge dependency 1', () => {
       const res = extractPackageFile(aalib);

--- a/lib/manager/homebrew/update.spec.ts
+++ b/lib/manager/homebrew/update.spec.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { Readable } from 'stream';
 import * as httpMock from '../../../test/http-mock';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { updateDependency } from './update';
 
 const aide = fs.readFileSync(
@@ -15,7 +15,7 @@ const ibazel = fs.readFileSync(
 
 const baseUrl = 'https://github.com';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   beforeEach(() => {
     jest.resetAllMocks();
     jest.resetModules();

--- a/lib/manager/homebrew/util.spec.ts
+++ b/lib/manager/homebrew/util.spec.ts
@@ -1,7 +1,7 @@
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { skip } from './util';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('skip()', () => {
     it('handles out of bounds case', () => {
       const content = 'some content';

--- a/lib/manager/html/extract.spec.ts
+++ b/lib/manager/html/extract.spec.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'upath';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { extractPackageFile } from '.';
 
 const sample = readFileSync(
@@ -12,7 +12,7 @@ const nothing = readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   it('extractPackageFile', () => {
     expect(extractPackageFile(sample)).toMatchSnapshot();
   });

--- a/lib/manager/index.spec.ts
+++ b/lib/manager/index.spec.ts
@@ -1,9 +1,9 @@
-import { getName } from '../../test/util';
+import { testName } from '../../test/util';
 import { loadModules } from '../util/modules';
 import type { ManagerApi } from './types';
 import * as manager from '.';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('get()', () => {
     it('gets something', () => {
       expect(manager.get('dockerfile', 'extractPackageFile')).not.toBeNull();

--- a/lib/manager/jenkins/extract.spec.ts
+++ b/lib/manager/jenkins/extract.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 const invalidYamlFile = readFileSync(
@@ -25,7 +25,7 @@ const pluginsEmptyYamlFile = readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     it('returns empty list for an empty text file', () => {
       const res = extractPackageFile(pluginsEmptyTextFile, 'path/file.txt');

--- a/lib/manager/kubernetes/extract.spec.ts
+++ b/lib/manager/kubernetes/extract.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 const kubernetesImagesFile = readFileSync(
@@ -22,7 +22,7 @@ const otherYamlFile = readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty', () => {
       expect(extractPackageFile(kubernetesConfigMapFile)).toBeNull();

--- a/lib/manager/kustomize/extract.spec.ts
+++ b/lib/manager/kustomize/extract.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import * as datasourceDocker from '../../datasource/docker';
 import * as datasourceGitTags from '../../datasource/git-tags';
 import * as datasourceGitHubTags from '../../datasource/github-tags';
@@ -53,7 +53,7 @@ const kustomizeDepsInResources = readFileSync(
 
 const sha = readFileSync('lib/manager/kustomize/__fixtures__/sha.yaml', 'utf8');
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   it('should successfully parse a valid kustomize file', () => {
     const file = parseKustomize(kustomizeGitSSHBase);
     expect(file).not.toBeNull();

--- a/lib/manager/leiningen/extract.spec.ts
+++ b/lib/manager/leiningen/extract.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-template-curly-in-string */
 import { readFileSync } from 'fs';
 import { resolve } from 'upath';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import * as datasourceClojure from '../../datasource/clojure';
 import { extractFromVectors, extractPackageFile, trimAtKey } from './extract';
 
@@ -10,7 +10,7 @@ const leinProjectClj = readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   it('trimAtKey', () => {
     expect(trimAtKey('foo', 'bar')).toBeNull();
     expect(trimAtKey(':dependencies    ', 'dependencies')).toBeNull();

--- a/lib/manager/maven/extract.spec.ts
+++ b/lib/manager/maven/extract.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-template-curly-in-string */
 import { readFileSync } from 'fs';
 import { resolve } from 'upath';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { extractPackage } from './extract';
 
 const minimumContent = readFileSync(
@@ -14,7 +14,7 @@ const simpleContent = readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractDependencies', () => {
     it('returns null for invalid XML', () => {
       expect(extractPackage(undefined)).toBeNull();

--- a/lib/manager/maven/index.spec.ts
+++ b/lib/manager/maven/index.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { fs, getName } from '../../../test/util';
+import { fs, testName } from '../../../test/util';
 import type { PackageDependency, PackageFile } from '../types';
 import { extractPackage, resolveParents } from './extract';
 import { extractAllPackageFiles, updateDependency } from '.';
@@ -27,7 +27,7 @@ function selectDep(deps: PackageDependency[], name = 'org.example:quuz') {
   return deps.find((dep) => dep.depName === name);
 }
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractAllPackageFiles', () => {
     it('should return empty if package has no content', async () => {
       fs.readLocalFile.mockResolvedValueOnce(null);

--- a/lib/manager/meteor/extract.spec.ts
+++ b/lib/manager/meteor/extract.spec.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'upath';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 function readFixture(fixture: string) {
@@ -9,7 +9,7 @@ function readFixture(fixture: string) {
 
 const input01Content = readFixture('package-1.js');
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     it('returns empty if fails to parse', () => {
       const res = extractPackageFile('blahhhhh:foo:@what\n');

--- a/lib/manager/mix/artifacts.spec.ts
+++ b/lib/manager/mix/artifacts.spec.ts
@@ -1,6 +1,6 @@
 import { join } from 'upath';
 import { envMock, exec, mockExecAll } from '../../../test/exec-util';
-import { env, fs, getName } from '../../../test/util';
+import { env, fs, testName } from '../../../test/util';
 import { setExecConfig } from '../../util/exec';
 import { BinarySource } from '../../util/exec/common';
 import * as docker from '../../util/exec/docker';
@@ -15,7 +15,7 @@ const config = {
   localDir: join('/tmp/github/some/repo'),
 };
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   beforeEach(async () => {
     jest.resetAllMocks();
     jest.resetModules();

--- a/lib/manager/mix/extract.spec.ts
+++ b/lib/manager/mix/extract.spec.ts
@@ -1,6 +1,6 @@
 import fs from 'fs-extra';
 import upath from 'upath';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { extractPackageFile } from '.';
 
 const sample = fs.readFileSync(
@@ -8,7 +8,7 @@ const sample = fs.readFileSync(
   'utf-8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     it('returns empty for invalid dependency file', async () => {
       expect(

--- a/lib/manager/nodenv/extract.spec.ts
+++ b/lib/manager/nodenv/extract.spec.ts
@@ -1,7 +1,7 @@
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     it('returns a result', () => {
       const res = extractPackageFile('8.4.0\n');

--- a/lib/manager/npm/extract/index.spec.ts
+++ b/lib/manager/npm/extract/index.spec.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'fs';
 import upath from 'upath';
-import { getName } from '../../../../test/util';
+import { testName } from '../../../../test/util';
 import { getConfig } from '../../../config/defaults';
 import * as _fs from '../../../util/fs';
 import * as npmExtract from '.';
@@ -23,7 +23,7 @@ const workspacesSimpleContent = readFixture('inputs/workspaces-simple.json');
 const vendorisedContent = readFixture('is-object.json');
 const invalidNameContent = readFixture('invalid-name.json');
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('.extractPackageFile()', () => {
     beforeEach(() => {
       fs.readLocalFile = jest.fn(() => null);

--- a/lib/manager/npm/extract/locked-versions.spec.ts
+++ b/lib/manager/npm/extract/locked-versions.spec.ts
@@ -1,4 +1,4 @@
-import { getName } from '../../../../test/util';
+import { testName } from '../../../../test/util';
 import { getLockedVersions } from './locked-versions';
 
 /** @type any */
@@ -9,7 +9,7 @@ const yarn = require('./yarn');
 jest.mock('./npm');
 jest.mock('./yarn');
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('.getLockedVersions()', () => {
     it.each([['1.22.0'], ['2.1.0'], ['2.2.0']])(
       'uses yarn.lock with yarn v%s',

--- a/lib/manager/npm/extract/monorepo.spec.ts
+++ b/lib/manager/npm/extract/monorepo.spec.ts
@@ -1,7 +1,7 @@
-import { getName } from '../../../../test/util';
+import { testName } from '../../../../test/util';
 import { detectMonorepos } from './monorepo';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('.extractPackageFile()', () => {
     it('uses lerna package settings', () => {
       const packageFiles = [

--- a/lib/manager/npm/extract/npm.spec.ts
+++ b/lib/manager/npm/extract/npm.spec.ts
@@ -1,10 +1,10 @@
 import { readFileSync } from 'fs';
-import { fs, getName } from '../../../../test/util';
+import { fs, testName } from '../../../../test/util';
 import { getNpmLock } from './npm';
 
 jest.mock('../../../util/fs');
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('.getNpmLock()', () => {
     it('returns empty if failed to parse', async () => {
       fs.readLocalFile.mockResolvedValueOnce('abcd');

--- a/lib/manager/npm/extract/type.spec.ts
+++ b/lib/manager/npm/extract/type.spec.ts
@@ -1,7 +1,7 @@
-import { getName } from '../../../../test/util';
+import { testName } from '../../../../test/util';
 import { mightBeABrowserLibrary } from './type';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('.mightBeABrowserLibrary()', () => {
     it('is not a library if private', () => {
       const isLibrary = mightBeABrowserLibrary({ private: true });

--- a/lib/manager/npm/extract/yarn.spec.ts
+++ b/lib/manager/npm/extract/yarn.spec.ts
@@ -1,10 +1,10 @@
 import { readFileSync } from 'fs';
-import { fs, getName } from '../../../../test/util';
+import { fs, testName } from '../../../../test/util';
 import { getYarnLock } from './yarn';
 
 jest.mock('../../../util/fs');
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('.getYarnLock()', () => {
     it('returns empty if exception parsing', async () => {
       fs.readLocalFile.mockResolvedValueOnce('abcd');

--- a/lib/manager/npm/post-update/lerna.spec.ts
+++ b/lib/manager/npm/post-update/lerna.spec.ts
@@ -1,6 +1,6 @@
 import { exec as _exec } from 'child_process';
 import { envMock, mockExecAll } from '../../../../test/exec-util';
-import { getName, mocked } from '../../../../test/util';
+import { mocked, testName } from '../../../../test/util';
 import { setAdminConfig } from '../../../config/admin';
 import * as _env from '../../../util/exec/env';
 import * as _lernaHelper from './lerna';
@@ -25,7 +25,7 @@ function lernaPkgFileWithoutLernaDep(lernaClient: string) {
     lernaClient,
   };
 }
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('generateLockFiles()', () => {
     beforeEach(() => {
       jest.resetAllMocks();

--- a/lib/manager/npm/post-update/yarn.spec.ts
+++ b/lib/manager/npm/post-update/yarn.spec.ts
@@ -4,7 +4,7 @@ import {
   envMock,
   mockExecAll,
 } from '../../../../test/exec-util';
-import { fs, getName, mocked } from '../../../../test/util';
+import { fs, mocked, testName } from '../../../../test/util';
 import * as _env from '../../../util/exec/env';
 import * as _yarnHelper from './yarn';
 
@@ -26,7 +26,7 @@ const fixSnapshots = (snapshots: ExecSnapshots): ExecSnapshots =>
     cmd: snapshot.cmd.replace(/^.*\/yarn.*?\.js\s+/, '<yarn> '),
   }));
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   beforeEach(() => {
     jest.resetAllMocks();
     jest.resetModules();

--- a/lib/manager/npm/update/dependency/index.spec.ts
+++ b/lib/manager/npm/update/dependency/index.spec.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import upath from 'upath';
 
-import { getName } from '../../../../../test/util';
+import { testName } from '../../../../../test/util';
 import * as npmUpdater from '.';
 
 function readFixture(fixture: string) {
@@ -14,7 +14,7 @@ function readFixture(fixture: string) {
 const input01Content = readFixture('inputs/01.json');
 const input01GlobContent = readFixture('inputs/01-glob.json');
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('.updateDependency(fileContent, depType, depName, newValue)', () => {
     it('replaces a dependency value', () => {
       const upgrade = {

--- a/lib/manager/npm/update/locked-dependency/dep-constraints.spec.ts
+++ b/lib/manager/npm/update/locked-dependency/dep-constraints.spec.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'upath';
-import { getName } from '../../../../../test/util';
+import { testName } from '../../../../../test/util';
 import { findDepConstraints } from './dep-constraints';
 
 jest.mock('../../../../util/fs');
@@ -12,7 +12,7 @@ const packageLockJson = JSON.parse(
   readFileSync(resolve(__dirname, './__fixtures__/package-lock.json'), 'utf8')
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('findDepConstraints()', () => {
     it('finds indirect dependency', () => {
       expect(

--- a/lib/manager/npm/update/locked-dependency/get-locked.spec.ts
+++ b/lib/manager/npm/update/locked-dependency/get-locked.spec.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'upath';
-import { getName } from '../../../../../test/util';
+import { testName } from '../../../../../test/util';
 import { getLockedDependencies } from './get-locked';
 
 jest.mock('../../../../util/fs');
@@ -9,7 +9,7 @@ const packageLockJson = JSON.parse(
   readFileSync(resolve(__dirname, './__fixtures__/package-lock.json'), 'utf8')
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('getLockedDependencies()', () => {
     it('handles error', () => {
       expect(getLockedDependencies(null as any, 'some-dep', '1.0.0')).toEqual(

--- a/lib/manager/npm/update/locked-dependency/index.spec.ts
+++ b/lib/manager/npm/update/locked-dependency/index.spec.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'upath';
 import * as httpMock from '../../../../../test/http-mock';
-import { getName } from '../../../../../test/util';
+import { testName } from '../../../../../test/util';
 import { clone } from '../../../../util/clone';
 import type { UpdateLockedConfig } from '../../../types';
 import { updateLockedDependency } from '.';
@@ -39,7 +39,7 @@ const typeIsJson = JSON.parse(
   readFileSync(resolve(__dirname, './__fixtures__/type-is.json'), 'utf8')
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('updateLockedDependency()', () => {
     let config: UpdateLockedConfig;
     beforeEach(() => {

--- a/lib/manager/npm/update/locked-dependency/parent-version.spec.ts
+++ b/lib/manager/npm/update/locked-dependency/parent-version.spec.ts
@@ -1,14 +1,14 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'upath';
 import * as httpMock from '../../../../../test/http-mock';
-import { getName } from '../../../../../test/util';
+import { testName } from '../../../../../test/util';
 import { findFirstParentVersion } from './parent-version';
 
 const expressJson = JSON.parse(
   readFileSync(resolve(__dirname, './__fixtures__/express.json'), 'utf8')
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('getLockedDependencies()', () => {
     beforeEach(() => {
       httpMock.setup();

--- a/lib/manager/npm/update/package-version/index.spec.ts
+++ b/lib/manager/npm/update/package-version/index.spec.ts
@@ -1,7 +1,7 @@
-import { getName } from '../../../../../test/util';
+import { testName } from '../../../../../test/util';
 import * as npmUpdater from '.';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('.bumpPackageVersion()', () => {
     const content = JSON.stringify({
       name: 'some-package',

--- a/lib/manager/nuget/extract.spec.ts
+++ b/lib/manager/nuget/extract.spec.ts
@@ -1,10 +1,10 @@
 import { readFileSync } from 'fs';
 import * as upath from 'upath';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import type { ExtractConfig } from '../types';
 import { extractPackageFile } from './extract';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     let config: ExtractConfig;
     beforeEach(() => {

--- a/lib/manager/nvm/extract.spec.ts
+++ b/lib/manager/nvm/extract.spec.ts
@@ -1,7 +1,7 @@
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     it('returns a result', () => {
       const res = extractPackageFile('8.4.0\n');

--- a/lib/manager/pip_requirements/extract.spec.ts
+++ b/lib/manager/pip_requirements/extract.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { setAdminConfig } from '../../config/admin';
 import { extractPackageFile } from './extract';
 
@@ -36,7 +36,7 @@ const requirements7 = readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   beforeEach(() => {
     delete process.env.PIP_TEST_TOKEN;
     setAdminConfig();

--- a/lib/manager/pip_setup/extract.spec.ts
+++ b/lib/manager/pip_setup/extract.spec.ts
@@ -1,5 +1,5 @@
 import { envMock, exec, mockExecSequence } from '../../../test/exec-util';
-import { env, getName } from '../../../test/util';
+import { env, testName } from '../../../test/util';
 import {
   getPythonAlias,
   parsePythonVersion,
@@ -10,7 +10,7 @@ import {
 jest.mock('child_process');
 jest.mock('../../util/exec/env');
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   beforeEach(() => {
     jest.resetAllMocks();
     jest.resetModules();

--- a/lib/manager/pip_setup/index.spec.ts
+++ b/lib/manager/pip_setup/index.spec.ts
@@ -6,7 +6,7 @@ import {
   mockExecAll,
   mockExecSequence,
 } from '../../../test/exec-util';
-import { env, getName } from '../../../test/util';
+import { env, testName } from '../../../test/util';
 import { setUtilConfig } from '../../util';
 import { BinarySource } from '../../util/exec/common';
 import * as fs from '../../util/fs';
@@ -39,7 +39,7 @@ const fixSnapshots = (snapshots: ExecSnapshots): ExecSnapshots =>
     cmd: snapshot.cmd.replace(/^.*extract\.py"\s+/, '<extract.py> '),
   }));
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     beforeEach(async () => {
       jest.resetAllMocks();

--- a/lib/manager/pipenv/extract.spec.ts
+++ b/lib/manager/pipenv/extract.spec.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { fs as fsutil, getName } from '../../../test/util';
+import { fs as fsutil, testName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 jest.mock('../../util/fs');
@@ -25,7 +25,7 @@ const pipfile5 = fs.readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty', async () => {
       expect(await extractPackageFile('[packages]\r\n', 'Pipfile')).toBeNull();

--- a/lib/manager/poetry/extract.spec.ts
+++ b/lib/manager/poetry/extract.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { fs, getName } from '../../../test/util';
+import { fs, testName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 jest.mock('../../util/fs');
@@ -61,7 +61,7 @@ const pyproject11tomlLock = readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     let filename: string;
     const OLD_ENV = process.env;

--- a/lib/manager/pre-commit/extract.spec.ts
+++ b/lib/manager/pre-commit/extract.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { getName, mocked } from '../../../test/util';
+import { mocked, testName } from '../../../test/util';
 import * as _hostRules from '../../util/host-rules';
 import { extractPackageFile } from './extract';
 
@@ -38,7 +38,7 @@ const enterpriseGitPrecommitConfig = readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     beforeEach(() => {
       jest.resetAllMocks();

--- a/lib/manager/pub/extract.spec.ts
+++ b/lib/manager/pub/extract.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { extractPackageFile } from '.';
 
 const brokenYaml = readFileSync(
@@ -12,7 +12,7 @@ const packageFile = readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile', () => {
     it('should return null if package does not contain any deps', () => {
       const res = extractPackageFile('foo: bar', 'pubspec.yaml');

--- a/lib/manager/regex/index.spec.ts
+++ b/lib/manager/regex/index.spec.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'upath';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { logger } from '../../logger';
 import type { CustomExtractConfig } from '../types';
 import { defaultConfig, extractPackageFile } from '.';
@@ -18,7 +18,7 @@ const exampleJsonContent = readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   it('has default config', () => {
     expect(defaultConfig).toEqual({
       pinDigests: false,

--- a/lib/manager/ruby-version/extract.spec.ts
+++ b/lib/manager/ruby-version/extract.spec.ts
@@ -1,7 +1,7 @@
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     it('returns a result', () => {
       const res = extractPackageFile('8.4.0\n');

--- a/lib/manager/sbt/extract.spec.ts
+++ b/lib/manager/sbt/extract.spec.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'upath';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 const sbt = readFileSync(
@@ -26,7 +26,7 @@ const sbtPrivateVariableDependencyFile = readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty', () => {
       expect(extractPackageFile(null)).toBeNull();

--- a/lib/manager/sbt/update.spec.ts
+++ b/lib/manager/sbt/update.spec.ts
@@ -1,7 +1,7 @@
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import * as sbtUpdater from './update';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('.bumpPackageVersion()', () => {
     const content =
       'name := "test"\n' +

--- a/lib/manager/setup-cfg/extract.spec.ts
+++ b/lib/manager/setup-cfg/extract.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 const content = readFileSync(
@@ -7,7 +7,7 @@ const content = readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty', () => {
       expect(extractPackageFile('nothing here')).toBeNull();

--- a/lib/manager/swift/index.spec.ts
+++ b/lib/manager/swift/index.spec.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'upath';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 const pkgContent = readFileSync(
@@ -8,7 +8,7 @@ const pkgContent = readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty content', () => {
       expect(extractPackageFile(null)).toBeNull();

--- a/lib/manager/terraform-version/extract.spec.ts
+++ b/lib/manager/terraform-version/extract.spec.ts
@@ -1,7 +1,7 @@
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     it('returns a result', () => {
       const res = extractPackageFile('12.0.0\n');

--- a/lib/manager/terraform/extract.spec.ts
+++ b/lib/manager/terraform/extract.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 const tf1 = readFileSync('lib/manager/terraform/__fixtures__/1.tf', 'utf8');
@@ -9,7 +9,7 @@ const tf2 = `module "relative" {
 `;
 const helm = readFileSync('lib/manager/terraform/__fixtures__/helm.tf', 'utf8');
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty', () => {
       expect(extractPackageFile('nothing here')).toBeNull();

--- a/lib/manager/terraform/util.spec.ts
+++ b/lib/manager/terraform/util.spec.ts
@@ -1,7 +1,7 @@
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { TerraformDependencyTypes, getTerraformDependencyType } from './util';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('getTerraformDependencyType()', () => {
     it('returns TerraformDependencyTypes.module', () => {
       expect(getTerraformDependencyType('module')).toBe(

--- a/lib/manager/terragrunt-version/extract.spec.ts
+++ b/lib/manager/terragrunt-version/extract.spec.ts
@@ -1,7 +1,7 @@
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     it('returns a result', () => {
       const res = extractPackageFile('12.0.0\n');

--- a/lib/manager/terragrunt/extract.spec.ts
+++ b/lib/manager/terragrunt/extract.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 const tg1 = readFileSync('lib/manager/terragrunt/__fixtures__/2.hcl', 'utf8');
@@ -8,7 +8,7 @@ const tg2 = `terragrunt {
 }
 `;
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty', () => {
       expect(extractPackageFile('nothing here')).toBeNull();

--- a/lib/manager/terragrunt/util.spec.ts
+++ b/lib/manager/terragrunt/util.spec.ts
@@ -1,7 +1,7 @@
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { TerragruntDependencyTypes, getTerragruntDependencyType } from './util';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('getTerragruntDependencyType()', () => {
     it('returns TerragruntDependencyTypes.terragrunt', () => {
       expect(getTerragruntDependencyType('terraform')).toBe(

--- a/lib/manager/travis/extract.spec.ts
+++ b/lib/manager/travis/extract.spec.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'upath';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { extractPackageFile } from './extract';
 
 const invalidYAML = readFileSync(
@@ -8,7 +8,7 @@ const invalidYAML = readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractPackageFile()', () => {
     it('returns empty if fails to parse', () => {
       const res = extractPackageFile('blahhhhh:foo:@what\n');

--- a/lib/manager/travis/package.spec.ts
+++ b/lib/manager/travis/package.spec.ts
@@ -1,4 +1,4 @@
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { getConfig } from '../../config/defaults';
 import { getPkgReleases as _getPkgReleases } from '../../datasource';
 import { getPackageUpdates } from './package';
@@ -8,7 +8,7 @@ const getPkgReleases: any = _getPkgReleases;
 
 jest.mock('../../datasource');
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('getPackageUpdates', () => {
     // TODO: should be `PackageUpdateConfig`
     let config: any;

--- a/lib/manager/travis/update.spec.ts
+++ b/lib/manager/travis/update.spec.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'upath';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { updateDependency } from './update';
 
 const content = readFileSync(
@@ -8,7 +8,7 @@ const content = readFileSync(
   'utf8'
 );
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('updateDependency', () => {
     it('updates values', () => {
       // TODO: should be `Upgrade`

--- a/lib/platform/azure/azure-got-wrapper.spec.ts
+++ b/lib/platform/azure/azure-got-wrapper.spec.ts
@@ -1,8 +1,8 @@
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { PLATFORM_TYPE_AZURE } from '../../constants/platforms';
 import * as _hostRules from '../../util/host-rules';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   let azure: typeof import('./azure-got-wrapper');
   let hostRules: typeof _hostRules;
   beforeEach(() => {

--- a/lib/platform/azure/azure-helper.spec.ts
+++ b/lib/platform/azure/azure-helper.spec.ts
@@ -1,8 +1,8 @@
 import { Readable } from 'stream';
 import { GitPullRequestMergeStrategy } from 'azure-devops-node-api/interfaces/GitInterfaces';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   let azureHelper: typeof import('./azure-helper');
   let azureApi: jest.Mocked<typeof import('./azure-got-wrapper')>;
 

--- a/lib/platform/azure/index.spec.ts
+++ b/lib/platform/azure/index.spec.ts
@@ -5,14 +5,14 @@ import {
   GitStatusState,
   PullRequestStatus,
 } from 'azure-devops-node-api/interfaces/GitInterfaces';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { logger as _logger } from '../../logger';
 import { BranchStatus, PrState } from '../../types';
 import * as _git from '../../util/git';
 import * as _hostRules from '../../util/host-rules';
 import type { Platform, RepoParams } from '../types';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   let hostRules: jest.Mocked<typeof _hostRules>;
   let azure: Platform;
   let azureApi: jest.Mocked<typeof import('./azure-got-wrapper')>;

--- a/lib/platform/azure/util.spec.ts
+++ b/lib/platform/azure/util.spec.ts
@@ -1,5 +1,5 @@
 import { Readable } from 'stream';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import {
   getBranchNameWithoutRefsheadsPrefix,
   getGitStatusContextCombinedName,
@@ -13,7 +13,7 @@ import {
   streamToString,
 } from './util';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('getNewBranchName', () => {
     it('should add refs/heads', () => {
       const res = getNewBranchName('testBB');

--- a/lib/platform/bitbucket-server/index.spec.ts
+++ b/lib/platform/bitbucket-server/index.spec.ts
@@ -1,6 +1,6 @@
 import nock from 'nock';
 import * as httpMock from '../../../test/http-mock';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import {
   REPOSITORY_CHANGED,
   REPOSITORY_EMPTY,
@@ -169,7 +169,7 @@ const scenarios = {
   'endpoint with path': new URL('https://stash.renovatebot.com/vcs'),
 };
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   Object.entries(scenarios).forEach(([scenarioName, url]) => {
     const urlHost = url.origin;
     const urlPath = url.pathname === '/' ? '' : url.pathname;

--- a/lib/platform/bitbucket/comments.spec.ts
+++ b/lib/platform/bitbucket/comments.spec.ts
@@ -1,11 +1,11 @@
 import * as httpMock from '../../../test/http-mock';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { setBaseUrl } from '../../util/http/bitbucket';
 import * as comments from './comments';
 
 const baseUrl = 'https://api.bitbucket.org';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   const config: comments.CommentsConfig = { repository: 'some/repo' };
 
   beforeEach(() => {

--- a/lib/platform/bitbucket/index.spec.ts
+++ b/lib/platform/bitbucket/index.spec.ts
@@ -1,6 +1,6 @@
 import nock from 'nock';
 import * as httpMock from '../../../test/http-mock';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { logger as _logger } from '../../logger';
 import { BranchStatus, PrState } from '../../types';
 import * as _git from '../../util/git';
@@ -35,7 +35,7 @@ lxml==3.6.0
 mccabe==0.6.1
 `;
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   let bitbucket: Platform;
   let hostRules: jest.Mocked<typeof import('../../util/host-rules')>;
   let git: jest.Mocked<typeof _git>;

--- a/lib/platform/gitea/gitea-helper.spec.ts
+++ b/lib/platform/gitea/gitea-helper.spec.ts
@@ -1,10 +1,10 @@
 import * as httpMock from '../../../test/http-mock';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { PrState } from '../../types';
 import { setBaseUrl } from '../../util/http/gitea';
 import * as ght from './gitea-helper';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   const baseUrl = 'https://gitea.renovatebot.com/api/v1';
 
   const mockCommitHash = '0d9c7726c3d628b7e28af234595cfd20febdbf8e';

--- a/lib/platform/gitea/index.spec.ts
+++ b/lib/platform/gitea/index.spec.ts
@@ -1,5 +1,5 @@
 import { BranchStatusConfig, Platform, RepoParams, RepoResult } from '..';
-import { getName, partial } from '../../../test/util';
+import { partial, testName } from '../../../test/util';
 import {
   REPOSITORY_ACCESS_FORBIDDEN,
   REPOSITORY_ARCHIVED,
@@ -20,7 +20,7 @@ import * as ght from './gitea-helper';
  */
 const GITEA_VERSION = '1.14.0+dev-754-g5d2b7ba63';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   let gitea: Platform;
   let helper: jest.Mocked<typeof import('./gitea-helper')>;
   let logger: jest.Mocked<typeof _logger>;

--- a/lib/platform/github/index.spec.ts
+++ b/lib/platform/github/index.spec.ts
@@ -1,7 +1,7 @@
 import fs from 'fs-extra';
 import { DateTime } from 'luxon';
 import * as httpMock from '../../../test/http-mock';
-import { getName, mocked } from '../../../test/util';
+import { mocked, testName } from '../../../test/util';
 import {
   REPOSITORY_NOT_FOUND,
   REPOSITORY_RENAMED,
@@ -12,7 +12,7 @@ import type { Platform } from '../types';
 
 const githubApiHost = 'https://api.github.com';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   let github: Platform;
   let hostRules: jest.Mocked<typeof import('../../util/host-rules')>;
   let git: jest.Mocked<typeof _git>;

--- a/lib/platform/gitlab/index.spec.ts
+++ b/lib/platform/gitlab/index.spec.ts
@@ -2,7 +2,7 @@
 import nock from 'nock';
 import { Platform, RepoParams } from '..';
 import * as httpMock from '../../../test/http-mock';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import {
   REPOSITORY_ARCHIVED,
   REPOSITORY_CHANGED,
@@ -17,7 +17,7 @@ import * as _hostRules from '../../util/host-rules';
 
 const gitlabApiHost = 'https://gitlab.com';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   let gitlab: Platform;
   let hostRules: jest.Mocked<typeof _hostRules>;
   let git: jest.Mocked<typeof _git>;

--- a/lib/platform/index.spec.ts
+++ b/lib/platform/index.spec.ts
@@ -1,4 +1,4 @@
-import { getName } from '../../test/util';
+import { testName } from '../../test/util';
 import { PLATFORM_NOT_FOUND } from '../constants/error-messages';
 import { PLATFORM_TYPE_BITBUCKET } from '../constants/platforms';
 import { loadModules } from '../util/modules';
@@ -7,7 +7,7 @@ import * as platform from '.';
 
 jest.unmock('.');
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   beforeEach(() => {
     jest.resetModules();
   });

--- a/lib/platform/utils/pr-body.spec.ts
+++ b/lib/platform/utils/pr-body.spec.ts
@@ -1,8 +1,8 @@
 import fs from 'fs-extra';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { smartTruncate } from './pr-body';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   let prBody: string;
   beforeAll(async () => {
     prBody = await fs.readFile(

--- a/lib/platform/utils/read-only-issue-body.spec.ts
+++ b/lib/platform/utils/read-only-issue-body.spec.ts
@@ -1,8 +1,8 @@
 import fs from 'fs-extra';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { readOnlyIssueBody } from './read-only-issue-body';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   let issueBody: string;
   beforeAll(async () => {
     issueBody = await fs.readFile(

--- a/lib/util/cache/package/file.spec.ts
+++ b/lib/util/cache/package/file.spec.ts
@@ -1,8 +1,8 @@
 import os from 'os';
-import { getName } from '../../../../test/util';
+import { testName } from '../../../../test/util';
 import { get, init, set } from './file';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   it('returns if uninitiated', async () => {
     await set('test', 'key', 1234);
     expect(await get('test', 'key')).toBeUndefined();

--- a/lib/util/cache/package/index.spec.ts
+++ b/lib/util/cache/package/index.spec.ts
@@ -1,10 +1,10 @@
-import { getName } from '../../../../test/util';
+import { testName } from '../../../../test/util';
 import { cleanup, get, init, set } from '.';
 
 jest.mock('./file');
 jest.mock('./redis');
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   it('returns undefined if not initialized', async () => {
     expect(await get('test', 'missing-key')).toBeUndefined();
     expect(await set('test', 'some-key', 'some-value', 5)).toBeUndefined();

--- a/lib/util/cache/repository/index.spec.ts
+++ b/lib/util/cache/repository/index.spec.ts
@@ -1,12 +1,12 @@
 import * as _fs from 'fs-extra';
-import { getName, mocked } from '../../../../test/util';
+import { mocked, testName } from '../../../../test/util';
 import * as repositoryCache from '.';
 
 jest.mock('fs-extra');
 
 const fs = mocked(_fs);
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   beforeEach(() => {
     jest.resetAllMocks();
   });

--- a/lib/util/emoji.spec.ts
+++ b/lib/util/emoji.spec.ts
@@ -1,7 +1,7 @@
-import { getName } from '../../test/util';
+import { testName } from '../../test/util';
 import { setEmojiConfig, unemojify } from './emoji';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   it('strips emojis when the config has been set accordingly', () => {
     const emoji = '🚀💎';
     const otherText = 'regular text';

--- a/lib/util/exec/exec.spec.ts
+++ b/lib/util/exec/exec.spec.ts
@@ -4,7 +4,7 @@ import {
   exec as _cpExec,
 } from 'child_process';
 import { envMock } from '../../../test/exec-util';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { setAdminConfig } from '../../config/admin';
 import type { RepoAdminConfig } from '../../config/types';
 import { TEMPORARY_ERROR } from '../../constants/error-messages';
@@ -31,7 +31,7 @@ interface TestInput {
   adminConfig?: RepoAdminConfig;
 }
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   let processEnvOrig: NodeJS.ProcessEnv;
 
   const cacheDir = '/tmp/renovate/cache/';

--- a/lib/util/fs/index.spec.ts
+++ b/lib/util/fs/index.spec.ts
@@ -1,5 +1,5 @@
 import { withDir } from 'tmp-promise';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import {
   findLocalSiblingOrParent,
   getSubDirectory,
@@ -9,7 +9,7 @@ import {
   writeLocalFile,
 } from '.';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('readLocalFile', () => {
     it('reads buffer', async () => {
       expect(await readLocalFile(__filename)).toBeInstanceOf(Buffer);
@@ -25,7 +25,7 @@ describe(getName(__filename), () => {
   });
 });
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('localPathExists', () => {
     it('returns true for file', async () => {
       expect(await localPathExists(__filename)).toBe(true);
@@ -41,7 +41,7 @@ describe(getName(__filename), () => {
   });
 });
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('findLocalSiblingOrParent', () => {
     it('returns path for file', async () => {
       await withDir(

--- a/lib/util/fs/proxies.spec.ts
+++ b/lib/util/fs/proxies.spec.ts
@@ -1,10 +1,10 @@
 import * as fs from 'fs-extra';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { remove } from './proxies';
 
 jest.mock('fs-extra');
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('remove', () => {
     it('should call remove in fs-extra', async () => {
       (fs.remove as jest.Mock).mockResolvedValue(undefined);

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -1,10 +1,10 @@
 import fs from 'fs-extra';
 import Git from 'simple-git';
 import tmp from 'tmp-promise';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import * as git from '.';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   jest.setTimeout(15000);
 
   const masterCommitDate = new Date();

--- a/lib/util/git/private-key.spec.ts
+++ b/lib/util/git/private-key.spec.ts
@@ -1,4 +1,4 @@
-import { getName, mocked } from '../../../test/util';
+import { mocked, testName } from '../../../test/util';
 import * as exec_ from '../exec';
 import {
   configSigningKey,
@@ -11,7 +11,7 @@ jest.mock('../exec');
 
 const exec = mocked(exec_);
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('writePrivateKey()', () => {
     it('returns if no private key', async () => {
       await expect(writePrivateKey()).resolves.not.toThrow();

--- a/lib/util/host-rules.spec.ts
+++ b/lib/util/host-rules.spec.ts
@@ -1,9 +1,9 @@
-import { getName } from '../../test/util';
+import { testName } from '../../test/util';
 import { PLATFORM_TYPE_AZURE } from '../constants/platforms';
 import * as datasourceNuget from '../datasource/nuget';
 import { add, clear, find, findAll, hosts } from './host-rules';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   beforeEach(() => {
     clear();
   });

--- a/lib/util/html.spec.ts
+++ b/lib/util/html.spec.ts
@@ -1,7 +1,7 @@
-import { getName } from '../../test/util';
+import { testName } from '../../test/util';
 import { HTMLElement, parse } from './html';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   it('parses HTML', () => {
     const body = parse('<div>Hello, world!</div>');
     expect(body.childNodes).toHaveLength(1);

--- a/lib/util/http/auth.spec.ts
+++ b/lib/util/http/auth.spec.ts
@@ -1,5 +1,5 @@
 import { NormalizedOptions } from 'got';
-import { getName, partial } from '../../../test/util';
+import { partial, testName } from '../../../test/util';
 import {
   PLATFORM_TYPE_GITEA,
   PLATFORM_TYPE_GITLAB,
@@ -7,7 +7,7 @@ import {
 import { applyAuthorization, removeAuthorization } from './auth';
 import { GotOptions } from './types';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('applyAuthorization', () => {
     it('does nothing', () => {
       const opts: GotOptions = {

--- a/lib/util/http/bitbucket-server.spec.ts
+++ b/lib/util/http/bitbucket-server.spec.ts
@@ -1,12 +1,12 @@
 import * as httpMock from '../../../test/http-mock';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { PLATFORM_TYPE_BITBUCKET_SERVER } from '../../constants/platforms';
 import * as hostRules from '../host-rules';
 import { BitbucketServerHttp, setBaseUrl } from './bitbucket-server';
 
 const baseUrl = 'https://git.example.com';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   let api: BitbucketServerHttp;
   beforeEach(() => {
     api = new BitbucketServerHttp();

--- a/lib/util/http/bitbucket.spec.ts
+++ b/lib/util/http/bitbucket.spec.ts
@@ -1,12 +1,12 @@
 import * as httpMock from '../../../test/http-mock';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { PLATFORM_TYPE_BITBUCKET } from '../../constants/platforms';
 import * as hostRules from '../host-rules';
 import { BitbucketHttp, setBaseUrl } from './bitbucket';
 
 const baseUrl = 'https://api.bitbucket.org';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   let api: BitbucketHttp;
   beforeEach(() => {
     api = new BitbucketHttp();

--- a/lib/util/http/gitea.spec.ts
+++ b/lib/util/http/gitea.spec.ts
@@ -1,8 +1,8 @@
 import * as httpMock from '../../../test/http-mock';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { GiteaHttp, setBaseUrl } from './gitea';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   const baseUrl = 'https://gitea.renovatebot.com/api/v1';
 
   let giteaHttp: GiteaHttp;

--- a/lib/util/http/github.spec.ts
+++ b/lib/util/http/github.spec.ts
@@ -1,6 +1,6 @@
 import nock from 'nock';
 import * as httpMock from '../../../test/http-mock';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import {
   EXTERNAL_HOST_ERROR,
   PLATFORM_BAD_CREDENTIALS,
@@ -13,7 +13,7 @@ import { GithubHttp, setBaseUrl } from './github';
 
 const githubApiHost = 'https://api.github.com';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   let githubApi: GithubHttp;
   beforeEach(() => {
     githubApi = new GithubHttp();

--- a/lib/util/http/gitlab.spec.ts
+++ b/lib/util/http/gitlab.spec.ts
@@ -1,5 +1,5 @@
 import * as httpMock from '../../../test/http-mock';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { EXTERNAL_HOST_ERROR } from '../../constants/error-messages';
 import { PLATFORM_TYPE_GITLAB } from '../../constants/platforms';
 import * as hostRules from '../host-rules';
@@ -12,7 +12,7 @@ hostRules.add({
 
 const gitlabApiHost = 'https://gitlab.com';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   let gitlabApi: GitlabHttp;
 
   beforeEach(() => {

--- a/lib/util/http/host-rules.spec.ts
+++ b/lib/util/http/host-rules.spec.ts
@@ -1,5 +1,5 @@
 import * as httpMock from '../../../test/http-mock';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import {
   PLATFORM_TYPE_GITEA,
   PLATFORM_TYPE_GITHUB,
@@ -12,7 +12,7 @@ const url = 'https://github.com';
 
 jest.mock('global-agent');
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   const options = {
     hostType: PLATFORM_TYPE_GITHUB,
   };

--- a/lib/util/http/index.spec.ts
+++ b/lib/util/http/index.spec.ts
@@ -1,5 +1,5 @@
 import nock from 'nock';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import {
   EXTERNAL_HOST_ERROR,
   HOST_DISABLED,
@@ -10,7 +10,7 @@ import { Http } from '.';
 
 const baseUrl = 'http://renovate.com';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   let http: Http;
 
   beforeEach(() => {

--- a/lib/util/http/queue.spec.ts
+++ b/lib/util/http/queue.spec.ts
@@ -1,7 +1,7 @@
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { getQueue } from './queue';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   it('returns null for invalid URL', () => {
     expect(getQueue(null)).toBeNull();
   });

--- a/lib/util/index.spec.ts
+++ b/lib/util/index.spec.ts
@@ -1,7 +1,7 @@
-import { getName } from '../../test/util';
+import { testName } from '../../test/util';
 import { sampleSize } from '.';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('sampleSize', () => {
     const array = ['a', 'b', 'c', 'd'];
     it('returns correct sized array', () => {

--- a/lib/util/mask.spec.ts
+++ b/lib/util/mask.spec.ts
@@ -1,7 +1,7 @@
-import { getName } from '../../test/util';
+import { testName } from '../../test/util';
 import { maskToken } from './mask';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('.maskToken', () => {
     it('returns value if passed value is falsy', () => {
       expect(maskToken('')).toEqual('');

--- a/lib/util/object.spec.ts
+++ b/lib/util/object.spec.ts
@@ -1,7 +1,7 @@
-import { getName } from '../../test/util';
+import { testName } from '../../test/util';
 import { hasKey } from './object';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   beforeEach(() => {
     jest.resetModules();
   });

--- a/lib/util/regex.spec.ts
+++ b/lib/util/regex.spec.ts
@@ -1,10 +1,10 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import RE2 from 're2';
-import { getName } from '../../test/util';
+import { testName } from '../../test/util';
 import { CONFIG_VALIDATION } from '../constants/error-messages';
 import { regEx } from './regex';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   beforeEach(() => {
     jest.resetModules();
   });

--- a/lib/util/sanitize.spec.ts
+++ b/lib/util/sanitize.spec.ts
@@ -1,7 +1,7 @@
-import { getName } from '../../test/util';
+import { testName } from '../../test/util';
 import { add, clear, sanitize } from './sanitize';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   beforeEach(() => {
     clear();
   });

--- a/lib/util/split.spec.ts
+++ b/lib/util/split.spec.ts
@@ -1,7 +1,7 @@
-import { getName } from '../../test/util';
+import { testName } from '../../test/util';
 import { addSplit, getSplits, splitInit } from './split';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   it('adds splits and returns results', () => {
     splitInit();
     addSplit('one');

--- a/lib/util/template/index.spec.ts
+++ b/lib/util/template/index.spec.ts
@@ -1,8 +1,8 @@
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { getOptions } from '../../config/definitions';
 import * as template from '.';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   it('has valid exposed config options', () => {
     const allOptions = getOptions().map((option) => option.name);
     const missingOptions = template.exposedConfigOptions.filter(

--- a/lib/util/url.spec.ts
+++ b/lib/util/url.spec.ts
@@ -1,4 +1,4 @@
-import { getName } from '../../test/util';
+import { testName } from '../../test/util';
 import {
   parseUrl,
   resolveBaseUrl,
@@ -6,7 +6,7 @@ import {
   validateUrl,
 } from './url';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   test.each([
     ['http://foo.io', '', 'http://foo.io'],
     ['http://foo.io/', '', 'http://foo.io'],

--- a/lib/versioning/gradle/index.spec.ts
+++ b/lib/versioning/gradle/index.spec.ts
@@ -1,8 +1,8 @@
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { compare, parseMavenBasedRange, parsePrefixRange } from './compare';
 import { api } from '.';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   it('returns equality', () => {
     expect(compare('1', '1')).toEqual(0);
     expect(compare('a', 'a')).toEqual(0);
@@ -113,7 +113,7 @@ describe(getName(__filename), () => {
   });
 });
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   it('isValid', () => {
     expect(api.isValid('1.0.0')).toBe(true);
     expect(api.isValid('[1.12.6,1.18.6]')).toBe(true);

--- a/lib/versioning/hex/index.spec.ts
+++ b/lib/versioning/hex/index.spec.ts
@@ -1,7 +1,7 @@
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { api as hexScheme } from '.';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('hexScheme.matches()', () => {
     it('handles tilde greater than', () => {
       expect(hexScheme.matches('4.2.0', '~> 4.0')).toBe(true);

--- a/lib/versioning/ivy/index.spec.ts
+++ b/lib/versioning/ivy/index.spec.ts
@@ -1,4 +1,4 @@
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import {
   REV_TYPE_LATEST,
   REV_TYPE_RANGE,
@@ -9,7 +9,7 @@ import ivy from '.';
 
 const { getNewValue, isValid, isVersion, matches } = ivy;
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   it('parses dynamic revisions', () => {
     expect(parseDynamicRevision(null)).toBeNull();
     expect(parseDynamicRevision('')).toBeNull();
@@ -61,7 +61,7 @@ describe(getName(__filename), () => {
   });
 });
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   it('isValid', () => {
     expect(isValid('')).toBe(false);
     expect(isValid('1.0.0')).toBe(true);

--- a/lib/versioning/loose/utils.spec.ts
+++ b/lib/versioning/loose/utils.spec.ts
@@ -1,7 +1,7 @@
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { GenericVersion, GenericVersioningApi } from './generic';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   const optionalFunctions = [
     'isLessThanRange',
     'valueToVersion',

--- a/lib/versioning/maven/index.spec.ts
+++ b/lib/versioning/maven/index.spec.ts
@@ -1,4 +1,4 @@
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import {
   autoExtendMavenRange,
   compare,
@@ -18,7 +18,7 @@ const {
   getNewValue,
 } = maven;
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   it('returns equality', () => {
     expect(compare('1.0.0', '1')).toEqual(0);
     expect(compare('1-a1', '1-alpha-1')).toEqual(0);
@@ -286,7 +286,7 @@ describe(getName(__filename), () => {
   });
 });
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   it('returns valid', () => {
     expect(isValid('1.0.0')).toBe(true);
     expect(isValid('[1.12.6,1.18.6]')).toBe(true);

--- a/lib/versioning/poetry/index.spec.ts
+++ b/lib/versioning/poetry/index.spec.ts
@@ -1,7 +1,7 @@
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { api as versionig } from '.';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('equals', () => {
     it.each([
       ['1', '1'],

--- a/lib/versioning/ubuntu/index.spec.ts
+++ b/lib/versioning/ubuntu/index.spec.ts
@@ -1,7 +1,7 @@
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import { api as ubuntu } from '.';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   // validation
 
   it('isValid', () => {

--- a/lib/workers/branch/auto-replace.spec.ts
+++ b/lib/workers/branch/auto-replace.spec.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'upath';
-import { defaultConfig, getName } from '../../../test/util';
+import { defaultConfig, testName } from '../../../test/util';
 import { WORKER_FILE_UPDATE_FAILED } from '../../constants/error-messages';
 import { extractPackageFile } from '../../manager/html';
 import type { BranchUpgradeConfig } from '../types';
@@ -13,7 +13,7 @@ const sampleHtml = readFileSync(
 
 jest.mock('../../util/fs');
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('doAutoReplace', () => {
     let reuseExistingBranch: boolean;
     let upgrade: BranchUpgradeConfig;

--- a/lib/workers/branch/automerge.spec.ts
+++ b/lib/workers/branch/automerge.spec.ts
@@ -1,4 +1,4 @@
-import { defaultConfig, getName, git, platform } from '../../../test/util';
+import { defaultConfig, git, platform, testName } from '../../../test/util';
 import { setAdminConfig } from '../../config/admin';
 import type { RenovateConfig } from '../../config/types';
 import { BranchStatus } from '../../types';
@@ -6,7 +6,7 @@ import { tryBranchAutomerge } from './automerge';
 
 jest.mock('../../util/git');
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('tryBranchAutomerge', () => {
     let config: RenovateConfig;
     beforeEach(() => {

--- a/lib/workers/branch/check-existing.spec.ts
+++ b/lib/workers/branch/check-existing.spec.ts
@@ -1,9 +1,9 @@
-import { defaultConfig, getName, partial, platform } from '../../../test/util';
+import { defaultConfig, partial, platform, testName } from '../../../test/util';
 import { PrState } from '../../types';
 import type { BranchConfig } from '../types';
 import { prAlreadyExisted } from './check-existing';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('prAlreadyExisted', () => {
     let config: BranchConfig;
     beforeEach(() => {

--- a/lib/workers/branch/commit.spec.ts
+++ b/lib/workers/branch/commit.spec.ts
@@ -1,11 +1,11 @@
-import { defaultConfig, getName, git, partial } from '../../../test/util';
+import { defaultConfig, git, partial, testName } from '../../../test/util';
 import { setAdminConfig } from '../../config/admin';
 import type { BranchConfig } from '../types';
 import { commitFilesToBranch } from './commit';
 
 jest.mock('../../util/git');
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('commitFilesToBranch', () => {
     let config: BranchConfig;
     beforeEach(() => {

--- a/lib/workers/branch/get-updated.spec.ts
+++ b/lib/workers/branch/get-updated.spec.ts
@@ -1,4 +1,4 @@
-import { defaultConfig, getName, git, mocked } from '../../../test/util';
+import { defaultConfig, git, mocked, testName } from '../../../test/util';
 import * as datasourceGitRefs from '../../datasource/git-refs';
 import * as _composer from '../../manager/composer';
 import * as _gitSubmodules from '../../manager/git-submodules';
@@ -21,7 +21,7 @@ jest.mock('../../manager/git-submodules');
 jest.mock('../../util/git');
 jest.mock('./auto-replace');
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('getUpdatedPackageFiles()', () => {
     let config: BranchConfig;
     beforeEach(() => {

--- a/lib/workers/branch/index.spec.ts
+++ b/lib/workers/branch/index.spec.ts
@@ -1,10 +1,10 @@
 import * as _fs from 'fs-extra';
 import {
   defaultConfig,
-  getName,
   git,
   mocked,
   platform,
+  testName,
 } from '../../../test/util';
 import { setAdminConfig } from '../../config/admin';
 import {
@@ -62,7 +62,7 @@ const sanitize = mocked(_sanitize);
 const fs = mocked(_fs);
 const limits = mocked(_limits);
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('processBranch', () => {
     const updatedPackageFiles: PackageFilesResult = {
       updatedPackageFiles: [],

--- a/lib/workers/branch/lock-files/index.spec.ts
+++ b/lib/workers/branch/lock-files/index.spec.ts
@@ -1,4 +1,4 @@
-import { getName, git, mocked } from '../../../../test/util';
+import { git, mocked, testName } from '../../../../test/util';
 import { getConfig } from '../../../config/defaults';
 import * as _lockFiles from '../../../manager/npm/post-update';
 import * as _lerna from '../../../manager/npm/post-update/lerna';
@@ -27,7 +27,7 @@ hostRules.find = jest.fn((_) => ({
 
 const { writeUpdatedPackageFiles, getAdditionalFiles } = lockFiles;
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('writeUpdatedPackageFiles', () => {
     let config: PostUpdateConfig;
     beforeEach(() => {

--- a/lib/workers/branch/reuse.spec.ts
+++ b/lib/workers/branch/reuse.spec.ts
@@ -1,4 +1,4 @@
-import { getName, git, platform } from '../../../test/util';
+import { git, platform, testName } from '../../../test/util';
 import type { RenovateConfig } from '../../config/types';
 import { Pr } from '../../platform';
 import { PrState } from '../../types';
@@ -6,7 +6,7 @@ import { shouldReuseExistingBranch } from './reuse';
 
 jest.mock('../../util/git');
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('shouldReuseExistingBranch(config)', () => {
     const pr: Pr = {
       sourceBranch: 'master',

--- a/lib/workers/branch/schedule.spec.ts
+++ b/lib/workers/branch/schedule.spec.ts
@@ -1,9 +1,9 @@
 import mockDate from 'mockdate';
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import type { RenovateConfig } from '../../config/types';
 import * as schedule from './schedule';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('hasValidTimezone(schedule)', () => {
     it('returns false for invalid timezone', () => {
       expect(schedule.hasValidTimezone('Asia')[0]).toBe(false);

--- a/lib/workers/branch/status-checks.spec.ts
+++ b/lib/workers/branch/status-checks.spec.ts
@@ -1,8 +1,8 @@
-import { defaultConfig, getName, platform } from '../../../test/util';
+import { defaultConfig, platform, testName } from '../../../test/util';
 import { BranchStatus } from '../../types';
 import { StabilityConfig, setStability } from './status-checks';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('setStability', () => {
     let config: StabilityConfig;
     beforeEach(() => {

--- a/lib/workers/global/autodiscover.spec.ts
+++ b/lib/workers/global/autodiscover.spec.ts
@@ -1,4 +1,4 @@
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import type { RenovateConfig } from '../../config/types';
 import { PLATFORM_TYPE_GITHUB } from '../../constants/platforms';
 import * as platform from '../../platform';
@@ -13,7 +13,7 @@ jest.unmock('../../platform');
 const hostRules = _hostRules;
 const ghApi: jest.Mocked<typeof _ghApi> = _ghApi as never;
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   let config: RenovateConfig;
   beforeEach(async () => {
     jest.resetAllMocks();

--- a/lib/workers/global/index.spec.ts
+++ b/lib/workers/global/index.spec.ts
@@ -1,5 +1,5 @@
 import { ERROR, WARN } from 'bunyan';
-import { getName, logger } from '../../../test/util';
+import { logger, testName } from '../../../test/util';
 import * as _configParser from '../../config';
 import {
   PLATFORM_TYPE_GITHUB,
@@ -19,7 +19,7 @@ const configParser: jest.Mocked<typeof _configParser> = _configParser as never;
 const platform: jest.Mocked<typeof _platform> = _platform as never;
 const limits = _limits;
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   beforeEach(() => {
     jest.resetAllMocks();
     logger.getProblems.mockImplementationOnce(() => []);

--- a/lib/workers/global/limits.spec.ts
+++ b/lib/workers/global/limits.spec.ts
@@ -1,4 +1,4 @@
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import {
   Limit,
   incLimitedValue,
@@ -7,7 +7,7 @@ import {
   setMaxLimit,
 } from './limits';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   beforeEach(() => {
     resetAllLimits();
   });

--- a/lib/workers/pr/automerge.spec.ts
+++ b/lib/workers/pr/automerge.spec.ts
@@ -1,4 +1,4 @@
-import { getConfig, getName, git, mocked, partial } from '../../../test/util';
+import { getConfig, git, mocked, partial, testName } from '../../../test/util';
 import { Pr, platform as _platform } from '../../platform';
 import { BranchStatus } from '../../types';
 import { BranchConfig } from '../types';
@@ -9,7 +9,7 @@ jest.mock('../../util/git');
 const platform = mocked(_platform);
 const defaultConfig = getConfig();
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('checkAutoMerge(pr, config)', () => {
     let config: BranchConfig;
     let pr: Pr;

--- a/lib/workers/pr/body/controls.spec.ts
+++ b/lib/workers/pr/body/controls.spec.ts
@@ -1,11 +1,11 @@
 import { mock } from 'jest-mock-extended';
-import { getName, git } from '../../../../test/util';
+import { git, testName } from '../../../../test/util';
 import { BranchConfig } from '../../types';
 import { getControls } from './controls';
 
 jest.mock('../../../util/git');
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('getControls', () => {
     let branchConfig: BranchConfig;
     beforeEach(() => {

--- a/lib/workers/pr/changelog/github.spec.ts
+++ b/lib/workers/pr/changelog/github.spec.ts
@@ -1,4 +1,4 @@
-import { getName } from '../../../../test/util';
+import { testName } from '../../../../test/util';
 import { PLATFORM_TYPE_GITHUB } from '../../../constants/platforms';
 import * as hostRules from '../../../util/host-rules';
 import * as semverVersioning from '../../../versioning/semver';
@@ -29,7 +29,7 @@ const upgrade: BranchUpgradeConfig = {
   ],
 };
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('getChangeLogJSON', () => {
     beforeEach(() => {
       hostRules.clear();

--- a/lib/workers/pr/changelog/gitlab.spec.ts
+++ b/lib/workers/pr/changelog/gitlab.spec.ts
@@ -1,5 +1,5 @@
 import * as httpMock from '../../../../test/http-mock';
-import { getName } from '../../../../test/util';
+import { testName } from '../../../../test/util';
 import { PLATFORM_TYPE_GITLAB } from '../../../constants/platforms';
 import * as hostRules from '../../../util/host-rules';
 import * as semverVersioning from '../../../versioning/semver';
@@ -31,7 +31,7 @@ const upgrade: BranchUpgradeConfig = {
 
 const baseUrl = 'https://gitlab.com/';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('getChangeLogJSON', () => {
     beforeEach(() => {
       httpMock.setup();

--- a/lib/workers/pr/changelog/index.spec.ts
+++ b/lib/workers/pr/changelog/index.spec.ts
@@ -1,5 +1,5 @@
 import * as httpMock from '../../../../test/http-mock';
-import { getName, partial } from '../../../../test/util';
+import { partial, testName } from '../../../../test/util';
 import { PLATFORM_TYPE_GITHUB } from '../../../constants/platforms';
 import * as hostRules from '../../../util/host-rules';
 import * as semverVersioning from '../../../versioning/semver';
@@ -31,7 +31,7 @@ const upgrade: BranchConfig = partial<BranchConfig>({
   ],
 });
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('getChangeLogJSON', () => {
     beforeEach(() => {
       httpMock.setup();

--- a/lib/workers/pr/changelog/release-notes.spec.ts
+++ b/lib/workers/pr/changelog/release-notes.spec.ts
@@ -1,7 +1,7 @@
 import fs from 'fs-extra';
 import { DateTime } from 'luxon';
 import * as httpMock from '../../../../test/http-mock';
-import { getName, mocked } from '../../../../test/util';
+import { mocked, testName } from '../../../../test/util';
 import * as _hostRules from '../../../util/host-rules';
 import {
   addReleaseNotes,
@@ -59,7 +59,7 @@ const gitlabTreeResponse = [
   { path: 'README.md', type: 'blob' },
 ];
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   beforeEach(() => {
     httpMock.setup();
     hostRules.find.mockReturnValue({});

--- a/lib/workers/pr/changelog/releases.spec.ts
+++ b/lib/workers/pr/changelog/releases.spec.ts
@@ -1,11 +1,11 @@
-import { getName, partial } from '../../../../test/util';
+import { partial, testName } from '../../../../test/util';
 import * as datasource from '../../../datasource';
 import * as dockerVersioning from '../../../versioning/docker';
 import * as npmVersioning from '../../../versioning/npm';
 import type { BranchUpgradeConfig } from '../../types';
 import * as releases from './releases';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('getReleaseNotes()', () => {
     beforeEach(() => {
       jest.spyOn(datasource, 'getPkgReleases').mockResolvedValueOnce({

--- a/lib/workers/pr/code-owners.spec.ts
+++ b/lib/workers/pr/code-owners.spec.ts
@@ -1,12 +1,12 @@
 import { mock } from 'jest-mock-extended';
-import { fs, getName, git } from '../../../test/util';
+import { fs, git, testName } from '../../../test/util';
 import { Pr } from '../../platform';
 import { codeOwnersForPr } from './code-owners';
 
 jest.mock('../../util/fs');
 jest.mock('../../util/git');
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('codeOwnersForPr', () => {
     let pr: Pr;
     beforeEach(() => {

--- a/lib/workers/pr/index.spec.ts
+++ b/lib/workers/pr/index.spec.ts
@@ -1,4 +1,4 @@
-import { getName, git, mocked, partial } from '../../../test/util';
+import { git, mocked, partial, testName } from '../../../test/util';
 import { getConfig } from '../../config/defaults';
 import { PLATFORM_TYPE_GITLAB } from '../../constants/platforms';
 import { Pr, platform as _platform } from '../../platform';
@@ -99,7 +99,7 @@ function setupGitlabChangelogMock() {
   gitlabChangelogHelper.getChangeLogJSON.mockResolvedValue(resultValue);
 }
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('checkAutoMerge(pr, config)', () => {
     let config: BranchConfig;
     let pr: Pr;

--- a/lib/workers/repository/configured.spec.ts
+++ b/lib/workers/repository/configured.spec.ts
@@ -1,4 +1,4 @@
-import { RenovateConfig, getConfig, getName } from '../../../test/util';
+import { RenovateConfig, getConfig, testName } from '../../../test/util';
 import { checkIfConfigured } from './configured';
 
 let config: RenovateConfig;
@@ -7,7 +7,7 @@ beforeEach(() => {
   config = getConfig();
 });
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('checkIfConfigured()', () => {
     it('returns', () => {
       expect(() => checkIfConfigured(config)).not.toThrow();

--- a/lib/workers/repository/dependency-dashboard.spec.ts
+++ b/lib/workers/repository/dependency-dashboard.spec.ts
@@ -4,9 +4,9 @@ import { mock } from 'jest-mock-extended';
 import {
   RenovateConfig,
   getConfig,
-  getName,
   logger,
   platform,
+  testName,
 } from '../../../test/util';
 import { setAdminConfig } from '../../config/admin';
 import { PLATFORM_TYPE_GITHUB } from '../../constants/platforms';
@@ -46,7 +46,7 @@ async function dryRun(
   expect(platform.findPr).toHaveBeenCalledTimes(findPrCalls);
 }
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('ensureMasterIssue()', () => {
     beforeEach(() => {
       setAdminConfig();

--- a/lib/workers/repository/error-config.spec.ts
+++ b/lib/workers/repository/error-config.spec.ts
@@ -2,8 +2,8 @@ import { mock } from 'jest-mock-extended';
 import {
   RenovateConfig,
   getConfig,
-  getName,
   platform,
+  testName,
 } from '../../../test/util';
 import { setAdminConfig } from '../../config/admin';
 import { CONFIG_VALIDATION } from '../../constants/error-messages';
@@ -19,7 +19,7 @@ beforeEach(() => {
   config = getConfig();
 });
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('raiseConfigWarningIssue()', () => {
     beforeEach(() => {
       setAdminConfig();

--- a/lib/workers/repository/error.spec.ts
+++ b/lib/workers/repository/error.spec.ts
@@ -1,4 +1,4 @@
-import { RenovateConfig, getConfig, getName } from '../../../test/util';
+import { RenovateConfig, getConfig, testName } from '../../../test/util';
 import {
   CONFIG_SECRETS_EXPOSED,
   CONFIG_VALIDATION,
@@ -38,7 +38,7 @@ beforeEach(() => {
   config = getConfig();
 });
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('handleError()', () => {
     const errors = [
       REPOSITORY_UNINITIATED,

--- a/lib/workers/repository/extract/file-match.spec.ts
+++ b/lib/workers/repository/extract/file-match.spec.ts
@@ -1,9 +1,9 @@
-import { RenovateConfig, getName } from '../../../../test/util';
+import { RenovateConfig, testName } from '../../../../test/util';
 import * as fileMatch from './file-match';
 
 jest.mock('../../../util/git');
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   const fileList = ['package.json', 'frontend/package.json'];
   describe('getIncludedFiles()', () => {
     it('returns fileList if no includePaths', () => {

--- a/lib/workers/repository/extract/index.spec.ts
+++ b/lib/workers/repository/extract/index.spec.ts
@@ -1,4 +1,4 @@
-import { defaultConfig, getName, git, mocked } from '../../../../test/util';
+import { defaultConfig, git, mocked, testName } from '../../../../test/util';
 import type { RenovateConfig } from '../../../config/types';
 import * as _managerFiles from './manager-files';
 import { extractAllDependencies } from '.';
@@ -8,7 +8,7 @@ jest.mock('../../../util/git');
 
 const managerFiles = mocked(_managerFiles);
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extractAllDependencies()', () => {
     let config: RenovateConfig;
     const fileList = ['README', 'package.json', 'tasks/ansible.yaml'];

--- a/lib/workers/repository/extract/manager-files.spec.ts
+++ b/lib/workers/repository/extract/manager-files.spec.ts
@@ -1,4 +1,4 @@
-import { fs, getConfig, getName, mocked } from '../../../../test/util';
+import { fs, getConfig, mocked, testName } from '../../../../test/util';
 import type { RenovateConfig } from '../../../config/types';
 import * as _html from '../../../manager/html';
 import * as _fileMatch from './file-match';
@@ -11,7 +11,7 @@ jest.mock('../../../util/fs');
 const fileMatch = mocked(_fileMatch);
 const html = mocked(_html);
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('getManagerPackageFiles()', () => {
     let config: RenovateConfig;
     beforeEach(() => {

--- a/lib/workers/repository/finalise/prune.spec.ts
+++ b/lib/workers/repository/finalise/prune.spec.ts
@@ -1,9 +1,9 @@
 import {
   RenovateConfig,
   getConfig,
-  getName,
   git,
   platform,
+  testName,
 } from '../../../../test/util';
 import { setAdminConfig } from '../../../config/admin';
 import { PLATFORM_TYPE_GITHUB } from '../../../constants/platforms';
@@ -20,7 +20,7 @@ beforeEach(() => {
   config.warnings = [];
 });
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('pruneStaleBranches()', () => {
     beforeEach(() => {
       setAdminConfig();

--- a/lib/workers/repository/index.spec.ts
+++ b/lib/workers/repository/index.spec.ts
@@ -1,6 +1,11 @@
 import { mock } from 'jest-mock-extended';
 
-import { RenovateConfig, getConfig, getName, mocked } from '../../../test/util';
+import {
+  RenovateConfig,
+  getConfig,
+  mocked,
+  testName,
+} from '../../../test/util';
 import * as _process from './process';
 import { ExtractResult } from './process/extract-update';
 import { renovateRepository } from '.';
@@ -12,7 +17,7 @@ jest.mock('./process');
 jest.mock('./result');
 jest.mock('./error');
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('renovateRepository()', () => {
     let config: RenovateConfig;
     beforeEach(() => {

--- a/lib/workers/repository/init/apis.spec.ts
+++ b/lib/workers/repository/init/apis.spec.ts
@@ -1,8 +1,8 @@
 import {
   RenovateConfig,
   getConfig,
-  getName,
   platform,
+  testName,
 } from '../../../../test/util';
 import {
   REPOSITORY_DISABLED,
@@ -10,7 +10,7 @@ import {
 } from '../../../constants/error-messages';
 import { initApis } from './apis';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('initApis', () => {
     let config: RenovateConfig;
     beforeEach(() => {

--- a/lib/workers/repository/init/cache.spec.ts
+++ b/lib/workers/repository/init/cache.spec.ts
@@ -1,7 +1,7 @@
-import { RenovateConfig, getConfig, getName } from '../../../../test/util';
+import { RenovateConfig, getConfig, testName } from '../../../../test/util';
 import { initializeCaches } from './cache';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('initializeCaches()', () => {
     let config: RenovateConfig;
     beforeEach(() => {

--- a/lib/workers/repository/init/config.spec.ts
+++ b/lib/workers/repository/init/config.spec.ts
@@ -2,9 +2,9 @@ import {
   RenovateConfig,
   fs,
   getConfig,
-  getName,
   git,
   mocked,
+  testName,
 } from '../../../../test/util';
 import * as _migrateAndValidate from '../../../config/migrate-validate';
 import * as _migrate from '../../../config/migration';
@@ -31,7 +31,7 @@ beforeEach(() => {
 jest.mock('../../../config/migration');
 jest.mock('../../../config/migrate-validate');
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('detectRepoFileConfig()', () => {
     it('returns config if not found', () => {
       git.getFileList.mockResolvedValue(['package.json']);

--- a/lib/workers/repository/init/index.spec.ts
+++ b/lib/workers/repository/init/index.spec.ts
@@ -1,4 +1,4 @@
-import { getName, mocked } from '../../../../test/util';
+import { mocked, testName } from '../../../../test/util';
 import * as _secrets from '../../../config/secrets';
 import * as _onboarding from '../onboarding/branch';
 import * as _apis from './apis';
@@ -18,7 +18,7 @@ const config = mocked(_config);
 const onboarding = mocked(_onboarding);
 const secrets = mocked(_secrets);
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('initRepo', () => {
     it('runs', async () => {
       apis.initApis.mockResolvedValue({} as never);

--- a/lib/workers/repository/init/semantic.spec.ts
+++ b/lib/workers/repository/init/semantic.spec.ts
@@ -1,4 +1,9 @@
-import { RenovateConfig, getConfig, getName, git } from '../../../../test/util';
+import {
+  RenovateConfig,
+  getConfig,
+  git,
+  testName,
+} from '../../../../test/util';
 import { detectSemanticCommits } from './semantic';
 
 jest.mock('../../../util/git');
@@ -11,7 +16,7 @@ beforeEach(() => {
   config.warnings = [];
 });
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('detectSemanticCommits()', () => {
     it('detects false if unknown', async () => {
       config.semanticCommits = null;

--- a/lib/workers/repository/init/vulnerability.spec.ts
+++ b/lib/workers/repository/init/vulnerability.spec.ts
@@ -1,9 +1,9 @@
 import {
   RenovateConfig,
   defaultConfig,
-  getName,
   partial,
   platform,
+  testName,
 } from '../../../../test/util';
 import { NO_VULNERABILITY_ALERTS } from '../../../constants/error-messages';
 import { VulnerabilityAlert } from '../../../types';
@@ -15,7 +15,7 @@ beforeEach(() => {
   config = JSON.parse(JSON.stringify(defaultConfig));
 });
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('detectVulnerabilityAlerts()', () => {
     it('returns if alerts are missing', async () => {
       delete config.vulnerabilityAlerts;

--- a/lib/workers/repository/onboarding/branch/config.spec.ts
+++ b/lib/workers/repository/onboarding/branch/config.spec.ts
@@ -1,4 +1,4 @@
-import { RenovateConfig, getConfig, getName } from '../../../../../test/util';
+import { RenovateConfig, getConfig, testName } from '../../../../../test/util';
 import * as presets from '../../../../config/presets/local';
 import { PRESET_DEP_NOT_FOUND } from '../../../../config/presets/util';
 import { getOnboardingConfig } from './config';
@@ -7,7 +7,7 @@ jest.mock('../../../../config/presets/local');
 
 const mockedPresets = presets as jest.Mocked<typeof presets>;
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   let config: RenovateConfig;
   let onboardingConfig: string;
   beforeEach(() => {

--- a/lib/workers/repository/onboarding/branch/create.spec.ts
+++ b/lib/workers/repository/onboarding/branch/create.spec.ts
@@ -1,4 +1,4 @@
-import { RenovateConfig, getConfig, getName } from '../../../../../test/util';
+import { RenovateConfig, getConfig, testName } from '../../../../../test/util';
 import { commitFiles } from '../../../../util/git';
 import { COMMIT_MESSAGE_PREFIX_SEPARATOR } from '../../util/commit-message';
 import { createOnboardingBranch } from './create';
@@ -25,7 +25,7 @@ const buildExpectedCommitFilesArgument = (
   message,
 });
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   let config: RenovateConfig;
   beforeEach(() => {
     jest.clearAllMocks();

--- a/lib/workers/repository/onboarding/branch/index.spec.ts
+++ b/lib/workers/repository/onboarding/branch/index.spec.ts
@@ -3,9 +3,9 @@ import {
   RenovateConfig,
   fs,
   getConfig,
-  getName,
   git,
   platform,
+  testName,
 } from '../../../../../test/util';
 import { Pr } from '../../../../platform';
 import { PrState } from '../../../../types';
@@ -18,7 +18,7 @@ jest.mock('../../../../workers/repository/onboarding/branch/rebase');
 jest.mock('../../../../util/fs');
 jest.mock('../../../../util/git');
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('checkOnboardingBranch', () => {
     let config: RenovateConfig;
     beforeEach(() => {

--- a/lib/workers/repository/onboarding/branch/rebase.spec.ts
+++ b/lib/workers/repository/onboarding/branch/rebase.spec.ts
@@ -1,14 +1,14 @@
 import {
   RenovateConfig,
   defaultConfig,
-  getName,
   git,
+  testName,
 } from '../../../../../test/util';
 import { rebaseOnboardingBranch } from './rebase';
 
 jest.mock('../../../../util/git');
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('rebaseOnboardingBranch()', () => {
     let config: RenovateConfig;
     beforeEach(() => {

--- a/lib/workers/repository/onboarding/pr/base-branch.spec.ts
+++ b/lib/workers/repository/onboarding/pr/base-branch.spec.ts
@@ -1,8 +1,8 @@
-import { RenovateConfig, getConfig, getName } from '../../../../../test/util';
+import { RenovateConfig, getConfig, testName } from '../../../../../test/util';
 
 import { getBaseBranchDesc } from './base-branch';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('getBaseBranchDesc()', () => {
     let config: RenovateConfig;
     beforeEach(() => {

--- a/lib/workers/repository/onboarding/pr/config-description.spec.ts
+++ b/lib/workers/repository/onboarding/pr/config-description.spec.ts
@@ -1,8 +1,8 @@
-import { RenovateConfig, getConfig, getName } from '../../../../../test/util';
+import { RenovateConfig, getConfig, testName } from '../../../../../test/util';
 import type { PackageFile } from '../../../../manager/types';
 import { getConfigDesc } from './config-description';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('getConfigDesc()', () => {
     let config: RenovateConfig;
     beforeEach(() => {

--- a/lib/workers/repository/onboarding/pr/errors-warnings.spec.ts
+++ b/lib/workers/repository/onboarding/pr/errors-warnings.spec.ts
@@ -1,8 +1,8 @@
-import { RenovateConfig, getConfig, getName } from '../../../../../test/util';
+import { RenovateConfig, getConfig, testName } from '../../../../../test/util';
 import type { PackageFile } from '../../../../manager/types';
 import { getDepWarnings, getErrors, getWarnings } from './errors-warnings';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('getWarnings()', () => {
     let config: RenovateConfig;
     beforeEach(() => {

--- a/lib/workers/repository/onboarding/pr/index.spec.ts
+++ b/lib/workers/repository/onboarding/pr/index.spec.ts
@@ -1,10 +1,10 @@
 import {
   RenovateConfig,
   defaultConfig,
-  getName,
   git,
   partial,
   platform,
+  testName,
 } from '../../../../../test/util';
 import { setAdminConfig } from '../../../../config/admin';
 import { logger } from '../../../../logger';
@@ -15,7 +15,7 @@ import { ensureOnboardingPr } from '.';
 
 jest.mock('../../../../util/git');
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('ensureOnboardingPr()', () => {
     let config: RenovateConfig;
     let packageFiles: Record<string, PackageFile[]>;

--- a/lib/workers/repository/onboarding/pr/pr-list.spec.ts
+++ b/lib/workers/repository/onboarding/pr/pr-list.spec.ts
@@ -1,8 +1,8 @@
-import { RenovateConfig, getConfig, getName } from '../../../../../test/util';
+import { RenovateConfig, getConfig, testName } from '../../../../../test/util';
 import type { BranchConfig } from '../../../types';
 import { getPrList } from './pr-list';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('getPrList()', () => {
     let config: RenovateConfig;
     beforeEach(() => {

--- a/lib/workers/repository/process/deprecated.spec.ts
+++ b/lib/workers/repository/process/deprecated.spec.ts
@@ -1,7 +1,7 @@
-import { RenovateConfig, getName, platform } from '../../../../test/util';
+import { RenovateConfig, platform, testName } from '../../../../test/util';
 import { raiseDeprecationWarnings } from './deprecated';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('raiseDeprecationWarnings()', () => {
     it('returns if onboarding', async () => {
       const config = {};

--- a/lib/workers/repository/process/extract-update.spec.ts
+++ b/lib/workers/repository/process/extract-update.spec.ts
@@ -1,5 +1,5 @@
 import hasha from 'hasha';
-import { getName, git, mocked } from '../../../../test/util';
+import { git, mocked, testName } from '../../../../test/util';
 import type { PackageFile } from '../../../manager/types';
 import * as _repositoryCache from '../../../util/cache/repository';
 import * as _branchify from '../updates/branchify';
@@ -21,7 +21,7 @@ branchify.branchifyUpgrades.mockResolvedValueOnce({
   branchList: ['branchName'],
 });
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('extract()', () => {
     it('runs with no baseBranches', async () => {
       const config = {

--- a/lib/workers/repository/process/fetch.spec.ts
+++ b/lib/workers/repository/process/fetch.spec.ts
@@ -1,8 +1,8 @@
 import {
   RenovateConfig,
   getConfig,
-  getName,
   mocked,
+  testName,
 } from '../../../../test/util';
 import * as datasourceMaven from '../../../datasource/maven';
 import * as datasourceNpm from '../../../datasource/npm';
@@ -16,7 +16,7 @@ const lookupUpdates = mocked(lookup).lookupUpdates;
 
 jest.mock('./lookup');
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('fetchUpdates()', () => {
     let config: RenovateConfig;
     beforeEach(() => {

--- a/lib/workers/repository/process/index.spec.ts
+++ b/lib/workers/repository/process/index.spec.ts
@@ -1,9 +1,9 @@
 import {
   RenovateConfig,
   getConfig,
-  getName,
   git,
   mocked,
+  testName,
 } from '../../../../test/util';
 import * as _extractUpdate from './extract-update';
 import { extractDependencies, updateRepo } from '.';
@@ -19,7 +19,7 @@ beforeEach(() => {
   config = getConfig();
 });
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('processRepo()', () => {
     it('processes single branches', async () => {
       const res = await extractDependencies(config);

--- a/lib/workers/repository/process/limits.spec.ts
+++ b/lib/workers/repository/process/limits.spec.ts
@@ -2,9 +2,9 @@ import { DateTime } from 'luxon';
 import {
   RenovateConfig,
   getConfig,
-  getName,
   git,
   platform,
+  testName,
 } from '../../../../test/util';
 import { PrState } from '../../../types';
 import type { BranchConfig } from '../../types';
@@ -18,7 +18,7 @@ beforeEach(() => {
   config = getConfig();
 });
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('getPrHourlyRemaining()', () => {
     it('calculates hourly limit remaining', async () => {
       const time = DateTime.local();

--- a/lib/workers/repository/process/lookup/index.spec.ts
+++ b/lib/workers/repository/process/lookup/index.spec.ts
@@ -1,5 +1,5 @@
 import nock from 'nock';
-import { getConfig, getName, mocked, partial } from '../../../../../test/util';
+import { getConfig, mocked, partial, testName } from '../../../../../test/util';
 import qJson from '../../../../config/npm/__fixtures__/01.json';
 import helmetJson from '../../../../config/npm/__fixtures__/02.json';
 import coffeelintJson from '../../../../config/npm/__fixtures__/coffeelint.json';
@@ -40,7 +40,7 @@ Object.assign(githubReleases, { defaultRegistryUrls: ['https://github.com'] });
 
 let config: LookupUpdateConfig;
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   beforeEach(() => {
     // TODO: fix types
     config = partial<LookupUpdateConfig>(getConfig());

--- a/lib/workers/repository/process/sort.spec.ts
+++ b/lib/workers/repository/process/sort.spec.ts
@@ -1,8 +1,8 @@
-import { getName } from '../../../../test/util';
+import { testName } from '../../../../test/util';
 import type { UpdateType } from '../../../config/types';
 import { sortBranches } from './sort';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('sortBranches()', () => {
     it('sorts based on updateType and prTitle', () => {
       const branches = [

--- a/lib/workers/repository/process/write.spec.ts
+++ b/lib/workers/repository/process/write.spec.ts
@@ -1,9 +1,9 @@
 import {
   RenovateConfig,
   getConfig,
-  getName,
   git,
   mocked,
+  testName,
 } from '../../../../test/util';
 import * as _branchWorker from '../../branch';
 import { Limit, isLimitReached } from '../../global/limits';
@@ -27,7 +27,7 @@ beforeEach(() => {
   config = getConfig();
 });
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('writeUpdates()', () => {
     it('stops after automerge', async () => {
       const branches: BranchConfig[] = [

--- a/lib/workers/repository/result.spec.ts
+++ b/lib/workers/repository/result.spec.ts
@@ -1,4 +1,4 @@
-import { RenovateConfig, getConfig, getName } from '../../../test/util';
+import { RenovateConfig, getConfig, testName } from '../../../test/util';
 import { processResult } from './result';
 
 let config: RenovateConfig;
@@ -7,7 +7,7 @@ beforeEach(() => {
   config = getConfig();
 });
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('processResult()', () => {
     it('runs', () => {
       const result = processResult(config, 'done');

--- a/lib/workers/repository/stats.spec.ts
+++ b/lib/workers/repository/stats.spec.ts
@@ -1,4 +1,4 @@
-import { getName } from '../../../test/util';
+import { testName } from '../../../test/util';
 import * as memCache_ from '../../util/cache/memory';
 import { printRequestStats } from './stats';
 
@@ -6,7 +6,7 @@ jest.mock('../../util/cache/memory');
 
 const memCache: any = memCache_ as any;
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('printRequestStats()', () => {
     it('runs', () => {
       memCache.get = jest.fn(() => [

--- a/lib/workers/repository/updates/branch-name.spec.ts
+++ b/lib/workers/repository/updates/branch-name.spec.ts
@@ -1,8 +1,8 @@
-import { getName } from '../../../../test/util';
+import { testName } from '../../../../test/util';
 import type { RenovateConfig } from '../../../config/types';
 import { generateBranchName } from './branch-name';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('getBranchName()', () => {
     it('uses groupName if no slug defined', () => {
       const upgrade: RenovateConfig = {

--- a/lib/workers/repository/updates/branchify.spec.ts
+++ b/lib/workers/repository/updates/branchify.spec.ts
@@ -1,4 +1,4 @@
-import { RenovateConfig, getName, mocked } from '../../../../test/util';
+import { RenovateConfig, mocked, testName } from '../../../../test/util';
 import { getConfig } from '../../../config/defaults';
 import * as _changelog from '../changelog';
 import { branchifyUpgrades } from './branchify';
@@ -18,7 +18,7 @@ beforeEach(() => {
   config.warnings = [];
 });
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('branchifyUpgrades()', () => {
     it('returns empty', async () => {
       flattenUpdates.mockResolvedValueOnce([]);

--- a/lib/workers/repository/updates/flatten.spec.ts
+++ b/lib/workers/repository/updates/flatten.spec.ts
@@ -1,4 +1,4 @@
-import { RenovateConfig, getConfig, getName } from '../../../../test/util';
+import { RenovateConfig, getConfig, testName } from '../../../../test/util';
 
 import { LANGUAGE_DOCKER } from '../../../constants/languages';
 import { flattenUpdates } from './flatten';
@@ -11,7 +11,7 @@ beforeEach(() => {
   config.warnings = [];
 });
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('flattenUpdates()', () => {
     it('flattens', async () => {
       config.lockFileMaintenance.enabled = true;

--- a/lib/workers/repository/updates/generate.spec.ts
+++ b/lib/workers/repository/updates/generate.spec.ts
@@ -1,4 +1,4 @@
-import { defaultConfig, getName, partial } from '../../../../test/util';
+import { defaultConfig, partial, testName } from '../../../../test/util';
 import type { UpdateType } from '../../../config/types';
 import * as datasourceNpm from '../../../datasource/npm';
 import type { BranchUpgradeConfig } from '../../types';
@@ -8,7 +8,7 @@ beforeEach(() => {
   jest.resetAllMocks();
 });
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('generateBranchConfig()', () => {
     it('does not group single upgrade', () => {
       const branch = [

--- a/lib/workers/repository/util/commit-message.spec.ts
+++ b/lib/workers/repository/util/commit-message.spec.ts
@@ -1,10 +1,10 @@
-import { getName } from '../../../../test/util';
+import { testName } from '../../../../test/util';
 import {
   COMMIT_MESSAGE_PREFIX_SEPARATOR,
   formatCommitMessagePrefix,
 } from './commit-message';
 
-describe(getName(__filename), () => {
+describe(testName(), () => {
   describe('COMMIT_MESSAGE_PREFIX_END_CHARACTER', () => {
     it('is a colon character', () => {
       expect(COMMIT_MESSAGE_PREFIX_SEPARATOR).toBe(':');

--- a/test/util.ts
+++ b/test/util.ts
@@ -58,9 +58,11 @@ function getCallerFileName(): string | null {
         break;
       }
     }
-  } finally {
-    Error.prepareStackTrace = originalFunc;
+  } catch (e) {
+    // no-op
   }
+
+  Error.prepareStackTrace = originalFunc;
 
   return result;
 }

--- a/test/util.ts
+++ b/test/util.ts
@@ -39,7 +39,34 @@ export const defaultConfig = getConfig();
 
 export { getConfig };
 
-export function getName(file: string): string {
+function getCallerFileName(): string | null {
+  let result = null;
+
+  const originalFunc = Error.prepareStackTrace;
+  Error.prepareStackTrace = (_err, stack) => stack;
+
+  try {
+    const err: Error = new Error();
+
+    const stack = (err.stack as unknown) as NodeJS.CallSite[];
+    const currentFile = stack.shift().getFileName();
+
+    while (err.stack.length) {
+      result = stack.shift().getFileName();
+
+      if (currentFile !== result) {
+        break;
+      }
+    }
+  } finally {
+    Error.prepareStackTrace = originalFunc;
+  }
+
+  return result;
+}
+
+export function testName(): string {
+  const file = getCallerFileName();
   const [, name] = /lib\/(.*?)\.spec\.ts$/.exec(file.replace(/\\/g, '/'));
   return name;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Obtain test caller file from stacktrace instead of explicit `__filename`.

## Context:

Same helper will be used to introduce `loadFixture` helper, reducing boilerplate (i.e. cognitive penalty for writing more tests).

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/master/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
