### PR TITLE
fix: extract dependencies with extra features from setup-cfg

### DIFF
--- a/lib/manager/setup-cfg/__fixtures__/setup-cfg-1.txt
+++ b/lib/manager/setup-cfg/__fixtures__/setup-cfg-1.txt
@@ -16,7 +16,7 @@ install_requires =
     docopt ~=0.4
     fs ~=2.1
 
-    requests ~=2.18
+    requests[security] ~=2.18
 
 setup_requires =
     six ~=1.4

--- a/lib/manager/setup-cfg/extract.ts
+++ b/lib/manager/setup-cfg/extract.ts
@@ -32,8 +32,8 @@ function parseDep(
   section: string,
   record: string
 ): PackageDependency | null {
-  const [, depName, currentValue] =
-    /\s+([-_a-zA-Z0-9]*)\s*(.*)/.exec(line) || [];
+  const [, depName, , currentValue] =
+    /\s+([-_a-zA-Z0-9]*)(\[.*\])?\s*(.*)/.exec(line) || [];
   if (
     section &&
     record &&


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Fix extraction from setup-cfg when dependency is specified with extra features

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

setup-cfg supports defining dependencies with optional features (see [here](https://setuptools.readthedocs.io/en/latest/userguide/dependency_management.html#optional-dependencies))
Currently, setup-cfg extraction ignores these dependencies.


## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [X] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
