### PR TITLE
fix(secrets): fix host-rules in repo config

### DIFF
--- a/lib/config/secrets.ts
+++ b/lib/config/secrets.ts
@@ -113,12 +113,15 @@ function replaceSecretsinObject(
   return config;
 }
 
-export function applySecretsToConfig(config: RenovateConfig): RenovateConfig {
+export function applySecretsToConfig(
+  config: RenovateConfig,
+  secrets = config.secrets
+): RenovateConfig {
   // Add all secrets to be sanitized
-  if (is.plainObject(config.secrets)) {
-    for (const secret of Object.values(config.secrets)) {
+  if (is.plainObject(secrets)) {
+    for (const secret of Object.values(secrets)) {
       add(String(secret));
     }
   }
-  return replaceSecretsinObject(config, config.secrets);
+  return replaceSecretsinObject(config, secrets);
 }

--- a/lib/workers/repository/init/merge.ts
+++ b/lib/workers/repository/init/merge.ts
@@ -8,6 +8,7 @@ import { decryptConfig } from '../../../config/decrypt';
 import { migrateAndValidate } from '../../../config/migrate-validate';
 import { migrateConfig } from '../../../config/migration';
 import * as presets from '../../../config/presets';
+import { applySecretsToConfig } from '../../../config/secrets';
 import { RenovateConfig } from '../../../config/types';
 import {
   CONFIG_VALIDATION,
@@ -218,6 +219,10 @@ export async function mergeRenovateConfig(
     );
     npmApi.setNpmrc(resolvedConfig.npmrc);
   }
+  resolvedConfig = applySecretsToConfig(
+    resolvedConfig,
+    mergeChildConfig(config.secrets || {}, resolvedConfig.secrets || {})
+  );
   // istanbul ignore if
   if (resolvedConfig.hostRules) {
     logger.debug('Setting hostRules from config');


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Fixes use case of bot-configured `secrets` + repo-configured `hostRules`.

## Context:

Closes #10458

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
