### PR TITLE
feat(gitlab): allow override server version

### DIFF
--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -42,7 +42,7 @@ See <https://github.com/renovatebot/renovate/issues/8660> for background on why 
 
 ## RENOVATE_X_SERVER_VERSION
 
-If set, renovate will use that string as GitLab server version instead of checking via gitlab api.
+If set, renovate will use that string as GitLab server version instead of checking via GitLab api.
 This can be usefull when using the GitLab `CI_JOB_TOKEN` for running renovate.
 
-See <https://docs.gitlab.com/ee/api/version.html>
+Checkout [lib/platform/gitlab/index.md](https://github.com/renovatebot/renovate/blob/HEAD/lib/platform/gitlab/index.md) for why we need the server version on GitLab.

--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -45,4 +45,4 @@ See <https://github.com/renovatebot/renovate/issues/8660> for background on why 
 If set, Renovate will use this string as GitLab server version instead of checking via the GitLab API.
 This can be useful when you use the GitLab `CI_JOB_TOKEN` to authenticate Renovate.
 
-Read [lib/platform/gitlab/index.md](https://github.com/renovatebot/renovate/blob/HEAD/lib/platform/gitlab/index.md) to learn why we need the server version on GitLab.
+Read [platform details](modules/platform/gitlab/index.md) to learn why we need the server version on GitLab.

--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -40,7 +40,7 @@ If set to any string, Renovate will use this as the `user-agent` it sends with H
 If set to any value, Renovate will use a "hard" `process.exit()` once all work is done, even if a sub-process is otherwise delaying Node.js from exiting.
 See <https://github.com/renovatebot/renovate/issues/8660> for background on why this was created.
 
-## RENOVATE_X_SERVER_VERSION
+## RENOVATE_X_PLATFORM_VERSION
 
 If set, Renovate will use this string as GitLab server version instead of checking via the GitLab API.
 This can be useful when you use the GitLab `CI_JOB_TOKEN` to authenticate Renovate.

--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -43,6 +43,6 @@ See <https://github.com/renovatebot/renovate/issues/8660> for background on why 
 ## RENOVATE_X_SERVER_VERSION
 
 If set, Renovate will use this string as GitLab server version instead of checking via the GitLab API.
-This can be useful when using the GitLab `CI_JOB_TOKEN` for running Renovate.
+This can be useful when you use the GitLab `CI_JOB_TOKEN` to authenticate Renovate.
 
 Read [lib/platform/gitlab/index.md](https://github.com/renovatebot/renovate/blob/HEAD/lib/platform/gitlab/index.md) to learn why we need the server version on GitLab.

--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -39,3 +39,10 @@ If set to any string, Renovate will use this as the `user-agent` it sends with H
 
 If set to any value, Renovate will use a "hard" `process.exit()` once all work is done, even if a sub-process is otherwise delaying Node.js from exiting.
 See <https://github.com/renovatebot/renovate/issues/8660> for background on why this was created.
+
+## RENOVATE_X_SERVER_VERSION
+
+If set, renovate will use that string as GitLab server version instead of checking via gitlab api.
+This can be usefull when using the GitlBal `CI_JOB_TOKEN` for running renovate.
+
+See <https://docs.gitlab.com/ee/api/version.html>

--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -43,6 +43,6 @@ See <https://github.com/renovatebot/renovate/issues/8660> for background on why 
 ## RENOVATE_X_SERVER_VERSION
 
 If set, renovate will use that string as GitLab server version instead of checking via gitlab api.
-This can be usefull when using the GitlBal `CI_JOB_TOKEN` for running renovate.
+This can be usefull when using the GitLab `CI_JOB_TOKEN` for running renovate.
 
 See <https://docs.gitlab.com/ee/api/version.html>

--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -42,7 +42,7 @@ See <https://github.com/renovatebot/renovate/issues/8660> for background on why 
 
 ## RENOVATE_X_SERVER_VERSION
 
-If set, renovate will use that string as GitLab server version instead of checking via GitLab api.
-This can be usefull when using the GitLab `CI_JOB_TOKEN` for running renovate.
+If set, Renovate will use this string as GitLab server version instead of checking via the GitLab API.
+This can be useful when using the GitLab `CI_JOB_TOKEN` for running Renovate.
 
-Checkout [lib/platform/gitlab/index.md](https://github.com/renovatebot/renovate/blob/HEAD/lib/platform/gitlab/index.md) for why we need the server version on GitLab.
+Read [lib/platform/gitlab/index.md](https://github.com/renovatebot/renovate/blob/HEAD/lib/platform/gitlab/index.md) to learn why we need the server version on GitLab.

--- a/lib/platform/gitlab/index.md
+++ b/lib/platform/gitlab/index.md
@@ -7,7 +7,8 @@
 ## Server version dependent features
 
 We use the GitLab [version API](https://docs.gitlab.com/ee/api/version.html) to fetch the server version.
-This can be overridden by the experimental feature flag [`RENOVATE_X_SERVER_VERSION`](https://docs.renovatebot.com/self-hosted-experimental/#renovate_x_server_version).
+You can use the experimental feature flag [`RENOVATE_X_SERVER_VERSION`](https://docs.renovatebot.com/self-hosted-experimental/#renovate_x_server_version) to set a specific server version.
+By setting the server version yourself, you save a API call that fetches the server version.
 
 - Use `Draft:` MR prefix instead of `WIP:` prefix since `v13.2.0`
 - Do not truncate Markdown body to 25K chars since `v13.4.0`

--- a/lib/platform/gitlab/index.md
+++ b/lib/platform/gitlab/index.md
@@ -4,11 +4,11 @@
 
 - The `automergeStrategy` configuration option has not been implemented for this platform, and all values behave as if the value `auto` was used. Renovate will accept the Merge Request without further configuration, and respect the strategy defined in the Merge Request, and this cannot be overridden yet
 
-## Server version dependend features
+## Server version dependent features
 
-We use the GitLab [version api](https://docs.gitlab.com/ee/api/version.html) to fetch the server version.
+We use the GitLab [version API](https://docs.gitlab.com/ee/api/version.html) to fetch the server version.
 This can be overridden by the experimental feature flag [`RENOVATE_X_SERVER_VERSION`](https://docs.renovatebot.com/self-hosted-experimental/#renovate_x_server_version).
 
 - Use `Draft:` MR prefix instead of `WIP:` prefix since `v13.2.0`
-- Do not truncate markdown body to 25K since `v13.4.0`
+- Do not truncate Markdown body to 25K since `v13.4.0`
 - Allow configure reviewers since `v13.9.0`

--- a/lib/platform/gitlab/index.md
+++ b/lib/platform/gitlab/index.md
@@ -7,7 +7,7 @@
 ## Server version dependend features
 
 We use the GitLab [version api](https://docs.gitlab.com/ee/api/version.html) to fetch the server version.
-This can be overridden by the experimental feature flag (`RENOVATE_X_SERVER_VERSION`)(https://docs.renovatebot.com/self-hosted-experimental/#renovate_x_server_version).
+This can be overridden by the experimental feature flag [`RENOVATE_X_SERVER_VERSION`](https://docs.renovatebot.com/self-hosted-experimental/#renovate_x_server_version).
 
 - Use `Draft:` MR prefix instead of `WIP:` prefix since `v13.2.0`
 - Do not truncate markdown body to 25K since `v13.4.0`

--- a/lib/platform/gitlab/index.md
+++ b/lib/platform/gitlab/index.md
@@ -10,5 +10,5 @@ We use the GitLab [version API](https://docs.gitlab.com/ee/api/version.html) to 
 This can be overridden by the experimental feature flag [`RENOVATE_X_SERVER_VERSION`](https://docs.renovatebot.com/self-hosted-experimental/#renovate_x_server_version).
 
 - Use `Draft:` MR prefix instead of `WIP:` prefix since `v13.2.0`
-- Do not truncate Markdown body to 25K since `v13.4.0`
+- Do not truncate Markdown body to 25K chars since `v13.4.0`
 - Allow configure reviewers since `v13.9.0`

--- a/lib/platform/gitlab/index.md
+++ b/lib/platform/gitlab/index.md
@@ -7,7 +7,7 @@
 ## Server version dependent features
 
 We use the GitLab [version API](https://docs.gitlab.com/ee/api/version.html) to fetch the server version.
-You can use the experimental feature flag [`RENOVATE_X_SERVER_VERSION`](https://docs.renovatebot.com/self-hosted-experimental/#renovate_x_server_version) to set a specific server version.
+You can use the experimental feature flag [`RENOVATE_X_PLATFORM_VERSION`](https://docs.renovatebot.com/self-hosted-experimental/#renovate_x_platform_version) to set a specific server version.
 By setting the server version yourself, you save a API call that fetches the server version.
 
 - Use `Draft:` MR prefix instead of `WIP:` prefix since `v13.2.0`

--- a/lib/platform/gitlab/index.md
+++ b/lib/platform/gitlab/index.md
@@ -3,3 +3,12 @@
 ## Features awaiting implementation
 
 - The `automergeStrategy` configuration option has not been implemented for this platform, and all values behave as if the value `auto` was used. Renovate will accept the Merge Request without further configuration, and respect the strategy defined in the Merge Request, and this cannot be overridden yet
+
+## Server version dependend features
+
+We use the GitLab [version api](https://docs.gitlab.com/ee/api/version.html) to fetch the server version.
+This can be overridden by the experimental feature flag (`RENOVATE_X_SERVER_VERSION`)(https://docs.renovatebot.com/self-hosted-experimental/#renovate_x_server_version).
+
+- Use `Draft:` MR prefix instead of `WIP:` prefix since `v13.2.0`
+- Do not truncate markdown body to 25K since `v13.4.0`
+- Allow configure reviewers since `v13.9.0`

--- a/lib/platform/gitlab/index.ts
+++ b/lib/platform/gitlab/index.ts
@@ -105,8 +105,8 @@ export async function initPlatform({
       platformConfig.gitAuthor = `${user.name} <${user.email}>`;
     }
     // istanbul ignore if: experimental feature
-    if (process.env.RENOVATE_X_SERVER_VERSION) {
-      gitlabVersion = process.env.RENOVATE_X_SERVER_VERSION;
+    if (process.env.RENOVATE_X_PLATFORM_VERSION) {
+      gitlabVersion = process.env.RENOVATE_X_PLATFORM_VERSION;
     } else {
       const version = (
         await gitlabApi.getJson<{ version: string }>('version', { token })

--- a/lib/platform/gitlab/index.ts
+++ b/lib/platform/gitlab/index.ts
@@ -104,7 +104,7 @@ export async function initPlatform({
       ).body;
       platformConfig.gitAuthor = `${user.name} <${user.email}>`;
     }
-    // istabul ignore if: experimental feature
+    // istanbul ignore if: experimental feature
     if (process.env.RENOVATE_X_SERVER_VERSION) {
       gitlabVersion = process.env.RENOVATE_X_SERVER_VERSION;
     } else {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Allow overriding the GitLab sever version via `RENOVATE_X_SERVER_VERSION` environment, so renovate don't need to query the api for it.
It useful for using `$CI_JOB_TOKEN` as that seems to be not allowed to query the version.

Assigning `RENOVATE_X_SERVER_VERSION: $CI_SERVER_VERSION` will do it from GitLab pipelines, so we don't accidently override the version.
<!-- Describe what behavior is changed by this PR. -->

## Context:

https://gitlab.com/renovate-bot/renovate-runner/-/merge_requests/202

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
