### PR TITLE
docs(self-hosted experimental): monospace variable names

### DIFF
--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -14,33 +14,33 @@ We do not follow Semantic Versioning for any experimental variables.
 These variables may be removed or have their behavior changed in **any** version.
 We will try to keep breakage to a minimum, but make no guarantees that an experimental variable will keep working.
 
-## RENOVATE_CACHE_NPM_MINUTES
+## `RENOVATE_CACHE_NPM_MINUTES`
 
 If set to any integer, Renovate will use this integer instead of the default npm cache time (15 minutes) for the npm datasource.
 
-## RENOVATE_EXPERIMENTAL_NO_MAVEN_POM_CHECK
+## `RENOVATE_EXPERIMENTAL_NO_MAVEN_POM_CHECK`
 
 If set to any value, Renovate will skip its default artifacts filter check in the Maven datasource.
 Skipping the check will speed things up, but may result in versions being returned which don't properly exist on the server.
 
-## RENOVATE_PAGINATE_ALL
+## `RENOVATE_PAGINATE_ALL`
 
 If set to any value, Renovate will always paginate requests to GitHub fully, instead of stopping after 10 pages.
 
-## RENOVATE_REUSE_PACKAGE_LOCK
+## `RENOVATE_REUSE_PACKAGE_LOCK`
 
 If set to "false" (string), Renovate will remove any existing `package-lock.json` before attempting to update it.
 
-## RENOVATE_USER_AGENT
+## `RENOVATE_USER_AGENT`
 
 If set to any string, Renovate will use this as the `user-agent` it sends with HTTP requests.
 
-## RENOVATE_X_HARD_EXIT
+## `RENOVATE_X_HARD_EXIT`
 
 If set to any value, Renovate will use a "hard" `process.exit()` once all work is done, even if a sub-process is otherwise delaying Node.js from exiting.
 See <https://github.com/renovatebot/renovate/issues/8660> for background on why this was created.
 
-## RENOVATE_X_PLATFORM_VERSION
+## `RENOVATE_X_PLATFORM_VERSION`
 
 If set, Renovate will use this string as GitLab server version instead of checking via the GitLab API.
 This can be useful when you use the GitLab `CI_JOB_TOKEN` to authenticate Renovate.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Use monospace font for experimental variable names

## Context:

Driveby PR, not closing any existing issue.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
