### PR TITLE
fix: explain pending branch automerge checkbox behavior

### DIFF
--- a/lib/workers/repository/__fixtures__/master-issue_with_8_PR.txt
+++ b/lib/workers/repository/__fixtures__/master-issue_with_8_PR.txt
@@ -29,7 +29,7 @@ These updates encountered an error and will be retried. Click a checkbox below t
 
 ## Pending Branch Automerge
 
-These updates await pending status checks before automerging.
+These updates await pending status checks before automerging. Click on a checkbox to abort the branch automerge, and create a PR instead.
 
  - [ ] <!-- approvePr-branch=branchName9 -->pr9
 

--- a/lib/workers/repository/dependency-dashboard.ts
+++ b/lib/workers/repository/dependency-dashboard.ts
@@ -232,7 +232,7 @@ export async function ensureDependencyDashboard(
   );
   if (prPendingBranchAutomerge.length) {
     issueBody += '## Pending Branch Automerge\n\n';
-    issueBody += `These updates await pending status checks before automerging.\n\n`;
+    issueBody += `These updates await pending status checks before automerging. Click on a checkbox to abort the branch automerge, and create a PR instead.\n\n`;
     for (const branch of prPendingBranchAutomerge) {
       issueBody += getListItem(branch, 'approvePr');
     }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

- Add text to explain what the checkbox will do

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

Closes #10547

Do we need to adjust the unit tests? I'm not 100% sure if my change is properly captured by a test now.

I followed this process:

1. Make code change -> Run Jest -> Jest complains about a fixture.
2. Add new text to existing fixture, run Jest again -> Jest passes.
3. Done???

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
