### PR TITLE
fix(maven): Fetch latest when all releases are unstable

### DIFF
--- a/lib/datasource/maven/index.ts
+++ b/lib/datasource/maven/index.ts
@@ -29,12 +29,12 @@ function isStableVersion(x: string): boolean {
 }
 
 function getLatestSuitableVersion(releases: Release[]): string | undefined {
-  return releases
-    .map(({ version }) => version)
-    .filter(isStableVersion)
-    .reduce((latestVersion, version) =>
-      compare(version, latestVersion) === 1 ? version : latestVersion
-    );
+  const allVersions = releases.map(({ version }) => version);
+  const stableVersions = allVersions.filter(isStableVersion);
+  const versions = stableVersions.length ? stableVersions : allVersions;
+  return versions.reduce((latestVersion, version) =>
+    compare(version, latestVersion) === 1 ? version : latestVersion
+  );
 }
 
 function extractVersions(metadata: XmlDocument): string[] {
@@ -261,10 +261,10 @@ export async function getReleases({
     `Found ${releases.length} new releases for ${dependency.display} in repository ${repoUrl}`
   );
 
-  const latestStableVersion = getLatestSuitableVersion(releases);
+  const latestSuitableVersion = getLatestSuitableVersion(releases);
   const dependencyInfo =
-    latestStableVersion &&
-    (await getDependencyInfo(dependency, repoUrl, latestStableVersion));
+    latestSuitableVersion &&
+    (await getDependencyInfo(dependency, repoUrl, latestSuitableVersion));
 
   return { ...dependency, ...dependencyInfo, releases };
 }

--- a/lib/datasource/maven/index.ts
+++ b/lib/datasource/maven/index.ts
@@ -28,7 +28,7 @@ function isStableVersion(x: string): boolean {
   return mavenVersion.isStable(x);
 }
 
-function getLatestStableVersion(releases: Release[]): string | undefined {
+function getLatestSuitableVersion(releases: Release[]): string | undefined {
   return releases
     .map(({ version }) => version)
     .filter(isStableVersion)
@@ -261,7 +261,7 @@ export async function getReleases({
     `Found ${releases.length} new releases for ${dependency.display} in repository ${repoUrl}`
   );
 
-  const latestStableVersion = getLatestStableVersion(releases);
+  const latestStableVersion = getLatestSuitableVersion(releases);
   const dependencyInfo =
     latestStableVersion &&
     (await getDependencyInfo(dependency, repoUrl, latestStableVersion));

--- a/lib/datasource/maven/index.ts
+++ b/lib/datasource/maven/index.ts
@@ -28,13 +28,15 @@ function isStableVersion(x: string): boolean {
   return mavenVersion.isStable(x);
 }
 
-function getLatestSuitableVersion(releases: Release[]): string | undefined {
+function getLatestSuitableVersion(releases: Release[]): string | null {
   const allVersions = releases.map(({ version }) => version);
   const stableVersions = allVersions.filter(isStableVersion);
   const versions = stableVersions.length ? stableVersions : allVersions;
-  return versions.reduce((latestVersion, version) =>
-    compare(version, latestVersion) === 1 ? version : latestVersion
-  );
+  return versions.length
+    ? versions.reduce((latestVersion, version) =>
+        compare(version, latestVersion) === 1 ? version : latestVersion
+      )
+    : null;
 }
 
 function extractVersions(metadata: XmlDocument): string[] {

--- a/lib/datasource/maven/index.ts
+++ b/lib/datasource/maven/index.ts
@@ -29,14 +29,16 @@ function isStableVersion(x: string): boolean {
 }
 
 function getLatestSuitableVersion(releases: Release[]): string | null {
+  // istanbul ignore if
+  if (!releases?.length) {
+    return null;
+  }
   const allVersions = releases.map(({ version }) => version);
   const stableVersions = allVersions.filter(isStableVersion);
   const versions = stableVersions.length ? stableVersions : allVersions;
-  return versions.length
-    ? versions.reduce((latestVersion, version) =>
-        compare(version, latestVersion) === 1 ? version : latestVersion
-      )
-    : null;
+  return versions.reduce((latestVersion, version) =>
+    compare(version, latestVersion) === 1 ? version : latestVersion
+  );
 }
 
 function extractVersions(metadata: XmlDocument): string[] {


### PR DESCRIPTION
## Changes:

- Use latest unstable version for info, when there 
isn't any stable one

## Context:

Closes #12646

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

