### PR TITLE
fix(docker): Skip lookup of dependencies with variable in image name

### DIFF
--- a/lib/manager/dockerfile/extract.spec.ts
+++ b/lib/manager/dockerfile/extract.spec.ts
@@ -665,5 +665,53 @@ Object {
         }
       `);
     });
+
+    it('skips depName containing a non default variable at start', () => {
+      const res = getDep('$CI_REGISTRY/alpine:3.15');
+      expect(res).toMatchInlineSnapshot(`
+        Object {
+          "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
+          "datasource": "docker",
+          "replaceString": "$CI_REGISTRY/alpine:3.15",
+          "skipReason": "contains-variable",
+        }
+      `);
+    });
+
+    it('skips depName containing a non default variable with brackets at start', () => {
+      const res = getDep('${CI_REGISTRY}/alpine:3.15');
+      expect(res).toMatchInlineSnapshot(`
+        Object {
+          "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
+          "datasource": "docker",
+          "replaceString": "\${CI_REGISTRY}/alpine:3.15",
+          "skipReason": "contains-variable",
+        }
+      `);
+    });
+
+    it('skips depName containing a non default variable', () => {
+      const res = getDep('docker.io/$PREFIX/alpine:3.15');
+      expect(res).toMatchInlineSnapshot(`
+        Object {
+          "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
+          "datasource": "docker",
+          "replaceString": "docker.io/$PREFIX/alpine:3.15",
+          "skipReason": "contains-variable",
+        }
+      `);
+    });
+
+    it('skips depName containing a non default variable with brackets', () => {
+      const res = getDep('docker.io/${PREFIX}/alpine:3.15');
+      expect(res).toMatchInlineSnapshot(`
+        Object {
+          "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
+          "datasource": "docker",
+          "replaceString": "docker.io/\${PREFIX}/alpine:3.15",
+          "skipReason": "contains-variable",
+        }
+      `);
+    });
   });
 });

--- a/lib/manager/dockerfile/extract.ts
+++ b/lib/manager/dockerfile/extract.ts
@@ -56,6 +56,13 @@ export function splitImageParts(currentFrom: string): PackageDependency {
     depName = depTagSplit.join(':');
   }
 
+  if (depName && depName.indexOf(variableMarker) !== -1) {
+    // If depName contains a variable, after cleaning, e.g. "$REGISTRY/alpine", we currently not support this.
+    return {
+      skipReason: 'contains-variable',
+    };
+  }
+
   if (currentValue && currentValue.indexOf(variableMarker) !== -1) {
     // If tag contains a variable, e.g. "5.0${VERSION_SUFFIX}", we do not support this.
     return {

--- a/lib/manager/dockerfile/extract.ts
+++ b/lib/manager/dockerfile/extract.ts
@@ -56,14 +56,14 @@ export function splitImageParts(currentFrom: string): PackageDependency {
     depName = depTagSplit.join(':');
   }
 
-  if (depName && depName.indexOf(variableMarker) !== -1) {
+  if (depName?.includes(variableMarker)) {
     // If depName contains a variable, after cleaning, e.g. "$REGISTRY/alpine", we currently not support this.
     return {
       skipReason: 'contains-variable',
     };
   }
 
-  if (currentValue && currentValue.indexOf(variableMarker) !== -1) {
+  if (currentValue?.includes(variableMarker)) {
     // If tag contains a variable, e.g. "5.0${VERSION_SUFFIX}", we do not support this.
     return {
       skipReason: 'contains-variable',

--- a/lib/manager/gitlabci/__fixtures__/gitlab-ci.7.yaml
+++ b/lib/manager/gitlabci/__fixtures__/gitlab-ci.7.yaml
@@ -1,0 +1,17 @@
+image:
+  # comment
+  name: $VARIABLE/renovate/renovate:31.65.1-slim
+
+services:
+  # comment
+  - name: $VARIABLE/other/image1:1.0.0
+    alias: imagealias1
+  # comment
+  - name: ${VARIABLE}/other/image1:2.0.0
+    alias: imagealias2
+  # comment
+  - name: docker.io/$VARIABLE/image1:3.0.0
+    alias: imagealias1
+  # comment
+  - name: docker.io/${VARIABLE}/image1:4.0.0
+    alias: imagealias2

--- a/lib/manager/gitlabci/extract.spec.ts
+++ b/lib/manager/gitlabci/extract.spec.ts
@@ -101,5 +101,58 @@ describe('manager/gitlabci/extract', () => {
       expect(res).toBeNull();
       expect(logger.logger.warn).toHaveBeenCalled();
     });
+
+    it('skips images with variables', async () => {
+      const res = await extractAllPackageFiles(config, [
+        'lib/manager/gitlabci/__fixtures__/gitlab-ci.7.yaml',
+      ]);
+      expect(res).toEqual([
+        {
+          deps: [
+            {
+              autoReplaceStringTemplate:
+                '{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
+              datasource: 'docker',
+              depType: 'image-name',
+              replaceString: '$VARIABLE/renovate/renovate:31.65.1-slim',
+              skipReason: 'contains-variable',
+            },
+            {
+              autoReplaceStringTemplate:
+                '{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
+              datasource: 'docker',
+              depType: 'service-image',
+              replaceString: '$VARIABLE/other/image1:1.0.0',
+              skipReason: 'contains-variable',
+            },
+            {
+              autoReplaceStringTemplate:
+                '{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
+              datasource: 'docker',
+              depType: 'service-image',
+              replaceString: '${VARIABLE}/other/image1:2.0.0',
+              skipReason: 'contains-variable',
+            },
+            {
+              autoReplaceStringTemplate:
+                '{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
+              datasource: 'docker',
+              depType: 'service-image',
+              replaceString: 'docker.io/$VARIABLE/image1:3.0.0',
+              skipReason: 'contains-variable',
+            },
+            {
+              autoReplaceStringTemplate:
+                '{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
+              datasource: 'docker',
+              depType: 'service-image',
+              replaceString: 'docker.io/${VARIABLE}/image1:4.0.0',
+              skipReason: 'contains-variable',
+            },
+          ],
+          packageFile: 'lib/manager/gitlabci/__fixtures__/gitlab-ci.7.yaml',
+        },
+      ]);
+    });
   });
 });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Check for variable in cleaned depName. (Just like with variable check in docker image tag)

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->
Closes #13425

This check should be safe since according to [docker documentation](https://docs.docker.com/engine/reference/commandline/tag/#extended-description) it is not valid character in name components segments nor is it an allowed character in dns hostnames.



## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
