### PR TITLE
fix(config): do not massage lockFileMaintenance

### DIFF
--- a/lib/config/__snapshots__/massage.spec.ts.snap
+++ b/lib/config/__snapshots__/massage.spec.ts.snap
@@ -1,5 +1,26 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`config/massage massageConfig does not massage lockFileMaintenance 1`] = `
+Object {
+  "packageRules": Array [
+    Object {
+      "lockFileMaintenance": Object {
+        "enabled": true,
+      },
+      "matchBaseBranches": Array [
+        "release/ft10/1.9.x",
+      ],
+      "matchManagers": Array [
+        "helmv3",
+      ],
+      "schedule": Array [
+        "at any time",
+      ],
+    },
+  ],
+}
+`;
+
 exports[`config/massage massageConfig massages packageRules matchUpdateTypes 1`] = `
 Object {
   "packageRules": Array [

--- a/lib/config/massage.spec.ts
+++ b/lib/config/massage.spec.ts
@@ -42,5 +42,20 @@ describe('config/massage', () => {
       expect(res).toMatchSnapshot();
       expect(res.packageRules).toHaveLength(3);
     });
+    it('does not massage lockFileMaintenance', () => {
+      const config: RenovateConfig = {
+        packageRules: [
+          {
+            matchManagers: ['helmv3'],
+            matchBaseBranches: ['release/ft10/1.9.x'],
+            lockFileMaintenance: { enabled: true },
+            schedule: 'at any time',
+          },
+        ],
+      };
+      const res = massage.massageConfig(config);
+      expect(res).toMatchSnapshot();
+      expect(res.packageRules).toHaveLength(1);
+    });
   });
 });

--- a/lib/config/massage.spec.ts
+++ b/lib/config/massage.spec.ts
@@ -49,7 +49,7 @@ describe('config/massage', () => {
             matchManagers: ['helmv3'],
             matchBaseBranches: ['release/ft10/1.9.x'],
             lockFileMaintenance: { enabled: true },
-            schedule: 'at any time',
+            schedule: ['at any time'],
           },
         ],
       };

--- a/lib/config/massage.ts
+++ b/lib/config/massage.ts
@@ -47,7 +47,6 @@ export function massageConfig(config: RenovateConfig): RenovateConfig {
       'patch',
       'pin',
       'digest',
-      'lockFileMaintenance',
       'rollback',
     ];
     for (const rule of massagedConfig.packageRules) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Removes erroneous `lockFileMaintenance` flattening within `packageRules`.

## Context:

#11487

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
