### PR TITLE
feat(presets): Add redux-devtools-extension replacement

### DIFF
--- a/lib/config/presets/internal/replacements.ts
+++ b/lib/config/presets/internal/replacements.ts
@@ -85,6 +85,18 @@ export const presets: Record<string, Preset> = {
       },
     ],
   },
+  'redux-devtools-extension-to-scope': {
+    description:
+      'the redux-devtools-extension package was renamed to @redux-devtools/extension',
+    packageRules: [
+      {
+        matchDatasources: ['npm'],
+        matchPackageNames: ['redux-devtools-extension'],
+        replacementName: '@redux-devtools/extension',
+        replacementVersion: '3.0.0',
+      },
+    ],
+  },
   'renovate-pep440-to-renovatebot-pep440': {
     description:
       'the @renovate/pep440 package was renamed to @renovatebot/pep440',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds a mapping for `redux-devtools-extension` to `@redux-devtools/extension`
See https://github.com/reduxjs/redux-devtools/releases/tag/remotedev-redux-devtools-extension%403.0.0

<!-- Describe what behavior is changed by this PR. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [X] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
