### PR TITLE
fix(go): Escape dot for regexes produced for GONOPROXY

### DIFF
--- a/lib/datasource/go/goproxy.spec.ts
+++ b/lib/datasource/go/goproxy.spec.ts
@@ -98,6 +98,7 @@ describe('datasource/go/goproxy', () => {
       expect(parseNoproxy('[abc]')?.source).toEqual('^(?:[abc])$');
       expect(parseNoproxy('[a-c]')?.source).toEqual('^(?:[a-c])$');
       expect(parseNoproxy('[\\a-\\c]')?.source).toEqual('^(?:[a-c])$');
+      expect(parseNoproxy('a.b')?.source).toEqual('^(?:a\\.b)$');
     });
 
     it('matches on real package prefixes', () => {

--- a/lib/datasource/go/goproxy.spec.ts
+++ b/lib/datasource/go/goproxy.spec.ts
@@ -98,7 +98,7 @@ describe('datasource/go/goproxy', () => {
       expect(parseNoproxy('[abc]')?.source).toEqual('^(?:[abc])$');
       expect(parseNoproxy('[a-c]')?.source).toEqual('^(?:[a-c])$');
       expect(parseNoproxy('[\\a-\\c]')?.source).toEqual('^(?:[a-c])$');
-      expect(parseNoproxy('a.b')?.source).toEqual('^(?:a\\.b)$');
+      expect(parseNoproxy('a.b.c')?.source).toEqual('^(?:a\\.b\\.c)$');
     });
 
     it('matches on real package prefixes', () => {

--- a/lib/datasource/go/goproxy.ts
+++ b/lib/datasource/go/goproxy.ts
@@ -81,7 +81,7 @@ const lexer = moo.states({
     },
     char: {
       match: /[^*?\\[\n]/,
-      value: (s: string) => s.replace('.', '\\.'),
+      value: (s: string) => s.replace(/\./g, '\\.'),
     },
     escapedChar: {
       match: /\\./, // TODO #12070

--- a/lib/datasource/go/goproxy.ts
+++ b/lib/datasource/go/goproxy.ts
@@ -81,7 +81,7 @@ const lexer = moo.states({
     },
     char: {
       match: /[^*?\\[\n]/,
-      value: (s: string) => s.replace(/\./g, '\\.'),
+      value: (s: string) => s.replace(regEx('\\.', 'g'), '\\.'),
     },
     escapedChar: {
       match: /\\./, // TODO #12070

--- a/lib/datasource/go/goproxy.ts
+++ b/lib/datasource/go/goproxy.ts
@@ -79,7 +79,10 @@ const lexer = moo.states({
       push: 'characterRange',
       value: (_: string) => '[',
     },
-    char: /[^*?\\[\n]/, // TODO #12070
+    char: {
+      match: /[^*?\\[\n]/,
+      value: (s: string) => s.replace('.', '\\.'),
+    },
     escapedChar: {
       match: /\\./, // TODO #12070
       value: (s: string) => s.slice(1),


### PR DESCRIPTION
## Changes:

Fix regex generation such that `www.example.com` wouldn't match `www1example2com`.

## Context:

- Ref #11944
- Ref #12298

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
