### PR TITLE
fix(azure): add default branch policy support

### DIFF
--- a/lib/platform/azure/azure-helper.spec.ts
+++ b/lib/platform/azure/azure-helper.spec.ts
@@ -232,8 +232,47 @@ describe('platform/azure/azure-helper', () => {
         GitPullRequestMergeStrategy.Squash
       );
     });
+    it('should return default branch policy', async () => {
+      azureApi.policyApi.mockImplementationOnce(
+        () =>
+          ({
+            getPolicyConfigurations: jest.fn(() => [
+              {
+                settings: {
+                  allowSquash: true,
+                  scope: [
+                    {
+                      repositoryId: 'doo-dee-doo-repository-id',
+                    },
+                  ],
+                },
+                type: {
+                  id: 'fa4e907d-c16b-4a4c-9dfa-4916e5d171ab',
+                },
+              },
+              {
+                settings: {
+                  allowRebase: true,
+                  scope: [
+                    {
+                      matchKind: 'DefaultBranch',
+                    },
+                  ],
+                },
+                type: {
+                  id: 'fa4e907d-c16b-4a4c-9dfa-4916e5d171ab',
+                },
+              },
+            ]),
+          } as any)
+      );
+      expect(await azureHelper.getMergeMethod('', '')).toEqual(
+        GitPullRequestMergeStrategy.Rebase
+      );
+    });
     it('should return most specific exact branch policy', async () => {
       const refMock = 'refs/heads/ding';
+      const defaultBranchMock = 'dong';
       azureApi.policyApi.mockImplementationOnce(
         () =>
           ({
@@ -266,6 +305,19 @@ describe('platform/azure/azure-helper', () => {
               },
               {
                 settings: {
+                  allowSquash: true,
+                  scope: [
+                    {
+                      matchKind: 'DefaultBranch',
+                    },
+                  ],
+                },
+                type: {
+                  id: 'fa4e907d-c16b-4a4c-9dfa-4916e5d171ab',
+                },
+              },
+              {
+                settings: {
                   allowRebase: true,
                   scope: [
                     {
@@ -282,12 +334,13 @@ describe('platform/azure/azure-helper', () => {
             ]),
           } as any)
       );
-      expect(await azureHelper.getMergeMethod('', '', refMock)).toEqual(
-        GitPullRequestMergeStrategy.Rebase
-      );
+      expect(
+        await azureHelper.getMergeMethod('', '', refMock, defaultBranchMock)
+      ).toEqual(GitPullRequestMergeStrategy.Rebase);
     });
     it('should return most specific prefix branch policy', async () => {
       const refMock = 'refs/heads/ding-wow';
+      const defaultBranchMock = 'dong-wow';
       azureApi.policyApi.mockImplementationOnce(
         () =>
           ({
@@ -298,6 +351,19 @@ describe('platform/azure/azure-helper', () => {
                   scope: [
                     {
                       repositoryId: '',
+                    },
+                  ],
+                },
+                type: {
+                  id: 'fa4e907d-c16b-4a4c-9dfa-4916e5d171ab',
+                },
+              },
+              {
+                settings: {
+                  allowSquash: true,
+                  scope: [
+                    {
+                      matchKind: 'DefaultBranch',
                     },
                   ],
                 },
@@ -323,9 +389,9 @@ describe('platform/azure/azure-helper', () => {
             ]),
           } as any)
       );
-      expect(await azureHelper.getMergeMethod('', '', refMock)).toEqual(
-        GitPullRequestMergeStrategy.Rebase
-      );
+      expect(
+        await azureHelper.getMergeMethod('', '', refMock, defaultBranchMock)
+      ).toEqual(GitPullRequestMergeStrategy.Rebase);
     });
   });
 });

--- a/lib/platform/azure/azure-helper.ts
+++ b/lib/platform/azure/azure-helper.ts
@@ -110,14 +110,21 @@ export async function getCommitDetails(
 export async function getMergeMethod(
   repoId: string,
   project: string,
-  branchRef?: string
+  branchRef?: string,
+  defaultBranch?: string
 ): Promise<GitPullRequestMergeStrategy> {
   type Scope = {
     repositoryId: string;
     refName?: string;
-    matchKind: 'Prefix' | 'Exact';
+    matchKind: 'Prefix' | 'Exact' | 'DefaultBranch';
   };
   const isRelevantScope = (scope: Scope): boolean => {
+    if (
+      scope.matchKind === 'DefaultBranch' &&
+      (!branchRef || branchRef === `refs/heads/${defaultBranch}`)
+    ) {
+      return true;
+    }
     if (scope.repositoryId !== repoId) {
       return false;
     }

--- a/lib/platform/azure/index.ts
+++ b/lib/platform/azure/index.ts
@@ -167,7 +167,9 @@ export async function initRepo({
   const names = getProjectAndRepo(repository);
   config.defaultMergeMethod = await azureHelper.getMergeMethod(
     repo.id,
-    names.project
+    names.project,
+    null,
+    defaultBranch
   );
   config.mergeMethods = {};
   config.repoForceRebase = false;
@@ -616,7 +618,8 @@ export async function mergePr({
     (config.mergeMethods[pr.targetRefName] = await azureHelper.getMergeMethod(
       config.repoId,
       config.project,
-      pr.targetRefName
+      pr.targetRefName,
+      config.defaultBranch
     ));
 
   const objToUpdate: GitPullRequest = {


### PR DESCRIPTION
## Changes:

Make it so that `GitPullRequestMergeStrategy` also derives from `[Default Branch]` policies.

## Context:

The problem I'm currently facing is that my renovate PR's will not automatically complete since they use a `GitPullRequestMergeStrategy` that is not allowed on our repositories. This is because we use a default branch policy configured in Azure DevOps. The derivation method does not support this kind of policy.

Closes #12805

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [X] Both unit tests + ran on a real repository
