### PR TITLE
feat(npm): efficient update-lockfile branch reuse

### DIFF
--- a/lib/manager/npm/post-update/index.ts
+++ b/lib/manager/npm/post-update/index.ts
@@ -478,6 +478,14 @@ export async function getAdditionalFiles(
     logger.debug('Skipping lock file generation for remediations');
     return { artifactErrors, updatedArtifacts };
   }
+  if (
+    config.reuseExistingBranch &&
+    !config.updatedPackageFiles?.length &&
+    config.upgrades?.every((upgrade) => upgrade.isLockfileUpdate)
+  ) {
+    logger.debug('Existing branch contains all necessary lock file updates');
+    return { artifactErrors, updatedArtifacts };
+  }
   logger.debug('Getting updated lock files');
   if (
     config.updateType === 'lockFileMaintenance' &&

--- a/lib/manager/npm/update/locked-dependency/index.spec.ts
+++ b/lib/manager/npm/update/locked-dependency/index.spec.ts
@@ -142,5 +142,13 @@ describe('manager/npm/update/locked-dependency/index', () => {
       expect(packageLock.dependencies.express.version).toBe('4.16.0');
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
+    it('fails remediation if cannot update parent', async () => {
+      config.depName = 'mime';
+      config.currentVersion = '1.2.11';
+      config.newVersion = '1.4.1';
+      config.allowParentUpdates = false;
+      const res = await updateLockedDependency(config);
+      expect(res.status).toBe('update-failed');
+    });
   });
 });

--- a/lib/manager/npm/update/locked-dependency/package-lock/index.ts
+++ b/lib/manager/npm/update/locked-dependency/package-lock/index.ts
@@ -21,6 +21,7 @@ export async function updateLockedDependency(
     packageFileContent,
     lockFile,
     lockFileContent,
+    allowParentUpdates = true,
   } = config;
   logger.debug(
     `npm.updateLockedDependency: ${depName}@${currentVersion} -> ${newVersion} [${lockFile}]`
@@ -107,6 +108,12 @@ export async function updateLockedDependency(
           }`
         );
       } else if (parentDepName && parentVersion) {
+        if (!allowParentUpdates) {
+          logger.debug(
+            `Cannot update ${depName} to ${newVersion} without an update to ${parentDepName}`
+          );
+          return { status: 'update-failed' };
+        }
         // Parent dependency needs updating too
         const parentNewVersion = await findFirstParentVersion(
           parentDepName,

--- a/lib/manager/types.ts
+++ b/lib/manager/types.ts
@@ -228,10 +228,12 @@ export interface UpdateLockedConfig {
   depName?: string;
   currentVersion?: string;
   newVersion?: string;
+
+  allowParentUpdates?: boolean;
 }
 
 export interface UpdateLockedResult {
-  status: 'updated' | 'already-updated' | 'update-failed';
+  status: 'unsupported' | 'updated' | 'already-updated' | 'update-failed';
   files?: Record<string, string>;
 }
 

--- a/lib/manager/types.ts
+++ b/lib/manager/types.ts
@@ -228,7 +228,6 @@ export interface UpdateLockedConfig {
   depName?: string;
   currentVersion?: string;
   newVersion?: string;
-
   allowParentUpdates?: boolean;
 }
 

--- a/lib/workers/branch/get-updated.spec.ts
+++ b/lib/workers/branch/get-updated.spec.ts
@@ -266,6 +266,73 @@ describe('workers/branch/get-updated', () => {
         ],
       });
     });
+    it('attempts updateLockedDependency and handles unsupported', async () => {
+      config.upgrades.push({
+        packageFile: 'package.json',
+        lockFiles: ['package-lock.json'],
+        manager: 'npm',
+        branchName: undefined,
+        isLockfileUpdate: true,
+      });
+      npm.updateLockedDependency.mockResolvedValue({
+        status: 'unsupported',
+      });
+      const res = await getUpdatedPackageFiles(config);
+      expect(res).toMatchInlineSnapshot(`
+        Object {
+          "artifactErrors": Array [],
+          "reuseExistingBranch": undefined,
+          "updatedArtifacts": Array [],
+          "updatedPackageFiles": Array [],
+        }
+      `);
+    });
+    it('attempts updateLockedDependency and handles already-updated', async () => {
+      config.reuseExistingBranch = true;
+      config.upgrades.push({
+        packageFile: 'package.json',
+        lockFile: 'package-lock.json',
+        manager: 'npm',
+        branchName: undefined,
+        isLockfileUpdate: true,
+      });
+      npm.updateLockedDependency.mockResolvedValueOnce({
+        status: 'already-updated',
+      });
+      const res = await getUpdatedPackageFiles(config);
+      expect(res).toMatchInlineSnapshot(`
+        Object {
+          "artifactErrors": Array [],
+          "reuseExistingBranch": false,
+          "updatedArtifacts": Array [],
+          "updatedPackageFiles": Array [],
+        }
+      `);
+    });
+    it('attempts updateLockedDependency and handles updated files with reuse branch', async () => {
+      config.reuseExistingBranch = true;
+      config.upgrades.push({
+        packageFile: 'package.json',
+        lockFile: 'package-lock.json',
+        manager: 'npm',
+        branchName: undefined,
+        isLockfileUpdate: true,
+      });
+      git.getFile.mockResolvedValue('some content');
+      npm.updateLockedDependency.mockResolvedValue({
+        status: 'updated',
+        files: {},
+      });
+      const res = await getUpdatedPackageFiles(config);
+      expect(res).toMatchInlineSnapshot(`
+        Object {
+          "artifactErrors": Array [],
+          "reuseExistingBranch": false,
+          "updatedArtifacts": Array [],
+          "updatedPackageFiles": Array [],
+        }
+      `);
+    });
     it('bumps versions in updateDependency managers', async () => {
       config.upgrades.push({
         packageFile: 'package.json',

--- a/lib/workers/types.ts
+++ b/lib/workers/types.ts
@@ -45,6 +45,7 @@ export interface BranchUpgradeConfig
   manager?: string;
   packageFile?: string;
   lockFile?: string;
+  lockFiles?: string[];
   reuseExistingBranch?: boolean;
   prHeader?: string;
   prFooter?: string;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Refactors update-lockfile logic to reuse `updateLockedDependency()`. Importantly, it means we can detect if an existing branch is already updated without needing to run `npm install` every run for every affected branch.

## Context:

Performance improvement. First for npm@6 but others to follow.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
