### PR TITLE
fix(pre-commit): `pre-commit` spelling in default message topic

### DIFF
--- a/lib/manager/pre-commit/index.ts
+++ b/lib/manager/pre-commit/index.ts
@@ -1,6 +1,6 @@
 export { extractPackageFile } from './extract';
 
 export const defaultConfig = {
-  commitMessageTopic: 'precommit hook {{depName}}',
+  commitMessageTopic: 'pre-commit hook {{depName}}',
   fileMatch: ['(^|/)\\.pre-commit-config\\.yaml$'],
 };


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

The default commit message topic for `pre-commit` hook updates will say `pre-commit` (which is the name of the software), not `precommit`.

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
