### PR TITLE
feat(datasource/adoptium): support jre only releases

### DIFF
--- a/lib/datasource/adoptium-java/__fixtures__/jre.json
+++ b/lib/datasource/adoptium-java/__fixtures__/jre.json
@@ -1,0 +1,20 @@
+{
+  "versions": [
+    {
+      "build": 7,
+      "major": 11,
+      "minor": 0,
+      "openjdk_version": "11.0.12+7",
+      "security": 12,
+      "semver": "11.0.12+7"
+    },
+    {
+      "build": 8,
+      "major": 8,
+      "minor": 0,
+      "openjdk_version": "1.8.0_302-b08",
+      "security": 302,
+      "semver": "8.0.302+8"
+    }
+  ]
+}

--- a/lib/datasource/adoptium-java/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/adoptium-java/__snapshots__/index.spec.ts.snap
@@ -159,6 +159,21 @@ Object {
 }
 `;
 
+exports[`datasource/adoptium-java/index getReleases processes real data (jre) 1`] = `
+Object {
+  "homepage": "https://adoptium.net",
+  "registryUrl": "https://api.adoptium.net/",
+  "releases": Array [
+    Object {
+      "version": "8.0.302+8",
+    },
+    Object {
+      "version": "11.0.12+7",
+    },
+  ],
+}
+`;
+
 exports[`datasource/adoptium-java/index getReleases processes real data 1`] = `
 Object {
   "homepage": "https://adoptium.net",

--- a/lib/datasource/adoptium-java/common.ts
+++ b/lib/datasource/adoptium-java/common.ts
@@ -4,3 +4,12 @@ export const pageSize = 50;
 export const defaultRegistryUrl = 'https://api.adoptium.net/';
 
 export const datasource = 'adoptium-java';
+
+export function getImageType(lookupName: string): string {
+  switch (lookupName) {
+    case 'java-jre':
+      return 'jre';
+    default:
+      return 'jdk';
+  }
+}

--- a/lib/datasource/adoptium-java/index.ts
+++ b/lib/datasource/adoptium-java/index.ts
@@ -1,9 +1,15 @@
+import { logger } from '../../logger';
 import { ExternalHostError } from '../../types/errors/external-host-error';
 import { cache } from '../../util/cache/package/decorator';
 import { HttpError } from '../../util/http/types';
 import { Datasource } from '../datasource';
 import type { GetReleasesConfig, ReleaseResult } from '../types';
-import { datasource, defaultRegistryUrl, pageSize } from './common';
+import {
+  datasource,
+  defaultRegistryUrl,
+  getImageType,
+  pageSize,
+} from './common';
 import type { AdoptiumJavaResponse } from './types';
 
 export class AdoptiumJavaDatasource extends Datasource {
@@ -25,9 +31,15 @@ export class AdoptiumJavaDatasource extends Datasource {
   })
   async getReleases({
     registryUrl,
+    lookupName,
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
     let page = 0;
-    const url = `${registryUrl}v3/info/release_versions?page_size=${pageSize}&project=jdk&release_type=ga&sort_method=DATE&sort_order=DESC&vendor=adoptium`;
+    const imageType = getImageType(lookupName);
+    logger.trace(
+      { registryUrl, lookupName, imageType },
+      'fetching java release'
+    );
+    const url = `${registryUrl}v3/info/release_versions?page_size=${pageSize}&image_type=${imageType}&project=jdk&release_type=ga&sort_method=DATE&sort_order=DESC&vendor=adoptium`;
 
     const result: ReleaseResult = {
       homepage: 'https://adoptium.net',

--- a/lib/datasource/adoptium-java/readme.md
+++ b/lib/datasource/adoptium-java/readme.md
@@ -4,5 +4,7 @@ It uses `image_type=<jre|jdk>&project=jdk&release_type=ga&sort_method=DATE&sort_
 
 It only uses the first 50 pages with 50 items per page.
 
-Use `java-jdk` or `java` as `lookupName` to get releases with JDK available or use `java-jre` to only get releases with JRE available.
-Currently only the LTS releases have a JRE available.
+Use `java-jdk` or `java` as `lookupName` to get releases which come with the Java Development Kit.
+
+Use `java-jre`  as `lookupName` if you only want releases which come with the Java Runtime Environment.
+Currently only the LTS releases of Java come with the JRE.

--- a/lib/datasource/adoptium-java/readme.md
+++ b/lib/datasource/adoptium-java/readme.md
@@ -1,5 +1,8 @@
 This datasource returns releases from [Adoptium](https://adoptium.net/) API.
 
-It uses `project=jdk&release_type=ga&sort_method=DATE&sort_order=DESC&vendor=adoptium` as filter parameters.
+It uses `image_type=<jre|jdk>&project=jdk&release_type=ga&sort_method=DATE&sort_order=DESC&vendor=adoptium` as filter parameters.
 
 It only uses the first 50 pages with 50 items per page.
+
+Use `java-jdk` or `java` as `lookupName` to get releases with JDK available or use `java-jre` to only get releases with JRE available.
+Currently only the LTS releases have a JRE available.

--- a/lib/datasource/adoptium-java/readme.md
+++ b/lib/datasource/adoptium-java/readme.md
@@ -6,5 +6,5 @@ It only uses the first 50 pages with 50 items per page.
 
 Use `java-jdk` or `java` as `lookupName` to get releases which come with the Java Development Kit.
 
-Use `java-jre`  as `lookupName` if you only want releases which come with the Java Runtime Environment.
+Use `java-jre` as `lookupName` if you only want releases which come with the Java Runtime Environment.
 Currently only the LTS releases of Java come with the JRE.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

You can now pass `java-jre` as `lookupName` to only get releases with JRE available. Currently only LTS releases have a JRE available.
<!-- Describe what behavior is changed by this PR. -->

## Context:

We need this for our docker images. The JRE is typically only ~60MB where a JDK is about ~300MB.
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
