### PR TITLE
fix(validation): only warn when extending group in rules

### DIFF
--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -604,6 +604,7 @@ describe(getName(), () => {
     });
     it('warns on nested group packageRules', async () => {
       const config = {
+        extends: ['group:fortawesome'],
         packageRules: [
           {
             automerge: true,

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -256,7 +256,10 @@ export async function validateConfig(
               const tzRe = /^:timezone\((.+)\)$/;
               for (const subval of val) {
                 if (is.string(subval)) {
-                  if (subval.startsWith('group:')) {
+                  if (
+                    parentName === 'packageRules' &&
+                    subval.startsWith('group:')
+                  ) {
                     warnings.push({
                       topic: 'Configuration Warning',
                       message: `${currentPath}: you should not extend "group:" presets`,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Fixes to only warn if extending `group` presets within `packageRules`.

## Context:

#9868 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
