### PR TITLE
fix(npm): pass `Basic` token as `_auth` key

### DIFF
--- a/lib/manager/npm/post-update/index.ts
+++ b/lib/manager/npm/post-update/index.ts
@@ -447,15 +447,16 @@ export async function getAdditionalFiles(
   });
   for (const hostRule of npmHostRules) {
     if (hostRule.token) {
+      const key = hostRule.authType === 'Basic' ? '_auth' : '_authToken';
       if (hostRule.baseUrl) {
         additionalNpmrcContent.push(
-          `${hostRule.baseUrl}:_authToken=${hostRule.token}`
+          `${hostRule.baseUrl}:${key}=${hostRule.token}`
             .replace('https://', '//')
             .replace('http://', '//')
         );
       } else if (hostRule.hostName) {
         additionalNpmrcContent.push(
-          `//${hostRule.hostName}/:_authToken=${hostRule.token}`
+          `//${hostRule.hostName}/:${key}=${hostRule.token}`
         );
       }
     } else if (is.string(hostRule.username) && is.string(hostRule.password)) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Pass host rule with `authType=Basic` as `_auth=<token>` to `.npmrc`. This is a fix for `v24`, `main` fix will come later
<!-- Describe what behavior is changed by this PR. -->

## Context:

ref #9849
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
