### PR TITLE
fix: @types/node presets in config:base

### DIFF
--- a/lib/config/presets/internal/config.ts
+++ b/lib/config/presets/internal/config.ts
@@ -17,7 +17,6 @@ export const presets: Record<string, Preset> = {
       ':prConcurrentLimit20',
       'group:monorepos',
       'group:recommended',
-      'helpers:disableTypesNodeMajor',
       'workarounds:all',
     ],
   },

--- a/lib/config/presets/internal/workarounds.ts
+++ b/lib/config/presets/internal/workarounds.ts
@@ -9,6 +9,7 @@ export const presets: Record<string, Preset> = {
       'workarounds:mavenCommonsAncientVersion',
       'workarounds:ignoreSpringCloudNumeric',
       'workarounds:ignoreHttp4sDigestMilestones',
+      'workarounds:typesNodeVersioning',
     ],
   },
   mavenCommonsAncientVersion: {
@@ -39,6 +40,16 @@ export const presets: Record<string, Preset> = {
         matchManagers: ['sbt'],
         matchPackagePrefixes: ['org.http4s:'],
         allowedVersions: `!/^1\\.0-\\d+-[a-fA-F0-9]{7}$/`,
+      },
+    ],
+  },
+  typesNodeVersioning: {
+    description: 'Use node versioning for @types/node',
+    packageRules: [
+      {
+        matchManagers: ['npm'],
+        matchPackageNames: ['@types/node'],
+        versioning: `node`,
       },
     ],
   },


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

No longer disable @types/node major updates, instead use node versioning.

## Context:

#10034 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
