### PR TITLE
fix(git): skip null contents additions which aren't directories

### DIFF
--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -702,6 +702,14 @@ export async function commitFiles({
     for (const file of files) {
       let fileName = file.name;
       // istanbul ignore if
+      if (
+        file.contents === null &&
+        !(await isDirectory(upath.join(localDir, fileName)))
+      ) {
+        logger.debug({ fileName }, 'Skipping git file with null contents');
+        continue;
+      }
+      // istanbul ignore if
       if (fileName === '|delete|') {
         fileName = file.contents as string;
         try {

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -702,14 +702,6 @@ export async function commitFiles({
     for (const file of files) {
       let fileName = file.name;
       // istanbul ignore if
-      if (
-        file.contents === null &&
-        !(await isDirectory(upath.join(localDir, fileName)))
-      ) {
-        logger.debug({ fileName }, 'Skipping git file with null contents');
-        continue;
-      }
-      // istanbul ignore if
       if (fileName === '|delete|') {
         fileName = file.contents as string;
         try {
@@ -724,6 +716,9 @@ export async function commitFiles({
         if (await isDirectory(upath.join(localDir, fileName))) {
           // This is usually a git submodule update
           logger.trace({ fileName }, 'Adding directory commit');
+        } else if (file.contents === null) {
+          // istanbul ignore next
+          continue;
         } else {
           let contents: Buffer;
           // istanbul ignore else


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds a clause to skip git file additions where `null` contents are being added.

## Context:

Closes #13438

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
