### PR TITLE
fix(config/preset): correctly parse local Bitbucket user repo

### DIFF
--- a/lib/config/presets/index.spec.ts
+++ b/lib/config/presets/index.spec.ts
@@ -495,11 +495,20 @@ describe('config/presets/index', () => {
         presetSource: 'local',
       });
     });
-    it('parses local Bitbucket user repo', () => {
+    it('parses local Bitbucket user repo with preset name', () => {
       expect(presets.parsePreset('local>~john_doe/repo//somefile')).toEqual({
         packageName: '~john_doe/repo',
         params: undefined,
         presetName: 'somefile',
+        presetPath: undefined,
+        presetSource: 'local',
+      });
+    });
+    it('parses local Bitbucket user repo', () => {
+      expect(presets.parsePreset('local>~john_doe/renovate-config')).toEqual({
+        packageName: '~john_doe/renovate-config',
+        params: undefined,
+        presetName: 'default',
         presetPath: undefined,
         presetSource: 'local',
       });

--- a/lib/config/presets/index.ts
+++ b/lib/config/presets/index.ts
@@ -40,7 +40,7 @@ const nonScopedPresetWithSubdirRegex = regEx(
   /^(?<packageName>~?[\w\-./]+?)\/\/(?:(?<presetPath>[\w\-./]+)\/)?(?<presetName>[\w\-.]+)(?:#(?<packageTag>[\w\-./]+?))?$/
 );
 const gitPresetRegex = regEx(
-  /^(?<packageName>[\w\-. /]+)(?::(?<presetName>[\w\-.+/]+))?(?:#(?<packageTag>[\w\-./]+?))?$/
+  /^(?<packageName>~?[\w\-. /]+)(?::(?<presetName>[\w\-.+/]+))?(?:#(?<packageTag>[\w\-./]+?))?$/
 );
 
 export function replaceArgs(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->
Adds support for "~" to the other parse preset regex to fully support local Bitbucket user repo presets.

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->
This fixes renovate onboarding PRs for me with the following constellation:
Repo `~john_doe/app` that I want Renovate to run/onboard
Default preset `~john_doe/renovate-config` 

The problem was that `packageName` was undefined after `parsePreset()` which lead to `fetchJSONFile(repo: string, ..)` being called with undefined which in term lead to a `.split` call on undefined in https://github.com/renovatebot/renovate/blob/31.11.5/lib/config/presets/bitbucket-server/index.ts#L23

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
