### PR TITLE
fix(joi-to-hapi-joi-replacement): narrowed the range to prevent downgrading newer versions

### DIFF
--- a/lib/config/presets/internal/replacements.ts
+++ b/lib/config/presets/internal/replacements.ts
@@ -51,7 +51,7 @@ export const presets: Record<string, Preset> = {
     description: 'joi became scoped under the hapi organization',
     packageRules: [
       {
-        matchCurrentVersion: '>=14.0.0',
+        matchCurrentVersion: '>=14.0.0 <14.4.0',
         matchDatasources: ['npm'],
         matchPackageNames: ['joi'],
         replacementName: '@hapi/joi',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

as a follow-up to #13135, this narrows the `matchCurrentVersion` range for the `joi` to `@hapi/joi` replacement so that projects already past the later `@hapi/joi` to `joi` replacement are not downgraded back to the deprecated scoped version.

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

see form8ion/javascript#62

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
