### PR TITLE
feat(maven): treat the preview qualifier as rc

### DIFF
--- a/lib/versioning/maven/compare.spec.ts
+++ b/lib/versioning/maven/compare.spec.ts
@@ -35,6 +35,7 @@ describe('versioning/maven/compare', () => {
     ${'1.0beta-1'}          | ${'1.0-b1'}                | ${0}
     ${'1.0milestone1'}      | ${'1.0-m1'}                | ${0}
     ${'1.0milestone-1'}     | ${'1.0-m1'}                | ${0}
+    ${'1.0rc'}              | ${'1.0-preview'}           | ${0}
     ${'1.0rc1'}             | ${'1.0-cr1'}               | ${0}
     ${'1.0rc-1'}            | ${'1.0-cr1'}               | ${0}
     ${'1.0ga'}              | ${'1.0'}                   | ${0}
@@ -69,6 +70,7 @@ describe('versioning/maven/compare', () => {
     ${'0.0-1552'}           | ${'1.10.520'}              | ${-1}
     ${'0.0.1'}              | ${'999'}                   | ${-1}
     ${'1.3-RC1-groovy-2.5'} | ${'1.3-groovy-2.5'}        | ${-1}
+    ${'1-preview'}          | ${'1-snapshot'}            | ${-1}
     ${'1-abc'}              | ${'1-xyz'}                 | ${-1}
     ${'Hoxton.RELEASE'}     | ${'Hoxton.SR1'}            | ${-1}
     ${'1.1'}                | ${'1'}                     | ${1}
@@ -90,6 +92,7 @@ describe('versioning/maven/compare', () => {
     ${'1.10.520'}           | ${'0.0-1552'}              | ${1}
     ${'999'}                | ${'0.0.1'}                 | ${1}
     ${'1.3-groovy-2.5'}     | ${'1.3-RC1-groovy-2.5'}    | ${1}
+    ${'1-snapshot'}         | ${'1-milestone'}           | ${1}
     ${'1-xyz'}              | ${'1-abc'}                 | ${1}
     ${'Hoxton.SR1'}         | ${'Hoxton.RELEASE'}        | ${1}
   `('compare("$a", "$b") === $expected', ({ a, b, expected }) => {

--- a/lib/versioning/maven/compare.ts
+++ b/lib/versioning/maven/compare.ts
@@ -184,7 +184,7 @@ export function qualifierType(token: Token): number {
   if (val === 'milestone' || (token.isTransition && val === 'm')) {
     return QualifierTypes.Milestone;
   }
-  if (val === 'rc' || val === 'cr') {
+  if (val === 'rc' || val === 'cr' || val === 'preview') {
     return QualifierTypes.RC;
   }
   if (val === 'snapshot' || val === 'snap') {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->
The `-preview` qualifier is now treated as a synonym for `-rc`, which means it's now considered unstable by renovate.
Closes #12450 

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->
Even though `-preview` is not a qualifier defined by the [Maven versioning spec](https://maven.apache.org/pom.html#Version_Order_Specification), it's being used by [some libraries](https://search.maven.org/artifact/com.nimbusds/nimbus-jose-jwt/9.16-preview.1/jar) and needs to be understood by renovate as unstable to avoid issues.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->