### PR TITLE
fix(git): writeGitAuthor before conflicted check

### DIFF
--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -261,7 +261,12 @@ export function setGitAuthor(gitAuthor: string): void {
 }
 
 export async function writeGitAuthor(): Promise<void> {
-  const { gitAuthorName, gitAuthorEmail } = config;
+  const { gitAuthorName, gitAuthorEmail, writeGitDone } = config;
+  // istanbul ignore if
+  if (writeGitDone) {
+    return;
+  }
+  config.writeGitDone = true;
   try {
     if (gitAuthorName) {
       logger.debug({ gitAuthorName }, 'Setting git author name');
@@ -579,7 +584,7 @@ export async function isBranchConflicted(
 ): Promise<boolean> {
   logger.debug(`isBranchConflicted(${baseBranch}, ${branch})`);
   await syncGit();
-
+  await writeGitAuthor();
   if (!branchExists(baseBranch) || !branchExists(branch)) {
     logger.warn(
       { baseBranch, branch },

--- a/lib/util/git/types.ts
+++ b/lib/util/git/types.ts
@@ -28,6 +28,8 @@ export interface LocalConfig extends StorageConfig {
   ignoredAuthors: string[];
   gitAuthorName?: string;
   gitAuthorEmail?: string;
+
+  writeGitDone?: boolean;
 }
 
 export interface FileAddition {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Writes git author before any branch conflicted checks. Also adds some logic to prevent duplicate/unnecessary executions.

## Context:

#12575

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
