### PR TITLE
fix: keep stabilityDays pending check even if dashboard checked

### DIFF
--- a/lib/workers/branch/index.ts
+++ b/lib/workers/branch/index.ts
@@ -217,10 +217,7 @@ export async function processBranch(
       for (const upgrade of config.upgrades) {
         if (upgrade.stabilityDays && upgrade.releaseTimestamp) {
           const daysElapsed = getElapsedDays(upgrade.releaseTimestamp);
-          if (
-            !dependencyDashboardCheck &&
-            daysElapsed < upgrade.stabilityDays
-          ) {
+          if (daysElapsed < upgrade.stabilityDays) {
             logger.debug(
               {
                 depName: upgrade.depName,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Fixes code that resulted in `renovate/stability-days` being set to passing even if they were not, in the scenario where dependency dashboard was checked.

## Context:

In this scenario we want to create the PR but we don't want to set a misleading status check.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
