### PR TITLE
feat(composer): Default to 'widen' rangeStrategy for TYPO3 extensions

### DIFF
--- a/lib/manager/composer/range.spec.ts
+++ b/lib/manager/composer/range.spec.ts
@@ -41,4 +41,14 @@ describe('manager/composer/range', () => {
     const config: RangeConfig = { rangeStrategy: 'auto', depType: 'require' };
     expect(getRangeStrategy(config)).toBe('replace');
   });
+  it('defaults to widen for TYPO3 extensions', () => {
+    const config: RangeConfig = {
+      managerData: {
+        composerJsonType: 'typo3-cms-extension',
+      },
+      rangeStrategy: 'auto',
+      depType: 'require',
+    };
+    expect(getRangeStrategy(config)).toBe('widen');
+  });
 });

--- a/lib/manager/composer/range.ts
+++ b/lib/manager/composer/range.ts
@@ -42,7 +42,7 @@ export function getRangeStrategy(config: RangeConfig): RangeStrategy {
     logger.trace({ dependency: depName }, 'Pinning app require');
     return 'pin';
   }
-  if (isComplexRange) {
+  if (isComplexRange || ['typo3-cms-extension'].includes(composerJsonType)) {
     return 'widen';
   }
   return 'replace';


### PR DESCRIPTION
Closes #14172
Follows #14143
Related #13795

## Changes:

TYPO3 extension composer packages are classified as libraries. A `"rangeStrategy": "auto"` setting causes them to use the `"replace"` strategy.

This is changed with this PR. TYPO3 extension composer packages with `"rangeStrategy": "auto"` will use the `"widen"` strategy.

## Context:

See  #14172

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
