### PR TITLE
fix: add @types/eslint to packages:eslint

### DIFF
--- a/lib/config/presets/__snapshots__/index.spec.ts.snap
+++ b/lib/config/presets/__snapshots__/index.spec.ts.snap
@@ -396,6 +396,7 @@ Object {
 exports[`config/presets/index resolvePreset combines two package alls 1`] = `
 Object {
   "matchPackageNames": Array [
+    "@types/eslint",
     "babel-eslint",
   ],
   "matchPackagePrefixes": Array [
@@ -485,6 +486,7 @@ Object {
 exports[`config/presets/index resolvePreset resolves eslint 1`] = `
 Object {
   "matchPackageNames": Array [
+    "@types/eslint",
     "babel-eslint",
   ],
   "matchPackagePrefixes": Array [
@@ -500,6 +502,7 @@ Object {
     "All lint-related packages",
   ],
   "matchPackageNames": Array [
+    "@types/eslint",
     "babel-eslint",
     "codelyzer",
     "remark-lint",
@@ -528,6 +531,7 @@ Object {
         "All lint-related packages",
       ],
       "matchPackageNames": Array [
+        "@types/eslint",
         "babel-eslint",
         "codelyzer",
         "remark-lint",
@@ -552,6 +556,7 @@ Object {
     Object {
       "groupName": "eslint",
       "matchPackageNames": Array [
+        "@types/eslint",
         "babel-eslint",
       ],
       "matchPackagePrefixes": Array [

--- a/lib/config/presets/index.spec.ts
+++ b/lib/config/presets/index.spec.ts
@@ -188,7 +188,7 @@ describe(getName(), () => {
       config.extends = ['packages:linters'];
       const res = await presets.resolveConfigPresets(config);
       expect(res).toMatchSnapshot();
-      expect(res.matchPackageNames).toHaveLength(3);
+      expect(res.matchPackageNames).toHaveLength(4);
       expect(res.matchPackagePatterns).toHaveLength(1);
       expect(res.matchPackagePrefixes).toHaveLength(4);
     });
@@ -198,7 +198,7 @@ describe(getName(), () => {
       expect(res).toMatchSnapshot();
       const rule = res.packageRules[0];
       expect(rule.automerge).toBe(true);
-      expect(rule.matchPackageNames).toHaveLength(3);
+      expect(rule.matchPackageNames).toHaveLength(4);
       expect(rule.matchPackagePatterns).toHaveLength(1);
       expect(rule.matchPackagePrefixes).toHaveLength(4);
     });

--- a/lib/config/presets/internal/packages.ts
+++ b/lib/config/presets/internal/packages.ts
@@ -24,7 +24,7 @@ export const presets: Record<string, Preset> = {
   },
   eslint: {
     description: 'All eslint packages',
-    matchPackageNames: ['babel-eslint'],
+    matchPackageNames: ['@types/eslint', 'babel-eslint'],
     matchPackagePrefixes: ['@typescript-eslint/', 'eslint'],
   },
   stylelint: {


### PR DESCRIPTION
## Changes:

Add [`@types/eslint`](https://www.npmjs.com/package/@types/eslint) to the [`packages:eslint`](https://docs.renovatebot.com/presets-packages/#packageseslint) preset.

## Context:

I think it makes sense to group these dependencies together, particularly since there's already TypeScript ESLint dependencies in this preset.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added unit tests, or
- [ ] No new tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
