### PR TITLE
ci: use build-in yarn cache

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
 
 env:
-  YARN_MODULES_CACHE_KEY: v1
-  YARN_PACKAGE_CACHE_KEY: v1
-  YARN_CACHE_FOLDER: .cache/yarn
   NODE_VERSION: 14
   PYTHON_VERSION: 3.9
   SKIP_JAVA_TESTS: true
@@ -19,10 +16,15 @@ jobs:
     timeout-minutes: 30
 
     steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 2
+
       - name: Set up Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v2.2.0
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: yarn
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v2.2.2
@@ -40,24 +42,6 @@ jobs:
           echo "Node $(node --version)"
           python --version
           echo "Yarn $(yarn --version)"
-
-      - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 2
-
-      - name: Cache Yarn packages
-        id: yarn_cache_packages
-        uses: actions/cache@v2.1.6
-        with:
-          path: ${{ env.YARN_CACHE_FOLDER }}
-          key: ${{ env.YARN_PACKAGE_CACHE_KEY }}-${{ runner.os }}-yarn_cache-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ env.YARN_PACKAGE_CACHE_KEY }}-${{ runner.os }}-yarn_cache-
-
-      # Clear caches on cache miss, otherwise they will grow indefinitely
-      - name: Clear yarn cache
-        if: steps.yarn_cache_packages.outputs.cache-hit != 'true'
-        run: yarn cache clean
 
       - name: Installing dependencies
         run: yarn install --frozen-lockfile
@@ -83,10 +67,15 @@ jobs:
     timeout-minutes: 15
 
     steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 2
+
       - name: Set up Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v2.2.0
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: yarn
 
       - name: Init platform
         run: |
@@ -97,22 +86,6 @@ jobs:
           npm config set scripts-prepend-node-path true
           echo "Node $(node --version)"
           echo "Yarn $(yarn --version)"
-
-      - uses: actions/checkout@v2.3.4
-
-      - name: Cache Yarn packages
-        id: yarn_cache_packages
-        uses: actions/cache@v2.1.6
-        with:
-          path: ${{ env.YARN_CACHE_FOLDER }}
-          key: ${{ env.YARN_PACKAGE_CACHE_KEY }}-${{ runner.os }}-yarn_cache-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ env.YARN_PACKAGE_CACHE_KEY }}-${{ runner.os }}-yarn_cache-
-
-      # Clear caches on cache miss, otherwise they will grow indefinitely
-      - name: Clear yarn cache
-        if: steps.yarn_cache_packages.outputs.cache-hit != 'true'
-        run: yarn cache clean
 
       - name: Installing dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,13 +11,11 @@ on:
       dryRun:
         description: 'Dry-Run'
         default: 'true'
+        required: false
 
 env:
   # Currently no way to detect automatically (#8153)
   DEFAULT_BRANCH: main
-  YARN_MODULES_CACHE_KEY: v1
-  YARN_PACKAGE_CACHE_KEY: v1
-  YARN_CACHE_FOLDER: .cache/yarn
   NODE_VERSION: 14
   DRY_RUN: true
 
@@ -42,10 +40,15 @@ jobs:
       JAVA_VERSION: ${{ matrix.java-version }}
 
     steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 2
+
       - name: Set up Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v2.2.0
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: yarn
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v2.2.2
@@ -77,24 +80,6 @@ jobs:
           python --version
           echo "Yarn $(yarn --version)"
 
-      - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 2
-
-      - name: Cache Yarn packages
-        id: yarn_cache_packages
-        uses: actions/cache@v2.1.6
-        with:
-          path: ${{ env.YARN_CACHE_FOLDER }}
-          key: ${{ env.YARN_PACKAGE_CACHE_KEY }}-${{ runner.os }}-yarn_cache-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ env.YARN_PACKAGE_CACHE_KEY }}-${{ runner.os }}-yarn_cache-
-
-      # Clear caches on cache miss, otherwise they will grow indefinitely
-      - name: Clear yarn cache
-        if: steps.yarn_cache_packages.outputs.cache-hit != 'true'
-        run: yarn cache clean
-
       - name: Installing dependencies
         run: yarn install --frozen-lockfile
 
@@ -120,10 +105,15 @@ jobs:
     timeout-minutes: 15
 
     steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 2
