### PR TITLE
refactor(versioning/ivy): Enable strict null checks

### DIFF
--- a/lib/versioning/ivy/index.spec.ts
+++ b/lib/versioning/ivy/index.spec.ts
@@ -9,10 +9,10 @@ import ivy from '.';
 describe('versioning/ivy/index', () => {
   test.each`
     input                   | type               | value
-    ${'latest'}             | ${REV_TYPE_LATEST} | ${null}
+    ${'latest'}             | ${REV_TYPE_LATEST} | ${''}
     ${'latest.release'}     | ${REV_TYPE_LATEST} | ${'release'}
     ${'latest.milestone'}   | ${REV_TYPE_LATEST} | ${'milestone'}
-    ${'latest.integration'} | ${REV_TYPE_LATEST} | ${null}
+    ${'latest.integration'} | ${REV_TYPE_LATEST} | ${''}
     ${'1.0.+'}              | ${REV_TYPE_SUBREV} | ${'1.0'}
     ${'1.2.3.+'}            | ${REV_TYPE_SUBREV} | ${'1.2.3'}
     ${'[1.0,2.0]'}          | ${REV_TYPE_RANGE}  | ${'[1.0,2.0]'}

--- a/lib/versioning/ivy/index.ts
+++ b/lib/versioning/ivy/index.ts
@@ -49,35 +49,38 @@ function matches(a: string, b: string): boolean {
   if (!a || !b) {
     return false;
   }
-  const dynamicRevision = parseDynamicRevision(b);
-  if (!dynamicRevision) {
+  const rev = parseDynamicRevision(b);
+  if (!rev) {
     return equals(a, b);
   }
-  const { type, value } = dynamicRevision;
 
-  if (type === REV_TYPE_LATEST) {
-    if (!value) {
+  if (rev.type === REV_TYPE_LATEST) {
+    if (!rev.value) {
       return true;
     }
     const tokens = tokenize(a);
     if (tokens.length) {
       const token = tokens[tokens.length - 1];
       if (token.type === TYPE_QUALIFIER) {
-        return token.val.toLowerCase() === value;
+        return token.val.toLowerCase() === rev.value;
       }
     }
     return false;
   }
 
-  if (type === REV_TYPE_SUBREV) {
-    return isSubversion(value, a);
+  if (rev.type === REV_TYPE_SUBREV) {
+    rev;
+    return isSubversion(rev.value, a);
   }
 
-  return mavenMatches(a, value);
+  return mavenMatches(a, rev.value);
 }
 
-function getSatisfyingVersion(versions: string[], range: string): string {
-  return versions.reduce((result, version) => {
+function getSatisfyingVersion(
+  versions: string[],
+  range: string
+): string | null {
+  return versions.reduce((result: string | null, version) => {
     if (matches(version, range)) {
       if (!result) {
         return version;

--- a/lib/versioning/ivy/index.ts
+++ b/lib/versioning/ivy/index.ts
@@ -49,31 +49,32 @@ function matches(a: string, b: string): boolean {
   if (!a || !b) {
     return false;
   }
-  const rev = parseDynamicRevision(b);
-  if (!rev) {
+  const dynamicRevision = parseDynamicRevision(b);
+  if (!dynamicRevision) {
     return equals(a, b);
   }
+  const { type, value } = dynamicRevision;
 
-  if (rev.type === REV_TYPE_LATEST) {
-    if (!rev.value) {
+  if (type === REV_TYPE_LATEST) {
+    if (!value) {
       return true;
     }
     const tokens = tokenize(a);
     if (tokens.length) {
       const token = tokens[tokens.length - 1];
       if (token.type === TYPE_QUALIFIER) {
-        return token.val.toLowerCase() === rev.value;
+        return token.val.toLowerCase() === value;
       }
     }
     return false;
   }
 
-  if (rev.type === REV_TYPE_SUBREV) {
-    rev;
-    return isSubversion(rev.value, a);
+  if (type === REV_TYPE_SUBREV) {
+    dynamicRevision;
+    return isSubversion(value, a);
   }
 
-  return mavenMatches(a, rev.value);
+  return mavenMatches(a, value);
 }
 
 function getSatisfyingVersion(

--- a/lib/versioning/ivy/index.ts
+++ b/lib/versioning/ivy/index.ts
@@ -70,7 +70,6 @@ function matches(a: string, b: string): boolean {
   }
 
   if (type === REV_TYPE_SUBREV) {
-    dynamicRevision;
     return isSubversion(value, a);
   }
 

--- a/lib/versioning/ivy/parse.ts
+++ b/lib/versioning/ivy/parse.ts
@@ -19,10 +19,10 @@ function parseDynamicRevision(str: string): Revision | null {
   }
 
   if (LATEST_REGEX.test(str)) {
-    const value = str.replace(LATEST_REGEX, '').toLowerCase() || null;
+    const value = str.replace(LATEST_REGEX, '').toLowerCase() || '';
     return {
       type: REV_TYPE_LATEST,
-      value: value === 'integration' ? null : value,
+      value: value === 'integration' ? '' : value,
     };
   }
 
@@ -39,10 +39,13 @@ function parseDynamicRevision(str: string): Revision | null {
 
   const range = parseRange(str);
   if (range && range.length === 1) {
-    return {
-      type: REV_TYPE_RANGE,
-      value: rangeToStr(range),
-    };
+    const rangeValue = rangeToStr(range);
+    if (rangeValue) {
+      return {
+        type: REV_TYPE_RANGE,
+        value: rangeValue,
+      };
+    }
   }
 
   return null;

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -400,8 +400,6 @@
     "lib/versioning/hashicorp/index.ts",
     "lib/versioning/helm/index.ts",
     "lib/versioning/index.ts",
-    "lib/versioning/ivy/index.ts",
-    "lib/versioning/ivy/parse.ts",
     "lib/versioning/nuget/index.ts",
     "lib/versioning/poetry/index.ts",
     "lib/versioning/poetry/patterns.ts",


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Fix strict null errors

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
