### PR TITLE
fix(gitlab): correct labels to string type when ensureIssue

### DIFF
--- a/lib/platform/gitlab/__snapshots__/index.spec.ts.snap
+++ b/lib/platform/gitlab/__snapshots__/index.spec.ts.snap
@@ -490,7 +490,7 @@ Array [
   Object {
     "body": Object {
       "description": "the-body",
-      "labels": null,
+      "labels": "",
       "remove_source_branch": true,
       "source_branch": "some-branch",
       "squash": true,
@@ -501,7 +501,7 @@ Array [
       "accept": "application/json",
       "accept-encoding": "gzip, deflate, br",
       "authorization": "Bearer 123test",
-      "content-length": "158",
+      "content-length": "156",
       "content-type": "application/json",
       "host": "gitlab.com",
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
@@ -561,7 +561,7 @@ Array [
   Object {
     "body": Object {
       "description": "the-body",
-      "labels": null,
+      "labels": "",
       "remove_source_branch": true,
       "source_branch": "some-branch",
       "squash": true,
@@ -572,7 +572,7 @@ Array [
       "accept": "application/json",
       "accept-encoding": "gzip, deflate, br",
       "authorization": "Bearer 123test",
-      "content-length": "158",
+      "content-length": "156",
       "content-type": "application/json",
       "host": "gitlab.com",
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
@@ -621,7 +621,7 @@ Array [
   Object {
     "body": Object {
       "description": "the-body",
-      "labels": null,
+      "labels": "",
       "remove_source_branch": true,
       "source_branch": "some-branch",
       "target_branch": "master",
@@ -631,7 +631,7 @@ Array [
       "accept": "application/json",
       "accept-encoding": "gzip, deflate, br",
       "authorization": "Bearer 123test",
-      "content-length": "144",
+      "content-length": "142",
       "content-type": "application/json",
       "host": "gitlab.com",
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
@@ -796,7 +796,7 @@ Array [
   Object {
     "body": Object {
       "description": "the-body",
-      "labels": null,
+      "labels": "",
       "remove_source_branch": true,
       "source_branch": "some-branch",
       "target_branch": "master",
@@ -806,7 +806,7 @@ Array [
       "accept": "application/json",
       "accept-encoding": "gzip, deflate, br",
       "authorization": "Bearer 123test",
-      "content-length": "149",
+      "content-length": "147",
       "content-type": "application/json",
       "host": "gitlab.com",
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
@@ -856,7 +856,7 @@ Array [
   Object {
     "body": Object {
       "description": "the-body",
-      "labels": null,
+      "labels": "",
       "remove_source_branch": true,
       "source_branch": "some-branch",
       "target_branch": "master",
@@ -866,7 +866,7 @@ Array [
       "accept": "application/json",
       "accept-encoding": "gzip, deflate, br",
       "authorization": "Bearer 123test",
-      "content-length": "151",
+      "content-length": "149",
       "content-type": "application/json",
       "host": "gitlab.com",
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
@@ -1206,7 +1206,7 @@ Array [
   Object {
     "body": Object {
       "description": "new-content",
-      "labels": Array [],
+      "labels": "",
       "title": "new-title",
     },
     "headers": Object {
@@ -1240,17 +1240,14 @@ Array [
   Object {
     "body": Object {
       "description": "new-content",
-      "labels": Array [
-        "Renovate",
-        "Maintenance",
-      ],
+      "labels": "Renovate,Maintenance",
       "title": "new-title",
     },
     "headers": Object {
       "accept": "application/json",
       "accept-encoding": "gzip, deflate, br",
       "authorization": "Bearer 123test",
-      "content-length": "85",
+      "content-length": "81",
       "content-type": "application/json",
       "host": "gitlab.com",
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
@@ -1315,13 +1312,14 @@ Array [
   Object {
     "body": Object {
       "description": "newer-content",
+      "labels": "",
       "title": "title-2",
     },
     "headers": Object {
       "accept": "application/json",
       "accept-encoding": "gzip, deflate, br",
       "authorization": "Bearer 123test",
-      "content-length": "49",
+      "content-length": "61",
       "content-type": "application/json",
       "host": "gitlab.com",
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
@@ -1359,17 +1357,14 @@ Array [
   Object {
     "body": Object {
       "description": "newer-content",
-      "labels": Array [
-        "Renovate",
-        "Maintenance",
-      ],
+      "labels": "Renovate,Maintenance",
       "title": "title-2",
     },
     "headers": Object {
       "accept": "application/json",
       "accept-encoding": "gzip, deflate, br",
       "authorization": "Bearer 123test",
-      "content-length": "85",
+      "content-length": "81",
       "content-type": "application/json",
       "host": "gitlab.com",
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",

--- a/lib/platform/gitlab/index.ts
+++ b/lib/platform/gitlab/index.ts
@@ -561,7 +561,7 @@ export async function createPr({
         remove_source_branch: true,
         title,
         description,
-        labels: labels.join(','),
+        labels: (labels || []).join(','),
         squash: config.squash,
       },
     }

--- a/lib/platform/gitlab/index.ts
+++ b/lib/platform/gitlab/index.ts
@@ -561,7 +561,7 @@ export async function createPr({
         remove_source_branch: true,
         title,
         description,
-        labels: is.array(labels) ? labels.join(',') : null,
+        labels: labels.join(','),
         squash: config.squash,
       },
     }
@@ -875,7 +875,11 @@ export async function ensureIssue({
         await gitlabApi.putJson(
           `projects/${config.repository}/issues/${issue.iid}`,
           {
-            body: { title, description, labels: (labels ?? issue.labels).join(',') },
+            body: {
+              title,
+              description,
+              labels: (labels || issue.labels || []).join(','),
+            },
           }
         );
         return 'updated';
@@ -1003,7 +1007,9 @@ export async function deleteLabel(
   logger.debug(`Deleting label ${label} from #${issueNo}`);
   try {
     const pr = await getPr(issueNo);
-    const labels = (pr.labels || []).filter((l: string) => l !== label).join();
+    const labels = (pr.labels || [])
+      .filter((l: string) => l !== label)
+      .join(',');
     await gitlabApi.putJson(
       `projects/${config.repository}/merge_requests/${issueNo}`,
       {

--- a/lib/platform/gitlab/index.ts
+++ b/lib/platform/gitlab/index.ts
@@ -875,7 +875,7 @@ export async function ensureIssue({
         await gitlabApi.putJson(
           `projects/${config.repository}/issues/${issue.iid}`,
           {
-            body: { title, description, labels: labels ?? issue.labels },
+            body: { title, description, labels: (labels ?? issue.labels).join(',') },
           }
         );
         return 'updated';
@@ -885,7 +885,7 @@ export async function ensureIssue({
         body: {
           title,
           description,
-          labels: labels || [],
+          labels: (labels || []).join(','),
         },
       });
       logger.info('Issue created');


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->
fix https://github.com/renovatebot/renovate/issues/12160

`labels` in the body should be `string` instead of `string[]`, see: 
- New Issues: https://docs.gitlab.com/ce/api/issues.html#new-issues
- Update Issues:  https://docs.gitlab.com/ee/api/issues.html#edit-issue


## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
