### PR TITLE
feat: binarySource=docker avoid unstable tags

### DIFF
--- a/lib/manager/npm/post-update/lerna.ts
+++ b/lib/manager/npm/post-update/lerna.ts
@@ -82,7 +82,7 @@ export async function generateLockFiles(
       },
       docker: {
         image: 'node',
-        tagScheme: 'npm',
+        tagScheme: 'node',
         tagConstraint,
         preCommands,
       },

--- a/lib/manager/npm/post-update/lerna.ts
+++ b/lib/manager/npm/post-update/lerna.ts
@@ -72,8 +72,7 @@ export async function generateLockFiles(
       lernaCommand = lernaCommand.replace('--ignore-scripts ', '');
     }
     lernaCommand += cmdOptions;
-    const allowUnstable = true; // lerna will pick the default installed npm@6 unless we use node@>=15
-    const tagConstraint = await getNodeConstraint(config, allowUnstable);
+    const tagConstraint = await getNodeConstraint(config);
     const execOptions: ExecOptions = {
       cwd,
       extraEnv: {

--- a/lib/manager/npm/post-update/node-version.spec.ts
+++ b/lib/manager/npm/post-update/node-version.spec.ts
@@ -1,5 +1,4 @@
 import { fs } from '../../../../test/util';
-import { isStable } from '../../../versioning/node';
 import { getNodeConstraint } from './node-version';
 
 jest.mock('../../../util/fs');
@@ -15,45 +14,6 @@ describe('manager/npm/post-update/node-version', () => {
     fs.readLocalFile.mockResolvedValueOnce(null);
     const res = await getNodeConstraint(config);
     expect(res).toEqual('^12.16.0');
-  });
-  it('augments to avoid node 15', async () => {
-    fs.readLocalFile = jest.fn();
-    fs.readLocalFile.mockResolvedValueOnce(null);
-    fs.readLocalFile.mockResolvedValueOnce(null);
-    const res = await getNodeConstraint({
-      ...config,
-      constraints: { node: '>= 12.16.0' },
-    });
-    const isAugmentedRange = res === '>= 12.16.0 <15';
-    const node16IsStable = isStable('16.100.0');
-    expect(isAugmentedRange || node16IsStable).toBe(true);
-  });
-  it('forces node 15 if v2 lockfile detected and constraint allows', async () => {
-    fs.readLocalFile.mockResolvedValueOnce(null);
-    fs.readLocalFile.mockResolvedValueOnce(null);
-    fs.readLocalFile.mockResolvedValueOnce('{"lockfileVersion":2}');
-    const res = await getNodeConstraint({
-      ...config,
-      constraints: { node: '>= 12.16.0' },
-    });
-    const isAugmentedRange = res === '>=15 <17';
-    const node16IsStable = isStable('16.100.0');
-    expect(isAugmentedRange || node16IsStable).toBe(true);
-  });
-  it('forces node 15 if v2 lockfile detected and no constraint', async () => {
-    fs.readLocalFile.mockResolvedValueOnce(null);
-    fs.readLocalFile.mockResolvedValueOnce(null);
-    fs.readLocalFile.mockResolvedValueOnce('{"lockfileVersion":2}');
-    const res = await getNodeConstraint(
-      {
-        ...config,
-        constraints: {},
-      },
-      true
-    );
-    const isAugmentedRange = res === '>=15';
-    const node16IsStable = isStable('16.100.0');
-    expect(isAugmentedRange || node16IsStable).toBe(true);
   });
   it('returns .node-version value', async () => {
     fs.readLocalFile = jest.fn();

--- a/lib/manager/npm/post-update/node-version.ts
+++ b/lib/manager/npm/post-update/node-version.ts
@@ -1,8 +1,7 @@
-import { satisfies, validRange } from 'semver';
+import { validRange } from 'semver';
 import { logger } from '../../../logger';
 import { getSiblingFileName, readLocalFile } from '../../../util/fs';
 import { regEx } from '../../../util/regex';
-import { isStable } from '../../../versioning/node';
 import type { PostUpdateConfig } from '../../types';
 
 async function getNodeFile(filename: string): Promise<string> | null {
@@ -30,44 +29,14 @@ function getPackageJsonConstraint(config: PostUpdateConfig): string | null {
 }
 
 export async function getNodeConstraint(
-  config: PostUpdateConfig,
-  allowUnstable = false
+  config: PostUpdateConfig
 ): Promise<string> | null {
   const { packageFile } = config;
-  let constraint =
+  const constraint =
     (await getNodeFile(getSiblingFileName(packageFile, '.nvmrc'))) ||
     (await getNodeFile(getSiblingFileName(packageFile, '.node-version'))) ||
     getPackageJsonConstraint(config);
-  let lockfileVersion = 1;
-  try {
-    const lockFileName = getSiblingFileName(packageFile, 'package-lock.json');
-    lockfileVersion = JSON.parse(
-      await readLocalFile(lockFileName, 'utf8')
-    ).lockfileVersion;
-  } catch (err) {
-    // do nothing
-  }
-  // Avoid using node 15 if node 14 also satisfies the same constraint
-  // Remove this once node 16 is LTS
-  if (constraint) {
-    if (
-      validRange(constraint) &&
-      satisfies('14.100.0', constraint) &&
-      satisfies('15.100.0', constraint) &&
-      !isStable('16.100.0')
-    ) {
-      if (lockfileVersion === 2) {
-        logger.debug('Forcing node 15+ to ensure lockfileVersion=2 is used');
-        constraint = '>=15 <17';
-      } else if (validRange(`${constraint} <15`)) {
-        logger.debug('Augmenting constraint to avoid node 15');
-        constraint = `${constraint} <15`;
-      }
-    }
-  } else if (allowUnstable && lockfileVersion === 2) {
-    logger.debug('Using node >=15 for lockfileVersion=2');
-    constraint = '>=15';
-  } else {
+  if (!constraint) {
     logger.debug('No node constraint found - using latest');
   }
   return constraint;

--- a/lib/manager/npm/post-update/npm.ts
+++ b/lib/manager/npm/post-update/npm.ts
@@ -65,7 +65,7 @@ export async function generateLockFile(
       },
       docker: {
         image: 'node',
-        tagScheme: 'npm',
+        tagScheme: 'node',
         tagConstraint,
         preCommands,
       },

--- a/lib/manager/npm/post-update/pnpm.ts
+++ b/lib/manager/npm/post-update/pnpm.ts
@@ -38,7 +38,7 @@ export async function generateLockFile(
       },
       docker: {
         image: 'node',
-        tagScheme: 'npm',
+        tagScheme: 'node',
         tagConstraint,
         preCommands,
       },

--- a/lib/manager/npm/post-update/yarn.ts
+++ b/lib/manager/npm/post-update/yarn.ts
@@ -129,7 +129,7 @@ export async function generateLockFile(
       extraEnv,
       docker: {
         image: 'node',
-        tagScheme: 'npm',
+        tagScheme: 'node',
         tagConstraint,
         preCommands,
       },

--- a/lib/util/exec/docker/index.spec.ts
+++ b/lib/util/exec/docker/index.spec.ts
@@ -95,6 +95,16 @@ describe('util/exec/docker/index', () => {
       getPkgReleases.mockResolvedValueOnce({ releases } as never);
       expect(await getDockerTag('foo', '^1.2.3', 'npm')).toBe('1.9.9');
     });
+    it('filters out node unstable', async () => {
+      const releases = [
+        { version: '12.0.0' },
+        { version: '13.0.1' },
+        { version: '14.0.2' },
+        { version: '15.0.2' },
+      ];
+      getPkgReleases.mockResolvedValueOnce({ releases } as never);
+      expect(await getDockerTag('foo', '>=12', 'node')).toBe('14.0.2');
+    });
   });
 
   describe('removeDockerContainer', () => {

--- a/lib/util/exec/docker/index.ts
+++ b/lib/util/exec/docker/index.ts
@@ -93,6 +93,11 @@ export async function getDockerTag(
     versions = versions.filter(
       (version) => ver.isVersion(version) && ver.matches(version, constraint)
     );
+    // Prefer stable versions over unstable, even if the range satisfies both types
+    if (!versions.every((version) => ver.isStable(version))) {
+      logger.debug('Filtering out unstable versions');
+      versions = versions.filter((version) => ver.isStable(version));
+    }
     versions = versions.sort(ver.sortVersions.bind(ver));
     if (versions.length) {
       const version = versions.pop();


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Improves binarySource=docker handling for node in particular:
- Uses `node` versioning for npm
- Removes special `lerna` handling no longer necessary when npm@8 is the default
- filters out unstable tags if stable ones exist (to avoid node 17)

## Context:

Closes #12307

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
