### PR TITLE
fix(config): better decrypt errors

### DIFF
--- a/lib/config/decrypt.ts
+++ b/lib/config/decrypt.ts
@@ -101,27 +101,37 @@ export async function tryDecrypt(
               if (scopedRepository === repository) {
                 decryptedStr = value;
               } else {
-                logger.warn(
+                logger.debug(
                   { scopedRepository },
                   'Secret is scoped to a different repository'
                 );
+                const error = new Error('config-validation');
+                error.validationError = `Encrypted secret is scoped to a different repository: ${scopedRepository}.`;
+                throw error;
               }
             } else {
               const scopedOrg = `${orgName}/`;
               if (repository.startsWith(scopedOrg)) {
                 decryptedStr = value;
               } else {
-                logger.warn(
+                logger.debug(
                   { scopedOrg },
                   'Secret is scoped to a different org'
                 );
+                const error = new Error('config-validation');
+                error.validationError = `Encrypted secret is scoped to a different org" ${scopedOrg}.`;
+                throw error;
               }
             }
           } else {
-            logger.warn('Missing scope from decrypted object');
+            const error = new Error('config-validation');
+            error.validationError = `Encrypted value in config is missing a scope.`;
+            throw error;
           }
         } else {
-          logger.warn('Decrypted object is missing a value');
+          const error = new Error('config-validation');
+          error.validationError = `Encrypted value in config is missing a value.`;
+          throw error;
         }
       } catch (err) {
         logger.warn({ err }, 'Could not parse decrypted string');


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Throws custom config validation errors for each error condition instead of a generic one later.

## Context:

Better feedback in the validation issue.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
