### PR TITLE
refactor(maven): Prepare for hybrid fetching approach

### DIFF
--- a/lib/datasource/maven/index.ts
+++ b/lib/datasource/maven/index.ts
@@ -8,7 +8,7 @@ import * as mavenVersioning from '../../versioning/maven';
 import { compare } from '../../versioning/maven/compare';
 import type { GetReleasesConfig, Release, ReleaseResult } from '../types';
 import { MAVEN_REPO } from './common';
-import type { MavenDependency } from './types';
+import type { MavenDependency, ReleaseMap } from './types';
 import {
   downloadMavenXml,
   getDependencyInfo,
@@ -23,8 +23,6 @@ export const customRegistrySupport = true;
 export const defaultRegistryUrls = [MAVEN_REPO];
 export const defaultVersioning = mavenVersioning.id;
 export const registryStrategy = 'merge';
-
-type ReleaseMap = Record<string, Release | null>;
 
 function isStableVersion(x: string): boolean {
   return mavenVersion.isStable(x);

--- a/lib/datasource/maven/index.ts
+++ b/lib/datasource/maven/index.ts
@@ -26,6 +26,19 @@ export const registryStrategy = 'merge';
 
 type ReleaseMap = Record<string, Release | null>;
 
+function isStableVersion(x: string): boolean {
+  return mavenVersion.isStable(x);
+}
+
+function getLatestStableVersion(releases: Release[]): string | undefined {
+  return releases
+    .map(({ version }) => version)
+    .filter(isStableVersion)
+    .reduce((latestVersion, version) =>
+      compare(version, latestVersion) === 1 ? version : latestVersion
+    );
+}
+
 function extractVersions(metadata: XmlDocument): string[] {
   const versions = metadata.descendantWithPath('versioning.versions');
   const elements = versions?.childrenNamed('version');
@@ -222,19 +235,6 @@ function getReleasesFromMap(releaseMap: ReleaseMap): Release[] {
     return releases;
   }
   return Object.keys(releaseMap).map((version) => ({ version }));
-}
-
-function isStableVersion(x: string): boolean {
-  return mavenVersion.isStable(x);
-}
-
-function getLatestStableVersion(releases: Release[]): string | undefined {
-  return releases
-    .map(({ version }) => version)
-    .filter(isStableVersion)
-    .reduce((latestVersion, version) =>
-      compare(version, latestVersion) === 1 ? version : latestVersion
-    );
 }
 
 export async function getReleases({

--- a/lib/datasource/maven/index.ts
+++ b/lib/datasource/maven/index.ts
@@ -52,7 +52,7 @@ async function fetchReleasesFromMetadata(
 ): Promise<ReleaseMap> {
   const metadataUrl = getMavenUrl(dependency, repoUrl, 'maven-metadata.xml');
 
-  const cacheNamespace = 'datasource-maven-metadata@v2';
+  const cacheNamespace = 'datasource-maven:metadata-xml';
   const cacheKey = metadataUrl.toString();
   const cachedVersions = await packageCache.get<ReleaseMap>(
     cacheNamespace,
@@ -167,7 +167,7 @@ async function addReleasesUsingHeadRequests(
     return releaseMap;
   }
 
-  const cacheNs = 'datasource-maven-metadata@v2';
+  const cacheNs = 'datasource-maven:head-requests';
   const cacheKey = `${repoUrl}${dependency.dependencyUrl}`;
   let workingReleaseMap: ReleaseMap = await packageCache.get<ReleaseMap>(
     cacheNs,

--- a/lib/datasource/maven/types.ts
+++ b/lib/datasource/maven/types.ts
@@ -11,7 +11,3 @@ export interface MavenXml {
   authorization?: boolean;
   xml?: XmlDocument;
 }
-
-export type ArtifactsInfo = Record<string, boolean | null>;
-
-export type ArtifactInfoResult = [string, boolean | string | null];

--- a/lib/datasource/maven/types.ts
+++ b/lib/datasource/maven/types.ts
@@ -1,4 +1,5 @@
 import type { XmlDocument } from 'xmldoc';
+import type { Release } from '../types';
 
 export interface MavenDependency {
   display: string;

--- a/lib/datasource/maven/types.ts
+++ b/lib/datasource/maven/types.ts
@@ -11,3 +11,5 @@ export interface MavenXml {
   authorization?: boolean;
   xml?: XmlDocument;
 }
+
+export type ReleaseMap = Record<string, Release | null>;


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Introduce intermediate `ReleaseMap` structure
- Make current approach (based on HEAD requests) fill the release map values of type `Release`
- Return non-null values of `ReleaseMap` values

## Context:

Ref #12576

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
