### PR TITLE
feat(git): safely force push with lease

### DIFF
--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -757,7 +757,7 @@ export async function commitFiles({
     }
 
     const pushOptions: TaskOptions = {
-      '--force': null,
+      '--force-with-lease': null,
       '-u': null,
     };
     if (getNoVerify().includes(GitNoVerifyOption.Push)) {


### PR DESCRIPTION
## Changes:

Switches from `--force` to `--force-with-lease` for `git push` commands to push safer by avoiding to overwrite remote changes.

## Context:

Closes #11590

## Documentation

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

Details:
I tried to add a new test that would trigger the force-push error and verify the new behaviour but failed. It always force-pushed successfully in the tests, but manually (by switching in to the git repo dirs that were used for testing) it correctly failed, I unfortunately don't know why. But triggering the force-push error will be pretty rare anyways I guess.
Manually verified via
- Letting renovate rebase PRs in general (e.g. after I merged another PR to develop)
- Triggering the force-push error manually
  - Create changes on the develop branch
  - Start renovate to let it update the branches
  - Rebase a renovate branch on develop and force-push while renovate is still updating artifacts
  - See the force-push error in the debug logs and renovate skip this branch with a general `WARN: Error updating branch` and do nothing 
