### PR TITLE
fix(versioning): null check constraint

### DIFF
--- a/lib/versioning/npm/index.ts
+++ b/lib/versioning/npm/index.ts
@@ -35,7 +35,7 @@ export const isVersion = (input: string): string => valid(input);
 
 const isSingleVersion = (constraint: string): string =>
   isVersion(constraint) ||
-  (constraint.startsWith('=') && isVersion(constraint.substring(1).trim()));
+  (constraint?.startsWith('=') && isVersion(constraint.substring(1).trim()));
 
 export const api: VersioningApi = {
   equals,

--- a/lib/versioning/pep440/index.ts
+++ b/lib/versioning/pep440/index.ts
@@ -46,7 +46,7 @@ const minSatisfyingVersion = (versions: string[], range: string): string => {
 
 export const isSingleVersion = (constraint: string): string =>
   isVersion(constraint) ||
-  (constraint.startsWith('==') && isVersion(constraint.substring(2).trim()));
+  (constraint?.startsWith('==') && isVersion(constraint.substring(2).trim()));
 
 export { isVersion, matches };
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds defensive check to versioning startsWith checks.

## Context:

I have seen some errors in the hosted app because of this.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
