### PR TITLE
ci: run tests on macOS 11 Big Sur

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-11, windows-latest]
         node-version: [14]
         python-version: [3.9]
         java-version: [11]


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Try tests on `macos-11`, as `macos-latest` will point to that version soon

## Context:

GitHub Actions virtual environments will change `macos-latest` to point to `macos-11` over a period of several weeks, beginning on September, 15. They plan to have completed the migration by November, 3.

We should try this change ahead of time, to see if it all works, instead of suddenly finding out that our tests are failing and then scrambling to find out why. 😄 

https://github.com/actions/virtual-environments/issues/4060

All we need to do to try this is to change any mentions of `macos-latest` to `macos-11` in our GitHub Action workflow files, verify things keep working, and then we can revert the trial PR changes, and wait for upstream to make `macos-11` the latest version.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
