### PR TITLE
refactor: Centralize logging for ensureCacheDir function

### DIFF
--- a/lib/manager/bundler/artifacts.ts
+++ b/lib/manager/bundler/artifacts.ts
@@ -170,7 +170,6 @@ export async function updateArtifacts(
     }
 
     const cacheDir = await ensureCacheDir('./others/gem', 'GEM_HOME');
-    logger.debug(`Using gem home ${cacheDir}`);
 
     const execOptions: ExecOptions = {
       cwdFile: packageFileName,

--- a/lib/manager/cocoapods/artifacts.ts
+++ b/lib/manager/cocoapods/artifacts.ts
@@ -68,7 +68,6 @@ export async function updateArtifacts({
   const tagConstraint = match?.groups?.cocoapodsVersion ?? null;
 
   const cacheDir = await ensureCacheDir('./others/cocoapods', 'CP_HOME_DIR');
-  logger.debug(`Using cocoapods home ${cacheDir}`);
 
   const cmd = [...getPluginCommands(newPackageFileContent), 'pod install'];
   const execOptions: ExecOptions = {

--- a/lib/manager/composer/artifacts.ts
+++ b/lib/manager/composer/artifacts.ts
@@ -80,7 +80,6 @@ export async function updateArtifacts({
     './others/composer',
     'COMPOSER_CACHE_DIR'
   );
-  logger.debug(`Using composer cache ${cacheDir}`);
 
   const lockFileName = packageFileName.replace(/\.json$/, '.lock');
   const existingLockFileContent = await readLocalFile(lockFileName);

--- a/lib/manager/gomod/artifacts.ts
+++ b/lib/manager/gomod/artifacts.ts
@@ -93,7 +93,6 @@ export async function updateArtifacts({
   logger.debug(`gomod.updateArtifacts(${goModFileName})`);
 
   const goPath = await ensureCacheDir('./others/go', 'GOPATH');
-  logger.debug(`Using GOPATH: ${goPath}`);
 
   const sumFileName = goModFileName.replace(/\.mod$/, '.sum');
   const existingGoSumContent = await readLocalFile(sumFileName);

--- a/lib/manager/pipenv/artifacts.ts
+++ b/lib/manager/pipenv/artifacts.ts
@@ -78,7 +78,6 @@ export async function updateArtifacts({
   logger.debug(`pipenv.updateArtifacts(${pipfileName})`);
 
   const cacheDir = await ensureCacheDir('./others/pipenv', 'PIPENV_CACHE_DIR');
-  logger.debug('Using pipenv cache ' + cacheDir);
 
   const lockFileName = pipfileName + '.lock';
   const existingLockFileContent = await readLocalFile(lockFileName, 'utf8');

--- a/lib/util/fs/index.ts
+++ b/lib/util/fs/index.ts
@@ -88,14 +88,23 @@ export async function ensureCacheDir(
   envCacheVar?: string
 ): Promise<string> {
   const { cacheDir: adminCacheDir } = getAdminConfig();
-  let envCacheDir = null;
+
+  let cacheDir: string;
   if (envCacheVar) {
     const env = getChildProcessEnv([envCacheVar]);
-    envCacheDir = env[envCacheVar];
+    if (env[envCacheVar]) {
+      cacheDir = env[envCacheVar];
+      logger.trace(`Using cache directory from ${envCacheVar}=${cacheDir}`);
+    }
   }
-  const cacheDirName = envCacheDir || join(adminCacheDir, adminCacheSubdir);
-  await fs.ensureDir(cacheDirName);
-  return cacheDirName;
+
+  if (!cacheDir) {
+    cacheDir = join(adminCacheDir, adminCacheSubdir);
+    logger.trace(`Using cache directory ${cacheDir} (default)`);
+  }
+
+  await fs.ensureDir(cacheDir);
+  return cacheDir;
 }
 
 /**

--- a/lib/util/fs/index.ts
+++ b/lib/util/fs/index.ts
@@ -87,8 +87,6 @@ export async function ensureCacheDir(
   adminCacheSubdir: string,
   envCacheVar?: string
 ): Promise<string> {
-  const { cacheDir: adminCacheDir } = getAdminConfig();
-
   let cacheDir: string;
   if (envCacheVar) {
     const env = getChildProcessEnv([envCacheVar]);
@@ -99,6 +97,7 @@ export async function ensureCacheDir(
   }
 
   if (!cacheDir) {
+    const { cacheDir: adminCacheDir } = getAdminConfig();
     cacheDir = join(adminCacheDir, adminCacheSubdir);
     logger.trace(`Using cache directory ${cacheDir} (default)`);
   }

--- a/lib/util/fs/index.ts
+++ b/lib/util/fs/index.ts
@@ -92,7 +92,7 @@ export async function ensureCacheDir(
     const env = getChildProcessEnv([envCacheVar]);
     if (env[envCacheVar]) {
       cacheDir = env[envCacheVar];
-      logger.trace(
+      logger.debug(
         { cacheDir },
         `Using cache directory from environment: ${envCacheVar}`
       );
@@ -102,7 +102,7 @@ export async function ensureCacheDir(
   if (!cacheDir) {
     const { cacheDir: adminCacheDir } = getAdminConfig();
     cacheDir = join(adminCacheDir, adminCacheSubdir);
-    logger.trace({ cacheDir }, `Using cache directory from admin config`);
+    logger.debug({ cacheDir }, `Using cache directory from admin config`);
   }
 
   await fs.ensureDir(cacheDir);

--- a/lib/util/fs/index.ts
+++ b/lib/util/fs/index.ts
@@ -92,14 +92,17 @@ export async function ensureCacheDir(
     const env = getChildProcessEnv([envCacheVar]);
     if (env[envCacheVar]) {
       cacheDir = env[envCacheVar];
-      logger.trace(`Using cache directory from ${envCacheVar}=${cacheDir}`);
+      logger.trace(
+        { cacheDir },
+        `Using cache directory from environment: ${envCacheVar}`
+      );
     }
   }
 
   if (!cacheDir) {
     const { cacheDir: adminCacheDir } = getAdminConfig();
     cacheDir = join(adminCacheDir, adminCacheSubdir);
-    logger.trace(`Using cache directory ${cacheDir} (default)`);
+    logger.trace({ cacheDir }, `Using cache directory from admin config`);
   }
 
   await fs.ensureDir(cacheDir);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

## Context:

Related to #10526

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository