### PR TITLE
fix: set the pythonAlias to python3 when the python version is less than 3.7

### DIFF
--- a/lib/manager/pip_setup/extract.spec.ts
+++ b/lib/manager/pip_setup/extract.spec.ts
@@ -32,6 +32,8 @@ describe(getName(), () => {
         new Error(),
         { stdout: 'Python 3.8.0\\n', stderr: '' },
         new Error(),
+        { stdout: 'Python 3.6.8\\n', stderr: '' },
+        new Error(),
       ]);
       const result = await getPythonAlias();
       expect(pythonVersions).toContain(result);

--- a/lib/manager/pip_setup/extract.ts
+++ b/lib/manager/pip_setup/extract.ts
@@ -33,6 +33,9 @@ export async function getPythonAlias(): Promise<string> {
       if (version[0] >= 3 && version[1] >= 7) {
         pythonAlias = pythonVersion;
         break;
+      } else if (version[0] >= 3) {
+        pythonAlias = pythonVersion;
+        break;
       }
     } catch (err) {
       logger.debug(`${pythonVersion} alias not found`);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:
https://github.com/renovatebot/renovate/issues/10559
<!-- Describe what behavior is changed by this PR. -->
Couldn't set the pythonAlias to python3 when the python version is 3.6.8 because of this line where it checks for Python version greater than or equals to 3.7 only
## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number --> Closes #10559

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
