### PR TITLE
docs: use server relative URL

### DIFF
--- a/docs/development/new-package-manager-template.md
+++ b/docs/development/new-package-manager-template.md
@@ -2,7 +2,7 @@
 
 **Did you read our documentation on adding a package manager?**
 
-- [ ] I've read the [adding a package manager](../../docs/development/adding-a-package-manager.md) documentation.
+- [ ] I've read the [adding a package manager](/renovatebot/renovate/blob/HEAD/docs/development/adding-a-package-manager.md) documentation.
 
 ## Basics
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

- Change URL from a relative link to a server relative link

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

Steps to reproduce the current problem:

1. Get bot message: "Hey you need to fill out the new package manager questionnaire".
2. User copy/pastes questionnaire into new comment on their issue.
3. Navigate to comment on issue.
4. If you click on the link in "I've read the adding a package manager documentation." you get a "file not found" warning from GitHub.

I think it makes more sense to use a server relative link, as people will click on the link online more often than they will use the link locally on a cloned repository.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
