### PR TITLE
refactor: docker getRegistryRepository

### DIFF
--- a/lib/datasource/docker/__snapshots__/common.spec.ts.snap
+++ b/lib/datasource/docker/__snapshots__/common.spec.ts.snap
@@ -2,28 +2,28 @@
 
 exports[`datasource/docker/common getRegistryRepository handles local registries 1`] = `
 Object {
-  "registry": "https://registry:5000",
-  "repository": "org/package",
+  "dockerRepository": "org/package",
+  "registryHost": "https://registry:5000",
 }
 `;
 
 exports[`datasource/docker/common getRegistryRepository supports http registryUrls 1`] = `
 Object {
-  "registry": "http://my.local.registry/prefix",
-  "repository": "image",
+  "dockerRepository": "image",
+  "registryHost": "http://my.local.registry/prefix",
 }
 `;
 
 exports[`datasource/docker/common getRegistryRepository supports registryUrls 1`] = `
 Object {
-  "registry": "https://my.local.registry/prefix",
-  "repository": "image",
+  "dockerRepository": "image",
+  "registryHost": "https://my.local.registry/prefix",
 }
 `;
 
 exports[`datasource/docker/common getRegistryRepository supports schemeless registryUrls 1`] = `
 Object {
-  "registry": "https://my.local.registry/prefix",
-  "repository": "image",
+  "dockerRepository": "image",
+  "registryHost": "https://my.local.registry/prefix",
 }
 `;

