### PR TITLE
fix(git-refs): ignore refs/for

### DIFF
--- a/lib/datasource/git-refs/__fixtures__/ls-remote-1.txt
+++ b/lib/datasource/git-refs/__fixtures__/ls-remote-1.txt
@@ -1,4 +1,5 @@
 a9920c014aebc28dc1b23e7efcc006d0455cc710	HEAD
+46fd703d4738905cd55e1c5c36a70e5d43432b9c	refs/for/master
 2e24e927538bbc03cc3cd946834c8f5fe333f32c	refs/heads/feat/slim-image
 a9920c014aebc28dc1b23e7efcc006d0455cc710	refs/heads/master
 a9920c014aebc28dc1b23e7efcc006d045512345	refs/heads/v1.0.0

--- a/lib/datasource/git-refs/index.spec.ts
+++ b/lib/datasource/git-refs/index.spec.ts
@@ -91,6 +91,18 @@ describe('datasource/git-refs/index', () => {
       );
       expect(digest).toMatchSnapshot();
     });
+    it('ignores refs/for/', async () => {
+      simpleGit.mockReturnValue({
+        listRemote() {
+          return Promise.resolve(lsRemote1);
+        },
+      });
+      const digest = await new GitRefsDatasource().getDigest(
+        { lookupName: 'a tag to look up' },
+        'master'
+      );
+      expect(digest).toBe('a9920c014aebc28dc1b23e7efcc006d0455cc710');
+    });
     it('returns digest for HEAD', async () => {
       simpleGit.mockReturnValue({
         listRemote() {

--- a/lib/datasource/git-refs/index.ts
+++ b/lib/datasource/git-refs/index.ts
@@ -61,8 +61,17 @@ export class GitRefsDatasource extends Datasource {
       { lookupName },
       this.id
     );
-    const findValue = newValue || 'HEAD';
-    const ref = rawRefs.find((rawRef) => rawRef.value === findValue);
+    let ref: RawRefs;
+    if (newValue) {
+      ref = rawRefs.find(
+        (rawRef) =>
+          ['heads', 'tags'].includes(rawRef.type) && rawRef.value === newValue
+      );
+    } else {
+      ref = rawRefs.find(
+        (rawRef) => rawRef.type === '' && rawRef.value === 'HEAD'
+      );
+    }
     if (ref) {
       return ref.hash;
     }


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Improves git-refs filtering so it picks up only branches and tags

## Context:

Closes #12732

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
