### PR TITLE
feat(presets): add Apache Camel monorepo

### DIFF
--- a/lib/config/presets/internal/monorepo.ts
+++ b/lib/config/presets/internal/monorepo.ts
@@ -194,6 +194,7 @@ const repoGroups = {
 };
 
 const patternGroups = {
+  'apache-camel': '^org.apache.camel:',
   babel6: '^babel6$',
   clarity: ['^@cds/', '^@clr/'],
   wordpress: '^@wordpress/',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Add a monorepo entry for Apache Camel.

Homepage: https://camel.apache.org/
Artifacts on Maven Central: https://search.maven.org/search?q=g:org.apache.camel
Repository: https://github.com/apache/camel

## Context:

It seems Apache Camel publishes a huge amount of modules (see https://github.com/apache/camel/tree/main/components), all with the same versioning policy.  From a cursory check on Maven Cental, all modules under the `org.apache.camel` group ID are part of the same project...

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

I will probably add a similar rule to the internal project were I noticed this missing entry, I will report back if it works as expected.
