### PR TITLE
ci(workflow): add cache to workflows using actions/setup-node

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,8 +1,7 @@
 name: build-pr
 
 on:
-  pull_request:
-
+  pull_request: null
 env:
   YARN_MODULES_CACHE_KEY: v1
   YARN_PACKAGE_CACHE_KEY: v1
@@ -23,6 +22,7 @@ jobs:
         uses: actions/setup-node@v2.2.0
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: npm
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v2.2.2
@@ -50,7 +50,8 @@ jobs:
         uses: actions/cache@v2.1.6
         with:
           path: ${{ env.YARN_CACHE_FOLDER }}
-          key: ${{ env.YARN_PACKAGE_CACHE_KEY }}-${{ runner.os }}-yarn_cache-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ env.YARN_PACKAGE_CACHE_KEY }}-${{ runner.os }}-yarn_cache-${{
+            hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ env.YARN_PACKAGE_CACHE_KEY }}-${{ runner.os }}-yarn_cache-
 
@@ -87,6 +88,7 @@ jobs:
         uses: actions/setup-node@v2.2.0
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: npm
 
       - name: Init platform
         run: |
@@ -105,7 +107,8 @@ jobs:
         uses: actions/cache@v2.1.6
         with:
           path: ${{ env.YARN_CACHE_FOLDER }}
-          key: ${{ env.YARN_PACKAGE_CACHE_KEY }}-${{ runner.os }}-yarn_cache-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ env.YARN_PACKAGE_CACHE_KEY }}-${{ runner.os }}-yarn_cache-${{
+            hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ env.YARN_PACKAGE_CACHE_KEY }}-${{ runner.os }}-yarn_cache-
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,8 @@ on:
   workflow_dispatch:
     inputs:
       dryRun:
-        description: 'Dry-Run'
-        default: 'true'
+        description: "Dry-Run"
+        default: "true"
 
 env:
   # Currently no way to detect automatically (#8153)
@@ -46,6 +46,7 @@ jobs:
         uses: actions/setup-node@v2.2.0
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: npm
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v2.2.2
@@ -57,7 +58,7 @@ jobs:
         uses: actions/setup-java@v2.1.0
         with:
           java-version: ${{ env.JAVA_VERSION }}
-          distribution: 'adopt'
+          distribution: "adopt"
           java-package: jre
           check-latest: false
 
@@ -86,7 +87,8 @@ jobs:
         uses: actions/cache@v2.1.6
         with:
           path: ${{ env.YARN_CACHE_FOLDER }}
-          key: ${{ env.YARN_PACKAGE_CACHE_KEY }}-${{ runner.os }}-yarn_cache-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ env.YARN_PACKAGE_CACHE_KEY }}-${{ runner.os }}-yarn_cache-${{
+            hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ env.YARN_PACKAGE_CACHE_KEY }}-${{ runner.os }}-yarn_cache-
 
@@ -124,6 +126,7 @@ jobs:
         uses: actions/setup-node@v2.2.0
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: npm
 
       - name: Init platform
         run: |
@@ -142,7 +145,8 @@ jobs:
         uses: actions/cache@v2.1.6
         with:
           path: ${{ env.YARN_CACHE_FOLDER }}
-          key: ${{ env.YARN_PACKAGE_CACHE_KEY }}-${{ runner.os }}-yarn_cache-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ env.YARN_PACKAGE_CACHE_KEY }}-${{ runner.os }}-yarn_cache-${{
+            hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ env.YARN_PACKAGE_CACHE_KEY }}-${{ runner.os }}-yarn_cache-
 
@@ -178,6 +182,7 @@ jobs:
         uses: actions/setup-node@v2.2.0
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: npm
 
       - name: Init platform
         run: |
@@ -207,7 +212,8 @@ jobs:
         uses: actions/cache@v2.1.6
         with:
           path: ${{ env.YARN_CACHE_FOLDER }}
-          key: ${{ env.YARN_PACKAGE_CACHE_KEY }}-${{ runner.os }}-yarn_cache-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ env.YARN_PACKAGE_CACHE_KEY }}-${{ runner.os }}-yarn_cache-${{
+            hashFiles('**/yarn.lock') }}
 
       - name: Installing dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -7,14 +7,14 @@ on:
   workflow_dispatch:
     inputs:
       sha:
-        description: 'Git sha to checkout'
+        description: "Git sha to checkout"
         required: true
       version:
-        description: 'Version to release'
+        description: "Version to release"
         required: true
       tag:
-        description: 'Npm dist-tag'
-        default: 'latest'
+        description: "Npm dist-tag"
+        default: "latest"
 
 env:
   YARN_MODULES_CACHE_KEY: v1
@@ -33,6 +33,7 @@ jobs:
         uses: actions/setup-node@v2.2.0
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: npm
 
       - name: Init platform
         run: |
@@ -60,7 +61,8 @@ jobs:
         uses: actions/cache@v2.1.6
         with:
           path: ${{ env.YARN_CACHE_FOLDER }}
-          key: ${{ env.YARN_PACKAGE_CACHE_KEY }}-${{ runner.os }}-yarn_cache-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ env.YARN_PACKAGE_CACHE_KEY }}-${{ runner.os }}-yarn_cache-${{
+            hashFiles('**/yarn.lock') }}
 
       - name: Installing dependencies
         run: yarn install --frozen-lockfile


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
