### PR TITLE
docs(contributing): use update branch button

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -32,6 +32,8 @@ This makes it harder for us to review your work because we don't know what has c
 PRs will always be squashed by us when we merge your work.
 Commit as many times as you need in your pull request branch.
 
+If you are updating your PR branch from within the GitHub PR interface, then only use the default "Update branch" button.
+
 Force pushing a PR is OK when:
 
 - you need to make large changes on a PR which require a full review anyway


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Tell contributors to use the default "update branch" button

## Context:

GitHub added a new way to sync your PR branch.
You can now use the "Rebase branch" button to sync with the target branch.

When you rebase, you force push new commits into the branch which causes PR suggestions to break.
This all means that we should tell our contributors to use the default "Update branch" button.

[GitHub Docs, Updating your pull request branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/keeping-your-pull-request-in-sync-with-the-base-branch#updating-your-pull-request-branch)

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
