### PR TITLE
refactor(git): Rename File interface to FileChange

### DIFF
--- a/lib/manager/npm/post-update/index.ts
+++ b/lib/manager/npm/post-update/index.ts
@@ -23,7 +23,7 @@ import {
   writeLocalFile,
 } from '../../../util/fs';
 import { branchExists, getFile, getRepoStatus } from '../../../util/git';
-import type { File } from '../../../util/git/types';
+import type { FileChange } from '../../../util/git/types';
 import * as hostRules from '../../../util/host-rules';
 import { regEx } from '../../../util/regex';
 import { ensureTrailingSlash } from '../../../util/url';
@@ -361,7 +361,7 @@ async function resetNpmrcContent(
 async function updateYarnOffline(
   lockFileDir: string,
   localDir: string,
-  updatedArtifacts: File[]
+  updatedArtifacts: FileChange[]
 ): Promise<void> {
   try {
     const resolvedPaths: string[] = [];
@@ -414,7 +414,7 @@ async function updateYarnOffline(
 // exported for testing
 export async function updateYarnBinary(
   lockFileDir: string,
-  updatedArtifacts: File[],
+  updatedArtifacts: FileChange[],
   existingYarnrcYmlContent: string | undefined
 ): Promise<string | undefined> {
   let yarnrcYml = existingYarnrcYmlContent;
@@ -463,7 +463,7 @@ export async function getAdditionalFiles(
 ): Promise<WriteExistingFilesResult> {
   logger.trace({ config }, 'getAdditionalFiles');
   const artifactErrors: ArtifactError[] = [];
-  const updatedArtifacts: File[] = [];
+  const updatedArtifacts: FileChange[] = [];
   if (!packageFiles.npm?.length) {
     return { artifactErrors, updatedArtifacts };
   }

--- a/lib/manager/npm/post-update/types.ts
+++ b/lib/manager/npm/post-update/types.ts
@@ -1,4 +1,4 @@
-import type { File } from '../../../util/git/types';
+import type { FileChange } from '../../../util/git/types';
 import type { PackageFile } from '../../types';
 
 export interface DetermineLockFileDirsResult {
@@ -19,7 +19,7 @@ export interface ArtifactError {
 
 export interface WriteExistingFilesResult {
   artifactErrors: ArtifactError[];
-  updatedArtifacts: File[];
+  updatedArtifacts: FileChange[];
 }
 
 export interface GenerateLockFileResult {

--- a/lib/manager/types.ts
+++ b/lib/manager/types.ts
@@ -6,7 +6,7 @@ import type {
 } from '../config/types';
 import type { ProgrammingLanguage } from '../constants';
 import type { ModuleApi, RangeStrategy, SkipReason } from '../types';
-import type { File } from '../util/git/types';
+import type { FileChange } from '../util/git/types';
 
 export type Result<T> = T | Promise<T>;
 
@@ -201,7 +201,7 @@ export interface ArtifactError {
 
 export interface UpdateArtifactsResult {
   artifactError?: ArtifactError;
-  file?: File;
+  file?: FileChange;
 }
 
 export interface UpdateArtifact {
@@ -286,7 +286,7 @@ export interface ManagerApi extends ModuleApi {
 export interface PostUpdateConfig<T = Record<string, any>>
   extends Record<string, any>,
     ManagerData<T> {
-  updatedPackageFiles?: File[];
+  updatedPackageFiles?: FileChange[];
   postUpdateOptions?: string[];
   skipInstalls?: boolean;
   ignoreScripts?: boolean;

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -4,7 +4,7 @@ import SimpleGit from 'simple-git/src/git';
 import tmp from 'tmp-promise';
 import { GlobalConfig } from '../../config/global';
 import { CONFIG_VALIDATION } from '../../constants/error-messages';
-import type { File } from './types';
+import type { FileChange } from './types';
 import * as git from '.';
 import { setNoVerify } from '.';
 
@@ -206,7 +206,7 @@ describe('util/git/index', () => {
   });
   describe('getBranchFiles(branchName)', () => {
     it('detects changed files compared to current base branch', async () => {
-      const file: File = {
+      const file: FileChange = {
         type: 'addition',
         path: 'some-new-file',
         contents: 'some new-contents',
@@ -269,7 +269,7 @@ describe('util/git/index', () => {
   });
   describe('commitFiles({branchName, files, message})', () => {
     it('creates file', async () => {
-      const file: File = {
+      const file: FileChange = {
         type: 'addition',
         path: 'some-new-file',
         contents: 'some new-contents',
@@ -282,7 +282,7 @@ describe('util/git/index', () => {
       expect(commit).not.toBeNull();
     });
     it('deletes file', async () => {
-      const file: File = {
+      const file: FileChange = {
         type: 'deletion',
         path: 'file_to_delete',
       };
@@ -294,7 +294,7 @@ describe('util/git/index', () => {
       expect(commit).not.toBeNull();
     });
     it('updates multiple files', async () => {
-      const files: File[] = [
+      const files: FileChange[] = [
         {
           type: 'addition',
           path: 'some-existing-file',
@@ -314,7 +314,7 @@ describe('util/git/index', () => {
       expect(commit).not.toBeNull();
     });
     it('updates git submodules', async () => {
-      const files: File[] = [
+      const files: FileChange[] = [
         {
           type: 'addition',
           path: '.',
@@ -329,7 +329,7 @@ describe('util/git/index', () => {
       expect(commit).toBeNull();
     });
     it('does not push when no diff', async () => {
-      const files: File[] = [
+      const files: FileChange[] = [
         {
           type: 'addition',
           path: 'future_file',
@@ -348,7 +348,7 @@ describe('util/git/index', () => {
       const commitSpy = jest.spyOn(SimpleGit.prototype, 'commit');
       const pushSpy = jest.spyOn(SimpleGit.prototype, 'push');
 
-      const files: File[] = [
+      const files: FileChange[] = [
         {
           type: 'addition',
           path: 'some-new-file',
@@ -378,7 +378,7 @@ describe('util/git/index', () => {
       const commitSpy = jest.spyOn(SimpleGit.prototype, 'commit');
       const pushSpy = jest.spyOn(SimpleGit.prototype, 'push');
 
-      const files: File[] = [
+      const files: FileChange[] = [
         {
           type: 'addition',
           path: 'some-new-file',
@@ -409,7 +409,7 @@ describe('util/git/index', () => {
       const commitSpy = jest.spyOn(SimpleGit.prototype, 'commit');
       const pushSpy = jest.spyOn(SimpleGit.prototype, 'push');
 
-      const files: File[] = [
+      const files: FileChange[] = [
         {
           type: 'addition',
           path: 'some-new-file',
@@ -437,7 +437,7 @@ describe('util/git/index', () => {
     });
 
     it('creates file with the executable bit', async () => {
-      const file: File = {
+      const file: FileChange = {
         type: 'addition',
         path: 'some-executable',
         contents: 'some new-contents',

--- a/lib/util/git/types.ts
+++ b/lib/util/git/types.ts
@@ -64,11 +64,11 @@ export interface FileDeletion {
   path: string;
 }
 
-export type File = FileAddition | FileDeletion;
+export type FileChange = FileAddition | FileDeletion;
 
-export type CommitFilesConfig = {
+export interface CommitFilesConfig {
   branchName: string;
-  files: File[];
+  files: FileChange[];
   message: string;
   force?: boolean;
-};
+}

--- a/lib/workers/branch/execute-post-upgrade-commands.ts
+++ b/lib/workers/branch/execute-post-upgrade-commands.ts
@@ -6,14 +6,14 @@ import type { ArtifactError } from '../../manager/types';
 import { exec } from '../../util/exec';
 import { readLocalFile, writeLocalFile } from '../../util/fs';
 import { getRepoStatus } from '../../util/git';
-import type { File } from '../../util/git/types';
+import type { FileChange } from '../../util/git/types';
 import { regEx } from '../../util/regex';
 import { sanitize } from '../../util/sanitize';
 import { compile } from '../../util/template';
 import type { BranchConfig, BranchUpgradeConfig } from '../types';
 
 export type PostUpgradeCommandsExecutionResult = {
-  updatedArtifacts: File[];
+  updatedArtifacts: FileChange[];
   artifactErrors: ArtifactError[];
 };
 

--- a/lib/workers/branch/get-updated.ts
+++ b/lib/workers/branch/get-updated.ts
@@ -4,15 +4,15 @@ import { logger } from '../../logger';
 import { get } from '../../manager';
 import type { ArtifactError, PackageDependency } from '../../manager/types';
 import { getFile } from '../../util/git';
-import type { File, FileAddition } from '../../util/git/types';
+import type { FileAddition, FileChange } from '../../util/git/types';
 import type { BranchConfig } from '../types';
 import { doAutoReplace } from './auto-replace';
 
 export interface PackageFilesResult {
   artifactErrors: ArtifactError[];
   reuseExistingBranch?: boolean;
-  updatedPackageFiles: File[];
-  updatedArtifacts: File[];
+  updatedPackageFiles: FileChange[];
+  updatedArtifacts: FileChange[];
 }
 
 export async function getUpdatedPackageFiles(
@@ -220,7 +220,7 @@ export async function getUpdatedPackageFiles(
     path: name,
     contents: updatedFileContents[name],
   }));
-  const updatedArtifacts: File[] = [];
+  const updatedArtifacts: FileChange[] = [];
   const artifactErrors: ArtifactError[] = [];
   for (const packageFile of updatedPackageFiles) {
     const manager = packageFileManagers[packageFile.path];

--- a/lib/workers/branch/index.spec.ts
+++ b/lib/workers/branch/index.spec.ts
@@ -10,7 +10,7 @@ import * as _npmPostExtract from '../../manager/npm/post-update';
 import type { WriteExistingFilesResult } from '../../manager/npm/post-update/types';
 import { PrState } from '../../types';
 import * as _exec from '../../util/exec';
-import type { File, StatusResult } from '../../util/git/types';
+import type { FileChange, StatusResult } from '../../util/git/types';
 import * as _mergeConfidence from '../../util/merge-confidence';
 import * as _sanitize from '../../util/sanitize';
 import * as _limits from '../global/limits';
@@ -62,7 +62,7 @@ const limits = mocked(_limits);
 
 const adminConfig: RepoGlobalConfig = { localDir: '', cacheDir: '' };
 
-function findFileContent(files: File[], path: string): string | null {
+function findFileContent(files: FileChange[], path: string): string | null {
   const f = files.find((file) => file.path === path);
   if (f.type === 'addition') {
     return f.contents.toString();
@@ -1010,7 +1010,7 @@ describe('workers/branch/index', () => {
     });
 
     it('executes post-upgrade tasks if trust is high', async () => {
-      const updatedPackageFile: File = {
+      const updatedPackageFile: FileChange = {
         type: 'addition',
         path: 'pom.xml',
         contents: 'pom.xml file contents',
@@ -1093,7 +1093,7 @@ describe('workers/branch/index', () => {
     });
 
     it('handles post-upgrade task exec errors', async () => {
-      const updatedPackageFile: File = {
+      const updatedPackageFile: FileChange = {
         type: 'addition',
         path: 'pom.xml',
         contents: 'pom.xml file contents',
@@ -1164,7 +1164,7 @@ describe('workers/branch/index', () => {
     });
 
     it('executes post-upgrade tasks with disabled post-upgrade command templating', async () => {
-      const updatedPackageFile: File = {
+      const updatedPackageFile: FileChange = {
         type: 'addition',
         path: 'pom.xml',
         contents: 'pom.xml file contents',
@@ -1239,7 +1239,7 @@ describe('workers/branch/index', () => {
     });
 
     it('executes post-upgrade tasks with multiple dependecy in one branch', async () => {
-      const updatedPackageFile: File = {
+      const updatedPackageFile: FileChange = {
         type: 'addition',
         path: 'pom.xml',
         contents: 'pom.xml file contents',
@@ -1381,7 +1381,7 @@ describe('workers/branch/index', () => {
     });
 
     it('executes post-upgrade tasks once when set to branch mode', async () => {
-      const updatedPackageFile: File = {
+      const updatedPackageFile: FileChange = {
         type: 'addition',
         path: 'pom.xml',
         contents: 'pom.xml file contents',

--- a/lib/workers/types.ts
+++ b/lib/workers/types.ts
@@ -14,7 +14,7 @@ import type {
   PackageFile,
 } from '../manager/types';
 import type { PlatformPrOptions } from '../platform/types';
-import type { File } from '../util/git/types';
+import type { FileChange } from '../util/git/types';
 import type { MergeConfidence } from '../util/merge-confidence';
 import type { ChangeLogRelease, ChangeLogResult } from './pr/changelog/types';
 
@@ -59,8 +59,8 @@ export interface BranchUpgradeConfig
   minimumConfidence?: MergeConfidence;
   sourceDirectory?: string;
 
-  updatedPackageFiles?: File[];
-  updatedArtifacts?: File[];
+  updatedPackageFiles?: FileChange[];
+  updatedArtifacts?: FileChange[];
 
   logJSON?: ChangeLogResult;
 


### PR DESCRIPTION
## Changes:

Node already has its own `File` type, so it's useful to make it clear we're working with file changes, not with files.

## Context:

- Ref: #12410

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
