### PR TITLE
fix: Configurability host rules for datasources and changelogs

### DIFF
--- a/lib/constants/platform.spec.ts
+++ b/lib/constants/platform.spec.ts
@@ -1,10 +1,14 @@
+import { BitBucketTagsDatasource } from '../datasource/bitbucket-tags';
 import { id as GH_RELEASES_DS } from '../datasource/github-releases';
 import { id as GH_TAGS_DS } from '../datasource/github-tags';
 import { GitlabPackagesDatasource } from '../datasource/gitlab-packages';
 import { GitlabReleasesDatasource } from '../datasource/gitlab-releases';
 import { id as GL_TAGS_DS } from '../datasource/gitlab-tags';
 import { id as POD_DS } from '../datasource/pod';
+import { id as GITHUB_CHANGELOG_ID } from '../workers/pr/changelog/github';
+import { id as GITLAB_CHANGELOG_ID } from '../workers/pr/changelog/gitlab';
 import {
+  BITBUCKET_API_USING_HOST_TYPES,
   GITHUB_API_USING_HOST_TYPES,
   GITLAB_API_USING_HOST_TYPES,
   PlatformId,
@@ -19,6 +23,9 @@ describe('constants/platform', () => {
     expect(
       GITLAB_API_USING_HOST_TYPES.includes(GitlabPackagesDatasource.id)
     ).toBeTrue();
+    expect(
+      GITLAB_API_USING_HOST_TYPES.includes(GITLAB_CHANGELOG_ID)
+    ).toBeTrue();
     expect(GITLAB_API_USING_HOST_TYPES.includes(PlatformId.Gitlab)).toBeTrue();
   });
 
@@ -30,10 +37,22 @@ describe('constants/platform', () => {
     expect(GITHUB_API_USING_HOST_TYPES.includes(GH_TAGS_DS)).toBeTrue();
     expect(GITHUB_API_USING_HOST_TYPES.includes(GH_RELEASES_DS)).toBeTrue();
     expect(GITHUB_API_USING_HOST_TYPES.includes(POD_DS)).toBeTrue();
+    expect(
+      GITHUB_API_USING_HOST_TYPES.includes(GITHUB_CHANGELOG_ID)
+    ).toBeTrue();
     expect(GITHUB_API_USING_HOST_TYPES.includes(PlatformId.Github)).toBeTrue();
   });
 
   it('should be not part of the GITHUB_API_USING_HOST_TYPES ', () => {
     expect(GITHUB_API_USING_HOST_TYPES.includes(PlatformId.Gitlab)).toBeFalse();
+  });
+
+  it('should be part of the BITBUCKET_API_USING_HOST_TYPES ', () => {
+    expect(
+      BITBUCKET_API_USING_HOST_TYPES.includes(BitBucketTagsDatasource.id)
+    ).toBeTrue();
+    expect(
+      BITBUCKET_API_USING_HOST_TYPES.includes(PlatformId.Bitbucket)
+    ).toBeTrue();
   });
 });

--- a/lib/constants/platforms.ts
+++ b/lib/constants/platforms.ts
@@ -19,4 +19,5 @@ export const GITLAB_API_USING_HOST_TYPES = [
   'gitlab-releases',
   'gitlab-tags',
   'gitlab-packages',
+  'gitlab-changelog',
 ];

--- a/lib/constants/platforms.ts
+++ b/lib/constants/platforms.ts
@@ -22,3 +22,8 @@ export const GITLAB_API_USING_HOST_TYPES = [
   'gitlab-packages',
   'gitlab-changelog',
 ];
+
+export const BITBUCKET_API_USING_HOST_TYPES = [
+  PlatformId.Bitbucket,
+  'bitbucket-tags',
+];

