### PR TITLE
feat(docker): add possibility to define registry aliases

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -86,7 +86,7 @@ This makes it suitable for augmenting a preset or base list without displacing t
 ## aliases
 
 The `aliases` object is used for configuring registry aliases.
-Currently it is needed/supported for the `helm-requirements` and `docker` manager only.
+Currently it is needed/supported for the `helm-requirements` and `docker` managers only.
 
 `helm-requirements` includes this default alias:
 
@@ -98,7 +98,10 @@ Currently it is needed/supported for the `helm-requirements` and `docker` manage
 }
 ```
 
-When using a `docker` proxy cache `aliases` can be used to map the images prefix on the proxy to the original prefix:
+The following `alias` will result in Renovate treating docker images prefixed with `registry.example.com/proxy-cache` as if they were prefixed with `docker.io` instead.
+Renovate will get the tag list from Docker Hub instead of `registry.example.com`.
+This is useful when using a proxy registry like [Harbor Proxy Cache](https://goharbor.io/docs/2.1.0/administration/configure-proxy-cache/) or [Gitlab Dependency Proxy](https://docs.gitlab.com/ce/user/packages/dependency_proxy/).
+These proxies do not support the endpoint for listing all tags and thus can not be used to discover new versions of images.
 
 ```json
 {

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -100,7 +100,7 @@ Currently it is needed/supported for the `helm-requirements` and `docker` manage
 
 The following `alias` will result in Renovate treating docker images prefixed with `registry.example.com/proxy-cache` as if they were prefixed with `docker.io` instead.
 Renovate will get the tag list from Docker Hub instead of `registry.example.com`.
-This is useful when using a proxy registry like [Harbor Proxy Cache](https://goharbor.io/docs/2.1.0/administration/configure-proxy-cache/) or [Gitlab Dependency Proxy](https://docs.gitlab.com/ce/user/packages/dependency_proxy/).
+This is useful when using a proxy registry like [Harbor Proxy Cache](https://goharbor.io/docs/2.1.0/administration/configure-proxy-cache/) or [GitLab Dependency Proxy](https://docs.gitlab.com/ce/user/packages/dependency_proxy/).
 These proxies do not support the endpoint for listing all tags and thus can not be used to discover new versions of images.
 
 ```json

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -100,8 +100,8 @@ Currently it is needed/supported for the `helm-requirements` and `docker` manage
 
 The following `alias` will result in Renovate treating docker images prefixed with `registry.example.com/proxy-cache` as if they were prefixed with `docker.io` instead.
 Renovate will get the tag list from Docker Hub instead of `registry.example.com`.
-This is useful when using a proxy registry like [Harbor Proxy Cache](https://goharbor.io/docs/2.1.0/administration/configure-proxy-cache/) or [GitLab Dependency Proxy](https://docs.gitlab.com/ce/user/packages/dependency_proxy/).
-These proxies do not support the endpoint for listing all tags and thus can not be used to discover new versions of images.
+This is useful when using a proxy registry like [Harbor Proxy Cache](https://goharbor.io/docs/2.1.0/administration/configure-proxy-cache/) or [Gitlab Dependency Proxy](https://docs.gitlab.com/ce/user/packages/dependency_proxy/).
+These proxies do not natively support an endpoint that lists all tags and thus can not be used to discover new versions of images without this workaround.
 
 ```json
 {

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -86,7 +86,7 @@ This makes it suitable for augmenting a preset or base list without displacing t
 ## aliases
 
 The `aliases` object is used for configuring registry aliases.
-Currently it is needed/supported for the `helm-requirements` manager only.
+Currently it is needed/supported for the `helm-requirements` and `docker` manager only.
 
 `helm-requirements` includes this default alias:
 
@@ -94,6 +94,16 @@ Currently it is needed/supported for the `helm-requirements` manager only.
 {
   "aliases": {
     "stable": "https://charts.helm.sh/stable"
+  }
+}
+```
+
+When using a `docker` proxy cache `aliases` can be used to map the images prefix on the proxy to the original prefix:
+
+```json
+{
+  "aliases": {
+    "registry.example.com/proxy-cache": "docker.io"
   }
 }
 ```

--- a/lib/manager/ansible/extract.ts
+++ b/lib/manager/ansible/extract.ts
@@ -1,10 +1,12 @@
 import { logger } from '../../logger';
 import * as dockerVersioning from '../../versioning/docker';
 import { getDep } from '../dockerfile/extract';
-import type { PackageDependency, PackageFile } from '../types';
+import type { ExtractConfig, PackageDependency, PackageFile } from '../types';
 
 export default function extractPackageFile(
-  content: string
+  content: string,
+  packageFile?: string,
+  config?: ExtractConfig
 ): PackageFile | null {
   logger.trace('ansible.extractPackageFile()');
   let deps: PackageDependency[] = [];
@@ -13,7 +15,7 @@ export default function extractPackageFile(
     const match = re.exec(line);
     if (match) {
       const currentFrom = match[1];
-      const dep = getDep(currentFrom);
+      const dep = getDep(currentFrom, config.aliases);
       logger.debug(
         {
           depName: dep.depName,

--- a/lib/manager/ansible/extract.ts
+++ b/lib/manager/ansible/extract.ts
@@ -15,7 +15,7 @@ export default function extractPackageFile(
     const match = re.exec(line);
     if (match) {
       const currentFrom = match[1];
-      const dep = getDep(currentFrom, config.aliases);
+      const dep = getDep(currentFrom, config?.aliases);
       logger.debug(
         {
           depName: dep.depName,

--- a/lib/manager/azure-pipelines/extract.ts
+++ b/lib/manager/azure-pipelines/extract.ts
@@ -94,7 +94,7 @@ export function extractPackageFile(
 
   // grab the containers tags
   for (const container of pkg.resources.containers) {
-    const dep = extractContainer(container, config.aliases);
+    const dep = extractContainer(container, config?.aliases);
     if (dep) {
       deps.push(dep);
     }

--- a/lib/manager/azure-pipelines/extract.ts
+++ b/lib/manager/azure-pipelines/extract.ts
@@ -2,7 +2,7 @@ import { safeLoad } from 'js-yaml';
 import * as datasourceGitTags from '../../datasource/git-tags';
 import { logger } from '../../logger';
 import { getDep } from '../dockerfile/extract';
-import type { PackageDependency, PackageFile } from '../types';
+import type { ExtractConfig, PackageDependency, PackageFile } from '../types';
 import type { AzurePipelines, Container, Repository } from './types';
 
 export function extractRepository(
@@ -28,13 +28,14 @@ export function extractRepository(
 }
 
 export function extractContainer(
-  container: Container
+  container: Container,
+  aliases?: ExtractConfig['aliases']
 ): PackageDependency | null {
   if (!container.image) {
     return null;
   }
 
-  const dep = getDep(container.image);
+  const dep = getDep(container.image, aliases);
   logger.debug(
     {
       depName: dep.depName,
@@ -72,7 +73,8 @@ export function parseAzurePipelines(
 
 export function extractPackageFile(
   content: string,
-  filename: string
+  filename: string,
+  config?: ExtractConfig
 ): PackageFile | null {
   logger.trace(`azurePipelines.extractPackageFile(${filename})`);
   const deps: PackageDependency[] = [];
@@ -92,7 +94,7 @@ export function extractPackageFile(
 
   // grab the containers tags
   for (const container of pkg.resources.containers) {
-    const dep = extractContainer(container);
+    const dep = extractContainer(container, config.aliases);
     if (dep) {
       deps.push(dep);
     }

--- a/lib/manager/batect/extract.ts
+++ b/lib/manager/batect/extract.ts
@@ -37,16 +37,22 @@ function extractImages(config: BatectConfig): string[] {
     .map((container) => container.image);
 }
 
-function createImageDependency(tag: string): PackageDependency {
+function createImageDependency(
+  tag: string,
+  aliases?: ExtractConfig['aliases']
+): PackageDependency {
   return {
-    ...getDep(tag),
+    ...getDep(tag, aliases),
     versioning: dockerVersioning,
   };
 }
 
-function extractImageDependencies(config: BatectConfig): PackageDependency[] {
+function extractImageDependencies(
+  config: BatectConfig,
+  aliases?: ExtractConfig['aliases']
+): PackageDependency[] {
   const images = extractImages(config);
-  const deps = images.map((image) => createImageDependency(image));
+  const deps = images.map((image) => createImageDependency(image, aliases));
 
   logger.trace({ deps }, 'Loaded images from Batect configuration file');
 
@@ -118,14 +124,15 @@ function extractReferencedConfigFiles(
 
 export function extractPackageFile(
   content: string,
-  fileName: string
+  fileName: string,
+  extractConfig?: ExtractConfig
 ): ExtractionResult | null {
   logger.debug({ fileName }, 'batect.extractPackageFile()');
 
   try {
     const config = loadConfig(content);
     const deps = [
-      ...extractImageDependencies(config),
+      ...extractImageDependencies(config, extractConfig.aliases),
       ...extractBundleDependencies(config),
     ];
 

--- a/lib/manager/batect/extract.ts
+++ b/lib/manager/batect/extract.ts
@@ -132,7 +132,7 @@ export function extractPackageFile(
   try {
     const config = loadConfig(content);
     const deps = [
-      ...extractImageDependencies(config, extractConfig.aliases),
+      ...extractImageDependencies(config, extractConfig?.aliases),
       ...extractBundleDependencies(config),
     ];
 

--- a/lib/manager/circleci/extract.ts
+++ b/lib/manager/circleci/extract.ts
@@ -53,7 +53,7 @@ export function extractPackageFile(
       const match = /^\s*-? image:\s*'?"?([^\s'"]+)'?"?\s*$/.exec(line);
       if (match) {
         const currentFrom = match[1];
-        const dep = getDep(currentFrom, config.aliases);
+        const dep = getDep(currentFrom, config?.aliases);
         logger.debug(
           {
             depName: dep.depName,

--- a/lib/manager/circleci/extract.ts
+++ b/lib/manager/circleci/extract.ts
@@ -2,9 +2,13 @@ import * as datasourceOrb from '../../datasource/orb';
 import { logger } from '../../logger';
 import * as npmVersioning from '../../versioning/npm';
 import { getDep } from '../dockerfile/extract';
-import type { PackageDependency, PackageFile } from '../types';
+import type { ExtractConfig, PackageDependency, PackageFile } from '../types';
 
-export function extractPackageFile(content: string): PackageFile | null {
+export function extractPackageFile(
+  content: string,
+  packageFile?: string,
+  config?: ExtractConfig
+): PackageFile | null {
   const deps: PackageDependency[] = [];
   try {
     const lines = content.split('\n');
@@ -49,7 +53,7 @@ export function extractPackageFile(content: string): PackageFile | null {
       const match = /^\s*-? image:\s*'?"?([^\s'"]+)'?"?\s*$/.exec(line);
       if (match) {
         const currentFrom = match[1];
-        const dep = getDep(currentFrom);
+        const dep = getDep(currentFrom, config.aliases);
         logger.debug(
           {
             depName: dep.depName,

--- a/lib/manager/dockerfile/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/dockerfile/__snapshots__/extract.spec.ts.snap
@@ -450,3 +450,14 @@ Object {
   "skipReason": "invalid-value",
 }
 `;
+
+exports[`manager/dockerfile/extract getDep() resolves aliases 1`] = `
+Object {
+  "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
+  "currentDigest": undefined,
+  "currentValue": "25.0.0",
+  "datasource": "docker",
+  "depName": "docker.io/renovate/renovate",
+  "replaceString": "docker.io/renovate/renovate:25.0.0",
+}
+`;

--- a/lib/manager/dockerfile/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/dockerfile/__snapshots__/extract.spec.ts.snap
@@ -445,6 +445,17 @@ Array [
 ]
 `;
 
+exports[`manager/dockerfile/extract getDep() does not apply aliases to images not prefixed with the given alias 1`] = `
+Object {
+  "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
+  "currentDigest": undefined,
+  "currentValue": "25.0.0",
+  "datasource": "docker",
+  "depName": "renovate/renovate",
+  "replaceString": "renovate/renovate:25.0.0",
+}
+`;
+
 exports[`manager/dockerfile/extract getDep() rejects null 1`] = `
 Object {
   "skipReason": "invalid-value",

--- a/lib/manager/dockerfile/extract.spec.ts
+++ b/lib/manager/dockerfile/extract.spec.ts
@@ -167,5 +167,12 @@ describe(getName(), () => {
       };
       expect(getDep(from, aliases)).toMatchSnapshot();
     });
+    it('does not apply aliases to images not prefixed with the given alias', () => {
+      const from = 'renovate/renovate:25.0.0';
+      const aliases = {
+        'registry.example.com/proxy': 'docker.io',
+      };
+      expect(getDep(from, aliases)).toMatchSnapshot();
+    });
   });
 });

