### PR TITLE
fix(argocd): Skip apps with broken source

### DIFF
--- a/lib/manager/argocd/__fixtures__/validApplication.yml
+++ b/lib/manager/argocd/__fixtures__/validApplication.yml
@@ -7,6 +7,15 @@ spec:
     repoURL: https://prometheus-community.github.io/helm-charts
     targetRevision: 2.4.1
 ---
+# application with helm values
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+spec:
+  source:
+    chart: {{ .Values.chart }}
+    repoURL: {{ .Values.repoUrl}}
+    targetRevision: {{ .Values.targetRevision }}
+---
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 spec:

--- a/lib/manager/argocd/extract.ts
+++ b/lib/manager/argocd/extract.ts
@@ -1,3 +1,4 @@
+import is from '@sindresorhus/is';
 import { loadAll } from 'js-yaml';
 import * as gitTags from '../../datasource/git-tags';
 import { HelmDatasource } from '../../datasource/helm';
@@ -12,8 +13,8 @@ function createDependency(
 
   if (
     source == null ||
-    typeof source.repoURL !== 'string' ||
-    typeof source.targetRevision !== 'string'
+    !is.nonEmptyString(source.repoURL) ||
+    !is.nonEmptyString(source.targetRevision)
   ) {
     return null;
   }

--- a/lib/manager/argocd/extract.ts
+++ b/lib/manager/argocd/extract.ts
@@ -10,7 +10,11 @@ function createDependency(
 ): PackageDependency {
   const source = definition.spec?.source;
 
-  if (source == null) {
+  if (
+    source == null ||
+    typeof source.repoURL !== 'string' ||
+    typeof source.targetRevision !== 'string'
+  ) {
     return null;
   }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

The argo manager now checks if the `source.repoURL` and `source.targetRevision` fields are of type string. If one or both are no string it skips the dependency.

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

This fixes using helm templates with argo like this:

```yaml
apiVersion: argoproj.io/v1alpha1
kind: Application
spec:
  source:
    chart: {{ .Values.chart }}
    repoURL: {{ .Values.repoUrl}}
    targetRevision: {{ .Values.targetRevision }}
```

Without this check renovate fails on repositories containing such files since `{{ .Values.repoUrl }}` is parsed by the YAML parser as `{ [Object: object]: null }`.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
