### PR TITLE
fix(package-rules): add groupSlug to matched package rule if necessary

### DIFF
--- a/lib/util/package-rules.spec.ts
+++ b/lib/util/package-rules.spec.ts
@@ -714,6 +714,7 @@ describe('applyPackageRules()', () => {
       applyPackageRules({ ...config1, packageRules: null })
     ).toMatchSnapshot();
   });
+
   it('creates groupSlug if necessary', () => {
     const config: TestConfig = {
       depName: 'foo',

--- a/lib/util/package-rules.spec.ts
+++ b/lib/util/package-rules.spec.ts
@@ -714,4 +714,22 @@ describe('applyPackageRules()', () => {
       applyPackageRules({ ...config1, packageRules: null })
     ).toMatchSnapshot();
   });
+  it('creates groupSlug if necessary', () => {
+    const config: TestConfig = {
+      depName: 'foo',
+      packageRules: [
+        {
+          matchPackagePatterns: ['*'],
+          groupName: 'A',
+          groupSlug: 'a',
+        },
+        {
+          matchPackagePatterns: ['*'],
+          groupName: 'B',
+        },
+      ],
+    };
+    const res = applyPackageRules(config);
+    expect(res.groupSlug).toEqual('b');
+  });
 });

--- a/lib/util/package-rules.ts
+++ b/lib/util/package-rules.ts
@@ -1,5 +1,6 @@
 import is from '@sindresorhus/is';
 import minimatch from 'minimatch';
+import slugify from 'slugify';
 import { mergeChildConfig } from '../config';
 import type { PackageRule, PackageRuleInputConfig } from '../config/types';
 import { logger } from '../logger';
@@ -262,7 +263,14 @@ export function applyPackageRules<T extends PackageRuleInputConfig>(
     // This rule is considered matched if there was at least one positive match and no negative matches
     if (matchesRule(config, packageRule)) {
       // Package rule config overrides any existing config
-      config = mergeChildConfig(config, packageRule);
+      const toApply = { ...packageRule };
+      if (config.groupSlug && packageRule.groupName && !packageRule.groupSlug) {
+        // Need to apply groupSlug otherwise the existing one will take precedence
+        toApply.groupSlug = slugify(packageRule.groupName, {
+          lower: true,
+        });
+      }
+      config = mergeChildConfig(config, toApply);
       delete config.matchPackageNames;
       delete config.matchPackagePatterns;
       delete config.matchPackagePrefixes;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Generates and adds `groupSlug` when applying `packageRules` if the `groupSlug` was already set, and the matching rule contains a `groupName` but no `groupSlug`.

## Context:

Without this, the config retains its previous branch naming due to `groupSlug` being stronger than `groupName`. Closes #10613 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
