### PR TITLE
chore: Stop use setUtilConfig in tests

### DIFF
--- a/lib/manager/bundler/artifacts.spec.ts
+++ b/lib/manager/bundler/artifacts.spec.ts
@@ -3,10 +3,11 @@ import { join } from 'upath';
 import { envMock, mockExecAll } from '../../../test/exec-util';
 import { fs, git, mocked } from '../../../test/util';
 import * as _datasource from '../../datasource';
-import { setUtilConfig } from '../../util';
+import { setExecConfig } from '../../util/exec';
 import { BinarySource } from '../../util/exec/common';
 import * as docker from '../../util/exec/docker';
 import * as _env from '../../util/exec/env';
+import { setFsConfig } from '../../util/fs';
 import { StatusResult } from '../../util/git';
 import * as _bundlerHostRules from './host-rules';
 import { updateArtifacts } from '.';
@@ -44,7 +45,8 @@ describe('bundler.updateArtifacts()', () => {
     bundlerHostRules.findAllAuthenticatable.mockReturnValue([]);
     docker.resetPrefetchedImages();
 
-    await setUtilConfig(config);
+    await setExecConfig(config);
+    setFsConfig(config);
   });
   it('returns null by default', async () => {
     expect(
@@ -118,7 +120,8 @@ describe('bundler.updateArtifacts()', () => {
   describe('Docker', () => {
     beforeEach(async () => {
       jest.spyOn(docker, 'removeDanglingContainers').mockResolvedValueOnce();
-      await setUtilConfig({ ...config, binarySource: BinarySource.Docker });
+      await setExecConfig({ ...config, binarySource: BinarySource.Docker });
+      setFsConfig({ ...config, binarySource: BinarySource.Docker });
     });
     it('.ruby-version', async () => {
       fs.readLocalFile.mockResolvedValueOnce('Current Gemfile.lock');

--- a/lib/manager/composer/artifacts.spec.ts
+++ b/lib/manager/composer/artifacts.spec.ts
@@ -9,9 +9,10 @@ import {
 } from '../../constants/platforms';
 import * as _datasource from '../../datasource';
 import * as datasourcePackagist from '../../datasource/packagist';
-import { setUtilConfig } from '../../util';
+import { setExecConfig } from '../../util/exec';
 import { BinarySource } from '../../util/exec/common';
 import * as docker from '../../util/exec/docker';
+import { setFsConfig } from '../../util/fs';
 import { StatusResult } from '../../util/git';
 import * as hostRules from '../../util/host-rules';
 import * as composer from './artifacts';
@@ -44,7 +45,8 @@ describe('.updateArtifacts()', () => {
     jest.resetAllMocks();
     jest.resetModules();
     env.getChildProcessEnv.mockReturnValue(envMock.basic);
-    await setUtilConfig(config);
+    await setExecConfig(config);
+    setFsConfig(config);
     docker.resetPrefetchedImages();
     hostRules.clear();
     setAdminConfig({ allowScripts: false });
@@ -194,7 +196,8 @@ describe('.updateArtifacts()', () => {
   });
   it('supports docker mode', async () => {
     jest.spyOn(docker, 'removeDanglingContainers').mockResolvedValueOnce();
-    await setUtilConfig({ ...config, binarySource: BinarySource.Docker });
+    await setExecConfig({ ...config, binarySource: BinarySource.Docker });
+    setFsConfig({ ...config, binarySource: BinarySource.Docker });
     fs.readLocalFile.mockResolvedValueOnce('Current composer.lock' as any);
 
     const execSnapshots = mockExecAll(exec);

--- a/lib/manager/gomod/artifacts.spec.ts
+++ b/lib/manager/gomod/artifacts.spec.ts
@@ -3,10 +3,11 @@ import _fs from 'fs-extra';
 import { join } from 'upath';
 import { envMock, mockExecAll } from '../../../test/exec-util';
 import { git, mocked } from '../../../test/util';
-import { setUtilConfig } from '../../util';
+import { setExecConfig } from '../../util/exec';
 import { BinarySource } from '../../util/exec/common';
 import * as docker from '../../util/exec/docker';
 import * as _env from '../../util/exec/env';
+import { setFsConfig } from '../../util/fs';
 import { StatusResult } from '../../util/git';
 import * as _hostRules from '../../util/host-rules';
 import * as gomod from './artifacts';
@@ -57,7 +58,8 @@ describe('.updateArtifacts()', () => {
 
     delete process.env.GOPATH;
     env.getChildProcessEnv.mockReturnValue({ ...envMock.basic, ...goEnv });
-    await setUtilConfig(config);
+    await setExecConfig(config);
+    setFsConfig(config);
     docker.resetPrefetchedImages();
   });
   it('returns if no go.sum found', async () => {
@@ -145,7 +147,8 @@ describe('.updateArtifacts()', () => {
   });
   it('supports docker mode without credentials', async () => {
     jest.spyOn(docker, 'removeDanglingContainers').mockResolvedValueOnce();
-    await setUtilConfig({ ...config, binarySource: BinarySource.Docker });
+    await setExecConfig({ ...config, binarySource: BinarySource.Docker });
+    setFsConfig({ ...config, binarySource: BinarySource.Docker });
     fs.readFile.mockResolvedValueOnce('Current go.sum' as any);
     fs.readFile.mockResolvedValueOnce(null as any); // vendor modules filename
     const execSnapshots = mockExecAll(exec);
@@ -189,7 +192,8 @@ describe('.updateArtifacts()', () => {
   });
   it('supports docker mode with credentials', async () => {
     jest.spyOn(docker, 'removeDanglingContainers').mockResolvedValueOnce();
-    await setUtilConfig({ ...config, binarySource: BinarySource.Docker });
+    await setExecConfig({ ...config, binarySource: BinarySource.Docker });
+    setFsConfig({ ...config, binarySource: BinarySource.Docker });
     hostRules.find.mockReturnValueOnce({
       token: 'some-token',
     });
@@ -215,7 +219,8 @@ describe('.updateArtifacts()', () => {
   });
   it('supports docker mode with goModTidy', async () => {
     jest.spyOn(docker, 'removeDanglingContainers').mockResolvedValueOnce();
-    await setUtilConfig({ ...config, binarySource: BinarySource.Docker });
+    await setExecConfig({ ...config, binarySource: BinarySource.Docker });
+    setFsConfig({ ...config, binarySource: BinarySource.Docker });
     hostRules.find.mockReturnValueOnce({});
     fs.readFile.mockResolvedValueOnce('Current go.sum' as any);
     fs.readFile.mockResolvedValueOnce(null as any); // vendor modules filename

--- a/lib/manager/gradle-wrapper/artifacts-real.spec.ts
+++ b/lib/manager/gradle-wrapper/artifacts-real.spec.ts
@@ -3,7 +3,8 @@ import Git from 'simple-git';
 import { resolve } from 'upath';
 import * as httpMock from '../../../test/http-mock';
 import { getName, git, partial } from '../../../test/util';
-import { setUtilConfig } from '../../util';
+import { setExecConfig } from '../../util/exec';
+import { setFsConfig } from '../../util/fs';
 import { StatusResult } from '../../util/git';
 import { ifSystemSupportsGradle } from '../gradle/__testutil__/gradle';
 import * as dcUpdate from '.';
@@ -36,7 +37,8 @@ describe(getName(), () => {
 
     beforeEach(async () => {
       jest.resetAllMocks();
-      await setUtilConfig(config);
+      await setExecConfig(config);
+      setFsConfig(config);
       httpMock.setup();
     });
 
@@ -160,7 +162,8 @@ describe(getName(), () => {
     it('gradlew failed', async () => {
       const cfg = { ...config, localDir: resolve(fixtures, './wrongCmd') };
 
-      await setUtilConfig(cfg);
+      await setExecConfig(cfg);
+      setFsConfig(cfg);
       const res = await dcUpdate.updateArtifacts({
         packageFileName: 'gradle/wrapper/gradle-wrapper.properties',
         updatedDeps: [],

--- a/lib/manager/gradle-wrapper/artifacts.spec.ts
+++ b/lib/manager/gradle-wrapper/artifacts.spec.ts
@@ -12,9 +12,10 @@ import {
   git,
   partial,
 } from '../../../test/util';
-import { setUtilConfig } from '../../util';
+import { setExecConfig } from '../../util/exec';
 import { BinarySource } from '../../util/exec/common';
 import { resetPrefetchedImages } from '../../util/exec/docker';
+import { setFsConfig } from '../../util/fs';
 import { StatusResult } from '../../util/git';
 import * as dcUpdate from '.';
 
@@ -49,7 +50,8 @@ describe(getName(), () => {
       LC_ALL: 'en_US',
     });
 
-    await setUtilConfig(config);
+    await setExecConfig(config);
+    setFsConfig(config);
     resetPrefetchedImages();
 
     fs.readLocalFile.mockResolvedValue('test');

--- a/lib/manager/gradle/index.spec.ts
+++ b/lib/manager/gradle/index.spec.ts
@@ -10,11 +10,11 @@ import {
   loadFixture,
   mocked,
 } from '../../../test/util';
-import { setUtilConfig } from '../../util';
 import { setExecConfig } from '../../util/exec';
 import { BinarySource } from '../../util/exec/common';
 import * as docker from '../../util/exec/docker';
 import * as _env from '../../util/exec/env';
+import { setFsConfig } from '../../util/fs';
 import { extractAllPackageFiles, updateDependency } from '.';
 
 jest.mock('child_process');
@@ -83,7 +83,8 @@ describe(getName(), () => {
   }
 
   beforeAll(async () => {
-    await setUtilConfig(utilConfig);
+    await setExecConfig(utilConfig);
+    setFsConfig(utilConfig);
   });
 
   beforeEach(() => {

--- a/lib/manager/nuget/artifacts.spec.ts
+++ b/lib/manager/nuget/artifacts.spec.ts
@@ -2,10 +2,11 @@ import { exec as _exec } from 'child_process';
 import { join } from 'upath';
 import { envMock, mockExecAll } from '../../../test/exec-util';
 import { fs, mocked } from '../../../test/util';
-import { setUtilConfig } from '../../util';
+import { setExecConfig } from '../../util/exec';
 import { BinarySource } from '../../util/exec/common';
 import * as docker from '../../util/exec/docker';
 import * as _env from '../../util/exec/env';
+import { setFsConfig } from '../../util/fs';
 import * as _hostRules from '../../util/host-rules';
 import * as nuget from './artifacts';
 import {
@@ -49,7 +50,8 @@ describe('updateArtifacts', () => {
       Promise.resolve(dirName)
     );
     getRandomString.mockReturnValue('not-so-random' as any);
-    await setUtilConfig(config);
+    await setExecConfig(config);
+    setFsConfig(config);
     docker.resetPrefetchedImages();
   });
   it('aborts if no lock file found', async () => {
@@ -146,7 +148,8 @@ describe('updateArtifacts', () => {
 
   it('supports docker mode', async () => {
     jest.spyOn(docker, 'removeDanglingContainers').mockResolvedValueOnce();
-    await setUtilConfig({ ...config, binarySource: BinarySource.Docker });
+    await setExecConfig({ ...config, binarySource: BinarySource.Docker });
+    setFsConfig({ ...config, binarySource: BinarySource.Docker });
     const execSnapshots = mockExecAll(exec);
     fs.getSiblingFileName.mockReturnValueOnce('packages.lock.json');
     fs.readLocalFile.mockResolvedValueOnce('Current packages.lock.json' as any);

--- a/lib/manager/pip_setup/index.spec.ts
+++ b/lib/manager/pip_setup/index.spec.ts
@@ -6,9 +6,10 @@ import {
   mockExecSequence,
 } from '../../../test/exec-util';
 import { env, getName, loadFixture } from '../../../test/util';
-import { setUtilConfig } from '../../util';
+import { setExecConfig } from '../../util/exec';
 import { BinarySource } from '../../util/exec/common';
 import * as fs from '../../util/fs';
+import { setFsConfig } from '../../util/fs';
 import * as extract from './extract';
 import { extractPackageFile } from '.';
 
@@ -43,7 +44,8 @@ describe(getName(), () => {
       jest.resetModules();
       extract.resetModule();
 
-      await setUtilConfig(config);
+      await setExecConfig(config);
+      setFsConfig(config);
       env.getChildProcessEnv.mockReturnValue(envMock.basic);
 
       // do not copy extract.py

--- a/lib/manager/pipenv/artifacts.spec.ts
+++ b/lib/manager/pipenv/artifacts.spec.ts
@@ -3,10 +3,11 @@ import _fs from 'fs-extra';
 import { join } from 'upath';
 import { envMock, mockExecAll } from '../../../test/exec-util';
 import { git, mocked } from '../../../test/util';
-import { setUtilConfig } from '../../util';
+import { setExecConfig } from '../../util/exec';
 import { BinarySource } from '../../util/exec/common';
 import * as docker from '../../util/exec/docker';
 import * as _env from '../../util/exec/env';
+import { setFsConfig } from '../../util/fs';
 import type { StatusResult } from '../../util/git';
 import * as pipenv from './artifacts';
 
@@ -40,7 +41,8 @@ describe('.updateArtifacts()', () => {
       LC_ALL: 'en_US',
     });
 
-    await setUtilConfig(config);
+    await setExecConfig(config);
+    setFsConfig(config);
     docker.resetPrefetchedImages();
     pipFileLock = {
       _meta: { requires: {} },
@@ -107,7 +109,8 @@ describe('.updateArtifacts()', () => {
   });
   it('supports docker mode', async () => {
     jest.spyOn(docker, 'removeDanglingContainers').mockResolvedValueOnce();
-    await setUtilConfig(dockerConfig);
+    await setExecConfig(dockerConfig);
+    setFsConfig(dockerConfig);
     pipFileLock._meta.requires.python_version = '3.7';
     fs.readFile.mockResolvedValueOnce(JSON.stringify(pipFileLock) as any);
     const execSnapshots = mockExecAll(exec);
@@ -158,7 +161,8 @@ describe('.updateArtifacts()', () => {
   });
   it('uses pipenv version from Pipfile', async () => {
     jest.spyOn(docker, 'removeDanglingContainers').mockResolvedValueOnce();
-    await setUtilConfig(dockerConfig);
+    await setExecConfig(dockerConfig);
+    setFsConfig(dockerConfig);
     pipFileLock.default.pipenv.version = '==2020.8.13';
     fs.readFile.mockResolvedValueOnce(JSON.stringify(pipFileLock) as any);
     const execSnapshots = mockExecAll(exec);
@@ -178,7 +182,8 @@ describe('.updateArtifacts()', () => {
   });
   it('uses pipenv version from Pipfile dev packages', async () => {
     jest.spyOn(docker, 'removeDanglingContainers').mockResolvedValueOnce();
-    await setUtilConfig(dockerConfig);
+    await setExecConfig(dockerConfig);
+    setFsConfig(dockerConfig);
     pipFileLock.develop.pipenv.version = '==2020.8.13';
     fs.readFile.mockResolvedValueOnce(JSON.stringify(pipFileLock) as any);
     const execSnapshots = mockExecAll(exec);
@@ -198,7 +203,8 @@ describe('.updateArtifacts()', () => {
   });
   it('uses pipenv version from config', async () => {
     jest.spyOn(docker, 'removeDanglingContainers').mockResolvedValueOnce();
-    await setUtilConfig(dockerConfig);
+    await setExecConfig(dockerConfig);
+    setFsConfig(dockerConfig);
     pipFileLock.default.pipenv.version = '==2020.8.13';
     fs.readFile.mockResolvedValueOnce(JSON.stringify(pipFileLock) as any);
     const execSnapshots = mockExecAll(exec);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Use `setExecConfig` and `setFsConfig` instead, so that we can deal with them separatedly.

## Context:

Ref: #9932

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
