### PR TITLE
docs(configuration options): use admonitions

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -210,7 +210,7 @@ If by the next run the PR is already behind the base branch it will be automatic
 If Renovate is scheduled for hourly runs on the repository but commits are made every 15 minutes to the main branch, then an automerge like this will keep getting deferred with every rebase.
 
 <!-- prettier-ignore -->
-!!! note
+!!! tip
     If you have no tests but still want Renovate to automerge, you need to add `"ignoreTests": true` to your configuration.
 
 If you prefer that Renovate more silently automerge _without_ Pull Requests at all, you can configure `"automergeType": "branch"`. In this case Renovate will:

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -488,7 +488,7 @@ Examples of what having a Dependency Dashboard will allow you to do:
 - Recreate an unmerged PR (e.g. for a major update that you postponed by closing the original PR)
 
 <!-- prettier-ignore -->
-!!! note
+!!! tip
     Enabling the Dependency Dashboard does not itself change any of the "control flow" of Renovate, e.g. it will otherwise still create and manage PRs exactly as it always has, including scheduling and rate limiting.
     The Dependency Dashboard therefore provides visibility as well as additional control.
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -20,7 +20,9 @@ You can store your Renovate configuration file in one of the following locations
 1. `.renovaterc.json`
 1. `package.json` _(within a `"renovate"` section)_
 
-_Note_: Storing the Renovate configuration in a `package.json` file is deprecated and support may be removed in the future.
+<!-- prettier-ignore -->
+!!! warning
+    Storing the Renovate configuration in a `package.json` file is deprecated and support may be removed in the future.
 
 When renovating a repository, Renovate will try to detect the configuration files in the order listed above, and stop after the first one is found.
 
@@ -159,9 +161,11 @@ So for example you could elect to automerge all (passing) `devDependencies` only
 
 Important: Renovate won't automerge on GitHub if a PR has a negative review outstanding.
 
-Note: on Azure there can be a delay between a PR being set as completed by Renovate, and Azure merging the PR / finishing its tasks.
-Renovate will try to delay until Azure is in the expected state, however if it takes too long it will continue.
-In some cases this can result in a dependency not being merged, and a fresh PR being created for the dependency.
+<!-- prettier-ignore -->
+!!! note
+    On Azure there can be a delay between a PR being set as completed by Renovate, and Azure merging the PR / finishing its tasks.
+    Renovate will try to delay until Azure is in the expected state, however if it takes too long it will continue.
+    In some cases this can result in a dependency not being merged, and a fresh PR being created for the dependency.
 
 ## automergeComment
 
@@ -205,7 +209,9 @@ In that case Renovate first creates a branch and associated Pull Request, and th
 If by the next run the PR is already behind the base branch it will be automatically rebased, because Renovate only automerges branches which are up-to-date and green.
 If Renovate is scheduled for hourly runs on the repository but commits are made every 15 minutes to the main branch, then an automerge like this will keep getting deferred with every rebase.
 
-Note: if you have no tests but still want Renovate to automerge, you need to add `"ignoreTests": true` to your configuration.
+<!-- prettier-ignore -->
+!!! note
+    If you have no tests but still want Renovate to automerge, you need to add `"ignoreTests": true` to your configuration.
 
 If you prefer that Renovate more silently automerge _without_ Pull Requests at all, you can configure `"automergeType": "branch"`. In this case Renovate will:
 
@@ -240,7 +246,9 @@ However, Renovate also allows users to explicitly configure `baseBranches`, e.g.
 It's possible to add this setting into the `renovate.json` file as part of the "Configure Renovate" onboarding PR.
 If so then Renovate will reflect this setting in its description and use package file contents from the custom base branch(es) instead of default.
 
-Note: the `baseBranches` config option is not supported when `forkMode` is enabled, including in the Forking Renovate app.
+<!-- prettier-ignore -->
+!!! note
+    The `baseBranches` config option is not supported when `forkMode` is enabled, including in the Forking Renovate app.
 
 ## bbUseDefaultReviewers
 
