### PR TITLE
fix(onboarding): use semantic commit for onboarding PR

### DIFF
--- a/docs/development/local-development.md
+++ b/docs/development/local-development.md
@@ -113,7 +113,7 @@ You are better off to instead export the Environment Variable `RENOVATE_TOKEN` f
 To make sure everything is working, create a test repo in your account, e.g. like `https://github.com/r4harry/testrepo1`.
 Now, add a file called `.nvmrc` with the content `8.13.0`.
 Now run against the test repo you created, e.g. `yarn start r4harry/testrepo1`.
-If your token is set up correctly, you should find that Renovate created a "Configure Renovate" PR in the `testrepo1`.
+If your token is set up correctly, you should find that Renovate created a "chore: Configure Renovate" PR in the `testrepo1`.
 
 If this is working then in future you can create other test repos to verify your code changes against.
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -239,7 +239,7 @@ However, Renovate also allows users to explicitly configure `baseBranches`, e.g.
 - You wish Renovate to process only a non-default branch, e.g. `dev`: `"baseBranches": ["dev"]`
 - You have multiple release streams you need Renovate to keep up to date, e.g. in branches `main` and `next`: `"baseBranches": ["main", "next"]`
 
-It's possible to add this setting into the `renovate.json` file as part of the "Configure Renovate" onboarding PR.
+It's possible to add this setting into the `renovate.json` file as part of the "chore: Configure Renovate" onboarding PR.
 If so then Renovate will reflect this setting in its description and use package file contents from the custom base branch(es) instead of default.
 
 ## bbUseDefaultReviewers

--- a/docs/usage/getting-started/installing-onboarding.md
+++ b/docs/usage/getting-started/installing-onboarding.md
@@ -39,7 +39,7 @@ For more details on GitLab security for bots, please see the [GitLab Bot Securit
 
 ## Repository onboarding
 
-Once you have enabled Renovate on a repository, you will receive a "Configure Renovate" Pull Request looking something like this:
+Once you have enabled Renovate on a repository, you will receive a "chore: Configure Renovate" Pull Request looking something like this:
 
 ![Onboarding](../assets/images/onboarding.png)
 
@@ -57,7 +57,7 @@ Warnings and errors should be fixed on the base branch (e.g. `main`) so that Ren
 
 ### Configuration location
 
-The "Configure Renovate" PR will include a `renovate.json` file in the root directory, with suggested default settings.
+The "chore: Configure Renovate" PR will include a `renovate.json` file in the root directory, with suggested default settings.
 If you don't want a `renovate.json` file in your repository you can use one of the following files instead:
 
 - `renovate.json5`
@@ -125,9 +125,9 @@ Perhaps you really liked the interactive onboarding PR and want to use it again.
 You can follow the steps below to nuke the config and get a new PR.
 Any existing Renovate PRs will be closed after you've completed these steps.
 
-1. Find your original `Configure Renovate` PR
+1. Find your original `chore: Configure Renovate` PR
 1. Rename the original PR to something else, e.g. `Configure Renovate - old`
 1. Remove the current Renovate configuration file (e.g. `renovate.json`) from your mainline branch
 
-Following these steps will trick Renovate into thinking that your repository was _never_ onboarded, and will trigger a new "Configure Renovate" PR.
+Following these steps will trick Renovate into thinking that your repository was _never_ onboarded, and will trigger a new "chore: Configure Renovate" PR.
 If you're using the hosted WhiteSource Renovate App and you don't receive a new onboarding PR within a few hours, then please create a Discussions post to request staff trigger it manually.

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -78,7 +78,7 @@ const options: RenovateOptions[] = [
     description:
       'Change this value in order to override the default onboarding commit message.',
     type: 'string',
-    default: 'chore',
+    default: null,
     globalOnly: true,
     cli: false,
   },
@@ -96,7 +96,7 @@ const options: RenovateOptions[] = [
     description:
       'Change this value in order to override the default onboarding PR title.',
     type: 'string',
-    default: 'chore: Configure Renovate',
+    default: 'Configure Renovate',
     globalOnly: true,
     cli: false,
   },

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -96,7 +96,7 @@ const options: RenovateOptions[] = [
     description:
       'Change this value in order to override the default onboarding PR title.',
     type: 'string',
-    default: 'Configure Renovate',
+    default: 'chore: Configure Renovate',
     globalOnly: true,
     cli: false,
   },

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -78,7 +78,7 @@ const options: RenovateOptions[] = [
     description:
       'Change this value in order to override the default onboarding commit message.',
     type: 'string',
-    default: null,
+    default: 'chore',
     globalOnly: true,
     cli: false,
   },

--- a/lib/platform/bitbucket-server/index.md
+++ b/lib/platform/bitbucket-server/index.md
@@ -47,7 +47,7 @@ export LOG_LEVEL=debug
 yarn start --autodiscover=true
 ```
 
-You should then receive a "Configure Renovate" onboarding PR in any projects that `@renovate-bot` has been invited to.
+You should then receive a "chore: Configure Renovate" onboarding PR in any projects that `@renovate-bot` has been invited to.
 
 ## Supported versions
 

--- a/lib/workers/repository/onboarding/branch/commit-message.ts
+++ b/lib/workers/repository/onboarding/branch/commit-message.ts
@@ -36,6 +36,9 @@ export class OnboardingCommitMessageFactory {
   }
 
   private areSemanticCommitsEnabled(): boolean {
-    return this.config.semanticCommits === 'enabled';
+    return (
+      this.config.semanticCommits === 'enabled' ||
+      this.config.semanticCommits === 'auto'
+    );
   }
 }

--- a/lib/workers/repository/onboarding/branch/commit-message.ts
+++ b/lib/workers/repository/onboarding/branch/commit-message.ts
@@ -21,7 +21,7 @@ export class OnboardingCommitMessageFactory {
     const commitMessage = new CommitMessage();
 
     if (commitMessagePrefix) {
-      commitMessage.setCustomPrefix(commitMessagePrefix || 'chore:');
+      commitMessage.setCustomPrefix(commitMessagePrefix);
     } else if (this.areSemanticCommitsEnabled()) {
       commitMessage.setSemanticPrefix(semanticCommitType, semanticCommitScope);
     }

--- a/lib/workers/repository/onboarding/branch/commit-message.ts
+++ b/lib/workers/repository/onboarding/branch/commit-message.ts
@@ -21,7 +21,7 @@ export class OnboardingCommitMessageFactory {
     const commitMessage = new CommitMessage();
 
     if (commitMessagePrefix) {
-      commitMessage.setCustomPrefix(commitMessagePrefix);
+      commitMessage.setCustomPrefix(commitMessagePrefix || 'chore:');
     } else if (this.areSemanticCommitsEnabled()) {
       commitMessage.setSemanticPrefix(semanticCommitType, semanticCommitScope);
     }

--- a/lib/workers/repository/onboarding/branch/create.spec.ts
+++ b/lib/workers/repository/onboarding/branch/create.spec.ts
@@ -35,7 +35,7 @@ describe('workers/repository/onboarding/branch/create', () => {
     it('applies the default commit message', async () => {
       await createOnboardingBranch(config);
       expect(commitFiles).toHaveBeenCalledWith(
-        buildExpectedCommitFilesArgument('Add renovate.json')
+        buildExpectedCommitFilesArgument('chore: Add renovate.json')
       );
     });
     it('applies supplied commit message', async () => {

--- a/lib/workers/repository/onboarding/branch/create.spec.ts
+++ b/lib/workers/repository/onboarding/branch/create.spec.ts
@@ -35,13 +35,14 @@ describe('workers/repository/onboarding/branch/create', () => {
     it('applies the default commit message', async () => {
       await createOnboardingBranch(config);
       expect(commitFiles).toHaveBeenCalledWith(
-        buildExpectedCommitFilesArgument('chore: Add renovate.json')
+        buildExpectedCommitFilesArgument('chore(deps): add renovate.json')
       );
     });
     it('applies supplied commit message', async () => {
       const message =
         'We can Renovate if we want to, we can leave PRs in decline';
       config.onboardingCommitMessage = message;
+      config.semanticCommits = 'disabled';
       await createOnboardingBranch(config);
       expect(commitFiles).toHaveBeenCalledWith(
         buildExpectedCommitFilesArgument(`${message}`)
@@ -51,6 +52,7 @@ describe('workers/repository/onboarding/branch/create', () => {
       it('to the default commit message', async () => {
         const prefix = 'RENOV-123';
         config.commitMessagePrefix = prefix;
+        config.onboardingCommitMessage = null;
         await createOnboardingBranch(config);
         expect(commitFiles).toHaveBeenCalledWith(
           buildExpectedCommitFilesArgument(

--- a/lib/workers/repository/onboarding/pr/index.spec.ts
+++ b/lib/workers/repository/onboarding/pr/index.spec.ts
@@ -48,7 +48,7 @@ describe('workers/repository/onboarding/pr/index', () => {
     it('returns if PR does not need updating', async () => {
       platform.getBranchPr.mockResolvedValue(
         partial<Pr>({
-          title: 'Configure Renovate',
+          title: 'chore: Configure Renovate',
           body: createPrBody,
         })
       );
@@ -60,7 +60,7 @@ describe('workers/repository/onboarding/pr/index', () => {
       config.baseBranch = 'some-branch';
       platform.getBranchPr.mockResolvedValueOnce(
         partial<Pr>({
-          title: 'Configure Renovate',
+          title: 'chore: Configure Renovate',
           body: createPrBody,
           isConflicted: true,
         })
@@ -74,7 +74,7 @@ describe('workers/repository/onboarding/pr/index', () => {
       config.baseBranch = 'some-branch';
       platform.getBranchPr.mockResolvedValueOnce(
         partial<Pr>({
-          title: 'Configure Renovate',
+          title: 'chore: Configure Renovate',
           body: createPrBody,
         })
       );
@@ -93,7 +93,7 @@ describe('workers/repository/onboarding/pr/index', () => {
       config.baseBranch = 'some-branch';
       platform.getBranchPr.mockResolvedValueOnce(
         partial<Pr>({
-          title: 'Configure Renovate',
+          title: 'chore: Configure Renovate',
           body: createPrBody,
           isConflicted: true,
         })


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Use semantic commit for onboarding PR

## Context:

PR created when onboarding renovate is not following the semantic standard, this can break some automatic CI and force to modify the PR. Not a huge blocker but increase a bit the frustration; much better if everything is green when you see the PR imo.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
