### PR TITLE
fix(pnpm): use stdout as artifact error message

### DIFF
--- a/lib/manager/npm/post-update/index.ts
+++ b/lib/manager/npm/post-update/index.ts
@@ -662,7 +662,7 @@ export async function getAdditionalFiles(
       }
       artifactErrors.push({
         lockFile: pnpmShrinkwrap,
-        stderr: res.stderr,
+        stderr: res.stderr || res.stdout,
       });
     } else {
       const existingContent = await getFile(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

Use `stdout` as Artifact error message, when `stderr` is not set.

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

Closes #10270 

It seems like `pnpm` prints everything to `stdout`. See:

```bash
# redirecting stderr to /dev/null prints complete output
❯ pnpm install --frozen-lockfile 2>/dev/null
Scope: all 6 workspace projects
Lockfile is up-to-date, resolution step is skipped
 ERROR  Cannot install with "frozen-lockfile" because pnpm-lock.yaml is not up-to-date with package.json
```

```bash
# redirecting stdout to /dev/null does not print anything
❯ pnpm install --frozen-lockfile >/dev/null
```

`pnpm` can print to `stderr` when setting https://pnpm.io/npmrc#use-stderr.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
