### PR TITLE
docs(versioning): remove `versionScheme` references

### DIFF
--- a/docs/usage/modules/versioning.md
+++ b/docs/usage/modules/versioning.md
@@ -12,12 +12,12 @@ It's impossible to automatically detect **all** versioning schemes, so sometimes
 You can manually configure/override the `versioning` value for a particular dependency.
 You generally won't need to override the defaults for ecosystems which enforce a strict version scheme like `npm`.
 
-Configuring or overriding the default `versionScheme` can be particularly helpful for ecosystems like Docker/Kubernetes/Helm, where versioning is barely a "convention".
+Configuring or overriding the default `versioning` can be particularly helpful for ecosystems like Docker/Kubernetes/Helm, where versioning is barely a "convention".
 
 ## General concepts behind overriding versioning
 
 - Although you can reconfigure versioning per-manager or per-datasource, it's unlikely that such a broad change would ever be needed
-- More commonly you would need to configure `versionScheme` for individual packages or potentially package patterns
+- More commonly you would need to configure `versioning` for individual packages or potentially package patterns
 - The best way to do this is with `packageRules`, with a combination of `matchManagers`, `matchDatasources`, `matchPackageNames` and `matchPackagePatterns`
 
 ## Examples of versioning overrides
@@ -45,7 +45,7 @@ The configuration below overrides Renovate's default `docker` versioning for the
   "packageRules": [
     {
       "matchPackageNames": ["foo/bar"],
-      "versionScheme": "regex:^(?<compatibility>.*)-v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)?$"
+      "versioning": "regex:^(?<compatibility>.*)-v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)?$"
     }
   ]
 }


### PR DESCRIPTION


<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

The versioning doc uses both `versioning` and `versionScheme` terms, but
the latter does not occur anywhere else in the docs, and is not
explained anywhere. Use the former consistently instead.

<!-- Describe what behavior is changed by this PR. -->

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

The rename in code happened in #5504, follow suit in docs.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
