### PR TITLE
fix: patch grouping when separateMinorPatch=false

### DIFF
--- a/lib/workers/repository/updates/branch-name.spec.ts
+++ b/lib/workers/repository/updates/branch-name.spec.ts
@@ -67,6 +67,7 @@ describe(getName(), () => {
         groupSlug: 'some group slug',
         updateType: 'patch',
         separateMajorMinor: true,
+        separateMinorPatch: true,
         newMajor: 2,
         group: {},
       };

--- a/lib/workers/repository/updates/branch-name.ts
+++ b/lib/workers/repository/updates/branch-name.ts
@@ -41,7 +41,7 @@ export function generateBranchName(update: RenovateConfig): void {
         update.groupSlug = `major-${update.groupSlug}`;
       }
     }
-    if (update.updateType === 'patch') {
+    if (update.updateType === 'patch' && update.separateMinorPatch) {
       update.groupSlug = `patch-${update.groupSlug}`;
     }
     update.branchTopic = update.group.branchTopic || update.branchTopic;

--- a/lib/workers/repository/updates/generate.spec.ts
+++ b/lib/workers/repository/updates/generate.spec.ts
@@ -502,6 +502,7 @@ describe(getName(), () => {
           newValue: '0.6.0',
           isGroup: true,
           separateMajorMinor: true,
+          separateMinorPatch: true,
           updateType: 'patch' as UpdateType,
           fileReplacePosition: 0,
         },

--- a/lib/workers/repository/updates/generate.ts
+++ b/lib/workers/repository/updates/generate.ts
@@ -221,7 +221,10 @@ export function generateBranchConfig(
         upgrade.updateType === 'minor' && upgrade.separateMinorPatch
           ? ' (minor)'
           : '';
-      upgrade.prTitle += upgrade.updateType === 'patch' ? ' (patch)' : '';
+      upgrade.prTitle +=
+        upgrade.updateType === 'patch' && upgrade.separateMinorPatch
+          ? ' (patch)'
+          : '';
     }
     // Compile again to allow for nested templates
     upgrade.prTitle = template.compile(upgrade.prTitle, upgrade);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Fixes logic so that patch updates don't separate themselves from groupings.

## Context:

Previously, if `updateType=patch` then it could only be because separateMinorPatch=true, but now that is not the case and the extra checks are required.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
