### PR TITLE
feat(presets): Add google/cloud-sdk to manualChangelogUrls

### DIFF
--- a/lib/datasource/metadata.ts
+++ b/lib/datasource/metadata.ts
@@ -56,6 +56,7 @@ const manualChangelogUrls = {
       'https://gitlab.com/gitlab-org/gitlab-foss/-/blob/master/CHANGELOG.md',
     'gitlab/gitlab-runner':
       'https://gitlab.com/gitlab-org/gitlab-runner/-/blob/master/CHANGELOG.md',
+    'google/cloud-sdk': 'https://cloud.google.com/sdk/docs/release-notes',
     neo4j: 'https://neo4j.com/release-notes/',
   },
 };


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Add `google/cloud-sdk` to `manualChangelogUrls` in lib/datasource/metadata.ts

## Context:

Renovate does not give a lot of information when updating `google/cloud-sdk` dependency. With this change, it could display a link to the Changelog.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
