### PR TITLE
fix(gitlab): add missing "waiting_for_resource" branch status

### DIFF
--- a/lib/platform/gitlab/index.ts
+++ b/lib/platform/gitlab/index.ts
@@ -332,6 +332,7 @@ type BranchState =
   | 'pending'
   | 'created'
   | 'running'
+  | 'waiting_for_resource'
   | 'manual'
   | 'success'
   | 'failed'
@@ -372,6 +373,7 @@ const gitlabToRenovateStatusMapping: Record<BranchState, BranchStatus> = {
   created: BranchStatus.yellow,
   manual: BranchStatus.yellow,
   running: BranchStatus.yellow,
+  waiting_for_resource: BranchStatus.yellow,
   success: BranchStatus.green,
   failed: BranchStatus.red,
   canceled: BranchStatus.red,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds the GitLab Pipeline status `waiting_for_resource` (see https://docs.gitlab.com/ee/api/pipelines.html and https://docs.gitlab.com/ee/ci/resource_groups/) in order to map the GitLab pipeline status correctly to `BranchStatus.yellow`.

Therefore, if a pipeline has to wait until a resource group is free, the BranchStatus is marked yellow for renovate.

<!-- Describe what behavior is changed by this PR. -->

## Context:

Previously, the following warning occurred if a pipeline had to wait until the resource group becomes available:

```
DEBUG: getBranchStatus(renovate/digests-pin) (repository=mmichaelb/renovate-test-project)
DEBUG: Got res with 2 results (repository=mmichaelb/renovate-test-project)
WARN: Could not map GitLab check.status to Renovate status (repository=mmichaelb/renovate-test-project)
     "check": {
       "id": 1816816877,
       "sha": "d4ce06814d55b3260ae27cc9725be111ac40d472",
       "ref": "renovate/digests-pin",
       "status": "waiting_for_resource",
       "name": "unit-test-job",
       "target_url": null,
       "description": null,
       "created_at": "2021-11-24T17:29:46.624Z",
       "started_at": null,
       "finished_at": null,
       "allow_failure": false,
       "coverage": null,
       "author": {
         "id": 5899267,
         "name": "Michael B.",
         "username": "mmichaelb",
         "state": "active",
         "avatar_url": "https://secure.gravatar.com/avatar/80d9aa5622a7a8cc27d09946fba91032?s=80&d=identicon",
         "web_url": "https://gitlab.com/mmichaelb"
       }
     }
```

After adding the key-value-pair, the status gets mapped correctly:
```
DEBUG: getBranchStatus(renovate/digests-pin) (repository=mmichaelb/renovate-test-project, branch=renovate/digests-pin)
DEBUG: Got res with 2 results (repository=mmichaelb/renovate-test-project, branch=renovate/digests-pin)
DEBUG: Branch status yellow (repository=mmichaelb/renovate-test-project, branch=renovate/digests-pin)
DEBUG: Branch status is: yellow (repository=mmichaelb/renovate-test-project, branch=renovate/digests-pin)
```


<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
