### PR TITLE
docs(self-hosted config): use admonitions

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -183,7 +183,9 @@ The format of the environment variables must follow:
 Hyphens (`-`) in datasource or host name must be replaced with double underscores (`__`).
 Periods (`.`) in host names must be replaced with a single underscore (`_`).
 
-Note: the following prefixes cannot be supported for this functionality: `npm_config_`, `npm_lifecycle_`, `npm_package_`.
+<!-- prettier-ignore -->
+!!! note
+    The following prefixes cannot be supported for this functionality: `npm_config_`, `npm_lifecycle_`, `npm_package_`.
 
 ### npmjs registry token example
 
@@ -242,7 +244,9 @@ Adds a custom prefix to the default Renovate sidecar Docker containers name and 
 
 If this is set to `myprefix_` the final container created from `renovate/node` image would be named `myprefix_node` instead of currently used `renovate_node` and be labeled `myprefix_child` instead of `renovate_child`.
 
-Note that dangling containers will not be removed until Renovate is run with the same prefix again.
+<!-- prettier-ignore -->
+!!! note
+    Dangling containers will not be removed until Renovate is run with the same prefix again.
 
 ## dockerImagePrefix
 
@@ -385,13 +389,16 @@ Set this to `false` only if all three statements are true:
 
 ## onboardingBranch
 
-Note that this setting is independent of `branchPrefix`.
+<!-- prettier-ignore -->
+!!! note
+    This setting is independent of `branchPrefix`.
+
 For example, if you configure `branchPrefix` to be `renovate-` then you'd still have the onboarding PR created with branch `renovate/configure` until you configure `onboardingBranch=renovate-configure` or similar.
 If you have an existing Renovate installation and you change `onboardingBranch` then it's possible that you'll get onboarding PRs for repositories that had previously closed the onboarding PR unmerged.
 
 ## onboardingCommitMessage
 
-Note that if `commitMessagePrefix` or `semanticCommits` values are defined then they will be prepended to the commit message using the same logic that is used for adding them to non-onboarding commit messages.
+If `commitMessagePrefix` or `semanticCommits` values are defined then they will be prepended to the commit message using the same logic that is used for adding them to non-onboarding commit messages.
 
 ## onboardingConfig
 
@@ -505,7 +512,9 @@ Any encrypted secrets using GPG must have a mandatory organization/group scope, 
 The reason for this is to avoid "replay" attacks where someone could learn your encrypted secret and then reuse it in their own Renovate repositories.
 Instead, with scoped secrets it means that Renovate ensures that the organization and optionally repository values encrypted with the secret match against the running repository.
 
-Note: simple public key encryption was previously used to encrypt secrets, but this approach has now been deprecated and no longer documented.
+<!-- prettier-ignore -->
+!!! note
+    Simple public key encryption was previously used to encrypt secrets, but this approach has been deprecated and is no longer documented.
 
 ## privateKeyOld
 
@@ -543,7 +552,9 @@ Set this to `"enabled"` to have Renovate maintain a JSON file cache per-reposito
 Set to `"reset"` if you ever need to bypass the cache and have it overwritten.
 JSON files will be stored inside the `cacheDir` beside the existing file-based package cache.
 
-Warning: this is an experimental feature and may be modified or removed in a future non-major release.
+<!-- prettier-ignore -->
+!!! warning
+    This is an experimental feature and may be modified or removed in a future non-major release.
 
 ## requireConfig
 

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -246,7 +246,7 @@ If this is set to `myprefix_` the final container created from `renovate/node` i
 
 <!-- prettier-ignore -->
 !!! note
-    Dangling containers will not be removed until Renovate is run with the same prefix again.
+    Dangling containers will only be removed when Renovate runs again with the same prefix.
 
 ## dockerImagePrefix
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Rewrite one sentence so it no longer starts with `Note that if`
- Convert notes and one warning to their respective admonition blocks

## Context:

Helps with #13665 but does not close it.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
