### PR TITLE
refactor(datasource/go): Restrict parameters for "getDigest"

### DIFF
--- a/lib/datasource/go/get-datasource.spec.ts
+++ b/lib/datasource/go/get-datasource.spec.ts
@@ -88,6 +88,7 @@ describe('datasource/go/get-datasource', () => {
         expect(res).toEqual({
           datasource: githubDatasource,
           lookupName: 'golang/text',
+          registryUrl: 'https://github.com',
         });
       });
 

--- a/lib/datasource/go/get-datasource.ts
+++ b/lib/datasource/go/get-datasource.ts
@@ -35,6 +35,7 @@ async function goGetDatasource(goModule: string): Promise<DataSource | null> {
         lookupName: goSourceUrl
           .replace('https://github.com/', '')
           .replace(regEx(/\/$/), ''),
+        registryUrl: 'https://github.com',
       };
     }
     const gitlabUrl =
@@ -129,7 +130,11 @@ export async function getDatasource(
   if (goModule.startsWith('gopkg.in/')) {
     const [pkg] = goModule.replace('gopkg.in/', '').split('.');
     const lookupName = pkg.includes('/') ? pkg : `go-${pkg}/${pkg}`;
-    return { datasource: github.id, lookupName };
+    return {
+      datasource: github.id,
+      lookupName,
+      registryUrl: 'https://github.com',
+    };
   }
 
   if (goModule.startsWith('github.com/')) {
@@ -138,6 +143,7 @@ export async function getDatasource(
     return {
       datasource: github.id,
       lookupName,
+      registryUrl: 'https://github.com',
     };
   }
 
@@ -147,6 +153,7 @@ export async function getDatasource(
     return {
       datasource: bitbucket.id,
       lookupName,
+      registryUrl: 'https://bitbucket.org',
     };
   }
 

--- a/lib/datasource/go/releases-direct.spec.ts
+++ b/lib/datasource/go/releases-direct.spec.ts
@@ -42,6 +42,7 @@ describe('datasource/go/releases-direct', () => {
       ds.getDatasource.mockResolvedValueOnce({
         datasource: 'github-tags',
         lookupName: 'golang/text',
+        registryUrl: 'https://github.com',
       });
       httpMock
         .scope('https://api.github.com/')
@@ -98,6 +99,7 @@ describe('datasource/go/releases-direct', () => {
       ds.getDatasource.mockResolvedValueOnce({
         datasource: 'bitbucket-tags',
         lookupName: 'golang/text',
+        registryUrl: 'https://bitbucket.org',
       });
       httpMock
         .scope('https://api.bitbucket.org/')
@@ -139,14 +141,17 @@ describe('datasource/go/releases-direct', () => {
       ds.getDatasource.mockResolvedValueOnce({
         datasource: 'github-tags',
         lookupName: 'x/text',
+        registryUrl: 'https://github.com',
       });
       ds.getDatasource.mockResolvedValueOnce({
         datasource: 'github-tags',
         lookupName: 'x/text',
+        registryUrl: 'https://github.com',
       });
       ds.getDatasource.mockResolvedValueOnce({
         datasource: 'github-tags',
         lookupName: 'go-x/x',
+        registryUrl: 'https://github.com',
       });
       httpMock
         .scope('https://api.github.com/')
@@ -199,14 +204,17 @@ describe('datasource/go/releases-direct', () => {
       ds.getDatasource.mockResolvedValueOnce({
         datasource: 'github-tags',
         lookupName: 'x/text',
+        registryUrl: 'https://github.com',
       });
       ds.getDatasource.mockResolvedValueOnce({
         datasource: 'github-tags',
         lookupName: 'x/text',
+        registryUrl: 'https://github.com',
       });
       ds.getDatasource.mockResolvedValueOnce({
         datasource: 'github-tags',
         lookupName: 'x/text',
+        registryUrl: 'https://github.com',
       });
       const packages = [
         { lookupName: 'github.com/x/text/a' },
@@ -236,10 +244,12 @@ describe('datasource/go/releases-direct', () => {
       ds.getDatasource.mockResolvedValueOnce({
         datasource: 'github-tags',
         lookupName: 'x/text',
+        registryUrl: 'https://github.com',
       });
       ds.getDatasource.mockResolvedValueOnce({
         datasource: 'github-tags',
         lookupName: 'x/text',
+        registryUrl: 'https://github.com',
       });
       const packages = [
         { lookupName: 'github.com/x/text/a' },
@@ -267,6 +277,7 @@ describe('datasource/go/releases-direct', () => {
       ds.getDatasource.mockResolvedValueOnce({
         datasource: 'github-tags',
         lookupName: 'x/text',
+        registryUrl: 'https://github.com',
       });
       const pkg = { lookupName: 'github.com/x/text/b/v2' };
       const tags = [

--- a/lib/datasource/go/types.ts
+++ b/lib/datasource/go/types.ts
@@ -2,7 +2,7 @@ import type { GoproxyFallback } from './common';
 
 export interface DataSource {
   datasource: string;
-  registryUrl?: string;
+  registryUrl: string;
   lookupName: string;
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Always generate `registryUrl` parameter for `getDigest` calls

## Context:

- Ref: #13583

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
