### PR TITLE
feat(config): workaround for web3j v5.0.0

### DIFF
--- a/lib/config/presets/internal/workarounds.ts
+++ b/lib/config/presets/internal/workarounds.ts
@@ -42,7 +42,7 @@ export const presets: Record<string, Preset> = {
       {
         matchDatasources: ['maven'],
         matchPackageNames: ['org.web3j:core'],
-        allowedVersions: '/^(?!5\\.0\\.0)/',
+        allowedVersions: '!/^5\\.0\\.0/',
       },
     ],
   },

--- a/lib/config/presets/internal/workarounds.ts
+++ b/lib/config/presets/internal/workarounds.ts
@@ -8,6 +8,7 @@ export const presets: Record<string, Preset> = {
     extends: [
       'workarounds:mavenCommonsAncientVersion',
       'workarounds:ignoreSpringCloudNumeric',
+      'workarounds:ignoreWeb3jCoreWithOldReleaseTimestamp',
       'workarounds:ignoreHttp4sDigestMilestones',
       'workarounds:typesNodeVersioning',
       'workarounds:reduceRepologyServerLoad',
@@ -32,6 +33,16 @@ export const presets: Record<string, Preset> = {
           'org.springframework.cloud:spring-cloud-starter-parent',
         ],
         allowedVersions: '/^[A-Z]/',
+      },
+    ],
+  },
+  ignoreWeb3jCoreWithOldReleaseTimestamp: {
+    description: 'Ignore web3j 5.0.0 release',
+    packageRules: [
+      {
+        matchDatasources: ['maven'],
+        matchPackageNames: ['org.web3j:core'],
+        allowedVersions: '/^(?!5\\.0\\.0)/',
       },
     ],
   },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Adds a workaround for web3j v5.0.0

## Context:

Closes #13857

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [X] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
