### PR TITLE
refactor(go): Extract digest functionality to separate file

### DIFF
--- a/lib/datasource/go/digest.ts
+++ b/lib/datasource/go/digest.ts
@@ -1,0 +1,39 @@
+import * as github from '../github-tags';
+import type { DigestConfig } from '../types';
+import { bitbucket, getDatasource } from './util';
+
+/**
+ * go.getDigest
+ *
+ * This datasource resolves a go module URL into its source repository
+ *  and then fetches the digest it if it is on GitHub.
+ *
+ * This function will:
+ *  - Determine the source URL for the module
+ *  - Call the respective getDigest in github to retrieve the commit hash
+ */
+export async function getDigest(
+  { lookupName }: Partial<DigestConfig>,
+  value?: string
+): Promise<string | null> {
+  const source = await getDatasource(lookupName);
+  if (!source) {
+    return null;
+  }
+
+  // ignore v0.0.0- pseudo versions that are used Go Modules - look up default branch instead
+  const tag = value && !value.startsWith('v0.0.0-2') ? value : undefined;
+
+  switch (source.datasource) {
+    case github.id: {
+      return github.getDigest(source, tag);
+    }
+    case bitbucket.id: {
+      return bitbucket.getDigest(source, tag);
+    }
+    /* istanbul ignore next: can never happen, makes lint happy */
+    default: {
+      return null;
+    }
+  }
+}

--- a/lib/datasource/go/index.spec.ts
+++ b/lib/datasource/go/index.spec.ts
@@ -2,7 +2,8 @@ import { getPkgReleases } from '..';
 import * as httpMock from '../../../test/http-mock';
 import { logger, mocked } from '../../../test/util';
 import * as _hostRules from '../../util/host-rules';
-import { id as datasource, getDigest } from '.';
+import { getDigest } from './digest';
+import { id as datasource } from '.';
 
 jest.mock('../../util/host-rules');
 

--- a/lib/datasource/go/index.ts
+++ b/lib/datasource/go/index.ts
@@ -2,7 +2,7 @@ import { logger } from '../../logger';
 import { regEx } from '../../util/regex';
 import * as github from '../github-tags';
 import * as gitlab from '../gitlab-tags';
-import type { DigestConfig, GetReleasesConfig, ReleaseResult } from '../types';
+import type { GetReleasesConfig, ReleaseResult } from '../types';
 import * as goproxy from './goproxy';
 import { bitbucket, getDatasource } from './util';
 
@@ -114,40 +114,4 @@ export async function getReleases(
   }
 
   return res;
-}
-
-/**
- * go.getDigest
- *
- * This datasource resolves a go module URL into its source repository
- *  and then fetches the digest it if it is on GitHub.
- *
- * This function will:
- *  - Determine the source URL for the module
- *  - Call the respective getDigest in github to retrieve the commit hash
- */
-export async function getDigest(
-  { lookupName }: Partial<DigestConfig>,
-  value?: string
-): Promise<string | null> {
-  const source = await getDatasource(lookupName);
-  if (!source) {
-    return null;
-  }
-
-  // ignore v0.0.0- pseudo versions that are used Go Modules - look up default branch instead
-  const tag = value && !value.startsWith('v0.0.0-2') ? value : undefined;
-
-  switch (source.datasource) {
-    case github.id: {
-      return github.getDigest(source, tag);
-    }
-    case bitbucket.id: {
-      return bitbucket.getDigest(source, tag);
-    }
-    /* istanbul ignore next: can never happen, makes lint happy */
-    default: {
-      return null;
-    }
-  }
 }


### PR DESCRIPTION


<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Move `extractDigest` to separate file

## Context:

- Ref #11944
- Ref #12298

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
