### PR TITLE
fix(poetry): improve versioning resilience

### DIFF
--- a/lib/versioning/pep440/range.ts
+++ b/lib/versioning/pep440/range.ts
@@ -59,7 +59,7 @@ export function getNewValue({
     logger.warn('Empty currentValue: ' + currentValue);
     return currentValue;
   }
-  if (rangeStrategy === 'replace') {
+  if (rangeStrategy === 'auto' || rangeStrategy === 'replace') {
     if (satisfies(newVersion, currentValue)) {
       return currentValue;
     }

--- a/lib/versioning/poetry/index.ts
+++ b/lib/versioning/poetry/index.ts
@@ -80,18 +80,18 @@ const isGreaterThan = (a: string, b: string): boolean =>
   pep440.isGreaterThan(a, b);
 
 const isLessThanRange = (version: string, range: string): boolean =>
+  npm.isVersion(padZeroes(version)) &&
   npm.isLessThanRange(padZeroes(version), poetry2npm(range));
 
 export const isValid = (input: string): string | boolean =>
   npm.isValid(poetry2npm(input));
 
-const isStable = (version: string): boolean =>
-  version && npm.isStable(padZeroes(version));
+const isStable = (version: string): boolean => pep440.isStable(version);
 
-const isVersion = (input: string): string | boolean =>
-  npm.isVersion(padZeroes(input));
+const isVersion = (input: string): string | boolean => pep440.isVersion(input);
 
 const matches = (version: string, range: string): boolean =>
+  npm.isVersion(padZeroes(version)) &&
   npm.matches(padZeroes(version), poetry2npm(range));
 
 const getSatisfyingVersion = (versions: string[], range: string): string =>


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds some extra validation to avoid poetry versioning runtime errors.

## Context:

Runtime errors in the hosted app with non-pep440 compatible versions being compared.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
