### PR TITLE
fix(ruby): use hostType=rubygems for bundler env

### DIFF
--- a/docs/usage/private-modules.md
+++ b/docs/usage/private-modules.md
@@ -119,7 +119,7 @@ The following details the most common/popular manager artifacts updating and how
 
 ### bundler
 
-`hostRules` with `hostType=bundler` are converted into environment variables which Bundler supports.
+`hostRules` with `hostType=rubygems` are converted into environment variables which Bundler supports.
 
 ### composer
 

--- a/lib/manager/bundler/artifacts.ts
+++ b/lib/manager/bundler/artifacts.ts
@@ -125,7 +125,7 @@ export async function updateArtifacts(
     ];
 
     const bundlerHostRules = findAllAuthenticatable({
-      hostType: 'bundler',
+      hostType: 'rubygems',
     });
 
     const bundlerHostRulesVariables = bundlerHostRules.reduce(


### PR DESCRIPTION
As pointed out in https://github.com/renovatebot/renovate/pull/11131#issuecomment-894180661, `hostType=bundler` should not exist, and the artifact updater should look for `hostType=rubygems` instead.

## Changes:

The rubygems artifact updater now looks for `hostType=rubygems`, instead of `hostType=bundler`, in order to retrieve private dependencies credentials.

## Context:

https://github.com/renovatebot/renovate/pull/11131#issuecomment-894180661

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
