### PR TITLE
fix(npm): don't coerce npm constraint if already an exact version

### DIFF
--- a/lib/manager/npm/extract/locked-versions.ts
+++ b/lib/manager/npm/extract/locked-versions.ts
@@ -55,7 +55,10 @@ export async function getLockedVersions(
       const { lockfileVersion } = lockFileCache[npmLock];
       if (lockfileVersion === 1) {
         if (packageFile.constraints.npm) {
-          packageFile.constraints.npm += ' <7';
+          // Add a <7 constraint if it's not already a fixed version
+          if (!valid(packageFile.constraints.npm)) {
+            packageFile.constraints.npm += ' <7';
+          }
         } else {
           packageFile.constraints.npm = '<7';
         }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Skips npm constraint coercion when the existing constraint is a fixed value.

## Context:

Warnings in the app

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
