### PR TITLE
docs: add admonition for `deepExtract` deprecation

### DIFF
--- a/docs/usage/config-presets.md
+++ b/docs/usage/config-presets.md
@@ -253,7 +253,9 @@ For example the result may be:
 
 ## npm-hosted presets
 
-Using npm-hosted presets is deprecated, we recommend you do not follow these instructions and instead use a `local` preset.
+<!-- prettier-ignore -->
+!!! warning
+    Using npm-hosted presets is deprecated, we recommend you do not follow these instructions and instead use a `local` preset.
 
 If you manage multiple repositories using Renovate and want the same custom config across all or most of them, then you might want to consider publishing your own preset config so that you can "extend" it in every applicable repository.
 That way when you want to change your Renovate configuration you can make the change in one location rather than having to copy/paste it to every repository individually.

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -353,8 +353,10 @@ Another example would be if you want to configure a DCO signoff to each commit.
 
 ## commitMessage
 
-Editing of `commitMessage` directly is now deprecated and not recommended.
-Please instead edit the fields such as `commitMessageAction`, `commitMessageExtra`, etc.
+<!-- prettier-ignore -->
+!!! warning
+    Editing of `commitMessage` directly is now deprecated and not recommended.
+    Please instead edit the fields such as `commitMessageAction`, `commitMessageExtra`, etc.
 
 ## commitMessageAction
 

--- a/lib/manager/gradle/readme.md
+++ b/lib/manager/gradle/readme.md
@@ -1,7 +1,9 @@
 The `gradle` manager's default behavior uses a custom parser written in JavaScript, similar to many others managers.
 It was initially known as `gradle-lite` but is now integrated into the `gradle` manager and used as default.
 
-Note: the `deepExtract` configuration option is deprecated, and will be removed in a future Renovate release.
-
 If `deepExtract` is configured to `true`, Renovate instead extracts Gradle dependencies by calling a custom Gradle script.
 The `gradle` binary is then used to extract Maven-type dependencies.
+
+<!-- prettier-ignore -->
+!!! warning
+    The `deepExtract` configuration option is deprecated, and will be removed in a future Renovate release.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Add admonition for `deepExtract` deprecation

## Context:

Helps with #13665, but does not close it.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
