### PR TITLE
refactor(workers): Make reuse logic more consistent

### DIFF
--- a/lib/workers/branch/reuse.ts
+++ b/lib/workers/branch/reuse.ts
@@ -58,7 +58,6 @@ export async function shouldReuseExistingBranch(
       logger.debug(`Branch is stale and needs rebasing`);
       // We can rebase the branch only if no PR or PR can be rebased
       if (await isBranchModified(branchName)) {
-        // TODO: Warn here so that it appears in PR body (#9720)
         logger.debug('Cannot rebase branch as it has been modified');
         result.reuseExistingBranch = true;
         result.isModified = true;

--- a/lib/workers/branch/reuse.ts
+++ b/lib/workers/branch/reuse.ts
@@ -8,6 +8,7 @@ import type { BranchConfig } from '../types';
 type ParentBranch = {
   reuseExistingBranch: boolean;
   isModified?: boolean;
+  isConflicted?: boolean;
 };
 
 export async function shouldReuseExistingBranch(
@@ -74,7 +75,8 @@ export async function shouldReuseExistingBranch(
   }
 
   // Now check if PR is unmergeable. If so then we also rebase
-  if (pr?.isConflicted) {
+  result.isConflicted = pr?.isConflicted;
+  if (result.isConflicted) {
     logger.debug('PR is conflicted');
 
     if ((await isBranchModified(branchName)) === false) {

--- a/lib/workers/branch/reuse.ts
+++ b/lib/workers/branch/reuse.ts
@@ -62,9 +62,9 @@ export async function shouldReuseExistingBranch(
         logger.debug('Cannot rebase branch as it has been modified');
         result.reuseExistingBranch = true;
         result.isModified = true;
-      } else {
-        logger.debug('Branch is unmodified, so can be rebased');
+        return result;
       }
+      logger.debug('Branch is unmodified, so can be rebased');
       return result;
     }
     logger.debug('Branch is up-to-date');

--- a/lib/workers/branch/reuse.ts
+++ b/lib/workers/branch/reuse.ts
@@ -74,7 +74,7 @@ export async function shouldReuseExistingBranch(
   }
 
   // Now check if PR is unmergeable. If so then we also rebase
-  result.isConflicted = pr?.isConflicted;
+  result.isConflicted = !!pr?.isConflicted;
   if (result.isConflicted) {
     logger.debug('PR is conflicted');
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Use single `result` object for all return statements inside the function
- Introduce `isConflicted` flag for the result value

## Context:

- Ref #3866

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
