### PR TITLE
refactor: Identify tests relying on single snapshots

### DIFF
--- a/lib/config/massage.spec.ts
+++ b/lib/config/massage.spec.ts
@@ -7,6 +7,7 @@ describe(getName(), () => {
     it('returns empty', () => {
       const config: RenovateConfig = {};
       const res = massage.massageConfig(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('massages strings to array', () => {
@@ -20,6 +21,7 @@ describe(getName(), () => {
       const config: RenovateConfig = {
         npmToken: 'some-token',
       };
+      // FIXME: explicit assert condition
       expect(massage.massageConfig(config)).toMatchSnapshot();
     });
     it('massages packageRules matchUpdateTypes', () => {

--- a/lib/config/migrate-validate.spec.ts
+++ b/lib/config/migrate-validate.spec.ts
@@ -11,11 +11,13 @@ describe(getName(), () => {
   describe('migrateAndValidate()', () => {
     it('handles empty', async () => {
       const res = await migrateAndValidate(config, {});
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('handles migration', async () => {
       const input: RenovateConfig = { automerge: 'none' as any };
       const res = await migrateAndValidate(config, input);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('handles invalid', async () => {

--- a/lib/config/migration.spec.ts
+++ b/lib/config/migration.spec.ts
@@ -273,6 +273,7 @@ describe(getName(), () => {
         parentConfig
       );
       expect(isMigrated).toBe(true);
+      // FIXME: explicit assert condition
       expect(migratedConfig).toMatchSnapshot();
     });
     it('overrides existing automerge setting', () => {
@@ -444,6 +445,7 @@ describe(getName(), () => {
         config,
         defaultConfig
       );
+      // FIXME: explicit assert condition
       expect(migratedConfig).toMatchSnapshot();
       expect(isMigrated).toBe(true);
     });
@@ -625,6 +627,7 @@ describe(getName(), () => {
         defaultConfig
       );
       expect(isMigrated).toBe(true);
+      // FIXME: explicit assert condition
       expect(migratedConfig).toMatchSnapshot();
     });
   });
@@ -681,6 +684,7 @@ describe(getName(), () => {
       defaultConfig
     );
     expect(isMigrated).toBe(true);
+    // FIXME: explicit assert condition
     expect(migratedConfig).toMatchSnapshot();
   });
   it('it migrates presets', () => {
@@ -698,6 +702,7 @@ describe(getName(), () => {
       defaultConfig
     );
     expect(isMigrated).toBe(true);
+    // FIXME: explicit assert condition
     expect(migratedConfig).toMatchSnapshot();
   });
 });

--- a/lib/config/presets/bitbucket-server/index.spec.ts
+++ b/lib/config/presets/bitbucket-server/index.spec.ts
@@ -32,6 +32,7 @@ describe(getName(), () => {
         'some-filename.json',
         bitbucketApiHost
       );
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
       expect(httpMock.getTrace()).toMatchSnapshot();
     });

--- a/lib/config/presets/gitea/index.spec.ts
+++ b/lib/config/presets/gitea/index.spec.ts
@@ -32,6 +32,7 @@ describe(getName(), () => {
         'some-filename.json',
         giteaApiHost
       );
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
       expect(httpMock.getTrace()).toMatchSnapshot();
     });

--- a/lib/config/presets/github/index.spec.ts
+++ b/lib/config/presets/github/index.spec.ts
@@ -30,6 +30,7 @@ describe(getName(), () => {
         'some-filename.json',
         githubApiHost
       );
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
       expect(httpMock.getTrace()).toMatchSnapshot();
     });

--- a/lib/config/presets/index.spec.ts
+++ b/lib/config/presets/index.spec.ts
@@ -50,6 +50,7 @@ describe(getName(), () => {
       config.extends = [];
       const res = await presets.resolveConfigPresets(config);
       expect(config).toMatchObject(res);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('throws if invalid preset file', async () => {
@@ -62,6 +63,7 @@ describe(getName(), () => {
         e = err;
       }
       expect(e).toBeDefined();
+      // FIXME: explicit assert condition
       expect(e.validationSource).toMatchSnapshot();
       expect(e.validationError).toMatchSnapshot();
       expect(e.validationMessage).toMatchSnapshot();
@@ -76,6 +78,7 @@ describe(getName(), () => {
         e = err;
       }
       expect(e).toBeDefined();
+      // FIXME: explicit assert condition
       expect(e.validationSource).toMatchSnapshot();
       expect(e.validationError).toMatchSnapshot();
       expect(e.validationMessage).toMatchSnapshot();
@@ -91,6 +94,7 @@ describe(getName(), () => {
         e = err;
       }
       expect(e).toBeDefined();
+      // FIXME: explicit assert condition
       expect(e.validationSource).toMatchSnapshot();
       expect(e.validationError).toMatchSnapshot();
       expect(e.validationMessage).toMatchSnapshot();
@@ -106,6 +110,7 @@ describe(getName(), () => {
         e = err;
       }
       expect(e).toBeDefined();
+      // FIXME: explicit assert condition
       expect(e.validationSource).toMatchSnapshot();
       expect(e.validationError).toMatchSnapshot();
       expect(e.validationMessage).toMatchSnapshot();
@@ -121,6 +126,7 @@ describe(getName(), () => {
         e = err;
       }
       expect(e).toBeDefined();
+      // FIXME: explicit assert condition
       expect(e.validationSource).toMatchSnapshot();
       expect(e.validationError).toMatchSnapshot();
       expect(e.validationMessage).toMatchSnapshot();
@@ -136,6 +142,7 @@ describe(getName(), () => {
         e = err;
       }
       expect(e).toBeDefined();
+      // FIXME: explicit assert condition
       expect(e.validationSource).toMatchSnapshot();
       expect(e.validationError).toMatchSnapshot();
       expect(e.validationMessage).toMatchSnapshot();
@@ -159,6 +166,7 @@ describe(getName(), () => {
         e = err;
       }
       expect(e).toBeDefined();
+      // FIXME: explicit assert condition
       expect(e.validationSource).toMatchSnapshot();
       expect(e.validationError).toMatchSnapshot();
       expect(e.validationMessage).toMatchSnapshot();
@@ -166,6 +174,7 @@ describe(getName(), () => {
     it('combines two package alls', async () => {
       config.extends = ['packages:eslint', 'packages:stylelint'];
       const res = await presets.resolveConfigPresets(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('resolves packageRule', async () => {
@@ -176,6 +185,7 @@ describe(getName(), () => {
         },
       ];
       const res = await presets.resolveConfigPresets(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('resolves eslint', async () => {
@@ -216,6 +226,7 @@ describe(getName(), () => {
         'config:base',
       ]);
       expect(config).toMatchObject(res);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
 
@@ -242,6 +253,7 @@ describe(getName(), () => {
     it('replaces args in strings', () => {
       const str = '{{arg2}} foo {{arg0}}{{arg1}}';
       const res = presets.replaceArgs(str, argMappings);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('replaces args twice in same string', () => {
@@ -260,6 +272,7 @@ describe(getName(), () => {
         },
       };
       const res = presets.replaceArgs(obj, argMappings);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('replaces arrays', () => {
@@ -273,28 +286,34 @@ describe(getName(), () => {
         ],
       };
       const res = presets.replaceArgs(obj, argMappings);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
   });
   describe('parsePreset', () => {
     // default namespace
     it('returns default package name', () => {
+      // FIXME: explicit assert condition
       expect(presets.parsePreset(':base')).toMatchSnapshot();
     });
     it('parses github', () => {
+      // FIXME: explicit assert condition
       expect(presets.parsePreset('github>some/repo')).toMatchSnapshot();
     });
     it('parses github subfiles', () => {
+      // FIXME: explicit assert condition
       expect(
         presets.parsePreset('github>some/repo:somefile')
       ).toMatchSnapshot();
     });
     it('parses github subfiles with preset name', () => {
+      // FIXME: explicit assert condition
       expect(
         presets.parsePreset('github>some/repo:somefile/somepreset')
       ).toMatchSnapshot();
     });
     it('parses github subfiles with preset and sub-preset name', () => {
+      // FIXME: explicit assert condition
       expect(
         presets.parsePreset(
           'github>some/repo:somefile/somepreset/somesubpreset'
@@ -302,50 +321,62 @@ describe(getName(), () => {
       ).toMatchSnapshot();
     });
     it('parses github subdirectories', () => {
+      // FIXME: explicit assert condition
       expect(
         presets.parsePreset('github>some/repo//somepath/somesubpath/somefile')
       ).toMatchSnapshot();
     });
     it('parses github toplevel file using subdirectory syntax', () => {
+      // FIXME: explicit assert condition
       expect(
         presets.parsePreset('github>some/repo//somefile')
       ).toMatchSnapshot();
     });
     it('parses gitlab', () => {
+      // FIXME: explicit assert condition
       expect(presets.parsePreset('gitlab>some/repo')).toMatchSnapshot();
     });
     it('parses gitea', () => {
+      // FIXME: explicit assert condition
       expect(presets.parsePreset('gitea>some/repo')).toMatchSnapshot();
     });
     it('parses local', () => {
+      // FIXME: explicit assert condition
       expect(presets.parsePreset('local>some/repo')).toMatchSnapshot();
     });
     it('parses local with subdirectory', () => {
+      // FIXME: explicit assert condition
       expect(
         presets.parsePreset('local>some-group/some-repo//some-dir/some-file')
       ).toMatchSnapshot();
     });
     it('parses no prefix as local', () => {
+      // FIXME: explicit assert condition
       expect(presets.parsePreset('some/repo')).toMatchSnapshot();
     });
     it('returns default package name with params', () => {
+      // FIXME: explicit assert condition
       expect(
         presets.parsePreset(':group(packages/eslint, eslint)')
       ).toMatchSnapshot();
     });
     // scoped namespace
     it('returns simple scope', () => {
+      // FIXME: explicit assert condition
       expect(presets.parsePreset('@somescope')).toMatchSnapshot();
     });
     it('returns simple scope and params', () => {
+      // FIXME: explicit assert condition
       expect(presets.parsePreset('@somescope(param1)')).toMatchSnapshot();
     });
     it('returns scope with packageName and default', () => {
+      // FIXME: explicit assert condition
       expect(
         presets.parsePreset('@somescope/somepackagename')
       ).toMatchSnapshot();
     });
     it('returns scope with packageName and params and default', () => {
+      // FIXME: explicit assert condition
       expect(
         presets.parsePreset(
           '@somescope/somepackagename(param1, param2, param3)'
@@ -353,21 +384,25 @@ describe(getName(), () => {
       ).toMatchSnapshot();
     });
     it('returns scope with presetName', () => {
+      // FIXME: explicit assert condition
       expect(
         presets.parsePreset('@somescope:somePresetName')
       ).toMatchSnapshot();
     });
     it('returns scope with presetName and params', () => {
+      // FIXME: explicit assert condition
       expect(
         presets.parsePreset('@somescope:somePresetName(param1)')
       ).toMatchSnapshot();
     });
     it('returns scope with packageName and presetName', () => {
+      // FIXME: explicit assert condition
       expect(
         presets.parsePreset('@somescope/somepackagename:somePresetName')
       ).toMatchSnapshot();
     });
     it('returns scope with packageName and presetName and params', () => {
+      // FIXME: explicit assert condition
       expect(
         presets.parsePreset(
           '@somescope/somepackagename:somePresetName(param1, param2)'
@@ -376,17 +411,21 @@ describe(getName(), () => {
     });
     // non-scoped namespace
     it('returns non-scoped default', () => {
+      // FIXME: explicit assert condition
       expect(presets.parsePreset('somepackage')).toMatchSnapshot();
     });
     it('returns non-scoped package name', () => {
+      // FIXME: explicit assert condition
       expect(presets.parsePreset('somepackage:webapp')).toMatchSnapshot();
     });
     it('returns non-scoped package name full', () => {
+      // FIXME: explicit assert condition
       expect(
         presets.parsePreset('renovate-config-somepackage:webapp')
       ).toMatchSnapshot();
     });
     it('returns non-scoped package name with params', () => {
+      // FIXME: explicit assert condition
       expect(
         presets.parsePreset('somepackage:webapp(param1)')
       ).toMatchSnapshot();
@@ -395,6 +434,7 @@ describe(getName(), () => {
   describe('getPreset', () => {
     it('handles removed presets with a migration', async () => {
       const res = await presets.getPreset(':base', {});
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('handles removed presets with no migration', async () => {
@@ -412,14 +452,17 @@ describe(getName(), () => {
         ':group(packages:eslint, eslint)',
         {}
       );
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('handles missing params', async () => {
       const res = await presets.getPreset(':group()', {});
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('ignores irrelevant params', async () => {
       const res = await presets.getPreset(':pinVersions(foo, bar)', {});
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('handles 404 packages', async () => {
@@ -430,6 +473,7 @@ describe(getName(), () => {
         e = err;
       }
       expect(e).toBeDefined();
+      // FIXME: explicit assert condition
       expect(e.validationSource).toMatchSnapshot();
       expect(e.validationError).toMatchSnapshot();
       expect(e.validationMessage).toMatchSnapshot();
@@ -442,6 +486,7 @@ describe(getName(), () => {
         e = err;
       }
       expect(e).toBeDefined();
+      // FIXME: explicit assert condition
       expect(e.validationSource).toMatchSnapshot();
       expect(e.validationError).toMatchSnapshot();
       expect(e.validationMessage).toMatchSnapshot();
@@ -454,6 +499,7 @@ describe(getName(), () => {
         e = err;
       }
       expect(e).toBeDefined();
+      // FIXME: explicit assert condition
       expect(e.validationSource).toMatchSnapshot();
       expect(e.validationError).toMatchSnapshot();
       expect(e.validationMessage).toMatchSnapshot();
@@ -466,6 +512,7 @@ describe(getName(), () => {
         e = err;
       }
       expect(e).toBeDefined();
+      // FIXME: explicit assert condition
       expect(e.validationSource).toMatchSnapshot();
       expect(e.validationError).toMatchSnapshot();
       expect(e.validationMessage).toMatchSnapshot();

--- a/lib/config/presets/local/index.spec.ts
+++ b/lib/config/presets/local/index.spec.ts
@@ -65,6 +65,7 @@ describe(getName(), () => {
         },
       });
       expect(azure.getPresetFromEndpoint.mock.calls).toMatchSnapshot();
+      // FIXME: explicit assert condition
       expect(content).toMatchSnapshot();
     });
 
@@ -77,6 +78,7 @@ describe(getName(), () => {
         },
       });
       expect(bitbucket.getPresetFromEndpoint.mock.calls).toMatchSnapshot();
+      // FIXME: explicit assert condition
       expect(content).toMatchSnapshot();
     });
 
@@ -92,6 +94,7 @@ describe(getName(), () => {
       expect(
         bitbucketServer.getPresetFromEndpoint.mock.calls
       ).toMatchSnapshot();
+      // FIXME: explicit assert condition
       expect(content).toMatchSnapshot();
     });
 
@@ -103,6 +106,7 @@ describe(getName(), () => {
         },
       });
       expect(gitea.getPresetFromEndpoint.mock.calls).toMatchSnapshot();
+      // FIXME: explicit assert condition
       expect(content).toMatchSnapshot();
     });
     it('forwards to custom gitea', async () => {
@@ -115,6 +119,7 @@ describe(getName(), () => {
         },
       });
       expect(gitea.getPresetFromEndpoint.mock.calls).toMatchSnapshot();
+      // FIXME: explicit assert condition
       expect(content).toMatchSnapshot();
     });
 
@@ -126,6 +131,7 @@ describe(getName(), () => {
         },
       });
       expect(github.getPresetFromEndpoint.mock.calls).toMatchSnapshot();
+      // FIXME: explicit assert condition
       expect(content).toMatchSnapshot();
     });
     it('forwards to custom github', async () => {
@@ -138,6 +144,7 @@ describe(getName(), () => {
         },
       });
       expect(github.getPresetFromEndpoint.mock.calls).toMatchSnapshot();
+      // FIXME: explicit assert condition
       expect(content).toMatchSnapshot();
     });
 
@@ -150,6 +157,7 @@ describe(getName(), () => {
         },
       });
       expect(gitlab.getPresetFromEndpoint.mock.calls).toMatchSnapshot();
+      // FIXME: explicit assert condition
       expect(content).toMatchSnapshot();
     });
     it('forwards to custom gitlab', async () => {
@@ -162,6 +170,7 @@ describe(getName(), () => {
         },
       });
       expect(gitlab.getPresetFromEndpoint.mock.calls).toMatchSnapshot();
+      // FIXME: explicit assert condition
       expect(content).toMatchSnapshot();
     });
   });

--- a/lib/config/presets/npm/index.spec.ts
+++ b/lib/config/presets/npm/index.spec.ts
@@ -118,6 +118,7 @@ describe(getName(), () => {
       .get('/workingpreset')
       .reply(200, presetPackage);
     const res = await npm.getPreset({ packageName: 'workingpreset' });
+    // FIXME: explicit assert condition
     expect(res).toMatchSnapshot();
   });
 });

--- a/lib/datasource/index.spec.ts
+++ b/lib/datasource/index.spec.ts
@@ -116,6 +116,7 @@ describe(getName(), () => {
       datasource: datasourceNpm.id,
       depName: 'react-native',
     });
+    // FIXME: explicit assert condition
     expect(res).toMatchSnapshot();
     expect(res.changelogUrl).toBeDefined();
     expect(res.sourceUrl).toBeDefined();
@@ -145,6 +146,7 @@ describe(getName(), () => {
       datasource: datasourceNpm.id,
       depName: 'node',
     });
+    // FIXME: explicit assert condition
     expect(res).toMatchSnapshot();
     expect(res.sourceUrl).toBeDefined();
   });
@@ -163,6 +165,7 @@ describe(getName(), () => {
       depName: 'something',
       registryUrls: ['https://docker.com', 'https://docker.io'],
     });
+    // FIXME: explicit assert condition
     expect(res).toMatchSnapshot();
   });
   it('hunts registries and returns success', async () => {
@@ -228,6 +231,7 @@ describe(getName(), () => {
       depName: 'something',
       registryUrls: ['https://reg1.com', 'https://reg2.io'],
     });
+    // FIXME: explicit assert condition
     expect(res).toMatchSnapshot();
     expect(res.releases).toHaveLength(2);
   });

--- a/lib/datasource/metadata.spec.ts
+++ b/lib/datasource/metadata.spec.ts
@@ -26,6 +26,7 @@ describe(getName(), () => {
     const lookupName = 'django';
 
     addMetaData(dep, datasource, lookupName);
+    // FIXME: explicit assert condition
     expect(dep).toMatchSnapshot();
   });
 
@@ -46,6 +47,7 @@ describe(getName(), () => {
     const lookupName = 'mkdocs';
 
     addMetaData(dep, datasource, lookupName);
+    // FIXME: explicit assert condition
     expect(dep).toMatchSnapshot();
   });
 
@@ -66,6 +68,7 @@ describe(getName(), () => {
     const lookupName = 'django-filter';
 
     addMetaData(dep, datasource, lookupName);
+    // FIXME: explicit assert condition
     expect(dep).toMatchSnapshot();
   });
 
@@ -84,6 +87,7 @@ describe(getName(), () => {
     const lookupName = 'dropzone';
 
     addMetaData(dep, datasource, lookupName);
+    // FIXME: explicit assert condition
     expect(dep).toMatchSnapshot();
   });
   it('Should handle failed parsing of sourceUrls for GitLab', () => {
@@ -101,6 +105,7 @@ describe(getName(), () => {
     const lookupName = 'dropzone';
 
     addMetaData(dep, datasource, lookupName);
+    // FIXME: explicit assert condition
     expect(dep).toMatchSnapshot();
   });
   it('Should handle failed parsing of sourceUrls for other', () => {
@@ -118,6 +123,7 @@ describe(getName(), () => {
     const lookupName = 'dropzone';
 
     addMetaData(dep, datasource, lookupName);
+    // FIXME: explicit assert condition
     expect(dep).toMatchSnapshot();
   });
   it('Should handle non-url', () => {
@@ -135,6 +141,7 @@ describe(getName(), () => {
     const lookupName = 'dropzone';
 
     addMetaData(dep, datasource, lookupName);
+    // FIXME: explicit assert condition
     expect(dep).toMatchSnapshot();
   });
 

--- a/lib/logger/config-serializer.spec.ts
+++ b/lib/logger/config-serializer.spec.ts
@@ -7,12 +7,14 @@ describe(getName(), () => {
       nottoken: 'b',
       prBody: 'foo',
     };
+    // FIXME: explicit assert condition
     expect(configSerializer(config)).toMatchSnapshot();
   });
   it('suppresses content', () => {
     const config = {
       content: {},
     };
+    // FIXME: explicit assert condition
     expect(configSerializer(config)).toMatchSnapshot();
   });
 });

--- a/lib/logger/err-serializer.spec.ts
+++ b/lib/logger/err-serializer.spec.ts
@@ -21,6 +21,7 @@ describe(getName(), () => {
         },
       },
     });
+    // FIXME: explicit assert condition
     expect(errSerializer(err)).toMatchSnapshot();
   });
   it('handles missing fields', () => {
@@ -29,6 +30,7 @@ describe(getName(), () => {
       stack: 'foo',
       body: 'some body',
     });
+    // FIXME: explicit assert condition
     expect(errSerializer(err)).toMatchSnapshot();
   });
 
@@ -85,6 +87,7 @@ describe(getName(), () => {
       delete err.stack;
 
       // sanitize like Bunyan
+      // FIXME: explicit assert condition
       expect(sanitizeValue(err)).toMatchSnapshot();
     });
   });

--- a/lib/logger/index.spec.ts
+++ b/lib/logger/index.spec.ts
@@ -61,6 +61,7 @@ describe('logger', () => {
     logger.error({ some: 'meta' }, 'message');
     logger.warn('a warning with a p4$$w0rd');
     logger.info('ignored');
+    // FIXME: explicit assert condition
     expect(getProblems()).toMatchSnapshot();
     clearProblems();
     expect(getProblems()).toHaveLength(0);

--- a/lib/logger/pretty-stdout.spec.ts
+++ b/lib/logger/pretty-stdout.spec.ts
@@ -67,6 +67,7 @@ describe(getName(), () => {
           d: ['e', 'f'],
         },
       };
+      // FIXME: explicit assert condition
       expect(prettyStdout.getDetails(rec as any)).toMatchSnapshot();
     });
   });
@@ -87,6 +88,7 @@ describe(getName(), () => {
           d: ['e', 'f'],
         },
       };
+      // FIXME: explicit assert condition
       expect(prettyStdout.formatRecord(rec)).toMatchSnapshot();
     });
   });

--- a/lib/manager/azure-pipelines/extract.spec.ts
+++ b/lib/manager/azure-pipelines/extract.spec.ts
@@ -27,6 +27,7 @@ describe(getName(), () => {
 
   describe('extractRepository()', () => {
     it('should extract repository information', () => {
+      // FIXME: explicit assert condition
       expect(
         extractRepository({
           type: 'github',
@@ -69,6 +70,7 @@ describe(getName(), () => {
 
   describe('extractContainer()', () => {
     it('should extract container information', () => {
+      // FIXME: explicit assert condition
       expect(
         extractContainer({
           image: 'ubuntu:16.04',

--- a/lib/manager/bazel/extract.spec.ts
+++ b/lib/manager/bazel/extract.spec.ts
@@ -23,14 +23,17 @@ describe(getName(), () => {
     });
     it('extracts github tags', () => {
       const res = extractPackageFile(workspace2File);
+      // FIXME: explicit assert condition
       expect(res.deps).toMatchSnapshot();
     });
     it('handle comments and strings', () => {
       const res = extractPackageFile(workspace3File);
+      // FIXME: explicit assert condition
       expect(res.deps).toMatchSnapshot();
     });
     it('extracts dependencies from *.bzl files', () => {
       const res = extractPackageFile(fileWithBzlExtension);
+      // FIXME: explicit assert condition
       expect(res.deps).toMatchSnapshot();
     });
 
@@ -46,6 +49,7 @@ describe(getName(), () => {
           tag="v1.0.0-alpha31.cli-migrations"
         )`
       );
+      // FIXME: explicit assert condition
       expect(res.deps).toMatchSnapshot();
     });
 

--- a/lib/manager/bundler/artifacts.spec.ts
+++ b/lib/manager/bundler/artifacts.spec.ts
@@ -72,6 +72,7 @@ describe('bundler.updateArtifacts()', () => {
       modified: [],
     } as StatusResult);
     fs.readLocalFile.mockResolvedValueOnce('Updated Gemfile.lock' as any);
+    // FIXME: explicit assert condition
     expect(
       await updateArtifacts({
         packageFileName: 'Gemfile',
@@ -91,6 +92,7 @@ describe('bundler.updateArtifacts()', () => {
       modified: ['Gemfile.lock'],
     } as StatusResult);
     fs.readLocalFile.mockResolvedValueOnce('Updated Gemfile.lock' as any);
+    // FIXME: explicit assert condition
     expect(
       await updateArtifacts({
         packageFileName: 'Gemfile',
@@ -111,6 +113,7 @@ describe('bundler.updateArtifacts()', () => {
       modified: ['Gemfile.lock'],
     } as StatusResult);
     fs.readLocalFile.mockResolvedValueOnce('Updated Gemfile.lock' as any);
+    // FIXME: explicit assert condition
     expect(
       await updateArtifacts({
         packageFileName: 'Gemfile',
@@ -144,6 +147,7 @@ describe('bundler.updateArtifacts()', () => {
         modified: ['Gemfile.lock'],
       } as StatusResult);
       fs.readLocalFile.mockResolvedValueOnce('Updated Gemfile.lock' as any);
+      // FIXME: explicit assert condition
       expect(
         await updateArtifacts({
           packageFileName: 'Gemfile',
@@ -170,6 +174,7 @@ describe('bundler.updateArtifacts()', () => {
         modified: ['Gemfile.lock'],
       } as StatusResult);
       fs.readLocalFile.mockResolvedValueOnce('Updated Gemfile.lock' as any);
+      // FIXME: explicit assert condition
       expect(
         await updateArtifacts({
           packageFileName: 'Gemfile',
@@ -202,6 +207,7 @@ describe('bundler.updateArtifacts()', () => {
         modified: ['Gemfile.lock'],
       } as StatusResult);
       fs.readLocalFile.mockResolvedValueOnce('Updated Gemfile.lock' as any);
+      // FIXME: explicit assert condition
       expect(
         await updateArtifacts({
           packageFileName: 'Gemfile',
@@ -248,6 +254,7 @@ describe('bundler.updateArtifacts()', () => {
         modified: ['Gemfile.lock'],
       } as StatusResult);
       fs.readLocalFile.mockResolvedValueOnce('Updated Gemfile.lock' as any);
+      // FIXME: explicit assert condition
       expect(
         await updateArtifacts({
           packageFileName: 'Gemfile',
@@ -288,6 +295,7 @@ describe('bundler.updateArtifacts()', () => {
         modified: ['Gemfile.lock'],
       } as StatusResult);
       fs.readLocalFile.mockResolvedValueOnce('Updated Gemfile.lock' as any);
+      // FIXME: explicit assert condition
       expect(
         await updateArtifacts({
           packageFileName: 'Gemfile',
@@ -333,6 +341,7 @@ describe('bundler.updateArtifacts()', () => {
         modified: ['Gemfile.lock'],
       } as StatusResult);
       fs.readLocalFile.mockResolvedValueOnce('Updated Gemfile.lock' as any);
+      // FIXME: explicit assert condition
       expect(
         await updateArtifacts({
           packageFileName: 'Gemfile',
@@ -378,6 +387,7 @@ describe('bundler.updateArtifacts()', () => {
         modified: ['Gemfile.lock'],
       } as StatusResult);
       fs.readLocalFile.mockResolvedValueOnce('Updated Gemfile.lock' as any);
+      // FIXME: explicit assert condition
       expect(
         await updateArtifacts({
           packageFileName: 'Gemfile',
@@ -400,6 +410,7 @@ describe('bundler.updateArtifacts()', () => {
     git.getRepoStatus.mockResolvedValueOnce({
       modified: ['Gemfile.lock'],
     } as StatusResult);
+    // FIXME: explicit assert condition
     expect(
       await updateArtifacts({
         packageFileName: 'Gemfile',

--- a/lib/manager/bundler/gemfile.spec.ts
+++ b/lib/manager/bundler/gemfile.spec.ts
@@ -5,6 +5,7 @@ const gemLockFile = loadFixture('Gemfile.rails.lock');
 
 describe('extract lib/manager/bundler/gemfile.rails.lock', () => {
   it('matches the expected output', () => {
+    // FIXME: explicit assert condition
     expect(extractLockFileEntries(gemLockFile)).toMatchSnapshot();
   });
 });

--- a/lib/manager/bundler/locked-version.spec.ts
+++ b/lib/manager/bundler/locked-version.spec.ts
@@ -10,22 +10,27 @@ const gitlabFossGemfileLock = loadFixture('Gemfile.gitlab-foss.lock');
 describe('/lib/manager/bundler/locked-version', () => {
   test('Parse Rails Gem Lock File', () => {
     const parsedLockEntries = extractLockFileEntries(railsGemfileLock);
+    // FIXME: explicit assert condition
     expect(parsedLockEntries).toMatchSnapshot();
   });
   test('Parse WebPacker Gem Lock File', () => {
     const parsedLockEntries = extractLockFileEntries(webPackerGemfileLock);
+    // FIXME: explicit assert condition
     expect(parsedLockEntries).toMatchSnapshot();
   });
   test('Parse Mastodon Gem Lock File', () => {
     const parsedLockEntries = extractLockFileEntries(mastodonGemfileLock);
+    // FIXME: explicit assert condition
     expect(parsedLockEntries).toMatchSnapshot();
   });
   test('Parse Ruby CI Gem Lock File', () => {
     const parsedLockEntries = extractLockFileEntries(rubyCIGemfileLock);
+    // FIXME: explicit assert condition
     expect(parsedLockEntries).toMatchSnapshot();
   });
   test('Parse Gitlab Foss Gem Lock File', () => {
     const parsedLockEntries = extractLockFileEntries(gitlabFossGemfileLock);
+    // FIXME: explicit assert condition
     expect(parsedLockEntries).toMatchSnapshot();
   });
 });

--- a/lib/manager/cake/index.spec.ts
+++ b/lib/manager/cake/index.spec.ts
@@ -5,6 +5,7 @@ const content = loadFixture('build.cake');
 
 describe(getName(), () => {
   it('extracts', () => {
+    // FIXME: explicit assert condition
     expect(extractPackageFile(content)).toMatchSnapshot();
   });
 });

--- a/lib/manager/cargo/artifacts.spec.ts
+++ b/lib/manager/cargo/artifacts.spec.ts
@@ -201,6 +201,7 @@ describe('.updateArtifacts()', () => {
         depName: 'dep1',
       },
     ];
+    // FIXME: explicit assert condition
     expect(
       await cargo.updateArtifacts({
         packageFileName: 'Cargo.toml',

--- a/lib/manager/cdnurl/extract.spec.ts
+++ b/lib/manager/cdnurl/extract.spec.ts
@@ -5,6 +5,7 @@ const input = loadFixture(`sample.txt`);
 
 describe(getName(), () => {
   it('extractPackageFile', () => {
+    // FIXME: explicit assert condition
     expect(extractPackageFile(input)).toMatchSnapshot();
   });
 });

--- a/lib/manager/circleci/extract.spec.ts
+++ b/lib/manager/circleci/extract.spec.ts
@@ -17,11 +17,13 @@ describe(getName(), () => {
     });
     it('extracts orbs too', () => {
       const res = extractPackageFile(file2);
+      // FIXME: explicit assert condition
       expect(res.deps).toMatchSnapshot();
       // expect(res.deps).toHaveLength(4);
     });
     it('extracts image without leading dash', () => {
       const res = extractPackageFile(file3);
+      // FIXME: explicit assert condition
       expect(res.deps).toMatchSnapshot();
     });
   });

--- a/lib/manager/cocoapods/artifacts.spec.ts
+++ b/lib/manager/cocoapods/artifacts.spec.ts
@@ -130,6 +130,7 @@ describe('.updateArtifacts()', () => {
       modified: ['Podfile.lock'],
     } as StatusResult);
     fs.readFile.mockResolvedValueOnce('New Podfile' as any);
+    // FIXME: explicit assert condition
     expect(
       await updateArtifacts({
         packageFileName: 'Podfile',
@@ -151,6 +152,7 @@ describe('.updateArtifacts()', () => {
       modified: ['Podfile.lock', 'Pods/Manifest.lock'],
       deleted: ['Pods/Deleted'],
     } as StatusResult);
+    // FIXME: explicit assert condition
     expect(
       await updateArtifacts({
         packageFileName: 'Podfile',
@@ -167,6 +169,7 @@ describe('.updateArtifacts()', () => {
     fs.outputFile.mockImplementationOnce(() => {
       throw new Error('not found');
     });
+    // FIXME: explicit assert condition
     expect(
       await updateArtifacts({
         packageFileName: 'Podfile',
@@ -182,6 +185,7 @@ describe('.updateArtifacts()', () => {
     fs.readFile.mockResolvedValueOnce('Old Podfile.lock' as any);
     fs.outputFile.mockResolvedValueOnce(null as never);
     fs.readFile.mockResolvedValueOnce('Old Podfile.lock' as any);
+    // FIXME: explicit assert condition
     expect(
       await updateArtifacts({
         packageFileName: 'Podfile',
@@ -211,6 +215,7 @@ describe('.updateArtifacts()', () => {
       newPackageFileContent: '',
       config,
     });
+    // FIXME: explicit assert condition
     expect(execSnapshots).toMatchSnapshot();
   });
   it('falls back to the `latest` Docker image tag', async () => {
@@ -235,6 +240,7 @@ describe('.updateArtifacts()', () => {
       newPackageFileContent: '',
       config,
     });
+    // FIXME: explicit assert condition
     expect(execSnapshots).toMatchSnapshot();
   });
 });

--- a/lib/manager/cocoapods/extract.spec.ts
+++ b/lib/manager/cocoapods/extract.spec.ts
@@ -16,11 +16,14 @@ describe(getName(), () => {
       setAdminConfig(adminConfig);
       const simpleResult = (await extractPackageFile(simplePodfile, 'Podfile'))
         .deps;
+      // FIXME: explicit assert condition
       expect(simpleResult).toMatchSnapshot();
 
+      // TODO: split test
       const complexResult = (
         await extractPackageFile(complexPodfile, 'Podfile')
       ).deps;
+      // FIXME: explicit assert condition
       expect(complexResult).toMatchSnapshot();
     });
   });

--- a/lib/manager/composer/artifacts.spec.ts
+++ b/lib/manager/composer/artifacts.spec.ts
@@ -279,6 +279,7 @@ describe('.updateArtifacts()', () => {
     fs.writeLocalFile.mockImplementationOnce(() => {
       throw new Error('not found');
     });
+    // FIXME: explicit assert condition
     expect(
       await composer.updateArtifacts({
         packageFileName: 'composer.json',
@@ -296,6 +297,7 @@ describe('.updateArtifacts()', () => {
         'fooYour requirements could not be resolved to an installable set of packages.bar'
       );
     });
+    // FIXME: explicit assert condition
     expect(
       await composer.updateArtifacts({
         packageFileName: 'composer.json',

--- a/lib/manager/composer/extract.spec.ts
+++ b/lib/manager/composer/extract.spec.ts
@@ -24,6 +24,7 @@ describe(getName(), () => {
     });
     it('extracts dependencies with no lock file', async () => {
       const res = await extractPackageFile(requirements1, packageFile);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('extracts registryUrls', async () => {
@@ -50,6 +51,7 @@ describe(getName(), () => {
     it('extracts dependencies with lock file', async () => {
       fs.readLocalFile.mockResolvedValue('some content');
       const res = await extractPackageFile(requirements1, packageFile);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
   });

--- a/lib/manager/deps-edn/extract.spec.ts
+++ b/lib/manager/deps-edn/extract.spec.ts
@@ -5,6 +5,7 @@ const depsEdn = loadFixture('deps.edn');
 
 describe(getName(), () => {
   it('extractPackageFile', () => {
+    // FIXME: explicit assert condition
     expect(extractPackageFile(depsEdn)).toMatchSnapshot();
   });
 });

--- a/lib/manager/dockerfile/extract.spec.ts
+++ b/lib/manager/dockerfile/extract.spec.ts
@@ -12,48 +12,57 @@ describe(getName(), () => {
     });
     it('handles naked dep', () => {
       const res = extractPackageFile('FROM node\n').deps;
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('is case insensitive', () => {
       const res = extractPackageFile('From node\n').deps;
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('handles tag', () => {
       const res = extractPackageFile('FROM node:8.9.0-alpine\n').deps;
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('handles digest', () => {
       const res = extractPackageFile(
         'FROM node@sha256:eb85fc5b1198f5e1ec025ea07586bdbbf397e7d82df66c90d7511f533517e063\n'
       ).deps;
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('handles tag and digest', () => {
       const res = extractPackageFile(
         'FROM node:8.9.0@sha256:eb85fc5b1198f5e1ec025ea07586bdbbf397e7d82df66c90d7511f533517e063\n'
       ).deps;
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('handles from as', () => {
       const res = extractPackageFile('FROM node:8.9.0-alpine as base\n').deps;
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('handles comments', () => {
       const res = extractPackageFile(
         '# some comment\n# another\n\nFROM node\n'
       ).deps;
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('handles custom hosts', () => {
       const res = extractPackageFile(
         'FROM registry2.something.info/node:8\n'
       ).deps;
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('handles custom hosts and suffix', () => {
       const res = extractPackageFile(
         'FROM registry2.something.info/node:8-alpine\n'
       ).deps;
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('handles custom hosts with port', () => {
@@ -73,18 +82,21 @@ describe(getName(), () => {
     });
     it('handles namespaced images', () => {
       const res = extractPackageFile('FROM mynamespace/node:8\n').deps;
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('handles custom hosts with namespace', () => {
       const res = extractPackageFile(
         'FROM registry2.something.info/someaccount/node:8\n'
       ).deps;
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('handles abnormal spacing', () => {
       const res = extractPackageFile(
         'FROM    registry.allmine.info:5005/node:8.7.0\n\n'
       ).deps;
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('extracts multiple FROM tags', () => {
@@ -109,6 +121,7 @@ describe(getName(), () => {
       const res = extractPackageFile(
         'FROM scratch\nCOPY --from=gcr.io/k8s-skaffold/skaffold:v0.11.0 /usr/bin/skaffold /usr/bin/skaffold\n'
       ).deps;
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('skips named multistage COPY --from tags', () => {
@@ -149,15 +162,18 @@ describe(getName(), () => {
     });
     it('handles calico/node', () => {
       const res = extractPackageFile('FROM calico/node\n').deps;
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('handles ubuntu', () => {
       const res = extractPackageFile('FROM ubuntu:18.04\n').deps;
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
   });
   describe('getDep()', () => {
     it('rejects null', () => {
+      // FIXME: explicit assert condition
       expect(getDep(null)).toMatchSnapshot();
     });
   });

--- a/lib/manager/git-submodules/artifact.spec.ts
+++ b/lib/manager/git-submodules/artifact.spec.ts
@@ -4,6 +4,7 @@ import updateArtifacts from './artifacts';
 describe(getName(), () => {
   describe('updateArtifacts()', () => {
     it('returns empty content', () => {
+      // FIXME: explicit assert condition
       expect(
         updateArtifacts({
           packageFileName: '',
@@ -14,6 +15,7 @@ describe(getName(), () => {
       ).toMatchSnapshot();
     });
     it('returns two modules', () => {
+      // FIXME: explicit assert condition
       expect(
         updateArtifacts({
           packageFileName: '',

--- a/lib/manager/gomod/artifacts.spec.ts
+++ b/lib/manager/gomod/artifacts.spec.ts
@@ -243,6 +243,7 @@ describe('.updateArtifacts()', () => {
     fs.outputFile.mockImplementationOnce(() => {
       throw new Error('This update totally doesnt work');
     });
+    // FIXME: explicit assert condition
     expect(
       await gomod.updateArtifacts({
         packageFileName: 'go.mod',
@@ -264,6 +265,7 @@ describe('.updateArtifacts()', () => {
       .mockResolvedValueOnce('New go.sum' as any)
       .mockResolvedValueOnce('New main.go' as any)
       .mockResolvedValueOnce('New go.mod' as any);
+    // FIXME: explicit assert condition
     expect(
       await gomod.updateArtifacts({
         packageFileName: 'go.mod',
@@ -289,6 +291,7 @@ describe('.updateArtifacts()', () => {
     fs.readFile
       .mockResolvedValueOnce('New go.sum' as any)
       .mockResolvedValueOnce('New go.mod' as any);
+    // FIXME: explicit assert condition
     expect(
       await gomod.updateArtifacts({
         packageFileName: 'go.mod',
@@ -315,6 +318,7 @@ describe('.updateArtifacts()', () => {
       .mockResolvedValueOnce('New go.sum' as any)
       .mockResolvedValueOnce('New main.go' as any)
       .mockResolvedValueOnce('New go.mod' as any);
+    // FIXME: explicit assert condition
     expect(
       await gomod.updateArtifacts({
         packageFileName: 'go.mod',
@@ -344,6 +348,7 @@ describe('.updateArtifacts()', () => {
       .mockResolvedValueOnce('New go.sum' as any)
       .mockResolvedValueOnce('New main.go' as any)
       .mockResolvedValueOnce('New go.mod' as any);
+    // FIXME: explicit assert condition
     expect(
       await gomod.updateArtifacts({
         packageFileName: 'go.mod',
@@ -372,6 +377,7 @@ describe('.updateArtifacts()', () => {
     fs.readFile
       .mockResolvedValueOnce('New go.sum' as any)
       .mockResolvedValueOnce('New go.mod' as any);
+    // FIXME: explicit assert condition
     expect(
       await gomod.updateArtifacts({
         packageFileName: 'go.mod',

--- a/lib/manager/gradle-wrapper/extract.spec.ts
+++ b/lib/manager/gradle-wrapper/extract.spec.ts
@@ -17,11 +17,13 @@ describe(getName(), () => {
 
     it('extracts bin version line', () => {
       const res = extractPackageFile(propertiesFile1);
+      // FIXME: explicit assert condition
       expect(res.deps).toMatchSnapshot();
     });
 
     it('extracts all version line', () => {
       const res = extractPackageFile(propertiesFile2);
+      // FIXME: explicit assert condition
       expect(res.deps).toMatchSnapshot();
     });
 
@@ -38,6 +40,7 @@ describe(getName(), () => {
 
     it('handles whitespace', () => {
       const res = extractPackageFile(whitespacePropertiesFile);
+      // FIXME: explicit assert condition
       expect(res.deps).toMatchSnapshot();
     });
   });

--- a/lib/manager/gradle/gradle-updates-report.spec.ts
+++ b/lib/manager/gradle/gradle-updates-report.spec.ts
@@ -37,6 +37,7 @@ describe(getName(), () => {
             cwd: workingDir.path,
             extraEnv,
           });
+          // FIXME: explicit assert condition
           expect(
             fs.readJSONSync(
               `${workingDir.path}/${GRADLE_DEPENDENCY_REPORT_FILENAME}`

--- a/lib/manager/gradle/index.spec.ts
+++ b/lib/manager/gradle/index.spec.ts
@@ -107,6 +107,7 @@ describe(getName(), () => {
       const dependencies = await extractAllPackageFiles(config, [
         'build.gradle',
       ]);
+      // FIXME: explicit assert condition
       expect(dependencies).toMatchSnapshot();
       expect(execSnapshots).toMatchSnapshot();
     });
@@ -116,6 +117,7 @@ describe(getName(), () => {
       const dependencies = await extractAllPackageFiles(config, [
         'build.gradle.kts',
       ]);
+      // FIXME: explicit assert condition
       expect(dependencies).toMatchSnapshot();
       expect(execSnapshots).toMatchSnapshot();
     });
@@ -156,6 +158,7 @@ describe(getName(), () => {
       const dependencies = await extractAllPackageFiles(config, [
         'build.gradle',
       ]);
+      // FIXME: explicit assert condition
       expect(dependencies).toMatchSnapshot();
       expect(execSnapshots).toMatchSnapshot();
     });
@@ -165,6 +168,7 @@ describe(getName(), () => {
       const dependencies = await extractAllPackageFiles(config, [
         'build.gradle',
       ]);
+      // FIXME: explicit assert condition
       expect(dependencies).toMatchSnapshot();
       expect(execSnapshots).toMatchSnapshot();
     });
@@ -175,6 +179,7 @@ describe(getName(), () => {
       const dependencies = await extractAllPackageFiles(config, [
         'build.gradle',
       ]);
+      // FIXME: explicit assert condition
       expect(dependencies).toMatchSnapshot();
       expect(execSnapshots).toMatchSnapshot();
     });
@@ -184,6 +189,7 @@ describe(getName(), () => {
       const dependencies = await extractAllPackageFiles(config, [
         'build.gradle',
       ]);
+      // FIXME: explicit assert condition
       expect(dependencies).toMatchSnapshot();
       expect(execSnapshots).toMatchSnapshot();
     });
@@ -207,6 +213,7 @@ describe(getName(), () => {
       const dependencies = await extractAllPackageFiles(config, [
         'baz/qux/build.gradle',
       ]);
+      // FIXME: explicit assert condition
       expect(dependencies).toMatchSnapshot();
       expect(execSnapshots).toMatchSnapshot();
     });
@@ -217,6 +224,7 @@ describe(getName(), () => {
       const dependencies = await extractAllPackageFiles(config, [
         'build.gradle',
       ]);
+      // FIXME: explicit assert condition
       expect(dependencies).toMatchSnapshot();
       expect(execSnapshots).toMatchSnapshot();
     });
@@ -227,6 +235,7 @@ describe(getName(), () => {
       const dependencies = await extractAllPackageFiles(config, [
         'build.gradle',
       ]);
+      // FIXME: explicit assert condition
       expect(dependencies).toMatchSnapshot();
       expect(execSnapshots).toMatchSnapshot();
     });
@@ -238,6 +247,7 @@ describe(getName(), () => {
       const dependencies = await extractAllPackageFiles(config, [
         'build.gradle',
       ]);
+      // FIXME: explicit assert condition
       expect(dependencies).toMatchSnapshot();
       expect(execSnapshots).toMatchSnapshot();
     });

--- a/lib/manager/helm-requirements/extract.spec.ts
+++ b/lib/manager/helm-requirements/extract.spec.ts
@@ -62,6 +62,7 @@ describe(getName(), () => {
           stable: 'https://charts.helm.sh/stable/',
         },
       });
+      // FIXME: explicit assert condition
       expect(result).not.toBeNull();
       expect(result).toMatchSnapshot();
     });
@@ -131,6 +132,7 @@ describe(getName(), () => {
           stable: 'https://charts.helm.sh/stable/',
         },
       });
+      // FIXME: explicit assert condition
       expect(result).not.toBeNull();
       expect(result).toMatchSnapshot();
     });

--- a/lib/manager/helm-values/extract.spec.ts
+++ b/lib/manager/helm-values/extract.spec.ts
@@ -28,6 +28,7 @@ describe(getName(), () => {
     });
     it('extracts from values.yaml correctly with same structure as "helm create"', () => {
       const result = extractPackageFile(helmDefaultChartInitValues);
+      // FIXME: explicit assert condition
       expect(result).toMatchSnapshot();
     });
     it('extracts from complex values file correctly"', () => {

--- a/lib/manager/helmfile/extract.spec.ts
+++ b/lib/manager/helmfile/extract.spec.ts
@@ -81,6 +81,7 @@ describe(getName(), () => {
           stable: 'https://charts.helm.sh/stable',
         },
       });
+      // FIXME: explicit assert condition
       expect(result).not.toBeNull();
       expect(result).toMatchSnapshot();
     });
@@ -178,6 +179,7 @@ describe(getName(), () => {
           stable: 'https://charts.helm.sh/stable',
         },
       });
+      // FIXME: explicit assert condition
       expect(result).not.toBeNull();
       expect(result).toMatchSnapshot();
     });

--- a/lib/manager/helmv3/artifacts.spec.ts
+++ b/lib/manager/helmv3/artifacts.spec.ts
@@ -79,6 +79,7 @@ describe('.updateArtifacts()', () => {
     const execSnapshots = mockExecAll(exec);
     fs.readFile.mockResolvedValueOnce('New Chart.lock' as any);
     const updatedDeps = [{ depName: 'dep1' }];
+    // FIXME: explicit assert condition
     expect(
       await helmv3.updateArtifacts({
         packageFileName: 'Chart.yaml',
@@ -94,6 +95,7 @@ describe('.updateArtifacts()', () => {
     git.getFile.mockResolvedValueOnce('Old Chart.lock');
     const execSnapshots = mockExecAll(exec);
     fs.readFile.mockResolvedValueOnce('New Chart.lock' as any);
+    // FIXME: explicit assert condition
     expect(
       await helmv3.updateArtifacts({
         packageFileName: 'Chart.yaml',
@@ -111,6 +113,7 @@ describe('.updateArtifacts()', () => {
     const execSnapshots = mockExecAll(exec);
     fs.readFile.mockResolvedValueOnce('New Chart.lock' as any);
     const updatedDeps = [{ depName: 'dep1' }];
+    // FIXME: explicit assert condition
     expect(
       await helmv3.updateArtifacts({
         packageFileName: 'Chart.yaml',
@@ -127,6 +130,7 @@ describe('.updateArtifacts()', () => {
       throw new Error('not found');
     });
     const updatedDeps = [{ depName: 'dep1' }];
+    // FIXME: explicit assert condition
     expect(
       await helmv3.updateArtifacts({
         packageFileName: 'Chart.yaml',

--- a/lib/manager/helmv3/extract.spec.ts
+++ b/lib/manager/helmv3/extract.spec.ts
@@ -59,6 +59,7 @@ describe(getName(), () => {
           stable: 'https://charts.helm.sh/stable',
         },
       });
+      // FIXME: explicit assert condition
       expect(result).not.toBeNull();
       expect(result).toMatchSnapshot();
     });
@@ -123,6 +124,7 @@ describe(getName(), () => {
           stable: 'https://charts.helm.sh/stable',
         },
       });
+      // FIXME: explicit assert condition
       expect(result).not.toBeNull();
       expect(result).toMatchSnapshot();
     });

--- a/lib/manager/helmv3/update.spec.ts
+++ b/lib/manager/helmv3/update.spec.ts
@@ -15,6 +15,7 @@ describe(getName(), () => {
         '0.0.2',
         'patch'
       );
+      // FIXME: explicit assert condition
       expect(bumpedContent).toMatchSnapshot();
       expect(bumpedContent).not.toEqual(content);
     });
@@ -32,6 +33,7 @@ describe(getName(), () => {
         '0.0.1',
         'minor'
       );
+      // FIXME: explicit assert condition
       expect(bumpedContent).toMatchSnapshot();
       expect(bumpedContent).not.toEqual(content);
     });

--- a/lib/manager/homebrew/extract.spec.ts
+++ b/lib/manager/homebrew/extract.spec.ts
@@ -98,6 +98,7 @@ describe(getName(), () => {
           end
       `;
       const res = extractPackageFile(content);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('skips if invalid url version', () => {
@@ -110,6 +111,7 @@ describe(getName(), () => {
           end
       `;
       const res = extractPackageFile(content);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('skips if invalid url protocol', () => {
@@ -122,6 +124,7 @@ describe(getName(), () => {
           end
       `;
       const res = extractPackageFile(content);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('skips if invalid url', () => {
@@ -134,6 +137,7 @@ describe(getName(), () => {
           end
       `;
       const res = extractPackageFile(content);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('skips if there is no sha256 field', () => {

--- a/lib/manager/html/extract.spec.ts
+++ b/lib/manager/html/extract.spec.ts
@@ -6,6 +6,7 @@ const nothing = loadFixture(`nothing.html`);
 
 describe(getName(), () => {
   it('extractPackageFile', () => {
+    // FIXME: explicit assert condition
     expect(extractPackageFile(sample)).toMatchSnapshot();
   });
   it('returns null', () => {

--- a/lib/manager/kustomize/extract.spec.ts
+++ b/lib/manager/kustomize/extract.spec.ts
@@ -252,6 +252,7 @@ describe(getName(), () => {
       expect(res.deps[1].depName).toEqual('fluxcd/flux');
     });
     it('extracts sha256 instead of tag', () => {
+      // FIXME: explicit assert condition
       expect(extractPackageFile(sha)).toMatchSnapshot();
     });
   });

--- a/lib/manager/leiningen/extract.spec.ts
+++ b/lib/manager/leiningen/extract.spec.ts
@@ -53,6 +53,7 @@ describe(getName(), () => {
     ]);
   });
   it('extractPackageFile', () => {
+    // FIXME: explicit assert condition
     expect(extractPackageFile(leinProjectClj)).toMatchSnapshot();
   });
   it('extractVariables', () => {

--- a/lib/manager/maven/extract.spec.ts
+++ b/lib/manager/maven/extract.spec.ts
@@ -16,10 +16,12 @@ describe(getName(), () => {
 
     it('extract dependencies from any XML position', () => {
       const res = extractPackage(simpleContent);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('tries minimum manifests', () => {
       const res = extractPackage(minimumContent);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
   });

--- a/lib/manager/maven/index.spec.ts
+++ b/lib/manager/maven/index.spec.ts
@@ -37,6 +37,7 @@ describe(getName(), () => {
           p.parent = p.parent.replace(/\\/g, '/');
         }
       }
+      // FIXME: explicit assert condition
       expect(packages).toMatchSnapshot();
     });
   });
@@ -102,6 +103,7 @@ describe(getName(), () => {
           expect(depUrls).toEqual(urls);
         });
       });
+      // FIXME: explicit assert condition
       expect(packages).toMatchSnapshot();
     });
 

--- a/lib/manager/mix/artifacts.spec.ts
+++ b/lib/manager/mix/artifacts.spec.ts
@@ -86,6 +86,7 @@ describe(getName(), () => {
     fs.getSiblingFileName.mockReturnValueOnce('mix.lock');
     const execSnapshots = mockExecAll(exec);
     fs.readLocalFile.mockResolvedValueOnce('New mix.lock');
+    // FIXME: explicit assert condition
     expect(
       await updateArtifacts({
         packageFileName: 'mix.exs',
@@ -118,6 +119,7 @@ describe(getName(), () => {
     fs.writeLocalFile.mockImplementationOnce(() => {
       throw new Error('not found');
     });
+    // FIXME: explicit assert condition
     expect(
       await updateArtifacts({
         packageFileName: 'mix.exs',
@@ -134,6 +136,7 @@ describe(getName(), () => {
     exec.mockImplementationOnce(() => {
       throw new Error('exec-error');
     });
+    // FIXME: explicit assert condition
     expect(
       await updateArtifacts({
         packageFileName: 'mix.exs',

--- a/lib/manager/mix/extract.spec.ts
+++ b/lib/manager/mix/extract.spec.ts
@@ -11,11 +11,13 @@ describe(getName(), () => {
 
   describe('extractPackageFile()', () => {
     it('returns empty for invalid dependency file', async () => {
+      // FIXME: explicit assert condition
       expect(
         await extractPackageFile('nothing here', 'mix.exs')
       ).toMatchSnapshot();
     });
     it('extracts all dependencies', async () => {
+      // FIXME: explicit assert condition
       const res = await extractPackageFile(sample, 'mix.exs');
       expect(res).toMatchSnapshot();
     });

--- a/lib/manager/nodenv/extract.spec.ts
+++ b/lib/manager/nodenv/extract.spec.ts
@@ -5,14 +5,17 @@ describe(getName(), () => {
   describe('extractPackageFile()', () => {
     it('returns a result', () => {
       const res = extractPackageFile('8.4.0\n');
+      // FIXME: explicit assert condition
       expect(res.deps).toMatchSnapshot();
     });
     it('supports ranges', () => {
       const res = extractPackageFile('8.4\n');
+      // FIXME: explicit assert condition
       expect(res.deps).toMatchSnapshot();
     });
     it('skips non ranges', () => {
       const res = extractPackageFile('latestn');
+      // FIXME: explicit assert condition
       expect(res.deps).toMatchSnapshot();
     });
   });

--- a/lib/manager/npm/extract/index.spec.ts
+++ b/lib/manager/npm/extract/index.spec.ts
@@ -37,6 +37,7 @@ describe(getName(), () => {
         'package.json',
         defaultConfig
       );
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('ignores vendorised package.json', async () => {
@@ -78,6 +79,7 @@ describe(getName(), () => {
         'package.json',
         defaultConfig
       );
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('returns an array of dependencies with resolution comments', async () => {
@@ -87,6 +89,7 @@ describe(getName(), () => {
         defaultConfig
       );
       expect(res?.deps).toHaveLength(13);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('finds a lock file', async () => {
@@ -101,6 +104,7 @@ describe(getName(), () => {
         'package.json',
         defaultConfig
       );
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('finds and filters .npmrc', async () => {
@@ -158,6 +162,7 @@ describe(getName(), () => {
         'package.json',
         defaultConfig
       );
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('finds "npmClient":"npm" in lerna.json', async () => {
@@ -172,6 +177,7 @@ describe(getName(), () => {
         'package.json',
         defaultConfig
       );
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('finds "npmClient":"yarn" in lerna.json', async () => {
@@ -186,6 +192,7 @@ describe(getName(), () => {
         'package.json',
         defaultConfig
       );
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('finds simple yarn workspaces', async () => {
@@ -200,6 +207,7 @@ describe(getName(), () => {
         'package.json',
         defaultConfig
       );
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('finds simple yarn workspaces with lerna.json and useWorkspaces: true', async () => {
@@ -214,6 +222,7 @@ describe(getName(), () => {
         'package.json',
         defaultConfig
       );
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('finds complex yarn workspaces', async () => {
@@ -228,6 +237,7 @@ describe(getName(), () => {
         'package.json',
         defaultConfig
       );
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('extracts engines', async () => {
@@ -258,6 +268,7 @@ describe(getName(), () => {
         'package.json',
         defaultConfig
       );
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('extracts volta', async () => {
@@ -279,6 +290,7 @@ describe(getName(), () => {
         'package.json',
         defaultConfig
       );
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
 
@@ -299,6 +311,7 @@ describe(getName(), () => {
         'package.json',
         defaultConfig
       );
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('extracts non-npmjs', async () => {
@@ -326,6 +339,7 @@ describe(getName(), () => {
         'package.json',
         defaultConfig
       );
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('extracts npm package alias', async () => {
@@ -348,6 +362,7 @@ describe(getName(), () => {
         'package.json',
         defaultConfig
       );
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
   });

--- a/lib/manager/npm/extract/locked-versions.spec.ts
+++ b/lib/manager/npm/extract/locked-versions.spec.ts
@@ -46,6 +46,7 @@ describe(getName(), () => {
           },
         ];
         await getLockedVersions(packageFiles);
+        // FIXME: explicit assert condition
         expect(packageFiles).toMatchSnapshot();
       }
     );
@@ -78,6 +79,7 @@ describe(getName(), () => {
           },
         ];
         await getLockedVersions(packageFiles);
+        // FIXME: explicit assert condition
         expect(packageFiles).toMatchSnapshot();
       }
     );
@@ -109,6 +111,7 @@ describe(getName(), () => {
         },
       ];
       await getLockedVersions(packageFiles);
+      // FIXME: explicit assert condition
       expect(packageFiles).toMatchSnapshot();
     });
     it('ignores pnpm', async () => {
@@ -128,6 +131,7 @@ describe(getName(), () => {
         },
       ];
       await getLockedVersions(packageFiles);
+      // FIXME: explicit assert condition
       expect(packageFiles).toMatchSnapshot();
     });
   });

--- a/lib/manager/npm/extract/monorepo.spec.ts
+++ b/lib/manager/npm/extract/monorepo.spec.ts
@@ -153,6 +153,7 @@ describe(getName(), () => {
         },
       ];
       await detectMonorepos(packageFiles, false);
+      // FIXME: explicit assert condition
       expect(packageFiles).toMatchSnapshot();
     });
   });

--- a/lib/manager/npm/extract/pnpm.spec.ts
+++ b/lib/manager/npm/extract/pnpm.spec.ts
@@ -24,7 +24,7 @@ describe(getName(), () => {
         '..'
       );
       const res = await extractPnpmFilters(workSpaceFilePath);
-
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
       expect(logger.logger.trace).toHaveBeenCalledWith(
         {
@@ -40,7 +40,7 @@ describe(getName(), () => {
       });
 
       const res = await extractPnpmFilters('pnpm-workspace.yml');
-
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
       expect(logger.logger.trace).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -58,6 +58,7 @@ describe(getName(), () => {
 
       const packageFile = 'package.json';
       const res = await findPnpmWorkspace(packageFile);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
       expect(logger.logger.trace).toHaveBeenCalledWith(
         expect.objectContaining({ packageFile }),
@@ -70,6 +71,7 @@ describe(getName(), () => {
 
       const packageFile = 'package.json';
       const res = await findPnpmWorkspace(packageFile);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
       expect(logger.logger.trace).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -136,6 +138,7 @@ describe(getName(), () => {
       ];
 
       await detectPnpmWorkspaces(packageFiles);
+      // FIXME: explicit assert condition
       expect(packageFiles).toMatchSnapshot();
     });
 
@@ -158,6 +161,7 @@ describe(getName(), () => {
       ];
 
       await detectPnpmWorkspaces(packageFiles);
+      // FIXME: explicit assert condition
       expect(packageFiles).toMatchSnapshot();
       expect(
         packageFiles.find(

--- a/lib/manager/npm/post-update/rules.spec.ts
+++ b/lib/manager/npm/post-update/rules.spec.ts
@@ -26,6 +26,7 @@ describe(getName(), () => {
         password: 'pass123',
       });
       const res = processHostRules();
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('returns mixed rules content', () => {
@@ -47,6 +48,7 @@ describe(getName(), () => {
         password: 'pass123',
       });
       const res = processHostRules();
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
   });

--- a/lib/manager/npm/post-update/yarn.spec.ts
+++ b/lib/manager/npm/post-update/yarn.spec.ts
@@ -179,6 +179,7 @@ describe(getName(), () => {
         }
         return new Promise<string>((resolve) => resolve(''));
       });
+      // FIXME: explicit assert condition
       expect(await _yarnHelper.checkYarnrc('/tmp/renovate')).toMatchSnapshot();
     });
     it('returns no offline mirror and unquoted yarn path', async () => {
@@ -190,6 +191,7 @@ describe(getName(), () => {
         }
         return new Promise<string>((resolve) => resolve(''));
       });
+      // FIXME: explicit assert condition
       expect(await _yarnHelper.checkYarnrc('/tmp/renovate')).toMatchSnapshot();
     });
   });

--- a/lib/manager/npm/update/dependency/index.spec.ts
+++ b/lib/manager/npm/update/dependency/index.spec.ts
@@ -38,6 +38,7 @@ describe(getName(), () => {
         fileContent: input,
         upgrade,
       });
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('replaces a npm package alias', () => {
@@ -58,6 +59,7 @@ describe(getName(), () => {
         fileContent: input,
         upgrade,
       });
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('replaces a github short hash', () => {
@@ -77,6 +79,7 @@ describe(getName(), () => {
         fileContent: input,
         upgrade,
       });
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('replaces a github fully specified version', () => {

--- a/lib/manager/npm/update/locked-dependency/dep-constraints.spec.ts
+++ b/lib/manager/npm/update/locked-dependency/dep-constraints.spec.ts
@@ -9,6 +9,7 @@ const packageLockJson = loadJsonFixture('package-lock.json');
 describe(getName(), () => {
   describe('findDepConstraints()', () => {
     it('finds indirect dependency', () => {
+      // FIXME: explicit assert condition
       expect(
         findDepConstraints(
           packageJson,
@@ -20,6 +21,7 @@ describe(getName(), () => {
       ).toMatchSnapshot();
     });
     it('finds direct dependency', () => {
+      // FIXME: explicit assert condition
       expect(
         findDepConstraints(
           packageJson,
@@ -34,6 +36,7 @@ describe(getName(), () => {
       const packageJsonDev = { ...packageJson };
       packageJsonDev.devDependencies = packageJsonDev.dependencies;
       delete packageJsonDev.dependencies;
+      // FIXME: explicit assert condition
       expect(
         findDepConstraints(
           packageJsonDev,

--- a/lib/manager/npm/update/locked-dependency/get-locked.spec.ts
+++ b/lib/manager/npm/update/locked-dependency/get-locked.spec.ts
@@ -16,11 +16,13 @@ describe(getName(), () => {
       expect(getLockedDependencies({}, 'some-dep', '1.0.0')).toEqual([]);
     });
     it('finds direct dependency', () => {
+      // FIXME: explicit assert condition
       expect(
         getLockedDependencies(packageLockJson, 'express', '4.0.0')
       ).toMatchSnapshot();
     });
     it('finds indirect dependency', () => {
+      // FIXME: explicit assert condition
       expect(
         getLockedDependencies(packageLockJson, 'send', '0.2.0')
       ).toMatchSnapshot();

--- a/lib/manager/nuget/artifacts.spec.ts
+++ b/lib/manager/nuget/artifacts.spec.ts
@@ -187,6 +187,7 @@ describe('updateArtifacts', () => {
     fs.writeLocalFile.mockImplementationOnce(() => {
       throw new Error('not found');
     });
+    // FIXME: explicit assert condition
     expect(
       await nuget.updateArtifacts({
         packageFileName: 'project.csproj',

--- a/lib/manager/nuget/extract.spec.ts
+++ b/lib/manager/nuget/extract.spec.ts
@@ -20,6 +20,7 @@ describe(getName(), () => {
       setAdminConfig();
     });
     it('returns empty for invalid csproj', async () => {
+      // FIXME: explicit assert condition
       expect(
         await extractPackageFile('nothing here', 'bogus', config)
       ).toMatchSnapshot();
@@ -49,6 +50,7 @@ describe(getName(), () => {
     it('considers NuGet.config', async () => {
       const packageFile = 'with-config-file/with-config-file.csproj';
       const contents = loadFixture(packageFile);
+      // FIXME: explicit assert condition
       expect(
         await extractPackageFile(contents, packageFile, config)
       ).toMatchSnapshot();
@@ -57,7 +59,7 @@ describe(getName(), () => {
       const packageFile =
         'with-lower-case-config-file/with-lower-case-config-file.csproj';
       const contents = loadFixture(packageFile);
-
+      // FIXME: explicit assert condition
       expect(
         await extractPackageFile(contents, packageFile, config)
       ).toMatchSnapshot();
@@ -66,7 +68,7 @@ describe(getName(), () => {
       const packageFile =
         'with-pascal-case-config-file/with-pascal-case-config-file.csproj';
       const contents = loadFixture(packageFile);
-
+      // FIXME: explicit assert condition
       expect(
         await extractPackageFile(contents, packageFile, config)
       ).toMatchSnapshot();
@@ -75,7 +77,7 @@ describe(getName(), () => {
       const packageFile =
         'with-malformed-config-file/with-malformed-config-file.csproj';
       const contents = loadFixture(packageFile);
-
+      // FIXME: explicit assert condition
       expect(
         await extractPackageFile(contents, packageFile, config)
       ).toMatchSnapshot();
@@ -84,7 +86,7 @@ describe(getName(), () => {
       const packageFile =
         'without-package-sources/without-package-sources.csproj';
       const contents = loadFixture(packageFile);
-
+      // FIXME: explicit assert condition
       expect(
         await extractPackageFile(contents, packageFile, config)
       ).toMatchSnapshot();
@@ -93,7 +95,7 @@ describe(getName(), () => {
       const packageFile =
         'with-local-feed-in-config-file/with-local-feed-in-config-file.csproj';
       const contents = loadFixture(packageFile);
-
+      // FIXME: explicit assert condition
       expect(
         await extractPackageFile(contents, packageFile, config)
       ).toMatchSnapshot();
@@ -103,6 +105,7 @@ describe(getName(), () => {
       const contents = loadFixture(packageFile);
       const otherPackageFile = 'multiple-package-files/two/two.csproj';
       const otherContents = loadFixture(otherPackageFile);
+      // FIXME: explicit assert condition
       expect(
         await extractPackageFile(contents, packageFile, config)
       ).toMatchSnapshot();
@@ -124,12 +127,14 @@ describe(getName(), () => {
   }
 }`;
       it('works', async () => {
+        // FIXME: explicit assert condition
         expect(
           await extractPackageFile(contents, packageFile, config)
         ).toMatchSnapshot();
       });
 
       it('with-config', async () => {
+        // FIXME: explicit assert condition
         expect(
           await extractPackageFile(
             contents,

--- a/lib/manager/nvm/extract.spec.ts
+++ b/lib/manager/nvm/extract.spec.ts
@@ -5,14 +5,17 @@ describe(getName(), () => {
   describe('extractPackageFile()', () => {
     it('returns a result', () => {
       const res = extractPackageFile('8.4.0\n');
+      // FIXME: explicit assert condition
       expect(res.deps).toMatchSnapshot();
     });
     it('supports ranges', () => {
       const res = extractPackageFile('8.4\n');
+      // FIXME: explicit assert condition
       expect(res.deps).toMatchSnapshot();
     });
     it('skips non ranges', () => {
       const res = extractPackageFile('latestn');
+      // FIXME: explicit assert condition
       expect(res.deps).toMatchSnapshot();
     });
   });

--- a/lib/manager/pip-compile/artifacts.spec.ts
+++ b/lib/manager/pip-compile/artifacts.spec.ts
@@ -111,6 +111,7 @@ describe('.updateArtifacts()', () => {
     fs.outputFile.mockImplementationOnce(() => {
       throw new Error('not found');
     });
+    // FIXME: explicit assert condition
     expect(
       await pipCompile.updateArtifacts({
         packageFileName: 'requirements.in',

--- a/lib/manager/pip_setup/extract.spec.ts
+++ b/lib/manager/pip_setup/extract.spec.ts
@@ -35,6 +35,7 @@ describe(getName(), () => {
       ]);
       const result = await getPythonAlias();
       expect(pythonVersions).toContain(result);
+      // FIXME: explicit assert condition
       expect(result).toMatchSnapshot();
       expect(await getPythonAlias()).toEqual(result);
       expect(execSnapshots).toMatchSnapshot();

--- a/lib/manager/pip_setup/index.spec.ts
+++ b/lib/manager/pip_setup/index.spec.ts
@@ -67,6 +67,7 @@ describe(getName(), () => {
         },
       ]);
       jest.spyOn(fs, 'readLocalFile').mockResolvedValueOnce(jsonContent);
+      // FIXME: explicit assert condition
       expect(
         await extractPackageFile(content, packageFile, config)
       ).toMatchSnapshot();

--- a/lib/manager/pipenv/artifacts.spec.ts
+++ b/lib/manager/pipenv/artifacts.spec.ts
@@ -131,6 +131,7 @@ describe('.updateArtifacts()', () => {
     fs.outputFile.mockImplementationOnce(() => {
       throw new Error('not found');
     });
+    // FIXME: explicit assert condition
     expect(
       await pipenv.updateArtifacts({
         packageFileName: 'Pipfile',

--- a/lib/manager/pipenv/extract.spec.ts
+++ b/lib/manager/pipenv/extract.spec.ts
@@ -67,6 +67,7 @@ describe(getName(), () => {
     });
     it('extracts example pipfile', async () => {
       const res = await extractPackageFile(pipfile4, 'Pipfile');
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('supports custom index', async () => {

--- a/lib/manager/poetry/artifacts.spec.ts
+++ b/lib/manager/poetry/artifacts.spec.ts
@@ -184,6 +184,7 @@ describe('.updateArtifacts()', () => {
       throw new Error('not found');
     });
     const updatedDeps = [{ depName: 'dep1' }];
+    // FIXME: explicit assert condition
     expect(
       await updateArtifacts({
         packageFileName: 'pyproject.toml',

--- a/lib/manager/poetry/extract.spec.ts
+++ b/lib/manager/poetry/extract.spec.ts
@@ -73,15 +73,18 @@ describe(getName(), () => {
     });
     it('dedupes registries', async () => {
       const res = await extractPackageFile(pyproject8toml, filename);
+      // FIXME: explicit assert condition
       expect(res.registryUrls).toMatchSnapshot();
     });
     it('extracts mixed versioning types', async () => {
       const res = await extractPackageFile(pyproject9toml, filename);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('resolves lockedVersions from the lockfile', async () => {
       fs.readLocalFile.mockResolvedValue(pyproject11tomlLock);
       const res = await extractPackageFile(pyproject11toml, filename);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('skips git dependencies', async () => {

--- a/lib/manager/pre-commit/extract.spec.ts
+++ b/lib/manager/pre-commit/extract.spec.ts
@@ -50,20 +50,24 @@ describe(getName(), () => {
     });
     it('extracts from values.yaml correctly with same structure as "pre-commit sample-config"', () => {
       const result = extractPackageFile(examplePrecommitConfig, filename);
+      // FIXME: explicit assert condition
       expect(result).toMatchSnapshot();
     });
     it('extracts from complex config file correctly', () => {
       const result = extractPackageFile(complexPrecommitConfig, filename);
+      // FIXME: explicit assert condition
       expect(result).toMatchSnapshot();
     });
     it('can handle private git repos', () => {
       hostRules.find.mockReturnValue({ token: 'value' });
       const result = extractPackageFile(enterpriseGitPrecommitConfig, filename);
+      // FIXME: explicit assert condition
       expect(result).toMatchSnapshot();
     });
     it('can handle invalid private git repos', () => {
       hostRules.find.mockReturnValue({});
       const result = extractPackageFile(enterpriseGitPrecommitConfig, filename);
+      // FIXME: explicit assert condition
       expect(result).toMatchSnapshot();
     });
     it('can handle unknown private git repos', () => {
@@ -72,6 +76,7 @@ describe(getName(), () => {
       // But all subsequent checks (those with hostType), then fail:
       hostRules.find.mockReturnValue({});
       const result = extractPackageFile(enterpriseGitPrecommitConfig, filename);
+      // FIXME: explicit assert condition
       expect(result).toMatchSnapshot();
     });
   });

--- a/lib/manager/pub/extract.spec.ts
+++ b/lib/manager/pub/extract.spec.ts
@@ -16,6 +16,7 @@ describe(getName(), () => {
     });
     it('should return valid dependencies', () => {
       const res = extractPackageFile(packageFile, 'pubspec.yaml');
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
   });

--- a/lib/manager/pyenv/extract.spec.ts
+++ b/lib/manager/pyenv/extract.spec.ts
@@ -5,14 +5,17 @@ describe(getName(), () => {
   describe('extractPackageFile()', () => {
     it('returns a result', () => {
       const res = extractPackageFile('3.7.1\n');
+      // FIXME: explicit assert condition
       expect(res.deps).toMatchSnapshot();
     });
     it('supports ranges', () => {
       const res = extractPackageFile('3.8\n');
+      // FIXME: explicit assert condition
       expect(res.deps).toMatchSnapshot();
     });
     it('skips non ranges', () => {
       const res = extractPackageFile('latestn');
+      // FIXME: explicit assert condition
       expect(res.deps).toMatchSnapshot();
     });
   });

--- a/lib/manager/regex/index.spec.ts
+++ b/lib/manager/regex/index.spec.ts
@@ -104,6 +104,7 @@ describe(getName(), () => {
       'Dockerfile',
       config
     );
+    // FIXME: explicit assert condition
     expect(res).toMatchSnapshot();
   });
   it('extracts and applies a registryUrlTemplate', async () => {
@@ -137,6 +138,7 @@ describe(getName(), () => {
       'Dockerfile',
       config
     );
+    // FIXME: explicit assert condition
     expect(res).toMatchSnapshot();
     expect(logger.warn).toHaveBeenCalledWith(
       { value: 'this-is-not-a-valid-url-gradle' },

--- a/lib/manager/ruby-version/extract.spec.ts
+++ b/lib/manager/ruby-version/extract.spec.ts
@@ -5,14 +5,17 @@ describe(getName(), () => {
   describe('extractPackageFile()', () => {
     it('returns a result', () => {
       const res = extractPackageFile('8.4.0\n');
+      // FIXME: explicit assert condition
       expect(res.deps).toMatchSnapshot();
     });
     it('supports ranges', () => {
       const res = extractPackageFile('8.4\n');
+      // FIXME: explicit assert condition
       expect(res.deps).toMatchSnapshot();
     });
     it('skips non ranges', () => {
       const res = extractPackageFile('latestn');
+      // FIXME: explicit assert condition
       expect(res.deps).toMatchSnapshot();
     });
   });

--- a/lib/manager/sbt/extract.spec.ts
+++ b/lib/manager/sbt/extract.spec.ts
@@ -37,15 +37,19 @@ describe(getName(), () => {
       ).toBeNull();
     });
     it('extracts deps for generic use-cases', () => {
+      // FIXME: explicit assert condition
       expect(extractPackageFile(sbt)).toMatchSnapshot();
     });
     it('extracts deps when scala version is defined in a variable', () => {
+      // FIXME: explicit assert condition
       expect(extractPackageFile(sbtScalaVersionVariable)).toMatchSnapshot();
     });
     it('skips deps when scala version is missing', () => {
+      // FIXME: explicit assert condition
       expect(extractPackageFile(sbtMissingScalaVersion)).toMatchSnapshot();
     });
     it('extract deps from native scala file with variables', () => {
+      // FIXME: explicit assert condition
       expect(extractPackageFile(sbtDependencyFile)).toMatchSnapshot();
     });
     it('extracts deps when scala version is defined with a trailing comma', () => {
@@ -55,6 +59,7 @@ describe(getName(), () => {
         )
         libraryDependencies += "org.example" %% "bar" % "0.0.2"
       `;
+      // FIXME: explicit assert condition
       expect(extractPackageFile(content)).toMatchSnapshot();
     });
     it('extracts deps when scala version is defined in a variable with a trailing comma', () => {
@@ -65,9 +70,11 @@ describe(getName(), () => {
         )
         libraryDependencies += "org.example" %% "bar" % "0.0.2"
       `;
+      // FIXME: explicit assert condition
       expect(extractPackageFile(content)).toMatchSnapshot();
     });
     it('extract deps from native scala file with private variables', () => {
+      // FIXME: explicit assert condition
       expect(
         extractPackageFile(sbtPrivateVariableDependencyFile)
       ).toMatchSnapshot();

--- a/lib/manager/sbt/update.spec.ts
+++ b/lib/manager/sbt/update.spec.ts
@@ -15,6 +15,7 @@ describe(getName(), () => {
         'patch'
       );
 
+      // FIXME: explicit assert condition
       expect(bumpedContent).toMatchSnapshot();
       expect(bumpedContent).not.toEqual(content);
     });
@@ -33,7 +34,7 @@ describe(getName(), () => {
         '0.0.1',
         'minor'
       );
-
+      // FIXME: explicit assert condition
       expect(bumpedContent).toMatchSnapshot();
       expect(bumpedContent).not.toEqual(content);
     });

--- a/lib/manager/setup-cfg/extract.spec.ts
+++ b/lib/manager/setup-cfg/extract.spec.ts
@@ -10,6 +10,7 @@ describe(getName(), () => {
     });
     it('extracts dependencies', () => {
       const res = extractPackageFile(content);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
   });

--- a/lib/manager/swift/index.spec.ts
+++ b/lib/manager/swift/index.spec.ts
@@ -97,31 +97,37 @@ describe(getName(), () => {
       ).not.toBeNull();
     });
     it('parses package descriptions', () => {
+      // FIXME: explicit assert condition
       expect(
         extractPackageFile(
           `dependencies:[.package(url:"https://github.com/vapor/vapor.git",from:"1.2.3")]`
         )
       ).toMatchSnapshot();
+      // FIXME: explicit assert condition
       expect(
         extractPackageFile(
           `dependencies:[.package(url:"https://github.com/vapor/vapor.git","1.2.3"...)]`
         )
       ).toMatchSnapshot();
+      // FIXME: explicit assert condition
       expect(
         extractPackageFile(
           `dependencies:[.package(url:"https://github.com/vapor/vapor.git","1.2.3"..."1.2.4")]`
         )
       ).toMatchSnapshot();
+      // FIXME: explicit assert condition
       expect(
         extractPackageFile(
           `dependencies:[.package(url:"https://github.com/vapor/vapor.git","1.2.3"..<"1.2.4")]`
         )
       ).toMatchSnapshot();
+      // FIXME: explicit assert condition
       expect(
         extractPackageFile(
           `dependencies:[.package(url:"https://github.com/vapor/vapor.git",..."1.2.3")]`
         )
       ).toMatchSnapshot();
+      // FIXME: explicit assert condition
       expect(
         extractPackageFile(
           `dependencies:[.package(url:"https://github.com/vapor/vapor.git",..<"1.2.3")]`
@@ -129,6 +135,7 @@ describe(getName(), () => {
       ).toMatchSnapshot();
     });
     it('parses multiple packages', () => {
+      // FIXME: explicit assert condition
       expect(extractPackageFile(pkgContent)).toMatchSnapshot();
     });
   });

--- a/lib/manager/terraform-version/extract.spec.ts
+++ b/lib/manager/terraform-version/extract.spec.ts
@@ -5,10 +5,12 @@ describe(getName(), () => {
   describe('extractPackageFile()', () => {
     it('returns a result', () => {
       const res = extractPackageFile('12.0.0\n');
+      // FIXME: explicit assert condition
       expect(res.deps).toMatchSnapshot();
     });
     it('skips non ranges', () => {
       const res = extractPackageFile('latest');
+      // FIXME: explicit assert condition
       expect(res.deps).toMatchSnapshot();
     });
   });

--- a/lib/manager/terragrunt-version/extract.spec.ts
+++ b/lib/manager/terragrunt-version/extract.spec.ts
@@ -5,6 +5,7 @@ describe(getName(), () => {
   describe('extractPackageFile()', () => {
     it('returns a result', () => {
       const res = extractPackageFile('12.0.0\n');
+      // FIXME: explicit assert condition
       expect(res.deps).toMatchSnapshot();
     });
   });

--- a/lib/manager/travis/package.spec.ts
+++ b/lib/manager/travis/package.spec.ts
@@ -45,6 +45,7 @@ describe(getName(), () => {
     it('returns result if needing updates', async () => {
       config.currentValue = ['6', '8', '10'];
       config.supportPolicy = ['lts'];
+      // FIXME: explicit assert condition
       expect(await getPackageUpdates(config)).toMatchSnapshot();
     });
     it('detects pinning', async () => {
@@ -78,6 +79,7 @@ describe(getName(), () => {
           },
         ],
       });
+      // FIXME: explicit assert condition
       expect(await getPackageUpdates(config)).toMatchSnapshot();
     });
   });

--- a/lib/manager/travis/update.spec.ts
+++ b/lib/manager/travis/update.spec.ts
@@ -11,6 +11,7 @@ describe(getName(), () => {
         newValue: '6,8',
       };
       const res = updateDependency({ fileContent: content, upgrade });
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('falls back to 2 spaces', () => {
@@ -22,6 +23,7 @@ describe(getName(), () => {
         fileContent: 'hello: world',
         upgrade,
       });
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('uses double quotes', () => {
@@ -33,6 +35,7 @@ describe(getName(), () => {
         fileContent: 'node_js:\n  - "6"\n',
         upgrade,
       });
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('returns null if error', () => {

--- a/lib/platform/index.spec.ts
+++ b/lib/platform/index.spec.ts
@@ -51,6 +51,7 @@ describe(getName(), () => {
       username: 'abc',
       password: '123',
     };
+    // FIXME: explicit assert condition
     expect(await platform.initPlatform(config)).toMatchSnapshot();
   });
   it('initializes no author', async () => {
@@ -59,17 +60,20 @@ describe(getName(), () => {
       username: 'abc',
       password: '123',
     };
+    // FIXME: explicit assert condition
     expect(await platform.initPlatform(config)).toMatchSnapshot();
   });
   it('returns null if empty email given', () => {
     expect(platform.parseGitAuthor(undefined)).toBeNull();
   });
   it('parses bot email', () => {
+    // FIXME: explicit assert condition
     expect(
       platform.parseGitAuthor('some[bot]@users.noreply.github.com')
     ).toMatchSnapshot();
   });
   it('parses bot name and email', () => {
+    // FIXME: explicit assert condition
     expect(
       platform.parseGitAuthor(
         '"some[bot]" <some[bot]@users.noreply.github.com>'
@@ -77,6 +81,7 @@ describe(getName(), () => {
     ).toMatchSnapshot();
   });
   it('escapes names', () => {
+    // FIXME: explicit assert condition
     expect(
       platform.parseGitAuthor('name [what] <name@what.com>').name
     ).toMatchSnapshot();

--- a/lib/util/exec/exec.spec.ts
+++ b/lib/util/exec/exec.spec.ts
@@ -710,6 +710,7 @@ describe(getName(), () => {
     await exec(inCmd, { docker });
     await exec(inCmd, { docker });
 
+    // FIXME: explicit assert condition
     expect(actualCmd).toMatchSnapshot();
   });
 

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -105,6 +105,7 @@ describe(getName(), () => {
   });
   describe('getFileList()', () => {
     it('should return the correct files', async () => {
+      // FIXME: explicit assert condition
       expect(await git.getFileList()).toMatchSnapshot();
     });
     it('should exclude submodules', async () => {
@@ -117,6 +118,7 @@ describe(getName(), () => {
       });
       await git.syncGit();
       expect(await fs.exists(tmpDir.path + '/.gitmodules')).toBeTruthy();
+      // FIXME: explicit assert condition
       expect(await git.getFileList()).toMatchSnapshot();
       await repo.reset(['--hard', 'HEAD^']);
     });
@@ -202,6 +204,7 @@ describe(getName(), () => {
       const branchFiles = await git.getBranchFiles(
         'renovate/branch_with_changes'
       );
+      // FIXME: explicit assert condition
       expect(branchFiles).toMatchSnapshot();
     });
   });
@@ -414,6 +417,7 @@ describe(getName(), () => {
 
   describe('getCommitMessages()', () => {
     it('returns commit messages', async () => {
+      // FIXME: explicit assert condition
       expect(await git.getCommitMessages()).toMatchSnapshot();
     });
   });
@@ -461,6 +465,7 @@ describe(getName(), () => {
 
       expect(git.branchExists('test')).toBeFalsy();
 
+      // FIXME: explicit assert condition
       expect(await git.getCommitMessages()).toMatchSnapshot();
 
       await git.checkoutBranch('develop');

--- a/lib/util/host-rules.spec.ts
+++ b/lib/util/host-rules.spec.ts
@@ -41,6 +41,7 @@ describe(getName(), () => {
         username: 'user1',
         password: 'pass1',
       } as any);
+      // FIXME: explicit assert condition
       expect(find({ url: 'https://some.endpoint/v3/' })).toMatchSnapshot();
     });
   });
@@ -59,6 +60,7 @@ describe(getName(), () => {
         password: 'p4$$w0rd',
         token: undefined,
       } as any);
+      // FIXME: explicit assert condition
       expect(find({ hostType: datasourceNuget.id })).toMatchSnapshot();
       expect(
         find({ hostType: datasourceNuget.id, url: 'https://nuget.org' })
@@ -83,6 +85,7 @@ describe(getName(), () => {
         hostType: datasourceNuget.id,
         token: 'abc',
       });
+      // FIXME: explicit assert condition
       expect(
         find({ hostType: datasourceNuget.id, url: 'https://nuget.local/api' })
       ).toMatchSnapshot();
@@ -109,6 +112,7 @@ describe(getName(), () => {
         hostName: 'nuget.local',
         token: 'abc',
       } as any);
+      // FIXME: explicit assert condition
       expect(
         find({ hostType: datasourceNuget.id, url: 'https://nuget.local/api' })
       ).toMatchSnapshot();
@@ -153,6 +157,7 @@ describe(getName(), () => {
         matchHost: 'https://nuget.local/api',
         token: 'abc',
       } as any);
+      // FIXME: explicit assert condition
       expect(
         find({
           hostType: datasourceNuget.id,

--- a/lib/util/http/bitbucket.spec.ts
+++ b/lib/util/http/bitbucket.spec.ts
@@ -47,6 +47,7 @@ describe(getName(), () => {
   it('returns cached', async () => {
     httpMock.scope(baseUrl).get('/projects/foo').reply(200, {});
     const { body } = await api.getJson('projects/foo');
+    // FIXME: explicit assert condition
     expect(body).toMatchSnapshot();
     expect(httpMock.getTrace()).toMatchSnapshot();
   });

--- a/lib/util/http/index.spec.ts
+++ b/lib/util/http/index.spec.ts
@@ -20,6 +20,7 @@ describe(getName(), () => {
   });
   it('get', async () => {
     httpMock.scope(baseUrl).get('/test').reply(200);
+    // FIXME: explicit assert condition
     expect(await http.get('http://renovate.com/test')).toMatchSnapshot();
     expect(httpMock.allUsed()).toBe(true);
   });
@@ -54,10 +55,12 @@ describe(getName(), () => {
   });
   it('getJson', async () => {
     httpMock.scope(baseUrl).get('/').reply(200, '{ "test": true }');
+    // FIXME: explicit assert condition
     expect(await http.getJson('http://renovate.com')).toMatchSnapshot();
   });
   it('postJson', async () => {
     httpMock.scope(baseUrl).post('/').reply(200, {});
+    // FIXME: explicit assert condition
     expect(
       await http.postJson('http://renovate.com', { body: {}, baseUrl })
     ).toMatchSnapshot();
@@ -65,6 +68,7 @@ describe(getName(), () => {
   });
   it('putJson', async () => {
     httpMock.scope(baseUrl).put('/').reply(200, {});
+    // FIXME: explicit assert condition
     expect(
       await http.putJson('http://renovate.com', { body: {}, baseUrl })
     ).toMatchSnapshot();
@@ -72,6 +76,7 @@ describe(getName(), () => {
   });
   it('patchJson', async () => {
     httpMock.scope(baseUrl).patch('/').reply(200, {});
+    // FIXME: explicit assert condition
     expect(
       await http.patchJson('http://renovate.com', { body: {}, baseUrl })
     ).toMatchSnapshot();
@@ -79,6 +84,7 @@ describe(getName(), () => {
   });
   it('deleteJson', async () => {
     httpMock.scope(baseUrl).delete('/').reply(200, {});
+    // FIXME: explicit assert condition
     expect(
       await http.deleteJson('http://renovate.com', { body: {}, baseUrl })
     ).toMatchSnapshot();
@@ -86,6 +92,7 @@ describe(getName(), () => {
   });
   it('headJson', async () => {
     httpMock.scope(baseUrl).head('/').reply(200, {});
+    // FIXME: explicit assert condition
     expect(
       await http.headJson('http://renovate.com', { baseUrl })
     ).toMatchSnapshot();
@@ -127,6 +134,7 @@ describe(getName(), () => {
         .reply(500)
         .head('/')
         .reply(200, undefined, { 'x-some-header': 'abc' });
+      // FIXME: explicit assert condition
       expect(await http.head('http://renovate.com')).toMatchSnapshot();
       expect(httpMock.allUsed()).toBe(true);
     } finally {

--- a/lib/util/markdown.spec.ts
+++ b/lib/util/markdown.spec.ts
@@ -15,6 +15,7 @@ describe(getName(), () => {
 *   Mention: @wooorm
 `;
     it('works', async () => {
+      // FIXME: explicit assert condition
       expect(await linkify(md, { repository: 'some/repo' })).toMatchSnapshot();
     });
   });

--- a/lib/util/package-rules.spec.ts
+++ b/lib/util/package-rules.spec.ts
@@ -70,6 +70,7 @@ describe('applyPackageRules()', () => {
         },
       ],
     };
+    // FIXME: explicit assert condition
     expect(applyPackageRules(config)).toMatchSnapshot();
   });
   it('applies both rules for a', () => {
@@ -710,6 +711,7 @@ describe('applyPackageRules()', () => {
     expect(res3.x).toBeDefined();
   });
   it('empty rules', () => {
+    // FIXME: explicit assert condition
     expect(
       applyPackageRules({ ...config1, packageRules: null })
     ).toMatchSnapshot();

--- a/lib/util/sanitize.spec.ts
+++ b/lib/util/sanitize.spec.ts
@@ -17,6 +17,7 @@ describe(getName(), () => {
     const hashed = Buffer.from(`${username}:${password}`).toString('base64');
     add(hashed);
     add(password);
+    // FIXME: explicit assert condition
     expect(
       sanitize(
         `My token is ${token}, username is "${username}" and password is "${password}" (hashed: ${hashed})`

--- a/lib/versioning/index.spec.ts
+++ b/lib/versioning/index.spec.ts
@@ -12,6 +12,7 @@ const supportedSchemes = getOptions().find(
 
 describe('allVersioning.get(versioning)', () => {
   it('has api', () => {
+    // FIXME: explicit assert condition
     expect(Object.keys(allVersioning.get('semver')).sort()).toMatchSnapshot();
   });
   it('validates', () => {

--- a/lib/versioning/loose/index.spec.ts
+++ b/lib/versioning/loose/index.spec.ts
@@ -4,6 +4,7 @@ describe('loose.', () => {
   describe('isVersion', () => {
     ['1.1', '1.3.RC2', '2.1-rc2'].forEach((version) => {
       it(version, () => {
+        // FIXME: explicit assert condition
         expect(loose.isVersion(version)).toMatchSnapshot();
       });
     });

--- a/lib/versioning/loose/utils.spec.ts
+++ b/lib/versioning/loose/utils.spec.ts
@@ -53,6 +53,7 @@ describe(getName(), () => {
 
     for (const key of schemeKeys) {
       it(`${key}`, () => {
+        // FIXME: explicit assert condition
         expect(api[key]()).toMatchSnapshot();
       });
     }

--- a/lib/versioning/nuget/index.spec.ts
+++ b/lib/versioning/nuget/index.spec.ts
@@ -14,6 +14,7 @@ describe('nuget.', () => {
       '5.1.2-+',
     ].forEach((version) => {
       it(version, () => {
+        // FIXME: explicit assert condition
         expect(nuget.isVersion(version)).toMatchSnapshot();
         expect(nuget.isValid(version)).toMatchSnapshot();
       });
@@ -29,6 +30,7 @@ describe('nuget.', () => {
       '2.3.4-beta+1990ef74',
     ].forEach((version) => {
       it(version, () => {
+        // FIXME: explicit assert condition
         expect(nuget.isStable(version)).toMatchSnapshot();
       });
     });

--- a/lib/versioning/ruby/index.spec.ts
+++ b/lib/versioning/ruby/index.spec.ts
@@ -435,6 +435,7 @@ describe('semverRuby', () => {
     });
 
     it('does not error', () => {
+      // FIXME: explicit assert condition
       expect(
         semverRuby.getNewValue({
           currentValue: '>= 3.2, < 5.0',

--- a/lib/workers/branch/auto-replace.spec.ts
+++ b/lib/workers/branch/auto-replace.spec.ts
@@ -48,6 +48,7 @@ describe(getName(), () => {
       upgrade.newDigest = 'some-digest';
       upgrade.depIndex = 0;
       const res = await doAutoReplace(upgrade, src, reuseExistingBranch);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('handles a double attempt', async () => {
@@ -61,6 +62,7 @@ describe(getName(), () => {
       upgrade.newValue = '7.1.1';
       upgrade.depIndex = 1;
       const res = await doAutoReplace(upgrade, src, reuseExistingBranch);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('handles already updated', async () => {
@@ -81,6 +83,7 @@ describe(getName(), () => {
         srcAlreadyUpdated,
         reuseExistingBranch
       );
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('returns existing content if replaceString mismatch', async () => {
@@ -99,6 +102,7 @@ describe(getName(), () => {
         'wrong source',
         reuseExistingBranch
       );
+      // FIXME: explicit assert condition
       expect(res).toEqual('wrong source');
     });
     it('updates version and integrity', async () => {
@@ -116,6 +120,7 @@ describe(getName(), () => {
       upgrade.depIndex = 0;
       upgrade.replaceString = script;
       const res = await doAutoReplace(upgrade, src, reuseExistingBranch);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('updates with autoReplaceNewString', async () => {
@@ -135,6 +140,7 @@ describe(getName(), () => {
       upgrade.autoReplaceStringTemplate =
         '{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}';
       const res = await doAutoReplace(upgrade, dockerfile, reuseExistingBranch);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('fails with oldversion in depname', async () => {

--- a/lib/workers/branch/get-updated.spec.ts
+++ b/lib/workers/branch/get-updated.spec.ts
@@ -36,12 +36,14 @@ describe(getName(), () => {
       config.upgrades.push({ manager: 'html', branchName: undefined });
       autoReplace.doAutoReplace.mockResolvedValueOnce('updated-file');
       const res = await getUpdatedPackageFiles(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('handles autoreplace branch no update', async () => {
       config.upgrades.push({ manager: 'html', branchName: undefined });
       autoReplace.doAutoReplace.mockResolvedValueOnce('existing content');
       const res = await getUpdatedPackageFiles(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('handles autoreplace failure', async () => {
@@ -55,10 +57,12 @@ describe(getName(), () => {
       autoReplace.doAutoReplace.mockResolvedValueOnce(null);
       autoReplace.doAutoReplace.mockResolvedValueOnce('updated-file');
       const res = await getUpdatedPackageFiles(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('handles empty', async () => {
       const res = await getUpdatedPackageFiles(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('handles null content', async () => {
@@ -75,6 +79,7 @@ describe(getName(), () => {
       } as never);
       npm.updateDependency.mockReturnValue('some new content');
       const res = await getUpdatedPackageFiles(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('handles lock files', async () => {
@@ -93,6 +98,7 @@ describe(getName(), () => {
         },
       ]);
       const res = await getUpdatedPackageFiles(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('handles lockFileMaintenance', async () => {
@@ -109,6 +115,7 @@ describe(getName(), () => {
         },
       ]);
       const res = await getUpdatedPackageFiles(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('handles isRemediation success', async () => {
@@ -120,6 +127,7 @@ describe(getName(), () => {
         'package-lock.json': 'new contents',
       });
       const res = await getUpdatedPackageFiles(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('handles isRemediation rebase', async () => {
@@ -133,6 +141,7 @@ describe(getName(), () => {
         'package-lock.json': 'new contents',
       });
       const res = await getUpdatedPackageFiles(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('handles lockFileMaintenance error', async () => {
@@ -149,6 +158,7 @@ describe(getName(), () => {
         },
       ]);
       const res = await getUpdatedPackageFiles(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('handles lock file errors', async () => {
@@ -167,6 +177,7 @@ describe(getName(), () => {
         },
       ]);
       const res = await getUpdatedPackageFiles(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('handles git submodules', async () => {
@@ -176,6 +187,7 @@ describe(getName(), () => {
       } as never);
       gitSubmodules.updateDependency.mockResolvedValueOnce('existing content');
       const res = await getUpdatedPackageFiles(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('update artifacts on update-lockfile strategy', async () => {
@@ -194,6 +206,7 @@ describe(getName(), () => {
         },
       ]);
       const res = await getUpdatedPackageFiles(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('bumps versions in updateDependency managers', async () => {
@@ -205,6 +218,7 @@ describe(getName(), () => {
       npm.updateDependency.mockReturnValue('old version');
       npm.bumpPackageVersion.mockReturnValue({ bumpedContent: 'new version' });
       const res = await getUpdatedPackageFiles(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('bumps versions in autoReplace managers', async () => {
@@ -218,6 +232,7 @@ describe(getName(), () => {
         bumpedContent: 'version: 0.0.2',
       });
       const res = await getUpdatedPackageFiles(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
   });

--- a/lib/workers/branch/index.spec.ts
+++ b/lib/workers/branch/index.spec.ts
@@ -112,6 +112,7 @@ describe(getName(), () => {
     it('skips branch if not scheduled and branch does not exist', async () => {
       schedule.isScheduledNow.mockReturnValueOnce(false);
       const res = await branchWorker.processBranch(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('skips branch if not scheduled and not updating out of schedule', async () => {
@@ -119,6 +120,7 @@ describe(getName(), () => {
       config.updateNotScheduled = false;
       git.branchExists.mockReturnValue(true);
       const res = await branchWorker.processBranch(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('skips branch for fresh release with stabilityDays', async () => {
@@ -143,6 +145,7 @@ describe(getName(), () => {
 
       git.branchExists.mockReturnValue(false);
       const res = await branchWorker.processBranch(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('skips branch if not stabilityDays not met', async () => {
@@ -155,6 +158,7 @@ describe(getName(), () => {
         },
       ];
       const res = await branchWorker.processBranch(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
 
@@ -169,6 +173,7 @@ describe(getName(), () => {
       mergeConfidence.isActiveConfidenceLevel.mockReturnValue(true);
       mergeConfidence.satisfiesConfidenceLevel.mockReturnValueOnce(false);
       const res = await branchWorker.processBranch(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
 
@@ -183,6 +188,7 @@ describe(getName(), () => {
       mergeConfidence.isActiveConfidenceLevel.mockReturnValue(true);
       mergeConfidence.satisfiesConfidenceLevel.mockReturnValueOnce(true);
       const res = await branchWorker.processBranch(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
 
@@ -259,6 +265,7 @@ describe(getName(), () => {
       } as Pr);
       git.isBranchModified.mockResolvedValueOnce(true);
       const res = await branchWorker.processBranch(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('skips branch if edited PR found', async () => {
@@ -270,6 +277,7 @@ describe(getName(), () => {
       } as Pr);
       git.isBranchModified.mockResolvedValueOnce(true);
       const res = await branchWorker.processBranch(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('skips branch if target branch changed', async () => {
@@ -282,12 +290,14 @@ describe(getName(), () => {
       git.isBranchModified.mockResolvedValueOnce(false);
       config.baseBranch = 'master';
       const res = await branchWorker.processBranch(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('skips branch if branch edited and no PR found', async () => {
       git.branchExists.mockReturnValue(true);
       git.isBranchModified.mockResolvedValueOnce(true);
       const res = await branchWorker.processBranch(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('continues branch if branch edited and but PR found', async () => {
@@ -296,6 +306,7 @@ describe(getName(), () => {
       git.getBranchCommit.mockReturnValueOnce('abc123');
       platform.findPr.mockResolvedValueOnce({ sha: 'abc123' } as any);
       const res = await branchWorker.processBranch(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('skips branch if branch edited and and PR found with sha mismatch', async () => {
@@ -304,6 +315,7 @@ describe(getName(), () => {
       git.getBranchCommit.mockReturnValueOnce('abc123');
       platform.findPr.mockResolvedValueOnce({ sha: 'def456' } as any);
       const res = await branchWorker.processBranch(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('returns if branch creation limit exceeded', async () => {
@@ -316,6 +328,7 @@ describe(getName(), () => {
       });
       limits.isLimitReached.mockReturnValueOnce(true);
       limits.isLimitReached.mockReturnValueOnce(false);
+      // FIXME: explicit assert condition
       expect(await branchWorker.processBranch(config)).toMatchSnapshot();
     });
     it('returns if pr creation limit exceeded and branch exists', async () => {
@@ -331,6 +344,7 @@ describe(getName(), () => {
         prBlockedBy: 'RateLimited',
       });
       limits.isLimitReached.mockReturnValue(false);
+      // FIXME: explicit assert condition
       expect(await branchWorker.processBranch(config)).toMatchSnapshot();
     });
     it('returns if commit limit exceeded', async () => {
@@ -344,6 +358,7 @@ describe(getName(), () => {
       git.branchExists.mockReturnValue(false);
       limits.isLimitReached.mockReturnValueOnce(false);
       limits.isLimitReached.mockReturnValueOnce(true);
+      // FIXME: explicit assert condition
       expect(await branchWorker.processBranch(config)).toMatchSnapshot();
     });
     it('returns if no work', async () => {
@@ -356,6 +371,7 @@ describe(getName(), () => {
       });
       git.branchExists.mockReturnValue(false);
       commit.commitFilesToBranch.mockResolvedValueOnce(null);
+      // FIXME: explicit assert condition
       expect(await branchWorker.processBranch(config)).toMatchSnapshot();
     });
 
@@ -368,6 +384,7 @@ describe(getName(), () => {
         updatedArtifacts: [],
       });
       config.pendingChecks = true;
+      // FIXME: explicit assert condition
       expect(await branchWorker.processBranch(config)).toMatchSnapshot();
     });
 
@@ -436,6 +453,7 @@ describe(getName(), () => {
       prWorker.ensurePr.mockResolvedValueOnce({
         prBlockedBy: 'NeedsApproval',
       });
+      // FIXME: explicit assert condition
       expect(await branchWorker.processBranch(config)).toMatchSnapshot();
     });
     it('returns if branch exists but pending', async () => {
@@ -453,6 +471,7 @@ describe(getName(), () => {
       prWorker.ensurePr.mockResolvedValueOnce({
         prBlockedBy: 'AwaitingTests',
       });
+      // FIXME: explicit assert condition
       expect(await branchWorker.processBranch(config)).toMatchSnapshot();
     });
     it('returns if branch automerge is pending', async () => {
@@ -470,6 +489,7 @@ describe(getName(), () => {
       prWorker.ensurePr.mockResolvedValueOnce({
         prBlockedBy: 'BranchAutomerge',
       });
+      // FIXME: explicit assert condition
       expect(await branchWorker.processBranch(config)).toMatchSnapshot();
     });
     it('returns if PR creation failed', async () => {
@@ -487,6 +507,7 @@ describe(getName(), () => {
       prWorker.ensurePr.mockResolvedValueOnce({
         prBlockedBy: 'Error',
       });
+      // FIXME: explicit assert condition
       expect(await branchWorker.processBranch(config)).toMatchSnapshot();
     });
     it('handles unknown PrBlockedBy', async () => {
@@ -504,6 +525,7 @@ describe(getName(), () => {
       prWorker.ensurePr.mockResolvedValueOnce({
         prBlockedBy: 'whoops' as any,
       });
+      // FIXME: explicit assert condition
       expect(await branchWorker.processBranch(config)).toMatchSnapshot();
     });
     it('returns if branch exists but updated', async () => {
@@ -515,6 +537,7 @@ describe(getName(), () => {
         artifactErrors: [],
         updatedArtifacts: [{}],
       } as WriteExistingFilesResult);
+      // FIXME: explicit assert condition
       expect(
         await branchWorker.processBranch({
           ...config,
@@ -677,6 +700,7 @@ describe(getName(), () => {
         throw new Error('some error');
       });
       const processBranchResult = await branchWorker.processBranch(config);
+      // FIXME: explicit assert condition
       expect(processBranchResult).toMatchSnapshot();
     });
     it('throws and swallows branch errors', async () => {
@@ -688,6 +712,7 @@ describe(getName(), () => {
         updatedArtifacts: [{}],
       } as WriteExistingFilesResult);
       const processBranchResult = await branchWorker.processBranch(config);
+      // FIXME: explicit assert condition
       expect(processBranchResult).toMatchSnapshot();
     });
     it('swallows pr errors', async () => {
@@ -704,6 +729,7 @@ describe(getName(), () => {
         throw new Error('some error');
       });
       const processBranchResult = await branchWorker.processBranch(config);
+      // FIXME: explicit assert condition
       expect(processBranchResult).toMatchSnapshot();
     });
 
@@ -713,6 +739,7 @@ describe(getName(), () => {
         state: PrState.Closed,
       } as Pr);
       setAdminConfig({ ...adminConfig, dryRun: true });
+      // FIXME: explicit assert condition
       expect(await branchWorker.processBranch(config)).toMatchSnapshot();
     });
 
@@ -723,6 +750,7 @@ describe(getName(), () => {
       } as Pr);
       git.isBranchModified.mockResolvedValueOnce(true);
       setAdminConfig({ ...adminConfig, dryRun: true });
+      // FIXME: explicit assert condition
       expect(await branchWorker.processBranch(config)).toMatchSnapshot();
     });
 
@@ -745,6 +773,7 @@ describe(getName(), () => {
       schedule.isScheduledNow.mockReturnValueOnce(false);
       commit.commitFilesToBranch.mockResolvedValueOnce(null);
       setAdminConfig({ ...adminConfig, dryRun: true });
+      // FIXME: explicit assert condition
       expect(
         await branchWorker.processBranch({
           ...config,
@@ -777,6 +806,7 @@ describe(getName(), () => {
       } as EnsurePrResult);
       commit.commitFilesToBranch.mockResolvedValueOnce(null);
       setAdminConfig({ ...adminConfig, dryRun: true });
+      // FIXME: explicit assert condition
       expect(
         await branchWorker.processBranch({
           ...config,
@@ -803,6 +833,7 @@ describe(getName(), () => {
       git.isBranchModified.mockResolvedValueOnce(true);
       schedule.isScheduledNow.mockReturnValueOnce(false);
       commit.commitFilesToBranch.mockResolvedValueOnce(null);
+      // FIXME: explicit assert condition
       expect(
         await branchWorker.processBranch({
           ...config,
@@ -878,6 +909,7 @@ describe(getName(), () => {
         ],
       });
 
+      // FIXME: explicit assert condition
       expect(result).toMatchSnapshot();
       const errorMessage = expect.stringContaining(
         "Post-upgrade command 'disallowed task' does not match allowed pattern '^echo {{{versioning}}}$'"
@@ -1023,6 +1055,7 @@ describe(getName(), () => {
         ],
       });
 
+      // FIXME: explicit assert condition
       expect(result).toMatchSnapshot();
       expect(exec.exec).toHaveBeenCalledWith('echo {{{versioning}}}', {
         cwd: '/localDir',
@@ -1130,6 +1163,7 @@ describe(getName(), () => {
 
       const result = await branchWorker.processBranch(inconfig);
 
+      // FIXME: explicit assert condition
       expect(result).toMatchSnapshot();
       expect(exec.exec).toHaveBeenNthCalledWith(1, 'echo some-dep-name-1', {
         cwd: '/localDir',
@@ -1263,6 +1297,7 @@ describe(getName(), () => {
       };
 
       const result = await branchWorker.processBranch(inconfig);
+      // FIXME: explicit assert condition
       expect(result).toMatchSnapshot();
       expect(exec.exec).toHaveBeenNthCalledWith(1, 'echo hardcoded-string', {
         cwd: '/localDir',

--- a/lib/workers/global/config/parse/env.spec.ts
+++ b/lib/workers/global/config/parse/env.spec.ts
@@ -46,12 +46,14 @@ describe(getName(), () => {
       const envParam: NodeJS.ProcessEnv = {
         RENOVATE_TOKEN: 'github.com token',
       };
+      // FIXME: explicit assert condition
       expect(env.getConfig(envParam)).toMatchSnapshot();
     });
     it('supports GitHub custom endpoint', () => {
       const envParam: NodeJS.ProcessEnv = {
         RENOVATE_ENDPOINT: 'a ghe endpoint',
       };
+      // FIXME: explicit assert condition
       expect(env.getConfig(envParam)).toMatchSnapshot();
     });
     it('supports GitHub custom endpoint and github.com', () => {
@@ -60,6 +62,7 @@ describe(getName(), () => {
         RENOVATE_ENDPOINT: 'a ghe endpoint',
         RENOVATE_TOKEN: 'a ghe token',
       };
+      // FIXME: explicit assert condition
       expect(env.getConfig(envParam)).toMatchSnapshot();
     });
     it('supports GitHub custom endpoint and gitlab.com', () => {
@@ -67,6 +70,7 @@ describe(getName(), () => {
         RENOVATE_ENDPOINT: 'a ghe endpoint',
         RENOVATE_TOKEN: 'a ghe token',
       };
+      // FIXME: explicit assert condition
       expect(env.getConfig(envParam)).toMatchSnapshot();
     });
     it('supports GitLab token', () => {
@@ -74,6 +78,7 @@ describe(getName(), () => {
         RENOVATE_PLATFORM: PLATFORM_TYPE_GITLAB,
         RENOVATE_TOKEN: 'a gitlab.com token',
       };
+      // FIXME: explicit assert condition
       expect(env.getConfig(envParam)).toMatchSnapshot();
     });
     it('supports GitLab custom endpoint', () => {
@@ -82,6 +87,7 @@ describe(getName(), () => {
         RENOVATE_TOKEN: 'a gitlab token',
         RENOVATE_ENDPOINT: 'a gitlab endpoint',
       };
+      // FIXME: explicit assert condition
       expect(env.getConfig(envParam)).toMatchSnapshot();
     });
     it('supports Azure DevOps', () => {
@@ -90,6 +96,7 @@ describe(getName(), () => {
         RENOVATE_TOKEN: 'an Azure DevOps token',
         RENOVATE_ENDPOINT: 'an Azure DevOps endpoint',
       };
+      // FIXME: explicit assert condition
       expect(env.getConfig(envParam)).toMatchSnapshot();
     });
     it('supports docker username/password', () => {
@@ -97,12 +104,14 @@ describe(getName(), () => {
         DOCKER_USERNAME: 'some-username',
         DOCKER_PASSWORD: 'some-password',
       };
+      // FIXME: explicit assert condition
       expect(env.getConfig(envParam)).toMatchSnapshot();
     });
     it('supports password-only', () => {
       const envParam: NodeJS.ProcessEnv = {
         NPM_PASSWORD: 'some-password',
       };
+      // FIXME: explicit assert condition
       expect(env.getConfig(envParam)).toMatchSnapshot();
     });
     it('supports domain and host names with case insensitivity', () => {
@@ -133,6 +142,7 @@ describe(getName(), () => {
       const envParam: NodeJS.ProcessEnv = {
         PYPI_TOKEN: 'some-token',
       };
+      // FIXME: explicit assert condition
       expect(env.getConfig(envParam)).toMatchSnapshot();
     });
     it('rejects incomplete datasource env token', () => {
@@ -154,6 +164,7 @@ describe(getName(), () => {
         RENOVATE_USERNAME: 'some-username',
         RENOVATE_PASSWORD: 'app-password',
       };
+      // FIXME: explicit assert condition
       expect(env.getConfig(envParam)).toMatchSnapshot();
     });
     it('supports Bitbucket username/password', () => {
@@ -163,6 +174,7 @@ describe(getName(), () => {
         RENOVATE_USERNAME: 'some-username',
         RENOVATE_PASSWORD: 'app-password',
       };
+      // FIXME: explicit assert condition
       expect(env.getConfig(envParam)).toMatchSnapshot();
     });
     it('merges full config from env', () => {

--- a/lib/workers/pr/automerge.spec.ts
+++ b/lib/workers/pr/automerge.spec.ts
@@ -29,6 +29,7 @@ describe(getName(), () => {
       platform.getBranchStatus.mockResolvedValueOnce(BranchStatus.green);
       platform.mergePr.mockResolvedValueOnce(true);
       const res = await prAutomerge.checkAutoMerge(pr, config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
       expect(platform.mergePr).toHaveBeenCalledTimes(1);
     });
@@ -37,6 +38,7 @@ describe(getName(), () => {
       platform.getBranchStatus.mockResolvedValueOnce(BranchStatus.green);
       platform.mergePr.mockResolvedValueOnce(false);
       const res = await prAutomerge.checkAutoMerge(pr, config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
       expect(platform.mergePr).toHaveBeenCalledTimes(1);
     });
@@ -47,6 +49,7 @@ describe(getName(), () => {
       platform.getBranchStatus.mockResolvedValueOnce(BranchStatus.green);
       platform.ensureComment.mockResolvedValueOnce(true);
       const res = await prAutomerge.checkAutoMerge(pr, config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
       expect(platform.ensureCommentRemoval).toHaveBeenCalledTimes(0);
       expect(platform.ensureComment).toHaveBeenCalledTimes(1);
@@ -59,6 +62,7 @@ describe(getName(), () => {
       platform.getBranchStatus.mockResolvedValueOnce(BranchStatus.green);
       platform.ensureComment.mockResolvedValueOnce(true);
       const res = await prAutomerge.checkAutoMerge(pr, config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
       expect(platform.ensureCommentRemoval).toHaveBeenCalledTimes(1);
       expect(platform.ensureComment).toHaveBeenCalledTimes(1);
@@ -68,6 +72,7 @@ describe(getName(), () => {
       platform.getBranchStatus.mockResolvedValueOnce(BranchStatus.green);
       git.isBranchModified.mockResolvedValueOnce(true);
       const res = await prAutomerge.checkAutoMerge(pr, config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
       expect(platform.mergePr).toHaveBeenCalledTimes(0);
     });
@@ -75,6 +80,7 @@ describe(getName(), () => {
       config.automerge = true;
       platform.getBranchStatus.mockResolvedValueOnce(BranchStatus.yellow);
       const res = await prAutomerge.checkAutoMerge(pr, config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
       expect(platform.mergePr).toHaveBeenCalledTimes(0);
     });
@@ -82,6 +88,7 @@ describe(getName(), () => {
       config.automerge = true;
       pr.canMerge = undefined;
       const res = await prAutomerge.checkAutoMerge(pr, config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
       expect(platform.mergePr).toHaveBeenCalledTimes(0);
     });
@@ -89,6 +96,7 @@ describe(getName(), () => {
       config.automerge = true;
       pr.isConflicted = true;
       const res = await prAutomerge.checkAutoMerge(pr, config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
       expect(platform.mergePr).toHaveBeenCalledTimes(0);
     });

--- a/lib/workers/pr/body/controls.spec.ts
+++ b/lib/workers/pr/body/controls.spec.ts
@@ -19,6 +19,7 @@ describe(getName(), () => {
           git.isBranchModified.mockResolvedValue(modified);
         });
         it('has the correct contents', async () => {
+          // FIXME: explicit assert condition
           expect(await getControls(branchConfig)).toMatchSnapshot();
           expect(git.isBranchModified).toHaveBeenCalledTimes(1);
           expect(git.isBranchModified).toHaveBeenCalledWith(

--- a/lib/workers/pr/changelog/github.spec.ts
+++ b/lib/workers/pr/changelog/github.spec.ts
@@ -73,6 +73,7 @@ describe(getName(), () => {
       ).toBeNull();
     });
     it('works without Github', async () => {
+      // FIXME: explicit assert condition
       expect(
         await getChangeLogJSON({
           ...upgrade,
@@ -80,6 +81,7 @@ describe(getName(), () => {
       ).toMatchSnapshot();
     });
     it('uses GitHub tags', async () => {
+      // FIXME: explicit assert condition
       expect(
         await getChangeLogJSON({
           ...upgrade,
@@ -87,6 +89,7 @@ describe(getName(), () => {
       ).toMatchSnapshot();
     });
     it('filters unnecessary warns', async () => {
+      // FIXME: explicit assert condition
       expect(
         await getChangeLogJSON({
           ...upgrade,
@@ -95,6 +98,7 @@ describe(getName(), () => {
       ).toMatchSnapshot();
     });
     it('supports node engines', async () => {
+      // FIXME: explicit assert condition
       expect(
         await getChangeLogJSON({
           ...upgrade,
@@ -148,6 +152,7 @@ describe(getName(), () => {
         token: 'super_secret',
         matchHost: 'https://github-enterprise.example.com/',
       });
+      // FIXME: explicit assert condition
       expect(
         await getChangeLogJSON({
           ...upgrade,
@@ -162,6 +167,7 @@ describe(getName(), () => {
         token: 'abc',
       });
       process.env.GITHUB_ENDPOINT = '';
+      // FIXME: explicit assert condition
       expect(
         await getChangeLogJSON({
           ...upgrade,

--- a/lib/workers/pr/changelog/gitlab.spec.ts
+++ b/lib/workers/pr/changelog/gitlab.spec.ts
@@ -72,6 +72,7 @@ describe(getName(), () => {
       ).toBeNull();
     });
     it('works without GitLab', async () => {
+      // FIXME: explicit assert condition
       expect(
         await getChangeLogJSON({
           ...upgrade,
@@ -96,6 +97,7 @@ describe(getName(), () => {
         .persist()
         .get('/api/v4/projects/meno%2fdropzone/releases?per_page=100')
         .reply(200, []);
+      // FIXME: explicit assert condition
       expect(
         await getChangeLogJSON({
           ...upgrade,
@@ -114,6 +116,7 @@ describe(getName(), () => {
         .persist()
         .get('/api/v4/projects/meno%2fdropzone/releases?per_page=100')
         .reply(200, []);
+      // FIXME: explicit assert condition
       expect(
         await getChangeLogJSON({
           ...upgrade,
@@ -132,6 +135,7 @@ describe(getName(), () => {
         .persist()
         .get('/api/v4/projects/meno%2fdropzone/releases?per_page=100')
         .reply(200, []);
+      // FIXME: explicit assert condition
       expect(
         await getChangeLogJSON({
           ...upgrade,
@@ -178,6 +182,7 @@ describe(getName(), () => {
         token: 'abc',
       });
       process.env.GITHUB_ENDPOINT = '';
+      // FIXME: explicit assert condition
       expect(
         await getChangeLogJSON({
           ...upgrade,
@@ -194,6 +199,7 @@ describe(getName(), () => {
         token: 'abc',
       });
       process.env.GITHUB_ENDPOINT = '';
+      // FIXME: explicit assert condition
       expect(
         await getChangeLogJSON({
           ...upgrade,

--- a/lib/workers/pr/changelog/index.spec.ts
+++ b/lib/workers/pr/changelog/index.spec.ts
@@ -94,6 +94,7 @@ describe(getName(), () => {
         .get('/repos/chalk/chalk/releases?per_page=100')
         .times(4)
         .reply(500);
+      // FIXME: explicit assert condition
       expect(
         await getChangeLogJSON({
           ...upgrade,
@@ -116,6 +117,7 @@ describe(getName(), () => {
         .persist()
         .get(/.*/)
         .reply(200, []);
+      // FIXME: explicit assert condition
       expect(
         await getChangeLogJSON({
           ...upgrade,
@@ -133,10 +135,12 @@ describe(getName(), () => {
         ...upgrade,
         depName: '@renovate/no',
       });
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
     it('supports node engines', async () => {
+      // FIXME: explicit assert condition
       expect(
         await getChangeLogJSON({
           ...upgrade,
@@ -191,6 +195,7 @@ describe(getName(), () => {
         token: 'super_secret',
         matchHost: 'https://github-enterprise.example.com/',
       });
+      // FIXME: explicit assert condition
       expect(
         await getChangeLogJSON({
           ...upgrade,
@@ -211,6 +216,7 @@ describe(getName(), () => {
         token: 'abc',
       });
       process.env.GITHUB_ENDPOINT = '';
+      // FIXME: explicit assert condition
       expect(
         await getChangeLogJSON({
           ...upgrade,
@@ -232,6 +238,7 @@ describe(getName(), () => {
         matchHost: 'https://github-enterprise.example.com/',
         token: 'abc',
       });
+      // FIXME: explicit assert condition
       expect(
         await getChangeLogJSON({
           ...upgrade,

--- a/lib/workers/pr/changelog/release-notes.spec.ts
+++ b/lib/workers/pr/changelog/release-notes.spec.ts
@@ -76,6 +76,7 @@ describe(getName(), () => {
         project: { github: 'https://github.com/nodeca/js-yaml' },
         versions: [{ version: '3.10.0', compare: { url: '' } }],
       };
+      // FIXME: explicit assert condition
       expect(await addReleaseNotes(input as never)).toMatchSnapshot();
     });
     it('returns ChangeLogResult without release notes', async () => {
@@ -84,6 +85,7 @@ describe(getName(), () => {
         project: { gitlab: 'https://gitlab.com/gitlab-org/gitter/webapp/' },
         versions: [{ version: '20.26.0', compare: { url: '' } }],
       };
+      // FIXME: explicit assert condition
       expect(await addReleaseNotes(input as never)).toMatchSnapshot();
     });
   });
@@ -108,6 +110,7 @@ describe(getName(), () => {
         'https://api.github.com/',
         'some/yet-other-repository'
       );
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
@@ -128,6 +131,7 @@ describe(getName(), () => {
         'https://gitlab.com/api/v4/',
         'some/yet-other-repository'
       );
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
@@ -149,6 +153,7 @@ describe(getName(), () => {
         'https://my.custom.domain/api/v4/',
         'some/yet-other-repository'
       );
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
@@ -189,6 +194,7 @@ describe(getName(), () => {
           'https://github.com/',
           'https://api.github.com/'
         );
+        // FIXME: explicit assert condition
         expect(res).toMatchSnapshot();
         expect(httpMock.getTrace()).toMatchSnapshot();
       }
@@ -214,6 +220,7 @@ describe(getName(), () => {
           'https://gitlab.com/',
           'https://api.gitlab.com/'
         );
+        // FIXME: explicit assert condition
         expect(res).toMatchSnapshot();
         expect(httpMock.getTrace()).toMatchSnapshot();
       }
@@ -320,6 +327,7 @@ describe(getName(), () => {
         'https://github.com/',
         'https://api.github.com/'
       );
+      // FIXME: explicit assert condition
       expect(res).not.toBeNull();
       expect(res).toMatchSnapshot();
       expect(httpMock.getTrace()).toMatchSnapshot();
@@ -341,6 +349,7 @@ describe(getName(), () => {
         'https://api.gitlab.com/'
       );
       expect(httpMock.getTrace()).toMatchSnapshot();
+      // FIXME: explicit assert condition
       expect(res).not.toBeNull();
       expect(res).toMatchSnapshot();
     });
@@ -362,6 +371,7 @@ describe(getName(), () => {
         'https://my.custom.domain/'
       );
       expect(httpMock.getTrace()).toMatchSnapshot();
+      // FIXME: explicit assert condition
       expect(res).not.toBeNull();
       expect(res).toMatchSnapshot();
     });
@@ -383,6 +393,7 @@ describe(getName(), () => {
         'https://api.github.com/'
       );
       expect(httpMock.getTrace()).toMatchSnapshot();
+      // FIXME: explicit assert condition
       expect(res).not.toBeNull();
       expect(res).toMatchSnapshot();
     });
@@ -410,6 +421,7 @@ describe(getName(), () => {
         sourceDirectory
       );
       expect(httpMock.getTrace()).toMatchSnapshot();
+      // FIXME: explicit assert condition
       expect(res).not.toBeNull();
       expect(res).toMatchSnapshot();
     });
@@ -431,6 +443,7 @@ describe(getName(), () => {
         'https://api.github.com/'
       );
       expect(httpMock.getTrace()).toMatchSnapshot();
+      // FIXME: explicit assert condition
       expect(res).not.toBeNull();
       expect(res).toMatchSnapshot();
     });
@@ -456,6 +469,7 @@ describe(getName(), () => {
         );
         versionOneNotes = res;
         expect(httpMock.getTrace()).toMatchSnapshot();
+        // FIXME: explicit assert condition
         expect(res).not.toBeNull();
         expect(res).toMatchSnapshot();
       });
@@ -478,6 +492,7 @@ describe(getName(), () => {
         );
         versionTwoNotes = res;
         expect(httpMock.getTrace()).toMatchSnapshot();
+        // FIXME: explicit assert condition
         expect(res).not.toBeNull();
         expect(res).toMatchSnapshot();
       });
@@ -500,6 +515,7 @@ describe(getName(), () => {
         );
         versionTwoNotes = res;
         expect(httpMock.getTrace()).toMatchSnapshot();
+        // FIXME: explicit assert condition
         expect(res).not.toBeNull();
         expect(res).toMatchSnapshot();
       });
@@ -528,6 +544,7 @@ describe(getName(), () => {
         );
         versionTwoNotes = res;
         expect(httpMock.getTrace()).toMatchSnapshot();
+        // FIXME: explicit assert condition
         expect(res).not.toBeNull();
         expect(res).toMatchSnapshot();
       });

--- a/lib/workers/pr/index.spec.ts
+++ b/lib/workers/pr/index.spec.ts
@@ -242,6 +242,7 @@ describe(getName(), () => {
       config.schedule = ['before 5am'];
       const { pr } = await prWorker.ensurePr(config);
       expect(pr).toMatchObject({ displayNumber: 'New Pull Request' });
+      // FIXME: explicit assert condition
       expect(platform.createPr.mock.calls[0]).toMatchSnapshot();
       existingPr.body = platform.createPr.mock.calls[0][0].prBody;
       config.branchName = 'renovate/dummy-1.x';
@@ -257,6 +258,7 @@ describe(getName(), () => {
       config.schedule = ['before 5am'];
       const { pr } = await prWorker.ensurePr(config);
       expect(pr).toMatchObject({ displayNumber: 'New Pull Request' });
+      // FIXME: explicit assert condition
       expect(platform.createPr.mock.calls[0]).toMatchSnapshot();
       existingPr.body = platform.createPr.mock.calls[0][0].prBody;
     });
@@ -317,6 +319,7 @@ describe(getName(), () => {
       }
       const { pr } = await prWorker.ensurePr(config);
       expect(pr).toMatchObject({ displayNumber: 'New Pull Request' });
+      // FIXME: explicit assert condition
       expect(platform.createPr.mock.calls[0]).toMatchSnapshot();
     });
     it('should add note about Pin', async () => {
@@ -330,6 +333,7 @@ describe(getName(), () => {
       config.logJSON = await getChangeLogJSON(config);
       const { pr } = await prWorker.ensurePr(config);
       expect(pr).toMatchObject({ displayNumber: 'New Pull Request' });
+      // FIXME: explicit assert condition
       expect(platform.createPr.mock.calls[0]).toMatchSnapshot();
       expect(platform.createPr.mock.calls[0][0].prBody).toContain(
         'this Pin PR'
@@ -545,6 +549,7 @@ describe(getName(), () => {
       config.logJSON = await getChangeLogJSON(config);
       platform.getBranchPr.mockResolvedValueOnce(existingPr);
       const { pr } = await prWorker.ensurePr(config);
+      // FIXME: explicit assert condition
       expect(pr).toMatchSnapshot();
     });
     it('should return modified existing PR title', async () => {
@@ -554,6 +559,7 @@ describe(getName(), () => {
         title: 'wrong',
       });
       const { pr } = await prWorker.ensurePr(config);
+      // FIXME: explicit assert condition
       expect(pr).toMatchSnapshot();
     });
     it('should create PR if branch tests failed', async () => {

--- a/lib/workers/repository/dependency-dashboard.spec.ts
+++ b/lib/workers/repository/dependency-dashboard.spec.ts
@@ -54,6 +54,7 @@ describe(getName(), () => {
           '\n\n - [x] <!-- rebase-all-open-prs -->',
       });
       await dependencyDashboard.readDashboardBody(conf);
+      // FIXME: explicit assert condition
       expect(conf).toMatchSnapshot();
     });
   });

--- a/lib/workers/repository/extract/index.spec.ts
+++ b/lib/workers/repository/extract/index.spec.ts
@@ -26,6 +26,7 @@ describe(getName(), () => {
       config.enabledManagers = ['npm'];
       managerFiles.getManagerPackageFiles.mockResolvedValue([{} as never]);
       const res = await extractAllDependencies(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('checks custom managers', async () => {

--- a/lib/workers/repository/extract/manager-files.spec.ts
+++ b/lib/workers/repository/extract/manager-files.spec.ts
@@ -47,6 +47,7 @@ describe(getName(), () => {
         deps: [{}, { replaceString: 'abc' }],
       })) as never;
       const res = await getManagerPackageFiles(managerConfig);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('returns files with extractAllPackageFiles', async () => {
@@ -60,6 +61,7 @@ describe(getName(), () => {
         '{"dependencies":{"chalk":"2.0.0"}}'
       );
       const res = await getManagerPackageFiles(managerConfig);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
   });

--- a/lib/workers/repository/index.spec.ts
+++ b/lib/workers/repository/index.spec.ts
@@ -23,6 +23,7 @@ describe(getName(), () => {
     it('runs', async () => {
       process.extractDependencies.mockResolvedValue(mock<ExtractResult>());
       const res = await renovateRepository(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
   });

--- a/lib/workers/repository/init/index.spec.ts
+++ b/lib/workers/repository/init/index.spec.ts
@@ -38,6 +38,7 @@ describe(getName(), () => {
       merge.mergeRenovateConfig.mockResolvedValueOnce({});
       secrets.applySecretsToConfig.mockReturnValueOnce({} as never);
       const renovateConfig = await initRepo({});
+      // FIXME: explicit assert condition
       expect(renovateConfig).toMatchSnapshot();
     });
     it('warns on unsupported options', async () => {

--- a/lib/workers/repository/init/merge.spec.ts
+++ b/lib/workers/repository/init/merge.spec.ts
@@ -42,6 +42,7 @@ describe(getName(), () => {
     it('returns config if not found', async () => {
       git.getFileList.mockResolvedValue(['package.json']);
       fs.readLocalFile.mockResolvedValue('{}');
+      // FIXME: explicit assert condition
       expect(await detectRepoFileConfig()).toMatchSnapshot();
     });
     it('uses package.json config if found', async () => {
@@ -54,12 +55,14 @@ describe(getName(), () => {
       });
       fs.readLocalFile.mockResolvedValue(pJson);
       platform.getJsonFile.mockResolvedValueOnce(pJson);
+      // FIXME: explicit assert condition
       expect(await detectRepoFileConfig()).toMatchSnapshot();
       expect(await detectRepoFileConfig()).toMatchSnapshot();
     });
     it('returns error if cannot parse', async () => {
       git.getFileList.mockResolvedValue(['package.json', 'renovate.json']);
       fs.readLocalFile.mockResolvedValue('cannot parse');
+      // FIXME: explicit assert condition
       expect(await detectRepoFileConfig()).toMatchSnapshot();
     });
     it('throws error if duplicate keys', async () => {
@@ -67,6 +70,7 @@ describe(getName(), () => {
       fs.readLocalFile.mockResolvedValue(
         '{ "enabled": true, "enabled": false }'
       );
+      // FIXME: explicit assert condition
       expect(await detectRepoFileConfig()).toMatchSnapshot();
     });
     it('finds and parse renovate.json5', async () => {
@@ -74,6 +78,7 @@ describe(getName(), () => {
       fs.readLocalFile.mockResolvedValue(`{
         // this is json5 format
       }`);
+      // FIXME: explicit assert condition
       expect(await detectRepoFileConfig()).toMatchSnapshot();
     });
     it('finds .github/renovate.json', async () => {
@@ -82,6 +87,7 @@ describe(getName(), () => {
         '.github/renovate.json',
       ]);
       fs.readLocalFile.mockResolvedValue('{}');
+      // FIXME: explicit assert condition
       expect(await detectRepoFileConfig()).toMatchSnapshot();
     });
     it('finds .gitlab/renovate.json', async () => {
@@ -90,12 +96,14 @@ describe(getName(), () => {
         '.gitlab/renovate.json',
       ]);
       fs.readLocalFile.mockResolvedValue('{}');
+      // FIXME: explicit assert condition
       expect(await detectRepoFileConfig()).toMatchSnapshot();
     });
     it('finds .renovaterc.json', async () => {
       git.getFileList.mockResolvedValue(['package.json', '.renovaterc.json']);
       fs.readLocalFile.mockResolvedValue('{}');
       platform.getJsonFile.mockResolvedValueOnce('{"something":"new"}');
+      // FIXME: explicit assert condition
       expect(await detectRepoFileConfig()).toMatchSnapshot();
       expect(await detectRepoFileConfig()).toMatchSnapshot();
     });
@@ -132,6 +140,7 @@ describe(getName(), () => {
         e = err;
       }
       expect(e).toBeDefined();
+      // FIXME: explicit assert condition
       expect(e).toMatchSnapshot();
     });
     it('migrates nested config', async () => {

--- a/lib/workers/repository/init/vulnerability.spec.ts
+++ b/lib/workers/repository/init/vulnerability.spec.ts
@@ -290,6 +290,7 @@ describe(getName(), () => {
       const res = await detectVulnerabilityAlerts(config);
       expect(res.packageRules).toMatchSnapshot();
       expect(res.packageRules).toHaveLength(3);
+      // FIXME: explicit assert condition
       expect(res.remediations).toMatchSnapshot();
     });
   });

--- a/lib/workers/repository/onboarding/branch/index.spec.ts
+++ b/lib/workers/repository/onboarding/branch/index.spec.ts
@@ -63,6 +63,7 @@ describe(getName(), () => {
       git.getFileList.mockResolvedValue(['package.json']);
       fs.readLocalFile.mockResolvedValue('{}');
       await checkOnboardingBranch(config);
+      // FIXME: explicit assert condition
       expect(
         git.commitFiles.mock.calls[0][0].files[0].contents
       ).toMatchSnapshot();
@@ -86,6 +87,7 @@ describe(getName(), () => {
         renovateJsonPresent: true,
         warnings: [],
       });
+      // FIXME: explicit assert condition
       expect(
         git.commitFiles.mock.calls[0][0].files[0].contents
       ).toMatchSnapshot();

--- a/lib/workers/repository/onboarding/pr/base-branch.spec.ts
+++ b/lib/workers/repository/onboarding/pr/base-branch.spec.ts
@@ -16,11 +16,13 @@ describe(getName(), () => {
     it('describes baseBranch', () => {
       config.baseBranches = ['some-branch'];
       const res = getBaseBranchDesc(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('describes baseBranches', () => {
       config.baseBranches = ['some-branch', 'some-other-branch'];
       const res = getBaseBranchDesc(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
   });

--- a/lib/workers/repository/onboarding/pr/config-description.spec.ts
+++ b/lib/workers/repository/onboarding/pr/config-description.spec.ts
@@ -12,6 +12,7 @@ describe(getName(), () => {
     it('returns empty', () => {
       delete config.description;
       const res = getConfigDesc(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('returns a full list', () => {
@@ -36,6 +37,7 @@ describe(getName(), () => {
       config.labels = ['renovate', 'deps'];
       config.schedule = ['before 5am'];
       const res = getConfigDesc(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('contains the onboardingConfigFileName if set', () => {

--- a/lib/workers/repository/onboarding/pr/errors-warnings.spec.ts
+++ b/lib/workers/repository/onboarding/pr/errors-warnings.spec.ts
@@ -17,6 +17,7 @@ describe(getName(), () => {
         },
       ];
       const res = getWarnings(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
   });
@@ -57,6 +58,7 @@ describe(getName(), () => {
         ],
       };
       const res = getDepWarnings(packageFiles);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
   });
@@ -74,6 +76,7 @@ describe(getName(), () => {
         },
       ];
       const res = getErrors(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
   });

--- a/lib/workers/repository/onboarding/pr/pr-list.spec.ts
+++ b/lib/workers/repository/onboarding/pr/pr-list.spec.ts
@@ -12,6 +12,7 @@ describe(getName(), () => {
     it('handles empty', () => {
       const branches: BranchConfig[] = [];
       const res = getPrList(config, branches);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('has special lock file maintenance description', () => {
@@ -28,6 +29,7 @@ describe(getName(), () => {
         },
       ];
       const res = getPrList(config, branches);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('handles multiple', () => {
@@ -68,6 +70,7 @@ describe(getName(), () => {
       ];
       config.prHourlyLimit = 1;
       const res = getPrList(config, branches);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
   });

--- a/lib/workers/repository/process/deprecated.spec.ts
+++ b/lib/workers/repository/process/deprecated.spec.ts
@@ -59,6 +59,7 @@ describe(getName(), () => {
       ];
       platform.getIssueList.mockResolvedValue(mockIssue);
       await raiseDeprecationWarnings(config, packageFiles);
+      // FIXME: explicit assert condition
       expect(platform.ensureIssue.mock.calls).toMatchSnapshot();
       expect(platform.getIssueList).toHaveBeenCalledTimes(1);
       expect(platform.ensureIssue).toHaveBeenCalledTimes(1);

--- a/lib/workers/repository/process/extract-update.spec.ts
+++ b/lib/workers/repository/process/extract-update.spec.ts
@@ -32,6 +32,7 @@ describe(getName(), () => {
       git.checkoutBranch.mockResolvedValueOnce('abc123');
       const packageFiles = await extract(config);
       const res = await lookup(config, packageFiles);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
       await expect(update(config, res.branches)).resolves.not.toThrow();
     });
@@ -44,6 +45,7 @@ describe(getName(), () => {
       git.checkoutBranch.mockResolvedValueOnce('abc123');
       repositoryCache.getCache.mockReturnValueOnce({ scan: {} });
       const packageFiles = await extract(config);
+      // FIXME: explicit assert condition
       expect(packageFiles).toMatchSnapshot();
     });
     it('uses repository cache', async () => {

--- a/lib/workers/repository/process/fetch.spec.ts
+++ b/lib/workers/repository/process/fetch.spec.ts
@@ -28,6 +28,7 @@ describe(getName(), () => {
         npm: [{ packageFile: 'package.json', deps: [] }],
       };
       await fetchUpdates(config, packageFiles);
+      // FIXME: explicit assert condition
       expect(packageFiles).toMatchSnapshot();
     });
     it('handles ignored, skipped and disabled', async () => {

--- a/lib/workers/repository/process/index.spec.ts
+++ b/lib/workers/repository/process/index.spec.ts
@@ -23,6 +23,7 @@ describe(getName(), () => {
   describe('processRepo()', () => {
     it('processes single branches', async () => {
       const res = await extractDependencies(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('processes baseBranches', async () => {
@@ -34,6 +35,7 @@ describe(getName(), () => {
       git.branchExists.mockReturnValueOnce(true);
       const res = await extractDependencies(config);
       await updateRepo(config, res.branches);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
   });

--- a/lib/workers/repository/process/lookup/index.spec.ts
+++ b/lib/workers/repository/process/lookup/index.spec.ts
@@ -74,6 +74,7 @@ describe(getName(), () => {
       config.datasource = datasourceNpmId;
       config.rollbackPrs = true;
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('returns rollback for ranged version', async () => {
@@ -82,6 +83,7 @@ describe(getName(), () => {
       config.datasource = datasourceNpmId;
       config.rollbackPrs = true;
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('supports minor and major upgrades for tilde ranges', async () => {
@@ -90,6 +92,7 @@ describe(getName(), () => {
       config.depName = 'q';
       config.datasource = datasourceNpmId;
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('supports lock file updates mixed with regular updates', async () => {
@@ -100,6 +103,7 @@ describe(getName(), () => {
       config.separateMinorPatch = true;
       config.lockedVersion = '0.4.0';
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('returns multiple updates if grouping but separateMajorMinor=true', async () => {
@@ -144,6 +148,7 @@ describe(getName(), () => {
       config.depName = 'q';
       config.datasource = datasourceNpmId;
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('enforces allowedVersions', async () => {
@@ -233,6 +238,7 @@ describe(getName(), () => {
       config.depName = 'q';
       config.datasource = datasourceNpmId;
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('returns patch minor and major', async () => {
@@ -253,6 +259,7 @@ describe(getName(), () => {
       config.depName = 'q';
       config.datasource = datasourceNpmId;
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('disables major release separation (minor)', async () => {
@@ -262,6 +269,7 @@ describe(getName(), () => {
       config.depName = 'q';
       config.datasource = datasourceNpmId;
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('uses minimum version for vulnerabilityAlerts', async () => {
@@ -280,6 +288,7 @@ describe(getName(), () => {
       config.depName = 'q';
       config.datasource = datasourceNpmId;
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('ignores pinning for ranges when other upgrade exists', async () => {
@@ -288,6 +297,7 @@ describe(getName(), () => {
       config.depName = 'q';
       config.datasource = datasourceNpmId;
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('upgrades minor ranged versions', async () => {
@@ -296,6 +306,7 @@ describe(getName(), () => {
       config.depName = 'q';
       config.datasource = datasourceNpmId;
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('handles update-lockfile', async () => {
@@ -315,6 +326,7 @@ describe(getName(), () => {
       config.depName = 'q';
       config.datasource = datasourceNpmId;
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('replaces minor complex ranged versions if configured', async () => {
@@ -323,6 +335,7 @@ describe(getName(), () => {
       config.depName = 'q';
       config.datasource = datasourceNpmId;
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('widens major ranged versions if configured', async () => {
@@ -334,6 +347,7 @@ describe(getName(), () => {
         .scope('https://registry.npmjs.org')
         .get('/webpack')
         .reply(200, webpackJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('replaces major complex ranged versions if configured', async () => {
@@ -345,6 +359,7 @@ describe(getName(), () => {
         .scope('https://registry.npmjs.org')
         .get('/webpack')
         .reply(200, webpackJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('pins minor ranged versions', async () => {
@@ -353,6 +368,7 @@ describe(getName(), () => {
       config.depName = 'q';
       config.datasource = datasourceNpmId;
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('uses the locked version for pinning', async () => {
@@ -362,6 +378,7 @@ describe(getName(), () => {
       config.depName = 'q';
       config.datasource = datasourceNpmId;
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('ignores minor ranged versions when not pinning', async () => {
@@ -387,6 +404,7 @@ describe(getName(), () => {
       config.depName = 'q';
       config.datasource = datasourceNpmId;
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('upgrades .x minor ranges', async () => {
@@ -395,6 +413,7 @@ describe(getName(), () => {
       config.depName = 'q';
       config.datasource = datasourceNpmId;
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('upgrades tilde ranges without pinning', async () => {
@@ -403,6 +422,7 @@ describe(getName(), () => {
       config.depName = 'q';
       config.datasource = datasourceNpmId;
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('upgrades .x major ranges without pinning', async () => {
@@ -411,6 +431,7 @@ describe(getName(), () => {
       config.depName = 'q';
       config.datasource = datasourceNpmId;
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('upgrades .x minor ranges without pinning', async () => {
@@ -419,6 +440,7 @@ describe(getName(), () => {
       config.depName = 'q';
       config.datasource = datasourceNpmId;
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('upgrades .x complex minor ranges without pinning', async () => {
@@ -427,6 +449,7 @@ describe(getName(), () => {
       config.depName = 'q';
       config.datasource = datasourceNpmId;
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('upgrades shorthand major ranges without pinning', async () => {
@@ -435,6 +458,7 @@ describe(getName(), () => {
       config.depName = 'q';
       config.datasource = datasourceNpmId;
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('upgrades shorthand minor ranges without pinning', async () => {
@@ -443,6 +467,7 @@ describe(getName(), () => {
       config.depName = 'q';
       config.datasource = datasourceNpmId;
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('upgrades multiple tilde ranges without pinning', async () => {
@@ -451,6 +476,7 @@ describe(getName(), () => {
       config.depName = 'q';
       config.datasource = datasourceNpmId;
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('upgrades multiple caret ranges without pinning', async () => {
@@ -459,6 +485,7 @@ describe(getName(), () => {
       config.depName = 'q';
       config.datasource = datasourceNpmId;
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('supports complex ranges', async () => {
@@ -469,6 +496,7 @@ describe(getName(), () => {
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
       const res = await lookup.lookupUpdates(config);
       expect(res.updates).toHaveLength(2);
+      // FIXME: explicit assert condition
       expect(res.updates[0]).toMatchSnapshot();
     });
     it('supports complex major ranges', async () => {
@@ -480,6 +508,7 @@ describe(getName(), () => {
         .scope('https://registry.npmjs.org')
         .get('/webpack')
         .reply(200, webpackJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('supports complex major hyphen ranges', async () => {
@@ -491,6 +520,7 @@ describe(getName(), () => {
         .scope('https://registry.npmjs.org')
         .get('/webpack')
         .reply(200, webpackJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('widens .x OR ranges', async () => {
@@ -502,6 +532,7 @@ describe(getName(), () => {
         .scope('https://registry.npmjs.org')
         .get('/webpack')
         .reply(200, webpackJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('widens stanndalone major OR ranges', async () => {
@@ -513,6 +544,7 @@ describe(getName(), () => {
         .scope('https://registry.npmjs.org')
         .get('/webpack')
         .reply(200, webpackJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('supports complex tilde ranges', async () => {
@@ -521,6 +553,7 @@ describe(getName(), () => {
       config.depName = 'q';
       config.datasource = datasourceNpmId;
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('returns nothing for greater than ranges', async () => {
@@ -537,6 +570,7 @@ describe(getName(), () => {
       config.depName = 'q';
       config.datasource = datasourceNpmId;
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('upgrades less than ranges without pinning', async () => {
@@ -545,6 +579,7 @@ describe(getName(), () => {
       config.depName = 'q';
       config.datasource = datasourceNpmId;
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('upgrades less than major ranges', async () => {
@@ -553,6 +588,7 @@ describe(getName(), () => {
       config.depName = 'q';
       config.datasource = datasourceNpmId;
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('upgrades less than equal minor ranges', async () => {
@@ -561,6 +597,7 @@ describe(getName(), () => {
       config.depName = 'q';
       config.datasource = datasourceNpmId;
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('upgrades equal minor ranges', async () => {
@@ -569,6 +606,7 @@ describe(getName(), () => {
       config.depName = 'q';
       config.datasource = datasourceNpmId;
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('upgrades less than equal major ranges', async () => {
@@ -578,6 +616,7 @@ describe(getName(), () => {
       config.depName = 'q';
       config.datasource = datasourceNpmId;
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('upgrades major less than equal ranges', async () => {
@@ -639,6 +678,7 @@ describe(getName(), () => {
       config.datasource = datasourceNpmId;
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
       const res = await lookup.lookupUpdates(config);
+      // FIXME: explicit assert condition
       expect(res.updates).toMatchSnapshot();
     });
     it('supports > latest versions if configured', async () => {
@@ -647,6 +687,7 @@ describe(getName(), () => {
       config.depName = 'q';
       config.datasource = datasourceNpmId;
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('should ignore unstable versions if the current version is stable', async () => {
@@ -677,6 +718,7 @@ describe(getName(), () => {
           },
         ],
       });
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
 
@@ -875,6 +917,7 @@ describe(getName(), () => {
         .scope('https://registry.npmjs.org')
         .get('/@types%2Fhelmet')
         .reply(200, helmetJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('should downgrade from missing versions', async () => {
@@ -931,6 +974,7 @@ describe(getName(), () => {
       config.depName = 'q';
       config.datasource = datasourceNpmId;
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('supports in-range tilde updates', async () => {
@@ -940,6 +984,7 @@ describe(getName(), () => {
       config.separateMinorPatch = true;
       config.datasource = datasourceNpmId;
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('supports in-range tilde patch updates', async () => {
@@ -949,6 +994,7 @@ describe(getName(), () => {
       config.separateMinorPatch = true;
       config.datasource = datasourceNpmId;
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('supports in-range gte updates', async () => {
@@ -957,6 +1003,7 @@ describe(getName(), () => {
       config.depName = 'q';
       config.datasource = datasourceNpmId;
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('supports majorgte updates', async () => {
@@ -966,6 +1013,7 @@ describe(getName(), () => {
       config.datasource = datasourceNpmId;
       config.separateMajorMinor = false;
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('rejects in-range unsupported operator', async () => {
@@ -974,6 +1022,7 @@ describe(getName(), () => {
       config.depName = 'q';
       config.datasource = datasourceNpmId;
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('rejects non-fully specified in-range updates', async () => {
@@ -982,6 +1031,7 @@ describe(getName(), () => {
       config.depName = 'q';
       config.datasource = datasourceNpmId;
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('rejects complex range in-range updates', async () => {
@@ -990,6 +1040,7 @@ describe(getName(), () => {
       config.depName = 'q';
       config.datasource = datasourceNpmId;
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('replaces non-range in-range updates', async () => {
@@ -999,6 +1050,7 @@ describe(getName(), () => {
       config.rangeStrategy = 'bump';
       config.currentValue = '1.0.0';
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('handles github 404', async () => {
@@ -1007,6 +1059,7 @@ describe(getName(), () => {
       config.packageFile = 'package.json';
       config.currentValue = '1.0.0';
       httpMock.scope('https://pypi.org').get('/pypi/foo/json').reply(404);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('handles pypi 404', async () => {
@@ -1018,6 +1071,7 @@ describe(getName(), () => {
         .scope('https://api.github.com')
         .get('/repos/some/repo/git/refs/tags?per_page=100')
         .reply(404);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('handles packagist', async () => {
@@ -1030,6 +1084,7 @@ describe(getName(), () => {
         .scope('https://packagist.org')
         .get('/packages/foo/bar.json')
         .reply(404);
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('handles unknown datasource', async () => {
@@ -1037,6 +1092,7 @@ describe(getName(), () => {
       config.datasource = 'typo';
       config.packageFile = 'package.json';
       config.currentValue = '1.0.0';
+      // FIXME: explicit assert condition
       expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
     it('handles PEP440', async () => {
@@ -1052,6 +1108,7 @@ describe(getName(), () => {
       config.datasource = datasourceNpmId;
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
       const res = await lookup.lookupUpdates(config);
+      // FIXME: explicit assert condition
       expect(res.updates).toMatchSnapshot();
     });
     it('returns complex object', async () => {
@@ -1102,12 +1159,14 @@ describe(getName(), () => {
       config.depName = 'node';
       config.datasource = datasourceDockerId;
       const res = await lookup.lookupUpdates(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('skips undefined values', async () => {
       config.depName = 'node';
       config.datasource = datasourceDockerId;
       const res = await lookup.lookupUpdates(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('handles digest pin', async () => {
@@ -1128,6 +1187,7 @@ describe(getName(), () => {
       docker.getDigest.mockResolvedValueOnce('sha256:abcdef1234567890');
       docker.getDigest.mockResolvedValueOnce('sha256:0123456789abcdef');
       const res = await lookup.lookupUpdates(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     ['8.1.0', '8.1', '8'].forEach((currentValue) => {
@@ -1150,6 +1210,7 @@ describe(getName(), () => {
           ],
         });
         const res = await lookup.lookupUpdates(config);
+        // FIXME: explicit assert condition
         expect(res).toMatchSnapshot();
       });
     });
@@ -1170,6 +1231,7 @@ describe(getName(), () => {
       });
       docker.getDigest.mockResolvedValueOnce('sha256:abcdef1234567890');
       const res = await lookup.lookupUpdates(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('handles digest pin for non-version', async () => {
@@ -1192,6 +1254,7 @@ describe(getName(), () => {
       });
       docker.getDigest.mockResolvedValueOnce('sha256:abcdef1234567890');
       const res = await lookup.lookupUpdates(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('handles digest lookup failure', async () => {
@@ -1235,6 +1298,7 @@ describe(getName(), () => {
       docker.getDigest.mockResolvedValueOnce('sha256:abcdef1234567890');
       docker.getDigest.mockResolvedValueOnce('sha256:0123456789abcdef');
       const res = await lookup.lookupUpdates(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('handles digest update for non-version', async () => {
@@ -1258,6 +1322,7 @@ describe(getName(), () => {
       });
       docker.getDigest.mockResolvedValueOnce('sha256:abcdef1234567890');
       const res = await lookup.lookupUpdates(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('handles git submodule update', async () => {
@@ -1276,6 +1341,7 @@ describe(getName(), () => {
         '4b825dc642cb6eb9a060e54bf8d69288fbee4904'
       );
       const res = await lookup.lookupUpdates(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('handles sourceUrl packageRules with version restrictions', async () => {
@@ -1290,6 +1356,7 @@ describe(getName(), () => {
       ];
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
       const res = await lookup.lookupUpdates(config);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
   });

--- a/lib/workers/repository/process/sort.spec.ts
+++ b/lib/workers/repository/process/sort.spec.ts
@@ -24,6 +24,7 @@ describe(getName(), () => {
         },
       ];
       sortBranches(branches);
+      // FIXME: explicit assert condition
       expect(branches).toMatchSnapshot();
     });
     it('sorts based on prPriority', () => {
@@ -50,6 +51,7 @@ describe(getName(), () => {
         },
       ];
       sortBranches(branches);
+      // FIXME: explicit assert condition
       expect(branches).toMatchSnapshot();
     });
     it('sorts based on isVulnerabilityAlert', () => {
@@ -77,6 +79,7 @@ describe(getName(), () => {
         },
       ];
       sortBranches(branches);
+      // FIXME: explicit assert condition
       expect(branches).toMatchSnapshot();
     });
   });

--- a/lib/workers/repository/updates/generate.spec.ts
+++ b/lib/workers/repository/updates/generate.spec.ts
@@ -38,6 +38,7 @@ describe(getName(), () => {
         },
       ];
       const res = generateBranchConfig(branch);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('handles lockFileUpdate', () => {
@@ -54,6 +55,7 @@ describe(getName(), () => {
         },
       ];
       const res = generateBranchConfig(branch);
+      // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
     });
     it('does not group same upgrades', () => {
@@ -385,6 +387,7 @@ describe(getName(), () => {
         }),
       ];
       const res = generateBranchConfig(branch);
+      // FIXME: explicit assert condition
       expect(res.prTitle).toMatchSnapshot();
     });
     it('handles @types specially', () => {
@@ -426,6 +429,7 @@ describe(getName(), () => {
       const res = generateBranchConfig(branch);
       expect(res.recreateClosed).toBe(false);
       expect(res.groupName).toBeUndefined();
+      // FIXME: explicit assert condition
       expect(generateBranchConfig(branch)).toMatchSnapshot();
     });
     it('handles @types specially (reversed)', () => {
@@ -460,6 +464,7 @@ describe(getName(), () => {
           group: {},
         },
       ];
+      // FIXME: explicit assert condition
       expect(generateBranchConfig(branch)).toMatchSnapshot();
     });
     it('handles upgrades', () => {
@@ -508,6 +513,7 @@ describe(getName(), () => {
         },
       ];
       const res = generateBranchConfig(branch);
+      // FIXME: explicit assert condition
       expect(res.prTitle).toMatchSnapshot();
     });
     it('sorts upgrades, without position first', () => {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Non-destructive PR that marks (hopefully) all the tests for which we need to provide more asserts.

## Context:

Ref: #11149

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
