### PR TITLE
fix(dashboard): separate pending branch automerge

### DIFF
--- a/lib/workers/repository/__fixtures__/master-issue_with_8_PR.txt
+++ b/lib/workers/repository/__fixtures__/master-issue_with_8_PR.txt
@@ -27,3 +27,9 @@ These updates encountered an error and will be retried. Click a checkbox below t
  - [ ] <!-- retry-branch=branchName7 -->pr7
  - [ ] <!-- retry-branch=branchName8 -->pr8
 
+## Pending Branch Automerge
+
+These updates await pending status checks before automerging.
+
+ - [ ] <!-- approvePr-branch=branchName9 -->pr9
+

--- a/lib/workers/repository/dependency-dashboard.spec.ts
+++ b/lib/workers/repository/dependency-dashboard.spec.ts
@@ -213,6 +213,14 @@ describe(getName(), () => {
           result: BranchResult.Error,
           branchName: 'branchName8',
         },
+        {
+          ...mock<BranchConfig>(),
+          prTitle: 'pr9',
+          upgrades: [{ ...mock<PrUpgrade>(), depName: 'dep9' }],
+          result: BranchResult.Done,
+          prBlockedBy: 'BranchAutomerge',
+          branchName: 'branchName9',
+        },
       ];
       config.dependencyDashboard = true;
       await dependencyDashboard.ensureDependencyDashboard(config, branches);

--- a/lib/workers/repository/dependency-dashboard.ts
+++ b/lib/workers/repository/dependency-dashboard.ts
@@ -180,6 +180,17 @@ export async function ensureDependencyDashboard(
     }
     issueBody += '\n';
   }
+  const prPendingBranchAutomerge = branches.filter(
+    (branch) => branch.prBlockedBy === 'BranchAutomerge'
+  );
+  if (prPendingBranchAutomerge.length) {
+    issueBody += '## Pending Branch Automerge\n\n';
+    issueBody += `These updates await pending status checks before automerging.\n\n`;
+    for (const branch of prPendingBranchAutomerge) {
+      issueBody += getListItem(branch, 'approvePr');
+    }
+    issueBody += '\n';
+  }
   const otherRes = [
     BranchResult.Pending,
     BranchResult.NeedsApproval,
@@ -194,7 +205,9 @@ export async function ensureDependencyDashboard(
     BranchResult.PrEdited,
   ];
   let inProgress = branches.filter(
-    (branch) => !otherRes.includes(branch.result)
+    (branch) =>
+      !otherRes.includes(branch.result) &&
+      branch.prBlockedBy !== 'BranchAutomerge'
   );
   const otherBranches = inProgress.filter(
     (branch) => branch.prBlockedBy || !branch.prNo


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Fixes scenario of pending branch automerge in Dependency Dashboard.

## Context:

In earlier times this came under "Open" - which is incorrect - and currently it falls under "Other Branches", which is undesirable.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
