### PR TITLE
fix: Parse dependency definitions inside single and multi-line Sequences inside Scala dependency file

### DIFF
--- a/lib/manager/sbt/__fixtures__/dependency-file.scala
+++ b/lib/manager/sbt/__fixtures__/dependency-file.scala
@@ -10,4 +10,11 @@ object Dependencies {
   val ujson = "com.example" %% "foo" % "0.7.1"
 
   lazy val abc = "com.abc" % "abc" % abcVersion
+
+  val relatedDeps = Seq(
+    "com.abc" % "abc-a" % abcVersion,
+    "com.abc" % "abc-b" % abcVersion
+  )
+
+  val aloneDepInSeq = Seq("com.abc" % "abc-c" % abcVersion)
 }

--- a/lib/manager/sbt/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/sbt/__snapshots__/extract.spec.ts.snap
@@ -69,6 +69,36 @@ Object {
         "https://repo.maven.apache.org/maven2",
       ],
     },
+    Object {
+      "currentValue": "1.2.3",
+      "datasource": "sbt-package",
+      "depName": "com.abc:abc-a",
+      "groupName": "abcVersion for com.abc",
+      "lookupName": "com.abc:abc-a",
+      "registryUrls": Array [
+        "https://repo.maven.apache.org/maven2",
+      ],
+    },
+    Object {
+      "currentValue": "1.2.3",
+      "datasource": "sbt-package",
+      "depName": "com.abc:abc-b",
+      "groupName": "abcVersion for com.abc",
+      "lookupName": "com.abc:abc-b",
+      "registryUrls": Array [
+        "https://repo.maven.apache.org/maven2",
+      ],
+    },
+    Object {
+      "currentValue": "1.2.3",
+      "datasource": "sbt-package",
+      "depName": "com.abc:abc-c",
+      "groupName": "abcVersion for com.abc",
+      "lookupName": "com.abc:abc-c",
+      "registryUrls": Array [
+        "https://repo.maven.apache.org/maven2",
+      ],
+    },
   ],
   "packageFileVersion": undefined,
 }

--- a/lib/manager/sbt/extract.ts
+++ b/lib/manager/sbt/extract.ts
@@ -86,6 +86,16 @@ const isVarDef = (str: string): boolean =>
     str
   );
 
+const isVarSeqSingleLine = (str: string): boolean =>
+  /^\s*(private\s*)?(lazy\s*)?val\s+[_a-zA-Z][_a-zA-Z0-9]*\s*=\s*Seq\(.*\).*\s*$/.test(
+    str
+  );
+
+const isVarSeqMultipleLine = (str: string): boolean =>
+  /^\s*(private\s*)?(lazy\s*)?val\s+[_a-zA-Z][_a-zA-Z0-9]*\s*=\s*Seq\(.*[^)]*.*$/.test(
+    str
+  );
+
 const getVarName = (str: string): string =>
   str
     .replace(/^\s*(private\s*)?(lazy\s*)?val\s+/, '')
@@ -231,6 +241,18 @@ function parseSbtLine(
       isMultiDeps = false;
       const url = getResolverUrl(line);
       registryUrls.push(url);
+    } else if (isVarSeqSingleLine(line)) {
+      isMultiDeps = false;
+      const depExpr = line.replace(/^.*Seq\(\s*/, '').replace(/\).*$/, '');
+      dep = parseDepExpr(depExpr, {
+        ...ctx,
+      });
+    } else if (isVarSeqMultipleLine(line)) {
+      isMultiDeps = true;
+      const depExpr = line.replace(/^.*Seq\(\s*/, '');
+      dep = parseDepExpr(depExpr, {
+        ...ctx,
+      });
     } else if (isVarDef(line)) {
       variables[getVarName(line)] = getVarInfo(line, ctx);
     } else if (isVarDependency(line)) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Parse dependency definitions inside single and multi-line Sequences inside Scala dependency file

## Context:

We have Scala dependency files with just `val` and sequences of artifact coordinates.
Many times they are related dependencies like multiple artifacts for http4s.
Sometimes we wrap a single dep in a Seq just so it can be combined easily with others.
Renovate was missing any deps in a Seq.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
