### PR TITLE
fix(gitlab-packages): Add missing hostType for datasource calls

### DIFF
--- a/lib/datasource/gitlab-packages/index.ts
+++ b/lib/datasource/gitlab-packages/index.ts
@@ -21,7 +21,7 @@ export class GitlabPackagesDatasource extends Datasource {
 
   constructor() {
     super(datasource);
-    this.http = new GitlabHttp();
+    this.http = new GitlabHttp(datasource);
   }
 
   static getGitlabPackageApiUrl(

--- a/lib/util/http/host-rules.spec.ts
+++ b/lib/util/http/host-rules.spec.ts
@@ -153,16 +153,75 @@ describe('util/http/host-rules', () => {
     `);
   });
 
+  it('no fallback to gitlab', () => {
+    hostRules.add({
+      hostType: 'gitlab-packages',
+      token: 'package-token',
+    });
+    hostRules.add({
+      hostType: 'gitlab-releases',
+      token: 'release-token',
+    });
+    hostRules.add({
+      hostType: 'gitlab-tags',
+      token: 'tags-token',
+    });
+    expect(
+      applyHostRules(url, { ...options, hostType: 'gitlab-tags' })
+    ).toEqual({
+      context: {
+        authType: undefined,
+      },
+      hostType: 'gitlab-tags',
+      token: 'tags-token',
+    });
+    expect(
+      applyHostRules(url, { ...options, hostType: 'gitlab-releases' })
+    ).toEqual({
+      context: {
+        authType: undefined,
+      },
+      hostType: 'gitlab-releases',
+      token: 'release-token',
+    });
+    expect(
+      applyHostRules(url, { ...options, hostType: 'gitlab-packages' })
+    ).toEqual({
+      context: {
+        authType: undefined,
+      },
+      hostType: 'gitlab-packages',
+      token: 'package-token',
+    });
+  });
+
   it('fallback to gitlab', () => {
-    expect(applyHostRules(url, { ...options, hostType: 'gitlab-tags' }))
-      .toMatchInlineSnapshot(`
-      Object {
-        "context": Object {
-          "authType": undefined,
-        },
-        "hostType": "gitlab-tags",
-        "token": "abc",
-      }
-    `);
+    expect(
+      applyHostRules(url, { ...options, hostType: 'gitlab-tags' })
+    ).toEqual({
+      context: {
+        authType: undefined,
+      },
+      hostType: 'gitlab-tags',
+      token: 'abc',
+    });
+    expect(
+      applyHostRules(url, { ...options, hostType: 'gitlab-releases' })
+    ).toEqual({
+      context: {
+        authType: undefined,
+      },
+      hostType: 'gitlab-releases',
+      token: 'abc',
+    });
+    expect(
+      applyHostRules(url, { ...options, hostType: 'gitlab-packages' })
+    ).toEqual({
+      context: {
+        authType: undefined,
+      },
+      hostType: 'gitlab-packages',
+      token: 'abc',
+    });
   });
 });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

### Behaviour changes: 
- Making it possible to apply specific hostRules for the gitlab-packages datasource.

### Code changes
- Add missing hostType to gitlab-packages datasource. (Was already used in fallback configuration)
- Extended gitlab fallback testcases.


## Context:

Applying hostRules for specific datasources is usually done by adding hostType to be matched to the rule, containing the datasource id. However this is not possible for some datasources, like gitlab-packages.

This PR solves that for gitlab-packages datasource by adding its id as hostType. The fallback to platform rules was already in place(though never used). 

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
