### PR TITLE
fix(cache): log cache errors as trace

### DIFF
--- a/lib/util/cache/package/decorator.ts
+++ b/lib/util/cache/package/decorator.ts
@@ -119,7 +119,7 @@ export function cache<T>({
       await packageCache.set(finalNamespace, finalKey, result, ttlMinutes);
       return result;
     } catch (err) /* istanbul ignore next */ {
-      logger.error({ err }, 'cache decorate error');
+      logger.trace({ err }, 'cache decorate error');
       throw err;
     }
   });

--- a/lib/util/cache/package/decorator.ts
+++ b/lib/util/cache/package/decorator.ts
@@ -1,5 +1,4 @@
 import is from '@sindresorhus/is';
-import { logger } from '../../../logger';
 import * as packageCache from '.';
 
 type Handler<T> = (parameters: DecoratorParameters<T>) => Promise<unknown>;
@@ -90,37 +89,32 @@ export function cache<T>({
   ttlMinutes = 30,
 }: CacheParameters): Decorator<T> {
   return decorate(async ({ args, instance, callback }) => {
-    try {
-      let finalNamespace: string;
-      if (is.string(namespace)) {
-        finalNamespace = namespace;
-      } else if (is.function_(namespace)) {
-        finalNamespace = namespace.apply(instance, args);
-      }
-
-      let finalKey: string;
-      if (is.string(key)) {
-        finalKey = key;
-      } else if (is.function_(key)) {
-        finalKey = key.apply(instance, args);
-      }
-
-      const cachedResult = await packageCache.get<unknown>(
-        finalNamespace,
-        finalKey
-      );
-
-      if (cachedResult !== undefined) {
-        return cachedResult;
-      }
-
-      const result = await callback();
-
-      await packageCache.set(finalNamespace, finalKey, result, ttlMinutes);
-      return result;
-    } catch (err) /* istanbul ignore next */ {
-      logger.trace({ err }, 'cache decorate error');
-      throw err;
+    let finalNamespace: string;
+    if (is.string(namespace)) {
+      finalNamespace = namespace;
+    } else if (is.function_(namespace)) {
+      finalNamespace = namespace.apply(instance, args);
     }
+
+    let finalKey: string;
+    if (is.string(key)) {
+      finalKey = key;
+    } else if (is.function_(key)) {
+      finalKey = key.apply(instance, args);
+    }
+
+    const cachedResult = await packageCache.get<unknown>(
+      finalNamespace,
+      finalKey
+    );
+
+    if (cachedResult !== undefined) {
+      return cachedResult;
+    }
+
+    const result = await callback();
+
+    await packageCache.set(finalNamespace, finalKey, result, ttlMinutes);
+    return result;
   });
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

Log errors caught by the cache decorator as trace. 

This matches what's done further up the stack in `datasource/index.ts`: [[1]](https://github.com/renovatebot/renovate/blob/d3bce1b01a7d3d4e3180b4df7fab02839b04f58d/lib/datasource/index.ts#L116), [[2]](https://github.com/renovatebot/renovate/blob/d3bce1b01a7d3d4e3180b4df7fab02839b04f58d/lib/datasource/index.ts#L159). The error will eventually bubble up to `logError`, where selective details from it are logged at the debug level, instead of the entire error:

https://github.com/renovatebot/renovate/blob/d3bce1b01a7d3d4e3180b4df7fab02839b04f58d/lib/datasource/index.ts#L36-L50

While I could split this into 3 different try/catch blocks (for the cache get, the method call, and the cache set) I think these parts are less likely to throw an error.

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

Fixed #10445

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
