### PR TITLE
docs: capitalize proper nouns

### DIFF
--- a/docs/development/bump-node-major.md
+++ b/docs/development/bump-node-major.md
@@ -4,13 +4,13 @@
 
 - Add new version via `package.json>engines>node` and `package.json>engines-next>node`
 - Update the node version in the [local-development](./local-development.md) docs
-- Update the node version in the Github Actions workflow files
+- Update the node version in the GitHub Actions workflow files
 
 ## Deprecate old NodeJS version
 
 - Deprecate old LTS via `package.json>engines-next>node`
 - Update the node version in the [local-development](./local-development.md) docs
-- Remove the old node version in the Github Actions workflow files
+- Remove the old node version in the GitHub Actions workflow files
 
 ## Remove old NodeJS version
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -749,9 +749,9 @@ Otherwise, if another bot or human shares the same email and pushes to one of Re
 
 Specify commit authors ignored by Renovate.
 
-By default, Renovate will treat any PR as modified if another git author has added to the branch.
+By default, Renovate will treat any PR as modified if another Git author has added to the branch.
 When a PR is considered modified, Renovate won't perform any further commits such as if it's conflicted or needs a version update.
-If you have other bots which commit on top of Renovate PRs, and don't want Renovate to treat these PRs as modified, then add the other git author(s) to `gitIgnoredAuthors`.
+If you have other bots which commit on top of Renovate PRs, and don't want Renovate to treat these PRs as modified, then add the other Git author(s) to `gitIgnoredAuthors`.
 
 Example:
 

--- a/docs/usage/docker.md
+++ b/docs/usage/docker.md
@@ -222,7 +222,7 @@ When running Renovate in this context the Google access token must be retrieved 
 _This documentation gives **a few hints** on **a possible way** to achieve this end result._
 
 The basic approach is that you create a custom image and then run Renovate as one of the stages of your project.
-To make this run independent of any user you should use a [`Project Access Token`](https://docs.gitlab.com/ee/user/project/settings/project_access_tokens.html) (with Scopes: `api`, `read_api` and `write_repository`) for the project and use this as the `RENOVATE_TOKEN` variable for Gitlab CI.
+To make this run independent of any user you should use a [`Project Access Token`](https://docs.gitlab.com/ee/user/project/settings/project_access_tokens.html) (with Scopes: `api`, `read_api` and `write_repository`) for the project and use this as the `RENOVATE_TOKEN` variable for GitLab CI.
 See also the [renovate-runner repository on GitLab](https://gitlab.com/renovate-bot/renovate-runner) where `.gitlab-ci.yml` configuration examples can be found.
 
 To get access to the token a custom Renovate Docker image is needed that includes the Google Cloud SDK.

--- a/docs/usage/examples/self-hosting.md
+++ b/docs/usage/examples/self-hosting.md
@@ -271,9 +271,9 @@ You should save and test out this script manually first, and add it to cron once
 
 ## Kubernetes for GitLab, using Git over SSH
 
-This section describes how to use Git binary with SSH for Gitlab, to avoid API shortcomings.
+This section describes how to use Git binary with SSH for GitLab, to avoid API shortcomings.
 
-You need to first create a SSH key, then add the public part to Gitlab (see this [guide](https://docs.gitlab.com/ee/ssh/))
+You need to first create a SSH key, then add the public part to GitLab (see this [guide](https://docs.gitlab.com/ee/ssh/))
 
 Then, you need to create the secret to add the SSH key, and the following config to your container
 

--- a/docs/usage/getting-started/running.md
+++ b/docs/usage/getting-started/running.md
@@ -119,7 +119,7 @@ module.exports = {
 };
 ```
 
-`config.js` may also export a `Promise` of such an object, or a function that will return either a plain Javascript object or a `Promise` of such an object.
+`config.js` may also export a `Promise` of such an object, or a function that will return either a plain JavaScript object or a `Promise` of such an object.
 This allows one to include the results of asynchronous operations in the exported value.
 An example of a `config.js` that exports an async function (which is a function that returns a `Promise`) can be seen in a comment for [#10011: Allow autodiscover filtering for repo topic](https://github.com/renovatebot/renovate/issues/10011#issuecomment-992568583) and more examples can be seen in [`file.spec.ts`](https://github.com/renovatebot/renovate/blob/main/lib/workers/global/config/parse/file.spec.ts).
 

--- a/docs/usage/updating-rebasing.md
+++ b/docs/usage/updating-rebasing.md
@@ -52,7 +52,7 @@ This way:
 
 ## Manual rebasing
 
-You can request that Renovate rebase a PR by ticking the rebase/retry checkbox on GitHub or Gitlab.
+You can request that Renovate rebase a PR by ticking the rebase/retry checkbox on GitHub or GitLab.
 Or you can add a "rebase" label to the PR.
 The label name is configurable via the `rebaseLabel` option.
 

--- a/lib/manager/kustomize/readme.md
+++ b/lib/manager/kustomize/readme.md
@@ -9,7 +9,7 @@ This package will manage the following parts of the `kustomization.yaml` file:
 **How It Works**
 
 1. Renovate will search each repository for any `kustomization.yaml` files.
-2. Existing dependencies will be extracted from remote bases, image tags & helm charts
+2. Existing dependencies will be extracted from remote bases, image tags & Helm charts
 3. Renovate will resolve the dependency's source repository and check for SemVer tags if found.
 4. If an update was found, Renovate will update `kustomization.yaml`
 


### PR DESCRIPTION
## Changes:
Capitalize proper nouns:

- Git
- GitHub
- GitLab
- JavaScript
- Helm

## Context:

Checked the capitalization of common proper nouns in the `*.md` files again. 😄 

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository