### PR TITLE
fix(gradle): Resolve vars in plugin versions

### DIFF
--- a/lib/manager/gradle/shallow/parser.spec.ts
+++ b/lib/manager/gradle/shallow/parser.spec.ts
@@ -63,12 +63,16 @@ describe('manager/gradle/shallow/parser', () => {
 
     describe('plugins', () => {
       test.each`
-        input                               | output
-        ${'id "foo.bar" version "1.2.3"'}   | ${{ depName: 'foo.bar', lookupName: 'foo.bar:foo.bar.gradle.plugin', currentValue: '1.2.3' }}
-        ${'id("foo.bar") version "1.2.3"'}  | ${{ depName: 'foo.bar', lookupName: 'foo.bar:foo.bar.gradle.plugin', currentValue: '1.2.3' }}
-        ${'kotlin("jvm") version "1.3.71"'} | ${{ depName: 'org.jetbrains.kotlin.jvm', lookupName: 'org.jetbrains.kotlin.jvm:org.jetbrains.kotlin.jvm.gradle.plugin', currentValue: '1.3.71' }}
-      `('$input', ({ input, output }) => {
-        const { deps } = parseGradle(input);
+        def                 | input                               | output
+        ${''}               | ${'id "foo.bar" version "1.2.3"'}   | ${{ depName: 'foo.bar', lookupName: 'foo.bar:foo.bar.gradle.plugin', currentValue: '1.2.3' }}
+        ${''}               | ${'id("foo.bar") version "1.2.3"'}  | ${{ depName: 'foo.bar', lookupName: 'foo.bar:foo.bar.gradle.plugin', currentValue: '1.2.3' }}
+        ${''}               | ${'kotlin("jvm") version "1.3.71"'} | ${{ depName: 'org.jetbrains.kotlin.jvm', lookupName: 'org.jetbrains.kotlin.jvm:org.jetbrains.kotlin.jvm.gradle.plugin', currentValue: '1.3.71' }}
+        ${''}               | ${'id "foo.bar" version something'} | ${{ depName: 'foo.bar', currentValue: 'something', skipReason: SkipReason.UnknownVersion }}
+        ${'baz = "1.2.3"'}  | ${'id "foo.bar" version baz'}       | ${{ depName: 'foo.bar', lookupName: 'foo.bar:foo.bar.gradle.plugin', currentValue: '1.2.3' }}
+        ${'baz = "1.2.3"'}  | ${'id("foo.bar") version baz'}      | ${{ depName: 'foo.bar', lookupName: 'foo.bar:foo.bar.gradle.plugin', currentValue: '1.2.3' }}
+        ${'baz = "1.3.71"'} | ${'kotlin("jvm") version baz'}      | ${{ depName: 'org.jetbrains.kotlin.jvm', lookupName: 'org.jetbrains.kotlin.jvm:org.jetbrains.kotlin.jvm.gradle.plugin', currentValue: '1.3.71' }}
+      `('$input', ({ def, input, output }) => {
+        const { deps } = parseGradle([def, input].join('\n'));
         expect(deps).toMatchObject([output].filter(Boolean));
       });
     });

--- a/lib/manager/gradle/shallow/parser.ts
+++ b/lib/manager/gradle/shallow/parser.ts
@@ -203,6 +203,7 @@ function processDepInterpolation({
 function processPlugin({
   tokenMap,
   packageFile,
+  variables,
 }: SyntaxHandlerInput): SyntaxHandlerOutput {
   const { pluginName, pluginVersion, methodName } = tokenMap;
   const plugin = pluginName.value;
@@ -212,20 +213,36 @@ function processPlugin({
     methodName.value === 'kotlin'
       ? `org.jetbrains.kotlin.${plugin}:org.jetbrains.kotlin.${plugin}.gradle.plugin`
       : `${plugin}:${plugin}.gradle.plugin`;
-  const currentValue = pluginVersion.value;
-  const fileReplacePosition = pluginVersion.offset;
-  const dep = {
+
+  const dep: PackageDependency<GradleManagerData> = {
     depType: 'plugin',
     depName,
     lookupName,
     registryUrls: ['https://plugins.gradle.org/m2/'],
-    currentValue,
     commitMessageTopic: `plugin ${depName}`,
-    managerData: {
-      fileReplacePosition,
-      packageFile,
-    },
   };
+
+  if (pluginVersion.type === TokenType.Word) {
+    const varData = variables[pluginVersion.value];
+    if (varData) {
+      const currentValue = varData.value;
+      const fileReplacePosition = varData.fileReplacePosition;
+      dep.currentValue = currentValue;
+      dep.managerData = { fileReplacePosition, packageFile };
+    } else {
+      const currentValue = pluginVersion.value;
+      const fileReplacePosition = pluginVersion.offset;
+      dep.currentValue = currentValue;
+      dep.managerData = { fileReplacePosition, packageFile };
+      dep.skipReason = SkipReason.UnknownVersion;
+    }
+  } else {
+    const currentValue = pluginVersion.value;
+    const fileReplacePosition = pluginVersion.offset;
+    dep.currentValue = currentValue;
+    dep.managerData = { fileReplacePosition, packageFile };
+  }
+
   return { deps: [dep] };
 }
 
@@ -363,7 +380,10 @@ const matcherConfigs: SyntaxMatchConfig[] = [
       },
       { matchType: TokenType.String, tokenMapKey: 'pluginName' },
       { matchType: TokenType.Word, matchValue: 'version' },
-      { matchType: TokenType.String, tokenMapKey: 'pluginVersion' },
+      {
+        matchType: [TokenType.String, TokenType.Word],
+        tokenMapKey: 'pluginVersion',
+      },
       endOfInstruction,
     ],
     handler: processPlugin,
@@ -380,7 +400,10 @@ const matcherConfigs: SyntaxMatchConfig[] = [
       { matchType: TokenType.String, tokenMapKey: 'pluginName' },
       { matchType: TokenType.RightParen },
       { matchType: TokenType.Word, matchValue: 'version' },
-      { matchType: TokenType.String, tokenMapKey: 'pluginVersion' },
+      {
+        matchType: [TokenType.String, TokenType.Word],
+        tokenMapKey: 'pluginVersion',
+      },
       endOfInstruction,
     ],
     handler: processPlugin,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Resolve variables as version in plugin definitions

## Context:

- Closes #13533

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
