### PR TITLE
fix(platform): put typed platform rule first

### DIFF
--- a/lib/platform/index.spec.ts
+++ b/lib/platform/index.spec.ts
@@ -61,12 +61,12 @@ describe('platform/index', () => {
       gitAuthor: 'user@domain.com',
       hostRules: [
         {
+          hostType: 'bitbucket',
           matchHost: 'api.bitbucket.org',
           password: '123',
           username: 'abc',
         },
         {
-          hostType: 'bitbucket',
           matchHost: 'api.bitbucket.org',
           password: '123',
           username: 'abc',

--- a/lib/platform/index.ts
+++ b/lib/platform/index.ts
@@ -65,13 +65,13 @@ export async function initPlatform(config: AllConfig): Promise<AllConfig> {
     }
   });
   returnConfig.hostRules = returnConfig.hostRules || [];
-  returnConfig.hostRules.push(platformRule);
-  hostRules.add(platformRule);
   const typedPlatformRule = {
     ...platformRule,
     hostType: returnConfig.platform,
   };
   returnConfig.hostRules.push(typedPlatformRule);
   hostRules.add(typedPlatformRule);
+  returnConfig.hostRules.push(platformRule);
+  hostRules.add(platformRule);
   return returnConfig;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Reorders platform hostRules

## Context:

Closes #11710

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
