### PR TITLE
fix(git): try/catch git author check

### DIFF
--- a/lib/platform/github/index.ts
+++ b/lib/platform/github/index.ts
@@ -384,7 +384,7 @@ export async function initRepo({
           }
         );
       } catch (err) /* istanbul ignore next */ {
-        logger.error(
+        logger.warn(
           { err: err.err || err },
           'Error updating fork from upstream - cannot continue'
         );

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -483,15 +483,20 @@ export async function isBranchModified(branchName: string): Promise<boolean> {
     return false;
   }
   // Retrieve the author of the most recent commit
-  const lastAuthor = (
-    await git.raw([
-      'log',
-      '-1',
-      '--pretty=format:%ae',
-      `origin/${branchName}`,
-      '--',
-    ])
-  ).trim();
+  let lastAuthor: string;
+  try {
+    lastAuthor = (
+      await git.raw([
+        'log',
+        '-1',
+        '--pretty=format:%ae',
+        `origin/${branchName}`,
+        '--',
+      ])
+    ).trim();
+  } catch (err) /* istanbul ignore next */ {
+    logger.warn({ err }, 'Error checking last author for isBranchModified');
+  }
   const { gitAuthorEmail } = config;
   if (
     lastAuthor === gitAuthorEmail ||

--- a/lib/workers/repository/error-config.ts
+++ b/lib/workers/repository/error-config.ts
@@ -25,11 +25,15 @@ export async function raiseConfigWarningIssue(
     if (getAdminConfig().dryRun) {
       logger.info(`DRY-RUN: Would update PR #${pr.number}`);
     } else {
-      await platform.updatePr({
-        number: pr.number,
-        prTitle: config.onboardingPrTitle,
-        prBody: body,
-      });
+      try {
+        await platform.updatePr({
+          number: pr.number,
+          prTitle: config.onboardingPrTitle,
+          prBody: body,
+        });
+      } catch (err) /* istanbul ignore next */ {
+        logger.warn({ err }, 'Error updating onboarding PR');
+      }
     }
   } else if (getAdminConfig().dryRun) {
     logger.info('DRY-RUN: Would ensure config error issue');


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds a try/catch around the git author check so that any git errors don't cause the run to be aborted.

## Context:

Currently this causes an unknown repository error.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
