### PR TITLE
fix(config): Replace '__' to '_' globally when decoding hostRules

### DIFF
--- a/lib/workers/global/config/parse/env.spec.ts
+++ b/lib/workers/global/config/parse/env.spec.ts
@@ -114,6 +114,21 @@ describe(getName(), () => {
       expect(res).toMatchSnapshot();
       expect(res.hostRules).toHaveLength(2);
     });
+    it('regression test for #10937', () => {
+      const envParam: NodeJS.ProcessEnv = {
+        GIT__TAGS_GITLAB_EXAMPLE__DOMAIN_NET_USERNAME: 'some-user',
+        GIT__TAGS_GITLAB_EXAMPLE__DOMAIN_NET_PASSWORD: 'some-password',
+      };
+      const res = env.getConfig(envParam);
+      expect(res.hostRules).toMatchObject([
+        {
+          hostType: 'git-tags',
+          matchHost: 'gitlab.example-domain.net',
+          password: 'some-password',
+          username: 'some-user',
+        },
+      ]);
+    });
     it('supports datasource env token', () => {
       const envParam: NodeJS.ProcessEnv = {
         PYPI_TOKEN: 'some-token',

--- a/lib/workers/global/config/parse/env.ts
+++ b/lib/workers/global/config/parse/env.ts
@@ -100,7 +100,7 @@ export function getConfig(env: NodeJS.ProcessEnv): AllConfig {
       continue; // eslint-disable-line no-continue
     }
     // Double underscore __ is used in place of hyphen -
-    const splitEnv = envName.toLowerCase().replace('__', '-').split('_');
+    const splitEnv = envName.toLowerCase().replace(/__/g, '-').split('_');
     const hostType = splitEnv.shift();
     if (datasources.has(hostType)) {
       const suffix = splitEnv.pop();


### PR DESCRIPTION
## Changes:

Replace '__' to '_' globally when decoding hostRules from env.

## Context:

Fixes #10937

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
