### PR TITLE
feat: migratePresets

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -249,8 +249,8 @@ If left as default (null), a random short ID will be selected.
 
 ## migratePresets
 
-Use this is you have repositories extending a particular preset but it has been removed or renamed.
-This is especially handy if you have a large number of repositories extending a particular preset which you want to rename, without the hassle of updating every repository individually.
+Use this if you have repositories that extend from a particular preset, which has now been renamed or removed.
+This is handy if you have a large number of repositories that all extend from a particular preset which you want to rename, without the hassle of manually updating every repository individually.
 Use an empty string to indicate that the preset should be ignored rather than replaced.
 
 Example:
@@ -263,7 +263,7 @@ modules.exports = {
 };
 ```
 
-In the above example any reference to `@company` preset will be replaced with `local>org/renovate-config`.
+In the above example any reference to the `@company` preset will be replaced with `local>org/renovate-config`.
 
 ## onboarding
 

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -247,6 +247,24 @@ If left as default (null), a random short ID will be selected.
 
 ## logFileLevel
 
+## migratePresets
+
+Use this is you have repositories extending a particular preset but it has been removed or renamed.
+This is especially handy if you have a large number of repositories extending a particular preset which you want to rename, without the hassle of updating every repository individually.
+Use an empty string to indicate that the preset should be ignored rather than replaced.
+
+Example:
+
+```js
+modules.exports = {
+  migratePresets: {
+    '@company': 'local>org/renovate-config',
+  },
+};
+```
+
+In the above example any reference to `@company` preset will be replaced with `local>org/renovate-config`.
+
 ## onboarding
 
 Set this to `false` only if all three statements are true:

--- a/lib/config/__snapshots__/migration.spec.ts.snap
+++ b/lib/config/__snapshots__/migration.spec.ts.snap
@@ -51,6 +51,14 @@ Object {
 }
 `;
 
+exports[`config/migration it migrates presets 1`] = `
+Object {
+  "extends": Array [
+    "local>org/renovate-config",
+  ],
+}
+`;
+
 exports[`config/migration migrateConfig(config, parentConfig) does not migrate multi days 1`] = `
 Object {
   "schedule": "after 5:00pm on wednesday and thursday",

--- a/lib/config/admin.ts
+++ b/lib/config/admin.ts
@@ -14,6 +14,7 @@ const repoAdminOptions = [
   'dockerUser',
   'dryRun',
   'exposeAllEnv',
+  'migratePresets',
   'privateKey',
   'localDir',
   'cacheDir',

--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -149,6 +149,17 @@ const options: RenovateOptions[] = [
     cli: false,
   },
   {
+    name: 'migratePresets',
+    description:
+      'Define presets here which have been removed or renamed and should be migrated automatically.',
+    type: 'object',
+    admin: true,
+    default: {},
+    additionalProperties: {
+      type: 'string',
+    },
+  },
+  {
     name: 'description',
     description: 'Plain text description for a config or preset.',
     type: 'array',

--- a/lib/config/migration.spec.ts
+++ b/lib/config/migration.spec.ts
@@ -1,5 +1,6 @@
 import { getName } from '../../test/util';
 import { PLATFORM_TYPE_GITHUB } from '../constants/platforms';
+import { setAdminConfig } from './admin';
 import { getConfig } from './defaults';
 import * as configMigration from './migration';
 import type {
@@ -674,6 +675,23 @@ describe(getName(), () => {
           token: 'abc123',
         },
       ],
+    } as any;
+    const { isMigrated, migratedConfig } = configMigration.migrateConfig(
+      config,
+      defaultConfig
+    );
+    expect(isMigrated).toBe(true);
+    expect(migratedConfig).toMatchSnapshot();
+  });
+  it('it migrates presets', () => {
+    setAdminConfig({
+      migratePresets: {
+        '@org': 'local>org/renovate-config',
+        '@org2/foo': '',
+      },
+    });
+    const config: RenovateConfig = {
+      extends: ['@org', '@org2/foo'],
     } as any;
     const { isMigrated, migratedConfig } = configMigration.migrateConfig(
       config,

--- a/lib/config/migration.ts
+++ b/lib/config/migration.ts
@@ -3,6 +3,7 @@ import is from '@sindresorhus/is';
 import { dequal } from 'dequal';
 import { logger } from '../logger';
 import { clone } from '../util/clone';
+import { getAdminConfig } from './admin';
 import { getOptions } from './definitions';
 import { removedPresets } from './presets/common';
 import type {
@@ -54,6 +55,7 @@ export function migrateConfig(
       'optionalDependencies',
       'peerDependencies',
     ];
+    const { migratePresets } = getAdminConfig();
     for (const [key, val] of Object.entries(config)) {
       if (removedOptions.includes(key)) {
         delete migratedConfig[key];
@@ -260,7 +262,11 @@ export function migrateConfig(
         for (let i = 0; i < presets.length; i += 1) {
           const preset = presets[i];
           if (is.string(preset)) {
-            const newPreset = removedPresets[preset];
+            let newPreset = removedPresets[preset];
+            if (newPreset !== undefined) {
+              presets[i] = newPreset;
+            }
+            newPreset = migratePresets?.[preset];
             if (newPreset !== undefined) {
               presets[i] = newPreset;
             }

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -96,6 +96,7 @@ export interface RepoAdminConfig {
   dockerUser?: string;
   dryRun?: boolean;
   exposeAllEnv?: boolean;
+  migratePresets?: Record<string, string>;
   privateKey?: string | Buffer;
   localDir?: string;
   cacheDir?: string;

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -514,7 +514,7 @@ export async function validateConfig(
                   message: `Invalid \`${currentPath}.${key}.${res}\` configuration: value is not a url`,
                 });
               }
-            } else if (key === 'customEnvVariables') {
+            } else if (['customEnvVariables', 'migratePresets'].includes(key)) {
               const res = validatePlainObject(val);
               if (res !== true) {
                 errors.push({


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds new config option `migratePresets` which allows for admin control of migrating removed or renamed presets.

## Context:

Closes #9209

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
