### PR TITLE
docs: add `build` capture group to regex docs

### DIFF
--- a/lib/versioning/regex/readme.md
+++ b/lib/versioning/regex/readme.md
@@ -1,9 +1,11 @@
-Regular Expression Versioning is designed to be like a flexible fallback versioning approach is Renovate's other versioning schemes don't do the job.
+Regular Expression Versioning is designed to be a flexible fallback versioning approach if Renovate's other versioning schemes don't do the job.
 
-The `regex` scheme makes use of Regular Express capture groups. The valid capture groups for `regex` versioning are:
+The `regex` scheme makes use of Regular Express capture groups.
+The valid capture groups for `regex` versioning are:
 
-- `major`, `minor`, and `patch`: at least one of these must be provided. When determining whether a package has updated, these values will be compared in the standard semantic versioning fashion. If any of these fields are omitted, they will be treated as if they were `0` -- in this way, you can describe versioning schemes with up to three incrementing values.
-- `prerelease`: this value, if captured, will mark a given release as a prerelease (eg. unstable). If this value is captured and you have configured `"ignoreUnstable": true`, the given release will be skipped.
+- `major`, `minor`, and `patch`: at least one of these must be provided. When determining whether a package has updates, these values will be compared in the standard semantic versioning fashion. If any of these fields are omitted, they will be treated as if they were `0` -- in this way, you can describe versioning schemes with up to three incrementing values.
+- `build`: this capture group can be used when you need a fourth version.
+- `prerelease`: this value, if captured, will mark a given release as a prerelease (e.g. unstable). If this value is captured and you have configured `"ignoreUnstable": true`, the given release will be skipped.
 - `compatibility`: this value defines the "build compatibility" of a given dependency. A proposed Renovate update will never change the specified compatibility value. For example, if you are pinning to `1.2.3-linux` (and `linux` is captured as the compatibility value), Renovate will not update you to `1.2.4-osx`.
 
 The compatibility concept was originally introduced for Docker versioning but sometimes package authors may use/misuse suffixes to mean compatibility in other versioning schemes.

--- a/lib/versioning/regex/readme.md
+++ b/lib/versioning/regex/readme.md
@@ -4,7 +4,7 @@ The `regex` scheme makes use of Regular Express capture groups.
 The valid capture groups for `regex` versioning are:
 
 - `major`, `minor`, and `patch`: at least one of these must be provided. When determining whether a package has updates, these values will be compared in the standard semantic versioning fashion. If any of these fields are omitted, they will be treated as if they were `0` -- in this way, you can describe versioning schemes with up to three incrementing values.
-- `build`: this capture group can be used when you need a fourth version.
+- `build`: this capture group can be used after you've already used the `major`, `minor` and `patch` capture groups and need a fourth version component. `build` updates are handled like `patch` updates.
 - `prerelease`: this value, if captured, will mark a given release as a prerelease (e.g. unstable). If this value is captured and you have configured `"ignoreUnstable": true`, the given release will be skipped.
 - `compatibility`: this value defines the "build compatibility" of a given dependency. A proposed Renovate update will never change the specified compatibility value. For example, if you are pinning to `1.2.3-linux` (and `linux` is captured as the compatibility value), Renovate will not update you to `1.2.4-osx`.
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Add `build` capture group to regex docs
- Use one sentence per line
- Fix some grammar problems

## Context:

As requested by @viceice [^discussion].
PR #11115 added the `build` capture group feature.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

[^discussion]: https://github.com/renovatebot/renovate/discussions/12063#discussioncomment-1443330
