### PR TITLE
fix(managers/gradle): Fix possibly borked regex match

### DIFF
--- a/lib/manager/gradle/index.ts
+++ b/lib/manager/gradle/index.ts
@@ -31,7 +31,7 @@ export const language = ProgrammingLanguage.Java;
 export const defaultConfig = {
   fileMatch: [
     '\\.gradle(\\.kts)?$',
-    '(^|/)gradle.properties$',
+    '(^|\\/)gradle\\.properties$',
     '(^|\\/)gradle\\/.+\\.toml$',
     '\\.versions\\.toml$',
   ],


### PR DESCRIPTION
If I understand the regex correctly, the previous one could match a file named `gradleXproperties`, as `.` was unescaped. Also the slash at the beginning of the matcher was unescaped. I do not think it was intentional and thus opened a PR.

## Changes:

If I understand the regex correctly, the previous one could match a file named `gradleXproperties`, as `.` was unescaped. Also the slash at the beginning of the matcher was unescaped. I do not think it was intentional and thus opened a PR.

## Context:

I was looking at the code because I did not remember which patterns trigger a catalog upgrade and found that.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [X] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
