### PR TITLE
fix: semantic host stats

### DIFF
--- a/lib/workers/repository/stats.ts
+++ b/lib/workers/repository/stats.ts
@@ -30,7 +30,12 @@ export function printRequestStats(): void {
     requestHosts[hostname].push(httpRequest);
   }
   logger.trace({ allRequests, requestHosts }, 'full stats');
-  const hostStats: Record<string, any> = {};
+  type HostStats = {
+    requestCount: number;
+    requestAvgMs: number;
+    queueAvgMs: number;
+  };
+  const hostStats: Record<string, HostStats> = {};
   let totalRequests = 0;
   for (const [hostname, requests] of Object.entries(requestHosts)) {
     const requestCount = requests.length;

--- a/lib/workers/repository/stats.ts
+++ b/lib/workers/repository/stats.ts
@@ -30,25 +30,21 @@ export function printRequestStats(): void {
     requestHosts[hostname].push(httpRequest);
   }
   logger.trace({ allRequests, requestHosts }, 'full stats');
-  const hostStats: string[] = [];
+  const hostStats: Record<string, any> = {};
   let totalRequests = 0;
   for (const [hostname, requests] of Object.entries(requestHosts)) {
-    const hostRequests = requests.length;
-    totalRequests += hostRequests;
+    const requestCount = requests.length;
+    totalRequests += requestCount;
     const requestSum = requests
       .map(({ duration }) => duration)
       .reduce((a, b) => a + b, 0);
-    const requestAvg = Math.round(requestSum / hostRequests);
+    const requestAvgMs = Math.round(requestSum / requestCount);
 
     const queueSum = requests
       .map(({ queueDuration }) => queueDuration)
       .reduce((a, b) => a + b, 0);
-    const queueAvg = Math.round(queueSum / hostRequests);
-    const requestCount =
-      `${hostRequests} ` + (hostRequests > 1 ? 'requests' : 'request');
-    hostStats.push(
-      `${hostname}, ${requestCount}, ${requestAvg}ms request average, ${queueAvg}ms queue average`
-    );
+    const queueAvgMs = Math.round(queueSum / requestCount);
+    hostStats[hostname] = { requestCount, requestAvgMs, queueAvgMs };
   }
   logger.debug({ hostStats, totalRequests }, 'http statistics');
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Prints host stats semantically for better log processing.

## Context:

I'm going to start counting these in the app and being able to hopefully identify if our changes cause API requests per repo to go up or down.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
