### PR TITLE
fix(poetry): fall back to npm versioning completely

### DIFF
--- a/lib/versioning/poetry/index.ts
+++ b/lib/versioning/poetry/index.ts
@@ -1,7 +1,6 @@
 import { parseRange } from 'semver-utils';
 import { logger } from '../../logger';
 import { api as npm } from '../npm';
-import { api as pep440 } from '../pep440';
 import type { NewValueConfig, VersioningApi } from '../types';
 
 export const id = 'poetry';
@@ -68,16 +67,17 @@ function npm2poetry(input: string): string {
   return res.join(', ').replace(/\s*,?\s*\|\|\s*,?\s*/, ' || ');
 }
 
-const equals = (a: string, b: string): boolean => pep440.equals(a, b);
+const equals = (a: string, b: string): boolean =>
+  npm.equals(padZeroes(a), padZeroes(b));
 
-const getMajor = (version: string): number => pep440.getMajor(version);
+const getMajor = (version: string): number => npm.getMajor(padZeroes(version));
 
-const getMinor = (version: string): number => pep440.getMinor(version);
+const getMinor = (version: string): number => npm.getMinor(padZeroes(version));
 
-const getPatch = (version: string): number => pep440.getPatch(version);
+const getPatch = (version: string): number => npm.getPatch(padZeroes(version));
 
 const isGreaterThan = (a: string, b: string): boolean =>
-  pep440.isGreaterThan(a, b);
+  npm.isGreaterThan(padZeroes(a), padZeroes(b));
 
 const isLessThanRange = (version: string, range: string): boolean =>
   npm.isVersion(padZeroes(version)) &&
@@ -86,9 +86,10 @@ const isLessThanRange = (version: string, range: string): boolean =>
 export const isValid = (input: string): string | boolean =>
   npm.isValid(poetry2npm(input));
 
-const isStable = (version: string): boolean => pep440.isStable(version);
+const isStable = (version: string): boolean => npm.isStable(padZeroes(version));
 
-const isVersion = (input: string): string | boolean => pep440.isVersion(input);
+const isVersion = (input: string): string | boolean =>
+  npm.isVersion(padZeroes(input));
 
 const matches = (version: string, range: string): boolean =>
   npm.isVersion(padZeroes(version)) &&


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Use npm versioning for poetry versioning and not pep440.

## Context:

Attempts to be more flexible by using pep440 resulted in too many edge case errors. We need a different approach

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
