### PR TITLE
docs: mention access level for private GitLab repositories

### DIFF
--- a/docs/usage/config-presets.md
+++ b/docs/usage/config-presets.md
@@ -149,6 +149,8 @@ You do not need to add it as a devDependency or add any other files to the prese
 It is also possible to host your preset config using just a regular GitLab repository and without needing to publish it to npmjs.
 In such cases Renovate will simply look for a `default.json` file in the default branch.
 
+For a private GitLab repository Renovate requires at least _Reporter_ level access.
+
 To host your preset config on GitLab:
 
 - Create a new repository on GitLab. Normally you'd call it `renovate-config` but it can be named anything
@@ -181,6 +183,8 @@ But you also probably want the preset to be private too, so how can the other re
 
 The answer is to host your preset using GitHub or GitLab - not npmjs - and make sure you have added the preset's repo to Renovate too.
 GitHub will then allow Renovate to access the preset repo whenever it is processing any other repos within the same account/org.
+
+For a private GitLab repository Renovate requires at least _Reporter_ level access.
 
 ## Contributing to presets
 


### PR DESCRIPTION
With a Guest level access Renovate is not able to access the repository.

See https://docs.gitlab.com/ee/user/permissions.html

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

No behavior changes.

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->
Docs about private GitLab repository access for presets where unclear.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
