### PR TITLE
fix(lookup): use database versioning if none set

### DIFF
--- a/lib/workers/repository/changelog/index.ts
+++ b/lib/workers/repository/changelog/index.ts
@@ -3,7 +3,7 @@ import { getChangeLogJSON } from '../../pr/changelog';
 import type { BranchUpgradeConfig } from '../../types';
 
 // istanbul ignore next
-async function embedChangelog(upgrade): Promise<void> {
+async function embedChangelog(upgrade: BranchUpgradeConfig): Promise<void> {
   upgrade.logJSON = await getChangeLogJSON(upgrade); // eslint-disable-line
 }
 

--- a/lib/workers/repository/process/lookup/__snapshots__/index.spec.ts.snap
+++ b/lib/workers/repository/process/lookup/__snapshots__/index.spec.ts.snap
@@ -90,6 +90,7 @@ Object {
       "updateType": "pin",
     },
   ],
+  "versioning": "npm",
   "warnings": Array [],
 }
 `;
@@ -103,6 +104,7 @@ Object {
       "updateType": "pin",
     },
   ],
+  "versioning": "npm",
   "warnings": Array [],
 }
 `;
@@ -122,6 +124,7 @@ Object {
       "updateType": "pin",
     },
   ],
+  "versioning": "npm",
   "warnings": Array [],
 }
 `;
@@ -151,6 +154,7 @@ Object {
       "updateType": "digest",
     },
   ],
+  "versioning": "npm",
   "warnings": Array [],
 }
 `;
@@ -164,6 +168,7 @@ Object {
       "updateType": "digest",
     },
   ],
+  "versioning": "npm",
   "warnings": Array [],
 }
 `;
@@ -179,6 +184,7 @@ Object {
       "updateType": "digest",
     },
   ],
+  "versioning": "git",
   "warnings": Array [],
 }
 `;
@@ -209,6 +215,7 @@ Object {
       "updateType": "major",
     },
   ],
+  "versioning": "npm",
   "warnings": Array [],
 }
 `;
@@ -256,6 +263,7 @@ Marking the latest version of an npm package as deprecated results in the entire
       "updateType": "minor",
     },
   ],
+  "versioning": "npm",
   "warnings": Array [],
 }
 `;
@@ -301,6 +309,7 @@ Object {
       "updateType": "minor",
     },
   ],
+  "versioning": "npm",
   "warnings": Array [],
 }
 `;
@@ -449,6 +458,7 @@ Object {
       "updateType": "minor",
     },
   ],
+  "versioning": "npm",
   "warnings": Array [],
 }
 `;
@@ -765,6 +775,7 @@ Object {
       "updateType": "major",
     },
   ],
+  "versioning": "docker",
   "warnings": Array [],
 }
 `;
@@ -796,6 +807,7 @@ Object {
       "updateType": "major",
     },
   ],
+  "versioning": "docker",
   "warnings": Array [],
 }
 `;
@@ -819,6 +831,7 @@ Object {
       "updateType": "minor",
     },
   ],
