### PR TITLE
feat: add wordpress gutenberg monorepo

### DIFF
--- a/lib/config/presets/internal/monorepo.ts
+++ b/lib/config/presets/internal/monorepo.ts
@@ -53,6 +53,7 @@ const repoGroups = {
   tsoa: 'https://github.com/lukeautry/tsoa',
   'typescript-eslint': 'https://github.com/typescript-eslint/typescript-eslint',
   'typography-js': 'https://github.com/KyleAMathews/typography.js',
+  'wordpress gutenberg': 'https://github.com/WordPress/gutenberg',
   'vue-cli': 'https://github.com/vuejs/vue-cli',
   accounts: 'https://github.com/accounts-js/accounts',
   angularjs: 'https://github.com/angular/angular.js',


### PR DESCRIPTION
## Changes:

Add WordPress Gutenberg monorepo which contains packages like `@wordpress/scripts` that are the new way to use JS with asset bundling, transpiling and so on in WordPress plugins.

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
