### PR TITLE
fix:  Force pip regex to match dot character

### DIFF
--- a/lib/manager/pip_requirements/index.ts
+++ b/lib/manager/pip_requirements/index.ts
@@ -7,5 +7,5 @@ export { getRangeStrategy } from './range';
 export const language = LANGUAGE_PYTHON;
 
 export const defaultConfig = {
-  fileMatch: ['(^|/)([\\w-]*)requirements.(txt|pip)$'],
+  fileMatch: ['(^|/)([\\w-]*)requirements\\.(txt|pip)$'],
 };


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Replace `.` by `\\.` in the regex that matches pip requirement files.


## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

The dot character in regex matches any character. What we rather want is to match `.pip` or `.txt`.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
