### PR TITLE
feat(composer): bearer token authentication (#6901)

### DIFF
--- a/docs/usage/php.md
+++ b/docs/usage/php.md
@@ -31,6 +31,11 @@ If you are using a [privately hosted Composer package](https://getcomposer.org/d
       "hostType": "packagist",
       "username": "<your-username>",
       "password": "<your-password>"
+    },
+    {
+      "matchHost": "bearer-auth.for.vendor.com",
+      "hostType": "packagist",
+      "token": "abcdef0123456789"
     }
   ]
 }
@@ -49,8 +54,15 @@ You may encrypt your `password` only, but you can encrypt your `username` as wel
       "matchHost": "some.vendor.com",
       "hostType": "packagist",
       "encrypted": {
-        "username": "<your-encrypted-password",
-        "password": "<your-encrypted-password"
+        "username": "<your-encrypted-password>",
+        "password": "<your-encrypted-password>"
+      }
+    },
+    {
+      "matchHost": "bearer-auth.for.vendor.com",
+      "hostType": "packagist",
+      "encrypted": {
+        "token": "<your-encrypted-token>"
       }
     }
   ]

--- a/lib/manager/composer/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/manager/composer/__snapshots__/artifacts.spec.ts.snap
@@ -234,7 +234,7 @@ Array [
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
       "env": Object {
-        "COMPOSER_AUTH": "{\\"github-oauth\\":{\\"github.com\\":\\"github-token\\"},\\"gitlab-token\\":{\\"gitlab.com\\":\\"gitlab-token\\"},\\"gitlab-domains\\":[\\"gitlab.com\\"],\\"http-basic\\":{\\"packagist.renovatebot.com\\":{\\"username\\":\\"some-username\\",\\"password\\":\\"some-password\\"},\\"artifactory.yyyyyyy.com\\":{\\"username\\":\\"some-other-username\\",\\"password\\":\\"some-other-password\\"}}}",
+        "COMPOSER_AUTH": "{\\"github-oauth\\":{\\"github.com\\":\\"github-token\\"},\\"gitlab-token\\":{\\"gitlab.com\\":\\"gitlab-token\\"},\\"gitlab-domains\\":[\\"gitlab.com\\"],\\"http-basic\\":{\\"packagist.renovatebot.com\\":{\\"username\\":\\"some-username\\",\\"password\\":\\"some-password\\"},\\"artifactory.yyyyyyy.com\\":{\\"username\\":\\"some-other-username\\",\\"password\\":\\"some-other-password\\"}},\\"bearer\\":{\\"packages-bearer.example.com\\":\\"abcdef0123456789\\"}}",
         "COMPOSER_CACHE_DIR": "/tmp/renovate/cache/others/composer",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",

--- a/lib/manager/composer/artifacts.spec.ts
+++ b/lib/manager/composer/artifacts.spec.ts
@@ -123,6 +123,11 @@ describe('manager/composer/artifacts', () => {
       username: 'some-other-username',
       password: 'some-other-password',
     });
+    hostRules.add({
+      hostType: datasourcePackagist.id,
+      matchHost: 'https://packages-bearer.example.com/',
+      token: 'abcdef0123456789',
+    });
     fs.readLocalFile.mockResolvedValueOnce('{}');
     const execSnapshots = mockExecAll(exec);
     fs.readLocalFile.mockResolvedValueOnce('{}');

--- a/lib/manager/composer/artifacts.ts
+++ b/lib/manager/composer/artifacts.ts
@@ -63,10 +63,13 @@ function getAuthJson(): string | null {
   hostRules
     .findAll({ hostType: datasourcePackagist.id })
     ?.forEach((hostRule) => {
-      const { resolvedHost, username, password } = hostRule;
+      const { resolvedHost, username, password, token } = hostRule;
       if (resolvedHost && username && password) {
         authJson['http-basic'] = authJson['http-basic'] || {};
         authJson['http-basic'][resolvedHost] = { username, password };
+      } else if (resolvedHost && token) {
+        authJson.bearer = authJson.bearer || {};
+        authJson.bearer[resolvedHost] = token;
       }
     });
 

--- a/lib/manager/composer/types.ts
+++ b/lib/manager/composer/types.ts
@@ -41,6 +41,7 @@ export interface UserPass {
 }
 
 export interface AuthJson {
+  bearer?: Record<string, string>;
   'github-oauth'?: Record<string, string>;
   'gitlab-token'?: Record<string, string>;
   'gitlab-domains'?: string[];


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Implements support for specifying a Bearer auth token instead of username/password for a Composer repository.

## Context:

This closes #6901 as it is the only missing bit to that ticket.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
