### PR TITLE
fix: populate isLockFileMaintenance

### DIFF
--- a/lib/workers/repository/updates/flatten.spec.ts
+++ b/lib/workers/repository/updates/flatten.spec.ts
@@ -179,7 +179,10 @@ describe('workers/repository/updates/flatten', () => {
         res.filter((update) => update.sourceRepoName)[2].sourceRepoName
       ).toBe('node');
       expect(
-        res.filter((r) => r.updateType === 'lockFileMaintenance')
+        res.filter(
+          (r) =>
+            r.updateType === 'lockFileMaintenance' && r.isLockFileMaintenance
+        )
       ).toHaveLength(2);
       expect(res.filter((r) => r.isVulnerabilityAlert)).toHaveLength(1);
     });

--- a/lib/workers/repository/updates/flatten.ts
+++ b/lib/workers/repository/updates/flatten.ts
@@ -140,6 +140,7 @@ export async function flattenUpdates(
           packageFileConfig.lockFileMaintenance
         );
         lockFileConfig.updateType = 'lockFileMaintenance';
+        lockFileConfig.isLockFileMaintenance = true;
         lockFileConfig = applyPackageRules(lockFileConfig);
         // Apply lockFileMaintenance and packageRules again
         lockFileConfig = mergeChildConfig(


### PR DESCRIPTION
## Changes:

Lock file maintenance was broken as various managers rely on the
`isLockFileMaintenance` update flag to be set. This was not the
case as its config is generated afterwards (without the is*
auto-propagation).


<!-- Describe what behavior is changed by this PR. -->

## Context:

Fixes #9728

It restores the lock file maintenance feature for the `pip-compile` manager (it didn't fail but wouldn't report updates). Verified on a real repository. Based on a code search I suspect that at least the manager `bundler`, `composer`, `jsonnet-bundler`, `pipenv` are affected, too.

It would allow reverting #9695, and maybe refactoring other managers to use `isLockFileMaintenance` instead of `config.updateType === 'lockFileMaintenance'`. I can include that in this PR if wanted.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository (with `pip-compile`)
