### PR TITLE
fix(npm): use stdout for Yarn if stderr is empty

### DIFF
--- a/lib/manager/npm/post-update/index.ts
+++ b/lib/manager/npm/post-update/index.ts
@@ -608,7 +608,7 @@ export async function getAdditionalFiles(
       }
       artifactErrors.push({
         lockFile: yarnLock,
-        stderr: res.stderr,
+        stderr: res.stderr || res.stdout,
       });
     } else {
       const existingContent = await getFile(

--- a/lib/manager/npm/post-update/yarn.ts
+++ b/lib/manager/npm/post-update/yarn.ts
@@ -249,7 +249,7 @@ export async function generateLockFile(
         throw new ExternalHostError(err, npmId);
       }
     }
-    return { error: true, stderr: err.stderr };
+    return { error: true, stderr: err.stderr, stdout: err.stdout };
   }
   return { lockFile };
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Use stdout for `yarn.generateLockFile()` in `artifactErrors` if stderr is empty.

## Context:

Yarn 2+ uses stdout for printing warnings and errors: https://github.com/yarnpkg/berry/blob/master/packages/yarnpkg-core/sources/StreamReport.ts.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
