### PR TITLE
refactor(util/regex): Enable strict null checks

### DIFF
--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -1,6 +1,6 @@
 import is from '@sindresorhus/is';
 import { getLanguageList, getManagerList } from '../manager';
-import { isConfigRegex, parseConfigRegex, regEx } from '../util/regex';
+import { configRegexPredicate, isConfigRegex, regEx } from '../util/regex';
 import * as template from '../util/template';
 import { hasValidSchedule, hasValidTimezone } from '../workers/branch/schedule';
 import { migrateConfig } from './migration';
@@ -214,7 +214,7 @@ export async function validateConfig(
         ['allowedVersions', 'matchCurrentVersion'].includes(key) &&
         isConfigRegex(val)
       ) {
-        if (!parseConfigRegex(val)) {
+        if (!configRegexPredicate(val)) {
           errors.push({
             topic: 'Configuration Error',
             message: `Invalid regExp for ${currentPath}: \`${val}\``,

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -1,6 +1,6 @@
 import is from '@sindresorhus/is';
 import { getLanguageList, getManagerList } from '../manager';
-import { configRegexPredicate, isConfigRegex, regEx } from '../util/regex';
+import { isConfigRegex, parseConfigRegex, regEx } from '../util/regex';
 import * as template from '../util/template';
 import { hasValidSchedule, hasValidTimezone } from '../workers/branch/schedule';
 import { migrateConfig } from './migration';
@@ -214,7 +214,7 @@ export async function validateConfig(
         ['allowedVersions', 'matchCurrentVersion'].includes(key) &&
         isConfigRegex(val)
       ) {
-        if (!configRegexPredicate(val)) {
+        if (!parseConfigRegex(val)) {
           errors.push({
             topic: 'Configuration Error',
             message: `Invalid regExp for ${currentPath}: \`${val}\``,

--- a/lib/util/package-rules.ts
+++ b/lib/util/package-rules.ts
@@ -5,7 +5,7 @@ import { mergeChildConfig } from '../config';
 import type { PackageRule, PackageRuleInputConfig } from '../config/types';
 import { logger } from '../logger';
 import * as allVersioning from '../versioning';
-import { configRegexPredicate, isConfigRegex, regEx } from './regex';
+import { configRegexPredicate, regEx } from './regex';
 
 function matchesRule(
   inputConfig: PackageRuleInputConfig,
@@ -205,9 +205,11 @@ function matchesRule(
   if (matchCurrentVersion) {
     const version = allVersioning.get(versioning);
     const matchCurrentVersionStr = matchCurrentVersion.toString();
-    if (isConfigRegex(matchCurrentVersionStr)) {
-      const matches = configRegexPredicate(matchCurrentVersionStr);
-      if (!unconstrainedValue && !matches(currentValue)) {
+    const matchCurrentVersionPred = configRegexPredicate(
+      matchCurrentVersionStr
+    );
+    if (matchCurrentVersionPred) {
+      if (!unconstrainedValue && !matchCurrentVersionPred(currentValue)) {
         return false;
       }
       positiveMatch = true;

--- a/lib/util/regex.ts
+++ b/lib/util/regex.ts
@@ -22,8 +22,9 @@ try {
 export function regEx(pattern: string | RegExp, flags?: string): RegExp {
   const key = `${pattern.toString()}:${flags}`;
 
-  if (cache.has(key)) {
-    return cache.get(key);
+  const cachedResult = cache.get(key);
+  if (cachedResult) {
+    return cachedResult;
   }
 
   try {
@@ -51,7 +52,7 @@ export function isConfigRegex(input: unknown): input is string {
   );
 }
 
-function parseConfigRegex(input: string): RegExp | null {
+export function parseConfigRegex(input: string): RegExp | null {
   try {
     const regexString = input
       .replace(configValStart, '')
@@ -63,7 +64,7 @@ function parseConfigRegex(input: string): RegExp | null {
   return null;
 }
 
-type ConfigRegexPredicate = (string) => boolean;
+type ConfigRegexPredicate = (s: string) => boolean;
 
 export function configRegexPredicate(input: string): ConfigRegexPredicate {
   const configRegex = parseConfigRegex(input);
@@ -74,5 +75,5 @@ export function configRegexPredicate(input: string): ConfigRegexPredicate {
       return isPositive ? res : !res;
     };
   }
-  return null;
+  return () => false;
 }

--- a/lib/util/regex.ts
+++ b/lib/util/regex.ts
@@ -52,7 +52,7 @@ export function isConfigRegex(input: unknown): input is string {
   );
 }
 
-export function parseConfigRegex(input: string): RegExp | null {
+function parseConfigRegex(input: string): RegExp | null {
   try {
     const regexString = input
       .replace(configValStart, '')
@@ -66,15 +66,18 @@ export function parseConfigRegex(input: string): RegExp | null {
 
 type ConfigRegexPredicate = (s: string) => boolean;
 
-export function configRegexPredicate(input: string): ConfigRegexPredicate {
-  let result = (_: string): boolean => false;
-  const configRegex = parseConfigRegex(input);
-  if (configRegex) {
-    const isPositive = !input.startsWith('!');
-    result = (x: string): boolean => {
-      const res = configRegex.test(x);
-      return isPositive ? res : !res;
-    };
+export function configRegexPredicate(
+  input: string
+): ConfigRegexPredicate | null {
+  if (isConfigRegex(input)) {
+    const configRegex = parseConfigRegex(input);
+    if (configRegex) {
+      const isPositive = !input.startsWith('!');
+      return (x: string): boolean => {
+        const res = configRegex.test(x);
+        return isPositive ? res : !res;
+      };
+    }
   }
-  return result;
+  return null;
 }

--- a/lib/util/regex.ts
+++ b/lib/util/regex.ts
@@ -67,13 +67,14 @@ export function parseConfigRegex(input: string): RegExp | null {
 type ConfigRegexPredicate = (s: string) => boolean;
 
 export function configRegexPredicate(input: string): ConfigRegexPredicate {
+  let result = (_: string): boolean => false;
   const configRegex = parseConfigRegex(input);
   if (configRegex) {
     const isPositive = !input.startsWith('!');
-    return (x: string): boolean => {
+    result = (x: string): boolean => {
       const res = configRegex.test(x);
       return isPositive ? res : !res;
     };
   }
-  return () => false;
+  return result;
 }

--- a/lib/workers/repository/process/lookup/filter.ts
+++ b/lib/workers/repository/process/lookup/filter.ts
@@ -2,7 +2,7 @@ import * as semver from 'semver';
 import { CONFIG_VALIDATION } from '../../../../constants/error-messages';
 import type { Release } from '../../../../datasource/types';
 import { logger } from '../../../../logger';
-import { configRegexPredicate, isConfigRegex } from '../../../../util/regex';
+import { configRegexPredicate } from '../../../../util/regex';
 import type { VersioningApi } from '../../../../versioning';
 import * as npmVersioning from '../../../../versioning/npm';
 import * as pep440 from '../../../../versioning/pep440';
@@ -60,10 +60,10 @@ export function filterVersions(
   }
 
   if (allowedVersions) {
-    if (isConfigRegex(allowedVersions)) {
-      const isAllowed = configRegexPredicate(allowedVersions);
+    const isAllowedPred = configRegexPredicate(allowedVersions);
+    if (isAllowedPred) {
       filteredVersions = filteredVersions.filter(({ version }) =>
-        isAllowed(version)
+        isAllowedPred(version)
       );
     } else if (versioning.isValid(allowedVersions)) {
       filteredVersions = filteredVersions.filter((v) =>

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -127,6 +127,8 @@
     "./lib/util/mask.spec.ts",
     "./lib/util/mask.ts",
     "./lib/util/object.ts",
+    "./lib/util/regex.spec.ts",
+    "./lib/util/regex.ts",
     "./lib/util/sanitize.ts",
     "./lib/util/split.ts",
     "./lib/workers/pr/changelog/hbs-template.ts",


### PR DESCRIPTION
## Changes:

- Fix null errors
- Adjust config validation code

## Context:

- Ref: #7154

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
