### PR TITLE
fix(docker): don't removes additional variables from version

### DIFF
--- a/lib/manager/dockerfile/extract.spec.ts
+++ b/lib/manager/dockerfile/extract.spec.ts
@@ -647,14 +647,14 @@ Object {
       // eslint-disable-next-line no-template-curly-in-string
       const res3 = getDep('${REDIS_IMAGE:-redis@sha256:abcd}');
       expect(res3).toMatchInlineSnapshot(`
-        Object {
-          "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
-          "currentDigest": "sha256:abcd",
-          "datasource": "docker",
-          "depName": "redis",
-          "replaceString": "redis@sha256:abcd",
-        }
-      `);
+Object {
+  "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
+  "currentDigest": "sha256:abcd",
+  "datasource": "docker",
+  "depName": "redis",
+  "replaceString": "redis@sha256:abcd",
+}
+`);
     });
 
     it('skips tag containing a variable', () => {

--- a/lib/manager/dockerfile/extract.spec.ts
+++ b/lib/manager/dockerfile/extract.spec.ts
@@ -622,39 +622,52 @@ describe('manager/dockerfile/extract', () => {
       // eslint-disable-next-line no-template-curly-in-string
       const res = getDep('${REDIS_IMAGE:-redis:5.0.0@sha256:abcd}');
       expect(res).toMatchInlineSnapshot(`
-Object {
-  "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
-  "currentDigest": "sha256:abcd",
-  "currentValue": "5.0.0",
-  "datasource": "docker",
-  "depName": "redis",
-  "replaceString": "redis:5.0.0@sha256:abcd",
-}
-`);
+        Object {
+          "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
+          "currentDigest": "sha256:abcd",
+          "currentValue": "5.0.0",
+          "datasource": "docker",
+          "depName": "redis",
+          "replaceString": "redis:5.0.0@sha256:abcd",
+        }
+      `);
 
       // eslint-disable-next-line no-template-curly-in-string
       const res2 = getDep('${REDIS_IMAGE:-redis:5.0.0}');
       expect(res2).toMatchInlineSnapshot(`
-Object {
-  "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
-  "currentValue": "5.0.0",
-  "datasource": "docker",
-  "depName": "redis",
-  "replaceString": "redis:5.0.0",
-}
-`);
+        Object {
+          "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
+          "currentValue": "5.0.0",
+          "datasource": "docker",
+          "depName": "redis",
+          "replaceString": "redis:5.0.0",
+        }
+      `);
 
       // eslint-disable-next-line no-template-curly-in-string
       const res3 = getDep('${REDIS_IMAGE:-redis@sha256:abcd}');
       expect(res3).toMatchInlineSnapshot(`
-Object {
-  "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
-  "currentDigest": "sha256:abcd",
-  "datasource": "docker",
-  "depName": "redis",
-  "replaceString": "redis@sha256:abcd",
-}
-`);
+        Object {
+          "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
+          "currentDigest": "sha256:abcd",
+          "datasource": "docker",
+          "depName": "redis",
+          "replaceString": "redis@sha256:abcd",
+        }
+      `);
+    });
+
+    it('skips tag containing a variable', () => {
+      // eslint-disable-next-line no-template-curly-in-string
+      const res = getDep('mcr.microsoft.com/dotnet/sdk:5.0${IMAGESUFFIX}');
+      expect(res).toMatchInlineSnapshot(`
+        Object {
+          "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
+          "datasource": "docker",
+          "replaceString": "mcr.microsoft.com/dotnet/sdk:5.0\${IMAGESUFFIX}",
+          "skipReason": "contains-variable",
+        }
+      `);
     });
   });
 });

--- a/lib/manager/dockerfile/extract.spec.ts
+++ b/lib/manager/dockerfile/extract.spec.ts
@@ -622,27 +622,27 @@ describe('manager/dockerfile/extract', () => {
       // eslint-disable-next-line no-template-curly-in-string
       const res = getDep('${REDIS_IMAGE:-redis:5.0.0@sha256:abcd}');
       expect(res).toMatchInlineSnapshot(`
-        Object {
-          "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
-          "currentDigest": "sha256:abcd",
-          "currentValue": "5.0.0",
-          "datasource": "docker",
-          "depName": "redis",
-          "replaceString": "redis:5.0.0@sha256:abcd",
-        }
-      `);
+Object {
+  "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
+  "currentDigest": "sha256:abcd",
+  "currentValue": "5.0.0",
+  "datasource": "docker",
+  "depName": "redis",
+  "replaceString": "redis:5.0.0@sha256:abcd",
+}
+`);
 
       // eslint-disable-next-line no-template-curly-in-string
       const res2 = getDep('${REDIS_IMAGE:-redis:5.0.0}');
       expect(res2).toMatchInlineSnapshot(`
-        Object {
-          "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
-          "currentValue": "5.0.0",
-          "datasource": "docker",
-          "depName": "redis",
-          "replaceString": "redis:5.0.0",
-        }
-      `);
+Object {
+  "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
+  "currentValue": "5.0.0",
+  "datasource": "docker",
+  "depName": "redis",
+  "replaceString": "redis:5.0.0",
+}
+`);
 
       // eslint-disable-next-line no-template-curly-in-string
       const res3 = getDep('${REDIS_IMAGE:-redis@sha256:abcd}');

--- a/lib/manager/dockerfile/extract.ts
+++ b/lib/manager/dockerfile/extract.ts
@@ -6,6 +6,7 @@ import { regEx } from '../../util/regex';
 import * as ubuntuVersioning from '../../versioning/ubuntu';
 import type { PackageDependency, PackageFile } from '../types';
 
+const variableMarker = '$';
 const variableOpen = '${';
 const variableClose = '}';
 const variableDefaultValueSplit = ':-';
@@ -54,6 +55,13 @@ export function splitImageParts(currentFrom: string): PackageDependency {
   } else {
     currentValue = depTagSplit.pop();
     depName = depTagSplit.join(':');
+  }
+
+  if (currentValue && currentValue.indexOf(variableMarker) !== -1) {
+    // If tag contains a variable, e.g. "5.0${VERSION_SUFFIX}", we do not support this.
+    return {
+      skipReason: SkipReason.ContainsVariable,
+    };
   }
 
   if (isVariable) {


### PR DESCRIPTION
## Changes:

Renovate removes additional variables from version when bumping Docker image versions

## Context:

Closes #12420

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

I ran it on this test repo: https://github.com/olegkrivtsov/renovate-test-repo
Renovate reported 1 dependency and skipped it.