### PR TITLE
feat(github-actions): Change behavior to not add "renovate" to inline yaml comments when pinning

### DIFF
--- a/lib/manager/github-actions/__fixtures__/workflow_2.yml
+++ b/lib/manager/github-actions/__fixtures__/workflow_2.yml
@@ -20,3 +20,18 @@ jobs:
       - uses: docker/setup-qemu-action@c308fdd69d26ed66f4506ebd74b180abe5362145
       - name: Build
         uses: docker/build-push-action@v2
+  rustfmt:
+    name: Run Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # tag=v2.4.0
+      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # renovate: tag=v1.0.7
+        with:
+          profile: minimal
+          toolchain: stable
+          components: rustfmt
+          override: true
+      - uses: actions-rs/cargo@v1.0.3
+        with:
+          command: fmt
+          args: --all -- --check

--- a/lib/manager/github-actions/__snapshots__/extract.spec.ts.snap
+++ b/lib/manager/github-actions/__snapshots__/extract.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`manager/github-actions/extract extractPackageFile() extracts multiple action tag lines from yaml configuration file 1`] = `
 Array [
   Object {
-    "autoReplaceStringTemplate": "{{depName}}/shellcheck@{{#if newDigest}}{{newDigest}}{{#if newValue}} # renovate: tag={{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}",
+    "autoReplaceStringTemplate": "{{depName}}/shellcheck@{{#if newDigest}}{{newDigest}}{{#if newValue}} # tag={{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}",
     "commitMessageTopic": "{{{depName}}} action",
     "currentValue": "master",
     "datasource": "github-tags",
@@ -14,7 +14,7 @@ Array [
     "versioning": "docker",
   },
   Object {
-    "autoReplaceStringTemplate": "{{depName}}@{{#if newDigest}}{{newDigest}}{{#if newValue}} # renovate: tag={{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}",
+    "autoReplaceStringTemplate": "{{depName}}@{{#if newDigest}}{{newDigest}}{{#if newValue}} # tag={{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}",
     "commitMessageTopic": "{{{depName}}} action",
     "currentDigest": "c308fdd69d26ed66f4506ebd74b180abe5362145",
     "currentValue": "v1.1.0",
@@ -25,7 +25,7 @@ Array [
     "versioning": "docker",
   },
   Object {
-    "autoReplaceStringTemplate": "{{depName}}@{{#if newDigest}}{{newDigest}}{{#if newValue}} # renovate: tag={{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}",
+    "autoReplaceStringTemplate": "{{depName}}@{{#if newDigest}}{{newDigest}}{{#if newValue}} # tag={{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}",
     "commitMessageTopic": "{{{depName}}} action",
     "currentValue": "1.0.0",
     "datasource": "github-tags",
@@ -35,7 +35,7 @@ Array [
     "versioning": "docker",
   },
   Object {
-    "autoReplaceStringTemplate": "{{depName}}@{{#if newDigest}}{{newDigest}}{{#if newValue}} # renovate: tag={{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}",
+    "autoReplaceStringTemplate": "{{depName}}@{{#if newDigest}}{{newDigest}}{{#if newValue}} # tag={{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}",
     "commitMessageTopic": "{{{depName}}} action",
     "currentDigest": "c308fdd69d26ed66f4506ebd74b180abe5362145",
     "currentValue": undefined,
@@ -46,7 +46,7 @@ Array [
     "versioning": "docker",
   },
   Object {
-    "autoReplaceStringTemplate": "{{depName}}@{{#if newDigest}}{{newDigest}}{{#if newValue}} # renovate: tag={{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}",
+    "autoReplaceStringTemplate": "{{depName}}@{{#if newDigest}}{{newDigest}}{{#if newValue}} # tag={{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}",
     "commitMessageTopic": "{{{depName}}} action",
     "currentValue": "v2",
     "datasource": "github-tags",
@@ -55,13 +55,45 @@ Array [
     "replaceString": "docker/build-push-action@v2",
     "versioning": "docker",
   },
+  Object {
+    "autoReplaceStringTemplate": "{{depName}}@{{#if newDigest}}{{newDigest}}{{#if newValue}} # tag={{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}",
+    "commitMessageTopic": "{{{depName}}} action",
+    "currentDigest": "ec3a7ce113134d7a93b817d10a8272cb61118579",
+    "currentValue": "v2.4.0",
+    "datasource": "github-tags",
+    "depName": "actions/checkout",
+    "depType": "action",
+    "replaceString": "actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # tag=v2.4.0",
+    "versioning": "docker",
+  },
+  Object {
+    "autoReplaceStringTemplate": "{{depName}}@{{#if newDigest}}{{newDigest}}{{#if newValue}} # tag={{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}",
+    "commitMessageTopic": "{{{depName}}} action",
+    "currentDigest": "16499b5e05bf2e26879000db0c1d13f7e13fa3af",
+    "currentValue": "v1.0.7",
+    "datasource": "github-tags",
+    "depName": "actions-rs/toolchain",
+    "depType": "action",
+    "replaceString": "actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # renovate: tag=v1.0.7",
+    "versioning": "docker",
+  },
+  Object {
+    "autoReplaceStringTemplate": "{{depName}}@{{#if newDigest}}{{newDigest}}{{#if newValue}} # tag={{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}",
+    "commitMessageTopic": "{{{depName}}} action",
+    "currentValue": "v1.0.3",
+    "datasource": "github-tags",
+    "depName": "actions-rs/cargo",
+    "depType": "action",
+    "replaceString": "actions-rs/cargo@v1.0.3",
+    "versioning": "docker",
+  },
 ]
 `;
 
 exports[`manager/github-actions/extract extractPackageFile() extracts multiple docker image lines from yaml configuration file 1`] = `
 Array [
   Object {
-    "autoReplaceStringTemplate": "{{depName}}/shellcheck@{{#if newDigest}}{{newDigest}}{{#if newValue}} # renovate: tag={{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}",
+    "autoReplaceStringTemplate": "{{depName}}/shellcheck@{{#if newDigest}}{{newDigest}}{{#if newValue}} # tag={{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}",
     "commitMessageTopic": "{{{depName}}} action",
     "currentValue": "master",
     "datasource": "github-tags",
@@ -82,7 +114,7 @@ Array [
     "versioning": "docker",
   },
   Object {
-    "autoReplaceStringTemplate": "{{depName}}/cli@{{#if newDigest}}{{newDigest}}{{#if newValue}} # renovate: tag={{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}",
+    "autoReplaceStringTemplate": "{{depName}}/cli@{{#if newDigest}}{{newDigest}}{{#if newValue}} # tag={{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}",
     "commitMessageTopic": "{{{depName}}} action",
     "currentValue": "master",
     "datasource": "github-tags",

--- a/lib/manager/github-actions/extract.spec.ts
+++ b/lib/manager/github-actions/extract.spec.ts
@@ -16,7 +16,7 @@ describe('manager/github-actions/extract', () => {
       expect(res.deps).toMatchSnapshot();
       expect(
         res.deps.filter((d) => d.datasource === 'github-tags')
-      ).toHaveLength(5);
+      ).toHaveLength(8);
     });
   });
 });

--- a/lib/manager/github-actions/extract.ts
+++ b/lib/manager/github-actions/extract.ts
@@ -7,7 +7,7 @@ import type { PackageDependency, PackageFile } from '../types';
 
 const dockerRe = regEx(/^\s+uses: docker:\/\/([^"]+)\s*$/);
 const actionRe = regEx(
-  /^\s+-?\s+?uses: (?<replaceString>(?<depName>[\w-]+\/[\w-]+)(?<path>\/.*)?@(?<currentValue>.+?)(?: # renovate: tag=(?<tag>.+?))?)\s*?$/
+  /^\s+-?\s+?uses: (?<replaceString>(?<depName>[\w-]+\/[\w-]+)(?<path>\/.*)?@(?<currentValue>.+?)\s*(?:#\s+(?:renovate:\s+)?tag=(?<tag>.+?))?)\s*?$/
 );
 
 // SHA1 or SHA256, see https://github.blog/2020-10-19-git-2-29-released/
@@ -47,7 +47,7 @@ export function extractPackageFile(content: string): PackageFile | null {
         versioning: dockerVersioning.id,
         depType: 'action',
         replaceString,
-        autoReplaceStringTemplate: `{{depName}}${path}@{{#if newDigest}}{{newDigest}}{{#if newValue}} # renovate: tag={{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}`,
+        autoReplaceStringTemplate: `{{depName}}${path}@{{#if newDigest}}{{newDigest}}{{#if newValue}} # tag={{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}`,
       };
       if (shaRe.test(currentValue)) {
         dep.currentValue = tag;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

When Renovate pins docker hashes for github actions it adds an inline comment to the lines to specify which version of the action this hash refers to.

Currently the lines will look like this:
 `- uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # renovate: tag=v2.4.0`

after this change, any newly written lines will look like this:
 `- uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # tag=v2.4.0`

Existing lines will not be changed, but still be correctly parsed and written in the new format when they are next updated.

I have also slightly changed the Regex used to parse these strings to be more generous with extra whitespaces. In its current form the regex would tolerate extra whitespaces before the comment, but it seems like this is more or less accidental as they would be added to the currentValue capture group (and then probably stripped or trimmed somewhere, but why take the risk?).

## Context:

Closes #14105

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
