### PR TITLE
fix(go): Add source URLs to releases obtained via GOPROXY

### DIFF
--- a/lib/datasource/go/common.ts
+++ b/lib/datasource/go/common.ts
@@ -1,5 +1,11 @@
 import { Http } from '../../util/http';
 import { BitBucketTagsDatasource } from '../bitbucket-tags';
+import { getSourceUrl as githubSourceUrl } from '../github-releases/common';
+import { id as githubDatasource } from '../github-tags';
+import { id as gitlabDatasource } from '../gitlab-tags';
+import { getSourceUrl as gitlabSourceUrl } from '../gitlab-tags/util';
+
+import type { DataSource } from './types';
 
 export const id = 'go';
 
@@ -10,4 +16,25 @@ export const bitbucket = new BitBucketTagsDatasource();
 export enum GoproxyFallback {
   WhenNotFoundOrGone = ',',
   Always = '|',
+}
+
+export function getSourceUrl(dataSource?: DataSource): string | undefined {
+  if (dataSource) {
+    const { datasource, registryUrl, lookupName } = dataSource;
+
+    if (datasource === githubDatasource) {
+      return githubSourceUrl(lookupName, registryUrl);
+    }
+
+    if (datasource === gitlabDatasource) {
+      return gitlabSourceUrl(lookupName, registryUrl);
+    }
+
+    if (datasource === bitbucket.id) {
+      return BitBucketTagsDatasource.getSourceUrl(lookupName, registryUrl);
+    }
+  }
+
+  // istanbul ignore next
+  return undefined;
 }

--- a/lib/datasource/go/releases-direct.ts
+++ b/lib/datasource/go/releases-direct.ts
@@ -3,7 +3,7 @@ import { regEx } from '../../util/regex';
 import * as github from '../github-tags';
 import * as gitlab from '../gitlab-tags';
 import type { GetReleasesConfig, ReleaseResult } from '../types';
-import { bitbucket } from './common';
+import { bitbucket, getSourceUrl } from './common';
 import { getDatasource } from './get-datasource';
 
 /**
@@ -59,6 +59,8 @@ export async function getReleases(
     return null;
   }
 
+  const sourceUrl = getSourceUrl(source);
+
   /**
    * github.com/org/mod/submodule should be tagged as submodule/va.b.c
    * and that tag should be used instead of just va.b.c, although for compatibility
@@ -91,7 +93,7 @@ export async function getReleases(
       (source.datasource === gitlab.id && submodReleases.length)
     ) {
       return {
-        sourceUrl: res.sourceUrl,
+        sourceUrl,
         releases: submodReleases,
       };
     }
@@ -103,5 +105,5 @@ export async function getReleases(
     );
   }
 
-  return res;
+  return { ...res, sourceUrl };
 }

--- a/lib/datasource/go/releases-goproxy.spec.ts
+++ b/lib/datasource/go/releases-goproxy.spec.ts
@@ -179,10 +179,13 @@ describe('datasource/go/releases-goproxy', () => {
 
       const res = await getReleases({ lookupName: 'github.com/google/btree' });
       expect(httpMock.getTrace()).toMatchSnapshot();
-      expect(res?.releases).toMatchObject([
-        { releaseTimestamp: '2018-08-13T15:31:12Z', version: 'v1.0.0' },
-        { releaseTimestamp: '2019-10-16T16:15:28Z', version: 'v1.0.1' },
-      ]);
+      expect(res).toEqual({
+        releases: [
+          { releaseTimestamp: '2018-08-13T15:31:12Z', version: 'v1.0.0' },
+          { releaseTimestamp: '2019-10-16T16:15:28Z', version: 'v1.0.1' },
+        ],
+        sourceUrl: 'https://github.com/google/btree',
+      });
     });
 
     it('handles timestamp fetch errors', async () => {
@@ -199,10 +202,10 @@ describe('datasource/go/releases-goproxy', () => {
 
       const res = await getReleases({ lookupName: 'github.com/google/btree' });
       expect(httpMock.getTrace()).toMatchSnapshot();
-      expect(res?.releases).toMatchObject([
-        { version: 'v1.0.0' },
-        { version: 'v1.0.1' },
-      ]);
+      expect(res).toEqual({
+        releases: [{ version: 'v1.0.0' }, { version: 'v1.0.1' }],
+        sourceUrl: 'https://github.com/google/btree',
+      });
     });
 
     it('handles pipe fallback', async () => {
@@ -224,10 +227,13 @@ describe('datasource/go/releases-goproxy', () => {
 
       const res = await getReleases({ lookupName: 'github.com/google/btree' });
       expect(httpMock.getTrace()).toMatchSnapshot();
-      expect(res?.releases).toMatchObject([
-        { releaseTimestamp: '2018-08-13T15:31:12Z', version: 'v1.0.0' },
-        { releaseTimestamp: '2019-10-16T16:15:28Z', version: 'v1.0.1' },
-      ]);
+      expect(res).toEqual({
+        releases: [
+          { releaseTimestamp: '2018-08-13T15:31:12Z', version: 'v1.0.0' },
+          { releaseTimestamp: '2019-10-16T16:15:28Z', version: 'v1.0.1' },
+        ],
+        sourceUrl: 'https://github.com/google/btree',
+      });
     });
 
     it('handles comma fallback', async () => {
@@ -258,10 +264,13 @@ describe('datasource/go/releases-goproxy', () => {
 
       const res = await getReleases({ lookupName: 'github.com/google/btree' });
       expect(httpMock.getTrace()).toMatchSnapshot();
-      expect(res?.releases).toMatchObject([
-        { releaseTimestamp: '2018-08-13T15:31:12Z', version: 'v1.0.0' },
-        { releaseTimestamp: '2019-10-16T16:15:28Z', version: 'v1.0.1' },
-      ]);
+      expect(res).toEqual({
+        releases: [
+          { releaseTimestamp: '2018-08-13T15:31:12Z', version: 'v1.0.0' },
+          { releaseTimestamp: '2019-10-16T16:15:28Z', version: 'v1.0.1' },
+        ],
+        sourceUrl: 'https://github.com/google/btree',
+      });
     });
 
     it('short-circuits for errors other than 404 or 410', async () => {

--- a/lib/datasource/go/releases-goproxy.ts
+++ b/lib/datasource/go/releases-goproxy.ts
@@ -5,7 +5,8 @@ import { logger } from '../../logger';
 import * as packageCache from '../../util/cache/package';
 import { regEx } from '../../util/regex';
 import type { GetReleasesConfig, Release, ReleaseResult } from '../types';
-import { GoproxyFallback, http } from './common';
+import { GoproxyFallback, getSourceUrl, http } from './common';
+import { getDatasource } from './get-datasource';
 import * as direct from './releases-direct';
 import type { GoproxyItem, VersionInfo } from './types';
 
@@ -202,7 +203,9 @@ export async function getReleases(
       });
       const releases = await pAll(queue, { concurrency: 5 });
       if (releases.length) {
-        result = { releases };
+        const datasource = await getDatasource(lookupName);
+        const sourceUrl = getSourceUrl(datasource);
+        result = { releases, sourceUrl };
         break;
       }
     } catch (err) {


### PR DESCRIPTION
## Changes:

Share same `getSourceUrl()` function between `releases-direct.ts` and `releases-goproxy.ts`

## Context:

Closes #12486

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