+
       - name: Set up Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v2.2.0
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: yarn
 
       - name: Init platform
         run: |
@@ -134,22 +124,6 @@ jobs:
           npm config set scripts-prepend-node-path true
           echo "Node $(node --version)"
           echo "Yarn $(yarn --version)"
-
-      - uses: actions/checkout@v2.3.4
-
-      - name: Cache Yarn packages
-        id: yarn_cache_packages
-        uses: actions/cache@v2.1.6
-        with:
-          path: ${{ env.YARN_CACHE_FOLDER }}
-          key: ${{ env.YARN_PACKAGE_CACHE_KEY }}-${{ runner.os }}-yarn_cache-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ env.YARN_PACKAGE_CACHE_KEY }}-${{ runner.os }}-yarn_cache-
-
-      # Clear caches on cache miss, otherwise they will grow indefinitely
-      - name: Clear yarn cache
-        if: steps.yarn_cache_packages.outputs.cache-hit != 'true'
-        run: yarn cache clean
 
       - name: Installing dependencies
         run: yarn install --frozen-lockfile
@@ -174,10 +148,16 @@ jobs:
     timeout-minutes: 15
 
     steps:
+      # full checkout for semantic-release
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+
       - name: Set up Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v2.2.0
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: yarn
 
       - name: Init platform
         run: |
@@ -197,17 +177,6 @@ jobs:
           elif [[ "${{github.ref}}" =~ ^refs/heads/v[0-9]+(\.[0-9]+)?$ ]]; then
             echo "DRY_RUN=false" >> $GITHUB_ENV
           fi
-
-      # full checkout for semantic-release
-      - uses: actions/checkout@v2.3.4
-        with:
-          fetch-depth: 0
-
-      - name: Cache Yarn packages
-        uses: actions/cache@v2.1.6
-        with:
-          path: ${{ env.YARN_CACHE_FOLDER }}
-          key: ${{ env.YARN_PACKAGE_CACHE_KEY }}-${{ runner.os }}-yarn_cache-${{ hashFiles('**/yarn.lock') }}
 
       - name: Installing dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -15,11 +15,9 @@ on:
       tag:
         description: 'Npm dist-tag'
         default: 'latest'
+        required: false
 
 env:
-  YARN_MODULES_CACHE_KEY: v1
-  YARN_PACKAGE_CACHE_KEY: v1
-  YARN_CACHE_FOLDER: .cache/yarn
   NODE_VERSION: 14
   GIT_SHA: ${{ github.event.client_payload.sha }}
   NPM_VERSION: ${{ github.event.client_payload.version }}
@@ -29,20 +27,6 @@ jobs:
   release-npm:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v2.2.0
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-
-      - name: Init platform
-        run: |
-          git config --global core.autocrlf false
-          git config --global core.symlinks true
-          git config --global user.email 'renovate@whitesourcesoftware.com'
-          git config --global user.name  'Renovate Bot'
-          yarn config set version-git-tag false
-          npm config set scripts-prepend-node-path true
-
       - name: Prepare env
         run: |
           if [[ "${{github.event_name}}" == "workflow_dispatch" ]]; then
@@ -55,12 +39,20 @@ jobs:
         with:
           ref: ${{ env.GIT_SHA }}
 
-      - name: Cache Yarn packages
-        id: yarn_cache_packages
-        uses: actions/cache@v2.1.6
+      - name: Set up Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v2.2.0
         with:
-          path: ${{ env.YARN_CACHE_FOLDER }}
-          key: ${{ env.YARN_PACKAGE_CACHE_KEY }}-${{ runner.os }}-yarn_cache-${{ hashFiles('**/yarn.lock') }}
+          node-version: ${{ env.NODE_VERSION }}
+          cache: yarn
+
+      - name: Init platform
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.symlinks true
+          git config --global user.email 'renovate@whitesourcesoftware.com'
+          git config --global user.name  'Renovate Bot'
+          yarn config set version-git-tag false
+          npm config set scripts-prepend-node-path true
 
       - name: Installing dependencies
         run: yarn install --frozen-lockfile


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Use build-in caching of `actions/setup-node`.

<!-- Describe what behavior is changed by this PR. -->

## Context:

closes #10706
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
