### PR TITLE
refactor(managers): Use moo fallback for unknown fragments

### DIFF
--- a/lib/manager/bazel/extract.ts
+++ b/lib/manager/bazel/extract.ts
@@ -89,19 +89,19 @@ const lexer = moo.states({
   },
   longDoubleQuoted: {
     stringFinish: { match: '"""', pop: 1 },
-    char: { match: /[^]/, lineBreaks: true },
+    char: moo.fallback,
   },
   doubleQuoted: {
     stringFinish: { match: '"', pop: 1 },
-    char: { match: /[^]/, lineBreaks: true },
+    char: moo.fallback,
   },
   longSingleQuoted: {
     stringFinish: { match: "'''", pop: 1 },
-    char: { match: /[^]/, lineBreaks: true },
+    char: moo.fallback,
   },
   singleQuoted: {
     stringFinish: { match: "'", pop: 1 },
-    char: { match: /[^]/, lineBreaks: true },
+    char: moo.fallback,
   },
 });
 

--- a/lib/manager/bazel/extract.ts
+++ b/lib/manager/bazel/extract.ts
@@ -85,7 +85,7 @@ const lexer = moo.states({
         ].join('|')
       ),
     },
-    unknown: { match: /[^]/, lineBreaks: true },
+    unknown: moo.fallback,
   },
   longDoubleQuoted: {
     stringFinish: { match: '"""', pop: 1 },

--- a/lib/manager/cake/index.ts
+++ b/lib/manager/cake/index.ts
@@ -21,7 +21,7 @@ const lexer = moo.states({
       match: /^#(?:addin|tool|module)\s+"(?:nuget|dotnet):[^"]+"\s*$/,
       value: (s: string) => s.trim().slice(1, -1),
     },
-    unknown: { match: /[^]/, lineBreaks: true },
+    unknown: moo.fallback,
   },
 });
 

--- a/lib/manager/gradle-lite/common.ts
+++ b/lib/manager/gradle-lite/common.ts
@@ -60,7 +60,6 @@ export enum TokenType {
   EscapedChar = 'escapedChar',
   String = 'string',
 
-  UnknownLexeme = 'unknownChar',
   UnknownFragment = 'unknownFragment',
 }
 

