### PR TITLE
refactor(npm): move hash to toolConstraints

### DIFF
--- a/lib/manager/npm/post-update/npm.ts
+++ b/lib/manager/npm/post-update/npm.ts
@@ -28,7 +28,6 @@ export async function generateLockFile(
       toolName: 'npm',
       constraint: config.constraints?.npm,
     };
-    const preCommands = ['hash -d npm'];
     const commands = [];
     let cmdOptions = '';
     if (postUpdateOptions?.includes('npmDedupe') || skipInstalls === false) {
@@ -56,7 +55,6 @@ export async function generateLockFile(
         tagScheme: 'node',
         tagConstraint,
       },
-      preCommands,
     };
     // istanbul ignore if
     if (GlobalConfig.get('exposeAllEnv')) {

--- a/lib/util/exec/buildpack.spec.ts
+++ b/lib/util/exec/buildpack.spec.ts
@@ -95,5 +95,11 @@ describe('util/exec/buildpack', () => {
         ]
       `);
     });
+    it('hashes npm', async () => {
+      const toolConstraints: ToolConstraint[] = [{ toolName: 'npm' }];
+      const res = await generateInstallCommands(toolConstraints);
+      expect(res).toHaveLength(2);
+      expect(res[1]).toBe('hash -d npm');
+    });
   });
 });

--- a/lib/util/exec/buildpack.ts
+++ b/lib/util/exec/buildpack.ts
@@ -73,14 +73,17 @@ export async function resolveConstraint(
 export async function generateInstallCommands(
   toolConstraints: ToolConstraint[]
 ): Promise<string[]> {
+  const hashedTools = ['npm'];
   const installCommands = [];
   if (toolConstraints?.length) {
     for (const toolConstraint of toolConstraints) {
       const toolVersion = await resolveConstraint(toolConstraint);
-      const installCommand = `install-tool ${toolConstraint.toolName} ${quote(
-        toolVersion
-      )}`;
+      const { toolName } = toolConstraint;
+      const installCommand = `install-tool ${toolName} ${quote(toolVersion)}`;
       installCommands.push(installCommand);
+      if (hashedTools.includes(toolName)) {
+        installCommands.push(`hash -d ${toolName}`);
+      }
     }
   }
   return installCommands;

--- a/lib/util/exec/buildpack.ts
+++ b/lib/util/exec/buildpack.ts
@@ -70,10 +70,11 @@ export async function resolveConstraint(
   return latestVersion;
 }
 
+const hashedTools = ['npm'];
+
 export async function generateInstallCommands(
   toolConstraints: ToolConstraint[]
 ): Promise<string[]> {
-  const hashedTools = ['npm'];
   const installCommands = [];
   if (toolConstraints?.length) {
     for (const toolConstraint of toolConstraints) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Moves hash logic into util/exec

## Context:

Better for binarySource=install

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
