### PR TITLE
Added support for a multi-line replace directive inside go.mod files

### DIFF
--- a/lib/manager/gomod/artifacts.ts
+++ b/lib/manager/gomod/artifacts.ts
@@ -158,9 +158,7 @@ export async function updateArtifacts({
 
     const inlineCommentOut = '\n// renovate-replace $1';
 
-    const blockReplaceRegEx: RegExp = regEx(
-      /\n((replace\s+\(\n+(\s*[^)]+)+)\n+\))/
-    );
+    const blockReplaceRegEx: RegExp = regEx(/\nreplace\s*\([^)]+\s*\)/g);
 
     const blockCommentOut = (match): string =>
       match.replaceAll('\n', '\n// renovate-replace ');

--- a/lib/manager/gomod/artifacts.ts
+++ b/lib/manager/gomod/artifacts.ts
@@ -132,6 +132,23 @@ function useModcacherw(goVersion: string): boolean {
   );
 }
 
+function commentReplaceDirective(content: string): string {
+  const inlineReplaceRegEx: RegExp = regEx(
+    /\n(replace\s+[^\s]+\s+=>\s+\.\.\/.*)/g
+  );
+
+  const inlineCommentOut = '\n// renovate-replace $1';
+
+  const blockReplaceRegEx: RegExp = regEx(/\nreplace\s*\([^)]+\s*\)/g);
+
+  const blockCommentOut = (match): string =>
+    match.replaceAll('\n', '\n// renovate-replace ');
+
+  return content
+    .replace(inlineReplaceRegEx, inlineCommentOut)
+    .replace(blockReplaceRegEx, blockCommentOut);
+}
+
 export async function updateArtifacts({
   packageFileName: goModFileName,
   updatedDeps,
@@ -152,20 +169,7 @@ export async function updateArtifacts({
   const useVendor = (await readLocalFile(vendorModulesFileName)) !== null;
 
   try {
-    const inlineReplaceRegEx: RegExp = regEx(
-      /\n(replace\s+[^\s]+\s+=>\s+\.\.\/.*)/g
-    );
-
-    const inlineCommentOut = '\n// renovate-replace $1';
-
-    const blockReplaceRegEx: RegExp = regEx(/\nreplace\s*\([^)]+\s*\)/g);
-
-    const blockCommentOut = (match): string =>
-      match.replaceAll('\n', '\n// renovate-replace ');
-
-    const massagedGoMod = newGoModContent
-      .replace(inlineReplaceRegEx, inlineCommentOut)
-      .replace(blockReplaceRegEx, blockCommentOut);
+    const massagedGoMod = commentReplaceDirective(newGoModContent);
 
     if (massagedGoMod !== newGoModContent) {
       logger.debug('Removed some relative replace statements from go.mod');

--- a/lib/manager/gomod/artifacts.ts
+++ b/lib/manager/gomod/artifacts.ts
@@ -132,23 +132,6 @@ function useModcacherw(goVersion: string): boolean {
   );
 }
 
-function commentReplaceDirective(content: string): string {
-  const inlineReplaceRegEx: RegExp = regEx(
-    /\n(replace\s+[^\s]+\s+=>\s+\.\.\/.*)/g
-  );
-
-  const inlineCommentOut = '\n// renovate-replace $1';
-
-  const blockReplaceRegEx: RegExp = regEx(/\nreplace\s*\([^)]+\s*\)/g);
-
-  const blockCommentOut = (match): string =>
-    match.replaceAll('\n', '\n// renovate-replace ');
-
-  return content
-    .replace(inlineReplaceRegEx, inlineCommentOut)
-    .replace(blockReplaceRegEx, blockCommentOut);
-}
-
 export async function updateArtifacts({
   packageFileName: goModFileName,
   updatedDeps,
@@ -169,7 +152,20 @@ export async function updateArtifacts({
   const useVendor = (await readLocalFile(vendorModulesFileName)) !== null;
 
   try {
-    const massagedGoMod = commentReplaceDirective(newGoModContent);
+    const inlineReplaceRegEx: RegExp = regEx(
+      /\n(replace\s+[^\s]+\s+=>\s+\.\.\/.*)/g
+    );
+
+    const inlineCommentOut = '\n// renovate-replace $1';
+
+    const blockReplaceRegEx: RegExp = regEx(/\nreplace\s*\([^)]+\s*\)/g);
+
+    const blockCommentOut = (match): string =>
+      match.replaceAll('\n', '\n// renovate-replace ');
+
+    const massagedGoMod = newGoModContent
+      .replace(inlineReplaceRegEx, inlineCommentOut)
+      .replace(blockReplaceRegEx, blockCommentOut);
 
     if (massagedGoMod !== newGoModContent) {
       logger.debug('Removed some relative replace statements from go.mod');


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

As of now, only inline replace directives are commented out with - "// renovate-comment" before further processing. (lib/manager/gomod/artifacts.ts)

Added the same behavior for the multi-line replace variant.

## Context:

Closes #11428

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
