### PR TITLE
fix(git): support setting file mode

### DIFF
--- a/lib/manager/npm/post-update/types.ts
+++ b/lib/manager/npm/post-update/types.ts
@@ -19,6 +19,7 @@ export interface ArtifactError {
 export interface UpdatedArtifacts {
   name: string;
   contents: string | Buffer;
+  mode?: string | number;
 }
 
 export interface WriteExistingFilesResult {

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -412,6 +412,23 @@ describe('util/git/index', () => {
         expect.objectContaining({ '--no-verify': null })
       );
     });
+
+    it('creates file with specified mode', async () => {
+      const file = {
+        name: 'some-executable',
+        contents: 'some new-contents',
+        mode: 0o755,
+      };
+      const commit = await git.commitFiles({
+        branchName: 'renovate/past_branch',
+        files: [file],
+        message: 'Create something',
+      });
+      const { mode } = await fs.stat(tmpDir.path + '/some-executable');
+      expect(commit).not.toBeNull();
+      // eslint-disable-next-line no-bitwise
+      expect(mode & 0o777).toBe(0o755);
+    });
   });
 
   describe('getCommitMessages()', () => {

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -653,6 +653,11 @@ export interface File {
    * file contents
    */
   contents: string | Buffer;
+
+  /**
+   * file mode
+   */
+  mode?: fs.Mode;
 }
 
 export type CommitFilesConfig = {
@@ -698,7 +703,8 @@ export async function commitFiles({
           ignoredFiles.push(fileName);
         }
       } else {
-        if (await isDirectory(join(localDir, fileName))) {
+        const path = join(localDir, fileName);
+        if (await isDirectory(path)) {
           // This is usually a git submodule update
           logger.trace({ fileName }, 'Adding directory commit');
         } else {
@@ -709,7 +715,10 @@ export async function commitFiles({
           } else {
             contents = file.contents;
           }
-          await fs.outputFile(join(localDir, fileName), contents);
+          await fs.outputFile(path, contents);
+          if (file.mode) {
+            await fs.chmod(path, file.mode);
+          }
         }
         try {
           await git.add(fileName);


### PR DESCRIPTION
## Changes:

Support setting the file mode (`chmod`) in `git.commitFiles()`

## Context:

Sometimes, there is a need to set the file mode in committed files, e.g., executables.

This is a blocking issue for #11368.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository