### PR TITLE
docs: warn against using `rebaseWhen=never` plus `prCreation=not-pending`

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -1998,6 +1998,8 @@ Possible values and meanings:
 
 It is also recommended to avoid `rebaseWhen=never` as it can result in conflicted branches with outdated PR descriptions and/or status checks.
 
+Avoid setting `rebaseWhen=never` and then also setting `prCreation=not-pending` as this results in Renovate not creating any new PRs (unless you request them from the Dependency Dashboard).
+
 ## recreateClosed
 
 By default, Renovate will detect if it has proposed an update to a project before and not propose the same one again.

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -1998,7 +1998,7 @@ Possible values and meanings:
 
 It is also recommended to avoid `rebaseWhen=never` as it can result in conflicted branches with outdated PR descriptions and/or status checks.
 
-Avoid setting `rebaseWhen=never` and then also setting `prCreation=not-pending` as this results in Renovate not creating any new PRs (unless you request them from the Dependency Dashboard).
+Avoid setting `rebaseWhen=never` and then also setting `prCreation=not-pending` as this can prevent creation of PRs.
 
 ## recreateClosed
 


### PR DESCRIPTION
## Changes:

- Warn readers to not use `rebaseWhen=never` plus `prCreation=not-pending` as this will block Renovate from opening any new PRs

## Context:

https://github.com/renovatebot/renovate/issues/13219#issuecomment-998948152

Documents an edge case that was found in issue #13219, but does not fix the root problem.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository