### PR TITLE
fix: Revert "refactor(git): remove first git checkout as redundant"

### DIFF
--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -225,12 +225,6 @@ describe('util/git/index', () => {
 
   describe('mergeBranch(branchName)', () => {
     it('should perform a branch merge', async () => {
-      const repo = Git(GlobalConfig.get('localDir'));
-      await repo.checkout([
-        '-B',
-        'renovate/future_branch',
-        'origin/renovate/future_branch',
-      ]);
       await git.mergeBranch('renovate/future_branch');
       const merged = await Git(origin.path).branch([
         '--verbose',

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -610,6 +610,7 @@ export async function mergeBranch(branchName: string): Promise<void> {
   try {
     await syncGit();
     await git.reset(ResetMode.HARD);
+    await git.checkout(['-B', branchName, 'origin/' + branchName]);
     await git.checkout([
       '-B',
       config.currentBranch,


### PR DESCRIPTION
Reverts renovatebot/renovate#13509
Closes #13828