### PR TITLE
fix(git): clone renovate branches to depth=5

### DIFF
--- a/lib/util/git/__snapshots__/index.spec.ts.snap
+++ b/lib/util/git/__snapshots__/index.spec.ts.snap
@@ -41,5 +41,6 @@ exports[`util/git/index initRepo()) should fetch latest 2`] = `
 Array [
   "past message2",
   "master message",
+  "past message",
 ]
 `;

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -372,7 +372,7 @@ async function syncBranch(branchName: string): Promise<void> {
   // fetch the branch only if it's not part of the existing branchPrefix
   try {
     await git.raw(['remote', 'set-branches', '--add', 'origin', branchName]);
-    await git.fetch(['origin', branchName, '--depth=2']);
+    await git.fetch(['origin', branchName, '--depth=5']);
   } catch (err) /* istanbul ignore next */ {
     checkForPlatformFailure(err);
   }
@@ -784,7 +784,7 @@ export async function commitFiles({
     logger.debug({ result: pushRes }, 'git push');
     // Fetch it after create
     const ref = `refs/heads/${branchName}:refs/remotes/origin/${branchName}`;
-    await git.fetch(['origin', ref, '--depth=2', '--force']);
+    await git.fetch(['origin', ref, '--depth=5', '--force']);
     config.branchCommits[branchName] = (
       await git.revparse([branchName])
     ).trim();


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Clones renovate branches to depth 5 instead of depth 2.

## Context:

Kind of a hacky workaround, but closes #9351

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
