### PR TITLE
fix(config/preset): readd subpreset support

### DIFF
--- a/docs/development/shareable-configs.md
+++ b/docs/development/shareable-configs.md
@@ -54,40 +54,44 @@ You can set a Git tag (like a SemVer) to use a specific release of your shared c
 
 #### GitHub
 
-| name                                        | example use                     | preset    | resolves as                  | filename        | Git tag        |
-| ------------------------------------------- | ------------------------------- | --------- | ---------------------------- | --------------- | -------------- |
-| GitHub default                              | `github>abc/foo`                | `default` | `https://github.com/abc/foo` | `default.json`  | Default branch |
-| GitHub with preset name                     | `github>abc/foo:xyz`            | `xyz`     | `https://github.com/abc/foo` | `xyz.json`      | Default branch |
-| GitHub default with a tag                   | `github>abc/foo#1.5.4`          | `default` | `https://github.com/abc/foo` | `default.json`  | `1.5.4`        |
-| GitHub with preset name with a tag          | `github>abc/foo:xyz#1.5.4`      | `xyz`     | `https://github.com/abc/foo` | `xyz.json`      | `1.5.4`        |
-| GitHub with preset name and path with a tag | `github>abc/foo:path/xyz#1.5.4` | `xyz`     | `https://github.com/abc/foo` | `path/xyz.json` | `1.5.4`        |
+| name                                        | example use                      | preset    | resolves as                  | filename        | Git tag        |
+| ------------------------------------------- | -------------------------------- | --------- | ---------------------------- | --------------- | -------------- |
+| GitHub default                              | `github>abc/foo`                 | `default` | `https://github.com/abc/foo` | `default.json`  | Default branch |
+| GitHub with preset name                     | `github>abc/foo:xyz`             | `xyz`     | `https://github.com/abc/foo` | `xyz.json`      | Default branch |
+| GitHub default with a tag                   | `github>abc/foo#1.5.4`           | `default` | `https://github.com/abc/foo` | `default.json`  | `1.5.4`        |
+| GitHub with preset name with a tag          | `github>abc/foo:xyz#1.5.4`       | `xyz`     | `https://github.com/abc/foo` | `xyz.json`      | `1.5.4`        |
+| GitHub with preset name and path with a tag | `github>abc/foo//path/xyz#1.5.4` | `xyz`     | `https://github.com/abc/foo` | `path/xyz.json` | `1.5.4`        |
+| GitHub with subpreset name and tag          | `github>abc/foo:xyz/sub#1.5.4`   | `sub`     | `https://github.com/abc/foo` | `xyz.json`      | `1.5.4`        |
 
 #### GitLab
 
-| name                                        | example use                     | preset    | resolves as                  | filename        | Git tag        |
-| ------------------------------------------- | ------------------------------- | --------- | ---------------------------- | --------------- | -------------- |
-| GitLab default                              | `gitlab>abc/foo`                | `default` | `https://gitlab.com/abc/foo` | `default.json`  | Default branch |
-| GitLab with preset name                     | `gitlab>abc/foo:xyz`            | `xyz`     | `https://gitlab.com/abc/foo` | `xyz.json`      | Default branch |
-| GitLab default with a tag                   | `gitlab>abc/foo#1.5.4`          | `default` | `https://gitlab.com/abc/foo` | `default.json`  | `1.5.4`        |
-| GitLab with preset name with a tag          | `gitlab>abc/foo:xyz#1.5.4`      | `xyz`     | `https://gitlab.com/abc/foo` | `xyz.json`      | `1.5.4`        |
-| GitLab with preset name and path with a tag | `gitlab>abc/foo:path/xyz#1.5.4` | `xyz`     | `https://gitlab.com/abc/foo` | `path/xyz.json` | `1.5.4`        |
+| name                                        | example use                      | preset    | resolves as                  | filename        | Git tag        |
+| ------------------------------------------- | -------------------------------- | --------- | ---------------------------- | --------------- | -------------- |
+| GitLab default                              | `gitlab>abc/foo`                 | `default` | `https://gitlab.com/abc/foo` | `default.json`  | Default branch |
+| GitLab with preset name                     | `gitlab>abc/foo:xyz`             | `xyz`     | `https://gitlab.com/abc/foo` | `xyz.json`      | Default branch |
+| GitLab default with a tag                   | `gitlab>abc/foo#1.5.4`           | `default` | `https://gitlab.com/abc/foo` | `default.json`  | `1.5.4`        |
+| GitLab with preset name with a tag          | `gitlab>abc/foo:xyz#1.5.4`       | `xyz`     | `https://gitlab.com/abc/foo` | `xyz.json`      | `1.5.4`        |
+| GitLab with preset name and path with a tag | `gitlab>abc/foo//path/xyz#1.5.4` | `xyz`     | `https://gitlab.com/abc/foo` | `path/xyz.json` | `1.5.4`        |
+| GitLab with subpreset name and tag          | `gitlab>abc/foo:xyz/sub#1.5.4`   | `sub`     | `https://gitlab.com/abc/foo` | `xyz.json`      | `1.5.4`        |
 
 #### Gitea
 
-| name                                       | example use                    | preset    | resolves as                 | filename        | Git tag        |
-| ------------------------------------------ | ------------------------------ | --------- | --------------------------- | --------------- | -------------- |
-| Gitea default                              | `gitea>abc/foo`                | `default` | `https://gitea.com/abc/foo` | `default.json`  | Default branch |
-| Gitea with preset name                     | `gitea>abc/foo:xyz`            | `xyz`     | `https://gitea.com/abc/foo` | `xyz.json`      | Default branch |
-| Gitea default with a tag                   | `gitea>abc/foo#1.5.4`          | `default` | `https://gitea.com/abc/foo` | `default.json`  | `1.5.4`        |
-| Gitea with preset name with a tag          | `gitea>abc/foo:xyz#1.5.4`      | `xyz`     | `https://gitea.com/abc/foo` | `xyz.json`      | `1.5.4`        |
-| Gitea with preset name and path with a tag | `gitea>abc/foo:path/xyz#1.5.4` | `xyz`     | `https://gitea.com/abc/foo` | `path/xyz.json` | `1.5.4`        |
+| name                                       | example use                     | preset    | resolves as                 | filename        | Git tag        |
+| ------------------------------------------ | ------------------------------- | --------- | --------------------------- | --------------- | -------------- |
+| Gitea default                              | `gitea>abc/foo`                 | `default` | `https://gitea.com/abc/foo` | `default.json`  | Default branch |
+| Gitea with preset name                     | `gitea>abc/foo:xyz`             | `xyz`     | `https://gitea.com/abc/foo` | `xyz.json`      | Default branch |
+| Gitea default with a tag                   | `gitea>abc/foo#1.5.4`           | `default` | `https://gitea.com/abc/foo` | `default.json`  | `1.5.4`        |
+| Gitea with preset name with a tag          | `gitea>abc/foo:xyz#1.5.4`       | `xyz`     | `https://gitea.com/abc/foo` | `xyz.json`      | `1.5.4`        |
+| Gitea with preset name and path with a tag | `gitea>abc/foo//path/xyz#1.5.4` | `xyz`     | `https://gitea.com/abc/foo` | `path/xyz.json` | `1.5.4`        |
+| Gitea with subpreset name and tag          | `gitea>abc/foo:xyz/sub#1.5.4`   | `sub`     | `https://gitea.com/abc/foo` | `xyz.json`      | `1.5.4`        |
 
 #### Self-hosted Git
 
