### PR TITLE
docs(config-presets): use admonitions

### DIFF
--- a/docs/usage/config-presets.md
+++ b/docs/usage/config-presets.md
@@ -16,10 +16,14 @@ In short:
 
 Shareable config presets can only be used with the JSON format, other formats are not supported.
 
-**Warning:** `default.json` is intended for use with presets only!
-**Warning:** Do not use a `renovate.json` file as a preset.
+<!-- prettier-ignore -->
+!!! warning
+    `default.json` is intended for use with presets only!
+    Also, do not use a `renovate.json` file as a preset.
 
-**Info:** We've deprecated the use of a `renovate.json` file for presets as this can cause issues if the repository configuration uses a `renovate.json` file as well.
+<!-- prettier-ignore -->
+!!! info
+    We've deprecated the use of a `renovate.json` file for presets as this can cause issues if the repository configuration uses a `renovate.json` file as well.
 
 ## Goals of Preset Configs
 
@@ -87,9 +91,11 @@ You can set a Git tag (like a SemVer) to use a specific release of your shared c
 | Local with preset name and path with a tag | `local>abc/foo//path/xyz#1.5.4` | `xyz`     | `https://github.company.com/abc/foo` | `path/xyz.json` | `1.5.4`        |
 | Local with subpreset name and tag          | `local>abc/foo:xyz/sub#1.5.4`   | `sub`     | `https://github.company.com/abc/foo` | `xyz.json`      | `1.5.4`        |
 
-Note that you can't combine the path and sub-preset syntaxes.
-This means that anything in the form `provider>owner/repo//path/to/file:subsubpreset` is not supported.
-One workaround is to use distinct files instead of sub-presets.
+<!-- prettier-ignore -->
+!!! tip
+    You can't combine the path and sub-preset syntaxes.
+    This means that anything in the form `provider>owner/repo//path/to/file:subsubpreset` is not supported.
+    One workaround is to use distinct files instead of sub-presets.
 
 ## Example configs
 
@@ -99,8 +105,10 @@ It simply sets the configuration option `rangeStrategy` to `replace`.
 An example of a full config is `config:base`, which is Renovate's default configuration.
 It mostly uses Renovate config defaults but adds a few smart customisations such as grouping monorepo packages together.
 
-Special note: the `:xyz` naming convention (with `:` prefix) is a special shorthand for the `default:` presets.
-e.g. `:xyz` is equivalent to `default:xyz`.
+<!-- prettier-ignore -->
+!!! note
+    The `:xyz` naming convention (with `:` prefix) is a special shorthand for the `default:` presets.
+    e.g. `:xyz` is equivalent to `default:xyz`.
 
 ## How to Use Preset Configs
 
@@ -279,7 +287,7 @@ Then in each of your repositories you can add your Renovate config like:
 
 Any repository including this config will then adopt the rules of the default `library` preset but schedule it on weeknights or weekends.
 
-Note: if you prefer to publish using the namespace `@fastcore/renovate-config` then you would use the `@` prefix instead:
+If you prefer to publish using the namespace `@fastcore/renovate-config` then you would use the `@` prefix instead:
 
 ```json
 {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Use admonition blocks [^docs]
- Rewrite some text because a `note` is not needed there

## Context:

Helps with #13665, but does not close it.

## Why the `prettier-ignore` comments?

Input:

```markdown
!!! warning
    `default.json` is intended for use with presets only!
    Also, do not use a `renovate.json` file as a preset.
```

Output after Prettier run:

```markdown
!!! warning
`default.json` is intended for use with presets only!
Also, do not use a `renovate.json` file as a preset.
```

As you can see, Prettier removes the 4 spaces that are needed for the admonition to be picked up by MkDocs or Material for MkDocs.

I hope there's a better way to fix the formatting than putting `prettier-ignore` comments everywhere we use a admonition... I'm open for help on this! 😉 

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->

[^docs]: https://squidfunk.github.io/mkdocs-material/reference/admonitions/