### PR TITLE
refactor(pip_requirements): extractAllPackageFiles

### DIFF
--- a/lib/manager/pip_requirements/__fixtures__/requirements1.txt
+++ b/lib/manager/pip_requirements/__fixtures__/requirements1.txt
@@ -3,4 +3,4 @@
 some-package==0.3.1
 some-other-package==1.0.0
 not_semver==1.9
-
+unconstrained

--- a/lib/manager/pip_requirements/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/pip_requirements/__snapshots__/extract.spec.ts.snap
@@ -63,6 +63,37 @@ Array [
 ]
 `;
 
+exports[`manager/pip_requirements/extract extractPackageFile() extracts using extractAllPackageFiles 1`] = `
+Array [
+  Object {
+    "deps": Array [
+      Object {
+        "currentValue": "==0.3.1",
+        "currentVersion": "0.3.1",
+        "datasource": "pypi",
+        "depName": "some-package",
+      },
+      Object {
+        "currentValue": "==1.0.0",
+        "currentVersion": "1.0.0",
+        "datasource": "pypi",
+        "depName": "some-other-package",
+      },
+      Object {
+        "currentValue": "==1.9",
+        "currentVersion": "1.9",
+        "datasource": "pypi",
+        "depName": "not_semver",
+      },
+    ],
+    "packageFile": "unused_file_name",
+    "registryUrls": Array [
+      "http://example.com/private-pypi/",
+    ],
+  },
+]
+`;
+
 exports[`manager/pip_requirements/extract extractPackageFile() handles comments and commands 1`] = `
 Array [
   Object {

--- a/lib/manager/pip_requirements/extract.spec.ts
+++ b/lib/manager/pip_requirements/extract.spec.ts
@@ -1,6 +1,8 @@
-import { getName, loadFixture } from '../../../test/util';
+import { fs, getName, loadFixture } from '../../../test/util';
 import { setAdminConfig } from '../../config/admin';
-import { extractPackageFile } from './extract';
+import { extractAllPackageFiles, extractPackageFile } from './extract';
+
+jest.mock('../../util/fs');
 
 const requirements1 = loadFixture('requirements1.txt');
 const requirements2 = loadFixture('requirements2.txt');
@@ -38,6 +40,16 @@ describe(getName(), () => {
     it('extracts dependencies', () => {
       const res = extractPackageFile(requirements1, 'unused_file_name', config);
       expect(res).toMatchSnapshot();
+      expect(res.registryUrls).toEqual(['http://example.com/private-pypi/']);
+      expect(res.deps).toHaveLength(3);
+    });
+    it('extracts using extractAllPackageFiles', async () => {
+      fs.readLocalFile.mockResolvedValueOnce(requirements1);
+      const outerRes = await extractAllPackageFiles(config, [
+        'unused_file_name',
+      ]);
+      expect(outerRes).toMatchSnapshot();
+      const [res] = outerRes;
       expect(res.registryUrls).toEqual(['http://example.com/private-pypi/']);
       expect(res.deps).toHaveLength(3);
     });

--- a/lib/manager/pip_requirements/extract.ts
+++ b/lib/manager/pip_requirements/extract.ts
@@ -4,6 +4,7 @@ import { getAdminConfig } from '../../config/admin';
 import * as datasourcePypi from '../../datasource/pypi';
 import { logger } from '../../logger';
 import { SkipReason } from '../../types';
+import { readLocalFile } from '../../util/fs';
 import { isSkipComment } from '../../util/ignore';
 import type { ExtractConfig, PackageDependency, PackageFile } from '../types';
 
@@ -100,4 +101,27 @@ export function extractPackageFile(
     });
   }
   return res;
+}
+
+export async function extractAllPackageFiles(
+  config: ExtractConfig,
+  packageFiles: string[]
+): Promise<PackageFile[]> {
+  const requirementsFiles: PackageFile[] = [];
+  for (const packageFile of packageFiles) {
+    const content = await readLocalFile(packageFile, 'utf8');
+    // istanbul ignore else
+    if (content) {
+      const deps = extractPackageFile(content, packageFile, config);
+      if (deps) {
+        requirementsFiles.push({
+          packageFile,
+          ...deps,
+        });
+      }
+    } else {
+      logger.debug({ packageFile }, 'requirements file has no content');
+    }
+  }
+  return requirementsFiles;
 }

--- a/lib/manager/pip_requirements/index.ts
+++ b/lib/manager/pip_requirements/index.ts
@@ -1,7 +1,7 @@
 import { LANGUAGE_PYTHON } from '../../constants/languages';
 
 export { updateArtifacts } from './artifacts';
-export { extractPackageFile } from './extract';
+export { extractAllPackageFiles } from './extract';
 export { getRangeStrategy } from './range';
 
 export const language = LANGUAGE_PYTHON;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Refactors `pip_requirements` manager to use `extractAllPackageFiles()`.

## Context:

Refactoring to prepare for full `pip-compile` support.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
