### PR TITLE
feat(cache/package): Log warnings for nullable cache keys

### DIFF
--- a/lib/util/cache/package/index.ts
+++ b/lib/util/cache/package/index.ts
@@ -8,7 +8,7 @@ import type { PackageCache } from './types';
 
 let cacheProxy: PackageCache;
 
-const nullableString = regEx('undefined|null');
+const nullableString = regEx('undefined|null', 'i');
 
 function getGlobalKey(namespace: string, key: string): string {
   const result = `global%%${namespace}%%${key}`;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Though null checks are enabled for cache utilities, cache users still can store values using `undefined` as the part of key.

This PR enables warning logs once some key contains `undefined` or `null`. It's meant to find all the places (namespaces) where our code is forming cache keys not carefully enough.

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
