### PR TITLE
feat: Allow gomod manager to set git ssh config for projects that use it.

### DIFF
--- a/lib/manager/gomod/artifacts.spec.ts
+++ b/lib/manager/gomod/artifacts.spec.ts
@@ -1,6 +1,5 @@
 import { exec as _exec } from 'child_process';
 import _fs from 'fs-extra';
-import { JsxEmit } from 'typescript';
 import { join } from 'upath';
 import { envMock, mockExecAll } from '../../../test/exec-util';
 import { git, mocked } from '../../../test/util';

--- a/lib/manager/gomod/artifacts.ts
+++ b/lib/manager/gomod/artifacts.ts
@@ -28,7 +28,7 @@ function getPreCommands(): string[] | null {
     },
   ];
 
-  let preCommands: string[] | null = null;
+  let preCommands: string[] = [];
 
   for (let r of rules){
     let credentials = find(r);
@@ -57,7 +57,7 @@ function getPreCommands(): string[] | null {
     }
   }
 
-  return preCommands;
+  return preCommands?.length === 0? null: preCommands;
 }
 
 function getUpdateImportPathCmds(

--- a/lib/manager/gomod/artifacts.ts
+++ b/lib/manager/gomod/artifacts.ts
@@ -3,12 +3,15 @@ import { quote } from 'shlex';
 import { dirname, join } from 'upath';
 import { getAdminConfig } from '../../config/admin';
 import { TEMPORARY_ERROR } from '../../constants/error-messages';
-import { PLATFORM_TYPE_BITBUCKET, PLATFORM_TYPE_GITHUB } from '../../constants/platforms';
+import {
+  PLATFORM_TYPE_BITBUCKET,
+  PLATFORM_TYPE_GITHUB,
+} from '../../constants/platforms';
 import { logger } from '../../logger';
 import { ExecOptions, exec } from '../../util/exec';
 import { ensureCacheDir, readLocalFile, writeLocalFile } from '../../util/fs';
 import { getRepoStatus } from '../../util/git';
-import { find, HostRuleSearch } from '../../util/host-rules';
+import { HostRuleSearch, find } from '../../util/host-rules';
 import { isValid } from '../../versioning/semver';
 import type {
   PackageDependency,
@@ -28,36 +31,39 @@ function getPreCommands(): string[] | null {
     },
   ];
 
-  let preCommands: string[] = [];
+  const preCommands: string[] = [];
 
-  for (let r of rules){
-    let credentials = find(r);
+  for (const r of rules) {
+    const credentials = find(r);
     switch (credentials?.hostType) {
       case PLATFORM_TYPE_BITBUCKET: {
         if (credentials?.authType === 'ssh') {
           preCommands.push(
-            `git config --global url.\"git@bitbucket.org:\".insteadOf \"https://bitbucket.org/\"`, // eslint-disable-line no-useless-escape
+            `git config --global url.\"git@bitbucket.org:\".insteadOf \"https://bitbucket.org/\"` // eslint-disable-line no-useless-escape
           );
         }
         break;
       }
       case PLATFORM_TYPE_GITHUB: {
         if (credentials?.token) {
+          const token = quote(credentials.token);
           preCommands.push(
-            `git config --global url.\"https://${token}@github.com/\".insteadOf \"https://github.com/\"`, // eslint-disable-line no-useless-escape
+            `git config --global url.\"https://${token}@github.com/\".insteadOf \"https://github.com/\"` // eslint-disable-line no-useless-escape
           );
         }
         if (credentials?.authType === 'ssh') {
           preCommands.push(
-            `git config --global url.\"git@github.com:\".insteadOf \"https://github.com/\"`, // eslint-disable-line no-useless-escape
+            `git config --global url.\"git@github.com:\".insteadOf \"https://github.com/\"` // eslint-disable-line no-useless-escape
           );
         }
         break;
       }
+      default:
+        break;
     }
   }
 
-  return preCommands?.length === 0? null: preCommands;
+  return preCommands?.length === 0 ? null : preCommands;
 }
 
 function getUpdateImportPathCmds(

--- a/lib/manager/gomod/artifacts.ts
+++ b/lib/manager/gomod/artifacts.ts
@@ -20,8 +20,8 @@ import type {
   UpdateArtifactsResult,
 } from '../types';
 
-function getPreCommands(): string[] | null {
-  const rules: Readonly<HostRuleSearch[]> = [
+export function getPreCommands(): string[] | null {
+  const rules: HostRuleSearch[] = [
     {
       hostType: PLATFORM_TYPE_GITHUB,
       url: 'https://api.github.com/',
@@ -35,7 +35,7 @@ function getPreCommands(): string[] | null {
 
   for (const r of rules) {
     const credentials = find(r);
-    switch (credentials?.hostType) {
+    switch (r.hostType) {
       case PLATFORM_TYPE_BITBUCKET: {
         if (credentials?.authType === 'ssh') {
           preCommands.push(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

This PR allows for the gomod manager to set git config to connect via ssh if that authType is set.
This means that private repo access doesn't require tokens to be stored within config.

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->
A lot of the repos I work on are private and hosted on bitbucket cloud which gomod has not current support for providing access to those private repos beyond the aspect of mutating the environment that renovate runs in.

This change allows for renovate to make those changes to git config to allow for access to be made via config instead of pre script hack.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
