### PR TITLE
feat(gradle): treat the preview qualifier as unstable (#12450)

### DIFF
--- a/lib/versioning/gradle/index.spec.ts
+++ b/lib/versioning/gradle/index.spec.ts
@@ -19,6 +19,7 @@ describe('versioning/gradle/index', () => {
     ${'1.a-1'}                   | ${'1a1'}                     | ${0}
     ${'dev'}                     | ${'dev'}                     | ${0}
     ${'rc'}                      | ${'rc'}                      | ${0}
+    ${'preview'}                 | ${'preview'}                 | ${0}
     ${'release'}                 | ${'release'}                 | ${0}
     ${'final'}                   | ${'final'}                   | ${0}
     ${'snapshot'}                | ${'SNAPSHOT'}                | ${0}
@@ -43,6 +44,7 @@ describe('versioning/gradle/index', () => {
     ${'1.0-zeta'}                | ${'1.0-SNAPSHOT'}            | ${-1}
     ${'1.0-zeta'}                | ${'1.0-rc'}                  | ${-1}
     ${'1.0-rc'}                  | ${'1.0'}                     | ${-1}
+    ${'1.0-preview'}             | ${'1.0'}                     | ${-1}
     ${'1.0'}                     | ${'1.0-20150201.121010-123'} | ${-1}
     ${'1.0-20150201.121010-123'} | ${'1.1'}                     | ${-1}
     ${'Hoxton.RELEASE'}          | ${'Hoxton.SR1'}              | ${-1}
@@ -68,6 +70,7 @@ describe('versioning/gradle/index', () => {
     ${'1.0-SNAPSHOT'}            | ${'1.0-zeta'}                | ${1}
     ${'1.0-rc'}                  | ${'1.0-zeta'}                | ${1}
     ${'1.0'}                     | ${'1.0-rc'}                  | ${1}
+    ${'1.0'}                     | ${'1.0-preview'}             | ${1}
     ${'1.0-20150201.121010-123'} | ${'1.0'}                     | ${1}
     ${'1.1'}                     | ${'1.0-20150201.121010-123'} | ${1}
     ${'Hoxton.SR1'}              | ${'Hoxton.RELEASE'}          | ${1}
@@ -170,6 +173,7 @@ describe('versioning/gradle/index', () => {
     ${'1-ga-1'}                             | ${true}
     ${'1.3-groovy-2.5'}                     | ${true}
     ${'1.3-RC1-groovy-2.5'}                 | ${false}
+    ${'1-preview'}                          | ${false}
     ${'Hoxton.RELEASE'}                     | ${true}
     ${'Hoxton.SR'}                          | ${true}
     ${'Hoxton.SR1'}                         | ${true}

--- a/lib/versioning/gradle/index.ts
+++ b/lib/versioning/gradle/index.ts
@@ -83,6 +83,7 @@ const unstable = new Set([
   'milestone',
   'rc',
   'cr',
+  'preview',
   'snapshot',
 ]);
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Add `preview` to the list of unstable qualifiers for Gradle versioning.

<!-- Describe what behavior is changed by this PR. -->

## Context:

This is an add-on to PR #12461 (issue #12450) where we special cased the `-preview` qualifier to be treated as unstable (and equivalent to `-rc`) in the Maven versioning module.

Given that the Maven and Gradle versioning specs are very similar, with one exception related to the ordering, I think it makes sense to align them here.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