--- a/lib/datasource/docker/common.ts
+++ b/lib/datasource/docker/common.ts
@@ -47,11 +47,11 @@ async function getECRAuthToken(
 }
 
 export async function getAuthHeaders(
-  registry: string,
+  registryHost: string,
   dockerRepository: string
 ): Promise<OutgoingHttpHeaders | null> {
   try {
-    const apiCheckUrl = `${registry}/v2/`;
+    const apiCheckUrl = `${registryHost}/v2/`;
     const apiCheckResponse = await http.get(apiCheckUrl, {
       throwHttpErrors: false,
     });
@@ -65,8 +65,8 @@ export async function getAuthHeaders(
     const opts: HostRule & {
       headers?: Record<string, string>;
     } = hostRules.find({ hostType: id, url: apiCheckUrl });
-    if (ecrRegex.test(registry)) {
-      const [, region] = ecrRegex.exec(registry);
+    if (ecrRegex.test(registryHost)) {
+      const [, region] = ecrRegex.exec(registryHost);
       const auth = await getECRAuthToken(region, opts);
       if (auth) {
         opts.headers = { authorization: `Basic ${auth}` };
@@ -114,7 +114,7 @@ export async function getAuthHeaders(
     }
     if (err.statusCode === 401) {
       logger.debug(
-        { registry, dockerRepository },
+        { registryHost, dockerRepository },
         'Unauthorized docker lookup'
       );
       logger.debug({ err });
@@ -122,29 +122,29 @@ export async function getAuthHeaders(
     }
     if (err.statusCode === 403) {
       logger.debug(
-        { registry, dockerRepository },
+        { registryHost, dockerRepository },
         'Not allowed to access docker registry'
       );
       logger.debug({ err });
       return null;
     }
     // prettier-ignore
-    if (err.name === 'RequestError' && registry.endsWith('docker.io')) { // lgtm [js/incomplete-url-substring-sanitization]
+    if (err.name === 'RequestError' && registryHost.endsWith('docker.io')) { // lgtm [js/incomplete-url-substring-sanitization]
         throw new ExternalHostError(err);
       }
     // prettier-ignore
-    if (err.statusCode === 429 && registry.endsWith('docker.io')) { // lgtm [js/incomplete-url-substring-sanitization]
+    if (err.statusCode === 429 && registryHost.endsWith('docker.io')) { // lgtm [js/incomplete-url-substring-sanitization]
         throw new ExternalHostError(err);
       }
     if (err.statusCode >= 500 && err.statusCode < 600) {
       throw new ExternalHostError(err);
     }
     if (err.message === HOST_DISABLED) {
-      logger.trace({ registry, dockerRepository, err }, 'Host disabled');
+      logger.trace({ registryHost, dockerRepository, err }, 'Host disabled');
       return null;
     }
     logger.warn(
-      { registry, dockerRepository, err },
+      { registryHost, dockerRepository, err },
       'Error obtaining docker token'
     );
     return null;
@@ -160,42 +160,42 @@ export function getRegistryRepository(
       registryUrl.replace(/^https?:\/\//, '')
     );
     if (lookupName.startsWith(registryEndingWithSlash)) {
-      let registry = trimTrailingSlash(registryUrl);
-      if (!/^https?:\/\//.test(registry)) {
-        registry = `https://${registry}`;
+      let registryHost = trimTrailingSlash(registryUrl);
+      if (!/^https?:\/\//.test(registryHost)) {
+        registryHost = `https://${registryHost}`;
       }
       return {
-        registry,
-        repository: lookupName.replace(registryEndingWithSlash, ''),
+        registryHost,
+        dockerRepository: lookupName.replace(registryEndingWithSlash, ''),
       };
     }
   }
-  let registry: string;
+  let registryHost: string;
   const split = lookupName.split('/');
   if (split.length > 1 && (split[0].includes('.') || split[0].includes(':'))) {
-    [registry] = split;
+    [registryHost] = split;
     split.shift();
   }
-  let repository = split.join('/');
-  if (!registry) {
-    registry = registryUrl;
+  let dockerRepository = split.join('/');
+  if (!registryHost) {
+    registryHost = registryUrl;
   }
-  if (registry === 'docker.io') {
-    registry = 'index.docker.io';
+  if (registryHost === 'docker.io') {
+    registryHost = 'index.docker.io';
   }
-  if (!/^https?:\/\//.exec(registry)) {
-    registry = `https://${registry}`;
+  if (!/^https?:\/\//.exec(registryHost)) {
+    registryHost = `https://${registryHost}`;
   }
-  const opts = hostRules.find({ hostType: id, url: registry });
+  const opts = hostRules.find({ hostType: id, url: registryHost });
   if (opts?.insecureRegistry) {
-    registry = registry.replace('https', 'http');
+    registryHost = registryHost.replace('https', 'http');
   }
-  if (registry.endsWith('.docker.io') && !repository.includes('/')) {
-    repository = 'library/' + repository;
+  if (registryHost.endsWith('.docker.io') && !dockerRepository.includes('/')) {
+    dockerRepository = 'library/' + dockerRepository;
   }
   return {
-    registry,
-    repository,
+    registryHost,
+    dockerRepository,
   };
 }
 
@@ -214,20 +214,22 @@ export function extractDigestFromResponse(
 
 // TODO: debug why quay throws errors (#9612)
 export async function getManifestResponse(
-  registry: string,
+  registryHost: string,
   dockerRepository: string,
   tag: string
 ): Promise<HttpResponse> {
-  logger.debug(`getManifestResponse(${registry}, ${dockerRepository}, ${tag})`);
+  logger.debug(
+    `getManifestResponse(${registryHost}, ${dockerRepository}, ${tag})`
+  );
   try {
-    const headers = await getAuthHeaders(registry, dockerRepository);
+    const headers = await getAuthHeaders(registryHost, dockerRepository);
     if (!headers) {
       logger.debug('No docker auth found - returning');
       return null;
     }
     headers.accept =
       'application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json';
-    const url = `${registry}/v2/${dockerRepository}/manifests/${tag}`;
+    const url = `${registryHost}/v2/${dockerRepository}/manifests/${tag}`;
     const manifestResponse = await http.get(url, {
       headers,
     });
@@ -238,7 +240,7 @@ export async function getManifestResponse(
     }
     if (err.statusCode === 401) {
       logger.debug(
-        { registry, dockerRepository },
+        { registryHost, dockerRepository },
         'Unauthorized docker lookup'
       );
       logger.debug({ err });
@@ -248,7 +250,7 @@ export async function getManifestResponse(
       logger.debug(
         {
           err,
-          registry,
+          registryHost,
           dockerRepository,
           tag,
         },
@@ -257,7 +259,7 @@ export async function getManifestResponse(
       return null;
     }
     // prettier-ignore
-    if (err.statusCode === 429 && registry.endsWith('docker.io')) { // lgtm [js/incomplete-url-substring-sanitization]
+    if (err.statusCode === 429 && registryHost.endsWith('docker.io')) { // lgtm [js/incomplete-url-substring-sanitization]
       throw new ExternalHostError(err);
     }
     if (err.statusCode >= 500 && err.statusCode < 600) {
@@ -265,7 +267,7 @@ export async function getManifestResponse(
     }
     if (err.code === 'ETIMEDOUT') {
       logger.debug(
-        { registry },
+        { registryHost },
         'Timeout when attempting to connect to docker registry'
       );
       logger.debug({ err });
@@ -274,7 +276,7 @@ export async function getManifestResponse(
     logger.debug(
       {
         err,
-        registry,
+        registryHost,
         dockerRepository,
         tag,
       },
@@ -341,13 +343,13 @@ async function getConfigDigest(
  */
 
 export async function getLabels(
-  registry: string,
+  registryHost: string,
   dockerRepository: string,
   tag: string
 ): Promise<Record<string, string>> {
-  logger.debug(`getLabels(${registry}, ${dockerRepository}, ${tag})`);
+  logger.debug(`getLabels(${registryHost}, ${dockerRepository}, ${tag})`);
   const cacheNamespace = 'datasource-docker-labels';
-  const cacheKey = `${registry}:${dockerRepository}:${tag}`;
+  const cacheKey = `${registryHost}:${dockerRepository}:${tag}`;
   const cachedResult = await packageCache.get<Record<string, string>>(
     cacheNamespace,
     cacheKey
@@ -358,18 +360,22 @@ export async function getLabels(
   }
   try {
     let labels: Record<string, string> = {};
-    const configDigest = await getConfigDigest(registry, dockerRepository, tag);
+    const configDigest = await getConfigDigest(
+      registryHost,
+      dockerRepository,
+      tag
+    );
     if (!configDigest) {
       return {};
     }
 
-    const headers = await getAuthHeaders(registry, dockerRepository);
+    const headers = await getAuthHeaders(registryHost, dockerRepository);
     // istanbul ignore if: Should never be happen
     if (!headers) {
       logger.debug('No docker auth found - returning');
       return {};
     }
-    const url = `${registry}/v2/${dockerRepository}/blobs/${configDigest}`;
+    const url = `${registryHost}/v2/${dockerRepository}/blobs/${configDigest}`;
     const configResponse = await http.get(url, {
       headers,
     });
@@ -392,14 +398,14 @@ export async function getLabels(
     }
     if (err.statusCode === 400 || err.statusCode === 401) {
       logger.debug(
-        { registry, dockerRepository, err },
+        { registryHost, dockerRepository, err },
         'Unauthorized docker lookup'
       );
     } else if (err.statusCode === 404) {
       logger.warn(
         {
           err,
-          registry,
+          registryHost,
           dockerRepository,
           tag,
         },
@@ -407,14 +413,14 @@ export async function getLabels(
       );
     } else if (
       err.statusCode === 429 &&
-      registry.endsWith('docker.io') // lgtm [js/incomplete-url-substring-sanitization]
+      registryHost.endsWith('docker.io') // lgtm [js/incomplete-url-substring-sanitization]
     ) {
       logger.warn({ err }, 'docker registry failure: too many requests');
     } else if (err.statusCode >= 500 && err.statusCode < 600) {
       logger.debug(
         {
           err,
-          registry,
+          registryHost,
           dockerRepository,
           tag,
         },
@@ -424,15 +430,18 @@ export async function getLabels(
       err.code === 'ERR_TLS_CERT_ALTNAME_INVALID' ||
       err.code === 'ETIMEDOUT'
     ) {
-      logger.debug({ registry, err }, 'Error connecting to docker registry');
-    } else if (registry === 'https://quay.io') {
+      logger.debug(
+        { registryHost, err },
+        'Error connecting to docker registry'
+      );
+    } else if (registryHost === 'https://quay.io') {
       // istanbul ignore next
       logger.debug(
         'Ignoring quay.io errors until they fully support v2 schema'
       );
     } else {
       logger.info(
-        { registry, dockerRepository, tag, err },
+        { registryHost, dockerRepository, tag, err },
         'Unknown error getting Docker labels'
       );
     }

--- a/lib/datasource/docker/common.ts
+++ b/lib/datasource/docker/common.ts
@@ -16,7 +16,8 @@ export const id = 'docker';
 export const http = new Http(id);
 
 export const ecrRegex = /\d+\.dkr\.ecr\.([-a-z0-9]+)\.amazonaws\.com/;
-export const defaultRegistryUrls = ['https://index.docker.io'];
+const DOCKER_HUB = 'https://index.docker.io';
+export const defaultRegistryUrls = [DOCKER_HUB];
 
 async function getECRAuthToken(
   region: string,
@@ -155,7 +156,7 @@ export function getRegistryRepository(
   lookupName: string,
   registryUrl: string
 ): RegistryRepository {
-  if (registryUrl !== defaultRegistryUrls[0]) {
+  if (registryUrl !== DOCKER_HUB) {
     const registryEndingWithSlash = ensureTrailingSlash(
       registryUrl.replace(/^https?:\/\//, '')
     );

--- a/lib/datasource/docker/index.ts
+++ b/lib/datasource/docker/index.ts
@@ -54,13 +54,13 @@ export const defaultConfig = {
 };
 
 async function getTags(
-  registry: string,
+  registryHost: string,
   repository: string
 ): Promise<string[] | null> {
   let tags: string[] = [];
   try {
     const cacheNamespace = 'datasource-docker-tags';
-    const cacheKey = `${registry}:${repository}`;
+    const cacheKey = `${registryHost}:${repository}`;
     const cachedResult = await packageCache.get<string[]>(
       cacheNamespace,
       cacheKey
@@ -71,9 +71,9 @@ async function getTags(
     }
     // AWS ECR limits the maximum number of results to 1000
     // See https://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_DescribeRepositories.html#ECR-DescribeRepositories-request-maxResults
-    const limit = ecrRegex.test(registry) ? 1000 : 10000;
-    let url = `${registry}/v2/${repository}/tags/list?n=${limit}`;
-    const headers = await getAuthHeaders(registry, repository);
+    const limit = ecrRegex.test(registryHost) ? 1000 : 10000;
+    let url = `${registryHost}/v2/${repository}/tags/list?n=${limit}`;
+    const headers = await getAuthHeaders(registryHost, repository);
     if (!headers) {
       logger.debug('Failed to get authHeaders for getTags lookup');
       return null;
@@ -95,29 +95,29 @@ async function getTags(
     }
     if (err.statusCode === 404 && !repository.includes('/')) {
       logger.debug(
-        `Retrying Tags for ${registry}/${repository} using library/ prefix`
+        `Retrying Tags for ${registryHost}/${repository} using library/ prefix`
       );
-      return getTags(registry, 'library/' + repository);
+      return getTags(registryHost, 'library/' + repository);
     }
     // prettier-ignore
-    if (err.statusCode === 429 && registry.endsWith('docker.io')) { // lgtm [js/incomplete-url-substring-sanitization]
+    if (err.statusCode === 429 && registryHost.endsWith('docker.io')) { // lgtm [js/incomplete-url-substring-sanitization]
       logger.warn(
-        { registry, dockerRepository: repository, err },
+        { registryHost, dockerRepository: repository, err },
         'docker registry failure: too many requests'
       );
       throw new ExternalHostError(err);
     }
     // prettier-ignore
-    if (err.statusCode === 401 && registry.endsWith('docker.io')) { // lgtm [js/incomplete-url-substring-sanitization]
+    if (err.statusCode === 401 && registryHost.endsWith('docker.io')) { // lgtm [js/incomplete-url-substring-sanitization]
       logger.warn(
-        { registry, dockerRepository: repository, err },
+        { registryHost, dockerRepository: repository, err },
         'docker registry failure: unauthorized'
       );
       throw new ExternalHostError(err);
     }
     if (err.statusCode >= 500 && err.statusCode < 600) {
       logger.warn(
-        { registry, dockerRepository: repository, err },
+        { registryHost, dockerRepository: repository, err },
         'docker registry failure: internal error'
       );
       throw new ExternalHostError(err);
@@ -139,14 +139,14 @@ export async function getDigest(
   { registryUrl, lookupName }: GetReleasesConfig,
   newValue?: string
 ): Promise<string | null> {
-  const { registry, repository } = getRegistryRepository(
+  const { registryHost, dockerRepository } = getRegistryRepository(
     lookupName,
     registryUrl
   );
-  logger.debug(`getDigest(${registry}, ${repository}, ${newValue})`);
+  logger.debug(`getDigest(${registryHost}, ${dockerRepository}, ${newValue})`);
   const newTag = newValue || 'latest';
   const cacheNamespace = 'datasource-docker-digest';
-  const cacheKey = `${registry}:${repository}:${newTag}`;
+  const cacheKey = `${registryHost}:${dockerRepository}:${newTag}`;
   let digest: string = null;
   try {
     const cachedResult = await packageCache.get<string>(
@@ -158,8 +158,8 @@ export async function getDigest(
       return cachedResult;
     }
     const manifestResponse = await getManifestResponse(
-      registry,
-      repository,
+      registryHost,
+      dockerRepository,
       newTag
     );
     if (manifestResponse) {
@@ -199,11 +199,11 @@ export async function getReleases({
   lookupName,
   registryUrl,
 }: GetReleasesConfig): Promise<ReleaseResult | null> {
-  const { registry, repository } = getRegistryRepository(
+  const { registryHost, dockerRepository } = getRegistryRepository(
     lookupName,
     registryUrl
   );
-  const tags = await getTags(registry, repository);
+  const tags = await getTags(registryHost, dockerRepository);
   if (!tags) {
     return null;
   }
@@ -213,7 +213,7 @@ export async function getReleases({
   };
 
   const latestTag = tags.includes('latest') ? 'latest' : tags[tags.length - 1];
-  const labels = await getLabels(registry, repository, latestTag);
+  const labels = await getLabels(registryHost, dockerRepository, latestTag);
   if (labels && 'org.opencontainers.image.source' in labels) {
     ret.sourceUrl = labels['org.opencontainers.image.source'];
   }

--- a/lib/datasource/docker/types.ts
+++ b/lib/datasource/docker/types.ts
@@ -42,6 +42,6 @@ export interface Image extends MediaObject {
 }
 
 export interface RegistryRepository {
-  registry: string;
-  repository: string;
+  registryHost: string;
+  dockerRepository: string;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Renames results fields in `docker` datasource `getRegistryRepository` to make an existing bug more clear.

## Context:

#10135

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
