### PR TITLE
fix: no-param-reassign

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,6 +36,7 @@ module.exports = {
 
     // other rules
     'import/prefer-default-export': 0, // no benefit
+    'no-param-reassign': 'error',
     'no-restricted-syntax': 0,
     'no-await-in-loop': 0,
     'prefer-destructuring': 0,

--- a/lib/config/presets/index.ts
+++ b/lib/config/presets/index.ts
@@ -5,6 +5,7 @@ import {
 } from '../../constants/error-messages';
 import { logger } from '../../logger';
 import { ExternalHostError } from '../../types/errors/external-host-error';
+import { clone } from '../../util/clone';
 import { regEx } from '../../util/regex';
 import * as massage from '../massage';
 import * as migration from '../migration';
@@ -251,9 +252,10 @@ export async function getPreset(
 export async function resolveConfigPresets(
   inputConfig: AllConfig,
   baseConfig?: RenovateConfig,
-  ignorePresets?: string[],
+  _ignorePresets?: string[],
   existingPresets: string[] = []
 ): Promise<AllConfig> {
+  let ignorePresets = clone(_ignorePresets);
   if (!ignorePresets || ignorePresets.length === 0) {
     ignorePresets = inputConfig.ignorePresets || [];
   }

--- a/lib/config/presets/util.ts
+++ b/lib/config/presets/util.ts
@@ -14,11 +14,11 @@ export async function fetchPreset({
   pkgName,
   filePreset,
   presetPath,
-  endpoint,
+  endpoint: _endpoint,
   packageTag = null,
   fetch,
 }: FetchPresetConfig): Promise<Preset | undefined> {
-  endpoint = ensureTrailingSlash(endpoint);
+  const endpoint = ensureTrailingSlash(_endpoint);
   const [fileName, presetName, subPresetName] = filePreset.split('/');
   const pathPrefix = presetPath ? `${presetPath}/` : '';
   const buildFilePath = (name: string): string => `${pathPrefix}${name}`;

--- a/lib/logger/utils.ts
+++ b/lib/logger/utils.ts
@@ -89,7 +89,8 @@ export default function prepareError(err: Error): Record<string, unknown> {
   return response;
 }
 
-export function sanitizeValue(value: unknown, seen = new WeakMap()): any {
+export function sanitizeValue(_value: unknown, seen = new WeakMap()): any {
+  let value = _value;
   if (Array.isArray(value)) {
     const length = value.length;
     const arrayResult = Array(length);

--- a/lib/manager/ansible-galaxy/collections.ts
+++ b/lib/manager/ansible-galaxy/collections.ts
@@ -75,7 +75,6 @@ function handleGitDep(
       dep.currentValue = dep.managerData.version;
     }
   }
-  /* eslint-enable no-param-reassign */
 }
 
 function handleGalaxyDep(dep: PackageDependency): void {
@@ -83,7 +82,6 @@ function handleGalaxyDep(dep: PackageDependency): void {
   dep.depName = dep.managerData.name;
   dep.registryUrls = dep.managerData.source ? [dep.managerData.source] : [];
   dep.currentValue = dep.managerData.version;
-  /* eslint-enable no-param-reassign */
 }
 
 function finalize(dependency: PackageDependency): boolean {

--- a/lib/manager/terraform/modules.ts
+++ b/lib/manager/terraform/modules.ts
@@ -69,5 +69,4 @@ export function analyseTerraformModule(dep: PackageDependency): void {
     logger.debug({ dep }, 'terraform dep has no source');
     dep.skipReason = SkipReason.NoSource;
   }
-  /* eslint-enable no-param-reassign */
 }

--- a/lib/manager/terraform/providers.ts
+++ b/lib/manager/terraform/providers.ts
@@ -99,5 +99,4 @@ export function analyzeTerraformProvider(
   massageProviderLookupName(dep);
 
   dep.lockedVersion = getLockedVersion(dep, locks);
-  /* eslint-enable no-param-reassign */
 }

--- a/lib/manager/terraform/required-providers.ts
+++ b/lib/manager/terraform/required-providers.ts
@@ -33,7 +33,6 @@ function extractBlock(
         default:
           break;
       }
-      /* eslint-enable no-param-reassign */
     }
   } while (line.trim() !== '}');
   return lineNumber;
@@ -79,5 +78,4 @@ export function analyzeTerraformRequiredProvider(
 ): void {
   analyzeTerraformProvider(dep, locks);
   dep.depType = `required_provider`;
-  /* eslint-enable no-param-reassign */
 }

--- a/lib/manager/terraform/required-version.ts
+++ b/lib/manager/terraform/required-version.ts
@@ -49,5 +49,4 @@ export function analyseTerraformVersion(dep: PackageDependency): void {
   dep.datasource = datasourceGithubTags.id;
   dep.depName = 'hashicorp/terraform';
   dep.extractVersion = 'v(?<version>.*)$';
-  /* eslint-enable no-param-reassign */
 }

--- a/lib/manager/terraform/resources.ts
+++ b/lib/manager/terraform/resources.ts
@@ -109,5 +109,4 @@ export function analyseTerraformResource(
       dep.skipReason = SkipReason.InvalidValue;
       break;
   }
-  /* eslint-enable no-param-reassign */
 }

--- a/lib/manager/terraform/util.ts
+++ b/lib/manager/terraform/util.ts
@@ -59,7 +59,6 @@ export function massageProviderLookupName(dep: PackageDependency): void {
 
   // handle cases like `Telmate/proxmox`
   dep.lookupName = dep.lookupName.toLowerCase();
-  /* eslint-enable no-param-reassign */
 }
 
 export function getLockedVersion(

--- a/lib/manager/terragrunt/modules.ts
+++ b/lib/manager/terragrunt/modules.ts
@@ -70,5 +70,4 @@ export function analyseTerragruntModule(dep: PackageDependency): void {
     logger.debug({ dep }, 'terragrunt dep has no source');
     dep.skipReason = SkipReason.NoSource;
   }
-  /* eslint-enable no-param-reassign */
 }

--- a/lib/util/http/index.ts
+++ b/lib/util/http/index.ts
@@ -293,12 +293,13 @@ export class Http<GetOptions = HttpOptions, PostOptions = HttpPostOptions> {
       ...options,
     };
 
+    let resolvedUrl = url;
     // istanbul ignore else: needs test
     if (options?.baseUrl) {
-      url = resolveBaseUrl(options.baseUrl, url);
+      resolvedUrl = resolveBaseUrl(options.baseUrl, url);
     }
 
     applyDefaultHeaders(combinedOptions);
-    return got.stream(url, combinedOptions);
+    return got.stream(resolvedUrl, combinedOptions);
   }
 }

--- a/lib/util/index.ts
+++ b/lib/util/index.ts
@@ -4,14 +4,14 @@ export function sampleSize(array: string[], n: number): string[] {
     return [];
   }
 
-  n = n > length ? length : n;
+  const sampleNumber = n > length ? length : n;
   let index = 0;
   const lastIndex = length - 1;
   const result = [...array];
-  while (index < n) {
+  while (index < sampleNumber) {
     const rand = index + Math.floor(Math.random() * (lastIndex - index + 1));
     [result[rand], result[index]] = [result[index], result[rand]];
     index += 1;
   }
-  return result.slice(0, n);
+  return result.slice(0, sampleNumber);
 }

--- a/lib/versioning/regex/index.ts
+++ b/lib/versioning/regex/index.ts
@@ -41,11 +41,9 @@ export class RegExpVersioningApi extends GenericVersioningApi<RegExpVersion> {
   //   RegExp('^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(:?-(?<compatibility>.*-r)(?<build>\\d+))?$');
   private _config: RegExp = null;
 
-  constructor(new_config: string) {
+  constructor(_new_config: string) {
     super();
-    if (!new_config) {
-      new_config = '^(?<major>\\d+)?$';
-    }
+    const new_config = _new_config || '^(?<major>\\d+)?$';
 
     // without at least one of {major, minor, patch} specified in the regex,
     // this versioner will not work properly

--- a/lib/workers/pr/body/index.ts
+++ b/lib/workers/pr/body/index.ts
@@ -53,7 +53,6 @@ function massageUpdateMetadata(config: BranchConfig): void {
       references.push(`[changelog](${changelogUrl})`);
     }
     upgrade.references = references.join(', ');
-    /* eslint-enable no-param-reassign */
   });
 }
 

--- a/lib/workers/repository/dependency-dashboard.ts
+++ b/lib/workers/repository/dependency-dashboard.ts
@@ -29,7 +29,6 @@ function parseDashboardIssue(issueBody: string): DependencyDashboard {
   let dependencyDashboardRebaseAllOpen = false;
   if (checkedRebaseAll) {
     dependencyDashboardRebaseAllOpen = true;
-    /* eslint-enable no-param-reassign */
   }
   return { dependencyDashboardChecks, dependencyDashboardRebaseAllOpen };
 }
@@ -50,7 +49,6 @@ export async function readDashboardBody(config: RenovateConfig): Promise<void> {
       Object.assign(config, parseDashboardIssue(issue.body));
     }
   }
-  /* eslint-enable no-param-reassign */
 }
 
 function getListItem(branch: BranchConfig, type: string): string {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Re-introduces no-param-reassign eslint rule

## Context:

I think it was a mistake to drop this when we removed the airbnb preset

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
