### PR TITLE
refactor(git): Split commitFiles function into 3 phases

### DIFF
--- a/lib/util/git/error.ts
+++ b/lib/util/git/error.ts
@@ -1,0 +1,143 @@
+import { CONFIG_VALIDATION } from '../../constants/error-messages';
+import { logger } from '../../logger';
+import { ExternalHostError } from '../../types/errors/external-host-error';
+import { FileChange } from './types';
+
+// istanbul ignore next
+export function checkForPlatformFailure(err: Error): void {
+  if (process.env.NODE_ENV === 'test') {
+    return;
+  }
+  const externalHostFailureStrings = [
+    'remote: Invalid username or password',
+    'gnutls_handshake() failed',
+    'The requested URL returned error: 5',
+    'The remote end hung up unexpectedly',
+    'access denied or repository not exported',
+    'Could not write new index file',
+    'Failed to connect to',
+    'Connection timed out',
+    'malformed object name',
+    'Could not resolve host',
+    'early EOF',
+    'fatal: bad config', // .gitmodules problem
+    'expected flush after ref listing',
+  ];
+  for (const errorStr of externalHostFailureStrings) {
+    if (err.message.includes(errorStr)) {
+      logger.debug({ err }, 'Converting git error to ExternalHostError');
+      throw new ExternalHostError(err, 'git');
+    }
+  }
+
+  const configErrorStrings = [
+    {
+      error: 'GitLab: Branch name does not follow the pattern',
+      message:
+        "Cannot push because branch name does not follow project's push rules",
+    },
+    {
+      error: 'GitLab: Commit message does not follow the pattern',
+      message:
+        "Cannot push because commit message does not follow project's push rules",
+    },
+    {
+      error: ' is not a member of team',
+      message:
+        'The `Restrict commits to existing GitLab users` rule is blocking Renovate push. Check the Renovate `gitAuthor` setting',
+    },
+    {
+      error: 'TF401027:',
+      message:
+        'You need the Git `GenericContribute` permission to perform this action',
+    },
+    {
+      error: 'matches more than one',
+      message:
+        "Renovate cannot push branches if there are tags with names the same as Renovate's branches. Please remove conflicting tag names or change Renovate's branchPrefix to avoid conflicts.",
+    },
+  ];
+  for (const { error, message } of configErrorStrings) {
+    if (err.message.includes(error)) {
+      logger.debug({ err }, 'Converting git error to CONFIG_VALIDATION error');
+      const res = new Error(CONFIG_VALIDATION);
+      res.validationError = message;
+      res.validationMessage = err.message;
+      throw res;
+    }
+  }
+}
+
+// istanbul ignore next
+export function handleCommitError(
+  files: FileChange[],
+  branchName: string,
+  err: Error
+): null {
+  checkForPlatformFailure(err);
+  if (err.message.includes(`'refs/heads/renovate' exists`)) {
+    const error = new Error(CONFIG_VALIDATION);
+    error.validationSource = 'None';
+    error.validationError = 'An existing branch is blocking Renovate';
+    error.validationMessage = `Renovate needs to create the branch "${branchName}" but is blocked from doing so because of an existing branch called "renovate". Please remove it so that Renovate can proceed.`;
+    throw error;
+  }
+  if (
+    err.message.includes(
+      'refusing to allow a GitHub App to create or update workflow'
+    )
+  ) {
+    logger.warn(
+      'App has not been granted permissions to update Workflows - aborting branch.'
+    );
+    return null;
+  }
+  if (
+    (err.message.includes('remote rejected') || err.message.includes('403')) &&
+    files?.some((file) => file.path?.startsWith('.github/workflows/'))
+  ) {
+    logger.debug({ err }, 'commitFiles error');
+    logger.info('Workflows update rejection - aborting branch.');
+    return null;
+  }
+  if (err.message.includes('protected branch hook declined')) {
+    const error = new Error(CONFIG_VALIDATION);
+    error.validationSource = branchName;
+    error.validationError = 'Renovate branch is protected';
+    error.validationMessage = `Renovate cannot push to its branch because branch protection has been enabled.`;
+    throw error;
+  }
+  if (err.message.includes('can only push your own commits')) {
+    const error = new Error(CONFIG_VALIDATION);
+    error.validationSource = branchName;
+    error.validationError = 'Bitbucket committer error';
+    error.validationMessage = `Renovate has experienced the following error when attempting to push its branch to the server: "${String(
+      err.message
+    )}"`;
+    throw error;
+  }
+  if (err.message.includes('remote: error: cannot lock ref')) {
+    logger.error({ err }, 'Error committing files.');
+    return null;
+  }
+  if (err.message.includes('[rejected] (stale info)')) {
+    logger.info(
+      'Branch update was rejected because local copy is not up-to-date.'
+    );
+    return null;
+  }
+  if (
+    err.message.includes('denying non-fast-forward') ||
+    err.message.includes('GH003: Sorry, force-pushing')
+  ) {
+    logger.debug({ err }, 'Permission denied to update branch');
+    const error = new Error(CONFIG_VALIDATION);
+    error.validationSource = branchName;
+    error.validationError = 'Force push denied';
+    error.validationMessage = `Renovate is unable to update branch(es) due to force pushes being disallowed.`;
+    throw error;
+  }
+  logger.debug({ err }, 'Unknown error committing files');
+  // We don't know why this happened, so this will cause bubble up to a branch error
+  throw err;
+}

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -705,7 +705,7 @@ export async function prepareCommit({
 }: CommitFilesConfig): Promise<CommitResult | null> {
   const { localDir } = GlobalConfig.get();
   await syncGit();
-  logger.debug(`Preparing files for branch ${branchName}`);
+  logger.debug(`Preparing files for commiting to branch ${branchName}`);
   await handleCommitAuth(localDir);
   try {
     await git.reset(ResetMode.HARD);
@@ -788,7 +788,7 @@ export async function prepareCommit({
       { deletedFiles, ignoredFiles, result: commitRes },
       `git commit`
     );
-    const endSha = commitRes.commit;
+    const commit = commitRes?.commit || 'unknown';
     if (!force && !(await hasDiff(`origin/${branchName}`))) {
       logger.debug(
         { branchName, deletedFiles, addedModifiedFiles, ignoredFiles },
@@ -798,7 +798,7 @@ export async function prepareCommit({
     }
 
     const result: CommitResult = {
-      sha: endSha,
+      sha: commit,
       files: files.filter((fileChange) => {
         if (fileChange.type === 'deletion') {
           return deletedFiles.includes(fileChange.path);

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -835,6 +835,7 @@ export async function pushCommit({
     );
     delete pushRes.repo;
     logger.debug({ result: pushRes }, 'git push');
+    incLimitedValue(Limit.Commits);
   } catch (err) /* istanbul ignore next */ {
     handleCommitError(files, branchName, err);
   }
@@ -849,11 +850,10 @@ export async function fetchCommit({
   try {
     const ref = `refs/heads/${branchName}:refs/remotes/origin/${branchName}`;
     await git.fetch(['origin', ref, '--force']);
-    const sha = (await git.revparse([branchName])).trim();
-    config.branchCommits[branchName] = sha;
+    const commit = (await git.revparse([branchName])).trim();
+    config.branchCommits[branchName] = commit;
     config.branchIsModified[branchName] = false;
-    incLimitedValue(Limit.Commits);
-    return sha.slice(0, 7);
+    return commit;
   } catch (err) /* istanbul ignore next */ {
     return handleCommitError(files, branchName, err);
   }

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -27,6 +27,7 @@ import { Limit, incLimitedValue } from '../../workers/global/limits';
 import { regEx } from '../regex';
 import { parseGitAuthor } from './author';
 import { getNoVerify, simpleGitConfig } from './config';
+import { checkForPlatformFailure, handleCommitError } from './error';
 import { configSigningKey, writePrivateKey } from './private-key';
 import type {
   CommitFilesConfig,
@@ -41,71 +42,6 @@ export { setPrivateKey } from './private-key';
 
 // TODO: fix upstream types https://github.com/steveukx/git-js/issues/704
 const ResetMode = (simpleGit.default as any).ResetMode as typeof _ResetMode;
-
-// istanbul ignore next
-function checkForPlatformFailure(err: Error): void {
-  if (process.env.NODE_ENV === 'test') {
-    return;
-  }
-  const externalHostFailureStrings = [
-    'remote: Invalid username or password',
-    'gnutls_handshake() failed',
-    'The requested URL returned error: 5',
-    'The remote end hung up unexpectedly',
-    'access denied or repository not exported',
-    'Could not write new index file',
-    'Failed to connect to',
-    'Connection timed out',
-    'malformed object name',
-    'Could not resolve host',
-    'early EOF',
-    'fatal: bad config', // .gitmodules problem
-    'expected flush after ref listing',
-  ];
-  for (const errorStr of externalHostFailureStrings) {
-    if (err.message.includes(errorStr)) {
-      logger.debug({ err }, 'Converting git error to ExternalHostError');
-      throw new ExternalHostError(err, 'git');
-    }
-  }
-
-  const configErrorStrings = [
-    {
-      error: 'GitLab: Branch name does not follow the pattern',
-      message:
-        "Cannot push because branch name does not follow project's push rules",
-    },
-    {
-      error: 'GitLab: Commit message does not follow the pattern',
-      message:
-        "Cannot push because commit message does not follow project's push rules",
-    },
-    {
-      error: ' is not a member of team',
-      message:
-        'The `Restrict commits to existing GitLab users` rule is blocking Renovate push. Check the Renovate `gitAuthor` setting',
-    },
-    {
-      error: 'TF401027:',
-      message:
-        'You need the Git `GenericContribute` permission to perform this action',
-    },
-    {
-      error: 'matches more than one',
-      message:
-        "Renovate cannot push branches if there are tags with names the same as Renovate's branches. Please remove conflicting tag names or change Renovate's branchPrefix to avoid conflicts.",
-    },
-  ];
-  for (const { error, message } of configErrorStrings) {
-    if (err.message.includes(error)) {
-      logger.debug({ err }, 'Converting git error to CONFIG_VALIDATION error');
-      const res = new Error(CONFIG_VALIDATION);
-      res.validationError = message;
-      res.validationMessage = err.message;
-      throw res;
-    }
-  }
-}
 
 function localName(branchName: string): string {
   return branchName.replace(regEx(/^origin\//), '');
@@ -880,74 +816,8 @@ export async function commitFiles({
     config.branchIsModified[branchName] = false;
     incLimitedValue(Limit.Commits);
     return commit;
-  } catch (err) /* istanbul ignore next */ {
-    checkForPlatformFailure(err);
-    if (err.message.includes(`'refs/heads/renovate' exists`)) {
-      const error = new Error(CONFIG_VALIDATION);
-      error.validationSource = 'None';
-      error.validationError = 'An existing branch is blocking Renovate';
-      error.validationMessage = `Renovate needs to create the branch "${branchName}" but is blocked from doing so because of an existing branch called "renovate". Please remove it so that Renovate can proceed.`;
-      throw error;
-    }
-    if (
-      err.message.includes(
-        'refusing to allow a GitHub App to create or update workflow'
-      )
-    ) {
-      logger.warn(
-        'App has not been granted permissions to update Workflows - aborting branch.'
-      );
-      return null;
-    }
-    if (
-      (err.message.includes('remote rejected') ||
-        err.message.includes('403')) &&
-      files?.some((file) => file.path?.startsWith('.github/workflows/'))
-    ) {
-      logger.debug({ err }, 'commitFiles error');
-      logger.info('Workflows update rejection - aborting branch.');
-      return null;
-    }
-    if (err.message.includes('protected branch hook declined')) {
-      const error = new Error(CONFIG_VALIDATION);
-      error.validationSource = branchName;
-      error.validationError = 'Renovate branch is protected';
-      error.validationMessage = `Renovate cannot push to its branch because branch protection has been enabled.`;
-      throw error;
-    }
-    if (err.message.includes('can only push your own commits')) {
-      const error = new Error(CONFIG_VALIDATION);
-      error.validationSource = branchName;
-      error.validationError = 'Bitbucket committer error';
-      error.validationMessage = `Renovate has experienced the following error when attempting to push its branch to the server: "${String(
-        err.message
-      )}"`;
-      throw error;
-    }
-    if (err.message.includes('remote: error: cannot lock ref')) {
-      logger.error({ err }, 'Error committing files.');
-      return null;
-    }
-    if (err.message.includes('[rejected] (stale info)')) {
-      logger.info(
-        'Branch update was rejected because local copy is not up-to-date.'
-      );
-      return null;
-    }
-    if (
-      err.message.includes('denying non-fast-forward') ||
-      err.message.includes('GH003: Sorry, force-pushing')
-    ) {
-      logger.debug({ err }, 'Permission denied to update branch');
-      const error = new Error(CONFIG_VALIDATION);
-      error.validationSource = branchName;
-      error.validationError = 'Force push denied';
-      error.validationMessage = `Renovate is unable to update branch(es) due to force pushes being disallowed.`;
-      throw error;
-    }
-    logger.debug({ err }, 'Unknown error committing files');
-    // We don't know why this happened, so this will cause bubble up to a branch error
-    throw err;
+  } catch (err) {
+    return handleCommitError(files, branchName, err);
   }
 }
 

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -687,21 +687,25 @@ export async function hasDiff(branchName: string): Promise<boolean> {
   }
 }
 
+async function handleCommitAuth(localDir: string): Promise<void> {
+  if (!privateKeySet) {
+    await writePrivateKey();
+    privateKeySet = true;
+  }
+  await configSigningKey(localDir);
+  await writeGitAuthor();
+}
+
 export async function commitFiles({
   branchName,
   files,
   message,
   force = false,
 }: CommitFilesConfig): Promise<CommitSha | null> {
+  const { localDir } = GlobalConfig.get();
   await syncGit();
   logger.debug(`Committing files to branch ${branchName}`);
-  if (!privateKeySet) {
-    await writePrivateKey();
-    privateKeySet = true;
-  }
-  const { localDir } = GlobalConfig.get();
-  await configSigningKey(localDir);
-  await writeGitAuthor();
+  await handleCommitAuth(localDir);
   try {
     await git.reset(ResetMode.HARD);
     await git.raw(['clean', '-fd']);

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -862,11 +862,6 @@ export async function fetchCommit({
 export async function commitFiles(
   config: CommitFilesConfig
 ): Promise<CommitSha | null> {
-  const { branchName } = config;
-  const { localDir } = GlobalConfig.get();
-  await syncGit();
-  logger.debug(`Committing files to branch ${branchName}`);
-  await handleCommitAuth(localDir);
   const commitResult = await prepareCommit(config);
   if (!commitResult) {
     return null;

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -816,7 +816,7 @@ export async function commitFiles({
     config.branchIsModified[branchName] = false;
     incLimitedValue(Limit.Commits);
     return commit;
-  } catch (err) {
+  } catch (err) /* istanbul ignore next */ {
     return handleCommitError(files, branchName, err);
   }
 }

--- a/lib/util/git/types.ts
+++ b/lib/util/git/types.ts
@@ -76,3 +76,8 @@ export interface CommitFilesConfig {
   message: string;
   force?: boolean;
 }
+
+export interface CommitResult {
+  sha: string;
+  files: FileChange[];
+}


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Extract `prepareCommit` and make it return filtered file list
- Extract `pushCommit`
- Extract `fetchCommit` and make it return commit SHA

## Context:

- Ref: #11537

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
