### PR TITLE
feat: Add pub lockfile maintenance

### DIFF
--- a/lib/manager/pub/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/manager/pub/__snapshots__/artifacts.spec.ts.snap
@@ -1,0 +1,197 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`.updateArtifacts() catches errors 1`] = `
+Array [
+  Object {
+    "artifactError": Object {
+      "lockFile": "pubspec.lock",
+      "stderr": "not found",
+    },
+  },
+]
+`;
+
+exports[`.updateArtifacts() returns null if unchanged 1`] = `
+Array [
+  Object {
+    "cmd": "pub upgrade",
+    "options": Object {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": Object {
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+]
+`;
+
+exports[`.updateArtifacts() returns updated dart pubspec.lock 1`] = `
+Array [
+  Object {
+    "cmd": "pub upgrade",
+    "options": Object {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": Object {
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+]
+`;
+
+exports[`.updateArtifacts() returns updated dart pubspec.lock for lockfile maintenance 1`] = `
+Array [
+  Object {
+    "cmd": "pub upgrade",
+    "options": Object {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": Object {
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+]
+`;
+
+exports[`.updateArtifacts() returns updated dart pubspec.lock with docker 1`] = `
+Array [
+  Object {
+    "cmd": "docker pull renovate/cirrusci/flutter:latest",
+    "options": Object {
+      "encoding": "utf-8",
+    },
+  },
+  Object {
+    "cmd": "docker ps --filter name=renovate_cirrusci_flutter:latest -aq",
+    "options": Object {
+      "encoding": "utf-8",
+    },
+  },
+  Object {
+    "cmd": "docker run --rm --name=renovate_cirrusci_flutter:latest --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -w \\"/tmp/github/some/repo\\" renovate/cirrusci/flutter:latest bash -l -c \\"pub upgrade\\"",
+    "options": Object {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": Object {
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+]
+`;
+
+exports[`.updateArtifacts() returns updated flutter pubspec.lock 1`] = `
+Array [
+  Object {
+    "cmd": "flutter pub upgrade",
+    "options": Object {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": Object {
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+]
+`;
+
+exports[`.updateArtifacts() returns updated flutter pubspec.lock for lockfile maintenance 1`] = `
+Array [
+  Object {
+    "cmd": "flutter pub upgrade",
+    "options": Object {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": Object {
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+]
+`;
+
+exports[`.updateArtifacts() returns updated flutter pubspec.lock with docker 1`] = `
+Array [
+  Object {
+    "cmd": "docker pull renovate/cirrusci/flutter:latest",
+    "options": Object {
+      "encoding": "utf-8",
+    },
+  },
+  Object {
+    "cmd": "docker ps --filter name=renovate_cirrusci_flutter:latest -aq",
+    "options": Object {
+      "encoding": "utf-8",
+    },
+  },
+  Object {
+    "cmd": "docker run --rm --name=renovate_cirrusci_flutter:latest --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -w \\"/tmp/github/some/repo\\" renovate/cirrusci/flutter:latest bash -l -c \\"flutter pub upgrade\\"",
+    "options": Object {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": Object {
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+]
+`;

