### PR TITLE
fix(dashboard): handle update-not-scheduled PRs

### DIFF
--- a/lib/workers/branch/__snapshots__/index.spec.ts.snap
+++ b/lib/workers/branch/__snapshots__/index.spec.ts.snap
@@ -220,7 +220,7 @@ exports[`workers/branch/index processBranch skips branch if not scheduled and no
 Object {
   "branchExists": true,
   "prNo": undefined,
-  "result": "not-scheduled",
+  "result": "update-not-scheduled",
 }
 `;
 

--- a/lib/workers/branch/index.ts
+++ b/lib/workers/branch/index.ts
@@ -241,7 +241,7 @@ export async function processBranch(
         return {
           branchExists,
           prNo: branchPr?.number,
-          result: BranchResult.NotScheduled,
+          result: BranchResult.UpdateNotScheduled,
         };
       }
       // istanbul ignore if

--- a/lib/workers/types.ts
+++ b/lib/workers/types.ts
@@ -89,6 +89,7 @@ export enum BranchResult {
   CommitLimitReached = 'commit-limit-reached',
   BranchLimitReached = 'branch-limit-reached',
   Rebase = 'rebase',
+  UpdateNotScheduled = 'update-not-scheduled',
 }
 
 export interface BranchConfig


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds new Branch result value UpdateNotScheduled to separate "not scheduled" branches from "not scheduled for update" PRs.

## Context:

Closes #9275

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
