### PR TITLE
fix(npm): inherit `yarnZeroInstall` and `skipInstalls` to subpackages in monorepo

### DIFF
--- a/lib/manager/npm/extract/__snapshots__/monorepo.spec.ts.snap
+++ b/lib/manager/npm/extract/__snapshots__/monorepo.spec.ts.snap
@@ -43,20 +43,24 @@ Array [
     "lernaClient": undefined,
     "managerData": Object {
       "lernaJsonFile": "lerna.json",
+      "yarnZeroInstall": undefined,
     },
     "npmLock": undefined,
     "packageFile": "packages/a/package.json",
     "packageJsonName": "@org/a",
+    "skipInstalls": undefined,
     "yarnLock": undefined,
   },
   Object {
     "lernaClient": undefined,
     "managerData": Object {
       "lernaJsonFile": "lerna.json",
+      "yarnZeroInstall": undefined,
     },
     "npmLock": undefined,
     "packageFile": "packages/b/package.json",
     "packageJsonName": "@org/b",
+    "skipInstalls": undefined,
     "yarnLock": undefined,
   },
 ]
@@ -108,20 +112,24 @@ Array [
     "lernaClient": undefined,
     "managerData": Object {
       "lernaJsonFile": "lerna.json",
+      "yarnZeroInstall": undefined,
     },
     "npmLock": undefined,
     "packageFile": "packages/a/package.json",
     "packageJsonName": "@org/a",
+    "skipInstalls": undefined,
     "yarnLock": undefined,
   },
   Object {
     "lernaClient": undefined,
     "managerData": Object {
       "lernaJsonFile": "lerna.json",
+      "yarnZeroInstall": undefined,
     },
     "npmLock": undefined,
     "packageFile": "packages/b/package.json",
     "packageJsonName": "@org/b",
+    "skipInstalls": undefined,
     "yarnLock": undefined,
   },
 ]
@@ -146,20 +154,24 @@ Array [
     "lernaClient": "yarn",
     "managerData": Object {
       "lernaJsonFile": "lerna.json",
+      "yarnZeroInstall": undefined,
     },
     "npmLock": undefined,
     "packageFile": "packages/a/package.json",
     "packageJsonName": "@org/a",
+    "skipInstalls": undefined,
     "yarnLock": undefined,
   },
   Object {
     "lernaClient": "yarn",
     "managerData": Object {
       "lernaJsonFile": "lerna.json",
+      "yarnZeroInstall": undefined,
     },
     "npmLock": undefined,
     "packageFile": "packages/b/package.json",
     "packageJsonName": "@org/b",
+    "skipInstalls": undefined,
     "yarnLock": undefined,
   },
 ]
@@ -178,22 +190,68 @@ Array [
     "lernaClient": undefined,
     "managerData": Object {
       "lernaJsonFile": undefined,
+      "yarnZeroInstall": undefined,
     },
     "npmLock": undefined,
     "npmrc": "@org:registry=//registry.some.org
 ",
     "packageFile": "packages/a/package.json",
     "packageJsonName": "@org/a",
+    "skipInstalls": undefined,
     "yarnLock": "yarn.lock",
   },
   Object {
     "lernaClient": undefined,
     "managerData": Object {
       "lernaJsonFile": undefined,
+      "yarnZeroInstall": undefined,
     },
     "npmLock": undefined,
     "packageFile": "packages/b/package.json",
     "packageJsonName": "@org/b",
+    "skipInstalls": undefined,
+    "yarnLock": undefined,
+  },
+]
+`;
+
+exports[`manager/npm/extract/monorepo .extractPackageFile() uses yarnZeroInstall and skipInstalls from yarn workspaces package settings 1`] = `
+Array [
+  Object {
+    "managerData": Object {
+      "yarnZeroInstall": true,
+    },
+    "npmrc": "@org:registry=//registry.some.org
+",
+    "packageFile": "package.json",
+    "skipInstalls": false,
+    "yarnWorkspacesPackages": "packages/*",
+  },
+  Object {
+    "hasYarnWorkspaces": true,
+    "lernaClient": undefined,
+    "managerData": Object {
+      "lernaJsonFile": undefined,
+      "yarnZeroInstall": true,
+    },
+    "npmLock": undefined,
+    "npmrc": "@org:registry=//registry.some.org
+",
+    "packageFile": "packages/a/package.json",
+    "packageJsonName": "@org/a",
+    "skipInstalls": false,
+    "yarnLock": "yarn.lock",
+  },
+  Object {
+    "lernaClient": undefined,
+    "managerData": Object {
+      "lernaJsonFile": undefined,
+      "yarnZeroInstall": true,
+    },
+    "npmLock": undefined,
+    "packageFile": "packages/b/package.json",
+    "packageJsonName": "@org/b",
+    "skipInstalls": false,
     "yarnLock": undefined,
   },
 ]

