### PR TITLE
docs: create section linking to reconfiguring renovate documentation

### DIFF
--- a/docs/usage/configure-renovate.md
+++ b/docs/usage/configure-renovate.md
@@ -63,3 +63,8 @@ Renovate will update your PR description each time it finds changes.
 ## Merge
 
 Once you're done checking and configuring in your Configure Renovate PR, it's time to merge it to enable the real Pull Requests to begin.
+
+## Re-do configuration from scratch
+
+You might want to re-do the Renovate configuration _after_ you merged the initial onboarding PR.
+Get a new onboarding PR, by following the steps described in [Reconfiguring Renovate](https://docs.renovatebot.com/reconfigure-renovate/).


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

- Create section linking to reconfiguring renovate documentation

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

Might be nice to mention that you can get a new onboarding PR in case you want to re-do the configuration from scratch.

Do we want to mention the "manual way with renovate config validator" as well, or do we want to emphasize the onboarding PR part?

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
