### PR TITLE
feat(maven): Obtain "last-modified" timestamps for GitLab

### DIFF
--- a/lib/datasource/maven/util.ts
+++ b/lib/datasource/maven/util.ts
@@ -116,7 +116,7 @@ export async function isHttpResourceExists(
     const httpClient = httpByHostType(hostType);
     const res = await httpClient.head(pkgUrl.toString());
     const pkgUrlHost = url.parse(pkgUrl.toString()).host;
-    if (pkgUrlHost === 'repo.maven.apache.org') {
+    if (['repo.maven.apache.org', 'gitlab.com'].includes(pkgUrlHost)) {
       const timestamp = res?.headers?.['last-modified'] as string;
       return timestamp || true;
     }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Support `releaseTimestamp` not only for Maven central, but for GitLab registries as well

## Context:

Ref: #9784

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
