### PR TITLE
feat(platform/gitea): modify getJsonFile to use branchOrTag on Gitea

### DIFF
--- a/lib/platform/gitea/index.spec.ts
+++ b/lib/platform/gitea/index.spec.ts
@@ -1538,7 +1538,7 @@ describe('platform/gitea/index', () => {
       expect(res).toEqual(data);
     });
 
-    it('ignores branchOrTag', async () => {
+    it('returns file content from branch or tag', async () => {
       const data = { foo: 'bar' };
       helper.getRepoContents.mockResolvedValueOnce({
         contentString: JSON.stringify(data),

--- a/lib/platform/gitea/index.ts
+++ b/lib/platform/gitea/index.ts
@@ -215,7 +215,7 @@ const platform: Platform = {
     branchOrTag?: string
   ): Promise<string | null> {
     const repo = repoName ?? config.repository;
-    const contents = await helper.getRepoContents(repo, fileName);
+    const contents = await helper.getRepoContents(repo, fileName, branchOrTag);
     return contents.contentString;
   },
 


### PR DESCRIPTION
## Changes:

modify getJsonFile to use branchOrTag on Gitea

## Context:

Related to #2496 and PR https://github.com/renovatebot/renovate/pull/12514

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
