### PR TITLE
feat(workers): Fallbacks for getNewValue nullable results

### DIFF
--- a/lib/manager/npm/update/locked-dependency/package-lock/index.ts
+++ b/lib/manager/npm/update/locked-dependency/package-lock/index.ts
@@ -147,12 +147,13 @@ export async function updateLockedDependency(
         }
       } else if (depType) {
         // The constaint comes from the package.json file, so we need to update it
-        const newValue = semver.getNewValue({
-          currentValue: constraint,
-          rangeStrategy: 'replace',
-          currentVersion,
-          newVersion,
-        });
+        const newValue =
+          semver.getNewValue({
+            currentValue: constraint,
+            rangeStrategy: 'replace',
+            currentVersion,
+            newVersion,
+          }) ?? constraint;
         newPackageJsonContent = updateDependency({
           fileContent: packageFileContent,
           upgrade: { depName, depType, newValue },

--- a/lib/versioning/types.ts
+++ b/lib/versioning/types.ts
@@ -26,7 +26,7 @@ export interface VersioningApi {
   isLessThanRange?(version: string, range: string): boolean;
   getSatisfyingVersion(versions: string[], range: string): string | null;
   minSatisfyingVersion(versions: string[], range: string): string | null;
-  getNewValue(newValueConfig: NewValueConfig): string;
+  getNewValue(newValueConfig: NewValueConfig): string | null;
   sortVersions(version: string, other: string): number;
 
   matches(version: string, range: string | Range): boolean;

--- a/lib/workers/repository/process/lookup/generate.ts
+++ b/lib/workers/repository/process/lookup/generate.ts
@@ -34,12 +34,13 @@ export function generateUpdate(
   const { currentValue } = config;
   if (currentValue) {
     try {
-      update.newValue = versioning.getNewValue({
-        currentValue,
-        rangeStrategy,
-        currentVersion,
-        newVersion,
-      });
+      update.newValue =
+        versioning.getNewValue({
+          currentValue,
+          rangeStrategy,
+          currentVersion,
+          newVersion,
+        }) ?? currentValue;
     } catch (err) /* istanbul ignore next */ {
       logger.warn(
         { err, currentValue, rangeStrategy, currentVersion, newVersion },

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -151,11 +151,12 @@ export async function lookupUpdates(
         res.updates.push({
           updateType: 'replacement',
           newName: dependency.replacementName,
-          newValue: versioning.getNewValue({
-            currentValue,
-            newVersion: dependency.replacementVersion,
-            rangeStrategy,
-          }),
+          newValue:
+            versioning.getNewValue({
+              currentValue,
+              newVersion: dependency.replacementVersion,
+              rangeStrategy,
+            }) ?? currentValue,
         });
       }
       // istanbul ignore next
@@ -204,12 +205,13 @@ export async function lookupUpdates(
         res.updates.push({
           updateType: 'pin',
           isPin: true,
-          newValue: versioning.getNewValue({
-            currentValue,
-            rangeStrategy,
-            currentVersion,
-            newVersion: currentVersion,
-          }),
+          newValue:
+            versioning.getNewValue({
+              currentValue,
+              rangeStrategy,
+              currentVersion,
+              newVersion: currentVersion,
+            }) ?? currentValue,
           newMajor: versioning.getMajor(currentVersion),
         });
       }

--- a/lib/workers/repository/process/lookup/rollback.ts
+++ b/lib/workers/repository/process/lookup/rollback.ts
@@ -44,11 +44,12 @@ export function getRollbackUpdate(
     logger.debug('No newVersion to roll back to');
     return null;
   }
-  const newValue = version.getNewValue({
-    currentValue,
-    rangeStrategy: 'replace',
-    newVersion,
-  });
+  const newValue =
+    version.getNewValue({
+      currentValue,
+      rangeStrategy: 'replace',
+      newVersion,
+    }) ?? currentValue;
   return {
     bucket: 'rollback',
     newMajor: version.getMajor(newVersion),


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- For every downstream `getNewValue()` call, default to `currentValue` when null is being returned.

## Context:

https://github.com/renovatebot/renovate/pull/13334#discussion_r777330084

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
