### PR TITLE
fix(git): convert to config validation errors

### DIFF
--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -86,30 +86,34 @@ function checkForPlatformFailure(err: Error): void {
   }
 
   const configErrorStrings = [
-    [
-      'GitLab: Branch name does not follow the pattern',
-      "Cannot push because branch name does not follow project's push rules",
-    ],
-    [
-      'GitLab: Commit message does not follow the pattern',
-      "Cannot push because commit message does not follow project's push rules",
-    ],
-    [
-      ' is not a member of team',
-      'The `Restrict commits to existing GitLab users` rule is blocking Renovate push. Check the Renovate `gitAuthor` setting',
-    ],
-    [
-      'TF401027:', // You need the Git 'GenericContribute' permission to perform this action
-      'You need the Git `GenericContribute` permission to perform this action',
-    ],
+    {
+      error: 'GitLab: Branch name does not follow the pattern',
+      message:
+        "Cannot push because branch name does not follow project's push rules",
+    },
+    {
+      error: 'GitLab: Commit message does not follow the pattern',
+      message:
+        "Cannot push because commit message does not follow project's push rules",
+    },
+    {
+      error: ' is not a member of team',
+      message:
+        'The `Restrict commits to existing GitLab users` rule is blocking Renovate push. Check the Renovate `gitAuthor` setting',
+    },
+    {
+      error: 'TF401027:',
+      message:
+        'You need the Git `GenericContribute` permission to perform this action',
+    },
   ];
-  for (const [errorStr, validationError] of configErrorStrings) {
-    if (err.message.includes(errorStr)) {
+  for (const { error, message } of configErrorStrings) {
+    if (err.message.includes(error)) {
       logger.debug({ err }, 'Converting git error to CONFIG_VALIDATION error');
-      const error = new Error(CONFIG_VALIDATION);
-      error.validationError = validationError;
-      error.validationMessage = err.message;
-      throw error;
+      const res = new Error(CONFIG_VALIDATION);
+      res.validationError = message;
+      res.validationMessage = err.message;
+      throw res;
     }
   }
 }

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -74,9 +74,7 @@ function checkForPlatformFailure(err: Error): void {
     'Failed to connect to',
     'Connection timed out',
     'malformed object name',
-    'TF401027:', // You need the Git 'GenericContribute' permission to perform this action
     'Could not resolve host',
-    ' is not a member of team',
     'early EOF',
     'fatal: bad config', // .gitmodules problem
   ];
@@ -95,6 +93,14 @@ function checkForPlatformFailure(err: Error): void {
     [
       'GitLab: Commit message does not follow the pattern',
       "Cannot push because commit message does not follow project's push rules",
+    ],
+    [
+      ' is not a member of team',
+      '`Restrict commits to existing GitLab users` rule is blocking renovate push. Check renovate `gitAuthor` setting',
+    ],
+    [
+      'TF401027:', // You need the Git 'GenericContribute' permission to perform this action
+      'You need the Git `GenericContribute` permission to perform this action',
     ],
   ];
   for (const [errorStr, validationError] of configErrorStrings) {

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -96,7 +96,7 @@ function checkForPlatformFailure(err: Error): void {
     ],
     [
       ' is not a member of team',
-      '`Restrict commits to existing GitLab users` rule is blocking renovate push. Check renovate `gitAuthor` setting',
+      'The `Restrict commits to existing GitLab users` rule is blocking Renovate push. Check the Renovate `gitAuthor` setting',
     ],
     [
       'TF401027:', // You need the Git 'GenericContribute' permission to perform this action


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:
Converted some git errors to config validation errors, so users have more visibillity for them.
<!-- Describe what behavior is changed by this PR. -->

## Context:

fixes #10729
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
