### PR TITLE
feat: add support for authenticated go get [WIP]

### DIFF
--- a/docs/usage/golang.md
+++ b/docs/usage/golang.md
@@ -53,3 +53,22 @@ As an example, say you want Renovate to use the latest patch version of the `1.1
 
 We do not support patch level versions for the minimum `go` version.
 This means you cannot use `go 1.16.6`, but you can use `go 1.16` as a contraint.
+
+### Custom registry support, and authentication
+
+This example shows how you can use a `config.js` file to configure Renovate for use with a custom private Go module source using Git to pull the modules.
+We're using environment variables to pass the Git token to Renovate bot.
+
+```js
+module.exports = {
+  hostRules: [
+    {
+      matchHost: 'github.enterprise.com',
+      token: process.env.GO_GIT_TOKEN,
+    },
+  ],
+  golang: {
+    registryUrls: ['github.enterprise.com'],
+  },
+};
+```

--- a/docs/usage/private-modules.md
+++ b/docs/usage/private-modules.md
@@ -128,8 +128,11 @@ Any `hostRules` with `hostType=packagist` are also included.
 
 ### gomod
 
-If a `github.com` token is found in `hostRules`, then it is written out to local git config prior to running `go` commands.
-The command run is `git config --global url."https://${token}@github.com/".insteadOf "https://github.com/"`.
+The `GOPRIVATE` environment variable is used to decide if a package should be fetched from the `GOPROXY` or directly from the source.
+Most private modules will need to be fetched from the source directly, Renovate currently supports only Git for this.
+For each comma-separated module path in `GOPRIVATE` or `golang.registryUrls` Renovate will look for credentials in `hostRules`.
+Credentials are passed to Git via `GIT_CONFIG_KEY_x=url."https://${token}@${GOPRIVATE}/".insteadOf` and `GIT_CONFIG_VALUE_x=https://${GOPRIVATE}/` when running `go` commands.
+Glob syntax for `GOPRIVATE` is not supported.
 
 ### npm
 

