### PR TITLE
refactor: Use union type for SkipReason

### DIFF
--- a/lib/manager/ansible-galaxy/collections.ts
+++ b/lib/manager/ansible-galaxy/collections.ts
@@ -1,7 +1,6 @@
 import { GalaxyCollectionDatasource } from '../../datasource/galaxy-collection';
 import { GitTagsDatasource } from '../../datasource/git-tags';
 import * as datasourceGithubTags from '../../datasource/github-tags';
-import { SkipReason } from '../../types';
 import { regEx } from '../../util/regex';
 import type { PackageDependency } from '../types';
 import {
@@ -40,7 +39,7 @@ function interpretLine(
     }
     default: {
       // fail if we find an unexpected key
-      localDependency.skipReason = SkipReason.Unsupported;
+      localDependency.skipReason = 'unsupported';
     }
   }
 }
@@ -100,7 +99,7 @@ function finalize(dependency: PackageDependency): boolean {
       handleGitDep(dep, nameMatch);
       break;
     case 'file':
-      dep.skipReason = SkipReason.LocalDependency;
+      dep.skipReason = 'local-dependency';
       break;
     case null:
       // try to find out type based on source
@@ -113,15 +112,15 @@ function finalize(dependency: PackageDependency): boolean {
         dep.depName = dep.managerData.name;
         break;
       }
-      dep.skipReason = SkipReason.NoSourceMatch;
+      dep.skipReason = 'no-source-match';
       break;
     default:
-      dep.skipReason = SkipReason.Unsupported;
+      dep.skipReason = 'unsupported';
       return true;
   }
 
   if (!dependency.currentValue && !dep.skipReason) {
-    dep.skipReason = SkipReason.NoVersion;
+    dep.skipReason = 'no-version';
   }
   return true;
 }

--- a/lib/manager/ansible-galaxy/roles.ts
+++ b/lib/manager/ansible-galaxy/roles.ts
@@ -1,6 +1,5 @@
 import { GalaxyDatasource } from '../../datasource/galaxy';
 import { GitTagsDatasource } from '../../datasource/git-tags';
