### PR TITLE
docs: fix autoMerge typo in faq

### DIFF
--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -246,7 +246,7 @@ You can use the `branchName`, `commitMessage`, `prTitle` or `prBody` configurati
 
 ### Automatically merge passing Pull Requests
 
-Set the configuration option `autoMerge` to `true`.
+Set the configuration option `automerge` to `true`.
 Nest it inside config objects `patch` or `minor` if you want it to apply to certain types only.
 
 ### Separate patch releases from minor releases


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- rename *autoMerge* to the correct automerge

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository