### PR TITLE
fix: revert #11565 preset tags

### DIFF
--- a/docs/development/shareable-configs.md
+++ b/docs/development/shareable-configs.md
@@ -50,44 +50,12 @@ If you use a non-scoped config, you must use a preset name!
 In general, GitHub, GitLab or Gitea-based preset hosting is easier than npm because you avoid the "publish" step - simply commit preset code to the default branch and it will be picked up by Renovate the next time it runs.
 An additional benefit of using source code hosting is that the same token/authentication can be reused by Renovate in case you want to make your config private.
 
-You can set a Git tag (like a SemVer) to use a specific release of your shared config.
-
-#### GitHub
-
-| name                                        | example use                     | preset    | resolves as                  | filename        | Git tag        |
-| ------------------------------------------- | ------------------------------- | --------- | ---------------------------- | --------------- | -------------- |
-| GitHub default                              | `github>abc/foo`                | `default` | `https://github.com/abc/foo` | `default.json`  | Default branch |
-| GitHub with preset name                     | `github>abc/foo:xyz`            | `xyz`     | `https://github.com/abc/foo` | `xyz.json`      | Default branch |
-| GitHub default with a tag                   | `github>abc/foo#1.5.4`          | `default` | `https://github.com/abc/foo` | `default.json`  | `1.5.4`        |
-| GitHub with preset name with a tag          | `github>abc/foo:xyz#1.5.4`      | `xyz`     | `https://github.com/abc/foo` | `xyz.json`      | `1.5.4`        |
-| GitHub with preset name and path with a tag | `github>abc/foo:path/xyz#1.5.4` | `xyz`     | `https://github.com/abc/foo` | `path/xyz.json` | `1.5.4`        |
-
-#### GitLab
-
-| name                                        | example use                     | preset    | resolves as                  | filename        | Git tag        |
-| ------------------------------------------- | ------------------------------- | --------- | ---------------------------- | --------------- | -------------- |
-| GitLab default                              | `gitlab>abc/foo`                | `default` | `https://gitlab.com/abc/foo` | `default.json`  | Default branch |
-| GitLab with preset name                     | `gitlab>abc/foo:xyz`            | `xyz`     | `https://gitlab.com/abc/foo` | `xyz.json`      | Default branch |
-| GitLab default with a tag                   | `gitlab>abc/foo#1.5.4`          | `default` | `https://gitlab.com/abc/foo` | `default.json`  | `1.5.4`        |
-| GitLab with preset name with a tag          | `gitlab>abc/foo:xyz#1.5.4`      | `xyz`     | `https://gitlab.com/abc/foo` | `xyz.json`      | `1.5.4`        |
-| GitLab with preset name and path with a tag | `gitlab>abc/foo:path/xyz#1.5.4` | `xyz`     | `https://gitlab.com/abc/foo` | `path/xyz.json` | `1.5.4`        |
-
-#### Gitea
-
-| name                                       | example use                    | preset    | resolves as                 | filename        | Git tag        |
-| ------------------------------------------ | ------------------------------ | --------- | --------------------------- | --------------- | -------------- |
-| Gitea default                              | `gitea>abc/foo`                | `default` | `https://gitea.com/abc/foo` | `default.json`  | Default branch |
-| Gitea with preset name                     | `gitea>abc/foo:xyz`            | `xyz`     | `https://gitea.com/abc/foo` | `xyz.json`      | Default branch |
-| Gitea default with a tag                   | `gitea>abc/foo#1.5.4`          | `default` | `https://gitea.com/abc/foo` | `default.json`  | `1.5.4`        |
-| Gitea with preset name with a tag          | `gitea>abc/foo:xyz#1.5.4`      | `xyz`     | `https://gitea.com/abc/foo` | `xyz.json`      | `1.5.4`        |
-| Gitea with preset name and path with a tag | `gitea>abc/foo:path/xyz#1.5.4` | `xyz`     | `https://gitea.com/abc/foo` | `path/xyz.json` | `1.5.4`        |
-
-#### Self-hosted Git
-
-| name                                       | example use                    | preset    | resolves as                          | filename        | Git tag        |
-| ------------------------------------------ | ------------------------------ | --------- | ------------------------------------ | --------------- | -------------- |
-| Local default                              | `local>abc/foo`                | `default` | `https://github.company.com/abc/foo` | `default.json`  | Default branch |
-| Local with preset path                     | `local>abc/foo:path/xyz`       | `default` | `https://github.company.com/abc/foo` | `path/xyz.json` | Default branch |
-| Local default with a tag                   | `local>abc/foo#1.5.4`          | `default` | `https://github.company.com/abc/foo` | `default.json`  | `1.5.4`        |
-| Local with preset name with a tag          | `local>abc/foo:xyz#1.5.4`      | `default` | `https://github.company.com/abc/foo` | `xyz.json`      | `1.5.4`        |
-| Local with preset name and path with a tag | `local>abc/foo:path/xyz#1.5.4` | `default` | `https://github.company.com/abc/foo` | `path/xyz.json` | `1.5.4`        |
+| name                    | example use          | preset    | resolves as                          | filename       |
+| ----------------------- | -------------------- | --------- | ------------------------------------ | -------------- |
+| GitHub default          | `github>abc/foo`     | `default` | `https://github.com/abc/foo`         | `default.json` |
+| GitHub with preset name | `github>abc/foo:xyz` | `xyz`     | `https://github.com/abc/foo`         | `xyz.json`     |
+| GitLab default          | `gitlab>abc/foo`     | `default` | `https://gitlab.com/abc/foo`         | `default.json` |
+| GitLab with preset name | `gitlab>abc/foo:xyz` | `xyz`     | `https://gitlab.com/abc/foo`         | `xyz.json`     |
+| Gitea default           | `gitea>abc/foo`      | `default` | `https://gitea.com/abc/foo`          | `default.json` |
+| Gitea with preset name  | `gitea>abc/foo:xyz`  | `xyz`     | `https://gitea.com/abc/foo`          | `xyz.json`     |
+| Local default           | `local>abc/foo`      | `default` | `https://github.company.com/abc/foo` | `default.json` |

