### PR TITLE
refactor(platform): make repoName arg consistent in getJsonFile

### DIFF
--- a/lib/platform/bitbucket-server/index.ts
+++ b/lib/platform/bitbucket-server/index.ts
@@ -123,9 +123,9 @@ export async function getRepos(): Promise<string[]> {
 
 export async function getRawFile(
   fileName: string,
-  repo: string = config.repository
+  repoName: string = config.repository
 ): Promise<string | null> {
-  const [project, slug] = repo.split('/');
+  const [project, slug] = repoName.split('/');
   const fileUrl = `./rest/api/1.0/projects/${project}/repos/${slug}/browse/${fileName}?limit=20000`;
   const res = await bitbucketServerHttp.getJson<FileData>(fileUrl);
   const { isLastPage, lines, size } = res.body;
@@ -139,9 +139,9 @@ export async function getRawFile(
 
 export async function getJsonFile(
   fileName: string,
-  repo: string = config.repository
+  repoName: string = config.repository
 ): Promise<any | null> {
-  const raw = await getRawFile(fileName, repo);
+  const raw = await getRawFile(fileName, repoName);
   if (fileName.endsWith('.json5')) {
     return JSON5.parse(raw);
   }

--- a/lib/platform/bitbucket/index.ts
+++ b/lib/platform/bitbucket/index.ts
@@ -110,20 +110,20 @@ export async function getRepos(): Promise<string[]> {
 
 export async function getRawFile(
   fileName: string,
-  repo: string = config.repository
+  repoName: string = config.repository
 ): Promise<string | null> {
   // See: https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Bworkspace%7D/%7Brepo_slug%7D/src/%7Bcommit%7D/%7Bpath%7D
   const path = fileName;
-  const url = `/2.0/repositories/${repo}/src/HEAD/${path}`;
+  const url = `/2.0/repositories/${repoName}/src/HEAD/${path}`;
   const res = await bitbucketHttp.get(url);
   return res.body;
 }
 
 export async function getJsonFile(
   fileName: string,
-  repo: string = config.repository
+  repoName: string = config.repository
 ): Promise<any | null> {
-  const raw = await getRawFile(fileName, repo);
+  const raw = await getRawFile(fileName, repoName);
   if (fileName.endsWith('.json5')) {
     return JSON5.parse(raw);
   }

--- a/lib/platform/gitea/index.ts
+++ b/lib/platform/gitea/index.ts
@@ -211,17 +211,17 @@ const platform: Platform = {
 
   async getRawFile(
     fileName: string,
-    repo: string = config.repository
+    repoName: string = config.repository
   ): Promise<string | null> {
-    const contents = await helper.getRepoContents(repo, fileName);
+    const contents = await helper.getRepoContents(repoName, fileName);
     return contents.contentString;
   },
 
   async getJsonFile(
     fileName: string,
-    repo: string = config.repository
+    repoName: string = config.repository
   ): Promise<any | null> {
-    const raw = await platform.getRawFile(fileName, repo);
+    const raw = await platform.getRawFile(fileName, repoName);
     if (fileName.endsWith('.json5')) {
       return JSON5.parse(raw);
     }

--- a/lib/platform/github/index.ts
+++ b/lib/platform/github/index.ts
@@ -173,9 +173,9 @@ async function getBranchProtection(
 
 export async function getRawFile(
   fileName: string,
-  repo: string = config.repository
+  repoName: string = config.repository
 ): Promise<string | null> {
-  const url = `repos/${repo}/contents/${fileName}`;
+  const url = `repos/${repoName}/contents/${fileName}`;
   const res = await githubApi.getJson<{ content: string }>(url);
   const buf = res.body.content;
   const str = Buffer.from(buf, 'base64').toString();
@@ -184,9 +184,9 @@ export async function getRawFile(
 
 export async function getJsonFile(
   fileName: string,
-  repo: string = config.repository
+  repoName: string = config.repository
 ): Promise<any | null> {
-  const raw = await getRawFile(fileName, repo);
+  const raw = await getRawFile(fileName, repoName);
   if (fileName.endsWith('.json5')) {
     return JSON5.parse(raw);
   }

--- a/lib/platform/gitlab/index.ts
+++ b/lib/platform/gitlab/index.ts
@@ -157,10 +157,10 @@ function urlEscape(str: string): string {
 
 export async function getRawFile(
   fileName: string,
-  repo: string = config.repository
+  repoName: string = config.repository
 ): Promise<string | null> {
   const escapedFileName = urlEscape(fileName);
-  const url = `projects/${repo}/repository/files/${escapedFileName}?ref=HEAD`;
+  const url = `projects/${repoName}/repository/files/${escapedFileName}?ref=HEAD`;
   const res = await gitlabApi.getJson<{ content: string }>(url);
   const buf = res.body.content;
   const str = Buffer.from(buf, 'base64').toString();
@@ -169,9 +169,9 @@ export async function getRawFile(
 
 export async function getJsonFile(
   fileName: string,
-  repo: string = config.repository
+  repoName: string = config.repository
 ): Promise<any | null> {
-  const raw = await getRawFile(fileName, repo);
+  const raw = await getRawFile(fileName, repoName);
   if (fileName.endsWith('.json5')) {
     return JSON5.parse(raw);
   }

--- a/lib/platform/types.ts
+++ b/lib/platform/types.ts
@@ -152,8 +152,8 @@ export interface Platform {
   getIssueList(): Promise<Issue[]>;
   getIssue?(number: number, useCache?: boolean): Promise<Issue>;
   getVulnerabilityAlerts(): Promise<VulnerabilityAlert[]>;
-  getRawFile(fileName: string, repo?: string): Promise<string | null>;
-  getJsonFile(fileName: string, repo?: string): Promise<any | null>;
+  getRawFile(fileName: string, repoName?: string): Promise<string | null>;
+  getJsonFile(fileName: string, repoName?: string): Promise<any | null>;
   initRepo(config: RepoParams): Promise<RepoResult>;
   getPrList(): Promise<Pr[]>;
   ensureIssueClosing(title: string): Promise<void>;


### PR DESCRIPTION
## Changes:

Rename `repo` -> `repoName` in `getJsonFile()` and `getRawFile()` to make it consistent on all platforms. 

## Context:

Related to Read configuration from the branch(es) in baseBranches #2496 and PR https://github.com/renovatebot/renovate/pull/12710

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
