### PR TITLE
refactor(composer): Refactor Composer argument resolver to utils

### DIFF
--- a/lib/manager/composer/artifacts.ts
+++ b/lib/manager/composer/artifacts.ts
@@ -1,6 +1,5 @@
 import is from '@sindresorhus/is';
 import { quote } from 'shlex';
-import { getGlobalConfig } from '../../config/global';
 import { PlatformId } from '../../constants';
 import {
   SYSTEM_INSUFFICIENT_DISK_SPACE,
@@ -25,6 +24,7 @@ import type { AuthJson } from './types';
 import {
   composerVersioningId,
   extractContraints,
+  getComposerArguments,
   getComposerConstraint,
   getPhpConstraint,
 } from './utils';
@@ -129,19 +129,7 @@ export async function updateArtifacts({
           'update ' + updatedDeps.map((dep) => quote(dep.depName)).join(' ')
         ).trim() + ' --with-dependencies';
     }
-    if (config.composerIgnorePlatformReqs) {
-      if (config.composerIgnorePlatformReqs.length === 0) {
-        args += ' --ignore-platform-reqs';
-      } else {
-        config.composerIgnorePlatformReqs.forEach((req) => {
-          args += ' --ignore-platform-req ' + quote(req);
-        });
-      }
-    }
-    args += ' --no-ansi --no-interaction';
-    if (!getGlobalConfig().allowScripts || config.ignoreScripts) {
-      args += ' --no-scripts --no-autoloader --no-plugins';
-    }
+    args += getComposerArguments(config);
     logger.debug({ cmd, args }, 'composer command');
     await exec(`${cmd} ${args}`, execOptions);
     const status = await getRepoStatus();

--- a/lib/manager/composer/utils.spec.ts
+++ b/lib/manager/composer/utils.spec.ts
@@ -1,6 +1,11 @@
 import { mocked } from '../../../test/util';
+import { setGlobalConfig } from '../../config/global';
 import * as _datasource from '../../datasource';
-import { extractContraints, getComposerConstraint } from './utils';
+import {
+  extractContraints,
+  getComposerArguments,
+  getComposerConstraint,
+} from './utils';
 
 jest.mock('../../../lib/datasource');
 
@@ -83,6 +88,63 @@ describe('manager/composer/utils', () => {
 
     it('fallback to 1.*', () => {
       expect(extractContraints({}, {})).toEqual({ composer: '1.*' });
+    });
+  });
+
+  describe('getComposerArguments', () => {
+    afterEach(() => {
+      setGlobalConfig();
+    });
+
+    it('disables scripts and plugins by default', () => {
+      expect(getComposerArguments({})).toEqual(
+        ' --no-ansi --no-interaction --no-scripts --no-autoloader --no-plugins'
+      );
+    });
+    it('disables platform requirements', () => {
+      expect(
+        getComposerArguments({
+          composerIgnorePlatformReqs: [],
+        })
+      ).toEqual(
+        ' --ignore-platform-reqs --no-ansi --no-interaction --no-scripts --no-autoloader --no-plugins'
+      );
+    });
+    it('disables single platform requirement', () => {
+      expect(
+        getComposerArguments({
+          composerIgnorePlatformReqs: ['ext-intl'],
+        })
+      ).toEqual(
+        ' --ignore-platform-req ext-intl --no-ansi --no-interaction --no-scripts --no-autoloader --no-plugins'
+      );
+    });
+    it('disables multiple platform requirement', () => {
+      expect(
+        getComposerArguments({
+          composerIgnorePlatformReqs: ['ext-intl', 'ext-icu'],
+        })
+      ).toEqual(
+        ' --ignore-platform-req ext-intl --ignore-platform-req ext-icu --no-ansi --no-interaction --no-scripts --no-autoloader --no-plugins'
+      );
+    });
+    it('allows scripts/plugins when configured', () => {
+      setGlobalConfig({
+        allowScripts: true,
+      });
+      expect(getComposerArguments({})).toEqual(' --no-ansi --no-interaction');
+    });
+    it('disables scripts/plugins when configured locally', () => {
+      setGlobalConfig({
+        allowScripts: true,
+      });
+      expect(
+        getComposerArguments({
+          ignoreScripts: true,
+        })
+      ).toEqual(
+        ' --no-ansi --no-interaction --no-scripts --no-autoloader --no-plugins'
+      );
     });
   });
 });

--- a/lib/manager/composer/utils.ts
+++ b/lib/manager/composer/utils.ts
@@ -3,7 +3,7 @@ import { getGlobalConfig } from '../../config/global';
 import { getPkgReleases } from '../../datasource';
 import { logger } from '../../logger';
 import { api, id as composerVersioningId } from '../../versioning/composer';
-import { UpdateArtifactsConfig } from '../types';
+import type { UpdateArtifactsConfig } from '../types';
 import type { ComposerConfig, ComposerLock } from './types';
 
 export { composerVersioningId };

--- a/lib/manager/composer/utils.ts
+++ b/lib/manager/composer/utils.ts
@@ -1,9 +1,33 @@
+import { quote } from 'shlex';
+import { getGlobalConfig } from '../../config/global';
 import { getPkgReleases } from '../../datasource';
 import { logger } from '../../logger';
 import { api, id as composerVersioningId } from '../../versioning/composer';
+import { UpdateArtifactsConfig } from '../types';
 import type { ComposerConfig, ComposerLock } from './types';
 
 export { composerVersioningId };
+
+export function getComposerArguments(config: UpdateArtifactsConfig): string {
+  let args = '';
+
+  if (config.composerIgnorePlatformReqs) {
+    if (config.composerIgnorePlatformReqs.length === 0) {
+      args += ' --ignore-platform-reqs';
+    } else {
+      config.composerIgnorePlatformReqs.forEach((req) => {
+        args += ' --ignore-platform-req ' + quote(req);
+      });
+    }
+  }
+
+  args += ' --no-ansi --no-interaction';
+  if (!getGlobalConfig().allowScripts || config.ignoreScripts) {
+    args += ' --no-scripts --no-autoloader --no-plugins';
+  }
+
+  return args;
+}
 
 export async function getComposerConstraint(
   constraints: Record<string, string>


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->
Refactored `getComposerArguments` function into a separate file, as suggested in #11990. 

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

See #11990, this method will be update to add plugin support there.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
