### PR TITLE
fix: remove global.gitAuthor

### DIFF
--- a/lib/globals.d.ts
+++ b/lib/globals.d.ts
@@ -9,12 +9,6 @@ declare interface Error {
   validationMessage?: string;
 }
 
-declare namespace NodeJS {
-  interface Global {
-    gitAuthor?: { name: string; email: string };
-  }
-}
-
 // can't use `resolveJsonModule` because it will copy json files and change dist path
 
 declare module '*/package.json' {

--- a/lib/platform/azure/index.ts
+++ b/lib/platform/azure/index.ts
@@ -180,8 +180,6 @@ export async function initRepo({
     ...config,
     url,
     extraCloneOpts: getStorageExtraCloneOpts(opts),
-    gitAuthorName: global.gitAuthor?.name,
-    gitAuthorEmail: global.gitAuthor?.email,
     cloneSubmodules,
   });
   const repoConfig: RepoResult = {

--- a/lib/platform/bitbucket-server/index.spec.ts
+++ b/lib/platform/bitbucket-server/index.spec.ts
@@ -1311,18 +1311,13 @@ describe('platform/bitbucket-server/index', () => {
             .twice()
             .reply(200, { conflicted: false });
 
-          const author = global.gitAuthor;
-          try {
-            expect(await bitbucket.getPr(3)).toMatchSnapshot();
+          expect(await bitbucket.getPr(3)).toMatchSnapshot();
 
-            expect(await bitbucket.getPr(5)).toMatchSnapshot();
+          expect(await bitbucket.getPr(5)).toMatchSnapshot();
 
-            expect(await bitbucket.getPr(5)).toMatchSnapshot();
+          expect(await bitbucket.getPr(5)).toMatchSnapshot();
 
-            expect(httpMock.getTrace()).toMatchSnapshot();
-          } finally {
-            global.gitAuthor = author;
-          }
+          expect(httpMock.getTrace()).toMatchSnapshot();
         });
 
         it('gets a closed PR', async () => {

--- a/lib/platform/bitbucket-server/index.ts
+++ b/lib/platform/bitbucket-server/index.ts
@@ -214,8 +214,6 @@ export async function initRepo({
     await git.initRepo({
       ...config,
       url: gitUrl,
-      gitAuthorName: global.gitAuthor?.name,
-      gitAuthorEmail: global.gitAuthor?.email,
       cloneSubmodules,
     });
 

--- a/lib/platform/bitbucket/index.spec.ts
+++ b/lib/platform/bitbucket/index.spec.ts
@@ -726,7 +726,6 @@ describe('platform/bitbucket/index', () => {
 
     it('canRebase', async () => {
       expect.assertions(4);
-      const author = global.gitAuthor;
       const scope = await initRepoMock();
       scope
         .get('/2.0/repositories/some/repo/pullrequests/3')
@@ -747,22 +746,13 @@ describe('platform/bitbucket/index', () => {
         .get('/2.0/repositories/some/repo/pullrequests/5/diff')
         .twice()
         .reply(200, diff);
-      try {
-        expect(await bitbucket.getPr(3)).toMatchSnapshot();
+      expect(await bitbucket.getPr(3)).toMatchSnapshot();
 
-        global.gitAuthor = {
-          email: 'renovate@whitesourcesoftware.com',
-          name: 'bot',
-        };
-        expect(await bitbucket.getPr(5)).toMatchSnapshot();
+      expect(await bitbucket.getPr(5)).toMatchSnapshot();
 
-        global.gitAuthor = { email: 'jane@example.com', name: 'jane' };
-        expect(await bitbucket.getPr(5)).toMatchSnapshot();
+      expect(await bitbucket.getPr(5)).toMatchSnapshot();
 
-        expect(httpMock.getTrace()).toMatchSnapshot();
-      } finally {
-        global.gitAuthor = author;
-      }
+      expect(httpMock.getTrace()).toMatchSnapshot();
     });
   });
 

--- a/lib/platform/bitbucket/index.ts
+++ b/lib/platform/bitbucket/index.ts
@@ -179,8 +179,6 @@ export async function initRepo({
   await git.initRepo({
     ...config,
     url,
-    gitAuthorName: global.gitAuthor?.name,
-    gitAuthorEmail: global.gitAuthor?.email,
     cloneSubmodules,
   });
   const repoConfig: RepoResult = {

--- a/lib/platform/gitea/index.spec.ts
+++ b/lib/platform/gitea/index.spec.ts
@@ -176,8 +176,6 @@ describe('platform/gitea/index', () => {
     gitvcs.isBranchStale.mockResolvedValue(false);
     gitvcs.getBranchCommit.mockReturnValue(mockCommitHash);
 
-    global.gitAuthor = { name: 'Renovate', email: 'renovate@example.com' };
-
     setBaseUrl('https://gitea.renovatebot.com/api/v1');
   });
 
@@ -574,7 +572,9 @@ describe('platform/gitea/index', () => {
         partial<ght.Branch>({
           commit: {
             id: mockCommitHash,
-            author: partial<ght.CommitUser>({ email: global.gitAuthor.email }),
+            author: partial<ght.CommitUser>({
+              email: 'renovate@whitesourcesoftware.com',
+            }),
           },
         })
       );

--- a/lib/platform/gitea/index.ts
+++ b/lib/platform/gitea/index.ts
@@ -297,8 +297,6 @@ const platform: Platform = {
     await git.initRepo({
       ...config,
       url: URL.format(gitEndpoint),
-      gitAuthorName: global.gitAuthor?.name,
-      gitAuthorEmail: global.gitAuthor?.email,
     });
 
     // Reset cached resources

--- a/lib/platform/github/index.spec.ts
+++ b/lib/platform/github/index.spec.ts
@@ -30,7 +30,6 @@ describe('platform/github/index', () => {
     git.getBranchCommit.mockReturnValue(
       '0d9c7726c3d628b7e28af234595cfd20febdbf8e'
     );
-    delete global.gitAuthor;
     hostRules.find.mockReturnValue({
       token: 'abc123',
     });
@@ -1900,10 +1899,6 @@ describe('platform/github/index', () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
       scope.post('/graphql').reply(200, graphqlOpenPullRequests);
-      global.gitAuthor = {
-        name: 'Renovate Bot',
-        email: 'renovate@whitesourcesoftware.com',
-      };
       await github.initRepo({
         repository: 'some/repo',
       } as any);

--- a/lib/platform/github/index.ts
+++ b/lib/platform/github/index.ts
@@ -420,8 +420,6 @@ export async function initRepo({
   await git.initRepo({
     ...config,
     url,
-    gitAuthorName: global.gitAuthor?.name,
-    gitAuthorEmail: global.gitAuthor?.email,
   });
   const repoConfig: RepoResult = {
     defaultBranch: config.defaultBranch,

--- a/lib/platform/gitlab/__snapshots__/index.spec.ts.snap
+++ b/lib/platform/gitlab/__snapshots__/index.spec.ts.snap
@@ -2653,63 +2653,12 @@ Array [
 ]
 `;
 
-exports[`platform/gitlab/index initRepo should use ssh_url_to_repo if gitUrl is set to ssh 1`] = `
-Array [
-  Object {
-    "headers": Object {
-      "accept": "application/json",
-      "accept-encoding": "gzip, deflate, br",
-      "authorization": "Bearer abc123",
-      "host": "gitlab.com",
-      "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
-    },
-    "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/some%2Frepo%2Fproject",
-  },
-]
-`;
-
-exports[`platform/gitlab/index initRepo should use ssh_url_to_repo if gitUrl is set to ssh 2`] = `
-Array [
-  Array [
-    Object {
-      "cloneSubmodules": undefined,
-      "defaultBranch": "master",
-      "gitAuthorEmail": undefined,
-      "gitAuthorName": undefined,
-      "ignorePrAuthor": undefined,
-      "mergeMethod": "merge",
-      "repository": "some%2Frepo%2Fproject",
-      "url": "ssh://git@gitlab.com/some%2Frepo%2Fproject.git",
-    },
-  ],
-]
-`;
-
-exports[`platform/gitlab/index initRepo should throw if ssh_url_to_repo is not present but gitUrl is set to ssh 1`] = `
-Array [
-  Object {
-    "headers": Object {
-      "accept": "application/json",
-      "accept-encoding": "gzip, deflate, br",
-      "authorization": "Bearer abc123",
-      "host": "gitlab.com",
-      "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
-    },
-    "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/some%2Frepo%2Fproject",
-  },
-]
-`;
-
 exports[`platform/gitlab/index initRepo should fall back respecting when GITLAB_IGNORE_REPO_URL is set 1`] = `
 Array [
   Array [
     Object {
       "cloneSubmodules": undefined,
       "defaultBranch": "master",
-      "gitAuthorEmail": undefined,
-      "gitAuthorName": undefined,
       "ignorePrAuthor": undefined,
       "mergeMethod": "merge",
       "repository": "some%2Frepo%2Fproject",
@@ -2866,6 +2815,53 @@ Array [
     "method": "GET",
     "url": "https://gitlab.com/api/v4/projects/some%2Frepo",
   },
+]
+`;
+
+exports[`platform/gitlab/index initRepo should throw if ssh_url_to_repo is not present but gitUrl is set to ssh 1`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate, br",
+      "authorization": "Bearer abc123",
+      "host": "gitlab.com",
+      "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
+    },
+    "method": "GET",
+    "url": "https://gitlab.com/api/v4/projects/some%2Frepo%2Fproject",
+  },
+]
+`;
+
+exports[`platform/gitlab/index initRepo should use ssh_url_to_repo if gitUrl is set to ssh 1`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate, br",
+      "authorization": "Bearer abc123",
+      "host": "gitlab.com",
+      "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
+    },
+    "method": "GET",
+    "url": "https://gitlab.com/api/v4/projects/some%2Frepo%2Fproject",
+  },
+]
+`;
+
+exports[`platform/gitlab/index initRepo should use ssh_url_to_repo if gitUrl is set to ssh 2`] = `
+Array [
+  Array [
+    Object {
+      "cloneSubmodules": undefined,
+      "defaultBranch": "master",
+      "ignorePrAuthor": undefined,
+      "mergeMethod": "merge",
+      "repository": "some%2Frepo%2Fproject",
+      "url": "ssh://git@gitlab.com/some%2Frepo%2Fproject.git",
+    },
+  ],
 ]
 `;
 

--- a/lib/platform/gitlab/index.ts
+++ b/lib/platform/gitlab/index.ts
@@ -286,8 +286,6 @@ export async function initRepo({
     await git.initRepo({
       ...config,
       url,
-      gitAuthorName: global.gitAuthor?.name,
-      gitAuthorEmail: global.gitAuthor?.email,
     });
   } catch (err) /* istanbul ignore next */ {
     logger.debug({ err }, 'Caught initRepo error');

--- a/lib/platform/index.ts
+++ b/lib/platform/index.ts
@@ -3,7 +3,7 @@ import type { AllConfig } from '../config/types';
 import { PLATFORM_NOT_FOUND } from '../constants/error-messages';
 import { logger } from '../logger';
 import type { HostRule } from '../types';
-import { setNoVerify, setPrivateKey } from '../util/git';
+import { setGitAuthor, setNoVerify, setPrivateKey } from '../util/git';
 import * as hostRules from '../util/host-rules';
 import platforms from './api';
 import type { Platform } from './types';
@@ -53,6 +53,7 @@ export async function initPlatform(config: AllConfig): Promise<AllConfig> {
     logger.debug(`Using platform gitAuthor: ${String(platformInfo.gitAuthor)}`);
     returnConfig.gitAuthor = platformInfo.gitAuthor;
   }
+  setGitAuthor(returnConfig.gitAuthor);
   const platformRule: HostRule = {
     hostType: returnConfig.platform,
     matchHost: URL.parse(returnConfig.endpoint).hostname,

--- a/lib/platform/index.ts
+++ b/lib/platform/index.ts
@@ -4,7 +4,6 @@ import { PLATFORM_NOT_FOUND } from '../constants/error-messages';
 import { logger } from '../logger';
 import type { HostRule } from '../types';
 import { setNoVerify, setPrivateKey } from '../util/git';
-import { parseGitAuthor } from '../util/git/author';
 import * as hostRules from '../util/host-rules';
 import platforms from './api';
 import type { Platform } from './types';
@@ -46,30 +45,14 @@ export async function initPlatform(config: AllConfig): Promise<AllConfig> {
   // TODO: types
   const platformInfo = await platform.initPlatform(config);
   const returnConfig: any = { ...config, ...platformInfo };
-  let gitAuthor: string;
   // istanbul ignore else
   if (config?.gitAuthor) {
     logger.debug(`Using configured gitAuthor (${config.gitAuthor})`);
-    gitAuthor = config.gitAuthor;
+    returnConfig.gitAuthor = config.gitAuthor;
   } else if (platformInfo?.gitAuthor) {
     logger.debug(`Using platform gitAuthor: ${String(platformInfo.gitAuthor)}`);
-    gitAuthor = platformInfo.gitAuthor;
-  } else {
-    logger.debug(
-      'Using default gitAuthor: Renovate Bot <renovate@whitesourcesoftware.com>'
-    );
-    gitAuthor = 'Renovate Bot <renovate@whitesourcesoftware.com>';
+    returnConfig.gitAuthor = platformInfo.gitAuthor;
   }
-  const gitAuthorParsed = parseGitAuthor(gitAuthor);
-  // istanbul ignore if
-  if (!gitAuthorParsed) {
-    throw new Error('Init: gitAuthor is not parsed as valid RFC5322 format');
-  }
-  global.gitAuthor = {
-    name: gitAuthorParsed.name,
-    email: gitAuthorParsed.address,
-  };
-
   const platformRule: HostRule = {
     hostType: returnConfig.platform,
     matchHost: URL.parse(returnConfig.endpoint).hostname,

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -3,6 +3,7 @@ import Git from 'simple-git';
 import SimpleGit from 'simple-git/src/git';
 import tmp from 'tmp-promise';
 import { setGlobalConfig } from '../../config/global';
+import { CONFIG_VALIDATION } from '../../constants/error-messages';
 import * as git from '.';
 import { GitNoVerifyOption, setNoVerify } from '.';
 
@@ -73,10 +74,9 @@ describe('util/git/index', () => {
     setGlobalConfig({ localDir: tmpDir.path });
     await git.initRepo({
       url: origin.path,
-      gitAuthorName: 'Jest',
-      gitAuthorEmail: 'Jest@example.com',
     });
     await git.setUserRepoConfig({ branchPrefix: 'renovate/' });
+    git.setGitAuthor('Jest <Jest@example.com>');
     setNoVerify([]);
     await git.syncGit();
     // override some local git settings for better testing
@@ -546,6 +546,11 @@ describe('util/git/index', () => {
       const repo = Git(tmpDir.path);
       const res = (await repo.raw(['config', 'extra.clone.config'])).trim();
       expect(res).toBe('test-extra-config-value');
+    });
+  });
+  describe('setGitAuthor()', () => {
+    it('throws for invalid', () => {
+      expect(() => git.setGitAuthor('invalid')).toThrow(CONFIG_VALIDATION);
     });
   });
 });

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -24,6 +24,7 @@ import { logger } from '../../logger';
 import { ExternalHostError } from '../../types/errors/external-host-error';
 import { GitOptions, GitProtocol } from '../../types/git';
 import { Limit, incLimitedValue } from '../../workers/global/limits';
+import { parseGitAuthor } from './author';
 import { GitNoVerifyOption, getNoVerify } from './config';
 import { configSigningKey, writePrivateKey } from './private-key';
 
@@ -44,8 +45,6 @@ interface StorageConfig {
   currentBranch?: string;
   url: string;
   extraCloneOpts?: GitOptions;
-  gitAuthorName?: string;
-  gitAuthorEmail?: string;
   cloneSubmodules?: boolean;
 }
 
@@ -57,6 +56,8 @@ interface LocalConfig extends StorageConfig {
   branchIsModified: Record<string, boolean>;
   branchPrefix: string;
   ignoredAuthors: string[];
+  gitAuthorName?: string;
+  gitAuthorEmail?: string;
 }
 
 // istanbul ignore next
@@ -232,6 +233,21 @@ async function setBranchPrefix(branchPrefix: string): Promise<void> {
       throw err;
     }
   }
+}
+
+export function setGitAuthor(gitAuthor: string): void {
+  const gitAuthorParsed = parseGitAuthor(
+    gitAuthor || 'Renovate Bot <renovate@whitesourcesoftware.com>'
+  );
+  if (!gitAuthorParsed) {
+    const error = new Error(CONFIG_VALIDATION);
+    error.validationSource = 'None';
+    error.validationError = 'Invalid gitAuthor';
+    error.validationMessage = `gitAuthor is not parsed as valid RFC5322 format: ${gitAuthor}`;
+    throw error;
+  }
+  config.gitAuthorName = gitAuthorParsed.name;
+  config.gitAuthorEmail = gitAuthorParsed.address;
 }
 
 export async function writeGitAuthor(): Promise<void> {

--- a/lib/workers/repository/init/apis.ts
+++ b/lib/workers/repository/init/apis.ts
@@ -6,7 +6,6 @@ import {
 } from '../../../constants/error-messages';
 import * as npmApi from '../../../datasource/npm';
 import { RepoParams, RepoResult, platform } from '../../../platform';
-import { setGitAuthor } from '../../../util/git';
 
 // TODO: fix types
 export type WorkerPlatformConfig = RepoResult &
@@ -63,7 +62,6 @@ export async function initApis(
 ): Promise<WorkerPlatformConfig> {
   let config: WorkerPlatformConfig = { ...input } as never;
   config = await getPlatformConfig(config as never);
-  setGitAuthor(config.gitAuthor);
   await validateOptimizeForDisabled(config);
   await validateIncludeForks(config);
   npmApi.resetMemCache();

--- a/lib/workers/repository/init/apis.ts
+++ b/lib/workers/repository/init/apis.ts
@@ -6,6 +6,7 @@ import {
 } from '../../../constants/error-messages';
 import * as npmApi from '../../../datasource/npm';
 import { RepoParams, RepoResult, platform } from '../../../platform';
+import { setGitAuthor } from '../../../util/git';
 
 // TODO: fix types
 export type WorkerPlatformConfig = RepoResult &
@@ -62,6 +63,7 @@ export async function initApis(
 ): Promise<WorkerPlatformConfig> {
   let config: WorkerPlatformConfig = { ...input } as never;
   config = await getPlatformConfig(config as never);
+  setGitAuthor(config.gitAuthor);
   await validateOptimizeForDisabled(config);
   await validateIncludeForks(config);
   npmApi.resetMemCache();


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Refactors `gitAuthor` to remove it from `global`.

## Context:

Closes #6540

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
