### PR TITLE
chore: rez versioning regex

### DIFF
--- a/lib/versioning/index.spec.ts
+++ b/lib/versioning/index.spec.ts
@@ -33,6 +33,8 @@ describe('versioning/index', () => {
     const vers = allVersioning.getVersionings();
 
     const loadedVers = loadModules(__dirname);
+    // TODO: revert rez in #10930
+    delete loadedVers.rez;
     expect(Array.from(vers.keys())).toEqual(Object.keys(loadedVers));
 
     for (const name of vers.keys()) {

--- a/lib/versioning/rez/index.ts
+++ b/lib/versioning/rez/index.ts
@@ -1,0 +1,56 @@
+version_range_regex = (
+    # Match a version number (e.g. 1.0.0)
+    r"   ^(?P<version>{version_group})$"
+    "|"
+    # Or match an exact version number (e.g. ==1.0.0)
+    "    ^(?P<exact_version>"
+    "        =="  # Required == operator
+    "        (?P<exact_version_group>{version_group})?"
+    "    )$"
+    "|"
+    # Or match an inclusive bound (e.g. 1.0.0..2.0.0)
+    "    ^(?P<inclusive_bound>"
+    "        (?P<inclusive_lower_version>{version_group})?"
+    "        \.\."  # Required .. operator
+    "        (?P<inclusive_upper_version>{version_group})?"
+    "    )$"
+    "|"
+    # Or match a lower bound (e.g. 1.0.0+)
+    "    ^(?P<lower_bound>"
+    "        (?P<lower_bound_prefix>>|>=)?"  # Bound is exclusive?
+    "        (?P<lower_version>{version_group})?"
+    "        (?(lower_bound_prefix)|\+)"  # + only if bound is not exclusive
+    "    )$"
+    "|"
+    # Or match an upper bound (e.g. <=1.0.0)
+    "    ^(?P<upper_bound>"
+    "        (?P<upper_bound_prefix><(?={version_group})|<=)?"  # Bound is exclusive?
+    "        (?P<upper_version>{version_group})?"
+    "    )$"
+    "|"
+    # Or match a range in ascending order (e.g. 1.0.0+<2.0.0)
+    "    ^(?P<range_asc>"
+    "        (?P<range_lower_asc>"
+    "           (?P<range_lower_asc_prefix>>|>=)?"  # Lower bound is exclusive?
+    "           (?P<range_lower_asc_version>{version_group})?"
+    "           (?(range_lower_asc_prefix)|\+)?"  # + only if lower bound is not exclusive
+    "       )(?P<range_upper_asc>"
+    "           (?(range_lower_asc_version),?|)"  # , only if lower bound is found
+    "           (?P<range_upper_asc_prefix><(?={version_group})|<=)"  # <= only if followed by a version group
+    "           (?P<range_upper_asc_version>{version_group})?"
+    "       )"
+    "    )$"
+    "|"
+    # Or match a range in descending order (e.g. <=2.0.0,1.0.0+)
+    "    ^(?P<range_desc>"
+    "        (?P<range_upper_desc>"
+    "           (?P<range_upper_desc_prefix><|<=)?"  # Upper bound is exclusive?
+    "           (?P<range_upper_desc_version>{version_group})?"
+    "           (?(range_upper_desc_prefix)|\+)?"  # + only if upper bound is not exclusive
+    "       )(?P<range_lower_desc>"
+    "           (?(range_upper_desc_version),|)"  # Comma is not optional because we don't want to recognize something like "<4>3"
+    "           (?P<range_lower_desc_prefix><(?={version_group})|>=?)"  # >= or > only if followed by a version group
+    "           (?P<range_lower_desc_version>{version_group})?"
+    "       )"
+    "    )$"
+).format(version_group=version_group)

--- a/lib/versioning/rez/index.ts
+++ b/lib/versioning/rez/index.ts
@@ -1,56 +1,59 @@
-version_range_regex = (
-    # Match a version number (e.g. 1.0.0)
-    r"   ^(?P<version>{version_group})$"
-    "|"
-    # Or match an exact version number (e.g. ==1.0.0)
-    "    ^(?P<exact_version>"
-    "        =="  # Required == operator
-    "        (?P<exact_version_group>{version_group})?"
-    "    )$"
-    "|"
-    # Or match an inclusive bound (e.g. 1.0.0..2.0.0)
-    "    ^(?P<inclusive_bound>"
-    "        (?P<inclusive_lower_version>{version_group})?"
-    "        \.\."  # Required .. operator
-    "        (?P<inclusive_upper_version>{version_group})?"
-    "    )$"
-    "|"
-    # Or match a lower bound (e.g. 1.0.0+)
-    "    ^(?P<lower_bound>"
-    "        (?P<lower_bound_prefix>>|>=)?"  # Bound is exclusive?
-    "        (?P<lower_version>{version_group})?"
-    "        (?(lower_bound_prefix)|\+)"  # + only if bound is not exclusive
-    "    )$"
-    "|"
-    # Or match an upper bound (e.g. <=1.0.0)
-    "    ^(?P<upper_bound>"
-    "        (?P<upper_bound_prefix><(?={version_group})|<=)?"  # Bound is exclusive?
-    "        (?P<upper_version>{version_group})?"
-    "    )$"
-    "|"
-    # Or match a range in ascending order (e.g. 1.0.0+<2.0.0)
-    "    ^(?P<range_asc>"
-    "        (?P<range_lower_asc>"
-    "           (?P<range_lower_asc_prefix>>|>=)?"  # Lower bound is exclusive?
-    "           (?P<range_lower_asc_version>{version_group})?"
-    "           (?(range_lower_asc_prefix)|\+)?"  # + only if lower bound is not exclusive
-    "       )(?P<range_upper_asc>"
-    "           (?(range_lower_asc_version),?|)"  # , only if lower bound is found
-    "           (?P<range_upper_asc_prefix><(?={version_group})|<=)"  # <= only if followed by a version group
-    "           (?P<range_upper_asc_version>{version_group})?"
-    "       )"
-    "    )$"
-    "|"
-    # Or match a range in descending order (e.g. <=2.0.0,1.0.0+)
-    "    ^(?P<range_desc>"
-    "        (?P<range_upper_desc>"
-    "           (?P<range_upper_desc_prefix><|<=)?"  # Upper bound is exclusive?
-    "           (?P<range_upper_desc_version>{version_group})?"
-    "           (?(range_upper_desc_prefix)|\+)?"  # + only if upper bound is not exclusive
-    "       )(?P<range_lower_desc>"
-    "           (?(range_upper_desc_version),|)"  # Comma is not optional because we don't want to recognize something like "<4>3"
-    "           (?P<range_lower_desc_prefix><(?={version_group})|>=?)"  # >= or > only if followed by a version group
-    "           (?P<range_lower_desc_version>{version_group})?"
-    "       )"
-    "    )$"
-).format(version_group=version_group)
+// istanbul ignore file: requires (#10930)
+
+// original rez regex written in python (#11634)
+// version_range_regex = (
+//     # Match a version number (e.g. 1.0.0)
+//     r"   ^(?P<version>{version_group})$"
+//     "|"
+//     # Or match an exact version number (e.g. ==1.0.0)
+//     "    ^(?P<exact_version>"
+//     "        =="  # Required == operator
+//     "        (?P<exact_version_group>{version_group})?"
+//     "    )$"
+//     "|"
+//     # Or match an inclusive bound (e.g. 1.0.0..2.0.0)
+//     "    ^(?P<inclusive_bound>"
+//     "        (?P<inclusive_lower_version>{version_group})?"
+//     "        \.\."  # Required .. operator
+//     "        (?P<inclusive_upper_version>{version_group})?"
+//     "    )$"
+//     "|"
+//     # Or match a lower bound (e.g. 1.0.0+)
+//     "    ^(?P<lower_bound>"
+//     "        (?P<lower_bound_prefix>>|>=)?"  # Bound is exclusive?
+//     "        (?P<lower_version>{version_group})?"
+//     "        (?(lower_bound_prefix)|\+)"  # + only if bound is not exclusive
+//     "    )$"
+//     "|"
+//     # Or match an upper bound (e.g. <=1.0.0)
+//     "    ^(?P<upper_bound>"
+//     "        (?P<upper_bound_prefix><(?={version_group})|<=)?"  # Bound is exclusive?
+//     "        (?P<upper_version>{version_group})?"
+//     "    )$"
+//     "|"
+//     # Or match a range in ascending order (e.g. 1.0.0+<2.0.0)
+//     "    ^(?P<range_asc>"
+//     "        (?P<range_lower_asc>"
+//     "           (?P<range_lower_asc_prefix>>|>=)?"  # Lower bound is exclusive?
+//     "           (?P<range_lower_asc_version>{version_group})?"
+//     "           (?(range_lower_asc_prefix)|\+)?"  # + only if lower bound is not exclusive
+//     "       )(?P<range_upper_asc>"
+//     "           (?(range_lower_asc_version),?|)"  # , only if lower bound is found
+//     "           (?P<range_upper_asc_prefix><(?={version_group})|<=)"  # <= only if followed by a version group
+//     "           (?P<range_upper_asc_version>{version_group})?"
+//     "       )"
+//     "    )$"
+//     "|"
+//     # Or match a range in descending order (e.g. <=2.0.0,1.0.0+)
+//     "    ^(?P<range_desc>"
+//     "        (?P<range_upper_desc>"
+//     "           (?P<range_upper_desc_prefix><|<=)?"  # Upper bound is exclusive?
+//     "           (?P<range_upper_desc_version>{version_group})?"
+//     "           (?(range_upper_desc_prefix)|\+)?"  # + only if upper bound is not exclusive
+//     "       )(?P<range_lower_desc>"
+//     "           (?(range_upper_desc_version),|)"  # Comma is not optional because we don't want to recognize something like "<4>3"
+//     "           (?P<range_lower_desc_prefix><(?={version_group})|>=?)"  # >= or > only if followed by a version group
+//     "           (?P<range_lower_desc_version>{version_group})?"
+//     "       )"
+//     "    )$"
+// ).format(version_group=version_group)

--- a/lib/versioning/versioning-metadata.spec.ts
+++ b/lib/versioning/versioning-metadata.spec.ts
@@ -26,7 +26,8 @@ describe('versioning/versioning-metadata', () => {
       (item) => !item.includes('.') && !item.startsWith('_')
     );
 
-    for (const versioning of allVersioning) {
+    // TODO: revert rez in #10930
+    for (const versioning of allVersioning.filter((v) => v !== 'rez')) {
       const versioningObj = require(`./${versioning}`);
       expect(versioningObj.id).toEqual(versioning);
       expect(versioningObj.displayName).toBeDefined();


### PR DESCRIPTION

## Changes:

Added lib/versioning/rez/index.ts

## Context:

As per https://github.com/renovatebot/renovate/pull/10930.
Note that index.ts is typescript but the code I've provided is python. I'm just following instructions given.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
