### PR TITLE
docs: improve Go binary version docs

### DIFF
--- a/docs/usage/golang.md
+++ b/docs/usage/golang.md
@@ -42,11 +42,17 @@ Renovate will commit all files changed within the `vendor/` folder.
 
 By default, Renovate will keep up with the latest version of the `go` binary.
 
-You can set a contraint in your `go.mod` file to force Renovate to use a specific version.
-As an example, say you want Renovate to use the latest patch version of the `1.16` Go binary, then you would put `contstraints.go=1.16` in your `go.mod` file.
+You can force Renovate to use a specific version of Go by setting a constraint.
+As an example, say you want Renovate to use the latest patch version of the `1.16` Go binary, you'd put this in your Renovate config:
+
+```json
+  "constraints": {
+    "go": "1.16"
+  }
+```
 
 We do not support patch level versions for the minimum `go` version.
-This means you cannot use `go 1.16.6`, but you can use `go 1.16` in your `go.mod` file.
+This means you cannot use `go 1.16.6`, but you can use `go 1.16` as a contraint.
 
 ### Custom registry support, and authentication
 

--- a/docs/usage/golang.md
+++ b/docs/usage/golang.md
@@ -40,11 +40,13 @@ Renovate will commit all files changed within the `vendor/` folder.
 
 ### Go binary version
 
-By default, Renovate will keep up with the very latest version of `go`.
+By default, Renovate will keep up with the latest version of the `go` binary.
 
-You can "pin" the `go` version that Renovate uses.
-Say you want Renovate to use Go version 1.14, you can do this by adding `go 1.14` to your `go.mod` file.
-We do not support pinning Go versions to a specific patch level, so you cannot use `go 1.14.12`, but you can use `go 1.14` in your `go.mod` file.
+You can set the minimum version of `go` that Renovate uses.
+Say you want Renovate to use at least Go version 1.14, you would add `go 1.14` to your `go.mod` file.
+
+We do not support patch level versions for the minimum `go` version.
+This means you cannot use `go 1.14.12`, but you can use `go 1.14` in your `go.mod` file.
 
 ### Custom registry support, and authentication
 

--- a/docs/usage/golang.md
+++ b/docs/usage/golang.md
@@ -42,11 +42,11 @@ Renovate will commit all files changed within the `vendor/` folder.
 
 By default, Renovate will keep up with the latest version of the `go` binary.
 
-You can set the minimum version of `go` that Renovate uses.
-Say you want Renovate to use at least Go version 1.14, you would add `go 1.14` to your `go.mod` file.
+You can set a contraint in your `go.mod` file to force Renovate to use a specific version.
+As an example, say you want Renovate to use the latest patch version of the `1.16` Go binary, then you would put `contstraints.go=1.16` in your `go.mod` file.
 
 We do not support patch level versions for the minimum `go` version.
-This means you cannot use `go 1.14.12`, but you can use `go 1.14` in your `go.mod` file.
+This means you cannot use `go 1.16.6`, but you can use `go 1.16` in your `go.mod` file.
 
 ### Custom registry support, and authentication
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

- Improve Go binary version docs

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

In discussion #10941 @rarkins said:

> I think our documentation is outdated/wrong. The go authors recommended we treat the line in go.mod as a minimum version and not exact.
> 
> We do in general support override of auto detected versions using the `constraints` object and hopefully they works out of the box already. Eg configure constraints.go=1.15

I've rewritten the text so that we use "minimum version" instead of "pinned version" as the concept.
I don't know if we want to add text about the `constraints.go=1.15` thing?

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
