### PR TITLE
fix(config): warn not error if extending group presets

### DIFF
--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -602,5 +602,21 @@ describe(getName(), () => {
       expect(errors).toHaveLength(1);
       expect(errors).toMatchSnapshot();
     });
+    it('warns on nested group packageRules', async () => {
+      const config = {
+        packageRules: [
+          {
+            automerge: true,
+            extends: ['group:fortawesome'],
+          },
+        ],
+      };
+      const { warnings, errors } = await configValidation.validateConfig(
+        config,
+        true
+      );
+      expect(errors).toHaveLength(0);
+      expect(warnings).toHaveLength(1);
+    });
   });
 });

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -4,6 +4,7 @@ import { configRegexPredicate, isConfigRegex, regEx } from '../util/regex';
 import * as template from '../util/template';
 import { hasValidSchedule, hasValidTimezone } from '../workers/branch/schedule';
 import { getOptions } from './definitions';
+import { migrateConfig } from './migration';
 import { resolveConfigPresets } from './presets';
 import type {
   RenovateConfig,
@@ -255,6 +256,12 @@ export async function validateConfig(
               const tzRe = /^:timezone\((.+)\)$/;
               for (const subval of val) {
                 if (is.string(subval)) {
+                  if (subval.startsWith('group:')) {
+                    warnings.push({
+                      topic: 'Configuration Warning',
+                      message: `${currentPath}: you should not extend "group:" presets`,
+                    });
+                  }
                   if (tzRe.test(subval)) {
                     const [, timezone] = tzRe.exec(subval);
                     const [validTimezone, errorMessage] = hasValidTimezone(
@@ -297,10 +304,14 @@ export async function validateConfig(
             if (key === 'packageRules') {
               for (const [subIndex, packageRule] of val.entries()) {
                 if (is.object(packageRule)) {
-                  const resolvedRule = await resolveConfigPresets(
-                    packageRule as RenovateConfig,
-                    config
-                  );
+                  const resolvedRule = migrateConfig({
+                    packageRules: [
+                      await resolveConfigPresets(
+                        packageRule as RenovateConfig,
+                        config
+                      ),
+                    ],
+                  }).migratedConfig.packageRules[0];
                   errors.push(
                     ...managerValidator.check({ resolvedRule, currentPath })
                   );


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Warns instead of errors if extending `group:` presets in packageRules.

## Context:

We migrate this ok however it was erroring in validation. Now warn instead of error so that it can proceed, but hopefully people fix this config anyway.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
