### PR TITLE
fix(terraform): check for missing version provider blocks

### DIFF
--- a/lib/manager/terraform/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/terraform/__snapshots__/extract.spec.ts.snap
@@ -212,6 +212,7 @@ Object {
       "depType": "provider",
       "lockedVersion": undefined,
       "lookupName": "hashicorp/helm",
+      "skipReason": "no-version",
     },
     Object {
       "currentValue": "V1.9",

--- a/lib/manager/terraform/extract.spec.ts
+++ b/lib/manager/terraform/extract.spec.ts
@@ -36,7 +36,7 @@ describe('manager/terraform/extract', () => {
       const res = await extractPackageFile(tf1, '1.tf', {});
       expect(res).toMatchSnapshot();
       expect(res.deps).toHaveLength(51);
-      expect(res.deps.filter((dep) => dep.skipReason)).toHaveLength(8);
+      expect(res.deps.filter((dep) => dep.skipReason)).toHaveLength(9);
     });
 
     it('returns null if only local deps', async () => {

--- a/lib/manager/terraform/providers.ts
+++ b/lib/manager/terraform/providers.ts
@@ -99,4 +99,8 @@ export function analyzeTerraformProvider(
   massageProviderLookupName(dep);
 
   dep.lockedVersion = getLockedVersion(dep, locks);
+
+  if (!dep.currentValue) {
+    dep.skipReason = SkipReason.NoVersion;
+  }
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:
Add `skipReason.NoVersion` if a provider block does not contain a version after massaging/analyzing 
<!-- Describe what behavior is changed by this PR. -->

## Context:
Closes #12959
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository
https://gitlab.com/secustor/terraform-renovate-bug
<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
