### PR TITLE
fix: do not override labels when not configured

### DIFF
--- a/lib/platform/gitea/index.ts
+++ b/lib/platform/gitea/index.ts
@@ -696,8 +696,7 @@ const platform: Platform = {
           (label) => label.id
         );
         if (
-          labels !== undefined &&
-          labels.length !== 0 &&
+          labels &&
           (labels.length !== existingLabelIds.length ||
             labels.filter((labelId) => !existingLabelIds.includes(labelId))
               .length !== 0)

--- a/lib/platform/github/index.ts
+++ b/lib/platform/github/index.ts
@@ -1202,12 +1202,16 @@ export async function ensureIssue({
       }
       if (shouldReOpen) {
         logger.debug('Patching issue');
+        const data: Record<string, unknown> = { body, state: 'open', title };
+        if (labels) {
+          data.labels = labels;
+        }
         await githubApi.patchJson(
           `repos/${config.parentRepo || config.repository}/issues/${
             issue.number
           }`,
           {
-            body: { body, state: 'open', title, labels },
+            body: data,
           }
         );
         logger.debug('Issue updated');

--- a/lib/platform/gitlab/types.ts
+++ b/lib/platform/gitlab/types.ts
@@ -1,5 +1,8 @@
 export interface GitlabIssue {
   iid: number;
+
+  labels?: string[];
+
   title: string;
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Do not override issue labels if labels are not configured (`undefined` or `null`). To force empty labels use an empty array.

Regression of #10601
<!-- Describe what behavior is changed by this PR. -->

## Context:

see #10798

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
