### PR TITLE
docs: fix links

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -23,7 +23,7 @@ You can store your Renovate configuration file in one of the following locations
 Renovate always uses the config from the repository's default branch, even if that configuration specifies multiple `baseBranches`.
 Renovate does not read/override the config from within each base branch if present.
 
-Also, be sure to check out Renovate's [shareable config presets](/config-presets/) to save yourself from reinventing any wheels.
+Also, be sure to check out Renovate's [shareable config presets](./config-presets.md) to save yourself from reinventing any wheels.
 
 If you have any questions about the config options, or want to get help/feedback about a config, go to the [discussions tab in the Renovate repository](https://github.com/renovatebot/renovate/discussions) and start a new "config help" discussion.
 We will do our best to answer your question(s).

--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -37,7 +37,7 @@ You can set more than one PR target branch in the `baseBranches` array.
 
 ### Support private npm modules
 
-See the dedicated [Private npm module support](/private-modules/) page.
+See the dedicated [Private npm module support](./private-modules.md) page.
 
 ### Control Renovate's schedule
 

--- a/docs/usage/node.md
+++ b/docs/usage/node.md
@@ -30,7 +30,7 @@ When Renovate processes your project's repository it will look for the files lis
 
 ## Configuring Support Policy
 
-Renovate supports a [`supportPolicy`](/configuration-options/#supportpolicy) option that can be passed the following values and associated versions (current as of April 2021):
+Renovate supports a [`supportPolicy`](./configuration-options.md#supportpolicy) option that can be passed the following values and associated versions (current as of April 2021):
 
 **Default:** `lts`
 
@@ -54,7 +54,7 @@ For example, to instruct Renovate to upgrade your project to the latest [Long-te
 We recommend that you define this support policy inside the `node` configuration object.
 This way, it is applied to all Node.js-related files.
 
-For additional language support see the [`supportPolicy` documentation](/configuration-options/#supportpolicy).
+For additional language support see the [`supportPolicy` documentation](./configuration-options.md#supportpolicy).
 
 ## Configuring which version of npm Renovate uses
 

--- a/docs/usage/noise-reduction.md
+++ b/docs/usage/noise-reduction.md
@@ -20,7 +20,7 @@ If you have any ideas on this topic, please contact the author by starting a [ne
 
 To reduce noise, you can reduce the number of updates in total, and a good way to do that is via intelligent grouping of related packages.
 
-As an example, our default `":app"` and `":library"` [presets](/config-presets/) include the rule `"group:monorepos"`, which means that "sibling" packages from known monorepos will always be grouped into the same branch/PR by renovate.
+As an example, our default `":app"` and `":library"` [presets](./config-presets.md) include the rule `"group:monorepos"`, which means that "sibling" packages from known monorepos will always be grouped into the same branch/PR by renovate.
 For example, all `@angular/*` packages that are updated at the same time will be raised in a "Renovate angular monorepo packages" PR.
 And every package in the React monorepo will be grouped together in a React monorepo PR too.
 

--- a/docs/usage/private-modules.md
+++ b/docs/usage/private-modules.md
@@ -136,7 +136,7 @@ The command run is `git config --global url."https://${token}@github.com/".inste
 
 The best way to do this now is using `hostRules` and no longer via `.npmrc` files on disk or in config.
 `hostRules` credentials with `hostType=npm` are written to a `.npmrc` file in the same directory as the `package.json` being updated.
-See [private npm modules](/private-npm-modules) for more details.
+See [private npm modules](./private-npm-modules.md) for more details.
 
 ### nuget
 

--- a/docs/usage/private-modules.md
+++ b/docs/usage/private-modules.md
@@ -136,7 +136,7 @@ The command run is `git config --global url."https://${token}@github.com/".inste
 
 The best way to do this now is using `hostRules` and no longer via `.npmrc` files on disk or in config.
 `hostRules` credentials with `hostType=npm` are written to a `.npmrc` file in the same directory as the `package.json` being updated.
-See [private npm modules](./private-npm-modules) for more details.
+See [private npm modules](/private-npm-modules) for more details.
 
 ### nuget
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:
The link at https://docs.renovatebot.com/private-modules/#npm is broken.

Link must point to markdown file to be detected by `mkdocs`.
<!-- Describe what behavior is changed by this PR. -->

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