--- a/lib/manager/pub/artifacts.spec.ts
+++ b/lib/manager/pub/artifacts.spec.ts
@@ -1,0 +1,182 @@
+import { exec as _exec } from 'child_process';
+import _fs from 'fs-extra';
+import { join } from 'upath';
+import { envMock, mockExecAll } from '../../../test/exec-util';
+import { mocked } from '../../../test/util';
+import { setAdminConfig } from '../../config/admin';
+import type { RepoAdminConfig } from '../../config/types';
+import * as docker from '../../util/exec/docker';
+import * as _env from '../../util/exec/env';
+import type { UpdateArtifactsConfig } from '../types';
+import * as pub from './artifacts';
+
+jest.mock('fs-extra');
+jest.mock('child_process');
+jest.mock('../../util/exec/env');
+jest.mock('../../util/git');
+jest.mock('../../util/http');
+
+const fs: jest.Mocked<typeof _fs> = _fs as any;
+const exec: jest.Mock<typeof _exec> = _exec as any;
+const env = mocked(_env);
+
+const adminConfig: RepoAdminConfig = {
+  localDir: join('/tmp/github/some/repo'), // `join` fixes Windows CI
+};
+
+const config: UpdateArtifactsConfig = {};
+
+describe('.updateArtifacts()', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.resetModules();
+
+    env.getChildProcessEnv.mockReturnValue(envMock.basic);
+    setAdminConfig(adminConfig);
+    docker.resetPrefetchedImages();
+  });
+  afterEach(() => {
+    setAdminConfig();
+  });
+  it('returns null if no pubspec.lock found', async () => {
+    const updatedDeps = [{ depName: 'dep1' }];
+    expect(
+      await pub.updateArtifacts({
+        packageFileName: 'pubspec.yaml',
+        updatedDeps,
+        newPackageFileContent: '',
+        config,
+      })
+    ).toBeNull();
+  });
+  it('returns null if updatedDeps is empty', async () => {
+    expect(
+      await pub.updateArtifacts({
+        packageFileName: 'pubspec.yaml',
+        updatedDeps: [],
+        newPackageFileContent: '',
+        config,
+      })
+    ).toBeNull();
+  });
+  it('returns null if unchanged', async () => {
+    const execSnapshots = mockExecAll(exec);
+    fs.readFile.mockResolvedValueOnce('Current pubspec.lock' as any);
+    fs.readFile.mockResolvedValueOnce('Current pubspec.lock' as any);
+    const updatedDeps = [{ depName: 'dep1' }];
+    expect(
+      await pub.updateArtifacts({
+        packageFileName: 'pubspec.yaml',
+        updatedDeps,
+        newPackageFileContent: '',
+        config,
+      })
+    ).toBeNull();
+    expect(execSnapshots).toMatchSnapshot();
+  });
+  it('returns updated dart pubspec.lock', async () => {
+    const execSnapshots = mockExecAll(exec);
+    fs.readFile.mockResolvedValueOnce('Old pubspec.lock' as any);
+    fs.readFile.mockResolvedValueOnce('New pubspec.lock' as any);
+    const updatedDeps = [{ depName: 'dep1' }];
+    expect(
+      await pub.updateArtifacts({
+        packageFileName: 'pubspec.yaml',
+        updatedDeps,
+        newPackageFileContent: '',
+        config,
+      })
+    ).not.toBeNull();
+    expect(execSnapshots).toMatchSnapshot();
+  });
+  it('returns updated dart pubspec.lock for lockfile maintenance', async () => {
+    const execSnapshots = mockExecAll(exec);
+    fs.readFile.mockResolvedValueOnce('Old pubspec.lock' as any);
+    fs.readFile.mockResolvedValueOnce('New pubspec.lock' as any);
+    expect(
+      await pub.updateArtifacts({
+        packageFileName: 'pubspec.yaml',
+        updatedDeps: [],
+        newPackageFileContent: '',
+        config: { ...config, updateType: 'lockFileMaintenance' },
+      })
+    ).not.toBeNull();
+    expect(execSnapshots).toMatchSnapshot();
+  });
+  it('returns updated dart pubspec.lock with docker', async () => {
+    setAdminConfig({ ...adminConfig, binarySource: 'docker' });
+    const execSnapshots = mockExecAll(exec);
+    fs.readFile.mockResolvedValueOnce('Old pubspec.lock' as any);
+    fs.readFile.mockResolvedValueOnce('New pubspec.lock' as any);
+    const updatedDeps = [{ depName: 'dep1' }];
+    expect(
+      await pub.updateArtifacts({
+        packageFileName: 'pubspec.yaml',
+        updatedDeps,
+        newPackageFileContent: '',
+        config,
+      })
+    ).not.toBeNull();
+    expect(execSnapshots).toMatchSnapshot();
+  });
+  it('returns updated flutter pubspec.lock', async () => {
+    const execSnapshots = mockExecAll(exec);
+    fs.readFile.mockResolvedValueOnce('Old pubspec.lock' as any);
+    fs.readFile.mockResolvedValueOnce('New pubspec.lock' as any);
+    const updatedDeps = [{ depName: 'dep1' }];
+    expect(
+      await pub.updateArtifacts({
+        packageFileName: 'pubspec.yaml',
+        updatedDeps,
+        newPackageFileContent: 'sdk: flutter',
+        config,
+      })
+    ).not.toBeNull();
+    expect(execSnapshots).toMatchSnapshot();
+  });
+  it('returns updated flutter pubspec.lock for lockfile maintenance', async () => {
+    const execSnapshots = mockExecAll(exec);
+    fs.readFile.mockResolvedValueOnce('Old pubspec.lock' as any);
+    fs.readFile.mockResolvedValueOnce('New pubspec.lock' as any);
+    expect(
+      await pub.updateArtifacts({
+        packageFileName: 'pubspec.yaml',
+        updatedDeps: [],
+        newPackageFileContent: 'sdk: flutter',
+        config: { ...config, updateType: 'lockFileMaintenance' },
+      })
+    ).not.toBeNull();
+    expect(execSnapshots).toMatchSnapshot();
+  });
+  it('returns updated flutter pubspec.lock with docker', async () => {
+    setAdminConfig({ ...adminConfig, binarySource: 'docker' });
+    const execSnapshots = mockExecAll(exec);
+    fs.readFile.mockResolvedValueOnce('Old pubspec.lock' as any);
+    fs.readFile.mockResolvedValueOnce('New pubspec.lock' as any);
+    const updatedDeps = [{ depName: 'dep1' }];
+    expect(
+      await pub.updateArtifacts({
+        packageFileName: 'pubspec.yaml',
+        updatedDeps,
+        newPackageFileContent: 'sdk: flutter',
+        config,
+      })
+    ).not.toBeNull();
+    expect(execSnapshots).toMatchSnapshot();
+  });
+  it('catches errors', async () => {
+    fs.readFile.mockResolvedValueOnce('Current pubspec.lock' as any);
+    fs.outputFile.mockImplementationOnce(() => {
+      throw new Error('not found');
+    });
+    const updatedDeps = [{ depName: 'dep1' }];
+    expect(
+      await pub.updateArtifacts({
+        packageFileName: 'pubspec.yaml',
+        updatedDeps,
+        newPackageFileContent: '',
+        config,
+      })
+    ).toMatchSnapshot();
+  });
+});

