### PR TITLE
fix(config): workaround for Repology server overload

### DIFF
--- a/lib/config/presets/internal/workarounds.ts
+++ b/lib/config/presets/internal/workarounds.ts
@@ -10,6 +10,7 @@ export const presets: Record<string, Preset> = {
       'workarounds:ignoreSpringCloudNumeric',
       'workarounds:ignoreHttp4sDigestMilestones',
       'workarounds:typesNodeVersioning',
+      'workarounds:reduceRepologyServerLoad',
     ],
   },
   mavenCommonsAncientVersion: {

--- a/lib/config/presets/internal/workarounds.ts
+++ b/lib/config/presets/internal/workarounds.ts
@@ -53,4 +53,14 @@ export const presets: Record<string, Preset> = {
       },
     ],
   },
+  reduceRepologyServerLoad: {
+    description:
+      'Limit concurrent requests to reduce load on Repology servers until we can fix this properly, see issue 10133',
+    hostRules: [
+      {
+        matchHost: 'repology.org',
+        concurrentRequestLimit: 1,
+      },
+    ],
+  },
 };


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

- Add workaround to reduce incoming requests on the repology.org servers

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

Helps with issue #10133, as a "workaround", this is not a proper fix for the problem, as the root cause is not solved.

The idea of the workaround is to limit incoming requests to the `repology.org` domain by adding a workaround, that most users will then extend from because they have `config:base` in their Renovate config `extends` from array.

According to our docs on presets (https://docs.renovatebot.com/presets-config/), the `config:base` preset includes the `workarounds:all` preset. So I hope that by putting the new config in the `workarounds.ts` file, that we can reduce the requests that Renovate end-users fire at `repology.org`.

This workaround should be removed once we have the proper fix for issue #10133 or have implemented feature #9550.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
