### PR TITLE
feat(config): detectGlobalManagerConfig

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -134,8 +134,7 @@ This configuration will be applied after all other environment variables so that
 
 The purpose of this capability is to allow a bot admin to configure manager-specific files such as a global `.npmrc` file, instead of configuring it in Renovate config.
 
-This feature is disabled by default in the CLI because it may prove surprising or undesirable for some users who don't expect Renovate to go into their home directory and import registry or credential information.
-However, it is enabled by default in the official Renovate Docker images because if anyone chooses to add such config files to them then it's clearly not unintentional.
+This feature is disabled by default because it may prove surprising or undesirable for some users who don't expect Renovate to go into their home directory and import registry or credential information.
 
 Currently this capability is supported for the `npm` manager only - specifically the `~/.npmrc` file.
 If found, it will be imported into `config.npmrc` with `config.npmrcMerge` will be set to `true`.

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -130,6 +130,16 @@ e.g.
 
 This configuration will be applied after all other environment variables so that it can be used to override defaults.
 
+## detectGlobalManagerConfig
+
+The purpose of this capability is to allow a bot admin to configure manager-specific files such as a global `.npmrc` file, instead of configuring it in Renovate config.
+
+This feature is disabled by default in the CLI because it may prove surprising or undesirable for some users who don't expect Renovate to go into their home directory and import registry or credential information.
+However, it is enabled by default in the official Renovate Docker images because if anyone chooses to add such config files to them then it's clearly not unintentional.
+
+Currently this capability is supported for the `npm` manager only - specifically the `~/.npmrc` file.
+If found, it will be imported into `config.npmrc` with `config.npmrcMerge` will be set to `true`.
+
 ## dockerChildPrefix
 
 Adds a custom prefix to the default Renovate sidecar Docker containers name and label.

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -8,6 +8,14 @@ import type { RenovateOptions } from '../types';
 
 const options: RenovateOptions[] = [
   {
+    name: 'detectGlobalManagerConfig',
+    description:
+      'If true, Renovate will attempt to read global manager config from the file system.',
+    type: 'boolean',
+    default: false,
+    globalOnly: true,
+  },
+  {
     name: 'allowPostUpgradeCommandTemplating',
     description: 'If true allow templating for post-upgrade commands.',
     type: 'boolean',

--- a/lib/manager/index.spec.ts
+++ b/lib/manager/index.spec.ts
@@ -2,6 +2,8 @@ import { loadModules } from '../util/modules';
 import type { ManagerApi } from './types';
 import * as manager from '.';
 
+jest.mock('../util/fs');
+
 describe('manager/index', () => {
   describe('get()', () => {
     it('gets something', () => {
@@ -41,6 +43,12 @@ describe('manager/index', () => {
       const mgr = mgrs.get(name);
       expect(validate(mgr)).toBe(true);
     }
+  });
+
+  describe('detectGlobalConfig()', () => {
+    it('iterates through managers', async () => {
+      expect(await manager.detectAllGlobalConfig()).toEqual({});
+    });
   });
 
   describe('extractAllPackageFiles()', () => {

--- a/lib/manager/index.ts
+++ b/lib/manager/index.ts
@@ -15,6 +15,7 @@ import type { RangeStrategy } from '../types';
 import managers from './api';
 import type {
   ExtractConfig,
+  GlobalManagerConfig,
   ManagerApi,
   PackageFile,
   RangeConfig,
@@ -46,6 +47,18 @@ export function get<T extends keyof ManagerApi>(
 export const getLanguageList = (): string[] => languageList;
 export const getManagerList = (): string[] => managerList;
 export const getManagers = (): Map<string, ManagerApi> => managers;
+
+export async function detectAllGlobalConfig(): Promise<GlobalManagerConfig> {
+  let config: GlobalManagerConfig = {};
+  for (const managerName of managerList) {
+    const manager = managers.get(managerName);
+    if (manager.detectGlobalConfig) {
+      // This should use mergeChildConfig once more than one manager is supported, but introduces a cyclic dependency
+      config = { ...config, ...(await manager.detectGlobalConfig()) };
+    }
+  }
+  return config;
+}
 
 export async function extractAllPackageFiles(
   manager: string,

--- a/lib/manager/npm/detect.spec.ts
+++ b/lib/manager/npm/detect.spec.ts
@@ -1,0 +1,29 @@
+import { fs } from '../../../test/util';
+import { detectGlobalConfig } from './detect';
+
+jest.mock('../../util/fs');
+
+describe('manager/npm/detect', () => {
+  describe('.detectGlobalConfig()', () => {
+    it('detects .npmrc in home directory', async () => {
+      fs.readFile.mockResolvedValueOnce(
+        'registry=https://registry.npmjs.org\n'
+      );
+      const res = await detectGlobalConfig();
+      expect(res).toMatchInlineSnapshot(`
+Object {
+  "npmrc": "registry=https://registry.npmjs.org
+",
+  "npmrcMerge": true,
+}
+`);
+      expect(res.npmrc).toBeDefined();
+      expect(res.npmrcMerge).toBe(true);
+    });
+    it('handles no .npmrc', async () => {
+      fs.readFile.mockImplementationOnce(() => Promise.reject());
+      const res = await detectGlobalConfig();
+      expect(res).toEqual({});
+    });
+  });
+});

--- a/lib/manager/npm/detect.ts
+++ b/lib/manager/npm/detect.ts
@@ -17,7 +17,7 @@ export async function detectGlobalConfig(): Promise<GlobalManagerConfig> {
       logger.debug(`Detected ${npmrcFileName} and adding it to global config`);
     }
   } catch (err) {
-    logger.trace('No home .npmrc found');
+    logger.warn({ npmrcFileName }, 'Error reading .npmrc file');
   }
   return res;
 }

--- a/lib/manager/npm/detect.ts
+++ b/lib/manager/npm/detect.ts
@@ -1,0 +1,23 @@
+import os from 'os';
+import is from '@sindresorhus/is';
+import { join } from 'upath';
+import { logger } from '../../logger';
+import { readFile } from '../../util/fs';
+import { GlobalManagerConfig } from '../types';
+
+export async function detectGlobalConfig(): Promise<GlobalManagerConfig> {
+  const res: GlobalManagerConfig = {};
+  const homedir = os.homedir();
+  const npmrcFileName = join(homedir, '.npmrc');
+  try {
+    const npmrc = await readFile(npmrcFileName, 'utf8');
+    if (is.nonEmptyString(npmrc)) {
+      res.npmrc = npmrc;
+      res.npmrcMerge = true;
+      logger.debug(`Detected ${npmrcFileName} and adding it to global config`);
+    }
+  } catch (err) {
+    logger.trace('No home .npmrc found');
+  }
+  return res;
+}

--- a/lib/manager/npm/index.ts
+++ b/lib/manager/npm/index.ts
@@ -1,6 +1,7 @@
 import { LANGUAGE_JAVASCRIPT } from '../../constants/languages';
 import * as npmVersioning from '../../versioning/npm';
 
+export { detectGlobalConfig } from './detect';
 export { extractAllPackageFiles } from './extract';
 export {
   bumpPackageVersion,

--- a/lib/manager/types.ts
+++ b/lib/manager/types.ts
@@ -220,6 +220,11 @@ export interface UpdateLockedConfig {
   newVersion?: string;
 }
 
+export interface GlobalManagerConfig {
+  npmrc?: string;
+  npmrcMerge?: boolean;
+}
+
 export interface ManagerApi {
   defaultConfig: Record<string, unknown>;
   language?: string;
@@ -230,6 +235,8 @@ export interface ManagerApi {
     currentValue: string,
     bumpVersion: ReleaseType | string
   ): Result<BumpPackageVersionResult>;
+
+  detectGlobalConfig?(): Result<GlobalManagerConfig>;
 
   extractAllPackageFiles?(
     config: ExtractConfig,

--- a/lib/workers/global/config/parse/index.spec.ts
+++ b/lib/workers/global/config/parse/index.spec.ts
@@ -3,6 +3,8 @@ import { readFile } from '../../../../util/fs';
 import getArgv from './__fixtures__/argv';
 
 jest.mock('../../../../datasource/npm');
+jest.mock('../../../../util/fs');
+
 try {
   jest.mock('../../config.js');
 } catch (err) {
@@ -117,6 +119,11 @@ describe('workers/global/config/parse/index', () => {
       ]);
       const parsed = await configParser.parseConfigs(defaultEnv, defaultArgv);
       expect(parsed.endpoint).toEqual('https://github.renovatebot.com/api/v3/');
+    });
+    it('parses global manager config', async () => {
+      defaultArgv = defaultArgv.concat(['--detect-global-manager-config=true']);
+      const parsed = await configParser.parseConfigs(defaultEnv, defaultArgv);
+      expect(parsed.npmrc).toBeNull();
     });
   });
 });

--- a/lib/workers/global/config/parse/index.ts
+++ b/lib/workers/global/config/parse/index.ts
@@ -2,6 +2,7 @@ import * as defaultsParser from '../../../../config/defaults';
 import { AllConfig } from '../../../../config/types';
 import { mergeChildConfig } from '../../../../config/utils';
 import { addStream, logger, setContext } from '../../../../logger';
+import { detectAllGlobalConfig } from '../../../../manager';
 import { ensureDir, getSubDirectory, readFile } from '../../../../util/fs';
 import { ensureTrailingSlash } from '../../../../util/url';
 import * as cliParser from './cli';
@@ -72,6 +73,13 @@ export async function parseConfigs(
   logger.debug({ config: cliConfig }, 'CLI config');
   logger.debug({ config: envConfig }, 'Env config');
   logger.debug({ config: combinedConfig }, 'Combined config');
+
+  if (config.detectGlobalManagerConfig) {
+    logger.debug('Detecting global manager config');
+    const globalManagerConfig = await detectAllGlobalConfig();
+    logger.debug({ config: globalManagerConfig }, 'Global manager config');
+    config = mergeChildConfig(config, globalManagerConfig);
+  }
 
   // Get global config
   logger.trace({ config }, 'Full config');


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds new global option `detectGlobalManagerConfig`

## Context:

Closes #11300

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
