### PR TITLE
docs: replace as per fragment with in line with

### DIFF
--- a/lib/platform/bitbucket-server/index.md
+++ b/lib/platform/bitbucket-server/index.md
@@ -14,7 +14,7 @@
 
 If you want a test Bitbucket server locally rather than with your production server, [Atlassian's Bitbucket Server Docker image](https://hub.docker.com/r/atlassian/bitbucket-server) is really convenient.
 
-As per their instructions, the following commands bring up a new server:
+In line with their instructions, the following commands bring up a new server:
 
 ```
 docker volume create --name bitbucketVolume

--- a/lib/versioning/semver/readme.md
+++ b/lib/versioning/semver/readme.md
@@ -1,3 +1,3 @@
 Renovate's Semantic Versioning is a strict/independent implementation of [Semantic Versioning 2.0](https://semver.org). It has been developed to be used in situations where exact-only SemVer support is needed and not npm's extended semver implementation including ranges.
 
-Ranges are not supported, as per the specification.
+Ranges are not supported, in line with the specification.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Replace `as per` with `in line with`

## Context:

Simplify.
I'm not closing any existing issue with this PR.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
