### PR TITLE
refactor: prepare esm helper

### DIFF
--- a/lib/expose.cjs
+++ b/lib/expose.cjs
@@ -2,7 +2,7 @@
 
 /**
  * returns renovates package.json
- * @type {import('./types').RenovatPackageJson}
+ * @type {import('./types').RenovatePackageJson}
  */
 const pkg = (() => require('../package.json'))();
 

--- a/lib/expose.cjs
+++ b/lib/expose.cjs
@@ -1,0 +1,17 @@
+// https://stackoverflow.com/a/46745166/10109857
+
+/**
+ * returns renovates package.json
+ * @type {import('./types').RenovatPackageJson}
+ */
+const pkg = (() => require('../package.json'))();
+
+/**
+ * return's re2
+ * @returns {RegExpConstructor}
+ */
+function re2() {
+  return require('re2');
+}
+
+module.exports = { dirname: __dirname, re2, pkg };

--- a/lib/globals.d.ts
+++ b/lib/globals.d.ts
@@ -12,8 +12,8 @@ declare interface Error {
 // can't use `resolveJsonModule` because it will copy json files and change dist path
 
 declare module '*/package.json' {
-  import { PackageJson } from 'type-fest';
-  const value: PackageJson & { 'engines-next': Record<string, string> };
+  type RenovatPackageJson = import('./types').RenovatPackageJson;
+  const value: RenovatPackageJson;
   export = value;
 }
 

--- a/lib/globals.d.ts
+++ b/lib/globals.d.ts
@@ -12,8 +12,8 @@ declare interface Error {
 // can't use `resolveJsonModule` because it will copy json files and change dist path
 
 declare module '*/package.json' {
-  type RenovatPackageJson = import('./types').RenovatPackageJson;
-  const value: RenovatPackageJson;
+  type RenovatePackageJson = import('./types').RenovatePackageJson;
+  const value: RenovatePackageJson;
   export = value;
 }
 

--- a/lib/types/base.ts
+++ b/lib/types/base.ts
@@ -1,4 +1,10 @@
+import type { PackageJson } from 'type-fest';
+
 export interface ModuleApi {
   displayName?: string;
   url?: string;
 }
+
+export type RenovatPackageJson = PackageJson & {
+  'engines-next': Record<string, string>;
+};

--- a/lib/types/base.ts
+++ b/lib/types/base.ts
@@ -5,6 +5,6 @@ export interface ModuleApi {
   url?: string;
 }
 
-export type RenovatPackageJson = PackageJson & {
+export type RenovatePackageJson = PackageJson & {
   'engines-next': Record<string, string>;
 };

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -594,7 +594,7 @@ export async function deleteBranch(branchName: string): Promise<void> {
 }
 
 export async function mergeBranch(branchName: string): Promise<void> {
-  let status;
+  let status: StatusResult;
   try {
     await syncGit();
     await git.reset(ResetMode.HARD);

--- a/lib/util/http/index.ts
+++ b/lib/util/http/index.ts
@@ -2,6 +2,7 @@ import crypto from 'crypto';
 import merge from 'deepmerge';
 import got, { Options, Response } from 'got';
 import { HOST_DISABLED } from '../../constants/error-messages';
+import { pkg } from '../../expose.cjs';
 import { logger } from '../../logger';
 import { ExternalHostError } from '../../types/errors/external-host-error';
 import * as memCache from '../cache/memory';
@@ -69,13 +70,7 @@ function cloneResponse<T extends Buffer | string | any>(
 }
 
 function applyDefaultHeaders(options: Options): void {
-  let renovateVersion = 'unknown';
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    renovateVersion = require('../../../package.json').version;
-  } catch (err) /* istanbul ignore next */ {
-    logger.debug({ err }, 'Error getting renovate version');
-  }
+  const renovateVersion = pkg.version;
   options.headers = {
     ...options.headers,
     'user-agent':

--- a/lib/util/regex.ts
+++ b/lib/util/regex.ts
@@ -1,5 +1,6 @@
 import is from '@sindresorhus/is';
 import { CONFIG_VALIDATION } from '../constants/error-messages';
+import { re2 } from '../expose.cjs';
 
 import { logger } from '../logger';
 
@@ -8,8 +9,7 @@ let RegEx: RegExpConstructor;
 const cache = new Map<string, RegExp>();
 
 try {
-  // eslint-disable-next-line
-  const RE2 = require('re2');
+  const RE2 = re2();
   // Test if native is working
   new RE2('.*').exec('test');
   logger.debug('Using RE2 as regex engine');

--- a/lib/workers/global/config/parse/cli.ts
+++ b/lib/workers/global/config/parse/cli.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
-import { version } from '../../../../../package.json';
 import { getOptions } from '../../../../config/options';
 import type { AllConfig, RenovateOptions } from '../../../../config/types';
+import { pkg } from '../../../../expose.cjs';
 import { regEx } from '../../../../util/regex';
 
 export function getCliName(option: Partial<RenovateOptions>): string {
@@ -102,7 +102,7 @@ export function getConfig(input: string[]): AllConfig {
   }
 
   program = program
-    .version(version, '-v, --version')
+    .version(pkg.version, '-v, --version')
     .on('--help', helpConsole)
     .action((repositories: string[], opts: Record<string, unknown>) => {
       if (repositories?.length) {

--- a/lib/workers/global/index.ts
+++ b/lib/workers/global/index.ts
@@ -3,7 +3,6 @@ import { ERROR } from 'bunyan';
 import fs from 'fs-extra';
 import semver from 'semver';
 import upath from 'upath';
-import * as pkg from '../../../package.json';
 import * as configParser from '../../config';
 import { resolveConfigPresets } from '../../config/presets';
 import { validateConfigSecrets } from '../../config/secrets';
@@ -13,6 +12,7 @@ import type {
   RenovateRepository,
 } from '../../config/types';
 import { CONFIG_PRESETS_INVALID } from '../../constants/error-messages';
+import { pkg } from '../../expose.cjs';
 import { getProblems, logger, setMeta } from '../../logger';
 import { writeFile } from '../../util/fs';
 import * as hostRules from '../../util/host-rules';

--- a/lib/workers/repository/index.ts
+++ b/lib/workers/repository/index.ts
@@ -1,6 +1,7 @@
 import fs from 'fs-extra';
 import { GlobalConfig } from '../../config/global';
 import type { RenovateConfig } from '../../config/types';
+import { pkg } from '../../expose.cjs';
 import { logger, setMeta } from '../../logger';
 import { removeDanglingContainers } from '../../util/exec/docker';
 import { deleteLocalFile, privateCacheDir } from '../../util/fs';
@@ -16,14 +17,6 @@ import { extractDependencies, updateRepo } from './process';
 import { ProcessResult, processResult } from './result';
 import { printRequestStats } from './stats';
 
-let renovateVersion = 'unknown';
-try {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  renovateVersion = require('../../../package.json').version;
-} catch (err) /* istanbul ignore next */ {
-  logger.debug({ err }, 'Error getting renovate version');
-}
-
 // istanbul ignore next
 export async function renovateRepository(
   repoConfig: RenovateConfig,
@@ -33,7 +26,7 @@ export async function renovateRepository(
   let config = GlobalConfig.set(repoConfig);
   await removeDanglingContainers();
   setMeta({ repository: config.repository });
-  logger.info({ renovateVersion }, 'Repository started');
+  logger.info({ renovateVersion: pkg.version }, 'Repository started');
   logger.trace({ config });
   let repoResult: ProcessResult;
   queue.clear();

--- a/test/static-files.spec.ts
+++ b/test/static-files.spec.ts
@@ -1,8 +1,19 @@
 import util from 'util';
+import _glob from 'glob';
 
-const glob = util.promisify(require('glob'));
+const glob = util.promisify(_glob);
 
-const ignoredExtensions = ['js', 'ts', 'md', 'pyc', 'DS_Store', 'map', 'snap'];
+const ignoredExtensions = [
+  'js',
+  'cjs',
+  'ts',
+  'cts',
+  'md',
+  'pyc',
+  'DS_Store',
+  'map',
+  'snap',
+];
 
 function filterFiles(files: string[]): string[] {
   return files.filter((file) =>

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -7,20 +7,8 @@
     "sourceMap": true,
     "inlineSources": true,
     "importHelpers": true,
-    "allowJs": false,
-    "checkJs": false,
     "types": ["node"]
   },
-  "exclude": [
-    "./.cache",
-    "./dist",
-    "**/__mocks__/**",
-    "**/__fixtures__/**",
-    "**/__testutil__/**",
-    "**/test/**",
-    "**/*.spec.ts",
-    "jest.config.ts",
-    "./test",
-    "./tools"
-  ]
+  "files": ["lib/renovate.ts", "lib/config-validator.ts"],
+  "include": ["lib/**/*.d.ts"]
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:
- add `expose.cjs` file to (dynamic) import `package.json` and `re2`;
- I don't like to make the `regEx` async to use dynamic typescript import.
- We can't import json files in esm by default yet, needs node [`--experimental-json-modules`](https://nodejs.org/api/esm.html#no-json-module-loading)
<!-- Describe what behavior is changed by this PR. -->

## Context:
- #13181 
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
