### PR TITLE
feat(npm): optimize remediation to detect already updated branches

### DIFF
--- a/lib/manager/npm/update/locked-dependency/index.spec.ts
+++ b/lib/manager/npm/update/locked-dependency/index.spec.ts
@@ -120,12 +120,36 @@ describe('manager/npm/update/locked-dependency/index', () => {
       const packageLock = JSON.parse(res.files['package-lock.json']);
       expect(packageLock.dependencies.express.version).toBe('4.1.0');
     });
-    it('returns if already remediated', async () => {
+    it('returns already-updated if already remediated exactly', async () => {
       config.depName = 'mime';
       config.currentVersion = '1.2.10';
       config.newVersion = '1.2.11';
       const res = await updateLockedDependency(config);
       expect(res.status).toBe('already-updated');
+    });
+    it('returns already-updated if already remediated higher', async () => {
+      config.depName = 'mime';
+      config.currentVersion = '1.2.9';
+      config.newVersion = '1.2.10';
+      config.allowHigherOrRemoved = true;
+      const res = await updateLockedDependency(config);
+      expect(res.status).toBe('already-updated');
+    });
+    it('returns already-updated if not found', async () => {
+      config.depName = 'notfound';
+      config.currentVersion = '1.2.9';
+      config.newVersion = '1.2.10';
+      config.allowHigherOrRemoved = true;
+      const res = await updateLockedDependency(config);
+      expect(res.status).toBe('already-updated');
+    });
+    it('returns update-failed if other, lower version found', async () => {
+      config.depName = 'mime';
+      config.currentVersion = '1.2.5';
+      config.newVersion = '1.2.15';
+      config.allowHigherOrRemoved = true;
+      const res = await updateLockedDependency(config);
+      expect(res.status).toBe('update-failed');
     });
     it('remediates mime', async () => {
       config.depName = 'mime';

--- a/lib/manager/npm/update/locked-dependency/package-lock/get-locked.spec.ts
+++ b/lib/manager/npm/update/locked-dependency/package-lock/get-locked.spec.ts
@@ -36,6 +36,11 @@ describe('manager/npm/update/locked-dependency/package-lock/get-locked', () => {
         },
       ]);
     });
+    it('finds any version', () => {
+      expect(getLockedDependencies(packageLockJson, 'send', null)).toHaveLength(
+        2
+      );
+    });
     it('finds bundled dependency', () => {
       expect(
         getLockedDependencies(bundledPackageLockJson, 'ansi-regex', '3.0.0')

--- a/lib/manager/npm/update/locked-dependency/package-lock/get-locked.ts
+++ b/lib/manager/npm/update/locked-dependency/package-lock/get-locked.ts
@@ -5,7 +5,7 @@ import type { PackageLockDependency, PackageLockOrEntry } from './types';
 export function getLockedDependencies(
   entry: PackageLockOrEntry,
   depName: string,
-  currentVersion: string,
+  currentVersion: string | null,
   bundled = false
 ): PackageLockDependency[] {
   let res: PackageLockDependency[] = [];
@@ -15,7 +15,7 @@ export function getLockedDependencies(
       return [];
     }
     const dep = dependencies[depName];
-    if (dep?.version === currentVersion) {
+    if (dep && (currentVersion === null || dep?.version === currentVersion)) {
       if (bundled || entry.bundled) {
         dep.bundled = true;
       }

--- a/lib/manager/types.ts
+++ b/lib/manager/types.ts
@@ -229,6 +229,7 @@ export interface UpdateLockedConfig {
   currentVersion?: string;
   newVersion?: string;
   allowParentUpdates?: boolean;
+  allowHigherOrRemoved?: boolean;
 }
 
 export interface UpdateLockedResult {

--- a/lib/workers/branch/get-updated.ts
+++ b/lib/workers/branch/get-updated.ts
@@ -75,6 +75,7 @@ export async function getUpdatedPackageFiles(
         packageFileContent,
         lockFileContent,
         allowParentUpdates: true,
+        allowHigherOrRemoved: true,
       });
       if (reuseExistingBranch && status !== 'already-updated') {
         logger.debug(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Enhances transitive remediation logic to detect when a dependency is already updated via either:
- A higher than necessary upgraded version, or
- Removal of the dependency altogether

This should remove some unnecessary retrying of updates each run.

## Context:

Performance

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
