### PR TITLE
fix(kustomize): reject invalid newTag

### DIFF
--- a/lib/manager/kustomize/__fixtures__/gitImages.yaml
+++ b/lib/manager/kustomize/__fixtures__/gitImages.yaml
@@ -18,3 +18,5 @@ images:
 - name: this-lives/on-docker-hub
   newName: but.this.lives.on.local/private-registry # and therefore we need to check the versions available here
   newTag: v0.0.4
+- name: nginx
+  newTag: 2.5

--- a/lib/manager/kustomize/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/kustomize/__snapshots__/extract.spec.ts.snap
@@ -124,5 +124,10 @@ Array [
     "replaceString": "v0.0.4",
     "versioning": "docker",
   },
+  Object {
+    "currentValue": 2.5,
+    "depName": "nginx",
+    "skipReason": "invalid-value",
+  },
 ]
 `;

--- a/lib/manager/kustomize/extract.spec.ts
+++ b/lib/manager/kustomize/extract.spec.ts
@@ -2,6 +2,7 @@ import { getName, loadFixture } from '../../../test/util';
 import * as datasourceDocker from '../../datasource/docker';
 import * as datasourceGitTags from '../../datasource/git-tags';
 import * as datasourceGitHubTags from '../../datasource/github-tags';
+import { SkipReason } from '../../types';
 import * as dockerVersioning from '../../versioning/docker';
 import {
   extractBase,
@@ -230,9 +231,10 @@ describe(getName(), () => {
     it('should extract out image versions', () => {
       const res = extractPackageFile(gitImages);
       expect(res.deps).toMatchSnapshot();
-      expect(res.deps).toHaveLength(5);
+      expect(res.deps).toHaveLength(6);
       expect(res.deps[0].currentValue).toEqual('v0.1.0');
       expect(res.deps[1].currentValue).toEqual('v0.0.1');
+      expect(res.deps[5].skipReason).toEqual(SkipReason.InvalidValue);
     });
     it('ignores non-Kubernetes empty files', () => {
       expect(extractPackageFile('')).toBeNull();

--- a/lib/manager/kustomize/extract.ts
+++ b/lib/manager/kustomize/extract.ts
@@ -1,8 +1,10 @@
+import is from '@sindresorhus/is';
 import { load } from 'js-yaml';
 import * as datasourceDocker from '../../datasource/docker';
 import * as datasourceGitTags from '../../datasource/git-tags';
 import * as datasourceGitHubTags from '../../datasource/github-tags';
 import { logger } from '../../logger';
+import { SkipReason } from '../../types';
 import * as dockerVersioning from '../../versioning/docker';
 import type { PackageDependency, PackageFile } from '../types';
 import type { Image, Kustomize } from './types';
@@ -38,8 +40,15 @@ export function extractBase(base: string): PackageDependency | null {
 export function extractImage(image: Image): PackageDependency | null {
   if (image?.name && image.newTag) {
     const replaceString = image.newTag;
-    let currentValue;
-    let currentDigest;
+    let currentValue: string | undefined;
+    let currentDigest: string | undefined;
+    if (!is.string(replaceString)) {
+      return {
+        depName: image.newName ?? image.name,
+        currentValue: replaceString,
+        skipReason: SkipReason.InvalidValue,
+      };
+    }
     if (replaceString.startsWith('sha256:')) {
       currentDigest = replaceString;
       currentValue = undefined;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Reject invalid `newTag` values. This should now cause some logging.
<!-- Describe what behavior is changed by this PR. -->

## Context:
fixes #11076
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
