### PR TITLE
fix: pass undefined to global secret replace

### DIFF
--- a/lib/config/secrets.spec.ts
+++ b/lib/config/secrets.spec.ts
@@ -133,5 +133,26 @@ describe('config/secrets', () => {
       });
       expect(Object.keys(res)).toContain('secrets');
     });
+    it('{} as secrets will result in an error', () => {
+      const config = {
+        secrets: { SECRET_MANAGER: 'npm' },
+        allowedManagers: ['{{ secrets.SECRET_MANAGER }}'],
+      };
+      expect(() => applySecretsToConfig(config, {}, false)).toThrow(
+        CONFIG_VALIDATION
+      );
+    });
+    it('undefined as secrets will result replace the secret', () => {
+      const config = {
+        secrets: { SECRET_MANAGER: 'npm' },
+        allowedManagers: ['{{ secrets.SECRET_MANAGER }}'],
+      };
+      const res = applySecretsToConfig(config, undefined, false);
+      expect(res).toStrictEqual({
+        secrets: { SECRET_MANAGER: 'npm' },
+        allowedManagers: ['npm'],
+      });
+      expect(Object.keys(res)).toContain('secrets');
+    });
   });
 });

--- a/lib/config/secrets.spec.ts
+++ b/lib/config/secrets.spec.ts
@@ -159,7 +159,7 @@ describe('config/secrets', () => {
         secrets: { SECRET_MANAGER: 'npm' },
         allowedManagers: ['{{ secrets.SECRET_MANAGER }}'],
       };
-      expect(() => applySecretsToConfig(config, {}, false)).toThrow(
+      expect(() => applySecretsToConfig(config, null, false)).toThrow(
         CONFIG_VALIDATION
       );
     });

--- a/lib/config/secrets.spec.ts
+++ b/lib/config/secrets.spec.ts
@@ -154,5 +154,14 @@ describe('config/secrets', () => {
       });
       expect(Object.keys(res)).toContain('secrets');
     });
+    it('null as secrets will result in an error', () => {
+      const config = {
+        secrets: { SECRET_MANAGER: 'npm' },
+        allowedManagers: ['{{ secrets.SECRET_MANAGER }}'],
+      };
+      expect(() => applySecretsToConfig(config, {}, false)).toThrow(
+        CONFIG_VALIDATION
+      );
+    });
   });
 });

--- a/lib/workers/repository/index.ts
+++ b/lib/workers/repository/index.ts
@@ -24,7 +24,9 @@ export async function renovateRepository(
   canRetry = true
 ): Promise<ProcessResult> {
   splitInit();
-  let config = GlobalConfig.set(applySecretsToConfig(repoConfig, {}, false));
+  let config = GlobalConfig.set(
+    applySecretsToConfig(repoConfig, undefined, false)
+  );
   await removeDanglingContainers();
   setMeta({ repository: config.repository });
   logger.info({ renovateVersion: pkg.version }, 'Repository started');


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [X] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
