### PR TITLE
docs: update reference to react version

### DIFF
--- a/docs/usage/configuration-templates.md
+++ b/docs/usage/configuration-templates.md
@@ -14,8 +14,8 @@ If you change the `branchPrefix` while you have ignored some upgrades (closed PR
 
 `branchName` default value is `{{{branchPrefix}}}{{{additionalBranchPrefix}}}{{{branchTopic}}}`.
 
-The most common branch name you will see looks like this: `renovate/react-16.x`.
-In this example, the `branchPrefix` is the default `renovate/`, `additionalBranchPrefix` is empty, and `branchTopic` is `react-16.x`.
+The most common branch name you will see looks like this: `renovate/react-17.x`.
+In this example, the `branchPrefix` is the default `renovate/`, `additionalBranchPrefix` is empty, and `branchTopic` is `react-17.x`.
 
 Most users will be happy with the default `branchPrefix` of `renovate/`, but you can change this if you don't like the default.
 Say you don't want the forward slashes, in that case you would use `renovate-` as your `branchPrefix`.
@@ -47,7 +47,7 @@ You may want to edit this.
 If you think your new `commitMessageTopic` is helpful for others, please [open a PR](https://github.com/renovatebot/renovate/pulls).
 
 `commitMessageExtra` refers to the version being updated to.
-e.g. `to v16` for a major upgrade, or `to v16.0.3` for a patch update.
+e.g. `to v17` for a major upgrade, or `to v17.0.2` for a patch update.
 It can be empty in some cases, like if the action/topic doesn't change a package version, e.g. `Pin Docker digests`.
 
 `commitMessageSuffix` defaults to empty but is currently used in two cases:


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

- Use latest version of React in examples

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

It seems the idea behind this document is that it uses the latest React version as the version number in the examples.
The latest version of React is `17.0.2`, so its time to update the references. 😉 

I'm not fixing any existing issue with this PR.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
