### PR TITLE
refactor(maven): Extract util functions from datasource index

### DIFF
--- a/lib/datasource/maven/index.ts
+++ b/lib/datasource/maven/index.ts
@@ -1,5 +1,4 @@
 import url from 'url';
-import fs from 'fs-extra';
 import pAll from 'p-all';
 import { XmlDocument } from 'xmldoc';
 import { logger } from '../../logger';
@@ -9,7 +8,14 @@ import * as mavenVersioning from '../../versioning/maven';
 import { compare } from '../../versioning/maven/compare';
 import type { GetReleasesConfig, Release, ReleaseResult } from '../types';
 import { MAVEN_REPO } from './common';
-import { downloadHttpProtocol, isHttpResourceExists } from './util';
+import type { MavenDependency } from './types';
+import {
+  downloadMavenXml,
+  getDependencyInfo,
+  getDependencyParts,
+  getMavenUrl,
+  isHttpResourceExists,
+} from './util';
 
 export { id } from './common';
 
@@ -17,93 +23,6 @@ export const customRegistrySupport = true;
 export const defaultRegistryUrls = [MAVEN_REPO];
 export const defaultVersioning = mavenVersioning.id;
 export const registryStrategy = 'merge';
-
-function containsPlaceholder(str: string): boolean {
-  return /\${.*?}/g.test(str);
-}
-
-async function downloadFileProtocol(pkgUrl: url.URL): Promise<string | null> {
-  const pkgPath = pkgUrl.toString().replace('file://', '');
-  if (!(await fs.exists(pkgPath))) {
-    return null;
-  }
-  return fs.readFile(pkgPath, 'utf8');
-}
-
-function getMavenUrl(
-  dependency: MavenDependency,
-  repoUrl: string,
-  path: string
-): url.URL | null {
-  return new url.URL(`${dependency.dependencyUrl}/${path}`, repoUrl);
-}
-
-interface MavenXml {
-  authorization?: boolean;
-  xml?: XmlDocument;
-}
-
-async function downloadMavenXml(
-  pkgUrl: url.URL | null
-): Promise<MavenXml | null> {
-  /* istanbul ignore if */
-  if (!pkgUrl) {
-    return {};
-  }
-  let rawContent: string;
-  let authorization: boolean;
-  switch (pkgUrl.protocol) {
-    case 'file:':
-      rawContent = await downloadFileProtocol(pkgUrl);
-      break;
-    case 'http:':
-    case 'https:':
-      ({ authorization, body: rawContent } = await downloadHttpProtocol(
-        pkgUrl
-      ));
-      break;
-    case 's3:':
-      logger.debug('Skipping s3 dependency');
-      return {};
-    default:
-      logger.debug({ url: pkgUrl.toString() }, `Unsupported Maven protocol`);
-      return {};
-  }
-
-  if (!rawContent) {
-    logger.debug(`Content is not found for Maven url: ${pkgUrl.toString()}`);
-    return {};
-  }
-
-  return { authorization, xml: new XmlDocument(rawContent) };
-}
-
-async function getDependencyInfo(
-  dependency: MavenDependency,
-  repoUrl: string,
-  version: string
-): Promise<Partial<ReleaseResult>> {
-  const result: Partial<ReleaseResult> = {};
-  const path = `${version}/${dependency.name}-${version}.pom`;
-
-  const pomUrl = getMavenUrl(dependency, repoUrl, path);
-  const { xml: pomContent } = await downloadMavenXml(pomUrl);
-  if (!pomContent) {
-    return result;
-  }
-
-  const homepage = pomContent.valueWithPath('url');
-  if (homepage && !containsPlaceholder(homepage)) {
-    result.homepage = homepage;
-  }
-
-  const sourceUrl = pomContent.valueWithPath('scm.url');
-  if (sourceUrl && !containsPlaceholder(sourceUrl)) {
-    result.sourceUrl = sourceUrl.replace(/^scm:/, '');
-  }
-
-  return result;
-}
 
 function isStableVersion(x: string): boolean {
   return mavenVersion.isStable(x);
@@ -119,24 +38,6 @@ function getLatestStableVersion(releases: Release[]): string | null {
     );
   }
   return null;
