### PR TITLE
docs: `replacementName` and `replacementVersion` are `npm` manager only

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -1772,7 +1772,7 @@ For example to apply a special label for Major updates:
 
 ### replacementName
 
-This config option only works with the `npm` manager.
+This config option only works with the `npm` manager. Checkout [renovatebot/renovate#14149](https://github.com/renovatebot/renovate/issues/14149) for progress.
 
 Use this field to define the name of a replacement package.
 Must be used with `replacementVersion` (see example below).
@@ -1780,7 +1780,7 @@ You can suggest a new community package rule by editing [the `replacements.ts` f
 
 ### replacementVersion
 
-This config option only works with the `npm` manager.
+This config option only works with the `npm` manager. Checkout [renovatebot/renovate#14149](https://github.com/renovatebot/renovate/issues/14149) for progress.
 
 Use this field to define the version of a replacement package.
 Must be used with `replacementName`.

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -1773,7 +1773,7 @@ For example to apply a special label for Major updates:
 ### replacementName
 
 This config option only works with the `npm` manager.
-Checkout [renovatebot/renovate#14149](https://github.com/renovatebot/renovate/issues/14149) for progress.
+We're working to support more managers, subscribe to issue [renovatebot/renovate#14149](https://github.com/renovatebot/renovate/issues/14149) to follow our progress.
 
 Use this field to define the name of a replacement package.
 Must be used with `replacementVersion` (see example below).
@@ -1782,7 +1782,7 @@ You can suggest a new community package rule by editing [the `replacements.ts` f
 ### replacementVersion
 
 This config option only works with the `npm` manager.
-Checkout [renovatebot/renovate#14149](https://github.com/renovatebot/renovate/issues/14149) for progress.
+We're working to support more managers, subscribe to issue [renovatebot/renovate#14149](https://github.com/renovatebot/renovate/issues/14149) to follow our progress.
 
 Use this field to define the version of a replacement package.
 Must be used with `replacementName`.

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -1772,7 +1772,8 @@ For example to apply a special label for Major updates:
 
 ### replacementName
 
-This config option only works with the `npm` manager. Checkout [renovatebot/renovate#14149](https://github.com/renovatebot/renovate/issues/14149) for progress.
+This config option only works with the `npm` manager.
+Checkout [renovatebot/renovate#14149](https://github.com/renovatebot/renovate/issues/14149) for progress.
 
 Use this field to define the name of a replacement package.
 Must be used with `replacementVersion` (see example below).
@@ -1780,7 +1781,8 @@ You can suggest a new community package rule by editing [the `replacements.ts` f
 
 ### replacementVersion
 
-This config option only works with the `npm` manager. Checkout [renovatebot/renovate#14149](https://github.com/renovatebot/renovate/issues/14149) for progress.
+This config option only works with the `npm` manager.
+Checkout [renovatebot/renovate#14149](https://github.com/renovatebot/renovate/issues/14149) for progress.
 
 Use this field to define the version of a replacement package.
 Must be used with `replacementName`.

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -1772,11 +1772,15 @@ For example to apply a special label for Major updates:
 
 ### replacementName
 
+This config option only works with the `npm` manager.
+
 Use this field to define the name of a replacement package.
 Must be used with `replacementVersion` (see example below).
 You can suggest a new community package rule by editing [the `replacements.ts` file on the Renovate repository](https://github.com/renovatebot/renovate/blob/main/lib/config/presets/internal/replacements.ts) and opening a pull request.
 
 ### replacementVersion
+
+This config option only works with the `npm` manager.
 
 Use this field to define the version of a replacement package.
 Must be used with `replacementName`.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Add a note that `replacementName` and `replacementVersion` are `npm` manager only

## Context:

Fixes #12626.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
