### PR TITLE
docs(nuget): Document lockfile exception

### DIFF
--- a/docs/usage/nuget.md
+++ b/docs/usage/nuget.md
@@ -49,6 +49,8 @@ In this example we defined 3 NuGet feeds.
 The package resolving process uses the `merge` strategy to handle the 3 feeds.
 All feeds are checked for dependency updates, and duplicate updates are merged/joined together into a single dependency update.
 
+If your project uses lockfiles (a `package.lock.json` exists), configuration settings are ignored and _only_ `NuGet.config` and `https://api.nuget.org/v3/index.json` are considered for lookups.
+
 ### Protocol versions
 
 NuGet supports two protocol versions, `v2` and `v3`, the NuGet client and server must use the same protocol version.

--- a/docs/usage/nuget.md
+++ b/docs/usage/nuget.md
@@ -49,7 +49,7 @@ In this example we defined 3 NuGet feeds.
 The package resolving process uses the `merge` strategy to handle the 3 feeds.
 All feeds are checked for dependency updates, and duplicate updates are merged/joined together into a single dependency update.
 
-If your project uses lockfiles (a `package.lock.json` exists), alternate feed settings are ignored and _only_ `NuGet.config` and `https://api.nuget.org/v3/index.json` are considered for lookups.
+If your project uses lockfiles (a `package.lock.json` exists), alternate feed settings must be defined in a `NuGet.config` as `registryUrls` are not passed through to the NuGet commands used.
 
 ### Protocol versions
 

--- a/docs/usage/nuget.md
+++ b/docs/usage/nuget.md
@@ -49,7 +49,7 @@ In this example we defined 3 NuGet feeds.
 The package resolving process uses the `merge` strategy to handle the 3 feeds.
 All feeds are checked for dependency updates, and duplicate updates are merged/joined together into a single dependency update.
 
-If your project uses lockfiles (a `package.lock.json` exists), alternate feed settings must be defined in a `NuGet.config` as `registryUrls` are not passed through to the NuGet commands used.
+If your project uses lockfiles (a `package.lock.json` exists), alternate feed settings must be defined in a `NuGet.config` only, as `registryUrls` are not passed through to the NuGet commands used.
 
 ### Protocol versions
 

--- a/docs/usage/nuget.md
+++ b/docs/usage/nuget.md
@@ -49,7 +49,7 @@ In this example we defined 3 NuGet feeds.
 The package resolving process uses the `merge` strategy to handle the 3 feeds.
 All feeds are checked for dependency updates, and duplicate updates are merged/joined together into a single dependency update.
 
-If your project uses lockfiles (a `package.lock.json` exists), configuration settings are ignored and _only_ `NuGet.config` and `https://api.nuget.org/v3/index.json` are considered for lookups.
+If your project uses lockfiles (a `package.lock.json` exists), alternate feed settings are ignored and _only_ `NuGet.config` and `https://api.nuget.org/v3/index.json` are considered for lookups.
 
 ### Protocol versions
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

as dicussed in #13589 this exception to nuget behaviour should be documented

although this point can be removed if #13591 gets considered.

## Context:

This is to avoid confusion and potentially safe others the time I invested while trying to figure out why this didn't work.

## Documentation (please check one with an [x])

- [X] I have updated the documentation, or

## How I've tested my work (please tick one)

I have verified these changes via:

doc update only

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
