### PR TITLE
chore: automate asking for new package manager info

### DIFF
--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -99,3 +99,21 @@
         </details>
 
     </details>
+
+'new package manager':
+  comment: >
+    Hi there,
+
+
+    You're requesting support for a new package manager.
+    We need to know some basic information about this package manager first.
+    Please copy/paste [the new package manager questionnaire](https://github.com/renovatebot/renovate/blob/main/docs/development/new-package-manager-template.md), and fill it out in full.
+
+
+    Once the questionnaire is filled out we will evaluate if adding support for this manager is something we want to do.
+
+
+    Good luck,
+
+
+    The Renovate team


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

- Use the `dessant/label-actions` to comment on `new package manager` issues

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

We now have a package manager questionnaire, but we need to remember to ask contributors to fill this in.
We can automate this by using the label action.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

I've tested the new configuration on a throwaway repository: https://github.com/HonkingGoose/renovate-automate-ask/issues/1

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
