### PR TITLE
fix(github): handle secondary rate limit

### DIFF
--- a/lib/util/http/github.spec.ts
+++ b/lib/util/http/github.spec.ts
@@ -192,6 +192,14 @@ describe('util/http/github', () => {
           })
         ).rejects.toThrow(PLATFORM_RATE_LIMIT_EXCEEDED);
       });
+      it('should throw secondary rate limit exceeded', async () => {
+        await expect(
+          fail(403, {
+            message:
+              'You have exceeded a secondary rate limit and have been temporarily blocked from content creation. Please retry your request again later.',
+          })
+        ).rejects.toThrow(PLATFORM_RATE_LIMIT_EXCEEDED);
+      });
       it('should throw Bad credentials', async () => {
         await expect(
           fail(401, { message: 'Bad credentials. (401)' })

--- a/lib/util/http/github.ts
+++ b/lib/util/http/github.ts
@@ -78,6 +78,13 @@ function handleGotError(
     logger.debug({ err }, 'GitHub failure: abuse detection');
     throw new Error(PLATFORM_RATE_LIMIT_EXCEEDED);
   }
+  if (
+    err.statusCode === 403 &&
+    message.startsWith('You have exceeded a secondary rate limit')
+  ) {
+    logger.debug({ err }, 'GitHub failure: secondary rate limit');
+    throw new Error(PLATFORM_RATE_LIMIT_EXCEEDED);
+  }
   if (err.statusCode === 403 && message.includes('Upgrade to GitHub Pro')) {
     logger.debug({ path }, 'Endpoint needs paid GitHub plan');
     throw err;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Gracefully handles GitHub secondary rate limiting.

## Context:

Found this in the app.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
