### PR TITLE
fix(limits): Use PR hourly limits to calculate remaining branch count

### DIFF
--- a/lib/workers/repository/process/limits.spec.ts
+++ b/lib/workers/repository/process/limits.spec.ts
@@ -127,13 +127,30 @@ describe(getName(), () => {
   });
 
   describe('getBranchesRemaining()', () => {
-    it('returns concurrent branches', () => {
-      config.branchConcurrentLimit = 20;
-      git.branchExists.mockReturnValueOnce(true);
-      const res = limits.getBranchesRemaining(config, [
-        { branchName: 'foo' },
-      ] as never);
-      expect(res).toEqual(19);
+    it('returns minimal of both limits', async () => {
+      platform.getPrList.mockResolvedValue([]);
+
+      await expect(
+        limits.getBranchesRemaining(
+          {
+            ...config,
+            prHourlyLimit: 3,
+            branchConcurrentLimit: 5,
+          },
+          []
+        )
+      ).resolves.toEqual(3);
+
+      await expect(
+        limits.getBranchesRemaining(
+          {
+            ...config,
+            prHourlyLimit: 11,
+            branchConcurrentLimit: 7,
+          },
+          []
+        )
+      ).resolves.toEqual(7);
     });
   });
 });

--- a/lib/workers/repository/process/limits.ts
+++ b/lib/workers/repository/process/limits.ts
@@ -122,9 +122,11 @@ export function getConcurrentBranchesRemaining(
   return 99;
 }
 
-export function getBranchesRemaining(
+export async function getBranchesRemaining(
   config: RenovateConfig,
   branches: BranchConfig[]
-): number {
-  return getConcurrentBranchesRemaining(config, branches);
+): Promise<number> {
+  const hourlyRemaining = await getPrHourlyRemaining(config);
+  const concurrentRemaining = getConcurrentBranchesRemaining(config, branches);
+  return Math.min(hourlyRemaining, concurrentRemaining);
 }

--- a/lib/workers/repository/process/write.spec.ts
+++ b/lib/workers/repository/process/write.spec.ts
@@ -19,7 +19,7 @@ const limits = mocked(_limits);
 branchWorker.processBranch = jest.fn();
 
 limits.getPrsRemaining = jest.fn().mockResolvedValue(99);
-limits.getBranchesRemaining = jest.fn().mockReturnValue(99);
+limits.getBranchesRemaining = jest.fn().mockResolvedValue(99);
 
 let config: RenovateConfig;
 beforeEach(() => {
@@ -66,7 +66,7 @@ describe(getName(), () => {
       });
       git.branchExists.mockReturnValueOnce(false);
       git.branchExists.mockReturnValueOnce(true);
-      limits.getBranchesRemaining.mockReturnValueOnce(1);
+      limits.getBranchesRemaining.mockResolvedValueOnce(1);
       expect(isLimitReached(Limit.Branches)).toBeFalse();
       await writeUpdates({ config }, branches);
       expect(isLimitReached(Limit.Branches)).toBeTrue();

--- a/lib/workers/repository/process/write.ts
+++ b/lib/workers/repository/process/write.ts
@@ -25,7 +25,7 @@ export async function writeUpdates(
   logger.debug({ prsRemaining }, 'Calculated maximum PRs remaining this run');
   setMaxLimit(Limit.PullRequests, prsRemaining);
 
-  const branchesRemaining = getBranchesRemaining(config, branches);
+  const branchesRemaining = await getBranchesRemaining(config, branches);
   logger.debug(
     { branchesRemaining },
     'Calculated maximum branches remaining this run'


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

## Context:

Closes #10047

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

Example: https://github.com/renovate-testing/test-10047-ytools