### PR TITLE
fix: avoid error if no currentVersion found

### DIFF
--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -153,6 +153,10 @@ export async function lookupUpdates(
         latestVersion,
         allVersions.map((v) => v.version)
       );
+    // istanbul ignore if
+    if (!currentVersion) {
+      return res;
+    }
     res.currentVersion = currentVersion;
     if (
       currentVersion &&

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -154,7 +154,7 @@ export async function lookupUpdates(
         allVersions.map((v) => v.version)
       );
     // istanbul ignore if
-    if (!currentVersion) {
+    if (!currentVersion && lockedVersion) {
       return res;
     }
     res.currentVersion = currentVersion;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Aborts process lookup if no currentVersion is found.

## Context:

Closes #9097

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