-import { SkipReason } from '../../types';
 import { regEx } from '../../util/regex';
 import type { PackageDependency } from '../types';
 import {
@@ -47,7 +46,7 @@ function interpretLine(
 function finalize(dependency: PackageDependency): boolean {
   const dep = dependency;
   if (dependency.managerData.version === null) {
-    dep.skipReason = SkipReason.NoVersion;
+    dep.skipReason = 'no-version';
     return false;
   }
 
@@ -67,7 +66,7 @@ function finalize(dependency: PackageDependency): boolean {
     dep.depName = dep.managerData.name;
     dep.lookupName = dep.managerData.name;
   } else {
-    dep.skipReason = SkipReason.NoSourceMatch;
+    dep.skipReason = 'no-source-match';
     return false;
   }
   if (dep.managerData.name !== null) {

--- a/lib/manager/bazel/extract.ts
+++ b/lib/manager/bazel/extract.ts
@@ -7,7 +7,6 @@ import * as datasourceGithubReleases from '../../datasource/github-releases';
 import * as datasourceGithubTags from '../../datasource/github-tags';
 import * as datasourceGo from '../../datasource/go';
 import { logger } from '../../logger';
-import { SkipReason } from '../../types';
 import { regEx } from '../../util/regex';
 import * as dockerVersioning from '../../versioning/docker';
 import type { PackageDependency, PackageFile } from '../types';
@@ -263,7 +262,7 @@ export function extractPackageFile(
         if (remoteMatch && remoteMatch[0].length === remote.length) {
           dep.lookupName = remote.replace('https://', '');
         } else {
-          dep.skipReason = SkipReason.UnsupportedRemote;
+          dep.skipReason = 'unsupported-remote';
         }
       }
       if (commit) {

--- a/lib/manager/buildkite/extract.ts
+++ b/lib/manager/buildkite/extract.ts
@@ -62,14 +62,14 @@ export function extractPackageFile(content: string): PackageFile | null {
                 { dependency: depName },
                 'Something is wrong with buildkite plugin name'
               );
-              skipReason = SkipReason.InvalidDependencySpecification;
+              skipReason = 'invalid-dependency-specification';
             }
           } else {
             logger.debug(
               { currentValue },
               'Skipping non-pinned current version'
             );
-            skipReason = SkipReason.InvalidVersion;
+            skipReason = 'invalid-version';
           }
           const dep: PackageDependency = {
             depName,

--- a/lib/manager/cake/index.ts
+++ b/lib/manager/cake/index.ts
@@ -1,7 +1,6 @@
 import moo from 'moo';
 import { ProgrammingLanguage } from '../../constants';
 import { id as datasource } from '../../datasource/nuget';
-import { SkipReason } from '../../types';
 import { regEx } from '../../util/regex';
 import { PackageDependency, PackageFile } from '../types';
 
@@ -43,7 +42,7 @@ function parseDependencyLine(line: string): PackageDependency | null {
       if (protocol.startsWith('http')) {
         result.registryUrls = [registryUrl];
       } else {
-        result.skipReason = SkipReason.UnsupportedUrl;
+        result.skipReason = 'unsupported-url';
       }
     }
 

--- a/lib/manager/cargo/extract.ts
+++ b/lib/manager/cargo/extract.ts
@@ -45,24 +45,24 @@ function extractFromSection(
           if (registryUrl) {
             registryUrls = [registryUrl];
           } else {
-            skipReason = SkipReason.UnknownRegistry;
+            skipReason = 'unknown-registry';
           }
         }
         if (path) {
-          skipReason = SkipReason.PathDependency;
+          skipReason = 'path-dependency';
         }
         if (git) {
-          skipReason = SkipReason.GitDependency;
+          skipReason = 'git-dependency';
         }
       } else if (path) {
         currentValue = '';
-        skipReason = SkipReason.PathDependency;
+        skipReason = 'path-dependency';
       } else if (git) {
         currentValue = '';
-        skipReason = SkipReason.GitDependency;
+        skipReason = 'git-dependency';
       } else {
         currentValue = '';
-        skipReason = SkipReason.InvalidDependencySpecification;
+        skipReason = 'invalid-dependency-specification';
       }
     }
     const dep: PackageDependency = {

--- a/lib/manager/cocoapods/extract.ts
+++ b/lib/manager/cocoapods/extract.ts
@@ -3,7 +3,6 @@ import * as datasourceGithubTags from '../../datasource/github-tags';
 import * as datasourceGitlabTags from '../../datasource/gitlab-tags';
 import * as datasourcePod from '../../datasource/pod';
 import { logger } from '../../logger';
-import { SkipReason } from '../../types';
 import { getSiblingFileName, localPathExists } from '../../util/fs';
 import { regEx } from '../../util/regex';
 import type { PackageDependency, PackageFile } from '../types';
@@ -113,7 +112,7 @@ export async function extractPackageFile(
       let dep: PackageDependency = {
         depName,
         groupName,
-        skipReason: SkipReason.UnknownVersion,
+        skipReason: 'unknown-version',
       };
 
       if (currentValue) {
@@ -132,14 +131,14 @@ export async function extractPackageFile(
           dep = {
             depName,
             groupName,
-            skipReason: SkipReason.GitDependency,
+            skipReason: 'git-dependency',
           };
         }
       } else if (path) {
         dep = {
           depName,
           groupName,
-          skipReason: SkipReason.PathDependency,
+          skipReason: 'path-dependency',
         };
       }
 

--- a/lib/manager/composer/extract.ts
+++ b/lib/manager/composer/extract.ts
@@ -2,7 +2,6 @@ import is from '@sindresorhus/is';
 import { GitTagsDatasource } from '../../datasource/git-tags';
 import * as datasourcePackagist from '../../datasource/packagist';
 import { logger } from '../../logger';
-import { SkipReason } from '../../types';
 import { readLocalFile } from '../../util/fs';
 import { regEx } from '../../util/regex';
 import { api as semverComposer } from '../../versioning/composer';
@@ -148,7 +147,7 @@ export async function extractPackageFile(
             dep.lookupName = lookupName;
           }
           if (!depName.includes('/')) {
-            dep.skipReason = SkipReason.Unsupported;
+            dep.skipReason = 'unsupported';
           }
           if (lockParsed) {
             const lockField =

--- a/lib/manager/dockerfile/extract.ts
+++ b/lib/manager/dockerfile/extract.ts
@@ -1,7 +1,6 @@
 import is from '@sindresorhus/is';
 import * as datasourceDocker from '../../datasource/docker';
 import { logger } from '../../logger';
-import { SkipReason } from '../../types';
 import { regEx } from '../../util/regex';
 import * as ubuntuVersioning from '../../versioning/ubuntu';
 import type { PackageDependency, PackageFile } from '../types';
@@ -29,7 +28,7 @@ export function splitImageParts(currentFrom: string): PackageDependency {
       currentFrom.indexOf(variableDefaultValueSplit) === -1
     ) {
       return {
-        skipReason: SkipReason.ContainsVariable,
+        skipReason: 'contains-variable',
       };
     }
 
@@ -60,7 +59,7 @@ export function splitImageParts(currentFrom: string): PackageDependency {
   if (currentValue && currentValue.indexOf(variableMarker) !== -1) {
     // If tag contains a variable, e.g. "5.0${VERSION_SUFFIX}", we do not support this.
     return {
-      skipReason: SkipReason.ContainsVariable,
+      skipReason: 'contains-variable',
     };
   }
 
@@ -102,7 +101,7 @@ export function getDep(
 ): PackageDependency {
   if (!is.string(currentFrom)) {
     return {
-      skipReason: SkipReason.InvalidValue,
+      skipReason: 'invalid-value',
     };
   }
   const dep = splitImageParts(currentFrom);

--- a/lib/manager/flux/extract.spec.ts
+++ b/lib/manager/flux/extract.spec.ts
@@ -1,7 +1,6 @@
 import { loadFixture } from '../../../test/util';
 import { GlobalConfig } from '../../config/global';
 import type { RepoGlobalConfig } from '../../config/types';
-import { SkipReason } from '../../types';
 import type { ExtractConfig } from '../types';
 import { extractAllPackageFiles, extractPackageFile } from '.';
 
@@ -29,7 +28,7 @@ describe('manager/flux/extract', () => {
     });
     it('extracts releases without repositories', () => {
       const result = extractPackageFile(loadFixture('release.yaml'));
-      expect(result.deps[0].skipReason).toBe(SkipReason.UnknownRegistry);
+      expect(result.deps[0].skipReason).toBe('unknown-registry');
     });
     it('ignores HelmRelease resources without an apiVersion', () => {
       const result = extractPackageFile('kind: HelmRelease');
@@ -47,7 +46,7 @@ apiVersion: source.toolkit.fluxcd.io/v1beta1
 kind: HelmRepository
 `
       );
-      expect(result.deps[0].skipReason).toBe(SkipReason.UnknownRegistry);
+      expect(result.deps[0].skipReason).toBe('unknown-registry');
     });
     it('ignores HelmRelease resources without a chart name', () => {
       const result = extractPackageFile(
@@ -88,7 +87,7 @@ spec:
       version: "2.0.2"
 `
       );
-      expect(result.deps[0].skipReason).toBe(SkipReason.UnknownRegistry);
+      expect(result.deps[0].skipReason).toBe('unknown-registry');
     });
     it('does not match HelmRelease resources without a sourceRef', () => {
       const result = extractPackageFile(
@@ -105,7 +104,7 @@ spec:
       version: "2.0.2"
 `
       );
-      expect(result.deps[0].skipReason).toBe(SkipReason.UnknownRegistry);
+      expect(result.deps[0].skipReason).toBe('unknown-registry');
     });
     it('does not match HelmRelease resources without a namespace', () => {
       const result = extractPackageFile(
@@ -123,7 +122,7 @@ spec:
       version: "2.0.2"
 `
       );
-      expect(result.deps[0].skipReason).toBe(SkipReason.UnknownRegistry);
+      expect(result.deps[0].skipReason).toBe('unknown-registry');
     });
     it('ignores HelmRepository resources without a namespace', () => {
       const result = extractPackageFile(
@@ -135,7 +134,7 @@ metadata:
   name: test
 `
       );
-      expect(result.deps[0].skipReason).toBe(SkipReason.UnknownRegistry);
+      expect(result.deps[0].skipReason).toBe('unknown-registry');
     });
     it('ignores HelmRepository resources without a URL', () => {
       const result = extractPackageFile(
@@ -148,7 +147,7 @@ metadata:
   namespace: kube-system
 `
       );
-      expect(result.deps[0].skipReason).toBe(SkipReason.UnknownRegistry);
+      expect(result.deps[0].skipReason).toBe('unknown-registry');
     });
     it('ignores resources of an unknown kind', () => {
       const result = extractPackageFile(

--- a/lib/manager/flux/extract.ts
+++ b/lib/manager/flux/extract.ts
@@ -1,7 +1,6 @@
 import { loadAll } from 'js-yaml';
 import { HelmDatasource } from '../../datasource/helm';
 import { logger } from '../../logger';
-import { SkipReason } from '../../types';
 import { readLocalFile } from '../../util/fs';
 import type { ExtractConfig, PackageDependency, PackageFile } from '../types';
 import type {
@@ -69,7 +68,7 @@ function resolveReleases(
     if (matchingRepositories.length) {
       res.registryUrls = matchingRepositories.map((repo) => repo.spec.url);
     } else {
-      res.skipReason = SkipReason.UnknownRegistry;
+      res.skipReason = 'unknown-registry';
     }
 
     return res;

--- a/lib/manager/github-actions/extract.ts
+++ b/lib/manager/github-actions/extract.ts
@@ -1,6 +1,5 @@
 import * as githubTagsDatasource from '../../datasource/github-tags';
 import { logger } from '../../logger';
-import { SkipReason } from '../../types';
 import { regEx } from '../../util/regex';
 import * as dockerVersioning from '../../versioning/docker';
 import { getDep } from '../dockerfile/extract';
@@ -56,7 +55,7 @@ export function extractPackageFile(content: string): PackageFile | null {
       } else {
         dep.currentValue = currentValue;
         if (!dockerVersioning.api.isValid(currentValue)) {
-          dep.skipReason = SkipReason.InvalidVersion;
+          dep.skipReason = 'invalid-version';
         }
       }
       deps.push(dep);

--- a/lib/manager/gitlabci-include/extract.ts
+++ b/lib/manager/gitlabci-include/extract.ts
@@ -2,7 +2,6 @@ import is from '@sindresorhus/is';
 import { load } from 'js-yaml';
 import * as datasourceGitlabTags from '../../datasource/gitlab-tags';
 import { logger } from '../../logger';
-import { SkipReason } from '../../types';
 import { regEx } from '../../util/regex';
 import { replaceReferenceTags } from '../gitlabci/utils';
 import type { ExtractConfig, PackageDependency, PackageFile } from '../types';
@@ -18,7 +17,7 @@ function extractDepFromIncludeFile(includeObj: {
     depType: 'repository',
   };
   if (!includeObj.ref) {
-    dep.skipReason = SkipReason.UnknownVersion;
+    dep.skipReason = 'unknown-version';
     return dep;
   }
   dep.currentValue = includeObj.ref;

--- a/lib/manager/gomod/extract.ts
+++ b/lib/manager/gomod/extract.ts
@@ -1,7 +1,6 @@
 import semver from 'semver';
 import * as datasourceGo from '../../datasource/go';
 import { logger } from '../../logger';
-import { SkipReason } from '../../types';
 import { regEx } from '../../util/regex';
 import { isVersion } from '../../versioning/semver';
 import type { PackageDependency, PackageFile } from '../types';
@@ -25,7 +24,7 @@ function getDep(
   if (isVersion(currentValue)) {
     dep.datasource = datasourceGo.id;
   } else {
-    dep.skipReason = SkipReason.UnsupportedVersion;
+    dep.skipReason = 'unsupported-version';
   }
   const digestMatch = regEx(/v0\.0.0-\d{14}-([a-f0-9]{12})/).exec(currentValue);
   if (digestMatch) {

--- a/lib/manager/gradle/shallow/extract.spec.ts
+++ b/lib/manager/gradle/shallow/extract.spec.ts
@@ -1,6 +1,5 @@
 import { extractAllPackageFiles } from '..';
 import { fs, loadFixture } from '../../../../test/util';
-import { SkipReason } from '../../../types';
 import type { ExtractConfig } from '../../types';
 
 jest.mock('../../../util/fs');
@@ -71,7 +70,7 @@ describe('manager/gradle/shallow/extract', () => {
             depName: 'foo:bar',
             currentValue: '1.2.3',
             registryUrls: ['https://repo.maven.apache.org/maven2'],
-            skipReason: SkipReason.ContainsVariable,
+            skipReason: 'contains-variable',
             managerData: {
               packageFile: 'build.gradle',
             },

--- a/lib/manager/gradle/shallow/extract/catalog.ts
+++ b/lib/manager/gradle/shallow/extract/catalog.ts
@@ -1,6 +1,5 @@
 import { parse } from '@iarna/toml';
 import deepmerge from 'deepmerge';
-import { SkipReason } from '../../../../types';
 import { hasKey } from '../../../../util/object';
 import type { PackageDependency } from '../../../types';
 import type { GradleManagerData } from '../../types';
@@ -87,7 +86,7 @@ function extractDependency({
     if (!currentValue) {
       return {
         depName,
-        skipReason: SkipReason.NoVersion,
+        skipReason: 'no-version',
       };
     }
     return {
@@ -114,7 +113,7 @@ function extractDependency({
   if (!currentValue) {
     return {
       depName,
-      skipReason: SkipReason.NoVersion,
+      skipReason: 'no-version',
     };
   }
 

--- a/lib/manager/gradle/shallow/parser.spec.ts
+++ b/lib/manager/gradle/shallow/parser.spec.ts
@@ -1,5 +1,4 @@
 import { loadFixture } from '../../../../test/util';
-import { SkipReason } from '../../../types';
 import {
   GOOGLE_REPO,
   GRADLE_PLUGIN_PORTAL_REPO,
@@ -36,7 +35,7 @@ describe('manager/gradle/shallow/parser', () => {
         ${'group: "foo", name: "bar", version: depVersion'}                       | ${null}
         ${'("foo", "bar", "1.2.3")'}                                              | ${{ depName: 'foo:bar', currentValue: '1.2.3' }}
         ${'(group = "foo", name = "bar", version = "1.2.3")'}                     | ${{ depName: 'foo:bar', currentValue: '1.2.3' }}
-        ${'createXmlValueRemover("defaults", "integer", "integer")'}              | ${{ depName: 'defaults:integer', currentValue: 'integer', skipReason: SkipReason.Ignored }}
+        ${'createXmlValueRemover("defaults", "integer", "integer")'}              | ${{ depName: 'defaults:integer', currentValue: 'integer', skipReason: 'ignored' }}
         ${'"foo:bar:1.2.3@zip"'}                                                  | ${{ currentValue: '1.2.3', dataType: 'zip', depName: 'foo:bar' }}
       `('$input', ({ input, output }) => {
         const { deps } = parseGradle(input);
@@ -67,16 +66,16 @@ describe('manager/gradle/shallow/parser', () => {
         ${''}               | ${'id "foo.bar" version "1.2.3"'}   | ${{ depName: 'foo.bar', lookupName: 'foo.bar:foo.bar.gradle.plugin', currentValue: '1.2.3' }}
         ${''}               | ${'id("foo.bar") version "1.2.3"'}  | ${{ depName: 'foo.bar', lookupName: 'foo.bar:foo.bar.gradle.plugin', currentValue: '1.2.3' }}
         ${''}               | ${'kotlin("jvm") version "1.3.71"'} | ${{ depName: 'org.jetbrains.kotlin.jvm', lookupName: 'org.jetbrains.kotlin.jvm:org.jetbrains.kotlin.jvm.gradle.plugin', currentValue: '1.3.71' }}
-        ${''}               | ${'id "foo.bar" version something'} | ${{ depName: 'foo.bar', currentValue: 'something', skipReason: SkipReason.UnknownVersion }}
+        ${''}               | ${'id "foo.bar" version something'} | ${{ depName: 'foo.bar', currentValue: 'something', skipReason: 'unknown-version' }}
         ${'baz = "1.2.3"'}  | ${'id "foo.bar" version baz'}       | ${{ depName: 'foo.bar', lookupName: 'foo.bar:foo.bar.gradle.plugin', currentValue: '1.2.3' }}
         ${'baz = "1.2.3"'}  | ${'id("foo.bar") version baz'}      | ${{ depName: 'foo.bar', lookupName: 'foo.bar:foo.bar.gradle.plugin', currentValue: '1.2.3' }}
         ${'baz = "1.3.71"'} | ${'kotlin("jvm") version baz'}      | ${{ depName: 'org.jetbrains.kotlin.jvm', lookupName: 'org.jetbrains.kotlin.jvm:org.jetbrains.kotlin.jvm.gradle.plugin', currentValue: '1.3.71' }}
         ${'z = "1.2.3"'}    | ${'id "x.y" version "$z"'}          | ${{ depName: 'x.y', lookupName: 'x.y:x.y.gradle.plugin', currentValue: '1.2.3' }}
-        ${''}               | ${'id "x.y" version "$z"'}          | ${{ depName: 'x.y', skipReason: SkipReason.UnknownVersion, currentValue: 'z' }}
-        ${''}               | ${'id "x.y" version "x${y}z"'}      | ${{ depName: 'x.y', skipReason: SkipReason.UnknownVersion }}
+        ${''}               | ${'id "x.y" version "$z"'}          | ${{ depName: 'x.y', skipReason: 'unknown-version', currentValue: 'z' }}
+        ${''}               | ${'id "x.y" version "x${y}z"'}      | ${{ depName: 'x.y', skipReason: 'unknown-version' }}
         ${'z = "1.2.3"'}    | ${'id("x.y") version "$z"'}         | ${{ depName: 'x.y', lookupName: 'x.y:x.y.gradle.plugin', currentValue: '1.2.3' }}
-        ${''}               | ${'id("x.y") version "$z"'}         | ${{ depName: 'x.y', skipReason: SkipReason.UnknownVersion, currentValue: 'z' }}
-        ${''}               | ${'id("x.y") version "x${y}z"'}     | ${{ depName: 'x.y', skipReason: SkipReason.UnknownVersion }}
+        ${''}               | ${'id("x.y") version "$z"'}         | ${{ depName: 'x.y', skipReason: 'unknown-version', currentValue: 'z' }}
+        ${''}               | ${'id("x.y") version "x${y}z"'}     | ${{ depName: 'x.y', skipReason: 'unknown-version' }}
       `('$input', ({ def, input, output }) => {
         const { deps } = parseGradle([def, input].join('\n'));
         expect(deps).toMatchObject([output].filter(Boolean));

--- a/lib/manager/gradle/shallow/parser.ts
+++ b/lib/manager/gradle/shallow/parser.ts
@@ -1,7 +1,6 @@
 import url from 'url';
 import is from '@sindresorhus/is';
 import { logger } from '../../../logger';
-import { SkipReason } from '../../../types';
 import { regEx } from '../../../util/regex';
 import type { PackageDependency } from '../../types';
 import type { GradleManagerData } from '../types';
@@ -190,7 +189,7 @@ function processDepInterpolation({
           fileReplacePosition = lastToken.offset + 1;
           delete dep.groupName;
         } else {
-          dep.skipReason = SkipReason.ContainsVariable;
+          dep.skipReason = 'contains-variable';
         }
         dep.managerData = { fileReplacePosition, packageFile };
       }
@@ -234,7 +233,7 @@ function processPlugin({
       const fileReplacePosition = pluginVersion.offset;
       dep.currentValue = currentValue;
       dep.managerData = { fileReplacePosition, packageFile };
-      dep.skipReason = SkipReason.UnknownVersion;
+      dep.skipReason = 'unknown-version';
     }
   } else if (pluginVersion.type === TokenType.StringInterpolation) {
     const versionTpl = pluginVersion as StringInterpolation;
@@ -252,12 +251,12 @@ function processPlugin({
         const fileReplacePosition = child.offset;
         dep.currentValue = currentValue;
         dep.managerData = { fileReplacePosition, packageFile };
-        dep.skipReason = SkipReason.UnknownVersion;
+        dep.skipReason = 'unknown-version';
       }
     } else {
       const fileReplacePosition = versionTpl.offset;
       dep.managerData = { fileReplacePosition, packageFile };
-      dep.skipReason = SkipReason.UnknownVersion;
+      dep.skipReason = 'unknown-version';
     }
   } else {
     const currentValue = pluginVersion.value;
@@ -327,7 +326,7 @@ function processLongFormDep({
     }
     const methodName = tokenMap.methodName?.value;
     if (annoyingMethods.has(methodName)) {
-      dep.skipReason = SkipReason.Ignored;
+      dep.skipReason = 'ignored';
     }
 
     return { deps: [dep] };

--- a/lib/manager/helm-requirements/extract.spec.ts
+++ b/lib/manager/helm-requirements/extract.spec.ts
@@ -1,5 +1,4 @@
 import { fs } from '../../../test/util';
-import { SkipReason } from '../../types';
 import { extractPackageFile } from './extract';
 
 jest.mock('../../util/fs');
@@ -207,7 +206,7 @@ describe('manager/helm-requirements/extract', () => {
             {
               currentValue: undefined,
               depName: undefined,
-              skipReason: SkipReason.InvalidName,
+              skipReason: 'invalid-name',
             },
           ],
         },
@@ -224,7 +223,7 @@ describe('manager/helm-requirements/extract', () => {
             {
               currentValue: undefined,
               depName: 'postgres',
-              skipReason: SkipReason.InvalidVersion,
+              skipReason: 'invalid-version',
             },
           ],
         },
@@ -242,7 +241,7 @@ describe('manager/helm-requirements/extract', () => {
             {
               currentValue: '0.1.0',
               depName: 'postgres',
-              skipReason: SkipReason.NoRepository,
+              skipReason: 'no-repository',
             },
           ],
         },

--- a/lib/manager/helm-requirements/extract.ts
+++ b/lib/manager/helm-requirements/extract.ts
@@ -2,7 +2,6 @@ import is from '@sindresorhus/is';
 import { load } from 'js-yaml';
 import { HelmDatasource } from '../../datasource/helm';
 import { logger } from '../../logger';
-import { SkipReason } from '../../types';
 import type { ExtractConfig, PackageDependency, PackageFile } from '../types';
 
 export function extractPackageFile(
@@ -30,17 +29,17 @@ export function extractPackageFile(
     };
 
     if (!res.depName) {
-      res.skipReason = SkipReason.InvalidName;
+      res.skipReason = 'invalid-name';
       return res;
     }
 
     if (!res.currentValue) {
-      res.skipReason = SkipReason.InvalidVersion;
+      res.skipReason = 'invalid-version';
       return res;
     }
 
     if (!dep.repository) {
-      res.skipReason = SkipReason.NoRepository;
+      res.skipReason = 'no-repository';
       return res;
     }
 
@@ -55,16 +54,16 @@ export function extractPackageFile(
         return res;
       }
 
-      res.skipReason = SkipReason.PlaceholderUrl;
+      res.skipReason = 'placeholder-url';
     } else {
       try {
         const url = new URL(dep.repository);
         if (url.protocol === 'file:') {
-          res.skipReason = SkipReason.LocalDependency;
+          res.skipReason = 'local-dependency';
         }
       } catch (err) {
         logger.debug({ err }, 'Error parsing url');
-        res.skipReason = SkipReason.InvalidUrl;
+        res.skipReason = 'invalid-url';
       }
     }
     return res;

--- a/lib/manager/helmfile/extract.ts
+++ b/lib/manager/helmfile/extract.ts
@@ -2,7 +2,6 @@ import is from '@sindresorhus/is';
 import { loadAll } from 'js-yaml';
 import { HelmDatasource } from '../../datasource/helm';
 import { logger } from '../../logger';
-import { SkipReason } from '../../types';
 import { regEx } from '../../util/regex';
 import type { ExtractConfig, PackageDependency, PackageFile } from '../types';
 import type { Doc } from './types';
@@ -43,7 +42,7 @@ export function extractPackageFile(
       if (!is.string(dep.chart)) {
         return {
           depName: dep.name,
-          skipReason: SkipReason.InvalidName,
+          skipReason: 'invalid-name',
         };
       }
 
@@ -51,7 +50,7 @@ export function extractPackageFile(
       if (dep.chart.startsWith('./')) {
         return {
           depName,
-          skipReason: SkipReason.LocalChart,
+          skipReason: 'local-chart',
         };
       }
 
@@ -73,18 +72,18 @@ export function extractPackageFile(
 
       // If version is null is probably a local chart
       if (!res.currentValue) {
-        res.skipReason = SkipReason.LocalChart;
+        res.skipReason = 'local-chart';
       }
 
       // By definition on helm the chart name should be lowercase letter + number + -
       // However helmfile support templating of that field
       if (!isValidChartName(res.depName)) {
-        res.skipReason = SkipReason.UnsupportedChartType;
+        res.skipReason = 'unsupported-chart-type';
       }
 
       // Skip in case we cannot locate the registry
       if (is.emptyArray(res.registryUrls)) {
-        res.skipReason = SkipReason.UnknownRegistry;
+        res.skipReason = 'unknown-registry';
       }
 
       return res;

--- a/lib/manager/helmsman/extract.ts
+++ b/lib/manager/helmsman/extract.ts
@@ -2,7 +2,6 @@ import is from '@sindresorhus/is';
 import { load } from 'js-yaml';
 import { HelmDatasource } from '../../datasource/helm';
 import { logger } from '../../logger';
-import { SkipReason } from '../../types';
 import { regEx } from '../../util/regex';
 import type { ExtractConfig, PackageDependency, PackageFile } from '../types';
 import type { HelmsmanDocument } from './types';
@@ -20,26 +19,26 @@ function createDep(key: string, doc: HelmsmanDocument): PackageDependency {
   }
 
   if (!anApp.version) {
-    dep.skipReason = SkipReason.NoVersion;
+    dep.skipReason = 'no-version';
     return dep;
   }
   dep.currentValue = anApp.version;
 
   const regexResult = chartRegex.exec(anApp.chart);
   if (!regexResult) {
-    dep.skipReason = SkipReason.InvalidUrl;
+    dep.skipReason = 'invalid-url';
     return dep;
   }
 
   if (!is.nonEmptyString(regexResult.groups.lookupName)) {
-    dep.skipReason = SkipReason.InvalidName;
+    dep.skipReason = 'invalid-name';
     return dep;
   }
   dep.lookupName = regexResult.groups.lookupName;
 
   const registryUrl = doc.helmRepos[regexResult.groups.registryRef];
   if (!is.nonEmptyString(registryUrl)) {
-    dep.skipReason = SkipReason.NoRepository;
+    dep.skipReason = 'no-repository';
     return dep;
   }
   dep.registryUrls = [registryUrl];

--- a/lib/manager/helmv3/extract.ts
+++ b/lib/manager/helmv3/extract.ts
@@ -2,7 +2,6 @@ import is from '@sindresorhus/is';
 import { load } from 'js-yaml';
 import { HelmDatasource } from '../../datasource/helm';
 import { logger } from '../../logger';
-import { SkipReason } from '../../types';
 import { getSiblingFileName, localPathExists } from '../../util/fs';
 import type { ExtractConfig, PackageDependency, PackageFile } from '../types';
 import { parseRepository, resolveAlias } from './utils';
@@ -58,13 +57,13 @@ export async function extractPackageFile(
       currentValue: dep.version,
     };
     if (!dep.repository) {
-      res.skipReason = SkipReason.NoRepository;
+      res.skipReason = 'no-repository';
       return res;
     }
 
     const repository = resolveAlias(dep.repository, config.aliases);
     if (!repository) {
-      res.skipReason = SkipReason.PlaceholderUrl;
+      res.skipReason = 'placeholder-url';
       return res;
     }
 

--- a/lib/manager/helmv3/utils.ts
+++ b/lib/manager/helmv3/utils.ts
@@ -1,6 +1,5 @@
 import * as datasourceDocker from '../../datasource/docker';
 import { logger } from '../../logger';
-import { SkipReason } from '../../types';
 import type { PackageDependency } from '../types';
 
 export function parseRepository(
@@ -17,14 +16,14 @@ export function parseRepository(
         res.lookupName = `${repositoryURL.replace('oci://', '')}/${depName}`;
         break;
       case 'file:':
-        res.skipReason = SkipReason.LocalDependency;
+        res.skipReason = 'local-dependency';
         break;
       default:
         res.registryUrls = [repositoryURL];
     }
   } catch (err) {
     logger.debug({ err }, 'Error parsing url');
-    res.skipReason = SkipReason.InvalidUrl;
+    res.skipReason = 'invalid-url';
   }
   return res;
 }

--- a/lib/manager/homebrew/extract.ts
+++ b/lib/manager/homebrew/extract.ts
@@ -156,12 +156,12 @@ export function extractPackageFile(content: string): PackageFile | null {
     repoName = urlPathResult.repoName;
   } else {
     logger.debug('Error: Unsupported URL field');
-    skipReason = SkipReason.UnsupportedUrl;
+    skipReason = 'unsupported-url';
   }
   const sha256 = extractSha256(cleanContent);
   if (!sha256 || sha256.length !== 64) {
     logger.debug('Error: Invalid sha256 field');
-    skipReason = SkipReason.InvalidSha256;
+    skipReason = 'invalid-sha256';
   }
   const dep: PackageDependency = {
     depName: `${ownerName}/${repoName}`,

--- a/lib/manager/jenkins/extract.ts
+++ b/lib/manager/jenkins/extract.ts
@@ -2,7 +2,6 @@ import is from '@sindresorhus/is';
 import { load } from 'js-yaml';
 import { JenkinsPluginsDatasource } from '../../datasource/jenkins-plugins';
 import { logger } from '../../logger';
-import { SkipReason } from '../../types';
 import { isSkipComment } from '../../util/ignore';
 import { regEx } from '../../util/regex';
 import * as dockerVersioning from '../../versioning/docker';
@@ -21,14 +20,14 @@ function getDependency(plugin: JenkinsPlugin): PackageDependency {
   if (plugin.source?.version) {
     dep.currentValue = plugin.source.version.toString();
     if (typeof plugin.source.version !== 'string') {
-      dep.skipReason = SkipReason.InvalidVersion;
+      dep.skipReason = 'invalid-version';
       logger.warn(
         { dep },
         'Jenkins plugin dependency version is not a string and will be ignored'
       );
     }
   } else {
-    dep.skipReason = SkipReason.NoVersion;
+    dep.skipReason = 'no-version';
   }
 
   if (
@@ -36,15 +35,15 @@ function getDependency(plugin: JenkinsPlugin): PackageDependency {
     plugin.source?.version === 'experimental' ||
     plugin.groupId
   ) {
-    dep.skipReason = SkipReason.UnsupportedVersion;
+    dep.skipReason = 'unsupported-version';
   }
 
   if (plugin.source?.url) {
-    dep.skipReason = SkipReason.InternalPackage;
+    dep.skipReason = 'internal-package';
   }
 
   if (!dep.skipReason && plugin.renovate?.ignore) {
-    dep.skipReason = SkipReason.Ignored;
+    dep.skipReason = 'ignored';
   }
 
   logger.debug({ dep }, 'Jenkins plugin dependency');

--- a/lib/manager/kustomize/extract.spec.ts
+++ b/lib/manager/kustomize/extract.spec.ts
@@ -3,7 +3,6 @@ import * as datasourceDocker from '../../datasource/docker';
 import { GitTagsDatasource } from '../../datasource/git-tags';
 import * as datasourceGitHubTags from '../../datasource/github-tags';
 import { HelmDatasource } from '../../datasource/helm';
-import { SkipReason } from '../../types';
 import {
   extractHelmChart,
   extractImage,
@@ -259,7 +258,7 @@ describe('manager/kustomize/extract', () => {
       expect(res.deps).toHaveLength(6);
       expect(res.deps[0].currentValue).toBe('v0.1.0');
       expect(res.deps[1].currentValue).toBe('v0.0.1');
-      expect(res.deps[5].skipReason).toEqual(SkipReason.InvalidValue);
+      expect(res.deps[5].skipReason).toBe('invalid-value');
     });
     it('ignores non-Kubernetes empty files', () => {
       expect(extractPackageFile('')).toBeNull();
@@ -315,7 +314,7 @@ describe('manager/kustomize/extract', () => {
             replaceString: `11@${postgresDigest}`,
           },
           {
-            skipReason: SkipReason.InvalidValue,
+            skipReason: 'invalid-value',
           },
         ],
       });
@@ -335,13 +334,13 @@ describe('manager/kustomize/extract', () => {
             replaceString: postgresDigest,
           },
           {
-            skipReason: SkipReason.InvalidDependencySpecification,
+            skipReason: 'invalid-dependency-specification',
           },
           {
-            skipReason: SkipReason.InvalidValue,
+            skipReason: 'invalid-value',
           },
           {
-            skipReason: SkipReason.InvalidValue,
+            skipReason: 'invalid-value',
           },
         ],
       });

--- a/lib/manager/kustomize/extract.ts
+++ b/lib/manager/kustomize/extract.ts
@@ -5,7 +5,6 @@ import { GitTagsDatasource } from '../../datasource/git-tags';
 import * as datasourceGitHubTags from '../../datasource/github-tags';
 import { HelmDatasource } from '../../datasource/helm';
 import { logger } from '../../logger';
-import { SkipReason } from '../../types';
 import { regEx } from '../../util/regex';
 import { splitImageParts } from '../dockerfile/extract';
 import type { PackageDependency, PackageFile } from '../types';
@@ -57,7 +56,7 @@ export function extractImage(image: Image): PackageDependency | null {
       depName,
       currentValue: newTag,
       currentDigest: digest,
-      skipReason: SkipReason.InvalidDependencySpecification,
+      skipReason: 'invalid-dependency-specification',
     };
   }
 
@@ -66,7 +65,7 @@ export function extractImage(image: Image): PackageDependency | null {
       return {
         depName,
         currentValue: digest,
-        skipReason: SkipReason.InvalidValue,
+        skipReason: 'invalid-value',
       };
     }
 
@@ -84,7 +83,7 @@ export function extractImage(image: Image): PackageDependency | null {
       return {
         depName,
         currentValue: newTag,
-        skipReason: SkipReason.InvalidValue,
+        skipReason: 'invalid-value',
       };
     }
 

--- a/lib/manager/maven/extract.ts
+++ b/lib/manager/maven/extract.ts
@@ -4,7 +4,6 @@ import { XmlDocument, XmlElement } from 'xmldoc';
 import * as datasourceMaven from '../../datasource/maven';
 import { MAVEN_REPO } from '../../datasource/maven/common';
 import { logger } from '../../logger';
-import { SkipReason } from '../../types';
 import { readLocalFile } from '../../util/fs';
 import { regEx } from '../../util/regex';
 import type { ExtractConfig, PackageDependency, PackageFile } from '../types';
@@ -139,9 +138,9 @@ function applyProps(
   }
 
   if (containsPlaceholder(depName)) {
-    result.skipReason = SkipReason.NamePlaceholder;
+    result.skipReason = 'name-placeholder';
   } else if (containsPlaceholder(currentValue)) {
-    result.skipReason = SkipReason.VersionPlaceholder;
+    result.skipReason = 'version-placeholder';
   }
 
   if (propSource && depPackageFile !== propSource) {

--- a/lib/manager/mix/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/mix/__snapshots__/extract.spec.ts.snap
@@ -28,7 +28,7 @@ Object {
       "managerData": Object {
         "lineNumber": 20,
       },
-      "skipReason": "non-hex depTypes",
+      "skipReason": "non-hex-dep-types",
     },
     Object {
       "currentValue": "~> 1.0",

--- a/lib/manager/mix/extract.spec.ts
+++ b/lib/manager/mix/extract.spec.ts
@@ -24,7 +24,7 @@ describe('manager/mix/extract', () => {
             depName: 'cowboy',
             currentValue: 'ninenines/cowboy',
             datasource: 'github',
-            skipReason: 'non-hex depTypes',
+            skipReason: 'non-hex-dep-types',
           },
           {
             depName: 'secret',

--- a/lib/manager/mix/extract.ts
+++ b/lib/manager/mix/extract.ts
@@ -1,6 +1,5 @@
 import { HexDatasource } from '../../datasource/hex';
 import { logger } from '../../logger';
-import { SkipReason } from '../../types';
 import { findLocalSiblingOrParent, localPathExists } from '../../util/fs';
 import { regEx } from '../../util/regex';
 import type { PackageDependency, PackageFile } from '../types';
@@ -53,7 +52,7 @@ export async function extractPackageFile(
           }
 
           if (dep.datasource !== HexDatasource.id) {
-            dep.skipReason = SkipReason.NonHexDeptypes;
+            dep.skipReason = 'non-hex-dep-types';
           }
 
           // Find dep's line number

--- a/lib/manager/npm/extract/index.ts
+++ b/lib/manager/npm/extract/index.ts
@@ -5,7 +5,6 @@ import { CONFIG_VALIDATION } from '../../../constants/error-messages';
 import * as datasourceGithubTags from '../../../datasource/github-tags';
 import { id as npmId } from '../../../datasource/npm';
 import { logger } from '../../../logger';
-import { SkipReason } from '../../../types';
 import { getSiblingFileName, readLocalFile } from '../../../util/fs';
 import { regEx } from '../../../util/regex';
 import * as nodeVersioning from '../../../versioning/node';
@@ -179,11 +178,11 @@ export async function extractPackageFile(
   ): PackageDependency {
     const dep: PackageDependency = {};
     if (!validateNpmPackageName(depName).validForOldPackages) {
-      dep.skipReason = SkipReason.InvalidName;
+      dep.skipReason = 'invalid-name';
       return dep;
     }
     if (typeof input !== 'string') {
-      dep.skipReason = SkipReason.InvalidValue;
+      dep.skipReason = 'invalid-value';
       return dep;
     }
     dep.currentValue = input.trim();
@@ -216,10 +215,10 @@ export async function extractPackageFile(
         dep.lookupName = 'microsoft/vscode';
         constraints.vscode = dep.currentValue;
       } else {
-        dep.skipReason = SkipReason.UnknownEngines;
+        dep.skipReason = 'unknown-engines';
       }
       if (!isValid(dep.currentValue)) {
-        dep.skipReason = SkipReason.UnknownVersion;
+        dep.skipReason = 'unknown-version';
       }
       return dep;
     }
@@ -236,10 +235,10 @@ export async function extractPackageFile(
       } else if (depName === 'npm') {
         dep.datasource = npmId;
       } else {
-        dep.skipReason = SkipReason.UnknownVolta;
+        dep.skipReason = 'unknown-volta';
       }
       if (!isValid(dep.currentValue)) {
-        dep.skipReason = SkipReason.UnknownVersion;
+        dep.skipReason = 'unknown-version';
       }
       return dep;
     }
@@ -259,23 +258,23 @@ export async function extractPackageFile(
       }
     }
     if (dep.currentValue.startsWith('file:')) {
-      dep.skipReason = SkipReason.File;
+      dep.skipReason = 'file';
       hasFancyRefs = true;
       return dep;
     }
     if (isValid(dep.currentValue)) {
       dep.datasource = npmId;
       if (dep.currentValue === '*') {
-        dep.skipReason = SkipReason.AnyVersion;
+        dep.skipReason = 'any-version';
       }
       if (dep.currentValue === '') {
-        dep.skipReason = SkipReason.Empty;
+        dep.skipReason = 'empty';
       }
       return dep;
     }
     const hashSplit = dep.currentValue.split('#');
     if (hashSplit.length !== 2) {
-      dep.skipReason = SkipReason.UnknownVersion;
+      dep.skipReason = 'unknown-version';
       return dep;
     }
     const [depNamePart, depRefPart] = hashSplit;
@@ -292,7 +291,7 @@ export async function extractPackageFile(
         .replace(regEx(/\.git$/), '');
       const githubRepoSplit = githubOwnerRepo.split('/');
       if (githubRepoSplit.length !== 2) {
-        dep.skipReason = SkipReason.UnknownVersion;
+        dep.skipReason = 'unknown-version';
         return dep;
       }
       [githubOwner, githubRepo] = githubRepoSplit;
@@ -306,7 +305,7 @@ export async function extractPackageFile(
       !githubValidRegex.test(githubOwner) ||
       !githubValidRegex.test(githubRepo)
     ) {
-      dep.skipReason = SkipReason.UnknownVersion;
+      dep.skipReason = 'unknown-version';
       return dep;
     }
     if (isVersion(depRefPart)) {
@@ -325,7 +324,7 @@ export async function extractPackageFile(
       dep.datasource = datasourceGithubTags.id;
       dep.lookupName = githubOwnerRepo;
     } else {
-      dep.skipReason = SkipReason.UnversionedReference;
+      dep.skipReason = 'unversioned-reference';
       return dep;
     }
     dep.githubRepo = githubOwnerRepo;

--- a/lib/manager/npm/extract/monorepo.ts
+++ b/lib/manager/npm/extract/monorepo.ts
@@ -1,6 +1,5 @@
 import is from '@sindresorhus/is';
 import { logger } from '../../../logger';
-import { SkipReason } from '../../../types';
 import { getSiblingFileName, getSubDirectory } from '../../../util/fs';
 import type { PackageFile } from '../../types';
 import { detectPnpmWorkspaces } from './pnpm';
@@ -42,7 +41,7 @@ export async function detectMonorepos(
       if (!updateInternalDeps) {
         p.deps?.forEach((dep) => {
           if (internalPackageNames.includes(dep.depName)) {
-            dep.skipReason = SkipReason.InternalPackage;
+            dep.skipReason = 'internal-package';
           }
         });
       }
@@ -61,7 +60,7 @@ export async function detectMonorepos(
         if (!updateInternalDeps) {
           subPackage.deps?.forEach((dep) => {
             if (internalPackageNames.includes(dep.depName)) {
-              dep.skipReason = SkipReason.InternalPackage;
+              dep.skipReason = 'internal-package';
             }
           });
         }

--- a/lib/manager/nuget/extract/global-manifest.ts
+++ b/lib/manager/nuget/extract/global-manifest.ts
@@ -1,6 +1,5 @@
 import * as datasourceNuget from '../../../datasource/nuget';
 import { logger } from '../../../logger';
-import { SkipReason } from '../../../types';
 import type { PackageDependency, PackageFile } from '../../types';
 import type { MsbuildGlobalManifest } from '../types';
 
@@ -31,7 +30,7 @@ export function extractMsbuildGlobalManifest(
       depType: 'dotnet-sdk',
       depName: 'dotnet-sdk',
       currentValue: manifest.sdk?.version,
-      skipReason: SkipReason.UnsupportedDatasource,
+      skipReason: 'unsupported-datasource',
     });
   }
 

--- a/lib/manager/pip_requirements/extract.ts
+++ b/lib/manager/pip_requirements/extract.ts
@@ -4,7 +4,6 @@ import { GlobalConfig } from '../../config/global';
 import { GitTagsDatasource } from '../../datasource/git-tags';
 import { PypiDatasource } from '../../datasource/pypi';
 import { logger } from '../../logger';
-import { SkipReason } from '../../types';
 import { isSkipComment } from '../../util/ignore';
 import { regEx } from '../../util/regex';
 import type { ExtractConfig, PackageDependency, PackageFile } from '../types';
@@ -65,7 +64,7 @@ export function extractPackageFile(
       let dep: PackageDependency = {};
       const [line, comment] = rawline.split('#').map((part) => part.trim());
       if (isSkipComment(comment)) {
-        dep.skipReason = SkipReason.Ignored;
+        dep.skipReason = 'ignored';
       }
       const [lineNoEnvMarkers] = line.split(';').map((part) => part.trim());
       const lineNoHashes = lineNoEnvMarkers.split(' \\')[0];

--- a/lib/manager/pip_setup/extract.ts
+++ b/lib/manager/pip_setup/extract.ts
@@ -1,7 +1,6 @@
 import { RANGE_PATTERN } from '@renovatebot/pep440';
 import { lang, lexer, query as q } from 'good-enough-parser';
 import { PypiDatasource } from '../../datasource/pypi';
-import { SkipReason } from '../../types';
 import { regEx } from '../../util/regex';
 import type { ExtractConfig, PackageDependency, PackageFile } from '../types';
 
@@ -56,7 +55,7 @@ function depStringHandler(
 function depSkipHandler(ctx: Context): Context {
   const dep = ctx.deps[ctx.deps.length - 1];
   const deps = ctx.deps.slice(0, -1);
-  deps.push({ ...dep, skipReason: SkipReason.Ignored });
+  deps.push({ ...dep, skipReason: 'ignored' });
   return { ...ctx, deps };
 }
 

--- a/lib/manager/pipenv/extract.ts
+++ b/lib/manager/pipenv/extract.ts
@@ -36,21 +36,21 @@ function extractFromSection(
       let nestedVersion: boolean;
       let skipReason: SkipReason;
       if (requirements.git) {
-        skipReason = SkipReason.GitDependency;
+        skipReason = 'git-dependency';
       } else if (requirements.file) {
-        skipReason = SkipReason.FileDependency;
+        skipReason = 'file-dependency';
       } else if (requirements.path) {
-        skipReason = SkipReason.LocalDependency;
+        skipReason = 'local-dependency';
       } else if (requirements.version) {
         currentValue = requirements.version;
         nestedVersion = true;
       } else if (is.object(requirements)) {
-        skipReason = SkipReason.AnyVersion;
+        skipReason = 'any-version';
       } else {
         currentValue = requirements;
       }
       if (currentValue === '*') {
-        skipReason = SkipReason.AnyVersion;
+        skipReason = 'any-version';
       }
       if (!skipReason) {
         const packageMatches = packageRegex.exec(depName);
@@ -58,14 +58,14 @@ function extractFromSection(
           logger.debug(
             `Skipping dependency with malformed package name "${depName}".`
           );
-          skipReason = SkipReason.InvalidName;
+          skipReason = 'invalid-name';
         }
         const specifierMatches = specifierRegex.exec(currentValue);
         if (!specifierMatches) {
           logger.debug(
             `Skipping dependency with malformed version specifier "${currentValue}".`
           );
-          skipReason = SkipReason.InvalidVersion;
+          skipReason = 'invalid-version';
         }
       }
       const dep: PackageDependency = {

--- a/lib/manager/poetry/extract.ts
+++ b/lib/manager/poetry/extract.ts
@@ -44,20 +44,20 @@ function extractFromSection(
         currentValue = version;
         nestedVersion = true;
         if (path) {
-          skipReason = SkipReason.PathDependency;
+          skipReason = 'path-dependency';
         }
         if (git) {
-          skipReason = SkipReason.GitDependency;
+          skipReason = 'git-dependency';
         }
       } else if (path) {
         currentValue = '';
-        skipReason = SkipReason.PathDependency;
+        skipReason = 'path-dependency';
       } else if (git) {
         currentValue = '';
-        skipReason = SkipReason.GitDependency;
+        skipReason = 'git-dependency';
       } else {
         currentValue = '';
-        skipReason = SkipReason.MultipleConstraintDep;
+        skipReason = 'multiple-constraint-dep';
       }
     }
     const dep: PackageDependency = {
@@ -77,7 +77,7 @@ function extractFromSection(
     } else if (poetryVersioning.isValid(dep.currentValue)) {
       dep.versioning = poetryVersioning.id;
     } else {
-      dep.skipReason = SkipReason.UnknownVersion;
+      dep.skipReason = 'unknown-version';
     }
     deps.push(dep);
   });

--- a/lib/manager/pre-commit/extract.ts
+++ b/lib/manager/pre-commit/extract.ts
@@ -48,7 +48,7 @@ function determineDatasource(
       { repository, hostUrl },
       'Provided hostname does not match any hostRules. Ignoring'
     );
-    return { skipReason: SkipReason.UnknownRegistry, registryUrls: [hostname] };
+    return { skipReason: 'unknown-registry', registryUrls: [hostname] };
   }
   for (const [hostType, sourceId] of [
     [PlatformId.Gitea, gitlabTagsId],
@@ -67,7 +67,7 @@ function determineDatasource(
     { repository, registry: hostUrl },
     'Provided hostname did not match any of the hostRules of hostType gitea,github nor gitlab'
   );
-  return { skipReason: SkipReason.UnknownRegistry, registryUrls: [hostname] };
+  return { skipReason: 'unknown-registry', registryUrls: [hostname] };
 }
 
 function extractDependency(
@@ -115,7 +115,7 @@ function extractDependency(
     depType: 'repository',
     datasource: undefined,
     lookupName: undefined,
-    skipReason: SkipReason.InvalidUrl,
+    skipReason: 'invalid-url',
     currentValue: tag,
   };
 }

--- a/lib/manager/terraform/modules.ts
+++ b/lib/manager/terraform/modules.ts
@@ -3,7 +3,6 @@ import { GitTagsDatasource } from '../../datasource/git-tags';
 import * as datasourceGithubTags from '../../datasource/github-tags';
 import { TerraformModuleDatasource } from '../../datasource/terraform-module';
 import { logger } from '../../logger';
-import { SkipReason } from '../../types';
 import { regEx } from '../../util/regex';
 import type { PackageDependency } from '../types';
 import { TerraformDependencyTypes } from './common';
@@ -69,7 +68,7 @@ export function analyseTerraformModule(dep: PackageDependency): void {
   } else if (dep.managerData.source) {
     const moduleParts = dep.managerData.source.split('//')[0].split('/');
     if (moduleParts[0] === '..') {
-      dep.skipReason = SkipReason.Local;
+      dep.skipReason = 'local';
     } else if (moduleParts.length >= 3) {
       const hostnameMatch = hostnameMatchRegex.exec(dep.managerData.source);
       if (hostnameMatch) {
@@ -81,6 +80,6 @@ export function analyseTerraformModule(dep: PackageDependency): void {
     }
   } else {
     logger.debug({ dep }, 'terraform dep has no source');
-    dep.skipReason = SkipReason.NoSource;
+    dep.skipReason = 'no-source';
   }
 }

--- a/lib/manager/terraform/providers.ts
+++ b/lib/manager/terraform/providers.ts
@@ -1,7 +1,6 @@
 import is from '@sindresorhus/is';
 import { TerraformProviderDatasource } from '../../datasource/terraform-provider';
 import { logger } from '../../logger';
-import { SkipReason } from '../../types';
 import { regEx } from '../../util/regex';
 import type { PackageDependency } from '../types';
 import { TerraformDependencyTypes } from './common';
@@ -82,7 +81,7 @@ export function analyzeTerraformProvider(
   if (is.nonEmptyString(dep.managerData.source)) {
     const source = sourceExtractionRegex.exec(dep.managerData.source);
     if (!source) {
-      dep.skipReason = SkipReason.UnsupportedUrl;
+      dep.skipReason = 'unsupported-url';
       return;
     }
 
@@ -101,6 +100,6 @@ export function analyzeTerraformProvider(
   dep.lockedVersion = getLockedVersion(dep, locks);
 
   if (!dep.currentValue) {
-    dep.skipReason = SkipReason.NoVersion;
+    dep.skipReason = 'no-version';
   }
 }

--- a/lib/manager/terraform/resources.ts
+++ b/lib/manager/terraform/resources.ts
@@ -1,5 +1,4 @@
 import { HelmDatasource } from '../../datasource/helm';
-import { SkipReason } from '../../types';
 import { getDep } from '../dockerfile/extract';
 import type { PackageDependency } from '../types';
 import { TerraformDependencyTypes, TerraformResourceTypes } from './common';
@@ -71,7 +70,7 @@ export function analyseTerraformResource(
         applyDockerDependency(dep, dep.managerData.image);
         dep.depType = 'docker_container';
       } else {
-        dep.skipReason = SkipReason.InvalidDependencySpecification;
+        dep.skipReason = 'invalid-dependency-specification';
       }
       break;
 
@@ -80,7 +79,7 @@ export function analyseTerraformResource(
         applyDockerDependency(dep, dep.managerData.name);
         dep.depType = 'docker_image';
       } else {
-        dep.skipReason = SkipReason.InvalidDependencySpecification;
+        dep.skipReason = 'invalid-dependency-specification';
       }
       break;
 
@@ -89,15 +88,15 @@ export function analyseTerraformResource(
         applyDockerDependency(dep, dep.managerData.image);
         dep.depType = 'docker_service';
       } else {
-        dep.skipReason = SkipReason.InvalidDependencySpecification;
+        dep.skipReason = 'invalid-dependency-specification';
       }
       break;
 
     case TerraformResourceTypes.helm_release:
       if (!dep.managerData.chart) {
-        dep.skipReason = SkipReason.InvalidName;
+        dep.skipReason = 'invalid-name';
       } else if (checkIfStringIsPath(dep.managerData.chart)) {
-        dep.skipReason = SkipReason.LocalChart;
+        dep.skipReason = 'local-chart';
       }
       dep.depType = 'helm_release';
       dep.registryUrls = [dep.managerData.repository];
@@ -106,7 +105,7 @@ export function analyseTerraformResource(
       break;
 
     default:
-      dep.skipReason = SkipReason.InvalidValue;
+      dep.skipReason = 'invalid-value';
       break;
   }
 }

--- a/lib/manager/terragrunt/modules.ts
+++ b/lib/manager/terragrunt/modules.ts
@@ -2,7 +2,6 @@ import { GitTagsDatasource } from '../../datasource/git-tags';
 import * as datasourceGithubTags from '../../datasource/github-tags';
 import { TerraformModuleDatasource } from '../../datasource/terraform-module';
 import { logger } from '../../logger';
-import { SkipReason } from '../../types';
 import { regEx } from '../../util/regex';
 import type { PackageDependency } from '../types';
 import { TerragruntDependencyTypes } from './common';
@@ -56,7 +55,7 @@ export function analyseTerragruntModule(dep: PackageDependency): void {
   } else if (dep.managerData.source) {
     const moduleParts = dep.managerData.source.split('//')[0].split('/');
     if (moduleParts[0] === '..') {
-      dep.skipReason = SkipReason.Local;
+      dep.skipReason = 'local';
     } else if (moduleParts.length >= 3) {
       const hostnameMatch = hostnameMatchRegex.exec(dep.managerData.source);
       if (hostnameMatch) {
@@ -68,6 +67,6 @@ export function analyseTerragruntModule(dep: PackageDependency): void {
     }
   } else {
     logger.debug({ dep }, 'terragrunt dep has no source');
-    dep.skipReason = SkipReason.NoSource;
+    dep.skipReason = 'no-source';
   }
 }

--- a/lib/types/skip-reason.ts
+++ b/lib/types/skip-reason.ts
@@ -1,46 +1,45 @@
-export enum SkipReason {
-  AnyVersion = 'any-version',
-  ContainsVariable = 'contains-variable',
-  Disabled = 'disabled',
-  Empty = 'empty',
-  FileDependency = 'file-dependency',
-  File = 'file',
-  GitDependency = 'git-dependency',
-  GitPlugin = 'git-plugin',
-  Ignored = 'ignored',
-  InternalError = 'internal-error',
-  InternalPackage = 'internal-package',
-  InvalidConfig = 'invalid-config',
-  InvalidDependencySpecification = 'invalid-dependency-specification',
-  InvalidName = 'invalid-name',
-  InvalidSha256 = 'invalid-sha256',
-  InvalidUrl = 'invalid-url',
-  InvalidValue = 'invalid-value',
-  InvalidVersion = 'invalid-version',
-  LocalChart = 'local-chart',
-  LocalDependency = 'local-dependency',
-  Local = 'local',
-  MultipleConstraintDep = 'multiple-constraint-dep',
-  NamePlaceholder = 'name-placeholder',
-  NoRepository = 'no-repository',
-  NoSourceMatch = 'no-source-match',
-  NoSource = 'no-source',
-  NoVersion = 'no-version',
-  NonHexDeptypes = 'non-hex depTypes',
-  NotAVersion = 'not-a-version',
-  PathDependency = 'path-dependency',
-  PlaceholderUrl = 'placeholder-url',
-  UnknownEngines = 'unknown-engines',
-  UnknownRegistry = 'unknown-registry',
-  UnknownVersion = 'unknown-version',
-  UnknownVolta = 'unknown-volta',
-  UnsupportedChartType = 'unsupported-chart-type',
-  UnsupportedDatasource = 'unsupported-datasource',
-  UnsupportedRemote = 'unsupported-remote',
-  UnsupportedUrl = 'unsupported-url',
-  UnsupportedVersion = 'unsupported-version',
-  Unsupported = 'unsupported',
-  UnversionedReference = 'unversioned-reference',
-  VersionPlaceholder = 'version-placeholder',
-  IsPinned = 'is-pinned',
-}
+export type SkipReason =
+  | 'any-version'
+  | 'contains-variable'
+  | 'disabled'
+  | 'empty'
+  | 'file-dependency'
+  | 'file'
+  | 'git-dependency'
+  | 'git-plugin'
+  | 'ignored'
+  | 'internal-error'
+  | 'internal-package'
+  | 'invalid-config'
+  | 'invalid-dependency-specification'
+  | 'invalid-name'
+  | 'invalid-sha256'
+  | 'invalid-url'
+  | 'invalid-value'
+  | 'invalid-version'
+  | 'local-chart'
+  | 'local-dependency'
+  | 'local'
+  | 'multiple-constraint-dep'
+  | 'name-placeholder'
+  | 'no-repository'
+  | 'no-source-match'
+  | 'no-source'
+  | 'no-version'
+  | 'non-hex-dep-types'
+  | 'not-a-version'
+  | 'path-dependency'
+  | 'placeholder-url'
+  | 'unknown-engines'
+  | 'unknown-registry'
+  | 'unknown-version'
+  | 'unknown-volta'
+  | 'unsupported-chart-type'
+  | 'unsupported-datasource'
+  | 'unsupported-remote'
+  | 'unsupported-url'
+  | 'unsupported-version'
+  | 'unsupported'
+  | 'unversioned-reference'
+  | 'version-placeholder'
+  | 'is-pinned';

--- a/lib/workers/repository/process/fetch.ts
+++ b/lib/workers/repository/process/fetch.ts
@@ -4,7 +4,6 @@ import type { RenovateConfig } from '../../../config/types';
 import { getDefaultConfig } from '../../../datasource';
 import { logger } from '../../../logger';
 import type { PackageDependency, PackageFile } from '../../../manager/types';
-import { SkipReason } from '../../../types';
 import { clone } from '../../../util/clone';
 import { applyPackageRules } from '../../../util/package-rules';
 import { lookupUpdates } from './lookup';
@@ -27,10 +26,10 @@ async function fetchDepUpdates(
   depConfig = applyPackageRules(depConfig);
   if (depConfig.ignoreDeps.includes(depName)) {
     logger.debug({ dependency: depName }, 'Dependency is ignored');
-    dep.skipReason = SkipReason.Ignored;
+    dep.skipReason = 'ignored';
   } else if (depConfig.enabled === false) {
     logger.debug({ dependency: depName }, 'Dependency is disabled');
-    dep.skipReason = SkipReason.Disabled;
+    dep.skipReason = 'disabled';
   } else {
     if (depConfig.datasource) {
       dep = {

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -13,7 +13,6 @@ import {
 } from '../../../../datasource';
 import { logger } from '../../../../logger';
 import { getRangeStrategy } from '../../../../manager';
-import { SkipReason } from '../../../../types';
 import { ExternalHostError } from '../../../../types/errors/external-host-error';
 import { clone } from '../../../../util/clone';
 import { applyPackageRules } from '../../../../util/package-rules';
@@ -61,7 +60,7 @@ export async function lookupUpdates(
       !isGetPkgReleasesConfig(config) ||
       !getDatasourceList().includes(datasource)
     ) {
-      res.skipReason = SkipReason.InvalidConfig;
+      res.skipReason = 'invalid-config';
       return res;
     }
     const isValid = is.string(currentValue) && versioning.isValid(currentValue);
@@ -70,7 +69,7 @@ export async function lookupUpdates(
         !updatePinnedDependencies &&
         versioning.isSingleVersion(currentValue)
       ) {
-        res.skipReason = SkipReason.IsPinned;
+        res.skipReason = 'is-pinned';
         return res;
       }
 
@@ -215,7 +214,7 @@ export async function lookupUpdates(
       }
       // istanbul ignore if
       if (!versioning.isVersion(currentVersion)) {
-        res.skipReason = SkipReason.InvalidVersion;
+        res.skipReason = 'invalid-version';
         return res;
       }
       // Filter latest, unstable, etc
@@ -304,12 +303,12 @@ export async function lookupUpdates(
         `Dependency ${depName} has unsupported value ${currentValue}`
       );
       if (!pinDigests && !currentDigest) {
-        res.skipReason = SkipReason.InvalidValue;
+        res.skipReason = 'invalid-value';
       } else {
         delete res.skipReason;
       }
     } else {
-      res.skipReason = SkipReason.InvalidValue;
+      res.skipReason = 'invalid-value';
     }
 
     // Record if the dep is fixed to a version
@@ -388,7 +387,7 @@ export async function lookupUpdates(
       },
       'lookupUpdates error'
     );
-    res.skipReason = SkipReason.InternalError;
+    res.skipReason = 'internal-error';
   }
   return res;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Replace enum with string union type
- Change `'non-hex depTypes'` to `'non-hex-dep-types'`

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
