### PR TITLE
docs(contributing): clarify pull request review guidelines

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -37,6 +37,25 @@ Force pushing a PR is OK when:
 - you need to make large changes on a PR which require a full review anyway
 - you need to bring the branch up-to-date with the target branch and incorporating the changes is more work than to create a new PR
 
+## Apply maintainer provided review suggestions
+
+Maintainers can suggest changes while reviewing your pull request, please follow these steps to apply them:
+
+1. Batch the suggestions into a logical group by clicking on the **Add suggestion to batch** button
+2. Click on the **Commit suggestions** button
+
+Read the [GitHub docs, Applying suggested changes](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/incorporating-feedback-in-your-pull-request#applying-suggested-changes) to learn more.
+
+## Resolve review comments instead of commenting
+
+A maintainer/contributor can ask you to make changes, without providing a suggestion that you can apply.
+In this case you need to do some work yourself to address the feedback.
+
+Once you've done the work, resolve the conversation by clicking on the **Resolve conversation** button in the PR overview.
+Avoid posting comments like "I've done the work", or "Done".
+
+Read the [GitHub Docs, resolving conversations](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request#resolving-conversations) to learn more.
+
 ## Re-requesting a review
 
 Please do not ping your reviewer(s) by mentioning them in a new comment.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Explain how to apply reviewer suggested changes (and how to batch them, to reduce noise!)
- Explain how to resolve a review comment (instead of commenting "done")
- Link to relevant GitHub Docs for both concepts

## Context:

As asked for by @viceice in https://github.com/renovatebot/renovate/pull/13463#issuecomment-1012302283:

> So we only need some sentence about to suppress short comments like `Done` and instead resolve conversation.

I see that contributors sometimes do not use the maintainer provided code suggestions. It might be good to mention the "apply changes" workflow here as well, to nudge people into using the suggestion as-is, instead of duplicating the work, and then commenting "done", and leaving us to manually resolve the related items.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
