### PR TITLE
fix(gradle): Support gradle versions as templates

### DIFF
--- a/lib/manager/gradle/shallow/parser.spec.ts
+++ b/lib/manager/gradle/shallow/parser.spec.ts
@@ -74,6 +74,9 @@ describe('manager/gradle/shallow/parser', () => {
         ${'z = "1.2.3"'}    | ${'id "x.y" version "$z"'}          | ${{ depName: 'x.y', lookupName: 'x.y:x.y.gradle.plugin', currentValue: '1.2.3' }}
         ${''}               | ${'id "x.y" version "$z"'}          | ${{ depName: 'x.y', skipReason: SkipReason.UnknownVersion, currentValue: 'z' }}
         ${''}               | ${'id "x.y" version "x${y}z"'}      | ${{ depName: 'x.y', skipReason: SkipReason.UnknownVersion }}
+        ${'z = "1.2.3"'}    | ${'id("x.y") version "$z"'}         | ${{ depName: 'x.y', lookupName: 'x.y:x.y.gradle.plugin', currentValue: '1.2.3' }}
+        ${''}               | ${'id("x.y") version "$z"'}         | ${{ depName: 'x.y', skipReason: SkipReason.UnknownVersion, currentValue: 'z' }}
+        ${''}               | ${'id("x.y") version "x${y}z"'}     | ${{ depName: 'x.y', skipReason: SkipReason.UnknownVersion }}
       `('$input', ({ def, input, output }) => {
         const { deps } = parseGradle([def, input].join('\n'));
         expect(deps).toMatchObject([output].filter(Boolean));

--- a/lib/manager/gradle/shallow/parser.spec.ts
+++ b/lib/manager/gradle/shallow/parser.spec.ts
@@ -71,6 +71,9 @@ describe('manager/gradle/shallow/parser', () => {
         ${'baz = "1.2.3"'}  | ${'id "foo.bar" version baz'}       | ${{ depName: 'foo.bar', lookupName: 'foo.bar:foo.bar.gradle.plugin', currentValue: '1.2.3' }}
         ${'baz = "1.2.3"'}  | ${'id("foo.bar") version baz'}      | ${{ depName: 'foo.bar', lookupName: 'foo.bar:foo.bar.gradle.plugin', currentValue: '1.2.3' }}
         ${'baz = "1.3.71"'} | ${'kotlin("jvm") version baz'}      | ${{ depName: 'org.jetbrains.kotlin.jvm', lookupName: 'org.jetbrains.kotlin.jvm:org.jetbrains.kotlin.jvm.gradle.plugin', currentValue: '1.3.71' }}
+        ${'z = "1.2.3"'}    | ${'id "x.y" version "$z"'}          | ${{ depName: 'x.y', lookupName: 'x.y:x.y.gradle.plugin', currentValue: '1.2.3' }}
+        ${''}               | ${'id "x.y" version "$z"'}          | ${{ depName: 'x.y', skipReason: SkipReason.UnknownVersion, currentValue: 'z' }}
+        ${''}               | ${'id "x.y" version "x${y}z"'}      | ${{ depName: 'x.y', skipReason: SkipReason.UnknownVersion }}
       `('$input', ({ def, input, output }) => {
         const { deps } = parseGradle([def, input].join('\n'));
         expect(deps).toMatchObject([output].filter(Boolean));

--- a/lib/manager/gradle/shallow/tokenizer.ts
+++ b/lib/manager/gradle/shallow/tokenizer.ts
@@ -35,7 +35,7 @@ const lexer = moo.states({
     [TokenType.Comma]: ',',
     [TokenType.Operator]: /(?:==|\+=?|-=?|\/=?|\*\*?|\.+|:)/, // TODO #12870
     [TokenType.Assignment]: '=',
-    [TokenType.Word]: { match: /[a-zA-Z$_][a-zA-Z0-9$_]+/ }, // TODO #12870
+    [TokenType.Word]: { match: /[a-zA-Z$_][a-zA-Z0-9$_]*/ }, // TODO #12870
     [TokenType.LeftParen]: { match: '(' },
     [TokenType.RightParen]: { match: ')' },
     [TokenType.LeftBracket]: { match: '[' },


### PR DESCRIPTION
## Changes:

- Resolve variable inside the whole templated string

## Context:

- Closes: #12591

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
