### PR TITLE
feat(composer): support composer platform package constraint

### DIFF
--- a/lib/manager/composer/utils.spec.ts
+++ b/lib/manager/composer/utils.spec.ts
@@ -27,6 +27,18 @@ describe('manager/composer/utils', () => {
       ).toEqual({ composer: '1.1.0' });
     });
 
+    it('returns from composer platform require', () => {
+      expect(
+        extractContraints({ require: { php: '^8.1', composer: '2.2.0' } }, {})
+      ).toEqual({ php: '^8.1', composer: '2.2.0' });
+    });
+
+    it('returns from composer platform require-dev', () => {
+      expect(
+        extractContraints({ 'require-dev': { composer: '^2.2' } }, {})
+      ).toEqual({ composer: '^2.2' });
+    });
+
     it('returns from composer-runtime-api', () => {
       expect(
         extractContraints({ require: { 'composer-runtime-api': '^1.1.0' } }, {})

--- a/lib/manager/composer/utils.ts
+++ b/lib/manager/composer/utils.ts
@@ -71,6 +71,12 @@ export function extractContraints(
   } else if (composerJson['require-dev']?.['composer/composer']) {
     res.composer = composerJson['require-dev']?.['composer/composer'];
   }
+  // composer platform package
+  else if (composerJson.require?.['composer']) {
+    res.composer = composerJson.require?.['composer'];
+  } else if (composerJson['require-dev']?.['composer']) {
+    res.composer = composerJson['require-dev']?.['composer'];
+  }
   // check last used composer version
   else if (lockParsed?.['plugin-api-version']) {
     const major = api.getMajor(lockParsed?.['plugin-api-version']);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->
Adds support for the composer platform package for constraint extraction. This platform package is going to be available with Composer 2.2, see https://getcomposer.org/doc/articles/composer-platform-dependencies.md#composer-package-composer

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->
https://github.com/renovatebot/renovate/pull/13154#discussion_r771826058

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
