### PR TITLE
fix: move rebaseWhen=never check earlier

### DIFF
--- a/lib/workers/branch/index.ts
+++ b/lib/workers/branch/index.ts
@@ -341,7 +341,8 @@ export async function processBranch(
     // istanbul ignore if
     if (
       dependencyDashboardCheck === 'rebase' ||
-      config.dependencyDashboardRebaseAllOpen
+      config.dependencyDashboardRebaseAllOpen ||
+      config.rebaseRequested
     ) {
       logger.debug('Manual rebase requested via Dependency Dashboard');
       config.reuseExistingBranch = false;

--- a/lib/workers/branch/index.ts
+++ b/lib/workers/branch/index.ts
@@ -338,12 +338,12 @@ export async function processBranch(
       }
     }
 
-    // istanbul ignore if
-    if (
+    const userRebaseRequested =
       dependencyDashboardCheck === 'rebase' ||
       config.dependencyDashboardRebaseAllOpen ||
-      config.rebaseRequested
-    ) {
+      config.rebaseRequested;
+
+    if (userRebaseRequested) {
       logger.debug('Manual rebase requested via Dependency Dashboard');
       config.reuseExistingBranch = false;
     } else if (branchExists && config.rebaseWhen === 'never') {
@@ -438,8 +438,7 @@ export async function processBranch(
         });
       }
     }
-    const forcedManually =
-      !!dependencyDashboardCheck || config.rebaseRequested || !branchExists;
+    const forcedManually = userRebaseRequested || !branchExists;
     config.forceCommit = forcedManually || branchPr?.isConflicted;
     const commitSha = await commitFilesToBranch(config);
     // istanbul ignore if
@@ -466,8 +465,7 @@ export async function processBranch(
     // but do not break when there are artifact errors
     if (
       !config.artifactErrors?.length &&
-      !dependencyDashboardCheck &&
-      !config.rebaseRequested &&
+      !userRebaseRequested &&
       commitSha &&
       config.prCreation !== 'immediate'
     ) {

--- a/lib/workers/branch/index.ts
+++ b/lib/workers/branch/index.ts
@@ -345,6 +345,13 @@ export async function processBranch(
     ) {
       logger.debug('Manual rebase requested via Dependency Dashboard');
       config.reuseExistingBranch = false;
+    } else if (branchExists && config.rebaseWhen === 'never') {
+      logger.debug('rebaseWhen=never so skipping branch update check');
+      return {
+        branchExists,
+        prNo: branchPr?.number,
+        result: BranchResult.NoWork,
+      };
     } else {
       config = { ...config, ...(await shouldReuseExistingBranch(config)) };
     }
@@ -432,14 +439,6 @@ export async function processBranch(
     }
     const forcedManually =
       !!dependencyDashboardCheck || config.rebaseRequested || !branchExists;
-    if (!forcedManually && config.rebaseWhen === 'never') {
-      logger.debug(`Skipping commit (rebaseWhen=never)`);
-      return {
-        branchExists,
-        prNo: branchPr?.number,
-        result: BranchResult.NoWork,
-      };
-    }
     config.forceCommit = forcedManually || branchPr?.isConflicted;
     const commitSha = await commitFilesToBranch(config);
     // istanbul ignore if

--- a/lib/workers/repository/dependency-dashboard.ts
+++ b/lib/workers/repository/dependency-dashboard.ts
@@ -271,14 +271,6 @@ export async function ensureDependencyDashboard(
     issueBody += '## Other Branches\n\n';
     issueBody += `These updates are pending. To force PRs open, click the checkbox below.\n\n`;
     for (const branch of otherBranches) {
-      logger.info(
-        {
-          prBlockedBy: branch.prBlockedBy,
-          prNo: branch.prNo,
-          result: branch.result,
-        },
-        'Blocked PR'
-      );
       issueBody += getListItem(branch, 'other');
     }
     issueBody += '\n';


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Refactors rebaseWhen=never check to earlier to prevent unnecessary branch updates.

## Context:

Performance

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
