### PR TITLE
fix(docker): fix typo in manifest list for manifestV1 item

### DIFF
--- a/lib/datasource/docker/types.ts
+++ b/lib/datasource/docker/types.ts
@@ -3,7 +3,7 @@
  * https://docs.docker.com/registry/spec/manifest-v2-2/#media-types
  */
 export enum MediaType {
-  manifestV1 = 'pplication/vnd.docker.distribution.manifest.v1+json',
+  manifestV1 = 'application/vnd.docker.distribution.manifest.v1+json',
   manifestV2 = 'application/vnd.docker.distribution.manifest.v2+json',
   manifestListV2 = 'application/vnd.docker.distribution.manifest.list.v2+json',
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

- Fix typo in manifest list for `manifestV1` item

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

Fixes a typo found in issue #10317.

The Docker Hub documentation uses `application` instead of `pplication` as well: https://docs.docker.com/registry/spec/manifest-v2-2/#media-types

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
