### PR TITLE
docs(readme): add replacement PR feature to list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,12 +13,12 @@ Multi-platform and multi-language.
 ## Why Use Renovate?
 
 - Receive automated Pull Requests whenever dependencies need updating
-- Get replacement PRs to migrate from a deprecated dependency to the community suggested replacement (npm packages only)
 - Define schedules to avoid unnecessary noise in projects (e.g. for weekends or outside of working hours, or weekly updates, etc.)
 - Relevant package files are discovered automatically (e.g. supports monorepo architecture such as Lerna or Yarn workspaces without further configuration)
 - Bot behavior is extremely customizable via configuration files (config as code)
 - Use ESLint-like shared config presets for ease of use and simplifying configuration (JSON format only)
 - Lock files are natively supported and updated in the same commit, including immediately resolving conflicts whenever PRs are merged
+- Get replacement PRs to migrate from a deprecated dependency to the community suggested replacement (npm packages only)
 - Supports GitHub (.com and Enterprise), GitLab (.com and CE/EE), Bitbucket Cloud, Bitbucket Server, Azure DevOps and Gitea.
 - Open source (installable via npm/Yarn or Docker Hub) so can be self-hosted or used via GitHub App
 

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,7 @@ Multi-platform and multi-language.
 ## Why Use Renovate?
 
 - Receive automated Pull Requests whenever dependencies need updating
+- Get replacement PRs to migrate from a deprecated dependency to the community suggested replacement (npm packages only)
 - Define schedules to avoid unnecessary noise in projects (e.g. for weekends or outside of working hours, or weekly updates, etc.)
 - Relevant package files are discovered automatically (e.g. supports monorepo architecture such as Lerna or Yarn workspaces without further configuration)
 - Bot behavior is extremely customizable via configuration files (config as code)


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Add the replacement PR feature to our list of "selling points" for Renovate

## Context:

PR #5558 landed a major new feature: "replacement PRs for deprecated dependencies". 🥳 
I think this cool feature should be mentioned in our `README.md` file so that more people know about it, even if it's "just" for npm packages right now.

Mentioning this feature in our readme might also help get more contributions to the replacement presets, so that Renovate bot can help with more deprecated package updates.

Not closing any existing issue with this PR.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
