### PR TITLE
docs: update dependencyDashboard config option

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -402,6 +402,16 @@ This option applies only to the `gradle` manager.
 
 ## dependencyDashboard
 
+Starting from version `v26.0.0` the "Dependency Dashboard" is enabled by default via our `config:base` preset.
+
+To disable the Dependency Dashboard, add the preset `:disableDependencyDashboard` or set `dependencyDashboard` to `false`.
+
+```json
+{
+  "extends": ["config:base", ":disableDependencyDashboard"]
+}
+```
+
 Configuring `dependencyDashboard` to `true` will lead to the creation of a "Dependency Dashboard" issue within the repository.
 This issue contains a list of all PRs pending, open, closed (unmerged) or in error.
 The goal of this issue is to give visibility into all updates that Renovate is managing.

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -402,7 +402,7 @@ This option applies only to the `gradle` manager.
 
 ## dependencyDashboard
 
-Starting from version `v26.0.0` the "Dependency Dashboard" is enabled by default via our `config:base` preset.
+Starting from version `v26.0.0` the "Dependency Dashboard" is enabled by default as part of the commonly-used `config:base` preset.
 
 To disable the Dependency Dashboard, add the preset `:disableDependencyDashboard` or set `dependencyDashboard` to `false`.
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

- Explain that from version `v26.0.0` the dashboard is turned on by default
- Explain how to turn the dashboard off

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

I saw some confusion on how to turn off the dashboard in discussion #11330, so I'm trying to improve the docs here.

I noticed that https://docs.renovatebot.com/configuration-options/#dependencydashboard shows the following table for the `dependencyDashboard` property:

<html><body>
<!--StartFragment-->

Name | Value
-- | --
type | boolean
default | false

<!--EndFragment-->
</body>
</html>

I think this is the source of the table above?

https://github.com/renovatebot/renovate/blob/b9d015f025b0505af343d8482d355739b15a796e/lib/config/options/index.ts#L388-L395

Maybe we want/need to change this to `default: true`?

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