-| name                                       | example use                    | preset    | resolves as                          | filename        | Git tag        |
-| ------------------------------------------ | ------------------------------ | --------- | ------------------------------------ | --------------- | -------------- |
-| Local default                              | `local>abc/foo`                | `default` | `https://github.company.com/abc/foo` | `default.json`  | Default branch |
-| Local with preset path                     | `local>abc/foo:path/xyz`       | `default` | `https://github.company.com/abc/foo` | `path/xyz.json` | Default branch |
-| Local default with a tag                   | `local>abc/foo#1.5.4`          | `default` | `https://github.company.com/abc/foo` | `default.json`  | `1.5.4`        |
-| Local with preset name with a tag          | `local>abc/foo:xyz#1.5.4`      | `default` | `https://github.company.com/abc/foo` | `xyz.json`      | `1.5.4`        |
-| Local with preset name and path with a tag | `local>abc/foo:path/xyz#1.5.4` | `default` | `https://github.company.com/abc/foo` | `path/xyz.json` | `1.5.4`        |
+| name                                       | example use                     | preset    | resolves as                          | filename        | Git tag        |
+| ------------------------------------------ | ------------------------------- | --------- | ------------------------------------ | --------------- | -------------- |
+| Local default                              | `local>abc/foo`                 | `default` | `https://github.company.com/abc/foo` | `default.json`  | Default branch |
+| Local with preset path                     | `local>abc/foo:path/xyz`        | `default` | `https://github.company.com/abc/foo` | `path/xyz.json` | Default branch |
+| Local default with a tag                   | `local>abc/foo#1.5.4`           | `default` | `https://github.company.com/abc/foo` | `default.json`  | `1.5.4`        |
+| Local with preset name with a tag          | `local>abc/foo:xyz#1.5.4`       | `default` | `https://github.company.com/abc/foo` | `xyz.json`      | `1.5.4`        |
+| Local with preset name and path with a tag | `local>abc/foo//path/xyz#1.5.4` | `default` | `https://github.company.com/abc/foo` | `path/xyz.json` | `1.5.4`        |
+| Local with subpreset name and tag          | `local>abc/foo:xyz/sub#1.5.4`   | `sub`     | `https://github.company.com/abc/foo` | `xyz.json`      | `1.5.4`        |

--- a/docs/usage/config-presets.md
+++ b/docs/usage/config-presets.md
@@ -45,13 +45,14 @@ You can set a Git tag (like a SemVer) to use a specific release of your shared c
 
 ### GitHub
 
-| name                                        | example use                     | preset    | resolves as                  | filename        | Git tag        |
-| ------------------------------------------- | ------------------------------- | --------- | ---------------------------- | --------------- | -------------- |
-| GitHub default                              | `github>abc/foo`                | `default` | `https://github.com/abc/foo` | `default.json`  | Default branch |
-| GitHub with preset name                     | `github>abc/foo:xyz`            | `xyz`     | `https://github.com/abc/foo` | `xyz.json`      | Default branch |
-| GitHub default with a tag                   | `github>abc/foo#1.5.4`          | `default` | `https://github.com/abc/foo` | `default.json`  | `1.5.4`        |
-| GitHub with preset name with a tag          | `github>abc/foo:xyz#1.5.4`      | `xyz`     | `https://github.com/abc/foo` | `xyz.json`      | `1.5.4`        |
-| GitHub with preset name and path with a tag | `github>abc/foo:path/xyz#1.5.4` | `xyz`     | `https://github.com/abc/foo` | `path/xyz.json` | `1.5.4`        |
+| name                                        | example use                      | preset    | resolves as                  | filename        | Git tag        |
+| ------------------------------------------- | -------------------------------- | --------- | ---------------------------- | --------------- | -------------- |
+| GitHub default                              | `github>abc/foo`                 | `default` | `https://github.com/abc/foo` | `default.json`  | Default branch |
+| GitHub with preset name                     | `github>abc/foo:xyz`             | `xyz`     | `https://github.com/abc/foo` | `xyz.json`      | Default branch |
+| GitHub default with a tag                   | `github>abc/foo#1.5.4`           | `default` | `https://github.com/abc/foo` | `default.json`  | `1.5.4`        |
+| GitHub with preset name with a tag          | `github>abc/foo:xyz#1.5.4`       | `xyz`     | `https://github.com/abc/foo` | `xyz.json`      | `1.5.4`        |
+| GitHub with preset name and path with a tag | `github>abc/foo//path/xyz#1.5.4` | `xyz`     | `https://github.com/abc/foo` | `path/xyz.json` | `1.5.4`        |
+| GitHub with subpreset name and tag          | `github>abc/foo:xyz/sub#1.5.4`   | `sub`     | `https://github.com/abc/foo` | `xyz.json`      | `1.5.4`        |
 
 ### GitLab
 
