### PR TITLE
docs(dependency-pinning): use document fragment

### DIFF
--- a/docs/usage/dependency-pinning.md
+++ b/docs/usage/dependency-pinning.md
@@ -8,7 +8,7 @@ description: The pros and cons of dependency pinning for JavaScript/npm
 Once you start using a tool/service like Renovate, probably the biggest decision you need to make is whether to "pin" your dependencies instead of using SemVer ranges.
 The answer is "It's your choice", however we can certainly make some generalisations/recommendations to help you.
 
-If you do not want to read the in-depth discussion, and just want our recommendations, you can skip to the bottom.
+If you do not want to read the in-depth discussion, and just want our recommendations, skip ahead to the ["So what's best?" section](#so-whats-best).
 
 ## What is Dependency Pinning?
 


### PR DESCRIPTION
## Changes:

- Use document fragment to link to relevant section

## Context:

I think we should use a link to the section, instead of telling our readers to "scroll/go to" the bottom of the page.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
