### PR TITLE
docs: deprecate deepExtract

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -427,6 +427,8 @@ Note: make sure not to mix this up with the term `compatibility`, which Renovate
 
 ## deepExtract
 
+Note: the `deepExtract` configuration option is deprecated, and will be removed in a future Renovate release.
+
 If configured to `true`, then dependency extraction will be done using the relevant package manager instead of JavaScript-based parsing.
 
 This option applies only to the `gradle` manager.

--- a/docs/usage/java.md
+++ b/docs/usage/java.md
@@ -80,6 +80,7 @@ Renovate will search repositories for all `pom.xml` files and processes them ind
 ## Custom registry support, and authentication
 
 Unless using `deepExtract`, Renovate does not make use of authentication credentials available to Gradle.
+Note: the `deepExtract` configuration option is deprecated, and will be removed in a future Renovate release.
 
 The manager for Gradle makes use of the `maven` datasource.
 Renovate can be configured to access additional repositories and access repositories authenticated.

--- a/lib/manager/gradle/readme.md
+++ b/lib/manager/gradle/readme.md
@@ -1,5 +1,7 @@
 The `gradle` manager's default behavior uses a custom parser written in JavaScript, similar to many others managers.
 It was initially known as `gradle-lite` but is now integrated into the `gradle` manager and used as default.
 
+Note: the `deepExtract` configuration option is deprecated, and will be removed in a future Renovate release.
+
 If `deepExtract` is configured to `true`, Renovate instead extracts Gradle dependencies by calling a custom Gradle script.
 The `gradle` binary is then used to extract Maven-type dependencies.


### PR DESCRIPTION
## Changes:

- Deprecate the `deepExtract` config option in the docs

## Context:

Asked for in discussion https://github.com/renovatebot/renovate/discussions/13486#discussioncomment-1946621

> @HonkingGoose can you suggest a docs change to mark that feature as deprecated, so users see it?

I searched for hits of the string `deepExtract` and added notes to each hit in the docs.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
