### PR TITLE
fix: replace numbered capture group replaces with named capture groups

### DIFF
--- a/lib/manager/gomod/update.spec.ts
+++ b/lib/manager/gomod/update.spec.ts
@@ -185,7 +185,7 @@ describe('manager/gomod/update', () => {
       };
       const res = updateDependency({ fileContent: gomod2, upgrade });
       expect(res).not.toEqual(gomod2);
-      expect(res).not.toContain(upgrade.newDigest);
+      expect(res).toContain('github.com/spf13/jwalterweatherman 123456123456');
       expect(res).toContain(upgrade.newDigest.substring(0, 12));
     });
     it('skips already-updated multiline digest', () => {

--- a/lib/manager/gomod/update.ts
+++ b/lib/manager/gomod/update.ts
@@ -33,13 +33,15 @@ export function updateDependency({
     let updateLineExp: RegExp;
     if (depType === 'replace') {
       updateLineExp = regEx(
-        /^(replace\s+[^\s]+[\s]+[=][>]+\s+)([^\s]+\s+)([^\s]+)/
+        /^(?<depPart>replace\s+[^\s]+[\s]+[=][>]+\s+)(?<divider>[^\s]+\s+)[^\s]+/
       );
     } else if (depType === 'require') {
       if (upgrade.managerData.multiLine) {
-        updateLineExp = regEx(/^(\s+[^\s]+)(\s+)([^\s]+)/);
+        updateLineExp = regEx(/^(?<depPart>\s+[^\s]+)(?<divider>\s+)[^\s]+/);
       } else {
-        updateLineExp = regEx(/^(require\s+[^\s]+)(\s+)([^\s]+)/);
+        updateLineExp = regEx(
+          /^(?<depPart>require\s+[^\s]+)(?<divider>\s+)[^\s]+/
+        );
       }
     }
     if (updateLineExp && !updateLineExp.test(lineToChange)) {
@@ -61,14 +63,12 @@ export function updateDependency({
       );
       newLine = lineToChange.replace(
         updateLineExp,
-        (_, name: string, whitespace: string) =>
-          `${name}${whitespace}${newDigestRightSized}`
+        `$<depPart>$<divider>${newDigestRightSized}`
       );
     } else {
       newLine = lineToChange.replace(
         updateLineExp,
-        (_, name: string, whitespace: string) =>
-          `${name}${whitespace}${upgrade.newValue}`
+        `$<depPart>$<divider>${upgrade.newValue}`
       );
     }
     if (upgrade.updateType === 'major') {

--- a/lib/manager/gomod/update.ts
+++ b/lib/manager/gomod/update.ts
@@ -47,6 +47,8 @@ export function updateDependency({
       return null;
     }
     let newLine: string;
+    // This divider is to prevent something like `$1$2${digest}` becoming "$1$2345678abc"
+    const regexDivider = '""""';
     if (upgrade.updateType === 'digest') {
       const newDigestRightSized = upgrade.newDigest.substring(
         0,
@@ -59,13 +61,16 @@ export function updateDependency({
         { depName, lineToChange, newDigestRightSized },
         'gomod: need to update digest'
       );
+      newLine = lineToChange
+        .replace(updateLineExp, `$1$2${regexDivider}${newDigestRightSized}`)
+        .replace(regexDivider, '');
+    } else {
       newLine = lineToChange.replace(
         updateLineExp,
-        `$1$2${newDigestRightSized}`
+        `$1$2${regexDivider}${upgrade.newValue}`
       );
-    } else {
-      newLine = lineToChange.replace(updateLineExp, `$1$2${upgrade.newValue}`);
     }
+    newLine = newLine.replace(regexDivider, '');
     if (upgrade.updateType === 'major') {
       logger.debug({ depName }, 'gomod: major update');
       if (depName.startsWith('gopkg.in/')) {

--- a/lib/manager/gomod/update.ts
+++ b/lib/manager/gomod/update.ts
@@ -1,5 +1,5 @@
 import { logger } from '../../logger';
-import { regEx } from '../../util/regex';
+import { regEx, REGEX_DIVIDER } from '../../util/regex';
 import type { UpdateDependencyConfig } from '../types';
 
 function getDepNameWithNoVersion(depName: string): string {
@@ -47,8 +47,6 @@ export function updateDependency({
       return null;
     }
     let newLine: string;
-    // This divider is to prevent something like `$1$2${digest}` becoming "$1$2345678abc"
-    const regexDivider = '""""';
     if (upgrade.updateType === 'digest') {
       const newDigestRightSized = upgrade.newDigest.substring(
         0,
@@ -62,15 +60,15 @@ export function updateDependency({
         'gomod: need to update digest'
       );
       newLine = lineToChange
-        .replace(updateLineExp, `$1$2${regexDivider}${newDigestRightSized}`)
-        .replace(regexDivider, '');
+        .replace(updateLineExp, `$1$2${REGEX_DIVIDER}${newDigestRightSized}`)
+        .replace(REGEX_DIVIDER, '');
     } else {
       newLine = lineToChange.replace(
         updateLineExp,
-        `$1$2${regexDivider}${upgrade.newValue}`
+        `$1$2${REGEX_DIVIDER}${upgrade.newValue}`
       );
     }
-    newLine = newLine.replace(regexDivider, '');
+    newLine = newLine.replace(REGEX_DIVIDER, '');
     if (upgrade.updateType === 'major') {
       logger.debug({ depName }, 'gomod: major update');
       if (depName.startsWith('gopkg.in/')) {

--- a/lib/manager/gomod/update.ts
+++ b/lib/manager/gomod/update.ts
@@ -1,5 +1,5 @@
 import { logger } from '../../logger';
-import { regEx, REGEX_DIVIDER } from '../../util/regex';
+import { regEx } from '../../util/regex';
 import type { UpdateDependencyConfig } from '../types';
 
 function getDepNameWithNoVersion(depName: string): string {
@@ -59,16 +59,18 @@ export function updateDependency({
         { depName, lineToChange, newDigestRightSized },
         'gomod: need to update digest'
       );
-      newLine = lineToChange
-        .replace(updateLineExp, `$1$2${REGEX_DIVIDER}${newDigestRightSized}`)
-        .replace(REGEX_DIVIDER, '');
+      newLine = lineToChange.replace(
+        updateLineExp,
+        (_, name: string, whitespace: string) =>
+          `${name}${whitespace}${newDigestRightSized}`
+      );
     } else {
       newLine = lineToChange.replace(
         updateLineExp,
-        `$1$2${REGEX_DIVIDER}${upgrade.newValue}`
+        (_, name: string, whitespace: string) =>
+          `${name}${whitespace}${upgrade.newValue}`
       );
     }
-    newLine = newLine.replace(REGEX_DIVIDER, '');
     if (upgrade.updateType === 'major') {
       logger.debug({ depName }, 'gomod: major update');
       if (depName.startsWith('gopkg.in/')) {

--- a/lib/manager/helmv3/update.ts
+++ b/lib/manager/helmv3/update.ts
@@ -20,8 +20,8 @@ export function bumpPackageVersion(
     }
     logger.debug({ newChartVersion });
     bumpedContent = content.replace(
-      /^(version:\s*).*$/m, // TODO #12070
-      `$1${newChartVersion}`
+      /^(?<version>version:\s*).*$/m, // TODO #12070
+      `$<version>${newChartVersion}`
     );
     if (bumpedContent === content) {
       logger.debug('Version was already bumped');

--- a/lib/manager/npm/update/package-version/index.ts
+++ b/lib/manager/npm/update/package-version/index.ts
@@ -31,8 +31,8 @@ export function bumpPackageVersion(
     }
     logger.debug({ newPjVersion });
     bumpedContent = content.replace(
-      /("version":\s*")[^"]*/, // TODO #12070
-      `$1${newPjVersion}`
+      /(?<version>"version":\s*")[^"]*/, // TODO #12070
+      `$<version>${newPjVersion}`
     );
     if (bumpedContent === content) {
       logger.debug('Version was already bumped');

--- a/lib/manager/terraform/lockfile/util.ts
+++ b/lib/manager/terraform/lockfile/util.ts
@@ -159,7 +159,7 @@ export function writeLockUpdates(
     providerBlockLines.forEach((providerBlockLine, providerBlockIndex) => {
       const versionLine = providerBlockLine.replace(
         versionLineRegex,
-        `$1${update.newVersion}$3`
+        `$<prefix>${update.newVersion}$<suffix>`
       );
       if (versionLine !== providerBlockLine) {
         newProviderBlockLines.push(versionLine);
@@ -168,7 +168,7 @@ export function writeLockUpdates(
 
       const constraintLine = providerBlockLine.replace(
         constraintLineRegex,
-        `$1${update.newConstraint}$3`
+        `$<prefix>${update.newConstraint}$<suffix>`
       );
       if (constraintLine !== providerBlockLine) {
         newProviderBlockLines.push(constraintLine);

--- a/lib/util/regex.ts
+++ b/lib/util/regex.ts
@@ -5,9 +5,6 @@ import { logger } from '../logger';
 
 let RegEx: RegExpConstructor;
 
-// This divider is to prevent something like `$1$2${digest}` becoming "$1$2345678abc"
-export const REGEX_DIVIDER = '""""""';
-
 try {
   // eslint-disable-next-line
   const RE2 = require('re2');

--- a/lib/util/regex.ts
+++ b/lib/util/regex.ts
@@ -5,6 +5,9 @@ import { logger } from '../logger';
 
 let RegEx: RegExpConstructor;
 
+// This divider is to prevent something like `$1$2${digest}` becoming "$1$2345678abc"
+export const REGEX_DIVIDER = '""""""';
+
 try {
   // eslint-disable-next-line
   const RE2 = require('re2');

--- a/lib/versioning/hashicorp/index.ts
+++ b/lib/versioning/hashicorp/index.ts
@@ -40,17 +40,20 @@ function getNewValue({
       const testFullVersion = /(~>\s*0\.)(\d+)\.\d$/;
       let replaceValue = '';
       if (testFullVersion.test(currentValue)) {
-        replaceValue = `$1${npm.getMinor(newVersion)}.0`;
+        replaceValue = `$<prefix>${npm.getMinor(newVersion)}.0`;
       } else {
-        replaceValue = `$1${npm.getMinor(newVersion)}$3`;
+        replaceValue = `$<prefix>${npm.getMinor(newVersion)}$<suffix>`;
       }
-      return currentValue.replace(/(~>\s*0\.)(\d+)(.*)$/, replaceValue);
+      return currentValue.replace(
+        /(?<prefix>~>\s*0\.)\d+(?<suffix>.*)$/,
+        replaceValue
+      );
     }
     // handle special ~> 1.2 case
     if (/(~>\s*)\d+\.\d+$/.test(currentValue)) {
       return currentValue.replace(
-        /(~>\s*)\d+\.\d+$/,
-        `$1${npm.getMajor(newVersion)}.0`
+        /(?<prefix>~>\s*)\d+\.\d+$/,
+        `$<prefix>${npm.getMajor(newVersion)}.0`
       );
     }
   }

--- a/lib/versioning/ruby/index.ts
+++ b/lib/versioning/ruby/index.ts
@@ -126,8 +126,12 @@ const getNewValue = ({
     const delimiter = currentValue[0];
     return newValue
       .split(',')
-      .map((element) => element.replace(/^(\s*)/, `$1${delimiter}`))
-      .map((element) => element.replace(/(\s*)$/, `${delimiter}$1`))
+      .map((element) =>
+        element.replace(/^(?<whitespace>\s*)/, `$<whitespace>${delimiter}`)
+      )
+      .map((element) =>
+        element.replace(/(?<whitespace>\s*)$/, `${delimiter}$<whitespace>`)
+      )
       .join(',');
   }
   return newValue;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Uses a regex divider to ensure that numbered replacements don't cause a problem with `re2`

## Context:

Closes #12301

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
