### PR TITLE
fix: remove composer memory limit

### DIFF
--- a/lib/manager/regex/__fixtures__/Dockerfile
+++ b/lib/manager/regex/__fixtures__/Dockerfile
@@ -122,6 +122,8 @@ RUN apt-get update && apt-get install -y php-cli php-mbstring && \
 
 ENV COMPOSER_VERSION=1.9.3 # github-releases/composer/composer
 
+ENV COMPOSER_MEMORY_LIMIT=-1 # See https://github.com/renovatebot/renovate/issues/10624
+
 RUN php -r "copy('https://github.com/composer/composer/releases/download/$COMPOSER_VERSION/composer.phar', '/usr/local/bin/composer');"
 
 RUN chmod +x /usr/local/bin/composer


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

It should avoid errors such as:
```
Command failed: docker run --rm --name=renovate_composer --label=renovate_child -v "/mnt/renovate/gh/mikepsinn/qm-api":"/mnt/renovate/gh/mikepsinn/qm-api" -v "/tmp/renovate-cache":"/tmp/renovate-cache" -e COMPOSER_CACHE_DIR -e COMPOSER_AUTH -w "/mnt/renovate/gh/mikepsinn/qm-api" docker.io/renovate/composer:1.10.22 bash -l -c "composer update doctrine/dbal --with-dependencies --ignore-platform-reqs --no-ansi --no-interaction --no-scripts --no-autoloader"
Loading composer repositories with package information
������������������������������������������������������                                                      ������������������������������������������������������Warning from https://repo.packagist.org: Support for Composer 1 is deprecated and some packages will not be available. You should upgrade to Composer 2. See https://blog.packagist.com/deprecating-composer-1-support/
Updating dependencies (including require-dev)
PHP Fatal error:  Allowed memory size of 1610612736 bytes exhausted (tried to allocate 83886080 bytes) in phar:///usr/local/composer/1.10.22/bin/composer/src/Composer/DependencyResolver/RuleSet.php on line 90
```

## Context:

Closes https://github.com/renovatebot/renovate/issues/10624

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

