### PR TITLE
fix: enable eslint eqeqeq

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,6 +37,7 @@ module.exports = {
 
     // other rules
     'consistent-return': 'error',
+    eqeqeq: 'error',
     'no-negated-condition': 'error',
     'no-param-reassign': 'error',
     'sort-imports': [

--- a/lib/config/migration.ts
+++ b/lib/config/migration.ts
@@ -316,11 +316,11 @@ export function migrateConfig(
         migratedConfig.automergeType = 'branch';
       } else if (key === 'automergeMinor') {
         migratedConfig.minor = migratedConfig.minor || {};
-        migratedConfig.minor.automerge = val == true;
+        migratedConfig.minor.automerge = !!val;
         delete migratedConfig[key];
       } else if (key === 'automergeMajor') {
         migratedConfig.major = migratedConfig.major || {};
-        migratedConfig.major.automerge = val == true;
+        migratedConfig.major.automerge = !!val;
         delete migratedConfig[key];
       } else if (key === 'multipleMajorPrs') {
         delete migratedConfig.multipleMajorPrs;
@@ -336,7 +336,7 @@ export function migrateConfig(
         migratedConfig.separateMinorPatch = val;
       } else if (key === 'automergePatch') {
         migratedConfig.patch = migratedConfig.patch || {};
-        migratedConfig.patch.automerge = val == true;
+        migratedConfig.patch.automerge = !!val;
         delete migratedConfig[key];
       } else if (key === 'ignoreNodeModules') {
         delete migratedConfig.ignoreNodeModules;

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -228,7 +228,7 @@ export async function validateConfig(
             message: `${currentPath}: ${errorMessage}`,
           });
         }
-      } else if (val != null) {
+      } else if (val !== null) {
         const type = optionTypes[key];
         if (type === 'boolean') {
           if (val !== true && val !== false) {

--- a/lib/datasource/galaxy-collection/index.ts
+++ b/lib/datasource/galaxy-collection/index.ts
@@ -109,7 +109,7 @@ export class GalaxyCollectionDatasource extends Datasource {
       { concurrency: 5 } // allow 5 requests at maximum in parallel
     );
     // filter failed versions
-    const filteredReleases = enrichedReleases.filter((value) => value != null);
+    const filteredReleases = enrichedReleases.filter(Boolean);
     // extract base information which are only provided on the release from the newest release
     const result: ReleaseResult = {
       releases: filteredReleases,

--- a/lib/logger/utils.ts
+++ b/lib/logger/utils.ts
@@ -114,7 +114,7 @@ export function sanitizeValue(_value: unknown, seen = new WeakMap()): any {
 
   const valueType = typeof value;
 
-  if (value != null && valueType !== 'function' && valueType === 'object') {
+  if (value && valueType !== 'function' && valueType === 'object') {
     if (value instanceof Date) {
       return value;
     }

--- a/lib/manager/ansible-galaxy/collections.ts
+++ b/lib/manager/ansible-galaxy/collections.ts
@@ -120,7 +120,7 @@ function finalize(dependency: PackageDependency): boolean {
       return true;
   }
 
-  if (dependency.currentValue == null && dep.skipReason == null) {
+  if (!dependency.currentValue && !dep.skipReason) {
     dep.skipReason = SkipReason.NoVersion;
   }
   return true;

--- a/lib/manager/ansible-galaxy/extract.spec.ts
+++ b/lib/manager/ansible-galaxy/extract.spec.ts
@@ -35,9 +35,7 @@ describe('manager/ansible-galaxy/extract', () => {
       const res = extractPackageFile(collections1, 'requirements.yml');
       expect(res.deps).toMatchSnapshot();
       expect(res.deps).toHaveLength(13);
-      expect(res.deps.filter((value) => value.skipReason != null)).toHaveLength(
-        6
-      );
+      expect(res.deps.filter((value) => value.skipReason)).toHaveLength(6);
     });
     it('check collection style requirements file in reverse order and missing empty line', () => {
       const res = extractPackageFile(collections2, 'requirements.yml');

--- a/lib/manager/ansible-galaxy/roles.ts
+++ b/lib/manager/ansible-galaxy/roles.ts
@@ -94,7 +94,7 @@ export function extractRoles(lines: string[]): PackageDependency[] {
       };
       do {
         const localdep = interpretLine(lineMatch, lineNumber, dep);
-        if (localdep == null) {
+        if (!localdep) {
           break;
         }
         const line = lines[lineNumber + 1];

--- a/lib/manager/argocd/extract.ts
+++ b/lib/manager/argocd/extract.ts
@@ -12,7 +12,7 @@ function createDependency(
   const source = definition.spec?.source;
 
   if (
-    source == null ||
+    !source ||
     !is.nonEmptyString(source.repoURL) ||
     !is.nonEmptyString(source.targetRevision)
   ) {

--- a/lib/manager/gradle-wrapper/artifacts.ts
+++ b/lib/manager/gradle-wrapper/artifacts.ts
@@ -126,7 +126,7 @@ export async function updateArtifacts({
           addIfUpdated(status, fileProjectPath)
         )
       )
-    ).filter((e) => e != null);
+    ).filter(Boolean);
     logger.debug(
       { files: updateArtifactsResult.map((r) => r.file.name) },
       `Returning updated gradle-wrapper files`

--- a/lib/manager/gradle/deep/__testutil__/gradle.ts
+++ b/lib/manager/gradle/deep/__testutil__/gradle.ts
@@ -28,7 +28,7 @@ ${javaVersionOutput}`);
 let cachedJavaVersion: number | null = null;
 
 function determineJavaVersion(): number {
-  if (cachedJavaVersion == null) {
+  if (!cachedJavaVersion) {
     let javaVersionCommand: SpawnSyncReturns<string>;
     let error: Error;
     try {

--- a/lib/manager/regex/index.ts
+++ b/lib/manager/regex/index.ts
@@ -150,7 +150,7 @@ function handleRecursive(
     regEx(matchString, 'g')
   );
   // abort if we have no matchString anymore
-  if (regexes[index] == null) {
+  if (!regexes[index]) {
     return [];
   }
   return regexMatchAll(regexes[index], content).flatMap((match) => {

--- a/lib/manager/terraform/lockfile/index.ts
+++ b/lib/manager/terraform/lockfile/index.ts
@@ -110,10 +110,7 @@ export async function updateArtifacts({
       }
     }
     // if no updates have been found or there are failed hashes abort
-    if (
-      updates.length === 0 ||
-      updates.some((value) => value.newHashes == null)
-    ) {
+    if (updates.length === 0 || updates.some((value) => !value.newHashes)) {
       return null;
     }
 

--- a/lib/manager/terraform/resources.ts
+++ b/lib/manager/terraform/resources.ts
@@ -94,7 +94,7 @@ export function analyseTerraformResource(
       break;
 
     case TerraformResourceTypes.helm_release:
-      if (dep.managerData.chart == null) {
+      if (!dep.managerData.chart) {
         dep.skipReason = SkipReason.InvalidName;
       } else if (checkIfStringIsPath(dep.managerData.chart)) {
         dep.skipReason = SkipReason.LocalChart;

--- a/lib/util/index.ts
+++ b/lib/util/index.ts
@@ -1,5 +1,5 @@
 export function sampleSize(array: string[], n: number): string[] {
-  const length = array == null ? 0 : array.length;
+  const length = array ? array.length : 0;
   if (!length || n < 1) {
     return [];
   }

--- a/lib/workers/repository/onboarding/branch/check.ts
+++ b/lib/workers/repository/onboarding/branch/check.ts
@@ -121,5 +121,4 @@ export const isOnboarded = async (config: RenovateConfig): Promise<boolean> => {
 
 export const onboardingPrExists = async (
   config: RenovateConfig
-): Promise<boolean> =>
-  (await platform.getBranchPr(config.onboardingBranch)) != null;
+): Promise<boolean> => !!(await platform.getBranchPr(config.onboardingBranch));


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Re-enables `eqeqeq` eslint rule.

## Context:

Was lost when we removed airbnb preset.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
