### PR TITLE
fix(config): create jestPlusTSJest group preset

### DIFF
--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -572,6 +572,19 @@ const staticGroups = {
       },
     ],
   },
+  TSJestAndJest: {
+    description: 'Group major updates for jest and ts-jest together',
+    packageRules: [
+      {
+        matchSourceUrlPrefixes: [
+          'https://github.com/facebook/jest',
+          'https://github.com/kulshekhar/ts-jest',
+        ],
+        matchUpdateTypes: ['major'],
+        groupName: 'TS-jest and Jest',
+      },
+    ],
+  },
 };
 
 const config: any = { ...staticGroups };

--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -581,7 +581,7 @@ const staticGroups = {
           'https://github.com/kulshekhar/ts-jest',
         ],
         matchUpdateTypes: ['major'],
-        groupName: 'ts-jest and jest',
+        groupName: 'jest monorepo,
       },
     ],
   },

--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -573,7 +573,7 @@ const staticGroups = {
     ],
   },
   jestPlusTSJest: {
-    description: 'Group major updates for jest and ts-jest together',
+    description: 'Group major updates for ts-jest to jest monorepo',
     packageRules: [
       {
         matchSourceUrlPrefixes: [

--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -572,7 +572,7 @@ const staticGroups = {
       },
     ],
   },
-  JestPlusTSJest: {
+  jestPlusTSJest: {
     description: 'Group major updates for jest and ts-jest together',
     packageRules: [
       {

--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -577,7 +577,6 @@ const staticGroups = {
     packageRules: [
       {
         matchSourceUrlPrefixes: [
-          'https://github.com/facebook/jest',
           'https://github.com/kulshekhar/ts-jest',
         ],
         matchUpdateTypes: ['major'],

--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -573,14 +573,12 @@ const staticGroups = {
     ],
   },
   jestPlusTSJest: {
-    description: 'Group major updates for ts-jest to jest monorepo',
+    description: 'Add ts-jest major update to jest monorepo',
     packageRules: [
       {
-        matchSourceUrlPrefixes: [
-          'https://github.com/kulshekhar/ts-jest',
-        ],
+        matchSourceUrlPrefixes: ['https://github.com/kulshekhar/ts-jest'],
         matchUpdateTypes: ['major'],
-        groupName: 'jest monorepo,
+        groupName: 'jest monorepo',
       },
     ],
   },

--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -58,6 +58,7 @@ const staticGroups = {
       'group:hibernateCommons',
       'group:illuminate',
       'group:jekyllEcosystem',
+      'group:jestPlusTSJest',
       'group:polymer',
       'group:resilience4j',
       'group:rubyOmniauth',

--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -572,7 +572,7 @@ const staticGroups = {
       },
     ],
   },
-  TSJestAndJest: {
+  JestPlusTSJest: {
     description: 'Group major updates for jest and ts-jest together',
     packageRules: [
       {
@@ -581,7 +581,7 @@ const staticGroups = {
           'https://github.com/kulshekhar/ts-jest',
         ],
         matchUpdateTypes: ['major'],
-        groupName: 'TS-jest and Jest',
+        groupName: 'ts-jest and jest',
       },
     ],
   },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

- Creates new group to bundle Jest and TS-Jest major updates together

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

The idea is to group major Jest and TS-Jest updates into one PR, as things will break if you update them separately.
I don't think all Jest users use TypeScript, so this is a new group preset, instead of fixing up the Jest monorepo preset.

There's also this message on the `ts-jest` repo readme:

> We DO NOT use SemVer for versioning. Though you can think about SemVer when reading our version, except our major number follows the one of Jest. For the versions available, see the tags on this repository.

So we should only group **major** updates, as those are the only ones that are matched to the upstream Jest versioning.

Fixes #10594.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
