### PR TITLE
fix(lein): Group dependencies based on shared var

### DIFF
--- a/lib/manager/leiningen/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/leiningen/__snapshots__/extract.spec.ts.snap
@@ -116,6 +116,7 @@ Object {
       "datasource": "clojure",
       "depName": "clj-stacktrace:clj-stacktrace",
       "depType": "dependencies",
+      "groupName": "clj-stacktrace-version",
       "registryUrls": Array [
         "https://download.java.net/maven/2",
         "https://oss.sonatype.org/content/repositories/releases",

--- a/lib/manager/leiningen/extract.spec.ts
+++ b/lib/manager/leiningen/extract.spec.ts
@@ -35,6 +35,7 @@ describe('manager/leiningen/extract', () => {
         datasource: ClojureDatasource.id,
         depName: 'foo:bar',
         currentValue: '1.2.3',
+        groupName: 'baz',
       },
     ]);
     expect(
@@ -64,7 +65,11 @@ describe('manager/leiningen/extract', () => {
         { depName: 'org.lwjgl.lwjgl:lwjgl-platform', currentValue: '2.8.5' },
         { depName: 'org.clojure:clojure', currentValue: '1.4.0' },
         { depName: 'org.clojure:clojure', currentValue: '1.5.0' },
-        { depName: 'clj-stacktrace:clj-stacktrace', currentValue: '0.2.4' },
+        {
+          depName: 'clj-stacktrace:clj-stacktrace',
+          currentValue: '0.2.4',
+          groupName: 'clj-stacktrace-version',
+        },
         {
           depName: 'clj-time:clj-time',
           currentValue: '0.12.0',


### PR DESCRIPTION


<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Add `groupName` to the dependencies that are defined using vars

## Context:

Closes #12460

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
