### PR TITLE
feat(gitlab): allow override gitAuthor

### DIFF
--- a/lib/platform/github/index.ts
+++ b/lib/platform/github/index.ts
@@ -35,6 +35,7 @@ import type {
   FindPRConfig,
   Issue,
   MergePRConfig,
+  PlatformParams,
   PlatformResult,
   Pr,
   RepoParams,
@@ -80,12 +81,7 @@ export async function initPlatform({
   token,
   username,
   gitAuthor,
-}: {
-  endpoint: string;
-  token: string;
-  username?: string;
-  gitAuthor?: string;
-}): Promise<PlatformResult> {
+}: PlatformParams): Promise<PlatformResult> {
   if (!token) {
     throw new Error('Init: You must configure a GitHub personal access token');
   }

--- a/lib/platform/gitlab/index.spec.ts
+++ b/lib/platform/gitlab/index.spec.ts
@@ -115,6 +115,19 @@ describe('platform/gitlab/index', () => {
       ).toMatchSnapshot();
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
+
+    it(`should reuse existing gitAuthor`, async () => {
+      httpMock.scope(gitlabApiHost).get('/api/v4/version').reply(200, {
+        version: '13.3.6-ee',
+      });
+      expect(
+        await gitlab.initPlatform({
+          token: 'some-token',
+          endpoint: undefined,
+          gitAuthor: 'somebody',
+        })
+      ).toEqual({ endpoint: 'https://gitlab.com/api/v4/' });
+    });
   });
 
   describe('getRepos', () => {

--- a/lib/platform/types.ts
+++ b/lib/platform/types.ts
@@ -14,12 +14,13 @@ export interface PlatformParams {
   token?: string;
   username?: string;
   password?: string;
+  gitAuthor?: string;
 }
 
 export interface PlatformResult {
   endpoint: string;
-  renovateUsername?: any;
-  gitAuthor?: any;
+  renovateUsername?: string;
+  gitAuthor?: string;
 }
 
 export interface RepoResult {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Do not try to fetch gitAuthor if it's already user defined, renovate will ignore it anyways
<!-- Describe what behavior is changed by this PR. -->

## Context:

This allows to use `$CI_JOB_TOKEN`  to do yome dry run / run renovate withour PAT on gitlab.
https://gitlab.com/renovate-bot/renovate-runner/-/merge_requests/202

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
