### PR TITLE
fix(datasource): better massage github sourceUrl

### DIFF
--- a/lib/datasource/__snapshots__/metadata.spec.ts.snap
+++ b/lib/datasource/__snapshots__/metadata.spec.ts.snap
@@ -135,3 +135,27 @@ Object {
   "sourceUrl": "https://gitlab.com/meno/dropzone",
 }
 `;
+
+exports[`datasource/metadata Should massage github sourceUrls 1`] = `
+Object {
+  "releases": Array [
+    Object {
+      "releaseTimestamp": "2018-07-13T10:14:17.000Z",
+      "version": "2.0.0",
+    },
+    Object {
+      "releaseTimestamp": "2017-10-24T10:09:16.000Z",
+      "version": "2.0.0.dev1",
+    },
+    Object {
+      "releaseTimestamp": "2019-01-20T19:59:28.000Z",
+      "version": "2.1.0",
+    },
+    Object {
+      "releaseTimestamp": "2019-07-16T18:29:00.000Z",
+      "version": "2.2.0",
+    },
+  ],
+  "sourceUrl": "https://github.com/some/repo",
+}
+`;

--- a/lib/datasource/metadata.spec.ts
+++ b/lib/datasource/metadata.spec.ts
@@ -76,6 +76,28 @@ describe('datasource/metadata', () => {
     });
   });
 
+  it('Should massage github sourceUrls', () => {
+    const dep: ReleaseResult = {
+      sourceUrl: 'https://some.github.com/repo',
+      releases: [
+        { version: '2.0.0', releaseTimestamp: '2018-07-13T10:14:17.000Z' },
+        {
+          version: '2.0.0.dev1',
+          releaseTimestamp: '2017-10-24T10:09:16.000Z',
+        },
+        { version: '2.1.0', releaseTimestamp: '2019-01-20T19:59:28.000Z' },
+        { version: '2.2.0', releaseTimestamp: '2019-07-16T18:29:00.000Z' },
+      ],
+    };
+    const datasource = PypiDatasource.id;
+    const lookupName = 'django-filter';
+
+    addMetaData(dep, datasource, lookupName);
+    expect(dep).toMatchSnapshot({
+      sourceUrl: 'https://github.com/some/repo',
+    });
+  });
+
   it('Should handle parsing of sourceUrls correctly for GitLab also', () => {
     const dep: ReleaseResult = {
       sourceUrl: 'https://gitlab.com/meno/dropzone/tree/master',

--- a/lib/datasource/metadata.ts
+++ b/lib/datasource/metadata.ts
@@ -107,10 +107,16 @@ const manualSourceUrls = {
   },
 };
 
+const githubPages = regEx('^https://([^.]+).github.com/([^/]+)$');
+const gitPrefix = regEx('^git:/?/?');
+
 function massageGithubUrl(url: string): string {
   return url
     .replace('http:', 'https:')
-    .replace(regEx(/^git:\/?\/?/), 'https://')
+    .replace('http+git:', 'https:')
+    .replace('https+git:', 'https:')
+    .replace(gitPrefix, 'https://')
+    .replace(githubPages, 'https://github.com/$1/$2')
     .replace('www.github.com', 'github.com')
     .split('/')
     .slice(0, 5)


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Improves sourceUrl massaging.

## Context:

No issue

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
