### PR TITLE
feat: add react package preset

### DIFF
--- a/lib/config/presets/internal/packages.ts
+++ b/lib/config/presets/internal/packages.ts
@@ -10,6 +10,11 @@ export const presets: Record<string, Preset> = {
       'angular-sanitize',
     ],
   },
+  react: {
+    description: 'All react packages',
+    matchPackageNames: ['@types/react'],
+    matchPackagePrefixes: ['react'],
+  },
   apollographql: {
     description: 'All packages published by Apollo GraphQL',
     matchSourceUrlPrefixes: ['https://github.com/apollographql/'],


### PR DESCRIPTION
## Changes:

Adds a new package preset for Reach packages.

## Context:

I found it useful to group React related packages into a single PR and thought others might find it useful as well.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
