### PR TITLE
refactor(github): remove unused commits from pr graphql query

### DIFF
--- a/lib/platform/github/__fixtures__/graphql/pullrequest-1.json
+++ b/lib/platform/github/__fixtures__/graphql/pullrequest-1.json
@@ -17,31 +17,6 @@
                   "name": "blocked"
                 }
               ]
-            },
-            "commits": {
-              "nodes": [
-                {
-                  "commit": {
-                    "author": {
-                      "email": "renovate@whitesourcesoftware.com"
-                    },
-                    "committer": {
-                      "name": "Renovate Bot",
-                      "email": "renovate@whitesourcesoftware.com"
-                    },
-                    "parents": {
-                      "edges": [
-                        {
-                          "node": {
-                            "abbreviatedOid": "1234",
-                            "oid": "1234123412341234123412341234123412341234"
-                          }
-                        }
-                      ]
-                    }
-                  }
-                }
-              ]
             }
           },
           {
@@ -50,63 +25,13 @@
             "headRefName": "renovate/jest-monorepo",
             "title": "chore(deps): update dependency jest to v23.6.0",
             "mergeable": "UNKNOWN",
-            "mergeStateStatus": "DIRTY",
-            "commits": {
-              "nodes": [
-                {
-                  "commit": {
-                    "author": {
-                      "email": "renovate@whitesourcesoftware.com"
-                    },
-                    "committer": {
-                      "name": "Renovate Bot",
-                      "email": "renovate@whitesourcesoftware.com"
-                    },
-                    "parents": {
-                      "edges": [
-                        {
-                          "node": {
-                            "abbreviatedOid": "b08d1aa",
-                            "oid": "b08d1aa8150c31516dcdf1d50a30020612e65d04"
-                          }
-                        }
-                      ]
-                    }
-                  }
-                }
-              ]
-            }
+            "mergeStateStatus": "DIRTY"
           },
           {
             "number": 2079,
             "headRefName": "feat/nodever",
             "title": "feat: node versioning (WIP)",
-            "mergeable": "MERGEABLE",
-            "commits": {
-              "nodes": [
-                {
-                  "commit": {
-                    "author": {
-                      "email": "rhys@arkins.net"
-                    },
-                    "committer": {
-                      "name": "Rhys Arkins",
-                      "email": "rhys@arkins.net"
-                    },
-                    "parents": {
-                      "edges": [
-                        {
-                          "node": {
-                            "abbreviatedOid": "233fa20",
-                            "oid": "233fa2078104581fba6beac10f3fd6765dedb300"
-                          }
-                        }
-                      ]
-                    }
-                  }
-                }
-              ]
-            }
+            "mergeable": "MERGEABLE"
           },
           {
             "number": 2086,
@@ -114,53 +39,7 @@
             "title": "feat(azure): abandon pr after delete branch",
             "mergeable": "MERGEABLE",
             "mergeStateStatus": "BEHIND",
-            "reviews": { "nodes": [ ] },
-            "commits": {
-              "nodes": [
-                {
-                  "commit": {
-                    "author": {
-                      "email": "SESA8879@schneider-electric.com"
-                    },
-                    "committer": {
-                      "name": "Jean-Yves COUET",
-                      "email": "SESA8879@schneider-electric.com"
-                    },
-                    "parents": {
-                      "edges": [
-                        {
-                          "node": {
-                            "abbreviatedOid": "670cfd8",
-                            "oid": "670cfd8feeda9d6236caeb8afe5d60191a275bc6"
-                          }
-                        }
-                      ]
-                    }
-                  }
-                },
-                {
-                  "commit": {
-                    "author": {
-                      "email": "SESA8879@schneider-electric.com"
-                    },
-                    "committer": {
-                      "name": "Jean-Yves COUET",
-                      "email": "SESA8879@schneider-electric.com"
-                    },
-                    "parents": {
-                      "edges": [
-                        {
-                          "node": {
-                            "abbreviatedOid": "c696654",
-                            "oid": "c69665439d8c1bf25cafc9c2db8e87c7ab274714"
-                          }
-                        }
-                      ]
-                    }
-                  }
-                }
-              ]
-            }
+            "reviews": { "nodes": [ ] }
           }
         ]
       }