--- a/docs/usage/config-presets.md
+++ b/docs/usage/config-presets.md
@@ -38,54 +38,22 @@ In order to achieve these goals, preset configs allow for a very modular approac
 ## Preset Hosting
 
 In general, GitHub, GitLab or Gitea-based preset hosting is easier than npm because you avoid the "publish" step - simply commit preset code to the default branch and it will be picked up by Renovate the next time it runs.
-
 An additional benefit of using source code hosting is that the same token/authentication can be reused by Renovate in case you want to make your config private.
 
-You can set a Git tag (like a SemVer) to use a specific release of your shared config.
+| name                    | example use                | preset    | resolves as                          | filename        |
+| ----------------------- | -------------------------- | --------- | ------------------------------------ | --------------- |
+| GitHub default          | `github>abc/foo`           | `default` | `https://github.com/abc/foo`         | `default.json`  |
+| GitHub with preset name | `github>abc/foo:xyz`       | `xyz`     | `https://github.com/abc/foo`         | `xyz.json`      |
+| GitHub with preset path | `github>abc/foo//path/xyz` | `xyz`     | `https://github.com/abc/foo`         | `path/xyz.json` |
+| GitLab default          | `gitlab>abc/foo`           | `default` | `https://gitlab.com/abc/foo`         | `default.json`  |
+| GitLab with preset name | `gitlab>abc/foo:xyz`       | `xyz`     | `https://gitlab.com/abc/foo`         | `xyz.json`      |
+| GitLab with preset path | `gitlab>abc/foo//path/xyz` | `xyz`     | `https://gitlab.com/abc/foo`         | `path/xyz.json` |
+| Gitea default           | `gitea>abc/foo`            | `default` | `https://gitea.com/abc/foo`          | `default.json`  |
+| Gitea with preset name  | `gitea>abc/foo:xyz`        | `xyz`     | `https://gitea.com/abc/foo`          | `xyz.json`      |
+| Local default           | `local>abc/foo`            | `default` | `https://github.company.com/abc/foo` | `default.json`  |
+| Local with preset path  | `local>abc/foo//path/xyz`  | `xyz`     | `https://github.company.com/abc/foo` | `path/xyz.json` |
 
