### PR TITLE
refactor: rename Error location to validationSource

### DIFF
--- a/lib/config/presets/index.spec.ts
+++ b/lib/config/presets/index.spec.ts
@@ -62,7 +62,7 @@ describe(getName(), () => {
         e = err;
       }
       expect(e).toBeDefined();
-      expect(e.location).toMatchSnapshot();
+      expect(e.validationSource).toMatchSnapshot();
       expect(e.validationError).toMatchSnapshot();
       expect(e.validationMessage).toMatchSnapshot();
     });
@@ -76,7 +76,7 @@ describe(getName(), () => {
         e = err;
       }
       expect(e).toBeDefined();
-      expect(e.location).toMatchSnapshot();
+      expect(e.validationSource).toMatchSnapshot();
       expect(e.validationError).toMatchSnapshot();
       expect(e.validationMessage).toMatchSnapshot();
     });
@@ -91,7 +91,7 @@ describe(getName(), () => {
         e = err;
       }
       expect(e).toBeDefined();
-      expect(e.location).toMatchSnapshot();
+      expect(e.validationSource).toMatchSnapshot();
       expect(e.validationError).toMatchSnapshot();
       expect(e.validationMessage).toMatchSnapshot();
     });
@@ -106,7 +106,7 @@ describe(getName(), () => {
         e = err;
       }
       expect(e).toBeDefined();
-      expect(e.location).toMatchSnapshot();
+      expect(e.validationSource).toMatchSnapshot();
       expect(e.validationError).toMatchSnapshot();
       expect(e.validationMessage).toMatchSnapshot();
     });
@@ -121,7 +121,7 @@ describe(getName(), () => {
         e = err;
       }
       expect(e).toBeDefined();
-      expect(e.location).toMatchSnapshot();
+      expect(e.validationSource).toMatchSnapshot();
       expect(e.validationError).toMatchSnapshot();
       expect(e.validationMessage).toMatchSnapshot();
     });
@@ -136,7 +136,7 @@ describe(getName(), () => {
         e = err;
       }
       expect(e).toBeDefined();
-      expect(e.location).toMatchSnapshot();
+      expect(e.validationSource).toMatchSnapshot();
       expect(e.validationError).toMatchSnapshot();
       expect(e.validationMessage).toMatchSnapshot();
     });
@@ -159,7 +159,7 @@ describe(getName(), () => {
         e = err;
       }
       expect(e).toBeDefined();
-      expect(e.location).toMatchSnapshot();
+      expect(e.validationSource).toMatchSnapshot();
       expect(e.validationError).toMatchSnapshot();
       expect(e.validationMessage).toMatchSnapshot();
     });
@@ -430,7 +430,7 @@ describe(getName(), () => {
         e = err;
       }
       expect(e).toBeDefined();
-      expect(e.location).toMatchSnapshot();
+      expect(e.validationSource).toMatchSnapshot();
       expect(e.validationError).toMatchSnapshot();
       expect(e.validationMessage).toMatchSnapshot();
     });
@@ -442,7 +442,7 @@ describe(getName(), () => {
         e = err;
       }
       expect(e).toBeDefined();
-      expect(e.location).toMatchSnapshot();
+      expect(e.validationSource).toMatchSnapshot();
       expect(e.validationError).toMatchSnapshot();
       expect(e.validationMessage).toMatchSnapshot();
     });
@@ -454,7 +454,7 @@ describe(getName(), () => {
         e = err;
       }
       expect(e).toBeDefined();
-      expect(e.location).toMatchSnapshot();
+      expect(e.validationSource).toMatchSnapshot();
       expect(e.validationError).toMatchSnapshot();
       expect(e.validationMessage).toMatchSnapshot();
     });
@@ -466,7 +466,7 @@ describe(getName(), () => {
         e = err;
       }
       expect(e).toBeDefined();
-      expect(e.location).toMatchSnapshot();
+      expect(e.validationSource).toMatchSnapshot();
       expect(e.validationError).toMatchSnapshot();
       expect(e.validationMessage).toMatchSnapshot();
     });

