### PR TITLE
chore: add config field to bug report form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -52,6 +52,24 @@ body:
       required: true
 
   - type: textarea
+    id: renovate-configuration
+    attributes:
+      label: Renovate configuration
+      description: |
+        Copy/paste your Renovate configuration file(s) here.
+        Remove secret and private information before posting.
+      value: |
+        <details><summary>Renovate configuration</summary>
+
+        ```
+        Copy/paste your Renovate configuration file(s) here, between the starting and ending backticks.
+        ```
+
+        </details>
+    validations:
+      required: true
+
+  - type: textarea
     id: debug-logs
     attributes:
       label: Relevant debug logs
@@ -64,7 +82,7 @@ body:
         <details><summary>Logs</summary>
 
         ```
-        Copy/paste any log here, between the starting and ending backticks
+        Copy/paste any log here, between the starting and ending backticks.
         ```
 
         </details>

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -67,7 +67,7 @@ body:
 
         </details>
     validations:
-      required: true
+      required: false
 
   - type: textarea
     id: debug-logs


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Add Renovate config field to bug report form
- Add full stop at end of sentence

## Context:

It might be handy to ask for the Renovate configuration in the bug report form?

You can see the preview of the form on my forks branch here: https://github.com/HonkingGoose/renovate/blob/chore/bug-report-form/.github/ISSUE_TEMPLATE/bug_report.yml

Not closing any existing issue with this PR.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
