### PR TITLE
docs(automerge): use admonition

### DIFF
--- a/docs/usage/key-concepts/automerge.md
+++ b/docs/usage/key-concepts/automerge.md
@@ -128,7 +128,10 @@ If you see "Automerge: Disabled by config" it means you need to make a config ch
 
 By default, Renovate will not automerge until it sees passing status checks / check runs for the branch.
 If you have no tests but still want Renovate to automerge, you need to add `"ignoreTests": true` to your configuration.
-However, we strongly recommend you have tests in any project where you are regularly updating dependencies.
+
+<!-- prettier-ignore -->
+!!! tip
+    We strongly recommend you have tests in any project where you are regularly updating dependencies.
 
 ### Committer restrictions
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Convert to a `tip` style admonition for a recommendation

## Context:

Helps with #13665, but does not close it.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
