### PR TITLE
chore: use new input names, limit concurrency

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -12,6 +12,10 @@ permissions:
   issues: write
   pull-requests: write
 
+# Ensure only one lock action can run at a time
+concurrency:
+  group: lock
+
 jobs:
   lock:
     runs-on: ubuntu-latest
@@ -20,5 +24,5 @@ jobs:
         if: github.repository == 'renovatebot/renovate'
         with:
           github-token: ${{ github.token }}
-          issue-lock-inactive-days: 30
-          pr-lock-inactive-days: 30
+          issue-inactive-days: 30
+          pr-inactive-days: 30

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -16,7 +16,7 @@ jobs:
   lock:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@f1a42f0f44eb83361d617a014663e1a76cf282d2 # renovate: tag=v2.1.2
+      - uses: dessant/lock-threads@e460dfeb36e731f3aeb214be6b0c9a9d9a67eda6 # renovate: tag=v3.0.0
         if: github.repository == 'renovatebot/renovate'
         with:
           github-token: ${{ github.token }}


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Use new input names
- Limit concurrency

## Context:

I'm targeting the Renovate update branch for the dessant-lock-threads v3 update here.

Uses the new input names as described in the readme: https://github.com/dessant/lock-threads#inputs

Uses the new `concurrency` property that's suggested in the readme here: https://github.com/dessant/lock-threads#examples

GitHub docs for `concurrency` property: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
