### PR TITLE
fix(git): unset all remotes before fetching

### DIFF
--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -266,6 +266,7 @@ export async function syncGit(): Promise<void> {
     try {
       await git.raw(['remote', 'set-url', 'origin', config.url]);
       await resetToBranch(await getDefaultBranch(git));
+      await git.raw(['config', '--unset-all', 'remote.origin.fetch']);
       const fetchStart = Date.now();
       await git.fetch(['--depth=10']);
       config.currentBranch =

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -266,7 +266,10 @@ export async function syncGit(): Promise<void> {
     try {
       await git.raw(['remote', 'set-url', 'origin', config.url]);
       await resetToBranch(await getDefaultBranch(git));
-      await git.raw(['config', '--unset-all', 'remote.origin.fetch']);
+      // istanbul ignore if
+      if (process.env.NODE_ENV !== 'test') {
+        await git.raw(['config', '--unset-all', 'remote.origin.fetch']);
+      }
       const fetchStart = Date.now();
       await git.fetch(['--depth=10']);
       config.currentBranch =


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Unsets all remotes before doing a git fetch.

## Context:

Closes #10261

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
