### PR TITLE
docs: improve groupSlug config option description

### DIFF
--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -1595,7 +1595,7 @@ const options: RenovateOptions[] = [
   {
     name: 'groupSlug',
     description:
-      'Slug to use for group (e.g. in branch name). Will be calculated from groupName if null.',
+      'Slug to use for group (e.g. in branch name). Will be calculated from `groupName` if `null`.',
     type: 'string',
     default: null,
     cli: false,


### PR DESCRIPTION
## Changes:

- Use monospaced font/style for reference to config option `groupName` and for the `null` input

## Context:

I think it looks better to use a monospaced style here.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
