### PR TITLE
feat: introduce dockerPreCommands for all side car containers

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -153,7 +153,7 @@ By default Renovate pulls the sidecar Docker containers from `docker.io/renovate
 You can use the `dockerImagePrefix` option to override this default.
 
 Say you want to pull your images from `ghcr.io/renovatebot` instead of `docker.io/renovate`.
-You would use put this in your configuration file:
+You would use this in your configuration file:
 
 ```json
 {
@@ -162,6 +162,35 @@ You would use put this in your configuration file:
 ```
 
 If you pulled a new `node` image, the final image would be `ghcr.io/renovatebot/node` instead of `docker.io/renovate/node`.
+
+## dockerMapDotfiles
+
+This is used if you want to map "dotfiles" from your host computer home directory to containers that Renovate creates, e.g. for updating lock files.
+Currently applicable to `.npmrc` only.
+
+```json
+{
+  "dockerMapDotfiles": true
+}
+```
+
+## dockerPreCommands
+
+If needed you can use the `dockerPreCommands` option to add custom bash commands that will be executed in each side car container before the actual command runs.
+
+Say you want to add authentication to your GitHub Enterprise server for all commands in the docker container so that a `git fetch` o.s. is authenticated.
+You would use this in your configuration file:
+
+```json
+{
+  "dockerPreCommands": [
+    "git config --global url.\"https://{{secrets.token}}@git.corp.com/\".insteadOf \"https://git.corp.com/\"`"
+  ]
+}
+```
+
+If Renovate executes the side car container it will set up the authentication with the given command above.
+This is especially useful for golang repositories that use `go mod tidy` and require additional authentication.
 
 ## dockerUser
 

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -163,17 +163,6 @@ You would use this in your configuration file:
 
 If you pulled a new `node` image, the final image would be `ghcr.io/renovatebot/node` instead of `docker.io/renovate/node`.
 
-## dockerMapDotfiles
-
-This is used if you want to map "dotfiles" from your host computer home directory to containers that Renovate creates, e.g. for updating lock files.
-Currently applicable to `.npmrc` only.
-
-```json
-{
-  "dockerMapDotfiles": true
-}
-```
-
 ## dockerPreCommands
 
 If needed you can use the `dockerPreCommands` option to add custom bash commands that will be executed in each side car container before the actual command runs.

--- a/lib/config/global.ts
+++ b/lib/config/global.ts
@@ -12,6 +12,7 @@ const repoGlobalOptions = [
   'customEnvVariables',
   'dockerChildPrefix',
   'dockerImagePrefix',
+  'dockerPreCommands',
   'dockerUser',
   'dryRun',
   'exposeAllEnv',

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -297,6 +297,14 @@ const options: RenovateOptions[] = [
     globalOnly: true,
   },
   {
+    name: 'dockerPreCommands',
+    description:
+      'Add custom commands that should be executed in each side car container before the actual command is run.',
+    type: 'array',
+    default: [],
+    admin: true,
+  },
+  {
     name: 'dockerUser',
     description:
       'Specify UID and GID for Docker-based binaries when binarySource=docker is used.',

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -97,6 +97,7 @@ export interface RepoGlobalConfig {
   customEnvVariables?: Record<string, string>;
   dockerChildPrefix?: string;
   dockerImagePrefix?: string;
+  dockerPreCommands?: string[];
   dockerUser?: string;
   dryRun?: boolean;
   exposeAllEnv?: boolean;
@@ -132,8 +133,9 @@ export type PostUpgradeTasks = {
   executionMode: ExecutionMode;
 };
 
-type UpdateConfig<T extends RenovateSharedConfig = RenovateSharedConfig> =
-  Partial<Record<UpdateType, T>>;
+type UpdateConfig<
+  T extends RenovateSharedConfig = RenovateSharedConfig
+> = Partial<Record<UpdateType, T>>;
 
 export type RenovateRepository =
   | string

--- a/lib/util/exec/docker/index.ts
+++ b/lib/util/exec/docker/index.ts
@@ -203,6 +203,7 @@ export async function generateDockerCommand(
     dockerUser,
     dockerChildPrefix,
     dockerImagePrefix,
+    dockerPreCommands,
   } = getGlobalConfig();
   const result = ['docker run --rm'];
   const containerName = getContainerName(image, dockerChildPrefix);
@@ -248,6 +249,7 @@ export async function generateDockerCommand(
   result.push(taggedImage);
 
   const bashCommand = [
+    ...prepareCommands(dockerPreCommands),
     ...prepareCommands(preCommands),
     ...commands,
     ...prepareCommands(postCommands),

--- a/lib/util/exec/index.spec.ts
+++ b/lib/util/exec/index.spec.ts
@@ -490,6 +490,44 @@ describe('util/exec/index', () => {
     ],
 
     [
+      'Docker global extra commands',
+      {
+        execConfig: {
+          ...execConfig,
+          binarySource: BinarySource.Docker,
+        },
+        processEnv,
+        inCmd,
+        inOpts: {
+          docker: {
+            image,
+            preCommands: ['preCommand1', 'preCommand2', null],
+            postCommands: ['postCommand1', undefined, 'postCommand2'],
+          },
+        },
+        outCmd: [
+          dockerPullCmd,
+          dockerRemoveCmd,
+          `docker run --rm --name=${name} --label=renovate_child ${defaultVolumes} -w "${cwd}" ${fullImage} bash -l -c "globalPreCommand1 && globalPreCommand2 & preCommand1 && preCommand2 && ${inCmd} && postCommand1 && postCommand2"`,
+        ],
+        outOpts: [
+          dockerPullOpts,
+          dockerRemoveOpts,
+          {
+            cwd,
+            encoding,
+            env: envMock.basic,
+            timeout: 900000,
+            maxBuffer: 10485760,
+          },
+        ],
+        adminConfig: {
+          dockerPreCommands: ['globalPreCommand1', 'globalPreCommand2'],
+        },
+      },
+    ],
+
+    [
       'Docker commands are nullable',
       {
         processEnv,


### PR DESCRIPTION
## Changes:

Adds a new `dockerPreCommands` option for the global config.

## Context:

#12147 

## Documentation (please check one with an [x])

- [X] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [X] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
