### PR TITLE
chore(gitlab-packages): add support for the group packages API endpoint

### DIFF
--- a/lib/datasource/gitlab-packages/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/gitlab-packages/__snapshots__/index.spec.ts.snap
@@ -1,5 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`datasource/gitlab-packages/index getReleases automatically use the groups endpoints 1`] = `
+Object {
+  "registryUrl": "https://gitlab.com",
+  "releases": Array [
+    Object {
+      "releaseTimestamp": "2020-03-04T18:01:37.000Z",
+      "version": "1.0.0",
+    },
+    Object {
+      "releaseTimestamp": "2020-04-04T18:01:37.000Z",
+      "version": "v1.1.0",
+    },
+    Object {
+      "releaseTimestamp": "2020-05-04T18:01:37.000Z",
+      "version": "v1.1.1",
+    },
+  ],
+}
+`;
+
 exports[`datasource/gitlab-packages/index getReleases returns package from custom registry 1`] = `
 Object {
   "registryUrl": "https://gitlab.com",

--- a/lib/datasource/gitlab-packages/index.ts
+++ b/lib/datasource/gitlab-packages/index.ts
@@ -83,7 +83,7 @@ export class GitlabPackagesDatasource extends Datasource {
               })
             ).body;
           } catch (err2) {
-            this.handleGenericErrors(err1);
+            this.handleGenericErrors(err2);
           }
         } else {
           this.handleGenericErrors(err1);

--- a/lib/datasource/gitlab-packages/readme.md
+++ b/lib/datasource/gitlab-packages/readme.md
@@ -1,6 +1,6 @@
 [GitLab Packages API](https://docs.gitlab.com/ee/api/packages.html) supports looking up package versions from [all types of packages registry supported by GitLab](https://docs.gitlab.com/ee/user/packages/package_registry/index.html) and can be used in combination with [regex managers](https://docs.renovatebot.com/modules/manager/regex/) to keep dependencies up-to-date which are not specifically supported by Renovate.
 
-To specify which specific repository should be queried when looking up a package, the `depName` should be formed with the project path first, then a `:` and finally the package name.
+To specify which specific repository should be queried when looking up a package, the `depName` should be formed with the project path first, then a `:` and finally the package name. It is also possible to use a group path instead of a project path.
 
 As an example, `gitlab-org/ci-cd/package-stage/feature-testing/new-packages-list:@gitlab-org/nk-js` would look for the`@gitlab-org/nk-js` packages in the generic packages repository of the `gitlab-org/ci-cd/package-stage/feature-testing/new-packages-list` project.
 

--- a/lib/datasource/gitlab-packages/readme.md
+++ b/lib/datasource/gitlab-packages/readme.md
@@ -1,6 +1,7 @@
 [GitLab Packages API](https://docs.gitlab.com/ee/api/packages.html) supports looking up package versions from [all types of packages registry supported by GitLab](https://docs.gitlab.com/ee/user/packages/package_registry/index.html) and can be used in combination with [regex managers](https://docs.renovatebot.com/modules/manager/regex/) to keep dependencies up-to-date which are not specifically supported by Renovate.
 
-To specify which specific repository should be queried when looking up a package, the `depName` should be formed with the project path first, then a `:` and finally the package name. It is also possible to use a group path instead of a project path.
+To specify which specific repository should be queried when looking up a package, the `depName` should be formed with the project path first, then a `:` and finally the package name.
+It is also possible to use a group path instead of a project path.
 
 As an example, `gitlab-org/ci-cd/package-stage/feature-testing/new-packages-list:@gitlab-org/nk-js` would look for the`@gitlab-org/nk-js` packages in the generic packages repository of the `gitlab-org/ci-cd/package-stage/feature-testing/new-packages-list` project.
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

This add support for querying the Gitlab Package API at the group level instead of at the project level. With this change, the group level API will be use automatically if querying the project level API fails with a `404 NOT FOUND`

## Context:

The group level API is documented here: [Gitlab Documentation](https://docs.gitlab.com/ee/api/packages.html#within-a-group)

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

https://gitlab.com/samdolt1/renovate-test-1/-/merge_requests/9

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
