### PR TITLE
feat: Only pin Composer dependencies if already pinned; bump otherwise

### DIFF
--- a/lib/manager/composer/range.spec.ts
+++ b/lib/manager/composer/range.spec.ts
@@ -6,20 +6,39 @@ describe('manager/composer/range', () => {
     const config: RangeConfig = { rangeStrategy: 'widen' };
     expect(getRangeStrategy(config)).toBe('widen');
   });
-  it('pins require-dev', () => {
+  it('pins require-dev if already pinned', () => {
     const config: RangeConfig = {
       rangeStrategy: 'auto',
       depType: 'require-dev',
+      currentValue: '1.0.0',
     };
     expect(getRangeStrategy(config)).toBe('pin');
   });
-  it('pins project require', () => {
+  it('bumps require-dev if not pinned', () => {
+    const config: RangeConfig = {
+      rangeStrategy: 'auto',
+      depType: 'require-dev',
+      currentValue: '^1.0.0',
+    };
+    expect(getRangeStrategy(config)).toBe('bump');
+  });
+  it('pins project require if already pinned', () => {
     const config: RangeConfig = {
       rangeStrategy: 'auto',
       managerData: { composerJsonType: 'project' },
       depType: 'require',
+      currentValue: '1.0.0',
     };
     expect(getRangeStrategy(config)).toBe('pin');
+  });
+  it('bumps project require if not pinned', () => {
+    const config: RangeConfig = {
+      rangeStrategy: 'auto',
+      managerData: { composerJsonType: 'project' },
+      depType: 'require',
+      currentValue: '^1.0.0',
+    };
+    expect(getRangeStrategy(config)).toBe('bump');
   });
   it('widens complex ranges', () => {
     const config: RangeConfig = {

--- a/lib/manager/composer/range.ts
+++ b/lib/manager/composer/range.ts
@@ -23,18 +23,33 @@ export function getRangeStrategy(config: RangeConfig): RangeStrategy {
   if (rangeStrategy !== 'auto') {
     return rangeStrategy;
   }
+  const allowsRanges =
+    isComplexRange ||
+    currentValue?.includes('*') ||
+    currentValue?.includes('^') ||
+    currentValue?.includes('~');
   if (depType === 'require-dev') {
-    // Always pin dev dependencies
-    logger.trace({ dependency: depName }, 'Pinning require-dev');
-    return 'pin';
+    // Always pin or bump dev dependencies
+    if (allowsRanges) {
+      logger.trace({ dependency: depName }, 'Bumping require-dev');
+      return 'bump';
+    } else {
+      logger.trace({ dependency: depName }, 'Pinning require-dev');
+      return 'pin';
+    }
   }
   const isApp =
     composerJsonType &&
     !['library', 'metapackage', 'composer-plugin'].includes(composerJsonType);
   if (isApp && depType === 'require') {
-    // Pin dependencies if it's an app/project
-    logger.trace({ dependency: depName }, 'Pinning app require');
-    return 'pin';
+    // Pin or bump dependencies if it's an app/project
+    if (allowsRanges) {
+      logger.trace({ dependency: depName }, 'Bumping app require');
+      return 'bump';
+    } else {
+      logger.trace({ dependency: depName }, 'Pinning app require');
+      return 'pin';
+    }
   }
   if (isComplexRange) {
     return 'widen';


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Revises the `auto` range strategy for Composer to only `pin` versions if they're already pinned; otherwise, if a range is currently specified, the `bump` strategy will be used instead.

## Context:

Renovate automatically uses the `pin` strategy for certain packages you usually want to keep up-to-date (all dev dependencies, and non-dev dependencies for applications), and the logic behind that is sound. However, it's not uncommon for PHP repositories to have a mix of pinned and caret-based constraints for those packages, and for a good reason:

 - The pinned versions signal that devs really want to stay on the current version regardless of new updates; any changes should be considered carefully.
 - Caret-based constraints (like `^1.2.3`) signal that the newer versions should be safe

Think about it from the perspective of what would happen if a user ran `composer update` manually on such a repository:

 - Pinned versions would not be updated
 - Caret-based constraints would install the newer version

I think Renovate should respect the user's preference when following the `auto` strategy.

So instead of having the `auto` strategy always `pin` these, I propose that it **only** `pin` already-pinned versions and instead `bump` anything defined as a range.  This PR implements that change.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
