### PR TITLE
feat(presets): Add Microsoft Orleans Monorepo

### DIFF
--- a/lib/config/presets/internal/monorepo.ts
+++ b/lib/config/presets/internal/monorepo.ts
@@ -124,6 +124,7 @@ const repoGroups = {
   openfeign: 'https://github.com/OpenFeign/feign',
   opentelemetry: 'https://github.com/open-telemetry/opentelemetry-js',
   OpenTelemetryDotnet: 'https://github.com/open-telemetry/opentelemetry-dotnet',
+  Orleans: 'https://github.com/dotnet/orleans',
   picasso: 'https://github.com/qlik-oss/picasso.js',
   pnpjs: 'https://github.com/pnp/pnpjs',
   playwright: 'https://github.com/Microsoft/playwright',

--- a/lib/config/presets/internal/monorepo.ts
+++ b/lib/config/presets/internal/monorepo.ts
@@ -124,7 +124,7 @@ const repoGroups = {
   openfeign: 'https://github.com/OpenFeign/feign',
   opentelemetry: 'https://github.com/open-telemetry/opentelemetry-js',
   OpenTelemetryDotnet: 'https://github.com/open-telemetry/opentelemetry-dotnet',
-  Orleans: 'https://github.com/dotnet/orleans',
+  orleans: 'https://github.com/dotnet/orleans',
   picasso: 'https://github.com/qlik-oss/picasso.js',
   pnpjs: 'https://github.com/pnp/pnpjs',
   playwright: 'https://github.com/Microsoft/playwright',


### PR DESCRIPTION
## Changes:

Add Monorepo Preset for [Microsoft Orleans](https://github.com/dotnet/orleans) NuGet Packages. So all NuGet packages starting with Microsoft.Orleans.* on NuGet are updated together.