### PR TITLE
refactor(config/global): Enable strict null checks

### DIFF
--- a/lib/config/global.ts
+++ b/lib/config/global.ts
@@ -40,10 +40,7 @@ export class GlobalConfig {
 
     const result = { ...config };
     for (const option of GlobalConfig.OPTIONS) {
-      GlobalConfig.config = {
-        ...GlobalConfig.config,
-        [option]: config[option],
-      };
+      GlobalConfig.config[option] = config[option] as never;
       delete result[option];
     }
 

--- a/lib/config/global.ts
+++ b/lib/config/global.ts
@@ -2,7 +2,7 @@ import type { RenovateConfig, RepoGlobalConfig } from './types';
 
 export class GlobalConfig {
   // TODO: once global config work is complete, add a test to make sure this list includes all options with globalOnly=true (#9603)
-  private static readonly OPTIONS = [
+  private static readonly OPTIONS: (keyof RepoGlobalConfig)[] = [
     'allowCustomCrateRegistries',
     'allowedPostUpgradeCommands',
     'allowPlugins',
@@ -40,7 +40,10 @@ export class GlobalConfig {
 
     const result = { ...config };
     for (const option of GlobalConfig.OPTIONS) {
-      GlobalConfig.config[option] = config[option];
+      GlobalConfig.config = {
+        ...GlobalConfig.config,
+        [option]: config[option],
+      };
       delete result[option];
     }
 

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -7,6 +7,7 @@
   },
   "files": [
     "./lib/config/app-strings.ts",
+    "./lib/config/global.ts",
     "./lib/config/migrations/types.ts",
     "./lib/config/presets/common.ts",
     "./lib/constants/error-messages.ts",


### PR DESCRIPTION
## Changes:

- Make `lib/config/global.ts` pass strict null checks

## Context:

- Ref: #7154

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
