### PR TITLE
fix(yarn): skip installs even if fancy refs

### DIFF
--- a/lib/manager/npm/extract/__snapshots__/index.spec.ts.snap
+++ b/lib/manager/npm/extract/__snapshots__/index.spec.ts.snap
@@ -145,7 +145,7 @@ Object {
   "packageJsonName": undefined,
   "packageJsonType": "library",
   "pnpmShrinkwrap": undefined,
-  "skipInstalls": false,
+  "skipInstalls": true,
   "yarnLock": undefined,
   "yarnWorkspacesPackages": undefined,
   "yarnrc": undefined,
@@ -351,7 +351,7 @@ Object {
   "managerData": Object {
     "lernaJsonFile": undefined,
   },
-  "npmLock": undefined,
+  "npmLock": "package-lock.json",
   "npmrc": undefined,
   "packageFileVersion": undefined,
   "packageJsonName": undefined,

--- a/lib/manager/npm/extract/index.spec.ts
+++ b/lib/manager/npm/extract/index.spec.ts
@@ -318,6 +318,12 @@ describe(getName(), () => {
       expect(res).toMatchSnapshot();
     });
     it('extracts npm package alias', async () => {
+      fs.readLocalFile = jest.fn((fileName) => {
+        if (fileName === 'package-lock.json') {
+          return '{}';
+        }
+        return null;
+      });
       const pJson = {
         dependencies: {
           a: 'npm:foo@1',

--- a/lib/manager/npm/extract/index.ts
+++ b/lib/manager/npm/extract/index.ts
@@ -346,7 +346,7 @@ export async function extractPackageFile(
   }
   let skipInstalls = config.skipInstalls;
   if (skipInstalls === null) {
-    if (hasFancyRefs) {
+    if (hasFancyRefs && lockFiles.npmLock) {
       // https://github.com/npm/cli/issues/1432
       // Explanation:
       //  - npm install --package-lock-only is buggy for transitive deps in file: and npm: references


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Skips installs due to fancy package.json refs only if `package-lock.json` is present.

## Context:

No need to slow yarn down.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
