### PR TITLE
fix(go): Mimic Go logic for `GOPRIVATE` parsing

### DIFF
--- a/lib/datasource/go/releases-goproxy.spec.ts
+++ b/lib/datasource/go/releases-goproxy.spec.ts
@@ -98,22 +98,31 @@ describe('datasource/go/releases-goproxy', () => {
       expect(parseNoproxy(undefined)).toBeNull();
       expect(parseNoproxy(null)).toBeNull();
       expect(parseNoproxy('')).toBeNull();
-      expect(parseNoproxy('*')?.source).toBe('^(?:[^\\/]*)$');
-      expect(parseNoproxy('?')?.source).toBe('^(?:[^\\/])$');
-      expect(parseNoproxy('foo')?.source).toBe('^(?:foo)$');
-      expect(parseNoproxy('\\f\\o\\o')?.source).toBe('^(?:foo)$');
-      expect(parseNoproxy('foo,bar')?.source).toBe('^(?:foo|bar)$');
-      expect(parseNoproxy('[abc]')?.source).toBe('^(?:[abc])$');
-      expect(parseNoproxy('[a-c]')?.source).toBe('^(?:[a-c])$');
-      expect(parseNoproxy('[\\a-\\c]')?.source).toBe('^(?:[a-c])$');
-      expect(parseNoproxy('a.b.c')?.source).toBe('^(?:a\\.b\\.c)$');
+      expect(parseNoproxy('/')).toBeNull();
+      expect(parseNoproxy('*')?.source).toBe('^(?:[^\\/]*)(?:\\/.*)?$');
+      expect(parseNoproxy('?')?.source).toBe('^(?:[^\\/])(?:\\/.*)?$');
+      expect(parseNoproxy('foo')?.source).toBe('^(?:foo)(?:\\/.*)?$');
+      expect(parseNoproxy('\\f\\o\\o')?.source).toBe('^(?:foo)(?:\\/.*)?$');
+      expect(parseNoproxy('foo,bar')?.source).toBe('^(?:foo|bar)(?:\\/.*)?$');
+      expect(parseNoproxy('[abc]')?.source).toBe('^(?:[abc])(?:\\/.*)?$');
+      expect(parseNoproxy('[a-c]')?.source).toBe('^(?:[a-c])(?:\\/.*)?$');
+      expect(parseNoproxy('[\\a-\\c]')?.source).toBe('^(?:[a-c])(?:\\/.*)?$');
+      expect(parseNoproxy('a.b.c')?.source).toBe('^(?:a\\.b\\.c)(?:\\/.*)?$');
+      expect(parseNoproxy('trailing/')?.source).toBe(
+        '^(?:trailing)(?:\\/.*)?$'
+      );
     });
 
     it('matches on real package prefixes', () => {
+      expect(parseNoproxy('ex.co').test('ex.co/foo')).toBeTrue();
+      expect(parseNoproxy('ex.co/').test('ex.co/foo')).toBeTrue();
+      expect(parseNoproxy('ex.co/foo/bar').test('ex.co/foo/bar')).toBeTrue();
       expect(parseNoproxy('ex.co/foo/bar').test('ex.co/foo/bar')).toBeTrue();
       expect(parseNoproxy('*/foo/*').test('example.com/foo/bar')).toBeTrue();
       expect(parseNoproxy('ex.co/foo/*').test('ex.co/foo/bar')).toBeTrue();
       expect(parseNoproxy('ex.co/foo/*').test('ex.co/foo/baz')).toBeTrue();
+      expect(parseNoproxy('ex.co').test('ex.co/foo/v2')).toBeTrue();
+
       expect(
         parseNoproxy('ex.co/foo/bar,ex.co/foo/baz').test('ex.co/foo/bar')
       ).toBeTrue();
@@ -123,14 +132,44 @@ describe('datasource/go/releases-goproxy', () => {
       expect(
         parseNoproxy('ex.co/foo/bar,ex.co/foo/baz').test('ex.co/foo/qux')
       ).toBeFalse();
-    });
 
-    it('Matches from start to end', () => {
-      expect(parseNoproxy('x').test('x/aba')).toBeFalse();
+      expect(parseNoproxy('ex').test('ex.co/foo')).toBeFalse();
+
       expect(parseNoproxy('aba').test('x/aba')).toBeFalse();
       expect(parseNoproxy('x/b').test('x/aba')).toBeFalse();
       expect(parseNoproxy('x/ab').test('x/aba')).toBeFalse();
       expect(parseNoproxy('x/ab[a-b]').test('x/aba')).toBeTrue();
+    });
+
+    it('matches on wildcards', () => {
+      expect(parseNoproxy('/*/').test('ex.co/foo')).toBeFalse();
+      expect(parseNoproxy('*/foo').test('ex.co/foo')).toBeTrue();
+      expect(parseNoproxy('*/fo').test('ex.co/foo')).toBeFalse();
+      expect(parseNoproxy('*/fo?').test('ex.co/foo')).toBeTrue();
+      expect(parseNoproxy('*/fo*').test('ex.co/foo')).toBeTrue();
+      expect(parseNoproxy('*fo*').test('ex.co/foo')).toBeFalse();
+
+      expect(parseNoproxy('*.co').test('ex.co/foo')).toBeTrue();
+      expect(parseNoproxy('ex*').test('ex.co/foo')).toBeTrue();
+      expect(parseNoproxy('*/foo').test('ex.co/foo/v2')).toBeTrue();
+      expect(parseNoproxy('*/foo/').test('ex.co/foo/v2')).toBeTrue();
+      expect(parseNoproxy('*/foo/*').test('ex.co/foo/v2')).toBeTrue();
+      expect(parseNoproxy('*/foo/*/').test('ex.co/foo/v2')).toBeTrue();
+      expect(parseNoproxy('*/v2').test('ex.co/foo/v2')).toBeFalse();
+      expect(parseNoproxy('*/*/v2').test('ex.co/foo/v2')).toBeTrue();
+      expect(parseNoproxy('*/*/*').test('ex.co/foo/v2')).toBeTrue();
+      expect(parseNoproxy('*/*/*/').test('ex.co/foo/v2')).toBeTrue();
+      expect(parseNoproxy('*/*/*').test('ex.co/foo')).toBeFalse();
+      expect(parseNoproxy('*/*/*/').test('ex.co/foo')).toBeFalse();
+
+      expect(parseNoproxy('*/*/*,,').test('ex.co/repo')).toBeFalse();
+      expect(parseNoproxy('*/*/*,,*/repo').test('ex.co/repo')).toBeTrue();
+      expect(parseNoproxy(',,*/repo').test('ex.co/repo')).toBeTrue();
+    });
+
+    it('matches on character ranges', () => {
+      expect(parseNoproxy('x/ab[a-b]').test('x/aba')).toBeTrue();
+      expect(parseNoproxy('x/ab[a-b]').test('x/abc')).toBeFalse();
     });
   });
 

