### PR TITLE
fix(git): better commit message robustness

### DIFF
--- a/lib/workers/repository/model/commit-message.ts
+++ b/lib/workers/repository/model/commit-message.ts
@@ -22,17 +22,17 @@ export class CommitMessage {
   }
 
   public setMessage(message: string): void {
-    this.message = message.trim();
+    this.message = (message || '').trim();
   }
 
-  public setCustomPrefix(prefix = ''): void {
-    this.prefix = prefix.trim();
+  public setCustomPrefix(prefix?: string): void {
+    this.prefix = (prefix || '').trim();
   }
 
-  public setSemanticPrefix(type = '', scope = ''): void {
-    this.prefix = type.trim();
+  public setSemanticPrefix(type?: string, scope?: string): void {
+    this.prefix = (type || '').trim();
 
-    if (scope.trim()) {
+    if (scope?.trim()) {
       this.prefix += `(${scope.trim()})`;
     }
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds robustness to commit message trimming.

## Context:

Observed errors in the app. I'm guessing there are `null` values being passed.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
