### PR TITLE
feat(terraform): remove RENOVATE_X_TERRAFORM_LOCK_FILE flag 

### DIFF
--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -35,10 +35,6 @@ If set to any value, Renovate will always paginate requests to GitHub fully, ins
 
 If set to "false" (string), Renovate will remove any existing `package-lock.json` before attempting to update it.
 
-## RENOVATE_X_TERRAFORM_LOCK_FILE
-
-If set to any value, Renovate will update Terraform lock files and allow lockfile maintenance.
-
 ## RENOVATE_USER_AGENT
 
 If set to any string, Renovate will use this as the `user-agent` it sends with HTTP requests.

--- a/lib/manager/terraform/lockfile/index.spec.ts
+++ b/lib/manager/terraform/lockfile/index.spec.ts
@@ -35,14 +35,8 @@ describe(getName(), () => {
     setGlobalConfig(adminConfig);
   });
 
-  afterEach(() => {
-    delete process.env.RENOVATE_X_TERRAFORM_LOCK_FILE;
-  });
-
   it('returns null if no .terraform.lock.hcl found', async () => {
     fs.readLocalFile.mockResolvedValueOnce(null);
-
-    process.env.RENOVATE_X_TERRAFORM_LOCK_FILE = 'test';
 
     expect(
       await updateArtifacts({
@@ -56,8 +50,6 @@ describe(getName(), () => {
 
   it('returns null if .terraform.lock.hcl is empty', async () => {
     fs.readLocalFile.mockResolvedValueOnce('empty' as any);
-
-    process.env.RENOVATE_X_TERRAFORM_LOCK_FILE = 'test';
 
     expect(
       await updateArtifacts({
@@ -84,8 +76,6 @@ describe(getName(), () => {
       newValue: '3.36.0',
       ...config,
     };
-
-    process.env.RENOVATE_X_TERRAFORM_LOCK_FILE = 'test';
 
     const result = await updateArtifacts({
       packageFileName: 'main.tf',
@@ -117,8 +107,6 @@ describe(getName(), () => {
       newValue: '~> 2.50',
       ...config,
     };
-
-    process.env.RENOVATE_X_TERRAFORM_LOCK_FILE = 'test';
 
     const result = await updateArtifacts({
       packageFileName: 'main.tf',
@@ -157,8 +145,6 @@ describe(getName(), () => {
       ...config,
     };
 
-    process.env.RENOVATE_X_TERRAFORM_LOCK_FILE = 'test';
-
     const result = await updateArtifacts({
       packageFileName: 'main.tf',
       updatedDeps: [{ depName: 'random', lookupName: 'hashicorp/random' }],
@@ -189,8 +175,6 @@ describe(getName(), () => {
       newValue: '~> 3.0',
       ...config,
     };
-
-    process.env.RENOVATE_X_TERRAFORM_LOCK_FILE = 'test';
 
     const result = await updateArtifacts({
       packageFileName: 'test/main.tf',
@@ -264,8 +248,6 @@ describe(getName(), () => {
       ...config,
     };
 
-    process.env.RENOVATE_X_TERRAFORM_LOCK_FILE = 'test';
-
     const result = await updateArtifacts({
       packageFileName: '',
       updatedDeps: [],
@@ -338,8 +320,6 @@ describe(getName(), () => {
       updateType: 'lockFileMaintenance',
       ...config,
     };
-
-    process.env.RENOVATE_X_TERRAFORM_LOCK_FILE = 'test';
 
     const result = await updateArtifacts({
       packageFileName: '',
@@ -461,8 +441,6 @@ describe(getName(), () => {
       updateType: 'lockFileMaintenance',
       ...config,
     };
-
-    process.env.RENOVATE_X_TERRAFORM_LOCK_FILE = 'test';
 
     const result = await updateArtifacts({
       packageFileName: '',

--- a/lib/manager/terraform/lockfile/index.ts
+++ b/lib/manager/terraform/lockfile/index.ts
@@ -62,14 +62,6 @@ export async function updateArtifacts({
 }: UpdateArtifact): Promise<UpdateArtifactsResult[] | null> {
   logger.debug(`terraform.updateArtifacts(${packageFileName})`);
 
-  // TODO remove experimental flag, if functionality is confirmed
-  if (!process.env.RENOVATE_X_TERRAFORM_LOCK_FILE) {
-    logger.debug(
-      `terraform.updateArtifacts: skipping updates. Experimental feature not activated`
-    );
-    return null;
-  }
-
   const lockFilePath = findLockFile(packageFileName);
   try {
     const lockFileContent = await readLockFile(lockFilePath);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:
Removes RENOVATE_X_TERRAFORM_LOCK_FILE and enables default lock file handling for Terraform
<!-- Describe what behavior is changed by this PR. -->

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
