### PR TITLE
fix(npm): add .pnp.loader.mjs to Yarn zero-install paths

### DIFF
--- a/lib/manager/npm/extract/yarn.ts
+++ b/lib/manager/npm/extract/yarn.ts
@@ -44,7 +44,12 @@ export async function getYarnLock(filePath: string): Promise<LockFile> {
 
 export function getZeroInstallPaths(yarnrcYml: string): string[] {
   const conf = parseSyml(yarnrcYml);
-  const paths = [conf.cacheFolder || './.yarn/cache', '.pnp.cjs', '.pnp.js'];
+  const paths = [
+    conf.cacheFolder || './.yarn/cache',
+    '.pnp.cjs',
+    '.pnp.js',
+    '.pnp.loader.mjs',
+  ];
   if (miscUtils.tryParseOptionalBoolean(conf.pnpEnableInlining) === false) {
     paths.push(conf.pnpDataPath || './.pnp.data.json');
   }


### PR DESCRIPTION
## Changes:

Added `.pnp.loader.mjs` to Yarn zero-install paths

## Context:

`.pnp.loader.mjs` is generated when `pnpEnableEsmLoader: true` or Yarn detects ESM support is required since Yarn 3.1.0 (https://yarnpkg.com/configuration/yarnrc#pnpEnableEsmLoader).

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository