### PR TITLE
fix(github): Revert auto-merge feature

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -1669,11 +1669,8 @@ If enabled Renovate will pin Docker images by means of their SHA256 digest and n
 
 If you have enabled `automerge` and set `automergeType=pr` in the Renovate config, then `platformAutomerge` is enabled by default to speed up merging via the platform's native automerge functionality.
 
-Renovate tries platform-native automerge only when it initially creates the PR.
-Any PR that is being updated will be automerged with the Renovate-based automerge.
-
 `platformAutomerge` will configure PRs to be merged after all (if any) branch policies have been met.
-This option is available for Azure, GitHub and GitLab.
+This option is available for Azure and GitLab.
 It falls back to Renovate-based automerge if the platform-native automerge is not available.
 
 Though this option is enabled by default, you can fine tune the behavior by setting `packageRules` if you want to use it selectively (e.g. per-package).

--- a/lib/platform/github/graphql.ts
+++ b/lib/platform/github/graphql.ts
@@ -173,19 +173,3 @@ query($owner: String!, $name: String!) {
   }
 }
 `;
-
-export const enableAutoMergeMutation = `
-mutation EnablePullRequestAutoMerge(
-  $pullRequestId: ID!
-) {
-  enablePullRequestAutoMerge(
-    input: {
-      pullRequestId: $pullRequestId
-    }
-  ) {
-    pullRequest {
-      number
-    }
-  }
-}
-`;

--- a/lib/platform/github/types.ts
+++ b/lib/platform/github/types.ts
@@ -39,7 +39,6 @@ export interface GhRestPr extends GhPr {
   created_at: string;
   closed_at: string;
   user?: { login?: string };
-  node_id: string;
 }
 
 export interface GhGraphQlPr extends GhPr {
@@ -92,11 +91,5 @@ export interface GhRepo {
     target: {
       oid: string;
     };
-  };
-}
-
-export interface GhAutomergeResponse {
-  enablePullRequestAutoMerge: {
-    pullRequest: { number: number };
   };
 }

--- a/lib/util/cache/repository/types.ts
+++ b/lib/util/cache/repository/types.ts
@@ -39,5 +39,4 @@ export interface Cache {
   revision?: number;
   init?: RepoInitConfig;
   scan?: Record<string, BaseBranchCache>;
-  lastPlatformAutomergeFailure?: string;
 }

--- a/lib/util/http/github.ts
+++ b/lib/util/http/github.ts
@@ -37,11 +37,7 @@ interface GithubGraphqlRepoData<T = unknown> {
 
 interface GithubGraphqlResponse<T = unknown> {
   data?: T;
-  errors?: {
-    type?: string;
-    message: string;
-    locations: unknown;
-  }[];
+  errors?: { message: string; locations: unknown }[];
 }
 
 function handleGotError(


### PR DESCRIPTION
This reverts commit eef4c2f11f9c8ab819b332482af38aa426db6ed8.

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
