### PR TITLE
refactor(kustomize): Set `depType` when pushing deps

### DIFF
--- a/lib/manager/kustomize/extract.spec.ts
+++ b/lib/manager/kustomize/extract.spec.ts
@@ -46,7 +46,7 @@ describe('manager/kustomize/extract', () => {
         depName: 'user/test-repo',
       };
 
-      const pkg = extractBase(`${base}?ref=${version}`, 'Kustomization');
+      const pkg = extractBase(`${base}?ref=${version}`);
       expect(pkg).toEqual(sample);
     });
     it('should extract the version of a non http base', () => {

--- a/lib/manager/kustomize/extract.spec.ts
+++ b/lib/manager/kustomize/extract.spec.ts
@@ -34,7 +34,7 @@ describe('manager/kustomize/extract', () => {
   });
   describe('extractBase', () => {
     it('should return null for a local base', () => {
-      const res = extractBase('./service-1', 'Kustomization');
+      const res = extractBase('./service-1');
       expect(res).toBeNull();
     });
     it('should extract out the version of an http base', () => {
@@ -44,7 +44,6 @@ describe('manager/kustomize/extract', () => {
         currentValue: version,
         datasource: datasourceGitHubTags.id,
         depName: 'user/test-repo',
-        depType: 'Kustomization',
       };
 
       const pkg = extractBase(`${base}?ref=${version}`, 'Kustomization');
@@ -52,40 +51,34 @@ describe('manager/kustomize/extract', () => {
     });
     it('should extract the version of a non http base', () => {
       const pkg = extractBase(
-        'ssh://git@bitbucket.com/user/test-repo?ref=v1.2.3',
-        'Kustomization'
+        'ssh://git@bitbucket.com/user/test-repo?ref=v1.2.3'
       );
       expect(pkg).toEqual({
         currentValue: 'v1.2.3',
         datasource: GitTagsDatasource.id,
         depName: 'bitbucket.com/user/test-repo',
-        depType: 'Kustomization',
         lookupName: 'ssh://git@bitbucket.com/user/test-repo',
       });
     });
     it('should extract the depName if the URL includes a port number', () => {
       const pkg = extractBase(
-        'ssh://git@bitbucket.com:7999/user/test-repo?ref=v1.2.3',
-        'Kustomization'
+        'ssh://git@bitbucket.com:7999/user/test-repo?ref=v1.2.3'
       );
       expect(pkg).toEqual({
         currentValue: 'v1.2.3',
         datasource: GitTagsDatasource.id,
         depName: 'bitbucket.com:7999/user/test-repo',
-        depType: 'Kustomization',
         lookupName: 'ssh://git@bitbucket.com:7999/user/test-repo',
       });
     });
     it('should extract the version of a non http base with subdir', () => {
       const pkg = extractBase(
-        'ssh://git@bitbucket.com/user/test-repo/subdir?ref=v1.2.3',
-        'Kustomization'
+        'ssh://git@bitbucket.com/user/test-repo/subdir?ref=v1.2.3'
       );
       expect(pkg).toEqual({
         currentValue: 'v1.2.3',
         datasource: GitTagsDatasource.id,
         depName: 'bitbucket.com/user/test-repo',
-        depType: 'Kustomization',
         lookupName: 'ssh://git@bitbucket.com/user/test-repo',
       });
     });
@@ -96,10 +89,9 @@ describe('manager/kustomize/extract', () => {
         currentValue: version,
         datasource: datasourceGitHubTags.id,
         depName: 'fluxcd/flux',
-        depType: 'Kustomization',
       };
 
-      const pkg = extractBase(`${base}?ref=${version}`, 'Kustomization');
+      const pkg = extractBase(`${base}?ref=${version}`);
       expect(pkg).toEqual(sample);
     });
     it('should extract out the version of a git base', () => {
@@ -109,10 +101,9 @@ describe('manager/kustomize/extract', () => {
         currentValue: version,
         datasource: datasourceGitHubTags.id,
         depName: 'user/repo',
-        depType: 'Kustomization',
       };
 
-      const pkg = extractBase(`${base}?ref=${version}`, 'Kustomization');
+      const pkg = extractBase(`${base}?ref=${version}`);
       expect(pkg).toEqual(sample);
     });
     it('should extract out the version of a git base with subdir', () => {
@@ -122,22 +113,18 @@ describe('manager/kustomize/extract', () => {
         currentValue: version,
         datasource: datasourceGitHubTags.id,
         depName: 'user/repo',
-        depType: 'Kustomization',
       };
 
-      const pkg = extractBase(`${base}?ref=${version}`, 'Kustomization');
+      const pkg = extractBase(`${base}?ref=${version}`);
       expect(pkg).toEqual(sample);
     });
   });
   describe('image extraction', () => {
     it('should return null on a null input', () => {
-      const pkg = extractImage(
-        {
-          name: null,
-          newTag: null,
-        },
-        'Kustomization'
-      );
+      const pkg = extractImage({
+        name: null,
+        newTag: null,
+      });
       expect(pkg).toBeNull();
     });
     it('should correctly extract a default image', () => {
@@ -147,15 +134,11 @@ describe('manager/kustomize/extract', () => {
         datasource: datasourceDocker.id,
         replaceString: 'v1.0.0',
         depName: 'node',
-        depType: 'Kustomization',
       };
-      const pkg = extractImage(
-        {
-          name: sample.depName,
-          newTag: sample.currentValue,
-        },
-        'Kustomization'
-      );
+      const pkg = extractImage({
+        name: sample.depName,
+        newTag: sample.currentValue,
+      });
       expect(pkg).toEqual(sample);
     });
     it('should correctly extract an image in a repo', () => {
@@ -165,15 +148,11 @@ describe('manager/kustomize/extract', () => {
         datasource: datasourceDocker.id,
         replaceString: 'v1.0.0',
         depName: 'test/node',
-        depType: 'Kustomization',
       };
-      const pkg = extractImage(
-        {
-          name: sample.depName,
-          newTag: sample.currentValue,
-        },
-        'Kustomization'
-      );
+      const pkg = extractImage({
+        name: sample.depName,
+        newTag: sample.currentValue,
+      });
       expect(pkg).toEqual(sample);
     });
     it('should correctly extract from a different registry', () => {
@@ -183,15 +162,11 @@ describe('manager/kustomize/extract', () => {
         datasource: datasourceDocker.id,
         replaceString: 'v1.0.0',
         depName: 'quay.io/repo/image',
-        depType: 'Kustomization',
       };
-      const pkg = extractImage(
-        {
-          name: sample.depName,
-          newTag: sample.currentValue,
-        },
-        'Kustomization'
-      );
+      const pkg = extractImage({
+        name: sample.depName,
+        newTag: sample.currentValue,
+      });
       expect(pkg).toEqual(sample);
     });
     it('should correctly extract from a different port', () => {
@@ -201,15 +176,11 @@ describe('manager/kustomize/extract', () => {
         datasource: datasourceDocker.id,
         replaceString: 'v1.0.0',
         depName: 'localhost:5000/repo/image',
-        depType: 'Kustomization',
       };
-      const pkg = extractImage(
-        {
-          name: sample.depName,
-          newTag: sample.currentValue,
-        },
-        'Kustomization'
-      );
+      const pkg = extractImage({
+        name: sample.depName,
+        newTag: sample.currentValue,
+      });
       expect(pkg).toEqual(sample);
     });
     it('should correctly extract from a multi-depth registry', () => {
@@ -219,15 +190,11 @@ describe('manager/kustomize/extract', () => {
         replaceString: 'v1.0.0',
         datasource: datasourceDocker.id,
         depName: 'localhost:5000/repo/image/service',
-        depType: 'Kustomization',
       };
-      const pkg = extractImage(
-        {
-          name: sample.depName,
-          newTag: sample.currentValue,
-        },
-        'Kustomization'
-      );
+      const pkg = extractImage({
+        name: sample.depName,
+        newTag: sample.currentValue,
+      });
       expect(pkg).toEqual(sample);
     });
   });

--- a/lib/manager/kustomize/extract.ts
+++ b/lib/manager/kustomize/extract.ts
@@ -16,10 +16,7 @@ const gitUrl = regEx(
   /^(?:git::)?(?<url>(?:(?:(?:http|https|ssh):\/\/)?(?:.*@)?)?(?<path>(?:[^:/\s]+(?::[0-9]+)?[:/])?(?<project>[^/\s]+\/[^/\s]+)))(?<subdir>[^?\s]*)\?ref=(?<currentValue>.+)$/
 );
 
-export function extractBase(
-  base: string,
-  kind: string
-): PackageDependency | null {
+export function extractBase(base: string): PackageDependency | null {
   const match = gitUrl.exec(base);
 
   if (!match) {
@@ -32,23 +29,18 @@ export function extractBase(
       currentValue: match.groups.currentValue,
       datasource: datasourceGitHubTags.id,
       depName: match.groups.project.replace('.git', ''),
-      depType: kind,
     };
   }
 
   return {
     datasource: GitTagsDatasource.id,
     depName: path.replace('.git', ''),
-    depType: kind,
     lookupName: match.groups.url,
     currentValue: match.groups.currentValue,
   };
 }
 
-export function extractImage(
-  image: Image,
-  kind: string
-): PackageDependency | null {
+export function extractImage(image: Image): PackageDependency | null {
   if (!image.name) {
     return null;
   }
@@ -62,7 +54,6 @@ export function extractImage(
     );
     return {
       depName,
-      depType: kind,
       currentValue: newTag,
       currentDigest: digest,
       skipReason: SkipReason.InvalidDependencySpecification,
@@ -73,7 +64,6 @@ export function extractImage(
     if (!is.string(digest) || !digest.startsWith('sha256:')) {
       return {
         depName,
-        depType: kind,
         currentValue: digest,
         skipReason: SkipReason.InvalidValue,
       };
@@ -82,7 +72,6 @@ export function extractImage(
     return {
       datasource: datasourceDocker.id,
       depName,
-      depType: kind,
       currentValue: nameDep.currentValue,
       currentDigest: digest,
       replaceString: digest,
@@ -93,7 +82,6 @@ export function extractImage(
     if (!is.string(newTag) || newTag.startsWith('sha256:')) {
       return {
         depName,
-        depType: kind,
         currentValue: newTag,
         skipReason: SkipReason.InvalidValue,
       };
@@ -102,7 +90,6 @@ export function extractImage(
     const dep = splitImageParts(`${depName}:${newTag}`);
     return {
       ...dep,
-      depType: kind,
       datasource: datasourceDocker.id,
       replaceString: newTag,
     };
@@ -111,7 +98,6 @@ export function extractImage(
   if (image.newName) {
     return {
       ...nameDep,
-      depType: kind,
       datasource: datasourceDocker.id,
       replaceString: image.newName,
     };
@@ -156,17 +142,23 @@ export function extractPackageFile(content: string): PackageFile | null {
 
   // grab the remote bases
   for (const base of pkg.bases) {
-    const dep = extractBase(base, pkg.kind);
+    const dep = extractBase(base);
     if (dep) {
-      deps.push(dep);
+      deps.push({
+        ...dep,
+        depType: pkg.kind,
+      });
     }
   }
 
   // grab the image tags
   for (const image of pkg.images) {
-    const dep = extractImage(image, pkg.kind);
+    const dep = extractImage(image);
     if (dep) {
-      deps.push(dep);
+      deps.push({
+        ...dep,
+        depType: pkg.kind,
+      });
     }
   }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->
Set `depType` when pushing deps instead of passing it around and risking forgetting to set it.

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

Follow up on #12467.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