--- a/lib/datasource/go/releases-goproxy.ts
+++ b/lib/datasource/go/releases-goproxy.ts
@@ -72,6 +72,10 @@ const lexer = moo.states({
       push: 'characterRange',
       value: (_: string) => '[',
     },
+    trailingSlash: {
+      match: /\/$/,
+      value: (_: string) => '',
+    },
     char: {
       match: /[^*?\\[\n]/,
       value: (s: string) => s.replace(regEx('\\.', 'g'), '\\.'),
@@ -107,7 +111,9 @@ export function parseNoproxy(
   }
   lexer.reset(input);
   const noproxyPattern = [...lexer].map(({ value }) => value).join('');
-  const result = noproxyPattern ? regEx(`^(?:${noproxyPattern})$`) : null;
+  const result = noproxyPattern
+    ? regEx(`^(?:${noproxyPattern})(?:/.*)?$`)
+    : null;
   parsedNoproxy[input] = result;
   return result;
 }


### PR DESCRIPTION


<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->
Ensure that the parsing of `GOPRIVATE`/`GONOPROXY` matches the behaviour of Go itself.

The documentation for these values state it matches the logic of `path.Match`, however in reality it's actually a prefix based match.

Updating the regex to allow for either an exact match, or a match where the configured value is a prefix of the package, when a `/` is added.

Additionally, strip any trailing `/`'s from the configured value, as this matches the logic that Go takes when matching.

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->
Closes #13138


## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
