### PR TITLE
docs: Heading level of Azure DevOps in Running Renovate docs

### DIFF
--- a/docs/usage/getting-started/running.md
+++ b/docs/usage/getting-started/running.md
@@ -207,7 +207,7 @@ Don't forget to configure `platform=bitbucket-server` somewhere in config.
 
 If you use MySQL or MariaDB you must set `unicodeEmoji` to `false` in the bot config (`RENOVATE_CONFIG_FILE`) to prevent issues with emojis.
 
-### Azure DevOps
+#### Azure DevOps
 
 First, [create a Personal Access Token](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops&tabs=preview-page) for the bot account.
 Configure it either as `token` in your `config.js` file, or in environment variable `RENOVATE_TOKEN`, or via CLI `--token=`.


### PR DESCRIPTION
## Changes:

Moves `Azure DevOps` heading in "Running Renovate" docs back under "Authentication".
This also ensures that "Gitea" is back under "Authentication".

## Context:

Currently, the heading for "Gitea" is under "Azure Devops" and the latter not under "Authentication" but on the same level.

See: https://docs.renovatebot.com/getting-started/running/#gitea

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository