### PR TITLE
docs(dependency-pinning): use admonition

### DIFF
--- a/docs/usage/dependency-pinning.md
+++ b/docs/usage/dependency-pinning.md
@@ -52,7 +52,10 @@ e.g. there might be a space of 30 minutes where your package specifies foobar `1
 You mainly pin versions for certainty, and visibility.
 When you have a pinned version of each dependency in your `package.json`, you know exactly which version of each dependency is installed at any time.
 This benefits when upgrading versions as well as when rolling back in case of problems.
-Note: we'll cover lock files later, don't worry.
+
+<!-- prettier-ignore -->
+!!! note
+    We'll cover lock files later, don't worry.
 
 ### Upgrading pinned versions
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Use a `note` admonition block

## Context:

Helps with #13665, but does not close it.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
