### PR TITLE
feat(git): use git fetching for forkMode

### DIFF
--- a/lib/platform/github/__snapshots__/index.spec.ts.snap
+++ b/lib/platform/github/__snapshots__/index.spec.ts.snap
@@ -4120,23 +4120,6 @@ Array [
     "url": "https://api.github.com/repos/some/repo/forks",
   },
   Object {
-    "body": Object {
-      "force": true,
-      "sha": "1234",
-    },
-    "headers": Object {
-      "accept": "application/vnd.github.v3+json",
-      "accept-encoding": "gzip, deflate, br",
-      "authorization": "token 123test",
-      "content-length": "27",
-      "content-type": "application/json",
-      "host": "api.github.com",
-      "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
-    },
-    "method": "PATCH",
-    "url": "https://api.github.com/repos/forked/repo/git/refs/heads/master",
-  },
-  Object {
     "headers": Object {
       "accept": "application/vnd.github.v3+json",
       "accept-encoding": "gzip, deflate, br",
@@ -7401,23 +7384,6 @@ Array [
     "method": "PATCH",
     "url": "https://api.github.com/repos/forked/repo",
   },
-  Object {
-    "body": Object {
-      "force": true,
-      "sha": "1234",
-    },
-    "headers": Object {
-      "accept": "application/vnd.github.v3+json",
-      "accept-encoding": "gzip, deflate, br",
-      "authorization": "token 123test",
-      "content-length": "27",
-      "content-type": "application/json",
-      "host": "api.github.com",
-      "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
-    },
-    "method": "PATCH",
-    "url": "https://api.github.com/repos/forked/repo/git/refs/heads/master",
-  },
 ]
 `;
 
@@ -7903,23 +7869,6 @@ Array [
     },
     "method": "POST",
     "url": "https://api.github.com/repos/some/repo/forks",
-  },
-  Object {
-    "body": Object {
-      "force": true,
-      "sha": "1234",
-    },
-    "headers": Object {
-      "accept": "application/vnd.github.v3+json",
-      "accept-encoding": "gzip, deflate, br",
-      "authorization": "token 123test",
-      "content-length": "27",
-      "content-type": "application/json",
-      "host": "api.github.com",
-      "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
-    },
-    "method": "PATCH",
-    "url": "https://api.github.com/repos/forked/repo/git/refs/heads/master",
   },
 ]
 `;

--- a/lib/platform/github/index.spec.ts
+++ b/lib/platform/github/index.spec.ts
@@ -297,7 +297,6 @@ describe('platform/github/index', () => {
     it('should update fork when forkMode', async () => {
       const scope = httpMock.scope(githubApiHost);
       forkInitRepoMock(scope, 'some/repo', true);
-      scope.patch('/repos/forked/repo/git/refs/heads/master').reply(200);
       const config = await github.initRepo({
         repository: 'some/repo',
         forkMode: true,
@@ -310,7 +309,6 @@ describe('platform/github/index', () => {
       forkInitRepoMock(scope, 'some/repo', true, 'not_master');
       scope.post('/repos/forked/repo/git/refs').reply(200);
       scope.patch('/repos/forked/repo').reply(200);
-      scope.patch('/repos/forked/repo/git/refs/heads/master').reply(200);
       const config = await github.initRepo({
         repository: 'some/repo',
         forkMode: true,
@@ -729,9 +727,7 @@ describe('platform/github/index', () => {
           },
           head: { ref: 'somebranch', repo: { full_name: 'other/repo' } },
           state: PrState.Open,
-        })
-        .patch('/repos/forked/repo/git/refs/heads/master')
-        .reply(200);
+        });
       await github.initRepo({
         repository: 'some/repo',
         forkMode: true,

--- a/lib/platform/github/index.ts
+++ b/lib/platform/github/index.ts
@@ -422,33 +422,11 @@ export async function initRepo({
         { repository_fork: config.repository },
         'Found existing fork'
       );
-      // This is a lovely "hack" by GitHub that lets us force update our fork's default branch
-      // with the base commit from the parent repository
-      const url = `repos/${config.repository}/git/refs/heads/${config.defaultBranch}`;
-      const sha = repo.defaultBranchRef.target.oid;
-      try {
-        logger.debug(
-          `Updating forked repository default sha ${sha} to match upstream`
-        );
-        await githubApi.patchJson(url, {
-          body: {
-            sha,
-            force: true,
-          },
-          token: forkToken || opts.token,
-        });
-      } catch (err) /* istanbul ignore next */ {
-        logger.warn(
-          { url, sha, err: err.err || err },
-          'Error updating fork from upstream - cannot continue'
-        );
-        if (err instanceof ExternalHostError) {
-          throw err;
-        }
-        throw new ExternalHostError(err);
-      }
     } else {
-      logger.debug({ repository_fork: config.repository }, 'Created fork');
+      logger.debug(
+        { repository_fork: config.repository },
+        'Created fork, waiting 30s'
+      );
       existingRepos.push(config.repository);
       // Wait an arbitrary 30s to hopefully give GitHub enough time for forking to complete
       await delay(30000);
@@ -473,9 +451,15 @@ export async function initRepo({
   );
   parsedEndpoint.pathname = config.repository + '.git';
   const url = URL.format(parsedEndpoint);
+  let upstreamUrl: string;
+  if (forkMode) {
+    parsedEndpoint.pathname = config.parentRepo + '.git';
+    upstreamUrl = URL.format(parsedEndpoint);
+  }
   await git.initRepo({
     ...config,
     url,
+    upstreamUrl,
   });
   const repoConfig: RepoResult = {
     defaultBranch: config.defaultBranch,

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -402,6 +402,7 @@ export async function syncGit(): Promise<void> {
     logger.warn({ err }, 'Cannot retrieve latest commit');
   }
   config.currentBranch = config.currentBranch || (await getDefaultBranch(git));
+  // istanbul ignore if
   if (config.upstreamUrl) {
     logger.debug(`Resetting ${config.currentBranch} to upstream`);
     await git.addRemote('upstream', config.upstreamUrl);

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -184,9 +184,10 @@ export async function validateGitVersion(): Promise<boolean> {
   return true;
 }
 
-async function fetchBranchCommits(): Promise<void> {
+async function fetchBranchCommits(preferUpstream = true): Promise<void> {
   config.branchCommits = {};
-  const opts = ['ls-remote', '--heads', config.url];
+  const url = (preferUpstream && config.upstreamUrl) || config.url;
+  const opts = ['ls-remote', '--heads', url];
   if (config.extraCloneOpts) {
     Object.entries(config.extraCloneOpts).forEach((e) =>
       opts.unshift(e[0], `${e[1]}`)
@@ -376,7 +377,6 @@ export async function syncGit(): Promise<void> {
     const durationMs = Math.round(Date.now() - cloneStart);
     logger.debug({ durationMs }, 'git clone completed');
   }
-  config.currentBranchSha = (await git.raw(['rev-parse', 'HEAD'])).trim();
   if (config.cloneSubmodules) {
     const submodules = await getSubmodules();
     for (const submodule of submodules) {
@@ -402,6 +402,22 @@ export async function syncGit(): Promise<void> {
     logger.warn({ err }, 'Cannot retrieve latest commit');
   }
   config.currentBranch = config.currentBranch || (await getDefaultBranch(git));
+  if (config.upstreamUrl) {
+    logger.debug(`Resetting ${config.currentBranch} to upstream`);
+    await git.addRemote('upstream', config.upstreamUrl);
+    await git.fetch(['upstream']);
+    await resetToBranch(config.currentBranch);
+    const resetLog = await git.reset([
+      '--hard',
+      `upstream/${config.currentBranch}`,
+    ]);
+    logger.debug({ resetLog }, 'git reset log');
+    const pushLog = await git.push(['origin', config.currentBranch, '--force']);
+    logger.debug({ pushLog }, 'git push log');
+    await fetchBranchCommits(false);
+  }
+  config.currentBranchSha = (await git.raw(['rev-parse', 'HEAD'])).trim();
+  logger.debug(`Current branch SHA: ${config.currentBranchSha}`);
 }
 
 // istanbul ignore next
@@ -454,7 +470,10 @@ export async function checkoutBranch(branchName: string): Promise<CommitSha> {
     await git.checkout(['-f', branchName, '--']);
     const latestCommitDate = (await git.log({ n: 1 }))?.latest?.date;
     if (latestCommitDate) {
-      logger.debug({ branchName, latestCommitDate }, 'latest commit');
+      logger.debug(
+        { branchName, latestCommitDate, sha: config.currentBranchSha },
+        'latest commit'
+      );
     }
     await git.reset(ResetMode.HARD);
     return config.currentBranchSha;

--- a/lib/util/git/types.ts
+++ b/lib/util/git/types.ts
@@ -14,6 +14,8 @@ export type CommitSha = string;
 export interface StorageConfig {
   currentBranch?: string;
   url: string;
+
+  upstreamUrl?: string;
   extraCloneOpts?: GitOptions;
   cloneSubmodules?: boolean;
   fullClone?: boolean;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Uses `git` to fetch/sync with upstream when in fork mode, instead of GitHub's API.

## Context:

Closes #13586

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
