### PR TITLE
feat: Make this repository available for pre-commit

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+---
+- id: renovate-config-validator
+  name: renovate-config-validator
+  description: "renovatebot: Universal dependency update tool that fits into your workflows."
+  entry: renovate-config-validator
+  language: node
+  files: ^((\.git(hub|lab)/)?renovate\.json5?|\.renovaterc(\.json)?)

--- a/package.json
+++ b/package.json
@@ -109,7 +109,8 @@
     "Sebastian Poxhofer <sebastian@poxhofer.at>",
     "Henry Sachs <henrysachs@gmail.com>",
     "Arkadiusz Kosmala <kosmala.arkadiusz@gmail.com>",
-    "Markus Siebert <mail@markussiebert.com>"
+    "Markus Siebert <mail@markussiebert.com>",
+    "Silvio Knizek <knize@b1-systems.de>"
   ],
   "license": "AGPL-3.0",
   "bugs": {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

A configuration for [pre-commit](https://pre-commit.com/) is added.

Right now this is blocked by https://github.com/renovatebot/renovate/issues/12810.

## Context:

See the discussion at https://github.com/renovatebot/renovate/discussions/10973.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
