### PR TITLE
ci: Revert "chore: pin codecov uploader"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,8 +101,6 @@ jobs:
 
       - name: Codecov
         uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # renovate: tag=v2.1.0
-        with:
-          version: 'v0.1.15'
         if: always() && env.coverage == 'true'
 
       - name: E2E Test


### PR DESCRIPTION
Reverts renovatebot/renovate#14007

now fixed https://github.com/codecov/uploader/releases/tag/v0.1.17