### PR TITLE
fix(npm): retain package-lock indentation when massaging

### DIFF
--- a/lib/manager/npm/post-update/index.ts
+++ b/lib/manager/npm/post-update/index.ts
@@ -220,7 +220,11 @@ export async function writeExistingFiles(
           }
           if (lockFileChanged) {
             logger.debug('Massaging npm lock file before writing to disk');
-            existingNpmLock = JSON.stringify(npmLockParsed, null, 2);
+            existingNpmLock = JSON.stringify(
+              npmLockParsed,
+              null,
+              detectedIndent
+            );
           }
           await outputFile(npmLockPath, existingNpmLock);
         }

--- a/lib/manager/npm/post-update/index.ts
+++ b/lib/manager/npm/post-update/index.ts
@@ -265,6 +265,8 @@ export async function writeUpdatedPackageFiles(
       continue;
     }
     logger.debug(`Writing ${String(packageFile.name)}`);
+    const detectedIndent =
+      detectIndent(packageFile.contents.toString()).indent || '  ';
     const massagedFile = JSON.parse(packageFile.contents.toString());
     try {
       const { token } = hostRules.find({
@@ -286,7 +288,7 @@ export async function writeUpdatedPackageFiles(
     }
     await outputFile(
       upath.join(localDir, packageFile.name),
-      JSON.stringify(massagedFile)
+      JSON.stringify(massagedFile, null, detectedIndent)
     );
   }
 }

--- a/lib/manager/npm/post-update/index.ts
+++ b/lib/manager/npm/post-update/index.ts
@@ -220,11 +220,7 @@ export async function writeExistingFiles(
           }
           if (lockFileChanged) {
             logger.debug('Massaging npm lock file before writing to disk');
-            existingNpmLock = JSON.stringify(
-              npmLockParsed,
-              null,
-              detectedIndent
-            );
+            existingNpmLock = JSON.stringify(npmLockParsed, null, 2);
           }
           await outputFile(npmLockPath, existingNpmLock);
         }
@@ -255,8 +251,6 @@ export async function writeUpdatedPackageFiles(
   for (const packageFile of config.updatedPackageFiles) {
     if (packageFile.name.endsWith('package-lock.json')) {
       logger.debug(`Writing package-lock file: ${packageFile.name}`);
-      logger.warn('output updated package file ' + packageFile.name);
-      debugger;
       await outputFile(
         upath.join(localDir, packageFile.name),
         packageFile.contents
@@ -286,8 +280,6 @@ export async function writeUpdatedPackageFiles(
     } catch (err) {
       logger.warn({ err }, 'Error adding token to package files');
     }
-    logger.warn('output massaged package file ' + packageFile.name);
-    debugger;
     await outputFile(
       upath.join(localDir, packageFile.name),
       JSON.stringify(massagedFile)

--- a/lib/manager/npm/post-update/index.ts
+++ b/lib/manager/npm/post-update/index.ts
@@ -1,5 +1,6 @@
 import is from '@sindresorhus/is';
 import deepmerge from 'deepmerge';
+import detectIndent from 'detect-indent';
 import { dump, load } from 'js-yaml';
 import upath from 'upath';
 import { getGlobalConfig } from '../../../config/global';
@@ -167,9 +168,11 @@ export async function writeExistingFiles(
       } else {
         logger.debug(`Writing ${npmLock}`);
         let existingNpmLock: string;
+        let detectedIndent: string;
         let npmLockParsed: any;
         try {
           existingNpmLock = await getFile(npmLock);
+          detectedIndent = detectIndent(existingNpmLock).indent || '  ';
           npmLockParsed = JSON.parse(existingNpmLock);
         } catch (err) {
           logger.warn({ err }, 'Error parsing npm lock file');
@@ -217,7 +220,11 @@ export async function writeExistingFiles(
           }
           if (lockFileChanged) {
             logger.debug('Massaging npm lock file before writing to disk');
-            existingNpmLock = JSON.stringify(npmLockParsed, null, 2);
+            existingNpmLock = JSON.stringify(
+              npmLockParsed,
+              null,
+              detectedIndent
+            );
           }
           await outputFile(npmLockPath, existingNpmLock);
         }
@@ -248,6 +255,8 @@ export async function writeUpdatedPackageFiles(
   for (const packageFile of config.updatedPackageFiles) {
     if (packageFile.name.endsWith('package-lock.json')) {
       logger.debug(`Writing package-lock file: ${packageFile.name}`);
+      logger.warn('output updated package file ' + packageFile.name);
+      debugger;
       await outputFile(
         upath.join(localDir, packageFile.name),
         packageFile.contents
@@ -277,6 +286,8 @@ export async function writeUpdatedPackageFiles(
     } catch (err) {
       logger.warn({ err }, 'Error adding token to package files');
     }
+    logger.warn('output massaged package file ' + packageFile.name);
+    debugger;
     await outputFile(
       upath.join(localDir, packageFile.name),
       JSON.stringify(massagedFile)

--- a/lib/manager/npm/update/locked-dependency/index.ts
+++ b/lib/manager/npm/update/locked-dependency/index.ts
@@ -1,3 +1,4 @@
+import detectIndent from 'detect-indent';
 import type { PackageJson } from 'type-fest';
 import { logger } from '../../../../logger';
 import { api as semver } from '../../../../versioning/npm';
@@ -46,6 +47,7 @@ export async function updateLockedDependency(
     }
     let packageJson: PackageJson;
     let packageLockJson: PackageLockOrEntry;
+    const detectedIndent = detectIndent(lockFileContent).indent || '  ';
     let newPackageJsonContent: string;
     try {
       packageJson = JSON.parse(packageFileContent);
@@ -161,7 +163,11 @@ export async function updateLockedDependency(
       delete dependency.resolved;
       delete dependency.integrity;
     }
-    let newLockFileContent = JSON.stringify(packageLockJson, null, 2);
+    let newLockFileContent = JSON.stringify(
+      packageLockJson,
+      null,
+      detectedIndent
+    );
     // iterate through the parent updates first
     for (const parentUpdate of parentUpdates) {
       const parentUpdateConfig = {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Detects and retains custom package-lock.json indents when massaging before an update

## Context:

Closes #12714

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
