### PR TITLE
docs(faq): reorder sections

### DIFF
--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -18,19 +18,6 @@ Renovate will:
 - Update `yarn.lock` and/or `package-lock.json` files if found
 - Create Pull Requests immediately after branch creation
 
-## What is this `main` branch I see in the documentation?
-
-When you create a new repository with Git, Git creates a base branch for you.
-The default branch name that Git uses is `master` (this will be changed to `main` later).
-
-The Git-hosting ecosystem has settled on using `main` to replace `master`.
-When you create a new repository on say GitHub or GitLab, you'll get a `main` branch as your base branch.
-
-It therefore makes sense for Renovate to replace `master` with `main` where possible as well.
-
-A branch name has no special meaning within the Git program, it's just a name.
-The base branch could be called `trunk` or `mainline` or `prod`, and Git would work just as well.
-
 ## Which Renovate versions are officially supported?
 
 The Renovate maintainers only support the latest version of Renovate.
@@ -55,6 +42,19 @@ Some major platform features are not supported at all by Renovate.
 | Jira issues                             | BitBucket              | [#3796](https://github.com/renovatebot/renovate/issues/3796)                                                                                                                                                                                                |
 | Merge trains                            | GitLab                 | [#5573](https://github.com/renovatebot/renovate/issues/5573)                                                                                                                                                                                                |
 | Configurable merge strategy and message | Only BitBucket for now | [#10867](https://github.com/renovatebot/renovate/issues/10867) [#10868](https://github.com/renovatebot/renovate/issues/10868) [#10869](https://github.com/renovatebot/renovate/issues/10869) [#10870](https://github.com/renovatebot/renovate/issues/10870) |
+
+## What is this `main` branch I see in the documentation?
+
+When you create a new repository with Git, Git creates a base branch for you.
+The default branch name that Git uses is `master` (this will be changed to `main` later).
+
+The Git-hosting ecosystem has settled on using `main` to replace `master`.
+When you create a new repository on say GitHub or GitLab, you'll get a `main` branch as your base branch.
+
+It therefore makes sense for Renovate to replace `master` with `main` where possible as well.
+
+A branch name has no special meaning within the Git program, it's just a name.
+The base branch could be called `trunk` or `mainline` or `prod`, and Git would work just as well.
 
 ## What if I need to .. ?
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Reorder sections in the beginning of the FAQ

## Context:

I think this ordering makes a bit more sense.
It also increases the likelihood of the important things being in the viewport right away, instead of having to scroll.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
