### PR TITLE
fix: revert baseBranches config merge

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2585,14 +2585,6 @@ If you wish to disable all updates outside of scheduled hours then configure thi
 By default, Renovate will attempt to update all detected dependencies, regardless of whether they are defined using pinned single versions (e.g. `1.2.3`) or constraints/ranges (e.g. (`^1.2.3`).
 You can set this option to `false` if you wish to disable updating for pinned (single version) dependencies specifically.
 
-## useBaseBranchConfig
-
-By default, Renovate will read config file from the default branch only and will ignore any config files in base branches.
-You can configure `useBaseBranchConfig=merge` to instruct Renovate to merge the config from each base branch over the top of the config in the default branch.
-
-The config file name in the base branch must be the same as in the default branch and cannot be `package.json`.
-This scenario may be useful for testing the config changes in base branches instantly.
-
 ## userStrings
 
 When a PR is closed, Renovate posts a comment to let users know that future updates will be ignored.

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -695,14 +695,6 @@ const options: RenovateOptions[] = [
     cli: false,
   },
   {
-    name: 'useBaseBranchConfig',
-    description:
-      'Whether to read configuration from baseBranches instead of only the default branch',
-    type: 'string',
-    allowedValues: ['merge', 'none'],
-    default: 'none',
-  },
-  {
     name: 'gitAuthor',
     description: 'Author to use for Git commits. Must conform to RFC5322.',
     type: 'string',

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -159,8 +159,6 @@ export interface CustomManager {
   autoReplaceStringTemplate?: string;
 }
 
-export type UseBaseBranchConfigType = 'merge' | 'none';
-
 // TODO: Proper typings
 export interface RenovateConfig
   extends LegacyAdminConfig,
@@ -170,7 +168,6 @@ export interface RenovateConfig
     Record<string, unknown> {
   depName?: string;
   baseBranches?: string[];
-  useBaseBranchConfig?: UseBaseBranchConfigType;
   baseBranch?: string;
   defaultBranch?: string;
   branchList?: string[];

--- a/lib/workers/repository/process/index.spec.ts
+++ b/lib/workers/repository/process/index.spec.ts
@@ -1,12 +1,4 @@
-import {
-  RenovateConfig,
-  getConfig,
-  git,
-  mocked,
-  platform,
-} from '../../../../test/util';
-import { CONFIG_VALIDATION } from '../../../constants/error-messages';
-import { getCache } from '../../../util/cache/repository';
+import { RenovateConfig, getConfig, git, mocked } from '../../../../test/util';
 import * as _extractUpdate from './extract-update';
 import { extractDependencies, updateRepo } from '.';
 
@@ -41,62 +33,6 @@ describe('workers/repository/process/index', () => {
         branches: [undefined],
         packageFiles: undefined,
       });
-    });
-
-    it('reads config from default branch if useBaseBranchConfig not specified', async () => {
-      git.branchExists.mockReturnValue(true);
-      platform.getJsonFile.mockResolvedValueOnce({});
-      config.baseBranches = ['master', 'dev'];
-      config.useBaseBranchConfig = 'none';
-      getCache().configFileName = 'renovate.json';
-      const res = await extractDependencies(config);
-      expect(res).toEqual({
-        branchList: [undefined, undefined],
-        branches: [undefined, undefined],
-        packageFiles: undefined,
-      });
-      expect(platform.getJsonFile).not.toHaveBeenCalledWith(
-        'renovate.json',
-        undefined,
-        'dev'
-      );
-    });
-
-    it('reads config from branches in baseBranches if useBaseBranchConfig specified', async () => {
-      git.branchExists.mockReturnValue(true);
-      platform.getJsonFile = jest.fn().mockResolvedValue({});
-      config.baseBranches = ['master', 'dev'];
-      config.useBaseBranchConfig = 'merge';
-      getCache().configFileName = 'renovate.json';
-      const res = await extractDependencies(config);
-      expect(res).toEqual({
-        branchList: [undefined, undefined],
-        branches: [undefined, undefined],
-        packageFiles: undefined,
-      });
-      expect(platform.getJsonFile).toHaveBeenCalledWith(
-        'renovate.json',
-        undefined,
-        'dev'
-      );
-    });
-
-    it('handles config name mismatch between baseBranches if useBaseBranchConfig specified', async () => {
-      git.branchExists.mockReturnValue(true);
-      platform.getJsonFile = jest
-        .fn()
-        .mockImplementation((fileName, repoName, branchName) => {
-          if (branchName === 'dev') {
-            throw new Error();
-          }
-          return {};
-        });
-      getCache().configFileName = 'renovate.json';
-      config.baseBranches = ['master', 'dev'];
-      config.useBaseBranchConfig = 'merge';
-      await expect(extractDependencies(config)).rejects.toThrow(
-        CONFIG_VALIDATION
-      );
     });
   });
 });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Reverts #12514

## Context:

#13706

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
