### PR TITLE
fix(npm): skip Node 17 unless allowing unstable

### DIFF
--- a/lib/manager/npm/post-update/node-version.spec.ts
+++ b/lib/manager/npm/post-update/node-version.spec.ts
@@ -36,7 +36,7 @@ describe('manager/npm/post-update/node-version', () => {
       ...config,
       constraints: { node: '>= 12.16.0' },
     });
-    const isAugmentedRange = res === '>=15';
+    const isAugmentedRange = res === '>=15 <17';
     const node16IsStable = isStable('16.100.0');
     expect(isAugmentedRange || node16IsStable).toBe(true);
   });

--- a/lib/manager/npm/post-update/node-version.ts
+++ b/lib/manager/npm/post-update/node-version.ts
@@ -57,8 +57,8 @@ export async function getNodeConstraint(
       !isStable('16.100.0')
     ) {
       if (lockfileVersion === 2) {
-        logger.debug('Forcing node 15 to ensure lockfileVersion=2 is used');
-        constraint = '>=15';
+        logger.debug('Forcing node 15+ to ensure lockfileVersion=2 is used');
+        constraint = '>=15 <17';
       } else if (validRange(`${constraint} <15`)) {
         logger.debug('Augmenting constraint to avoid node 15');
         constraint = `${constraint} <15`;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Avoids Node.js 17

## Context:

Fixes #12263

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
