### PR TITLE
chore: add link to docs to issue select template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Renovate documentation
+    url: https://docs.renovatebot.com/
+    about: Read our documentation.
   - name: Start a discussion (config, doubts, docs)
     url: https://github.com/renovatebot/renovate/discussions/new
     about: If you have any questions about bot configuration or doubts about whether you should create a feature request or bug report, or have problems with the documentation please click here to create a Discussion instead of an Issue.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Add link to Renovate docs to our issue select template [^template]

## Context:

When people are about to open a new issue, they'll now see a button which takes them to the Renovate docs.
This helps give more visibility to our documentation site.

I'm not closing any existing issue with this PR.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->

[^template]: https://github.com/renovatebot/renovate/issues/new/choose