-### GitHub
-
-| name                                        | example use                     | preset    | resolves as                  | filename        | Git tag        |
-| ------------------------------------------- | ------------------------------- | --------- | ---------------------------- | --------------- | -------------- |
-| GitHub default                              | `github>abc/foo`                | `default` | `https://github.com/abc/foo` | `default.json`  | Default branch |
-| GitHub with preset name                     | `github>abc/foo:xyz`            | `xyz`     | `https://github.com/abc/foo` | `xyz.json`      | Default branch |
-| GitHub default with a tag                   | `github>abc/foo#1.5.4`          | `default` | `https://github.com/abc/foo` | `default.json`  | `1.5.4`        |
-| GitHub with preset name with a tag          | `github>abc/foo:xyz#1.5.4`      | `xyz`     | `https://github.com/abc/foo` | `xyz.json`      | `1.5.4`        |
-| GitHub with preset name and path with a tag | `github>abc/foo:path/xyz#1.5.4` | `xyz`     | `https://github.com/abc/foo` | `path/xyz.json` | `1.5.4`        |
-
-### GitLab
-
-| name                                        | example use                     | preset    | resolves as                  | filename        | Git tag        |
-| ------------------------------------------- | ------------------------------- | --------- | ---------------------------- | --------------- | -------------- |
-| GitLab default                              | `gitlab>abc/foo`                | `default` | `https://gitlab.com/abc/foo` | `default.json`  | Default branch |
-| GitLab with preset name                     | `gitlab>abc/foo:xyz`            | `xyz`     | `https://gitlab.com/abc/foo` | `xyz.json`      | Default branch |
-| GitLab default with a tag                   | `gitlab>abc/foo#1.5.4`          | `default` | `https://gitlab.com/abc/foo` | `default.json`  | `1.5.4`        |
-| GitLab with preset name with a tag          | `gitlab>abc/foo:xyz#1.5.4`      | `xyz`     | `https://gitlab.com/abc/foo` | `xyz.json`      | `1.5.4`        |
-| GitLab with preset name and path with a tag | `gitlab>abc/foo:path/xyz#1.5.4` | `xyz`     | `https://gitlab.com/abc/foo` | `path/xyz.json` | `1.5.4`        |
-
-### Gitea
-
-| name                                       | example use                    | preset    | resolves as                 | filename        | Git tag        |
-| ------------------------------------------ | ------------------------------ | --------- | --------------------------- | --------------- | -------------- |
-| Gitea default                              | `gitea>abc/foo`                | `default` | `https://gitea.com/abc/foo` | `default.json`  | Default branch |
-| Gitea with preset name                     | `gitea>abc/foo:xyz`            | `xyz`     | `https://gitea.com/abc/foo` | `xyz.json`      | Default branch |
-| Gitea default with a tag                   | `gitea>abc/foo#1.5.4`          | `default` | `https://gitea.com/abc/foo` | `default.json`  | `1.5.4`        |
-| Gitea with preset name with a tag          | `gitea>abc/foo:xyz#1.5.4`      | `xyz`     | `https://gitea.com/abc/foo` | `xyz.json`      | `1.5.4`        |
-| Gitea with preset name and path with a tag | `gitea>abc/foo:path/xyz#1.5.4` | `xyz`     | `https://gitea.com/abc/foo` | `path/xyz.json` | `1.5.4`        |
-
-### Self-hosted Git
-
-| name                                       | example use                    | preset    | resolves as                          | filename        | Git tag        |
-| ------------------------------------------ | ------------------------------ | --------- | ------------------------------------ | --------------- | -------------- |
-| Local default                              | `local>abc/foo`                | `default` | `https://github.company.com/abc/foo` | `default.json`  | Default branch |
-| Local with preset path                     | `local>abc/foo:path/xyz`       | `xyz`     | `https://github.company.com/abc/foo` | `path/xyz.json` | Default branch |
-| Local default with a tag                   | `local>abc/foo#1.5.4`          | `default` | `https://github.company.com/abc/foo` | `default.json`  | `1.5.4`        |
-| Local with preset name with a tag          | `local>abc/foo:xyz#1.5.4`      | `xyz`     | `https://github.company.com/abc/foo` | `xyz.json`      | `1.5.4`        |
-| Local with preset name and path with a tag | `local>abc/foo:path/xyz#1.5.4` | `xyz`     | `https://github.company.com/abc/foo` | `path/xyz.json` | `1.5.4`        |
-
-Note that you can't combine the path and sub-preset syntaxes.
-This means that anything in the form `provider>owner/repo//path/to/file:subsubpreset` is not supported.
-One workaround is to use distinct files instead of sub-presets.
+Note that you can't combine the path and sub-preset syntaxes (i.e. anything in the form `provider>owner/repo//path/to/file:subsubpreset`) is not supported. One workaround is to use distinct files instead of sub-presets.
 
 ## Example configs
 

--- a/lib/config/presets/gitea/__snapshots__/index.spec.ts.snap
+++ b/lib/config/presets/gitea/__snapshots__/index.spec.ts.snap
@@ -187,22 +187,6 @@ Array [
 ]
 `;
 
-exports[`config/presets/gitea/index getPresetFromEndpoint() uses custom endpoint with a tag 1`] = `
-Array [
-  Object {
-    "headers": Object {
-      "accept": "application/json",
-      "accept-encoding": "gzip, deflate, br",
-      "authorization": "token abc",
-      "host": "api.gitea.example.org",
-      "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
-    },
-    "method": "GET",
-    "url": "https://api.gitea.example.org/repos/some/repo/contents/default.json?ref=someTag",
-  },
-]
-`;
-
 exports[`config/presets/gitea/index getPresetFromEndpoint() uses default endpoint 1`] = `
 Array [
   Object {
@@ -215,22 +199,6 @@ Array [
     },
     "method": "GET",
     "url": "https://gitea.com/api/v1/repos/some/repo/contents/default.json?",
-  },
-]
-`;
-
-exports[`config/presets/gitea/index getPresetFromEndpoint() uses default endpoint with a tag 1`] = `
-Array [
-  Object {
-    "headers": Object {
-      "accept": "application/json",
-      "accept-encoding": "gzip, deflate, br",
-      "authorization": "token abc",
-      "host": "gitea.com",
-      "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
-    },
-    "method": "GET",
-    "url": "https://gitea.com/api/v1/repos/some/repo/contents/default.json?ref=someTag",
   },
 ]
 `;

--- a/lib/config/presets/gitea/index.spec.ts
+++ b/lib/config/presets/gitea/index.spec.ts
@@ -30,8 +30,7 @@ describe('config/presets/gitea/index', () => {
       const res = await gitea.fetchJSONFile(
         'some/repo',
         'some-filename.json',
-        giteaApiHost,
-        null
+        giteaApiHost
       );
       expect(res).toEqual({ from: 'api' });
       expect(httpMock.getTrace()).toMatchSnapshot();
@@ -201,45 +200,6 @@ describe('config/presets/gitea/index', () => {
             'default',
             undefined,
             'https://api.gitea.example.org'
-          )
-          .catch(() => ({ from: 'api' }))
-      ).toEqual({ from: 'api' });
-      expect(httpMock.getTrace()).toMatchSnapshot();
-    });
-
-    it('uses default endpoint with a tag', async () => {
-      httpMock
-        .scope(giteaApiHost)
-        .get(`${basePath}/default.json?ref=someTag`)
-        .reply(200, {
-          content: Buffer.from('{"from":"api"}').toString('base64'),
-        });
-      expect(
-        await gitea.getPresetFromEndpoint(
-          'some/repo',
-          'default',
-          undefined,
-          giteaApiHost,
-          'someTag'
-        )
-      ).toEqual({ from: 'api' });
-      expect(httpMock.getTrace()).toMatchSnapshot();
-    });
-    it('uses custom endpoint with a tag', async () => {
-      httpMock
-        .scope('https://api.gitea.example.org')
-        .get(`${basePath}/default.json?ref=someTag`)
-        .reply(200, {
-          content: Buffer.from('{"from":"api"}').toString('base64'),
-        });
-      expect(
-        await gitea
-          .getPresetFromEndpoint(
-            'some/repo',
-            'default',
-            undefined,
-            'https://api.gitea.example.org',
-            'someTag'
           )
           .catch(() => ({ from: 'api' }))
       ).toEqual({ from: 'api' });

--- a/lib/config/presets/gitea/index.ts
+++ b/lib/config/presets/gitea/index.ts
@@ -16,14 +16,11 @@ export const Endpoint = 'https://gitea.com/api/v1/';
 export async function fetchJSONFile(
   repo: string,
   fileName: string,
-  endpoint: string,
-  packageTag?: string
+  endpoint: string
 ): Promise<Preset> {
   let res: RepoContents;
   try {
-    res = await getRepoContents(repo, fileName, packageTag, {
-      baseUrl: endpoint,
-    });
+    res = await getRepoContents(repo, fileName, null, { baseUrl: endpoint });
   } catch (err) {
     // istanbul ignore if: not testable with nock
     if (err instanceof ExternalHostError) {
@@ -48,15 +45,13 @@ export function getPresetFromEndpoint(
   pkgName: string,
   filePreset: string,
   presetPath: string,
-  endpoint = Endpoint,
-  packageTag?: string
+  endpoint = Endpoint
 ): Promise<Preset> {
   return fetchPreset({
     pkgName,
     filePreset,
     presetPath,
     endpoint,
-    packageTag,
     fetch: fetchJSONFile,
   });
 }
@@ -65,13 +60,6 @@ export function getPreset({
   packageName: pkgName,
   presetName = 'default',
   presetPath,
-  packageTag = null,
 }: PresetConfig): Promise<Preset> {
-  return getPresetFromEndpoint(
-    pkgName,
-    presetName,
-    presetPath,
-    Endpoint,
-    packageTag
-  );
+  return getPresetFromEndpoint(pkgName, presetName, presetPath, Endpoint);
 }

--- a/lib/config/presets/github/__snapshots__/index.spec.ts.snap
+++ b/lib/config/presets/github/__snapshots__/index.spec.ts.snap
@@ -187,22 +187,6 @@ Array [
 ]
 `;
 
-exports[`config/presets/github/index getPresetFromEndpoint() uses custom endpoint with a tag 1`] = `
-Array [
-  Object {
-    "headers": Object {
-      "accept": "application/vnd.github.v3+json",
-      "accept-encoding": "gzip, deflate, br",
-      "authorization": "token abc",
-      "host": "api.github.example.org",
-      "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
-    },
-    "method": "GET",
-    "url": "https://api.github.example.org/repos/some/repo/contents/default.json?ref=someTag",
-  },
-]
-`;
-
 exports[`config/presets/github/index getPresetFromEndpoint() uses default endpoint 1`] = `
 Array [
   Object {
@@ -215,22 +199,6 @@ Array [
     },
     "method": "GET",
     "url": "https://api.github.com/repos/some/repo/contents/default.json",
-  },
-]
-`;
-
-exports[`config/presets/github/index getPresetFromEndpoint() uses default endpoint with a tag 1`] = `
-Array [
-  Object {
-    "headers": Object {
-      "accept": "application/vnd.github.v3+json",
-      "accept-encoding": "gzip, deflate, br",
-      "authorization": "token abc",
-      "host": "api.github.com",
-      "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
-    },
-    "method": "GET",
-    "url": "https://api.github.com/repos/some/repo/contents/default.json?ref=someTag",
   },
 ]
 `;

