### PR TITLE
chore: delete auto-cancel-actions.yml

### DIFF
--- a/.github/auto-cancel-actions.yml
+++ b/.github/auto-cancel-actions.yml
@@ -1,5 +1,0 @@
-version: 1
-push:
-  branches:
-    - '!main'
-pull_request:


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

- Delete `auto-cancel-actions.yml`

## Context:

I think we (used to) rely on this repository for the app: https://github.com/renovatebot/auto-cancel-actions, this repository is now archived.

I think we can delete the file now?

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