--- a/lib/platform/github/__snapshots__/index.spec.ts.snap
+++ b/lib/platform/github/__snapshots__/index.spec.ts.snap
@@ -3527,32 +3527,6 @@ Array [
               },
               "baseRefName": null,
               "body": null,
-              "commits": Object {
-                "__args": Object {
-                  "first": "2",
-                },
-                "nodes": Object {
-                  "commit": Object {
-                    "author": Object {
-                      "email": null,
-                    },
-                    "committer": Object {
-                      "email": null,
-                    },
-                    "parents": Object {
-                      "__args": Object {
-                        "last": "1",
-                      },
-                      "edges": Object {
-                        "node": Object {
-                          "abbreviatedOid": null,
-                          "oid": null,
-                        },
-                      },
-                    },
-                  },
-                },
-              },
               "headRefName": null,
               "labels": Object {
                 "__args": Object {
@@ -3599,7 +3573,7 @@ Array [
       "accept": "application/vnd.github.merge-info-preview+json, application/vnd.github.v3+json",
       "accept-encoding": "gzip, deflate, br",
       "authorization": "token 123test",
-      "content-length": "1377",
+      "content-length": "934",
       "content-type": "application/json",
       "host": "api.github.com",
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
@@ -3864,32 +3838,6 @@ Array [
               },
               "baseRefName": null,
               "body": null,
-              "commits": Object {
-                "__args": Object {
-                  "first": "2",
-                },
-                "nodes": Object {
-                  "commit": Object {
-                    "author": Object {
-                      "email": null,
-                    },
-                    "committer": Object {
-                      "email": null,
-                    },
-                    "parents": Object {
-                      "__args": Object {
-                        "last": "1",
-                      },
-                      "edges": Object {
-                        "node": Object {
-                          "abbreviatedOid": null,
-                          "oid": null,
-                        },
-                      },
-                    },
-                  },
-                },
-              },
               "headRefName": null,
               "labels": Object {
                 "__args": Object {
@@ -3936,7 +3884,7 @@ Array [
       "accept": "application/vnd.github.merge-info-preview+json, application/vnd.github.v3+json",
       "accept-encoding": "gzip, deflate, br",
       "authorization": "token 123test",
-      "content-length": "1377",
+      "content-length": "934",
       "content-type": "application/json",
       "host": "api.github.com",
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
@@ -4179,32 +4127,6 @@ Array [
               },
               "baseRefName": null,
               "body": null,
-              "commits": Object {
-                "__args": Object {
-                  "first": "2",
-                },
-                "nodes": Object {
-                  "commit": Object {
-                    "author": Object {
-                      "email": null,
-                    },
-                    "committer": Object {
-                      "email": null,
-                    },
-                    "parents": Object {
-                      "__args": Object {
-                        "last": "1",
-                      },
-                      "edges": Object {
-                        "node": Object {
-                          "abbreviatedOid": null,
-                          "oid": null,
-                        },
-                      },
-                    },
-                  },
-                },
-              },
               "headRefName": null,
               "labels": Object {
                 "__args": Object {
@@ -4251,7 +4173,7 @@ Array [
       "accept": "application/vnd.github.merge-info-preview+json, application/vnd.github.v3+json",
       "accept-encoding": "gzip, deflate, br",
       "authorization": "token 123test",
-      "content-length": "1377",
+      "content-length": "934",
       "content-type": "application/json",
       "host": "api.github.com",
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
@@ -5413,32 +5335,6 @@ Array [
               },
               "baseRefName": null,
               "body": null,
-              "commits": Object {
-                "__args": Object {
-                  "first": "2",
-                },
-                "nodes": Object {
-                  "commit": Object {
-                    "author": Object {
-                      "email": null,
-                    },
-                    "committer": Object {
-                      "email": null,
-                    },
-                    "parents": Object {
-                      "__args": Object {
-                        "last": "1",
-                      },
-                      "edges": Object {
-                        "node": Object {
-                          "abbreviatedOid": null,
-                          "oid": null,
-                        },
-                      },
-                    },
-                  },
-                },
-              },
               "headRefName": null,
               "labels": Object {
                 "__args": Object {
@@ -5485,7 +5381,7 @@ Array [
       "accept": "application/vnd.github.merge-info-preview+json, application/vnd.github.v3+json",
       "accept-encoding": "gzip, deflate, br",
       "authorization": "token 123test",
-      "content-length": "1377",
+      "content-length": "934",
       "content-type": "application/json",
       "host": "api.github.com",
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
@@ -5658,32 +5554,6 @@ Array [
               },
               "baseRefName": null,
               "body": null,
-              "commits": Object {
-                "__args": Object {
-                  "first": "2",
-                },
-                "nodes": Object {
-                  "commit": Object {
-                    "author": Object {
-                      "email": null,
-                    },
-                    "committer": Object {
-                      "email": null,
-                    },
-                    "parents": Object {
-                      "__args": Object {
-                        "last": "1",
-                      },
-                      "edges": Object {
-                        "node": Object {
-                          "abbreviatedOid": null,
-                          "oid": null,
-                        },
-                      },
-                    },
-                  },
-                },
-              },
               "headRefName": null,
               "labels": Object {
                 "__args": Object {
@@ -5730,7 +5600,7 @@ Array [
       "accept": "application/vnd.github.merge-info-preview+json, application/vnd.github.v3+json",
       "accept-encoding": "gzip, deflate, br",
       "authorization": "token 123test",
-      "content-length": "1377",
+      "content-length": "934",
       "content-type": "application/json",
       "host": "api.github.com",
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
@@ -5833,32 +5703,6 @@ Array [
               },
               "baseRefName": null,
               "body": null,
-              "commits": Object {
-                "__args": Object {
-                  "first": "2",
-                },
-                "nodes": Object {
-                  "commit": Object {
-                    "author": Object {
-                      "email": null,
-                    },
-                    "committer": Object {
-                      "email": null,
-                    },
-                    "parents": Object {
-                      "__args": Object {
-                        "last": "1",
-                      },
-                      "edges": Object {
-                        "node": Object {
-                          "abbreviatedOid": null,
-                          "oid": null,
-                        },
-                      },
-                    },
-                  },
-                },
-              },
               "headRefName": null,
               "labels": Object {
                 "__args": Object {
@@ -5905,7 +5749,7 @@ Array [
       "accept": "application/vnd.github.merge-info-preview+json, application/vnd.github.v3+json",
       "accept-encoding": "gzip, deflate, br",
       "authorization": "token 123test",
-      "content-length": "1377",
+      "content-length": "934",
       "content-type": "application/json",
       "host": "api.github.com",
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
@@ -6091,32 +5935,6 @@ Array [
               },
               "baseRefName": null,
               "body": null,
-              "commits": Object {
-                "__args": Object {
-                  "first": "2",
-                },
-                "nodes": Object {
-                  "commit": Object {
-                    "author": Object {
-                      "email": null,
-                    },
-                    "committer": Object {
-                      "email": null,
-                    },
-                    "parents": Object {
-                      "__args": Object {
-                        "last": "1",
-                      },
-                      "edges": Object {
-                        "node": Object {
-                          "abbreviatedOid": null,
-                          "oid": null,
-                        },
-                      },
-                    },
-                  },
-                },
-              },
               "headRefName": null,
               "labels": Object {
                 "__args": Object {
@@ -6163,7 +5981,7 @@ Array [
       "accept": "application/vnd.github.merge-info-preview+json, application/vnd.github.v3+json",
       "accept-encoding": "gzip, deflate, br",
       "authorization": "token 123test",
-      "content-length": "1377",
+      "content-length": "934",
       "content-type": "application/json",
       "host": "api.github.com",
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
@@ -6348,32 +6166,6 @@ Array [
               },
               "baseRefName": null,
               "body": null,
-              "commits": Object {
-                "__args": Object {
-                  "first": "2",
-                },
-                "nodes": Object {
-                  "commit": Object {
-                    "author": Object {
-                      "email": null,
-                    },
-                    "committer": Object {
-                      "email": null,
-                    },
-                    "parents": Object {
-                      "__args": Object {
-                        "last": "1",
-                      },
-                      "edges": Object {
-                        "node": Object {
-                          "abbreviatedOid": null,
-                          "oid": null,
-                        },
-                      },
-                    },
-                  },
-                },
-              },
               "headRefName": null,
               "labels": Object {
                 "__args": Object {
@@ -6420,7 +6212,7 @@ Array [
       "accept": "application/vnd.github.merge-info-preview+json, application/vnd.github.v3+json",
       "accept-encoding": "gzip, deflate, br",
       "authorization": "token 123test",
-      "content-length": "1377",
+      "content-length": "934",
       "content-type": "application/json",
       "host": "api.github.com",
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
@@ -6589,32 +6381,6 @@ Array [
               },
               "baseRefName": null,
               "body": null,
-              "commits": Object {
-                "__args": Object {
-                  "first": "2",
-                },
-                "nodes": Object {
-                  "commit": Object {
-                    "author": Object {
-                      "email": null,
-                    },
-                    "committer": Object {
-                      "email": null,
-                    },
-                    "parents": Object {
-                      "__args": Object {
-                        "last": "1",
-                      },
-                      "edges": Object {
-                        "node": Object {
-                          "abbreviatedOid": null,
-                          "oid": null,
-                        },
-                      },
-                    },
-                  },
-                },
-              },
               "headRefName": null,
               "labels": Object {
                 "__args": Object {
@@ -6661,7 +6427,7 @@ Array [
       "accept": "application/vnd.github.merge-info-preview+json, application/vnd.github.v3+json",
       "accept-encoding": "gzip, deflate, br",
       "authorization": "token 123test",
-      "content-length": "1377",
+      "content-length": "934",
       "content-type": "application/json",
       "host": "api.github.com",
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",

--- a/lib/platform/github/graphql.ts
+++ b/lib/platform/github/graphql.ts
@@ -86,26 +86,6 @@ query($owner: String!, $name: String!, $count: Int, $cursor: String) {
         reviewRequests {
           totalCount
         }
-        commits(first: 2) {
-          nodes {
-            commit {
-              author {
-                email
-              }
-              committer {
-                email
-              }
-              parents(last: 1) {
-                edges {
-                  node {
-                    abbreviatedOid
-                    oid
-                  }
-                }
-              }
-            }
-          }
-        }
         body
         reviews(first: 1, states: [CHANGES_REQUESTED]){
           nodes{

--- a/lib/platform/github/index.ts
+++ b/lib/platform/github/index.ts
@@ -633,7 +633,6 @@ async function getOpenPrs(): Promise<PrList> {
         delete pr.reviewRequests;
         delete pr.mergeable;
         delete pr.mergeStateStatus;
-        delete pr.commits;
         config.openPrList[pr.number] = pr;
         prNumbers.push(pr.number);
       }

--- a/lib/platform/github/types.ts
+++ b/lib/platform/github/types.ts
@@ -43,7 +43,6 @@ export interface GhRestPr extends GhPr {
 }
 
 export interface GhGraphQlPr extends GhPr {
-  commits: any;
   reviewRequests: any;
   assignees: any;
   mergeStateStatus: string;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Removes unused `commits` from PRs query

## Context:

Unused field, we now check commit authors using git

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
