### PR TITLE
docs: explain limitation on amount of branches that can be automerged in one run

### DIFF
--- a/docs/usage/key-concepts/automerge.md
+++ b/docs/usage/key-concepts/automerge.md
@@ -14,9 +14,9 @@ If you or others keep committing to the default branch then Renovate cannot find
 
 Once a branch is automerged, the "Git state" needs to be recalculated for every remaining branch.
 At times, merging one branch could result in another branch's updates being changed or even removed as unnecessary.
-Our process is that automerging branches need to be up-to-date with their target branch before automerging.
+Renovate's approach is to ensure that automerging branches are up-to-date with their target branch before automerging.
 Therefore merging multiple branches in a row won't reliably work, we prefer not to do that.
-What all this means is that Renovate will only automerge one or two updates at once, before you need to wait for the next run.
+What all this means is that Renovate will only automerge at most one branch/PR per target branch per run, before you need to wait for the next run.
 
 As a general guide, we recommend that you enable automerge for any type of dependency updates where you would just click "merge" anyway.
 For any updates where you want to review the release notes - or code - before you merge, you can keep automerge disabled.

--- a/docs/usage/key-concepts/automerge.md
+++ b/docs/usage/key-concepts/automerge.md
@@ -12,6 +12,12 @@ Keep in mind that Renovate automerges take a bit of time, do not expect Renovate
 Wait for at least an hour or two before troubleshooting to ensure that Renovate has had the time to run once in a state where tests have passed and the branch is up-to-date with its base branch.
 If you or others keep committing to the default branch then Renovate cannot find a suitable gap to automerge into!
 
+Once a branch is automerged, the "Git state" needs to be recalculated for every remaining branch.
+At times, merging one branch could result in another branch's updates being changed or even removed as unnecessary.
+Our process is that automerging branches need to be up-to-date with their target branch before automerging.
+Therefore merging multiple branches in a row won't reliably work, we prefer not to do that.
+What all this means is that Renovate will only automerge one or two updates at once, before you need to wait for the next run.
+
 As a general guide, we recommend that you enable automerge for any type of dependency updates where you would just click "merge" anyway.
 For any updates where you want to review the release notes - or code - before you merge, you can keep automerge disabled.
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Copy/paste and adjust explanation by @rarkins from: https://github.com/renovatebot/renovate/discussions/11889#discussioncomment-1382806

## Context:

Might be good to put this explanation in the `key-concepts/automerge.md` page.

If this is not suitable, feel free to close the PR and explain the reasoning. 😉 

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
