### PR TITLE
fix(gomod): use latest go version when binarySource=docker

### DIFF
--- a/lib/manager/gomod/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/gomod/__snapshots__/extract.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`manager/gomod/extract extractPackageFile() extracts constraints 1`] = `
 Object {
   "constraints": Object {
-    "go": "1.13",
+    "go": "^1.13",
   },
   "deps": Array [
     Object {

--- a/lib/manager/gomod/extract.spec.ts
+++ b/lib/manager/gomod/extract.spec.ts
@@ -21,7 +21,7 @@ describe(getName(__filename), () => {
     it('extracts constraints', () => {
       const res = extractPackageFile(gomod3);
       expect(res).toMatchSnapshot();
-      expect(res.constraints.go).toEqual('1.13');
+      expect(res.constraints.go).toEqual('^1.13');
     });
     it('extracts multi-line requires', () => {
       const res = extractPackageFile(gomod2).deps;

--- a/lib/manager/gomod/extract.ts
+++ b/lib/manager/gomod/extract.ts
@@ -43,7 +43,7 @@ export function extractPackageFile(content: string): PackageFile | null {
     for (let lineNumber = 0; lineNumber < lines.length; lineNumber += 1) {
       let line = lines[lineNumber];
       if (line.startsWith('go ') && validRange(line.replace('go ', ''))) {
-        constraints.go = line.replace('go ', '');
+        constraints.go = line.replace('go ', '^');
       }
       const replaceMatch = /^replace\s+[^\s]+[\s]+[=][>]\s+([^\s]+)\s+([^\s]+)/.exec(
         line


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Changes go constraint detection to be "greater than or equal to", as recommended by Go maintainers.

## Context:

Fixes #9761, maybe others

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
