### PR TITLE
fix(lookup): currentVersion = lockedVersion

### DIFF
--- a/lib/workers/repository/process/lookup/current.ts
+++ b/lib/workers/repository/process/lookup/current.ts
@@ -11,9 +11,6 @@ export function getCurrentVersion(
   latestVersion: string,
   allVersions: string[]
 ): string | null {
-  if (lockedVersion && is.undefined(currentValue)) {
-    return allVersions.pop();
-  }
   // istanbul ignore if
   if (!is.string(currentValue)) {
     return null;

--- a/lib/workers/repository/process/lookup/filter.ts
+++ b/lib/workers/repository/process/lookup/filter.ts
@@ -29,6 +29,7 @@ export function filterVersions(
     }
     return true;
   }
+  // istanbul ignore if: shouldn't happen
   if (!currentVersion) {
     return [];
   }

--- a/lib/workers/repository/process/lookup/index.spec.ts
+++ b/lib/workers/repository/process/lookup/index.spec.ts
@@ -351,7 +351,7 @@ describe('workers/repository/process/lookup/index', () => {
       expect(res.updates).toMatchInlineSnapshot(`
         Array [
           Object {
-            "bucket": "major",
+            "bucket": "non-major",
             "isLockfileUpdate": true,
             "isRange": true,
             "newMajor": 1,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Uses `lockedVersion` as `currentVersion` in case of `rangeStrategy=update-lockfile`.

## Context:

Currently inaccurate updateTypes when rangeStrategy=update-lockfile

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
