### PR TITLE
fix(manager/mix): support lockfiles in subdirs

### DIFF
--- a/lib/manager/mix/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/manager/mix/__snapshots__/artifacts.spec.ts.snap
@@ -90,3 +90,5 @@ Array [
   },
 ]
 `;
+
+exports[`manager/mix/artifacts returns updated mix.lock in subdir 1`] = `null`;

--- a/lib/manager/mix/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/manager/mix/__snapshots__/artifacts.spec.ts.snap
@@ -90,5 +90,3 @@ Array [
   },
 ]
 `;
-
-exports[`manager/mix/artifacts returns updated mix.lock in subdir 1`] = `null`;

--- a/lib/manager/mix/artifacts.spec.ts
+++ b/lib/manager/mix/artifacts.spec.ts
@@ -101,7 +101,7 @@ describe(getName(), () => {
     setAdminConfig({ ...adminConfig, binarySource: 'docker' });
     fs.writeLocalFile.mockResolvedValueOnce('New mix.exs');
     fs.getSiblingFileName.mockReturnValueOnce('subdir/mix.lock');
-    const execSnapshots = mockExecAll(exec);
+    mockExecAll(exec);
     expect(
       await updateArtifacts({
         packageFileName: 'subdir/mix.exs',
@@ -109,8 +109,8 @@ describe(getName(), () => {
         newPackageFileContent: '{}',
         config,
       })
-    ).toMatchSnapshot();
-    expect(fs.readLocalFile).toBeCalledWith('subdir/mix.lock', 'utf8');
+    ).toBeNull();
+    expect(fs.readLocalFile).toHaveBeenCalledWith('subdir/mix.lock', 'utf8');
   });
 
   it('catches write errors', async () => {

--- a/lib/manager/mix/artifacts.spec.ts
+++ b/lib/manager/mix/artifacts.spec.ts
@@ -99,7 +99,6 @@ describe(getName(), () => {
 
   it('returns updated mix.lock in subdir', async () => {
     setAdminConfig({ ...adminConfig, binarySource: 'docker' });
-    fs.writeLocalFile.mockResolvedValueOnce('New mix.exs');
     fs.getSiblingFileName.mockReturnValueOnce('subdir/mix.lock');
     mockExecAll(exec);
     expect(

--- a/lib/manager/mix/artifacts.ts
+++ b/lib/manager/mix/artifacts.ts
@@ -16,7 +16,7 @@ export async function updateArtifacts({
     return null;
   }
 
-  const lockFileName = 'mix.lock';
+  const lockFileName = [...packageFileName.split('/').slice(0, -1), 'mix.lock'].join('/');
   try {
     await writeLocalFile(packageFileName, newPackageFileContent);
   } catch (err) {

--- a/lib/manager/mix/artifacts.ts
+++ b/lib/manager/mix/artifacts.ts
@@ -2,7 +2,11 @@ import { quote } from 'shlex';
 import { TEMPORARY_ERROR } from '../../constants/error-messages';
 import { logger } from '../../logger';
 import { ExecOptions, exec } from '../../util/exec';
-import { getSiblingFileName, readLocalFile, writeLocalFile } from '../../util/fs';
+import {
+  getSiblingFileName,
+  readLocalFile,
+  writeLocalFile,
+} from '../../util/fs';
 import type { UpdateArtifact, UpdateArtifactsResult } from '../types';
 
 export async function updateArtifacts({

--- a/lib/manager/mix/artifacts.ts
+++ b/lib/manager/mix/artifacts.ts
@@ -2,7 +2,7 @@ import { quote } from 'shlex';
 import { TEMPORARY_ERROR } from '../../constants/error-messages';
 import { logger } from '../../logger';
 import { ExecOptions, exec } from '../../util/exec';
-import { readLocalFile, writeLocalFile } from '../../util/fs';
+import { getSiblingFileName, readLocalFile, writeLocalFile } from '../../util/fs';
 import type { UpdateArtifact, UpdateArtifactsResult } from '../types';
 
 export async function updateArtifacts({
@@ -16,7 +16,7 @@ export async function updateArtifacts({
     return null;
   }
 
-  const lockFileName = [...packageFileName.split('/').slice(0, -1), 'mix.lock'].join('/');
+  const lockFileName = getSiblingFileName(packageFileName, 'mix.lock');
   try {
     await writeLocalFile(packageFileName, newPackageFileContent);
   } catch (err) {


### PR DESCRIPTION
## Changes:

Fixes a bug where the `mix.exs` file may be in a subdir of the repo but
the `mix.lock` file is always searched for in the root -- they should
always be in the same folder.

I suspect a better TypeScript programmer more familiar with this repo
could come up with a better way to do this -- let me know if you have
any suggestions!

## Context:

Closes #9992

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository