### PR TITLE
refactor: use `import()` to enable update of `p-map`

### DIFF
--- a/lib/datasource/galaxy-collection/index.ts
+++ b/lib/datasource/galaxy-collection/index.ts
@@ -1,4 +1,3 @@
-import pMap from 'p-map';
 import { logger } from '../../logger';
 import { cache } from '../../util/cache/package/decorator';
 import type { HttpResponse } from '../../util/http';
@@ -72,6 +71,7 @@ export class GalaxyCollectionDatasource extends Datasource {
     });
 
     let newestVersionDetails: VersionsDetailResult;
+    const pMap = (await import('p-map')).default;
     // asynchronously get release details
     const enrichedReleases: Release[] = await pMap(
       releases,

--- a/lib/datasource/galaxy-collection/index.ts
+++ b/lib/datasource/galaxy-collection/index.ts
@@ -1,3 +1,4 @@
+import inclusion from 'inclusion';
 import { logger } from '../../logger';
 import { cache } from '../../util/cache/package/decorator';
 import type { HttpResponse } from '../../util/http';
@@ -71,7 +72,8 @@ export class GalaxyCollectionDatasource extends Datasource {
     });
 
     let newestVersionDetails: VersionsDetailResult;
-    const pMap = (await import('p-map')).default;
+    const pMap: typeof import('p-map')['default'] = (await inclusion('p-map'))
+      .default;
     // asynchronously get release details
     const enrichedReleases: Release[] = await pMap(
       releases,

--- a/lib/datasource/terraform-provider/index.ts
+++ b/lib/datasource/terraform-provider/index.ts
@@ -1,3 +1,4 @@
+import inclusion from 'inclusion';
 import { logger } from '../../logger';
 import { ExternalHostError } from '../../types/errors/external-host-error';
 import { cache } from '../../util/cache/package/decorator';
@@ -192,7 +193,8 @@ export class TerraformProviderDatasource extends TerraformDatasource {
       return null;
     }
 
-    const pMap = (await import('p-map')).default;
+    const pMap: typeof import('p-map')['default'] = (await inclusion('p-map'))
+      .default;
 
     const result = await pMap(
       builds.platforms,

--- a/lib/datasource/terraform-provider/index.ts
+++ b/lib/datasource/terraform-provider/index.ts
@@ -1,4 +1,3 @@
-import pMap from 'p-map';
 import { logger } from '../../logger';
 import { ExternalHostError } from '../../types/errors/external-host-error';
 import { cache } from '../../util/cache/package/decorator';
@@ -192,6 +191,9 @@ export class TerraformProviderDatasource extends TerraformDatasource {
       );
       return null;
     }
+
+    const pMap = (await import('p-map')).default;
+
     const result = await pMap(
       builds.platforms,
       async (platform) => {

--- a/lib/manager/terraform/lockfile/hash.ts
+++ b/lib/manager/terraform/lockfile/hash.ts
@@ -1,5 +1,6 @@
 import crypto from 'crypto';
 import extract from 'extract-zip';
+import inclusion from 'inclusion';
 import { join } from 'upath';
 import { TerraformProviderDatasource } from '../../../datasource/terraform-provider';
 import type { TerraformBuild } from '../../../datasource/terraform-provider/types';
@@ -94,7 +95,8 @@ export class TerraformProviderHash {
   }
 
   static async calculateHashes(builds: TerraformBuild[]): Promise<string[]> {
-    const pMap = (await import('p-map')).default;
+    const pMap: typeof import('p-map')['default'] = (await inclusion('p-map'))
+      .default;
     const cacheDir = await ensureCacheDir('./others/terraform');
 
     // for each build download ZIP, extract content and generate hash for all containing files

--- a/lib/manager/terraform/lockfile/hash.ts
+++ b/lib/manager/terraform/lockfile/hash.ts
@@ -1,6 +1,5 @@
 import crypto from 'crypto';
 import extract from 'extract-zip';
-import pMap from 'p-map';
 import { join } from 'upath';
 import { TerraformProviderDatasource } from '../../../datasource/terraform-provider';
 import type { TerraformBuild } from '../../../datasource/terraform-provider/types';
@@ -95,6 +94,7 @@ export class TerraformProviderHash {
   }
 
   static async calculateHashes(builds: TerraformBuild[]): Promise<string[]> {
+    const pMap = (await import('p-map')).default;
     const cacheDir = await ensureCacheDir('./others/terraform');
 
     // for each build download ZIP, extract content and generate hash for all containing files

--- a/lib/manager/terraform/lockfile/index.ts
+++ b/lib/manager/terraform/lockfile/index.ts
@@ -1,4 +1,3 @@
-import pMap from 'p-map';
 import { GetPkgReleasesConfig, getPkgReleases } from '../../../datasource';
 import { TerraformProviderDatasource } from '../../../datasource/terraform-provider';
 import { logger } from '../../../logger';
@@ -17,6 +16,8 @@ import {
 async function updateAllLocks(
   locks: ProviderLock[]
 ): Promise<ProviderLockUpdate[]> {
+  const pMap = (await import('p-map')).default;
+
   const updates = await pMap(
     locks,
     async (lock) => {

--- a/lib/manager/terraform/lockfile/index.ts
+++ b/lib/manager/terraform/lockfile/index.ts
@@ -1,3 +1,4 @@
+import inclusion from 'inclusion';
 import { GetPkgReleasesConfig, getPkgReleases } from '../../../datasource';
 import { TerraformProviderDatasource } from '../../../datasource/terraform-provider';
 import { logger } from '../../../logger';
@@ -16,7 +17,8 @@ import {
 async function updateAllLocks(
   locks: ProviderLock[]
 ): Promise<ProviderLockUpdate[]> {
-  const pMap = (await import('p-map')).default;
+  const pMap: typeof import('p-map')['default'] = (await inclusion('p-map'))
+    .default;
 
   const updates = await pMap(
     locks,

--- a/lib/workers/repository/changelog/index.ts
+++ b/lib/workers/repository/changelog/index.ts
@@ -1,4 +1,3 @@
-import pMap from 'p-map';
 import { getChangeLogJSON } from '../../pr/changelog';
 import type { BranchUpgradeConfig } from '../../types';
 
@@ -11,6 +10,7 @@ async function embedChangelog(upgrade: BranchUpgradeConfig): Promise<void> {
 export async function embedChangelogs(
   branchUpgrades: Record<string, BranchUpgradeConfig[]>
 ): Promise<void> {
+  const pMap = (await import('p-map')).default;
   const upgrades = [];
   for (const branchName of Object.keys(branchUpgrades)) {
     for (const upgrade of branchUpgrades[branchName]) {

--- a/lib/workers/repository/changelog/index.ts
+++ b/lib/workers/repository/changelog/index.ts
@@ -1,3 +1,4 @@
+import inclusion from 'inclusion';
 import { getChangeLogJSON } from '../../pr/changelog';
 import type { BranchUpgradeConfig } from '../../types';
 
@@ -10,7 +11,8 @@ async function embedChangelog(upgrade: BranchUpgradeConfig): Promise<void> {
 export async function embedChangelogs(
   branchUpgrades: Record<string, BranchUpgradeConfig[]>
 ): Promise<void> {
-  const pMap = (await import('p-map')).default;
+  const pMap: typeof import('p-map')['default'] = (await inclusion('p-map'))
+    .default;
   const upgrades = [];
   for (const branchName of Object.keys(branchUpgrades)) {
     for (const upgrade of branchUpgrades[branchName]) {

--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
     "moo": "0.5.1",
     "node-html-parser": "3.3.6",
     "p-all": "3.0.0",
-    "p-map": "4.0.0",
+    "p-map": "5.1.0",
     "p-queue": "6.6.2",
     "parse-diff": "0.8.1",
     "parse-link-header": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
     "handy-redis": "2.2.2",
     "hasha": "5.2.2",
     "ignore": "5.1.8",
+    "inclusion": "1.0.0",
     "ini": "2.0.0",
     "js-yaml": "4.1.0",
     "json-dup-key-validator": "1.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2258,6 +2258,14 @@ aggregate-error@^3.0.0:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
 
+aggregate-error@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-4.0.0.tgz#83dbdb53a0d500721281d22e19eee9bc352a89cd"
+  integrity sha512-8DGp7zUt1E9k0NE2q4jlXHk+V3ORErmwolEdRz9iV+LKJ40WhMHh92cxAvhqV2I+zEn/gotIoqoMs0NjF3xofg==
+  dependencies:
+    clean-stack "^4.0.0"
+    indent-string "^5.0.0"
+
 ajv@^6.10.0, ajv@^6.12.3, ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
@@ -2975,6 +2983,13 @@ clean-stack@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
   integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
+
+clean-stack@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-4.1.0.tgz#5ce5a2fd19a12aecdce8570daefddb7ac94b6b4e"
+  integrity sha512-dxXQYI7mfQVcaF12s6sjNFoZ6ZPDQuBBLp3QJ5156k9EvUFClUoZ11fo8HnLQO241DDVntHEug8MOuFO5PSfRg==
+  dependencies:
+    escape-string-regexp "5.0.0"
 
 cli-columns@^3.1.2:
   version "3.1.2"
@@ -3804,6 +3819,11 @@ escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
   integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
+
+escape-string-regexp@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz#4683126b500b61762f2dbebace1806e8be31b1c8"
+  integrity sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==
 
 escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -4890,6 +4910,11 @@ indent-string@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
   integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
+
+indent-string@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-5.0.0.tgz#4fd2980fccaf8622d14c64d694f4cf33c81951a5"
+  integrity sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==
 
 infer-owner@^1.0.4:
   version "1.0.4"
@@ -7426,17 +7451,24 @@ p-locate@^5.0.0:
   dependencies:
     p-limit "^3.0.2"
 
-p-map@4.0.0, p-map@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/p-map/-/p-map-4.0.0.tgz#bb2f95a5eda2ec168ec9274e06a747c3e2904d2b"
-  integrity sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==
+p-map@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-5.1.0.tgz#1c31bdfc492910098bdb4e63d099efbdd9b37755"
+  integrity sha512-hDTnBRGPXM4hUkmV4Nbe9ZyFnqUAHFYq5S/3+P38TRf0KbmkQuRSzfGM+JngEJsvB0m6nHvhsSv5E6VsGSB2zA==
   dependencies:
-    aggregate-error "^3.0.0"
+    aggregate-error "^4.0.0"
 
 p-map@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-2.1.0.tgz#310928feef9c9ecc65b68b17693018a665cea175"
   integrity sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==
+
+p-map@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-4.0.0.tgz#bb2f95a5eda2ec168ec9274e06a747c3e2904d2b"
+  integrity sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==
+  dependencies:
+    aggregate-error "^3.0.0"
 
 p-queue@6.6.2:
   version "6.6.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2845,7 +2845,7 @@ call-bind@^1.0.0, call-bind@^1.0.2:
     function-bind "^1.1.1"
     get-intrinsic "^1.0.2"
 
-callsites@^3.0.0:
+callsites@^3.0.0, callsites@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
@@ -4905,6 +4905,13 @@ imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
+
+inclusion@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/inclusion/-/inclusion-1.0.0.tgz#4f3331ae18b6e27807fcbc3f81204eb81230bdc9"
+  integrity sha512-5rnJkax1rtkMWCDGeRLFQJIZCKMrCTrH89mm4l3JfpnKC0tEvL7SuasSiutr6vNfBG31YoVmlo79Wwqif48azA==
+  dependencies:
+    parent-module "^2.0.0"
 
 indent-string@^4.0.0:
   version "4.0.0"
@@ -7539,6 +7546,13 @@ parent-module@^1.0.0:
   integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
   dependencies:
     callsites "^3.0.0"
+
+parent-module@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-2.0.0.tgz#fa71f88ff1a50c27e15d8ff74e0e3a9523bf8708"
+  integrity sha512-uo0Z9JJeWzv8BG+tRcapBKNJ0dro9cLyczGzulS6EfeyAdeC9sbojtW6XwvYxJkEne9En+J2XEl4zyglVeIwFg==
+  dependencies:
+    callsites "^3.1.0"
 
 parse-conflict-json@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Makes use of `await import()` unblock the update of ESM-only modules like eg. `p-map` and thus enabling it to be removed from https://github.com/renovatebot/renovate/issues/2958#issuecomment-848513199 and no longer be blocked by #9890.

## Context:

As more and more modules are becoming ESM-only, and since Jest is still blocking #9890 from being solved, the challenge of not being able to use ESM-only modules is getting increasingly larger and often the possibility of using `await import()` is easy to miss.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
