### PR TITLE
fix(presets): set global host rules before validating presets

### DIFF
--- a/lib/workers/global/index.spec.ts
+++ b/lib/workers/global/index.spec.ts
@@ -43,6 +43,7 @@ describe('workers/global/index', () => {
     configParser.parseConfigs.mockResolvedValueOnce({
       repositories: [],
       globalExtends: [':pinVersions'],
+      hostRules: [{ matchHost: 'github.com', token: 'abc123' }],
     });
     presets.resolveConfigPresets.mockResolvedValueOnce({});
     await expect(globalWorker.start()).resolves.toBe(0);

--- a/lib/workers/global/index.ts
+++ b/lib/workers/global/index.ts
@@ -78,6 +78,7 @@ function checkEnv(): void {
 }
 
 export async function validatePresets(config: AllConfig): Promise<void> {
+  logger.debug('validatePresets()');
   try {
     await resolveConfigPresets(config);
   } catch (err) /* istanbul ignore next */ {
@@ -141,6 +142,7 @@ export async function start(): Promise<number> {
       }
       const repoConfig = await getRepositoryConfig(config, repository);
       if (repoConfig.hostRules) {
+        logger.debug('Reinitializing hostRules for repo');
         hostRules.clear();
         repoConfig.hostRules.forEach((rule) => hostRules.add(rule));
         repoConfig.hostRules = [];

--- a/lib/workers/global/initialize.ts
+++ b/lib/workers/global/initialize.ts
@@ -7,6 +7,7 @@ import { initPlatform } from '../../platform';
 import * as packageCache from '../../util/cache/package';
 import { setEmojiConfig } from '../../util/emoji';
 import { validateGitVersion } from '../../util/git';
+import * as hostRules from '../../util/host-rules';
 import { Limit, setMaxLimit } from './limits';
 
 async function setDirectories(input: AllConfig): Promise<AllConfig> {
@@ -42,6 +43,13 @@ async function checkVersions(): Promise<void> {
   }
 }
 
+function setGlobalHostRules(config: RenovateConfig): void {
+  if (config.hostRules) {
+    logger.debug('Setting global hostRules');
+    config.hostRules.forEach((rule) => hostRules.add(rule));
+  }
+}
+
 export async function globalInitialize(
   config_: RenovateConfig
 ): Promise<RenovateConfig> {
@@ -52,6 +60,7 @@ export async function globalInitialize(
   await packageCache.init(config);
   limitCommitsPerRun(config);
   setEmojiConfig(config);
+  setGlobalHostRules(config);
   return config;
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Sets any global host rules before validating presets. This ensures that any github-hosted presets use a github.com token if configured.

## Context:

Closes #10893

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
