### PR TITLE
fix(presets): migrate renamed monorepos

### DIFF
--- a/lib/config/presets/common.ts
+++ b/lib/config/presets/common.ts
@@ -1,4 +1,4 @@
-export const removedPresets = {
+export const removedPresets: Record<string, string | null> = {
   ':automergeBranchMergeCommit': ':automergeBranch',
   ':automergeBranchPush': ':automergeBranch',
   ':base': 'config:base',
@@ -23,3 +23,39 @@ export const removedPresets = {
   'helpers:oddIsUnstable': null,
   'helpers:oddIsUnstablePackages': null,
 };
+
+const renamedMonorepos: Record<string, string> = {
+  'arcus event-grid': 'arcus.event-grid',
+  'arcus security': 'arcus.security',
+  'arcus messaging': 'arcus.messaging',
+  'arcus observability': 'arcus.observability',
+  'arcus webap': 'arcus.webap',
+  'arcus background-jobs': 'arcus.background-jobs',
+  'aspnet AspNetWebStack': 'aspnet aspnetwebstack',
+  'aspnet Extensions': 'aspnet extensions',
+  'System.IO.Abstractions': 'system.io.abstractions',
+  angular1: 'angularjs',
+  angularcli: 'angular-cli',
+  Fontsource: 'fontsource',
+  hamcrest: 'javahamcrest',
+  HotChocolate: 'hotchocolate',
+  infrastructure: 'infrastructure-ui',
+  lingui: 'linguijs',
+  MassTransit: 'masstransit',
+  material: 'material-components-web',
+  mui: 'material-ui',
+  openfeign: 'feign',
+  opentelemetry: 'opentelemetry-js',
+  OpenTelemetryDotnet: 'opentelemetry-dotnet',
+  picasso: 'picassojs',
+  reactrouter: 'react-router',
+  sentry: 'sentry-javascript',
+  Steeltoe: 'steeltoe',
+  stryker: 'stryker-js',
+  Swashbuckle: 'swashbuckle-aspnetcore',
+};
+
+for (const [from, to] of Object.entries(renamedMonorepos)) {
+  removedPresets[`monorepo:${from}`] = `monorepo:${to}`;
+  removedPresets[`group:${from}Monorepo`] = `group:${to}Monorepo`;
+}

--- a/lib/config/presets/common.ts
+++ b/lib/config/presets/common.ts
@@ -29,7 +29,7 @@ const renamedMonorepos: Record<string, string> = {
   'arcus security': 'arcus.security',
   'arcus messaging': 'arcus.messaging',
   'arcus observability': 'arcus.observability',
-  'arcus webap': 'arcus.webap',
+  'arcus webapi': 'arcus.webapi',
   'arcus background-jobs': 'arcus.background-jobs',
   'aspnet AspNetWebStack': 'aspnet aspnetwebstack',
   'aspnet Extensions': 'aspnet extensions',

--- a/lib/config/presets/index.spec.ts
+++ b/lib/config/presets/index.spec.ts
@@ -575,6 +575,37 @@ describe('config/presets/index', () => {
       const res = await presets.getPreset('helpers:oddIsUnstable', {});
       expect(res).toEqual({});
     });
+    it('handles renamed monorepos', async () => {
+      const res = await presets.getPreset('monorepo:opentelemetry', {});
+      expect(res).toMatchInlineSnapshot(`
+Object {
+  "description": Array [
+    "opentelemetry-js monorepo",
+  ],
+  "matchSourceUrlPrefixes": Array [
+    "https://github.com/open-telemetry/opentelemetry-js",
+  ],
+}
+`);
+    });
+    it('handles renamed monorepo groups', async () => {
+      const res = await presets.getPreset('group:opentelemetryMonorepo', {});
+      expect(res).toMatchInlineSnapshot(`
+Object {
+  "packageRules": Array [
+    Object {
+      "description": Array [
+        "Group packages from opentelemetry-js monorepo together",
+      ],
+      "extends": Array [
+        "monorepo:opentelemetry-js",
+      ],
+      "groupName": "opentelemetry-js monorepo",
+    },
+  ],
+}
+`);
+    });
     it('gets linters', async () => {
       const res = await presets.getPreset('packages:linters', {});
       expect(res).toMatchSnapshot();


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds migrations for renamed monorepo presets.

## Context:

Closes #11318

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