--- a/lib/manager/pub/artifacts.ts
+++ b/lib/manager/pub/artifacts.ts
@@ -1,0 +1,91 @@
+import { TEMPORARY_ERROR } from '../../constants/error-messages';
+import { logger } from '../../logger';
+import { ExecOptions, exec } from '../../util/exec';
+import {
+  getSiblingFileName,
+  readLocalFile,
+  writeLocalFile,
+} from '../../util/fs';
+import type { UpdateArtifact, UpdateArtifactsResult } from '../types';
+
+async function pubUpdate(
+  pubspecPath: string,
+  newPackageFileContent: string
+): Promise<void> {
+  let cmd = '';
+  if (newPackageFileContent.includes('sdk: flutter')) {
+    cmd = 'flutter pub upgrade';
+  } else {
+    cmd = 'pub upgrade';
+  }
+
+  const execOptions: ExecOptions = {
+    cwdFile: pubspecPath,
+    docker: {
+      image: 'cirrusci/flutter:latest', // Ideally there would be an official image, but this at least gets updated very frequently
+    },
+  };
+  await exec(cmd, execOptions);
+}
+
+export async function updateArtifacts({
+  packageFileName,
+  updatedDeps,
+  newPackageFileContent,
+  config,
+}: UpdateArtifact): Promise<UpdateArtifactsResult[] | null> {
+  logger.debug(`pub.updateArtifacts(${packageFileName})`);
+
+  const isLockFileMaintenance = config.updateType === 'lockFileMaintenance';
+
+  if (
+    !isLockFileMaintenance &&
+    (updatedDeps === undefined || updatedDeps.length < 1)
+  ) {
+    logger.debug('No updated pub deps - returning null');
+    return null;
+  }
+
+  const lockFileName = getSiblingFileName(packageFileName, 'pubspec.lock');
+  const existingLockFileContent = await readLocalFile(lockFileName);
+  if (!existingLockFileContent) {
+    logger.debug('No pubspec.lock found');
+    return null;
+  }
+  try {
+    await writeLocalFile(packageFileName, newPackageFileContent);
+    logger.debug('Updating ' + lockFileName);
+    await pubUpdate(packageFileName, newPackageFileContent);
+    logger.debug('Returning updated pubspec.lock');
+    const newPubspecLockContent = await readLocalFile(lockFileName);
+    if (
+      existingLockFileContent === newPubspecLockContent ||
+      newPubspecLockContent === undefined
+    ) {
+      logger.debug('pubspec.lock is unchanged');
+      return null;
+    }
+    return [
+      {
+        file: {
+          name: lockFileName,
+          contents: newPubspecLockContent,
+        },
+      },
+    ];
+  } catch (err) {
+    // istanbul ignore if
+    if (err.message === TEMPORARY_ERROR) {
+      throw err;
+    }
+    logger.warn({ err }, 'Failed to update pubspec.lock file');
+    return [
+      {
+        artifactError: {
+          lockFile: lockFileName,
+          stderr: err.message,
+        },
+      },
+    ];
+  }
+}

--- a/lib/manager/pub/index.ts
+++ b/lib/manager/pub/index.ts
@@ -1,6 +1,9 @@
 import * as npmVersioning from '../../versioning/npm';
 
+export { updateArtifacts } from './artifacts';
 export { extractPackageFile } from './extract';
+
+export const supportsLockFileMaintenance = true;
 
 export const defaultConfig = {
   fileMatch: ['(^|/)pubspec\\.ya?ml$'],


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->
`pubspec.lock` file now gets updated when a pub dependency changes.

## Context:

- closes #6049
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
