### PR TITLE
chore: run dessant/label-actions on discussions

### DIFF
--- a/.github/workflows/label-actions.yml
+++ b/.github/workflows/label-actions.yml
@@ -3,10 +3,13 @@ name: 'Label Actions'
 on:
   issues:
     types: [labeled]
+  discussion:
+    types: [labeled]
 
 permissions:
   contents: read
   issues: write
+  discussions: write
 
 jobs:
   reaction:
@@ -15,4 +18,4 @@ jobs:
       - uses: dessant/label-actions@93ea5ec1d65e6a21427a1571a18a5b8861206b0b # renovate: tag=v2.2.0
         with:
           github-token: ${{ github.token }}
-          process-only: 'issues'
+          process-only: 'issues, discussions'


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Configure `dessant/label-actions` so it works on discussions

## Context:

We use `desssant/label-actions` to comment on issues when we apply a label like `needs:reproduction` or `logs:problem`.
`dessant/label-actions` now supports discussions. [^release-notes] 

This PR configures the action so it will work with discussions.
The action gains `write` level rights for discussions.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

[^release-notes]: https://github.com/dessant/label-actions/blob/master/CHANGELOG.md#220-2021-10-01