### PR TITLE
refactor(migrations): raiseDeprecationWarnings

### DIFF
--- a/lib/config/migration.ts
+++ b/lib/config/migration.ts
@@ -425,13 +425,6 @@ export function migrateConfig(
         if (subMigrate.isMigrated) {
           migratedConfig[key] = subMigrate.migratedConfig;
         }
-      } else if (key === 'raiseDeprecationWarnings') {
-        delete migratedConfig.raiseDeprecationWarnings;
-        if (val === false) {
-          migratedConfig.suppressNotifications =
-            migratedConfig.suppressNotifications || [];
-          migratedConfig.suppressNotifications.push('deprecationWarningIssues');
-        }
       } else if (key === 'azureAutoComplete' || key === 'gitLabAutomerge') {
         if (migratedConfig[key] !== undefined) {
           migratedConfig.platformAutomerge = migratedConfig[key];

--- a/lib/config/migrations/custom/raise-deprecation-warnings-migration.spec.ts
+++ b/lib/config/migrations/custom/raise-deprecation-warnings-migration.spec.ts
@@ -1,0 +1,31 @@
+import { RaiseDeprecationWarningsMigration } from './raise-deprecation-warnings-migration';
+
+describe('config/migrations/custom/raise-deprecation-warnings-migration', () => {
+  it('should migrate false', () => {
+    expect(RaiseDeprecationWarningsMigration).toMigrate(
+      { raiseDeprecationWarnings: false },
+      {
+        suppressNotifications: ['deprecationWarningIssues'],
+      }
+    );
+  });
+
+  it('should migrate false and concat with existing value', () => {
+    expect(RaiseDeprecationWarningsMigration).toMigrate(
+      {
+        raiseDeprecationWarnings: false,
+        suppressNotifications: ['test'],
+      },
+      { suppressNotifications: ['test', 'deprecationWarningIssues'] }
+    );
+  });
+
+  it('should just remove property when raiseDeprecationWarnings not equals to true', () => {
+    expect(RaiseDeprecationWarningsMigration).toMigrate(
+      {
+        raiseDeprecationWarnings: true,
+      },
+      {}
+    );
+  });
+});

--- a/lib/config/migrations/custom/raise-deprecation-warnings-migration.ts
+++ b/lib/config/migrations/custom/raise-deprecation-warnings-migration.ts
@@ -1,0 +1,19 @@
+import { AbstractMigration } from '../base/abstract-migration';
+
+export class RaiseDeprecationWarningsMigration extends AbstractMigration {
+  override readonly deprecated = true;
+  override readonly propertyName = 'raiseDeprecationWarnings';
+
+  override run(value: unknown): void {
+    const suppressNotifications = this.get('suppressNotifications');
+
+    if (value === false) {
+      this.setHard(
+        'suppressNotifications',
+        Array.isArray(suppressNotifications)
+          ? suppressNotifications.concat(['deprecationWarningIssues'])
+          : ['deprecationWarningIssues']
+      );
+    }
+  }
+}

--- a/lib/config/migrations/migrations-service.ts
+++ b/lib/config/migrations/migrations-service.ts
@@ -8,6 +8,7 @@ import { EnabledManagersMigration } from './custom/enabled-managers-migration';
 import { GoModTidyMigration } from './custom/go-mod-tidy-migration';
 import { IgnoreNodeModulesMigration } from './custom/ignore-node-modules-migration';
 import { PinVersionsMigration } from './custom/pin-versions-migration';
+import { RaiseDeprecationWarningsMigration } from './custom/raise-deprecation-warnings-migration';
 import { RebaseConflictedPrs } from './custom/rebase-conflicted-prs-migration';
 import { RebaseStalePrsMigration } from './custom/rebase-stale-prs-migration';
 import { RequiredStatusChecksMigration } from './custom/required-status-checks-migration';
@@ -51,6 +52,7 @@ export class MigrationsService {
     GoModTidyMigration,
     IgnoreNodeModulesMigration,
     PinVersionsMigration,
+    RaiseDeprecationWarningsMigration,
     RebaseConflictedPrs,
     RebaseStalePrsMigration,
     RequiredStatusChecksMigration,


### PR DESCRIPTION
## Changes:

One more migration from previously huge PR https://github.com/renovatebot/renovate/pull/12957

## Context:

1. https://github.com/renovatebot/renovate/issues/11459
2. Part of https://github.com/renovatebot/renovate/pull/12957 

## Documentation

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository