### PR TITLE
fix(gradle): Enhance parsing

### DIFF
--- a/lib/manager/gradle/shallow/extract.spec.ts
+++ b/lib/manager/gradle/shallow/extract.spec.ts
@@ -61,12 +61,12 @@ describe('manager/gradle/shallow/extract', () => {
           },
         ],
       },
-      { packageFile: 'build.gradle', deps: [] },
       {
         datasource: 'maven',
         deps: [],
         packageFile: 'settings.gradle',
       },
+      { packageFile: 'build.gradle', deps: [] },
     ]);
   });
 
@@ -89,6 +89,11 @@ describe('manager/gradle/shallow/extract', () => {
         deps: [],
       },
       {
+        datasource: 'maven',
+        deps: [],
+        packageFile: 'settings.gradle',
+      },
+      {
         packageFile: 'build.gradle',
         deps: [
           {
@@ -100,11 +105,6 @@ describe('manager/gradle/shallow/extract', () => {
             ],
           },
         ],
-      },
-      {
-        datasource: 'maven',
-        deps: [],
-        packageFile: 'settings.gradle',
       },
     ]);
   });
@@ -164,12 +164,12 @@ describe('manager/gradle/shallow/extract', () => {
           },
         ],
       },
-      { packageFile: 'build.gradle', deps: [] },
       {
         datasource: 'maven',
         deps: [],
         packageFile: 'settings.gradle',
       },
+      { packageFile: 'build.gradle', deps: [] },
     ]);
   });
 

