### PR TITLE
fix: ignore yargs-parser false positive

### DIFF
--- a/lib/workers/repository/init/vulnerability.spec.ts
+++ b/lib/workers/repository/init/vulnerability.spec.ts
@@ -63,6 +63,21 @@ describe(getName(), () => {
           },
         },
         {
+          // this will be ignored
+          dismissReason: null,
+          vulnerableManifestFilename: 'package-lock.json',
+          vulnerableManifestPath: 'backend/package-lock.json',
+          securityAdvisory: {
+            references: [],
+            severity: null,
+          },
+          securityVulnerability: {
+            package: { ecosystem: 'NPM', name: 'yargs-parser' },
+            vulnerableVersionRange: '>5.0.0-security.0',
+          },
+          vulnerableRequirements: '= 5.0.1',
+        },
+        {
           dismissReason: 'some reason',
           vulnerableManifestFilename: 'package-lock.json',
           vulnerableManifestPath: 'package-lock.json',

--- a/lib/workers/repository/init/vulnerability.ts
+++ b/lib/workers/repository/init/vulnerability.ts
@@ -67,6 +67,13 @@ export async function detectVulnerabilityAlerts(
   };
   const combinedAlerts: CombinedAlert = {};
   for (const alert of alerts) {
+    if (
+      alert.securityVulnerability?.package?.name === 'yargs-parser' &&
+      (alert.vulnerableRequirements === '= 5.0.0-security.0' ||
+        alert.vulnerableRequirements === '= 5.0.1')
+    ) {
+      continue; // eslint-disable-line no-continue
+    }
     try {
       if (alert.dismissReason) {
         continue; // eslint-disable-line no-continue


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds a manual fix to work around a problem with GitHub's vulnerability metadata for `yargs-parser`.

## Context:

Otherwise there's a continuous loop of GitHub finding the version to be vulnerable.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
