### PR TITLE
feat(migrations): versionStrategy

### DIFF
--- a/lib/config/migration.ts
+++ b/lib/config/migration.ts
@@ -174,11 +174,6 @@ export function migrateConfig(
         const templateIndex = val.indexOf(`{{`);
         migratedConfig.branchPrefix = val.substring(0, templateIndex);
         migratedConfig.additionalBranchPrefix = val.substring(templateIndex);
-      } else if (key === 'versionStrategy') {
-        delete migratedConfig.versionStrategy;
-        if (val === 'widen') {
-          migratedConfig.rangeStrategy = 'widen';
-        }
       } else if (key === 'semanticPrefix' && is.string(val)) {
         delete migratedConfig.semanticPrefix;
         let [text] = val.split(':') as any; // TODO: fixme

--- a/lib/config/migrations/custom/version-strategy-migration.spec.ts
+++ b/lib/config/migrations/custom/version-strategy-migration.spec.ts
@@ -1,0 +1,23 @@
+import { VersionStrategyMigration } from './version-strategy-migration';
+
+describe('config/migrations/custom/version-strategy-migration', () => {
+  it('should migrate versionStrategy="widen" to rangeStrategy="widen"', () => {
+    expect(VersionStrategyMigration).toMigrate(
+      {
+        versionStrategy: 'widen',
+      },
+      {
+        rangeStrategy: 'widen',
+      }
+    );
+  });
+
+  it('should just remove property when versionStrategy not equals to "widen"', () => {
+    expect(VersionStrategyMigration).toMigrate(
+      {
+        versionStrategy: 'test',
+      },
+      {}
+    );
+  });
+});

--- a/lib/config/migrations/custom/version-strategy-migration.ts
+++ b/lib/config/migrations/custom/version-strategy-migration.ts
@@ -1,0 +1,12 @@
+import { AbstractMigration } from '../base/abstract-migration';
+
+export class VersionStrategyMigration extends AbstractMigration {
+  override readonly deprecated = true;
+  readonly propertyName = 'versionStrategy';
+
+  override run(value): void {
+    if (value === 'widen') {
+      this.setSafely('rangeStrategy', 'widen');
+    }
+  }
+}

--- a/lib/config/migrations/migrations-service.ts
+++ b/lib/config/migrations/migrations-service.ts
@@ -13,6 +13,7 @@ import { RequiredStatusChecksMigration } from './custom/required-status-checks-m
 import { SemanticCommitsMigration } from './custom/semantic-commits-migration';
 import { TrustLevelMigration } from './custom/trust-level-migration';
 import { UpgradeInRangeMigration } from './custom/upgrade-in-range-migration';
+import { VersionStrategyMigration } from './custom/version-strategy-migration';
 import type { Migration, MigrationConstructor } from './types';
 
 export class MigrationsService {
@@ -53,6 +54,7 @@ export class MigrationsService {
     SemanticCommitsMigration,
     TrustLevelMigration,
     UpgradeInRangeMigration,
+    VersionStrategyMigration,
   ];
 
   static run(originalConfig: RenovateConfig): RenovateConfig {


### PR DESCRIPTION
## Changes:

1. One more migration from previously huge PR https://github.com/renovatebot/renovate/pull/12957

## Context:

1. https://github.com/renovatebot/renovate/issues/11459
2. Part of https://github.com/renovatebot/renovate/pull/12957 

## Documentation

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository