### PR TITLE
fix(manager/terraform): add required_version to preflight content check

### DIFF
--- a/lib/manager/terraform/__fixtures__/terraformBlock.tf
+++ b/lib/manager/terraform/__fixtures__/terraformBlock.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = "1.0.0"
+}

--- a/lib/manager/terraform/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/terraform/__snapshots__/extract.spec.ts.snap
@@ -390,6 +390,21 @@ Object {
 }
 `;
 
+exports[`manager/terraform/extract extractPackageFile() test terraform block with only requirement_terraform_version 1`] = `
+Object {
+  "deps": Array [
+    Object {
+      "currentValue": "1.0.0",
+      "datasource": "github-tags",
+      "depName": "hashicorp/terraform",
+      "depType": "required_version",
+      "extractVersion": "v(?<version>.*)$",
+      "lineNumber": 1,
+    },
+  ],
+}
+`;
+
 exports[`manager/terraform/extract extractPackageFile() update lockfile constraints with range strategy update-lockfile 1`] = `
 Object {
   "deps": Array [

--- a/lib/manager/terraform/extract.spec.ts
+++ b/lib/manager/terraform/extract.spec.ts
@@ -12,6 +12,7 @@ const tf2 = `module "relative" {
 const helm = loadFixture('helm.tf');
 const lockedVersion = loadFixture('lockedVersion.tf');
 const lockedVersionLockfile = loadFixture('rangeStrategy.hcl');
+const terraformBlock = loadFixture('terraformBlock.tf');
 
 const adminConfig: RepoGlobalConfig = {
   // `join` fixes Windows CI
@@ -61,6 +62,17 @@ describe('manager/terraform/extract', () => {
       expect(res).toMatchSnapshot();
       expect(res.deps).toHaveLength(3);
       expect(res.deps.filter((dep) => dep.skipReason)).toHaveLength(0);
+    });
+
+    it('test terraform block with only requirement_terraform_version', async () => {
+      const res = await extractPackageFile(
+        terraformBlock,
+        'terraformBlock.tf',
+        {}
+      );
+      expect(res.deps).toHaveLength(1);
+      expect(res.deps.filter((dep) => dep.skipReason)).toHaveLength(0);
+      expect(res).toMatchSnapshot();
     });
   });
 });

--- a/lib/manager/terraform/extract.ts
+++ b/lib/manager/terraform/extract.ts
@@ -36,6 +36,7 @@ const contentCheckList = [
   'required_providers ',
   ' "helm_release" ',
   ' "docker_image" ',
+  'required_version',
 ];
 
 export async function extractPackageFile(
@@ -45,6 +46,10 @@ export async function extractPackageFile(
 ): Promise<PackageFile | null> {
   logger.trace({ content }, 'terraform.extractPackageFile()');
   if (!checkFileContainsDependency(content, contentCheckList)) {
+    logger.trace(
+      { fileName },
+      'preflight content check has not found any relevant content'
+    );
     return null;
   }
   let deps: PackageDependency<TerraformManagerData>[] = [];


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:
Add `required_version` to the list of strings which triggers a deeper inspection  
<!-- Describe what behavior is changed by this PR. -->

## Context:
Fixes: #12271
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
