### PR TITLE
feat: sourceRepoSlug

### DIFF
--- a/lib/util/template/index.ts
+++ b/lib/util/template/index.ts
@@ -88,6 +88,7 @@ export const allowedFields = {
   releaseNotes: 'A ChangeLogNotes object for the release',
   repository: 'The current repository',
   semanticPrefix: 'The fully generated semantic prefix for commit messages',
+  sourceRepoSlug: 'The slugified pathname of the sourceUrl, if present',
   sourceUrl: 'The source URL for the package',
   updateType: 'One of digest, pin, rollback, patch, minor, major',
   upgrades: 'An array of upgrade objects in the branch',

--- a/lib/workers/repository/updates/flatten.spec.ts
+++ b/lib/workers/repository/updates/flatten.spec.ts
@@ -44,8 +44,24 @@ describe(getName(), () => {
             packageFile: 'package.json',
             lockFiles: ['package-lock.json'],
             deps: [
-              { depName: '@org/a', updates: [{ newValue: '1.0.0' }] },
-              { depName: 'foo', updates: [{ newValue: '2.0.0' }] },
+              {
+                depName: '@org/a',
+                updates: [
+                  {
+                    newValue: '1.0.0',
+                    sourceUrl: 'https://github.com/org/repo',
+                  },
+                ],
+              },
+              {
+                depName: 'foo',
+                updates: [
+                  {
+                    newValue: '2.0.0',
+                    sourceUrl: 'https://github.com/org/repo',
+                  },
+                ],
+              },
               {
                 updateTypes: ['pin'],
                 updates: [{ newValue: '2.0.0' }],
@@ -54,7 +70,12 @@ describe(getName(), () => {
           },
           {
             packageFile: 'backend/package.json',
-            deps: [{ depName: 'bar', updates: [{ newValue: '3.0.0' }] }],
+            deps: [
+              {
+                depName: 'bar',
+                updates: [{ newValue: '3.0.0', sourceUrl: 3 }],
+              },
+            ],
           },
           {
             packageFile: 'frontend/package.json',
@@ -68,6 +89,7 @@ describe(getName(), () => {
               {
                 depName: 'amd64/node',
                 language: LANGUAGE_DOCKER,
+                sourceUrl: 'https://github.com/nodejs/node',
                 updates: [{ newValue: '10.0.1' }],
               },
             ],
@@ -78,6 +100,7 @@ describe(getName(), () => {
               {
                 depName: 'calico/node',
                 language: LANGUAGE_DOCKER,
+                sourceUrl: 'https://calico.com',
                 updates: [{ newValue: '3.2.0', updateType: 'minor' }],
               },
             ],
@@ -109,6 +132,7 @@ describe(getName(), () => {
       };
       const res = await flattenUpdates(config, packageFiles);
       expect(res).toHaveLength(13);
+      expect(res.filter((update) => update.sourceRepoSlug)).toHaveLength(3);
       expect(
         res.filter((r) => r.updateType === 'lockFileMaintenance')
       ).toHaveLength(2);

--- a/lib/workers/repository/updates/flatten.ts
+++ b/lib/workers/repository/updates/flatten.ts
@@ -7,6 +7,7 @@ import type { RenovateConfig } from '../../../config/types';
 import { getDefaultConfig } from '../../../datasource';
 import { get } from '../../../manager';
 import { applyPackageRules } from '../../../util/package-rules';
+import { parseUrl } from '../../../util/url';
 import type { BranchUpgradeConfig } from '../../types';
 import { generateBranchName } from './branch-name';
 
@@ -26,6 +27,15 @@ export function applyUpdateConfig(input: BranchUpgradeConfig): any {
         .replace(/-+/, '-')
         .toLowerCase()
     : undefined;
+  if (updateConfig.sourceUrl) {
+    const parsedSourceUrl = parseUrl(updateConfig.sourceUrl);
+    if (parsedSourceUrl?.pathname) {
+      updateConfig.sourceRepoSlug = parsedSourceUrl.pathname
+        .replace(/^\//, '') // remove leading slash
+        .replace(/\//g, '-') // change slashes to hyphens
+        .replace(/-+/g, '-'); // remove multiple hyphens
+    }
+  }
   generateBranchName(updateConfig);
   return updateConfig;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds new field `sourceRepoSlug` to templates.

## Context:

Useful for using the source URL in branch names in a manageable way.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or (indirectly via template addition)
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
