### PR TITLE
refactor(git): gitAuthor writing

### DIFF
--- a/lib/platform/index.spec.ts
+++ b/lib/platform/index.spec.ts
@@ -70,31 +70,4 @@ describe('platform/index', () => {
       platform: PLATFORM_TYPE_BITBUCKET,
     });
   });
-
-  it('returns null if empty email given', () => {
-    expect(platform.parseGitAuthor(undefined)).toBeNull();
-  });
-  it('parses bot email', () => {
-    // FIXME: explicit assert condition
-    expect(
-      platform.parseGitAuthor('some[bot]@users.noreply.github.com')
-    ).toMatchSnapshot();
-  });
-  it('parses bot name and email', () => {
-    // FIXME: explicit assert condition
-    expect(
-      platform.parseGitAuthor(
-        '"some[bot]" <some[bot]@users.noreply.github.com>'
-      )
-    ).toMatchSnapshot();
-  });
-  it('escapes names', () => {
-    // FIXME: explicit assert condition
-    expect(
-      platform.parseGitAuthor('name [what] <name@what.com>').name
-    ).toMatchSnapshot();
-  });
-  it('gives up', () => {
-    expect(platform.parseGitAuthor('a.b.c')).toBeNull();
-  });
 });

--- a/lib/platform/index.ts
+++ b/lib/platform/index.ts
@@ -1,10 +1,10 @@
 import URL from 'url';
-import addrs from 'email-addresses';
 import type { AllConfig } from '../config/types';
 import { PLATFORM_NOT_FOUND } from '../constants/error-messages';
 import { logger } from '../logger';
 import type { HostRule } from '../types';
 import { setNoVerify, setPrivateKey } from '../util/git';
+import { parseGitAuthor } from '../util/git/author';
 import * as hostRules from '../util/host-rules';
 import platforms from './api';
 import type { Platform } from './types';
@@ -37,48 +37,6 @@ export function setPlatformApi(name: string): void {
     );
   }
   _platform = platforms.get(name);
-}
-
-interface GitAuthor {
-  name?: string;
-  address?: string;
-}
-
-export function parseGitAuthor(input: string): GitAuthor | null {
-  let result: GitAuthor = null;
-  if (!input) {
-    return null;
-  }
-  try {
-    result = addrs.parseOneAddress(input);
-    if (result) {
-      return result;
-    }
-    if (input.includes('[bot]@')) {
-      // invalid github app/bot addresses
-      const parsed = addrs.parseOneAddress(
-        input.replace('[bot]@', '@')
-      ) as addrs.ParsedMailbox;
-      if (parsed?.address) {
-        result = {
-          name: parsed.name || input.replace(/@.*/, ''),
-          address: parsed.address.replace('@', '[bot]@'),
-        };
-        return result;
-      }
-    }
-    if (input.includes('<') && input.includes('>')) {
-      // try wrapping the name part in quotations
-      result = addrs.parseOneAddress('"' + input.replace(/(\s?<)/, '"$1'));
-      if (result) {
-        return result;
-      }
-    }
-  } catch (err) /* istanbul ignore next */ {
-    logger.error({ err }, 'Unknown error parsing gitAuthor');
-  }
-  // give up
-  return null;
 }
 
 export async function initPlatform(config: AllConfig): Promise<AllConfig> {

--- a/lib/util/git/__snapshots__/author.spec.ts.snap
+++ b/lib/util/git/__snapshots__/author.spec.ts.snap
@@ -1,15 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`platform/index escapes names 1`] = `"name [what]"`;
+exports[`util/git/author parseGitAuthor escapes names 1`] = `"name [what]"`;
 
-exports[`platform/index parses bot email 1`] = `
+exports[`util/git/author parseGitAuthor parses bot email 1`] = `
 Object {
   "address": "some[bot]@users.noreply.github.com",
   "name": "some[bot]",
 }
 `;
 
-exports[`platform/index parses bot name and email 1`] = `
+exports[`util/git/author parseGitAuthor parses bot name and email 1`] = `
 Object {
   "address": "some[bot]@users.noreply.github.com",
   "name": "some[bot]",

--- a/lib/util/git/author.spec.ts
+++ b/lib/util/git/author.spec.ts
@@ -1,0 +1,30 @@
+import { parseGitAuthor } from './author';
+
+describe('util/git/author', () => {
+  describe('parseGitAuthor', () => {
+    it('returns null if empty email given', () => {
+      expect(parseGitAuthor(undefined)).toBeNull();
+    });
+    it('parses bot email', () => {
+      // FIXME: explicit assert condition
+      expect(
+        parseGitAuthor('some[bot]@users.noreply.github.com')
+      ).toMatchSnapshot();
+    });
+    it('parses bot name and email', () => {
+      // FIXME: explicit assert condition
+      expect(
+        parseGitAuthor('"some[bot]" <some[bot]@users.noreply.github.com>')
+      ).toMatchSnapshot();
+    });
+    it('escapes names', () => {
+      // FIXME: explicit assert condition
+      expect(
+        parseGitAuthor('name [what] <name@what.com>').name
+      ).toMatchSnapshot();
+    });
+    it('gives up', () => {
+      expect(parseGitAuthor('a.b.c')).toBeNull();
+    });
+  });
+});

--- a/lib/util/git/author.ts
+++ b/lib/util/git/author.ts
@@ -1,0 +1,44 @@
+import addrs from 'email-addresses';
+import { logger } from '../../logger';
+
+export interface GitAuthor {
+  name?: string;
+  address?: string;
+}
+
+export function parseGitAuthor(input: string): GitAuthor | null {
+  let result: GitAuthor = null;
+  if (!input) {
+    return null;
+  }
+  try {
+    result = addrs.parseOneAddress(input);
+    if (result) {
+      return result;
+    }
+    if (input.includes('[bot]@')) {
+      // invalid github app/bot addresses
+      const parsed = addrs.parseOneAddress(
+        input.replace('[bot]@', '@')
+      ) as addrs.ParsedMailbox;
+      if (parsed?.address) {
+        result = {
+          name: parsed.name || input.replace(/@.*/, ''),
+          address: parsed.address.replace('@', '[bot]@'),
+        };
+        return result;
+      }
+    }
+    if (input.includes('<') && input.includes('>')) {
+      // try wrapping the name part in quotations
+      result = addrs.parseOneAddress('"' + input.replace(/(\s?<)/, '"$1'));
+      if (result) {
+        return result;
+      }
+    }
+  } catch (err) /* istanbul ignore next */ {
+    logger.debug({ err }, 'Unknown error parsing gitAuthor');
+  }
+  // give up
+  return null;
+}


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Refactors some gitAuthor logic into functions

## Context:

Preparation for #7273

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
