### PR TITLE
fix(config/presets): wrong `node.js` group

### DIFF
--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -39,7 +39,7 @@ const staticGroups = {
         matchDatasources: ['docker'],
         matchPackageNames: ['node'],
         matchPackagePatterns: ['/node$'],
-        excludePackageNames: ['calico/node'],
+        excludePackageNames: ['calico/node', 'kindest/node'],
         commitMessageTopic: 'Node.js',
       },
     ],


### PR DESCRIPTION
Exclude `kindest/node` from `node.js` group.

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:
 exclude `kindest/node` from `node.js` group
<!-- Describe what behavior is changed by this PR. -->

## Context:
- fixes #13095 
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
