### PR TITLE
feat: support detecting ESM libraries

### DIFF
--- a/lib/manager/npm/extract/type.ts
+++ b/lib/manager/npm/extract/type.ts
@@ -6,7 +6,7 @@ export function mightBeABrowserLibrary(packageJson: NpmPackage): boolean {
     // it's not published
     return false;
   }
-  if (packageJson.main === undefined) {
+  if (packageJson.main === undefined && packageJson.exports === undefined) {
     // it can't be required
     return false;
   }


### PR DESCRIPTION
rel: https://nodejs.org/api/packages.html#packages_exports

## Changes:

Adds support for `"exports"` in `package.json` to mark decide it's a library

## Context:

When switching `webtorrent-hybrid` to ESM, we received this PR afterwards: https://github.com/webtorrent/webtorrent-hybrid/pull/142. ESM does not require `"main"` because `"exports"` is supported by all Node versions that support ESM and it's stricter.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository