### PR TITLE
fix(github): Disable platform-native automerge for GHE

### DIFF
--- a/lib/platform/github/index.ts
+++ b/lib/platform/github/index.ts
@@ -1444,11 +1444,11 @@ async function tryPrAutomerge(
   prNodeId: string,
   platformOptions: PlatformPrOptions
 ): Promise<void> {
-  if (!platformOptions?.usePlatformAutomerge) {
+  if (platformConfig.isGhe || !platformOptions?.usePlatformAutomerge) {
     return;
   }
 
-  if (config.autoMergeAllowed === false) {
+  if (!config.autoMergeAllowed) {
     logger.debug(
       { prNumber },
       'GitHub-native automerge: not enabled in repo settings'


### PR DESCRIPTION


<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Shor-circuit platform-native automerge when `platformConfig.isGhe` is true.

## Context:

#12464

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
