### PR TITLE
fix(yarn): don't base64 encode npmAuthIdent

### DIFF
--- a/lib/manager/npm/post-update/__snapshots__/rules.spec.ts.snap
+++ b/lib/manager/npm/post-update/__snapshots__/rules.spec.ts.snap
@@ -11,7 +11,7 @@ Object {
   "additionalYarnRcYml": Object {
     "npmRegistries": Object {
       "//registry.company.com/": Object {
-        "npmAuthIdent": "dXNlcjEyMzpwYXNzMTIz",
+        "npmAuthIdent": "user123:pass123",
       },
       "//registry.npmjs.org": Object {
         "npmAuthToken": "token123",
@@ -33,7 +33,7 @@ Object {
   "additionalYarnRcYml": Object {
     "npmRegistries": Object {
       "//registry.company.com/": Object {
-        "npmAuthIdent": "dXNlcjEyMzpwYXNzMTIz",
+        "npmAuthIdent": "user123:pass123",
       },
     },
   },

--- a/lib/manager/npm/post-update/rules.ts
+++ b/lib/manager/npm/post-update/rules.ts
@@ -38,9 +38,7 @@ export function processHostRules(): HostRulesResult {
         additionalNpmrcContent.push(`${uri}:_password=${password}`);
         additionalYarnRcYml ||= { npmRegistries: {} };
         additionalYarnRcYml.npmRegistries[uri] = {
-          npmAuthIdent: Buffer.from(
-            `${hostRule.username}:${hostRule.password}`
-          ).toString('base64'),
+          npmAuthIdent: `${hostRule.username}:${hostRule.password}`,
         };
       }
     }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Fixes `hostRules` -> Yarn `authIdent` by removing erroneous base64 encoding.

## Context:

#11862

fixes #11864

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
