### PR TITLE
fix(config): Massage config everytime

### DIFF
--- a/lib/config/file.ts
+++ b/lib/config/file.ts
@@ -1,5 +1,6 @@
 import upath from 'upath';
 import { logger } from '../logger';
+import { massageConfig } from './massage';
 import { migrateConfig } from './migration';
 import type { GlobalConfig } from './types';
 
@@ -30,5 +31,5 @@ export function getConfig(env: NodeJS.ProcessEnv): GlobalConfig {
     );
     config = migratedConfig;
   }
-  return config;
+  return massageConfig(migratedConfig);
 }

--- a/lib/workers/global/autodiscover.spec.ts
+++ b/lib/workers/global/autodiscover.spec.ts
@@ -5,6 +5,7 @@ import * as platform from '../../platform';
 import * as _ghApi from '../../platform/github';
 import * as _hostRules from '../../util/host-rules';
 import { autodiscoverRepositories } from './autodiscover';
+import { massageConfig } from '../../config/massage';
 
 jest.mock('../../platform/github');
 jest.unmock('../../platform');
@@ -34,6 +35,7 @@ describe(getName(), () => {
       token: 'abc',
     }));
     ghApi.getRepos = jest.fn(() => Promise.resolve([]));
+    config = massageConfig(config);
     const res = await autodiscoverRepositories(config);
     expect(res).toEqual(config);
   });
@@ -44,6 +46,7 @@ describe(getName(), () => {
       token: 'abc',
     }));
     ghApi.getRepos = jest.fn(() => Promise.resolve(['a', 'b']));
+    config = massageConfig(config);
     const res = await autodiscoverRepositories(config);
     expect(res.repositories).toHaveLength(2);
   });
@@ -57,12 +60,13 @@ describe(getName(), () => {
     ghApi.getRepos = jest.fn(() =>
       Promise.resolve(['project/repo', 'project/another-repo'])
     );
+    config = massageConfig(config);
     const res = await autodiscoverRepositories(config);
     expect(res.repositories).toEqual(['project/repo']);
   });
   it('filters autodiscovered github repos but nothing matches', async () => {
     config.autodiscover = true;
-    config.autodiscoverFilter = 'project/re*';
+    config.autodiscoverFilter = ['project/re*'];
     config.platform = 'github';
     hostRules.find = jest.fn(() => ({
       token: 'abc',
@@ -70,7 +74,53 @@ describe(getName(), () => {
     ghApi.getRepos = jest.fn(() =>
       Promise.resolve(['another-project/repo', 'another-project/another-repo'])
     );
+    config = massageConfig(config);
     const res = await autodiscoverRepositories(config);
     expect(res).toEqual(config);
+  });
+  it('filters autodiscovered github repos with string variable', async () => {
+    config.autodiscover = true;
+    config.autodiscoverFilter = 'project/re*';
+    config.platform = 'github';
+    hostRules.find = jest.fn(() => ({
+      token: 'abc',
+    }));
+    ghApi.getRepos = jest.fn(() =>
+      Promise.resolve(['project/repo', 'another-project/another-repo'])
+    );
+    config = massageConfig(config);
+    const res = await autodiscoverRepositories(config);
+    expect(res.repositories).toEqual(['project/repo']);
+  });
+  it('filters autodiscovered github repos with string variable but empty', async () => {
+    config.autodiscover = true;
+    config.autodiscoverFilter = 'project/re*';
+    config.platform = 'github';
+    hostRules.find = jest.fn(() => ({
+      token: 'abc',
+    }));
+    ghApi.getRepos = jest.fn(() =>
+      Promise.resolve(['not-a-target/repo', 'another-project/another-repo'])
+    );
+    config = massageConfig(config);
+    const res = await autodiscoverRepositories(config);
+    expect(res).toEqual(config);
+  });
+  it('filters autodiscoverd repos with string variable deeper', async () => {
+    config.autodiscover = true;
+    config.autodiscoverFilter = 'myprj/**/*';
+    config.platform = 'github';
+    hostRules.find = jest.fn(() => ({
+      token: 'abc',
+    }));
+    ghApi.getRepos = jest.fn(() =>
+      Promise.resolve([
+        'myprj/subgroup-1/renovate-test-3',
+        'another-project/another-repo',
+      ])
+    );
+    config = massageConfig(config);
+    const res = await autodiscoverRepositories(config);
+    expect(res.repositories).toEqual(['myprj/subgroup-1/renovate-test-3']);
   });
 });


### PR DESCRIPTION
The config has only been "massaged" when presets where used.
This lead into problems as described in #9639.

Ref #8763


After this PR has been merged we can undo #9641.


## Changes:

When the config is read (via `getConfig(…)`) it was returned directly, without calling `massageConfig(…)`.
`massageConfig(…)` is only called when presets are used in the `renovate.json` config.

## Context:

Used renovate config to test against real repos:
```js
const baseConfig = {
  semanticCommits: "disabled",
  // Configure to `false` to disable deleting orphan branches and autoclosing PRs.
  pruneStaleBranches: false,
  enabledManagers: [
    'dockerfile',
  ],
};

module.exports = {
  dryRun: true,
  autodiscover: true,
  autodiscoverFilter: 'rentest/**/*',
  dependencyDashboard: true,
  dependencyDashboardAutoclose: true,
  persistRepoData: true,
  endpoint: "https://********/api/v4/",
  logLevel: "debug",
  platform: "gitlab",
  printConfig: false,
};

```

The group structure in GitLab is as shown:
```
rentest/
├── nicegrp/
│   ├── prj-1
│   └── prj-2
```

Renovate processes `prj-1` and `prj-2`

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
