### PR TITLE
fix(versioning/nuget): sort numerically

### DIFF
--- a/lib/versioning/nuget/index.spec.ts
+++ b/lib/versioning/nuget/index.spec.ts
@@ -64,6 +64,13 @@ describe('versioning/nuget/index', () => {
     ${'2.4.0'}          | ${'2.4.0-beta'}    | ${true}
     ${'2.4.0-alpha'}    | ${'2.4.0'}         | ${false}
     ${'1.2.0-beta.333'} | ${'1.2.0-beta.66'} | ${true}
+    ${'1.2.0-beta2'}    | ${'1.2.0-beta10'}  | ${true}
+    ${'1.2.0.1'}        | ${'1.2.0'}         | ${true}
+    ${'1.2.0.1'}        | ${'1.2.0.1-beta'}  | ${true}
+    ${'1.2.0.1-beta'}   | ${'1.2.0.1'}       | ${false}
+    ${undefined}        | ${'1.2.0'}         | ${true}
+    ${'1.2.0+1'}        | ${'1.2.0'}         | ${false}
+    ${'1.2.0'}          | ${'1.2.0+1'}       | ${false}
   `('isGreaterThan($a, $b) === $expected', ({ a, b, expected }) => {
     expect(nuget.isGreaterThan(a, b)).toBe(expected);
   });

--- a/lib/versioning/nuget/index.spec.ts
+++ b/lib/versioning/nuget/index.spec.ts
@@ -56,13 +56,14 @@ describe('versioning/nuget/index', () => {
   });
 
   test.each`
-    a                | b               | expected
-    ${'2.4.2'}       | ${'2.4.1'}      | ${true}
-    ${'2.4-beta'}    | ${'2.4-alpha'}  | ${true}
-    ${'1.9'}         | ${'2'}          | ${false}
-    ${'1.9'}         | ${'1.9.1'}      | ${false}
-    ${'2.4.0'}       | ${'2.4.0-beta'} | ${true}
-    ${'2.4.0-alpha'} | ${'2.4.0'}      | ${false}
+    a                   | b                  | expected
+    ${'2.4.2'}          | ${'2.4.1'}         | ${true}
+    ${'2.4-beta'}       | ${'2.4-alpha'}     | ${true}
+    ${'1.9'}            | ${'2'}             | ${false}
+    ${'1.9'}            | ${'1.9.1'}         | ${false}
+    ${'2.4.0'}          | ${'2.4.0-beta'}    | ${true}
+    ${'2.4.0-alpha'}    | ${'2.4.0'}         | ${false}
+    ${'1.2.0-beta.333'} | ${'1.2.0-beta.66'} | ${true}
   `('isGreaterThan($a, $b) === $expected', ({ a, b, expected }) => {
     expect(nuget.isGreaterThan(a, b)).toBe(expected);
   });

--- a/lib/versioning/nuget/index.ts
+++ b/lib/versioning/nuget/index.ts
@@ -1,5 +1,6 @@
 import { regEx } from '../../util/regex';
 import * as generic from '../loose/generic';
+import type { GenericVersion } from '../loose/generic';
 import type { VersioningApi } from '../types';
 
 export const id = 'nuget';
@@ -11,7 +12,7 @@ export const supportsRanges = false;
 
 const pattern = regEx(/^(\d+(?:\.\d+)*)(-[^+]+)?(\+.*)?$/);
 
-function parse(version: string): any {
+function parse(version: string): GenericVersion {
   const matches = pattern.exec(version);
   if (!matches) {
     return null;
@@ -38,7 +39,11 @@ function compare(version1: string, version2: string): number {
     }
   }
   // numeric version equals
-  const suffixComparison = parsed1.suffix.localeCompare(parsed2.suffix);
+  const suffixComparison = parsed1.suffix.localeCompare(
+    parsed2.suffix,
+    undefined,
+    { numeric: true }
+  );
   if (suffixComparison !== 0) {
     // Empty suffix should compare greater than non-empty suffix
     if (parsed1.suffix === '') {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:
- try to use semver v2 to compare and fallback to legacy compare
- use `prerelease` instead of `suffix`, simplifies code as it can reuse base code.
<!-- Describe what behavior is changed by this PR. -->

## Context:

- fixes #11769
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
