### PR TITLE
fix(github): use forkToken if present for automerge

### DIFF
--- a/lib/platform/github/index.ts
+++ b/lib/platform/github/index.ts
@@ -1569,9 +1569,13 @@ export async function mergePr(
   const url = `repos/${
     config.parentRepo || config.repository
   }/pulls/${prNo}/merge`;
-  const options = {
+  const options: any = {
     body: {} as { merge_method?: string },
   };
+  // istanbul ignore if
+  if (config.forkToken) {
+    options.token = config.forkToken;
+  }
   let automerged = false;
   if (config.mergeMethod) {
     // This path is taken if we have auto-detected the allowed merge types from the repo

--- a/lib/platform/github/index.ts
+++ b/lib/platform/github/index.ts
@@ -1592,7 +1592,7 @@ export async function mergePr(
           'GitHub blocking PR merge -- will keep trying'
         );
       } else {
-        logger.warn({ err }, `Failed to ${options.body.merge_method} merge PR`);
+        logger.warn({ err }, `Failed to ${config.mergeMethod} merge PR`);
         return false;
       }
     }
@@ -1604,29 +1604,20 @@ export async function mergePr(
       logger.debug({ options, url }, `mergePr`);
       await githubApi.putJson(url, options);
     } catch (err1) {
-      logger.debug(
-        { err: err1 },
-        `Failed to ${options.body.merge_method} merge PR`
-      );
+      logger.debug({ err: err1 }, `Failed to rebase merge PR`);
       try {
         options.body.merge_method = 'squash';
         logger.debug({ options, url }, `mergePr`);
         await githubApi.putJson(url, options);
       } catch (err2) {
-        logger.debug(
-          { err: err2 },
-          `Failed to ${options.body.merge_method} merge PR`
-        );
+        logger.debug({ err: err2 }, `Failed to merge squash PR`);
         try {
           options.body.merge_method = 'merge';
           logger.debug({ options, url }, `mergePr`);
           await githubApi.putJson(url, options);
         } catch (err3) {
-          logger.debug(
-            { err: err3 },
-            `Failed to ${options.body.merge_method} merge PR`
-          );
-          logger.debug({ pr: prNo }, 'All merge attempts failed');
+          logger.debug({ err: err3 }, `Failed to merge commit PR`);
+          logger.info({ pr: prNo }, 'All merge attempts failed');
           return false;
         }
       }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Uses forkToken for automerging if configured.

## Context:

#9866

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
