### PR TITLE
fix: filter pendingChecks per-branch

### DIFF
--- a/lib/workers/repository/updates/generate.spec.ts
+++ b/lib/workers/repository/updates/generate.spec.ts
@@ -546,5 +546,46 @@ describe(getName(), () => {
         res.upgrades.map((upgrade) => upgrade.fileReplacePosition)
       ).toStrictEqual([undefined, undefined, 4, 1]);
     });
+    it('passes through pendingChecks', () => {
+      const branch = [
+        {
+          depName: 'some-dep',
+          groupName: 'some-group',
+          branchName: 'some-branch',
+          prTitle: 'some-title',
+          pendingChecks: ['check'],
+        },
+        {
+          depName: 'some-dep',
+          groupName: 'some-group',
+          branchName: 'some-branch',
+          prTitle: 'some-title',
+          pendingChecks: ['check'],
+        },
+      ];
+      const res = generateBranchConfig(branch);
+      expect(res.pendingChecks).toHaveLength(1);
+      expect(res.upgrades).toHaveLength(2);
+    });
+    it('filters pendingChecks', () => {
+      const branch = [
+        {
+          depName: 'some-dep',
+          groupName: 'some-group',
+          branchName: 'some-branch',
+          prTitle: 'some-title',
+          pendingChecks: ['check'],
+        },
+        {
+          depName: 'some-dep',
+          groupName: 'some-group',
+          branchName: 'some-branch',
+          prTitle: 'some-title',
+        },
+      ];
+      const res = generateBranchConfig(branch);
+      expect(res.pendingChecks).toBeUndefined();
+      expect(res.upgrades).toHaveLength(1);
+    });
   });
 });

--- a/lib/workers/repository/updates/generate.ts
+++ b/lib/workers/repository/updates/generate.ts
@@ -311,6 +311,14 @@ export function generateBranchConfig(
       config.constraints = { ...config.constraints, ...upgrade.constraints };
     }
   }
+  if (!config.upgrades?.every((upgrade) => upgrade.pendingChecks)) {
+    // A branch should only have pendingChecks if all upgrades have pendingChecks
+    delete config.pendingChecks;
+    // If the branch isn't pending, then remove any upgrades within which *are*
+    config.upgrades = config.upgrades.filter(
+      (upgrade) => !upgrade.pendingChecks
+    );
+  }
   const tableRows = config.upgrades
     .map((upgrade) => getTableValues(upgrade))
     .filter(Boolean);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Filters out upgrades with pendingChecks if not all upgrades in a branch are pending.

## Context:

Allows combining internalChecksFilter=strict with grouping.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
