### PR TITLE
fix(npm): allow hash -d to fail

### DIFF
--- a/lib/manager/npm/post-update/lerna.ts
+++ b/lib/manager/npm/post-update/lerna.ts
@@ -58,7 +58,7 @@ export async function generateLockFiles(
       if (validRange(npmCompatibility)) {
         installNpm += `@${quote(npmCompatibility)} || true`;
       }
-      preCommands.push(installNpm, 'hash -d npm');
+      preCommands.push(installNpm, 'hash -d npm 2>/dev/null || true');
       cmdOptions = '--ignore-scripts  --no-audit';
       if (skipInstalls !== false) {
         cmdOptions += ' --package-lock-only';

--- a/lib/util/exec/buildpack.spec.ts
+++ b/lib/util/exec/buildpack.spec.ts
@@ -99,7 +99,7 @@ describe('util/exec/buildpack', () => {
       const toolConstraints: ToolConstraint[] = [{ toolName: 'npm' }];
       const res = await generateInstallCommands(toolConstraints);
       expect(res).toHaveLength(2);
-      expect(res[1]).toBe('hash -d npm');
+      expect(res[1]).toBe('hash -d npm 2>/dev/null || true');
     });
   });
 });

--- a/lib/util/exec/buildpack.ts
+++ b/lib/util/exec/buildpack.ts
@@ -82,7 +82,7 @@ export async function generateInstallCommands(
       const installCommand = `install-tool ${toolName} ${quote(toolVersion)}`;
       installCommands.push(installCommand);
       if (allToolConfig[toolName].hash) {
-        installCommands.push(`hash -d ${toolName}`);
+        installCommands.push(`hash -d ${toolName} 2>/dev/null || true`);
       }
     }
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Swallows `hash -d` errors.

## Context:

Fixes #12958

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
