### PR TITLE
feat(platform/bitbucket-server): modify getJsonFile to use branchOrTag on Bitbucket server

### DIFF
--- a/lib/platform/bitbucket-server/__snapshots__/index.spec.ts.snap
+++ b/lib/platform/bitbucket-server/__snapshots__/index.spec.ts.snap
@@ -2027,7 +2027,7 @@ Array [
 ]
 `;
 
-exports[`platform/bitbucket-server/index endpoint with no path getJsonFile() ignores branchOrTag argument 1`] = `
+exports[`platform/bitbucket-server/index endpoint with no path getJsonFile() returns file content 1`] = `
 Array [
   Object {
     "headers": Object {
@@ -2068,7 +2068,7 @@ Array [
 ]
 `;
 
-exports[`platform/bitbucket-server/index endpoint with no path getJsonFile() returns file content 1`] = `
+exports[`platform/bitbucket-server/index endpoint with no path getJsonFile() returns file content from branch or tag 1`] = `
 Array [
   Object {
     "headers": Object {
@@ -2104,7 +2104,7 @@ Array [
       "x-atlassian-token": "no-check",
     },
     "method": "GET",
-    "url": "https://stash.renovatebot.com/rest/api/1.0/projects/SOME/repos/repo/browse/file.json?limit=20000",
+    "url": "https://stash.renovatebot.com/rest/api/1.0/projects/SOME/repos/repo/browse/file.json?limit=20000&at=dev",
   },
 ]
 `;
@@ -6525,7 +6525,7 @@ Array [
 ]
 `;
 
-exports[`platform/bitbucket-server/index endpoint with path getJsonFile() ignores branchOrTag argument 1`] = `
+exports[`platform/bitbucket-server/index endpoint with path getJsonFile() returns file content 1`] = `
 Array [
   Object {
     "headers": Object {
@@ -6566,7 +6566,7 @@ Array [
 ]
 `;
 
-exports[`platform/bitbucket-server/index endpoint with path getJsonFile() returns file content 1`] = `
+exports[`platform/bitbucket-server/index endpoint with path getJsonFile() returns file content from branch or tag 1`] = `
 Array [
   Object {
     "headers": Object {
@@ -6602,7 +6602,7 @@ Array [
       "x-atlassian-token": "no-check",
     },
     "method": "GET",
-    "url": "https://stash.renovatebot.com/vcs/rest/api/1.0/projects/SOME/repos/repo/browse/file.json?limit=20000",
+    "url": "https://stash.renovatebot.com/vcs/rest/api/1.0/projects/SOME/repos/repo/browse/file.json?limit=20000&at=dev",
   },
 ]
 `;

--- a/lib/platform/bitbucket-server/index.spec.ts
+++ b/lib/platform/bitbucket-server/index.spec.ts
@@ -2150,12 +2150,12 @@ Followed by some information.
           expect(httpMock.getTrace()).toMatchSnapshot();
         });
 
-        it('ignores branchOrTag argument', async () => {
+        it('returns file content from branch or tag', async () => {
           const data = { foo: 'bar' };
           const scope = await initRepo();
           scope
             .get(
-              `${urlPath}/rest/api/1.0/projects/SOME/repos/repo/browse/file.json?limit=20000`
+              `${urlPath}/rest/api/1.0/projects/SOME/repos/repo/browse/file.json?limit=20000&at=dev`
             )
             .reply(200, {
               isLastPage: true,

--- a/lib/platform/bitbucket-server/index.ts
+++ b/lib/platform/bitbucket-server/index.ts
@@ -128,7 +128,9 @@ export async function getRawFile(
 ): Promise<string | null> {
   const repo = repoName ?? config.repository;
   const [project, slug] = repo.split('/');
-  const fileUrl = `./rest/api/1.0/projects/${project}/repos/${slug}/browse/${fileName}?limit=20000`;
+  const fileUrl =
+    `./rest/api/1.0/projects/${project}/repos/${slug}/browse/${fileName}?limit=20000` +
+    (branchOrTag ? '&at=' + branchOrTag : '');
   const res = await bitbucketServerHttp.getJson<FileData>(fileUrl);
   const { isLastPage, lines, size } = res.body;
   if (isLastPage) {


### PR DESCRIPTION
## Changes:

modify getJsonFile to use branchOrTag on Bitbucket server

## Context:

Related to #2496 and PR https://github.com/renovatebot/renovate/pull/12514

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
