### PR TITLE
fix(npm): don't remediate unrelated package.json version

### DIFF
--- a/lib/manager/npm/update/locked-dependency/package-lock/dep-constraints.spec.ts
+++ b/lib/manager/npm/update/locked-dependency/package-lock/dep-constraints.spec.ts
@@ -36,6 +36,17 @@ describe('manager/npm/update/locked-dependency/package-lock/dep-constraints', ()
         )
       ).toEqual([{ constraint: '4.0.0', depType: 'dependencies' }]);
     });
+    it('skips non-matching direct dependency', () => {
+      expect(
+        findDepConstraints(
+          packageJson,
+          packageLockJson,
+          'express',
+          '4.4.0',
+          '4.5.0'
+        )
+      ).toHaveLength(0);
+    });
     it('finds direct devDependency', () => {
       const packageJsonDev = { ...packageJson };
       packageJsonDev.devDependencies = packageJsonDev.dependencies;

--- a/lib/manager/npm/update/locked-dependency/package-lock/dep-constraints.ts
+++ b/lib/manager/npm/update/locked-dependency/package-lock/dep-constraints.ts
@@ -15,14 +15,20 @@ export function findDepConstraints(
 ): ParentDependency[] {
   let parents: ParentDependency[] = [];
   let packageJsonConstraint = packageJson.dependencies?.[depName];
-  if (packageJsonConstraint) {
+  if (
+    packageJsonConstraint &&
+    semver.matches(currentVersion, packageJsonConstraint)
+  ) {
     parents.push({
       depType: 'dependencies',
       constraint: packageJsonConstraint,
     });
   }
   packageJsonConstraint = packageJson.devDependencies?.[depName];
-  if (packageJsonConstraint) {
+  if (
+    packageJsonConstraint &&
+    semver.matches(currentVersion, packageJsonConstraint)
+  ) {
     parents.push({
       depType: 'devDependencies',
       constraint: packageJsonConstraint,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Ensures we only match a `package.json` vulnerable entry if the constraint matches the vulnerable version we're searching for.

## Context:

Closes #14106

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
