### PR TITLE
fix(config): massage package.json>renovate string

### DIFF
--- a/lib/workers/repository/init/merge.spec.ts
+++ b/lib/workers/repository/init/merge.spec.ts
@@ -58,6 +58,25 @@ describe('workers/repository/init/merge', () => {
       expect(await detectRepoFileConfig()).toMatchSnapshot();
       expect(await detectRepoFileConfig()).toMatchSnapshot();
     });
+    it('massages package.json renovate string', async () => {
+      git.getFileList.mockResolvedValue(['package.json']);
+      const pJson = JSON.stringify({
+        name: 'something',
+        renovate: 'github>renovatebot/renovate',
+      });
+      fs.readLocalFile.mockResolvedValue(pJson);
+      platform.getJsonFile.mockResolvedValueOnce(pJson);
+      expect(await detectRepoFileConfig()).toMatchInlineSnapshot(`
+        Object {
+          "configFileName": "package.json",
+          "configFileParsed": Object {
+            "extends": Array [
+              "github>renovatebot/renovate",
+            ],
+          },
+        }
+      `);
+    });
     it('returns error if cannot parse', async () => {
       git.getFileList.mockResolvedValue(['package.json', 'renovate.json']);
       fs.readLocalFile.mockResolvedValue('cannot parse');

--- a/lib/workers/repository/init/merge.ts
+++ b/lib/workers/repository/init/merge.ts
@@ -1,4 +1,5 @@
 import is from '@sindresorhus/is';
+import { sign } from 'crypto';
 import jsonValidator from 'json-dup-key-validator';
 import JSON5 from 'json5';
 import upath from 'upath';
@@ -68,6 +69,10 @@ export async function detectRepoFileConfig(): Promise<RepoFileConfig> {
     configFileParsed = JSON.parse(
       await readLocalFile('package.json', 'utf8')
     ).renovate;
+    if (is.string(configFileParsed)) {
+      logger.debug('Massaging string renovate config to extends array');
+      configFileParsed = { extends: [configFileParsed] };
+    }
     logger.debug({ config: configFileParsed }, 'package.json>renovate config');
   } else {
     let rawFileContents = await readLocalFile(configFileName, 'utf8');

--- a/lib/workers/repository/init/merge.ts
+++ b/lib/workers/repository/init/merge.ts
@@ -1,5 +1,4 @@
 import is from '@sindresorhus/is';
-import { sign } from 'crypto';
 import jsonValidator from 'json-dup-key-validator';
 import JSON5 from 'json5';
 import upath from 'upath';


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Massages a `package.json>renovate` string to an `extends` array if found.

## Context:

I found this occurring in the hosted app. It's same config approach as `prettier`.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