--- a/lib/constants/platforms.ts
+++ b/lib/constants/platforms.ts
@@ -12,6 +12,7 @@ export const GITHUB_API_USING_HOST_TYPES = [
   'github-releases',
   'github-tags',
   'pod',
+  'github-changelog',
 ];
 
 export const GITLAB_API_USING_HOST_TYPES = [

--- a/lib/datasource/bitbucket-tags/index.ts
+++ b/lib/datasource/bitbucket-tags/index.ts
@@ -7,7 +7,7 @@ import type { DigestConfig, GetReleasesConfig, ReleaseResult } from '../types';
 import { BitbucketCommit, BitbucketTag } from './types';
 
 export class BitBucketTagsDatasource extends Datasource {
-  bitbucketHttp = new BitbucketHttp();
+  bitbucketHttp = new BitbucketHttp(BitBucketTagsDatasource.id);
 
   static readonly id = 'bitbucket-tags';
 

--- a/lib/datasource/gitlab-packages/index.ts
+++ b/lib/datasource/gitlab-packages/index.ts
@@ -21,7 +21,7 @@ export class GitlabPackagesDatasource extends Datasource {
 
   constructor() {
     super(datasource);
-    this.http = new GitlabHttp();
+    this.http = new GitlabHttp(datasource);
   }
 
   static getGitlabPackageApiUrl(

--- a/lib/util/http/bitbucket.ts
+++ b/lib/util/http/bitbucket.ts
@@ -8,8 +8,8 @@ export const setBaseUrl = (url: string): void => {
 };
 
 export class BitbucketHttp extends Http {
-  constructor(options?: HttpOptions) {
-    super(PlatformId.Bitbucket, options);
+  constructor(type: string = PlatformId.Bitbucket, options?: HttpOptions) {
+    super(type, options);
   }
 
   protected override request<T>(

--- a/lib/util/http/host-rules.spec.ts
+++ b/lib/util/http/host-rules.spec.ts
@@ -40,9 +40,8 @@ describe('util/http/host-rules', () => {
     });
 
     hostRules.add({
-      hostType: 'github-releases',
-      username: 'some',
-      password: 'xxx',
+      hostType: PlatformId.Bitbucket,
+      token: 'cdef',
     });
   });
 
@@ -130,7 +129,25 @@ describe('util/http/host-rules', () => {
     `);
   });
 
-  it('no fallback', () => {
+  it('no fallback to github', () => {
+    hostRules.add({
+      hostType: 'github-tags',
+      username: 'some2',
+      password: 'xxx2',
+    });
+    hostRules.add({
+      hostType: 'github-changelog',
+      token: 'changelogtoken',
+    });
+    hostRules.add({
+      hostType: 'pod',
+      token: 'pod-token',
+    });
+    hostRules.add({
+      hostType: 'github-releases',
+      username: 'some',
+      password: 'xxx',
+    });
     expect(
       applyHostRules(url, { ...options, hostType: 'github-releases' })
     ).toEqual({
@@ -138,31 +155,176 @@ describe('util/http/host-rules', () => {
       username: 'some',
       password: 'xxx',
     });
+    expect(
+      applyHostRules(url, { ...options, hostType: 'github-tags' })
+    ).toEqual({
+      hostType: 'github-tags',
+      username: 'some2',
+      password: 'xxx2',
+    });
+    expect(applyHostRules(url, { ...options, hostType: 'pod' })).toEqual({
+      context: {
+        authType: undefined,
+      },
+      hostType: 'pod',
+      token: 'pod-token',
+    });
+    expect(
+      applyHostRules(url, { ...options, hostType: 'github-changelog' })
+    ).toEqual({
+      context: {
+        authType: undefined,
+      },
+      hostType: 'github-changelog',
+      token: 'changelogtoken',
+    });
   });
 
   it('fallback to github', () => {
-    expect(applyHostRules(url, { ...options, hostType: 'github-tags' }))
-      .toMatchInlineSnapshot(`
-      Object {
-        "context": Object {
-          "authType": undefined,
-        },
-        "hostType": "github-tags",
-        "token": "token",
-      }
-    `);
+    expect(
+      applyHostRules(url, { ...options, hostType: 'github-tags' })
+    ).toEqual({
+      context: {
+        authType: undefined,
+      },
+      hostType: 'github-tags',
+      token: 'token',
+    });
+    expect(
+      applyHostRules(url, { ...options, hostType: 'github-changelog' })
+    ).toEqual({
+      context: {
+        authType: undefined,
+      },
+      hostType: 'github-changelog',
+      token: 'token',
+    });
+    expect(applyHostRules(url, { ...options, hostType: 'pod' })).toEqual({
+      context: {
+        authType: undefined,
+      },
+      hostType: 'pod',
+      token: 'token',
+    });
+  });
+  it('no fallback to gitlab', () => {
+    hostRules.add({
+      hostType: 'gitlab-changelog',
+      token: 'changelog-token',
+    });
+    hostRules.add({
+      hostType: 'gitlab-packages',
+      token: 'package-token',
+    });
+    hostRules.add({
+      hostType: 'gitlab-releases',
+      token: 'release-token',
+    });
+    hostRules.add({
+      hostType: 'gitlab-tags',
+      token: 'tags-token',
+    });
+    expect(
+      applyHostRules(url, { ...options, hostType: 'gitlab-tags' })
+    ).toEqual({
+      context: {
+        authType: undefined,
+      },
+      hostType: 'gitlab-tags',
+      token: 'tags-token',
+    });
+    expect(
+      applyHostRules(url, { ...options, hostType: 'gitlab-releases' })
+    ).toEqual({
+      context: {
+        authType: undefined,
+      },
+      hostType: 'gitlab-releases',
+      token: 'release-token',
+    });
+    expect(
+      applyHostRules(url, { ...options, hostType: 'gitlab-packages' })
+    ).toEqual({
+      context: {
+        authType: undefined,
+      },
+      hostType: 'gitlab-packages',
+      token: 'package-token',
+    });
+    expect(
+      applyHostRules(url, { ...options, hostType: 'gitlab-changelog' })
+    ).toEqual({
+      context: {
+        authType: undefined,
+      },
+      hostType: 'gitlab-changelog',
+      token: 'changelog-token',
+    });
   });
 
   it('fallback to gitlab', () => {
-    expect(applyHostRules(url, { ...options, hostType: 'gitlab-tags' }))
-      .toMatchInlineSnapshot(`
-      Object {
-        "context": Object {
-          "authType": undefined,
-        },
-        "hostType": "gitlab-tags",
-        "token": "abc",
-      }
-    `);
+    expect(
+      applyHostRules(url, { ...options, hostType: 'gitlab-tags' })
+    ).toEqual({
+      context: {
+        authType: undefined,
+      },
+      hostType: 'gitlab-tags',
+      token: 'abc',
+    });
+    expect(
+      applyHostRules(url, { ...options, hostType: 'gitlab-releases' })
+    ).toEqual({
+      context: {
+        authType: undefined,
+      },
+      hostType: 'gitlab-releases',
+      token: 'abc',
+    });
+    expect(
+      applyHostRules(url, { ...options, hostType: 'gitlab-packages' })
+    ).toEqual({
+      context: {
+        authType: undefined,
+      },
+      hostType: 'gitlab-packages',
+      token: 'abc',
+    });
+    expect(
+      applyHostRules(url, { ...options, hostType: 'gitlab-changelog' })
+    ).toEqual({
+      context: {
+        authType: undefined,
+      },
+      hostType: 'gitlab-changelog',
+      token: 'abc',
+    });
+  });
+
+  it('no fallback to bitbucket', () => {
+    hostRules.add({
+      hostType: 'bitbucket-tags',
+      username: 'some',
+      password: 'xxx',
+    });
+    expect(
+      applyHostRules(url, { ...options, hostType: 'bitbucket-tags' })
+    ).toEqual({
+      hostType: 'bitbucket-tags',
+      username: 'some',
+      password: 'xxx',
+    });
+  });
+
+  it('fallback to bitbucket', () => {
+    expect(
+      applyHostRules(url, { ...options, hostType: 'bitbucket-tags' })
+    ).toEqual({
+      context: {
+        authType: undefined,
+      },
+      hostType: 'bitbucket-tags',
+      token: 'cdef',
+    });
   });
 });

--- a/lib/util/http/host-rules.ts
+++ b/lib/util/http/host-rules.ts
@@ -1,4 +1,5 @@
 import {
+  BITBUCKET_API_USING_HOST_TYPES,
   GITHUB_API_USING_HOST_TYPES,
   GITLAB_API_USING_HOST_TYPES,
   PlatformId,
@@ -42,6 +43,21 @@ function findMatchingRules(options: GotOptions, url: string): HostRule {
     res = {
       ...hostRules.find({
         hostType: PlatformId.Gitlab,
+        url,
+      }),
+      ...res,
+    };
+  }
+
+  // Fallback to `bitbucket` hostType
+  if (
+    hostType &&
+    BITBUCKET_API_USING_HOST_TYPES.includes(hostType) &&
+    hostType !== PlatformId.Bitbucket
+  ) {
+    res = {
+      ...hostRules.find({
+        hostType: PlatformId.Bitbucket,
         url,
       }),
       ...res,

--- a/lib/workers/pr/changelog/__snapshots__/gitlab.spec.ts.snap
+++ b/lib/workers/pr/changelog/__snapshots__/gitlab.spec.ts.snap
@@ -56,7 +56,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/repository/tags?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/repository/tags?per_page=100",
   },
   Object {
     "headers": Object {
@@ -67,7 +67,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/repository/tree?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/repository/tree?per_page=100",
   },
   Object {
     "headers": Object {
@@ -78,7 +78,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/releases?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/releases?per_page=100",
   },
   Object {
     "headers": Object {
@@ -89,7 +89,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/repository/tree?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/repository/tree?per_page=100",
   },
   Object {
     "headers": Object {
@@ -100,7 +100,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/releases?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/releases?per_page=100",
   },
   Object {
     "headers": Object {
@@ -111,7 +111,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/repository/tree?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/repository/tree?per_page=100",
   },
   Object {
     "headers": Object {
@@ -122,7 +122,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/releases?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/releases?per_page=100",
   },
   Object {
     "headers": Object {
@@ -133,7 +133,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/repository/tree?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/repository/tree?per_page=100",
   },
   Object {
     "headers": Object {
@@ -144,7 +144,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/releases?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/releases?per_page=100",
   },
 ]
 `;
@@ -315,7 +315,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/repository/tags?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/repository/tags?per_page=100",
   },
   Object {
     "headers": Object {
@@ -326,7 +326,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/repository/tree?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/repository/tree?per_page=100",
   },
   Object {
     "headers": Object {
@@ -337,7 +337,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/releases?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/releases?per_page=100",
   },
   Object {
     "headers": Object {
@@ -348,7 +348,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/repository/tree?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/repository/tree?per_page=100",
   },
   Object {
     "headers": Object {
@@ -359,7 +359,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/releases?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/releases?per_page=100",
   },
   Object {
     "headers": Object {
@@ -370,7 +370,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/repository/tree?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/repository/tree?per_page=100",
   },
   Object {
     "headers": Object {
@@ -381,7 +381,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/releases?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/releases?per_page=100",
   },
   Object {
     "headers": Object {
@@ -392,7 +392,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/repository/tree?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/repository/tree?per_page=100",
   },
   Object {
     "headers": Object {
@@ -403,7 +403,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/releases?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/releases?per_page=100",
   },
 ]
 `;
@@ -464,7 +464,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/repository/tags?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/repository/tags?per_page=100",
   },
   Object {
     "headers": Object {
@@ -475,7 +475,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/repository/tree?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/repository/tree?per_page=100",
   },
   Object {
     "headers": Object {
@@ -486,7 +486,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/releases?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/releases?per_page=100",
   },
   Object {
     "headers": Object {
@@ -497,7 +497,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/repository/tree?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/repository/tree?per_page=100",
   },
   Object {
     "headers": Object {
@@ -508,7 +508,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/releases?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/releases?per_page=100",
   },
   Object {
     "headers": Object {
@@ -519,7 +519,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/repository/tree?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/repository/tree?per_page=100",
   },
   Object {
     "headers": Object {
@@ -530,7 +530,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/releases?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/releases?per_page=100",
   },
   Object {
     "headers": Object {
@@ -541,7 +541,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/repository/tree?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/repository/tree?per_page=100",
   },
   Object {
     "headers": Object {
@@ -552,7 +552,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/releases?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/releases?per_page=100",
   },
 ]
 `;

--- a/lib/workers/pr/changelog/__snapshots__/release-notes.spec.ts.snap
+++ b/lib/workers/pr/changelog/__snapshots__/release-notes.spec.ts.snap
@@ -41,16 +41,16 @@ Array [
   Object {
     "body": undefined,
     "name": undefined,
-    "notesSourceUrl": "https://gitlab.com/api/v4/projects/some%2fyet-other-repository/releases",
+    "notesSourceUrl": "https://gitlab.com/api/v4/projects/some%2Fyet-other-repository/releases",
     "tag": "v1.0.0",
-    "url": "https://gitlab.com/api/v4/projects/some%2fyet-other-repository/releases/v1.0.0",
+    "url": "https://gitlab.com/api/v4/projects/some%2Fyet-other-repository/releases/v1.0.0",
   },
   Object {
     "body": undefined,
     "name": undefined,
-    "notesSourceUrl": "https://gitlab.com/api/v4/projects/some%2fyet-other-repository/releases",
+    "notesSourceUrl": "https://gitlab.com/api/v4/projects/some%2Fyet-other-repository/releases",
     "tag": "v1.0.1",
-    "url": "https://gitlab.com/api/v4/projects/some%2fyet-other-repository/releases/v1.0.1",
+    "url": "https://gitlab.com/api/v4/projects/some%2Fyet-other-repository/releases/v1.0.1",
   },
 ]
 `;
@@ -65,7 +65,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/some%2fyet-other-repository/releases?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/some%2Fyet-other-repository/releases?per_page=100",
   },
 ]
 `;
@@ -75,16 +75,16 @@ Array [
   Object {
     "body": undefined,
     "name": undefined,
-    "notesSourceUrl": "https://my.custom.domain/api/v4/projects/some%2fyet-other-repository/releases",
+    "notesSourceUrl": "https://my.custom.domain/api/v4/projects/some%2Fyet-other-repository/releases",
     "tag": "v1.0.0",
-    "url": "https://my.custom.domain/api/v4/projects/some%2fyet-other-repository/releases/v1.0.0",
+    "url": "https://my.custom.domain/api/v4/projects/some%2Fyet-other-repository/releases/v1.0.0",
   },
   Object {
     "body": undefined,
     "name": undefined,
-    "notesSourceUrl": "https://my.custom.domain/api/v4/projects/some%2fyet-other-repository/releases",
+    "notesSourceUrl": "https://my.custom.domain/api/v4/projects/some%2Fyet-other-repository/releases",
     "tag": "v1.0.1",
-    "url": "https://my.custom.domain/api/v4/projects/some%2fyet-other-repository/releases/v1.0.1",
+    "url": "https://my.custom.domain/api/v4/projects/some%2Fyet-other-repository/releases/v1.0.1",
   },
 ]
 `;
@@ -100,7 +100,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://my.custom.domain/api/v4/projects/some%2fyet-other-repository/releases?per_page=100",
+    "url": "https://my.custom.domain/api/v4/projects/some%2Fyet-other-repository/releases?per_page=100",
   },
 ]
 `;
@@ -190,7 +190,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://api.gitlab.com/projects/some%2fother-repository/releases?per_page=100",
+    "url": "https://api.gitlab.com/projects/some%2Fother-repository/releases?per_page=100",
   },
 ]
 `;
@@ -205,7 +205,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://api.gitlab.com/projects/some%2fother-repository/releases?per_page=100",
+    "url": "https://api.gitlab.com/projects/some%2Fother-repository/releases?per_page=100",
   },
 ]
 `;
@@ -220,7 +220,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://api.gitlab.com/projects/some%2fother-repository/releases?per_page=100",
+    "url": "https://api.gitlab.com/projects/some%2Fother-repository/releases?per_page=100",
   },
 ]
 `;
@@ -250,7 +250,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/itentialopensource%2fadapter-utils/repository/tree?per_page=100&path=packages/foo",
+    "url": "https://gitlab.com/api/v4/projects/itentialopensource%2Fadapter-utils/repository/tree?per_page=100&path=packages/foo",
   },
   Object {
     "headers": Object {
@@ -259,7 +259,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/itentialopensource%2fadapter-utils/repository/blobs/abcd/raw",
+    "url": "https://gitlab.com/api/v4/projects/itentialopensource%2Fadapter-utils/repository/blobs/abcd/raw",
   },
 ]
 `;
@@ -289,7 +289,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/itentialopensource%2fadapter-utils/repository/tree?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/itentialopensource%2Fadapter-utils/repository/tree?per_page=100",
   },
   Object {
     "headers": Object {
@@ -298,7 +298,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/itentialopensource%2fadapter-utils/repository/blobs/abcd/raw",
+    "url": "https://gitlab.com/api/v4/projects/itentialopensource%2Fadapter-utils/repository/blobs/abcd/raw",
   },
 ]
 `;
@@ -651,7 +651,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://api.gitlab.com/projects/gitlab-org%2fgitter%2fwebapp/repository/tree?per_page=100",
+    "url": "https://api.gitlab.com/projects/gitlab-org%2Fgitter%2Fwebapp/repository/tree?per_page=100",
   },
   Object {
     "headers": Object {
@@ -660,7 +660,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://api.gitlab.com/projects/gitlab-org%2fgitter%2fwebapp/repository/blobs/abcd/raw",
+    "url": "https://api.gitlab.com/projects/gitlab-org%2Fgitter%2Fwebapp/repository/blobs/abcd/raw",
   },
 ]
 `;
@@ -966,7 +966,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://my.custom.domain/projects/gitlab-org%2fgitter%2fwebapp/repository/tree?per_page=100",
+    "url": "https://my.custom.domain/projects/gitlab-org%2Fgitter%2Fwebapp/repository/tree?per_page=100",
   },
   Object {
     "headers": Object {
@@ -976,7 +976,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://my.custom.domain/projects/gitlab-org%2fgitter%2fwebapp/repository/blobs/abcd/raw",
+    "url": "https://my.custom.domain/projects/gitlab-org%2Fgitter%2Fwebapp/repository/blobs/abcd/raw",
   },
 ]
 `;

--- a/lib/workers/pr/changelog/github/index.ts
+++ b/lib/workers/pr/changelog/github/index.ts
@@ -11,7 +11,8 @@ import { GithubHttp } from '../../../../util/http/github';
 import { ensureTrailingSlash } from '../../../../util/url';
 import type { ChangeLogFile, ChangeLogNotes } from '../types';
 
-const http = new GithubHttp();
+export const id = 'github-changelog';
+const http = new GithubHttp(id);
 
 export async function getTags(
   endpoint: string,

--- a/lib/workers/pr/changelog/gitlab.spec.ts
+++ b/lib/workers/pr/changelog/gitlab.spec.ts
@@ -102,7 +102,7 @@ describe('workers/pr/changelog/gitlab', () => {
     it('uses GitLab tags', async () => {
       httpMock
         .scope(matchHost)
-        .get('/api/v4/projects/meno%2fdropzone/repository/tags?per_page=100')
+        .get('/api/v4/projects/meno%2Fdropzone/repository/tags?per_page=100')
         .reply(200, [
           { name: 'v5.2.0' },
           { name: 'v5.4.0' },
@@ -112,10 +112,10 @@ describe('workers/pr/changelog/gitlab', () => {
           { name: 'v5.7.0' },
         ])
         .persist()
-        .get('/api/v4/projects/meno%2fdropzone/repository/tree?per_page=100')
+        .get('/api/v4/projects/meno%2Fdropzone/repository/tree?per_page=100')
         .reply(200, [])
         .persist()
-        .get('/api/v4/projects/meno%2fdropzone/releases?per_page=100')
+        .get('/api/v4/projects/meno%2Fdropzone/releases?per_page=100')
         .reply(200, []);
       expect(
         await getChangeLogJSON({
@@ -144,13 +144,13 @@ describe('workers/pr/changelog/gitlab', () => {
     it('handles empty GitLab tags response', async () => {
       httpMock
         .scope(matchHost)
-        .get('/api/v4/projects/meno%2fdropzone/repository/tags?per_page=100')
+        .get('/api/v4/projects/meno%2Fdropzone/repository/tags?per_page=100')
         .reply(200, [])
         .persist()
-        .get('/api/v4/projects/meno%2fdropzone/repository/tree?per_page=100')
+        .get('/api/v4/projects/meno%2Fdropzone/repository/tree?per_page=100')
         .reply(200, [])
         .persist()
-        .get('/api/v4/projects/meno%2fdropzone/releases?per_page=100')
+        .get('/api/v4/projects/meno%2Fdropzone/releases?per_page=100')
         .reply(200, []);
       expect(
         await getChangeLogJSON({
@@ -179,13 +179,13 @@ describe('workers/pr/changelog/gitlab', () => {
     it('uses GitLab tags with error', async () => {
       httpMock
         .scope(matchHost)
-        .get('/api/v4/projects/meno%2fdropzone/repository/tags?per_page=100')
+        .get('/api/v4/projects/meno%2Fdropzone/repository/tags?per_page=100')
         .replyWithError('Unknown GitLab Repo')
         .persist()
-        .get('/api/v4/projects/meno%2fdropzone/repository/tree?per_page=100')
+        .get('/api/v4/projects/meno%2Fdropzone/repository/tree?per_page=100')
         .reply(200, [])
         .persist()
-        .get('/api/v4/projects/meno%2fdropzone/releases?per_page=100')
+        .get('/api/v4/projects/meno%2Fdropzone/releases?per_page=100')
         .reply(200, []);
       expect(
         await getChangeLogJSON({

--- a/lib/workers/pr/changelog/gitlab/index.ts
+++ b/lib/workers/pr/changelog/gitlab/index.ts
@@ -4,24 +4,20 @@ import type { GitlabTag } from '../../../../datasource/gitlab-tags/types';
 import { logger } from '../../../../logger';
 import type { GitlabTreeNode } from '../../../../types/platform/gitlab';
 import { GitlabHttp } from '../../../../util/http/gitlab';
-import { regEx } from '../../../../util/regex';
 import { ensureTrailingSlash } from '../../../../util/url';
 import type { ChangeLogFile, ChangeLogNotes } from '../types';
 
 const http = new GitlabHttp();
-
-function getRepoId(repository: string): string {
-  return repository.replace(regEx(/\//g), '%2f');
-}
 
 export async function getTags(
   endpoint: string,
   repository: string
 ): Promise<string[]> {
   logger.trace('gitlab.getTags()');
-  const url = `${ensureTrailingSlash(endpoint)}projects/${getRepoId(
-    repository
-  )}/repository/tags?per_page=100`;
+  const urlEncodedRepo = encodeURIComponent(repository);
+  const url = `${ensureTrailingSlash(
+    endpoint
+  )}projects/${urlEncodedRepo}/repository/tags?per_page=100`;
   try {
     const res = await http.getJson<GitlabTag[]>(url, {
       paginate: true,
@@ -54,10 +50,10 @@ export async function getReleaseNotesMd(
   sourceDirectory?: string
 ): Promise<ChangeLogFile> | null {
   logger.trace('gitlab.getReleaseNotesMd()');
-  const repoid = getRepoId(repository);
+  const urlEncodedRepo = encodeURIComponent(repository);
   const apiPrefix = `${ensureTrailingSlash(
     apiBaseUrl
-  )}projects/${repoid}/repository/`;
+  )}projects/${urlEncodedRepo}/repository/`;
 
   // https://docs.gitlab.com/13.2/ee/api/repositories.html#list-repository-tree
   const tree = (
@@ -99,10 +95,10 @@ export async function getReleaseList(
 ): Promise<ChangeLogNotes[]> {
   logger.trace('gitlab.getReleaseNotesMd()');
 
-  const repoId = getRepoId(repository);
+  const urlEncodedRepo = encodeURIComponent(repository);
   const apiUrl = `${ensureTrailingSlash(
     apiBaseUrl
-  )}projects/${repoId}/releases`;
+  )}projects/${urlEncodedRepo}/releases`;
 
   const res = await http.getJson<GitlabRelease[]>(`${apiUrl}?per_page=100`, {
     paginate: true,

--- a/lib/workers/pr/changelog/gitlab/index.ts
+++ b/lib/workers/pr/changelog/gitlab/index.ts
@@ -7,7 +7,7 @@ import { GitlabHttp } from '../../../../util/http/gitlab';
 import { ensureTrailingSlash } from '../../../../util/url';
 import type { ChangeLogFile, ChangeLogNotes } from '../types';
 
-const http = new GitlabHttp();
+const http = new GitlabHttp('gitlab-changelog');
 
 export async function getTags(
   endpoint: string,

--- a/lib/workers/pr/changelog/gitlab/index.ts
+++ b/lib/workers/pr/changelog/gitlab/index.ts
@@ -7,7 +7,8 @@ import { GitlabHttp } from '../../../../util/http/gitlab';
 import { ensureTrailingSlash } from '../../../../util/url';
 import type { ChangeLogFile, ChangeLogNotes } from '../types';
 
-const http = new GitlabHttp('gitlab-changelog');
+export const id = 'gitlab-changelog';
+const http = new GitlabHttp(id);
 
 export async function getTags(
   endpoint: string,

--- a/lib/workers/pr/changelog/release-notes.spec.ts
+++ b/lib/workers/pr/changelog/release-notes.spec.ts
@@ -194,7 +194,7 @@ describe('workers/pr/changelog/release-notes', () => {
       httpMock
         .scope('https://gitlab.com/')
         .get(
-          '/api/v4/projects/some%2fyet-other-repository/releases?per_page=100'
+          '/api/v4/projects/some%2Fyet-other-repository/releases?per_page=100'
         )
         .reply(200, [
           { tag_name: `v1.0.0` },
@@ -210,15 +210,15 @@ describe('workers/pr/changelog/release-notes', () => {
       expect(res).toMatchSnapshot([
         {
           notesSourceUrl:
-            'https://gitlab.com/api/v4/projects/some%2fyet-other-repository/releases',
+            'https://gitlab.com/api/v4/projects/some%2Fyet-other-repository/releases',
           tag: 'v1.0.0',
-          url: 'https://gitlab.com/api/v4/projects/some%2fyet-other-repository/releases/v1.0.0',
+          url: 'https://gitlab.com/api/v4/projects/some%2Fyet-other-repository/releases/v1.0.0',
         },
         {
           notesSourceUrl:
-            'https://gitlab.com/api/v4/projects/some%2fyet-other-repository/releases',
+            'https://gitlab.com/api/v4/projects/some%2Fyet-other-repository/releases',
           tag: 'v1.0.1',
-          url: 'https://gitlab.com/api/v4/projects/some%2fyet-other-repository/releases/v1.0.1',
+          url: 'https://gitlab.com/api/v4/projects/some%2Fyet-other-repository/releases/v1.0.1',
         },
       ]);
       expect(httpMock.getTrace()).toMatchSnapshot();
@@ -229,7 +229,7 @@ describe('workers/pr/changelog/release-notes', () => {
       httpMock
         .scope('https://my.custom.domain/')
         .get(
-          '/api/v4/projects/some%2fyet-other-repository/releases?per_page=100'
+          '/api/v4/projects/some%2Fyet-other-repository/releases?per_page=100'
         )
         .reply(200, [
           { tag_name: `v1.0.0` },
@@ -247,15 +247,15 @@ describe('workers/pr/changelog/release-notes', () => {
       expect(res).toMatchSnapshot([
         {
           notesSourceUrl:
-            'https://my.custom.domain/api/v4/projects/some%2fyet-other-repository/releases',
+            'https://my.custom.domain/api/v4/projects/some%2Fyet-other-repository/releases',
           tag: 'v1.0.0',
-          url: 'https://my.custom.domain/api/v4/projects/some%2fyet-other-repository/releases/v1.0.0',
+          url: 'https://my.custom.domain/api/v4/projects/some%2Fyet-other-repository/releases/v1.0.0',
         },
         {
           notesSourceUrl:
-            'https://my.custom.domain/api/v4/projects/some%2fyet-other-repository/releases',
+            'https://my.custom.domain/api/v4/projects/some%2Fyet-other-repository/releases',
           tag: 'v1.0.1',
-          url: 'https://my.custom.domain/api/v4/projects/some%2fyet-other-repository/releases/v1.0.1',
+          url: 'https://my.custom.domain/api/v4/projects/some%2Fyet-other-repository/releases/v1.0.1',
         },
       ]);
       expect(httpMock.getTrace()).toMatchSnapshot();
@@ -440,7 +440,7 @@ describe('workers/pr/changelog/release-notes', () => {
       const prefix = '';
       httpMock
         .scope('https://api.gitlab.com/')
-        .get('/projects/some%2fother-repository/releases?per_page=100')
+        .get('/projects/some%2Fother-repository/releases?per_page=100')
         .reply(200, [
           { tag_name: `${prefix}1.0.0` },
           {
@@ -463,7 +463,7 @@ describe('workers/pr/changelog/release-notes', () => {
         body: 'some body #123, [#124](https://gitlab.com/some/yet-other-repository/issues/124)',
         name: undefined,
         notesSourceUrl:
-          'https://api.gitlab.com/projects/some%2fother-repository/releases',
+          'https://api.gitlab.com/projects/some%2Fother-repository/releases',
         tag: '1.0.1',
         url: 'https://gitlab.com/some/other-repository/tags/1.0.1',
       });
@@ -473,7 +473,7 @@ describe('workers/pr/changelog/release-notes', () => {
       const prefix = 'v';
       httpMock
         .scope('https://api.gitlab.com/')
-        .get('/projects/some%2fother-repository/releases?per_page=100')
+        .get('/projects/some%2Fother-repository/releases?per_page=100')
         .reply(200, [
           { tag_name: `${prefix}1.0.0` },
           {
@@ -496,7 +496,7 @@ describe('workers/pr/changelog/release-notes', () => {
         body: 'some body #123, [#124](https://gitlab.com/some/yet-other-repository/issues/124)',
         name: undefined,
         notesSourceUrl:
-          'https://api.gitlab.com/projects/some%2fother-repository/releases',
+          'https://api.gitlab.com/projects/some%2Fother-repository/releases',
         tag: 'v1.0.1',
         url: 'https://gitlab.com/some/other-repository/tags/v1.0.1',
       });
@@ -506,7 +506,7 @@ describe('workers/pr/changelog/release-notes', () => {
       const prefix = 'other-';
       httpMock
         .scope('https://api.gitlab.com/')
-        .get('/projects/some%2fother-repository/releases?per_page=100')
+        .get('/projects/some%2Fother-repository/releases?per_page=100')
         .reply(200, [
           { tag_name: `${prefix}1.0.0` },
           {
@@ -529,7 +529,7 @@ describe('workers/pr/changelog/release-notes', () => {
         body: 'some body #123, [#124](https://gitlab.com/some/yet-other-repository/issues/124)',
         name: undefined,
         notesSourceUrl:
-          'https://api.gitlab.com/projects/some%2fother-repository/releases',
+          'https://api.gitlab.com/projects/some%2Fother-repository/releases',
         tag: 'other-1.0.1',
         url: 'https://gitlab.com/some/other-repository/tags/other-1.0.1',
       });
@@ -661,10 +661,10 @@ describe('workers/pr/changelog/release-notes', () => {
       httpMock
         .scope('https://api.gitlab.com/')
         .get(
-          '/projects/gitlab-org%2fgitter%2fwebapp/repository/tree?per_page=100'
+          '/projects/gitlab-org%2Fgitter%2Fwebapp/repository/tree?per_page=100'
         )
         .reply(200, gitlabTreeResponse)
-        .get('/projects/gitlab-org%2fgitter%2fwebapp/repository/blobs/abcd/raw')
+        .get('/projects/gitlab-org%2Fgitter%2Fwebapp/repository/blobs/abcd/raw')
         .reply(200, gitterWebappChangelogMd);
       const res = await getReleaseNotesMd(
         {
@@ -688,10 +688,10 @@ describe('workers/pr/changelog/release-notes', () => {
       httpMock
         .scope('https://my.custom.domain/')
         .get(
-          '/projects/gitlab-org%2fgitter%2fwebapp/repository/tree?per_page=100'
+          '/projects/gitlab-org%2Fgitter%2Fwebapp/repository/tree?per_page=100'
         )
         .reply(200, gitlabTreeResponse)
-        .get('/projects/gitlab-org%2fgitter%2fwebapp/repository/blobs/abcd/raw')
+        .get('/projects/gitlab-org%2Fgitter%2Fwebapp/repository/blobs/abcd/raw')
         .reply(200, gitterWebappChangelogMd);
       const res = await getReleaseNotesMd(
         {
@@ -865,11 +865,11 @@ describe('workers/pr/changelog/release-notes', () => {
         httpMock
           .scope('https://gitlab.com/')
           .get(
-            '/api/v4/projects/itentialopensource%2fadapter-utils/repository/tree?per_page=100'
+            '/api/v4/projects/itentialopensource%2Fadapter-utils/repository/tree?per_page=100'
           )
           .reply(200, gitlabTreeResponse)
           .get(
-            '/api/v4/projects/itentialopensource%2fadapter-utils/repository/blobs/abcd/raw'
+            '/api/v4/projects/itentialopensource%2Fadapter-utils/repository/blobs/abcd/raw'
           )
           .reply(200, adapterutilsChangelogMd);
         const res = await getReleaseNotesMd(
@@ -897,11 +897,11 @@ describe('workers/pr/changelog/release-notes', () => {
         httpMock
           .scope('https://gitlab.com/')
           .get(
-            `/api/v4/projects/itentialopensource%2fadapter-utils/repository/tree?per_page=100&path=${sourceDirectory}`
+            `/api/v4/projects/itentialopensource%2Fadapter-utils/repository/tree?per_page=100&path=${sourceDirectory}`
           )
           .reply(200, response)
           .get(
-            '/api/v4/projects/itentialopensource%2fadapter-utils/repository/blobs/abcd/raw'
+            '/api/v4/projects/itentialopensource%2Fadapter-utils/repository/blobs/abcd/raw'
           )
           .reply(200, adapterutilsChangelogMd);
         const res = await getReleaseNotesMd(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Make url encoding consistent gitlab-changelog consistent with other gitlab datasources.
- Add hostType for gitlab changelog lookups, to differentiate them from platform calls.
- Add hostType for github changelog lookups, to differentiate them from platform calls.
- Add fallback mechanism for bitbucket datasource hostTypes(like is done for gitlab and github)
- Add missing hostType to bitbucket-tags datasource.
- Add missing hostType to gitlab-packages datasource. (Was already used in fallback configuration)
- Extend tests for hostRules fallback mechanism
- Extend regression tests for fallback constants.

## Context:

Applying hostRules for specific datsources is usually done by adding hostType to be matched to the rule, containing the datasource id. However this is not possible for all datasources, since a few don't add their id as hostType, but instead use the default hostType added by the platform specific Http client, which usually matches the platformId.  Which doesn't make it possible to differentiate between datasource and platform calls. They also cannot be overriden when running on that platform as noticed in #https://github.com/renovatebot/renovate/issues/13497

This is the case for the following datasources:
- gitlab-packages
- bitbucket-tags

The changelog modules which run after datasource lookups also don't add a hostType make it impossible to differentiate them between platform calls and lookups for changelogs. So one can configure token for gitlab-tags, but fail on changelog lookup.(See #13497)

This PR resolves this by treating the changelogs modules like any other (platform) datasource module(gitlab-tags, github-tags), which add a specific hostType to make it possible to add specific hostRules, while still having a fallback to the platform rules in case no specific rules are present.
The added hostTypes are
- gitlab-changelog
- github-changelog

Closes #13497
Replaces https://github.com/renovatebot/renovate/pull/13577

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
