### PR TITLE
fix(datasource/docker): override registry source url

### DIFF
--- a/lib/datasource/metadata.ts
+++ b/lib/datasource/metadata.ts
@@ -74,6 +74,7 @@ const manualSourceUrls: Record<string, Record<string, string>> = {
       'https://github.com/hyper-expanse/library-release-workflows',
   },
   docker: {
+    'amd64/registry': 'https://github.com/distribution/distribution',
     'amd64/traefik': 'https://github.com/containous/traefik',
     'coredns/coredns': 'https://github.com/coredns/coredns',
     'docker/compose': 'https://github.com/docker/compose',
@@ -91,6 +92,7 @@ const manualSourceUrls: Record<string, Record<string, string>> = {
     'gitea/gitea': 'https://github.com/go-gitea/gitea',
     'hashicorp/terraform': 'https://github.com/hashicorp/terraform',
     node: 'https://github.com/nodejs/node',
+    registry: 'https://github.com/distribution/distribution',
     traefik: 'https://github.com/containous/traefik',
   },
   kubernetes: {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:
Just add manual source url to get release notes

- https://github.com/docker/distribution-library-image/blob/master/Dockerfile#L6
- https://github.com/distribution/distribution/releases
<!-- Describe what behavior is changed by this PR. -->

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
