### PR TITLE
fix: issue where helm index.yaml cannot be read

### DIFF
--- a/lib/datasource/helm/common.spec.ts
+++ b/lib/datasource/helm/common.spec.ts
@@ -15,7 +15,7 @@ describe('datasource/helm/common', () => {
       ${'airflow'}  | ${{ sourceUrl: 'https://github.com/bitnami/charts', sourceDirectory: 'bitnami/airflow' }}
       ${'coredns'}  | ${{ sourceUrl: 'https://github.com/coredns/helm', sourceDirectory: undefined }}
       ${'pgadmin4'} | ${{ sourceUrl: 'https://github.com/rowanruseler/helm-charts', sourceDirectory: undefined }}
-      ${'dummy'}    | ${undefined}
+      ${'dummy'}    | ${{}}
     `(
       '$input -> $output',
       ({ input, output }: { input: string; output: string }) => {

--- a/lib/datasource/helm/common.ts
+++ b/lib/datasource/helm/common.ts
@@ -22,7 +22,7 @@ export function findSourceUrl(release: HelmRelease): RepoSource {
   }
 
   if (!release.sources?.length) {
-    return undefined;
+    return {};
   }
 
   for (const url of release.sources) {


### PR DESCRIPTION
## Changes:

Update findSourceUrl to never return "undefined" in the helm datasource

## Context:

The result of this function call is destructured here: https://github.com/renovatebot/renovate/blob/d0d482155dbc8ec6d901105c246fb1542b6a3b00/lib/datasource/helm/index.ts#L65

If the return value is undefiend this causes an error, an empty object satisfies the RepoSource interface and can also be destructured without issue.

fixes #13125

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
