### PR TITLE
docs: clarify packages.config usage

### DIFF
--- a/docs/usage/nuget.md
+++ b/docs/usage/nuget.md
@@ -9,7 +9,7 @@ Renovate supports upgrading dependencies in `.csproj`, `.fsproj`, and `.vbproj` 
 
 ## Version Support
 
-Only SDK-style `.csproj`/`.fsproj`/`.vbproj`files are currently supported. By default, this includes:
+Only SDK-style `.csproj`/`.fsproj`/`.vbproj` files are currently supported. By default, this includes:
 
 - .NET Core 1.0 and above
 - .NET Standard class libraries
@@ -23,6 +23,8 @@ To convert your .NET Framework `.csproj`/`.fsproj`/`.vbproj` into an SDK-style p
 1. Existing dependencies are extracted from `<PackageReference>` and `<PackageVersion>` tags
 1. Renovate looks up the latest version on [nuget.org](https://nuget.org) (or on [alternate feeds](#Alternate%20feeds)) to determine if any upgrades are available
 1. If the source package includes a GitHub URL as its source, and has either a "changelog" file or uses GitHub releases, then Release Notes for each version are embedded in the generated PR
+
+If your project file references `packages.config` file, no dependencies will be extracted. Find out here how to [migrate from packages.config to PackageReference](https://docs.microsoft.com/en-us/nuget/consume-packages/migrate-packages-config-to-package-reference).
 
 ## Alternate feeds
 


### PR DESCRIPTION


<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Related to #12776 👉 clarify `packages.config` isnt't supported, use PackageReference instead.


## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
