### PR TITLE
docs(local development): add refactor PR test note

### DIFF
--- a/docs/development/local-development.md
+++ b/docs/development/local-development.md
@@ -120,6 +120,8 @@ You can run `yarn test` locally to test your code.
 We test all PRs using the same tests, run on GitHub Actions.
 `yarn test` runs an `eslint` check, a `prettier` check, a `type` check and then all the unit tests using `jest`.
 
+Refactor PRs should ideally not change or remove tests (adding tests is OK).
+
 ### Jest
 
 You can run just the Jest unit tests by running `yarn jest`.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Add note that explains that refactoring PRs should not change tests (ideally)

## Context:

Inspired by the comment from the head maintainer (https://github.com/renovatebot/renovate/pull/13328#issuecomment-1003904278):

> For future reference, refactor PRs should ideally not change or remove tests (adding tests is OK). This PR as it is demands that the reviewer do a lot of manual testing, which increases the chance that it sits unreviewed.

Not closing any issue with this PR.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
