### PR TITLE
fix: add xterm to repo groups

### DIFF
--- a/lib/config/presets/internal/monorepo.ts
+++ b/lib/config/presets/internal/monorepo.ts
@@ -182,6 +182,7 @@ const repoGroups = {
   webdriverio: 'https://github.com/webdriverio/webdriverio',
   workbox: 'https://github.com/googlechrome/workbox',
   vstest: 'https://github.com/microsoft/vstest',
+  xterm: 'https://github.com/xtermjs/xterm.js',
 };
 
 const patternGroups = {


### PR DESCRIPTION
## Changes:

Add [`xterm`](https://github.com/xtermjs/xterm.js) to the repo groups

<!-- Describe what behavior is changed by this PR. -->

## Context:

xterm has addons in the monorepo that should be updated together.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
