### PR TITLE
feat: add types and ts-jest to jsUnitTest preset

### DIFF
--- a/lib/config/presets/internal/packages.ts
+++ b/lib/config/presets/internal/packages.ts
@@ -54,6 +54,17 @@ export const presets: Record<string, Preset> = {
   jsUnitTest: {
     description: 'Unit test packages for javascript',
     matchPackageNames: [
+      '@types/chai',
+      '@types/ember-mocha',
+      '@types/ember-qunit',
+      '@types/enzyme',
+      '@types/istanbul',
+      '@types/jest',
+      '@types/mocha',
+      '@types/mock-fs',
+      '@types/proxyquire',
+      '@types/sinon',
+      '@types/supertest',
       'coveralls',
       'ember-exam',
       'ember-mocha',

--- a/lib/config/presets/internal/packages.ts
+++ b/lib/config/presets/internal/packages.ts
@@ -76,6 +76,7 @@ export const presets: Record<string, Preset> = {
       'nyc',
       'proxyquire',
       'supertest',
+      'ts-jest',
     ],
     matchPackagePrefixes: [
       '@testing-library',


### PR DESCRIPTION
## Changes:

Add DefinitelyTyped packages to `jsUnitTest` preset. I also added `ts-jest` to the package names.

## Context:

`eslint` has DefinitelyTyped packages. I thought it'd be useful to include the types on other presets, starting with the `jsUnitTest` preset.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
