### PR TITLE
feat(config): Add Open Telemetry Dotnet monorepo

### DIFF
--- a/lib/config/presets/internal/monorepo.ts
+++ b/lib/config/presets/internal/monorepo.ts
@@ -119,6 +119,7 @@ const repoGroups = {
   nuxtjs: 'https://github.com/nuxt/nuxt.js',
   openfeign: 'https://github.com/OpenFeign/feign',
   opentelemetry: 'https://github.com/open-telemetry/opentelemetry-js',
+  OpenTelemetryDotnet: 'https://github.com/open-telemetry/opentelemetry-dotnet',
   picasso: 'https://github.com/qlik-oss/picasso.js',
   pnpjs: 'https://github.com/pnp/pnpjs',
   playwright: 'https://github.com/Microsoft/playwright',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds a Open Telemetry Dotnet monorepo, so that you get a single PR containing updates to Open Telemetry NuGet packages instead of one for each NuGet package.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
