### PR TITLE
fix(travis): massage currentValue to string

### DIFF
--- a/lib/manager/travis/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/travis/__snapshots__/extract.spec.ts.snap
@@ -4,13 +4,13 @@ exports[`manager/travis/extract extractPackageFile() returns results 1`] = `
 Object {
   "deps": Array [
     Object {
-      "currentValue": 6,
+      "currentValue": "6",
       "datasource": "github-tags",
       "depName": "node",
       "lookupName": "nodejs/node",
     },
     Object {
-      "currentValue": 8,
+      "currentValue": "8",
       "datasource": "github-tags",
       "depName": "node",
       "lookupName": "nodejs/node",

--- a/lib/manager/travis/extract.ts
+++ b/lib/manager/travis/extract.ts
@@ -19,7 +19,7 @@ export function extractPackageFile(content: string): PackageFile | null {
       depName: 'node',
       datasource: datasourceGithubTags.id,
       lookupName: 'nodejs/node',
-      currentValue,
+      currentValue: currentValue.toString(),
     }));
   }
   if (!deps.length) {

--- a/lib/util/cache/repository/index.ts
+++ b/lib/util/cache/repository/index.ts
@@ -9,7 +9,7 @@ import { logger } from '../../../logger';
 import type { Cache } from './types';
 
 // Increment this whenever there could be incompatibilities between old and new cache structure
-export const CACHE_REVISION = 8;
+export const CACHE_REVISION = 9;
 
 let repositoryCache: RepositoryCacheConfig = 'disabled';
 let cacheFileName: string;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Massages currentValue to a string for Travis.

## Context:

Errors in the app since v26

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
