### PR TITLE
refactor: move preCommands out of docker options

### DIFF
--- a/lib/manager/bundler/artifacts.ts
+++ b/lib/manager/bundler/artifacts.ts
@@ -183,8 +183,8 @@ export async function updateArtifacts(
         image: 'ruby',
         tagScheme: 'ruby',
         tagConstraint: await getRubyConstraint(updateArtifact),
-        preCommands,
       },
+      preCommands,
     };
     await exec(cmd, execOptions);
 

--- a/lib/manager/gradle/deep/index.ts
+++ b/lib/manager/gradle/deep/index.ts
@@ -74,8 +74,8 @@ export async function executeGradle(
       tagConstraint:
         config.constraints?.java ?? (await getDockerConstraint(gradleRoot)),
       tagScheme: getJavaVersioning(),
-      preCommands: await getDockerPreCommands(gradleRoot),
     },
+    preCommands: await getDockerPreCommands(gradleRoot),
     extraEnv,
   };
   try {

--- a/lib/manager/mix/artifacts.ts
+++ b/lib/manager/mix/artifacts.ts
@@ -75,8 +75,8 @@ export async function updateArtifacts({
     cwdFile: packageFileName,
     docker: {
       image: 'elixir',
-      preCommands,
     },
+    preCommands,
   };
   const command = [
     'mix',

--- a/lib/manager/npm/post-update/lerna.ts
+++ b/lib/manager/npm/post-update/lerna.ts
@@ -83,8 +83,8 @@ export async function generateLockFiles(
         image: 'node',
         tagScheme: 'node',
         tagConstraint,
-        preCommands,
       },
+      preCommands,
     };
     // istanbul ignore if
     if (GlobalConfig.get('exposeAllEnv')) {

--- a/lib/manager/npm/post-update/npm.ts
+++ b/lib/manager/npm/post-update/npm.ts
@@ -67,8 +67,8 @@ export async function generateLockFile(
         image: 'node',
         tagScheme: 'node',
         tagConstraint,
-        preCommands,
       },
+      preCommands,
     };
     // istanbul ignore if
     if (GlobalConfig.get('exposeAllEnv')) {

--- a/lib/manager/npm/post-update/pnpm.ts
+++ b/lib/manager/npm/post-update/pnpm.ts
@@ -46,8 +46,8 @@ export async function generateLockFile(
         image: 'node',
         tagScheme: 'node',
         tagConstraint,
-        preCommands,
       },
+      preCommands,
     };
     // istanbul ignore if
     if (GlobalConfig.get('exposeAllEnv')) {

--- a/lib/manager/npm/post-update/yarn.ts
+++ b/lib/manager/npm/post-update/yarn.ts
@@ -148,8 +148,8 @@ export async function generateLockFile(
         image: 'node',
         tagScheme: 'node',
         tagConstraint,
-        preCommands,
       },
+      preCommands,
     };
     // istanbul ignore if
     if (GlobalConfig.get('exposeAllEnv')) {

--- a/lib/manager/pip-compile/artifacts.ts
+++ b/lib/manager/pip-compile/artifacts.ts
@@ -67,10 +67,10 @@ export async function updateArtifacts({
         image: 'python',
         tagConstraint,
         tagScheme: 'pep440',
-        preCommands: [
-          `pip install --user ${quote(`pip-tools${pipToolsConstraint}`)}`,
-        ],
       },
+      preCommands: [
+        `pip install --user ${quote(`pip-tools${pipToolsConstraint}`)}`,
+      ],
     };
     logger.debug({ cmd }, 'pip-compile command');
     await exec(cmd, execOptions);

--- a/lib/manager/pip_requirements/artifacts.ts
+++ b/lib/manager/pip_requirements/artifacts.ts
@@ -40,8 +40,8 @@ export async function updateArtifacts({
       docker: {
         image: 'python',
         tagScheme: 'pip_requirements',
-        preCommands: ['pip install hashin'],
       },
+      preCommands: ['pip install hashin'],
     };
     await exec(cmd, execOptions);
     const newContent = await readLocalFile(packageFileName, 'utf8');

--- a/lib/manager/pipenv/artifacts.ts
+++ b/lib/manager/pipenv/artifacts.ts
@@ -103,10 +103,8 @@ export async function updateArtifacts({
         image: 'python',
         tagConstraint,
         tagScheme: 'pep440',
-        preCommands: [
-          `pip install --user ${quote(`pipenv${pipenvConstraint}`)}`,
-        ],
       },
+      preCommands: [`pip install --user ${quote(`pipenv${pipenvConstraint}`)}`],
     };
     logger.debug({ cmd }, 'pipenv lock command');
     await exec(cmd, execOptions);

--- a/lib/manager/poetry/artifacts.ts
+++ b/lib/manager/poetry/artifacts.ts
@@ -139,8 +139,8 @@ export async function updateArtifacts({
         image: 'python',
         tagConstraint,
         tagScheme: 'poetry',
-        preCommands: [poetryInstall],
       },
+      preCommands: [poetryInstall],
     };
     await exec(cmd, execOptions);
     const newPoetryLockContent = await readLocalFile(lockFileName, 'utf8');

--- a/lib/util/exec/common.ts
+++ b/lib/util/exec/common.ts
@@ -20,8 +20,6 @@ export interface DockerOptions {
   volumes?: Opt<VolumeOption[]>;
   envVars?: Opt<Opt<string>[]>;
   cwd?: Opt<string>;
-  preCommands?: DockerExtraCommands;
-  postCommands?: DockerExtraCommands;
 }
 
 export interface RawExecOptions extends ChildProcessExecOptions {

--- a/lib/util/exec/docker/index.spec.ts
+++ b/lib/util/exec/docker/index.spec.ts
@@ -213,8 +213,6 @@ describe('util/exec/docker/index', () => {
     const envVars = ['FOO', 'BAR'];
     const image = 'sample_image';
     const dockerOptions = {
-      preCommands,
-      postCommands,
       image,
       cwd: '/tmp/foobar',
       envVars,
@@ -236,7 +234,12 @@ describe('util/exec/docker/index', () => {
 
     it('returns executable command', async () => {
       mockExecAll(exec);
-      const res = await generateDockerCommand(commands, dockerOptions);
+      const res = await generateDockerCommand(
+        commands,
+        preCommands,
+        postCommands,
+        dockerOptions
+      );
       expect(res).toBe(command(image));
     });
 
@@ -247,10 +250,15 @@ describe('util/exec/docker/index', () => {
         ['/tmp/bar', `/tmp/bar`],
         ['/tmp/baz', `/home/baz`],
       ];
-      const res = await generateDockerCommand(commands, {
-        ...dockerOptions,
-        volumes: [...volumes, ...volumes],
-      });
+      const res = await generateDockerCommand(
+        commands,
+        preCommands,
+        postCommands,
+        {
+          ...dockerOptions,
+          volumes: [...volumes, ...volumes],
+        }
+      );
       expect(res).toBe(
         command(
           image,
@@ -261,10 +269,15 @@ describe('util/exec/docker/index', () => {
 
     it('handles tag parameter', async () => {
       mockExecAll(exec);
-      const res = await generateDockerCommand(commands, {
-        ...dockerOptions,
-        tag: '1.2.3',
-      });
+      const res = await generateDockerCommand(
+        commands,
+        preCommands,
+        postCommands,
+        {
+          ...dockerOptions,
+          tag: '1.2.3',
+        }
+      );
       expect(res).toBe(command(`${image}:1.2.3`));
     });
 
@@ -277,11 +290,16 @@ describe('util/exec/docker/index', () => {
           { version: '2.0.0' },
         ],
       } as never);
-      const res = await generateDockerCommand(commands, {
-        ...dockerOptions,
-        tagScheme: 'npm',
-        tagConstraint: '^1.2.3',
-      });
+      const res = await generateDockerCommand(
+        commands,
+        preCommands,
+        postCommands,
+        {
+          ...dockerOptions,
+          tagScheme: 'npm',
+          tagConstraint: '^1.2.3',
+        }
+      );
       expect(res).toBe(command(`${image}:1.2.4`));
     });
   });

--- a/lib/util/exec/docker/index.spec.ts
+++ b/lib/util/exec/docker/index.spec.ts
@@ -209,7 +209,6 @@ describe('util/exec/docker/index', () => {
   describe('generateDockerCommand', () => {
     const preCommands = [null, 'foo', undefined];
     const commands = ['bar'];
-    const postCommands = [undefined, 'baz', null];
     const envVars = ['FOO', 'BAR'];
     const image = 'sample_image';
     const dockerOptions = {
@@ -237,7 +236,6 @@ describe('util/exec/docker/index', () => {
       const res = await generateDockerCommand(
         commands,
         preCommands,
-        postCommands,
         dockerOptions
       );
       expect(res).toBe(command(image));
@@ -250,15 +248,10 @@ describe('util/exec/docker/index', () => {
         ['/tmp/bar', `/tmp/bar`],
         ['/tmp/baz', `/home/baz`],
       ];
-      const res = await generateDockerCommand(
-        commands,
-        preCommands,
-        postCommands,
-        {
-          ...dockerOptions,
-          volumes: [...volumes, ...volumes],
-        }
-      );
+      const res = await generateDockerCommand(commands, preCommands, {
+        ...dockerOptions,
+        volumes: [...volumes, ...volumes],
+      });
       expect(res).toBe(
         command(
           image,
@@ -269,15 +262,10 @@ describe('util/exec/docker/index', () => {
 
     it('handles tag parameter', async () => {
       mockExecAll(exec);
-      const res = await generateDockerCommand(
-        commands,
-        preCommands,
-        postCommands,
-        {
-          ...dockerOptions,
-          tag: '1.2.3',
-        }
-      );
+      const res = await generateDockerCommand(commands, preCommands, {
+        ...dockerOptions,
+        tag: '1.2.3',
+      });
       expect(res).toBe(command(`${image}:1.2.3`));
     });
 
@@ -290,16 +278,11 @@ describe('util/exec/docker/index', () => {
           { version: '2.0.0' },
         ],
       } as never);
-      const res = await generateDockerCommand(
-        commands,
-        preCommands,
-        postCommands,
-        {
-          ...dockerOptions,
-          tagScheme: 'npm',
-          tagConstraint: '^1.2.3',
-        }
-      );
+      const res = await generateDockerCommand(commands, preCommands, {
+        ...dockerOptions,
+        tagScheme: 'npm',
+        tagConstraint: '^1.2.3',
+      });
       expect(res).toBe(command(`${image}:1.2.4`));
     });
   });

--- a/lib/util/exec/docker/index.spec.ts
+++ b/lib/util/exec/docker/index.spec.ts
@@ -225,7 +225,7 @@ describe('util/exec/docker/index', () => {
       `-e FOO -e BAR ` +
       `-w "/tmp/foobar" ` +
       `renovate/${img} ` +
-      `bash -l -c "foo && bar && baz"`;
+      `bash -l -c "foo && bar"`;
 
     beforeEach(() => {
       GlobalConfig.set({ dockerUser: 'some-user' });

--- a/lib/util/exec/docker/index.ts
+++ b/lib/util/exec/docker/index.ts
@@ -199,13 +199,13 @@ export async function removeDanglingContainers(): Promise<void> {
 
 export async function generateDockerCommand(
   commands: string[],
+  preCommands: string[] = [],
+  postCommands: string[] = [],
   options: DockerOptions
 ): Promise<string> {
   const { envVars, cwd, tagScheme, tagConstraint } = options;
   let image = options.image;
   const volumes = options.volumes || [];
-  const preCommands = options.preCommands || [];
-  const postCommands = options.postCommands || [];
   const {
     localDir,
     cacheDir,

--- a/lib/util/exec/docker/index.ts
+++ b/lib/util/exec/docker/index.ts
@@ -199,8 +199,7 @@ export async function removeDanglingContainers(): Promise<void> {
 
 export async function generateDockerCommand(
   commands: string[],
-  preCommands: string[] = [],
-  postCommands: string[] = [],
+  preCommands: string[],
   options: DockerOptions
 ): Promise<string> {
   const { envVars, cwd, tagScheme, tagConstraint } = options;
@@ -256,11 +255,9 @@ export async function generateDockerCommand(
   await prefetchDockerImage(taggedImage);
   result.push(taggedImage);
 
-  const bashCommand = [
-    ...prepareCommands(preCommands),
-    ...commands,
-    ...prepareCommands(postCommands),
-  ].join(' && ');
+  const bashCommand = [...prepareCommands(preCommands), ...commands].join(
+    ' && '
+  );
   result.push(`bash -l -c "${bashCommand.replace(regEx(/"/g), '\\"')}"`); // lgtm [js/incomplete-sanitization]
 
   return result.join(' ');

--- a/lib/util/exec/index.spec.ts
+++ b/lib/util/exec/index.spec.ts
@@ -464,9 +464,9 @@ describe('util/exec/index', () => {
         inOpts: {
           docker: {
             image,
-            preCommands: ['preCommand1', 'preCommand2', null],
-            postCommands: ['postCommand1', undefined, 'postCommand2'],
           },
+          preCommands: ['preCommand1', 'preCommand2', null],
+          postCommands: ['postCommand1', undefined, 'postCommand2'],
         },
         outCmd: [
           dockerPullCmd,
@@ -496,8 +496,6 @@ describe('util/exec/index', () => {
         inOpts: {
           docker: {
             image,
-            preCommands: null,
-            postCommands: undefined,
           },
         },
         outCmd: [

--- a/lib/util/exec/index.spec.ts
+++ b/lib/util/exec/index.spec.ts
@@ -470,7 +470,7 @@ describe('util/exec/index', () => {
         outCmd: [
           dockerPullCmd,
           dockerRemoveCmd,
-          `docker run --rm --name=${name} --label=renovate_child ${defaultVolumes} -w "${cwd}" ${fullImage} bash -l -c "preCommand1 && preCommand2 && ${inCmd} && postCommand1 && postCommand2"`,
+          `docker run --rm --name=${name} --label=renovate_child ${defaultVolumes} -w "${cwd}" ${fullImage} bash -l -c "preCommand1 && preCommand2 && ${inCmd}"`,
         ],
         outOpts: [
           dockerPullOpts,

--- a/lib/util/exec/index.spec.ts
+++ b/lib/util/exec/index.spec.ts
@@ -466,7 +466,6 @@ describe('util/exec/index', () => {
             image,
           },
           preCommands: ['preCommand1', 'preCommand2', null],
-          postCommands: ['postCommand1', undefined, 'postCommand2'],
         },
         outCmd: [
           dockerPullCmd,

--- a/lib/util/exec/index.ts
+++ b/lib/util/exec/index.ts
@@ -24,7 +24,6 @@ export interface ExecOptions extends ChildProcessExecOptions {
   docker?: Opt<DockerOptions>;
   toolConstraints?: Opt<ToolConstraint[]>;
   preCommands?: DockerExtraCommands;
-  postCommands?: DockerExtraCommands;
 }
 
 function getChildEnv({
@@ -78,7 +77,6 @@ function getRawExecOptions(opts: ExecOptions): RawExecOptions {
   delete execOptions.cwdFile;
   delete execOptions.toolConstraints;
   delete execOptions.preCommands;
-  delete execOptions.postCommands;
 
   const childEnv = getChildEnv(opts);
   const cwd = getCwd(opts);
@@ -137,7 +135,6 @@ async function prepareRawExec(
     const dockerCommand = await generateDockerCommand(
       rawCommands,
       preCommands,
-      opts.postCommands,
       dockerOptions
     );
     rawCommands = [dockerCommand];


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Moves `preCommands` and `postCommands` out of docker options and into exec options.

## Context:

Preparing for binarySource=install

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
