### PR TITLE
chore: automate asking retry newer Renovate version

### DIFF
--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -117,3 +117,17 @@
 
 
     The Renovate team
+
+'retry latest version':
+  comment: >
+    Hi there,
+
+
+    You're reporting a problem with an outdated version of Renovate.
+    Please try the latest version and tell us if that fixes your problem.
+
+
+    Good luck,
+
+
+    The Renovate team


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

- Let label-action bot ask for retry with latest Renovate version when a label is applied

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

I notice that we have to ask reporters to try again on a newer version.
This is a thing that we could let the bot do once we apply a suitable label.

I'm marking this as a draft, as we need to agree on a label name, create the agreed on label, and maybe adjust the text of the bot message.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
