### PR TITLE
refactor: remove unused postCommands

### DIFF
--- a/lib/util/exec/common.ts
+++ b/lib/util/exec/common.ts
@@ -21,7 +21,6 @@ export interface DockerOptions {
   envVars?: Opt<Opt<string>[]>;
   cwd?: Opt<string>;
   preCommands?: DockerExtraCommands;
-  postCommands?: DockerExtraCommands;
 }
 
 export interface RawExecOptions extends ChildProcessExecOptions {

--- a/lib/util/exec/docker/index.spec.ts
+++ b/lib/util/exec/docker/index.spec.ts
@@ -209,12 +209,10 @@ describe('util/exec/docker/index', () => {
   describe('generateDockerCommand', () => {
     const preCommands = [null, 'foo', undefined];
     const commands = ['bar'];
-    const postCommands = [undefined, 'baz', null];
     const envVars = ['FOO', 'BAR'];
     const image = 'sample_image';
     const dockerOptions = {
       preCommands,
-      postCommands,
       image,
       cwd: '/tmp/foobar',
       envVars,

--- a/lib/util/exec/docker/index.spec.ts
+++ b/lib/util/exec/docker/index.spec.ts
@@ -226,7 +226,7 @@ describe('util/exec/docker/index', () => {
       `-e FOO -e BAR ` +
       `-w "/tmp/foobar" ` +
       `renovate/${img} ` +
-      `bash -l -c "foo && bar && baz"`;
+      `bash -l -c "foo && bar"`;
 
     beforeEach(() => {
       GlobalConfig.set({ dockerUser: 'some-user' });

--- a/lib/util/exec/docker/index.ts
+++ b/lib/util/exec/docker/index.ts
@@ -205,7 +205,6 @@ export async function generateDockerCommand(
   let image = options.image;
   const volumes = options.volumes || [];
   const preCommands = options.preCommands || [];
-  const postCommands = options.postCommands || [];
   const {
     localDir,
     cacheDir,
@@ -256,11 +255,9 @@ export async function generateDockerCommand(
   await prefetchDockerImage(taggedImage);
   result.push(taggedImage);
 
-  const bashCommand = [
-    ...prepareCommands(preCommands),
-    ...commands,
-    ...prepareCommands(postCommands),
-  ].join(' && ');
+  const bashCommand = [...prepareCommands(preCommands), ...commands].join(
+    ' && '
+  );
   result.push(`bash -l -c "${bashCommand.replace(regEx(/"/g), '\\"')}"`); // lgtm [js/incomplete-sanitization]
 
   return result.join(' ');

--- a/lib/util/exec/index.spec.ts
+++ b/lib/util/exec/index.spec.ts
@@ -470,7 +470,7 @@ describe('util/exec/index', () => {
         outCmd: [
           dockerPullCmd,
           dockerRemoveCmd,
-          `docker run --rm --name=${name} --label=renovate_child ${defaultVolumes} -w "${cwd}" ${fullImage} bash -l -c "preCommand1 && preCommand2 && ${inCmd} && postCommand1 && postCommand2"`,
+          `docker run --rm --name=${name} --label=renovate_child ${defaultVolumes} -w "${cwd}" ${fullImage} bash -l -c "preCommand1 && preCommand2 && ${inCmd}"`,
         ],
         outOpts: [
           dockerPullOpts,

--- a/lib/util/exec/index.spec.ts
+++ b/lib/util/exec/index.spec.ts
@@ -465,7 +465,6 @@ describe('util/exec/index', () => {
           docker: {
             image,
             preCommands: ['preCommand1', 'preCommand2', null],
-            postCommands: ['postCommand1', undefined, 'postCommand2'],
           },
         },
         outCmd: [
@@ -497,7 +496,6 @@ describe('util/exec/index', () => {
           docker: {
             image,
             preCommands: null,
-            postCommands: undefined,
           },
         },
         outCmd: [


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Removes unused `postCommands`

## Context:

Preparation for binarySource=install

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
