### PR TITLE
fix: @ mentions in any created issues no longer link to a user.

### DIFF
--- a/lib/platform/bitbucket/index.spec.ts
+++ b/lib/platform/bitbucket/index.spec.ts
@@ -773,6 +773,12 @@ describe(getName(), () => {
         )
       ).toMatchSnapshot();
     });
+    it('sanitizes body content', () => {
+      const issueBody = '@Test';
+      const sanitizedBody = bitbucket.massageMarkdown(issueBody);
+      expect(sanitizedBody).not.toBe(issueBody);
+      expect(sanitizedBody).toBe('@&#8203;Test');
+    });
   });
 
   describe('updatePr()', () => {

--- a/lib/platform/github/index.spec.ts
+++ b/lib/platform/github/index.spec.ts
@@ -1997,6 +1997,12 @@ describe(getName(), () => {
       expect(github.massageMarkdown(input)).toEqual(input);
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
+    it('sanitizes body content', () => {
+      const issueBody = '@Test';
+      const sanitizedBody = github.massageMarkdown(issueBody);
+      expect(sanitizedBody).not.toBe(issueBody);
+      expect(sanitizedBody).toBe('@&#8203;Test');
+    });
   });
   describe('mergePr(prNo) - autodetection', () => {
     it('should try rebase first', async () => {

--- a/lib/platform/gitlab/index.spec.ts
+++ b/lib/platform/gitlab/index.spec.ts
@@ -1551,13 +1551,26 @@ These updates have all been created already. Click a checkbox below to force a r
     });
 
     it('truncates description if too low API version', async () => {
-      jest.mock('../utils/pr-body');
-      const { smartTruncate } = require('../utils/pr-body');
+      const prBodyUtil = require('../utils/pr-body');
+      prBodyUtil.smartTruncate = jest.fn().mockReturnValue(prBody);
 
       await initFakePlatform('13.3.0');
       gitlab.massageMarkdown(prBody);
-      expect(smartTruncate).toHaveBeenCalledTimes(1);
-      expect(smartTruncate).toHaveBeenCalledWith(expect.any(String), 25000);
+      expect(prBodyUtil.smartTruncate).toHaveBeenCalledTimes(1);
+      expect(prBodyUtil.smartTruncate).toHaveBeenCalledWith(
+        expect.any(String),
+        25000
+      );
+    });
+    it('sanitizes body content', () => {
+      const issueBody = '@Test';
+
+      const prBodyUtil = require('../utils/pr-body');
+      prBodyUtil.smartTruncate = jest.fn().mockReturnValue(issueBody);
+
+      const sanitizedBody = gitlab.massageMarkdown(issueBody);
+      expect(sanitizedBody).not.toBe(issueBody);
+      expect(sanitizedBody).toBe('@&#8203;Test');
     });
   });
 

--- a/lib/platform/gitlab/index.ts
+++ b/lib/platform/gitlab/index.ts
@@ -21,6 +21,7 @@ import * as git from '../../util/git';
 import * as hostRules from '../../util/host-rules';
 import { HttpResponse } from '../../util/http';
 import { setBaseUrl } from '../../util/http/gitlab';
+import { sanitizeMarkdown } from '../../util/markdown';
 import { sanitize } from '../../util/sanitize';
 import { ensureTrailingSlash, getQueryString, parseUrl } from '../../util/url';
 import type {
@@ -620,8 +621,7 @@ export function massageMarkdown(input: string): string {
 
     desc = smartTruncate(desc, 25000);
   }
-
-  return desc;
+  return sanitizeMarkdown(desc);
 }
 
 // Branch
@@ -795,6 +795,7 @@ export async function ensureIssue({
   body,
 }: EnsureIssueConfig): Promise<'updated' | 'created' | null> {
   logger.debug(`ensureIssue()`);
+
   const description = massageMarkdown(sanitize(body));
   try {
     const issueList = await getIssueList();

--- a/lib/util/markdown.ts
+++ b/lib/util/markdown.ts
@@ -3,6 +3,9 @@ import github from 'remark-github';
 
 // Generic replacements/link-breakers
 export function sanitizeMarkdown(markdown: string): string {
+  if (!markdown) {
+    return markdown;
+  }
   let res = markdown;
   // Put a zero width space after every # followed by a digit
   res = res.replace(/#(\d)/gi, '#&#8203;$1');


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:
Issue markdown is being sanitized to prevent unwanted side effects. 

<!-- Describe what behavior is changed by this PR. -->

## Context:

When Issues were being created that named a package beginning with "@" and a user existed with the same name as the package, then the platform would send the user a message as if they had been tagged in the issue. This PR fixes this.

Closes #8030.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
