### PR TITLE
feat(cucumber-replacement): added the switch to scoped to the replacements list

### DIFF
--- a/lib/config/presets/internal/replacements.ts
+++ b/lib/config/presets/internal/replacements.ts
@@ -3,7 +3,7 @@ import type { Preset } from '../types';
 export const presets: Record<string, Preset> = {
   all: {
     description: 'All replacements',
-    extends: ['replacements:jade-to-pug'],
+    extends: ['replacements:jade-to-pug', 'replacements:cucumber-to-scoped'],
   },
   'jade-to-pug': {
     description: 'Jade was renamed to Pug',
@@ -13,6 +13,17 @@ export const presets: Record<string, Preset> = {
         matchPackageNames: ['jade'],
         replacementName: 'pug',
         replacementVersion: '2.0.0',
+      },
+    ],
+  },
+  'cucumber-to-scoped': {
+    description: 'cucumber became scoped',
+    packageRules: [
+      {
+        matchDatasources: ['npm'],
+        matchPackageNames: ['cucumber'],
+        replacementName: '@cucumber/cucumber',
+        replacementVersion: '7.0.0',
       },
     ],
   },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

added cucumber switch to scoped version to the replacements list

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

[`cucumber`](https://www.npmjs.com/package/cucumber), under that name, has been deprecated and renamed to [`@cucumber/cucumber'](https://www.npmjs.com/package/cucumber).

v7.0.0 is the first stable [version available after the name change](https://www.npmjs.com/package/@cucumber/cucumber?activeTab=versions)

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