@@ -264,8 +272,10 @@ Example config:
 }
 ```
 
-Warning: Leaving PRs/branches as unlimited or as a high number increases the time it takes for Renovate to process a repository.
-If you find that Renovate is too slow when rebasing out-of-date branches, decrease the `branchConcurrentLimit`.
+<!-- prettier-ignore -->
+!!! warning
+    Leaving PRs/branches as unlimited or as a high number increases the time it takes for Renovate to process a repository.
+    If you find that Renovate is too slow when rebasing out-of-date branches, decrease the `branchConcurrentLimit`.
 
 If you have too many concurrent branches which rebase themselves each run, Renovate can take a lot of time to rebase.
 Solutions:
@@ -275,8 +285,11 @@ Solutions:
 
 ## branchName
 
-Warning: it's strongly recommended not to configure this field directly.
-Use at your own risk.
+<!-- prettier-ignore -->
+!!! warning
+    We strongly recommended that you do not configure this field directly.
+    Use at your own risk.
+
 If you truly need to configure this then it probably means either:
 
 - You are hopefully mistaken, and there's a better approach you should use, so open a new "config help" discussion at the [Renovate discussions tab](https://github.com/renovatebot/renovate/discussions) or
@@ -291,8 +304,10 @@ Or if you wish to avoid forward slashes in branch names then you could use `reno
 `branchPrefix` must be configured at the root of the configuration (e.g. not within any package rule) and is not allowed to use template values.
 e.g. instead of `renovate/{{parentDir}}-`, configure the template part in `additionalBranchPrefix`, like `"additionalBranchPrefix": "{{parentDir}}-"`.
 
-Note that this setting does not change the default _onboarding_ branch name, i.e. `renovate/configure`.
-If you wish to change that too, you need to also configure the field `onboardingBranch` in your global bot config.
+<!-- prettier-ignore -->
+!!! note
+    This setting does not change the default _onboarding_ branch name, i.e. `renovate/configure`.
+    If you wish to change that too, you need to also configure the field `onboardingBranch` in your global bot config.
 
 ## branchTopic
 
@@ -390,9 +405,15 @@ The Composer output should inform you about the reasons the update failed.
 ## confidential
 
 If enabled, all issues created by Renovate are set as confidential, even in a public repository.
-**Note:** the Dependency Dashboard issue will also be confidential.
-By default issues created by Renovate are visible to all users.
-This option is applicable to GitLab only.
+
+<!-- prettier-ignore -->
+!!! note
+    The Dependency Dashboard issue will also be confidential.
+    By default issues created by Renovate are visible to all users.
+
+<!-- prettier-ignore -->
+!!! note
+    This option is applicable to GitLab only.
 
 ## configWarningReuseIssue
 
