### PR TITLE
fix(poetry): add versioning resilience

### DIFF
--- a/lib/versioning/poetry/index.spec.ts
+++ b/lib/versioning/poetry/index.spec.ts
@@ -139,6 +139,9 @@ describe(getName(), () => {
     it('handles wildcards', () => {
       expect(versionig.matches('4.2.0', '*')).toBe(true);
     });
+    it('handles short', () => {
+      expect(versionig.matches('1.4', '1.4')).toBe(true);
+    });
   });
   describe('isLessThanRange()', () => {
     it('handles comma', () => {

--- a/lib/versioning/poetry/index.ts
+++ b/lib/versioning/poetry/index.ts
@@ -1,6 +1,7 @@
 import { parseRange } from 'semver-utils';
 import { logger } from '../../logger';
 import { api as npm } from '../npm';
+import { api as pep440 } from '../pep440';
 import type { NewValueConfig, VersioningApi } from '../types';
 
 export const id = 'poetry';
@@ -67,17 +68,16 @@ function npm2poetry(input: string): string {
   return res.join(', ').replace(/\s*,?\s*\|\|\s*,?\s*/, ' || ');
 }
 
-const equals = (a: string, b: string): boolean =>
-  npm.equals(padZeroes(a), padZeroes(b));
+const equals = (a: string, b: string): boolean => pep440.equals(a, b);
 
-const getMajor = (version: string): number => npm.getMajor(padZeroes(version));
+const getMajor = (version: string): number => pep440.getMajor(version);
 
-const getMinor = (version: string): number => npm.getMinor(padZeroes(version));
+const getMinor = (version: string): number => pep440.getMinor(version);
 
-const getPatch = (version: string): number => npm.getPatch(padZeroes(version));
+const getPatch = (version: string): number => pep440.getPatch(version);
 
 const isGreaterThan = (a: string, b: string): boolean =>
-  npm.isGreaterThan(padZeroes(a), padZeroes(b));
+  pep440.isGreaterThan(a, b);
 
 const isLessThanRange = (version: string, range: string): boolean =>
   npm.isLessThanRange(padZeroes(version), poetry2npm(range));
@@ -90,8 +90,9 @@ const isStable = (version: string): boolean =>
 
 const isVersion = (input: string): string | boolean =>
   npm.isVersion(padZeroes(input));
+
 const matches = (version: string, range: string): boolean =>
-  npm.matches(version, poetry2npm(range));
+  npm.matches(padZeroes(version), poetry2npm(range));
 
 const getSatisfyingVersion = (versions: string[], range: string): string =>
   npm.getSatisfyingVersion(versions, poetry2npm(range));


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds resilience checks to poetry versioning to reduce chances of pep440 versions being passed to npm versioning.

## Context:

Fixes #9369

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
