### PR TITLE
fix(github): Disable autoMergeAllowed field for GHE

### DIFF
--- a/lib/platform/github/__snapshots__/index.spec.ts.snap
+++ b/lib/platform/github/__snapshots__/index.spec.ts.snap
@@ -7845,6 +7845,17 @@ Array [
       "host": "github.company.com",
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
+    "method": "HEAD",
+    "url": "https://github.company.com/",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate, br",
+      "authorization": "token 123test",
+      "host": "github.company.com",
+      "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
+    },
     "method": "GET",
     "url": "https://github.company.com/user",
   },
@@ -7858,17 +7869,6 @@ Array [
     },
     "method": "GET",
     "url": "https://github.company.com/user/emails",
-  },
-  Object {
-    "headers": Object {
-      "accept": "application/vnd.github.v3+json",
-      "accept-encoding": "gzip, deflate, br",
-      "authorization": "token 123test",
-      "host": "github.company.com",
-      "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
-    },
-    "method": "HEAD",
-    "url": "https://github.company.com/",
   },
   Object {
     "graphql": Object {

--- a/lib/platform/github/__snapshots__/index.spec.ts.snap
+++ b/lib/platform/github/__snapshots__/index.spec.ts.snap
@@ -7860,6 +7860,17 @@ Array [
     "url": "https://github.company.com/user/emails",
   },
   Object {
+    "headers": Object {
+      "accept": "application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate, br",
+      "authorization": "token 123test",
+      "host": "github.company.com",
+      "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
+    },
+    "method": "HEAD",
+    "url": "https://github.company.com/",
+  },
+  Object {
     "graphql": Object {
       "query": Object {
         "__vars": Object {
@@ -7871,7 +7882,6 @@ Array [
             "name": "$name",
             "owner": "$owner",
           },
-          "autoMergeAllowed": null,
           "defaultBranchRef": Object {
             "name": null,
             "target": Object {
@@ -7896,7 +7906,7 @@ Array [
       "accept": "application/vnd.github.v3+json",
       "accept-encoding": "gzip, deflate, br",
       "authorization": "token 123test",
-      "content-length": "395",
+      "content-length": "373",
       "content-type": "application/json",
       "host": "github.company.com",
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",

--- a/lib/platform/github/__snapshots__/index.spec.ts.snap
+++ b/lib/platform/github/__snapshots__/index.spec.ts.snap
@@ -7006,6 +7006,17 @@ Array [
       "host": "ghe.renovatebot.com",
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
+    "method": "HEAD",
+    "url": "https://ghe.renovatebot.com/",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate, br",
+      "authorization": "token 123test",
+      "host": "ghe.renovatebot.com",
+      "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
+    },
     "method": "GET",
     "url": "https://ghe.renovatebot.com/user",
   },

--- a/lib/platform/github/index.spec.ts
+++ b/lib/platform/github/index.spec.ts
@@ -2224,7 +2224,7 @@ describe('platform/github/index', () => {
       const scope = httpMock
         .scope('https://github.company.com')
         .head('/')
-        .reply(200, '', { 'x-github-enterprise-version': '3.0.15' })
+        .reply(200, '', { 'x-github-enterprise-version': '3.1.7' })
         .get('/user')
         .reply(200, {
           login: 'renovate-bot',

--- a/lib/platform/github/index.spec.ts
+++ b/lib/platform/github/index.spec.ts
@@ -2220,6 +2220,8 @@ describe('platform/github/index', () => {
     it('returns not-updated pr body for GHE', async () => {
       const scope = httpMock
         .scope('https://github.company.com')
+        .head('/')
+        .reply(200, '', { 'x-github-enterprise-version': '3.0.15' })
         .get('/user')
         .reply(200, {
           login: 'renovate-bot',
@@ -2407,9 +2409,9 @@ describe('platform/github/index', () => {
     });
     it('returns file content in json5 format', async () => {
       const json5Data = `
-        { 
+        {
           // json5 comment
-          foo: 'bar' 
+          foo: 'bar'
         }
       `;
       const scope = httpMock.scope(githubApiHost);

--- a/lib/platform/github/index.spec.ts
+++ b/lib/platform/github/index.spec.ts
@@ -111,6 +111,9 @@ describe('platform/github/index', () => {
     it('should support custom endpoint', async () => {
       httpMock
         .scope('https://ghe.renovatebot.com')
+        .head('/')
+        .reply(200, '', { 'x-github-enterprise-version': '3.0.15' })
+
         .get('/user')
         .reply(200, {
           login: 'renovate-bot',

--- a/lib/platform/github/index.ts
+++ b/lib/platform/github/index.ts
@@ -102,7 +102,7 @@ export async function initPlatform({
   config.isGhe = URL.parse(defaults.endpoint).host !== 'api.github.com';
   if (config.isGhe) {
     const gheHeaderKey = 'x-github-enterprise-version';
-    const gheQueryRes = await githubApi.head('/');
+    const gheQueryRes = await githubApi.head('/', { throwHttpErrors: false });
     const gheHeaders: Record<string, string> = gheQueryRes?.headers || {};
     const [, gheVersion] =
       Object.entries(gheHeaders).find(

--- a/lib/platform/github/index.ts
+++ b/lib/platform/github/index.ts
@@ -226,7 +226,10 @@ export async function initRepo({
     let infoQuery = repoInfoQuery;
     if (
       config.isGhe &&
-      (!config.gheVersion || semverLessThan(config.gheVersion, '3.1.8'))
+      (!config.gheVersion ||
+        (config.gheVersion.startsWith('3.1') &&
+          semverLessThan(config.gheVersion, '3.1.8')) ||
+        semverLessThan(config.gheVersion, '3.0.16'))
     ) {
       infoQuery = infoQuery.replace(/\n\s*autoMergeAllowed\s*\n/, '\n');
     }

--- a/lib/platform/github/index.ts
+++ b/lib/platform/github/index.ts
@@ -228,6 +228,7 @@ export async function initRepo({
     if (
       config.isGhe &&
       (!config.gheVersion ||
+        semverSatisfies(config.gheVersion, '>=3.2.0 <3.3.0') ||
         semverSatisfies(config.gheVersion, '>=3.0.0 <3.0.16') ||
         semverSatisfies(config.gheVersion, '>=3.1.0 <3.1.8'))
     ) {

--- a/lib/platform/github/index.ts
+++ b/lib/platform/github/index.ts
@@ -206,7 +206,6 @@ export async function initRepo({
   let repo: GhRepo;
   try {
     let infoQuery = repoInfoQuery;
-    // istanbul ignore if
     if (config.isGhe) {
       const gheHeaderKey = 'x-github-enterprise-version';
       const gheQueryRes = await githubApi.head('/');

--- a/lib/platform/github/index.ts
+++ b/lib/platform/github/index.ts
@@ -228,8 +228,8 @@ export async function initRepo({
     if (
       config.isGhe &&
       (!config.gheVersion ||
-        semverSatisfies(config.gheVersion, '>=3.1.0 <3.1.8') ||
-        semverSatisfies(config.gheVersion, '>=3.0.0 <3.0.16'))
+        semverSatisfies(config.gheVersion, '>=3.0.0 <3.0.16') ||
+        semverSatisfies(config.gheVersion, '>=3.1.0 <3.1.8'))
     ) {
       // Changelog: https://docs.github.com/en/github-ae@latest/graphql/overview/changelog?query=#schema-changes-for-2021-08-03
       // Release schedule: https://enterprise.github.com/releases

--- a/lib/platform/github/index.ts
+++ b/lib/platform/github/index.ts
@@ -3,7 +3,7 @@ import is from '@sindresorhus/is';
 import delay from 'delay';
 import JSON5 from 'json5';
 import { DateTime } from 'luxon';
-import { satisfies as semverSatisfies, valid as semverValid } from 'semver';
+import { valid as semverValid } from 'semver';
 import { PlatformId } from '../../constants';
 import {
   PLATFORM_INTEGRATION_UNAUTHORIZED,
@@ -225,15 +225,7 @@ export async function initRepo({
   try {
     let infoQuery = repoInfoQuery;
 
-    if (
-      config.isGhe &&
-      (!config.gheVersion ||
-        semverSatisfies(config.gheVersion, '>=3.2.0 <3.3.0') ||
-        semverSatisfies(config.gheVersion, '>=3.0.0 <3.0.16') ||
-        semverSatisfies(config.gheVersion, '>=3.1.0 <3.1.8'))
-    ) {
-      // Changelog: https://docs.github.com/en/github-ae@latest/graphql/overview/changelog?query=#schema-changes-for-2021-08-03
-      // Release schedule: https://enterprise.github.com/releases
+    if (config.isGhe) {
       infoQuery = infoQuery.replace(/\n\s*autoMergeAllowed\s*\n/, '\n');
     }
 

--- a/lib/platform/github/types.ts
+++ b/lib/platform/github/types.ts
@@ -71,6 +71,7 @@ export interface LocalRepoConfig {
   repositoryOwner: string;
   repository: string | null;
   isGhe: boolean;
+  gheVersion?: string | null;
   renovateUsername: string;
   productLinks: any;
   ignorePrAuthor: boolean;


### PR DESCRIPTION


<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Detect lower GHE versions and avoid query for `autoMergeAllowed` field

## Context:

#12451

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
