### PR TITLE
docs: clarify how `bumpVersion` for `sbt` works

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -283,6 +283,8 @@ For `npm` only you can also configure this field to `"mirror:x"` where `x` is th
 Doing so means that the `package.json` `version` field will mirror whatever the version is that `x` depended on.
 Make sure that version is a pinned version of course, as otherwise it won't be valid.
 
+For `sbt` note that Renovate will update the version string only if it's found in the project's `built.sbt` file.
+
 ## cloneSubmodules
 
 ## commitBody

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -283,7 +283,7 @@ For `npm` only you can also configure this field to `"mirror:x"` where `x` is th
 Doing so means that the `package.json` `version` field will mirror whatever the version is that `x` depended on.
 Make sure that version is a pinned version of course, as otherwise it won't be valid.
 
-For `sbt` note that Renovate will update the version string only if it's found in the project's `built.sbt` file.
+For `sbt` note that Renovate will update the version string only for packages that have the version string in their project's `built.sbt` file.
 
 ## cloneSubmodules
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

No change in behaviour, just a small change to the docs.


## Context:

we put our version string in `project/Version.scala` instead of `build.sbt` for reasons. 

if updating PRs by hand becomes annoying enough, we'll see about adding something Renovate. 

thanks for this great tool! :-)

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
