### PR TITLE
fix(docker): Allow ports usage for Quay deps

### DIFF
--- a/lib/datasource/docker/index.ts
+++ b/lib/datasource/docker/index.ts
@@ -100,10 +100,12 @@ async function getTags(
       return cachedResult;
     }
 
-    const isQuay = registryHost === 'https://quay.io';
+    const isQuay = /^https:\/\/quay\.io(?::[1-9][0-9]{0,4})?$/i.test(
+      registryHost
+    );
     let tags: string[] | null;
     if (isQuay) {
-      tags = await getTagsQuayRegistry(dockerRepository);
+      tags = await getTagsQuayRegistry(registryHost, dockerRepository);
     } else {
       tags = await getDockerApiTags(registryHost, dockerRepository);
     }

--- a/lib/datasource/docker/quay.ts
+++ b/lib/datasource/docker/quay.ts
@@ -1,9 +1,9 @@
 import { http } from './common';
 
 export async function getTagsQuayRegistry(
+  registry: string,
   repository: string
 ): Promise<string[]> {
-  const registry = 'https://quay.io';
   let tags: string[] = [];
   const limit = 100;
 


### PR DESCRIPTION
## Changes:

When checking for Quay host, treat port number as sufficient part and use it when performing HTTP request.

## Context:

Closes #11227 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

Example: https://github.com/renovate-testing/test-11227-docker-from-port/pull/1