### PR TITLE
test: fix memory leak

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -26,7 +26,7 @@ const config: InitialOptionsTsJest = {
   },
   modulePathIgnorePatterns: ['<rootDir>/dist/'],
   reporters: ['default', './tmp/tools/jest-gh-reporter.js'],
-  setupFilesAfterEnv: ['<rootDir>/test/globals.ts'],
+  setupFilesAfterEnv: ['jest-extended', '<rootDir>/test/setup.ts'],
   snapshotSerializers: ['<rootDir>/test/newline-snapshot-serializer.ts'],
   testEnvironment: 'node',
   testRunner: 'jest-circus/runner',

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,13 +1,6 @@
-import nock from 'nock';
-import 'jest-extended';
-
 jest.mock('../lib/platform', () => ({
   platform: jest.createMockFromModule('../lib/platform/github'),
   initPlatform: jest.fn(),
   getPlatformList: jest.fn(),
 }));
 jest.mock('../lib/logger');
-
-beforeAll(() => {
-  nock.disableNetConnect();
-});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "resolveJsonModule": false,
     "noUnusedLocals": true,
     "lib": ["es2018"],
-    "types": ["node", "jest"],
+    "types": ["node", "jest", "jest-extended"],
     "allowJs": true,
     "checkJs": true
   },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Fix a huge memory leak in jest. It seems global `nock` usage caused it. Also refactord a litle bit to reduce more leaks.
This fix reduced the node heap usage with 8 worker down from ~700MB to ~200MB. 🎉 
Also test time went down from ~90s to ~80s.
<!-- Describe what behavior is changed by this PR. -->

## Context:

Extracted from #10160, ref #10159
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