--- a/lib/manager/gradle-lite/common.ts
+++ b/lib/manager/gradle-lite/common.ts
@@ -56,7 +56,7 @@ export enum TokenType {
   TripleDoubleQuotedStart = 'tripleDoubleQuotedStart',
   TripleQuotedFinish = 'tripleQuotedFinish',
 
-  Char = 'char',
+  Chars = 'chars',
   EscapedChar = 'escapedChar',
   String = 'string',
 

--- a/lib/manager/gradle-lite/tokenizer.spec.ts
+++ b/lib/manager/gradle-lite/tokenizer.spec.ts
@@ -35,7 +35,7 @@ describe(getName(), () => {
         TokenType.RightBrace,
         TokenType.RightBrace,
       ],
-      '@': [TokenType.UnknownLexeme],
+      '@': [TokenType.UnknownFragment],
       "'\\''": [
         TokenType.SingleQuotedStart,
         TokenType.EscapedChar,
@@ -130,9 +130,7 @@ describe(getName(), () => {
       '"${x()}"': [
         TokenType.DoubleQuotedStart,
         TokenType.IgnoredInterpolationStart,
-        TokenType.UnknownLexeme,
-        TokenType.UnknownLexeme,
-        TokenType.UnknownLexeme,
+        TokenType.UnknownFragment,
         TokenType.RightBrace,
         TokenType.DoubleQuotedFinish,
       ],
@@ -140,7 +138,7 @@ describe(getName(), () => {
       '"${x{}}"': [
         TokenType.DoubleQuotedStart,
         TokenType.IgnoredInterpolationStart,
-        TokenType.UnknownLexeme,
+        TokenType.UnknownFragment,
         TokenType.LeftBrace,
         TokenType.RightBrace,
         TokenType.RightBrace,

--- a/lib/manager/gradle-lite/tokenizer.spec.ts
+++ b/lib/manager/gradle-lite/tokenizer.spec.ts
@@ -54,23 +54,22 @@ describe(getName(), () => {
       ],
       "'x'": [
         TokenType.SingleQuotedStart,
-        TokenType.Char,
+        TokenType.Chars,
         TokenType.SingleQuotedFinish,
       ],
       "'\n'": [
         TokenType.SingleQuotedStart,
-        TokenType.Char,
+        TokenType.Chars,
         TokenType.SingleQuotedFinish,
       ],
       "'$x'": [
         TokenType.SingleQuotedStart,
-        TokenType.Char,
-        TokenType.Char,
+        TokenType.Chars,
         TokenType.SingleQuotedFinish,
       ],
       "''''''": ['tripleQuotedStart', 'tripleQuotedFinish'],
-      "'''x'''": ['tripleQuotedStart', TokenType.Char, 'tripleQuotedFinish'],
-      "'''\n'''": ['tripleQuotedStart', TokenType.Char, 'tripleQuotedFinish'],
+      "'''x'''": ['tripleQuotedStart', TokenType.Chars, 'tripleQuotedFinish'],
+      "'''\n'''": ['tripleQuotedStart', TokenType.Chars, 'tripleQuotedFinish'],
       "'''\\''''": [
         'tripleQuotedStart',
         TokenType.EscapedChar,
@@ -106,12 +105,12 @@ describe(getName(), () => {
       ],
       '"x"': [
         TokenType.DoubleQuotedStart,
-        TokenType.Char,
+        TokenType.Chars,
         TokenType.DoubleQuotedFinish,
       ],
       '"\n"': [
         TokenType.DoubleQuotedStart,
-        TokenType.Char,
+        TokenType.Chars,
         TokenType.DoubleQuotedFinish,
       ],
       // eslint-disable-next-line no-template-curly-in-string

--- a/lib/manager/gradle-lite/tokenizer.ts
+++ b/lib/manager/gradle-lite/tokenizer.ts
@@ -55,7 +55,7 @@ const lexer = moo.states({
       match: '"',
       push: TokenType.DoubleQuotedStart,
     },
-    [TokenType.UnknownLexeme]: { match: /./ },
+    [TokenType.UnknownFragment]: moo.fallback,
   },
 
   // Tokenize triple-quoted string literal characters
@@ -102,26 +102,9 @@ const lexer = moo.states({
       push: TokenType.IgnoredInterpolationStart,
     },
     [TokenType.RightBrace]: { match: '}', pop: 1 },
-    [TokenType.UnknownLexeme]: { match: /[^]/, lineBreaks: true },
+    [TokenType.UnknownFragment]: moo.fallback,
   },
 });
-
-/*
-  Turn UnknownLexeme chars to UnknownFragment strings
- */
-function processUnknownLexeme(acc: Token[], token: Token): Token[] {
-  if (token.type === TokenType.UnknownLexeme) {
-    const prevToken: Token = acc[acc.length - 1];
-    if (prevToken?.type === TokenType.UnknownFragment) {
-      prevToken.value += token.value;
-    } else {
-      acc.push({ ...token, type: TokenType.UnknownFragment });
-    }
-  } else {
-    acc.push(token);
-  }
-  return acc;
-}
 
 //
 // Turn separated chars of string literal to single String token
@@ -221,7 +204,6 @@ export function extractRawTokens(input: string): Token[] {
 
 export function processTokens(tokens: Token[]): Token[] {
   return tokens
-    .reduce(processUnknownLexeme, [])
     .reduce(processChar, [])
     .reduce(processInterpolation, [])
     .filter(filterTokens);

--- a/lib/manager/gradle-lite/tokenizer.ts
+++ b/lib/manager/gradle-lite/tokenizer.ts
@@ -62,19 +62,19 @@ const lexer = moo.states({
   [TokenType.TripleSingleQuotedStart]: {
     ...escapedChars,
     [TokenType.TripleQuotedFinish]: { match: "'''", pop: 1 },
-    [TokenType.Char]: { match: /[^]/, lineBreaks: true },
+    [TokenType.Chars]: moo.fallback,
   },
   [TokenType.TripleDoubleQuotedStart]: {
     ...escapedChars,
     [TokenType.TripleQuotedFinish]: { match: '"""', pop: 1 },
-    [TokenType.Char]: { match: /[^]/, lineBreaks: true },
+    [TokenType.Chars]: moo.fallback,
   },
 
   // Tokenize single-quoted string literal characters
   [TokenType.SingleQuotedStart]: {
     ...escapedChars,
     [TokenType.SingleQuotedFinish]: { match: "'", pop: 1 },
-    [TokenType.Char]: { match: /[^]/, lineBreaks: true },
+    [TokenType.Chars]: moo.fallback,
   },
 
   // Tokenize double-quoted string literal chars and interpolations
@@ -91,7 +91,7 @@ const lexer = moo.states({
       match: /\${/,
       push: TokenType.IgnoredInterpolationStart,
     },
-    [TokenType.Char]: { match: /[^]/, lineBreaks: true },
+    [TokenType.Chars]: moo.fallback,
   },
 
   // Ignore interpolation of complex expressions˙,
@@ -107,12 +107,12 @@ const lexer = moo.states({
 });
 
 //
-// Turn separated chars of string literal to single String token
+// Turn substrings of chars and escaped chars into single String token
 //
-function processChar(acc: Token[], token: Token): Token[] {
+function processChars(acc: Token[], token: Token): Token[] {
   const tokenType = token.type;
   const prevToken: Token = acc[acc.length - 1];
-  if ([TokenType.Char, TokenType.EscapedChar].includes(tokenType)) {
+  if ([TokenType.Chars, TokenType.EscapedChar].includes(tokenType)) {
     if (prevToken?.type === TokenType.String) {
       prevToken.value += token.value;
     } else {
@@ -204,7 +204,7 @@ export function extractRawTokens(input: string): Token[] {
 
 export function processTokens(tokens: Token[]): Token[] {
   return tokens
-    .reduce(processChar, [])
+    .reduce(processChars, [])
     .reduce(processInterpolation, [])
     .filter(filterTokens);
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Use undocumented `moo.fallback` token instead of parsing unknown chars and aggregating them into fragments.
This should decrease garbage memory pollination.

## Context:

Missed this option: https://github.com/no-context/moo/issues/112

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
