### PR TITLE
fix(renovate): Print preset validation errors so that they don't get lost

### DIFF
--- a/lib/workers/global/index.ts
+++ b/lib/workers/global/index.ts
@@ -80,6 +80,7 @@ export async function validatePresets(config: AllConfig): Promise<void> {
   try {
     await resolveConfigPresets(config);
   } catch (err) /* istanbul ignore next */ {
+    logger.error({ err }, CONFIG_PRESETS_INVALID);
     throw new Error(CONFIG_PRESETS_INVALID);
   }
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

Renovate Global Worker [swallows config validation errors](https://github.com/renovatebot/renovate/blob/a6af88eb231a6f990b1f055c772228856425b5c5/lib/workers/global/index.ts#L83), making them impossible to diagnose.

This PR adds error logging when an error is caught.

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