--- a/lib/manager/gradle/shallow/extract.ts
+++ b/lib/manager/gradle/shallow/extract.ts
@@ -46,7 +46,8 @@ export async function extractAllPackageFiles(
   const registry: VariableRegistry = {};
   const packageFilesByName: Record<string, PackageFile> = {};
   const registryUrls = [];
-  for (const packageFile of reorderFiles(packageFiles)) {
+  const reorderedFiles = reorderFiles(packageFiles);
+  for (const packageFile of reorderedFiles) {
     packageFilesByName[packageFile] = {
       packageFile,
       datasource,

--- a/lib/manager/gradle/shallow/parser.spec.ts
+++ b/lib/manager/gradle/shallow/parser.spec.ts
@@ -1,4 +1,5 @@
 import { loadFixture } from '../../../../test/util';
+import { SkipReason } from '../../../types';
 import {
   GOOGLE_REPO,
   GRADLE_PLUGIN_PORTAL_REPO,
@@ -45,6 +46,52 @@ describe('manager/gradle/shallow/parser', () => {
 
     ({ deps } = parseGradle('version = "1.2.3"\n"foo:bar:$version@@@"'));
     expect(deps).toBeEmpty();
+
+    ({ deps } = parseGradle(
+      // eslint-disable-next-line no-template-curly-in-string
+      ['versions.foobar = "1.2.3"', '"foo:bar:${versions.foobar}"'].join('\n')
+    ));
+    expect(deps).toMatchObject([
+      {
+        depName: 'foo:bar',
+        currentValue: '1.2.3',
+        groupName: 'versions.foobar',
+      },
+    ]);
+
+    ({ deps } = parseGradle(
+      ['versions.foobar = "1.2.3"', '"foo:bar:$versions.foobar"'].join('\n')
+    ));
+    expect(deps).toMatchObject([
+      {
+        depName: 'foo:bar',
+        currentValue: '1.2.3',
+        groupName: 'versions.foobar',
+      },
+    ]);
+
+    expect(
+      parseGradle('foo.bar = "foo:bar:1.2.3"', {}, 'versions.gradle')
+    ).toMatchObject({
+      vars: {
+        'foo.bar': {
+          fileReplacePosition: 11,
+          key: 'foo.bar',
+          packageFile: 'versions.gradle',
+          value: 'foo:bar:1.2.3',
+        },
+      },
+      deps: [
+        {
+          depName: 'foo:bar',
+          currentValue: '1.2.3',
+          groupName: 'foo.bar',
+          managerData: {
+            fileReplacePosition: 19,
+          },
+        },
+      ],
+    });
   });
   it('parses registryUrls', () => {
     let urls;
@@ -146,6 +193,17 @@ describe('manager/gradle/shallow/parser', () => {
       {
         depName: 'com.example:my.dependency',
         currentValue: '1.2.3',
+      },
+    ]);
+
+    ({ deps } = parseGradle(
+      'createXmlValueRemover("defaults", "integer", "integer")'
+    ));
+    expect(deps).toMatchObject([
+      {
+        depName: 'defaults:integer',
+        currentValue: 'integer',
+        skipReason: SkipReason.Ignored,
       },
     ]);
   });

--- a/lib/manager/gradle/shallow/parser.ts
+++ b/lib/manager/gradle/shallow/parser.ts
@@ -113,14 +113,32 @@ function handleAssignment({
   packageFile,
   tokenMap,
 }: SyntaxHandlerInput): SyntaxHandlerOutput {
-  const { keyToken, valToken } = tokenMap;
-  const variableData: VariableData = {
-    key: keyToken.value,
+  const { objectToken, keyToken, valToken } = tokenMap;
+  const obj = objectToken?.value;
+  const key = obj ? `${obj}.${keyToken.value}` : keyToken.value;
+
+  const dep = parseDependencyString(valToken.value);
+  if (dep) {
+    dep.groupName = key;
+    dep.managerData = {
+      fileReplacePosition: valToken.offset + dep.depName.length + 1,
+      packageFile,
+    };
+  }
+
+  const varData: VariableData = {
+    key,
     value: valToken.value,
     fileReplacePosition: valToken.offset,
     packageFile,
   };
-  return { vars: { [variableData.key]: variableData } };
+
+  const result: SyntaxHandlerOutput = {
+    vars: { [key]: varData },
+    deps: dep ? [dep] : [],
+  };
+
+  return result;
 }
 
 function processDepString({
@@ -230,6 +248,8 @@ function processPredefinedRegistryUrl({
   return { urls: [registryUrl] };
 }
 
+const annoyingMethods = new Set(['createXmlValueRemover']);
+
 function processLongFormDep({
   tokenMap,
   variables,
@@ -253,12 +273,29 @@ function processLongFormDep({
         packageFile,
       };
     }
+    const methodName = tokenMap.methodName?.value;
+    if (annoyingMethods.has(methodName)) {
+      dep.skipReason = SkipReason.Ignored;
+    }
+
     return { deps: [dep] };
   }
   return null;
 }
 
 const matcherConfigs: SyntaxMatchConfig[] = [
+  {
+    // foo.bar = 'baz'
+    matchers: [
+      { matchType: TokenType.Word, tokenMapKey: 'objectToken' },
+      { matchType: TokenType.Dot },
+      { matchType: TokenType.Word, tokenMapKey: 'keyToken' },
+      { matchType: TokenType.Assignment },
+      { matchType: TokenType.String, tokenMapKey: 'valToken' },
+      endOfInstruction,
+    ],
+    handler: handleAssignment,
+  },
   {
     // foo = 'bar'
     matchers: [
@@ -462,6 +499,20 @@ const matcherConfigs: SyntaxMatchConfig[] = [
       { matchType: potentialStringTypes, tokenMapKey: 'version' },
       { matchType: TokenType.RightParen },
       endOfInstruction,
+    ],
+    handler: processLongFormDep,
+  },
+  {
+    // fooBarBaz("com.example", "my.dependency", "1.2.3")
+    matchers: [
+      { matchType: TokenType.Word, tokenMapKey: 'methodName' },
+      { matchType: TokenType.LeftParen },
+      { matchType: potentialStringTypes, tokenMapKey: 'groupId' },
+      { matchType: TokenType.Comma },
+      { matchType: potentialStringTypes, tokenMapKey: 'artifactId' },
+      { matchType: TokenType.Comma },
+      { matchType: potentialStringTypes, tokenMapKey: 'version' },
+      { matchType: TokenType.RightParen },
     ],
     handler: processLongFormDep,
   },

--- a/lib/manager/gradle/shallow/utils.spec.ts
+++ b/lib/manager/gradle/shallow/utils.spec.ts
@@ -98,23 +98,41 @@ describe('manager/gradle/shallow/utils', () => {
   });
 
   it('reorderFiles', () => {
-    expect(reorderFiles(['a.gradle', 'b.gradle', 'a.gradle'])).toStrictEqual([
+    expect(
+      reorderFiles([
+        'build.gradle',
+        'a.gradle',
+        'b.gradle',
+        'a.gradle',
+        'versions.gradle',
+      ])
+    ).toStrictEqual([
+      'versions.gradle',
       'a.gradle',
       'a.gradle',
       'b.gradle',
+      'build.gradle',
     ]);
 
     expect(
       reorderFiles([
         'a/b/c/build.gradle',
+        'a/b/versions.gradle',
         'a/build.gradle',
+        'versions.gradle',
         'a/b/build.gradle',
+        'a/versions.gradle',
         'build.gradle',
+        'a/b/c/versions.gradle',
       ])
     ).toStrictEqual([
+      'versions.gradle',
       'build.gradle',
+      'a/versions.gradle',
       'a/build.gradle',
+      'a/b/versions.gradle',
       'a/b/build.gradle',
+      'a/b/c/versions.gradle',
       'a/b/c/build.gradle',
     ]);
 
@@ -146,8 +164,8 @@ describe('manager/gradle/shallow/utils', () => {
       'gradle.properties',
       'a.gradle',
       'b.gradle',
-      'build.gradle',
       'c.gradle',
+      'build.gradle',
       'a/gradle.properties',
       'a/build.gradle',
       'a/b/gradle.properties',

--- a/lib/manager/gradle/shallow/utils.ts
+++ b/lib/manager/gradle/shallow/utils.ts
@@ -95,9 +95,19 @@ export function interpolateString(
   return resolvedSubstrings.join('');
 }
 
+export function isGradleVersionsFile(path: string): boolean {
+  const filename = upath.basename(path).toLowerCase();
+  return /^versions\.gradle(?:\.kts)?$/.test(filename);
+}
+
+export function isGradleBuildFile(path: string): boolean {
+  const filename = upath.basename(path).toLowerCase();
+  return /^build\.gradle(?:\.kts)?$/.test(filename);
+}
+
 export function isGradleFile(path: string): boolean {
   const filename = upath.basename(path).toLowerCase();
-  return filename.endsWith('.gradle') || filename.endsWith('.gradle.kts');
+  return /\.gradle(?:\.kts)?$/.test(filename);
 }
 
 export function isPropsFile(path: string): boolean {
@@ -114,6 +124,19 @@ export function toAbsolutePath(packageFile: string): string {
   return upath.join(packageFile.replace(regEx(/^[/\\]*/), '/'));
 }
 
+function getFileRank(filename: string): number {
+  if (isPropsFile(filename)) {
+    return 0;
+  }
+  if (isGradleVersionsFile(filename)) {
+    return 1;
+  }
+  if (isGradleBuildFile(filename)) {
+    return 3;
+  }
+  return 2;
+}
+
 export function reorderFiles(packageFiles: string[]): string[] {
   return packageFiles.sort((x, y) => {
     const xAbs = toAbsolutePath(x);
@@ -123,19 +146,18 @@ export function reorderFiles(packageFiles: string[]): string[] {
     const yDir = upath.dirname(yAbs);
 
     if (xDir === yDir) {
-      if (
-        (isGradleFile(xAbs) && isGradleFile(yAbs)) ||
-        (isPropsFile(xAbs) && isPropsFile(yAbs))
-      ) {
+      const xRank = getFileRank(xAbs);
+      const yRank = getFileRank(yAbs);
+      if (xRank === yRank) {
         if (xAbs > yAbs) {
           return 1;
         }
         if (xAbs < yAbs) {
           return -1;
         }
-      } else if (isGradleFile(xAbs)) {
+      } else if (xRank > yRank) {
         return 1;
-      } else if (isGradleFile(yAbs)) {
+      } else if (yRank > xRank) {
         return -1;
       }
     } else if (xDir.startsWith(yDir)) {

--- a/lib/manager/gradle/shallow/utils.ts
+++ b/lib/manager/gradle/shallow/utils.ts
@@ -95,19 +95,23 @@ export function interpolateString(
   return resolvedSubstrings.join('');
 }
 
+const gradleVersionsFileRegex = regEx('^versions\\.gradle(?:\\.kts)?$', 'i');
+const gradleBuildFileRegex = regEx('^build\\.gradle(?:\\.kts)?$', 'i');
+const gradleFileRegex = regEx('\\.gradle(?:\\.kts)?$', 'i');
+
 export function isGradleVersionsFile(path: string): boolean {
-  const filename = upath.basename(path).toLowerCase();
-  return /^versions\.gradle(?:\.kts)?$/.test(filename);
+  const filename = upath.basename(path);
+  return gradleVersionsFileRegex.test(filename);
 }
 
 export function isGradleBuildFile(path: string): boolean {
-  const filename = upath.basename(path).toLowerCase();
-  return /^build\.gradle(?:\.kts)?$/.test(filename);
+  const filename = upath.basename(path);
+  return gradleBuildFileRegex.test(filename);
 }
 
 export function isGradleFile(path: string): boolean {
-  const filename = upath.basename(path).toLowerCase();
-  return /\.gradle(?:\.kts)?$/.test(filename);
+  const filename = upath.basename(path);
+  return gradleFileRegex.test(filename);
 }
 
 export function isPropsFile(path: string): boolean {


### PR DESCRIPTION
## Changes:

- Handle two-part variable definitions (e.g. `foo.bar = 'baz'`)
- Change processing order: `versions.gradle` is always first, `build.gradle` is always last of `*.gradle.files`
- Handle assignment of dep string (e.g. update dependencies defined as `foobar = 'foo:bar:1.2.3'`)
- Skip-reason for incorrectly parsed deps, e.g. `createXmlValueRemover("defaults", "integer", "integer")`

## Context:

Closes #12518

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
