### PR TITLE
fix: branchName massage hyphens

### DIFF
--- a/lib/workers/repository/updates/branch-name.spec.ts
+++ b/lib/workers/repository/updates/branch-name.spec.ts
@@ -220,7 +220,7 @@ describe('workers/repository/updates/branch-name', () => {
         },
         {
           upgrade: { branchName: 'renovate/~bad-branch-name2' },
-          expectedBranchName: 'renovate/-bad-branch-name2',
+          expectedBranchName: 'renovate/bad-branch-name2',
         },
         {
           upgrade: { branchName: 'renovate/bad-branch-^-name3' },
@@ -257,6 +257,10 @@ describe('workers/repository/updates/branch-name', () => {
         {
           upgrade: { branchName: 'renovate/bad--branch---name11' },
           expectedBranchName: 'renovate/bad-branch-name11',
+        },
+        {
+          upgrade: { branchName: 'renovate-/[start]-something-[end]' },
+          expectedBranchName: 'renovate/start-something-end',
         },
       ];
       fixtures.forEach((fixture) => {

--- a/lib/workers/repository/updates/branch-name.ts
+++ b/lib/workers/repository/updates/branch-name.ts
@@ -24,6 +24,8 @@ function cleanBranchName(branchName: string): string {
     .replace(regEx(/\/\./g), '/') // leading dot after slash
     .replace(regEx(/\s/g), '') // whitespace
     .replace(regEx(/[[\]?:\\^~]/g), '-') // massage out all these characters: : ? [ \ ^ ~
+    .replace(regEx(/(^|\/)-+/g), '$1') // leading dashes
+    .replace(regEx(/-+(\/|$)/g), '$1') // trailing dashes
     .replace(RE_MULTIPLE_DASH, '-'); // chained dashes
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Extra massaging of branchName to remove some invalid combinations.

## Context:

Previously we massage some invalid names into ones which are still invalid, such as leading hyphen.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
