### PR TITLE
docs: composer supports update-lockfile rangeStrategy

### DIFF
--- a/lib/versioning/composer/index.ts
+++ b/lib/versioning/composer/index.ts
@@ -14,7 +14,13 @@ export const urls = [
   'https://semver.mwl.be',
 ];
 export const supportsRanges = true;
-export const supportedRangeStrategies = ['bump', 'extend', 'pin', 'replace'];
+export const supportedRangeStrategies = [
+  'bump',
+  'extend',
+  'pin',
+  'replace',
+  'update-lockfile',
+];
 
 function getVersionParts(input: string): [string, string] {
   const versionParts = input.split('-');


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->
Adapts the Composer versioning constant that is responsible for the generation of https://docs.renovatebot.com/modules/versioning/#composer-versioning to also list the supported `update-lockfile` strategy.

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->
Composer versioning supports this for a while already, see also https://docs.renovatebot.com/configuration-options/#rangestrategy

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
