### PR TITLE
fix(presets): Spring Boot group includes Gradle plugin

### DIFF
--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -265,7 +265,7 @@ const staticGroups = {
     packageRules: [
       {
         groupName: 'spring boot',
-        matchPackagePrefixes: ['org.springframework.boot:'],
+        matchPackagePrefixes: ['org.springframework.boot:', 'org.springframework.boot'],
       },
     ],
   },

--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -265,7 +265,8 @@ const staticGroups = {
     packageRules: [
       {
         groupName: 'spring boot',
-        matchPackagePrefixes: ['org.springframework.boot:', 'org.springframework.boot'],
+        matchPackagePrefixes: ['org.springframework.boot:'],
+        matchPackageNames: ['org.springframework.boot'],
       },
     ],
   },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->
Including a `matchPackagePrefixes` for the Spring Boot Gradle plugin for the `group:springBoot` preset.

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->
Closes #11950 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

N.B.: I think no update of [documentation](https://docs.renovatebot.com/presets-group/#groupspringboot) is required as it should be updated automatically, let me know if I'm wrong!

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

N.B.: Tested on my self-hosted Renovate, the grouping was successful

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
