### PR TITLE
feat(migrations): strict null checks

### DIFF
--- a/lib/config/migrations/base/remove-property-migration.ts
+++ b/lib/config/migrations/base/remove-property-migration.ts
@@ -2,7 +2,7 @@ import type { RenovateConfig } from '../../types';
 import { AbstractMigration } from './abstract-migration';
 
 export class RemovePropertyMigration extends AbstractMigration {
-  readonly propertyName: string;
+  override readonly propertyName: string;
 
   constructor(
     propertyName: string,

--- a/lib/config/migrations/base/rename-property-migration.ts
+++ b/lib/config/migrations/base/rename-property-migration.ts
@@ -3,7 +3,7 @@ import { AbstractMigration } from './abstract-migration';
 
 export class RenamePropertyMigration extends AbstractMigration {
   override readonly deprecated = true;
-  readonly propertyName: string;
+  override readonly propertyName: string;
 
   private readonly newPropertyName: string;
 
@@ -18,7 +18,7 @@ export class RenamePropertyMigration extends AbstractMigration {
     this.newPropertyName = newPropertyName;
   }
 
-  override run(value): void {
+  override run(value: unknown): void {
     this.setSafely(this.newPropertyName, value);
   }
 }

--- a/lib/config/migrations/custom/binary-source-migration.ts
+++ b/lib/config/migrations/custom/binary-source-migration.ts
@@ -1,9 +1,9 @@
 import { AbstractMigration } from '../base/abstract-migration';
 
 export class BinarySourceMigration extends AbstractMigration {
-  readonly propertyName = 'binarySource';
+  override readonly propertyName = 'binarySource';
 
-  override run(value): void {
+  override run(value: unknown): void {
     if (value === 'auto') {
       this.rewrite('global');
     }

--- a/lib/config/migrations/custom/enabled-managers-migration.ts
+++ b/lib/config/migrations/custom/enabled-managers-migration.ts
@@ -2,9 +2,9 @@ import is from '@sindresorhus/is';
 import { AbstractMigration } from '../base/abstract-migration';
 
 export class EnabledManagersMigration extends AbstractMigration {
-  readonly propertyName = 'enabledManagers';
+  override readonly propertyName = 'enabledManagers';
 
-  override run(value: string[]): void {
+  override run(value: unknown): void {
     if (is.array(value)) {
       const newValue = value.map((manager) =>
         manager === 'yarn' ? 'npm' : manager

--- a/lib/config/migrations/custom/go-mod-tidy-migration.ts
+++ b/lib/config/migrations/custom/go-mod-tidy-migration.ts
@@ -2,9 +2,9 @@ import { AbstractMigration } from '../base/abstract-migration';
 
 export class GoModTidyMigration extends AbstractMigration {
   override readonly deprecated = true;
-  readonly propertyName = 'gomodTidy';
+  override readonly propertyName = 'gomodTidy';
 
-  override run(value): void {
+  override run(value: unknown): void {
     const postUpdateOptions = this.get('postUpdateOptions');
 
     if (value) {

--- a/lib/config/migrations/custom/ignore-node-modules-migration.ts
+++ b/lib/config/migrations/custom/ignore-node-modules-migration.ts
@@ -2,9 +2,9 @@ import { AbstractMigration } from '../base/abstract-migration';
 
 export class IgnoreNodeModulesMigration extends AbstractMigration {
   override readonly deprecated = true;
-  readonly propertyName = 'ignoreNodeModules';
+  override readonly propertyName = 'ignoreNodeModules';
 
-  override run(value): void {
+  override run(value: unknown): void {
     this.setSafely('ignorePaths', value ? ['node_modules/'] : []);
   }
 }

--- a/lib/config/migrations/custom/pin-versions-migration.ts
+++ b/lib/config/migrations/custom/pin-versions-migration.ts
@@ -3,9 +3,9 @@ import { AbstractMigration } from '../base/abstract-migration';
 
 export class PinVersionsMigration extends AbstractMigration {
   override readonly deprecated = true;
-  readonly propertyName = 'pinVersions';
+  override readonly propertyName = 'pinVersions';
 
-  override run(value): void {
+  override run(value: unknown): void {
     if (is.boolean(value)) {
       this.setSafely('rangeStrategy', value ? 'pin' : 'replace');
     }

--- a/lib/config/migrations/custom/rebase-conflicted-prs-migration.ts
+++ b/lib/config/migrations/custom/rebase-conflicted-prs-migration.ts
@@ -2,9 +2,9 @@ import { AbstractMigration } from '../base/abstract-migration';
 
 export class RebaseConflictedPrs extends AbstractMigration {
   override readonly deprecated = true;
-  readonly propertyName = 'rebaseConflictedPrs';
+  override readonly propertyName = 'rebaseConflictedPrs';
 
-  override run(value): void {
+  override run(value: unknown): void {
     if (value === false) {
       this.setSafely('rebaseWhen', 'never');
     }

--- a/lib/config/migrations/custom/rebase-stale-prs-migration.ts
+++ b/lib/config/migrations/custom/rebase-stale-prs-migration.ts
@@ -3,9 +3,9 @@ import { AbstractMigration } from '../base/abstract-migration';
 
 export class RebaseStalePrsMigration extends AbstractMigration {
   override readonly deprecated = true;
-  readonly propertyName = 'rebaseStalePrs';
+  override readonly propertyName = 'rebaseStalePrs';
 
-  override run(value): void {
+  override run(value: unknown): void {
     const rebaseConflictedPrs = this.get('rebaseConflictedPrs');
 
     if (rebaseConflictedPrs !== false) {

--- a/lib/config/migrations/custom/required-status-checks-migration.ts
+++ b/lib/config/migrations/custom/required-status-checks-migration.ts
@@ -2,9 +2,9 @@ import { AbstractMigration } from '../base/abstract-migration';
 
 export class RequiredStatusChecksMigration extends AbstractMigration {
   override readonly deprecated = true;
-  readonly propertyName = 'requiredStatusChecks';
+  override readonly propertyName = 'requiredStatusChecks';
 
-  override run(value): void {
+  override run(value: unknown): void {
     if (value === null) {
       this.setSafely('ignoreTests', true);
     }

--- a/lib/config/migrations/custom/semantic-commits-migration.ts
+++ b/lib/config/migrations/custom/semantic-commits-migration.ts
@@ -2,9 +2,9 @@ import is from '@sindresorhus/is';
 import { AbstractMigration } from '../base/abstract-migration';
 
 export class SemanticCommitsMigration extends AbstractMigration {
-  readonly propertyName = 'semanticCommits';
+  override readonly propertyName = 'semanticCommits';
 
-  override run(value): void {
+  override run(value: unknown): void {
     if (is.boolean(value)) {
       this.rewrite(value ? 'enabled' : 'disabled');
     } else if (value !== 'enabled' && value !== 'disabled') {

--- a/lib/config/migrations/custom/trust-level-migration.ts
+++ b/lib/config/migrations/custom/trust-level-migration.ts
@@ -2,9 +2,9 @@ import { AbstractMigration } from '../base/abstract-migration';
 
 export class TrustLevelMigration extends AbstractMigration {
   override readonly deprecated = true;
-  readonly propertyName = 'trustLevel';
+  override readonly propertyName = 'trustLevel';
 
-  override run(value): void {
+  override run(value: unknown): void {
     if (value === 'high') {
       this.setSafely('allowCustomCrateRegistries', true);
       this.setSafely('allowScripts', true);

--- a/lib/config/migrations/custom/upgrade-in-range-migration.ts
+++ b/lib/config/migrations/custom/upgrade-in-range-migration.ts
@@ -2,9 +2,9 @@ import { AbstractMigration } from '../base/abstract-migration';
 
 export class UpgradeInRangeMigration extends AbstractMigration {
   override readonly deprecated = true;
-  readonly propertyName = 'upgradeInRange';
+  override readonly propertyName = 'upgradeInRange';
 
-  override run(value): void {
+  override run(value: unknown): void {
     if (value === true) {
       this.setSafely('rangeStrategy', 'bump');
     }

--- a/lib/config/migrations/custom/version-strategy-migration.ts
+++ b/lib/config/migrations/custom/version-strategy-migration.ts
@@ -2,9 +2,9 @@ import { AbstractMigration } from '../base/abstract-migration';
 
 export class VersionStrategyMigration extends AbstractMigration {
   override readonly deprecated = true;
-  readonly propertyName = 'versionStrategy';
+  override readonly propertyName = 'versionStrategy';
 
-  override run(value): void {
+  override run(value: unknown): void {
     if (value === 'widen') {
       this.setSafely('rangeStrategy', 'widen');
     }

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -8,7 +8,7 @@
   "include": [
     "lib/config/app-strings.ts",
     "lib/config/global.ts",
-    "lib/config/migrations/types.ts",
+    "lib/config/migrations/*",
     "lib/config/presets/common.ts",
     "lib/constants/**/*.ts",
     "lib/data-files.generated.ts",


### PR DESCRIPTION
## Changes:

Enable strict null checks for migrations folder

## Context:

1. https://github.com/renovatebot/renovate/issues/11459
2. Part of https://github.com/renovatebot/renovate/pull/12957 

## Documentation

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository