### PR TITLE
refactor(gitlab-changelog): Make url encoding consistent

### DIFF
--- a/lib/workers/pr/changelog/__snapshots__/gitlab.spec.ts.snap
+++ b/lib/workers/pr/changelog/__snapshots__/gitlab.spec.ts.snap
@@ -56,7 +56,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/repository/tags?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/repository/tags?per_page=100",
   },
   Object {
     "headers": Object {
@@ -67,7 +67,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/repository/tree?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/repository/tree?per_page=100",
   },
   Object {
     "headers": Object {
@@ -78,7 +78,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/releases?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/releases?per_page=100",
   },
   Object {
     "headers": Object {
@@ -89,7 +89,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/repository/tree?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/repository/tree?per_page=100",
   },
   Object {
     "headers": Object {
@@ -100,7 +100,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/releases?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/releases?per_page=100",
   },
   Object {
     "headers": Object {
@@ -111,7 +111,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/repository/tree?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/repository/tree?per_page=100",
   },
   Object {
     "headers": Object {
@@ -122,7 +122,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/releases?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/releases?per_page=100",
   },
   Object {
     "headers": Object {
@@ -133,7 +133,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/repository/tree?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/repository/tree?per_page=100",
   },
   Object {
     "headers": Object {
@@ -144,7 +144,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/releases?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/releases?per_page=100",
   },
 ]
 `;
@@ -315,7 +315,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/repository/tags?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/repository/tags?per_page=100",
   },
   Object {
     "headers": Object {
@@ -326,7 +326,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/repository/tree?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/repository/tree?per_page=100",
   },
   Object {
     "headers": Object {
@@ -337,7 +337,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/releases?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/releases?per_page=100",
   },
   Object {
     "headers": Object {
@@ -348,7 +348,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/repository/tree?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/repository/tree?per_page=100",
   },
   Object {
     "headers": Object {
@@ -359,7 +359,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/releases?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/releases?per_page=100",
   },
   Object {
     "headers": Object {
@@ -370,7 +370,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/repository/tree?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/repository/tree?per_page=100",
   },
   Object {
     "headers": Object {
@@ -381,7 +381,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/releases?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/releases?per_page=100",
   },
   Object {
     "headers": Object {
@@ -392,7 +392,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/repository/tree?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/repository/tree?per_page=100",
   },
   Object {
     "headers": Object {
@@ -403,7 +403,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/releases?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/releases?per_page=100",
   },
 ]
 `;
@@ -464,7 +464,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/repository/tags?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/repository/tags?per_page=100",
   },
   Object {
     "headers": Object {
@@ -475,7 +475,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/repository/tree?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/repository/tree?per_page=100",
   },
   Object {
     "headers": Object {
@@ -486,7 +486,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/releases?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/releases?per_page=100",
   },
   Object {
     "headers": Object {
@@ -497,7 +497,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/repository/tree?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/repository/tree?per_page=100",
   },
   Object {
     "headers": Object {
@@ -508,7 +508,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/releases?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/releases?per_page=100",
   },
   Object {
     "headers": Object {
@@ -519,7 +519,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/repository/tree?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/repository/tree?per_page=100",
   },
   Object {
     "headers": Object {
@@ -530,7 +530,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/releases?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/releases?per_page=100",
   },
   Object {
     "headers": Object {
@@ -541,7 +541,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/repository/tree?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/repository/tree?per_page=100",
   },
   Object {
     "headers": Object {
@@ -552,7 +552,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/meno%2fdropzone/releases?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/meno%2Fdropzone/releases?per_page=100",
   },
 ]
 `;

--- a/lib/workers/pr/changelog/__snapshots__/release-notes.spec.ts.snap
+++ b/lib/workers/pr/changelog/__snapshots__/release-notes.spec.ts.snap
@@ -41,16 +41,16 @@ Array [
   Object {
     "body": undefined,
     "name": undefined,
-    "notesSourceUrl": "https://gitlab.com/api/v4/projects/some%2fyet-other-repository/releases",
+    "notesSourceUrl": "https://gitlab.com/api/v4/projects/some%2Fyet-other-repository/releases",
     "tag": "v1.0.0",
-    "url": "https://gitlab.com/api/v4/projects/some%2fyet-other-repository/releases/v1.0.0",
+    "url": "https://gitlab.com/api/v4/projects/some%2Fyet-other-repository/releases/v1.0.0",
   },
   Object {
     "body": undefined,
     "name": undefined,
-    "notesSourceUrl": "https://gitlab.com/api/v4/projects/some%2fyet-other-repository/releases",
+    "notesSourceUrl": "https://gitlab.com/api/v4/projects/some%2Fyet-other-repository/releases",
     "tag": "v1.0.1",
-    "url": "https://gitlab.com/api/v4/projects/some%2fyet-other-repository/releases/v1.0.1",
+    "url": "https://gitlab.com/api/v4/projects/some%2Fyet-other-repository/releases/v1.0.1",
   },
 ]
 `;
@@ -65,7 +65,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/some%2fyet-other-repository/releases?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/some%2Fyet-other-repository/releases?per_page=100",
   },
 ]
 `;
@@ -75,16 +75,16 @@ Array [
   Object {
     "body": undefined,
     "name": undefined,
-    "notesSourceUrl": "https://my.custom.domain/api/v4/projects/some%2fyet-other-repository/releases",
+    "notesSourceUrl": "https://my.custom.domain/api/v4/projects/some%2Fyet-other-repository/releases",
     "tag": "v1.0.0",
-    "url": "https://my.custom.domain/api/v4/projects/some%2fyet-other-repository/releases/v1.0.0",
+    "url": "https://my.custom.domain/api/v4/projects/some%2Fyet-other-repository/releases/v1.0.0",
   },
   Object {
     "body": undefined,
     "name": undefined,
-    "notesSourceUrl": "https://my.custom.domain/api/v4/projects/some%2fyet-other-repository/releases",
+    "notesSourceUrl": "https://my.custom.domain/api/v4/projects/some%2Fyet-other-repository/releases",
     "tag": "v1.0.1",
-    "url": "https://my.custom.domain/api/v4/projects/some%2fyet-other-repository/releases/v1.0.1",
+    "url": "https://my.custom.domain/api/v4/projects/some%2Fyet-other-repository/releases/v1.0.1",
   },
 ]
 `;
@@ -100,7 +100,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://my.custom.domain/api/v4/projects/some%2fyet-other-repository/releases?per_page=100",
+    "url": "https://my.custom.domain/api/v4/projects/some%2Fyet-other-repository/releases?per_page=100",
   },
 ]
 `;
@@ -190,7 +190,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://api.gitlab.com/projects/some%2fother-repository/releases?per_page=100",
+    "url": "https://api.gitlab.com/projects/some%2Fother-repository/releases?per_page=100",
   },
 ]
 `;
@@ -205,7 +205,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://api.gitlab.com/projects/some%2fother-repository/releases?per_page=100",
+    "url": "https://api.gitlab.com/projects/some%2Fother-repository/releases?per_page=100",
   },
 ]
 `;
@@ -220,7 +220,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://api.gitlab.com/projects/some%2fother-repository/releases?per_page=100",
+    "url": "https://api.gitlab.com/projects/some%2Fother-repository/releases?per_page=100",
   },
 ]
 `;
@@ -250,7 +250,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/itentialopensource%2fadapter-utils/repository/tree?per_page=100&path=packages/foo",
+    "url": "https://gitlab.com/api/v4/projects/itentialopensource%2Fadapter-utils/repository/tree?per_page=100&path=packages/foo",
   },
   Object {
     "headers": Object {
@@ -259,7 +259,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/itentialopensource%2fadapter-utils/repository/blobs/abcd/raw",
+    "url": "https://gitlab.com/api/v4/projects/itentialopensource%2Fadapter-utils/repository/blobs/abcd/raw",
   },
 ]
 `;
@@ -289,7 +289,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/itentialopensource%2fadapter-utils/repository/tree?per_page=100",
+    "url": "https://gitlab.com/api/v4/projects/itentialopensource%2Fadapter-utils/repository/tree?per_page=100",
   },
   Object {
     "headers": Object {
@@ -298,7 +298,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://gitlab.com/api/v4/projects/itentialopensource%2fadapter-utils/repository/blobs/abcd/raw",
+    "url": "https://gitlab.com/api/v4/projects/itentialopensource%2Fadapter-utils/repository/blobs/abcd/raw",
   },
 ]
 `;
@@ -651,7 +651,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://api.gitlab.com/projects/gitlab-org%2fgitter%2fwebapp/repository/tree?per_page=100",
+    "url": "https://api.gitlab.com/projects/gitlab-org%2Fgitter%2Fwebapp/repository/tree?per_page=100",
   },
   Object {
     "headers": Object {
@@ -660,7 +660,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://api.gitlab.com/projects/gitlab-org%2fgitter%2fwebapp/repository/blobs/abcd/raw",
+    "url": "https://api.gitlab.com/projects/gitlab-org%2Fgitter%2Fwebapp/repository/blobs/abcd/raw",
   },
 ]
 `;
@@ -966,7 +966,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://my.custom.domain/projects/gitlab-org%2fgitter%2fwebapp/repository/tree?per_page=100",
+    "url": "https://my.custom.domain/projects/gitlab-org%2Fgitter%2Fwebapp/repository/tree?per_page=100",
   },
   Object {
     "headers": Object {
@@ -976,7 +976,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://my.custom.domain/projects/gitlab-org%2fgitter%2fwebapp/repository/blobs/abcd/raw",
+    "url": "https://my.custom.domain/projects/gitlab-org%2Fgitter%2Fwebapp/repository/blobs/abcd/raw",
   },
 ]
 `;

--- a/lib/workers/pr/changelog/gitlab.spec.ts
+++ b/lib/workers/pr/changelog/gitlab.spec.ts
@@ -102,7 +102,7 @@ describe('workers/pr/changelog/gitlab', () => {
     it('uses GitLab tags', async () => {
       httpMock
         .scope(matchHost)
-        .get('/api/v4/projects/meno%2fdropzone/repository/tags?per_page=100')
+        .get('/api/v4/projects/meno%2Fdropzone/repository/tags?per_page=100')
         .reply(200, [
           { name: 'v5.2.0' },
           { name: 'v5.4.0' },
@@ -112,10 +112,10 @@ describe('workers/pr/changelog/gitlab', () => {
           { name: 'v5.7.0' },
         ])
         .persist()
-        .get('/api/v4/projects/meno%2fdropzone/repository/tree?per_page=100')
+        .get('/api/v4/projects/meno%2Fdropzone/repository/tree?per_page=100')
         .reply(200, [])
         .persist()
-        .get('/api/v4/projects/meno%2fdropzone/releases?per_page=100')
+        .get('/api/v4/projects/meno%2Fdropzone/releases?per_page=100')
         .reply(200, []);
       expect(
         await getChangeLogJSON({
@@ -144,13 +144,13 @@ describe('workers/pr/changelog/gitlab', () => {
     it('handles empty GitLab tags response', async () => {
       httpMock
         .scope(matchHost)
-        .get('/api/v4/projects/meno%2fdropzone/repository/tags?per_page=100')
+        .get('/api/v4/projects/meno%2Fdropzone/repository/tags?per_page=100')
         .reply(200, [])
         .persist()
-        .get('/api/v4/projects/meno%2fdropzone/repository/tree?per_page=100')
+        .get('/api/v4/projects/meno%2Fdropzone/repository/tree?per_page=100')
         .reply(200, [])
         .persist()
-        .get('/api/v4/projects/meno%2fdropzone/releases?per_page=100')
+        .get('/api/v4/projects/meno%2Fdropzone/releases?per_page=100')
         .reply(200, []);
       expect(
         await getChangeLogJSON({
@@ -179,13 +179,13 @@ describe('workers/pr/changelog/gitlab', () => {
     it('uses GitLab tags with error', async () => {
       httpMock
         .scope(matchHost)
-        .get('/api/v4/projects/meno%2fdropzone/repository/tags?per_page=100')
+        .get('/api/v4/projects/meno%2Fdropzone/repository/tags?per_page=100')
         .replyWithError('Unknown GitLab Repo')
         .persist()
-        .get('/api/v4/projects/meno%2fdropzone/repository/tree?per_page=100')
+        .get('/api/v4/projects/meno%2Fdropzone/repository/tree?per_page=100')
         .reply(200, [])
         .persist()
-        .get('/api/v4/projects/meno%2fdropzone/releases?per_page=100')
+        .get('/api/v4/projects/meno%2Fdropzone/releases?per_page=100')
         .reply(200, []);
       expect(
         await getChangeLogJSON({

--- a/lib/workers/pr/changelog/gitlab/index.ts
+++ b/lib/workers/pr/changelog/gitlab/index.ts
@@ -4,24 +4,20 @@ import type { GitlabTag } from '../../../../datasource/gitlab-tags/types';
 import { logger } from '../../../../logger';
 import type { GitlabTreeNode } from '../../../../types/platform/gitlab';
 import { GitlabHttp } from '../../../../util/http/gitlab';
-import { regEx } from '../../../../util/regex';
 import { ensureTrailingSlash } from '../../../../util/url';
 import type { ChangeLogFile, ChangeLogNotes } from '../types';
 
 const http = new GitlabHttp();
-
-function getRepoId(repository: string): string {
-  return repository.replace(regEx(/\//g), '%2f');
-}
 
 export async function getTags(
   endpoint: string,
   repository: string
 ): Promise<string[]> {
   logger.trace('gitlab.getTags()');
-  const url = `${ensureTrailingSlash(endpoint)}projects/${getRepoId(
-    repository
-  )}/repository/tags?per_page=100`;
+  const urlEncodedRepo = encodeURIComponent(repository);
+  const url = `${ensureTrailingSlash(
+    endpoint
+  )}projects/${urlEncodedRepo}/repository/tags?per_page=100`;
   try {
     const res = await http.getJson<GitlabTag[]>(url, {
       paginate: true,
@@ -54,10 +50,10 @@ export async function getReleaseNotesMd(
   sourceDirectory?: string
 ): Promise<ChangeLogFile> | null {
   logger.trace('gitlab.getReleaseNotesMd()');
-  const repoid = getRepoId(repository);
+  const urlEncodedRepo = encodeURIComponent(repository);
   const apiPrefix = `${ensureTrailingSlash(
     apiBaseUrl
-  )}projects/${repoid}/repository/`;
+  )}projects/${urlEncodedRepo}/repository/`;
 
   // https://docs.gitlab.com/13.2/ee/api/repositories.html#list-repository-tree
   const tree = (
@@ -99,10 +95,10 @@ export async function getReleaseList(
 ): Promise<ChangeLogNotes[]> {
   logger.trace('gitlab.getReleaseNotesMd()');
 
-  const repoId = getRepoId(repository);
+  const urlEncodedRepo = encodeURIComponent(repository);
   const apiUrl = `${ensureTrailingSlash(
     apiBaseUrl
-  )}projects/${repoId}/releases`;
+  )}projects/${urlEncodedRepo}/releases`;
 
   const res = await http.getJson<GitlabRelease[]>(`${apiUrl}?per_page=100`, {
     paginate: true,

--- a/lib/workers/pr/changelog/release-notes.spec.ts
+++ b/lib/workers/pr/changelog/release-notes.spec.ts
@@ -194,7 +194,7 @@ describe('workers/pr/changelog/release-notes', () => {
       httpMock
         .scope('https://gitlab.com/')
         .get(
-          '/api/v4/projects/some%2fyet-other-repository/releases?per_page=100'
+          '/api/v4/projects/some%2Fyet-other-repository/releases?per_page=100'
         )
         .reply(200, [
           { tag_name: `v1.0.0` },
@@ -210,15 +210,15 @@ describe('workers/pr/changelog/release-notes', () => {
       expect(res).toMatchSnapshot([
         {
           notesSourceUrl:
-            'https://gitlab.com/api/v4/projects/some%2fyet-other-repository/releases',
+            'https://gitlab.com/api/v4/projects/some%2Fyet-other-repository/releases',
           tag: 'v1.0.0',
-          url: 'https://gitlab.com/api/v4/projects/some%2fyet-other-repository/releases/v1.0.0',
+          url: 'https://gitlab.com/api/v4/projects/some%2Fyet-other-repository/releases/v1.0.0',
         },
         {
           notesSourceUrl:
-            'https://gitlab.com/api/v4/projects/some%2fyet-other-repository/releases',
+            'https://gitlab.com/api/v4/projects/some%2Fyet-other-repository/releases',
           tag: 'v1.0.1',
-          url: 'https://gitlab.com/api/v4/projects/some%2fyet-other-repository/releases/v1.0.1',
+          url: 'https://gitlab.com/api/v4/projects/some%2Fyet-other-repository/releases/v1.0.1',
         },
       ]);
       expect(httpMock.getTrace()).toMatchSnapshot();
@@ -229,7 +229,7 @@ describe('workers/pr/changelog/release-notes', () => {
       httpMock
         .scope('https://my.custom.domain/')
         .get(
-          '/api/v4/projects/some%2fyet-other-repository/releases?per_page=100'
+          '/api/v4/projects/some%2Fyet-other-repository/releases?per_page=100'
         )
         .reply(200, [
           { tag_name: `v1.0.0` },
@@ -247,15 +247,15 @@ describe('workers/pr/changelog/release-notes', () => {
       expect(res).toMatchSnapshot([
         {
           notesSourceUrl:
-            'https://my.custom.domain/api/v4/projects/some%2fyet-other-repository/releases',
+            'https://my.custom.domain/api/v4/projects/some%2Fyet-other-repository/releases',
           tag: 'v1.0.0',
-          url: 'https://my.custom.domain/api/v4/projects/some%2fyet-other-repository/releases/v1.0.0',
+          url: 'https://my.custom.domain/api/v4/projects/some%2Fyet-other-repository/releases/v1.0.0',
         },
         {
           notesSourceUrl:
-            'https://my.custom.domain/api/v4/projects/some%2fyet-other-repository/releases',
+            'https://my.custom.domain/api/v4/projects/some%2Fyet-other-repository/releases',
           tag: 'v1.0.1',
-          url: 'https://my.custom.domain/api/v4/projects/some%2fyet-other-repository/releases/v1.0.1',
+          url: 'https://my.custom.domain/api/v4/projects/some%2Fyet-other-repository/releases/v1.0.1',
         },
       ]);
       expect(httpMock.getTrace()).toMatchSnapshot();
@@ -440,7 +440,7 @@ describe('workers/pr/changelog/release-notes', () => {
       const prefix = '';
       httpMock
         .scope('https://api.gitlab.com/')
-        .get('/projects/some%2fother-repository/releases?per_page=100')
+        .get('/projects/some%2Fother-repository/releases?per_page=100')
         .reply(200, [
           { tag_name: `${prefix}1.0.0` },
           {
@@ -463,7 +463,7 @@ describe('workers/pr/changelog/release-notes', () => {
         body: 'some body #123, [#124](https://gitlab.com/some/yet-other-repository/issues/124)',
         name: undefined,
         notesSourceUrl:
-          'https://api.gitlab.com/projects/some%2fother-repository/releases',
+          'https://api.gitlab.com/projects/some%2Fother-repository/releases',
         tag: '1.0.1',
         url: 'https://gitlab.com/some/other-repository/tags/1.0.1',
       });
@@ -473,7 +473,7 @@ describe('workers/pr/changelog/release-notes', () => {
       const prefix = 'v';
       httpMock
         .scope('https://api.gitlab.com/')
-        .get('/projects/some%2fother-repository/releases?per_page=100')
+        .get('/projects/some%2Fother-repository/releases?per_page=100')
         .reply(200, [
           { tag_name: `${prefix}1.0.0` },
           {
@@ -496,7 +496,7 @@ describe('workers/pr/changelog/release-notes', () => {
         body: 'some body #123, [#124](https://gitlab.com/some/yet-other-repository/issues/124)',
         name: undefined,
         notesSourceUrl:
-          'https://api.gitlab.com/projects/some%2fother-repository/releases',
+          'https://api.gitlab.com/projects/some%2Fother-repository/releases',
         tag: 'v1.0.1',
         url: 'https://gitlab.com/some/other-repository/tags/v1.0.1',
       });
@@ -506,7 +506,7 @@ describe('workers/pr/changelog/release-notes', () => {
       const prefix = 'other-';
       httpMock
         .scope('https://api.gitlab.com/')
-        .get('/projects/some%2fother-repository/releases?per_page=100')
+        .get('/projects/some%2Fother-repository/releases?per_page=100')
         .reply(200, [
           { tag_name: `${prefix}1.0.0` },
           {
@@ -529,7 +529,7 @@ describe('workers/pr/changelog/release-notes', () => {
         body: 'some body #123, [#124](https://gitlab.com/some/yet-other-repository/issues/124)',
         name: undefined,
         notesSourceUrl:
-          'https://api.gitlab.com/projects/some%2fother-repository/releases',
+          'https://api.gitlab.com/projects/some%2Fother-repository/releases',
         tag: 'other-1.0.1',
         url: 'https://gitlab.com/some/other-repository/tags/other-1.0.1',
       });
@@ -661,10 +661,10 @@ describe('workers/pr/changelog/release-notes', () => {
       httpMock
         .scope('https://api.gitlab.com/')
         .get(
-          '/projects/gitlab-org%2fgitter%2fwebapp/repository/tree?per_page=100'
+          '/projects/gitlab-org%2Fgitter%2Fwebapp/repository/tree?per_page=100'
         )
         .reply(200, gitlabTreeResponse)
-        .get('/projects/gitlab-org%2fgitter%2fwebapp/repository/blobs/abcd/raw')
+        .get('/projects/gitlab-org%2Fgitter%2Fwebapp/repository/blobs/abcd/raw')
         .reply(200, gitterWebappChangelogMd);
       const res = await getReleaseNotesMd(
         {
@@ -688,10 +688,10 @@ describe('workers/pr/changelog/release-notes', () => {
       httpMock
         .scope('https://my.custom.domain/')
         .get(
-          '/projects/gitlab-org%2fgitter%2fwebapp/repository/tree?per_page=100'
+          '/projects/gitlab-org%2Fgitter%2Fwebapp/repository/tree?per_page=100'
         )
         .reply(200, gitlabTreeResponse)
-        .get('/projects/gitlab-org%2fgitter%2fwebapp/repository/blobs/abcd/raw')
+        .get('/projects/gitlab-org%2Fgitter%2Fwebapp/repository/blobs/abcd/raw')
         .reply(200, gitterWebappChangelogMd);
       const res = await getReleaseNotesMd(
         {
@@ -865,11 +865,11 @@ describe('workers/pr/changelog/release-notes', () => {
         httpMock
           .scope('https://gitlab.com/')
           .get(
-            '/api/v4/projects/itentialopensource%2fadapter-utils/repository/tree?per_page=100'
+            '/api/v4/projects/itentialopensource%2Fadapter-utils/repository/tree?per_page=100'
           )
           .reply(200, gitlabTreeResponse)
           .get(
-            '/api/v4/projects/itentialopensource%2fadapter-utils/repository/blobs/abcd/raw'
+            '/api/v4/projects/itentialopensource%2Fadapter-utils/repository/blobs/abcd/raw'
           )
           .reply(200, adapterutilsChangelogMd);
         const res = await getReleaseNotesMd(
@@ -897,11 +897,11 @@ describe('workers/pr/changelog/release-notes', () => {
         httpMock
           .scope('https://gitlab.com/')
           .get(
-            `/api/v4/projects/itentialopensource%2fadapter-utils/repository/tree?per_page=100&path=${sourceDirectory}`
+            `/api/v4/projects/itentialopensource%2Fadapter-utils/repository/tree?per_page=100&path=${sourceDirectory}`
           )
           .reply(200, response)
           .get(
-            '/api/v4/projects/itentialopensource%2fadapter-utils/repository/blobs/abcd/raw'
+            '/api/v4/projects/itentialopensource%2Fadapter-utils/repository/blobs/abcd/raw'
           )
           .reply(200, adapterutilsChangelogMd);
         const res = await getReleaseNotesMd(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->
### Behaviour changes
- Slashes are now replaced by %2F instead of lowercases %2f.
- Fully url encode repository name instead of only replacing slashes trough regex. Which means other to be escaped characters will now also be url encoded for changelog calls.

### Code changes
- Replace encoding function with builtin url encoding function.

## Context:

The url encoding used in changelog calls is different than the url encoding in all other gitlab datasources, which use the builtin encoding function. This PR refactors the code so that this is consistent.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
