### PR TITLE
refactor(git): Extract auth handling from commitFiles

### DIFF
--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -751,21 +751,25 @@ export async function hasDiff(branchName: string): Promise<boolean> {
   }
 }
 
+async function handleCommitAuth(localDir: string): Promise<void> {
+  if (!privateKeySet) {
+    await writePrivateKey();
+    privateKeySet = true;
+  }
+  await configSigningKey(localDir);
+  await writeGitAuthor();
+}
+
 export async function commitFiles({
   branchName,
   files,
   message,
   force = false,
 }: CommitFilesConfig): Promise<CommitSha | null> {
+  const { localDir } = GlobalConfig.get();
   await syncGit();
   logger.debug(`Committing files to branch ${branchName}`);
-  if (!privateKeySet) {
-    await writePrivateKey();
-    privateKeySet = true;
-  }
-  const { localDir } = GlobalConfig.get();
-  await configSigningKey(localDir);
-  await writeGitAuthor();
+  await handleCommitAuth(localDir);
   try {
     await git.reset(ResetMode.HARD);
     await git.raw(['clean', '-fd']);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Extract pre-commit part related to private keys and authorship

## Context:

- Ref: #11537

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
