### PR TITLE
docs: shareable configs only work with JSON format

### DIFF
--- a/docs/development/shareable-configs.md
+++ b/docs/development/shareable-configs.md
@@ -7,6 +7,7 @@ Unlike ESLint though:
 - Shared config files can contain many presets
 
 Presets can be defined using either npm packages, or with GitHub/GitLab repositories.
+Only the JSON format is supported.
 Bitbucket-hosted presets are yet to be implemented.
 
 ## Preset config URIs

--- a/docs/usage/config-presets.md
+++ b/docs/usage/config-presets.md
@@ -14,6 +14,8 @@ In short:
 - Browse [Renovate's default presets](https://docs.renovatebot.com/presets-default/) to find any that are useful to you
 - Publish your own if you wish to reuse them across repositories
 
+Shareable config presets can only be used with the JSON format, other formats are not supported.
+
 ## Goals of Preset Configs
 
 The main reason for supporting preset configs is to decrease duplication.

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -24,6 +24,7 @@ Renovate always uses the config from the repository's default branch, even if th
 Renovate does not read/override the config from within each base branch if present.
 
 Also, be sure to check out Renovate's [shareable config presets](./config-presets.md) to save yourself from reinventing any wheels.
+Shareable config presets only work with the JSON format.
 
 If you have any questions about the config options, or want to get help/feedback about a config, go to the [discussions tab in the Renovate repository](https://github.com/renovatebot/renovate/discussions) and start a new "config help" discussion.
 We will do our best to answer your question(s).

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ Multi-platform and multi-language.
 - Define schedules to avoid unnecessary noise in projects (e.g. for weekends or outside of working hours, or weekly updates, etc.)
 - Relevant package files are discovered automatically (e.g. supports monorepo architecture such as Lerna or Yarn workspaces without further configuration)
 - Bot behavior is extremely customizable via configuration files (config as code)
-- Use ESLint-like shared config presets for ease of use and simplifying configuration
+- Use ESLint-like shared config presets for ease of use and simplifying configuration (JSON format only)
 - Lock files are natively supported and updated in the same commit, including immediately resolving conflicts whenever PRs are merged
 - Supports GitHub (.com and Enterprise), GitLab (.com and CE/EE), Bitbucket Cloud, Bitbucket Server, Azure DevOps and Gitea.
 - Open source (installable via npm/Yarn or Docker Hub) so can be self-hosted or used via GitHub App


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

- Document that shareable configs only work with the JSON format

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

Based on end-user confusion about shareable configs not working with the JSON5 format (see discussion #10087).

For now we only support the normal JSON format until we implement feature request in issue #7674.

I did a search for `share` in the `*.md` files, and added the information that JSON is the only supported format if you want to use the shareable config.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
