### PR TITLE
fix(cake): load preprocessor directive

### DIFF
--- a/lib/manager/cake/__fixtures__/build.cake
+++ b/lib/manager/cake/__fixtures__/build.cake
@@ -3,6 +3,8 @@ foo
 #addin "nuget:?package=Bim.Bim&version=6.6.6"
 #tool nuget:https://example.com?package=Bar.Bar&version=2.2.2
 #module nuget:file:///tmp/?package=Baz.Baz&version=3.3.3
+#load nuget:?package=Cake.7zip&version=1.0.3
+#l nuget:?package=Cake.asciidoctorj&version=1.0.0
 // #module nuget:?package=Qux.Qux&version=4.4.4
 /*
 #module nuget:?package=Quux.Quux&version=5.5.5

--- a/lib/manager/cake/__snapshots__/index.spec.ts.snap
+++ b/lib/manager/cake/__snapshots__/index.spec.ts.snap
@@ -27,6 +27,16 @@ Object {
       "depName": "Baz.Baz",
       "skipReason": "unsupported-url",
     },
+    Object {
+      "currentValue": "1.0.3",
+      "datasource": "nuget",
+      "depName": "Cake.7zip",
+    },
+    Object {
+      "currentValue": "1.0.0",
+      "datasource": "nuget",
+      "depName": "Cake.asciidoctorj",
+    },
   ],
 }
 `;

--- a/lib/manager/cake/index.ts
+++ b/lib/manager/cake/index.ts
@@ -15,10 +15,10 @@ const lexer = moo.states({
     lineComment: { match: /\/\/.*?$/ },
     multiLineComment: { match: /\/\*[^]*?\*\//, lineBreaks: true },
     dependency: {
-      match: /^#(?:addin|tool|module)\s+(?:nuget|dotnet):.*$/,
+      match: /^#(?:addin|tool|module|load|l)\s+(?:nuget|dotnet):.*$/,
     },
     dependencyQuoted: {
-      match: /^#(?:addin|tool|module)\s+"(?:nuget|dotnet):[^"]+"\s*$/,
+      match: /^#(?:addin|tool|module|load|l)\s+"(?:nuget|dotnet):[^"]+"\s*$/,
       value: (s: string) => s.trim().slice(1, -1),
     },
     unknown: moo.fallback,


### PR DESCRIPTION
## Changes:

Modified the parser, to additionally recognize preprocessor directives of `#load` and it's short form of `#l`.

## Context:

Closes #10256 

## Documentation

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [X] Both unit tests + ran on a real repository
