### PR TITLE
refactor: Fair coverage for docker exec utils

### DIFF
--- a/lib/util/exec/docker/index.spec.ts
+++ b/lib/util/exec/docker/index.spec.ts
@@ -1,0 +1,300 @@
+import { getName } from '../../../../test/util';
+import { setAdminConfig } from '../../../config/admin';
+import { SYSTEM_INSUFFICIENT_MEMORY } from '../../../constants/error-messages';
+import { getPkgReleases as _getPkgReleases } from '../../../datasource';
+import { logger } from '../../../logger';
+import { VolumeOption, rawExec as _rawExec } from '../common';
+import {
+  generateDockerCommand,
+  getDockerTag,
+  prefetchDockerImage,
+  removeDanglingContainers,
+  removeDockerContainer,
+  resetPrefetchedImages,
+} from '.';
+
+const rawExec: jest.Mock<typeof _rawExec> = _rawExec as any;
+jest.mock('../common');
+
+const getPkgReleases: jest.Mock<typeof _getPkgReleases> =
+  _getPkgReleases as any;
+jest.mock('../../../datasource');
+
+describe(getName(), () => {
+  const execOpts = { encoding: 'utf-8' };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('prefetchDockerImage', () => {
+    beforeEach(() => {
+      rawExec.mockResolvedValue(null as never);
+      resetPrefetchedImages();
+    });
+
+    it('runs prefetch command', async () => {
+      await prefetchDockerImage('foo:1.2.3');
+      expect(rawExec).toHaveBeenCalledWith('docker pull foo:1.2.3', execOpts);
+    });
+
+    it('performs prefetch once for each image', async () => {
+      await prefetchDockerImage('foo:1.0.0');
+      await prefetchDockerImage('foo:2.0.0');
+      await prefetchDockerImage('bar:3.0.0');
+      await prefetchDockerImage('foo:1.0.0');
+
+      expect(rawExec).toHaveBeenNthCalledWith(
+        1,
+        'docker pull foo:1.0.0',
+        execOpts
+      );
+      expect(rawExec).toHaveBeenNthCalledWith(
+        2,
+        'docker pull foo:2.0.0',
+        execOpts
+      );
+      expect(rawExec).toHaveBeenNthCalledWith(
+        3,
+        'docker pull bar:3.0.0',
+        execOpts
+      );
+      expect(rawExec).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('getDockerTag', () => {
+    it('returns "latest" for invalid constraint', async () => {
+      const res = await getDockerTag('foo', '!@#$%', 'semver');
+      expect(res).toBe('latest');
+    });
+
+    it('returns "latest" for bad release results', async () => {
+      getPkgReleases.mockResolvedValueOnce(undefined as never);
+      expect(await getDockerTag('foo', '1.2.3', 'semver')).toBe('latest');
+
+      getPkgReleases.mockResolvedValueOnce({} as never);
+      expect(await getDockerTag('foo', '1.2.3', 'semver')).toBe('latest');
+
+      getPkgReleases.mockResolvedValueOnce({ releases: [] } as never);
+      expect(await getDockerTag('foo', '1.2.3', 'semver')).toBe('latest');
+    });
+
+    it('returns tag for good release results', async () => {
+      const releases = [
+        { version: '1.0.0' },
+        { version: '1.0.1' },
+        { version: '1.0.2' },
+        { version: '1.2.0' },
+        { version: '1.2.1' },
+        { version: '1.2.2' },
+        { version: '1.2.3' },
+        { version: '1.2.4' },
+        { version: '1.9.0' },
+        { version: '1.9.1' },
+        { version: '1.9.2' },
+        { version: '1.9.9' },
+        { version: '2.0.0' },
+        { version: '2.0.1' },
+        { version: '2.0.2' },
+        { version: '2.1.0' },
+        { version: '2.1.1' },
+        { version: '2.1.2' },
+      ];
+      getPkgReleases.mockResolvedValueOnce({ releases } as never);
+      expect(await getDockerTag('foo', '^1.2.3', 'npm')).toBe('1.9.9');
+    });
+  });
+
+  describe('removeDockerContainer', () => {
+    it('gracefully handles container list error', async () => {
+      rawExec.mockRejectedValueOnce('unknown' as never);
+      await expect(removeDockerContainer('bar', 'foo_')).resolves.not.toThrow();
+    });
+
+    it('gracefully handles container removal error', async () => {
+      rawExec.mockResolvedValueOnce({ stdout: '12345' } as never);
+      rawExec.mockRejectedValueOnce('unknown' as never);
+      await expect(removeDockerContainer('bar', 'foo_')).resolves.not.toThrow();
+    });
+
+    it('gracefully handles empty container list', async () => {
+      rawExec.mockResolvedValueOnce({ stdout: '\n' } as never);
+      await expect(removeDockerContainer('bar', 'foo_')).resolves.not.toThrow();
+    });
+
+    it('runs Docker commands for container removal', async () => {
+      rawExec.mockResolvedValueOnce({ stdout: '12345' } as never);
+      rawExec.mockResolvedValueOnce(null as never);
+      await removeDockerContainer('bar', 'foo_');
+      expect(rawExec).toHaveBeenNthCalledWith(
+        1,
+        'docker ps --filter name=foo_bar -aq',
+        execOpts
+      );
+      expect(rawExec).toHaveBeenNthCalledWith(
+        2,
+        'docker rm -f 12345',
+        execOpts
+      );
+    });
+  });
+
+  describe('removeDanglingContainers', () => {
+    beforeEach(() => {
+      setAdminConfig({ binarySource: 'docker' });
+    });
+
+    it('short-circuits in non-Docker environment', async () => {
+      setAdminConfig({ binarySource: 'global' });
+      await removeDanglingContainers();
+      expect(rawExec).not.toHaveBeenCalled();
+    });
+
+    it('handles insufficient memory error', async () => {
+      rawExec.mockRejectedValueOnce({ errno: 'ENOMEM' } as never);
+      await expect(removeDanglingContainers).rejects.toThrow(
+        SYSTEM_INSUFFICIENT_MEMORY
+      );
+    });
+
+    it('handles missing Docker daemon', async () => {
+      rawExec.mockRejectedValueOnce({
+        stderr: 'Cannot connect to the Docker daemon',
+      } as never);
+      await removeDanglingContainers();
+      expect(rawExec).toHaveBeenNthCalledWith(
+        1,
+        'docker ps --filter label=renovate_child -aq',
+        execOpts
+      );
+      expect(rawExec).toHaveBeenCalledTimes(1);
+      expect(logger.info).toHaveBeenCalled();
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('handles unknown error', async () => {
+      rawExec.mockRejectedValueOnce('unknown' as never);
+      await removeDanglingContainers();
+      expect(rawExec).toHaveBeenNthCalledWith(
+        1,
+        'docker ps --filter label=renovate_child -aq',
+        execOpts
+      );
+      expect(rawExec).toHaveBeenCalledTimes(1);
+      expect(logger.info).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalled();
+    });
+
+    it('handles empty container list ', async () => {
+      rawExec.mockResolvedValueOnce({ stdout: '\n\n\n' } as never);
+      await removeDanglingContainers();
+      expect(rawExec).toHaveBeenNthCalledWith(
+        1,
+        'docker ps --filter label=renovate_child -aq',
+        execOpts
+      );
+      expect(rawExec).toHaveBeenCalledTimes(1);
+      expect(logger.info).not.toHaveBeenCalled();
+      expect(logger.warn).not.toHaveBeenCalled();
+      expect(logger.debug).toHaveBeenCalled();
+    });
+
+    it('removes containers', async () => {
+      rawExec.mockResolvedValueOnce({ stdout: '111\n222\n333' } as never);
+      rawExec.mockResolvedValueOnce(null as never);
+      await removeDanglingContainers();
+      expect(rawExec).toHaveBeenNthCalledWith(
+        1,
+        'docker ps --filter label=renovate_child -aq',
+        execOpts
+      );
+      expect(rawExec).toHaveBeenNthCalledWith(
+        2,
+        'docker rm -f 111 222 333',
+        execOpts
+      );
+      expect(rawExec).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('generateDockerCommand', () => {
+    const preCommands = [null, 'foo', undefined];
+    const commands = ['bar'];
+    const postCommands = [undefined, 'baz', null];
+    const envVars = ['FOO', 'BAR'];
+    const image = 'sample_image';
+    const dockerOptions = {
+      preCommands,
+      postCommands,
+      image,
+      cwd: '/tmp/foobar',
+      envVars,
+    };
+    const command = (img: string, vol?: string): string =>
+      `docker run --rm ` +
+      `--name=renovate_sample_image ` +
+      `--label=renovate_child ` +
+      `--user=some-user ` +
+      (vol ? `${vol} ` : '') +
+      `-e FOO -e BAR ` +
+      `-w "/tmp/foobar" ` +
+      `renovate/${img} ` +
+      `bash -l -c "foo && bar && baz"`;
+
+    beforeEach(() => {
+      setAdminConfig({ dockerUser: 'some-user' });
+    });
+
+    it('returns executable command', async () => {
+      rawExec.mockResolvedValue(null as never);
+      const res = await generateDockerCommand(commands, dockerOptions);
+      expect(res).toBe(command(image));
+    });
+
+    it('handles volumes', async () => {
+      rawExec.mockResolvedValue(null as never);
+      const volumes: VolumeOption[] = [
+        '/tmp/foo',
+        ['/tmp/bar', `/tmp/bar`],
+        ['/tmp/baz', `/home/baz`],
+      ];
+      const res = await generateDockerCommand(commands, {
+        ...dockerOptions,
+        volumes: [...volumes, ...volumes],
+      });
+      expect(res).toBe(
+        command(
+          image,
+          `-v "/tmp/foo":"/tmp/foo" -v "/tmp/bar":"/tmp/bar" -v "/tmp/baz":"/home/baz"`
+        )
+      );
+    });
+
+    it('handles tag parameter', async () => {
+      rawExec.mockResolvedValue(null as never);
+      const res = await generateDockerCommand(commands, {
+        ...dockerOptions,
+        tag: '1.2.3',
+      });
+      expect(res).toBe(command(`${image}:1.2.3`));
+    });
+
+    it('handles tag constraint', async () => {
+      rawExec.mockResolvedValue(null as never);
+      getPkgReleases.mockResolvedValueOnce({
+        releases: [
+          { version: '1.2.3' },
+          { version: '1.2.4' },
+          { version: '2.0.0' },
+        ],
+      } as never);
+      const res = await generateDockerCommand(commands, {
+        ...dockerOptions,
+        tagScheme: 'npm',
+        tagConstraint: '^1.2.3',
+      });
+      expect(res).toBe(command(`${image}:1.2.4`));
+    });
+  });
+});

--- a/lib/util/exec/docker/index.spec.ts
+++ b/lib/util/exec/docker/index.spec.ts
@@ -1,6 +1,4 @@
 import {
-  ExecSnapshots,
-  envMock,
   exec,
   mockExecAll,
   mockExecSequence,

--- a/lib/util/exec/docker/index.spec.ts
+++ b/lib/util/exec/docker/index.spec.ts
@@ -8,7 +8,7 @@ import { setAdminConfig } from '../../../config/admin';
 import { SYSTEM_INSUFFICIENT_MEMORY } from '../../../constants/error-messages';
 import { getPkgReleases as _getPkgReleases } from '../../../datasource';
 import { logger } from '../../../logger';
-import { VolumeOption } from '../common';
+import type { VolumeOption } from '../common';
 import {
   generateDockerCommand,
   getDockerTag,

--- a/lib/util/exec/docker/index.ts
+++ b/lib/util/exec/docker/index.ts
@@ -15,7 +15,7 @@ import {
 
 const prefetchedImages = new Set<string>();
 
-async function prefetchDockerImage(taggedImage: string): Promise<void> {
+export async function prefetchDockerImage(taggedImage: string): Promise<void> {
   if (prefetchedImages.has(taggedImage)) {
     logger.debug(`Docker image is already prefetched: ${taggedImage}`);
   } else {
@@ -67,7 +67,7 @@ function prepareCommands(commands: Opt<string>[]): string[] {
   return commands.filter((command) => command && typeof command === 'string');
 }
 
-async function getDockerTag(
+export async function getDockerTag(
   depName: string,
   constraint: string,
   scheme: string
@@ -102,7 +102,7 @@ async function getDockerTag(
       );
       return version;
     }
-  } /* istanbul ignore next */ else {
+  } else {
     logger.error(`No ${depName} releases found`);
     return 'latest';
   }
@@ -132,7 +132,6 @@ export async function removeDockerContainer(
       encoding: 'utf-8',
     });
     const containerId = res?.stdout?.trim() || '';
-    // istanbul ignore if
     if (containerId.length) {
       logger.debug({ containerId }, 'Removing container');
       cmd = `docker rm -f ${containerId}`;
@@ -142,7 +141,7 @@ export async function removeDockerContainer(
     } else {
       logger.trace({ image, containerName }, 'No running containers to remove');
     }
-  } catch (err) /* istanbul ignore next */ {
+  } catch (err) {
     logger.warn(
       { image, containerName, cmd, err },
       'Could not remove Docker container'
@@ -150,7 +149,6 @@ export async function removeDockerContainer(
   }
 }
 
-// istanbul ignore next
 export async function removeDanglingContainers(): Promise<void> {
   const { binarySource, dockerChildPrefix } = getAdminConfig();
   if (binarySource !== 'docker') {
@@ -178,7 +176,7 @@ export async function removeDanglingContainers(): Promise<void> {
     } else {
       logger.debug('No dangling containers to remove');
     }
-  } catch (err) /* istanbul ignore next */ {
+  } catch (err) {
     if (err.errno === 'ENOMEM') {
       throw new Error(SYSTEM_INSUFFICIENT_MEMORY);
     }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Add `index.spec.ts` for `util/docker`

## Context:

Ref: #10526

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
