### PR TITLE
fix(gomod): update go.sum entries for dependencies only referenced in tests

### DIFF
--- a/lib/manager/gomod/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/manager/gomod/__snapshots__/artifacts.spec.ts.snap
@@ -24,7 +24,7 @@ Array [
 exports[`manager/gomod/artifacts does not execute go mod tidy when none of gomodTidy and gomodUpdateImportPaths are set 2`] = `
 Array [
   Object {
-    "cmd": "go get -d ./...",
+    "cmd": "go get -d -t ./...",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -55,7 +55,7 @@ exports[`manager/gomod/artifacts returns if no go.sum found 1`] = `Array []`;
 exports[`manager/gomod/artifacts returns null if unchanged 1`] = `
 Array [
   Object {
-    "cmd": "go get -d ./...",
+    "cmd": "go get -d -t ./...",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -84,7 +84,7 @@ Array [
 exports[`manager/gomod/artifacts returns updated go.sum 1`] = `
 Array [
   Object {
-    "cmd": "go get -d ./...",
+    "cmd": "go get -d -t ./...",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -132,7 +132,7 @@ Array [
 exports[`manager/gomod/artifacts skips gomodTidy without gomodUpdateImportPaths on major update 2`] = `
 Array [
   Object {
-    "cmd": "go get -d ./...",
+    "cmd": "go get -d -t ./...",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -161,7 +161,7 @@ Array [
 exports[`manager/gomod/artifacts skips updating import paths for gopkg.in dependencies 1`] = `
 Array [
   Object {
-    "cmd": "go get -d ./...",
+    "cmd": "go get -d -t ./...",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -238,7 +238,7 @@ Array [
 exports[`manager/gomod/artifacts skips updating import paths with gomodUpdateImportPaths on v0 to v1 1`] = `
 Array [
   Object {
-    "cmd": "go get -d ./...",
+    "cmd": "go get -d -t ./...",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -279,7 +279,7 @@ Array [
     },
   },
   Object {
-    "cmd": "docker run --rm --name=renovate_go --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -e GOPROXY -e GOPRIVATE -e GONOPROXY -e GONOSUMDB -e GOFLAGS -e CGO_ENABLED -e GIT_CONFIG_KEY_0 -e GIT_CONFIG_VALUE_0 -e GIT_CONFIG_COUNT -w \\"/tmp/github/some/repo\\" renovate/go:latest bash -l -c \\"go get -d ./...\\"",
+    "cmd": "docker run --rm --name=renovate_go --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -e GOPROXY -e GOPRIVATE -e GONOPROXY -e GONOSUMDB -e GOFLAGS -e CGO_ENABLED -e GIT_CONFIG_KEY_0 -e GIT_CONFIG_VALUE_0 -e GIT_CONFIG_COUNT -w \\"/tmp/github/some/repo\\" renovate/go:latest bash -l -c \\"go get -d -t ./...\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -323,7 +323,7 @@ Array [
     },
   },
   Object {
-    "cmd": "docker run --rm --name=renovate_go --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -e GOPROXY -e GOPRIVATE -e GONOPROXY -e GONOSUMDB -e GOFLAGS -e CGO_ENABLED -w \\"/tmp/github/some/repo\\" renovate/go:latest bash -l -c \\"go get -d ./... && go mod tidy && go mod tidy\\"",
+    "cmd": "docker run --rm --name=renovate_go --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -e GOPROXY -e GOPRIVATE -e GONOPROXY -e GONOSUMDB -e GOFLAGS -e CGO_ENABLED -w \\"/tmp/github/some/repo\\" renovate/go:latest bash -l -c \\"go get -d -t ./... && go mod tidy && go mod tidy\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -364,7 +364,7 @@ Array [
     },
   },
   Object {
-    "cmd": "docker run --rm --name=renovate_go --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -e GOPROXY -e GOPRIVATE -e GONOPROXY -e GONOSUMDB -e GOFLAGS -e CGO_ENABLED -w \\"/tmp/github/some/repo\\" renovate/go:latest bash -l -c \\"go get -d ./... && go mod tidy -compat=1.17 && go mod tidy -compat=1.17\\"",
+    "cmd": "docker run --rm --name=renovate_go --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -e GOPROXY -e GOPRIVATE -e GONOPROXY -e GONOSUMDB -e GOFLAGS -e CGO_ENABLED -w \\"/tmp/github/some/repo\\" renovate/go:latest bash -l -c \\"go get -d -t ./... && go mod tidy -compat=1.17 && go mod tidy -compat=1.17\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -405,7 +405,7 @@ Array [
     },
   },
   Object {
-    "cmd": "docker run --rm --name=renovate_go --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -e GOPROXY -e GOPRIVATE -e GONOPROXY -e GONOSUMDB -e GOFLAGS -e CGO_ENABLED -w \\"/tmp/github/some/repo\\" renovate/go:latest bash -l -c \\"go get -d ./...\\"",
+    "cmd": "docker run --rm --name=renovate_go --label=renovate_child -v \\"/tmp/github/some/repo\\":\\"/tmp/github/some/repo\\" -v \\"/tmp/renovate/cache\\":\\"/tmp/renovate/cache\\" -e GOPROXY -e GOPRIVATE -e GONOPROXY -e GONOSUMDB -e GOFLAGS -e CGO_ENABLED -w \\"/tmp/github/some/repo\\" renovate/go:latest bash -l -c \\"go get -d -t ./...\\"",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -434,7 +434,7 @@ Array [
 exports[`manager/gomod/artifacts supports global mode 1`] = `
 Array [
   Object {
-    "cmd": "go get -d ./...",
+    "cmd": "go get -d -t ./...",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -463,7 +463,7 @@ Array [
 exports[`manager/gomod/artifacts supports vendor directory update 1`] = `
 Array [
   Object {
-    "cmd": "go get -d ./...",
+    "cmd": "go get -d -t ./...",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -588,7 +588,7 @@ Array [
 exports[`manager/gomod/artifacts updates import paths with gomodUpdateImportPaths 1`] = `
 Array [
   Object {
-    "cmd": "go get -d ./...",
+    "cmd": "go get -d -t ./...",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -713,7 +713,7 @@ Array [
 exports[`manager/gomod/artifacts updates import paths with latest tool version on invalid version constraint 1`] = `
 Array [
   Object {
-    "cmd": "go get -d ./...",
+    "cmd": "go get -d -t ./...",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -838,7 +838,7 @@ Array [
 exports[`manager/gomod/artifacts updates import paths with specific tool version from constraint 1`] = `
 Array [
   Object {
-    "cmd": "go get -d ./...",
+    "cmd": "go get -d -t ./...",
     "options": Object {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",

--- a/lib/manager/gomod/artifacts.ts
+++ b/lib/manager/gomod/artifacts.ts
@@ -184,7 +184,7 @@ export async function updateArtifacts({
 
     const execCommands = [];
 
-    let args = 'get -d ./...';
+    let args = 'get -d -t ./...';
     logger.debug({ cmd, args }, 'go get command included');
     execCommands.push(`${cmd} ${args}`);
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

* `go.sum` entries are now correctly updated for dependencies only referenced in test code

<!-- Describe what behavior is changed by this PR. -->

## Context:

Closes #13822.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
