### PR TITLE
fix(nodenv): Monorepo support

### DIFF
--- a/lib/manager/nodenv/index.ts
+++ b/lib/manager/nodenv/index.ts
@@ -6,6 +6,6 @@ export { extractPackageFile } from './extract';
 export const language = LANGUAGE_NODE;
 
 export const defaultConfig = {
-  fileMatch: ['^.node-version$'],
+  fileMatch: ['(^|/).node-version$'],
   versioning: nodeVersioning.id,
 };


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

This PR allows Renovate to find `.node-version` files in subdirectories, not only in the root directory.

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

I'm making this change so that projects with a monorepo layout can benefit from Node bumps via `nodenv`.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
