### PR TITLE
fix(helmv3): set helm repositories from aliases to update Chart.lock

### DIFF
--- a/lib/manager/helmv3/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/manager/helmv3/__snapshots__/artifacts.spec.ts.snap
@@ -166,25 +166,6 @@ Array [
 exports[`manager/helmv3/artifacts sets repositories from aliases 2`] = `
 Array [
   Object {
-    "cmd": "helm dependency update ''",
-    "options": Object {
-      "cwd": "/tmp/github/some/repo",
-      "encoding": "utf-8",
-      "env": Object {
-        "HELM_EXPERIMENTAL_OCI": "1",
-        "HOME": "/home/user",
-        "HTTPS_PROXY": "https://example.com",
-        "HTTP_PROXY": "http://example.com",
-        "LANG": "en_US.UTF-8",
-        "LC_ALL": "en_US",
-        "NO_PROXY": "localhost",
-        "PATH": "/tmp/path",
-      },
-      "maxBuffer": 10485760,
-      "timeout": 900000,
-    },
-  },
-  Object {
     "cmd": "helm repo add stable the_stable_url",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
@@ -205,6 +186,25 @@ Array [
   },
   Object {
     "cmd": "helm repo add repo1 the_repo1_url",
+    "options": Object {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": Object {
+        "HELM_EXPERIMENTAL_OCI": "1",
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+  Object {
+    "cmd": "helm dependency update ''",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -251,7 +251,7 @@ Array [
     },
   },
   Object {
-    "cmd": "docker run --rm --name=renovate_helm --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -e HELM_EXPERIMENTAL_OCI -w \\"/tmp/github/some/repo\\" renovate/helm bash -l -c \\"helm dependency update '' && helm repo add stable the_stable_url && helm repo add repo1 the_repo1_url\\"",
+    "cmd": "docker run --rm --name=renovate_helm --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -e HELM_EXPERIMENTAL_OCI -w \\"/tmp/github/some/repo\\" renovate/helm bash -l -c \\"helm repo add stable the_stable_url && helm repo add repo1 the_repo1_url && helm dependency update ''\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",

--- a/lib/manager/helmv3/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/manager/helmv3/__snapshots__/artifacts.spec.ts.snap
@@ -166,6 +166,25 @@ Array [
 exports[`manager/helmv3/artifacts sets repositories from aliases 2`] = `
 Array [
   Object {
+    "cmd": "helm dependency update ''",
+    "options": Object {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": Object {
+        "HELM_EXPERIMENTAL_OCI": "1",
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+  Object {
     "cmd": "helm repo add stable the_stable_url",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
@@ -186,25 +205,6 @@ Array [
   },
   Object {
     "cmd": "helm repo add repo1 the_repo1_url",
-    "options": Object {
-      "cwd": "/tmp/github/some/repo",
-      "encoding": "utf-8",
-      "env": Object {
-        "HELM_EXPERIMENTAL_OCI": "1",
-        "HOME": "/home/user",
-        "HTTPS_PROXY": "https://example.com",
-        "HTTP_PROXY": "http://example.com",
-        "LANG": "en_US.UTF-8",
-        "LC_ALL": "en_US",
-        "NO_PROXY": "localhost",
-        "PATH": "/tmp/path",
-      },
-      "maxBuffer": 10485760,
-      "timeout": 900000,
-    },
-  },
-  Object {
-    "cmd": "helm dependency update ''",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -251,57 +251,7 @@ Array [
     },
   },
   Object {
-    "cmd": "docker ps --filter name=renovate_helm -aq",
-    "options": Object {
-      "encoding": "utf-8",
-    },
-  },
-  Object {
-    "cmd": "docker run --rm --name=renovate_helm --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -e HELM_EXPERIMENTAL_OCI -w \\"/tmp/github/some/repo\\" renovate/helm bash -l -c \\"helm repo add repo1 the_repo1_url\\"",
-    "options": Object {
-      "cwd": "/tmp/github/some/repo",
-      "encoding": "utf-8",
-      "env": Object {
-        "HELM_EXPERIMENTAL_OCI": "1",
-        "HOME": "/home/user",
-        "HTTPS_PROXY": "https://example.com",
-        "HTTP_PROXY": "http://example.com",
-        "LANG": "en_US.UTF-8",
-        "LC_ALL": "en_US",
-        "NO_PROXY": "localhost",
-        "PATH": "/tmp/path",
-      },
-      "maxBuffer": 10485760,
-      "timeout": 900000,
-    },
-  },
-  Object {
-    "cmd": "docker run --rm --name=renovate_helm --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -e HELM_EXPERIMENTAL_OCI -w \\"/tmp/github/some/repo\\" renovate/helm bash -l -c \\"helm repo add stable the_stable_url\\"",
-    "options": Object {
-      "cwd": "/tmp/github/some/repo",
-      "encoding": "utf-8",
-      "env": Object {
-        "HELM_EXPERIMENTAL_OCI": "1",
-        "HOME": "/home/user",
-        "HTTPS_PROXY": "https://example.com",
-        "HTTP_PROXY": "http://example.com",
-        "LANG": "en_US.UTF-8",
-        "LC_ALL": "en_US",
-        "NO_PROXY": "localhost",
-        "PATH": "/tmp/path",
-      },
-      "maxBuffer": 10485760,
-      "timeout": 900000,
-    },
-  },
-  Object {
-    "cmd": "docker ps --filter name=renovate_helm -aq",
-    "options": Object {
-      "encoding": "utf-8",
-    },
-  },
-  Object {
-    "cmd": "docker run --rm --name=renovate_helm --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -e HELM_EXPERIMENTAL_OCI -w \\"/tmp/github/some/repo\\" renovate/helm bash -l -c \\"helm dependency update ''\\"",
+    "cmd": "docker run --rm --name=renovate_helm --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -e HELM_EXPERIMENTAL_OCI -w \\"/tmp/github/some/repo\\" renovate/helm bash -l -c \\"helm dependency update '' && helm repo add stable the_stable_url && helm repo add repo1 the_repo1_url\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",

--- a/lib/manager/helmv3/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/manager/helmv3/__snapshots__/artifacts.spec.ts.snap
@@ -151,3 +151,173 @@ Array [
   },
 ]
 `;
+
+exports[`manager/helmv3/artifacts sets repositories from aliases 1`] = `
+Array [
+  Object {
+    "file": Object {
+      "contents": "New Chart.lock",
+      "name": "Chart.lock",
+    },
+  },
+]
+`;
+
+exports[`manager/helmv3/artifacts sets repositories from aliases 2`] = `
+Array [
+  Object {
+    "cmd": "helm repo add stable the_stable_url",
+    "options": Object {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": Object {
+        "HELM_EXPERIMENTAL_OCI": "1",
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+  Object {
+    "cmd": "helm repo add repo1 the_repo1_url",
+    "options": Object {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": Object {
+        "HELM_EXPERIMENTAL_OCI": "1",
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+  Object {
+    "cmd": "helm dependency update ''",
+    "options": Object {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": Object {
+        "HELM_EXPERIMENTAL_OCI": "1",
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+]
+`;
+
+exports[`manager/helmv3/artifacts sets repositories from aliases with docker 1`] = `
+Array [
+  Object {
+    "file": Object {
+      "contents": "New Chart.lock",
+      "name": "Chart.lock",
+    },
+  },
+]
+`;
+
+exports[`manager/helmv3/artifacts sets repositories from aliases with docker 2`] = `
+Array [
+  Object {
+    "cmd": "docker pull renovate/helm",
+    "options": Object {
+      "encoding": "utf-8",
+    },
+  },
+  Object {
+    "cmd": "docker ps --filter name=renovate_helm -aq",
+    "options": Object {
+      "encoding": "utf-8",
+    },
+  },
+  Object {
+    "cmd": "docker ps --filter name=renovate_helm -aq",
+    "options": Object {
+      "encoding": "utf-8",
+    },
+  },
+  Object {
+    "cmd": "docker run --rm --name=renovate_helm --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -e HELM_EXPERIMENTAL_OCI -w \\"/tmp/github/some/repo\\" renovate/helm bash -l -c \\"helm repo add repo1 the_repo1_url\\"",
+    "options": Object {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": Object {
+        "HELM_EXPERIMENTAL_OCI": "1",
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+  Object {
+    "cmd": "docker run --rm --name=renovate_helm --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -e HELM_EXPERIMENTAL_OCI -w \\"/tmp/github/some/repo\\" renovate/helm bash -l -c \\"helm repo add stable the_stable_url\\"",
+    "options": Object {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": Object {
+        "HELM_EXPERIMENTAL_OCI": "1",
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+  Object {
+    "cmd": "docker ps --filter name=renovate_helm -aq",
+    "options": Object {
+      "encoding": "utf-8",
+    },
+  },
+  Object {
+    "cmd": "docker run --rm --name=renovate_helm --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -e HELM_EXPERIMENTAL_OCI -w \\"/tmp/github/some/repo\\" renovate/helm bash -l -c \\"helm dependency update ''\\"",
+    "options": Object {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": Object {
+        "HELM_EXPERIMENTAL_OCI": "1",
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+]
+`;

--- a/lib/manager/helmv3/artifacts.spec.ts
+++ b/lib/manager/helmv3/artifacts.spec.ts
@@ -148,4 +148,47 @@ describe('manager/helmv3/artifacts', () => {
       },
     ]);
   });
+
+  it('sets repositories from aliases', async () => {
+    fs.readFile.mockResolvedValueOnce('Old Chart.lock' as never);
+    const execSnapshots = mockExecAll(exec);
+    fs.readFile.mockResolvedValueOnce('New Chart.lock' as never);
+    expect(
+      await helmv3.updateArtifacts({
+        packageFileName: 'Chart.yaml',
+        updatedDeps: [],
+        newPackageFileContent: '{}',
+        config: {
+          ...config,
+          updateType: 'lockFileMaintenance',
+          aliases: { stable: 'the_stable_url', repo1: 'the_repo1_url' },
+        },
+      })
+    ).toMatchSnapshot([
+      { file: { contents: 'New Chart.lock', name: 'Chart.lock' } },
+    ]);
+    expect(execSnapshots).toMatchSnapshot();
+  });
+
+  it('sets repositories from aliases with docker', async () => {
+    setGlobalConfig({ ...adminConfig, binarySource: 'docker' });
+    fs.readFile.mockResolvedValueOnce('Old Chart.lock' as never);
+    const execSnapshots = mockExecAll(exec);
+    fs.readFile.mockResolvedValueOnce('New Chart.lock' as never);
+    expect(
+      await helmv3.updateArtifacts({
+        packageFileName: 'Chart.yaml',
+        updatedDeps: [],
+        newPackageFileContent: '{}',
+        config: {
+          ...config,
+          updateType: 'lockFileMaintenance',
+          aliases: { stable: 'the_stable_url', repo1: 'the_repo1_url' },
+        },
+      })
+    ).toMatchSnapshot([
+      { file: { contents: 'New Chart.lock', name: 'Chart.lock' } },
+    ]);
+    expect(execSnapshots).toMatchSnapshot();
+  });
 });

--- a/lib/manager/helmv3/artifacts.ts
+++ b/lib/manager/helmv3/artifacts.ts
@@ -22,15 +22,15 @@ async function helmCommands(
       HELM_EXPERIMENTAL_OCI: '1',
     },
   };
-  const cmd = [
-    `helm dependency update ${quote(getSubDirectory(manifestPath))}`,
-  ];
+  const cmd = [];
 
   if (aliases) {
     Object.entries(aliases).forEach(([alias, url]) =>
       cmd.push(`helm repo add ${quote(alias)} ${quote(url)}`)
     );
   }
+  cmd.push(`helm dependency update ${quote(getSubDirectory(manifestPath))}`);
+
   await exec(cmd, execOptions);
 }
 

--- a/lib/manager/types.ts
+++ b/lib/manager/types.ts
@@ -49,6 +49,7 @@ export interface UpdateArtifactsConfig {
   newValue?: string;
   newVersion?: string;
   newMajor?: number;
+  aliases?: Record<string, string>;
 }
 
 export interface RangeConfig<T = Record<string, any>> extends ManagerData<T> {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->
Execute `helm repo add <alias> <url>` for all aliases.
Required for helm to update Chart.lock files

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->
Closes #8542

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository (https://gitlab.com/jgarec/renovate-helmv3/-/merge_requests)

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