--- a/lib/manager/npm/extract/monorepo.spec.ts
+++ b/lib/manager/npm/extract/monorepo.spec.ts
@@ -57,6 +57,7 @@ describe('manager/npm/extract/monorepo', () => {
         )
       ).toBe(true);
     });
+
     it('updates internal packages', async () => {
       const packageFiles = [
         {
@@ -110,6 +111,7 @@ describe('manager/npm/extract/monorepo', () => {
         )
       ).toBe(false);
     });
+
     it('uses yarn workspaces package settings with lerna', async () => {
       const packageFiles = [
         {
@@ -134,6 +136,7 @@ describe('manager/npm/extract/monorepo', () => {
       expect(packageFiles).toMatchSnapshot();
       expect(packageFiles[1].managerData.lernaJsonFile).toEqual('lerna.json');
     });
+
     it('uses yarn workspaces package settings without lerna', async () => {
       const packageFiles = [
         {
@@ -149,6 +152,33 @@ describe('manager/npm/extract/monorepo', () => {
         {
           packageFile: 'packages/b/package.json',
           packageJsonName: '@org/b',
+        },
+      ];
+      await detectMonorepos(packageFiles, false);
+      // FIXME: explicit assert condition
+      expect(packageFiles).toMatchSnapshot();
+    });
+
+    it('uses yarnZeroInstall and skipInstalls from yarn workspaces package settings', async () => {
+      const packageFiles = [
+        {
+          packageFile: 'package.json',
+          managerData: {
+            yarnZeroInstall: true,
+          },
+          skipInstalls: false,
+          npmrc: '@org:registry=//registry.some.org\n',
+          yarnWorkspacesPackages: 'packages/*',
+        },
+        {
+          packageFile: 'packages/a/package.json',
+          packageJsonName: '@org/a',
+          yarnLock: 'yarn.lock',
+        },
+        {
+          packageFile: 'packages/b/package.json',
+          packageJsonName: '@org/b',
+          skipInstalls: true,
         },
       ];
       await detectMonorepos(packageFiles, false);

--- a/lib/manager/npm/extract/monorepo.ts
+++ b/lib/manager/npm/extract/monorepo.ts
@@ -22,8 +22,9 @@ export async function detectMonorepos(
       lernaClient,
       lernaPackages,
       yarnWorkspacesPackages,
+      skipInstalls,
     } = p;
-    const { lernaJsonFile } = managerData;
+    const { lernaJsonFile, yarnZeroInstall } = managerData;
     const packages = yarnWorkspacesPackages || lernaPackages;
     if (packages?.length) {
       const internalPackagePatterns = (
@@ -48,9 +49,11 @@ export async function detectMonorepos(
       for (const subPackage of internalPackageFiles) {
         subPackage.managerData = subPackage.managerData || {};
         subPackage.managerData.lernaJsonFile = lernaJsonFile;
+        subPackage.managerData.yarnZeroInstall = yarnZeroInstall;
         subPackage.lernaClient = lernaClient;
         subPackage.yarnLock = subPackage.yarnLock || yarnLock;
         subPackage.npmLock = subPackage.npmLock || npmLock;
+        subPackage.skipInstalls = skipInstalls && subPackage.skipInstalls; // skip if both are true
         if (subPackage.yarnLock) {
           subPackage.hasYarnWorkspaces = !!yarnWorkspacesPackages;
           subPackage.npmrc = subPackage.npmrc || npmrc;


### PR DESCRIPTION
## Changes:

Inherit `managerData.yarnZeroInstall` and `skipInstalls` to subpackages in monorepo (workspaces).

<!-- Describe what behavior is changed by this PR. -->

## Context:

Yarn zero-install is detected in the workspace root (#11012 and #11448). Therefore, `managerData.yarnZeroInstall` and `skipInstalls` need to be passed to subpackages. `managerData.yarnZeroInstall` is overwritten and `skipInstalls` is merged with AND.

Fixes #11581.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository (https://github.com/ylemkimon/pob/pulls, forked from #11581)
