### PR TITLE
docs: bump npm version used in example

### DIFF
--- a/docs/usage/node.md
+++ b/docs/usage/node.md
@@ -24,12 +24,12 @@ When `binarySource=docker`, such as in the hosted WhiteSource Renovate App, Reno
 To control which version or constraint is installed, you should use the `engines.npm` property in your `package.json` file.
 Renovate bot will then use that version constraint for npm when it creates a pull request.
 
-For example, if you want to use at least npm `6.14.11` and also allow newer versions of npm in the `6.x` range, you would put this in your `package.json` file:
+For example, if you want to use at least npm `8.1.0` and also allow newer versions of npm in the `8.x` range, you would put this in your `package.json` file:
 
 ```json
 {
   "engines": {
-    "npm": "^6.14.11"
+    "npm": "^8.1.0"
   }
 }
 ```


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Bump npm version used in example from `6.14.11` to `8.1.0`

## Context:

npm is now on the `8.x` range, with npm `8.1.0` coming with Node.js `16.13.0` which is now the current LTS.

Not closing any issue with this.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