@@ -429,11 +450,15 @@ If you need to _override_ constraints that Renovate detects from the repository,
 }
 ```
 
-Note: make sure not to mix this up with the term `compatibility`, which Renovate uses in the context of version releases, e.g. if a Docker image is `node:12.16.0-alpine` then the `-alpine` suffix represents `compatibility`.
+<!-- prettier-ignore -->
+!!! note
+    Make sure not to mix this up with the term `compatibility`, which Renovate uses in the context of version releases, e.g. if a Docker image is `node:12.16.0-alpine` then the `-alpine` suffix represents `compatibility`.
 
 ## deepExtract
 
-Note: the `deepExtract` configuration option is deprecated, and will be removed in a future Renovate release.
+<!-- prettier-ignore -->
+!!! warning
+    The `deepExtract` configuration option is deprecated, and will be removed in a future Renovate release.
 
 If configured to `true`, then dependency extraction will be done using the relevant package manager instead of JavaScript-based parsing.
 
@@ -462,8 +487,10 @@ Examples of what having a Dependency Dashboard will allow you to do:
 - Override any rate limiting (e.g. concurrent PRs) or scheduling to force Renovate to create a PR that would otherwise be suppressed
 - Recreate an unmerged PR (e.g. for a major update that you postponed by closing the original PR)
 
-Note: Enabling the Dependency Dashboard does not itself change any of the "control flow" of Renovate, e.g. it will otherwise still create and manage PRs exactly as it always has, including scheduling and rate limiting.
-The Dependency Dashboard therefore provides visibility as well as additional control.
+<!-- prettier-ignore -->
+!!! note
+    Enabling the Dependency Dashboard does not itself change any of the "control flow" of Renovate, e.g. it will otherwise still create and manage PRs exactly as it always has, including scheduling and rate limiting.
+    The Dependency Dashboard therefore provides visibility as well as additional control.
 
 ## dependencyDashboardApproval
 
@@ -472,7 +499,9 @@ This feature allows you to use Renovate's Dependency Dashboard to force approval
 By setting `dependencyDashboardApproval` to `true` in config (including within `packageRules`), you can tell Renovate to wait for your approval from the Dependency Dashboard before creating a branch/PR.
 You can approve a pending PR by ticking the checkbox in the Dependency Dashboard issue.
 
-Note: When you set `dependencyDashboardApproval` to `true` the Dependency Dashboard issue will be created automatically, you do not need to turn on `dependencyDashboard` explicitly.
+<!-- prettier-ignore -->
+!!! tip
+    When you set `dependencyDashboardApproval` to `true` the Dependency Dashboard issue will be created automatically, you do not need to turn on `dependencyDashboard` explicitly.
 
 You can configure Renovate to wait for approval for:
 
@@ -568,8 +597,10 @@ If you want the PRs created by Renovate to be considered as drafts rather than n
 
 This option is evaluated at PR/MR creation time and is only supported on the following platforms: GitHub, GitLab, Azure.
 
-Note that GitLab implements draft status by checking whether the PR's title starts with certain strings.
-Therefore, draftPR on GitLab is incompatible with the legacy method of triggering Renovate to rebase a PR by renaming the PR to start with `rebase!`.
+<!-- prettier-ignore -->
+!!! note
+    GitLab implements draft status by checking whether the PR's title starts with certain strings.
+    Therefore, `draftPR` on GitLab is incompatible with the legacy method of triggering Renovate to rebase a PR by renaming the PR to start with `rebase!`.
 
 ## enabled
 
@@ -628,12 +659,16 @@ For the full list of available managers, see the [Supported Managers](https://do
 
 See [Private module support](https://docs.renovatebot.com/getting-started/private-packages) for details on how this is used to encrypt npm tokens.
 
-Note: encrypted secrets must have at least an org/group scope, and optionally a repository scope.
-This means that Renovate will check if a secret's scope matches the current repository before applying it, and warn/discard if there is a mismatch.
+<!-- prettier-ignore -->
+!!! note
+    Encrypted secrets must have at least an org/group scope, and optionally a repository scope.
+    This means that Renovate will check if a secret's scope matches the current repository before applying it, and warn/discard if there is a mismatch.
 
 ## excludeCommitPaths
 
-Warning: Advanced use!
+<!-- prettier-ignore -->
+!!! warning
+    For advanced users only!
 
 Be careful you know what you're doing with this option.
 The initial intended use is to allow the user to exclude certain dependencies from being added/removed/modified when "vendoring" dependencies.
@@ -750,8 +785,10 @@ For example, if you are following a tag like `next` and then that stream is rele
 You can customize the Git author that's used whenever Renovate creates a commit.
 The `gitAuthor` option accepts a RFC5322-compliant string.
 
-**Note** We strongly recommend that the Git author email you use is unique to Renovate.
-Otherwise, if another bot or human shares the same email and pushes to one of Renovate's branches then Renovate will mistake the branch as unmodified and potentially force push over the changes.
+<!-- prettier-ignore -->
+!!! danger
+    We strongly recommend that the Git author email you use is unique to Renovate.
+    Otherwise, if another bot or human shares the same email and pushes to one of Renovate's branches then Renovate will mistake the branch as unmodified and potentially force push over the changes.
 
 ## gitIgnoredAuthors
 
@@ -836,7 +873,9 @@ If you wished to override this then you could configure like this:
 
 As a result of the above, the branchName would be `renovate/dev-dependencies` instead.
 
-Note: you shouldn't usually need to configure this unless you really care about your branch names.
+<!-- prettier-ignore -->
+!!! note
+    You shouldn't usually need to configure this unless you really care about your branch names.
 
 ## hashedBranchLength
 
@@ -889,8 +928,10 @@ A preset alternative to the above is:
 }
 ```
 
-Note: Disabling a host is only 100% effective if added to self-hosted config.
-Renovate currently still checks its _cache_ for results first before making connection attempts, so if a public host is blocked in your repository config (e.g. `renovate.json`) then it's possible you may get cached _results_ from that host if another repository using the same bot has successfully queried for the same dependency recently.
+<!-- prettier-ignore -->
+!!! note
+    Disabling a host is only 100% effective if added to self-hosted config.
+    Renovate currently still checks its _cache_ for results first before making connection attempts, so if a public host is blocked in your repository config (e.g. `renovate.json`) then it's possible you may get cached _results_ from that host if another repository using the same bot has successfully queried for the same dependency recently.
 
 ### abortIgnoreStatusCodes
 
