### PR TITLE
refactor(github): Extract getSourceUrl function

### DIFF
--- a/lib/datasource/github-releases/common.ts
+++ b/lib/datasource/github-releases/common.ts
@@ -13,10 +13,16 @@ export function getSourceUrlBase(registryUrl: string): string {
   return ensureTrailingSlash(registryUrl ?? defaultSourceUrlBase);
 }
 
-export function getApiBaseUrl(sourceUrlBase: string): string {
+export function getApiBaseUrl(registryUrl: string): string {
+  const sourceUrlBase = getSourceUrlBase(registryUrl);
   return sourceUrlBase === defaultSourceUrlBase
     ? `https://api.github.com/`
     : `${sourceUrlBase}api/v3/`;
+}
+
+export function getSourceUrl(lookupName: string, registryUrl?: string): string {
+  const sourceUrlBase = getSourceUrlBase(registryUrl);
+  return `${sourceUrlBase}${lookupName}`;
 }
 
 export async function getGithubRelease(

--- a/lib/datasource/github-releases/index.ts
+++ b/lib/datasource/github-releases/index.ts
@@ -5,7 +5,7 @@ import {
   cacheNamespace,
   getApiBaseUrl,
   getGithubRelease,
-  getSourceUrlBase,
+  getSourceUrl,
   http,
   id,
 } from './common';
@@ -45,15 +45,14 @@ export async function getReleases({
   if (cachedResult) {
     return cachedResult;
   }
-  const sourceUrlBase = getSourceUrlBase(registryUrl);
-  const apiBaseUrl = getApiBaseUrl(sourceUrlBase);
+  const apiBaseUrl = getApiBaseUrl(registryUrl);
   const url = `${apiBaseUrl}repos/${repo}/releases?per_page=100`;
   const res = await http.getJson<GithubRelease[]>(url, {
     paginate: true,
   });
   const githubReleases = res.body;
   const dependency: ReleaseResult = {
-    sourceUrl: `${sourceUrlBase}${repo}`,
+    sourceUrl: getSourceUrl(repo, registryUrl),
     releases: null,
   };
   dependency.releases = githubReleases.map(
@@ -113,7 +112,7 @@ export async function getDigest(
     return cachedResult;
   }
 
-  const apiBaseUrl = getApiBaseUrl(getSourceUrlBase(registryUrl));
+  const apiBaseUrl = getApiBaseUrl(registryUrl);
   const currentRelease = await getGithubRelease(apiBaseUrl, repo, currentValue);
   const digestAsset = await findDigestAsset(currentRelease, currentDigest);
   let newDigest: string;

--- a/lib/datasource/github-tags/index.ts
+++ b/lib/datasource/github-tags/index.ts
@@ -1,8 +1,8 @@
 import { logger } from '../../logger';
 import * as packageCache from '../../util/cache/package';
 import { GithubHttp } from '../../util/http/github';
-import { ensureTrailingSlash } from '../../util/url';
 import * as githubReleases from '../github-releases';
+import { getApiBaseUrl, getSourceUrl } from '../github-releases/common';
 import type { DigestConfig, GetReleasesConfig, ReleaseResult } from '../types';
 import type { GitHubTag, TagResponse } from './types';
 
@@ -33,14 +33,7 @@ async function getTagCommit(
     return cachedResult;
   }
 
-  // default to GitHub.com if no GHE host is specified.
-  const sourceUrlBase = ensureTrailingSlash(
-    registryUrl ?? 'https://github.com/'
-  );
-  const apiBaseUrl =
-    sourceUrlBase === 'https://github.com/'
-      ? `https://api.github.com/`
-      : `${sourceUrlBase}api/v3/`;
+  const apiBaseUrl = getApiBaseUrl(registryUrl);
   let digest: string;
   try {
     const url = `${apiBaseUrl}repos/${githubRepo}/git/refs/tags/${tag}`;
@@ -93,14 +86,7 @@ export async function getDigest(
   if (cachedResult) {
     return cachedResult;
   }
-  // default to GitHub.com if no GHE host is specified.
-  const sourceUrlBase = ensureTrailingSlash(
-    registryUrl ?? 'https://github.com/'
-  );
-  const apiBaseUrl =
-    sourceUrlBase === 'https://github.com/'
-      ? `https://api.github.com/`
-      : `${sourceUrlBase}api/v3/`;
+  const apiBaseUrl = getApiBaseUrl(registryUrl);
   let digest: string;
   try {
     const url = `${apiBaseUrl}repos/${repo}/commits?per_page=1`;
@@ -138,14 +124,7 @@ async function getTags({
     return cachedResult;
   }
 
-  // default to GitHub.com if no GHE host is specified.
-  const sourceUrlBase = ensureTrailingSlash(
-    registryUrl ?? 'https://github.com/'
-  );
-  const apiBaseUrl =
-    sourceUrlBase === 'https://github.com/'
-      ? `https://api.github.com/`
-      : `${sourceUrlBase}api/v3/`;
+  const apiBaseUrl = getApiBaseUrl(registryUrl);
   // tag
   const url = `${apiBaseUrl}repos/${repo}/tags?per_page=100`;
 
@@ -155,7 +134,7 @@ async function getTags({
     })
   ).body.map((o) => o.name);
   const dependency: ReleaseResult = {
-    sourceUrl: `${sourceUrlBase}${repo}`,
+    sourceUrl: getSourceUrl(repo, registryUrl),
     releases: null,
   };
   dependency.releases = versions.map((version) => ({


### PR DESCRIPTION


<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Generate source URL directly without any release fetching

## Context:

Ref: #12486

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
