### PR TITLE
fix(fs): only ensureDir non-empty string

### DIFF
--- a/lib/util/fs/index.ts
+++ b/lib/util/fs/index.ts
@@ -1,3 +1,4 @@
+import is from '@sindresorhus/is';
 import * as fs from 'fs-extra';
 import { isAbsolute, join, parse } from 'upath';
 import { getAdminConfig } from '../../config/admin';
@@ -65,7 +66,9 @@ export async function renameLocalFile(
 
 // istanbul ignore next
 export async function ensureDir(dirName: string): Promise<void> {
-  await fs.ensureDir(dirName);
+  if (is.nonEmptyString(dirName)) {
+    await fs.ensureDir(dirName);
+  }
 }
 
 // istanbul ignore next


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Only ensures a non-empty directory.

## Context:

Empty directory ensuring is broken in fs-extract@10

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
