### PR TITLE
fix(manager/mix): Support umbrella projects

### DIFF
--- a/lib/manager/mix/artifacts.spec.ts
+++ b/lib/manager/mix/artifacts.spec.ts
@@ -84,7 +84,7 @@ describe('manager/mix/artifacts', () => {
     jest.spyOn(docker, 'removeDanglingContainers').mockResolvedValueOnce();
     setGlobalConfig({ ...adminConfig, binarySource: 'docker' });
     fs.readLocalFile.mockResolvedValueOnce('Old mix.lock');
-    fs.getSiblingFileName.mockReturnValueOnce('mix.lock');
+    fs.findLocalSiblingOrParent.mockResolvedValueOnce('mix.lock');
     const execSnapshots = mockExecAll(exec);
     fs.readLocalFile.mockResolvedValueOnce('New mix.lock');
     expect(
@@ -102,7 +102,7 @@ describe('manager/mix/artifacts', () => {
     jest.spyOn(docker, 'removeDanglingContainers').mockResolvedValueOnce();
     setGlobalConfig({ ...adminConfig, binarySource: 'docker' });
     fs.readLocalFile.mockResolvedValueOnce('Old mix.lock');
-    fs.getSiblingFileName.mockReturnValueOnce('mix.lock');
+    fs.findLocalSiblingOrParent.mockResolvedValueOnce('mix.lock');
     const execSnapshots = mockExecAll(exec);
     fs.readLocalFile.mockResolvedValueOnce('New mix.lock');
     hostRules.find.mockReturnValueOnce({ token: 'valid_test_token' });
@@ -141,7 +141,7 @@ describe('manager/mix/artifacts', () => {
 
   it('returns updated mix.lock in subdir', async () => {
     setGlobalConfig({ ...adminConfig, binarySource: 'docker' });
-    fs.getSiblingFileName.mockReturnValueOnce('subdir/mix.lock');
+    fs.findLocalSiblingOrParent.mockResolvedValueOnce('subdir/mix.lock');
     mockExecAll(exec);
     expect(
       await updateArtifacts({
@@ -156,7 +156,7 @@ describe('manager/mix/artifacts', () => {
 
   it('catches write errors', async () => {
     fs.readLocalFile.mockResolvedValueOnce('Current mix.lock');
-    fs.getSiblingFileName.mockReturnValueOnce('mix.lock');
+    fs.findLocalSiblingOrParent.mockResolvedValueOnce('mix.lock');
     fs.writeLocalFile.mockImplementationOnce(() => {
       throw new Error('not found');
     });
@@ -174,7 +174,7 @@ describe('manager/mix/artifacts', () => {
 
   it('catches exec errors', async () => {
     fs.readLocalFile.mockResolvedValueOnce('Current mix.lock');
-    fs.getSiblingFileName.mockReturnValueOnce('mix.lock');
+    fs.findLocalSiblingOrParent.mockResolvedValueOnce('mix.lock');
     exec.mockImplementationOnce(() => {
       throw new Error('exec-error');
     });

--- a/lib/manager/mix/artifacts.ts
+++ b/lib/manager/mix/artifacts.ts
@@ -4,7 +4,6 @@ import { logger } from '../../logger';
 import { ExecOptions, exec } from '../../util/exec';
 import {
   findLocalSiblingOrParent,
-  getSiblingFileName,
   readLocalFile,
   writeLocalFile,
 } from '../../util/fs';
@@ -25,7 +24,10 @@ export async function updateArtifacts({
     return null;
   }
 
-  const lockFileName = await findLocalSiblingOrParent(packageFileName, 'mix.lock');
+  const lockFileName = await findLocalSiblingOrParent(
+    packageFileName,
+    'mix.lock'
+  );
   try {
     await writeLocalFile(packageFileName, newPackageFileContent);
   } catch (err) {

--- a/lib/manager/mix/artifacts.ts
+++ b/lib/manager/mix/artifacts.ts
@@ -24,10 +24,8 @@ export async function updateArtifacts({
     return null;
   }
 
-  const lockFileName = await findLocalSiblingOrParent(
-    packageFileName,
-    'mix.lock'
-  );
+  const lockFileName =
+    (await findLocalSiblingOrParent(packageFileName, 'mix.lock')) || 'mix.lock';
   try {
     await writeLocalFile(packageFileName, newPackageFileContent);
   } catch (err) {

--- a/lib/manager/mix/artifacts.ts
+++ b/lib/manager/mix/artifacts.ts
@@ -3,6 +3,7 @@ import { TEMPORARY_ERROR } from '../../constants/error-messages';
 import { logger } from '../../logger';
 import { ExecOptions, exec } from '../../util/exec';
 import {
+  findLocalSiblingOrParent,
   getSiblingFileName,
   readLocalFile,
   writeLocalFile,
@@ -24,7 +25,7 @@ export async function updateArtifacts({
     return null;
   }
 
-  const lockFileName = getSiblingFileName(packageFileName, 'mix.lock');
+  const lockFileName = await findLocalSiblingOrParent(packageFileName, 'mix.lock');
   try {
     await writeLocalFile(packageFileName, newPackageFileContent);
   } catch (err) {

--- a/lib/manager/mix/extract.ts
+++ b/lib/manager/mix/extract.ts
@@ -67,7 +67,8 @@ export async function extractPackageFile(
     }
   }
   const res: PackageFile = { deps };
-  const lockFileName = await findLocalSiblingOrParent(fileName, 'mix.lock');
+  const lockFileName =
+    (await findLocalSiblingOrParent(fileName, 'mix.lock')) || 'mix.lock';
   // istanbul ignore if
   if (await localPathExists(lockFileName)) {
     res.lockFiles = [lockFileName];

--- a/lib/manager/mix/extract.ts
+++ b/lib/manager/mix/extract.ts
@@ -1,7 +1,7 @@
 import { HexDatasource } from '../../datasource/hex';
 import { logger } from '../../logger';
 import { SkipReason } from '../../types';
-import { getSiblingFileName, localPathExists } from '../../util/fs';
+import { findLocalSiblingOrParent, localPathExists } from '../../util/fs';
 import type { PackageDependency, PackageFile } from '../types';
 
 const depSectionRegExp = /defp\s+deps.*do/g;
@@ -67,7 +67,7 @@ export async function extractPackageFile(
     }
   }
   const res: PackageFile = { deps };
-  const lockFileName = getSiblingFileName(fileName, 'mix.lock');
+  const lockFileName = await findLocalSiblingOrParent(fileName, 'mix.lock');
   // istanbul ignore if
   if (await localPathExists(lockFileName)) {
     res.lockFiles = [lockFileName];


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:


Currently, renovate only looks for `mix.lock` in the same directory as `mix.exs`, but in umbrella apps there is only one `mix.lock` file at the top level of the repository. This change means we recursively look in parent directories until finding a `mix.lock` file.

Output from the fork can be seen here: https://github.com/tpbowden/renovate-umbrella-reproduction/pull/5

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

Closes https://github.com/renovatebot/renovate/issues/11851

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
