### PR TITLE
fix(dashboard): don't remove issue labels

### DIFF
--- a/lib/config/definitions.ts
+++ b/lib/config/definitions.ts
@@ -425,6 +425,7 @@ const options: RenovateOptions[] = [
       'These labels will always be applied on the Dependency Dashboard issue, even when they have been removed manually.',
     type: 'array',
     subType: 'string',
+    default: null,
   },
   {
     name: 'configWarningReuseIssue',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Sets default dependencyDashboardLabels to `null` so that Renovate stops stripping labels from the issue.

## Context:

Fixes #10798

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
