### PR TITLE
test(onboarding): Remove inconvenient helper function

### DIFF
--- a/lib/workers/repository/onboarding/branch/create.spec.ts
+++ b/lib/workers/repository/onboarding/branch/create.spec.ts
@@ -31,7 +31,6 @@ describe('workers/repository/onboarding/branch/create', () => {
           },
         ],
         message: 'Add renovate.json',
-        platformCommit: false,
       });
     });
     it('applies supplied commit message', async () => {
@@ -52,7 +51,6 @@ describe('workers/repository/onboarding/branch/create', () => {
           },
         ],
         message,
-        platformCommit: false,
       });
     });
     describe('applies the commitMessagePrefix value', () => {
@@ -74,7 +72,6 @@ describe('workers/repository/onboarding/branch/create', () => {
             },
           ],
           message,
-          platformCommit: false,
         });
       });
       it('to the supplied commit message', async () => {
@@ -98,7 +95,6 @@ describe('workers/repository/onboarding/branch/create', () => {
             },
           ],
           message,
-          platformCommit: false,
         });
       });
     });
@@ -121,7 +117,6 @@ describe('workers/repository/onboarding/branch/create', () => {
             },
           ],
           message,
-          platformCommit: false,
         });
       });
       it('to the supplied commit message', async () => {
@@ -145,7 +140,6 @@ describe('workers/repository/onboarding/branch/create', () => {
             },
           ],
           message,
-          platformCommit: false,
         });
       });
     });
@@ -169,7 +163,6 @@ describe('workers/repository/onboarding/branch/create', () => {
             },
           ],
           message,
-          platformCommit: false,
         });
       });
       it('falls back to the default option if in list of allowed names', async () => {
@@ -191,7 +184,6 @@ describe('workers/repository/onboarding/branch/create', () => {
             },
           ],
           message,
-          platformCommit: false,
         });
       });
       it('uses the given name if valid', async () => {
@@ -214,7 +206,6 @@ describe('workers/repository/onboarding/branch/create', () => {
             },
           ],
           message,
-          platformCommit: false,
         });
       });
       it('applies to the default commit message', async () => {
@@ -231,7 +222,6 @@ describe('workers/repository/onboarding/branch/create', () => {
           branchName: 'renovate/configure',
           files: [{ type: 'addition', path, contents: '{"foo":"bar"}' }],
           message,
-          platformCommit: false,
         });
       });
     });

--- a/lib/workers/repository/onboarding/branch/create.spec.ts
+++ b/lib/workers/repository/onboarding/branch/create.spec.ts
@@ -11,21 +11,6 @@ jest.mock('./config', () => ({
     }),
 }));
 
