### PR TITLE
docs: document how docker datasource resolve sourceUrl

### DIFF
--- a/lib/datasource/docker/readme.md
+++ b/lib/datasource/docker/readme.md
@@ -1,3 +1,5 @@
 This datasource will fetch a release note from a source repository specified according to the [pre-defined annotation keys](https://github.com/opencontainers/image-spec/blob/main/annotations.md) of the OCI Image Format Specification.
 
 Namely, it will extract the value of label `org.opencontainers.image.source` if it exist **on the latest stable tags**.
+
+[Label Schema](https://label-schema.org/) is now superceded by OCI by annotations, and this datasource do not support `org.label-schema.vcs-url` label.

--- a/lib/datasource/docker/readme.md
+++ b/lib/datasource/docker/readme.md
@@ -1,0 +1,3 @@
+This datasource will fetch a release note from a source repository specified according to the [pre-defined annotation keys](https://github.com/opencontainers/image-spec/blob/main/annotations.md) of the OCI Image Format Specification.
+
+Namely, it will extract the value of label `org.opencontainers.image.source` if it exist **on the latest stable tags**.

--- a/lib/datasource/docker/readme.md
+++ b/lib/datasource/docker/readme.md
@@ -1,4 +1,4 @@
-This datasource fetches the release note from a source repository specified according to the [pre-defined annotation keys of the OCI Image Format Specification](https://github.com/opencontainers/image-spec/blob/main/annotations.md).
+This datasource identifies an image's source repository according to the [pre-defined annotation keys of the OCI Image Format Specification](https://github.com/opencontainers/image-spec/blob/main/annotations.md).
 
 This datasource looks for the metadata of the **latest stable** image found on the Docker registry and uses the value of the label `org.opencontainers.image.source` as the `sourceUrl`.
 

--- a/lib/datasource/docker/readme.md
+++ b/lib/datasource/docker/readme.md
@@ -1,5 +1,5 @@
 This datasource fetches the release note from a source repository specified according to the [pre-defined annotation keys of the OCI Image Format Specification](https://github.com/opencontainers/image-spec/blob/main/annotations.md).
 
-Namely, it will extract the value of label `org.opencontainers.image.source` if it exist **on the latest stable tags**.
+This datasource looks for the metadata of the **latest stable** image found on the Docker registry and uses the value of the label `org.opencontainers.image.source` as the `sourceUrl`.
 
 The [Label Schema](https://label-schema.org/) is superseded by OCI annotations, therefore this datasource does not support the `org.label-schema.vcs-url` label.

--- a/lib/datasource/docker/readme.md
+++ b/lib/datasource/docker/readme.md
@@ -2,4 +2,4 @@ This datasource fetches the release note from a source repository specified acco
 
 Namely, it will extract the value of label `org.opencontainers.image.source` if it exist **on the latest stable tags**.
 
-The [Label Schema](https://label-schema.org/) is now superseded by OCI by annotations, and this datasource does not support the `org.label-schema.vcs-url` label.
+The [Label Schema](https://label-schema.org/) is now superseded by OCI annotations, and this datasource does not support the `org.label-schema.vcs-url` label.

--- a/lib/datasource/docker/readme.md
+++ b/lib/datasource/docker/readme.md
@@ -1,5 +1,5 @@
-This datasource will fetch a release note from a source repository specified according to the [pre-defined annotation keys](https://github.com/opencontainers/image-spec/blob/main/annotations.md) of the OCI Image Format Specification.
+This datasource fetches the release note from a source repository specified according to the [pre-defined annotation keys of the OCI Image Format Specification](https://github.com/opencontainers/image-spec/blob/main/annotations.md).
 
 Namely, it will extract the value of label `org.opencontainers.image.source` if it exist **on the latest stable tags**.
 
-[Label Schema](https://label-schema.org/) is now superceded by OCI by annotations, and this datasource do not support `org.label-schema.vcs-url` label.
+The [Label Schema](https://label-schema.org/) is now superseded by OCI by annotations, and this datasource does not support the `org.label-schema.vcs-url` label.

--- a/lib/datasource/docker/readme.md
+++ b/lib/datasource/docker/readme.md
@@ -2,4 +2,4 @@ This datasource fetches the release note from a source repository specified acco
 
 Namely, it will extract the value of label `org.opencontainers.image.source` if it exist **on the latest stable tags**.
 
-The [Label Schema](https://label-schema.org/) is now superseded by OCI annotations, and this datasource does not support the `org.label-schema.vcs-url` label.
+The [Label Schema](https://label-schema.org/) is superseded by OCI annotations, therefore this datasource does not support the `org.label-schema.vcs-url` label.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Doc

## Context:

Relates to #12346 #2395.
I think that not a lot of project (especially private one) knows about oci spec. I was still using the old label schema and thought renovate was not able to fetch release note from the source repo. Adding some documentation may help others use the most from renovate.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
