### PR TITLE
docs: private Git submodules are not supported

### DIFF
--- a/lib/manager/git-submodules/readme.md
+++ b/lib/manager/git-submodules/readme.md
@@ -1,4 +1,4 @@
 Keeps publicly accessible Git submodules updated within a repository.
 
 Renovate does not support updating Git submodules that are hosted on a private repository.
-Subscribe to issue #... on GitHub to keep track of our progress towards supporting private Git submodules.
+Subscribe to [issue #10149 on GitHub](https://github.com/renovatebot/renovate/issues/10149) to keep track of our progress towards supporting private Git submodules.

--- a/lib/manager/git-submodules/readme.md
+++ b/lib/manager/git-submodules/readme.md
@@ -1,1 +1,4 @@
-Keeps Git submodules updated within a repository.
+Keeps publicly accessible Git submodules updated within a repository.
+
+Renovate does not support updating Git submodules that are hosted on a private repository.
+Subscribe to issue #... on GitHub to keep track of our progress towards supporting private Git submodules.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Explain that we only support publicliy accessible Git submodules right now
- Explain that private Git submodules is work in progress
- Link to issue to track for supporting this feature

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

Closes #11810.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
