### PR TITLE
fix(azure): correctly map autoApprove response

### DIFF
--- a/lib/platform/azure/__snapshots__/index.spec.ts.snap
+++ b/lib/platform/azure/__snapshots__/index.spec.ts.snap
@@ -66,12 +66,7 @@ Object {
   "number": 456,
   "pullRequestId": 456,
   "reviewers": Array [
-    Object {
-      "isFlagged": false,
-      "isRequired": false,
-      "reviewerUrl": "user-url",
-      "vote": 10,
-    },
+    "user-url",
   ],
   "sourceBranch": undefined,
   "sourceRefName": undefined,

--- a/lib/platform/azure/__snapshots__/index.spec.ts.snap
+++ b/lib/platform/azure/__snapshots__/index.spec.ts.snap
@@ -65,9 +65,6 @@ Object {
   "displayNumber": "Pull Request #456",
   "number": 456,
   "pullRequestId": 456,
-  "reviewers": Array [
-    "user-url",
-  ],
   "sourceBranch": undefined,
   "sourceRefName": undefined,
   "state": "open",

--- a/lib/platform/azure/index.spec.ts
+++ b/lib/platform/azure/index.spec.ts
@@ -668,15 +668,10 @@ describe('platform/azure/index', () => {
         },
       };
       const prUpdateResult = {
-        ...prResult,
-        reviewers: [
-          {
-            reviewerUrl: prResult.createdBy.url,
-            vote: AzurePrVote.Approved,
-            isFlagged: false,
-            isRequired: false,
-          },
-        ],
+        reviewerUrl: prResult.createdBy.url,
+        vote: AzurePrVote.Approved,
+        isFlagged: false,
+        isRequired: false,
       };
       const updateFn = jest
         .fn(() => prUpdateResult)

--- a/lib/platform/azure/index.ts
+++ b/lib/platform/azure/index.ts
@@ -410,19 +410,17 @@ export async function createPr({
     );
   }
   if (platformOptions?.azureAutoApprove) {
-    pr.reviewers = [
-      await azureApiGit.createPullRequestReviewer(
-        {
-          reviewerUrl: pr.createdBy.url,
-          vote: AzurePrVote.Approved,
-          isFlagged: false,
-          isRequired: false,
-        },
-        config.repoId,
-        pr.pullRequestId,
-        pr.createdBy.id
-      ),
-    ];
+    await azureApiGit.createPullRequestReviewer(
+      {
+        reviewerUrl: pr.createdBy.url,
+        vote: AzurePrVote.Approved,
+        isFlagged: false,
+        isRequired: false,
+      },
+      config.repoId,
+      pr.pullRequestId,
+      pr.createdBy.id
+    );
   }
   await Promise.all(
     labels.map((label) =>

--- a/lib/platform/azure/index.ts
+++ b/lib/platform/azure/index.ts
@@ -410,17 +410,19 @@ export async function createPr({
     );
   }
   if (platformOptions?.azureAutoApprove) {
-    pr = await azureApiGit.createPullRequestReviewer(
-      {
-        reviewerUrl: pr.createdBy.url,
-        vote: AzurePrVote.Approved,
-        isFlagged: false,
-        isRequired: false,
-      },
-      config.repoId,
-      pr.pullRequestId,
-      pr.createdBy.id
-    );
+    pr.reviewers = [
+      await azureApiGit.createPullRequestReviewer(
+        {
+          reviewerUrl: pr.createdBy.url,
+          vote: AzurePrVote.Approved,
+          isFlagged: false,
+          isRequired: false,
+        },
+        config.repoId,
+        pr.pullRequestId,
+        pr.createdBy.id
+      ),
+    ];
   }
   await Promise.all(
     labels.map((label) =>

--- a/lib/platform/azure/util.ts
+++ b/lib/platform/azure/util.ts
@@ -105,8 +105,6 @@ export function getRenovatePRFormat(azurePr: GitPullRequest): AzurePr {
 
   const isConflicted = azurePr.mergeStatus === PullRequestAsyncStatus.Conflicts;
 
-  const reviewers = azurePr.reviewers?.map((reviewer) => reviewer.reviewerUrl);
-
   return {
     ...azurePr,
     sourceBranch,
@@ -118,7 +116,6 @@ export function getRenovatePRFormat(azurePr: GitPullRequest): AzurePr {
     targetBranch,
     createdAt,
     ...(isConflicted && { isConflicted }),
-    ...(reviewers && { reviewers }),
   } as AzurePr;
 }
 

--- a/lib/platform/azure/util.ts
+++ b/lib/platform/azure/util.ts
@@ -105,6 +105,8 @@ export function getRenovatePRFormat(azurePr: GitPullRequest): AzurePr {
 
   const isConflicted = azurePr.mergeStatus === PullRequestAsyncStatus.Conflicts;
 
+  const reviewers = azurePr.reviewers?.map((reviewer) => reviewer.reviewerUrl);
+
   return {
     ...azurePr,
     sourceBranch,
@@ -116,6 +118,7 @@ export function getRenovatePRFormat(azurePr: GitPullRequest): AzurePr {
     targetBranch,
     createdAt,
     ...(isConflicted && { isConflicted }),
+    ...(reviewers && { reviewers }),
   } as AzurePr;
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Currently there is a type mismatch when autoApproving a pull request in Azure. When adding a reviewer with the Azure API, the response type is `IdentityRefWithVote`, see [here](https://github.com/microsoft/azure-devops-node-api/blob/e3daeea0d23b9d011a88b120e53eb4f8aa475542/api/GitApi.ts#L100). However, the `pr` variable which should have type `GitPullRequest` is overriden with the response, which leads to the PR information getting lost.

## Context:

Closes #12303

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->