### PR TITLE
refactor(platform): Change PlatformId from enum to union type

### DIFF
--- a/lib/config/migration.spec.ts
+++ b/lib/config/migration.spec.ts
@@ -1,4 +1,3 @@
-import { PlatformId } from '../constants';
 import { getConfig } from './defaults';
 import { GlobalConfig } from './global';
 import * as configMigration from './migration';
@@ -20,7 +19,7 @@ describe('config/migration', () => {
       const config: TestRenovateConfig = {
         endpoints: [{}] as never,
         enabled: true,
-        platform: PlatformId.Github,
+        platform: 'github',
         hostRules: [
           {
             platform: 'docker',

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -1,4 +1,3 @@
-import { PlatformId } from '../../constants';
 import { getManagers } from '../../manager';
 import { getPlatformList } from '../../platform';
 import { getVersioningList } from '../../versioning';
@@ -592,7 +591,7 @@ const options: RenovateOptions[] = [
     description: 'Platform type of repository.',
     type: 'string',
     allowedValues: getPlatformList(),
-    default: PlatformId.Github,
+    default: 'github',
     globalOnly: true,
   },
   {

--- a/lib/config/presets/local/index.ts
+++ b/lib/config/presets/local/index.ts
@@ -7,13 +7,21 @@ import * as github from '../github';
 import * as gitlab from '../gitlab';
 import type { Preset, PresetConfig } from '../types';
 
-const resolvers = {
-  [PlatformId.Azure]: azure,
-  [PlatformId.Bitbucket]: bitbucket,
-  [PlatformId.BitbucketServer]: bitbucketServer,
-  [PlatformId.Gitea]: gitea,
-  [PlatformId.Github]: github,
-  [PlatformId.Gitlab]: gitlab,
+type PresetApi =
+  | typeof azure
+  | typeof bitbucket
+  | typeof bitbucketServer
+  | typeof gitea
+  | typeof github
+  | typeof gitlab;
+
+const resolvers: Record<PlatformId, PresetApi> = {
+  ['azure']: azure,
+  ['bitbucket']: bitbucket,
+  ['bitbucket-server']: bitbucketServer,
+  ['gitea']: gitea,
+  ['github']: github,
+  ['gitlab']: gitlab,
 };
 
 export function getPreset({

--- a/lib/constants/platform.spec.ts
+++ b/lib/constants/platform.spec.ts
@@ -9,7 +9,6 @@ import {
   BITBUCKET_API_USING_HOST_TYPES,
   GITHUB_API_USING_HOST_TYPES,
   GITLAB_API_USING_HOST_TYPES,
-  PlatformId,
 } from './platforms';
 
 describe('constants/platform', () => {
@@ -21,30 +20,28 @@ describe('constants/platform', () => {
     expect(
       GITLAB_API_USING_HOST_TYPES.includes(GitlabPackagesDatasource.id)
     ).toBeTrue();
-    expect(GITLAB_API_USING_HOST_TYPES.includes(PlatformId.Gitlab)).toBeTrue();
+    expect(GITLAB_API_USING_HOST_TYPES.includes('gitlab')).toBeTrue();
   });
 
   it('should be not part of the GITLAB_API_USING_HOST_TYPES ', () => {
-    expect(GITLAB_API_USING_HOST_TYPES.includes(PlatformId.Github)).toBeFalse();
+    expect(GITLAB_API_USING_HOST_TYPES.includes('github')).toBeFalse();
   });
 
   it('should be part of the GITHUB_API_USING_HOST_TYPES ', () => {
     expect(GITHUB_API_USING_HOST_TYPES.includes(GH_TAGS_DS)).toBeTrue();
     expect(GITHUB_API_USING_HOST_TYPES.includes(GH_RELEASES_DS)).toBeTrue();
     expect(GITHUB_API_USING_HOST_TYPES.includes(POD_DS)).toBeTrue();
-    expect(GITHUB_API_USING_HOST_TYPES.includes(PlatformId.Github)).toBeTrue();
+    expect(GITHUB_API_USING_HOST_TYPES.includes('github')).toBeTrue();
   });
 
   it('should be not part of the GITHUB_API_USING_HOST_TYPES ', () => {
-    expect(GITHUB_API_USING_HOST_TYPES.includes(PlatformId.Gitlab)).toBeFalse();
+    expect(GITHUB_API_USING_HOST_TYPES.includes('gitlab')).toBeFalse();
   });
 
   it('should be part of the BITBUCKET_API_USING_HOST_TYPES ', () => {
     expect(
       BITBUCKET_API_USING_HOST_TYPES.includes(BitBucketTagsDatasource.id)
     ).toBeTrue();
-    expect(
-      BITBUCKET_API_USING_HOST_TYPES.includes(PlatformId.Bitbucket)
-    ).toBeTrue();
+    expect(BITBUCKET_API_USING_HOST_TYPES.includes('bitbucket')).toBeTrue();
   });
 });

--- a/lib/constants/platforms.ts
+++ b/lib/constants/platforms.ts
@@ -1,28 +1,23 @@
-// eslint-disable-next-line typescript-enum/no-enum, typescript-enum/no-const-enum
-export const enum PlatformId {
-  Azure = 'azure',
-  Bitbucket = 'bitbucket',
-  BitbucketServer = 'bitbucket-server',
-  Gitea = 'gitea',
-  Github = 'github',
-  Gitlab = 'gitlab',
-}
+export type PlatformId =
+  | 'azure'
+  | 'bitbucket-server'
+  | 'bitbucket'
+  | 'gitea'
+  | 'github'
+  | 'gitlab';
 
 export const GITHUB_API_USING_HOST_TYPES = [
-  PlatformId.Github,
+  'github',
   'github-releases',
   'github-tags',
   'pod',
 ];
 
 export const GITLAB_API_USING_HOST_TYPES = [
-  PlatformId.Gitlab,
+  'gitlab',
   'gitlab-releases',
   'gitlab-tags',
   'gitlab-packages',
 ];
 
-export const BITBUCKET_API_USING_HOST_TYPES = [
-  PlatformId.Bitbucket,
-  'bitbucket-tags',
-];
+export const BITBUCKET_API_USING_HOST_TYPES = ['bitbucket', 'bitbucket-tags'];

--- a/lib/datasource/go/get-datasource.ts
+++ b/lib/datasource/go/get-datasource.ts
@@ -1,5 +1,4 @@
 import URL from 'url';
-import { PlatformId } from '../../constants';
 import { logger } from '../../logger';
 import * as hostRules from '../../util/host-rules';
 import { regEx } from '../../util/regex';
@@ -70,7 +69,7 @@ async function goGetDatasource(goModule: string): Promise<DataSource | null> {
     }
 
     const opts = hostRules.find({
-      hostType: PlatformId.Gitlab,
+      hostType: 'gitlab',
       url: goSourceUrl,
     });
     if (opts.token) {

--- a/lib/manager/composer/artifacts.spec.ts
+++ b/lib/manager/composer/artifacts.spec.ts
@@ -3,7 +3,6 @@ import { envMock, exec, mockExecAll } from '../../../test/exec-util';
 import { env, fs, git, mocked, partial } from '../../../test/util';
 import { GlobalConfig } from '../../config/global';
 import type { RepoGlobalConfig } from '../../config/types';
-import { PlatformId } from '../../constants';
 import * as _datasource from '../../datasource';
 import * as datasourcePackagist from '../../datasource/packagist';
 import * as docker from '../../util/exec/docker';
@@ -99,12 +98,12 @@ describe('manager/composer/artifacts', () => {
 
   it('uses hostRules to set COMPOSER_AUTH', async () => {
     hostRules.add({
-      hostType: PlatformId.Github,
+      hostType: 'github',
       matchHost: 'api.github.com',
       token: 'github-token',
     });
     hostRules.add({
-      hostType: PlatformId.Gitlab,
+      hostType: 'gitlab',
       matchHost: 'gitlab.com',
       token: 'gitlab-token',
     });

--- a/lib/manager/composer/artifacts.ts
+++ b/lib/manager/composer/artifacts.ts
@@ -34,7 +34,7 @@ function getAuthJson(): string | null {
   const authJson: AuthJson = {};
 
   const githubCredentials = hostRules.find({
-    hostType: PlatformId.Github,
+    hostType: 'github',
     url: 'https://api.github.com/',
   });
   if (githubCredentials?.token) {
@@ -43,20 +43,18 @@ function getAuthJson(): string | null {
     };
   }
 
-  hostRules
-    .findAll({ hostType: PlatformId.Gitlab })
-    ?.forEach((gitlabHostRule) => {
-      if (gitlabHostRule?.token) {
-        const host = gitlabHostRule.resolvedHost || 'gitlab.com';
-        authJson['gitlab-token'] = authJson['gitlab-token'] || {};
-        authJson['gitlab-token'][host] = gitlabHostRule.token;
-        // https://getcomposer.org/doc/articles/authentication-for-private-packages.md#gitlab-token
-        authJson['gitlab-domains'] = [
-          host,
-          ...(authJson['gitlab-domains'] || []),
-        ];
-      }
-    });
+  hostRules.findAll({ hostType: 'gitlab' })?.forEach((gitlabHostRule) => {
+    if (gitlabHostRule?.token) {
+      const host = gitlabHostRule.resolvedHost || 'gitlab.com';
+      authJson['gitlab-token'] = authJson['gitlab-token'] || {};
+      authJson['gitlab-token'][host] = gitlabHostRule.token;
+      // https://getcomposer.org/doc/articles/authentication-for-private-packages.md#gitlab-token
+      authJson['gitlab-domains'] = [
+        host,
+        ...(authJson['gitlab-domains'] || []),
+      ];
+    }
+  });
 
   hostRules
     .findAll({ hostType: datasourcePackagist.id })

--- a/lib/manager/gomod/artifacts.spec.ts
+++ b/lib/manager/gomod/artifacts.spec.ts
@@ -223,7 +223,7 @@ describe('manager/gomod/artifacts', () => {
       {
         token: 'some-enterprise-token',
         matchHost: 'github.enterprise.com',
-        hostType: PlatformId.Github,
+        hostType: 'github',
       },
     ]);
     fs.readLocalFile.mockResolvedValueOnce('Current go.sum');
@@ -265,7 +265,7 @@ describe('manager/gomod/artifacts', () => {
       {
         token: 'some-enterprise-token',
         matchHost: 'gitlab.enterprise.com',
-        hostType: PlatformId.Gitlab,
+        hostType: 'gitlab',
       },
     ]);
     fs.readLocalFile.mockResolvedValueOnce('Current go.sum');
@@ -305,12 +305,12 @@ describe('manager/gomod/artifacts', () => {
       {
         token: 'some-enterprise-token-repo1',
         matchHost: 'https://gitlab.enterprise.com/repo1',
-        hostType: PlatformId.Gitlab,
+        hostType: 'gitlab',
       },
       {
         token: 'some-enterprise-token-repo2',
         matchHost: 'https://gitlab.enterprise.com/repo2',
-        hostType: PlatformId.Gitlab,
+        hostType: 'gitlab',
       },
     ]);
     fs.readLocalFile.mockResolvedValueOnce('Current go.sum');
@@ -353,12 +353,12 @@ describe('manager/gomod/artifacts', () => {
       {
         token: 'some-token',
         matchHost: 'ssh://github.enterprise.com',
-        hostType: PlatformId.Github,
+        hostType: 'github',
       },
       {
         token: 'some-gitlab-token',
         matchHost: 'gitlab.enterprise.com',
-        hostType: PlatformId.Gitlab,
+        hostType: 'gitlab',
       },
     ]);
     fs.readLocalFile.mockResolvedValueOnce('Current go.sum');
@@ -401,17 +401,17 @@ describe('manager/gomod/artifacts', () => {
       {
         token: 'some-token',
         matchHost: 'api.github.com',
-        hostType: PlatformId.Github,
+        hostType: 'github',
       },
       {
         token: 'some-enterprise-token',
         matchHost: 'github.enterprise.com',
-        hostType: PlatformId.Github,
+        hostType: 'github',
       },
       {
         token: 'some-gitlab-token',
         matchHost: 'gitlab.enterprise.com',
-        hostType: PlatformId.Gitlab,
+        hostType: 'gitlab',
       },
     ]);
     fs.readLocalFile.mockResolvedValueOnce('Current go.sum');

--- a/lib/manager/gomod/artifacts.ts
+++ b/lib/manager/gomod/artifacts.ts
@@ -25,7 +25,7 @@ function getGitEnvironmentVariables(): NodeJS.ProcessEnv {
 
   // hard-coded logic to use authentication for github.com based on the githubToken for api.github.com
   const githubToken = find({
-    hostType: PlatformId.Github,
+    hostType: 'github',
     url: 'https://api.github.com/',
   });
 
@@ -41,12 +41,12 @@ function getGitEnvironmentVariables(): NodeJS.ProcessEnv {
 
   const goGitAllowedHostType: string[] = [
     // All known git platforms
-    PlatformId.Azure,
-    PlatformId.Bitbucket,
-    PlatformId.BitbucketServer,
-    PlatformId.Gitea,
-    PlatformId.Github,
-    PlatformId.Gitlab,
+    'azure',
+    'bitbucket',
+    'bitbucket-server',
+    'gitea',
+    'github',
+    'gitlab',
     // plus all without a host type (=== undefined)
     undefined,
   ];

--- a/lib/manager/pre-commit/extract.ts
+++ b/lib/manager/pre-commit/extract.ts
@@ -1,6 +1,5 @@
 import is from '@sindresorhus/is';
 import { load } from 'js-yaml';
-import { PlatformId } from '../../constants';
 import { id as githubTagsId } from '../../datasource/github-tags';
 import { id as gitlabTagsId } from '../../datasource/gitlab-tags';
 import { logger } from '../../logger';
@@ -51,9 +50,9 @@ function determineDatasource(
     return { skipReason: 'unknown-registry', registryUrls: [hostname] };
   }
   for (const [hostType, sourceId] of [
-    [PlatformId.Gitea, gitlabTagsId],
-    [PlatformId.Github, githubTagsId],
-    [PlatformId.Gitlab, gitlabTagsId],
+    ['gitea', gitlabTagsId],
+    ['github', githubTagsId],
+    ['gitlab', gitlabTagsId],
   ]) {
     if (!isEmptyObject(find({ hostType, url: hostUrl }))) {
       logger.debug(

--- a/lib/platform/azure/azure-got-wrapper.spec.ts
+++ b/lib/platform/azure/azure-got-wrapper.spec.ts
@@ -1,4 +1,3 @@
-import { PlatformId } from '../../constants';
 import * as _hostRules from '../../util/host-rules';
 
 describe('platform/azure/azure-got-wrapper', () => {
@@ -19,7 +18,7 @@ describe('platform/azure/azure-got-wrapper', () => {
     });
     it('should set personal access token and endpoint', () => {
       hostRules.add({
-        hostType: PlatformId.Azure,
+        hostType: 'azure',
         token: '123test',
         matchHost: 'https://dev.azure.com/renovate1',
       });
@@ -35,7 +34,7 @@ describe('platform/azure/azure-got-wrapper', () => {
     });
     it('should set bearer token and endpoint', () => {
       hostRules.add({
-        hostType: PlatformId.Azure,
+        hostType: 'azure',
         token: 'testtoken',
         matchHost: 'https://dev.azure.com/renovate2',
       });
@@ -52,7 +51,7 @@ describe('platform/azure/azure-got-wrapper', () => {
 
     it('should set password and endpoint', () => {
       hostRules.add({
-        hostType: PlatformId.Azure,
+        hostType: 'azure',
         username: 'user',
         password: 'pass',
         matchHost: 'https://dev.azure.com/renovate3',

--- a/lib/platform/azure/azure-got-wrapper.ts
+++ b/lib/platform/azure/azure-got-wrapper.ts
@@ -4,11 +4,10 @@ import { ICoreApi } from 'azure-devops-node-api/CoreApi';
 import { IGitApi } from 'azure-devops-node-api/GitApi';
 import { IPolicyApi } from 'azure-devops-node-api/PolicyApi';
 import { IRequestHandler } from 'azure-devops-node-api/interfaces/common/VsoBaseInterfaces';
-import { PlatformId } from '../../constants';
 import { HostRule } from '../../types';
 import * as hostRules from '../../util/host-rules';
 
-const hostType = PlatformId.Azure;
+const hostType = 'azure';
 let endpoint: string;
 
 function getAuthenticationHandler(config: HostRule): IRequestHandler {

--- a/lib/platform/azure/index.ts
+++ b/lib/platform/azure/index.ts
@@ -10,7 +10,6 @@ import {
 } from 'azure-devops-node-api/interfaces/GitInterfaces.js';
 import delay from 'delay';
 import JSON5 from 'json5';
-import { PlatformId } from '../../constants';
 import {
   REPOSITORY_ARCHIVED,
   REPOSITORY_EMPTY,
@@ -79,7 +78,7 @@ const defaults: {
   endpoint?: string;
   hostType: string;
 } = {
-  hostType: PlatformId.Azure,
+  hostType: 'azure',
 };
 
 export function initPlatform({

--- a/lib/platform/bitbucket-server/index.ts
+++ b/lib/platform/bitbucket-server/index.ts
@@ -3,7 +3,6 @@ import is from '@sindresorhus/is';
 import delay from 'delay';
 import JSON5 from 'json5';
 import type { PartialDeep } from 'type-fest';
-import { PlatformId } from '../../constants';
 import {
   REPOSITORY_CHANGED,
   REPOSITORY_EMPTY,
@@ -70,7 +69,7 @@ const defaults: {
   endpoint?: string;
   hostType: string;
 } = {
-  hostType: PlatformId.BitbucketServer,
+  hostType: 'bitbucket-server',
 };
 
 /* istanbul ignore next */

--- a/lib/platform/bitbucket/index.ts
+++ b/lib/platform/bitbucket/index.ts
@@ -2,7 +2,6 @@ import URL from 'url';
 import is from '@sindresorhus/is';
 import JSON5 from 'json5';
 import parseDiff from 'parse-diff';
-import { PlatformId } from '../../constants';
 import { REPOSITORY_NOT_FOUND } from '../../constants/error-messages';
 import { logger } from '../../logger';
 import { BranchStatus, PrState, VulnerabilityAlert } from '../../types';
@@ -157,7 +156,7 @@ export async function initRepo({
 }: RepoParams): Promise<RepoResult> {
   logger.debug(`initRepo("${repository}")`);
   const opts = hostRules.find({
-    hostType: PlatformId.Bitbucket,
+    hostType: 'bitbucket',
     url: defaults.endpoint,
   });
   config = {

--- a/lib/platform/gitea/index.ts
+++ b/lib/platform/gitea/index.ts
@@ -2,7 +2,6 @@ import URL from 'url';
 import is from '@sindresorhus/is';
 import JSON5 from 'json5';
 import semver from 'semver';
-import { PlatformId } from '../../constants';
 import {
   REPOSITORY_ACCESS_FORBIDDEN,
   REPOSITORY_ARCHIVED,
@@ -51,7 +50,7 @@ interface GiteaRepoConfig {
 }
 
 const defaults = {
-  hostType: PlatformId.Gitea,
+  hostType: 'gitea',
   endpoint: 'https://gitea.com/api/v1/',
   version: '0.0.0',
 };
@@ -294,7 +293,7 @@ const platform: Platform = {
 
     // Find options for current host and determine Git endpoint
     const opts = hostRules.find({
-      hostType: PlatformId.Gitea,
+      hostType: 'gitea',
       url: defaults.endpoint,
     });
     const gitEndpoint = URL.parse(repo.clone_url);

--- a/lib/platform/github/index.ts
+++ b/lib/platform/github/index.ts
@@ -4,7 +4,6 @@ import delay from 'delay';
 import JSON5 from 'json5';
 import { DateTime } from 'luxon';
 import semver from 'semver';
-import { PlatformId } from '../../constants';
 import {
   PLATFORM_INTEGRATION_UNAUTHORIZED,
   REPOSITORY_ACCESS_FORBIDDEN,
@@ -76,7 +75,7 @@ const githubApi = new githubHttp.GithubHttp();
 let config: LocalRepoConfig = {} as any;
 
 const platformConfig: PlatformConfig = {
-  hostType: PlatformId.Github,
+  hostType: 'github',
   endpoint: 'https://api.github.com/',
 };
 
@@ -239,7 +238,7 @@ export async function initRepo({
     githubHttp.setBaseUrl(endpoint);
   }
   const opts = hostRules.find({
-    hostType: PlatformId.Github,
+    hostType: 'github',
     url: platformConfig.endpoint,
   });
   config.renovateUsername = renovateUsername;
@@ -726,7 +725,7 @@ export async function getPrList(): Promise<Pr[]> {
       ).body;
     } catch (err) /* istanbul ignore next */ {
       logger.debug({ err }, 'getPrList err');
-      throw new ExternalHostError(err, PlatformId.Github);
+      throw new ExternalHostError(err, 'github');
     }
     config.prList = prList
       .filter(
@@ -1358,7 +1357,7 @@ async function getComments(issueNo: number): Promise<Comment[]> {
   } catch (err) /* istanbul ignore next */ {
     if (err.statusCode === 404) {
       logger.debug('404 response when retrieving comments');
-      throw new ExternalHostError(err, PlatformId.Github);
+      throw new ExternalHostError(err, 'github');
     }
     throw err;
   }

--- a/lib/platform/gitlab/index.ts
+++ b/lib/platform/gitlab/index.ts
@@ -68,7 +68,7 @@ let config: {
 } = {} as any;
 
 const defaults = {
-  hostType: PlatformId.Gitlab,
+  hostType: 'gitlab',
   endpoint: 'https://gitlab.com/api/v4/',
   version: '0.0.0',
 };

--- a/lib/platform/index.spec.ts
+++ b/lib/platform/index.spec.ts
@@ -51,7 +51,7 @@ describe('platform/index', () => {
       .basicAuth({ user: 'abc', pass: '123' })
       .reply(200, { uuid: 123 });
     const config = {
-      platform: PlatformId.Bitbucket,
+      platform: 'bitbucket',
       gitAuthor: 'user@domain.com',
       username: 'abc',
       password: '123',
@@ -67,7 +67,7 @@ describe('platform/index', () => {
           username: 'abc',
         },
       ],
-      platform: PlatformId.Bitbucket,
+      platform: 'bitbucket',
     });
   });
 });

--- a/lib/util/git/auth.spec.ts
+++ b/lib/util/git/auth.spec.ts
@@ -10,7 +10,7 @@ describe('util/git/auth', () => {
       expect(
         getGitAuthenticatedEnvironmentVariables('https://github.com/', {
           token: 'token1234',
-          hostType: PlatformId.Github,
+          hostType: 'github',
           matchHost: 'github.com',
         })
       ).toStrictEqual({
@@ -24,7 +24,7 @@ describe('util/git/auth', () => {
       expect(
         getGitAuthenticatedEnvironmentVariables('https://github.com/', {
           token: 'x-access-token:token1234',
-          hostType: PlatformId.Github,
+          hostType: 'github',
           matchHost: 'github.com',
         })
       ).toStrictEqual({
@@ -41,7 +41,7 @@ describe('util/git/auth', () => {
           'https://github.com/',
           {
             token: 'token1234',
-            hostType: PlatformId.Github,
+            hostType: 'github',
             matchHost: 'github.com',
           },
           { GIT_CONFIG_COUNT: '1' }
@@ -60,7 +60,7 @@ describe('util/git/auth', () => {
           'https://github.com/',
           {
             token: 'token1234',
-            hostType: PlatformId.Github,
+            hostType: 'github',
             matchHost: 'github.com',
           },
           { GIT_CONFIG_COUNT: '1' }
@@ -77,7 +77,7 @@ describe('util/git/auth', () => {
       expect(
         getGitAuthenticatedEnvironmentVariables('https://github.com/', {
           token: 'token1234',
-          hostType: PlatformId.Github,
+          hostType: 'github',
           matchHost: 'github.com',
         })
       ).toStrictEqual({
@@ -93,7 +93,7 @@ describe('util/git/auth', () => {
           'https://github.com/',
           {
             token: 'token1234',
-            hostType: PlatformId.Github,
+            hostType: 'github',
             matchHost: 'github.com',
           },
           { RANDOM_VARIABLE: 'random' }
@@ -111,7 +111,7 @@ describe('util/git/auth', () => {
       expect(
         getGitAuthenticatedEnvironmentVariables('https://github.com/', {
           token: 'token1234',
-          hostType: PlatformId.Github,
+          hostType: 'github',
           matchHost: 'github.com',
         })
       ).toStrictEqual({
@@ -125,7 +125,7 @@ describe('util/git/auth', () => {
       expect(
         getGitAuthenticatedEnvironmentVariables('https://gitlab.com/', {
           token: 'token1234',
-          hostType: PlatformId.Gitlab,
+          hostType: 'gitlab',
           matchHost: 'github.com',
         })
       ).toStrictEqual({
@@ -143,7 +143,7 @@ describe('util/git/auth', () => {
           {
             username: 'testing',
             password: '1234',
-            hostType: PlatformId.Gitlab,
+            hostType: 'gitlab',
             matchHost: 'github.com',
           },
           { env: 'value' }

--- a/lib/util/git/auth.ts
+++ b/lib/util/git/auth.ts
@@ -53,7 +53,7 @@ function getUrlWithToken(
   authToken: string
 ): string {
   let token = authToken;
-  if (hostType === PlatformId.Gitlab) {
+  if (hostType === 'gitlab') {
     token = `gitlab-ci-token:${token}`;
   }
 

--- a/lib/util/host-rules.spec.ts
+++ b/lib/util/host-rules.spec.ts
@@ -1,4 +1,3 @@
-import { PlatformId } from '../constants';
 import * as datasourceNuget from '../datasource/nuget';
 import { add, clear, find, findAll, getAll, hosts } from './host-rules';
 
@@ -10,7 +9,7 @@ describe('util/host-rules', () => {
     it('throws if both domainName and hostName', () => {
       expect(() =>
         add({
-          hostType: PlatformId.Azure,
+          hostType: 'azure',
           domainName: 'github.com',
           hostName: 'api.github.com',
         } as any)
@@ -19,7 +18,7 @@ describe('util/host-rules', () => {
     it('throws if both domainName and baseUrl', () => {
       expect(() =>
         add({
-          hostType: PlatformId.Azure,
+          hostType: 'azure',
           domainName: 'github.com',
           matchHost: 'https://api.github.com',
         } as any)
@@ -28,7 +27,7 @@ describe('util/host-rules', () => {
     it('throws if both hostName and baseUrl', () => {
       expect(() =>
         add({
-          hostType: PlatformId.Azure,
+          hostType: 'azure',
           hostName: 'api.github.com',
           matchHost: 'https://api.github.com',
         } as any)
@@ -110,25 +109,25 @@ describe('util/host-rules', () => {
     it('matches on specific path', () => {
       // Initialized platform holst rule
       add({
-        hostType: PlatformId.Github,
+        hostType: 'github',
         matchHost: 'https://api.github.com',
         token: 'abc',
       });
       // Initialized generic host rule for github platform
       add({
-        hostType: PlatformId.Github,
+        hostType: 'github',
         matchHost: 'https://api.github.com',
         token: 'abc',
       });
       // specific host rule for using other token in different org
       add({
-        hostType: PlatformId.Github,
+        hostType: 'github',
         matchHost: 'https://api.github.com/repos/org-b/',
         token: 'def',
       });
       expect(
         find({
-          hostType: PlatformId.Github,
+          hostType: 'github',
           url: 'https://api.github.com/repos/org-b/someRepo/tags?per_page=100',
         }).token
       ).toBe('def');
@@ -141,7 +140,7 @@ describe('util/host-rules', () => {
       });
       expect(
         find({
-          hostType: PlatformId.Github,
+          hostType: 'github',
           url: 'https://api.github.com/repos/org-b/someRepo/tags?per_page=100',
         }).token
       ).toBe('abc');
@@ -155,7 +154,7 @@ describe('util/host-rules', () => {
 
     it('matches if hostType is configured and host rule is filtered with datasource', () => {
       add({
-        hostType: PlatformId.Github,
+        hostType: 'github',
         matchHost: 'https://api.github.com',
         token: 'abc',
       });

--- a/lib/util/http/auth.spec.ts
+++ b/lib/util/http/auth.spec.ts
@@ -1,6 +1,5 @@
 import { NormalizedOptions } from 'got';
 import { partial } from '../../../test/util';
-import { PlatformId } from '../../constants';
 import { applyAuthorization, removeAuthorization } from './auth';
 import { GotOptions } from './types';
 
@@ -29,7 +28,7 @@ describe('util/http/auth', () => {
     it('gitea password', () => {
       const opts: GotOptions = {
         headers: {},
-        hostType: PlatformId.Gitea,
+        hostType: 'gitea',
         password: 'XXXX',
       };
 
@@ -50,7 +49,7 @@ describe('util/http/auth', () => {
       const opts: GotOptions = {
         headers: {},
         token: 'XXXX',
-        hostType: PlatformId.Gitea,
+        hostType: 'gitea',
       };
 
       applyAuthorization(opts);
@@ -70,7 +69,7 @@ describe('util/http/auth', () => {
       const opts: GotOptions = {
         headers: {},
         token: 'XXX',
-        hostType: PlatformId.Github,
+        hostType: 'github',
       };
 
       applyAuthorization(opts);
@@ -108,7 +107,7 @@ describe('util/http/auth', () => {
         headers: {},
         // Personal Access Token is exactly 20 characters long
         token: '0123456789012345test',
-        hostType: PlatformId.Gitlab,
+        hostType: 'gitlab',
       };
 
       applyAuthorization(opts);
@@ -129,7 +128,7 @@ describe('util/http/auth', () => {
         headers: {},
         token:
           'a40bdd925a0c0b9c4cdd19d101c0df3b2bcd063ab7ad6706f03bcffcec01test',
-        hostType: PlatformId.Gitlab,
+        hostType: 'gitlab',
       };
 
       applyAuthorization(opts);

--- a/lib/util/http/auth.ts
+++ b/lib/util/http/auth.ts
@@ -3,7 +3,6 @@ import type { Options } from 'got';
 import {
   GITHUB_API_USING_HOST_TYPES,
   GITLAB_API_USING_HOST_TYPES,
-  PlatformId,
 } from '../../constants';
 import type { GotOptions } from './types';
 
@@ -16,7 +15,7 @@ export function applyAuthorization(inOptions: GotOptions): GotOptions {
 
   options.headers ??= {};
   if (options.token) {
-    if (options.hostType === PlatformId.Gitea) {
+    if (options.hostType === 'gitea') {
       options.headers.authorization = `token ${options.token}`;
     } else if (
       options.hostType &&

--- a/lib/util/http/bitbucket-server.spec.ts
+++ b/lib/util/http/bitbucket-server.spec.ts
@@ -1,5 +1,4 @@
 import * as httpMock from '../../../test/http-mock';
-import { PlatformId } from '../../constants';
 import * as hostRules from '../host-rules';
 import { BitbucketServerHttp, setBaseUrl } from './bitbucket-server';
 
@@ -16,7 +15,7 @@ describe('util/http/bitbucket-server', () => {
     // clean up hostRules
     hostRules.clear();
     hostRules.add({
-      hostType: PlatformId.BitbucketServer,
+      hostType: 'bitbucket-server',
       matchHost: baseUrl,
       token: 'token',
     });

--- a/lib/util/http/bitbucket-server.ts
+++ b/lib/util/http/bitbucket-server.ts
@@ -1,4 +1,3 @@
-import { PlatformId } from '../../constants';
 import { resolveBaseUrl } from '../url';
 import { Http, HttpOptions, HttpResponse, InternalHttpOptions } from '.';
 
@@ -9,7 +8,7 @@ export const setBaseUrl = (url: string): void => {
 
 export class BitbucketServerHttp extends Http {
   constructor(options?: HttpOptions) {
-    super(PlatformId.BitbucketServer, options);
+    super('bitbucket-server', options);
   }
 
   protected override request<T>(

--- a/lib/util/http/bitbucket.spec.ts
+++ b/lib/util/http/bitbucket.spec.ts
@@ -16,7 +16,7 @@ describe('util/http/bitbucket', () => {
     // clean up hostRules
     hostRules.clear();
     hostRules.add({
-      hostType: PlatformId.Bitbucket,
+      hostType: 'bitbucket',
       matchHost: baseUrl,
       token: 'token',
     });

--- a/lib/util/http/bitbucket.ts
+++ b/lib/util/http/bitbucket.ts
@@ -1,4 +1,3 @@
-import { PlatformId } from '../../constants';
 import { Http, HttpOptions, HttpResponse, InternalHttpOptions } from '.';
 
 let baseUrl = 'https://api.bitbucket.org/';
@@ -8,7 +7,7 @@ export const setBaseUrl = (url: string): void => {
 };
 
 export class BitbucketHttp extends Http {
-  constructor(type: string = PlatformId.Bitbucket, options?: HttpOptions) {
+  constructor(type = 'bitbucket', options?: HttpOptions) {
     super(type, options);
   }
 

--- a/lib/util/http/gitea.ts
+++ b/lib/util/http/gitea.ts
@@ -1,5 +1,4 @@
 import is from '@sindresorhus/is';
-import { PlatformId } from '../../constants';
 import { resolveBaseUrl } from '../url';
 import { Http, HttpOptions, HttpResponse, InternalHttpOptions } from '.';
 
@@ -32,7 +31,7 @@ function resolveUrl(path: string, base: string): URL {
 
 export class GiteaHttp extends Http<GiteaHttpOptions, GiteaHttpOptions> {
   constructor(options?: HttpOptions) {
-    super(PlatformId.Gitea, options);
+    super('gitea', options);
   }
 
   protected override async request<T>(

--- a/lib/util/http/github.ts
+++ b/lib/util/http/github.ts
@@ -1,7 +1,6 @@
 import is from '@sindresorhus/is';
 import { DateTime } from 'luxon';
 import pAll from 'p-all';
-import { PlatformId } from '../../constants';
 import {
   PLATFORM_BAD_CREDENTIALS,
   PLATFORM_INTEGRATION_UNAUTHORIZED,
@@ -66,15 +65,15 @@ function handleGotError(
     err.code === 'ECONNRESET'
   ) {
     logger.debug({ err }, 'GitHub failure: RequestError');
-    return new ExternalHostError(err, PlatformId.Github);
+    return new ExternalHostError(err, 'github');
   }
   if (err.name === 'ParseError') {
     logger.debug({ err }, '');
-    return new ExternalHostError(err, PlatformId.Github);
+    return new ExternalHostError(err, 'github');
   }
   if (err.statusCode && err.statusCode >= 500 && err.statusCode < 600) {
     logger.debug({ err }, 'GitHub failure: 5xx');
-    return new ExternalHostError(err, PlatformId.Github);
+    return new ExternalHostError(err, 'github');
   }
   if (
     err.statusCode === 403 &&
@@ -118,7 +117,7 @@ function handleGotError(
       'GitHub failure: Bad credentials'
     );
     if (rateLimit === '60') {
-      return new ExternalHostError(err, PlatformId.Github);
+      return new ExternalHostError(err, 'github');
     }
     return new Error(PLATFORM_BAD_CREDENTIALS);
   }
@@ -138,7 +137,7 @@ function handleGotError(
       return err;
     }
     logger.debug({ err }, '422 Error thrown from GitHub');
-    return new ExternalHostError(err, PlatformId.Github);
+    return new ExternalHostError(err, 'github');
   }
   if (
     err.statusCode === 410 &&
@@ -254,10 +253,7 @@ function setGraphqlPageSize(fieldName: string, newPageSize: number): void {
 }
 
 export class GithubHttp extends Http<GithubHttpOptions, GithubHttpOptions> {
-  constructor(
-    hostType: string = PlatformId.Github,
-    options?: GithubHttpOptions
-  ) {
+  constructor(hostType = 'github', options?: GithubHttpOptions) {
     super(hostType, options);
   }
 

--- a/lib/util/http/gitlab.spec.ts
+++ b/lib/util/http/gitlab.spec.ts
@@ -1,12 +1,11 @@
 import * as httpMock from '../../../test/http-mock';
-import { PlatformId } from '../../constants';
 import { EXTERNAL_HOST_ERROR } from '../../constants/error-messages';
 import { GitlabReleasesDatasource } from '../../datasource/gitlab-releases';
 import * as hostRules from '../host-rules';
 import { GitlabHttp, setBaseUrl } from './gitlab';
 
 hostRules.add({
-  hostType: PlatformId.Gitlab,
+  hostType: 'gitlab',
   token: '123test',
 });
 
@@ -22,7 +21,7 @@ describe('util/http/gitlab', () => {
     delete process.env.GITLAB_IGNORE_REPO_URL;
 
     hostRules.add({
-      hostType: PlatformId.Gitlab,
+      hostType: 'gitlab',
       token: 'abc123',
     });
   });
@@ -79,7 +78,7 @@ describe('util/http/gitlab', () => {
 
   it('supports different datasources', async () => {
     const gitlabApiDatasource = new GitlabHttp(GitlabReleasesDatasource.id);
-    hostRules.add({ hostType: PlatformId.Gitlab, token: 'abc' });
+    hostRules.add({ hostType: 'gitlab', token: 'abc' });
     hostRules.add({
       hostType: GitlabReleasesDatasource.id,
       token: 'def',

--- a/lib/util/http/gitlab.ts
+++ b/lib/util/http/gitlab.ts
@@ -1,5 +1,4 @@
 import is from '@sindresorhus/is';
-import { PlatformId } from '../../constants';
 import { logger } from '../../logger';
 import { ExternalHostError } from '../../types/errors/external-host-error';
 import { parseLinkHeader, parseUrl } from '../url';
@@ -20,7 +19,7 @@ export interface GitlabHttpOptions extends InternalHttpOptions {
 }
 
 export class GitlabHttp extends Http<GitlabHttpOptions, GitlabHttpOptions> {
-  constructor(type: string = PlatformId.Gitlab, options?: GitlabHttpOptions) {
+  constructor(type = 'gitlab', options?: GitlabHttpOptions) {
     super(type, options);
   }
 
@@ -71,7 +70,7 @@ export class GitlabHttp extends Http<GitlabHttpOptions, GitlabHttpOptions> {
         err.statusCode === 429 ||
         (err.statusCode >= 500 && err.statusCode < 600)
       ) {
-        throw new ExternalHostError(err, PlatformId.Gitlab);
+        throw new ExternalHostError(err, 'gitlab');
       }
       const platformFailureCodes = [
         'EAI_AGAIN',
@@ -80,10 +79,10 @@ export class GitlabHttp extends Http<GitlabHttpOptions, GitlabHttpOptions> {
         'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
       ];
       if (platformFailureCodes.includes(err.code)) {
-        throw new ExternalHostError(err, PlatformId.Gitlab);
+        throw new ExternalHostError(err, 'gitlab');
       }
       if (err.name === 'ParseError') {
-        throw new ExternalHostError(err, PlatformId.Gitlab);
+        throw new ExternalHostError(err, 'gitlab');
       }
       throw err;
     }

--- a/lib/util/http/host-rules.spec.ts
+++ b/lib/util/http/host-rules.spec.ts
@@ -1,4 +1,3 @@
-import { PlatformId } from '../../constants';
 import { bootstrap } from '../../proxy';
 import * as hostRules from '../host-rules';
 import { applyHostRules } from './host-rules';
@@ -9,7 +8,7 @@ jest.mock('global-agent');
 
 describe('util/http/host-rules', () => {
   const options = {
-    hostType: PlatformId.Github,
+    hostType: 'github',
   };
   beforeEach(() => {
     // reset module
@@ -20,11 +19,11 @@ describe('util/http/host-rules', () => {
     // clean up hostRules
     hostRules.clear();
     hostRules.add({
-      hostType: PlatformId.Github,
+      hostType: 'github',
       token: 'token',
     });
     hostRules.add({
-      hostType: PlatformId.Gitea,
+      hostType: 'gitea',
       password: 'password',
     });
 
@@ -35,7 +34,7 @@ describe('util/http/host-rules', () => {
     });
 
     hostRules.add({
-      hostType: PlatformId.Gitlab,
+      hostType: 'gitlab',
       token: 'abc',
     });
 
@@ -46,7 +45,7 @@ describe('util/http/host-rules', () => {
     });
 
     hostRules.add({
-      hostType: PlatformId.Bitbucket,
+      hostType: 'bitbucket',
       token: 'cdef',
     });
   });
@@ -68,8 +67,7 @@ describe('util/http/host-rules', () => {
   });
 
   it('adds auth', () => {
-    expect(applyHostRules(url, { hostType: PlatformId.Gitea }))
-      .toMatchInlineSnapshot(`
+    expect(applyHostRules(url, { hostType: 'gitea' })).toMatchInlineSnapshot(`
       Object {
         "hostType": "gitea",
         "password": "password",

--- a/lib/util/http/host-rules.ts
+++ b/lib/util/http/host-rules.ts
@@ -2,7 +2,6 @@ import {
   BITBUCKET_API_USING_HOST_TYPES,
   GITHUB_API_USING_HOST_TYPES,
   GITLAB_API_USING_HOST_TYPES,
-  PlatformId,
 } from '../../constants';
 import { logger } from '../../logger';
 import { hasProxy } from '../../proxy';
@@ -23,11 +22,11 @@ function findMatchingRules(options: GotOptions, url: string): HostRule {
   if (
     hostType &&
     GITHUB_API_USING_HOST_TYPES.includes(hostType) &&
-    hostType !== PlatformId.Github
+    hostType !== 'github'
   ) {
     res = {
       ...hostRules.find({
-        hostType: PlatformId.Github,
+        hostType: 'github',
         url,
       }),
       ...res,
@@ -38,11 +37,11 @@ function findMatchingRules(options: GotOptions, url: string): HostRule {
   if (
     hostType &&
     GITLAB_API_USING_HOST_TYPES.includes(hostType) &&
-    hostType !== PlatformId.Gitlab
+    hostType !== 'gitlab'
   ) {
     res = {
       ...hostRules.find({
-        hostType: PlatformId.Gitlab,
+        hostType: 'gitlab',
         url,
       }),
       ...res,
@@ -53,11 +52,11 @@ function findMatchingRules(options: GotOptions, url: string): HostRule {
   if (
     hostType &&
     BITBUCKET_API_USING_HOST_TYPES.includes(hostType) &&
-    hostType !== PlatformId.Bitbucket
+    hostType !== 'bitbucket'
   ) {
     res = {
       ...hostRules.find({
-        hostType: PlatformId.Bitbucket,
+        hostType: 'bitbucket',
         url,
       }),
       ...res,

--- a/lib/workers/global/autodiscover.spec.ts
+++ b/lib/workers/global/autodiscover.spec.ts
@@ -1,5 +1,4 @@
 import type { RenovateConfig } from '../../config/types';
-import { PlatformId } from '../../constants';
 import * as platform from '../../platform';
 import * as _ghApi from '../../platform/github';
 import * as _hostRules from '../../util/host-rules';
@@ -18,7 +17,7 @@ describe('workers/global/autodiscover', () => {
     jest.resetAllMocks();
     config = {};
     await platform.initPlatform({
-      platform: PlatformId.Github,
+      platform: 'github',
       token: '123test',
       endpoint: 'endpoint',
     });
@@ -28,7 +27,7 @@ describe('workers/global/autodiscover', () => {
   });
   it('autodiscovers github but empty', async () => {
     config.autodiscover = true;
-    config.platform = PlatformId.Github;
+    config.platform = 'github';
     hostRules.find = jest.fn(() => ({
       token: 'abc',
     }));
@@ -38,7 +37,7 @@ describe('workers/global/autodiscover', () => {
   });
   it('autodiscovers github repos', async () => {
     config.autodiscover = true;
-    config.platform = PlatformId.Github;
+    config.platform = 'github';
     hostRules.find = jest.fn(() => ({
       token: 'abc',
     }));
@@ -49,7 +48,7 @@ describe('workers/global/autodiscover', () => {
   it('filters autodiscovered github repos', async () => {
     config.autodiscover = true;
     config.autodiscoverFilter = 'project/re*';
-    config.platform = PlatformId.Github;
+    config.platform = 'github';
     hostRules.find = jest.fn(() => ({
       token: 'abc',
     }));
@@ -75,7 +74,7 @@ describe('workers/global/autodiscover', () => {
   it('filters autodiscovered github repos with regex', async () => {
     config.autodiscover = true;
     config.autodiscoverFilter = '/project/re*./';
-    config.platform = PlatformId.Github;
+    config.platform = 'github';
     hostRules.find = jest.fn(() => ({
       token: 'abc',
     }));
@@ -88,7 +87,7 @@ describe('workers/global/autodiscover', () => {
   it('filters autodiscovered github repos with regex negation', async () => {
     config.autodiscover = true;
     config.autodiscoverFilter = '!/project/re*./';
-    config.platform = PlatformId.Github;
+    config.platform = 'github';
     hostRules.find = jest.fn(() => ({
       token: 'abc',
     }));
@@ -101,7 +100,7 @@ describe('workers/global/autodiscover', () => {
   it('fail if regex pattern is not valid', async () => {
     config.autodiscover = true;
     config.autodiscoverFilter = '/project/re**./';
-    config.platform = PlatformId.Github;
+    config.platform = 'github';
     hostRules.find = jest.fn(() => ({
       token: 'abc',
     }));

--- a/lib/workers/global/config/parse/env.spec.ts
+++ b/lib/workers/global/config/parse/env.spec.ts
@@ -1,5 +1,4 @@
 import type { RenovateOptions } from '../../../../config/types';
-import { PlatformId } from '../../../../constants';
 import { logger } from '../../../../logger';
 import * as env from './env';
 
@@ -126,7 +125,7 @@ describe('workers/global/config/parse/env', () => {
     });
     it('supports GitLab token', () => {
       const envParam: NodeJS.ProcessEnv = {
-        RENOVATE_PLATFORM: PlatformId.Gitlab,
+        RENOVATE_PLATFORM: 'gitlab',
         RENOVATE_TOKEN: 'a gitlab.com token',
       };
       expect(env.getConfig(envParam)).toMatchSnapshot({
@@ -136,7 +135,7 @@ describe('workers/global/config/parse/env', () => {
     });
     it('supports GitLab custom endpoint', () => {
       const envParam: NodeJS.ProcessEnv = {
-        RENOVATE_PLATFORM: PlatformId.Gitlab,
+        RENOVATE_PLATFORM: 'gitlab',
         RENOVATE_TOKEN: 'a gitlab token',
         RENOVATE_ENDPOINT: 'a gitlab endpoint',
       };
@@ -160,7 +159,7 @@ describe('workers/global/config/parse/env', () => {
     });
     it('supports Bitbucket token', () => {
       const envParam: NodeJS.ProcessEnv = {
-        RENOVATE_PLATFORM: PlatformId.Bitbucket,
+        RENOVATE_PLATFORM: 'bitbucket',
         RENOVATE_ENDPOINT: 'a bitbucket endpoint',
         RENOVATE_USERNAME: 'some-username',
         RENOVATE_PASSWORD: 'app-password',
@@ -174,7 +173,7 @@ describe('workers/global/config/parse/env', () => {
     });
     it('supports Bitbucket username/password', () => {
       const envParam: NodeJS.ProcessEnv = {
-        RENOVATE_PLATFORM: PlatformId.Bitbucket,
+        RENOVATE_PLATFORM: 'bitbucket',
         RENOVATE_ENDPOINT: 'a bitbucket endpoint',
         RENOVATE_USERNAME: 'some-username',
         RENOVATE_PASSWORD: 'app-password',

--- a/lib/workers/global/config/parse/env.ts
+++ b/lib/workers/global/config/parse/env.ts
@@ -1,7 +1,6 @@
 import is from '@sindresorhus/is';
 import { getOptions } from '../../../../config/options';
 import type { AllConfig, RenovateOptions } from '../../../../config/types';
-import { PlatformId } from '../../../../constants';
 import { logger } from '../../../../logger';
 
 function normalizePrefixes(
@@ -111,7 +110,7 @@ export function getConfig(inputEnv: NodeJS.ProcessEnv): AllConfig {
   if (env.GITHUB_COM_TOKEN) {
     logger.debug(`Converting GITHUB_COM_TOKEN into a global host rule`);
     config.hostRules.push({
-      hostType: PlatformId.Github,
+      hostType: 'github',
       matchHost: 'github.com',
       token: env.GITHUB_COM_TOKEN,
     });

--- a/lib/workers/global/index.spec.ts
+++ b/lib/workers/global/index.spec.ts
@@ -1,7 +1,6 @@
 import { expect } from '@jest/globals';
 import { ERROR, WARN } from 'bunyan';
 import { fs, logger } from '../../../test/util';
-import { PlatformId } from '../../constants';
 import * as datasourceDocker from '../../datasource/docker';
 import * as _platform from '../../platform';
 import * as _repositoryWorker from '../repository';
@@ -111,7 +110,7 @@ describe('workers/global/index', () => {
     it('github', async () => {
       configParser.parseConfigs.mockResolvedValueOnce({
         repositories: ['a'],
-        platform: PlatformId.Github,
+        platform: 'github',
         endpoint: 'https://github.com/',
       });
       await globalWorker.start();
@@ -121,7 +120,7 @@ describe('workers/global/index', () => {
     it('gitlab', async () => {
       configParser.parseConfigs.mockResolvedValueOnce({
         repositories: [{ repository: 'a' }],
-        platform: PlatformId.Gitlab,
+        platform: 'gitlab',
         endpoint: 'https://my.gitlab.com/',
       });
       await globalWorker.start();
@@ -134,7 +133,7 @@ describe('workers/global/index', () => {
     it('successfully write file', async () => {
       configParser.parseConfigs.mockResolvedValueOnce({
         repositories: ['myOrg/myRepo'],
-        platform: PlatformId.Github,
+        platform: 'github',
         endpoint: 'https://github.com/',
         writeDiscoveredRepos: '/tmp/renovate-output.json',
       });

--- a/lib/workers/pr/changelog/github.spec.ts
+++ b/lib/workers/pr/changelog/github.spec.ts
@@ -1,5 +1,4 @@
 import * as httpMock from '../../../../test/http-mock';
-import { PlatformId } from '../../../constants';
 import * as hostRules from '../../../util/host-rules';
 import * as semverVersioning from '../../../versioning/semver';
 import type { BranchUpgradeConfig } from '../../types';
@@ -39,7 +38,7 @@ describe('workers/pr/changelog/github', () => {
     beforeEach(() => {
       hostRules.clear();
       hostRules.add({
-        hostType: PlatformId.Github,
+        hostType: 'github',
         matchHost: 'https://api.github.com/',
         token: 'abc',
       });
@@ -231,7 +230,7 @@ describe('workers/pr/changelog/github', () => {
 
     it('supports github enterprise and github.com changelog', async () => {
       hostRules.add({
-        hostType: PlatformId.Github,
+        hostType: 'github',
         token: 'super_secret',
         matchHost: 'https://github-enterprise.example.com/',
       });
@@ -262,7 +261,7 @@ describe('workers/pr/changelog/github', () => {
 
     it('supports github enterprise and github enterprise changelog', async () => {
       hostRules.add({
-        hostType: PlatformId.Github,
+        hostType: 'github',
         matchHost: 'https://github-enterprise.example.com/',
         token: 'abc',
       });

--- a/lib/workers/pr/changelog/gitlab.spec.ts
+++ b/lib/workers/pr/changelog/gitlab.spec.ts
@@ -1,5 +1,4 @@
 import * as httpMock from '../../../../test/http-mock';
-import { PlatformId } from '../../../constants';
 import * as hostRules from '../../../util/host-rules';
 import * as semverVersioning from '../../../versioning/semver';
 import type { BranchUpgradeConfig } from '../../types';
@@ -40,7 +39,7 @@ describe('workers/pr/changelog/gitlab', () => {
     beforeEach(() => {
       hostRules.clear();
       hostRules.add({
-        hostType: PlatformId.Gitlab,
+        hostType: 'gitlab',
         matchHost,
         token: 'abc',
       });
@@ -245,7 +244,7 @@ describe('workers/pr/changelog/gitlab', () => {
     });
     it('supports gitlab enterprise and gitlab enterprise changelog', async () => {
       hostRules.add({
-        hostType: PlatformId.Gitlab,
+        hostType: 'gitlab',
         matchHost: 'https://gitlab-enterprise.example.com/',
         token: 'abc',
       });
@@ -278,7 +277,7 @@ describe('workers/pr/changelog/gitlab', () => {
     it('supports self-hosted gitlab changelog', async () => {
       httpMock.scope('https://git.test.com').persist().get(/.*/).reply(200, []);
       hostRules.add({
-        hostType: PlatformId.Gitlab,
+        hostType: 'gitlab',
         matchHost: 'https://git.test.com/',
         token: 'abc',
       });
@@ -286,7 +285,7 @@ describe('workers/pr/changelog/gitlab', () => {
       expect(
         await getChangeLogJSON({
           ...upgrade,
-          platform: PlatformId.Gitlab,
+          platform: 'gitlab',
           sourceUrl: 'https://git.test.com/meno/dropzone/',
           endpoint: 'https://git.test.com/api/v4/',
         })

--- a/lib/workers/pr/changelog/index.spec.ts
+++ b/lib/workers/pr/changelog/index.spec.ts
@@ -1,6 +1,5 @@
 import * as httpMock from '../../../../test/http-mock';
 import { partial } from '../../../../test/util';
-import { PlatformId } from '../../../constants';
 import * as hostRules from '../../../util/host-rules';
 import * as semverVersioning from '../../../versioning/semver';
 import type { BranchConfig } from '../../types';
@@ -36,7 +35,7 @@ describe('workers/pr/changelog/index', () => {
     beforeEach(() => {
       hostRules.clear();
       hostRules.add({
-        hostType: PlatformId.Github,
+        hostType: 'github',
         matchHost: 'https://api.github.com/',
         token: 'abc',
       });
@@ -257,7 +256,7 @@ describe('workers/pr/changelog/index', () => {
     it('supports github enterprise and github.com changelog', async () => {
       httpMock.scope(githubApiHost).persist().get(/.*/).reply(200, []);
       hostRules.add({
-        hostType: PlatformId.Github,
+        hostType: 'github',
         token: 'super_secret',
         matchHost: 'https://github-enterprise.example.com/',
       });
@@ -293,7 +292,7 @@ describe('workers/pr/changelog/index', () => {
         .get(/.*/)
         .reply(200, []);
       hostRules.add({
-        hostType: PlatformId.Github,
+        hostType: 'github',
         matchHost: 'https://github-enterprise.example.com/',
         token: 'abc',
       });
@@ -332,7 +331,7 @@ describe('workers/pr/changelog/index', () => {
         .get(/.*/)
         .reply(200, []);
       hostRules.add({
-        hostType: PlatformId.Github,
+        hostType: 'github',
         matchHost: 'https://github-enterprise.example.com/',
         token: 'abc',
       });

--- a/lib/workers/pr/changelog/source-github.ts
+++ b/lib/workers/pr/changelog/source-github.ts
@@ -1,5 +1,4 @@
 import URL from 'url';
-import { PlatformId } from '../../../constants';
 import type { Release } from '../../../datasource/types';
 import { logger } from '../../../logger';
 import * as memCache from '../../../util/cache/memory';
@@ -48,7 +47,7 @@ export async function getChangeLogJSON({
     ? 'https://api.github.com/'
     : sourceUrl;
   const config = hostRules.find({
-    hostType: PlatformId.Github,
+    hostType: 'github',
     url,
   });
   // istanbul ignore if

--- a/lib/workers/pr/index.spec.ts
+++ b/lib/workers/pr/index.spec.ts
@@ -1,5 +1,4 @@
 import { getConfig, git, mocked, partial, platform } from '../../../test/util';
-import { PlatformId } from '../../constants';
 import type { Pr } from '../../platform/types';
 import { BranchStatus } from '../../types';
 import * as _limits from '../global/limits';
@@ -674,7 +673,7 @@ describe('workers/pr/index', () => {
       git.getBranchLastCommitTime.mockResolvedValueOnce(new Date());
       config.prCreation = 'not-pending';
       config.artifactErrors = [{}];
-      config.platform = PlatformId.Gitlab;
+      config.platform = 'gitlab';
       const { pr } = await prWorker.ensurePr(config);
       expect(pr).toMatchObject({ displayNumber: 'New Pull Request' });
     });

--- a/lib/workers/repository/dependency-dashboard.spec.ts
+++ b/lib/workers/repository/dependency-dashboard.spec.ts
@@ -8,7 +8,6 @@ import {
   platform,
 } from '../../../test/util';
 import { GlobalConfig } from '../../config/global';
-import { PlatformId } from '../../constants';
 import type { Platform } from '../../platform';
 import { BranchConfig, BranchResult, BranchUpgradeConfig } from '../types';
 import * as dependencyDashboard from './dependency-dashboard';
@@ -19,7 +18,7 @@ let config: RenovateConfig;
 beforeEach(() => {
   jest.clearAllMocks();
   config = getConfig();
-  config.platform = PlatformId.Github;
+  config.platform = 'github';
   config.errors = [];
   config.warnings = [];
 });

--- a/lib/workers/repository/finalise/prune.spec.ts
+++ b/lib/workers/repository/finalise/prune.spec.ts
@@ -5,7 +5,6 @@ import {
   platform,
 } from '../../../../test/util';
 import { GlobalConfig } from '../../../config/global';
-import { PlatformId } from '../../../constants';
 import * as cleanup from './prune';
 
 jest.mock('../../../util/git');
@@ -14,7 +13,7 @@ let config: RenovateConfig;
 beforeEach(() => {
   jest.resetAllMocks();
   config = getConfig();
-  config.platform = PlatformId.Github;
+  config.platform = 'github';
   config.errors = [];
   config.warnings = [];
 });


### PR DESCRIPTION
## Changes:

- Replace `PlatformId` enum with strings union type

## Context:

- Ref: #13743


## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
