### PR TITLE
fix(git): detect github force push rejection

### DIFF
--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -850,7 +850,10 @@ export async function commitFiles({
       );
       return null;
     }
-    if (err.message.includes('denying non-fast-forward')) {
+    if (
+      err.message.includes('denying non-fast-forward') ||
+      err.message.includes('GH003: Sorry, force-pushing')
+    ) {
       logger.debug({ err }, 'Permission denied to update branch');
       const error = new Error(CONFIG_VALIDATION);
       error.validationSource = branchName;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Catches when GitHub rejects force pushing commits.

## Context:

Found multiple instances of this in the hosted app.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