@@ -908,7 +949,9 @@ For example to also skip 404 responses then configure the following:
 }
 ```
 
-Note that this field is _not_ mergeable, so the last-applied host rule will take precedence.
+<!-- prettier-ignore -->
+!!! tip
+    This field is _not_ mergeable, so the last-applied host rule takes precedence.
 
 ### abortOnError
 
@@ -1022,7 +1065,9 @@ You usually don't need to configure it in a host rule if you have already config
 
 ### insecureRegistry
 
-Warning: Advanced config, use at own risk.
+<!-- prettier-ignore -->
+!!! warning
+    Advanced config, use at your own risk.
 
 Enable this option to allow Renovate to connect to an [insecure Docker registry](https://docs.docker.com/registry/insecure/) that is http only.
 This is insecure and is not recommended.
@@ -1778,7 +1823,9 @@ For example, GitHub might automerge a Renovate branch even if it's behind the ba
 
 ## postUpgradeTasks
 
-Note: post-upgrade tasks can only be used on self-hosted Renovate instances.
+<!-- prettier-ignore -->
+!!! note
+    Post-upgrade tasks can only be used on self-hosted Renovate instances.
 
 Post-upgrade tasks are commands that are executed by Renovate after a dependency has been updated but before the commit is created.
 The intention is to run any additional command line tools that would modify existing files or generate new files when a dependency changes.
@@ -1833,7 +1880,9 @@ For example, if you wish to add the package file name to the table, you would ad
 }
 ```
 
-Note: "Package file" is predefined in the default `prBodyDefinitions` object so does not require a definition before it can be used.
+<!-- prettier-ignore -->
+!!! note
+    "Package file" is predefined in the default `prBodyDefinitions` object so does not require a definition before it can be used.
 
 ## prBodyDefinitions
 
@@ -1866,7 +1915,9 @@ Here is an example of adding a custom `"Sourcegraph"` column definition:
 }
 ```
 
-Note: Columns must also be included in the `prBodyColumns` array in order to be used, so that's why it's included above in the example.
+<!-- prettier-ignore -->
+!!! tip
+    Columns must also be included in the `prBodyColumns` array in order to be used, so that's why it's included above in the example.
 
 ## prBodyNotes
 
@@ -1890,7 +1941,7 @@ The available sections are header, table, notes, changelogs, configDescription, 
 
 This setting - if enabled - limits Renovate to a maximum of x concurrent PRs open at any time.
 
-Note that this limit is enforced on a per-repository basis.
+This limit is enforced on a per-repository basis.
 
 ## prCreation
 
@@ -1930,7 +1981,7 @@ Instead, if `prHourlyLimit` is configure to a value like 1 or 2, it will mean th
 So the project should still result in all PRs created perhaps within the first 24 hours maximum, but at a rate that may allow users to merge them once they pass tests.
 It does not place a limit on the number of _concurrently open_ PRs - only on the rate they are created.
 
-Note that this limit is enforced on a per-repository basis.
+This limit is enforced on a per-repository basis.
 
 ## prNotPendingHours
 
@@ -1938,7 +1989,9 @@ If you configure `prCreation=not-pending`, then Renovate will wait until tests a
 However there are cases where PRs may remain in pending state forever, e.g. absence of tests or status checks that are configure to pending indefinitely.
 Therefore we configure an upper limit for how long we wait until creating a PR.
 
-Note: if the option `stabilityDays` is non-zero then Renovate will disable the `prNotPendingHours` functionality.
+<!-- prettier-ignore -->
+!!! note
+    If the option `stabilityDays` is non-zero then Renovate disables the `prNotPendingHours` functionality.
 
 ## prPriority
 
@@ -2397,7 +2450,9 @@ every 3 months on the first day of the month
 * 0 2 * *
 ```
 
-Note: For Cron schedules, you _must_ use the `*` wildcard for the minutes value, as Renovate doesn't support minute granularity.
+<!-- prettier-ignore -->
+!!! warning
+    For Cron schedules, you _must_ use the `*` wildcard for the minutes value, as Renovate doesn't support minute granularity.
 
 One example might be that you don't want Renovate to run during your typical business hours, so that your build machines don't get clogged up testing `package.json` updates.
 You could then configure a schedule like this at the repository level:


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Use admonitions
- Rewrite some sentences so they no longer need a `note` text

## Context:

Helps with #13665 but does not close it.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
