### PR TITLE
fix(config): don't treat package.json like a config object

### DIFF
--- a/lib/workers/repository/init/__snapshots__/merge.spec.ts.snap
+++ b/lib/workers/repository/init/__snapshots__/merge.spec.ts.snap
@@ -66,4 +66,11 @@ Object {
 }
 `;
 
+exports[`workers/repository/init/merge detectRepoFileConfig() uses package.json config if found 2`] = `
+Object {
+  "configFileName": "package.json",
+  "configFileParsed": undefined,
+}
+`;
+
 exports[`workers/repository/init/merge mergeRenovateConfig() throws error if misconfigured 1`] = `[Error: config-validation]`;

--- a/lib/workers/repository/init/merge.spec.ts
+++ b/lib/workers/repository/init/merge.spec.ts
@@ -53,6 +53,8 @@ describe(getName(), () => {
         },
       });
       fs.readLocalFile.mockResolvedValue(pJson);
+      platform.getJsonFile.mockResolvedValueOnce(pJson);
+      expect(await detectRepoFileConfig()).toMatchSnapshot();
       expect(await detectRepoFileConfig()).toMatchSnapshot();
     });
     it('returns error if cannot parse', async () => {

--- a/lib/workers/repository/init/merge.ts
+++ b/lib/workers/repository/init/merge.ts
@@ -26,9 +26,11 @@ export async function detectRepoFileConfig(): Promise<RepoFileConfig> {
   const cache = getCache();
   let { configFileName } = cache;
   if (configFileName) {
-    const configFileParsed = await platform.getJsonFile(configFileName);
+    let configFileParsed = await platform.getJsonFile(configFileName);
     if (configFileParsed) {
-      logger.debug('Existing config file confirmed');
+      if (configFileName === 'package.json') {
+        configFileParsed = configFileParsed.renovate;
+      }
       return { configFileName, configFileParsed };
     }
     logger.debug('Existing config file no longer exists');

--- a/lib/workers/repository/onboarding/branch/check.ts
+++ b/lib/workers/repository/onboarding/branch/check.ts
@@ -66,8 +66,13 @@ export const isOnboarded = async (config: RenovateConfig): Promise<boolean> => {
         cache.configFileName
       );
       if (configFileContent) {
-        logger.debug('Existing config file confirmed');
-        return true;
+        if (
+          cache.configFileName !== 'package.json' ||
+          configFileContent.renovate
+        ) {
+          logger.debug('Existing config file confirmed');
+          return true;
+        }
       }
     } catch (err) {
       // probably file doesn't exist

--- a/lib/workers/repository/onboarding/branch/index.spec.ts
+++ b/lib/workers/repository/onboarding/branch/index.spec.ts
@@ -131,6 +131,14 @@ describe(getName(), () => {
       expect(res.repoIsOnboarded).toBe(true);
     });
 
+    it('handles cached package.json', async () => {
+      cache.getCache.mockReturnValue({ configFileName: 'package.json' });
+      platform.getJsonFile.mockResolvedValueOnce({ renovate: {} });
+      fs.readLocalFile.mockResolvedValueOnce('{}');
+      const res = await checkOnboardingBranch(config);
+      expect(res.repoIsOnboarded).toBe(true);
+    });
+
     it('detects repo is onboarded via package.json config', async () => {
       git.getFileList.mockResolvedValueOnce(['package.json']);
       fs.readLocalFile.mockResolvedValueOnce('{"renovate":{}}');


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Fixes a bug where Renovate incorrectly treated the `package.json` as the whole config, instead of just the `renovate` sub-object.

## Context:

Closes #10230

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
