### PR TITLE
docs: hostType=bundler for private modules

### DIFF
--- a/docs/usage/private-modules.md
+++ b/docs/usage/private-modules.md
@@ -119,7 +119,7 @@ The following details the most common/popular manager artifacts updating and how
 
 ### bundler
 
-`hostRules` with `hostType=rubygems` are converted into environment variables which Bundler supports.
+`hostRules` with `hostType=bundler` are converted into environment variables which Bundler supports.
 
 ### composer
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

To use private gems, `hostType` should be `bundler`, not `rubygems`.

This is confirmed by [these lines](https://github.com/renovatebot/renovate/blob/25.69.0/lib/manager/bundler/artifacts.ts#L127-L129).

<!-- Describe what behavior is changed by this PR. -->

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