+  "versioning": "docker",
   "warnings": Array [],
 }
 `;
@@ -827,6 +840,7 @@ exports[`workers/repository/process/lookup/index .lookupUpdates() skips undefine
 Object {
   "skipReason": "invalid-value",
   "updates": Array [],
+  "versioning": "npm",
   "warnings": Array [],
 }
 `;
@@ -835,6 +849,7 @@ exports[`workers/repository/process/lookup/index .lookupUpdates() skips unsuppor
 Object {
   "skipReason": "invalid-value",
   "updates": Array [],
+  "versioning": "npm",
   "warnings": Array [],
 }
 `;

--- a/lib/workers/repository/process/lookup/bucket.ts
+++ b/lib/workers/repository/process/lookup/bucket.ts
@@ -1,4 +1,4 @@
-import * as allVersioning from '../../../../versioning';
+import type { VersioningApi } from '../../../../versioning/types';
 
 export interface BucketConfig {
   separateMajorMinor?: boolean;
@@ -10,7 +10,7 @@ export function getBucket(
   config: BucketConfig,
   currentVersion: string,
   newVersion: string,
-  versioning: allVersioning.VersioningApi
+  versioning: VersioningApi
 ): string {
   const { separateMajorMinor, separateMultipleMajor, separateMinorPatch } =
     config;

--- a/lib/workers/repository/process/lookup/current.ts
+++ b/lib/workers/repository/process/lookup/current.ts
@@ -1,10 +1,10 @@
 import { logger } from '../../../../logger';
-import * as allVersioning from '../../../../versioning';
+import type { VersioningApi } from '../../../../versioning/types';
 import type { LookupUpdateConfig } from './types';
 
 export function getCurrentVersion(
   config: LookupUpdateConfig,
-  versioning: allVersioning.VersioningApi,
+  versioning: VersioningApi,
   rangeStrategy: string,
   latestVersion: string,
   allVersions: string[]

--- a/lib/workers/repository/process/lookup/filter.ts
+++ b/lib/workers/repository/process/lookup/filter.ts
@@ -3,7 +3,7 @@ import { CONFIG_VALIDATION } from '../../../../constants/error-messages';
 import type { Release } from '../../../../datasource/types';
 import { logger } from '../../../../logger';
 import { configRegexPredicate, isConfigRegex } from '../../../../util/regex';
-import * as allVersioning from '../../../../versioning';
+import type { VersioningApi } from '../../../../versioning';
 import * as npmVersioning from '../../../../versioning/npm';
 import * as pep440 from '../../../../versioning/pep440';
 import * as poetryVersioning from '../../../../versioning/poetry';
@@ -13,11 +13,11 @@ export function filterVersions(
   config: FilterConfig,
   currentVersion: string,
   latestVersion: string,
-  releases: Release[]
+  releases: Release[],
+  versioning: VersioningApi
 ): Release[] {
   const { ignoreUnstable, ignoreDeprecated, respectLatest, allowedVersions } =
     config;
-  let versioning;
   function isVersionStable(version: string): boolean {
     if (!versioning.isStable(version)) {
       return false;
@@ -29,7 +29,6 @@ export function filterVersions(
     }
     return true;
   }
-  versioning = allVersioning.get(config.versioning);
   if (!currentVersion) {
     return [];
   }

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -42,10 +42,13 @@ export async function lookupUpdates(
   } = config;
   logger.trace({ dependency: depName, currentValue }, 'lookupUpdates');
   // Use the datasource's default versioning if none is configured
-  const versioning = allVersioning.get(
-    config.versioning || getDefaultVersioning(datasource)
-  );
-  const res: UpdateResult = { updates: [], warnings: [] } as any;
+  config.versioning ??= getDefaultVersioning(datasource);
+  const versioning = allVersioning.get(config.versioning);
+  const res: UpdateResult = {
+    updates: [],
+    warnings: [],
+    versioning: config.versioning,
+  } as any;
   // istanbul ignore if
   if (
     !isGetPkgReleasesConfig(config) ||
@@ -115,7 +118,7 @@ export async function lookupUpdates(
       versioning.matches(v.version, currentValue)
     );
     if (rollbackPrs && !allSatisfyingVersions.length) {
-      const rollback = getRollbackUpdate(config, allVersions);
+      const rollback = getRollbackUpdate(config, allVersions, versioning);
       // istanbul ignore if
       if (!rollback) {
         res.warnings.push({
@@ -185,7 +188,8 @@ export async function lookupUpdates(
       config,
       filterStart,
       latestVersion,
-      allVersions
+      allVersions,
+      versioning
     ).filter((v) =>
       // Leave only compatible versions
       versioning.isCompatible(v.version, currentValue)

--- a/lib/workers/repository/process/lookup/rollback.ts
+++ b/lib/workers/repository/process/lookup/rollback.ts
@@ -1,15 +1,15 @@
 import type { Release } from '../../../../datasource/types';
 import { logger } from '../../../../logger';
 import type { LookupUpdate } from '../../../../manager/types';
-import * as allVersioning from '../../../../versioning';
+import type { VersioningApi } from '../../../../versioning';
 import type { RollbackConfig } from './types';
 
 export function getRollbackUpdate(
   config: RollbackConfig,
-  versions: Release[]
+  versions: Release[],
+  version: VersioningApi
 ): LookupUpdate {
   const { packageFile, versioning, depName, currentValue } = config;
-  const version = allVersioning.get(versioning);
   // istanbul ignore if
   if (!('isLessThanRange' in version)) {
     logger.debug(

--- a/lib/workers/repository/process/lookup/types.ts
+++ b/lib/workers/repository/process/lookup/types.ts
@@ -55,4 +55,6 @@ export interface UpdateResult {
   fixedVersion?: string;
   updates: LookupUpdate[];
   warnings: ValidationMessage[];
+
+  versioning: string;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

* Pass versioning to childs of `lookupUpdates`
* Return versioning from  `lookupUpdates`, so it can be used for changelog retrival.
* repro: https://github.com/viceice-tests/nuget-versioning

<!-- Describe what behavior is changed by this PR. -->

## Context:

see discussion at #10487
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
