### PR TITLE
fix(dependency-dashboard): Add missing newline to "Awaiting Schedule" section

### DIFF
--- a/lib/workers/repository/__fixtures__/master-issue_with_8_PR.txt
+++ b/lib/workers/repository/__fixtures__/master-issue_with_8_PR.txt
@@ -10,6 +10,7 @@ These branches will be created by Renovate only once you click their checkbox be
 ## Awaiting Schedule
 
 These updates are awaiting their schedule. Click on a checkbox to get an update now.
+
  - [ ] <!-- unschedule-branch=branchName3 -->pr3
  - [ ] <!-- unschedule-branch=branchName4 -->pr4
 

--- a/lib/workers/repository/__snapshots__/dependency-dashboard.spec.ts.snap
+++ b/lib/workers/repository/__snapshots__/dependency-dashboard.spec.ts.snap
@@ -55,6 +55,7 @@ These branches will be created by Renovate only once you click their checkbox be
 ## Awaiting Schedule
 
 These updates are awaiting their schedule. Click on a checkbox to get an update now.
+
  - [x] <!-- unschedule-branch=branchName3 -->pr3
 
 "

--- a/lib/workers/repository/dependency-dashboard.spec.ts
+++ b/lib/workers/repository/dependency-dashboard.spec.ts
@@ -527,6 +527,7 @@ describe('workers/repository/dependency-dashboard', () => {
         ## Awaiting Schedule
 
         These updates are awaiting their schedule. Click on a checkbox to get an update now.
+
          - [x] <!-- unschedule-branch=branchName3 -->pr3
 
          - [x] <!-- rebase-all-open-prs -->'

--- a/lib/workers/repository/dependency-dashboard.ts
+++ b/lib/workers/repository/dependency-dashboard.ts
@@ -169,7 +169,7 @@ export async function ensureDependencyDashboard(
   if (awaitingSchedule.length) {
     issueBody += '## Awaiting Schedule\n\n';
     issueBody +=
-      'These updates are awaiting their schedule. Click on a checkbox to get an update now.\n';
+      'These updates are awaiting their schedule. Click on a checkbox to get an update now.\n\n';
     for (const branch of awaitingSchedule) {
       issueBody += getListItem(branch, 'unschedule');
     }


### PR DESCRIPTION
## Changes:

As in title

## Context:

Bitbucket Cloud has a stricter markdown-flavor than Github. Without this newline, the list turns into a large blob instead of being rendered. This was also inconsistent with the other sections.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository