### PR TITLE
fix: Revert "feat(git): use git fetching for forkMode (#13808)"

### DIFF
--- a/lib/platform/github/__snapshots__/index.spec.ts.snap
+++ b/lib/platform/github/__snapshots__/index.spec.ts.snap
@@ -4120,6 +4120,23 @@ Array [
     "url": "https://api.github.com/repos/some/repo/forks",
   },
   Object {
+    "body": Object {
+      "force": true,
+      "sha": "1234",
+    },
+    "headers": Object {
+      "accept": "application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate, br",
+      "authorization": "token 123test",
+      "content-length": "27",
+      "content-type": "application/json",
+      "host": "api.github.com",
+      "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
+    },
+    "method": "PATCH",
+    "url": "https://api.github.com/repos/forked/repo/git/refs/heads/master",
+  },
+  Object {
     "headers": Object {
       "accept": "application/vnd.github.v3+json",
       "accept-encoding": "gzip, deflate, br",
@@ -7384,6 +7401,23 @@ Array [
     "method": "PATCH",
     "url": "https://api.github.com/repos/forked/repo",
   },
+  Object {
+    "body": Object {
+      "force": true,
+      "sha": "1234",
+    },
+    "headers": Object {
+      "accept": "application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate, br",
+      "authorization": "token 123test",
+      "content-length": "27",
+      "content-type": "application/json",
+      "host": "api.github.com",
+      "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
+    },
+    "method": "PATCH",
+    "url": "https://api.github.com/repos/forked/repo/git/refs/heads/master",
+  },
 ]
 `;
 
@@ -7869,6 +7903,23 @@ Array [
     },
     "method": "POST",
     "url": "https://api.github.com/repos/some/repo/forks",
+  },
+  Object {
+    "body": Object {
+      "force": true,
+      "sha": "1234",
+    },
+    "headers": Object {
+      "accept": "application/vnd.github.v3+json",
+      "accept-encoding": "gzip, deflate, br",
+      "authorization": "token 123test",
+      "content-length": "27",
+      "content-type": "application/json",
+      "host": "api.github.com",
+      "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
+    },
+    "method": "PATCH",
+    "url": "https://api.github.com/repos/forked/repo/git/refs/heads/master",
   },
 ]
 `;

--- a/lib/platform/github/index.spec.ts
+++ b/lib/platform/github/index.spec.ts
@@ -300,6 +300,7 @@ describe('platform/github/index', () => {
     it('should update fork when forkMode', async () => {
       const scope = httpMock.scope(githubApiHost);
       forkInitRepoMock(scope, 'some/repo', true);
+      scope.patch('/repos/forked/repo/git/refs/heads/master').reply(200);
       const config = await github.initRepo({
         repository: 'some/repo',
         forkMode: true,
@@ -312,6 +313,7 @@ describe('platform/github/index', () => {
       forkInitRepoMock(scope, 'some/repo', true, 'not_master');
       scope.post('/repos/forked/repo/git/refs').reply(200);
       scope.patch('/repos/forked/repo').reply(200);
+      scope.patch('/repos/forked/repo/git/refs/heads/master').reply(200);
       const config = await github.initRepo({
         repository: 'some/repo',
         forkMode: true,
@@ -730,7 +732,9 @@ describe('platform/github/index', () => {
           },
           head: { ref: 'somebranch', repo: { full_name: 'other/repo' } },
           state: PrState.Open,
-        });
+        })
+        .patch('/repos/forked/repo/git/refs/heads/master')
+        .reply(200);
       await github.initRepo({
         repository: 'some/repo',
         forkMode: true,

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -121,10 +121,9 @@ export async function validateGitVersion(): Promise<boolean> {
   return true;
 }
 
-async function fetchBranchCommits(preferUpstream = true): Promise<void> {
+async function fetchBranchCommits(): Promise<void> {
   config.branchCommits = {};
-  const url = (preferUpstream && config.upstreamUrl) || config.url;
-  const opts = ['ls-remote', '--heads', url];
+  const opts = ['ls-remote', '--heads', config.url];
   if (config.extraCloneOpts) {
     Object.entries(config.extraCloneOpts).forEach((e) =>
       opts.unshift(e[0], `${e[1]}`)
@@ -314,6 +313,7 @@ export async function syncGit(): Promise<void> {
     const durationMs = Math.round(Date.now() - cloneStart);
     logger.debug({ durationMs }, 'git clone completed');
   }
+  config.currentBranchSha = (await git.raw(['rev-parse', 'HEAD'])).trim();
   if (config.cloneSubmodules) {
     const submodules = await getSubmodules();
     for (const submodule of submodules) {
@@ -339,23 +339,6 @@ export async function syncGit(): Promise<void> {
     logger.warn({ err }, 'Cannot retrieve latest commit');
   }
   config.currentBranch = config.currentBranch || (await getDefaultBranch(git));
-  // istanbul ignore if
-  if (config.upstreamUrl) {
-    logger.debug(`Resetting ${config.currentBranch} to upstream`);
-    await git.addRemote('upstream', config.upstreamUrl);
-    await git.fetch(['upstream']);
-    await resetToBranch(config.currentBranch);
-    const resetLog = await git.reset([
-      '--hard',
-      `upstream/${config.currentBranch}`,
-    ]);
-    logger.debug({ resetLog }, 'git reset log');
-    const pushLog = await git.push(['origin', config.currentBranch, '--force']);
-    logger.debug({ pushLog }, 'git push log');
-    await fetchBranchCommits(false);
-  }
-  config.currentBranchSha = (await git.raw(['rev-parse', 'HEAD'])).trim();
-  logger.debug(`Current branch SHA: ${config.currentBranchSha}`);
 }
 
 // istanbul ignore next
@@ -408,10 +391,7 @@ export async function checkoutBranch(branchName: string): Promise<CommitSha> {
     await git.checkout(['-f', branchName, '--']);
     const latestCommitDate = (await git.log({ n: 1 }))?.latest?.date;
     if (latestCommitDate) {
-      logger.debug(
-        { branchName, latestCommitDate, sha: config.currentBranchSha },
-        'latest commit'
-      );
+      logger.debug({ branchName, latestCommitDate }, 'latest commit');
     }
     await git.reset(ResetMode.HARD);
     return config.currentBranchSha;

--- a/lib/util/git/types.ts
+++ b/lib/util/git/types.ts
@@ -14,8 +14,6 @@ export type CommitSha = string;
 export interface StorageConfig {
   currentBranch?: string;
   url: string;
-
-  upstreamUrl?: string;
   extraCloneOpts?: GitOptions;
   cloneSubmodules?: boolean;
   fullClone?: boolean;


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

This reverts commit 152ad14672fb5de9569adadb6a7feeb2fa3c2c22.

## Context:

https://github.com/renovatebot/renovate/discussions/13800#discussioncomment-2050215

I believe the original problem was due to the fact that the PAT didn't have `workflow` permissions and GitHub has some hardcoded logic to block any push which changes `.github/workflows/*` without such permission. So reverting back for now.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
