### PR TITLE
feat(gitlab): support getDigest for gitlab repositories

### DIFF
--- a/lib/datasource/gitlab-tags/index.spec.ts
+++ b/lib/datasource/gitlab-tags/index.spec.ts
@@ -1,4 +1,4 @@
-import { getPkgReleases } from '..';
+import { getDigest, getPkgReleases } from '..';
 import * as httpMock from '../../../test/http-mock';
 import { id as datasource } from '.';
 
@@ -74,6 +74,47 @@ describe('datasource/gitlab-tags/index', () => {
       });
       expect(res).toMatchSnapshot();
       expect(res.releases).toHaveLength(2);
+    });
+  });
+
+  describe('getDigest', () => {
+    it('returns commits from gitlab installation', async () => {
+      const digest = 'abcd00001234';
+      const body = [
+        {
+          id: digest,
+        },
+      ];
+      httpMock
+        .scope('https://gitlab.company.com')
+        .get('/api/v4/projects/some%2Fdep2/repository/commits?per_page=1')
+        .reply(200, body);
+      const res = await getDigest({
+        datasource,
+        registryUrls: ['https://gitlab.company.com/api/v4/'],
+        depName: 'some/dep2',
+      });
+      expect(res).toBe(digest);
+    });
+
+    it('returns commits from gitlab installation for a specific branch', async () => {
+      const digest = 'abcd00001234';
+      const body = {
+        id: digest,
+      };
+      httpMock
+        .scope('https://gitlab.company.com')
+        .get('/api/v4/projects/some%2Fdep2/repository/commits/branch')
+        .reply(200, body);
+      const res = await getDigest(
+        {
+          datasource,
+          registryUrls: ['https://gitlab.company.com/api/v4/'],
+          depName: 'some/dep2',
+        },
+        'branch'
+      );
+      expect(res).toBe(digest);
     });
   });
 });

--- a/lib/datasource/gitlab-tags/index.spec.ts
+++ b/lib/datasource/gitlab-tags/index.spec.ts
@@ -116,5 +116,35 @@ describe('datasource/gitlab-tags/index', () => {
       );
       expect(res).toBe(digest);
     });
+
+    it('returns null from gitlab installation with no commits', async () => {
+      const body = [];
+      httpMock
+        .scope('https://gitlab.company.com')
+        .get('/api/v4/projects/some%2Fdep2/repository/commits?per_page=1')
+        .reply(200, body);
+      const res = await getDigest({
+        datasource,
+        registryUrls: ['https://gitlab.company.com/api/v4/'],
+        depName: 'some/dep2',
+      });
+      expect(res).toBeNull();
+    });
+
+    it('returns null from gitlab installation with unknown branch', async () => {
+      httpMock
+        .scope('https://gitlab.company.com')
+        .get('/api/v4/projects/some%2Fdep2/repository/commits/unknown-branch')
+        .reply(404, null);
+      const res = await getDigest(
+        {
+          datasource,
+          registryUrls: ['https://gitlab.company.com/api/v4/'],
+          depName: 'some/dep2',
+        },
+        'unknown-branch'
+      );
+      expect(res).toBeNull();
+    });
   });
 });

--- a/lib/datasource/gitlab-tags/index.ts
+++ b/lib/datasource/gitlab-tags/index.ts
@@ -1,8 +1,8 @@
 import * as packageCache from '../../util/cache/package';
 import { GitlabHttp } from '../../util/http/gitlab';
 import { joinUrlParts } from '../../util/url';
-import type { GetReleasesConfig, ReleaseResult } from '../types';
-import type { GitlabTag } from './types';
+import type { DigestConfig, GetReleasesConfig, ReleaseResult } from '../types';
+import type { GitlabCommit, GitlabTag } from './types';
 import { defaultRegistryUrl, getDepHost, getSourceUrl } from './util';
 
 export const id = 'gitlab-tags';
@@ -14,8 +14,7 @@ export const registryStrategy = 'first';
 
 const cacheNamespace = 'datasource-gitlab';
 
