### PR TITLE
feat(composer): Read provided COMPOSER_AUTH (#12586)

### DIFF
--- a/docs/usage/getting-started/private-packages.md
+++ b/docs/usage/getting-started/private-packages.md
@@ -120,6 +120,7 @@ The following details the most common/popular manager artifacts updating and how
 
 Any `hostRules` token for `github.com` or `gitlab.com` are found and written out to `COMPOSER_AUTH` in env for Composer to parse.
 Any `hostRules` with `hostType=packagist` are also included.
+When `COMPOSER_AUTH` env variable is provided, it will be used and the `hostRules` will be appended to the final `COMPOSER_AUTH`.
 
 ### gomod
 

--- a/lib/manager/composer/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/manager/composer/__snapshots__/artifacts.spec.ts.snap
@@ -24,6 +24,17 @@ Array [
 ]
 `;
 
+exports[`manager/composer/artifacts breaks on invalid provided COMPOSER_AUTH 1`] = `
+Array [
+  Object {
+    "artifactError": Object {
+      "lockFile": "composer.lock",
+      "stderr": "Failed to parse COMPOSER_AUTH: Unexpected token o in JSON at position 1",
+    },
+  },
+]
+`;
+
 exports[`manager/composer/artifacts catches errors 1`] = `
 Array [
   Object {
@@ -360,6 +371,31 @@ Array [
 ]
 `;
 
+exports[`manager/composer/artifacts updates provided COMPOSER_AUTH 1`] = `
+Array [
+  Object {
+    "cmd": "composer update --with-dependencies --ignore-platform-reqs --no-ansi --no-interaction --no-scripts --no-autoloader --no-plugins",
+    "options": Object {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": Object {
+        "COMPOSER_AUTH": "{\\"github-oauth\\":{\\"github.com\\":\\"new-token\\"},\\"http-basic\\":{\\"gitlab.my-domain.com\\":{\\"username\\":\\"my-user\\",\\"password\\":\\"my-password\\"}},\\"gitlab-token\\":{\\"gitlab.com\\":\\"gitlab-token\\"},\\"gitlab-domains\\":[\\"gitlab.com\\"]}",
+        "COMPOSER_CACHE_DIR": "/tmp/renovate/cache/others/composer",
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+]
+`;
+
 exports[`manager/composer/artifacts uses hostRules to set COMPOSER_AUTH 1`] = `
 Array [
   Object {
@@ -369,6 +405,31 @@ Array [
       "encoding": "utf-8",
       "env": Object {
         "COMPOSER_AUTH": "{\\"github-oauth\\":{\\"github.com\\":\\"github-token\\"},\\"gitlab-token\\":{\\"gitlab.com\\":\\"gitlab-token\\"},\\"gitlab-domains\\":[\\"gitlab.com\\"],\\"http-basic\\":{\\"packagist.renovatebot.com\\":{\\"username\\":\\"some-username\\",\\"password\\":\\"some-password\\"},\\"artifactory.yyyyyyy.com\\":{\\"username\\":\\"some-other-username\\",\\"password\\":\\"some-other-password\\"}},\\"bearer\\":{\\"packages-bearer.example.com\\":\\"abcdef0123456789\\"}}",
+        "COMPOSER_CACHE_DIR": "/tmp/renovate/cache/others/composer",
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+]
+`;
+
+exports[`manager/composer/artifacts uses provided COMPOSER_AUTH 1`] = `
+Array [
+  Object {
+    "cmd": "composer update --with-dependencies --ignore-platform-reqs --no-ansi --no-interaction --no-scripts --no-autoloader --no-plugins",
+    "options": Object {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": Object {
+        "COMPOSER_AUTH": "{\\"github-oauth\\":{\\"github.com\\":\\"abcdef012345678\\"},\\"http-basic\\":{\\"gitlab.my-domain.com\\":{\\"username\\":\\"my-user\\",\\"password\\":\\"my-password\\"}}}",
         "COMPOSER_CACHE_DIR": "/tmp/renovate/cache/others/composer",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",

--- a/lib/manager/composer/artifacts.ts
+++ b/lib/manager/composer/artifacts.ts
@@ -31,7 +31,17 @@ import {
 } from './utils';
 
 function getAuthJson(): string | null {
-  const authJson: AuthJson = {};
+  let authJson: AuthJson = {};
+
+  if (process.env.COMPOSER_AUTH) {
+    try {
+      authJson = JSON.parse(process.env.COMPOSER_AUTH);
+    } catch (err) {
+      throw new Error(
+        `Failed to parse COMPOSER_AUTH: ${err.message as string}`
+      );
+    }
+  }
 
   const githubCredentials = hostRules.find({
     hostType: PlatformId.Github,


### PR DESCRIPTION
## Changes:

Read `COMPOSER_AUTH` environment variable when provided.
The provided `hostRules` will overwrite provided `COMPOSER_AUTH` values when defined.
An `Error` will be thrown on an invalid `COMPOSER_AUTH` variable.

## Context:

Closes #12586

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository