### PR TITLE
fix: cache handle nested err

### DIFF
--- a/lib/workers/repository/cache.ts
+++ b/lib/workers/repository/cache.ts
@@ -75,7 +75,8 @@ async function generateBranchCache(branch: BranchConfig): Promise<BranchCache> {
       isModified,
       upgrades,
     };
-  } catch (err) {
+  } catch (error) {
+    const err = error.err || error; // external host error nests err
     const errCodes = [401, 404];
     // istanbul ignore if
     if (errCodes.includes(err.response?.statusCode)) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Handles nested `err` during cache generation.

## Context:

Error observed in the app.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
