### PR TITLE
fix(manager:regex): allow no match in combination

### DIFF
--- a/lib/manager/regex/index.spec.ts
+++ b/lib/manager/regex/index.spec.ts
@@ -240,6 +240,20 @@ describe('manager/regex/index', () => {
     expect(res.deps).toHaveLength(1);
   });
 
+  it('extracts with combination strategy and empty file', async () => {
+    const config: CustomExtractConfig = {
+      matchStringsStrategy: 'combination',
+      matchStrings: [
+        'CHART_REPOSITORY_URL: "(?<registryUrl>.*)\\/(?<depName>[a-z]+)\\/"',
+        'CHART_VERSION: (?<currentValue>.*?)\n',
+      ],
+      datasourceTemplate: 'helm',
+      depNameTemplate: 'helm_repo/{{{ depName }}}',
+    };
+    const res = await extractPackageFile('', '.gitlab-ci.yml', config);
+    expect(res).toBeNull();
+  });
+
   it('extracts with recursive strategy and single match', async () => {
     const config: CustomExtractConfig = {
       matchStrings: [

--- a/lib/manager/regex/index.ts
+++ b/lib/manager/regex/index.ts
@@ -147,12 +147,17 @@ function handleCombination(
     .map((matchString) => regEx(matchString, 'g'))
     .flatMap((regex) => regexMatchAll(regex, content)); // match all regex to content, get all matches, reduce to single array
 
+  if (!matches.length) {
+    return [];
+  }
+
   const combinedGroup = matches
     .map((match) => match.groups)
     .reduce((mergedGroup, currentGroup) =>
       mergeGroups(mergedGroup, currentGroup)
     );
 
+  // TODO: this seems to be buggy behavior, needs to be checked
   const dep = matches
     .map((match) => createDependency(match, combinedGroup, config))
     .reduce(

--- a/lib/manager/regex/index.ts
+++ b/lib/manager/regex/index.ts
@@ -157,7 +157,7 @@ function handleCombination(
       mergeGroups(mergedGroup, currentGroup)
     );
 
-  // TODO: this seems to be buggy behavior, needs to be checked
+  // TODO: this seems to be buggy behavior, needs to be checked #11387
   const dep = matches
     .map((match) => createDependency(match, combinedGroup, config))
     .reduce(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:
 Check for empty combination matches and return early.

<!-- Describe what behavior is changed by this PR. -->

## Context:

fixes #11385
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