-function getCacheKey(depHost: string, repo: string): string {
-  const type = 'tags';
+function getCacheKey(depHost: string, repo: string, type = 'tags'): string {
   return `${depHost}:${repo}:${type}`;
 }
 
@@ -68,4 +67,65 @@ export async function getReleases({
     cacheMinutes
   );
   return dependency;
+}
+
+/**
+ * gitlab.getDigest
+ *
+ * This function will simply return the latest commit hash for the configured repository.
+ */
+export async function getDigest(
+  { lookupName: repo, registryUrl }: Partial<DigestConfig>,
+  newValue?: string
+): Promise<string | null> {
+  const depHost = getDepHost(registryUrl);
+
+  const cachedResult = await packageCache.get<string>(
+    cacheNamespace,
+    getCacheKey(depHost, repo, 'commit')
+  );
+  // istanbul ignore if
+  if (cachedResult) {
+    return cachedResult;
+  }
+
+  const urlEncodedRepo = encodeURIComponent(repo);
+  let digest;
+
+  if (newValue) {
+    const url = joinUrlParts(
+      depHost,
+      `api/v4/projects`,
+      urlEncodedRepo,
+      `repository/commits/`,
+      newValue
+    );
+    const gitlabCommits = await gitlabApi.getJson<GitlabCommit>(url, {
+      paginate: true,
+    });
+    digest = gitlabCommits.body.id;
+  } else {
+    const url = joinUrlParts(
+      depHost,
+      `api/v4/projects`,
+      urlEncodedRepo,
+      `repository/commits?per_page=1`
+    );
+    const gitlabCommits = await gitlabApi.getJson<GitlabCommit[]>(url, {
+      paginate: true,
+    });
+    digest = gitlabCommits.body[0].id;
+  }
+
+  if (!digest) {
+    return null;
+  }
+  const cacheMinutes = 10;
+  await packageCache.set(
+    cacheNamespace,
+    getCacheKey(registryUrl, repo, 'commit'),
+    digest,
+    cacheMinutes
+  );
+  return digest;
 }

--- a/lib/datasource/gitlab-tags/index.ts
+++ b/lib/datasource/gitlab-tags/index.ts
@@ -90,7 +90,7 @@ export async function getDigest(
   }
 
   const urlEncodedRepo = encodeURIComponent(repo);
-  let digest;
+  let digest: string;
 
   if (newValue) {
     const url = joinUrlParts(
@@ -100,9 +100,7 @@ export async function getDigest(
       `repository/commits/`,
       newValue
     );
-    const gitlabCommits = await gitlabApi.getJson<GitlabCommit>(url, {
-      paginate: true,
-    });
+    const gitlabCommits = await gitlabApi.getJson<GitlabCommit>(url);
     digest = gitlabCommits.body.id;
   } else {
     const url = joinUrlParts(
@@ -111,9 +109,7 @@ export async function getDigest(
       urlEncodedRepo,
       `repository/commits?per_page=1`
     );
-    const gitlabCommits = await gitlabApi.getJson<GitlabCommit[]>(url, {
-      paginate: true,
-    });
+    const gitlabCommits = await gitlabApi.getJson<GitlabCommit[]>(url);
     digest = gitlabCommits.body[0].id;
   }
 

--- a/lib/datasource/gitlab-tags/types.ts
+++ b/lib/datasource/gitlab-tags/types.ts
@@ -4,3 +4,7 @@ export type GitlabTag = {
     created_at?: string;
   };
 };
+
+export type GitlabCommit = {
+  id: string;
+};

--- a/lib/datasource/go/__snapshots__/digest.spec.ts.snap
+++ b/lib/datasource/go/__snapshots__/digest.spec.ts.snap
@@ -1,19 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`datasource/go/digest getDigest gitlab digest is not supported at the moment 1`] = `
-Array [
-  Object {
-    "headers": Object {
-      "accept-encoding": "gzip, deflate, br",
-      "host": "gitlab.com",
-      "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
-    },
-    "method": "GET",
-    "url": "https://gitlab.com/golang/text?go-get=1",
-  },
-]
-`;
-
 exports[`datasource/go/digest getDigest returns digest 1`] = `
 Array [
   Object {
@@ -89,6 +75,32 @@ Array [
     },
     "method": "GET",
     "url": "https://api.bitbucket.org/2.0/repositories/golang/text/commits/master",
+  },
+]
+`;
+
+exports[`datasource/go/digest getDigest supports gitlab digest 1`] = `"abcdefabcdefabcdefabcdef"`;
+
+exports[`datasource/go/digest getDigest supports gitlab digest 2`] = `
+Array [
+  Object {
+    "headers": Object {
+      "accept-encoding": "gzip, deflate, br",
+      "host": "gitlab.com",
+      "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
+    },
+    "method": "GET",
+    "url": "https://gitlab.com/group/subgroup?go-get=1",
+  },
+  Object {
+    "headers": Object {
+      "accept": "application/json",
+      "accept-encoding": "gzip, deflate, br",
+      "host": "gitlab.com",
+      "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
+    },
+    "method": "GET",
+    "url": "https://gitlab.com/api/v4/projects/group%2Fsubgroup/repository/commits?per_page=1",
   },
 ]
 `;

--- a/lib/datasource/go/__snapshots__/digest.spec.ts.snap
+++ b/lib/datasource/go/__snapshots__/digest.spec.ts.snap
@@ -78,29 +78,3 @@ Array [
   },
 ]
 `;
-
-exports[`datasource/go/digest getDigest supports gitlab digest 1`] = `"abcdefabcdefabcdefabcdef"`;
-
-exports[`datasource/go/digest getDigest supports gitlab digest 2`] = `
-Array [
-  Object {
-    "headers": Object {
-      "accept-encoding": "gzip, deflate, br",
-      "host": "gitlab.com",
-      "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
-    },
-    "method": "GET",
-    "url": "https://gitlab.com/group/subgroup?go-get=1",
-  },
-  Object {
-    "headers": Object {
-      "accept": "application/json",
-      "accept-encoding": "gzip, deflate, br",
-      "host": "gitlab.com",
-      "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
-    },
-    "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/group%2Fsubgroup/repository/commits?per_page=1",
-  },
-]
-`;

--- a/lib/datasource/go/digest.spec.ts
+++ b/lib/datasource/go/digest.spec.ts
@@ -64,6 +64,22 @@ describe('datasource/go/digest', () => {
       );
       expect(res).toBe('abcdefabcdefabcdefabcdef');
     });
+    it('supports gitlab digest with a specific branch', async () => {
+      const branch = 'some-branch';
+      httpMock
+        .scope('https://gitlab.com/')
+        .get('/group/subgroup?go-get=1')
+        .reply(200, loadFixture('go-get-gitlab.html'));
+      httpMock
+        .scope('https://gitlab.com/')
+        .get(`/api/v4/projects/group%2Fsubgroup/repository/commits/${branch}`)
+        .reply(200, { id: 'abcdefabcdefabcdefabcdef' });
+      const res = await getDigest(
+        { lookupName: 'gitlab.com/group/subgroup' },
+        branch
+      );
+      expect(res).toBe('abcdefabcdefabcdefabcdef');
+    });
     it('returns digest', async () => {
       httpMock
         .scope('https://golang.org/')

--- a/lib/datasource/go/digest.spec.ts
+++ b/lib/datasource/go/digest.spec.ts
@@ -1,5 +1,5 @@
 import * as httpMock from '../../../test/http-mock';
-import { mocked } from '../../../test/util';
+import { loadFixture, mocked } from '../../../test/util';
 import * as _hostRules from '../../util/host-rules';
 import { getDigest } from '.';
 
@@ -49,16 +49,23 @@ describe('datasource/go/digest', () => {
       expect(res).toBeNull();
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
-    it('gitlab digest is not supported at the moment', async () => {
+    it('supports gitlab digest', async () => {
       httpMock
         .scope('https://gitlab.com/')
-        .get('/golang/text?go-get=1')
-        .reply(200, '');
+        .get('/group/subgroup?go-get=1')
+        .reply(200, loadFixture('go-get-gitlab.html'));
+      httpMock
+        .scope('https://gitlab.com/')
+        .get('/api/v4/projects/group%2Fsubgroup/repository/commits?per_page=1')
+        .reply(200, [{ id: 'abcdefabcdefabcdefabcdef' }]);
       const res = await getDigest(
-        { lookupName: 'gitlab.com/golang/text' },
+        { lookupName: 'gitlab.com/group/subgroup' },
         null
       );
-      expect(res).toBeNull();
+      expect(res).toMatchSnapshot();
+      expect(res).not.toBeNull();
+      expect(res).toBeDefined();
+      expect(res).toBe('abcdefabcdefabcdefabcdef');
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
     it('returns digest', async () => {

--- a/lib/datasource/go/digest.spec.ts
+++ b/lib/datasource/go/digest.spec.ts
@@ -62,11 +62,7 @@ describe('datasource/go/digest', () => {
         { lookupName: 'gitlab.com/group/subgroup' },
         null
       );
-      expect(res).toMatchSnapshot();
-      expect(res).not.toBeNull();
-      expect(res).toBeDefined();
       expect(res).toBe('abcdefabcdefabcdefabcdef');
-      expect(httpMock.getTrace()).toMatchSnapshot();
     });
     it('returns digest', async () => {
       httpMock

--- a/lib/datasource/go/digest.ts
+++ b/lib/datasource/go/digest.ts
@@ -1,4 +1,5 @@
 import * as github from '../github-tags';
+import * as gitlab from '../gitlab-tags';
 import type { DigestConfig } from '../types';
 import { bitbucket } from './common';
 import { getDatasource } from './get-datasource';
@@ -31,6 +32,9 @@ export async function getDigest(
     }
     case bitbucket.id: {
       return bitbucket.getDigest(source, tag);
+    }
+    case gitlab.id: {
+      return gitlab.getDigest(source, tag);
     }
     /* istanbul ignore next: can never happen, makes lint happy */
     default: {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Support `getDigest` for gitlab repositories.

<!-- Describe what behavior is changed by this PR. -->

## Context:

`gitlab-tags` currently does not support `getDigest` (github and bitbucket do). This change adds `getDigest` to `gitlab-tags`

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository