### PR TITLE
refactor(github): Generic graphql request helper

### DIFF
--- a/lib/platform/github/index.ts
+++ b/lib/platform/github/index.ts
@@ -196,12 +196,15 @@ export async function initRepo({
   [config.repositoryOwner, config.repositoryName] = repository.split('/');
   let repo: GhRepo;
   try {
-    repo = await githubApi.queryRepo<GhRepo>(repoInfoQuery, {
+    const res = await githubApi.requestGraphql<{
+      repository: GhRepo;
+    }>(repoInfoQuery, {
       variables: {
         owner: config.repositoryOwner,
         name: config.repositoryName,
       },
     });
+    repo = res?.data?.repository;
     // istanbul ignore if
     if (!repo) {
       throw new Error(REPOSITORY_NOT_FOUND);

--- a/lib/util/http/github.spec.ts
+++ b/lib/util/http/github.spec.ts
@@ -353,7 +353,7 @@ describe('util/http/github', () => {
         .scope('https://ghe.mycompany.com')
         .post('/api/graphql')
         .reply(200, { data: { repository } });
-      await githubApi.queryRepo(graphqlQuery);
+      await githubApi.requestGraphql(graphqlQuery);
       const [req] = httpMock.getTrace();
       expect(req).toBeDefined();
       expect(req.url).toEqual('https://ghe.mycompany.com/api/graphql');
@@ -432,9 +432,9 @@ describe('util/http/github', () => {
         .post('/graphql')
         .reply(200, { data: { repository } });
 
-      const result = await githubApi.queryRepo(graphqlQuery);
+      const { data } = await githubApi.requestGraphql(graphqlQuery);
       expect(httpMock.getTrace()).toHaveLength(1);
-      expect(result).toStrictEqual(repository);
+      expect(data).toStrictEqual({ repository });
     });
     it('queryRepoField', async () => {
       httpMock

--- a/lib/util/http/github.ts
+++ b/lib/util/http/github.ts
@@ -30,10 +30,12 @@ export interface GithubHttpOptions extends InternalHttpOptions {
   token?: string;
 }
 
+interface GithubGraphqlRepoData<T = unknown> {
+  repository?: T;
+}
+
 interface GithubGraphqlResponse<T = unknown> {
-  data?: {
-    repository?: T;
-  };
+  data?: T;
   errors?: { message: string; locations: unknown }[];
 }
 
@@ -242,10 +244,10 @@ export class GithubHttp extends Http<GithubHttpOptions, GithubHttpOptions> {
     return result;
   }
 
-  public async queryRepo<T = unknown>(
+  public async requestGraphql<T = unknown>(
     query: string,
     options: GraphqlOptions = {}
-  ): Promise<T> {
+  ): Promise<GithubGraphqlResponse<T>> {
     let result = null;
 
     const path = 'graphql';
@@ -274,7 +276,7 @@ export class GithubHttp extends Http<GithubHttpOptions, GithubHttpOptions> {
         'graphql',
         opts
       );
-      result = res?.body?.data?.repository;
+      result = res?.body;
     } catch (err) {
       if (err instanceof ExternalHostError) {
         const gotError = err.err as GotLegacyError;
@@ -309,14 +311,15 @@ export class GithubHttp extends Http<GithubHttpOptions, GithubHttpOptions> {
 
     let isIterating = true;
     while (isIterating) {
-      const gqlRes = await this.queryRepo<T>(query, {
+      const res = await this.requestGraphql<GithubGraphqlRepoData<T>>(query, {
         ...options,
         count: Math.min(count, limit),
         cursor,
         paginate,
       });
-      if (gqlRes?.[fieldName]) {
-        const { nodes = [], edges = [], pageInfo } = gqlRes[fieldName];
+      const fieldData = res?.data?.repository?.[fieldName];
+      if (fieldData) {
+        const { nodes = [], edges = [], pageInfo } = fieldData;
         result.push(...nodes);
         result.push(...edges);
 
@@ -335,7 +338,7 @@ export class GithubHttp extends Http<GithubHttpOptions, GithubHttpOptions> {
       } else {
         count = Math.floor(count / 2);
         if (count === 0) {
-          logger.error({ gqlRes }, 'Error fetching GraphQL nodes');
+          logger.error({ res }, 'Error fetching GraphQL nodes');
           isIterating = false;
         }
       }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Make it possible to obtain `errors` from GraphQL response. Useful for logging and potentially we may need to behave differently depending on particular error type.

The core idea ot this PR is to have generic function that returns the whole response data instead of deeply nested query-specific fields. Though, more specific method named `queryRepoField()` remains same.

## Context:

Ref: #12045

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
