### PR TITLE
feat: add stringToPrettyJSON handlebars function

### DIFF
--- a/docs/usage/templates.md
+++ b/docs/usage/templates.md
@@ -20,3 +20,13 @@ Some are configuration options passed through, while others are generated as par
 ## Other available fields
 
 <!-- Insert runtime fields here -->
+
+## Additional Handlebars helpers
+
+### stringToPrettyJSON
+
+If you want to print pretty JSON with Handlebars you can use the built-in function `StringToPrettyJSON` like this:
+
+`{{{stringToPrettyJSON myvar}}}`
+
+In the example above `myvar` is a variable/field, that contains valid JSON.

--- a/docs/usage/templates.md
+++ b/docs/usage/templates.md
@@ -25,7 +25,7 @@ Some are configuration options passed through, while others are generated as par
 
 ### stringToPrettyJSON
 
-If you want to print pretty JSON with Handlebars you can use the built-in function `StringToPrettyJSON` like this:
+If you want to print pretty JSON with Handlebars you can use the built-in function `stringToPrettyJSON` like this:
 
 `{{{stringToPrettyJSON myvar}}}`
 

--- a/lib/util/template/__snapshots__/index.spec.ts.snap
+++ b/lib/util/template/__snapshots__/index.spec.ts.snap
@@ -1,3 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`util/template/index filters out disallowed fields 1`] = `"github token = \\"\\""`;
+
+exports[`util/template/index string to pretty JSON  1`] = `
+"{
+  \\"some\\": {
+    \\"fancy\\": \\"json\\"
+  }
+}"
+`;

--- a/lib/util/template/index.spec.ts
+++ b/lib/util/template/index.spec.ts
@@ -18,4 +18,10 @@ describe('util/template/index', () => {
     expect(output).toContain('github');
     expect(output).not.toContain('123test');
   });
+  it('string to pretty JSON ', () => {
+    const userTemplate =
+      '{{{ stringToPrettyJSON \'{"some":{"fancy":"json"}}\'}}}';
+    const output = template.compile(userTemplate, undefined);
+    expect(output).toMatchSnapshot();
+  });
 });

--- a/lib/util/template/index.ts
+++ b/lib/util/template/index.ts
@@ -6,6 +6,10 @@ import { clone } from '../clone';
 
 handlebars.registerHelper('encodeURIComponent', encodeURIComponent);
 
+handlebars.registerHelper('stringToPrettyJSON', (input: string): string =>
+  JSON.stringify(JSON.parse(input), null, 2)
+);
+
 // istanbul ignore next
 handlebars.registerHelper(
   'replace',


### PR DESCRIPTION
## Changes:

This PR adds a handlebar function that can pars string representations of JSON and prints it out in a pretty way.

## Context:

This feature can be handy, if you want to print out JSON in PRs or commit messages.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository
