### PR TITLE
fix(artifactory): assume UTC timezone

### DIFF
--- a/lib/datasource/artifactory/index.ts
+++ b/lib/datasource/artifactory/index.ts
@@ -109,6 +109,6 @@ export class ArtifactoryDatasource extends Datasource {
   }
 
   private static parseReleaseTimestamp(rawText: string): string {
-    return rawText.trim().replace(regEx(/ ?-$/), ''); // TODO #12071
+    return rawText.trim().replace(regEx(/ ?-$/), '') + 'Z'; // TODO #12071
   }
 }

--- a/lib/datasource/artifactory/readme.md
+++ b/lib/datasource/artifactory/readme.md
@@ -3,3 +3,5 @@ Artifactory is the recommended registry for Conan packages.
 This datasource returns releases from given custom `registryUrl`(s).
 
 The target URL is composed by the `registryUrl` and the `lookupName`, which defaults to `depName` when `lookupName` is not defined.
+
+The release timestamp is taken from the date in the directory listing, and is assumed to be in UTC time.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "generate": "run-s generate:*",
     "generate:imports": "node tools/generate-imports.mjs",
     "git-check": "node tools/check-git-version.mjs",
-    "jest": "cross-env NODE_ENV=test LOG_LEVEL=fatal TZ=UTC node --expose-gc node_modules/jest/bin/jest.js --logHeapUsage",
+    "jest": "cross-env NODE_ENV=test LOG_LEVEL=fatal node --expose-gc node_modules/jest/bin/jest.js --logHeapUsage",
     "jest-debug": "cross-env NODE_OPTIONS=--inspect-brk yarn jest --testTimeout=100000000",
     "jest-silent": "cross-env yarn jest --reporters jest-silent-reporter",
     "lint": "run-s ls-lint eslint prettier markdown-lint git-check doc-fence-check",


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds TZ=UTC logic directly to the artifactory datasource and removes it from `yarn jest`.

## Context:

Cleaner tests, more easier to understand.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
