### PR TITLE
fix: widening support in composer versioning

### DIFF
--- a/lib/versioning/composer/index.spec.ts
+++ b/lib/versioning/composer/index.spec.ts
@@ -344,6 +344,14 @@ describe('semver.getNewValue()', () => {
         newVersion: '1.9.0',
       })
     ).toEqual('^1.2');
+    expect(
+      semver.getNewValue({
+        currentValue: '^1.0 || ^2.0',
+        rangeStrategy: 'widen',
+        currentVersion: '2.0.0',
+        newVersion: '2.1.0',
+      })
+    ).toEqual('^1.0 || ^2.0');
   });
   it('returns newVersion if unsupported', () => {
     expect(

--- a/lib/versioning/composer/index.spec.ts
+++ b/lib/versioning/composer/index.spec.ts
@@ -312,6 +312,22 @@ describe('semver.getNewValue()', () => {
         newVersion: '3.1.0',
       })
     ).toEqual('~1.2 || ~2.0 || ~3.0');
+    expect(
+      semver.getNewValue({
+        currentValue: '^1.2',
+        rangeStrategy: 'widen',
+        currentVersion: '1.2.0',
+        newVersion: '2.0.0',
+      })
+    ).toEqual('^1.2 || ^2.0');
+    expect(
+      semver.getNewValue({
+        currentValue: '~1.2',
+        rangeStrategy: 'widen',
+        currentVersion: '1.2.0',
+        newVersion: '2.4.0',
+      })
+    ).toEqual('~1.2 || ~2.0');
   });
   it('returns newVersion if unsupported', () => {
     expect(

--- a/lib/versioning/composer/index.spec.ts
+++ b/lib/versioning/composer/index.spec.ts
@@ -306,12 +306,12 @@ describe('semver.getNewValue()', () => {
     ).toEqual('~3.0');
     expect(
       semver.getNewValue({
-        currentValue: '~1.2 || ~2.0',
+        currentValue: '~1.2 || ~2.0 || ~3.0',
         rangeStrategy: 'widen',
         currentVersion: '2.0.0',
-        newVersion: '3.1.0',
+        newVersion: '5.1.0',
       })
-    ).toEqual('~1.2 || ~2.0 || ~3.0');
+    ).toEqual('~1.2 || ~2.0 || ~3.0 || ~5.0');
     expect(
       semver.getNewValue({
         currentValue: '^1.2',
@@ -328,6 +328,22 @@ describe('semver.getNewValue()', () => {
         newVersion: '2.4.0',
       })
     ).toEqual('~1.2 || ~2.0');
+    expect(
+      semver.getNewValue({
+        currentValue: '~1.2',
+        rangeStrategy: 'widen',
+        currentVersion: '1.2.0',
+        newVersion: '1.9.0',
+      })
+    ).toEqual('~1.2');
+    expect(
+      semver.getNewValue({
+        currentValue: '^1.2',
+        rangeStrategy: 'widen',
+        currentVersion: '1.2.0',
+        newVersion: '1.9.0',
+      })
+    ).toEqual('^1.2');
   });
   it('returns newVersion if unsupported', () => {
     expect(

--- a/lib/versioning/composer/index.ts
+++ b/lib/versioning/composer/index.ts
@@ -183,7 +183,11 @@ function getNewValue({
     if (rangeStrategy === 'replace') {
       newValue = replacementValue;
     } else if (rangeStrategy === 'widen') {
-      newValue = currentValue + ' || ' + replacementValue;
+      if (matches(newVersion, currentValue)) {
+        newValue = currentValue;
+      } else {
+        newValue = currentValue + ' || ' + replacementValue;
+      }
     }
   } else if (rangeStrategy === 'widen') {
     if (matches(newVersion, currentValue)) {

--- a/lib/versioning/composer/index.ts
+++ b/lib/versioning/composer/index.ts
@@ -186,13 +186,17 @@ function getNewValue({
       newValue = currentValue + ' || ' + replacementValue;
     }
   } else if (rangeStrategy === 'widen') {
-    const replacementValue = getNewValue({
-      currentValue: currentValue,
-      rangeStrategy: 'replace',
-      currentVersion,
-      newVersion,
-    });
-    newValue = currentValue + ' || ' + replacementValue;
+    if (matches(newVersion, currentValue)) {
+      newValue = currentValue;
+    } else {
+      const replacementValue = getNewValue({
+        currentValue: currentValue,
+        rangeStrategy: 'replace',
+        currentVersion,
+        newVersion,
+      });
+      newValue = currentValue + ' || ' + replacementValue;
+    }
   }
   if (!newValue) {
     logger.warn(

--- a/lib/versioning/composer/index.ts
+++ b/lib/versioning/composer/index.ts
@@ -2,7 +2,6 @@ import { coerce } from 'semver';
 import { logger } from '../../logger';
 import { api as npm } from '../npm';
 import type { NewValueConfig, VersioningApi } from '../types';
-import { satisfies } from 'semver';
 
 export const id = 'composer';
 export const displayName = 'Composer';

--- a/lib/versioning/composer/index.ts
+++ b/lib/versioning/composer/index.ts
@@ -172,36 +172,29 @@ function getNewValue({
       newVersion: padZeroes(normalizeVersion(newVersion)),
     });
   }
-  if (currentValue.includes(' || ')) {
-    const lastValue = currentValue.split('||').pop().trim();
-    const replacementValue = getNewValue({
-      currentValue: lastValue,
-      rangeStrategy: 'replace',
-      currentVersion,
-      newVersion,
-    });
-    if (rangeStrategy === 'replace') {
-      newValue = replacementValue;
-    } else if (rangeStrategy === 'widen') {
-      if (matches(newVersion, currentValue)) {
-        newValue = currentValue;
-      } else {
-        newValue = currentValue + ' || ' + replacementValue;
-      }
-    }
-  } else if (rangeStrategy === 'widen') {
-    if (matches(newVersion, currentValue)) {
-      newValue = currentValue;
-    } else {
+
+  if (rangeStrategy === 'widen' && matches(newVersion, currentValue)) {
+    newValue = currentValue;
+  } else {
+    const hasOr = currentValue.includes(' || ');
+    if (hasOr || rangeStrategy === 'widen') {
+      const lastValue = hasOr
+        ? currentValue.split('||').pop().trim()
+        : currentValue;
       const replacementValue = getNewValue({
-        currentValue: currentValue,
+        currentValue: lastValue,
         rangeStrategy: 'replace',
         currentVersion,
         newVersion,
       });
-      newValue = currentValue + ' || ' + replacementValue;
+      if (rangeStrategy === 'replace') {
+        newValue = replacementValue;
+      } else {
+        newValue = currentValue + ' || ' + replacementValue;
+      }
     }
   }
+
   if (!newValue) {
     logger.warn(
       { currentValue, rangeStrategy, currentVersion, newVersion },

--- a/lib/versioning/composer/index.ts
+++ b/lib/versioning/composer/index.ts
@@ -2,6 +2,7 @@ import { coerce } from 'semver';
 import { logger } from '../../logger';
 import { api as npm } from '../npm';
 import type { NewValueConfig, VersioningApi } from '../types';
+import { satisfies } from 'semver';
 
 export const id = 'composer';
 export const displayName = 'Composer';
@@ -176,7 +177,7 @@ function getNewValue({
     const lastValue = currentValue.split('||').pop().trim();
     const replacementValue = getNewValue({
       currentValue: lastValue,
-      rangeStrategy,
+      rangeStrategy: 'replace',
       currentVersion,
       newVersion,
     });
@@ -185,6 +186,14 @@ function getNewValue({
     } else if (rangeStrategy === 'widen') {
       newValue = currentValue + ' || ' + replacementValue;
     }
+  } else if (rangeStrategy === 'widen') {
+    const replacementValue = getNewValue({
+      currentValue: currentValue,
+      rangeStrategy: 'replace',
+      currentVersion,
+      newVersion,
+    });
+    newValue = currentValue + ' || ' + replacementValue;
   }
   if (!newValue) {
     logger.warn(


### PR DESCRIPTION
## Changes:

Updates composer to support widening when there isn't already a ` || `

## Context:

See https://github.com/renovatebot/renovate/discussions/10747

Currently the composer behaviour does not widen, but instead replaces, with `rangeStrategy: widen`, unless the existing value already has a ` || `.

This updates it to widen when there is no existing ` || `.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository