### PR TITLE
fix: remove quotations around git insteadOf url

### DIFF
--- a/lib/manager/gomod/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/manager/gomod/__snapshots__/artifacts.spec.ts.snap
@@ -286,9 +286,9 @@ Array [
       "env": Object {
         "CGO_ENABLED": "1",
         "GIT_CONFIG_COUNT": "3",
-        "GIT_CONFIG_KEY_0": "url.\\"https://ssh:some-token@github.com/\\".insteadOf",
-        "GIT_CONFIG_KEY_1": "url.\\"https://git:some-token@github.com/\\".insteadOf",
-        "GIT_CONFIG_KEY_2": "url.\\"https://some-token@github.com/\\".insteadOf",
+        "GIT_CONFIG_KEY_0": "url.https://ssh:some-token@github.com/.insteadOf",
+        "GIT_CONFIG_KEY_1": "url.https://git:some-token@github.com/.insteadOf",
+        "GIT_CONFIG_KEY_2": "url.https://some-token@github.com/.insteadOf",
         "GIT_CONFIG_VALUE_0": "ssh://git@github.com/",
         "GIT_CONFIG_VALUE_1": "git@github.com:",
         "GIT_CONFIG_VALUE_2": "https://github.com/",

--- a/lib/manager/gomod/artifacts.spec.ts
+++ b/lib/manager/gomod/artifacts.spec.ts
@@ -248,17 +248,16 @@ describe('manager/gomod/artifacts', () => {
             env: expect.objectContaining({
               GIT_CONFIG_COUNT: '6',
               GIT_CONFIG_KEY_0:
-                'url."https://ssh:some-token@github.com/".insteadOf',
+                'url.https://ssh:some-token@github.com/.insteadOf',
               GIT_CONFIG_KEY_1:
-                'url."https://git:some-token@github.com/".insteadOf',
-              GIT_CONFIG_KEY_2:
-                'url."https://some-token@github.com/".insteadOf',
+                'url.https://git:some-token@github.com/.insteadOf',
+              GIT_CONFIG_KEY_2: 'url.https://some-token@github.com/.insteadOf',
               GIT_CONFIG_KEY_3:
-                'url."https://ssh:some-enterprise-token@github.enterprise.com/".insteadOf',
+                'url.https://ssh:some-enterprise-token@github.enterprise.com/.insteadOf',
               GIT_CONFIG_KEY_4:
-                'url."https://git:some-enterprise-token@github.enterprise.com/".insteadOf',
+                'url.https://git:some-enterprise-token@github.enterprise.com/.insteadOf',
               GIT_CONFIG_KEY_5:
-                'url."https://some-enterprise-token@github.enterprise.com/".insteadOf',
+                'url.https://some-enterprise-token@github.enterprise.com/.insteadOf',
               GIT_CONFIG_VALUE_0: 'ssh://git@github.com/',
               GIT_CONFIG_VALUE_1: 'git@github.com:',
               GIT_CONFIG_VALUE_2: 'https://github.com/',
@@ -303,11 +302,11 @@ describe('manager/gomod/artifacts', () => {
             env: expect.objectContaining({
               GIT_CONFIG_COUNT: '3',
               GIT_CONFIG_KEY_0:
-                'url."https://gitlab-ci-token:some-enterprise-token@gitlab.enterprise.com/".insteadOf',
+                'url.https://gitlab-ci-token:some-enterprise-token@gitlab.enterprise.com/.insteadOf',
               GIT_CONFIG_KEY_1:
-                'url."https://gitlab-ci-token:some-enterprise-token@gitlab.enterprise.com/".insteadOf',
+                'url.https://gitlab-ci-token:some-enterprise-token@gitlab.enterprise.com/.insteadOf',
               GIT_CONFIG_KEY_2:
-                'url."https://gitlab-ci-token:some-enterprise-token@gitlab.enterprise.com/".insteadOf',
+                'url.https://gitlab-ci-token:some-enterprise-token@gitlab.enterprise.com/.insteadOf',
               GIT_CONFIG_VALUE_0: 'ssh://git@gitlab.enterprise.com/',
               GIT_CONFIG_VALUE_1: 'git@gitlab.enterprise.com:',
               GIT_CONFIG_VALUE_2: 'https://gitlab.enterprise.com/',
@@ -354,17 +353,17 @@ describe('manager/gomod/artifacts', () => {
             env: expect.objectContaining({
               GIT_CONFIG_COUNT: '6',
               GIT_CONFIG_KEY_0:
-                'url."https://gitlab-ci-token:some-enterprise-token-repo1@gitlab.enterprise.com/repo1".insteadOf',
+                'url.https://gitlab-ci-token:some-enterprise-token-repo1@gitlab.enterprise.com/repo1.insteadOf',
               GIT_CONFIG_KEY_1:
-                'url."https://gitlab-ci-token:some-enterprise-token-repo1@gitlab.enterprise.com/repo1".insteadOf',
+                'url.https://gitlab-ci-token:some-enterprise-token-repo1@gitlab.enterprise.com/repo1.insteadOf',
               GIT_CONFIG_KEY_2:
-                'url."https://gitlab-ci-token:some-enterprise-token-repo1@gitlab.enterprise.com/repo1".insteadOf',
+                'url.https://gitlab-ci-token:some-enterprise-token-repo1@gitlab.enterprise.com/repo1.insteadOf',
               GIT_CONFIG_KEY_3:
-                'url."https://gitlab-ci-token:some-enterprise-token-repo2@gitlab.enterprise.com/repo2".insteadOf',
+                'url.https://gitlab-ci-token:some-enterprise-token-repo2@gitlab.enterprise.com/repo2.insteadOf',
               GIT_CONFIG_KEY_4:
-                'url."https://gitlab-ci-token:some-enterprise-token-repo2@gitlab.enterprise.com/repo2".insteadOf',
+                'url.https://gitlab-ci-token:some-enterprise-token-repo2@gitlab.enterprise.com/repo2.insteadOf',
               GIT_CONFIG_KEY_5:
-                'url."https://gitlab-ci-token:some-enterprise-token-repo2@gitlab.enterprise.com/repo2".insteadOf',
+                'url.https://gitlab-ci-token:some-enterprise-token-repo2@gitlab.enterprise.com/repo2.insteadOf',
               GIT_CONFIG_VALUE_0: 'ssh://git@gitlab.enterprise.com/repo1',
               GIT_CONFIG_VALUE_1: 'git@gitlab.enterprise.com:repo1',
               GIT_CONFIG_VALUE_2: 'https://gitlab.enterprise.com/repo1',
@@ -414,11 +413,11 @@ describe('manager/gomod/artifacts', () => {
             env: expect.objectContaining({
               GIT_CONFIG_COUNT: '3',
               GIT_CONFIG_KEY_0:
-                'url."https://gitlab-ci-token:some-gitlab-token@gitlab.enterprise.com/".insteadOf',
+                'url.https://gitlab-ci-token:some-gitlab-token@gitlab.enterprise.com/.insteadOf',
               GIT_CONFIG_KEY_1:
-                'url."https://gitlab-ci-token:some-gitlab-token@gitlab.enterprise.com/".insteadOf',
+                'url.https://gitlab-ci-token:some-gitlab-token@gitlab.enterprise.com/.insteadOf',
               GIT_CONFIG_KEY_2:
-                'url."https://gitlab-ci-token:some-gitlab-token@gitlab.enterprise.com/".insteadOf',
+                'url.https://gitlab-ci-token:some-gitlab-token@gitlab.enterprise.com/.insteadOf',
               GIT_CONFIG_VALUE_0: 'ssh://git@gitlab.enterprise.com/',
               GIT_CONFIG_VALUE_1: 'git@gitlab.enterprise.com:',
               GIT_CONFIG_VALUE_2: 'https://gitlab.enterprise.com/',
@@ -473,29 +472,28 @@ describe('manager/gomod/artifacts', () => {
             env: expect.objectContaining({
               GIT_CONFIG_COUNT: '12',
               GIT_CONFIG_KEY_0:
-                'url."https://ssh:some-token@github.com/".insteadOf',
+                'url.https://ssh:some-token@github.com/.insteadOf',
               GIT_CONFIG_KEY_1:
-                'url."https://git:some-token@github.com/".insteadOf',
-              GIT_CONFIG_KEY_2:
-                'url."https://some-token@github.com/".insteadOf',
+                'url.https://git:some-token@github.com/.insteadOf',
+              GIT_CONFIG_KEY_2: 'url.https://some-token@github.com/.insteadOf',
               GIT_CONFIG_KEY_3:
-                'url."https://ssh:some-token@api.github.com/".insteadOf',
+                'url.https://ssh:some-token@api.github.com/.insteadOf',
               GIT_CONFIG_KEY_4:
-                'url."https://git:some-token@api.github.com/".insteadOf',
+                'url.https://git:some-token@api.github.com/.insteadOf',
               GIT_CONFIG_KEY_5:
-                'url."https://some-token@api.github.com/".insteadOf',
+                'url.https://some-token@api.github.com/.insteadOf',
               GIT_CONFIG_KEY_6:
-                'url."https://ssh:some-enterprise-token@github.enterprise.com/".insteadOf',
+                'url.https://ssh:some-enterprise-token@github.enterprise.com/.insteadOf',
               GIT_CONFIG_KEY_7:
-                'url."https://git:some-enterprise-token@github.enterprise.com/".insteadOf',
+                'url.https://git:some-enterprise-token@github.enterprise.com/.insteadOf',
               GIT_CONFIG_KEY_8:
-                'url."https://some-enterprise-token@github.enterprise.com/".insteadOf',
+                'url.https://some-enterprise-token@github.enterprise.com/.insteadOf',
               GIT_CONFIG_KEY_9:
-                'url."https://gitlab-ci-token:some-gitlab-token@gitlab.enterprise.com/".insteadOf',
+                'url.https://gitlab-ci-token:some-gitlab-token@gitlab.enterprise.com/.insteadOf',
               GIT_CONFIG_KEY_10:
-                'url."https://gitlab-ci-token:some-gitlab-token@gitlab.enterprise.com/".insteadOf',
+                'url.https://gitlab-ci-token:some-gitlab-token@gitlab.enterprise.com/.insteadOf',
               GIT_CONFIG_KEY_11:
-                'url."https://gitlab-ci-token:some-gitlab-token@gitlab.enterprise.com/".insteadOf',
+                'url.https://gitlab-ci-token:some-gitlab-token@gitlab.enterprise.com/.insteadOf',
               GIT_CONFIG_VALUE_0: 'ssh://git@github.com/',
               GIT_CONFIG_VALUE_1: 'git@github.com:',
               GIT_CONFIG_VALUE_2: 'https://github.com/',
@@ -549,11 +547,10 @@ describe('manager/gomod/artifacts', () => {
             env: expect.objectContaining({
               GIT_CONFIG_COUNT: '3',
               GIT_CONFIG_KEY_0:
-                'url."https://ssh:some-token@github.com/".insteadOf',
+                'url.https://ssh:some-token@github.com/.insteadOf',
               GIT_CONFIG_KEY_1:
-                'url."https://git:some-token@github.com/".insteadOf',
-              GIT_CONFIG_KEY_2:
-                'url."https://some-token@github.com/".insteadOf',
+                'url.https://git:some-token@github.com/.insteadOf',
+              GIT_CONFIG_KEY_2: 'url.https://some-token@github.com/.insteadOf',
               GIT_CONFIG_VALUE_0: 'ssh://git@github.com/',
               GIT_CONFIG_VALUE_1: 'git@github.com:',
               GIT_CONFIG_VALUE_2: 'https://github.com/',

--- a/lib/util/git/auth.spec.ts
+++ b/lib/util/git/auth.spec.ts
@@ -15,9 +15,9 @@ describe('util/git/auth', () => {
         })
       ).toStrictEqual({
         GIT_CONFIG_COUNT: '3',
-        GIT_CONFIG_KEY_0: 'url."https://ssh:token1234@github.com/".insteadOf',
-        GIT_CONFIG_KEY_1: 'url."https://git:token1234@github.com/".insteadOf',
-        GIT_CONFIG_KEY_2: 'url."https://token1234@github.com/".insteadOf',
+        GIT_CONFIG_KEY_0: 'url.https://ssh:token1234@github.com/.insteadOf',
+        GIT_CONFIG_KEY_1: 'url.https://git:token1234@github.com/.insteadOf',
+        GIT_CONFIG_KEY_2: 'url.https://token1234@github.com/.insteadOf',
         GIT_CONFIG_VALUE_0: 'ssh://git@github.com/',
         GIT_CONFIG_VALUE_1: 'git@github.com:',
         GIT_CONFIG_VALUE_2: 'https://github.com/',
@@ -33,9 +33,9 @@ describe('util/git/auth', () => {
         })
       ).toStrictEqual({
         GIT_CONFIG_COUNT: '3',
-        GIT_CONFIG_KEY_0: 'url."https://ssh:token1234@github.com/".insteadOf',
-        GIT_CONFIG_KEY_1: 'url."https://git:token1234@github.com/".insteadOf',
-        GIT_CONFIG_KEY_2: 'url."https://token1234@github.com/".insteadOf',
+        GIT_CONFIG_KEY_0: 'url.https://ssh:token1234@github.com/.insteadOf',
+        GIT_CONFIG_KEY_1: 'url.https://git:token1234@github.com/.insteadOf',
+        GIT_CONFIG_KEY_2: 'url.https://token1234@github.com/.insteadOf',
         GIT_CONFIG_VALUE_0: 'ssh://git@github.com/',
         GIT_CONFIG_VALUE_1: 'git@github.com:',
         GIT_CONFIG_VALUE_2: 'https://github.com/',
@@ -52,11 +52,11 @@ describe('util/git/auth', () => {
       ).toStrictEqual({
         GIT_CONFIG_COUNT: '3',
         GIT_CONFIG_KEY_0:
-          'url."https://x-access-token:token1234@github.com/".insteadOf',
+          'url.https://x-access-token:token1234@github.com/.insteadOf',
         GIT_CONFIG_KEY_1:
-          'url."https://x-access-token:token1234@github.com/".insteadOf',
+          'url.https://x-access-token:token1234@github.com/.insteadOf',
         GIT_CONFIG_KEY_2:
-          'url."https://x-access-token:token1234@github.com/".insteadOf',
+          'url.https://x-access-token:token1234@github.com/.insteadOf',
         GIT_CONFIG_VALUE_0: 'ssh://git@github.com/',
         GIT_CONFIG_VALUE_1: 'git@github.com:',
         GIT_CONFIG_VALUE_2: 'https://github.com/',
@@ -76,9 +76,9 @@ describe('util/git/auth', () => {
         )
       ).toStrictEqual({
         GIT_CONFIG_COUNT: '4',
-        GIT_CONFIG_KEY_1: 'url."https://ssh:token1234@github.com/".insteadOf',
-        GIT_CONFIG_KEY_2: 'url."https://git:token1234@github.com/".insteadOf',
-        GIT_CONFIG_KEY_3: 'url."https://token1234@github.com/".insteadOf',
+        GIT_CONFIG_KEY_1: 'url.https://ssh:token1234@github.com/.insteadOf',
+        GIT_CONFIG_KEY_2: 'url.https://git:token1234@github.com/.insteadOf',
+        GIT_CONFIG_KEY_3: 'url.https://token1234@github.com/.insteadOf',
         GIT_CONFIG_VALUE_1: 'ssh://git@github.com/',
         GIT_CONFIG_VALUE_2: 'git@github.com:',
         GIT_CONFIG_VALUE_3: 'https://github.com/',
@@ -99,9 +99,9 @@ describe('util/git/auth', () => {
         )
       ).toStrictEqual({
         GIT_CONFIG_COUNT: '4',
-        GIT_CONFIG_KEY_1: 'url."https://ssh:token1234@github.com/".insteadOf',
-        GIT_CONFIG_KEY_2: 'url."https://git:token1234@github.com/".insteadOf',
-        GIT_CONFIG_KEY_3: 'url."https://token1234@github.com/".insteadOf',
+        GIT_CONFIG_KEY_1: 'url.https://ssh:token1234@github.com/.insteadOf',
+        GIT_CONFIG_KEY_2: 'url.https://git:token1234@github.com/.insteadOf',
+        GIT_CONFIG_KEY_3: 'url.https://token1234@github.com/.insteadOf',
         GIT_CONFIG_VALUE_1: 'ssh://git@github.com/',
         GIT_CONFIG_VALUE_2: 'git@github.com:',
         GIT_CONFIG_VALUE_3: 'https://github.com/',
@@ -118,9 +118,9 @@ describe('util/git/auth', () => {
         })
       ).toStrictEqual({
         GIT_CONFIG_COUNT: '4',
-        GIT_CONFIG_KEY_1: 'url."https://ssh:token1234@github.com/".insteadOf',
-        GIT_CONFIG_KEY_2: 'url."https://git:token1234@github.com/".insteadOf',
-        GIT_CONFIG_KEY_3: 'url."https://token1234@github.com/".insteadOf',
+        GIT_CONFIG_KEY_1: 'url.https://ssh:token1234@github.com/.insteadOf',
+        GIT_CONFIG_KEY_2: 'url.https://git:token1234@github.com/.insteadOf',
+        GIT_CONFIG_KEY_3: 'url.https://token1234@github.com/.insteadOf',
         GIT_CONFIG_VALUE_1: 'ssh://git@github.com/',
         GIT_CONFIG_VALUE_2: 'git@github.com:',
         GIT_CONFIG_VALUE_3: 'https://github.com/',
@@ -140,9 +140,9 @@ describe('util/git/auth', () => {
         )
       ).toStrictEqual({
         GIT_CONFIG_COUNT: '3',
-        GIT_CONFIG_KEY_0: 'url."https://ssh:token1234@github.com/".insteadOf',
-        GIT_CONFIG_KEY_1: 'url."https://git:token1234@github.com/".insteadOf',
-        GIT_CONFIG_KEY_2: 'url."https://token1234@github.com/".insteadOf',
+        GIT_CONFIG_KEY_0: 'url.https://ssh:token1234@github.com/.insteadOf',
+        GIT_CONFIG_KEY_1: 'url.https://git:token1234@github.com/.insteadOf',
+        GIT_CONFIG_KEY_2: 'url.https://token1234@github.com/.insteadOf',
         GIT_CONFIG_VALUE_0: 'ssh://git@github.com/',
         GIT_CONFIG_VALUE_1: 'git@github.com:',
         GIT_CONFIG_VALUE_2: 'https://github.com/',
@@ -160,9 +160,9 @@ describe('util/git/auth', () => {
         })
       ).toStrictEqual({
         GIT_CONFIG_COUNT: '3',
-        GIT_CONFIG_KEY_0: 'url."https://ssh:token1234@github.com/".insteadOf',
-        GIT_CONFIG_KEY_1: 'url."https://git:token1234@github.com/".insteadOf',
-        GIT_CONFIG_KEY_2: 'url."https://token1234@github.com/".insteadOf',
+        GIT_CONFIG_KEY_0: 'url.https://ssh:token1234@github.com/.insteadOf',
+        GIT_CONFIG_KEY_1: 'url.https://git:token1234@github.com/.insteadOf',
+        GIT_CONFIG_KEY_2: 'url.https://token1234@github.com/.insteadOf',
         GIT_CONFIG_VALUE_0: 'ssh://git@github.com/',
         GIT_CONFIG_VALUE_1: 'git@github.com:',
         GIT_CONFIG_VALUE_2: 'https://github.com/',
@@ -179,11 +179,11 @@ describe('util/git/auth', () => {
       ).toStrictEqual({
         GIT_CONFIG_COUNT: '3',
         GIT_CONFIG_KEY_0:
-          'url."https://gitlab-ci-token:token1234@gitlab.com/".insteadOf',
+          'url.https://gitlab-ci-token:token1234@gitlab.com/.insteadOf',
         GIT_CONFIG_KEY_1:
-          'url."https://gitlab-ci-token:token1234@gitlab.com/".insteadOf',
+          'url.https://gitlab-ci-token:token1234@gitlab.com/.insteadOf',
         GIT_CONFIG_KEY_2:
-          'url."https://gitlab-ci-token:token1234@gitlab.com/".insteadOf',
+          'url.https://gitlab-ci-token:token1234@gitlab.com/.insteadOf',
         GIT_CONFIG_VALUE_0: 'ssh://git@gitlab.com/',
         GIT_CONFIG_VALUE_1: 'git@gitlab.com:',
         GIT_CONFIG_VALUE_2: 'https://gitlab.com/',
@@ -216,9 +216,9 @@ describe('util/git/auth', () => {
         })
       ).toStrictEqual({
         GIT_CONFIG_COUNT: '3',
-        GIT_CONFIG_KEY_0: 'url."http://ssh:token1234@github.com/".insteadOf',
-        GIT_CONFIG_KEY_1: 'url."http://git:token1234@github.com/".insteadOf',
-        GIT_CONFIG_KEY_2: 'url."http://token1234@github.com/".insteadOf',
+        GIT_CONFIG_KEY_0: 'url.http://ssh:token1234@github.com/.insteadOf',
+        GIT_CONFIG_KEY_1: 'url.http://git:token1234@github.com/.insteadOf',
+        GIT_CONFIG_KEY_2: 'url.http://token1234@github.com/.insteadOf',
         GIT_CONFIG_VALUE_0: 'ssh://git@github.com/',
         GIT_CONFIG_VALUE_1: 'git@github.com:',
         GIT_CONFIG_VALUE_2: 'http://github.com/',
@@ -234,11 +234,9 @@ describe('util/git/auth', () => {
         })
       ).toStrictEqual({
         GIT_CONFIG_COUNT: '3',
-        GIT_CONFIG_KEY_0:
-          'url."https://ssh:token1234@github.com/org".insteadOf',
-        GIT_CONFIG_KEY_1:
-          'url."https://git:token1234@github.com/org".insteadOf',
-        GIT_CONFIG_KEY_2: 'url."https://token1234@github.com/org".insteadOf',
+        GIT_CONFIG_KEY_0: 'url.https://ssh:token1234@github.com/org.insteadOf',
+        GIT_CONFIG_KEY_1: 'url.https://git:token1234@github.com/org.insteadOf',
+        GIT_CONFIG_KEY_2: 'url.https://token1234@github.com/org.insteadOf',
         GIT_CONFIG_VALUE_0: 'ssh://git@github.com/org',
         GIT_CONFIG_VALUE_1: 'git@github.com:org',
         GIT_CONFIG_VALUE_2: 'https://github.com/org',
@@ -255,11 +253,10 @@ describe('util/git/auth', () => {
       ).toStrictEqual({
         GIT_CONFIG_COUNT: '3',
         GIT_CONFIG_KEY_0:
-          'url."https://ssh:token1234@github.com/org/repo".insteadOf',
+          'url.https://ssh:token1234@github.com/org/repo.insteadOf',
         GIT_CONFIG_KEY_1:
-          'url."https://git:token1234@github.com/org/repo".insteadOf',
-        GIT_CONFIG_KEY_2:
-          'url."https://token1234@github.com/org/repo".insteadOf',
+          'url.https://git:token1234@github.com/org/repo.insteadOf',
+        GIT_CONFIG_KEY_2: 'url.https://token1234@github.com/org/repo.insteadOf',
         GIT_CONFIG_VALUE_0: 'ssh://git@github.com/org/repo',
         GIT_CONFIG_VALUE_1: 'git@github.com:org/repo',
         GIT_CONFIG_VALUE_2: 'https://github.com/org/repo',
@@ -279,11 +276,11 @@ describe('util/git/auth', () => {
       ).toStrictEqual({
         GIT_CONFIG_COUNT: '3',
         GIT_CONFIG_KEY_0:
-          'url."https://ssh:token1234@github.com:89/org/repo.git".insteadOf',
+          'url.https://ssh:token1234@github.com:89/org/repo.git.insteadOf',
         GIT_CONFIG_KEY_1:
-          'url."https://git:token1234@github.com:89/org/repo.git".insteadOf',
+          'url.https://git:token1234@github.com:89/org/repo.git.insteadOf',
         GIT_CONFIG_KEY_2:
-          'url."https://token1234@github.com:89/org/repo.git".insteadOf',
+          'url.https://token1234@github.com:89/org/repo.git.insteadOf',
         GIT_CONFIG_VALUE_0: 'ssh://git@github.com:89/org/repo.git',
         GIT_CONFIG_VALUE_1: 'ssh://git@github.com:89/org/repo.git',
         GIT_CONFIG_VALUE_2: 'https://github.com:89/org/repo.git',

--- a/lib/util/git/auth.ts
+++ b/lib/util/git/auth.ts
@@ -51,7 +51,7 @@ export function getGitAuthenticatedEnvironmentVariables(
   for (const rule of authenticationRules) {
     newEnvironmentVariables[
       `GIT_CONFIG_KEY_${gitConfigCount}`
-    ] = `url."${rule.url}".insteadOf`;
+    ] = `url.${rule.url}.insteadOf`;
     newEnvironmentVariables[`GIT_CONFIG_VALUE_${gitConfigCount}`] =
       rule.insteadOf;
     gitConfigCount++;


### PR DESCRIPTION
## Changes:

Removes the quotations around the git `insteadOf` urls

## Context:

Closes #14075

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [X] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
