### PR TITLE
docs: fix relative assets path

### DIFF
--- a/docs/usage/getting-started/installing-onboarding.md
+++ b/docs/usage/getting-started/installing-onboarding.md
@@ -17,11 +17,11 @@ Installing/enabling WhiteSource's Renovate GitHub App is simple.
 
 First, navigate to [https://github.com/apps/renovate](https://github.com/apps/renovate) and click the Install button:
 
-![Github App Install button](assets/images/github-app-install.png)
+![Github App Install button](../assets/images/github-app-install.png)
 
 The only choice you need to make is whether to run Renovate on all repositories or on selected repositories:
 
-![Github App repositories](assets/images/github-app-choose-repos.png)
+![Github App repositories](../assets/images/github-app-choose-repos.png)
 
 Renovate will ignore any repositories that don't have known package files, as well as any forks, so you can enable Renovate for all your repositories with no problems.
 That said, most people run Renovate on selected repositories.
@@ -41,7 +41,7 @@ For more details on GitLab security for bots, please see the [GitLab Bot Securit
 
 Once you have enabled Renovate on a repository, you will receive a "Configure Renovate" Pull Request looking something like this:
 
-![Onboarding](assets/images/onboarding.png)
+![Onboarding](../assets/images/onboarding.png)
 
 ### No risk onboarding
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Fixes assets path in getting started docs

## Context:

Fixes problem introduced with docs path refactoring

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
