### PR TITLE
feat(datasource/docker): support legacy `org.label-schema.vcs-url` label

### DIFF
--- a/lib/datasource/docker/common.ts
+++ b/lib/datasource/docker/common.ts
@@ -1,0 +1,4 @@
+export const sourceLabels: string[] = [
+  'org.opencontainers.image.source',
+  'org.label-schema.vcs-url',
+];

--- a/lib/datasource/docker/index.ts
+++ b/lib/datasource/docker/index.ts
@@ -27,6 +27,7 @@ import {
   id as dockerVersioningId,
 } from '../../versioning/docker';
 import type { GetReleasesConfig, ReleaseResult } from '../types';
+import { sourceLabels } from './common';
 import { MediaType, RegistryRepository } from './types';
 
 export const ecrRegex = regEx(/\d+\.dkr\.ecr\.([-a-z0-9]+)\.amazonaws\.com/);
@@ -814,8 +815,13 @@ export async function getReleases({
 
   const latestTag = tags.includes('latest') ? 'latest' : findLatestStable(tags);
   const labels = await getLabels(registryHost, dockerRepository, latestTag);
-  if (labels && 'org.opencontainers.image.source' in labels) {
-    ret.sourceUrl = labels['org.opencontainers.image.source'];
+  if (labels) {
+    for (const label of sourceLabels) {
+      if (is.nonEmptyString(labels[label])) {
+        ret.sourceUrl = labels[label];
+        break;
+      }
+    }
   }
   return ret;
 }

--- a/lib/datasource/docker/readme.md
+++ b/lib/datasource/docker/readme.md
@@ -1,5 +1,5 @@
 This datasource identifies an image's source repository according to the [pre-defined annotation keys of the OCI Image Format Specification](https://github.com/opencontainers/image-spec/blob/main/annotations.md).
 
-This datasource looks for the metadata of the **latest stable** image found on the Docker registry and uses the value of the label `org.opencontainers.image.source` as the `sourceUrl`.
+This datasource looks for the metadata of the **latest stable** image found on the Docker registry and uses the value of the label `org.opencontainers.image.source` and `org.label-schema.vcs-url` as the `sourceUrl`.
 
-The [Label Schema](https://label-schema.org/) is superseded by OCI annotations, therefore this datasource does not support the `org.label-schema.vcs-url` label.
+The [Label Schema](https://label-schema.org/) is superseded by OCI annotations, therefore `org.opencontainers.image.source` label should be preferred.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Add support for legacy `org.label-schema.vcs-url` label. Maybe there are some old docker images with that in the wild and it's no coast for us to check that.
<!-- Describe what behavior is changed by this PR. -->

## Context:
- ref #12346
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