--- a/lib/manager/dockerfile/extract.spec.ts
+++ b/lib/manager/dockerfile/extract.spec.ts
@@ -160,5 +160,12 @@ describe(getName(), () => {
     it('rejects null', () => {
       expect(getDep(null)).toMatchSnapshot();
     });
+    it('resolves aliases', () => {
+      const from = 'registry.example.com/proxy/renovate/renovate:25.0.0';
+      const aliases = {
+        'registry.example.com/proxy': 'docker.io',
+      };
+      expect(getDep(from, aliases)).toMatchSnapshot();
+    });
   });
 });

--- a/lib/manager/dockerfile/extract.ts
+++ b/lib/manager/dockerfile/extract.ts
@@ -34,7 +34,7 @@ export function splitImageParts(currentFrom: string): PackageDependency {
 
 export function getDep(
   currentFrom: string,
-  aliases: ExtractConfig['aliases'],
+  aliases?: ExtractConfig['aliases'],
   specifyReplaceString = true
 ): PackageDependency {
   if (!is.string(currentFrom)) {

--- a/lib/manager/dockerfile/extract.ts
+++ b/lib/manager/dockerfile/extract.ts
@@ -83,7 +83,7 @@ export function extractPackageFile(
     } else if (stageNames.includes(fromMatch.groups.image)) {
       logger.debug({ image: fromMatch.groups.image }, 'Skipping alias FROM');
     } else {
-      const dep = getDep(fromMatch.groups.image, config.aliases);
+      const dep = getDep(fromMatch.groups.image, config?.aliases);
       logger.trace(
         {
           depName: dep.depName,
@@ -107,7 +107,7 @@ export function extractPackageFile(
         'Skipping alias COPY --from'
       );
     } else if (Number.isNaN(Number(copyFromMatch.groups.image))) {
-      const dep = getDep(copyFromMatch.groups.image, config.aliases);
+      const dep = getDep(copyFromMatch.groups.image, config?.aliases);
       logger.debug(
         {
           depName: dep.depName,

--- a/lib/manager/dockerfile/extract.ts
+++ b/lib/manager/dockerfile/extract.ts
@@ -34,17 +34,17 @@ export function splitImageParts(currentFrom: string): PackageDependency {
 
 export function getDep(
   currentFrom: string,
-  specifyReplaceString = true,
-  config: ExtractConfig
+  aliases: ExtractConfig['aliases'],
+  specifyReplaceString = true
 ): PackageDependency {
   if (!is.string(currentFrom)) {
     return {
       skipReason: SkipReason.InvalidValue,
     };
   }
-  const aliasedFrom = Object.keys(config.aliases).reduce((from, alias) => {
+  const aliasedFrom = Object.keys(aliases).reduce((from, alias) => {
     if (from.startsWith(alias)) {
-      return from.replace(alias, config.aliases[alias]);
+      return from.replace(alias, aliases[alias]);
     }
     return from;
   }, currentFrom);
@@ -83,7 +83,7 @@ export function extractPackageFile(
     } else if (stageNames.includes(fromMatch.groups.image)) {
       logger.debug({ image: fromMatch.groups.image }, 'Skipping alias FROM');
     } else {
-      const dep = getDep(fromMatch.groups.image, true, config);
+      const dep = getDep(fromMatch.groups.image, config.aliases);
       logger.trace(
         {
           depName: dep.depName,
@@ -107,7 +107,7 @@ export function extractPackageFile(
         'Skipping alias COPY --from'
       );
     } else if (Number.isNaN(Number(copyFromMatch.groups.image))) {
-      const dep = getDep(copyFromMatch.groups.image, true, config);
+      const dep = getDep(copyFromMatch.groups.image, config.aliases);
       logger.debug(
         {
           depName: dep.depName,

--- a/lib/manager/dockerfile/extract.ts
+++ b/lib/manager/dockerfile/extract.ts
@@ -42,12 +42,15 @@ export function getDep(
       skipReason: SkipReason.InvalidValue,
     };
   }
-  const aliasedFrom = Object.keys(aliases).reduce((from, alias) => {
-    if (from.startsWith(alias)) {
-      return from.replace(alias, aliases[alias]);
-    }
-    return from;
-  }, currentFrom);
+  let aliasedFrom = currentFrom;
+  if (aliases) {
+    aliasedFrom = Object.keys(aliases).reduce((from, alias) => {
+      if (from.startsWith(alias)) {
+        return from.replace(alias, aliases[alias]);
+      }
+      return from;
+    }, currentFrom);
+  }
   const dep = splitImageParts(aliasedFrom);
   if (specifyReplaceString) {
     dep.replaceString = aliasedFrom;

--- a/lib/manager/droneci/extract.ts
+++ b/lib/manager/droneci/extract.ts
@@ -15,7 +15,7 @@ export function extractPackageFile(
       const match = /^\s* image:\s*'?"?([^\s'"]+)'?"?\s*$/.exec(line);
       if (match) {
         const currentFrom = match[1];
-        const dep = getDep(currentFrom, config.aliases);
+        const dep = getDep(currentFrom, config?.aliases);
         logger.debug(
           {
             depName: dep.depName,

--- a/lib/manager/droneci/extract.ts
+++ b/lib/manager/droneci/extract.ts
@@ -1,8 +1,12 @@
 import { logger } from '../../logger';
 import { getDep } from '../dockerfile/extract';
-import type { PackageDependency, PackageFile } from '../types';
+import type { ExtractConfig, PackageDependency, PackageFile } from '../types';
 
-export function extractPackageFile(content: string): PackageFile | null {
+export function extractPackageFile(
+  content: string,
+  packageFile?: string,
+  config?: ExtractConfig
+): PackageFile | null {
   const deps: PackageDependency[] = [];
   try {
     const lines = content.split('\n');
@@ -11,7 +15,7 @@ export function extractPackageFile(content: string): PackageFile | null {
       const match = /^\s* image:\s*'?"?([^\s'"]+)'?"?\s*$/.exec(line);
       if (match) {
         const currentFrom = match[1];
-        const dep = getDep(currentFrom);
+        const dep = getDep(currentFrom, config.aliases);
         logger.debug(
           {
             depName: dep.depName,

--- a/lib/manager/github-actions/extract.ts
+++ b/lib/manager/github-actions/extract.ts
@@ -20,7 +20,7 @@ export function extractPackageFile(
     const dockerMatch = /^\s+uses: docker:\/\/([^"]+)\s*$/.exec(line);
     if (dockerMatch) {
       const [, currentFrom] = dockerMatch;
-      const dep = getDep(currentFrom, config.aliases);
+      const dep = getDep(currentFrom, config?.aliases);
       dep.depType = 'docker';
       dep.versioning = dockerVersioning.id;
       deps.push(dep);

--- a/lib/manager/github-actions/extract.ts
+++ b/lib/manager/github-actions/extract.ts
@@ -3,9 +3,13 @@ import { logger } from '../../logger';
 import { SkipReason } from '../../types';
 import * as dockerVersioning from '../../versioning/docker';
 import { getDep } from '../dockerfile/extract';
-import type { PackageDependency, PackageFile } from '../types';
+import type { ExtractConfig, PackageDependency, PackageFile } from '../types';
 
-export function extractPackageFile(content: string): PackageFile | null {
+export function extractPackageFile(
+  content: string,
+  packageFile?: string,
+  config?: ExtractConfig
+): PackageFile | null {
   logger.trace('github-actions.extractPackageFile()');
   const deps: PackageDependency[] = [];
   for (const line of content.split('\n')) {
@@ -16,7 +20,7 @@ export function extractPackageFile(content: string): PackageFile | null {
     const dockerMatch = /^\s+uses: docker:\/\/([^"]+)\s*$/.exec(line);
     if (dockerMatch) {
       const [, currentFrom] = dockerMatch;
-      const dep = getDep(currentFrom);
+      const dep = getDep(currentFrom, config.aliases);
       dep.depType = 'docker';
       dep.versioning = dockerVersioning.id;
       deps.push(dep);

--- a/lib/manager/gitlabci/extract.ts
+++ b/lib/manager/gitlabci/extract.ts
@@ -19,7 +19,11 @@ function skipCommentLines(
   return { line: lines[ln], lineNumber: ln };
 }
 
-export function extractPackageFile(content: string): PackageFile | null {
+export function extractPackageFile(
+  content: string,
+  packageFile?: string,
+  config?: ExtractConfig
+): PackageFile | null {
   const deps: PackageDependency[] = [];
   try {
     const lines = content.split('\n');
@@ -38,7 +42,7 @@ export function extractPackageFile(content: string): PackageFile | null {
               lineNumber = imageNameLine.lineNumber;
               logger.trace(`Matched image name on line ${lineNumber}`);
               const currentFrom = imageNameMatch[1];
-              const dep = getDep(currentFrom);
+              const dep = getDep(currentFrom, config.aliases);
               dep.depType = 'image-name';
               deps.push(dep);
             }
@@ -47,7 +51,7 @@ export function extractPackageFile(content: string): PackageFile | null {
           default: {
             logger.trace(`Matched image on line ${lineNumber}`);
             const currentFrom = imageMatch[1];
-            const dep = getDep(currentFrom);
+            const dep = getDep(currentFrom, config.aliases);
             dep.depType = 'image';
             deps.push(dep);
           }
@@ -70,7 +74,7 @@ export function extractPackageFile(content: string): PackageFile | null {
             foundImage = true;
             const currentFrom = serviceImageMatch[1];
             lineNumber = serviceImageLine.lineNumber;
-            const dep = getDep(currentFrom);
+            const dep = getDep(currentFrom, config.aliases);
             dep.depType = 'service-image';
             deps.push(dep);
           }
@@ -87,7 +91,7 @@ export function extractPackageFile(content: string): PackageFile | null {
 }
 
 export async function extractAllPackageFiles(
-  _config: ExtractConfig,
+  config: ExtractConfig,
   packageFiles: string[]
 ): Promise<PackageFile[] | null> {
   const filesToExamine = [...packageFiles];
@@ -126,7 +130,7 @@ export async function extractAllPackageFiles(
       }
     }
 
-    const result = extractPackageFile(content);
+    const result = extractPackageFile(content, undefined, config.aliases);
     if (result !== null) {
       results.push({
         packageFile: file,

--- a/lib/manager/gitlabci/extract.ts
+++ b/lib/manager/gitlabci/extract.ts
@@ -42,7 +42,7 @@ export function extractPackageFile(
               lineNumber = imageNameLine.lineNumber;
               logger.trace(`Matched image name on line ${lineNumber}`);
               const currentFrom = imageNameMatch[1];
-              const dep = getDep(currentFrom, config.aliases);
+              const dep = getDep(currentFrom, config?.aliases);
               dep.depType = 'image-name';
               deps.push(dep);
             }
@@ -51,7 +51,7 @@ export function extractPackageFile(
           default: {
             logger.trace(`Matched image on line ${lineNumber}`);
             const currentFrom = imageMatch[1];
-            const dep = getDep(currentFrom, config.aliases);
+            const dep = getDep(currentFrom, config?.aliases);
             dep.depType = 'image';
             deps.push(dep);
           }
@@ -74,7 +74,7 @@ export function extractPackageFile(
             foundImage = true;
             const currentFrom = serviceImageMatch[1];
             lineNumber = serviceImageLine.lineNumber;
-            const dep = getDep(currentFrom, config.aliases);
+            const dep = getDep(currentFrom, config?.aliases);
             dep.depType = 'service-image';
             deps.push(dep);
           }

--- a/lib/manager/helm-values/extract.ts
+++ b/lib/manager/helm-values/extract.ts
@@ -72,7 +72,7 @@ export function extractPackageFile(
     return null;
   }
   try {
-    const deps = findDependencies(parsedContent, [], config.aliases);
+    const deps = findDependencies(parsedContent, [], config?.aliases);
     if (deps.length) {
       logger.debug({ deps }, 'Found dependencies in helm-values');
       return { deps };

--- a/lib/manager/kubernetes/extract.ts
+++ b/lib/manager/kubernetes/extract.ts
@@ -20,7 +20,7 @@ export function extractPackageFile(
     const match = /^\s*-?\s*image:\s*'?"?([^\s'"]+)'?"?\s*$/.exec(line);
     if (match) {
       const currentFrom = match[1];
-      const dep = getDep(currentFrom, config.aliases);
+      const dep = getDep(currentFrom, config?.aliases);
       logger.debug(
         {
           depName: dep.depName,

--- a/lib/manager/kubernetes/extract.ts
+++ b/lib/manager/kubernetes/extract.ts
@@ -1,8 +1,12 @@
 import { logger } from '../../logger';
 import { getDep } from '../dockerfile/extract';
-import type { PackageDependency, PackageFile } from '../types';
+import type { ExtractConfig, PackageDependency, PackageFile } from '../types';
 
-export function extractPackageFile(content: string): PackageFile | null {
+export function extractPackageFile(
+  content: string,
+  packageFile?: string,
+  config?: ExtractConfig
+): PackageFile | null {
   logger.trace('kubernetes.extractPackageFile()');
   let deps: PackageDependency[] = [];
 
@@ -16,7 +20,7 @@ export function extractPackageFile(content: string): PackageFile | null {
     const match = /^\s*-?\s*image:\s*'?"?([^\s'"]+)'?"?\s*$/.exec(line);
     if (match) {
       const currentFrom = match[1];
-      const dep = getDep(currentFrom);
+      const dep = getDep(currentFrom, config.aliases);
       logger.debug(
         {
           depName: dep.depName,

--- a/lib/manager/terraform/extract.ts
+++ b/lib/manager/terraform/extract.ts
@@ -1,5 +1,5 @@
 import { logger } from '../../logger';
-import type { PackageDependency, PackageFile } from '../types';
+import type { ExtractConfig, PackageDependency, PackageFile } from '../types';
 import { TerraformDependencyTypes } from './common';
 import { analyseTerraformModule, extractTerraformModule } from './modules';
 import {
@@ -34,7 +34,11 @@ const contentCheckList = [
   ' "docker_image" ',
 ];
 
-export function extractPackageFile(content: string): PackageFile | null {
+export function extractPackageFile(
+  content: string,
+  packageFile?: string,
+  config?: ExtractConfig
+): PackageFile | null {
   logger.trace({ content }, 'terraform.extractPackageFile()');
   if (!checkFileContainsDependency(content, contentCheckList)) {
     return null;
@@ -111,7 +115,7 @@ export function extractPackageFile(content: string): PackageFile | null {
         analyseTerraformModule(dep);
         break;
       case TerraformDependencyTypes.resource:
-        analyseTerraformResource(dep);
+        analyseTerraformResource(dep, config.aliases);
         break;
       case TerraformDependencyTypes.terraform_version:
         analyseTerraformVersion(dep);

--- a/lib/manager/terraform/extract.ts
+++ b/lib/manager/terraform/extract.ts
@@ -115,7 +115,7 @@ export function extractPackageFile(
         analyseTerraformModule(dep);
         break;
       case TerraformDependencyTypes.resource:
-        analyseTerraformResource(dep, config.aliases);
+        analyseTerraformResource(dep, config?.aliases);
         break;
       case TerraformDependencyTypes.terraform_version:
         analyseTerraformVersion(dep);

--- a/lib/manager/terraform/resources.ts
+++ b/lib/manager/terraform/resources.ts
@@ -1,7 +1,7 @@
 import * as datasourceHelm from '../../datasource/helm';
 import { SkipReason } from '../../types';
 import { getDep } from '../dockerfile/extract';
-import type { PackageDependency } from '../types';
+import type { ExtractConfig, PackageDependency } from '../types';
 import { TerraformDependencyTypes, TerraformResourceTypes } from './common';
 import type { ExtractionResult, ResourceManagerData } from './types';
 import {
@@ -12,9 +12,10 @@ import {
 
 function applyDockerDependency(
   dep: PackageDependency<ResourceManagerData>,
-  value: string
+  value: string,
+  aliases?: ExtractConfig['aliases']
 ): void {
-  const dockerDep = getDep(value);
+  const dockerDep = getDep(value, aliases);
   Object.assign(dep, dockerDep);
 }
 
@@ -63,14 +64,15 @@ export function extractTerraformResource(
 }
 
 export function analyseTerraformResource(
-  dep: PackageDependency<ResourceManagerData>
+  dep: PackageDependency<ResourceManagerData>,
+  aliases?: ExtractConfig['aliases']
 ): void {
   /* eslint-disable no-param-reassign */
 
   switch (dep.managerData.resourceType) {
     case TerraformResourceTypes.docker_container:
       if (dep.managerData.image) {
-        applyDockerDependency(dep, dep.managerData.image);
+        applyDockerDependency(dep, dep.managerData.image, aliases);
         dep.depType = 'docker_container';
       } else {
         dep.skipReason = SkipReason.InvalidDependencySpecification;
@@ -79,7 +81,7 @@ export function analyseTerraformResource(
 
     case TerraformResourceTypes.docker_image:
       if (dep.managerData.name) {
-        applyDockerDependency(dep, dep.managerData.name);
+        applyDockerDependency(dep, dep.managerData.name, aliases);
         dep.depType = 'docker_image';
       } else {
         dep.skipReason = SkipReason.InvalidDependencySpecification;
@@ -88,7 +90,7 @@ export function analyseTerraformResource(
 
     case TerraformResourceTypes.docker_service:
       if (dep.managerData.image) {
-        applyDockerDependency(dep, dep.managerData.image);
+        applyDockerDependency(dep, dep.managerData.image, aliases);
         dep.depType = 'docker_service';
       } else {
         dep.skipReason = SkipReason.InvalidDependencySpecification;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds support for [aliases](https://docs.renovatebot.com/configuration-options/#aliases) to the docker manager.

The following config will result in renovate treating images starting with `registry.example.com/proxy-cache` as if the image starts with `docker.io` instead. This way renovate will get the tag list from docker hub fixing the issue outlined below.

```json
{
  "aliases": {
    "registry.example.com/proxy-cache": "docker.io"
  }
}
```

Additional aliases that might even be useful defaults (since e.g. `alpine` === `library/alpine` === `docker.io/alpine`):

```json
{
  "aliases": {
    "docker.io/": "",
    "library/": ""
  }
}
```

<!-- Describe what behavior is changed by this PR. -->

## Context:

When using a docker proxy cache, images are prepended with a prefix pointing to the proxy.

```Dockerfile
# without proxy cache
FROM node:12.19.1
# with proxy cache
FROM registry.example.com/proxy-cache/library/node:12.19.1
```

Since these proxies do not return a full tag list, renovate is unable to update images containing the prefix.

Also discussed in https://github.com/renovatebot/renovate/discussions/9004

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
