### PR TITLE
fix(package rules): wrong matchPackagePatterns addition

### DIFF
--- a/lib/util/package-rules.spec.ts
+++ b/lib/util/package-rules.spec.ts
@@ -10,7 +10,11 @@ import * as datasourceDocker from '../datasource/docker';
 import * as datasourceOrb from '../datasource/orb';
 import { applyPackageRules } from './package-rules';
 
-type TestConfig = PackageRuleInputConfig & { x?: number; y?: number };
+type TestConfig = PackageRuleInputConfig & {
+  x?: number;
+  y?: number;
+  groupName?: string;
+};
 
 describe('applyPackageRules()', () => {
   const config1: TestConfig = {
@@ -28,6 +32,11 @@ describe('applyPackageRules()', () => {
         excludePackageNames: ['aa'],
         excludePackagePatterns: ['d'],
         y: 2,
+      },
+      {
+        matchPackagePrefixes: ['xyz/'],
+        excludePackageNames: ['xyz/foo'],
+        groupName: 'xyz',
       },
     ],
   };
@@ -70,6 +79,7 @@ describe('applyPackageRules()', () => {
     const res = applyPackageRules({ ...config1, ...dep });
     expect(res.x).toBe(2);
     expect(res.y).toBe(2);
+    expect(res.groupName).toBeUndefined();
   });
   it('applies both rules for b', () => {
     const dep = {
@@ -78,6 +88,7 @@ describe('applyPackageRules()', () => {
     const res = applyPackageRules({ ...config1, ...dep });
     expect(res.x).toBe(2);
     expect(res.y).toBe(2);
+    expect(res.groupName).toBeUndefined();
   });
   it('applies the second rule', () => {
     const dep = {
@@ -86,6 +97,7 @@ describe('applyPackageRules()', () => {
     const res = applyPackageRules({ ...config1, ...dep });
     expect(res.x).toBeUndefined();
     expect(res.y).toBe(2);
+    expect(res.groupName).toBeUndefined();
   });
   it('applies matchPackagePrefixes', () => {
     const dep = {
@@ -94,13 +106,24 @@ describe('applyPackageRules()', () => {
     const res = applyPackageRules({ ...config1, ...dep });
     expect(res.x).toBe(2);
     expect(res.y).toBe(2);
+    expect(res.groupName).toBe('xyz');
   });
+
+  it('applies excludePackageNames', () => {
+    const dep = {
+      depName: 'xyz/foo',
+    };
+    const res = applyPackageRules({ ...config1, ...dep });
+    expect(res.groupName).toBeUndefined();
+  });
+
   it('applies excludePackagePrefixes', () => {
     const dep = {
       depName: 'xyz/foo-a',
     };
     const res = applyPackageRules({ ...config1, ...dep });
     expect(res.x).toBeUndefined();
+    expect(res.groupName).toBe('xyz');
   });
   it('applies the second second rule', () => {
     const dep = {

--- a/lib/util/package-rules.ts
+++ b/lib/util/package-rules.ts
@@ -48,8 +48,14 @@ function matchesRule(
   let positiveMatch = false;
   // Massage a positive patterns patch if an exclude one is present
   if (
-    (excludePackageNames.length || excludePackagePatterns.length) &&
-    !(matchPackageNames.length || matchPackagePatterns.length)
+    (excludePackageNames.length ||
+      excludePackagePatterns.length ||
+      excludePackagePrefixes.length) &&
+    !(
+      matchPackageNames.length ||
+      matchPackagePatterns.length ||
+      matchPackagePrefixes.length
+    )
   ) {
     matchPackagePatterns = ['.*'];
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Before renovate has add `matchPackagePatterns =  ['.*']` to package rule if `matchPackagePrefixes` is present, which causes to match all packages.

<!-- Describe what behavior is changed by this PR. -->

## Context:

see discussion at https://github.com/renovatebot/renovate/discussions/9804#discussioncomment-721995
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