--- a/lib/manager/gomod/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/manager/gomod/__snapshots__/artifacts.spec.ts.snap
@@ -13,6 +13,48 @@ Array [
 
 exports[`.updateArtifacts() catches errors 2`] = `Array []`;
 
+exports[`.updateArtifacts() ignore docker mode passthrough of invalid GIT_CONFIG_COUNT 1`] = `
+Array [
+  Object {
+    "cmd": "docker pull renovate/go:latest",
+    "options": Object {
+      "encoding": "utf-8",
+    },
+  },
+  Object {
+    "cmd": "docker ps --filter name=renovate_go -aq",
+    "options": Object {
+      "encoding": "utf-8",
+    },
+  },
+  Object {
+    "cmd": "docker run --rm --name=renovate_go --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -v \\"/tmp/renovate/cache/others/go\\":\\"/tmp/renovate/cache/others/go\\" -e GOPATH -e GOPROXY -e GOPRIVATE -e GONOPROXY -e GONOSUMDB -e GOFLAGS -e CGO_ENABLED -w \\"/tmp/github/some/repo\\" renovate/go:latest bash -l -c \\"go get -d ./...\\"",
+    "options": Object {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": Object {
+        "CGO_ENABLED": "1",
+        "GOFLAGS": "-modcacherw",
+        "GONOPROXY": "noproxy.example.com/*",
+        "GONOSUMDB": "1",
+        "GOPATH": "/tmp/renovate/cache/others/go",
+        "GOPRIVATE": "private.example.com/*",
+        "GOPROXY": "proxy.example.com",
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+]
+`;
+
 exports[`.updateArtifacts() returns if no go.sum found 1`] = `Array []`;
 
 exports[`.updateArtifacts() returns null if unchanged 1`] = `
@@ -269,6 +311,49 @@ Array [
 ]
 `;
 
+exports[`.updateArtifacts() supports docker mode passthrough of GIT_CONFIG_COUNT 1`] = `
+Array [
+  Object {
+    "cmd": "docker pull renovate/go:latest",
+    "options": Object {
+      "encoding": "utf-8",
+    },
+  },
+  Object {
+    "cmd": "docker ps --filter name=renovate_go -aq",
+    "options": Object {
+      "encoding": "utf-8",
+    },
+  },
+  Object {
+    "cmd": "docker run --rm --name=renovate_go --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -v \\"/tmp/renovate/cache/others/go\\":\\"/tmp/renovate/cache/others/go\\" -e GOPATH -e GOPROXY -e GOPRIVATE -e GONOPROXY -e GONOSUMDB -e GOFLAGS -e CGO_ENABLED -e GIT_CONFIG_COUNT -w \\"/tmp/github/some/repo\\" renovate/go:latest bash -l -c \\"go get -d ./...\\"",
+    "options": Object {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": Object {
+        "CGO_ENABLED": "1",
+        "GIT_CONFIG_COUNT": "2",
+        "GOFLAGS": "-modcacherw",
+        "GONOPROXY": "noproxy.example.com/*",
+        "GONOSUMDB": "1",
+        "GOPATH": "/tmp/renovate/cache/others/go",
+        "GOPRIVATE": "private.example.com/*",
+        "GOPROXY": "proxy.example.com",
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+]
+`;
+
 exports[`.updateArtifacts() supports docker mode with credentials 1`] = `
 Array [
   Object {
@@ -284,17 +369,118 @@ Array [
     },
   },
   Object {
-    "cmd": "docker run --rm --name=renovate_go --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -v \\"/tmp/renovate/cache/others/go\\":\\"/tmp/renovate/cache/others/go\\" -e GOPATH -e GOPROXY -e GOPRIVATE -e GONOPROXY -e GONOSUMDB -e GOFLAGS -e CGO_ENABLED -w \\"/tmp/github/some/repo\\" renovate/go:latest bash -l -c \\"git config --global url.\\\\\\"https://some-token@github.com/\\\\\\".insteadOf \\\\\\"https://github.com/\\\\\\" && go get -d ./...\\"",
+    "cmd": "docker run --rm --name=renovate_go --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -v \\"/tmp/renovate/cache/others/go\\":\\"/tmp/renovate/cache/others/go\\" -e GOPATH -e GOPROXY -e GOPRIVATE -e GONOPROXY -e GONOSUMDB -e GOFLAGS -e CGO_ENABLED -e GIT_CONFIG_KEY_0 -e GIT_CONFIG_VALUE_0 -e GIT_CONFIG_COUNT -w \\"/tmp/github/some/repo\\" renovate/go:latest bash -l -c \\"go get -d ./...\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
       "env": Object {
         "CGO_ENABLED": "1",
+        "GIT_CONFIG_COUNT": "1",
+        "GIT_CONFIG_KEY_0": "url.https://some-token@github.com/.insteadOf",
+        "GIT_CONFIG_VALUE_0": "https://github.com/",
         "GOFLAGS": "-modcacherw",
         "GONOPROXY": "noproxy.example.com/*",
         "GONOSUMDB": "1",
         "GOPATH": "/tmp/renovate/cache/others/go",
-        "GOPRIVATE": "private.example.com/*",
+        "GOPRIVATE": "github.com",
+        "GOPROXY": "proxy.example.com",
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+]
+`;
+
+exports[`.updateArtifacts() supports docker mode with credentials with golang.registryUrls 1`] = `
+Array [
+  Object {
+    "cmd": "docker pull renovate/go:latest",
+    "options": Object {
+      "encoding": "utf-8",
+    },
+  },
+  Object {
+    "cmd": "docker ps --filter name=renovate_go -aq",
+    "options": Object {
+      "encoding": "utf-8",
+    },
+  },
+  Object {
+    "cmd": "docker run --rm --name=renovate_go --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -v \\"/tmp/renovate/cache/others/go\\":\\"/tmp/renovate/cache/others/go\\" -e GOPATH -e GOPROXY -e GOPRIVATE -e GONOPROXY -e GONOSUMDB -e GOFLAGS -e CGO_ENABLED -e GIT_CONFIG_KEY_0 -e GIT_CONFIG_VALUE_0 -e GIT_CONFIG_COUNT -w \\"/tmp/github/some/repo\\" renovate/go:latest bash -l -c \\"go get -d ./...\\"",
+    "options": Object {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": Object {
+        "CGO_ENABLED": "1",
+        "GIT_CONFIG_COUNT": "1",
+        "GIT_CONFIG_KEY_0": "url.https://some-token@github.com/.insteadOf",
+        "GIT_CONFIG_VALUE_0": "https://github.com/",
+        "GOFLAGS": "-modcacherw",
+        "GONOPROXY": "noproxy.example.com/*",
+        "GONOSUMDB": "1",
+        "GOPATH": "/tmp/renovate/cache/others/go",
+        "GOPRIVATE": "github.com,github.enterprise.com/test,github2.enterprise.com",
+        "GOPROXY": "proxy.example.com",
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+]
+`;
+
+exports[`.updateArtifacts() supports docker mode with custom credentials 1`] = `
+Array [
+  Object {
+    "cmd": "docker pull renovate/go:latest",
+    "options": Object {
+      "encoding": "utf-8",
+    },
+  },
+  Object {
+    "cmd": "docker ps --filter name=renovate_go -aq",
+    "options": Object {
+      "encoding": "utf-8",
+    },
+  },
+  Object {
+    "cmd": "docker run --rm --name=renovate_go --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -v \\"/tmp/renovate/cache/others/go\\":\\"/tmp/renovate/cache/others/go\\" -e GOPATH -e GOPROXY -e GOPRIVATE -e GONOPROXY -e GONOSUMDB -e GOFLAGS -e CGO_ENABLED -e GIT_CONFIG_KEY_0 -e GIT_CONFIG_VALUE_0 -e GIT_CONFIG_COUNT -e GIT_CONFIG_KEY_1 -e GIT_CONFIG_VALUE_1 -e GIT_CONFIG_KEY_2 -e GIT_CONFIG_VALUE_2 -e GIT_CONFIG_KEY_3 -e GIT_CONFIG_VALUE_3 -e GIT_CONFIG_KEY_4 -e GIT_CONFIG_VALUE_4 -w \\"/tmp/github/some/repo\\" renovate/go:latest bash -l -c \\"go get -d ./...\\"",
+    "options": Object {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": Object {
+        "CGO_ENABLED": "1",
+        "GIT_CONFIG_COUNT": "5",
+        "GIT_CONFIG_KEY_0": "url.https://some-github-enterprise-token@github.enterprise.com/.insteadOf",
+        "GIT_CONFIG_KEY_1": "url.https://some-git-private-token@git.private.com/.insteadOf",
+        "GIT_CONFIG_KEY_2": "url.https://some-git2-private-token@git2.private.com/.insteadOf",
+        "GIT_CONFIG_KEY_3": "url.https://some-git3-private-token@git3.private.com/test-org.insteadOf",
+        "GIT_CONFIG_KEY_4": "url.https://username:password@git4.private.com/.insteadOf",
+        "GIT_CONFIG_VALUE_0": "https://github.enterprise.com/",
+        "GIT_CONFIG_VALUE_1": "https://git.private.com/",
+        "GIT_CONFIG_VALUE_2": "https://git2.private.com/",
+        "GIT_CONFIG_VALUE_3": "https://git3.private.com/test-org",
+        "GIT_CONFIG_VALUE_4": "https://git4.private.com/",
+        "GOFLAGS": "-modcacherw",
+        "GONOPROXY": "noproxy.example.com/*",
+        "GONOSUMDB": "1",
+        "GOPATH": "/tmp/renovate/cache/others/go",
+        "GOPRIVATE": "github.enterprise.com,git.private.com,git2.private.com,git3.private.com/test-org,git4.private.com,git5.private.com",
         "GOPROXY": "proxy.example.com",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
@@ -337,6 +523,47 @@ Array [
         "GONOSUMDB": "1",
         "GOPATH": "/tmp/renovate/cache/others/go",
         "GOPRIVATE": "private.example.com/*",
+        "GOPROXY": "proxy.example.com",
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+]
+`;
+
+exports[`.updateArtifacts() supports docker mode without GORPIVATE 1`] = `
+Array [
+  Object {
+    "cmd": "docker pull renovate/go:latest",
+    "options": Object {
+      "encoding": "utf-8",
+    },
+  },
+  Object {
+    "cmd": "docker ps --filter name=renovate_go -aq",
+    "options": Object {
+      "encoding": "utf-8",
+    },
+  },
+  Object {
+    "cmd": "docker run --rm --name=renovate_go --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -v \\"/tmp/renovate/cache/others/go\\":\\"/tmp/renovate/cache/others/go\\" -e GOPATH -e GOPROXY -e GONOPROXY -e GONOSUMDB -e GOFLAGS -e CGO_ENABLED -w \\"/tmp/github/some/repo\\" renovate/go:latest bash -l -c \\"go get -d ./...\\"",
+    "options": Object {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": Object {
+        "CGO_ENABLED": "1",
+        "GOFLAGS": "-modcacherw",
+        "GONOPROXY": "noproxy.example.com/*",
+        "GONOSUMDB": "1",
+        "GOPATH": "/tmp/renovate/cache/others/go",
         "GOPROXY": "proxy.example.com",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",

--- a/lib/manager/gomod/artifacts.ts
+++ b/lib/manager/gomod/artifacts.ts
@@ -1,14 +1,14 @@
 import is from '@sindresorhus/is';
-import { quote } from 'shlex';
 import { dirname, join } from 'upath';
 import { getAdminConfig } from '../../config/admin';
 import { TEMPORARY_ERROR } from '../../constants/error-messages';
-import { PLATFORM_TYPE_GITHUB } from '../../constants/platforms';
 import { logger } from '../../logger';
 import { ExecOptions, exec } from '../../util/exec';
 import { ensureCacheDir, readLocalFile, writeLocalFile } from '../../util/fs';
 import { getRepoStatus } from '../../util/git';
-import { find } from '../../util/host-rules';
+import { getGitAuthenticatedEnvironmentVariables } from '../../util/git/auth';
+import { getHttpUrl } from '../../util/git/url';
+import { parseUrl } from '../../util/url';
 import { isValid } from '../../versioning/semver';
 import type {
   PackageDependency,
@@ -17,19 +17,18 @@ import type {
   UpdateArtifactsResult,
 } from '../types';
 
-function getPreCommands(): string[] | null {
-  const credentials = find({
-    hostType: PLATFORM_TYPE_GITHUB,
-    url: 'https://api.github.com/',
-  });
-  let preCommands = null;
-  if (credentials?.token) {
-    const token = quote(credentials.token);
-    preCommands = [
-      `git config --global url.\"https://${token}@github.com/\".insteadOf \"https://github.com/\"`, // eslint-disable-line no-useless-escape
-    ];
+function getGoEnvironmentVariables(registryUrls: string[]): NodeJS.ProcessEnv {
+  let goEnvVariables: NodeJS.ProcessEnv = {};
+
+  for (const registryUrl of registryUrls) {
+    const goPrivateWithProtocol = getHttpUrl(registryUrl);
+    goEnvVariables = getGitAuthenticatedEnvironmentVariables(
+      goPrivateWithProtocol,
+      goEnvVariables
+    );
   }
-  return preCommands;
+
+  return goEnvVariables;
 }
 
 function getUpdateImportPathCmds(
@@ -116,6 +115,51 @@ export async function updateArtifacts({
       logger.debug('Removed some relative replace statements from go.mod');
     }
     await writeLocalFile(goModFileName, massagedGoMod);
+    // array of GOMODULE registries which should be fetched from
+    // passed to go as GOPRIVATE
+    let registryUrls: string[] = [];
+    let goPrivates: string[] = [];
+
+    // add GOPRIVATE environment variables
+    if (process.env.GOPRIVATE) {
+      goPrivates = process.env.GOPRIVATE.split(',');
+      // GOPRIVATE is without protocol so we add the https protocol before adding it to the registryUrls
+      const goPrivatesWithProtocol = goPrivates.map(
+        (goPrivate) => `https://${goPrivate}`
+      );
+      registryUrls = registryUrls.concat(goPrivatesWithProtocol);
+    }
+
+    // add explicit registryUrls
+    if (config.registryUrls) {
+      for (const registryUrl of config.registryUrls) {
+        // if the registryUrl could not be parsed, retry with a protocol
+        const parsedRegistryUrl =
+          parseUrl(registryUrl) || parseUrl(`https://${registryUrl}`);
+
+        // Only allow http(s)
+        if (parsedRegistryUrl?.protocol?.startsWith('http')) {
+          // Add the full URL to the registryUrls
+          registryUrls.push(parsedRegistryUrl.toString());
+
+          // Add only the domain + path to the goPrivates
+          let goPrivate = parsedRegistryUrl.host;
+          // only add the pathname if it is not just the base path
+          if (parsedRegistryUrl.pathname !== '/') {
+            goPrivate += parsedRegistryUrl.pathname;
+          }
+          goPrivates.push(goPrivate);
+        } else {
+          // ignore if registryUrl could not be parsed
+          logger.warn(
+            `Could not parse registryUrl ${registryUrl} or not using http(s). Ignoring`
+          );
+        }
+      }
+    }
+
+    // create comma-separated GOPRIVATE environment variable if any goPrivates exist
+    const goPrivate = goPrivates.length > 0 ? goPrivates.join(',') : undefined;
 
     const cmd = 'go';
     const execOptions: ExecOptions = {
@@ -123,18 +167,18 @@ export async function updateArtifacts({
       extraEnv: {
         GOPATH: goPath,
         GOPROXY: process.env.GOPROXY,
-        GOPRIVATE: process.env.GOPRIVATE,
+        GOPRIVATE: goPrivate,
         GONOPROXY: process.env.GONOPROXY,
         GONOSUMDB: process.env.GONOSUMDB,
         GOFLAGS: useModcacherw(config.constraints?.go) ? '-modcacherw' : null,
         CGO_ENABLED: getAdminConfig().binarySource === 'docker' ? '0' : null,
+        ...getGoEnvironmentVariables(registryUrls),
       },
       docker: {
         image: 'go',
         tagConstraint: config.constraints?.go,
         tagScheme: 'npm',
         volumes: [goPath],
-        preCommands: getPreCommands(),
       },
     };
 

--- a/lib/util/git/auth.ts
+++ b/lib/util/git/auth.ts
@@ -1,0 +1,43 @@
+import { logger } from '../../logger';
+import { getRemoteUrlWithToken } from './url';
+
+/*
+    Add authorization to a Git Url and returns the updated environment variables
+*/
+export function getGitAuthenticatedEnvironmentVariables(
+  gitUrl: string,
+  environmentVariables: NodeJS.ProcessEnv
+): NodeJS.ProcessEnv {
+  // check if the environmentVariables already contain a GIT_CONFIG_COUNT or if the process has one
+  const gitConfigCountEnvVariable =
+    environmentVariables.GIT_CONFIG_COUNT || process.env.GIT_CONFIG_COUNT;
+  let gitConfigCount = 0;
+  if (gitConfigCountEnvVariable) {
+    // passthrough the gitConfigCountEnvVariable environment variable as start value of the index count
+    gitConfigCount = parseInt(gitConfigCountEnvVariable, 10);
+    if (Number.isNaN(gitConfigCount)) {
+      logger.warn(
+        `Found GIT_CONFIG_COUNT env variable, but couldn't parse the value to an integer: ${process.env.GIT_CONFIG_COUNT}. Ignoring it.`
+      );
+      gitConfigCount = 0;
+    }
+  }
+
+  const gitUrlWithToken = getRemoteUrlWithToken(gitUrl);
+  const returnEnvironmentVariables = { ...environmentVariables };
+
+  // only if credentials got injected and thus the urls are no longer equal
+  if (gitUrlWithToken !== gitUrl) {
+    // prettier-ignore
+    returnEnvironmentVariables[`GIT_CONFIG_KEY_${gitConfigCount}`] = `url.${gitUrlWithToken}.insteadOf`;
+    // prettier-ignore
+    returnEnvironmentVariables[`GIT_CONFIG_VALUE_${gitConfigCount}`] = gitUrl;
+    gitConfigCount += 1;
+  }
+
+  if (gitConfigCount > 0) {
+    returnEnvironmentVariables.GIT_CONFIG_COUNT = gitConfigCount.toString();
+  }
+
+  return returnEnvironmentVariables;
+}


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

**DUE TO Problems, this is a reraise and requires some modifications before being reviewed**

> - Seems like a good idea to keep using env variables
> - The list of registries to provide authentation from should not be derived from registryUrls
> - Instead, the list should come from hostRules
> - Host rules could have hostType=go but we should probably also automatically do any with hostType=github too, maybe also hostType=gitlab?
> - Need to think about if we need to distinguish between api.github.com and github.com
> - Need to be clear that it relates to artifacts updating (go.sum, vendored modules, etc) and not to Renovate's own lookup phase

---

This PR adds support for authenticated go git requests from the source for e.g. updating of `go.sum` files via `go get`.
The credentials can be specified via `hostRules`.

Requires git cli [>=2.31](https://github.com/git/git/blob/master/Documentation/RelNotes/2.31.0.txt) to use [`GIT_CONFIG_` variables](https://git-scm.com/docs/git-config#Documentation/git-config.txt-GITCONFIGCOUNT) to provide the credentials as environment variables to the `go get` process, which then invokes `git` underneath.



## Context:

Fixes #7361 and build onto assumptions outlined in https://github.com/renovatebot/renovate/issues/7361#issuecomment-869926945.

Also offers a (manual) configuration solution for #3497, #4601, although not an out-of-the-box solution like for github.com.

This is my first actual code contribution to renovate, so not sure if I made all the right implementation decisions.

This is a reraise of #10750, which got rolled back due to problems (#10946) in #11021
TODO: 
- [x] Add unit tests
- [x] Add documentation

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
