### PR TITLE
refactor(datasource/go): Unify delegation to bitbucket

### DIFF
--- a/lib/datasource/go/__snapshots__/index.spec.ts.snap
+++ b/lib/datasource/go/__snapshots__/index.spec.ts.snap
@@ -54,27 +54,4 @@ Array [
 
 exports[`datasource/go/index getDigest support bitbucket digest 1`] = `"123"`;
 
-exports[`datasource/go/index getDigest support bitbucket digest 2`] = `
-Array [
-  Object {
-    "headers": Object {
-      "accept": "application/json",
-      "accept-encoding": "gzip, deflate, br",
-      "host": "api.bitbucket.org",
-      "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
-    },
-    "method": "GET",
-    "url": "https://api.bitbucket.org/2.0/repositories/golang/text",
-  },
-  Object {
-    "headers": Object {
-      "accept": "application/json",
-      "accept-encoding": "gzip, deflate, br",
-      "host": "api.bitbucket.org",
-      "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
-    },
-    "method": "GET",
-    "url": "https://api.bitbucket.org/2.0/repositories/golang/text/commits/master",
-  },
-]
-`;
+exports[`datasource/go/index getDigest support bitbucket digest 2`] = `Array []`;

--- a/lib/datasource/go/base.ts
+++ b/lib/datasource/go/base.ts
@@ -5,9 +5,9 @@ import * as hostRules from '../../util/host-rules';
 import { Http } from '../../util/http';
 import { regEx } from '../../util/regex';
 import { trimTrailingSlash } from '../../util/url';
+import { BitBucketTagsDatasource } from '../bitbucket-tags';
 import * as github from '../github-tags';
 import { GitlabTagsDatasource } from '../gitlab-tags';
-import { bitbucket } from './common';
 import type { DataSource } from './types';
 
 // TODO: figure out class hierarchy (#10532)
@@ -47,7 +47,7 @@ export class BaseGoDatasource {
       const split = goModule.split('/');
       const lookupName = split[1] + '/' + split[2];
       return {
-        datasource: bitbucket.id,
+        datasource: BitBucketTagsDatasource.id,
         lookupName,
         registryUrl: 'https://bitbucket.org',
       };

--- a/lib/datasource/go/common.ts
+++ b/lib/datasource/go/common.ts
@@ -6,8 +6,6 @@ import { getSourceUrl as gitlabSourceUrl } from '../gitlab-tags/util';
 
 import type { DataSource } from './types';
 
-export const bitbucket = new BitBucketTagsDatasource();
-
 // eslint-disable-next-line typescript-enum/no-enum
 export enum GoproxyFallback {
   WhenNotFoundOrGone = ',',
@@ -26,7 +24,7 @@ export function getSourceUrl(dataSource?: DataSource): string | undefined {
       return gitlabSourceUrl(lookupName, registryUrl);
     }
 
-    if (datasource === bitbucket.id) {
+    if (datasource === BitBucketTagsDatasource.id) {
       return BitBucketTagsDatasource.getSourceUrl(lookupName, registryUrl);
     }
   }

--- a/lib/datasource/go/index.ts
+++ b/lib/datasource/go/index.ts
@@ -1,10 +1,10 @@
 import { cache } from '../../util/cache/package/decorator';
+import { BitBucketTagsDatasource } from '../bitbucket-tags';
 import { Datasource } from '../datasource';
 import * as github from '../github-tags';
 import { GitlabTagsDatasource } from '../gitlab-tags';
 import type { DigestConfig, GetReleasesConfig, ReleaseResult } from '../types';
 import { BaseGoDatasource } from './base';
-import { bitbucket } from './common';
 import { GoDirectDatasource } from './releases-direct';
 import { GoProxyDatasource } from './releases-goproxy';
 
@@ -60,8 +60,8 @@ export class GoDatasource extends Datasource {
       case github.id: {
         return github.getDigest(source, tag);
       }
-      case bitbucket.id: {
-        return bitbucket.getDigest(source, tag);
+      case BitBucketTagsDatasource.id: {
+        return this.direct.bitbucket.getDigest(source, tag);
       }
       case GitlabTagsDatasource.id: {
         return this.direct.gitlab.getDigest(source, tag);

--- a/lib/datasource/go/releases-direct.ts
+++ b/lib/datasource/go/releases-direct.ts
@@ -1,21 +1,24 @@
 import { logger } from '../../logger';
 import { cache } from '../../util/cache/package/decorator';
 import { regEx } from '../../util/regex';
+import { BitBucketTagsDatasource } from '../bitbucket-tags';
 import { Datasource } from '../datasource';
 import * as github from '../github-tags';
 import { GitlabTagsDatasource } from '../gitlab-tags';
 import type { DatasourceApi, GetReleasesConfig, ReleaseResult } from '../types';
 import { BaseGoDatasource } from './base';
-import { bitbucket, getSourceUrl } from './common';
+import { getSourceUrl } from './common';
 
 export class GoDirectDatasource extends Datasource {
   static readonly id = 'go-direct';
 
   gitlab: DatasourceApi;
+  bitbucket: DatasourceApi;
 
   constructor() {
     super(GoDirectDatasource.id);
     this.gitlab = new GitlabTagsDatasource();
+    this.bitbucket = new BitBucketTagsDatasource();
   }
 
   /**
@@ -58,8 +61,8 @@ export class GoDirectDatasource extends Datasource {
         res = await this.gitlab.getReleases(source);
         break;
       }
-      case bitbucket.id: {
-        res = await bitbucket.getReleases(source);
+      case BitBucketTagsDatasource.id: {
+        res = await this.bitbucket.getReleases(source);
         break;
       }
       /* istanbul ignore next: can never happen, makes lint happy */


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Use `id` from static field when possible
- Move `bitbucket` http instance to direct datasource field

## Context:

- Ref: #8647

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
