### PR TITLE
fix(bitbucket-tags): Add hostType and fallback for bitbucket-tags dat…

### DIFF
--- a/lib/constants/platform.spec.ts
+++ b/lib/constants/platform.spec.ts
@@ -1,3 +1,4 @@
+import { BitBucketTagsDatasource } from '../datasource/bitbucket-tags';
 import { id as GH_RELEASES_DS } from '../datasource/github-releases';
 import { id as GH_TAGS_DS } from '../datasource/github-tags';
 import { GitlabPackagesDatasource } from '../datasource/gitlab-packages';
@@ -5,6 +6,7 @@ import { GitlabReleasesDatasource } from '../datasource/gitlab-releases';
 import { id as GL_TAGS_DS } from '../datasource/gitlab-tags';
 import { id as POD_DS } from '../datasource/pod';
 import {
+  BITBUCKET_API_USING_HOST_TYPES,
   GITHUB_API_USING_HOST_TYPES,
   GITLAB_API_USING_HOST_TYPES,
   PlatformId,
@@ -35,5 +37,14 @@ describe('constants/platform', () => {
 
   it('should be not part of the GITHUB_API_USING_HOST_TYPES ', () => {
     expect(GITHUB_API_USING_HOST_TYPES.includes(PlatformId.Gitlab)).toBeFalse();
+  });
+
+  it('should be part of the BITBUCKET_API_USING_HOST_TYPES ', () => {
+    expect(
+      BITBUCKET_API_USING_HOST_TYPES.includes(BitBucketTagsDatasource.id)
+    ).toBeTrue();
+    expect(
+      BITBUCKET_API_USING_HOST_TYPES.includes(PlatformId.Bitbucket)
+    ).toBeTrue();
   });
 });

--- a/lib/constants/platforms.ts
+++ b/lib/constants/platforms.ts
@@ -20,3 +20,8 @@ export const GITLAB_API_USING_HOST_TYPES = [
   'gitlab-tags',
   'gitlab-packages',
 ];
+
+export const BITBUCKET_API_USING_HOST_TYPES = [
+  PlatformId.Bitbucket,
+  'bitbucket-tags',
+];

--- a/lib/datasource/bitbucket-tags/index.ts
+++ b/lib/datasource/bitbucket-tags/index.ts
@@ -7,7 +7,7 @@ import type { DigestConfig, GetReleasesConfig, ReleaseResult } from '../types';
 import { BitbucketCommit, BitbucketTag } from './types';
 
 export class BitBucketTagsDatasource extends Datasource {
-  bitbucketHttp = new BitbucketHttp();
+  bitbucketHttp = new BitbucketHttp(BitBucketTagsDatasource.id);
 
   static readonly id = 'bitbucket-tags';
 

--- a/lib/util/http/bitbucket.ts
+++ b/lib/util/http/bitbucket.ts
@@ -8,8 +8,8 @@ export const setBaseUrl = (url: string): void => {
 };
 
 export class BitbucketHttp extends Http {
-  constructor(options?: HttpOptions) {
-    super(PlatformId.Bitbucket, options);
+  constructor(type: string = PlatformId.Bitbucket, options?: HttpOptions) {
+    super(type, options);
   }
 
   protected override request<T>(

--- a/lib/util/http/host-rules.spec.ts
+++ b/lib/util/http/host-rules.spec.ts
@@ -44,6 +44,11 @@ describe('util/http/host-rules', () => {
       username: 'some',
       password: 'xxx',
     });
+
+    hostRules.add({
+      hostType: PlatformId.Bitbucket,
+      token: 'cdef',
+    });
   });
 
   afterEach(() => {
@@ -164,5 +169,32 @@ describe('util/http/host-rules', () => {
         "token": "abc",
       }
     `);
+  });
+
+  it('no fallback to bitbucket', () => {
+    hostRules.add({
+      hostType: 'bitbucket-tags',
+      username: 'some',
+      password: 'xxx',
+    });
+    expect(
+      applyHostRules(url, { ...options, hostType: 'bitbucket-tags' })
+    ).toEqual({
+      hostType: 'bitbucket-tags',
+      username: 'some',
+      password: 'xxx',
+    });
+  });
+
+  it('fallback to bitbucket', () => {
+    expect(
+      applyHostRules(url, { ...options, hostType: 'bitbucket-tags' })
+    ).toEqual({
+      context: {
+        authType: undefined,
+      },
+      hostType: 'bitbucket-tags',
+      token: 'cdef',
+    });
   });
 });

--- a/lib/util/http/host-rules.ts
+++ b/lib/util/http/host-rules.ts
@@ -1,4 +1,5 @@
 import {
+  BITBUCKET_API_USING_HOST_TYPES,
   GITHUB_API_USING_HOST_TYPES,
   GITLAB_API_USING_HOST_TYPES,
   PlatformId,
@@ -42,6 +43,21 @@ function findMatchingRules(options: GotOptions, url: string): HostRule {
     res = {
       ...hostRules.find({
         hostType: PlatformId.Gitlab,
+        url,
+      }),
+      ...res,
+    };
+  }
+
+  // Fallback to `bitbucket` hostType
+  if (
+    hostType &&
+    BITBUCKET_API_USING_HOST_TYPES.includes(hostType) &&
+    hostType !== PlatformId.Bitbucket
+  ) {
+    res = {
+      ...hostRules.find({
+        hostType: PlatformId.Bitbucket,
         url,
       }),
       ...res,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->
### Behaviour changes: 
- Making it possible to apply specific hostRules for the bitbucket-tags datasource.

### Code changes:
- Add fallback mechanism for bitbucket datasource hostTypes(like is done for gitlab and github)
- Add missing hostType to bitbucket-tags datasource.
- Extend tests for hostRules fallback mechanism
- Extend regression tests for fallback constants.

## Context:

Applying hostRules for specific datasources is usually done by adding hostType to be matched to the rule, containing the datasource id. However this is not possible for some datasources, like bitbucket tags.

This PR solves that for bitbucket-tags datasource by adding its id as hostType and adding fallback mechanism to rules for bitbucket platform rules, just like is done for gitlab-tags and github-tags datasources.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
