### PR TITLE
fix: pass ECR credentials properly

### DIFF
--- a/lib/datasource/docker/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/docker/__snapshots__/index.spec.ts.snap
@@ -110,6 +110,42 @@ Array [
 ]
 `;
 
+exports[`datasource/docker/index getDigest passes credentials to ECR client 1`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept-encoding": "gzip, deflate, br",
+      "authorization": "Basic c29tZS11c2VybmFtZTpzb21lLXBhc3N3b3Jk",
+      "host": "123456789.dkr.ecr.us-east-1.amazonaws.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://123456789.dkr.ecr.us-east-1.amazonaws.com/v2/",
+  },
+  Object {
+    "headers": Object {
+      "accept-encoding": "gzip, deflate, br",
+      "authorization": "Basic abcdef",
+      "host": "123456789.dkr.ecr.us-east-1.amazonaws.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://123456789.dkr.ecr.us-east-1.amazonaws.com/v2/",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json",
+      "accept-encoding": "gzip, deflate, br",
+      "authorization": "Basic abcdef",
+      "host": "123456789.dkr.ecr.us-east-1.amazonaws.com",
+      "user-agent": "https://github.com/renovatebot/renovate",
+    },
+    "method": "GET",
+    "url": "https://123456789.dkr.ecr.us-east-1.amazonaws.com/v2/node/manifests/some-tag",
+  },
+]
+`;
+
 exports[`datasource/docker/index getDigest returns digest 1`] = `
 Array [
   Object {

--- a/lib/datasource/docker/index.spec.ts
+++ b/lib/datasource/docker/index.spec.ts
@@ -255,7 +255,7 @@ describe(getName(), () => {
       expect(res).toBeNull();
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
-    it('passes credentials to client', async () => {
+    it('passes credentials to ECR client', async () => {
       httpMock
         .scope(amazonUrl)
         .get('/')
@@ -267,6 +267,10 @@ describe(getName(), () => {
         .get('/node/manifests/some-tag')
         .reply(200, '', { 'docker-content-digest': 'some-digest' });
 
+      mockEcrAuthResolve({
+        authorizationData: [{ authorizationToken: 'abcdef' }],
+      });
+
       await getDigest(
         {
           datasource: 'docker',
@@ -275,6 +279,8 @@ describe(getName(), () => {
         'some-tag'
       );
 
+      const trace = httpMock.getTrace();
+      expect(trace).toMatchSnapshot();
       expect(AWS.ECR).toHaveBeenCalledWith({
         credentials: {
           accessKeyId: 'some-username',

--- a/lib/datasource/docker/index.ts
+++ b/lib/datasource/docker/index.ts
@@ -1,5 +1,5 @@
 import URL from 'url';
-import { ECR } from '@aws-sdk/client-ecr';
+import { ECR, ECRClientConfig } from '@aws-sdk/client-ecr';
 import hasha from 'hasha';
 import parseLinkHeader from 'parse-link-header';
 import wwwAuthenticate from 'www-authenticate';
@@ -113,7 +113,7 @@ async function getECRAuthToken(
   region: string,
   opts: HostRule
 ): Promise<string | null> {
-  const config = { region, credentials: undefined };
+  const config: ECRClientConfig = { region };
   if (opts.username && opts.password) {
     config.credentials = {
       accessKeyId: opts.username,

--- a/lib/datasource/docker/index.ts
+++ b/lib/datasource/docker/index.ts
@@ -113,10 +113,12 @@ async function getECRAuthToken(
   region: string,
   opts: HostRule
 ): Promise<string | null> {
-  const config = { region, accessKeyId: undefined, secretAccessKey: undefined };
+  const config = { region, credentials: undefined };
   if (opts.username && opts.password) {
-    config.accessKeyId = opts.username;
-    config.secretAccessKey = opts.password;
+    config.credentials = {
+      accessKeyId: opts.username,
+      secretAccessKey: opts.password,
+    };
   }
   const ecr = new ECR(config);
   try {


### PR DESCRIPTION
## Changes:

Seems that the AWS SDK introduced a subtle breaking change with v3 where it is now required to pass credentials differently. This MR fixes that, based on looking at the [relevant source code](https://github.com/aws/aws-sdk-js-v3/blob/e3772e0ade/packages/middleware-signing/src/configurations.ts#L12) and a [related StackOverflow answer](https://stackoverflow.com/a/65710211). 

## Context:

Fixes #9766

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
