### PR TITLE
fix(github): separate platformConfig

### DIFF
--- a/lib/platform/github/index.ts
+++ b/lib/platform/github/index.ts
@@ -83,12 +83,12 @@ const platformConfig: PlatformConfig = {
 const escapeHash = (input: string): string =>
   input ? input.replace(regEx(/#/g), '%23') : input;
 
-export async function detectGhe(): Promise<void> {
+export async function detectGhe(token: string): Promise<void> {
   platformConfig.isGhe =
     URL.parse(platformConfig.endpoint).host !== 'api.github.com';
   if (platformConfig.isGhe) {
     const gheHeaderKey = 'x-github-enterprise-version';
-    const gheQueryRes = await githubApi.head('/', { throwHttpErrors: false });
+    const gheQueryRes = await githubApi.headJson('/', { token });
     const gheHeaders: Record<string, string> = gheQueryRes?.headers || {};
     const [, gheVersion] =
       Object.entries(gheHeaders).find(
@@ -115,7 +115,7 @@ export async function initPlatform({
     logger.debug('Using default github endpoint: ' + platformConfig.endpoint);
   }
 
-  await detectGhe();
+  await detectGhe(token);
 
   let userDetails: UserDetails;
   let renovateUsername: string;

--- a/lib/platform/github/index.ts
+++ b/lib/platform/github/index.ts
@@ -89,7 +89,7 @@ const platformConfig: PlatformConfig = {
 const escapeHash = (input: string): string =>
   input ? input.replace(regEx(/#/g), '%23') : input;
 
-export async function detectPlatformConfig(): Promise<void> {
+export async function detectGhe(): Promise<void> {
   platformConfig.isGhe =
     URL.parse(platformConfig.endpoint).host !== 'api.github.com';
   if (platformConfig.isGhe) {
@@ -121,7 +121,7 @@ export async function initPlatform({
     logger.debug('Using default github endpoint: ' + platformConfig.endpoint);
   }
 
-  await detectPlatformConfig();
+  await detectGhe();
 
   let userDetails: UserDetails;
   let renovateUsername: string;
@@ -139,7 +139,7 @@ export async function initPlatform({
       discoveredGitAuthor = `${userDetails.name} <${userEmail}>`;
     }
   }
-  logger.debug('Authenticated as GitHub user: ' + renovateUsername);
+  logger.debug({ platformConfig, renovateUsername }, 'Platform config');
   const platformResult: PlatformResult = {
     endpoint: platformConfig.endpoint,
     gitAuthor: gitAuthor || discoveredGitAuthor,

--- a/lib/platform/github/index.ts
+++ b/lib/platform/github/index.ts
@@ -66,6 +66,7 @@ import {
   GhRepo,
   GhRestPr,
   LocalRepoConfig,
+  PlatformConfig,
   PrList,
 } from './types';
 import { UserDetails, getUserDetails, getUserEmail } from './user';
@@ -73,13 +74,6 @@ import { UserDetails, getUserDetails, getUserEmail } from './user';
 const githubApi = new githubHttp.GithubHttp();
 
 let config: LocalRepoConfig = {} as any;
-
-interface PlatformConfig {
-  hostType: string;
-  endpoint: string;
-  isGhe?: boolean;
-  gheVersion?: string | null;
-}
 
 const platformConfig: PlatformConfig = {
   hostType: PlatformId.Github,

--- a/lib/platform/github/types.ts
+++ b/lib/platform/github/types.ts
@@ -54,6 +54,13 @@ export interface GhGraphQlPr extends GhPr {
   labels: string[] & { nodes?: { name: string }[] };
 }
 
+export interface PlatformConfig {
+  hostType: string;
+  endpoint: string;
+  isGhe?: boolean;
+  gheVersion?: string | null;
+}
+
 export interface LocalRepoConfig {
   repositoryName: string;
   pushProtection: boolean;

--- a/lib/platform/github/types.ts
+++ b/lib/platform/github/types.ts
@@ -70,8 +70,6 @@ export interface LocalRepoConfig {
   defaultBranch: string;
   repositoryOwner: string;
   repository: string | null;
-  isGhe: boolean;
-  gheVersion?: string | null;
   renovateUsername: string;
   productLinks: any;
   ignorePrAuthor: boolean;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Separates out platformConfig detection from initPlatform

## Context:

GHE-related graphql problems.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
