### PR TITLE
test(git): disable gpgsign

### DIFF
--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -77,6 +77,9 @@ describe(getName(), () => {
     });
     await git.setUserRepoConfig({ branchPrefix: 'renovate/' });
     await git.syncGit();
+    // override some local git settings for better testing
+    const local = Git(tmpDir.path);
+    await local.addConfig('commit.gpgsign', 'false');
   });
 
   afterEach(async () => {

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -332,11 +332,11 @@ export async function syncGit(): Promise<void> {
     const { gitAuthorName, gitAuthorEmail } = config;
     if (gitAuthorName) {
       logger.debug({ gitAuthorName }, 'Setting git author name');
-      await git.raw(['config', 'user.name', gitAuthorName]);
+      await git.addConfig('user.name', gitAuthorName);
     }
     if (gitAuthorEmail) {
       logger.debug({ gitAuthorEmail }, 'Setting git author email');
-      await git.raw(['config', 'user.email', gitAuthorEmail]);
+      await git.addConfig('user.email', gitAuthorEmail);
     }
   } catch (err) /* istanbul ignore next */ {
     checkForPlatformFailure(err);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Disable local gpgsing for renovate repo's, so we don't get a gpg passphrase request while running tests.

The other change is just cosmetic and does same as before.
<!-- Describe what behavior is changed by this PR. -->

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
