### PR TITLE
fix(npm): don't disable lock file updates when remediating

### DIFF
--- a/lib/workers/repository/init/__snapshots__/vulnerability.spec.ts.snap
+++ b/lib/workers/repository/init/__snapshots__/vulnerability.spec.ts.snap
@@ -3,7 +3,6 @@
 exports[`workers/repository/init/vulnerability detectVulnerabilityAlerts() returns alerts and remediations 1`] = `
 Array [
   Object {
-    "enabled": false,
     "matchCurrentVersion": "= 1.8.2",
     "matchDatasources": Array [
       "npm",

--- a/lib/workers/repository/init/vulnerability.ts
+++ b/lib/workers/repository/init/vulnerability.ts
@@ -208,8 +208,6 @@ export async function detectVulnerabilityAlerts(
               prBodyNotes,
             };
             config.remediations[fileName].push(remediation);
-            // Disable the package rule as all vulnerabilities will be remediated via the lock file
-            matchRule.enabled = false;
           } else {
             // Remediate only direct dependencies
             matchRule = {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Removes code which disabled npm updates if a remediation was also available.

## Context:

Fixes #14024

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
