### PR TITLE
feat(managers/gradle): add support for plugin short syntax in gradle TOML catalogs

### DIFF
--- a/lib/manager/gradle/shallow/__fixtures__/2/libs.versions.toml
+++ b/lib/manager/gradle/shallow/__fixtures__/2/libs.versions.toml
@@ -14,3 +14,4 @@ google-firebase-messaging = "com.google.firebase:firebase-messaging"
 [plugins]
 kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version = "1.5.21" }
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+multiJvm = "org.danilopianini.multi-jvm-test-plugin:0.3.0"

--- a/lib/manager/gradle/shallow/extract.spec.ts
+++ b/lib/manager/gradle/shallow/extract.spec.ts
@@ -382,6 +382,22 @@ describe('manager/gradle/shallow/extract', () => {
               'https://plugins.gradle.org/m2/',
             ],
           },
+          {
+            depName: 'org.danilopianini.multi-jvm-test-plugin',
+            depType: 'plugin',
+            currentValue: '0.3.0',
+            commitMessageTopic: 'plugin multiJvm',
+            lookupName:
+              'org.danilopianini.multi-jvm-test-plugin:org.danilopianini.multi-jvm-test-plugin.gradle.plugin',
+            managerData: {
+              fileReplacePosition: 21,
+              packageFile: 'gradle/libs.versions.toml',
+            },
+            registryUrls: [
+              'https://repo.maven.apache.org/maven2',
+              'https://plugins.gradle.org/m2/',
+            ],
+          },
         ],
       },
     ]);

--- a/lib/manager/gradle/shallow/extract.spec.ts
+++ b/lib/manager/gradle/shallow/extract.spec.ts
@@ -390,7 +390,7 @@ describe('manager/gradle/shallow/extract', () => {
             lookupName:
               'org.danilopianini.multi-jvm-test-plugin:org.danilopianini.multi-jvm-test-plugin.gradle.plugin',
             managerData: {
-              fileReplacePosition: 21,
+              fileReplacePosition: 822,
               packageFile: 'gradle/libs.versions.toml',
             },
             registryUrls: [

--- a/lib/manager/gradle/shallow/extract/catalog.ts
+++ b/lib/manager/gradle/shallow/extract/catalog.ts
@@ -168,9 +168,13 @@ export function parseCatalog(
   const pluginsSubContent = content.slice(pluginsStartIndex);
   for (const pluginName of Object.keys(plugins)) {
     const pluginDescriptor = plugins[pluginName];
-    const depName = pluginDescriptor.id;
+    const [depName, version] =
+      typeof pluginDescriptor === 'string'
+        ? pluginDescriptor.split(':')
+        : [pluginDescriptor.id, pluginDescriptor.version];
+    // const depName = pluginDescriptor.id;
     const { currentValue, fileReplacePosition } = extractVersion({
-      version: pluginDescriptor.version,
+      version: version,
       versions,
       depStartIndex: pluginsStartIndex,
       depSubContent: pluginsSubContent,

--- a/lib/manager/gradle/shallow/extract/catalog.ts
+++ b/lib/manager/gradle/shallow/extract/catalog.ts
@@ -172,7 +172,6 @@ export function parseCatalog(
       typeof pluginDescriptor === 'string'
         ? pluginDescriptor.split(':')
         : [pluginDescriptor.id, pluginDescriptor.version];
-    // const depName = pluginDescriptor.id;
     const { currentValue, fileReplacePosition } = extractVersion({
       version: version,
       versions,

--- a/lib/manager/gradle/shallow/extract/catalog.ts
+++ b/lib/manager/gradle/shallow/extract/catalog.ts
@@ -173,7 +173,7 @@ export function parseCatalog(
         ? pluginDescriptor.split(':')
         : [pluginDescriptor.id, pluginDescriptor.version];
     const { currentValue, fileReplacePosition } = extractVersion({
-      version: version,
+      version,
       versions,
       depStartIndex: pluginsStartIndex,
       depSubContent: pluginsSubContent,

--- a/lib/manager/gradle/shallow/types.ts
+++ b/lib/manager/gradle/shallow/types.ts
@@ -68,7 +68,7 @@ export interface GradleCatalog {
     string,
     GradleCatalogModuleDescriptor | GradleCatalogArtifactDescriptor | string
   >;
-  plugins?: Record<string, GradleCatalogPluginDescriptor>;
+  plugins?: Record<string, GradleCatalogPluginDescriptor | string>;
 }
 
 export interface GradleCatalogModuleDescriptor {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

This PR adds support for plugin entries in the Gradle catalog using the short string-form syntax, see #13146.

## Context:

- fixes #13146

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [X] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
