### PR TITLE
docs: put trailing slash behind matchHost URL

### DIFF
--- a/docs/usage/private-npm-modules.md
+++ b/docs/usage/private-npm-modules.md
@@ -77,7 +77,7 @@ module.exports = {
 };
 ```
 
-**NOTE:** Remember to put a trailing slash at the end of your `matchHost` URL, like this: `https://artifactory.my-company.com/artifactory/api/npm/npm/`.
+**NOTE:** Remember to put a trailing slash at the end of your `matchHost` URL.
 
 **NOTE:** Do not use `NPM_TOKEN` as an environment variable.
 

--- a/docs/usage/private-npm-modules.md
+++ b/docs/usage/private-npm-modules.md
@@ -69,13 +69,15 @@ module.exports = {
       // https://www.jfrog.com/confluence/display/JFROG/npm+Registry
       // Will be passed as `//artifactory.my-company.com/artifactory/api/npm/npm:_auth=<TOKEN>` to `.npmrc`
       hostType: 'npm',
-      matchHost: 'https://artifactory.my-company.com/artifactory/api/npm/npm',
+      matchHost: 'https://artifactory.my-company.com/artifactory/api/npm/npm/',
       token: process.env.ARTIFACTORY_NPM_TOKEN,
       authType: 'Basic',
     },
   ],
 };
 ```
+
+**NOTE:** Remember to put a trailing slash at the end of your `matchHost` URL, like this: `https://artifactory.my-company.com/artifactory/api/npm/npm/`.
 
 **NOTE:** Do not use `NPM_TOKEN` as an environment variable.
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

- Use the proper trailing slash behind matchHost URL

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

Based on https://github.com/renovatebot/renovate/discussions/10150#discussioncomment-784396

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
