### PR TITLE
feat(pr): internalChecksFilter override

### DIFF
--- a/lib/workers/pr/body/controls.ts
+++ b/lib/workers/pr/body/controls.ts
@@ -3,8 +3,15 @@ import { isBranchModified } from '../../../util/git';
 import { BranchConfig } from '../../types';
 
 export async function getControls(config: BranchConfig): Promise<string> {
+  let controls = '\n\n---\n\n';
+  if (config.hasPendingVersions) {
+    // if it was already checked, then keep it checked
+    const checkbox = config.pendingVersionsRequested ? '[x]' : '[ ]';
+    controls += `- ${checkbox} <!-- pending-version-check --> One or more pending versions are filtered due to \`internalChecksFilter\`. Tick this checkbox to use them in this PR.\n`;
+  }
   const warning = (await isBranchModified(config.branchName))
     ? emojify(' :warning: **Warning**: custom changes will be lost.')
     : '';
-  return `\n\n---\n\n - [ ] <!-- rebase-check -->If you want to rebase/retry this PR, click this checkbox.${warning}\n\n`;
+  controls += ` - [ ] <!-- rebase-check -->If you want to rebase/retry this PR, click this checkbox.${warning}\n\n`;
+  return controls;
 }

--- a/lib/workers/repository/updates/generate.ts
+++ b/lib/workers/repository/updates/generate.ts
@@ -302,6 +302,9 @@ export function generateBranchConfig(
   config.dependencyDashboardPrApproval = config.upgrades.some(
     (upgrade) => upgrade.prCreation === 'approval'
   );
+  config.hasPendingVersions = config.upgrades.some(
+    (upgrade) => upgrade.pendingVersions?.length
+  );
   config.automerge = config.upgrades.every((upgrade) => upgrade.automerge);
   // combine all labels
   config.labels = [

--- a/lib/workers/types.ts
+++ b/lib/workers/types.ts
@@ -113,6 +113,8 @@ export interface BranchConfig
   dependencyDashboardChecks?: Record<string, string>;
   releaseTimestamp?: string;
   forceCommit?: boolean;
+  hasPendingVersions?: boolean;
+  pendingVersionsRequested?: boolean;
   rebaseRequested?: boolean;
   result?: BranchResult;
   upgrades: BranchUpgradeConfig[];


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds option to override `internalChecksFilter` to force pending updates.

## Context:

Closes #10914

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
