### PR TITLE
fix(git): fetch before pull

### DIFF
--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -283,8 +283,8 @@ export async function syncGit(): Promise<void> {
       await git.raw(['remote', 'set-url', 'origin', config.url]);
       await resetToBranch(await getDefaultBranch(git));
       const fetchStart = Date.now();
-      await git.pull();
       await git.fetch();
+      await git.pull();
       config.currentBranch =
         config.currentBranch || (await getDefaultBranch(git));
       await resetToBranch(config.currentBranch);


### PR DESCRIPTION
## Changes:

fetching from the origin should happened before pulling

## Context:

Renovate stuck and does not merge anything for one of the projects
in logs it says follow

```
 INFO: Branch update was rejected because local copy is not up-to-date. (repository=repository_name_here, branch=renovate/patch-spring-cloud-gcp-monorepo)
```
this should help fetching fresh copy of the repo

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
