### PR TITLE
fix(config): nested packageRules migration

### DIFF
--- a/lib/config/__snapshots__/migration.spec.ts.snap
+++ b/lib/config/__snapshots__/migration.spec.ts.snap
@@ -1,5 +1,37 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`config/migration it migrates nested packageRules 1`] = `
+Object {
+  "packageRules": Array [
+    Object {
+      "enabled": false,
+      "matchDepTypes": Array [
+        "devDependencies",
+      ],
+    },
+    Object {
+      "automerge": true,
+      "excludePackageNames": Array [
+        "@types/react-table",
+      ],
+      "groupName": "definitelyTyped",
+      "matchPackagePrefixes": Array [
+        "@types/",
+      ],
+    },
+    Object {
+      "automerge": false,
+      "excludePackageNames": Array [
+        "@types/react-table",
+      ],
+      "matchDepTypes": Array [
+        "dependencies",
+      ],
+    },
+  ],
+}
+`;
+
 exports[`config/migration migrateConfig(config, parentConfig) does not migrate multi days 1`] = `
 Object {
   "schedule": "after 5:00pm on wednesday and thursday",
@@ -174,6 +206,15 @@ Object {
       "versioning": "maven",
     },
     Object {
+      "automerge": true,
+      "matchDepTypes": Array [
+        "bar",
+      ],
+      "matchPackageNames": Array [
+        "foo",
+      ],
+    },
+    Object {
       "matchDepTypes": Array [
         "peerDependencies",
       ],
@@ -203,15 +244,6 @@ Object {
       },
       "respectLatest": false,
       "schedule": "before 5am on Monday",
-    },
-    Object {
-      "automerge": true,
-      "matchDepTypes": Array [
-        "bar",
-      ],
-      "matchPackageNames": Array [
-        "foo",
-      ],
     },
   ],
   "patch": Object {

--- a/lib/config/migration.spec.ts
+++ b/lib/config/migration.spec.ts
@@ -628,4 +628,35 @@ describe(getName(), () => {
       expect(migratedConfig).toMatchSnapshot();
     });
   });
+  it('it migrates nested packageRules', () => {
+    const config: RenovateConfig = {
+      packageRules: [
+        {
+          matchDepTypes: ['devDependencies'],
+          enabled: false,
+        },
+        {
+          automerge: true,
+          excludePackageNames: ['@types/react-table'],
+          packageRules: [
+            {
+              groupName: 'definitelyTyped',
+              matchPackagePrefixes: ['@types/'],
+            },
+            {
+              matchDepTypes: ['dependencies'],
+              automerge: false,
+            },
+          ],
+        },
+      ],
+    };
+    const { isMigrated, migratedConfig } = configMigration.migrateConfig(
+      config,
+      defaultConfig
+    );
+    expect(isMigrated).toBe(true);
+    expect(migratedConfig).toMatchSnapshot();
+    expect(migratedConfig.packageRules).toHaveLength(3);
+  });
 });

--- a/lib/config/migration.ts
+++ b/lib/config/migration.ts
@@ -554,7 +554,9 @@ export function migrateConfig(
     }
     // Migrate nested packageRules
     if (is.nonEmptyArray(migratedConfig.packageRules)) {
-      for (const packageRule of migratedConfig.packageRules) {
+      const existingRules = migratedConfig.packageRules;
+      migratedConfig.packageRules = [];
+      for (const packageRule of existingRules) {
         if (is.array(packageRule.packageRules)) {
           logger.debug('Flattening nested packageRules');
           // merge each subrule and add to the parent list
@@ -563,22 +565,10 @@ export function migrateConfig(
             delete combinedRule.packageRules;
             migratedConfig.packageRules.push(combinedRule);
           }
-          // delete the nested packageRules
-          delete packageRule.packageRules;
-          // mark the original rule for deletion if it's now pointless
-          if (
-            !Object.keys(packageRule).some(
-              (key) => !key.startsWith('match') && !key.startsWith('exclude')
-            )
-          ) {
-            packageRule._delete = true;
-          }
+        } else {
+          migratedConfig.packageRules.push(packageRule);
         }
       }
-      // filter out any rules which were marked for deletion in the previous step
-      migratedConfig.packageRules = migratedConfig.packageRules.filter(
-        (rule) => !rule._delete
-      );
     }
     const isMigrated = !dequal(config, migratedConfig);
     if (isMigrated) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Fixes nested `packageRules` migration so that:
- a "base" rule is no longer added in addition to the flattened nested rules
- such rules are inserted in the right sorted order cmopared to other rules

## Context:

#9807

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
