### PR TITLE
feat(config): Add Shopify App Bridge monorepo

### DIFF
--- a/lib/config/presets/internal/monorepo.ts
+++ b/lib/config/presets/internal/monorepo.ts
@@ -42,7 +42,7 @@ const repoGroups = {
   'reactivestack-cookies': 'https://github.com/reactivestack/cookies',
   'reg-suit': 'https://github.com/reg-viz/reg-suit',
   'semantic-release': 'https://github.com/semantic-release/',
-  'shopify app-bridge': 'https://github.com/Shopify/app-bridge',
+  'shopify-app-bridge': 'https://github.com/Shopify/app-bridge',
   'System.IO.Abstractions':
     'https://github.com/System-IO-Abstractions/System.IO.Abstractions/',
   'telus-tds': 'https://github.com/telusdigital/tds',

--- a/lib/config/presets/internal/monorepo.ts
+++ b/lib/config/presets/internal/monorepo.ts
@@ -42,6 +42,7 @@ const repoGroups = {
   'reactivestack-cookies': 'https://github.com/reactivestack/cookies',
   'reg-suit': 'https://github.com/reg-viz/reg-suit',
   'semantic-release': 'https://github.com/semantic-release/',
+  'shopify app-bridge': 'https://github.com/Shopify/app-bridge',
   'System.IO.Abstractions':
     'https://github.com/System-IO-Abstractions/System.IO.Abstractions/',
   'telus-tds': 'https://github.com/telusdigital/tds',


### PR DESCRIPTION
Refiling #10138 from a non-organization repo due to https://github.com/isaacs/github/issues/1681.

## Changes:

Adds the Shopify App Bridge monorepo group.

**The repository is closed source, but the NPM packages are public.** They get 50K+ weekly downloads and must be upgraded together, so I think the config still adds value for other Renovate users.

- https://www.npmjs.com/package/@shopify/app-bridge
- https://www.npmjs.com/package/@shopify/app-bridge-react
- https://www.npmjs.com/package/@shopify/app-bridge-utils

## Context:

I'm using this grouping locally, and wanted to contribute it back to the project.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
