### PR TITLE
fix: updateType for update-lockfile

### DIFF
--- a/lib/workers/repository/process/lookup/__snapshots__/index.spec.ts.snap
+++ b/lib/workers/repository/process/lookup/__snapshots__/index.spec.ts.snap
@@ -215,6 +215,22 @@ Object {
 
 exports[`workers/repository/process/lookup/index .lookupUpdates() handles unknown datasource 1`] = `Array []`;
 
+exports[`workers/repository/process/lookup/index .lookupUpdates() handles update-lockfile 1`] = `
+Array [
+  Object {
+    "bucket": "non-major",
+    "isLockfileUpdate": true,
+    "isRange": true,
+    "newMajor": 1,
+    "newMinor": 4,
+    "newValue": "^1.2.1",
+    "newVersion": "1.4.1",
+    "releaseTimestamp": "2015-05-17T04:25:07.299Z",
+    "updateType": "minor",
+  },
+]
+`;
+
 exports[`workers/repository/process/lookup/index .lookupUpdates() ignores deprecated 1`] = `
 Object {
   "changelogUrl": undefined,

--- a/lib/workers/repository/process/lookup/index.spec.ts
+++ b/lib/workers/repository/process/lookup/index.spec.ts
@@ -295,6 +295,17 @@ describe(getName(), () => {
       nock('https://registry.npmjs.org').get('/q').reply(200, qJson);
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
+    it('handles update-lockfile', async () => {
+      config.currentValue = '^1.2.1';
+      config.lockedVersion = '1.2.1';
+      config.rangeStrategy = 'update-lockfile';
+      config.depName = 'q';
+      config.datasource = datasourceNpmId;
+      nock('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      const res = await lookup.lookupUpdates(config);
+      expect(res.updates).toMatchSnapshot();
+      expect(res.updates[0].updateType).toEqual('minor');
+    });
     it('widens minor ranged versions if configured', async () => {
       config.currentValue = '~1.3.0';
       config.rangeStrategy = 'widen';

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -226,7 +226,7 @@ export async function lookupUpdates(
       const update = generateUpdate(
         config,
         versioning,
-        currentVersion,
+        lockedVersion || currentVersion,
         bucket,
         release
       );


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Uses `lockedVersion` instead of `currentVersion` to calculate `updateType`.

## Context:

Closes #9983

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
