### PR TITLE
fix(cargo): use package name as lookup name if specified

### DIFF
--- a/lib/manager/cargo/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/cargo/__snapshots__/extract.spec.ts.snap
@@ -391,6 +391,21 @@ Array [
 ]
 `;
 
+exports[`manager/cargo/extract extractPackageFile() extracts original package name of renamed dependencies 1`] = `
+Array [
+  Object {
+    "currentValue": "0.4.0",
+    "datasource": "crate",
+    "depName": "boolector-solver",
+    "depType": "dependencies",
+    "lookupName": "boolector",
+    "managerData": Object {
+      "nestedVersion": true,
+    },
+  },
+]
+`;
+
 exports[`manager/cargo/extract extractPackageFile() extracts platform specific dependencies 1`] = `
 Array [
   Object {

--- a/lib/manager/cargo/extract.spec.ts
+++ b/lib/manager/cargo/extract.spec.ts
@@ -122,5 +122,14 @@ describe(getName(), () => {
       expect(res.deps).toMatchSnapshot();
       expect(res.deps).toHaveLength(3);
     });
+    it('extracts original package name of renamed dependencies', async () => {
+      const cargotoml =
+        '[dependencies]\nboolector-solver = { package = "boolector", version = "0.4.0" }';
+      const res = await extractPackageFile(cargotoml, 'Cargo.toml', config);
+
+      expect(res.deps).toMatchSnapshot();
+      expect(res.deps).toHaveLength(1);
+      expect(res.deps[0].lookupName).toEqual('boolector');
+    });
   });
 });

--- a/lib/manager/cargo/extract.ts
+++ b/lib/manager/cargo/extract.ts
@@ -27,12 +27,16 @@ function extractFromSection(
     let currentValue = sectionContent[depName];
     let nestedVersion = false;
     let registryUrls: string[] | undefined;
+    let lookupName: string | undefined;
 
     if (typeof currentValue !== 'string') {
       const version = currentValue.version;
       const path = currentValue.path;
       const git = currentValue.git;
       const registryName = currentValue.registry;
+
+      lookupName = currentValue.package;
+
       if (version) {
         currentValue = version;
         nestedVersion = true;
@@ -76,6 +80,9 @@ function extractFromSection(
     }
     if (target) {
       dep.target = target;
+    }
+    if (lookupName) {
+      dep.lookupName = lookupName;
     }
     deps.push(dep);
   });

--- a/lib/manager/cargo/types.ts
+++ b/lib/manager/cargo/types.ts
@@ -7,6 +7,8 @@ export interface CargoDep {
   version?: string;
   /** Name of a registry whose URL is configured in `.cargo/config.toml` */
   registry?: string;
+  /** Name of a package to look up */
+  package?: string;
 }
 
 export type CargoDeps = Record<string, CargoDep | string>;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

In a Cargo manifest someone can name a dependency independent of the actual package name. (package flag)
This PR ensures, that the actual package name is used to lookup the dependency.

## Context:

We discovered this problem in the initial "Configure Renovate" PR (cksystemsgroup/monster#148) in our GitHub.com repository, where it could not lookup renamed dependencies.
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
