### PR TITLE
fix: simplify issue creation error messages

### DIFF
--- a/lib/platform/bitbucket/index.ts
+++ b/lib/platform/bitbucket/index.ts
@@ -536,11 +536,7 @@ export async function ensureIssue({
     }
   } catch (err) /* istanbul ignore next */ {
     if (err.message.startsWith('Repository has no issue tracker.')) {
-      logger.debug(
-        `Issues are disabled, so could not create issue: ${
-          err.message as string
-        }`
-      );
+      logger.debug(`Issues are disabled, so could not create issue: ${title}`);
     } else {
       logger.warn({ err }, 'Could not ensure issue');
     }

--- a/lib/platform/github/index.ts
+++ b/lib/platform/github/index.ts
@@ -1148,11 +1148,7 @@ export async function ensureIssue({
     return 'created';
   } catch (err) /* istanbul ignore next */ {
     if (err.body?.message?.startsWith('Issues are disabled for this repo')) {
-      logger.debug(
-        `Issues are disabled, so could not create issue: ${
-          (err as Error).message
-        }`
-      );
+      logger.debug(`Issues are disabled, so could not create issue: ${title}`);
     } else {
       logger.warn({ err }, 'Could not ensure issue');
     }

--- a/lib/util/http/github.spec.ts
+++ b/lib/util/http/github.spec.ts
@@ -160,6 +160,13 @@ describe(getName(), () => {
           'Response code 404 (Not Found)'
         );
       });
+      it('should throw 410', async () => {
+        await expect(
+          fail(410, { message: 'Issues are disabled for this repo' })
+        ).rejects.toThrow(
+          'Response code 410 (Issues are disabled for this repo)'
+        );
+      });
       it('should throw rate limit exceeded', async () => {
         await expect(
           fail(403, {

--- a/lib/util/http/github.ts
+++ b/lib/util/http/github.ts
@@ -122,6 +122,12 @@ function handleGotError(
     logger.debug({ err }, '422 Error thrown from GitHub');
     throw new ExternalHostError(err, PLATFORM_TYPE_GITHUB);
   }
+  if (
+    err.statusCode === 410 &&
+    err.body?.message === 'Issues are disabled for this repo'
+  ) {
+    throw err;
+  }
   if (err.statusCode === 404) {
     logger.debug({ url: path }, 'GitHub 404');
   } else {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Closes #11177

## Context:

Important before enabling dependencyDashboard by default in v26.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