--- a/lib/config/secrets.ts
+++ b/lib/config/secrets.ts
@@ -64,7 +64,7 @@ function replaceSecretsInString(
   const disallowedPrefixes = ['branch', 'commit', 'group', 'pr', 'semantic'];
   if (disallowedPrefixes.some((prefix) => key.startsWith(prefix))) {
     const error = new Error(CONFIG_VALIDATION);
-    error.location = 'config';
+    error.validationSource = 'config';
     error.validationError = 'Disallowed secret substitution';
     error.validationMessage = `The field ${key} may not use secret substitution`;
     throw error;
@@ -74,7 +74,7 @@ function replaceSecretsInString(
       return secrets[secretName];
     }
     const error = new Error(CONFIG_VALIDATION);
-    error.location = 'config';
+    error.validationSource = 'config';
     error.validationError = 'Unknown secret name';
     error.validationMessage = `The following secret name was not found in config: ${String(
       secretName

--- a/lib/globals.d.ts
+++ b/lib/globals.d.ts
@@ -3,7 +3,7 @@
  */
 
 declare interface Error {
-  location?: string;
+  validationSource?: string;
 
   validationError?: string;
   validationMessage?: string;

--- a/lib/manager/npm/extract/index.ts
+++ b/lib/manager/npm/extract/index.ts
@@ -51,7 +51,7 @@ export async function extractPackageFile(
   }
   if (fileName !== 'package.json' && packageJson.renovate) {
     const error = new Error(CONFIG_VALIDATION);
-    error.location = fileName;
+    error.validationSource = fileName;
     error.validationError =
       'Nested package.json must not contain renovate configuration. Please use `packageRules` with `matchPaths` in your main config instead.';
     throw error;

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -774,7 +774,7 @@ export async function commitFiles({
     checkForPlatformFailure(err);
     if (err.message.includes(`'refs/heads/renovate' exists`)) {
       const error = new Error(CONFIG_VALIDATION);
-      error.location = 'None';
+      error.validationSource = 'None';
       error.validationError = 'An existing branch is blocking Renovate';
       error.validationMessage = `Renovate needs to create the branch "${branchName}" but is blocked from doing so because of an existing branch called "renovate". Please remove it so that Renovate can proceed.`;
       throw error;
@@ -800,7 +800,7 @@ export async function commitFiles({
     }
     if (err.message.includes('protected branch hook declined')) {
       const error = new Error(CONFIG_VALIDATION);
-      error.location = branchName;
+      error.validationSource = branchName;
       error.validationError = 'Renovate branch is protected';
       error.validationMessage = `Renovate cannot push to its branch because branch protection has been enabled.`;
       throw error;

--- a/lib/util/regex.ts
+++ b/lib/util/regex.ts
@@ -21,7 +21,7 @@ export function regEx(pattern: string, flags?: string): RegExp {
     return new RegEx(pattern, flags);
   } catch (err) {
     const error = new Error(CONFIG_VALIDATION);
-    error.location = pattern;
+    error.validationSource = pattern;
     error.validationError = `Invalid regular expression: ${pattern}`;
     throw error;
   }

--- a/lib/versioning/regex/index.ts
+++ b/lib/versioning/regex/index.ts
@@ -55,7 +55,7 @@ export class RegExpVersioningApi extends GenericVersioningApi<RegExpVersion> {
       !new_config.includes('<patch>')
     ) {
       const error = new Error(CONFIG_VALIDATION);
-      error.location = new_config;
+      error.validationSource = new_config;
       error.validationError =
         'regex versioning needs at least one major, minor or patch group defined';
       throw error;

--- a/lib/workers/repository/error-config.spec.ts
+++ b/lib/workers/repository/error-config.spec.ts
@@ -26,7 +26,7 @@ describe(getName(), () => {
     });
     it('creates issues', async () => {
       const error = new Error(CONFIG_VALIDATION);
-      error.location = 'package.json';
+      error.validationSource = 'package.json';
       error.validationMessage = 'some-message';
       platform.ensureIssue.mockResolvedValueOnce('created');
       const res = await raiseConfigWarningIssue(config, error);
@@ -34,7 +34,7 @@ describe(getName(), () => {
     });
     it('creates issues (dryRun)', async () => {
       const error = new Error(CONFIG_VALIDATION);
-      error.location = 'package.json';
+      error.validationSource = 'package.json';
       error.validationMessage = 'some-message';
       platform.ensureIssue.mockResolvedValueOnce('created');
       setAdminConfig({ dryRun: true });
@@ -43,7 +43,7 @@ describe(getName(), () => {
     });
     it('handles onboarding', async () => {
       const error = new Error(CONFIG_VALIDATION);
-      error.location = 'package.json';
+      error.validationSource = 'package.json';
       error.validationMessage = 'some-message';
       platform.getBranchPr.mockResolvedValue({
         ...mock<Pr>(),
@@ -55,7 +55,7 @@ describe(getName(), () => {
     });
     it('handles onboarding (dryRun)', async () => {
       const error = new Error(CONFIG_VALIDATION);
-      error.location = 'package.json';
+      error.validationSource = 'package.json';
       error.validationMessage = 'some-message';
       platform.getBranchPr.mockResolvedValue({
         ...mock<Pr>(),

--- a/lib/workers/repository/error-config.ts
+++ b/lib/workers/repository/error-config.ts
@@ -10,8 +10,8 @@ export async function raiseConfigWarningIssue(
 ): Promise<void> {
   logger.debug('raiseConfigWarningIssue()');
   let body = `There is an error with this repository's Renovate configuration that needs to be fixed. As a precaution, Renovate will stop PRs until it is resolved.\n\n`;
-  if (error.location) {
-    body += `Location: \`${error.location}\`\n`;
+  if (error.validationSource) {
+    body += `Location: \`${error.validationSource}\`\n`;
   }
   body += `Error type: ${error.validationError}\n`;
   if (error.validationMessage) {

--- a/lib/workers/repository/init/merge.ts
+++ b/lib/workers/repository/init/merge.ts
@@ -136,7 +136,7 @@ export function checkForRepoConfigError(repoConfig: RepoFileConfig): void {
     return;
   }
   const error = new Error(CONFIG_VALIDATION);
-  error.location = repoConfig.configFileName;
+  error.validationSource = repoConfig.configFileName;
   error.validationError = repoConfig.configFileParseError.validationError;
   error.validationMessage = repoConfig.configFileParseError.validationMessage;
   throw error;
@@ -160,7 +160,7 @@ export async function mergeRenovateConfig(
   const migratedConfig = await migrateAndValidate(config, configFileParsed);
   if (migratedConfig.errors.length) {
     const error = new Error(CONFIG_VALIDATION);
-    error.location = repoConfig.configFileName;
+    error.validationSource = repoConfig.configFileName;
     error.validationError =
       'The renovate configuration file contains some invalid settings';
     error.validationMessage = migratedConfig.errors

--- a/lib/workers/repository/process/lookup/filter.ts
+++ b/lib/workers/repository/process/lookup/filter.ts
@@ -98,7 +98,7 @@ export function filterVersions(
       );
     } else {
       const error = new Error(CONFIG_VALIDATION);
-      error.location = 'config';
+      error.validationSource = 'config';
       error.validationError = 'Invalid `allowedVersions`';
       error.validationMessage =
         'The following allowedVersions does not parse as a valid version or range: ' +


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Rename `Error.location` to `Error.validationSource` otherwise it collides with `vfile-message` type


<!-- Describe what behavior is changed by this PR. -->

## Context:

blocks #9954
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
