### PR TITLE
feat: github-releases fill newDigest

### DIFF
--- a/lib/datasource/github-releases/index.ts
+++ b/lib/datasource/github-releases/index.ts
@@ -1,8 +1,13 @@
 import * as packageCache from '../../util/cache/package';
 import { GithubHttp } from '../../util/http/github';
 import { ensureTrailingSlash } from '../../util/url';
-import type { GetReleasesConfig, ReleaseResult } from '../types';
+import type {
+  GetReleasesConfig,
+  GetPkgReleasesConfig,
+  ReleaseResult,
+} from '../types';
 import type { GithubRelease } from './types';
+import { logger } from '../../logger';
 
 export const id = 'github-releases';
 export const customRegistrySupport = true;
@@ -31,7 +36,12 @@ function getCacheKey(depHost: string, repo: string): string {
 export async function getReleases({
   lookupName: repo,
   registryUrl,
-}: GetReleasesConfig): Promise<ReleaseResult | null> {
+  currentValue,
+  currentDigest,
+}: GetReleasesConfig & GetPkgReleasesConfig): Promise<ReleaseResult | null> {
+  logger.debug(
+    `getReleases(${repo}, ${registryUrl}, ${currentValue}, ${currentDigest})`
+  );
   const cachedResult = await packageCache.get<ReleaseResult>(
     cacheNamespace,
     getCacheKey(registryUrl, repo)

--- a/lib/datasource/github-releases/types.ts
+++ b/lib/datasource/github-releases/types.ts
@@ -2,4 +2,11 @@ export type GithubRelease = {
   tag_name: string;
   published_at: string;
   prerelease: boolean;
+  assets: GithubReleaseAsset[];
+};
+
+export type GithubReleaseAsset = {
+  name: string;
+  browser_download_url: string;
+  size: number;
 };

--- a/lib/datasource/types.ts
+++ b/lib/datasource/types.ts
@@ -26,6 +26,8 @@ export interface GetPkgReleasesConfig extends ReleasesConfigBase {
   versioning?: string;
   extractVersion?: string;
   constraints?: Record<string, string>;
+  currentValue?: string;
+  currentDigest?: string;
 }
 
 export interface Release {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

This modifies the `github-releases` datasource to fill the `newDigest` field according to checksum files as release assets.

To accomplish this, the current release and digest are passed as parameters to `getReleases()`:
1. All `<5KB` assets are downloaded from the current release in an attempt to find the relevant checksum asset for the project (e.g. `SHASUMS`, `SHASUMS.txt`, `${artifact}.sha256`).
2. The corresponding checksum file is fetched from each release, and the appropriate updated checksum is returned.

## Context:

I built the version of this functionality that I care about in https://github.com/thepwagner/action-update-dockerurl ; but the Renovate's `regexManager` handles 90% of the functionality I'm interested in! This algorithm is based on [updatedHash](https://github.com/thepwagner/action-update-dockerurl/blob/305f0418457a3b1559894debad88b10748bdcbfe/dockerurl/applyupdate.go#L97) from that project. I skipped the bit that fetches full asset files as that would be very expensive in the `getReleases()` context.

I'm using test cases from https://github.com/thepwagner/renovate-github-releases-digests .

Closes https://github.com/renovatebot/renovate/issues/7928

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
