### PR TITLE
fix(datasource/docker): ignore "/" paths in registryUrls

### DIFF
--- a/lib/datasource/docker/common.spec.ts
+++ b/lib/datasource/docker/common.spec.ts
@@ -70,6 +70,17 @@ describe('datasource/docker/common', () => {
         }
       `);
     });
+
+    it('ignores "/" paths in registryUrls', () => {
+      const res = dockerCommon.getRegistryRepository(
+        'defaultbackend-amd64',
+        'https://k8s.gcr.io/'
+      );
+      expect(res).toEqual({
+        dockerRepository: 'defaultbackend-amd64',
+        registryHost: 'https://k8s.gcr.io',
+      });
+    });
   });
   describe('getAuthHeaders', () => {
     beforeEach(() => {

--- a/lib/datasource/docker/common.ts
+++ b/lib/datasource/docker/common.ts
@@ -207,6 +207,18 @@ export function getRegistryRepository(
   if (!/^https?:\/\//.exec(registryHost)) {
     registryHost = `https://${registryHost}`;
   }
+
+  const parsedRegistryHost = new URL(registryHost);
+  if (
+    // path+search+hash consist just of "/"
+    registryHost.endsWith('/') &&
+    parsedRegistryHost.hash === '' &&
+    parsedRegistryHost.search === '' &&
+    parsedRegistryHost.pathname === '/'
+  ) {
+    registryHost = registryHost.substr(0, registryHost.length - 1);
+  }
+
   const opts = hostRules.find({ hostType: id, url: registryHost });
   if (opts?.insecureRegistry) {
     registryHost = registryHost.replace('https', 'http');


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Stop adding / to registry URLs with no path when parsing with regex manager.
<!-- Describe what behavior is changed by this PR. -->

## Context:
Closes #11254 
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
