### PR TITLE
fix(config): improve descriptions for default presets

### DIFF
--- a/lib/config/presets/__snapshots__/index.spec.ts.snap
+++ b/lib/config/presets/__snapshots__/index.spec.ts.snap
@@ -31,7 +31,7 @@ Object {
     "Use <code>renovate/</code> as prefix for all branch names",
     "If semantic commits detected, use semantic commit type <code>fix</code> for dependencies and <code>chore</code> for all others",
     "Require all status checks to pass before any automerging",
-    "Pin dependency versions for <code>devDependencies</code> and retain semver ranges for others",
+    "Pin dependency versions for <code>devDependencies</code> and retain SemVer ranges for others",
   ],
   "ignoreTests": false,
   "ignoreUnstable": true,

--- a/lib/config/presets/index.spec.ts
+++ b/lib/config/presets/index.spec.ts
@@ -649,7 +649,7 @@ Object {
       const res = await presets.getPreset(':pinVersions(foo, bar)', {});
       expect(res).toEqual({
         description: [
-          'Use version pinning (maintain a single version only and not semver ranges)',
+          'Use version pinning (maintain a single version only and not SemVer ranges)',
         ],
         rangeStrategy: 'pin',
       });

--- a/lib/config/presets/internal/default.ts
+++ b/lib/config/presets/internal/default.ts
@@ -2,11 +2,11 @@ import type { Preset } from '../types';
 
 export const presets: Record<string, Preset> = {
   enableRenovate: {
-    description: 'Enable renovate',
+    description: 'Enable Renovate',
     enabled: true,
   },
   disableRenovate: {
-    description: 'Disable renovate',
+    description: 'Disable Renovate',
     enabled: false,
   },
   disableMajorUpdates: {
@@ -60,12 +60,12 @@ export const presets: Record<string, Preset> = {
   },
   pinVersions: {
     description:
-      'Use version pinning (maintain a single version only and not semver ranges)',
+      'Use version pinning (maintain a single version only and not SemVer ranges)',
     rangeStrategy: 'pin',
   },
   preserveSemverRanges: {
     description:
-      'Preserve (but continue to upgrade) any existing semver ranges',
+      'Preserve (but continue to upgrade) any existing SemVer ranges',
     rangeStrategy: 'replace',
   },
   pinAllExceptPeerDependencies: {
@@ -102,7 +102,7 @@ export const presets: Record<string, Preset> = {
   },
   pinOnlyDevDependencies: {
     description:
-      'Pin dependency versions for <code>devDependencies</code> and retain semver ranges for others',
+      'Pin dependency versions for <code>devDependencies</code> and retain SemVer ranges for others',
     packageRules: [
       {
         matchPackagePatterns: ['*'],
@@ -182,7 +182,7 @@ export const presets: Record<string, Preset> = {
     ],
   },
   disableDigestUpdates: {
-    description: 'Disable digest and git hash updates',
+    description: 'Disable digest and Git hash updates',
     digest: {
       enabled: false,
     },
@@ -242,11 +242,11 @@ export const presets: Record<string, Preset> = {
     prHourlyLimit: 4,
   },
   prConcurrentLimitNone: {
-    description: 'Remove limit for open PRs',
+    description: 'Remove limit for open PRs at any time',
     prConcurrentLimit: 0,
   },
   prConcurrentLimit10: {
-    description: 'Limit to maximum 10 open PRs',
+    description: 'Limit to maximum 10 open PRs at any time',
     prConcurrentLimit: 10,
   },
   prConcurrentLimit20: {
@@ -330,7 +330,7 @@ export const presets: Record<string, Preset> = {
     },
   },
   pinDigestsDisabled: {
-    description: 'Disable pinning of docker dependency digests',
+    description: 'Disable pinning of Docker dependency digests',
     pinDigests: false,
   },
   maintainLockFilesWeekly: {
@@ -408,11 +408,12 @@ export const presets: Record<string, Preset> = {
     },
   },
   gitSignOff: {
-    description: 'Append git Signed-off-by signature to git commits.',
+    description:
+      'Append Git <code>Signed-off-by:</code> signature to Git commits.',
     commitBody: 'Signed-off-by: {{{gitAuthor}}}',
   },
   npm: {
-    description: 'Keep package.json npm dependencies updated',
+    description: 'Keep <code>package.json</code> npm dependencies updated',
     npm: {
       enabled: true,
     },
@@ -517,7 +518,7 @@ export const presets: Record<string, Preset> = {
   },
   widenPeerDependencies: {
     description:
-      'Always widen peerDependencies semver ranges when updating, instead of replacing',
+      'Always widen peerDependencies SemVer ranges when updating, instead of replacing',
     packageRules: [
       {
         matchDepTypes: ['peerDependencies'],


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Capitalize proper noun Git
- Capitalize proper noun Docker
- Capitalize proper noun Renovate
- Change `semver` -> `SemVer`
- Add some `<code></code>` blocks to improve ease of reading
- Improve descriptions for `prConcurrentLimitNone` and `prConcurrentLimit10`

## Context:

Fixing up some descriptions.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
