### PR TITLE
refactor(bitbucket): Extract getSourceUrl function

### DIFF
--- a/lib/datasource/bitbucket-tags/index.ts
+++ b/lib/datasource/bitbucket-tags/index.ts
@@ -34,6 +34,12 @@ export class BitBucketTagsDatasource extends Datasource {
     )}:${repo}:${type}`;
   }
 
+  static getSourceUrl(lookupName: string, registryUrl?: string): string {
+    const url = BitBucketTagsDatasource.getRegistryURL(registryUrl);
+    const normalizedUrl = ensureTrailingSlash(url);
+    return `${normalizedUrl}${lookupName}`;
+  }
+
   // getReleases fetches list of tags for the repository
   @cache({
     namespace: BitBucketTagsDatasource.cacheNamespace,
@@ -51,9 +57,7 @@ export class BitBucketTagsDatasource extends Datasource {
     ).body;
 
     const dependency: ReleaseResult = {
-      sourceUrl: `${ensureTrailingSlash(
-        BitBucketTagsDatasource.getRegistryURL(registryUrl)
-      )}${repo}`,
+      sourceUrl: BitBucketTagsDatasource.getSourceUrl(repo, registryUrl),
       registryUrl: BitBucketTagsDatasource.getRegistryURL(registryUrl),
       releases: null,
     };


### PR DESCRIPTION


<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Generate source URL directly without any release fetching

## Context:

Ref: #12486

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
