### PR TITLE
docs:  fix repology example

### DIFF
--- a/lib/datasource/repology/readme.md
+++ b/lib/datasource/repology/readme.md
@@ -16,7 +16,7 @@ A real world example for this specific datasource would be maintaining system pa
     {
       "fileMatch": ["^Dockerfile$"],
       "matchStrings": [
-        "#\\s*renovate:\\s*datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\sENV .*?_VERSION=(?<currentValue>.*)\\s"
+        "#\\s*renovate:\\s*datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\sENV .*?_VERSION=\"(?<currentValue>.*)\"\\s"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
     }


### PR DESCRIPTION
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

adds missing `"` in documentation example.

## Context:

PR #12191

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only,
