### PR TITLE
feat(preset): add AWS Java SDK v2 monorepo

### DIFF
--- a/lib/config/presets/internal/monorepo.ts
+++ b/lib/config/presets/internal/monorepo.ts
@@ -174,6 +174,7 @@ const patternGroups = {
   wordpress: '^@wordpress/',
   angularmaterial: ['^@angular/material', '^@angular/cdk'],
   'aws-java-sdk': '^com.amazonaws:aws-java-sdk-',
+  'aws-java-sdk-v2': '^software.amazon.awssdk:',
   embroider: '^@embroider/',
   fullcalendar: '^@fullcalendar/',
 };


### PR DESCRIPTION
## Changes:

Add [AWS Java SDK v2](https://github.com/aws/aws-sdk-java-v2/) monorepo. Its `groupId` is always `software.amazon.awssdk`, `artifactId`s don't have any common prefixes.

## Context:

Adds a parity with the existing AWS Java SDK v1 monorepo preset. 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository