### PR TITLE
fix(manager): optimize lockfile cache handling

### DIFF
--- a/lib/manager/terraform/lockfile/__snapshots__/index.spec.ts.snap
+++ b/lib/manager/terraform/lockfile/__snapshots__/index.spec.ts.snap
@@ -50,12 +50,10 @@ Array [
   Array [
     "hashicorp/azurerm",
     "2.56.0",
-    "/tmp/renovate/cache",
   ],
   Array [
     "hashicorp/random",
     "2.2.2",
-    "/tmp/renovate/cache",
   ],
 ]
 `;
@@ -67,12 +65,10 @@ Array [
   Array [
     "hashicorp/azurerm",
     "2.56.0",
-    "/tmp/renovate/cache",
   ],
   Array [
     "hashicorp/random",
     "2.2.2",
-    "/tmp/renovate/cache",
   ],
 ]
 `;
@@ -139,7 +135,6 @@ Array [
   Array [
     "hashicorp/aws",
     "3.36.0",
-    "/tmp/renovate/cache",
   ],
 ]
 `;
@@ -204,7 +199,6 @@ Array [
   Array [
     "hashicorp/random",
     "3.1.0",
-    "/tmp/renovate/cache",
   ],
 ]
 `;
@@ -270,7 +264,6 @@ Array [
   Array [
     "hashicorp/azurerm",
     "2.56.0",
-    "/tmp/renovate/cache",
   ],
 ]
 `;

--- a/lib/manager/terraform/lockfile/hash.spec.ts
+++ b/lib/manager/terraform/lockfile/hash.spec.ts
@@ -4,7 +4,7 @@ import * as httpMock from '../../../../test/http-mock';
 import { getFixturePath, getName, loadFixture } from '../../../../test/util';
 import { setAdminConfig } from '../../../config/admin';
 import { TerraformProviderDatasource } from '../../../datasource/terraform-provider';
-import createHashes from './hash';
+import { createHashes } from './hash';
 
 const terraformProviderDatasource = new TerraformProviderDatasource();
 const releaseBackendUrl = terraformProviderDatasource.defaultRegistryUrls[1];

--- a/lib/manager/terraform/lockfile/hash.ts
+++ b/lib/manager/terraform/lockfile/hash.ts
@@ -11,7 +11,7 @@ import { logger } from '../../../logger';
 import * as packageCache from '../../../util/cache/package';
 import * as fs from '../../../util/fs';
 import { Http } from '../../../util/http';
-import { repositoryRegex } from './util';
+import { getCacheDir, repositoryRegex } from './util';
 
 const http = new Http(TerraformProviderDatasource.id);
 const hashCacheTTL = 10080; // in seconds == 1 week
@@ -74,9 +74,10 @@ async function getReleaseBackendIndex(
 }
 
 export async function calculateHashes(
-  builds: TerraformBuild[],
-  cacheDir: string
+  builds: TerraformBuild[]
 ): Promise<string[]> {
+  const cacheDir = await getCacheDir();
+
   // for each build download ZIP, extract content and generate hash for all containing files
   const hashes = await pMap(
     builds,
@@ -114,8 +115,7 @@ export async function calculateHashes(
 
 export default async function createHashes(
   repository: string,
-  version: string,
-  cacheDir: string
+  version: string
 ): Promise<string[]> {
   // check cache for hashes
   const repositoryRegexResult = repositoryRegex.exec(repository);
@@ -135,7 +135,7 @@ export default async function createHashes(
   if (cachedRelease) {
     return cachedRelease;
   }
-  let versionReleaseBackend;
+  let versionReleaseBackend: VersionDetailResponse;
   try {
     versionReleaseBackend = await getReleaseBackendIndex(
       backendLookUpName,
@@ -150,7 +150,7 @@ export default async function createHashes(
   }
 
   const builds = versionReleaseBackend.builds;
-  const hashes = await calculateHashes(builds, cacheDir);
+  const hashes = await calculateHashes(builds);
 
   // if a hash could not be produced skip caching and return null
   if (hashes.some((value) => value == null)) {

--- a/lib/manager/terraform/lockfile/hash.ts
+++ b/lib/manager/terraform/lockfile/hash.ts
@@ -113,7 +113,7 @@ export async function calculateHashes(
   return hashes;
 }
 
-export default async function createHashes(
+export async function createHashes(
   repository: string,
   version: string
 ): Promise<string[]> {

--- a/lib/manager/terraform/lockfile/index.spec.ts
+++ b/lib/manager/terraform/lockfile/index.spec.ts
@@ -1,9 +1,9 @@
 import { join } from 'upath';
-import { fs, getName, loadFixture } from '../../../../test/util';
+import { fs, getName, loadFixture, mocked } from '../../../../test/util';
 import { setAdminConfig } from '../../../config/admin';
 import { getPkgReleases } from '../../../datasource';
 import type { UpdateArtifactsConfig } from '../../types';
-import hash from './hash';
+import * as hash from './hash';
 import { updateArtifacts } from './index';
 
 // auto-mock fs
@@ -23,7 +23,7 @@ const adminConfig = {
 
 const validLockfile = loadFixture('validLockfile.hcl');
 
-const mockHash = hash as jest.MockedFunction<typeof hash>;
+const mockHash = mocked(hash).createHashes;
 const mockGetPkgReleases = getPkgReleases as jest.MockedFunction<
   typeof getPkgReleases
 >;

--- a/lib/manager/terraform/lockfile/util.ts
+++ b/lib/manager/terraform/lockfile/util.ts
@@ -1,4 +1,7 @@
-import { getSiblingFileName, readLocalFile } from '../../../util/fs';
+import { join } from 'upath';
+import { getAdminConfig } from '../../../config/admin';
+import { logger } from '../../../logger';
+import { ensureDir, getSiblingFileName, readLocalFile } from '../../../util/fs';
 import { get as getVersioning } from '../../../versioning';
 import type { UpdateArtifactsResult } from '../../types';
 import type {
@@ -206,4 +209,11 @@ export function writeLockUpdates(
       contents: newContent,
     },
   };
+}
+
+export async function getCacheDir(): Promise<string> {
+  const cacheDir = join(getAdminConfig().cacheDir, './others/terraform');
+  await ensureDir(cacheDir);
+  logger.debug(`Using terraform cache: ${cacheDir}`);
+  return cacheDir;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

* Use admin `cacheDir`
* Add `./others/terrafrom` to cache path
* Create temp dir as admin `cacheDir`
<!-- Describe what behavior is changed by this PR. -->

## Context:

failed tests on main branch because of missing `cacheDir`
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