-}
-
-interface MavenDependency {
-  display: string;
-  group?: string;
-  name?: string;
-  dependencyUrl: string;
-}
-
-function getDependencyParts(lookupName: string): MavenDependency {
-  const [group, name] = lookupName.split(':');
-  const dependencyUrl = `${group.replace(/\./g, '/')}/${name}`;
-  return {
-    display: lookupName,
-    group,
-    name,
-    dependencyUrl,
-  };
 }
 
 function extractVersions(metadata: XmlDocument): string[] {

--- a/lib/datasource/maven/types.ts
+++ b/lib/datasource/maven/types.ts
@@ -1,0 +1,6 @@
+export interface MavenDependency {
+  display: string;
+  group?: string;
+  name?: string;
+  dependencyUrl: string;
+}

--- a/lib/datasource/maven/types.ts
+++ b/lib/datasource/maven/types.ts
@@ -1,6 +1,13 @@
+import type { XmlDocument } from 'xmldoc';
+
 export interface MavenDependency {
   display: string;
   group?: string;
   name?: string;
   dependencyUrl: string;
+}
+
+export interface MavenXml {
+  authorization?: boolean;
+  xml?: XmlDocument;
 }

--- a/lib/datasource/maven/util.ts
+++ b/lib/datasource/maven/util.ts
@@ -1,10 +1,14 @@
 import url from 'url';
+import fs from 'fs-extra';
+import { XmlDocument } from 'xmldoc';
 import { HOST_DISABLED } from '../../constants/error-messages';
 import { logger } from '../../logger';
 import { ExternalHostError } from '../../types/errors/external-host-error';
 import { Http, HttpResponse } from '../../util/http';
 
+import type { ReleaseResult } from '../types';
 import { MAVEN_REPO, id } from './common';
+import type { MavenDependency } from './types';
 
 const http: Record<string, Http> = {};
 
@@ -118,4 +122,102 @@ export async function isHttpResourceExists(
     logger.debug({ failedUrl }, `Can't check HTTP resource existence`);
     return null;
   }
+}
+
+function containsPlaceholder(str: string): boolean {
+  return /\${.*?}/g.test(str);
+}
+
+async function downloadFileProtocol(pkgUrl: url.URL): Promise<string | null> {
+  const pkgPath = pkgUrl.toString().replace('file://', '');
+  if (!(await fs.exists(pkgPath))) {
+    return null;
+  }
+  return fs.readFile(pkgPath, 'utf8');
+}
+
+export function getMavenUrl(
+  dependency: MavenDependency,
+  repoUrl: string,
+  path: string
+): url.URL | null {
+  return new url.URL(`${dependency.dependencyUrl}/${path}`, repoUrl);
+}
+
+interface MavenXml {
+  authorization?: boolean;
+  xml?: XmlDocument;
+}
+
+export async function downloadMavenXml(
+  pkgUrl: url.URL | null
+): Promise<MavenXml | null> {
+  /* istanbul ignore if */
+  if (!pkgUrl) {
+    return {};
+  }
+  let rawContent: string;
+  let authorization: boolean;
+  switch (pkgUrl.protocol) {
+    case 'file:':
+      rawContent = await downloadFileProtocol(pkgUrl);
+      break;
+    case 'http:':
+    case 'https:':
+      ({ authorization, body: rawContent } = await downloadHttpProtocol(
+        pkgUrl
+      ));
+      break;
+    case 's3:':
+      logger.debug('Skipping s3 dependency');
+      return {};
+    default:
+      logger.debug({ url: pkgUrl.toString() }, `Unsupported Maven protocol`);
+      return {};
+  }
+
+  if (!rawContent) {
+    logger.debug(`Content is not found for Maven url: ${pkgUrl.toString()}`);
+    return {};
+  }
+
+  return { authorization, xml: new XmlDocument(rawContent) };
+}
+
+export async function getDependencyInfo(
+  dependency: MavenDependency,
+  repoUrl: string,
+  version: string
+): Promise<Partial<ReleaseResult>> {
+  const result: Partial<ReleaseResult> = {};
+  const path = `${version}/${dependency.name}-${version}.pom`;
+
+  const pomUrl = getMavenUrl(dependency, repoUrl, path);
+  const { xml: pomContent } = await downloadMavenXml(pomUrl);
+  if (!pomContent) {
+    return result;
+  }
+
+  const homepage = pomContent.valueWithPath('url');
+  if (homepage && !containsPlaceholder(homepage)) {
+    result.homepage = homepage;
+  }
+
+  const sourceUrl = pomContent.valueWithPath('scm.url');
+  if (sourceUrl && !containsPlaceholder(sourceUrl)) {
+    result.sourceUrl = sourceUrl.replace(/^scm:/, '');
+  }
+
+  return result;
+}
+
+export function getDependencyParts(lookupName: string): MavenDependency {
+  const [group, name] = lookupName.split(':');
+  const dependencyUrl = `${group.replace(/\./g, '/')}/${name}`;
+  return {
+    display: lookupName,
+    group,
+    name,
+    dependencyUrl,
+  };
 }

--- a/lib/datasource/maven/util.ts
+++ b/lib/datasource/maven/util.ts
@@ -8,7 +8,7 @@ import { Http, HttpResponse } from '../../util/http';
 
 import type { ReleaseResult } from '../types';
 import { MAVEN_REPO, id } from './common';
-import type { MavenDependency } from './types';
+import type { MavenDependency, MavenXml } from './types';
 
 const http: Record<string, Http> = {};
 
@@ -100,6 +100,14 @@ export async function downloadHttpProtocol(
   }
 }
 
+async function downloadFileProtocol(pkgUrl: url.URL): Promise<string | null> {
+  const pkgPath = pkgUrl.toString().replace('file://', '');
+  if (!(await fs.exists(pkgPath))) {
+    return null;
+  }
+  return fs.readFile(pkgPath, 'utf8');
+}
+
 export async function isHttpResourceExists(
   pkgUrl: url.URL | string,
   hostType = id
@@ -128,25 +136,12 @@ function containsPlaceholder(str: string): boolean {
   return /\${.*?}/g.test(str);
 }
 
-async function downloadFileProtocol(pkgUrl: url.URL): Promise<string | null> {
-  const pkgPath = pkgUrl.toString().replace('file://', '');
-  if (!(await fs.exists(pkgPath))) {
-    return null;
-  }
-  return fs.readFile(pkgPath, 'utf8');
-}
-
 export function getMavenUrl(
   dependency: MavenDependency,
   repoUrl: string,
   path: string
 ): url.URL | null {
   return new url.URL(`${dependency.dependencyUrl}/${path}`, repoUrl);
-}
-
-interface MavenXml {
-  authorization?: boolean;
-  xml?: XmlDocument;
 }
 
 export async function downloadMavenXml(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Move `getDependencyInfo` to `util.ts`.

## Context:

Prerequisite for #9722, to make further review a bit easier

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
