### PR TITLE
chore: clean up ManagerConfig types

### DIFF
--- a/lib/config/index.ts
+++ b/lib/config/index.ts
@@ -1,12 +1,7 @@
 import { logger } from '../logger';
 import { get, getLanguageList, getManagerList } from '../manager';
 import * as options from './options';
-import type {
-  AllConfig,
-  ManagerConfig,
-  RenovateConfig,
-  RenovateConfigStage,
-} from './types';
+import type { AllConfig, RenovateConfig, RenovateConfigStage } from './types';
 import { mergeChildConfig } from './utils';
 
 export { mergeChildConfig };
@@ -14,8 +9,8 @@ export { mergeChildConfig };
 export function getManagerConfig(
   config: RenovateConfig,
   manager: string
-): ManagerConfig {
-  let managerConfig: ManagerConfig = {
+): RenovateConfig {
+  let managerConfig: RenovateConfig = {
     ...config,
     language: null,
     manager: null,

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -375,11 +375,6 @@ export interface PackageRuleInputConfig extends Record<string, unknown> {
   packageRules?: (PackageRule & PackageRuleInputConfig)[];
 }
 
-export interface ManagerConfig extends RenovateConfig {
-  language: string;
-  manager: string;
-}
-
 export interface MigratedConfig {
   isMigrated: boolean;
   migratedConfig: RenovateConfig;

--- a/lib/manager/git-submodules/extract.ts
+++ b/lib/manager/git-submodules/extract.ts
@@ -5,7 +5,7 @@ import { getGlobalConfig } from '../../config/global';
 import * as datasourceGitRefs from '../../datasource/git-refs';
 import { logger } from '../../logger';
 import { getHttpUrl, getRemoteUrlWithToken } from '../../util/git/url';
-import type { ManagerConfig, PackageFile } from '../types';
+import type { ExtractConfig, PackageFile } from '../types';
 import { GitModule } from './types';
 
 async function getUrl(
@@ -86,7 +86,7 @@ async function getModules(
 export default async function extractPackageFile(
   _content: string,
   fileName: string,
-  config: ManagerConfig
+  config: ExtractConfig
 ): Promise<PackageFile | null> {
   const { localDir } = getGlobalConfig();
   const git = Git(localDir);

--- a/lib/manager/types.ts
+++ b/lib/manager/types.ts
@@ -9,10 +9,6 @@ import type { File } from '../util/git';
 
 export type Result<T> = T | Promise<T>;
 
-export interface ManagerConfig {
-  registryUrls?: string[];
-}
-
 export interface ManagerData<T> {
   managerData?: T;
 }
@@ -38,7 +34,7 @@ export interface CustomExtractConfig extends ExtractConfig {
   versioningTemplate?: string;
 }
 
-export interface UpdateArtifactsConfig extends ManagerConfig {
+export interface UpdateArtifactsConfig {
   isLockFileMaintenance?: boolean;
   constraints?: Record<string, string>;
   composerIgnorePlatformReqs?: string[];
@@ -259,7 +255,7 @@ export interface ManagerApi {
 }
 
 // TODO: name and properties used by npm manager
-export interface PostUpdateConfig extends ManagerConfig, Record<string, any> {
+export interface PostUpdateConfig extends Record<string, any> {
   updatedPackageFiles?: File[];
   postUpdateOptions?: string[];
   skipInstalls?: boolean;

--- a/lib/workers/repository/process/fetch.ts
+++ b/lib/workers/repository/process/fetch.ts
@@ -1,6 +1,6 @@
 import pAll from 'p-all';
 import { getManagerConfig, mergeChildConfig } from '../../../config';
-import type { ManagerConfig, RenovateConfig } from '../../../config/types';
+import type { RenovateConfig } from '../../../config/types';
 import { getDefaultConfig } from '../../../datasource';
 import { logger } from '../../../logger';
 import type { PackageDependency, PackageFile } from '../../../manager/types';
@@ -11,7 +11,7 @@ import { lookupUpdates } from './lookup';
 import type { LookupUpdateConfig } from './lookup/types';
 
 async function fetchDepUpdates(
-  packageFileConfig: ManagerConfig & PackageFile,
+  packageFileConfig: RenovateConfig & PackageFile,
   indep: PackageDependency
 ): Promise<PackageDependency> {
   let dep = clone(indep);
@@ -45,7 +45,7 @@ async function fetchDepUpdates(
 
 async function fetchManagerPackagerFileUpdates(
   config: RenovateConfig,
-  managerConfig: ManagerConfig,
+  managerConfig: RenovateConfig,
   pFile: PackageFile
 ): Promise<void> {
   const { packageFile } = pFile;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Removes some unnecessary ManagerConfig types

## Context:

Cleanup when investigating ExtractConfig

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
