### PR TITLE
fix(pre-commit): allow hooks in the format git://

### DIFF
--- a/lib/manager/pre-commit/__fixtures__/.pre-commit-config.yaml
+++ b/lib/manager/pre-commit/__fixtures__/.pre-commit-config.yaml
@@ -8,3 +8,7 @@ repos:
     -   id: end-of-file-fixer
     -   id: check-yaml
     -   id: check-added-large-files
+- repo: git://github.com/pre-commit/pre-commit-hooks
+  rev: v2.1.0
+  hooks:
+    - id: check-merge-conflict

--- a/lib/manager/pre-commit/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/pre-commit/__snapshots__/extract.spec.ts.snap
@@ -118,6 +118,13 @@ Object {
       "depType": "repository",
       "lookupName": "pre-commit/pre-commit-hooks",
     },
+    Object {
+      "currentValue": "v2.1.0",
+      "datasource": "github-tags",
+      "depName": "pre-commit/pre-commit-hooks",
+      "depType": "repository",
+      "lookupName": "pre-commit/pre-commit-hooks",
+    },
   ],
 }
 `;

--- a/lib/manager/pre-commit/extract.ts
+++ b/lib/manager/pre-commit/extract.ts
@@ -92,6 +92,8 @@ function extractDependency(
     regEx('^https?:\\/\\/(?<hostname>[^\\/]+)\\/(?<depName>\\S*)'),
     // This splits "git@private.registry.com:user/repo" -> "private.registry.com" "user/repo
     regEx('^git@(?<hostname>[^:]+):(?<depName>\\S*)'),
+    // This split "git://github.com/pre-commit/pre-commit-hooks" -> "github.com" "pre-commit/pre-commit-hooks"
+    /^git:\/\/(?<hostname>[^/]+)\/(?<depName>\S*)/,
   ];
   for (const urlMatcher of urlMatchers) {
     const match = urlMatcher.exec(repository);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->
This PR enables the pre-commit manager to process git URLs with a `git://` prefix

## Context:

If this URL style is used renovate ignores them at the moment. 

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
