### PR TITLE
docs: Replace outdated GHA security notice with general description

### DIFF
--- a/lib/manager/github-actions/readme.md
+++ b/lib/manager/github-actions/readme.md
@@ -1,1 +1,1 @@
-For security reasons, GitHub has blocked integrations/apps from editing GitHub Actions workflow files in _any_ branch, so this only works on GitHub if using a Personal Access Token instead of using the WhiteSource Renovate app.
+The `github-actions` manager extracts dependencies from GitHub Actions workflow files.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Replaces the security notice about GitHub apps not being allowed to update workflow files with a general description of readme `github-actions` manager.

It's very vague, but all of the managers appear to have a description in the readme so I put the best I could manage there (knowing very little of renovate). The goal of the PR is to get rid of the outdated info.

## Context:

According to discussion here https://github.com/INRIA/spoon/pull/3935#issuecomment-845334008, the information about GitHub apps/integrations not being allowed to update workflow files is no longer correct.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
