### PR TITLE
fix(azure): use pr title as merge commit message

### DIFF
--- a/lib/platform/azure/__snapshots__/index.spec.ts.snap
+++ b/lib/platform/azure/__snapshots__/index.spec.ts.snap
@@ -36,6 +36,7 @@ Object {
   "body": undefined,
   "completionOptions": Object {
     "deleteSourceBranch": true,
+    "mergeCommitMessage": "The Title",
     "squashMerge": true,
   },
   "createdAt": undefined,
@@ -49,6 +50,7 @@ Object {
   "sourceRefName": undefined,
   "state": "open",
   "targetBranch": undefined,
+  "title": "The Title",
 }
 `;
 

--- a/lib/platform/azure/index.spec.ts
+++ b/lib/platform/azure/index.spec.ts
@@ -629,6 +629,7 @@ describe(getName(), () => {
       await initRepo({ repository: 'some/repo' });
       const prResult = {
         pullRequestId: 456,
+        title: 'The Title',
         displayNumber: `Pull Request #456`,
         createdBy: {
           id: 123,
@@ -642,6 +643,7 @@ describe(getName(), () => {
         completionOptions: {
           squashMerge: true,
           deleteSourceBranch: true,
+          mergeCommitMessage: 'The Title',
         },
       };
       const updateFn = jest
@@ -1068,6 +1070,7 @@ describe(getName(), () => {
             getPullRequestById: jest.fn(() => ({
               lastMergeSourceCommit: lastMergeSourceCommitMock,
               targetRefName: 'refs/heads/ding',
+              title: 'title',
             })),
             updatePullRequest: updatePullRequestMock,
           } as any)
@@ -1086,6 +1089,7 @@ describe(getName(), () => {
           completionOptions: {
             mergeStrategy: GitPullRequestMergeStrategy.Squash,
             deleteSourceBranch: true,
+            mergeCommitMessage: 'title',
           },
         },
         '1',

--- a/lib/platform/azure/index.ts
+++ b/lib/platform/azure/index.ts
@@ -410,6 +410,7 @@ export async function createPr({
         completionOptions: {
           mergeStrategy: config.defaultMergeMethod,
           deleteSourceBranch: true,
+          mergeCommitMessage: title,
         },
       },
       config.repoId,
@@ -632,6 +633,7 @@ export async function mergePr(
     completionOptions: {
       mergeStrategy: mergeMethod,
       deleteSourceBranch: true,
+      mergeCommitMessage: pr.title,
     },
   };
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Uses the pull request title as the merge commit message

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

Fixes #9939

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