--- a/lib/config/presets/github/index.spec.ts
+++ b/lib/config/presets/github/index.spec.ts
@@ -28,8 +28,7 @@ describe('config/presets/github/index', () => {
       const res = await github.fetchJSONFile(
         'some/repo',
         'some-filename.json',
-        githubApiHost,
-        undefined
+        githubApiHost
       );
       expect(res).toEqual({ from: 'api' });
       expect(httpMock.getTrace()).toMatchSnapshot();
@@ -198,48 +197,7 @@ describe('config/presets/github/index', () => {
             'some/repo',
             'default',
             undefined,
-            'https://api.github.example.org',
-            undefined
-          )
-          .catch(() => ({ from: 'api' }))
-      ).toEqual({ from: 'api' });
-      expect(httpMock.getTrace()).toMatchSnapshot();
-    });
-
-    it('uses default endpoint with a tag', async () => {
-      httpMock
-        .scope(githubApiHost)
-        .get(`${basePath}/default.json?ref=someTag`)
-        .reply(200, {
-          content: Buffer.from('{"from":"api"}').toString('base64'),
-        });
-      expect(
-        await github.getPresetFromEndpoint(
-          'some/repo',
-          'default',
-          undefined,
-          githubApiHost,
-          'someTag'
-        )
-      ).toEqual({ from: 'api' });
-      expect(httpMock.getTrace()).toMatchSnapshot();
-    });
-
-    it('uses custom endpoint with a tag', async () => {
-      httpMock
-        .scope('https://api.github.example.org')
-        .get(`${basePath}/default.json?ref=someTag`)
-        .reply(200, {
-          content: Buffer.from('{"from":"api"}').toString('base64'),
-        });
-      expect(
-        await github
-          .getPresetFromEndpoint(
-            'some/repo',
-            'default',
-            undefined,
-            'https://api.github.example.org',
-            'someTag'
+            'https://api.github.example.org'
           )
           .catch(() => ({ from: 'api' }))
       ).toEqual({ from: 'api' });

--- a/lib/config/presets/github/index.ts
+++ b/lib/config/presets/github/index.ts
@@ -1,4 +1,3 @@
-import is from '@sindresorhus/is';
 import { logger } from '../../../logger';
 import { ExternalHostError } from '../../../types/errors/external-host-error';
 import { GithubHttp } from '../../../util/http/github';
@@ -16,15 +15,9 @@ const http = new GithubHttp();
 export async function fetchJSONFile(
   repo: string,
   fileName: string,
-  endpoint: string,
-  packageTag?: string
+  endpoint: string
 ): Promise<Preset> {
-  let ref = '';
-  if (is.nonEmptyString(packageTag)) {
-    ref = `?ref=${packageTag}`;
-  }
-  const url = `${endpoint}repos/${repo}/contents/${fileName}${ref}`;
-  logger.trace({ url }, `Preset URL`);
+  const url = `${endpoint}repos/${repo}/contents/${fileName}`;
   let res: { body: { content: string } };
   try {
     res = await http.getJson(url);
@@ -52,15 +45,13 @@ export function getPresetFromEndpoint(
   pkgName: string,
   filePreset: string,
   presetPath: string,
-  endpoint = Endpoint,
-  packageTag?: string
+  endpoint = Endpoint
 ): Promise<Preset> {
   return fetchPreset({
     pkgName,
     filePreset,
     presetPath,
     endpoint,
-    packageTag,
     fetch: fetchJSONFile,
   });
 }
@@ -69,13 +60,6 @@ export function getPreset({
   packageName: pkgName,
   presetName = 'default',
   presetPath,
-  packageTag = null,
 }: PresetConfig): Promise<Preset> {
-  return getPresetFromEndpoint(
-    pkgName,
-    presetName,
-    presetPath,
-    Endpoint,
-    packageTag
-  );
+  return getPresetFromEndpoint(pkgName, presetName, presetPath, Endpoint);
 }

--- a/lib/config/presets/gitlab/__snapshots__/index.spec.ts.snap
+++ b/lib/config/presets/gitlab/__snapshots__/index.spec.ts.snap
@@ -50,21 +50,6 @@ Array [
 ]
 `;
 
-exports[`config/presets/gitlab/index getPreset() should return the preset with a tag 1`] = `
-Array [
-  Object {
-    "headers": Object {
-      "accept": "application/json",
-      "accept-encoding": "gzip, deflate, br",
-      "host": "gitlab.com",
-      "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
-    },
-    "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/some%2Frepo/repository/files/default.json/raw?ref=someTag",
-  },
-]
-`;
-
 exports[`config/presets/gitlab/index getPreset() throws EXTERNAL_HOST_ERROR 1`] = `
 Array [
   Object {
@@ -150,21 +135,6 @@ Array [
 ]
 `;
 
-exports[`config/presets/gitlab/index getPresetFromEndpoint() uses custom endpoint with a tag 1`] = `
-Array [
-  Object {
-    "headers": Object {
-      "accept": "application/json",
-      "accept-encoding": "gzip, deflate, br",
-      "host": "gitlab.example.org",
-      "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
-    },
-    "method": "GET",
-    "url": "https://gitlab.example.org/api/v4/projects/some%2Frepo/repository/files/some.json/raw?ref=someTag",
-  },
-]
-`;
-
 exports[`config/presets/gitlab/index getPresetFromEndpoint() uses default endpoint 1`] = `
 Array [
   Object {
@@ -186,21 +156,6 @@ Array [
     },
     "method": "GET",
     "url": "https://gitlab.com/api/v4/projects/some%2Frepo/repository/files/some.json/raw?ref=devel",
-  },
-]
-`;
-
-exports[`config/presets/gitlab/index getPresetFromEndpoint() uses default endpoint with a tag 1`] = `
-Array [
-  Object {
-    "headers": Object {
-      "accept": "application/json",
-      "accept-encoding": "gzip, deflate, br",
-      "host": "gitlab.com",
-      "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
-    },
-    "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/some%2Frepo/repository/files/some.json/raw?ref=someTag",
   },
 ]
 `;

--- a/lib/config/presets/gitlab/index.spec.ts
+++ b/lib/config/presets/gitlab/index.spec.ts
@@ -60,20 +60,6 @@ describe('config/presets/gitlab/index', () => {
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
 
-    it('should return the preset with a tag', async () => {
-      httpMock
-        .scope(gitlabApiHost)
-        .get(`${basePath}/files/default.json/raw?ref=someTag`)
-        .reply(200, { foo: 'bar' }, {});
-
-      const content = await gitlab.getPreset({
-        packageName: 'some/repo',
-        packageTag: 'someTag',
-      });
-      expect(content).toEqual({ foo: 'bar' });
-      expect(httpMock.getTrace()).toMatchSnapshot();
-    });
-
     it('should query custom paths', async () => {
       httpMock
         .scope(gitlabApiHost)
@@ -143,40 +129,6 @@ describe('config/presets/gitlab/index', () => {
           'https://gitlab.example.org/api/v4'
         )
       ).rejects.toThrow(PRESET_DEP_NOT_FOUND);
-      expect(httpMock.getTrace()).toMatchSnapshot();
-    });
-
-    it('uses default endpoint with a tag', async () => {
-      httpMock
-        .scope(gitlabApiHost)
-        .get(`${basePath}/files/some.json/raw?ref=someTag`)
-        .reply(200, { preset: { file: {} } });
-      expect(
-        await gitlab.getPresetFromEndpoint(
-          'some/repo',
-          'some/preset/file',
-          undefined,
-          'https://gitlab.com/api/v4',
-          'someTag'
-        )
-      ).toEqual({});
-      expect(httpMock.getTrace()).toMatchSnapshot();
-    });
-
-    it('uses custom endpoint with a tag', async () => {
-      httpMock
-        .scope('https://gitlab.example.org')
-        .get(`${basePath}/files/some.json/raw?ref=someTag`)
-        .reply(200, { preset: { file: {} } });
-      expect(
-        await gitlab.getPresetFromEndpoint(
-          'some/repo',
-          'some/preset/file',
-          undefined,
-          'https://gitlab.example.org/api/v4',
-          'someTag'
-        )
-      ).toEqual({});
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
   });

--- a/lib/config/presets/gitlab/index.ts
+++ b/lib/config/presets/gitlab/index.ts
@@ -1,4 +1,3 @@
-import is from '@sindresorhus/is';
 import { logger } from '../../../logger';
 import { ExternalHostError } from '../../../types/errors/external-host-error';
 import type { GitLabBranch } from '../../../types/platform/gitlab';
@@ -31,25 +30,17 @@ async function getDefaultBranchName(
 export async function fetchJSONFile(
   repo: string,
   fileName: string,
-  endpoint: string,
-  packageTag?: string
+  endpoint: string
 ): Promise<Preset> {
   let url = endpoint;
-  let ref = '';
   try {
     const urlEncodedRepo = encodeURIComponent(repo);
     const urlEncodedPkgName = encodeURIComponent(fileName);
-    if (is.nonEmptyString(packageTag)) {
-      ref = `?ref=${packageTag}`;
-    } else {
-      const defaultBranchName = await getDefaultBranchName(
-        urlEncodedRepo,
-        endpoint
-      );
-      ref = `?ref=${defaultBranchName}`;
-    }
-    url += `projects/${urlEncodedRepo}/repository/files/${urlEncodedPkgName}/raw${ref}`;
-    logger.trace({ url }, `Preset URL`);
+    const defaultBranchName = await getDefaultBranchName(
+      urlEncodedRepo,
+      endpoint
+    );
+    url += `projects/${urlEncodedRepo}/repository/files/${urlEncodedPkgName}/raw?ref=${defaultBranchName}`;
     return (await gitlabApi.getJson<Preset>(url)).body;
   } catch (err) {
     if (err instanceof ExternalHostError) {
@@ -67,15 +58,13 @@ export function getPresetFromEndpoint(
   pkgName: string,
   presetName: string,
   presetPath: string,
-  endpoint = Endpoint,
-  packageTag?: string
+  endpoint = Endpoint
 ): Promise<Preset> {
   return fetchPreset({
     pkgName,
     filePreset: presetName,
     presetPath,
     endpoint,
-    packageTag,
     fetch: fetchJSONFile,
   });
 }
@@ -84,13 +73,6 @@ export function getPreset({
   packageName: pkgName,
   presetPath,
   presetName = 'default',
-  packageTag = null,
 }: PresetConfig): Promise<Preset> {
-  return getPresetFromEndpoint(
-    pkgName,
-    presetName,
-    presetPath,
-    Endpoint,
-    packageTag
-  );
+  return getPresetFromEndpoint(pkgName, presetName, presetPath, Endpoint);
 }

--- a/lib/config/presets/index.spec.ts
+++ b/lib/config/presets/index.spec.ts
@@ -342,8 +342,8 @@ describe('config/presets/index', () => {
       ).toEqual({
         packageName: 'some/repo',
         params: undefined,
-        presetName: 'somepreset',
-        presetPath: 'somefile',
+        presetName: 'somefile/somepreset',
+        presetPath: undefined,
         presetSource: 'github',
       });
     });
@@ -355,8 +355,8 @@ describe('config/presets/index', () => {
       ).toEqual({
         packageName: 'some/repo',
         params: undefined,
-        presetName: 'somesubpreset',
-        presetPath: 'somefile/somepreset',
+        presetName: 'somefile/somepreset/somesubpreset',
+        presetPath: undefined,
         presetSource: 'github',
       });
     });

--- a/lib/config/presets/local/__snapshots__/index.spec.ts.snap
+++ b/lib/config/presets/local/__snapshots__/index.spec.ts.snap
@@ -7,7 +7,6 @@ Array [
     "default",
     undefined,
     undefined,
-    undefined,
   ],
 ]
 `;
@@ -17,7 +16,6 @@ Array [
   Array [
     "some/repo",
     "default",
-    undefined,
     undefined,
     undefined,
   ],
@@ -31,7 +29,6 @@ Array [
     "default",
     undefined,
     "https://git.example.com",
-    undefined,
   ],
 ]
 `;
@@ -43,7 +40,6 @@ Array [
     "default",
     undefined,
     "https://api.gitea.example.com",
-    undefined,
   ],
 ]
 `;
@@ -55,19 +51,6 @@ Array [
     "default",
     undefined,
     "https://api.github.example.com",
-    undefined,
-  ],
-]
-`;
-
-exports[`config/presets/local/index getPreset() forwards to custom github with a tag 1`] = `
-Array [
-  Array [
-    "some/repo",
-    "default",
-    undefined,
-    "https://api.github.example.com",
-    "someTag",
   ],
 ]
 `;
@@ -79,19 +62,6 @@ Array [
     "default",
     undefined,
     "https://gitlab.example.com/api/v4",
-    undefined,
-  ],
-]
-`;
-
-exports[`config/presets/local/index getPreset() forwards to custom gitlab with a tag 1`] = `
-Array [
-  Array [
-    "some/repo",
-    "default",
-    undefined,
-    "https://gitlab.example.com/api/v4",
-    "someTag",
   ],
 ]
 `;
@@ -101,7 +71,6 @@ Array [
   Array [
     "some/repo",
     "default",
-    undefined,
     undefined,
     undefined,
   ],
@@ -115,19 +84,6 @@ Array [
     "default",
     undefined,
     undefined,
-    undefined,
-  ],
-]
-`;
-
-exports[`config/presets/local/index getPreset() forwards to github with a tag 1`] = `
-Array [
-  Array [
-    "some/repo",
-    "default",
-    undefined,
-    undefined,
-    "someTag",
   ],
 ]
 `;
@@ -139,19 +95,6 @@ Array [
     "default",
     undefined,
     undefined,
-    undefined,
-  ],
-]
-`;
-
-exports[`config/presets/local/index getPreset() forwards to gitlab with a tag 1`] = `
-Array [
-  Array [
-    "some/repo",
-    "default",
-    undefined,
-    undefined,
-    "someTag",
   ],
 ]
 `;

--- a/lib/config/presets/local/index.spec.ts
+++ b/lib/config/presets/local/index.spec.ts
@@ -140,30 +140,6 @@ describe('config/presets/local/index', () => {
       expect(github.getPresetFromEndpoint.mock.calls).toMatchSnapshot();
       expect(content).toEqual({ resolved: 'preset' });
     });
-    it('forwards to github with a tag', async () => {
-      const content = await local.getPreset({
-        packageName: 'some/repo',
-        packageTag: 'someTag',
-        baseConfig: {
-          platform: 'github',
-        },
-      });
-      expect(github.getPresetFromEndpoint.mock.calls).toMatchSnapshot();
-      expect(content).toEqual({ resolved: 'preset' });
-    });
-    it('forwards to custom github with a tag', async () => {
-      const content = await local.getPreset({
-        packageName: 'some/repo',
-        presetName: 'default',
-        packageTag: 'someTag',
-        baseConfig: {
-          platform: 'github',
-          endpoint: 'https://api.github.example.com',
-        },
-      });
-      expect(github.getPresetFromEndpoint.mock.calls).toMatchSnapshot();
-      expect(content).toEqual({ resolved: 'preset' });
-    });
 
     it('forwards to gitlab', async () => {
       const content = await local.getPreset({
@@ -180,31 +156,6 @@ describe('config/presets/local/index', () => {
       const content = await local.getPreset({
         packageName: 'some/repo',
         presetName: 'default',
-        baseConfig: {
-          platform: 'gitlab',
-          endpoint: 'https://gitlab.example.com/api/v4',
-        },
-      });
-      expect(gitlab.getPresetFromEndpoint.mock.calls).toMatchSnapshot();
-      expect(content).toEqual({ resolved: 'preset' });
-    });
-    it('forwards to gitlab with a tag', async () => {
-      const content = await local.getPreset({
-        packageName: 'some/repo',
-        presetName: 'default',
-        packageTag: 'someTag',
-        baseConfig: {
-          platform: 'GitLab',
-        },
-      });
-      expect(gitlab.getPresetFromEndpoint.mock.calls).toMatchSnapshot();
-      expect(content).toEqual({ resolved: 'preset' });
-    });
-    it('forwards to custom gitlab with a tag', async () => {
-      const content = await local.getPreset({
-        packageName: 'some/repo',
-        presetName: 'default',
-        packageTag: 'someTag',
         baseConfig: {
           platform: 'gitlab',
           endpoint: 'https://gitlab.example.com/api/v4',

--- a/lib/config/presets/local/index.ts
+++ b/lib/config/presets/local/index.ts
@@ -20,7 +20,6 @@ export function getPreset({
   packageName: pkgName,
   presetName = 'default',
   presetPath,
-  packageTag,
   baseConfig,
 }: PresetConfig): Promise<Preset> {
   const { platform, endpoint } = baseConfig;
@@ -37,7 +36,6 @@ export function getPreset({
     pkgName,
     presetName,
     presetPath,
-    endpoint,
-    packageTag
+    endpoint
   );
 }

--- a/lib/config/presets/types.ts
+++ b/lib/config/presets/types.ts
@@ -8,7 +8,6 @@ export type PresetConfig = {
   presetPath?: string;
   presetName?: string;
   baseConfig?: RenovateConfig;
-  packageTag?: string;
 };
 
 export interface PresetApi {
@@ -20,15 +19,13 @@ export interface ParsedPreset {
   packageName: string;
   presetPath?: string;
   presetName: string;
-  packageTag?: string;
   params?: string[];
 }
 
 export type PresetFetcher = (
   repo: string,
   fileName: string,
-  endpoint: string,
-  packageTag?: string
+  endpoint: string
 ) => Promise<Preset>;
 
 export type FetchPresetConfig = {
@@ -36,6 +33,5 @@ export type FetchPresetConfig = {
   filePreset: string;
   presetPath?: string;
   endpoint: string;
-  packageTag?: string;
   fetch: PresetFetcher;
 };

--- a/lib/config/presets/util.ts
+++ b/lib/config/presets/util.ts
@@ -15,7 +15,6 @@ export async function fetchPreset({
   filePreset,
   presetPath,
   endpoint: _endpoint,
-  packageTag = null,
   fetch,
 }: FetchPresetConfig): Promise<Preset | undefined> {
   const endpoint = ensureTrailingSlash(_endpoint);
@@ -28,8 +27,7 @@ export async function fetchPreset({
       jsonContent = await fetch(
         pkgName,
         buildFilePath('default.json'),
-        endpoint,
-        packageTag
+        endpoint
       );
     } catch (err) {
       if (err.message !== PRESET_DEP_NOT_FOUND) {
@@ -41,16 +39,14 @@ export async function fetchPreset({
       jsonContent = await fetch(
         pkgName,
         buildFilePath('renovate.json'),
-        endpoint,
-        packageTag
+        endpoint
       );
     }
   } else {
     jsonContent = await fetch(
       pkgName,
       buildFilePath(`${fileName}.json`),
-      endpoint,
-      packageTag
+      endpoint
     );
   }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Reverts git preset tags in #11565

## Context:

#12595

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
