### PR TITLE
fix: don't semver filter git-refs and git-tags

### DIFF
--- a/lib/datasource/git-refs/index.ts
+++ b/lib/datasource/git-refs/index.ts
@@ -1,6 +1,5 @@
 import { cache } from '../../util/cache/package/decorator';
 import { regEx } from '../../util/regex';
-import * as semver from '../../versioning/semver';
 import { Datasource } from '../datasource';
 import type { DigestConfig, GetReleasesConfig, ReleaseResult } from '../types';
 import { GitDatasource } from './base';
@@ -32,8 +31,7 @@ export class GitRefsDatasource extends Datasource {
 
     const refs = rawRefs
       .filter((ref) => ref.type === 'tags' || ref.type === 'heads')
-      .map((ref) => ref.value)
-      .filter((ref) => semver.isVersion(ref));
+      .map((ref) => ref.value);
 
     const uniqueRefs = [...new Set(refs)];
 

--- a/lib/datasource/git-tags/index.ts
+++ b/lib/datasource/git-tags/index.ts
@@ -1,6 +1,5 @@
 import { cache } from '../../util/cache/package/decorator';
 import { regEx } from '../../util/regex';
-import * as semver from '../../versioning/semver';
 import { Datasource } from '../datasource';
 import { GitDatasource } from '../git-refs/base';
 import type { DigestConfig, GetReleasesConfig, ReleaseResult } from '../types';
@@ -28,7 +27,6 @@ export class GitTagsDatasource extends Datasource {
     }
     const releases = rawRefs
       .filter((ref) => ref.type === 'tags')
-      .filter((ref) => semver.isVersion(ref.value))
       .map((ref) => ({
         version: ref.value,
         gitRef: ref.value,


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Removes datasource semver filtering from git-refs and git-tags.

## Context:

Closes #13034

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
