### PR TITLE
docs(templates): fix code example

### DIFF
--- a/docs/usage/templates.md
+++ b/docs/usage/templates.md
@@ -52,7 +52,7 @@ Read the [MDN Web Docs, encodeURIComponent()](https://developer.mozilla.org/en-U
 The `replace` helper replaces _all_ found strings with the replacement string.
 If you want to replace some characters in a string, use the built-in function `replace` like this:
 
-`{{{replace 'github.com', 'ghc', depName}}}`
+`{{{replace 'github.com' 'ghc' depName}}}`
 
 In the example above all matches of `github.com` will be replaced by `ghc` in `depName`.
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Remove the commas in the code example

## Context:

As requested by @viceice in https://github.com/renovatebot/renovate/discussions/13791#discussioncomment-2045123

> @HonkingGoose can you please fix the docs, comma's need to be removed.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
