### PR TITLE
fix(github): paginationField for check runs

### DIFF
--- a/lib/platform/github/index.ts
+++ b/lib/platform/github/index.ts
@@ -920,6 +920,7 @@ export async function getBranchStatus(
         accept: 'application/vnd.github.antiope-preview+json',
       },
       paginate: true,
+      paginationField: 'check_runs',
     };
     const checkRunsRaw = (
       await githubApi.getJson<{

--- a/lib/util/http/github.ts
+++ b/lib/util/http/github.ts
@@ -25,6 +25,7 @@ interface GithubInternalOptions extends InternalHttpOptions {
 
 export interface GithubHttpOptions extends InternalHttpOptions {
   paginate?: boolean | string;
+  paginationField?: string;
   pageLimit?: number;
   token?: string;
 }
@@ -208,9 +209,19 @@ export class GithubHttp extends Http<GithubHttpOptions, GithubHttpOptions> {
               }
             );
             const pages = await pAll(queue, { concurrency: 5 });
-            result.body = result.body.concat(
-              ...pages.filter(Boolean).map((page) => page.body)
-            );
+            if (opts.paginationField) {
+              result.body[opts.paginationField] = result.body[
+                opts.paginationField
+              ].concat(
+                ...pages
+                  .filter(Boolean)
+                  .map((page) => page.body[opts.paginationField])
+              );
+            } else {
+              result.body = result.body.concat(
+                ...pages.filter(Boolean).map((page) => page.body)
+              );
+            }
           }
         }
       }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds new option `paginationFields` for GitHub HTTP wrapper to support check-runs.

## Context:

`res.body` is not an array: https://docs.github.com/en/rest/reference/checks#list-check-runs-for-a-git-reference

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
