### PR TITLE
docs: expand requireConfig

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -331,6 +331,8 @@ Warning: this is an experimental feature and may be modified or removed in a fut
 
 ## requireConfig
 
+If this is configured to `false`, it means that Renovate won't require a config file such as `renovate.json` to be present in each repository and will run even if one is missing.
+
 ## secrets
 
 Secrets may be configured by a bot admin in `config.js`, which will then make them available for templating within repository configs.

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -331,7 +331,7 @@ Warning: this is an experimental feature and may be modified or removed in a fut
 
 ## requireConfig
 
-If this is configured to `false`, it means that Renovate won't require a config file such as `renovate.json` to be present in each repository and will run even if one is missing.
+If this is set to `false`, it means that Renovate won't require a config file such as `renovate.json` to be present in each repository and will run even if one is missing.
 
 ## secrets
 

--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -351,7 +351,8 @@ const options: RenovateOptions[] = [
   },
   {
     name: 'requireConfig',
-    description: 'Set to true if repositories must have a config to activate.',
+    description:
+      'Set to false if it should be optional for repositories to contain a config.',
     stage: 'repository',
     type: 'boolean',
     default: true,

--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -352,7 +352,7 @@ const options: RenovateOptions[] = [
   {
     name: 'requireConfig',
     description:
-      'Set to false if it should be optional for repositories to contain a config.',
+      'Set to false if it is optional for repositories to contain a config.',
     stage: 'repository',
     type: 'boolean',
     default: true,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds docs for `requireConfig`

## Context:

Docs are good

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
