### PR TITLE
feat(versioning:regex): support build number

### DIFF
--- a/lib/versioning/regex/index.spec.ts
+++ b/lib/versioning/regex/index.spec.ts
@@ -413,10 +413,16 @@ describe('regex', () => {
       expect(
         re.isGreaterThan('12.7.0-debian-10-r69', '12.7.0-debian-10-r100')
       ).toBe(false);
-
       expect(
         re.isGreaterThan('12.7.0-debian-10-r169', '12.7.0-debian-10-r100')
       ).toBe(true);
+
+      expect(re.matches('12.7.0-debian-9-r69', '12.7.0-debian-10-r69')).toBe(
+        true
+      );
+      expect(re.matches('12.7.0-debian-9-r69', '12.7.0-debian-10-r68')).toBe(
+        true
+      );
     });
   });
 });

--- a/lib/versioning/regex/index.spec.ts
+++ b/lib/versioning/regex/index.spec.ts
@@ -396,4 +396,27 @@ describe('regex', () => {
       expect(regex.matches('1.2.4a1-foo', '1.2.3a1-bar')).toBe(false);
     });
   });
+
+  describe('Supported 4th number as build', () => {
+    it('supports Bitnami docker versioning', () => {
+      const re = get(
+        'regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(:?-(?<compatibility>.*-r)(?<build>\\d+))?$'
+      );
+
+      expect(re.isValid('12.7.0-debian-10-r69')).toBe(true);
+      expect(re.isValid('12.7.0-debian-10-r100')).toBe(true);
+
+      expect(
+        re.isCompatible('12.7.0-debian-10-r69', '12.7.0-debian-10-r100')
+      ).toBe(true);
+
+      expect(
+        re.isGreaterThan('12.7.0-debian-10-r69', '12.7.0-debian-10-r100')
+      ).toBe(false);
+
+      expect(
+        re.isGreaterThan('12.7.0-debian-10-r169', '12.7.0-debian-10-r100')
+      ).toBe(true);
+    });
+  });
 });

--- a/lib/versioning/regex/index.ts
+++ b/lib/versioning/regex/index.ts
@@ -1,4 +1,5 @@
-import { compare, ltr, maxSatisfying, minSatisfying, satisfies } from 'semver';
+import is from '@sindresorhus/is';
+import { ltr, maxSatisfying, minSatisfying, satisfies } from 'semver';
 import { CONFIG_VALIDATION } from '../../constants/error-messages';
 import { regEx } from '../../util/regex';
 import { GenericVersion, GenericVersioningApi } from '../loose/generic';
@@ -10,8 +11,6 @@ export const urls = [];
 export const supportsRanges = false;
 
 export interface RegExpVersion extends GenericVersion {
-  /** prereleases are treated in the standard semver manner, if present */
-  prerelease: string;
   /**
    * compatibility, if present, are treated as a compatibility layer: we will
    * never try to update to a version with a different compatibility.
@@ -22,7 +21,7 @@ export interface RegExpVersion extends GenericVersion {
 // convenience method for passing a Version object into any semver.* method.
 function asSemver(version: RegExpVersion): string {
   let vstring = `${version.release[0]}.${version.release[1]}.${version.release[2]}`;
-  if (typeof version.prerelease !== 'undefined') {
+  if (is.nonEmptyString(version.prerelease)) {
     vstring += `-${version.prerelease}`;
   }
   return vstring;
@@ -38,6 +37,8 @@ export class RegExpVersioningApi extends GenericVersioningApi<RegExpVersion> {
   //   RegExp('^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(-(?<compatibility>.*))?$')
   // * matches the versioning approach used by the Python images on DockerHub:
   //   RegExp('^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(?<prerelease>[^.-]+)?(-(?<compatibility>.*))?$');
+  // * matches the versioning approach used by the Bitnami images on DockerHub:
+  //   RegExp('^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(:?-(?<compatibility>.*-r)(?<build>\\d+))?$');
   private _config: RegExp = null;
 
   constructor(new_config: string) {
@@ -66,13 +67,6 @@ export class RegExpVersioningApi extends GenericVersioningApi<RegExpVersion> {
     this._config = regEx(new_config);
   }
 
-  protected _compare(version: string, other: string): number {
-    return compare(
-      asSemver(this._parse(version)),
-      asSemver(this._parse(other))
-    );
-  }
-
   // convenience method for passing a string into a Version given current config.
   protected _parse(version: string): RegExpVersion | null {
     const match = this._config.exec(version);
@@ -81,12 +75,18 @@ export class RegExpVersioningApi extends GenericVersioningApi<RegExpVersion> {
     }
 
     const groups = match.groups;
+    const release = [
+      typeof groups.major === 'undefined' ? 0 : Number(groups.major),
+      typeof groups.minor === 'undefined' ? 0 : Number(groups.minor),
+      typeof groups.patch === 'undefined' ? 0 : Number(groups.patch),
+    ];
+
+    if (groups.build) {
+      release.push(Number(groups.build));
+    }
+
     return {
-      release: [
-        typeof groups.major === 'undefined' ? 0 : Number(groups.major),
-        typeof groups.minor === 'undefined' ? 0 : Number(groups.minor),
-        typeof groups.patch === 'undefined' ? 0 : Number(groups.patch),
-      ],
+      release,
       prerelease: groups.prerelease,
       compatibility: groups.compatibility,
     };
@@ -96,10 +96,6 @@ export class RegExpVersioningApi extends GenericVersioningApi<RegExpVersion> {
     return (
       this._parse(version).compatibility === this._parse(range).compatibility
     );
-  }
-
-  isStable(version: string): boolean {
-    return typeof this._parse(version).prerelease === 'undefined';
   }
 
   isLessThanRange(version: string, range: string): boolean {

--- a/lib/versioning/regex/readme.md
+++ b/lib/versioning/regex/readme.md
@@ -34,3 +34,17 @@ Here is another example, this time for handling `python` Docker images, which us
   ]
 }
 ```
+
+Here is another example, this time for handling Bitnami Docker images, which use build indicators as well as version suffixes for compatibility:
+
+```json
+{
+  "packageRules": [
+    {
+      "matchDatasources": ["docker"],
+      "matchPackagePrefixes": ["bitnami/"],
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(:?-(?<compatibility>.*-r)(?<build>\\d+))?$"
+    }
+  ]
+}
+```


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

The regex versioning now supports an optional `build` match group, which is handled as 4th version part.


<!-- Describe what behavior is changed by this PR. -->

## Context:

This way we can easily support rolling docker releases like:
```Dockerfile
# Support bitnami rolling releases
FROM bitnami/postgresql:12.6.0-debian-10-r87

# Support linuxserver rolling releases
FROM linuxserver/ddclient:v3.9.1-ls62
```

Test repo: https://github.com/viceice-tests/docker-bitnami-versioning/pulls
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository


<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
