### PR TITLE
fix(npm): use install-tool instead of raw npm install

### DIFF
--- a/lib/manager/npm/post-update/lerna.ts
+++ b/lib/manager/npm/post-update/lerna.ts
@@ -41,10 +41,10 @@ export async function generateLockFiles(
   let cmdOptions = '';
   try {
     if (lernaClient === 'yarn') {
-      let installYarn = 'npm i -g yarn';
+      let installYarn = 'install-tool yarn';
       const yarnCompatibility = config.constraints?.yarn;
       if (validRange(yarnCompatibility)) {
-        installYarn += `@${quote(yarnCompatibility)}`;
+        installYarn += ` ${quote(yarnCompatibility)}`;
       }
       preCommands.push(installYarn);
       if (skipInstalls !== false) {
@@ -52,12 +52,12 @@ export async function generateLockFiles(
       }
       cmdOptions = '--ignore-scripts --ignore-engines --ignore-platform';
     } else if (lernaClient === 'npm') {
-      let installNpm = 'npm i -g npm';
+      let installNpm = 'install-tool npm';
       const npmCompatibility = config.constraints?.npm;
       if (validRange(npmCompatibility)) {
-        installNpm += `@${quote(npmCompatibility)} || true`;
+        installNpm += ` ${quote(npmCompatibility)}`;
       }
-      preCommands.push(installNpm, 'hash -d npm');
+      preCommands.push(installNpm);
       cmdOptions = '--ignore-scripts  --no-audit';
       if (skipInstalls !== false) {
         cmdOptions += ' --package-lock-only';

--- a/lib/manager/npm/post-update/npm.ts
+++ b/lib/manager/npm/post-update/npm.ts
@@ -25,13 +25,13 @@ export async function generateLockFile(
 
   let lockFile = null;
   try {
-    let installNpm = 'npm i -g npm';
+    let installNpm = 'install-tool npm';
     const npmCompatibility = config.constraints?.npm as string;
     // istanbul ignore else
     if (npmCompatibility) {
       // istanbul ignore else
       if (validRange(npmCompatibility)) {
-        installNpm = `npm i -g ${quote(`npm@${npmCompatibility}`)} || true`;
+        installNpm = `install-tool npm ${quote(npmCompatibility)}`;
       } else {
         logger.debug(
           { npmCompatibility },
@@ -41,7 +41,7 @@ export async function generateLockFile(
     } else {
       logger.debug('No npm compatibility range found - installing npm latest');
     }
-    const preCommands = [installNpm, 'hash -d npm'];
+    const preCommands = [installNpm, 'npm --version'];
     const commands = [];
     let cmdOptions = '';
     if (postUpdateOptions?.includes('npmDedupe') || skipInstalls === false) {

--- a/lib/manager/npm/post-update/pnpm.ts
+++ b/lib/manager/npm/post-update/pnpm.ts
@@ -23,7 +23,7 @@ export async function generateLockFile(
   let stderr: string;
   let cmd = 'pnpm';
   try {
-    let installPnpm = 'npm i -g pnpm';
+    let installPnpm = 'install-tool pnpm';
     const pnpmUpdate = upgrades.find(
       (upgrade) =>
         upgrade.depType === 'packageManager' && upgrade.depName === 'pnpm'
@@ -32,7 +32,7 @@ export async function generateLockFile(
       ? pnpmUpdate.newValue
       : config.constraints?.pnpm;
     if (validRange(pnpmCompatibility)) {
-      installPnpm += `@${quote(pnpmCompatibility)}`;
+      installPnpm += ` ${quote(pnpmCompatibility)}`;
     }
     const preCommands = [installPnpm];
     const tagConstraint = await getNodeConstraint(config);

--- a/lib/manager/npm/post-update/yarn.ts
+++ b/lib/manager/npm/post-update/yarn.ts
@@ -82,9 +82,9 @@ export async function generateLockFile(
       minYarnVersion && gte(minYarnVersion, '2.2.0');
     const isYarnModeAvailable = minYarnVersion && gte(minYarnVersion, '3.0.0');
 
-    let installYarn = 'npm i -g yarn';
+    let installYarn = 'install-tool yarn';
     if (isYarn1 && minYarnVersion) {
-      installYarn += `@${quote(yarnCompatibility)}`;
+      installYarn += ` ${quote(yarnCompatibility)}`;
     }
 
     const preCommands = [installYarn];


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Changes `npm i -g` to be `install-tool` for npm, pnpm, and yarn. lerna is still pending buildpack.

## Context:

This will make binarySource=install easier after some further refactoring

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
