### PR TITLE
refactor(go): Extract datasource detection to separate module

### DIFF
--- a/lib/datasource/go/common.ts
+++ b/lib/datasource/go/common.ts
@@ -1,8 +1,11 @@
 import { Http } from '../../util/http';
+import { BitBucketTagsDatasource } from '../bitbucket-tags';
 
 export const id = 'go';
 
 export const http = new Http(id);
+
+export const bitbucket = new BitBucketTagsDatasource();
 
 export enum GoproxyFallback {
   WhenNotFoundOrGone = ',',

--- a/lib/datasource/go/digest.ts
+++ b/lib/datasource/go/digest.ts
@@ -1,6 +1,7 @@
 import * as github from '../github-tags';
 import type { DigestConfig } from '../types';
-import { bitbucket, getDatasource } from './util';
+import { bitbucket } from './common';
+import { getDatasource } from './get-datasource';
 
 /**
  * go.getDigest

--- a/lib/datasource/go/get-datasource.ts
+++ b/lib/datasource/go/get-datasource.ts
@@ -121,6 +121,7 @@ export async function getDatasource(
     const lookupName = pkg.includes('/') ? pkg : `go-${pkg}/${pkg}`;
     return { datasource: github.id, lookupName };
   }
+
   if (goModule.startsWith('github.com/')) {
     const split = goModule.split('/');
     const lookupName = split[1] + '/' + split[2];

--- a/lib/datasource/go/get-datasource.ts
+++ b/lib/datasource/go/get-datasource.ts
@@ -1,7 +1,6 @@
 import URL from 'url';
 import { PlatformId } from '../../constants';
 import { logger } from '../../logger';
-import * as packageCache from '../../util/cache/package';
 import * as hostRules from '../../util/host-rules';
 import { regEx } from '../../util/regex';
 import { trimTrailingSlash } from '../../util/url';
@@ -140,19 +139,6 @@ export async function getDatasource(
     };
   }
 
-  const cacheNamespace = 'datasource-go-get-datasource';
-  const cacheKey = goModule;
-  const cacheMinutes = 24 * 60;
-  const cachedGoGetResult = await packageCache.get<DataSource | null>(
-    cacheNamespace,
-    cacheKey
-  );
-  // istanbul ignore if
-  if (cachedGoGetResult || cachedGoGetResult === null) {
-    return cachedGoGetResult;
-  }
-
   const goGetResult = await goGetDatasource(goModule);
-  await packageCache.set(cacheNamespace, cacheKey, goGetResult, cacheMinutes);
   return goGetResult;
 }

--- a/lib/datasource/go/releases-direct.ts
+++ b/lib/datasource/go/releases-direct.ts
@@ -3,7 +3,8 @@ import { regEx } from '../../util/regex';
 import * as github from '../github-tags';
 import * as gitlab from '../gitlab-tags';
 import type { GetReleasesConfig, ReleaseResult } from '../types';
-import { bitbucket, getDatasource } from './util';
+import { bitbucket } from './common';
+import { getDatasource } from './get-datasource';
 
 /**
  * go.getReleases


### PR DESCRIPTION


<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Further it will be tested separately from `releases-direct.ts` module too

## Context:

Ref: #12486

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
