### PR TITLE
docs(self-hosted): correct variable part username in hostRules

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -179,7 +179,7 @@ The format of the environment variables must follow:
 - Underscore (`_`)
 - `matchHost`
 - Underscore (`_`)
-- Field name (`TOKEN`, `USER_NAME`, or `PASSWORD`)
+- Field name (`TOKEN`, `USERNAME`, or `PASSWORD`)
 
 Hyphens (`-`) in datasource or host name must be replaced with double underscores (`__`).
 Periods (`.`) in host names must be replaced with a single underscore (`_`).


### PR DESCRIPTION
## Changes:

Minor documentation fix: there is a discrepancy between the description and examples concerning configuring `hostRules` through environment variables: `USER_NAME` vs. `USERNAME`.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
- [x] No code has been changed