### PR TITLE
feat(platform/gitlab): modify getJsonFile to use branchOrTag on GitLab

### DIFF
--- a/lib/platform/gitlab/__snapshots__/index.spec.ts.snap
+++ b/lib/platform/gitlab/__snapshots__/index.spec.ts.snap
@@ -2272,7 +2272,7 @@ Array [
 ]
 `;
 
-exports[`platform/gitlab/index getJsonFile() ingores branchOrTag 1`] = `
+exports[`platform/gitlab/index getJsonFile() returns file content 1`] = `
 Array [
   Object {
     "headers": Object {
@@ -2299,7 +2299,7 @@ Array [
 ]
 `;
 
-exports[`platform/gitlab/index getJsonFile() returns file content 1`] = `
+exports[`platform/gitlab/index getJsonFile() returns file content from branch or tag 1`] = `
 Array [
   Object {
     "headers": Object {
@@ -2321,7 +2321,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/some%2Frepo/repository/files/dir%2Ffile.json?ref=HEAD",
+    "url": "https://gitlab.com/api/v4/projects/some%2Frepo/repository/files/dir%2Ffile.json?ref=dev",
   },
 ]
 `;

--- a/lib/platform/gitlab/index.spec.ts
+++ b/lib/platform/gitlab/index.spec.ts
@@ -2020,12 +2020,12 @@ These updates have all been created already. Click a checkbox below to force a r
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
 
-    it('ingores branchOrTag', async () => {
+    it('returns file content from branch or tag', async () => {
       const data = { foo: 'bar' };
       const scope = await initRepo();
       scope
         .get(
-          '/api/v4/projects/some%2Frepo/repository/files/dir%2Ffile.json?ref=HEAD'
+          '/api/v4/projects/some%2Frepo/repository/files/dir%2Ffile.json?ref=dev'
         )
         .reply(200, {
           content: Buffer.from(JSON.stringify(data)).toString('base64'),

--- a/lib/platform/gitlab/index.ts
+++ b/lib/platform/gitlab/index.ts
@@ -162,7 +162,9 @@ export async function getRawFile(
 ): Promise<string | null> {
   const escapedFileName = urlEscape(fileName);
   const repo = repoName ?? config.repository;
-  const url = `projects/${repo}/repository/files/${escapedFileName}?ref=HEAD`;
+  const url =
+    `projects/${repo}/repository/files/${escapedFileName}?ref=` +
+    (branchOrTag || `HEAD`);
   const res = await gitlabApi.getJson<{ content: string }>(url);
   const buf = res.body.content;
   const str = Buffer.from(buf, 'base64').toString();


### PR DESCRIPTION
## Changes:

modify getJsonFile to use branchOrTag on GitLab

## Context:

Related to #12514 and PR https://github.com/renovatebot/renovate/pull/12514

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
