### PR TITLE
fix(dependency-dashboard): Adjust dry run log output

### DIFF
--- a/lib/workers/repository/dependency-dashboard.ts
+++ b/lib/workers/repository/dependency-dashboard.ts
@@ -115,7 +115,7 @@ export async function ensureDependencyDashboard(
   ) {
     if (getGlobalConfig().dryRun) {
       logger.info(
-        'DRY-RUN: Would close Dependency Dashboard ' +
+        'DRY-RUN: Would close Dependency Dashboard: ' +
           config.dependencyDashboardTitle
       );
     } else {

--- a/lib/workers/repository/dependency-dashboard.ts
+++ b/lib/workers/repository/dependency-dashboard.ts
@@ -136,8 +136,8 @@ export async function ensureDependencyDashboard(
   if (config.dependencyDashboardAutoclose && !hasBranches) {
     if (getGlobalConfig().dryRun) {
       logger.info(
-        'DRY-RUN: Would close Dependency Dashboard ' +
-          config.dependencyDashboardTitle
+        { title: config.dependencyDashboardTitle },
+        'DRY-RUN: Would close Dependency Dashboard'
       );
     } else {
       logger.debug('Closing Dependency Dashboard');
@@ -349,8 +349,8 @@ export async function ensureDependencyDashboard(
 
   if (getGlobalConfig().dryRun) {
     logger.info(
-      'DRY-RUN: Would ensure Dependency Dashboard ' +
-        config.dependencyDashboardTitle
+      { title: config.dependencyDashboardTitle },
+      'DRY-RUN: Would ensure Dependency Dashboard'
     );
   } else {
     await platform.ensureIssue({

--- a/lib/workers/repository/dependency-dashboard.ts
+++ b/lib/workers/repository/dependency-dashboard.ts
@@ -115,8 +115,8 @@ export async function ensureDependencyDashboard(
   ) {
     if (getGlobalConfig().dryRun) {
       logger.info(
-        'DRY-RUN: Would close Dependency Dashboard: ' +
-          config.dependencyDashboardTitle
+        { title: config.dependencyDashboardTitle },
+        'DRY-RUN: Would close Dependency Dashboard'
       );
     } else {
       logger.debug('Closing Dependency Dashboard');


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

This PR slightly adjusts the dry run log output for the dependency dashboard, which is currently a little confusing.

## Context:

The log output is currently:

> INFO: DRY-RUN: Would ensure Dependency Dashboard Dependency Dashboard (repository=npm-packages/ember-template-lint-plugin-qonto)
 
and the "Dependency Dashboard Dependency Dashboard" part appears a little confusing. This PR should fix it by making it at least a little clearer that the second "Dependency Dashboard" could be the title of the issue.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
