### PR TITLE
feat(poetry): support binarySource=install

### DIFF
--- a/lib/manager/poetry/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/manager/poetry/__snapshots__/artifacts.spec.ts.snap
@@ -100,7 +100,7 @@ Array [
     },
   },
   Object {
-    "cmd": "docker run --rm --name=renovate_python --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -w \\"/tmp/github/some/repo\\" renovate/python:2.7.5 bash -l -c \\"pip install 'poetry>=1.0' && poetry update --lock --no-interaction dep1\\"",
+    "cmd": "docker run --rm --name=renovate_python --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -w \\"/tmp/github/some/repo\\" renovate/python:2.7.5 bash -l -c \\"install-tool poetry 1.2.0 && poetry update --lock --no-interaction dep1\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -135,7 +135,7 @@ Array [
     },
   },
   Object {
-    "cmd": "docker run --rm --name=renovate_python --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -w \\"/tmp/github/some/repo\\" renovate/python:3.4.2 bash -l -c \\"pip install 'poetry>=1.1.2' setuptools 'poetry-dynamic-versioning>1' && poetry update --lock --no-interaction dep1\\"",
+    "cmd": "docker run --rm --name=renovate_python --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -w \\"/tmp/github/some/repo\\" renovate/python:3.4.2 bash -l -c \\"install-tool poetry 1.2.0 && poetry update --lock --no-interaction dep1\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",

--- a/lib/manager/poetry/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/poetry/__snapshots__/extract.spec.ts.snap
@@ -533,9 +533,7 @@ Array [
 
 exports[`manager/poetry/extract extractPackageFile() handles multiple constraint dependencies 1`] = `
 Object {
-  "constraints": Object {
-    "poetry": "poetry>=1.1.2 setuptools poetry-dynamic-versioning",
-  },
+  "constraints": Object {},
   "deps": Array [
     Object {
       "currentValue": "",

--- a/lib/manager/poetry/artifacts.ts
+++ b/lib/manager/poetry/artifacts.ts
@@ -58,7 +58,10 @@ function getPoetryRequirement(pyProjectContent: string): string | null {
           const pkgValMatch = pkgValRegex.exec(requirement);
           if (pkgValMatch) {
             const [, depName, , currVal] = pkgValMatch;
-            if (depName === 'poetry' && currVal) {
+            if (
+              (depName === 'poetry' || depName === 'poetry-core') &&
+              currVal
+            ) {
               return currVal.trim();
             }
           }

--- a/lib/manager/poetry/artifacts.ts
+++ b/lib/manager/poetry/artifacts.ts
@@ -4,7 +4,7 @@ import { quote } from 'shlex';
 import { TEMPORARY_ERROR } from '../../constants/error-messages';
 import { logger } from '../../logger';
 import { exec } from '../../util/exec';
-import type { ExecOptions } from '../../util/exec/types';
+import type { ExecOptions, ToolConstraint } from '../../util/exec/types';
 import {
   deleteLocalFile,
   getSiblingFileName,
@@ -12,6 +12,8 @@ import {
   writeLocalFile,
 } from '../../util/fs';
 import { find } from '../../util/host-rules';
+import { regEx } from '../../util/regex';
+import { dependencyPattern } from '../pip_requirements/extract';
 import type {
   UpdateArtifact,
   UpdateArtifactsConfig,
@@ -39,6 +41,34 @@ function getPythonConstraint(
     // Do nothing
   }
   return undefined;
+}
+
+const pkgValRegex = regEx(`^${dependencyPattern}$`);
+
+function getPoetryRequirement(pyProjectContent: string): string | null {
+  try {
+    const pyproject: PoetryFile = parse(pyProjectContent);
+    // https://python-poetry.org/docs/pyproject/#poetry-and-pep-517
+    if (
+      pyproject['build-system']?.['build-backend'] === 'poetry.masonry.api' &&
+      is.nonEmptyArray(pyproject['build-system']?.requires)
+    ) {
+      for (const requirement of pyproject['build-system'].requires) {
+        if (is.nonEmptyString(requirement)) {
+          const pkgValMatch = pkgValRegex.exec(requirement);
+          if (pkgValMatch) {
+            const [, depName, , currVal] = pkgValMatch;
+            if (depName === 'poetry' && currVal) {
+              return currVal.trim();
+            }
+          }
+        }
+      }
+    }
+  } catch (err) {
+    logger.debug({ err }, 'Error parsing pyproject.toml file');
+  }
+  return null;
 }
 
 function getPoetrySources(content: string, fileName: string): PoetrySource[] {
@@ -125,13 +155,16 @@ export async function updateArtifacts({
       );
     }
     const tagConstraint = getPythonConstraint(existingLockFileContent, config);
-    const poetryRequirement = config.constraints?.poetry || 'poetry';
-    const poetryInstall =
-      'pip install ' + poetryRequirement.split(' ').map(quote).join(' ');
+    const constraint =
+      config.constraints?.poetry || getPoetryRequirement(newPackageFileContent);
     const extraEnv = getSourceCredentialVars(
       newPackageFileContent,
       packageFileName
     );
+    const toolConstraint: ToolConstraint = {
+      toolName: 'poetry',
+      constraint,
+    };
 
     const execOptions: ExecOptions = {
       cwdFile: packageFileName,
@@ -141,7 +174,7 @@ export async function updateArtifacts({
         tagConstraint,
         tagScheme: 'poetry',
       },
-      preCommands: [poetryInstall],
+      toolConstraints: [toolConstraint],
     };
     await exec(cmd, execOptions);
     const newPoetryLockContent = await readLocalFile(lockFileName, 'utf8');

--- a/lib/manager/poetry/artifacts.ts
+++ b/lib/manager/poetry/artifacts.ts
@@ -46,11 +46,14 @@ function getPythonConstraint(
 const pkgValRegex = regEx(`^${dependencyPattern}$`);
 
 function getPoetryRequirement(pyProjectContent: string): string | null {
+  debugger;
   try {
     const pyproject: PoetryFile = parse(pyProjectContent);
     // https://python-poetry.org/docs/pyproject/#poetry-and-pep-517
+    const buildBackend = pyproject['build-system']?.['build-backend'];
     if (
-      pyproject['build-system']?.['build-backend'] === 'poetry.masonry.api' &&
+      (buildBackend === 'poetry.masonry.api' ||
+        buildBackend === 'poetry.core.masonry.api') &&
       is.nonEmptyArray(pyproject['build-system']?.requires)
     ) {
       for (const requirement of pyproject['build-system'].requires) {
@@ -59,7 +62,7 @@ function getPoetryRequirement(pyProjectContent: string): string | null {
           if (pkgValMatch) {
             const [, depName, , currVal] = pkgValMatch;
             if (
-              (depName === 'poetry' || depName === 'poetry-core') &&
+              (depName === 'poetry' || depName === 'poetry_core') &&
               currVal
             ) {
               return currVal.trim();

--- a/lib/manager/poetry/artifacts.ts
+++ b/lib/manager/poetry/artifacts.ts
@@ -46,7 +46,6 @@ function getPythonConstraint(
 const pkgValRegex = regEx(`^${dependencyPattern}$`);
 
 function getPoetryRequirement(pyProjectContent: string): string | null {
-  debugger;
   try {
     const pyproject: PoetryFile = parse(pyProjectContent);
     // https://python-poetry.org/docs/pyproject/#poetry-and-pep-517

--- a/lib/manager/poetry/extract.spec.ts
+++ b/lib/manager/poetry/extract.spec.ts
@@ -40,7 +40,6 @@ describe('manager/poetry/extract', () => {
       expect(res.deps).toMatchSnapshot();
       expect(res.deps).toHaveLength(9);
       expect(res.constraints).toEqual({
-        poetry: 'poetry>=1.0 wheel',
         python: '~2.7 || ^3.4',
       });
     });

--- a/lib/manager/poetry/extract.ts
+++ b/lib/manager/poetry/extract.ts
@@ -149,13 +149,6 @@ export async function extractPackageFile(
 
   const constraints: Record<string, any> = {};
 
-  // https://python-poetry.org/docs/pyproject/#poetry-and-pep-517
-  if (
-    pyprojectfile['build-system']?.['build-backend'] === 'poetry.masonry.api'
-  ) {
-    constraints.poetry = pyprojectfile['build-system']?.requires.join(' ');
-  }
-
   if (is.nonEmptyString(pyprojectfile.tool?.poetry?.dependencies?.python)) {
     constraints.python = pyprojectfile.tool?.poetry?.dependencies?.python;
   }

--- a/lib/util/exec/buildpack.ts
+++ b/lib/util/exec/buildpack.ts
@@ -93,7 +93,9 @@ export async function resolveConstraint(
   const releases = pkgReleases?.releases ?? [];
   const versions = releases.map((r) => r.version);
   const resolvedVersion = versions
-    .filter((v) => !constraint || versioning.matches(v, constraint))
+    .filter((v) =>
+      constraint ? versioning.matches(v, constraint) : versioning.isStable(v)
+    )
     .pop();
 
   if (resolvedVersion) {

--- a/lib/util/exec/buildpack.ts
+++ b/lib/util/exec/buildpack.ts
@@ -5,6 +5,7 @@ import { logger } from '../../logger';
 import * as allVersioning from '../../versioning';
 import { id as composerVersioningId } from '../../versioning/composer';
 import { id as npmVersioningId } from '../../versioning/npm';
+import { id as pep440VersioningId } from '../../versioning/pep440';
 import { id as semverVersioningId } from '../../versioning/semver';
 import type { ToolConfig, ToolConstraint } from './types';
 
@@ -34,6 +35,11 @@ const allToolConfig: Record<string, ToolConfig> = {
     datasource: 'npm',
     depName: 'pnpm',
     versioning: npmVersioningId,
+  },
+  poetry: {
+    datasource: 'pypi',
+    depName: 'poetry',
+    versioning: pep440VersioningId,
   },
 };
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds support for binarySource=install for `poetry`.

## Context:

Closes #13781

Part of #13683

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
