### PR TITLE
fix: rethrow ExternalHostError error

### DIFF
--- a/lib/datasource/datasource.ts
+++ b/lib/datasource/datasource.ts
@@ -37,6 +37,10 @@ export abstract class Datasource implements DatasourceApi {
   handleSpecificErrors(err: HttpError): void {}
 
   protected handleGenericErrors(err: HttpError): never {
+    // istanbul ignore if: not easy testable with nock
+    if (err instanceof ExternalHostError) {
+      throw err;
+    }
     this.handleSpecificErrors(err);
     if (err.response?.statusCode !== undefined) {
       if (


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Force `Datasource` class error handling to always rethrow `ExternalHostError`.

<!-- Describe what behavior is changed by this PR. -->

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
