### PR TITLE
refactor: simplify lockfile-update logic

### DIFF
--- a/lib/workers/branch/get-updated.spec.ts
+++ b/lib/workers/branch/get-updated.spec.ts
@@ -157,6 +157,7 @@ describe('workers/branch/get-updated', () => {
     it('handles isRemediation success', async () => {
       config.upgrades.push({
         manager: 'npm',
+        lockFile: 'package-lock.json',
         isRemediation: true,
       } as never);
       npm.updateLockedDependency.mockResolvedValueOnce({

--- a/lib/workers/branch/get-updated.spec.ts
+++ b/lib/workers/branch/get-updated.spec.ts
@@ -245,9 +245,8 @@ describe('workers/branch/get-updated', () => {
         packageFile: 'composer.json',
         manager: 'composer',
         branchName: undefined,
-        rangeStrategy: 'update-lockfile',
+        isLockfileUpdate: true,
       });
-      autoReplace.doAutoReplace.mockResolvedValueOnce('existing content');
       composer.updateArtifacts.mockResolvedValueOnce([
         {
           file: {

--- a/lib/workers/branch/get-updated.ts
+++ b/lib/workers/branch/get-updated.ts
@@ -92,6 +92,8 @@ export async function getUpdatedPackageFiles(
       if (files) {
         updatedFileContents = { ...updatedFileContents, ...files };
       }
+    } else if (upgrade.isLockfileUpdate) {
+      nonUpdatedFileContents[packageFile] = packageFileContent;
     } else {
       const bumpPackageVersion = get(manager, 'bumpPackageVersion');
       const updateDependency = get(manager, 'updateDependency');
@@ -112,10 +114,6 @@ export async function getUpdatedPackageFiles(
           }
           if (res === packageFileContent) {
             logger.debug({ packageFile, depName }, 'No content changed');
-            if (upgrade.rangeStrategy === 'update-lockfile') {
-              logger.debug({ packageFile, depName }, 'update-lockfile add');
-              nonUpdatedFileContents[packageFile] = res;
-            }
           } else {
             logger.debug({ packageFile, depName }, 'Contents updated');
             updatedFileContents[packageFile] = res;
@@ -178,8 +176,6 @@ export async function getUpdatedPackageFiles(
         // istanbul ignore else
         if (upgrade.manager === 'git-submodules') {
           updatedFileContents[packageFile] = newContent;
-        } else if (upgrade.rangeStrategy === 'update-lockfile') {
-          nonUpdatedFileContents[packageFile] = newContent;
         }
       }
     }

--- a/lib/workers/branch/get-updated.ts
+++ b/lib/workers/branch/get-updated.ts
@@ -30,6 +30,7 @@ export async function getUpdatedPackageFiles(
   const lockFileMaintenanceFiles = [];
   for (const upgrade of config.upgrades) {
     const { manager, packageFile, lockFile, depName } = upgrade;
+    const updateLockedDependency = get(manager, 'updateLockedDependency');
     packageFileManagers[packageFile] = manager;
     packageFileUpdatedDeps[packageFile] =
       packageFileUpdatedDeps[packageFile] || [];
@@ -41,8 +42,21 @@ export async function getUpdatedPackageFiles(
         reuseExistingBranch ? config.branchName : config.baseBranch
       );
     }
+    let lockFileContent: string;
+    if (lockFile) {
+      lockFileContent = updatedFileContents[lockFile];
+      if (!lockFileContent) {
+        lockFileContent = await getFile(
+          lockFile,
+          reuseExistingBranch ? config.branchName : config.baseBranch
+        );
+      }
+    }
     // istanbul ignore if
-    if (reuseExistingBranch && !packageFileContent) {
+    if (
+      reuseExistingBranch &&
+      (!packageFileContent || (lockFile && !lockFileContent))
+    ) {
       logger.debug(
         { packageFile, depName },
         'Rebasing branch after file not found'
@@ -55,25 +69,6 @@ export async function getUpdatedPackageFiles(
     if (upgrade.updateType === 'lockFileMaintenance') {
       lockFileMaintenanceFiles.push(packageFile);
     } else if (upgrade.isRemediation) {
-      let lockFileContent = updatedFileContents[lockFile];
-      if (!lockFileContent) {
-        lockFileContent = await getFile(
-          lockFile,
-          reuseExistingBranch ? config.branchName : config.baseBranch
-        );
-      }
-      // istanbul ignore if: to hard to test
-      if (reuseExistingBranch && !lockFileContent) {
-        logger.debug(
-          { lockFile, depName },
-          'Rebasing branch after lock file not found'
-        );
-        return getUpdatedPackageFiles({
-          ...config,
-          reuseExistingBranch: false,
-        });
-      }
-      const updateLockedDependency = get(manager, 'updateLockedDependency');
       const { status, files } = await updateLockedDependency({
         ...upgrade,
         packageFileContent,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Simplifies lock file update handling in branch worker

## Context:

None

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
