### PR TITLE
fix(ubuntu): Consider 22.04 unstable

### DIFF
--- a/lib/versioning/ubuntu/index.spec.ts
+++ b/lib/versioning/ubuntu/index.spec.ts
@@ -121,6 +121,7 @@ describe('versioning/ubuntu/index', () => {
     ${'42.10'}   | ${false}
     ${'42.11'}   | ${false}
     ${'2020.04'} | ${false}
+    ${'22.04'}   | ${false}
   `('isStable("$version") === $expected', ({ version, expected }) => {
     const res = !!ubuntu.isStable(version);
     expect(res).toBe(expected);

--- a/lib/versioning/ubuntu/index.ts
+++ b/lib/versioning/ubuntu/index.ts
@@ -6,6 +6,9 @@ export const displayName = 'Ubuntu';
 export const urls = ['https://changelogs.ubuntu.com/meta-release'];
 export const supportsRanges = false;
 
+// #12509
+const temporarilyUnstable = ['22.04'];
+
 // validation
 
 function isValid(input: string): string | boolean | null {
@@ -32,6 +35,9 @@ function isSingleVersion(version: string): string | boolean | null {
 
 function isStable(version: string): boolean {
   if (!isValid(version)) {
+    return false;
+  }
+  if (temporarilyUnstable.includes(version)) {
     return false;
   }
   return regEx(/^\d?[02468]\.04/).test(version);


### PR DESCRIPTION
## Changes:

In our simple stability detection algorithm, make an exception for some versions.

## Context:

Closes #12509

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
