### PR TITLE
fix(dashboard): add link to docs in default header

### DIFF
--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -419,7 +419,7 @@ const options: RenovateOptions[] = [
       'Any text added here will be placed first in the Dependency Dashboard issue body.',
     type: 'string',
     default:
-      'This issue contains a list of Renovate updates and their statuses.',
+      'This issue provides visibility into Renovate updates and their statuses. [Learn more](https://docs.renovatebot.com/key-concepts/dashboard/)',
   },
   {
     name: 'dependencyDashboardFooter',

--- a/lib/workers/repository/__fixtures__/master-issue_with_2_PR_closed_ignored.txt
+++ b/lib/workers/repository/__fixtures__/master-issue_with_2_PR_closed_ignored.txt
@@ -1,4 +1,4 @@
-This issue contains a list of Renovate updates and their statuses.
+This issue provides visibility into Renovate updates and their statuses. [Learn more](https://docs.renovatebot.com/key-concepts/dashboard/)
 
 ## Ignored or Blocked
 

--- a/lib/workers/repository/__fixtures__/master-issue_with_2_PR_edited.txt
+++ b/lib/workers/repository/__fixtures__/master-issue_with_2_PR_edited.txt
@@ -1,4 +1,4 @@
-This issue contains a list of Renovate updates and their statuses.
+This issue provides visibility into Renovate updates and their statuses. [Learn more](https://docs.renovatebot.com/key-concepts/dashboard/)
 
 ## Edited/Blocked
 

--- a/lib/workers/repository/__fixtures__/master-issue_with_3_PR_in_approval.txt
+++ b/lib/workers/repository/__fixtures__/master-issue_with_3_PR_in_approval.txt
@@ -1,4 +1,4 @@
-This issue contains a list of Renovate updates and their statuses.
+This issue provides visibility into Renovate updates and their statuses. [Learn more](https://docs.renovatebot.com/key-concepts/dashboard/)
 
 ## PR Creation Approval Required
 

--- a/lib/workers/repository/__fixtures__/master-issue_with_3_PR_in_progress.txt
+++ b/lib/workers/repository/__fixtures__/master-issue_with_3_PR_in_progress.txt
@@ -1,4 +1,4 @@
-This issue contains a list of Renovate updates and their statuses.
+This issue provides visibility into Renovate updates and their statuses. [Learn more](https://docs.renovatebot.com/key-concepts/dashboard/)
 
 ## Open
 

--- a/lib/workers/repository/__fixtures__/master-issue_with_8_PR.txt
+++ b/lib/workers/repository/__fixtures__/master-issue_with_8_PR.txt
@@ -1,4 +1,4 @@
-This issue contains a list of Renovate updates and their statuses.
+This issue provides visibility into Renovate updates and their statuses. [Learn more](https://docs.renovatebot.com/key-concepts/dashboard/)
 
 ## Pending Approval
 

--- a/lib/workers/repository/__snapshots__/dependency-dashboard.spec.ts.snap
+++ b/lib/workers/repository/__snapshots__/dependency-dashboard.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`workers/repository/dependency-dashboard ensureDependencyDashboard() contains logged problems 1`] = `
-"This issue contains a list of Renovate updates and their statuses.
+"This issue provides visibility into Renovate updates and their statuses. [Learn more](https://docs.renovatebot.com/key-concepts/dashboard/)
 
 ## Repository problems
 
@@ -23,7 +23,7 @@ These updates await pending status checks. To force their creation now, click th
 `;
 
 exports[`workers/repository/dependency-dashboard ensureDependencyDashboard() open or update Dependency Dashboard when all branches are closed and dependencyDashboardAutoclose is false 1`] = `
-"This issue contains a list of Renovate updates and their statuses.
+"This issue provides visibility into Renovate updates and their statuses. [Learn more](https://docs.renovatebot.com/key-concepts/dashboard/)
 
 This repository currently has no open or pending branches.
 
@@ -33,7 +33,7 @@ And this is a footer
 `;
 
 exports[`workers/repository/dependency-dashboard ensureDependencyDashboard() open or update Dependency Dashboard when rules contain approvals 1`] = `
-"This issue contains a list of Renovate updates and their statuses.
+"This issue provides visibility into Renovate updates and their statuses. [Learn more](https://docs.renovatebot.com/key-concepts/dashboard/)
 
 This repository currently has no open or pending branches.
 
@@ -43,7 +43,7 @@ And this is a footer
 `;
 
 exports[`workers/repository/dependency-dashboard ensureDependencyDashboard() rechecks branches 1`] = `
-"This issue contains a list of Renovate updates and their statuses.
+"This issue provides visibility into Renovate updates and their statuses. [Learn more](https://docs.renovatebot.com/key-concepts/dashboard/)
 
 ## Pending Approval
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds link to doc in Dashboard header default

## Context:

#11415

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
