### PR TITLE
chore: rename ensureMasterIssue

### DIFF
--- a/lib/workers/repository/dependency-dashboard.spec.ts
+++ b/lib/workers/repository/dependency-dashboard.spec.ts
@@ -37,7 +37,7 @@ async function dryRun(
 ) {
   jest.clearAllMocks();
   setAdminConfig({ dryRun: true });
-  await dependencyDashboard.ensureMasterIssue(config, branches);
+  await dependencyDashboard.ensureDependencyDashboard(config, branches);
   expect(platform.ensureIssueClosing).toHaveBeenCalledTimes(
     ensureIssueClosingCalls
   );
@@ -53,7 +53,7 @@ describe(getName(), () => {
     });
     it('do nothing if masterissue is disable', async () => {
       const branches: BranchConfig[] = [];
-      await dependencyDashboard.ensureMasterIssue(config, branches);
+      await dependencyDashboard.ensureDependencyDashboard(config, branches);
       expect(platform.ensureIssueClosing).toHaveBeenCalledTimes(0);
       expect(platform.ensureIssue).toHaveBeenCalledTimes(0);
       expect(platform.getBranchPr).toHaveBeenCalledTimes(0);
@@ -75,7 +75,7 @@ describe(getName(), () => {
           dependencyDashboardApproval: false,
         },
       ];
-      await dependencyDashboard.ensureMasterIssue(config, branches);
+      await dependencyDashboard.ensureDependencyDashboard(config, branches);
       expect(platform.ensureIssueClosing).toHaveBeenCalledTimes(0);
       expect(platform.ensureIssue).toHaveBeenCalledTimes(0);
       expect(platform.getBranchPr).toHaveBeenCalledTimes(0);
@@ -89,7 +89,7 @@ describe(getName(), () => {
       const branches: BranchConfig[] = [];
       config.dependencyDashboard = true;
       config.dependencyDashboardAutoclose = true;
-      await dependencyDashboard.ensureMasterIssue(config, branches);
+      await dependencyDashboard.ensureDependencyDashboard(config, branches);
       expect(platform.ensureIssueClosing).toHaveBeenCalledTimes(1);
       expect(platform.ensureIssueClosing.mock.calls[0][0]).toBe(
         config.dependencyDashboardTitle
@@ -118,7 +118,7 @@ describe(getName(), () => {
       ];
       config.dependencyDashboard = true;
       config.dependencyDashboardAutoclose = true;
-      await dependencyDashboard.ensureMasterIssue(config, branches);
+      await dependencyDashboard.ensureDependencyDashboard(config, branches);
       expect(platform.ensureIssueClosing).toHaveBeenCalledTimes(1);
       expect(platform.ensureIssueClosing.mock.calls[0][0]).toBe(
         config.dependencyDashboardTitle
@@ -135,7 +135,7 @@ describe(getName(), () => {
       const branches: BranchConfig[] = [];
       config.dependencyDashboard = true;
       config.dependencyDashboardFooter = 'And this is a footer';
-      await dependencyDashboard.ensureMasterIssue(config, branches);
+      await dependencyDashboard.ensureDependencyDashboard(config, branches);
       expect(platform.ensureIssueClosing).toHaveBeenCalledTimes(0);
       expect(platform.ensureIssue).toHaveBeenCalledTimes(1);
       expect(platform.ensureIssue.mock.calls[0][0].title).toBe(
@@ -158,7 +158,7 @@ describe(getName(), () => {
         {},
       ];
       config.dependencyDashboardFooter = 'And this is a footer';
-      await dependencyDashboard.ensureMasterIssue(config, branches);
+      await dependencyDashboard.ensureDependencyDashboard(config, branches);
       expect(platform.ensureIssueClosing).toHaveBeenCalledTimes(0);
       expect(platform.ensureIssue).toHaveBeenCalledTimes(1);
       expect(platform.ensureIssue.mock.calls[0][0].title).toBe(
@@ -232,7 +232,7 @@ describe(getName(), () => {
         },
       ];
       config.dependencyDashboard = true;
-      await dependencyDashboard.ensureMasterIssue(config, branches);
+      await dependencyDashboard.ensureDependencyDashboard(config, branches);
       expect(platform.ensureIssueClosing).toHaveBeenCalledTimes(0);
       expect(platform.ensureIssue).toHaveBeenCalledTimes(1);
       expect(platform.ensureIssue.mock.calls[0][0].title).toBe(
@@ -272,7 +272,7 @@ describe(getName(), () => {
       platform.getBranchPr
         .mockResolvedValueOnce({ ...mock<Pr>(), number: 1 })
         .mockResolvedValueOnce(undefined);
-      await dependencyDashboard.ensureMasterIssue(config, branches);
+      await dependencyDashboard.ensureDependencyDashboard(config, branches);
       expect(platform.ensureIssueClosing).toHaveBeenCalledTimes(0);
       expect(platform.ensureIssue).toHaveBeenCalledTimes(1);
       expect(platform.ensureIssue.mock.calls[0][0].title).toBe(
@@ -322,7 +322,7 @@ describe(getName(), () => {
         .mockResolvedValueOnce({ ...mock<Pr>(), number: 1 })
         .mockResolvedValueOnce(undefined)
         .mockResolvedValueOnce({ ...mock<Pr>(), number: 3 });
-      await dependencyDashboard.ensureMasterIssue(config, branches);
+      await dependencyDashboard.ensureDependencyDashboard(config, branches);
       expect(platform.ensureIssueClosing).toHaveBeenCalledTimes(0);
       expect(platform.ensureIssue).toHaveBeenCalledTimes(1);
       expect(platform.ensureIssue.mock.calls[0][0].title).toBe(
@@ -366,7 +366,7 @@ describe(getName(), () => {
         .mockResolvedValueOnce({ ...mock<Pr>(), number: 1 })
         .mockResolvedValueOnce(undefined)
         .mockResolvedValueOnce({ ...mock<Pr>(), number: 3 });
-      await dependencyDashboard.ensureMasterIssue(config, branches);
+      await dependencyDashboard.ensureDependencyDashboard(config, branches);
       expect(platform.ensureIssueClosing).toHaveBeenCalledTimes(0);
       expect(platform.ensureIssue).toHaveBeenCalledTimes(1);
       expect(platform.ensureIssue.mock.calls[0][0].title).toBe(
@@ -424,7 +424,7 @@ describe(getName(), () => {
       ];
       config.dependencyDashboard = true;
       config.dependencyDashboardPrApproval = true;
-      await dependencyDashboard.ensureMasterIssue(config, branches);
+      await dependencyDashboard.ensureDependencyDashboard(config, branches);
       expect(platform.ensureIssueClosing).toHaveBeenCalledTimes(0);
       expect(platform.ensureIssue).toHaveBeenCalledTimes(1);
       expect(platform.ensureIssue.mock.calls[0][0].title).toBe(
@@ -483,7 +483,7 @@ describe(getName(), () => {
         },
       ]);
       config.dependencyDashboard = true;
-      await dependencyDashboard.ensureMasterIssue(config, branches);
+      await dependencyDashboard.ensureDependencyDashboard(config, branches);
       expect(platform.ensureIssue).toHaveBeenCalledTimes(1);
       expect(platform.ensureIssue.mock.calls[0][0].body).toMatchSnapshot();
     });

--- a/lib/workers/repository/dependency-dashboard.ts
+++ b/lib/workers/repository/dependency-dashboard.ts
@@ -49,7 +49,7 @@ function appendRepoProblems(config: RenovateConfig, issueBody: string): string {
   return newIssueBody;
 }
 
-export async function ensureMasterIssue(
+export async function ensureDependencyDashboard(
   config: RenovateConfig,
   branches: BranchConfig[]
 ): Promise<void> {

--- a/lib/workers/repository/index.ts
+++ b/lib/workers/repository/index.ts
@@ -6,7 +6,7 @@ import { deleteLocalFile, privateCacheDir } from '../../util/fs';
 import * as queue from '../../util/http/queue';
 import { addSplit, getSplits, splitInit } from '../../util/split';
 import { setBranchCache } from './cache';
-import { ensureMasterIssue } from './dependency-dashboard';
+import { ensureDependencyDashboard } from './dependency-dashboard';
 import handleError from './error';
 import { finaliseRepo } from './finalise';
 import { initRepo } from './init';
@@ -56,7 +56,7 @@ export async function renovateRepository(
       }
       logger.debug(`Automerged but already retried once`);
     } else {
-      await ensureMasterIssue(config, branches);
+      await ensureDependencyDashboard(config, branches);
     }
     await finaliseRepo(config, branchList);
     repoResult = processResult(config, res);


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Rename ensureMasterIssue to ensureDependencyDashboard

## Context:

Closes #10254
## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
