### PR TITLE
fix(git): drop force push onboarding

### DIFF
--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -9,7 +9,6 @@ import Git, {
   TaskOptions,
 } from 'simple-git';
 import { join } from 'upath';
-import { configFileNames } from '../../config/app-strings';
 import { getGlobalConfig } from '../../config/global';
 import type { RenovateConfig } from '../../config/types';
 import {

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -769,10 +769,6 @@ export async function commitFiles({
         await fs.outputFile(join(localDir, file.name), contents);
       }
     }
-    // istanbul ignore if
-    if (fileNames.length === 1 && configFileNames.includes(fileNames[0])) {
-      fileNames.unshift('-f');
-    }
     if (fileNames.length) {
       await gitAdd(fileNames);
     }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Removes an undocumented and hopefully unused `-f` param from onboarding.

## Context:

This was added long ago, probably to mask a different problem. I have tested with a regular scenario of updating to an onboarding PR and it works OK. I'll test this in the app and see if it introduces any problems.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
