### PR TITLE
fix(datasource/maven): look for maven snapshot pom

### DIFF
--- a/lib/datasource/maven/__fixtures__/repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.10-SNAPSHOT/maven-metadata.xml
+++ b/lib/datasource/maven/__fixtures__/repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.10-SNAPSHOT/maven-metadata.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?><metadata>
+  <groupId>mysql</groupId>
+  <artifactId>mysql-connector-java</artifactId>
+  <version>8.0.10-SNAPSHOT</version>
+  <versioning>
+    <snapshot>
+      <timestamp>20200101.123456</timestamp>
+      <buildNumber>5</buildNumber>
+    </snapshot>
+    <snapshotVersions>
+      <snapshotVersion>
+        <extension>jar</extension>
+        <value>8.0.10-20200101.123456-5</value>
+        <updated>20200101123456</updated>
+      </snapshotVersion>
+      <snapshotVersion>
+        <extension>pom</extension>
+        <value>8.0.10-20200101.123456-5</value>
+        <updated>20200101123456</updated>
+      </snapshotVersion>
+      <snapshotVersion>
+        <classifier>javadoc</classifier>
+        <extension>jar</extension>
+        <value>8.0.10-20200101.123456-5</value>
+        <updated>20200101123456</updated>
+      </snapshotVersion>
+    </snapshotVersions>
+    <lastUpdated>20130301200000</lastUpdated>
+  </versioning>
+</metadata>

--- a/lib/datasource/maven/__fixtures__/repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.10-SNAPSHOT/mysql-connector-java-8.0.10-20200101.123456-5.pom
+++ b/lib/datasource/maven/__fixtures__/repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.10-SNAPSHOT/mysql-connector-java-8.0.10-20200101.123456-5.pom
@@ -1,0 +1,38 @@
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>mysql</groupId>
+  <artifactId>mysql-connector-java</artifactId>
+  <version>8.0.13-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>MySQL Connector/J</name>
+  <description>JDBC Type 4 driver for MySQL</description>
+
+  <licenses>
+    <license>
+      <name>The GNU General Public License, v2 with FOSS exception</name>
+      <distribution>repo</distribution>
+      <comments>For detailed license information see the LICENSE file in this distribution.</comments>
+    </license>
+  </licenses>
+
+  <url>http://dev.mysql.com/doc/connector-j/en/</url>
+
+  <scm>
+    <connection>scm:git:git@github.com:mysql/mysql-connector-j.git</connection>
+    <url>https://github.com/mysql/mysql-connector-j</url>
+  </scm>
+
+  <organization>
+    <name>Oracle Corporation</name>
+    <url>http://www.oracle.com</url>
+  </organization>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>2.6.0</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/lib/datasource/maven/__fixtures__/repo1.maven.org/maven2/mysql/mysql-connector-java/maven-metadata.xml
+++ b/lib/datasource/maven/__fixtures__/repo1.maven.org/maven2/mysql/mysql-connector-java/maven-metadata.xml
@@ -6,6 +6,7 @@
     <versions>
       <version>8.0.12</version>
       <version>8.0.11</version>
+      <version>8.0.10-SNAPSHOT</version>
       <version>8.0.9</version>
       <version>8.0.8</version>
       <version>8.0.7</version>

--- a/lib/datasource/maven/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/maven/__snapshots__/index.spec.ts.snap
@@ -23,6 +23,9 @@ Object {
       "version": "8.0.9",
     },
     Object {
+      "version": "8.0.10-SNAPSHOT",
+    },
+    Object {
       "version": "8.0.11",
     },
     Object {

--- a/lib/datasource/maven/index.ts
+++ b/lib/datasource/maven/index.ts
@@ -191,6 +191,66 @@ function isValidArtifactsInfo(
   return versions.every((v) => info[v] !== undefined);
 }
 
+function isSnapshotVersion(version: string): boolean {
+  if (version.endsWith('-SNAPSHOT')) {
+    return true;
+  }
+  return false;
+}
+
+function extractSnapshotVersion(metadata: XmlDocument): string {
+  const version = metadata
+    .descendantWithPath('version')
+    ?.val?.replace('-SNAPSHOT', '');
+
+  const snapshot = metadata.descendantWithPath('versioning.snapshot');
+  const timestamp = snapshot?.childNamed('timestamp')?.val;
+  const build = snapshot?.childNamed('buildNumber')?.val;
+
+  if (!version || !timestamp || !build) {
+    return null;
+  }
+  return `${version}-${timestamp}-${build}`;
+}
+
+async function getSnapshotFullVersion(
+  version: string,
+  dependency: MavenDependency,
+  repoUrl: string
+): Promise<string | null> {
+  const metadataUrl = getMavenUrl(
+    dependency,
+    repoUrl,
+    `${version}/maven-metadata.xml`
+  );
+
+  const { xml: mavenMetadata } = await downloadMavenXml(metadataUrl);
+  if (!mavenMetadata) {
+    return null;
+  }
+
+  return extractSnapshotVersion(mavenMetadata);
+}
+
+async function createUrlForDependencyPom(
+  version: string,
+  dependency: MavenDependency,
+  repoUrl: string
+): Promise<string> {
+  if (isSnapshotVersion(version)) {
+    const fullVersion = await getSnapshotFullVersion(
+      version,
+      dependency,
+      repoUrl
+    );
+    if (fullVersion !== null) {
+      return `${version}/${dependency.name}-${fullVersion}.pom`;
+    }
+  }
+
+  return `${version}/${dependency.name}-${version}.pom`;
+}
+
 type ArtifactInfoResult = [string, boolean | string | null];
 
 async function getArtifactInfo(
@@ -218,15 +278,17 @@ async function filterMissingArtifacts(
   );
 
   if (!isValidArtifactsInfo(artifactsInfo, versions)) {
-    const queue = versions
-      .map((version): [string, url.URL | null] => {
+    const versionUrls = versions.map(
+      async (version): Promise<[string, url.URL | null]> => {
         const artifactUrl = getMavenUrl(
           dependency,
           repoUrl,
-          `${version}/${dependency.name}-${version}.pom`
+          await createUrlForDependencyPom(version, dependency, repoUrl)
         );
         return [version, artifactUrl];
-      })
+      }
+    );
+    const queue = (await Promise.all(versionUrls))
       .filter(([_, artifactUrl]) => Boolean(artifactUrl))
       .map(([version, artifactUrl]) => (): Promise<ArtifactInfoResult> =>
         getArtifactInfo(version, artifactUrl)


### PR DESCRIPTION
Maven snapshot poms are stored in the repository with timestamp & build number replacing the -SNAPSHOT in the name.

The check for missing artifacts did not resolve these files and so SNAPSHOTS always appeared missing and were filtered out.

Not sure if the async handling in `filterMissingArtifacts()` is the best, please let me know if changes needed.

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->
Maven snapshot dependencies should now be included without wholesale disabling the pom check via `RENOVATE_EXPERIMENTAL_NO_MAVEN_POM_CHECK`.

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->
This should fix issue #3728

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