@@ -62,6 +63,7 @@ You can set a Git tag (like a SemVer) to use a specific release of your shared c
 | GitLab default with a tag                   | `gitlab>abc/foo#1.5.4`          | `default` | `https://gitlab.com/abc/foo` | `default.json`  | `1.5.4`        |
 | GitLab with preset name with a tag          | `gitlab>abc/foo:xyz#1.5.4`      | `xyz`     | `https://gitlab.com/abc/foo` | `xyz.json`      | `1.5.4`        |
 | GitLab with preset name and path with a tag | `gitlab>abc/foo:path/xyz#1.5.4` | `xyz`     | `https://gitlab.com/abc/foo` | `path/xyz.json` | `1.5.4`        |
+| GitLab with subpreset name and tag          | `gitlab>abc/foo:xyz/sub#1.5.4`  | `sub`     | `https://gitlab.com/abc/foo` | `xyz.json`      | `1.5.4`        |
 
 ### Gitea
 
@@ -72,6 +74,7 @@ You can set a Git tag (like a SemVer) to use a specific release of your shared c
 | Gitea default with a tag                   | `gitea>abc/foo#1.5.4`          | `default` | `https://gitea.com/abc/foo` | `default.json`  | `1.5.4`        |
 | Gitea with preset name with a tag          | `gitea>abc/foo:xyz#1.5.4`      | `xyz`     | `https://gitea.com/abc/foo` | `xyz.json`      | `1.5.4`        |
 | Gitea with preset name and path with a tag | `gitea>abc/foo:path/xyz#1.5.4` | `xyz`     | `https://gitea.com/abc/foo` | `path/xyz.json` | `1.5.4`        |
+| Gitea with subpreset name and tag          | `gitea>abc/foo:xyz/sub#1.5.4`  | `sub`     | `https://gitea.com/abc/foo` | `xyz.json`      | `1.5.4`        |
 
 ### Self-hosted Git
 
@@ -82,6 +85,7 @@ You can set a Git tag (like a SemVer) to use a specific release of your shared c
 | Local default with a tag                   | `local>abc/foo#1.5.4`          | `default` | `https://github.company.com/abc/foo` | `default.json`  | `1.5.4`        |
 | Local with preset name with a tag          | `local>abc/foo:xyz#1.5.4`      | `xyz`     | `https://github.company.com/abc/foo` | `xyz.json`      | `1.5.4`        |
 | Local with preset name and path with a tag | `local>abc/foo:path/xyz#1.5.4` | `xyz`     | `https://github.company.com/abc/foo` | `path/xyz.json` | `1.5.4`        |
+| Local with subpreset name and tag          | `local>abc/foo:xyz/sub#1.5.4`  | `sub`     | `https://github.company.com/abc/foo` | `xyz.json`      | `1.5.4`        |
 
 Note that you can't combine the path and sub-preset syntaxes.
 This means that anything in the form `provider>owner/repo//path/to/file:subsubpreset` is not supported.

--- a/lib/config/presets/index.spec.ts
+++ b/lib/config/presets/index.spec.ts
@@ -342,8 +342,8 @@ describe('config/presets/index', () => {
       ).toEqual({
         packageName: 'some/repo',
         params: undefined,
-        presetName: 'somepreset',
-        presetPath: 'somefile',
+        presetName: 'somefile/somepreset',
+        presetPath: undefined,
         presetSource: 'github',
       });
     });
@@ -355,8 +355,8 @@ describe('config/presets/index', () => {
       ).toEqual({
         packageName: 'some/repo',
         params: undefined,
-        presetName: 'somesubpreset',
-        presetPath: 'somefile/somepreset',
+        presetName: 'somefile/somepreset/somesubpreset',
+        presetPath: undefined,
         presetSource: 'github',
       });
     });
@@ -425,6 +425,34 @@ describe('config/presets/index', () => {
         presetName: 'some-file',
         presetPath: 'some-dir',
         presetSource: 'local',
+      });
+    });
+    it('parses local with sub preset and tag', () => {
+      expect(
+        presets.parsePreset(
+          'local>some-group/some-repo:some-file/subpreset#1.2.3'
+        )
+      ).toEqual({
+        packageName: 'some-group/some-repo',
+        params: undefined,
+        presetName: 'some-file/subpreset',
+        presetPath: undefined,
+        presetSource: 'local',
+        packageTag: '1.2.3',
+      });
+    });
+    it('parses local with subdirectory and tag', () => {
+      expect(
+        presets.parsePreset(
+          'local>some-group/some-repo//some-dir/some-file#1.2.3'
+        )
+      ).toEqual({
+        packageName: 'some-group/some-repo',
+        params: undefined,
+        presetName: 'some-file',
+        presetPath: 'some-dir',
+        presetSource: 'local',
+        packageTag: '1.2.3',
       });
     });
     it('parses no prefix as local', () => {

--- a/lib/config/presets/index.ts
+++ b/lib/config/presets/index.ts
@@ -40,7 +40,7 @@ const nonScopedPresetWithSubdirRegex = regEx(
   /^(?<packageName>~?[\w\-./]+?)\/\/(?:(?<presetPath>[\w\-./]+)\/)?(?<presetName>[\w\-.]+)(?:#(?<packageTag>[\w\-.]+?))?$/
 );
 const gitPresetRegex = regEx(
-  /^(?<packageName>[\w\-. /]+)(?::(?<presetPath>[\w-./]+\/))?(?::?(?<presetName>[\w\-.+]+))?(?:#(?<packageTag>[\w\-.]+?))?$/
+  /^(?<packageName>[\w\-. /]+)(?::(?<presetName>[\w\-.+/]+))?(?:#(?<packageTag>[\w\-.]+?))?$/
 );
 
 export function replaceArgs(

--- a/lib/config/presets/index.ts
+++ b/lib/config/presets/index.ts
@@ -75,10 +75,10 @@ export function replaceArgs(
 export function parsePreset(input: string): ParsedPreset {
   let str = input;
   let presetSource: string;
-  let presetPath: string;
+  let presetPath: string | undefined;
   let packageName: string;
   let presetName: string;
-  let packageTag: string;
+  let packageTag: string | undefined;
   let params: string[];
   if (str.startsWith('github>')) {
     presetSource = 'github';
@@ -159,12 +159,8 @@ export function parsePreset(input: string): ParsedPreset {
     ({ packageName, presetPath, presetName, packageTag } =
       nonScopedPresetWithSubdirRegex.exec(str)?.groups || {});
   } else {
-    ({ packageName, presetPath, presetName, packageTag } =
+    ({ packageName, presetName, packageTag } =
       gitPresetRegex.exec(str)?.groups || {});
-
-    if (is.nonEmptyString(presetPath) && presetPath.endsWith('/')) {
-      presetPath = presetPath.slice(0, -1);
-    }
 
     if (presetSource === 'npm' && !packageName.startsWith('renovate-config-')) {
       packageName = `renovate-config-${packageName}`;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Readd sub preset support.
<!-- Describe what behavior is changed by this PR. -->

## Context:

- regression of #11565
- fixes #12595
- closes #12725
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
