### PR TITLE
fix(hostRules): domainName matching

### DIFF
--- a/lib/util/host-rules.spec.ts
+++ b/lib/util/host-rules.spec.ts
@@ -96,6 +96,13 @@ describe(getName(), () => {
         find({ hostType: datasourceNuget.id, url: 'https://api.github.com' })
           .token
       ).toEqual('def');
+      expect(
+        find({ hostType: datasourceNuget.id, url: 'https://github.com' }).token
+      ).toEqual('def');
+      expect(
+        find({ hostType: datasourceNuget.id, url: 'https://apigithub.com' })
+          .token
+      ).toBeUndefined();
     });
     it('matches on hostName', () => {
       add({

--- a/lib/util/host-rules.ts
+++ b/lib/util/host-rules.ts
@@ -94,7 +94,7 @@ function matchesDomainName(rule: HostRule, search: HostRuleSearch): boolean {
     search.url &&
     rule.domainName &&
     hostname &&
-    hostname.endsWith(rule.domainName)
+    (hostname === rule.domainName || hostname.endsWith(`.${rule.domainName}`))
   );
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Fixes domainName endsWith matching in hostRules.

## Context:

Current approach was too flexible.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
