### PR TITLE
chore: improve warning message on unsupported custom registries

### DIFF
--- a/lib/datasource/index.ts
+++ b/lib/datasource/index.ts
@@ -188,7 +188,7 @@ function resolveRegistryUrls(
     if (is.nonEmptyArray(extractedUrls)) {
       logger.warn(
         { datasource: datasource.id, registryUrls: extractedUrls },
-        'Custom datasources are not allowed for this datasource and will be ignored'
+        'Custom registries are not allowed for this datasource and will be ignored'
       );
     }
     return defaultRegistryUrls;


### PR DESCRIPTION
## Changes:

Improve the warning message when custom registries are configured but unsupported by the datasource.

## Context:

The current wording is wrong in my opinion. Maybe we can improve even more (e.g. allow datasource to define a specific call to action in this case) to reduce confusion like in https://github.com/renovatebot/renovate/discussions/9508.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
