### PR TITLE
feat(npm): extract rules from npmrc [WIP]

### DIFF
--- a/lib/config/npmrc.spec.ts
+++ b/lib/config/npmrc.spec.ts
@@ -4,7 +4,12 @@ import { getConfigFromNpmrc } from './npmrc';
 describe(getName(), () => {
   describe('getConfigFromNpmrc()', () => {
     it('works with empty string', () => {
-      expect(getConfigFromNpmrc()).toEqual({});
+      expect(getConfigFromNpmrc()).toMatchInlineSnapshot(`
+        Object {
+          "hostRules": Array [],
+          "packageRules": Array [],
+        }
+      `);
     });
     it('supports naked _auth', () => {
       expect(getConfigFromNpmrc('_auth=some-token')).toMatchInlineSnapshot(`
@@ -16,6 +21,7 @@ describe(getName(), () => {
               "token": "some-token",
             },
           ],
+          "packageRules": Array [],
         }
       `);
     });

--- a/lib/config/npmrc.spec.ts
+++ b/lib/config/npmrc.spec.ts
@@ -61,7 +61,7 @@ describe(getName(), () => {
             Object {
               "authType": "Basic",
               "hostType": "npm",
-              "matchHost": "other.registry",
+              "matchHost": "https://other.registry",
               "token": "other-token",
             },
           ],

--- a/lib/config/npmrc.spec.ts
+++ b/lib/config/npmrc.spec.ts
@@ -1,0 +1,85 @@
+import { getName } from '../../test/util';
+import { getConfigFromNpmrc } from './npmrc';
+
+describe(getName(), () => {
+  describe('getConfigFromNpmrc()', () => {
+    it('works with empty string', () => {
+      expect(getConfigFromNpmrc()).toEqual({});
+    });
+    it('supports naked _auth', () => {
+      expect(getConfigFromNpmrc('_auth=some-token')).toMatchInlineSnapshot(`
+        Object {
+          "hostRules": Array [
+            Object {
+              "authType": "Basic",
+              "hostType": "npm",
+              "token": "some-token",
+            },
+          ],
+        }
+      `);
+    });
+    it('supports naked registry and _authToken', () => {
+      expect(
+        getConfigFromNpmrc(
+          'registry=https://corp.registry\n_authToken=some-token'
+        )
+      ).toMatchInlineSnapshot(`
+        Object {
+          "hostRules": Array [
+            Object {
+              "hostType": "npm",
+              "token": "some-token",
+            },
+          ],
+          "packageRules": Array [
+            Object {
+              "matchDatasources": Array [
+                "npm",
+              ],
+              "registryUrls": Array [
+                "https://corp.registry",
+              ],
+            },
+          ],
+        }
+      `);
+    });
+    it('supports scoped registries', () => {
+      expect(
+        getConfigFromNpmrc(
+          '@org:registry=https://corp.registry\n//corp.registry:_authToken=some-token\nhttps://other.registry:_auth=other-token\n'
+        )
+      ).toMatchInlineSnapshot(`
+        Object {
+          "hostRules": Array [
+            Object {
+              "hostType": "npm",
+              "matchHost": "corp.registry",
+              "token": "some-token",
+            },
+            Object {
+              "authType": "Basic",
+              "hostType": "npm",
+              "matchHost": "other.registry",
+              "token": "other-token",
+            },
+          ],
+          "packageRules": Array [
+            Object {
+              "matchDatasources": Array [
+                "npm",
+              ],
+              "matchPackagePrefixes": Array [
+                "@org",
+              ],
+              "registryUrls": Array [
+                "https://corp.registry",
+              ],
+            },
+          ],
+        }
+      `);
+    });
+  });
+});

--- a/lib/config/npmrc.spec.ts
+++ b/lib/config/npmrc.spec.ts
@@ -1,10 +1,10 @@
 import { getName } from '../../test/util';
-import { getConfigRulesFromNpmrc } from './npmrc';
+import { getConfigFromNpmrc } from './npmrc';
 
 describe(getName(), () => {
-  describe('getConfigRulesFromNpmrc()', () => {
+  describe('getConfigFromNpmrc()', () => {
     it('works with empty string', () => {
-      expect(getConfigRulesFromNpmrc()).toMatchInlineSnapshot(`
+      expect(getConfigFromNpmrc()).toMatchInlineSnapshot(`
         Object {
           "hostRules": Array [],
           "packageRules": Array [],
@@ -12,8 +12,7 @@ describe(getName(), () => {
       `);
     });
     it('supports naked _auth', () => {
-      expect(getConfigRulesFromNpmrc('_auth=some-token'))
-        .toMatchInlineSnapshot(`
+      expect(getConfigFromNpmrc('_auth=some-token')).toMatchInlineSnapshot(`
         Object {
           "hostRules": Array [
             Object {
@@ -28,7 +27,7 @@ describe(getName(), () => {
     });
     it('supports naked registry and _authToken', () => {
       expect(
-        getConfigRulesFromNpmrc(
+        getConfigFromNpmrc(
           'registry=https://corp.registry\n_authToken=some-token'
         )
       ).toMatchInlineSnapshot(`
@@ -54,22 +53,22 @@ describe(getName(), () => {
     });
     it('supports scoped registries', () => {
       expect(
-        getConfigRulesFromNpmrc(
+        getConfigFromNpmrc(
           '@org:registry=https://corp.registry\n//corp.registry:_authToken=some-token\nhttps://other.registry:_auth=other-token\n'
         )
       ).toMatchInlineSnapshot(`
         Object {
           "hostRules": Array [
             Object {
+              "hostType": "npm",
+              "matchHost": "corp.registry",
+              "token": "some-token",
+            },
+            Object {
               "authType": "Basic",
               "hostType": "npm",
               "matchHost": "https://other.registry",
               "token": "other-token",
-            },
-            Object {
-              "hostType": "npm",
-              "matchHost": "corp.registry",
-              "token": "some-token",
             },
           ],
           "packageRules": Array [

--- a/lib/config/npmrc.spec.ts
+++ b/lib/config/npmrc.spec.ts
@@ -1,10 +1,10 @@
 import { getName } from '../../test/util';
-import { getConfigFromNpmrc } from './npmrc';
+import { getConfigRulesFromNpmrc } from './npmrc';
 
 describe(getName(), () => {
-  describe('getConfigFromNpmrc()', () => {
+  describe('getConfigRulesFromNpmrc()', () => {
     it('works with empty string', () => {
-      expect(getConfigFromNpmrc()).toMatchInlineSnapshot(`
+      expect(getConfigRulesFromNpmrc()).toMatchInlineSnapshot(`
         Object {
           "hostRules": Array [],
           "packageRules": Array [],
@@ -12,7 +12,8 @@ describe(getName(), () => {
       `);
     });
     it('supports naked _auth', () => {
-      expect(getConfigFromNpmrc('_auth=some-token')).toMatchInlineSnapshot(`
+      expect(getConfigRulesFromNpmrc('_auth=some-token'))
+        .toMatchInlineSnapshot(`
         Object {
           "hostRules": Array [
             Object {
@@ -27,7 +28,7 @@ describe(getName(), () => {
     });
     it('supports naked registry and _authToken', () => {
       expect(
-        getConfigFromNpmrc(
+        getConfigRulesFromNpmrc(
           'registry=https://corp.registry\n_authToken=some-token'
         )
       ).toMatchInlineSnapshot(`
@@ -53,22 +54,22 @@ describe(getName(), () => {
     });
     it('supports scoped registries', () => {
       expect(
-        getConfigFromNpmrc(
+        getConfigRulesFromNpmrc(
           '@org:registry=https://corp.registry\n//corp.registry:_authToken=some-token\nhttps://other.registry:_auth=other-token\n'
         )
       ).toMatchInlineSnapshot(`
         Object {
           "hostRules": Array [
             Object {
-              "hostType": "npm",
-              "matchHost": "corp.registry",
-              "token": "some-token",
-            },
-            Object {
               "authType": "Basic",
               "hostType": "npm",
               "matchHost": "https://other.registry",
               "token": "other-token",
+            },
+            Object {
+              "hostType": "npm",
+              "matchHost": "corp.registry",
+              "token": "some-token",
             },
           ],
           "packageRules": Array [

--- a/lib/config/npmrc.ts
+++ b/lib/config/npmrc.ts
@@ -3,85 +3,53 @@ import { id as hostType } from '../datasource/npm';
 import { validateUrl } from '../util/url';
 import { RenovateConfig } from './types';
 
-export interface NpmrcConfig {
-  defaultRegistry?: string;
-  auth?: string;
-  authToken?: string;
-  scopedRegistries?: Record<string, string>;
-  authRegistries?: Record<string, string>;
-  authTokenRegistries?: Record<string, string>;
-}
-
-export function getConfigFromNpmrc(npmrc = ''): NpmrcConfig {
-  const res: NpmrcConfig = {
-    scopedRegistries: {},
-    authRegistries: {},
-    authTokenRegistries: {},
-  };
+export function getConfigFromNpmrc(npmrc = ''): RenovateConfig {
+  const res: RenovateConfig = { hostRules: [], packageRules: [] };
   const parsed = ini.parse(npmrc);
   for (const [key, val] of Object.entries(parsed)) {
+    // hostRules
     if (key === '_auth') {
-      res.auth = val;
+      res.hostRules.push({
+        hostType,
+        authType: 'Basic',
+        token: val,
+      });
     } else if (key === '_authToken') {
-      res.authToken = val;
-    } else if (key === 'registry') {
-      res.defaultRegistry = val;
+      res.hostRules ||= [];
+      res.hostRules.push({ hostType, token: val });
     } else if (key.endsWith(':_auth')) {
-      const registry = key.replace(/:_auth$/, '').replace(/^\/\//, '');
-      res.authRegistries[registry] = val;
+      const matchHost = key.replace(/:_auth$/, '').replace(/^\/\//, '');
+      res.hostRules.push({
+        hostType,
+        matchHost,
+        authType: 'Basic',
+        token: val,
+      });
     } else if (key.endsWith(':_authToken')) {
-      const registry = key.replace(/:_authToken$/, '').replace(/^\/\//, '');
-      res.authTokenRegistries[registry] = val;
+      const matchHost = key.replace(/:_authToken$/, '').replace(/^\/\//, '');
+      res.hostRules.push({
+        hostType,
+        matchHost,
+        token: val,
+      });
+      // packageRules
+    } else if (key === 'registry') {
+      if (validateUrl(val, false)) {
+        res.packageRules.push({
+          matchDatasources: [hostType],
+          registryUrls: [val],
+        });
+      }
     } else if (key.endsWith(':registry')) {
       if (validateUrl(val, false)) {
         const [scope] = key.split(':');
-        res.scopedRegistries[scope] = val;
+        res.packageRules.push({
+          matchDatasources: [hostType],
+          matchPackagePrefixes: [scope],
+          registryUrls: [val],
+        });
       }
     }
-  }
-  return res;
-}
-
-export function getConfigRulesFromNpmrc(npmrc = ''): RenovateConfig {
-  const config = getConfigFromNpmrc(npmrc);
-  const res: RenovateConfig = { hostRules: [], packageRules: [] };
-  if (config.defaultRegistry) {
-    res.packageRules.push({
-      matchDatasources: [hostType],
-      registryUrls: [config.defaultRegistry],
-    });
-  }
-  if (config.auth) {
-    res.hostRules.push({
-      hostType,
-      authType: 'Basic',
-      token: config.auth,
-    });
-  }
-  if (config.authToken) {
-    res.hostRules.push({ hostType, token: config.authToken });
-  }
-  for (const [matchHost, token] of Object.entries(config.authRegistries)) {
-    res.hostRules.push({
-      hostType,
-      matchHost,
-      authType: 'Basic',
-      token,
-    });
-  }
-  for (const [matchHost, token] of Object.entries(config.authTokenRegistries)) {
-    res.hostRules.push({
-      hostType,
-      matchHost,
-      token,
-    });
-  }
-  for (const [scope, registryUrl] of Object.entries(config.scopedRegistries)) {
-    res.packageRules.push({
-      matchDatasources: [hostType],
-      matchPackagePrefixes: [scope],
-      registryUrls: [registryUrl],
-    });
   }
   return res;
 }

--- a/lib/config/npmrc.ts
+++ b/lib/config/npmrc.ts
@@ -46,7 +46,7 @@ export function getConfigFromNpmrc(npmrc = ''): RenovateConfig {
         const [scope] = key.split(':');
         res.packageRules.push({
           matchDatasources: [hostType],
-          matchPackagePrefixes: [scope],
+          matchPackagePrefixes: [ensureTrailingSlash(scope)],
           registryUrls: [val],
         });
       }

--- a/lib/config/npmrc.ts
+++ b/lib/config/npmrc.ts
@@ -2,6 +2,13 @@ import ini from 'ini';
 import { id as hostType } from '../datasource/npm';
 import { RenovateConfig } from './types';
 
+function getMatchHost(input: string): string {
+  if (input.startsWith('https://')) {
+    return input;
+  }
+  return input.split('//')[1];
+}
+
 export function getConfigFromNpmrc(npmrc = ''): RenovateConfig {
   const res: RenovateConfig = {};
   const parsed = ini.parse(npmrc);
@@ -18,24 +25,23 @@ export function getConfigFromNpmrc(npmrc = ''): RenovateConfig {
       res.hostRules ||= [];
       res.hostRules.push({ hostType, token: val });
     } else if (key.endsWith(':_auth')) {
-      const [hostPart] = key.replace(/^https?:/, '').split(':');
-      const [, matchHost] = hostPart.split('//');
+      const hostPart = key.replace(/:_auth$/, '');
       res.hostRules ||= [];
       res.hostRules.push({
         hostType,
-        matchHost,
+        matchHost: getMatchHost(hostPart),
         authType: 'Basic',
         token: val,
       });
     } else if (key.endsWith(':_authToken')) {
-      const [hostPart] = key.split(':');
-      const [, matchHost] = hostPart.split('//');
+      const hostPart = key.replace(/:_authToken$/, '');
       res.hostRules ||= [];
       res.hostRules.push({
         hostType,
-        matchHost,
+        matchHost: getMatchHost(hostPart),
         token: val,
       });
+      // packageRules
     } else if (key === 'registry') {
       const [, host] = val.split('//');
       res.packageRules ||= [];

--- a/lib/config/npmrc.ts
+++ b/lib/config/npmrc.ts
@@ -3,53 +3,85 @@ import { id as hostType } from '../datasource/npm';
 import { validateUrl } from '../util/url';
 import { RenovateConfig } from './types';
 
-export function getConfigFromNpmrc(npmrc = ''): RenovateConfig {
-  const res: RenovateConfig = { hostRules: [], packageRules: [] };
+export interface NpmrcConfig {
+  defaultRegistry?: string;
+  auth?: string;
+  authToken?: string;
+  scopedRegistries?: Record<string, string>;
+  authRegistries?: Record<string, string>;
+  authTokenRegistries?: Record<string, string>;
+}
+
+export function getConfigFromNpmrc(npmrc = ''): NpmrcConfig {
+  const res: NpmrcConfig = {
+    scopedRegistries: {},
+    authRegistries: {},
+    authTokenRegistries: {},
+  };
   const parsed = ini.parse(npmrc);
   for (const [key, val] of Object.entries(parsed)) {
-    // hostRules
     if (key === '_auth') {
-      res.hostRules.push({
-        hostType,
-        authType: 'Basic',
-        token: val,
-      });
+      res.auth = val;
     } else if (key === '_authToken') {
-      res.hostRules ||= [];
-      res.hostRules.push({ hostType, token: val });
-    } else if (key.endsWith(':_auth')) {
-      const matchHost = key.replace(/:_auth$/, '').replace(/^\/\//, '');
-      res.hostRules.push({
-        hostType,
-        matchHost,
-        authType: 'Basic',
-        token: val,
-      });
-    } else if (key.endsWith(':_authToken')) {
-      const matchHost = key.replace(/:_authToken$/, '').replace(/^\/\//, '');
-      res.hostRules.push({
-        hostType,
-        matchHost,
-        token: val,
-      });
-      // packageRules
+      res.authToken = val;
     } else if (key === 'registry') {
-      if (validateUrl(val, false)) {
-        res.packageRules.push({
-          matchDatasources: [hostType],
-          registryUrls: [val],
-        });
-      }
+      res.defaultRegistry = val;
+    } else if (key.endsWith(':_auth')) {
+      const registry = key.replace(/:_auth$/, '').replace(/^\/\//, '');
+      res.authRegistries[registry] = val;
+    } else if (key.endsWith(':_authToken')) {
+      const registry = key.replace(/:_authToken$/, '').replace(/^\/\//, '');
+      res.authTokenRegistries[registry] = val;
     } else if (key.endsWith(':registry')) {
       if (validateUrl(val, false)) {
         const [scope] = key.split(':');
-        res.packageRules.push({
-          matchDatasources: [hostType],
-          matchPackagePrefixes: [scope],
-          registryUrls: [val],
-        });
+        res.scopedRegistries[scope] = val;
       }
     }
+  }
+  return res;
+}
+
+export function getConfigRulesFromNpmrc(npmrc = ''): RenovateConfig {
+  const config = getConfigFromNpmrc(npmrc);
+  const res: RenovateConfig = { hostRules: [], packageRules: [] };
+  if (config.defaultRegistry) {
+    res.packageRules.push({
+      matchDatasources: [hostType],
+      registryUrls: [config.defaultRegistry],
+    });
+  }
+  if (config.auth) {
+    res.hostRules.push({
+      hostType,
+      authType: 'Basic',
+      token: config.auth,
+    });
+  }
+  if (config.authToken) {
+    res.hostRules.push({ hostType, token: config.authToken });
+  }
+  for (const [matchHost, token] of Object.entries(config.authRegistries)) {
+    res.hostRules.push({
+      hostType,
+      matchHost,
+      authType: 'Basic',
+      token,
+    });
+  }
+  for (const [matchHost, token] of Object.entries(config.authTokenRegistries)) {
+    res.hostRules.push({
+      hostType,
+      matchHost,
+      token,
+    });
+  }
+  for (const [scope, registryUrl] of Object.entries(config.scopedRegistries)) {
+    res.packageRules.push({
+      matchDatasources: [hostType],
+      matchPackagePrefixes: [scope],
+      registryUrls: [registryUrl],
+    });
   }
   return res;
 }

--- a/lib/config/npmrc.ts
+++ b/lib/config/npmrc.ts
@@ -6,6 +6,7 @@ import { RenovateConfig } from './types';
 export function getConfigFromNpmrc(npmrc = ''): RenovateConfig {
   const res: RenovateConfig = { hostRules: [], packageRules: [] };
   const parsed = ini.parse(npmrc);
+  // Process rules in order so that they have the same precedence as in the `.npmrc`
   for (const [key, val] of Object.entries(parsed)) {
     // hostRules
     if (key === '_auth') {

--- a/lib/config/npmrc.ts
+++ b/lib/config/npmrc.ts
@@ -1,0 +1,58 @@
+import ini from 'ini';
+import { id as hostType } from '../datasource/npm';
+import { RenovateConfig } from './types';
+
+export function getConfigFromNpmrc(npmrc = ''): RenovateConfig {
+  const res: RenovateConfig = {};
+  const parsed = ini.parse(npmrc);
+  for (const [key, val] of Object.entries(parsed)) {
+    // hostRules
+    if (key === '_auth') {
+      res.hostRules ||= [];
+      res.hostRules.push({
+        hostType,
+        authType: 'Basic',
+        token: val,
+      });
+    } else if (key === '_authToken') {
+      res.hostRules ||= [];
+      res.hostRules.push({ hostType, token: val });
+    } else if (key.endsWith(':_auth')) {
+      const [hostPart] = key.replace(/^https?:/, '').split(':');
+      const [, matchHost] = hostPart.split('//');
+      res.hostRules ||= [];
+      res.hostRules.push({
+        hostType,
+        matchHost,
+        authType: 'Basic',
+        token: val,
+      });
+    } else if (key.endsWith(':_authToken')) {
+      const [hostPart] = key.split(':');
+      const [, matchHost] = hostPart.split('//');
+      res.hostRules ||= [];
+      res.hostRules.push({
+        hostType,
+        matchHost,
+        token: val,
+      });
+    } else if (key === 'registry') {
+      const [, host] = val.split('//');
+      res.packageRules ||= [];
+      res.packageRules.push({
+        matchDatasources: [hostType],
+        registryUrls: [`https://${host}`],
+      });
+    } else if (key.endsWith(':registry')) {
+      const [scope] = key.split(':');
+      const [, host] = val.split('//');
+      res.packageRules ||= [];
+      res.packageRules.push({
+        matchDatasources: [hostType],
+        matchPackagePrefixes: [scope],
+        registryUrls: [`https://${host}`],
+      });
+    }
+  }
+  return res;
+}


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds function to extract `hostRules` and `packageRules` from `npmrc` content.

## Context:

Required as part of #10110 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
