### PR TITLE
refactor(gitlab): Extract getSourceUrl function

### DIFF
--- a/lib/datasource/gitlab-tags/index.ts
+++ b/lib/datasource/gitlab-tags/index.ts
@@ -1,15 +1,15 @@
 import * as packageCache from '../../util/cache/package';
 import { GitlabHttp } from '../../util/http/gitlab';
-import { regEx } from '../../util/regex';
 import { joinUrlParts } from '../../util/url';
 import type { GetReleasesConfig, ReleaseResult } from '../types';
 import type { GitlabTag } from './types';
+import { defaultRegistryUrl, getDepHost, getSourceUrl } from './util';
 
 export const id = 'gitlab-tags';
 const gitlabApi = new GitlabHttp(id);
 
 export const customRegistrySupport = true;
-export const defaultRegistryUrls = ['https://gitlab.com'];
+export const defaultRegistryUrls = [defaultRegistryUrl];
 export const registryStrategy = 'first';
 
 const cacheNamespace = 'datasource-gitlab';
@@ -23,7 +23,7 @@ export async function getReleases({
   registryUrl,
   lookupName: repo,
 }: GetReleasesConfig): Promise<ReleaseResult | null> {
-  const depHost = registryUrl.replace(regEx(/\/api\/v4$/), '');
+  const depHost = getDepHost(registryUrl);
 
   const cachedResult = await packageCache.get<ReleaseResult>(
     cacheNamespace,
@@ -51,7 +51,7 @@ export async function getReleases({
   ).body;
 
   const dependency: ReleaseResult = {
-    sourceUrl: joinUrlParts(depHost, repo),
+    sourceUrl: getSourceUrl(repo, registryUrl),
     releases: null,
   };
   dependency.releases = gitlabTags.map(({ name, commit }) => ({

--- a/lib/datasource/gitlab-tags/util.ts
+++ b/lib/datasource/gitlab-tags/util.ts
@@ -1,0 +1,13 @@
+import { regEx } from '../../util/regex';
+import { joinUrlParts } from '../../util/url';
+
+export const defaultRegistryUrl = 'https://gitlab.com';
+
+export function getDepHost(registryUrl: string = defaultRegistryUrl): string {
+  return registryUrl.replace(regEx(/\/api\/v4$/), '');
+}
+
+export function getSourceUrl(lookupName: string, registryUrl?: string): string {
+  const depHost = getDepHost(registryUrl);
+  return joinUrlParts(depHost, lookupName);
+}


### PR DESCRIPTION


<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Generate source URL directly without any release fetching

## Context:

Ref: #12486

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
