### PR TITLE
docs: improve stabilityDays config option documentation

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2191,10 +2191,6 @@ Renovate does not wait until the package has seen no releases for x `stabilityDa
 If you want to slow down PRs for a specific package, setup a custom schedule for that package.
 Read [our selective-scheduling help](https://docs.renovatebot.com/noise-reduction/#selective-scheduling) to learn how to set the schedule.
 
-One usecase of `stabilityDays` is to prevent holding a broken package, in cases where the package registry allows maintainers to unpublish versions within a certain timeframe.
-As an example: npm packages less than 72 hours old can be unpublished, which could result in a service impact if you have already updated to it.
-To prevent this you can configure Renovate to wait for 3 `stabilityDays` before upgrading npm packages.
-
 If the amount of days since the release is less than the set `stabilityDays` a "pending" status check is added to the branch.
 If enough days have passed then the "pending" status is removed, and a "passing" status check is added.
 
@@ -2210,6 +2206,22 @@ There are a couple of uses for `stabilityDays`:
 
 If you combine `stabilityDays=3` and `prCreation="not-pending"` then Renovate will hold back from creating branches until 3 or more days have elapsed since the version was released.
 It's recommended that you enable `dependencyDashboard=true` so you don't lose visibility of these pending PRs.
+
+#### Prevent holding broken npm packages
+
+npm packages less than 72 hours (3 days) old can be unpublished, which could result in a service impact if you have already updated to it.
+Set `stabilityDays` to 3 for npm packages to prevent relying on a package that can be removed from the registry:
+
+```json
+{
+  "packageRules": [
+    {
+      "matchDatasources": ["npm"],
+      "stabilityDays": 3
+    }
+  ]
+}
+```
 
 #### Await X days before Automerging
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2191,6 +2191,10 @@ Renovate does not wait until the package has seen no releases for x `stabilityDa
 If you want to slow down PRs for a specific package, setup a custom schedule for that package.
 Read [our selective-scheduling help](https://docs.renovatebot.com/noise-reduction/#selective-scheduling) to learn how to set the schedule.
 
+One usecase of `stabilityDays` is to prevent holding a broken package, in cases where the package registry allows maintainers to unpublish versions within a certain timeframe.
+As an example: npm packages less than 72 hours old can be unpublished, which could result in a service impact if you have already updated to it.
+To prevent this you can configure Renovate to wait for 3 `stabilityDays` before upgrading npm packages.
+
 If the amount of days since the release is less than the set `stabilityDays` a "pending" status check is added to the branch.
 If enough days have passed then the "pending" status is removed, and a "passing" status check is added.
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2185,6 +2185,12 @@ If this setting is true then you would get one PR for webpack@v2 and one for web
 
 If this is set to a non-zero value, _and_ an update contains a release timestamp header, then Renovate will check if the "stability days" have passed.
 
+Note: Renovate will wait for the set amount of `stabilityDays` to pass for each **separate** version.
+Renovate does not wait until the package has seen no releases for x `stabilityDays`.
+`stabilityDays` is not intended to help with slowing down fast releasing project updates.
+If you want to slow down PRs for a specific package, setup a custom schedule for that package.
+Read [our selective-scheduling help](https://docs.renovatebot.com/noise-reduction/#selective-scheduling) to learn how to set the schedule.
+
 If the amount of days since the release is less than the set `stabilityDays` a "pending" status check is added to the branch.
 If enough days have passed then the "pending" status is removed, and a "passing" status check is added.
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

- Explain that `stabilityDays` only cares about the time since the release of that specific version not about whether the project as a whole has not released a new version in x days
- Explain that you should set up a custom schedule for fast-releasing projects to slow down the barrage of PRs
- Cover one usecase for `stabilityDays`: prevent holding broken npm packages (they can be unpublished with 72 hours)

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

Based on the confusion from a Renovate user on how stablityDays works.
See discussion #10419.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
