### PR TITLE
fix(git): Don't fetch if push has failed

### DIFF
--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -818,6 +818,7 @@ export async function pushCommit({
 }: CommitFilesConfig): Promise<boolean> {
   await syncGit();
   logger.debug(`Pushing branch ${branchName}`);
+  let result = false;
   try {
     const pushOptions: TaskOptions = {
       '--force-with-lease': null,
@@ -835,11 +836,11 @@ export async function pushCommit({
     delete pushRes.repo;
     logger.debug({ result: pushRes }, 'git push');
     incLimitedValue(Limit.Commits);
-    return true;
+    result = true;
   } catch (err) /* istanbul ignore next */ {
     handleCommitError(files, branchName, err);
   }
-  return false;
+  return result;
 }
 
 export async function fetchCommit({


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

<!-- Describe what behavior is changed by this PR. -->

## Context:

- Closes: #13996

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
