### PR TITLE
fix(git): support setting executable bit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - file-mode
+      - v25
 
   workflow_dispatch:
     inputs:
@@ -143,4 +143,51 @@ jobs:
       - name: Type check
         run: yarn type-check
 
-  
+  release:
+    needs: [lint, test]
+    runs-on: ubuntu-latest
+    # release shouldn't need more than 5 min
+    timeout-minutes: 15
+
+    steps:
+      # full checkout for semantic-release
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # renovate: tag=v2.3.4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@270253e841af726300e85d718a5f606959b2903c # renovate: tag=v2.4.1
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: yarn
+
+      - name: Init platform
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.symlinks true
+          git config --global user.email 'renovate@whitesourcesoftware.com'
+          git config --global user.name  'Renovate Bot'
+          yarn config set version-git-tag false
+          npm config set scripts-prepend-node-path true
+
+      - name: Check dry run
+        run: |
+          if [[ "${{github.event_name}}" == "workflow_dispatch" && "${{ github.event.inputs.dryRun }}" != "true"  ]]; then
+            echo "DRY_RUN=false" >> $GITHUB_ENV
+          elif [[ "${{github.ref}}" == "refs/heads/${{env.DEFAULT_BRANCH}}" ]]; then
+            echo "DRY_RUN=false" >> $GITHUB_ENV
+          elif [[ "${{github.ref}}" =~ ^refs/heads/v[0-9]+(\.[0-9]+)?$ ]]; then
+            echo "DRY_RUN=false" >> $GITHUB_ENV
+          fi
+
+      - name: Installing dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: semantic-release
+        run: |
+          echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> ./.npmrc
+          npx semantic-release --dry-run ${{env.DRY_RUN}}
+          git checkout -- .npmrc
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - v25
+      - file-mode
 
   workflow_dispatch:
     inputs:
@@ -143,51 +143,4 @@ jobs:
       - name: Type check
         run: yarn type-check
 
-  release:
-    needs: [lint, test]
-    runs-on: ubuntu-latest
-    # release shouldn't need more than 5 min
-    timeout-minutes: 15
-
-    steps:
-      # full checkout for semantic-release
-      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # renovate: tag=v2.3.4
-        with:
-          fetch-depth: 0
-
-      - name: Set up Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@270253e841af726300e85d718a5f606959b2903c # renovate: tag=v2.4.1
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: yarn
-
-      - name: Init platform
-        run: |
-          git config --global core.autocrlf false
-          git config --global core.symlinks true
-          git config --global user.email 'renovate@whitesourcesoftware.com'
-          git config --global user.name  'Renovate Bot'
-          yarn config set version-git-tag false
-          npm config set scripts-prepend-node-path true
-
-      - name: Check dry run
-        run: |
-          if [[ "${{github.event_name}}" == "workflow_dispatch" && "${{ github.event.inputs.dryRun }}" != "true"  ]]; then
-            echo "DRY_RUN=false" >> $GITHUB_ENV
-          elif [[ "${{github.ref}}" == "refs/heads/${{env.DEFAULT_BRANCH}}" ]]; then
-            echo "DRY_RUN=false" >> $GITHUB_ENV
-          elif [[ "${{github.ref}}" =~ ^refs/heads/v[0-9]+(\.[0-9]+)?$ ]]; then
-            echo "DRY_RUN=false" >> $GITHUB_ENV
-          fi
-
-      - name: Installing dependencies
-        run: yarn install --frozen-lockfile
-
-      - name: semantic-release
-        run: |
-          echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> ./.npmrc
-          npx semantic-release --dry-run ${{env.DRY_RUN}}
-          git checkout -- .npmrc
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  

--- a/lib/manager/npm/post-update/types.ts
+++ b/lib/manager/npm/post-update/types.ts
@@ -19,6 +19,7 @@ export interface ArtifactError {
 export interface UpdatedArtifacts {
   name: string;
   contents: string | Buffer;
+  executable?: boolean;
 }
 
 export interface WriteExistingFilesResult {

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -413,7 +413,7 @@ describe('util/git/index', () => {
       );
     });
 
-    it('creates file with specified mode', async () => {
+    it('creates file with the executable bit', async () => {
       const file = {
         name: 'some-executable',
         contents: 'some new-contents',

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -412,6 +412,24 @@ describe('util/git/index', () => {
         expect.objectContaining({ '--no-verify': null })
       );
     });
+
+    it('creates file with specified mode', async () => {
+      const file = {
+        name: 'some-executable',
+        contents: 'some new-contents',
+        executable: true,
+      };
+      const commit = await git.commitFiles({
+        branchName: 'renovate/past_branch',
+        files: [file],
+        message: 'Create something',
+      });
+      expect(commit).not.toBeNull();
+
+      const repo = Git(tmpDir.path);
+      const result = await repo.raw(['ls-tree', 'HEAD', 'some-executable']);
+      expect(result).toStartWith('100755');
+    });
   });
 
   describe('getCommitMessages()', () => {

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -653,6 +653,11 @@ export interface File {
    * file contents
    */
   contents: string | Buffer;
+
+  /**
+   * the executable bit
+   */
+  executable?: boolean;
 }
 
 export type CommitFilesConfig = {
@@ -709,10 +714,17 @@ export async function commitFiles({
           } else {
             contents = file.contents;
           }
-          await fs.outputFile(join(localDir, fileName), contents);
+          // some file systems including Windows don't support the mode
+          // so the index should be manually updated after adding the file
+          await fs.outputFile(join(localDir, fileName), contents, {
+            mode: file.executable ? 0o777 : 0o666,
+          });
         }
         try {
           await git.add(fileName);
+          if (file.executable) {
+            await git.raw(['update-index', '--chmod=+x', fileName]);
+          }
           addedModifiedFiles.push(fileName);
         } catch (err) /* istanbul ignore next */ {
           if (


### PR DESCRIPTION
## Changes:

Support setting the executable bit (`chmod +x`) in `git.commitFiles()`

## Context:

Sometimes, there is a need to set the executable bit in committed files, e.g., binary files.

This is a blocking issue for #11368.

The actual mode of the written file cannot be tested as:

- `umask` of test environments may vary
- some file systems including Windows don't support the `mode`

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

Windows and macOS tests: https://github.com/ylemkimon/renovate/actions/runs/1322981586 