### PR TITLE
docs: explain that Renovate automerge takes time

### DIFF
--- a/docs/usage/key-concepts/automerge.md
+++ b/docs/usage/key-concepts/automerge.md
@@ -8,6 +8,10 @@ description: Learn all about Renovate's automerge functionality here
 Automerging is a Renovate feature that you can use to automate upgrading dependencies.
 When enabled, Renovate will attempt to merge the proposed update once the tests pass.
 
+Keep in mind that Renovate automerges take a bit of time, do not expect Renovate to automerge a PR the second it opens and passes tests.
+Wait for at least an hour before troubleshooting.
+If you or others keep committing to the default branch then Renovate cannot find a suitable gap to automerge into!
+
 As a general guide, we recommend that you enable automerge for any type of dependency updates where you would just click "merge" anyway.
 For any updates where you want to review the release notes - or code - before you merge, you can keep automerge disabled.
 

--- a/docs/usage/key-concepts/automerge.md
+++ b/docs/usage/key-concepts/automerge.md
@@ -9,7 +9,7 @@ Automerging is a Renovate feature that you can use to automate upgrading depende
 When enabled, Renovate will attempt to merge the proposed update once the tests pass.
 
 Keep in mind that Renovate automerges take a bit of time, do not expect Renovate to automerge a PR the second it opens and passes tests.
-Wait for at least an hour before troubleshooting.
+Wait for at least an hour or two before troubleshooting to ensure that Renovate has had the time to run once in a state where tests have passed and the branch is up-to-date with its base branch.
 If you or others keep committing to the default branch then Renovate cannot find a suitable gap to automerge into!
 
 As a general guide, we recommend that you enable automerge for any type of dependency updates where you would just click "merge" anyway.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

- Explain that Renovate automerges takes time
- Explain that users should not expect Renovate automerges to happen right away
- Explain that Renovate needs "a gap to merge into the commit highway"

## Context:

Based on discussion: https://github.com/renovatebot/renovate/discussions/11853

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
