### PR TITLE
fix(gomod): remove token encoding

### DIFF
--- a/lib/manager/gomod/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/manager/gomod/__snapshots__/artifacts.spec.ts.snap
@@ -290,7 +290,7 @@ Array [
       "env": Object {
         "CGO_ENABLED": "1",
         "GIT_CONFIG_COUNT": "1",
-        "GIT_CONFIG_KEY_0": "url.https://some-token@github.com/.insteadOf",
+        "GIT_CONFIG_KEY_0": "url.https://x-access-token:some-token@github.com/.insteadOf",
         "GIT_CONFIG_VALUE_0": "https://github.com/",
         "GOFLAGS": "-modcacherw",
         "GONOPROXY": "noproxy.example.com/*",

--- a/lib/manager/gomod/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/manager/gomod/__snapshots__/artifacts.spec.ts.snap
@@ -290,7 +290,7 @@ Array [
       "env": Object {
         "CGO_ENABLED": "1",
         "GIT_CONFIG_COUNT": "1",
-        "GIT_CONFIG_KEY_0": "url.https://x-access-token:some-token@github.com/.insteadOf",
+        "GIT_CONFIG_KEY_0": "url.https://some-token@github.com/.insteadOf",
         "GIT_CONFIG_VALUE_0": "https://github.com/",
         "GOFLAGS": "-modcacherw",
         "GONOPROXY": "noproxy.example.com/*",

--- a/lib/util/git/auth.spec.ts
+++ b/lib/util/git/auth.spec.ts
@@ -18,24 +18,11 @@ describe('util/git/auth', () => {
       });
     });
 
-    it('returns url with correctly encoded token', () => {
-      expect(
-        getGitAuthenticatedEnvironmentVariables(
-          'https://github.com/',
-          'token:1234'
-        )
-      ).toStrictEqual({
-        GIT_CONFIG_KEY_0: 'url.https://token1234@github.com/.insteadOf',
-        GIT_CONFIG_VALUE_0: 'https://github.com/',
-        GIT_CONFIG_COUNT: '1',
-      });
-    });
-
     it('returns correct url if token already contains GitHub App username', () => {
       expect(
         getGitAuthenticatedEnvironmentVariables(
           'https://github.com/',
-          'x-access-token:token:1234'
+          'x-access-token:token1234'
         )
       ).toStrictEqual({
         GIT_CONFIG_KEY_0:

--- a/lib/util/git/auth.spec.ts
+++ b/lib/util/git/auth.spec.ts
@@ -25,7 +25,7 @@ describe('util/git/auth', () => {
           'token:1234'
         )
       ).toStrictEqual({
-        GIT_CONFIG_KEY_0: 'url.https://token%3A1234@github.com/.insteadOf',
+        GIT_CONFIG_KEY_0: 'url.https://token1234@github.com/.insteadOf',
         GIT_CONFIG_VALUE_0: 'https://github.com/',
         GIT_CONFIG_COUNT: '1',
       });
@@ -39,7 +39,7 @@ describe('util/git/auth', () => {
         )
       ).toStrictEqual({
         GIT_CONFIG_KEY_0:
-          'url.https://x-access-token:token%3A1234@github.com/.insteadOf',
+          'url.https://x-access-token:token1234@github.com/.insteadOf',
         GIT_CONFIG_VALUE_0: 'https://github.com/',
         GIT_CONFIG_COUNT: '1',
       });

--- a/lib/util/git/auth.spec.ts
+++ b/lib/util/git/auth.spec.ts
@@ -31,6 +31,20 @@ describe('util/git/auth', () => {
       });
     });
 
+    it('returns correct url if token already contains GitHub App username', () => {
+      expect(
+        getGitAuthenticatedEnvironmentVariables(
+          'https://github.com/',
+          'x-access-token:token:1234'
+        )
+      ).toStrictEqual({
+        GIT_CONFIG_KEY_0:
+          'url.https://x-access-token:token%3A1234@github.com/.insteadOf',
+        GIT_CONFIG_VALUE_0: 'https://github.com/',
+        GIT_CONFIG_COUNT: '1',
+      });
+    });
+
     it('returns url with token and already existing GIT_CONFIG_COUNT from parameter', () => {
       expect(
         getGitAuthenticatedEnvironmentVariables(

--- a/lib/util/git/auth.ts
+++ b/lib/util/git/auth.ts
@@ -1,17 +1,6 @@
 import { logger } from '../../logger';
 import { getHttpUrl } from './url';
 
-function encodeToken(token: string): string {
-  // if the token already starts with the `x-access-token:` username we encode only the token part
-  // This ensures that GitHub Apps work
-  if (token.startsWith('x-access-token:')) {
-    const appToken = token.replace('x-access-token:', '');
-    return `x-access-token:${encodeURIComponent(appToken)}`;
-  }
-
-  return encodeURIComponent(token);
-}
-
 /*
     Add authorization to a Git Url and returns the updated environment variables
 */
@@ -35,7 +24,7 @@ export function getGitAuthenticatedEnvironmentVariables(
     }
   }
 
-  const gitUrlWithToken = getHttpUrl(gitUrl, encodeToken(token));
+  const gitUrlWithToken = getHttpUrl(gitUrl, token);
 
   // create a shallow copy of the environmentVariables as base so we don't modify the input parameter object
   // add the two new config key and value to the returnEnvironmentVariables object

--- a/lib/util/git/auth.ts
+++ b/lib/util/git/auth.ts
@@ -1,14 +1,24 @@
 import { logger } from '../../logger';
 import { getHttpUrl } from './url';
 
+function encodeToken(token: string): string {
+  // if the token already starts with the `x-access-token:` username we encode only the token part
+  // This ensures that GitHub Apps work
+  if (token.startsWith('x-access-token:')) {
+    const appToken = token.replace('x-access-token:', '');
+    return `x-access-token:${encodeURIComponent(appToken)}`;
+  }
+
+  return encodeURIComponent(token);
+}
+
 /*
     Add authorization to a Git Url and returns the updated environment variables
 */
 export function getGitAuthenticatedEnvironmentVariables(
   gitUrl: string,
   token: string,
-  environmentVariables?: NodeJS.ProcessEnv,
-  user = 'x-access-token'
+  environmentVariables?: NodeJS.ProcessEnv
 ): NodeJS.ProcessEnv {
   // check if the environmentVariables already contain a GIT_CONFIG_COUNT or if the process has one
   const gitConfigCountEnvVariable =
@@ -25,10 +35,7 @@ export function getGitAuthenticatedEnvironmentVariables(
     }
   }
 
-  const gitUrlWithToken = getHttpUrl(
-    gitUrl,
-    `${encodeURIComponent(user)}:${encodeURIComponent(token)}`
-  );
+  const gitUrlWithToken = getHttpUrl(gitUrl, encodeToken(token));
 
   // create a shallow copy of the environmentVariables as base so we don't modify the input parameter object
   // add the two new config key and value to the returnEnvironmentVariables object

--- a/lib/util/git/auth.ts
+++ b/lib/util/git/auth.ts
@@ -7,7 +7,8 @@ import { getHttpUrl } from './url';
 export function getGitAuthenticatedEnvironmentVariables(
   gitUrl: string,
   token: string,
-  environmentVariables?: NodeJS.ProcessEnv
+  environmentVariables?: NodeJS.ProcessEnv,
+  user = 'x-access-token'
 ): NodeJS.ProcessEnv {
   // check if the environmentVariables already contain a GIT_CONFIG_COUNT or if the process has one
   const gitConfigCountEnvVariable =
@@ -24,7 +25,10 @@ export function getGitAuthenticatedEnvironmentVariables(
     }
   }
 
-  const gitUrlWithToken = getHttpUrl(gitUrl, encodeURIComponent(token));
+  const gitUrlWithToken = getHttpUrl(
+    gitUrl,
+    `${encodeURIComponent(user)}:${encodeURIComponent(token)}`
+  );
 
   // create a shallow copy of the environmentVariables as base so we don't modify the input parameter object
   // add the two new config key and value to the returnEnvironmentVariables object


### PR DESCRIPTION
## Changes:

This PR checks if a given token starts with `x-access-token:` as the token is constructed in this way to support GitHub App functionality in other places. 
If this is the case only the token part after `x-access-token:` is encoded.

## Context:

Fixes #12339

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
