### PR TITLE
fix(buildpack): filter stable if no constraint

### DIFF
--- a/lib/util/exec/buildpack.ts
+++ b/lib/util/exec/buildpack.ts
@@ -87,7 +87,9 @@ export async function resolveConstraint(
   const releases = pkgReleases?.releases ?? [];
   const versions = releases.map((r) => r.version);
   const resolvedVersion = versions
-    .filter((v) => !constraint || versioning.matches(v, constraint))
+    .filter((v) =>
+      constraint ? versioning.matches(v, constraint) : versioning.isStable(v)
+    )
     .pop();
 
   if (resolvedVersion) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Buildpack filter for stable releases if no constraint is specified.

## Context:

Prevents use of e.g. `poetry@1.2.0a1` if no constraint.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
