### PR TITLE
feat(pip-compile): lockFileMaintenance

### DIFF
--- a/lib/manager/pip-compile/index.ts
+++ b/lib/manager/pip-compile/index.ts
@@ -4,7 +4,13 @@ export { extractPackageFile } from '../pip_requirements/extract';
 export { updateArtifacts } from './artifacts';
 
 export const language = LANGUAGE_PYTHON;
+export const supportsLockFileMaintenance = true;
 
 export const defaultConfig = {
   fileMatch: [],
+  lockFileMaintenance: {
+    enabled: true,
+    branchTopic: 'pip-compile-refresh',
+    commitMessageAction: 'Refresh pip-compile outputs',
+  },
 };


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Enables lock file maintenance for pip-compile.

## Context:

The purpose `pip-compile` is to generate "artifacts" in Renovate terms. Therefore it makes sense to enable lockFileMaintenance by default as well as customize how it looks for users.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [x] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
