### PR TITLE
fix: matchSourceUrlPrefixes compares case insensitive

### DIFF
--- a/lib/util/package-rules.ts
+++ b/lib/util/package-rules.ts
@@ -194,7 +194,7 @@ function matchesRule(
   }
   if (matchSourceUrlPrefixes.length) {
     const isMatch = matchSourceUrlPrefixes.some((prefix) =>
-      sourceUrl?.startsWith(prefix)
+      sourceUrl?.toLowerCase().startsWith(prefix.toLowerCase())
     );
     if (!isMatch) {
       return false;

--- a/lib/util/package-rules.ts
+++ b/lib/util/package-rules.ts
@@ -193,8 +193,9 @@ function matchesRule(
     positiveMatch = true;
   }
   if (matchSourceUrlPrefixes.length) {
+    const lowerCaseSourceUrl = sourceUrl.toLowerCase();
     const isMatch = matchSourceUrlPrefixes.some((prefix) =>
-      sourceUrl?.toLowerCase().startsWith(prefix.toLowerCase())
+      lowerCaseSourceUrl?.startsWith(prefix.toLowerCase())
     );
     if (!isMatch) {
       return false;


### PR DESCRIPTION
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

matchSourceUrlPrefixes now compares as case insensitive

## Context:

Fixes #10962

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository