### PR TITLE
fix(dashboard): improve wording checkbox to ignore schedule

### DIFF
--- a/lib/workers/repository/__fixtures__/master-issue_with_8_PR.txt
+++ b/lib/workers/repository/__fixtures__/master-issue_with_8_PR.txt
@@ -9,7 +9,7 @@ These branches will be created by Renovate only once you click their checkbox be
 
 ## Awaiting Schedule
 
-These updates are awaiting their schedule. Click on a checkbox to get a update now.
+These updates are awaiting their schedule. Click on a checkbox to get an update now.
  - [ ] <!-- unschedule-branch=branchName3 -->pr3
  - [ ] <!-- unschedule-branch=branchName4 -->pr4
 

--- a/lib/workers/repository/__fixtures__/master-issue_with_8_PR.txt
+++ b/lib/workers/repository/__fixtures__/master-issue_with_8_PR.txt
@@ -9,7 +9,7 @@ These branches will be created by Renovate only once you click their checkbox be
 
 ## Awaiting Schedule
 
-These updates are awaiting their schedule. Click on a checkbox to ignore the schedule.
+These updates are awaiting their schedule. Click on a checkbox to get a update now.
  - [ ] <!-- unschedule-branch=branchName3 -->pr3
  - [ ] <!-- unschedule-branch=branchName4 -->pr4
 

--- a/lib/workers/repository/__snapshots__/dependency-dashboard.spec.ts.snap
+++ b/lib/workers/repository/__snapshots__/dependency-dashboard.spec.ts.snap
@@ -54,7 +54,7 @@ These branches will be created by Renovate only once you click their checkbox be
 
 ## Awaiting Schedule
 
-These updates are awaiting their schedule. Click on a checkbox to ignore the schedule.
+These updates are awaiting their schedule. Click on a checkbox to get a update now.
  - [x] <!-- unschedule-branch=branchName3 -->pr3
 
 "

--- a/lib/workers/repository/__snapshots__/dependency-dashboard.spec.ts.snap
+++ b/lib/workers/repository/__snapshots__/dependency-dashboard.spec.ts.snap
@@ -54,7 +54,7 @@ These branches will be created by Renovate only once you click their checkbox be
 
 ## Awaiting Schedule
 
-These updates are awaiting their schedule. Click on a checkbox to get a update now.
+These updates are awaiting their schedule. Click on a checkbox to get an update now.
  - [x] <!-- unschedule-branch=branchName3 -->pr3
 
 "

--- a/lib/workers/repository/dependency-dashboard.spec.ts
+++ b/lib/workers/repository/dependency-dashboard.spec.ts
@@ -508,7 +508,7 @@ describe(getName(), () => {
 
         ## Awaiting Schedule
 
-        These updates are awaiting their schedule. Click on a checkbox to ignore the schedule.
+        These updates are awaiting their schedule. Click on a checkbox to get a update now.
          - [x] <!-- unschedule-branch=branchName3 -->pr3
 
          - [x] <!-- rebase-all-open-prs -->'

--- a/lib/workers/repository/dependency-dashboard.spec.ts
+++ b/lib/workers/repository/dependency-dashboard.spec.ts
@@ -508,7 +508,7 @@ describe(getName(), () => {
 
         ## Awaiting Schedule
 
-        These updates are awaiting their schedule. Click on a checkbox to get a update now.
+        These updates are awaiting their schedule. Click on a checkbox to get an update now.
          - [x] <!-- unschedule-branch=branchName3 -->pr3
 
          - [x] <!-- rebase-all-open-prs -->'

--- a/lib/workers/repository/dependency-dashboard.ts
+++ b/lib/workers/repository/dependency-dashboard.ts
@@ -160,7 +160,7 @@ export async function ensureDependencyDashboard(
   if (awaitingSchedule.length) {
     issueBody += '## Awaiting Schedule\n\n';
     issueBody +=
-      'These updates are awaiting their schedule. Click on a checkbox to ignore the schedule.\n';
+      'These updates are awaiting their schedule. Click on a checkbox to get a update now.\n';
     for (const branch of awaitingSchedule) {
       issueBody += getListItem(branch, 'unschedule');
     }

--- a/lib/workers/repository/dependency-dashboard.ts
+++ b/lib/workers/repository/dependency-dashboard.ts
@@ -160,7 +160,7 @@ export async function ensureDependencyDashboard(
   if (awaitingSchedule.length) {
     issueBody += '## Awaiting Schedule\n\n';
     issueBody +=
-      'These updates are awaiting their schedule. Click on a checkbox to get a update now.\n';
+      'These updates are awaiting their schedule. Click on a checkbox to get an update now.\n';
     for (const branch of awaitingSchedule) {
       issueBody += getListItem(branch, 'unschedule');
     }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

- Improve wording checkbox to ignore schedule

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

Based on the discussion at #10509.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