-const buildExpectedCommitFilesArgument = (
-  message: string,
-  filename = 'renovate.json'
-) => ({
-  branchName: 'renovate/configure',
-  files: [
-    {
-      type: 'addition',
-      path: filename,
-      contents: '{"foo":"bar"}',
-    },
-  ],
-  message,
-});
-
 describe('workers/repository/onboarding/branch/create', () => {
   let config: RenovateConfig;
   beforeEach(() => {
@@ -35,115 +20,219 @@ describe('workers/repository/onboarding/branch/create', () => {
   describe('createOnboardingBranch', () => {
     it('applies the default commit message', async () => {
       await createOnboardingBranch(config);
-      expect(commitFiles).toHaveBeenCalledWith(
-        buildExpectedCommitFilesArgument('Add renovate.json')
-      );
+
+      expect(commitFiles).toHaveBeenCalledWith({
+        branchName: 'renovate/configure',
+        files: [
+          {
+            type: 'addition',
+            path: 'renovate.json',
+            contents: '{"foo":"bar"}',
+          },
+        ],
+        message: 'Add renovate.json',
+        platformCommit: false,
+      });
     });
     it('applies supplied commit message', async () => {
       const message =
         'We can Renovate if we want to, we can leave PRs in decline';
+
       config.onboardingCommitMessage = message;
+
       await createOnboardingBranch(config);
-      expect(commitFiles).toHaveBeenCalledWith(
-        buildExpectedCommitFilesArgument(`${message}`)
-      );
+
+      expect(commitFiles).toHaveBeenCalledWith({
+        branchName: 'renovate/configure',
+        files: [
+          {
+            type: 'addition',
+            path: 'renovate.json',
+            contents: '{"foo":"bar"}',
+          },
+        ],
+        message,
+        platformCommit: false,
+      });
     });
     describe('applies the commitMessagePrefix value', () => {
       it('to the default commit message', async () => {
         const prefix = 'RENOV-123';
+        const message = `${prefix}${CommitMessage.SEPARATOR} add renovate.json`;
+
         config.commitMessagePrefix = prefix;
+
         await createOnboardingBranch(config);
-        expect(commitFiles).toHaveBeenCalledWith(
-          buildExpectedCommitFilesArgument(
-            `${prefix}${CommitMessage.SEPARATOR} add renovate.json`
-          )
-        );
+
+        expect(commitFiles).toHaveBeenCalledWith({
+          branchName: 'renovate/configure',
+          files: [
+            {
+              type: 'addition',
+              path: 'renovate.json',
+              contents: '{"foo":"bar"}',
+            },
+          ],
+          message,
+          platformCommit: false,
+        });
       });
       it('to the supplied commit message', async () => {
         const prefix = 'RENOV-123';
-        const message =
+        const text =
           "Cause your deps need an update and if they dont update, well they're no deps of mine";
+        const message = `${prefix}${CommitMessage.SEPARATOR} ${text}`;
+
         config.commitMessagePrefix = prefix;
-        config.onboardingCommitMessage = message;
+        config.onboardingCommitMessage = text;
+
         await createOnboardingBranch(config);
-        expect(commitFiles).toHaveBeenCalledWith(
-          buildExpectedCommitFilesArgument(
-            `${prefix}${CommitMessage.SEPARATOR} ${message}`
-          )
-        );
+
+        expect(commitFiles).toHaveBeenCalledWith({
+          branchName: 'renovate/configure',
+          files: [
+            {
+              type: 'addition',
+              path: 'renovate.json',
+              contents: '{"foo":"bar"}',
+            },
+          ],
+          message,
+          platformCommit: false,
+        });
       });
     });
     describe('applies semanticCommit prefix', () => {
       it('to the default commit message', async () => {
         const prefix = 'chore(deps)';
+        const message = `${prefix}${CommitMessage.SEPARATOR} add renovate.json`;
+
         config.semanticCommits = 'enabled';
+
         await createOnboardingBranch(config);
-        expect(commitFiles).toHaveBeenCalledWith(
-          buildExpectedCommitFilesArgument(
-            `${prefix}${CommitMessage.SEPARATOR} add renovate.json`
-          )
-        );
+
+        expect(commitFiles).toHaveBeenCalledWith({
+          branchName: 'renovate/configure',
+          files: [
+            {
+              type: 'addition',
+              path: 'renovate.json',
+              contents: '{"foo":"bar"}',
+            },
+          ],
+          message,
+          platformCommit: false,
+        });
       });
       it('to the supplied commit message', async () => {
         const prefix = 'chore(deps)';
-        const message =
+        const text =
           'I say, we can update when we want to, a commit they will never mind';
+        const message = `${prefix}${CommitMessage.SEPARATOR} ${text}`;
+
         config.semanticCommits = 'enabled';
-        config.onboardingCommitMessage = message;
+        config.onboardingCommitMessage = text;
+
         await createOnboardingBranch(config);
-        expect(commitFiles).toHaveBeenCalledWith(
-          buildExpectedCommitFilesArgument(
-            `${prefix}${CommitMessage.SEPARATOR} ${message}`
-          )
-        );
+
+        expect(commitFiles).toHaveBeenCalledWith({
+          branchName: 'renovate/configure',
+          files: [
+            {
+              type: 'addition',
+              path: 'renovate.json',
+              contents: '{"foo":"bar"}',
+            },
+          ],
+          message,
+          platformCommit: false,
+        });
       });
     });
     describe('setting the onboarding configuration file name', () => {
       it('falls back to the default option if not present', async () => {
         const prefix = 'chore(deps)';
+        const message = `${prefix}${CommitMessage.SEPARATOR} add renovate.json`;
+
         config.semanticCommits = 'enabled';
         config.onboardingConfigFileName = undefined;
+
         await createOnboardingBranch(config);
-        expect(commitFiles).toHaveBeenCalledWith(
-          buildExpectedCommitFilesArgument(
-            `${prefix}${CommitMessage.SEPARATOR} add renovate.json`
-          )
-        );
+
+        expect(commitFiles).toHaveBeenCalledWith({
+          branchName: 'renovate/configure',
+          files: [
+            {
+              type: 'addition',
+              path: 'renovate.json',
+              contents: '{"foo":"bar"}',
+            },
+          ],
+          message,
+          platformCommit: false,
+        });
       });
       it('falls back to the default option if in list of allowed names', async () => {
         const prefix = 'chore(deps)';
+        const message = `${prefix}${CommitMessage.SEPARATOR} add renovate.json`;
+
         config.semanticCommits = 'enabled';
         config.onboardingConfigFileName = 'superConfigFile.yaml';
+
         await createOnboardingBranch(config);
-        expect(commitFiles).toHaveBeenCalledWith(
-          buildExpectedCommitFilesArgument(
-            `${prefix}${CommitMessage.SEPARATOR} add renovate.json`
-          )
-        );
+
+        expect(commitFiles).toHaveBeenCalledWith({
+          branchName: 'renovate/configure',
+          files: [
+            {
+              type: 'addition',
+              path: 'renovate.json',
+              contents: '{"foo":"bar"}',
+            },
+          ],
+          message,
+          platformCommit: false,
+        });
       });
       it('uses the given name if valid', async () => {
         const prefix = 'chore(deps)';
+        const path = '.gitlab/renovate.json';
+        const message = `${prefix}${CommitMessage.SEPARATOR} add ${path}`;
+
         config.semanticCommits = 'enabled';
-        config.onboardingConfigFileName = '.gitlab/renovate.json';
+        config.onboardingConfigFileName = path;
+
         await createOnboardingBranch(config);
-        expect(commitFiles).toHaveBeenCalledWith(
-          buildExpectedCommitFilesArgument(
-            `${prefix}${CommitMessage.SEPARATOR} add ${config.onboardingConfigFileName}`,
-            config.onboardingConfigFileName
-          )
-        );
+
+        expect(commitFiles).toHaveBeenCalledWith({
+          branchName: 'renovate/configure',
+          files: [
+            {
+              type: 'addition',
+              path,
+              contents: '{"foo":"bar"}',
+            },
+          ],
+          message,
+          platformCommit: false,
+        });
       });
       it('applies to the default commit message', async () => {
         const prefix = 'chore(deps)';
+        const path = `.renovaterc`;
+        const message = `${prefix}${CommitMessage.SEPARATOR} add ${path}`;
+
         config.semanticCommits = 'enabled';
-        config.onboardingConfigFileName = `.renovaterc`;
+        config.onboardingConfigFileName = path;
+
         await createOnboardingBranch(config);
-        expect(commitFiles).toHaveBeenCalledWith(
-          buildExpectedCommitFilesArgument(
-            `${prefix}${CommitMessage.SEPARATOR} add ${config.onboardingConfigFileName}`,
-            config.onboardingConfigFileName
-          )
-        );
+
+        expect(commitFiles).toHaveBeenCalledWith({
+          branchName: 'renovate/configure',
+          files: [{ type: 'addition', path, contents: '{"foo":"bar"}' }],
+          message,
+          platformCommit: false,
+        });
       });
     });
   });


### PR DESCRIPTION
## Changes:

- Remove `buildExpectedCommitFilesArgument` function
- Accentuate Arrange/Act/Assert sections

## Context:

- Auxilary for #13823

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
