### PR TITLE
fix(util/git): Skip PR update on "force-with-lease" errors

### DIFF
--- a/lib/util/git/error.ts
+++ b/lib/util/git/error.ts
@@ -22,6 +22,7 @@ export function checkForPlatformFailure(err: Error): void {
     'early EOF',
     'fatal: bad config', // .gitmodules problem
     'expected flush after ref listing',
+    '[rejected] (stale info)',
   ];
   for (const errorStr of externalHostFailureStrings) {
     if (err.message.includes(errorStr)) {
@@ -119,12 +120,6 @@ export function handleCommitError(
   if (err.message.includes('remote: error: cannot lock ref')) {
     logger.error({ err }, 'Error committing files.');
     return null;
-  }
-  if (err.message.includes('[rejected] (stale info)')) {
-    logger.info(
-      'Branch update was rejected because local copy is not up-to-date.'
-    );
-    throw new ExternalHostError(err, 'git');
   }
   if (
     err.message.includes('denying non-fast-forward') ||

--- a/lib/util/git/error.ts
+++ b/lib/util/git/error.ts
@@ -121,7 +121,7 @@ export function handleCommitError(
     return null;
   }
   if (err.message.includes('[rejected] (stale info)')) {
-    logger.warn(
+    logger.info(
       'Branch update was rejected because local copy is not up-to-date.'
     );
     throw new ExternalHostError(err, 'git');

--- a/lib/util/git/error.ts
+++ b/lib/util/git/error.ts
@@ -121,10 +121,10 @@ export function handleCommitError(
     return null;
   }
   if (err.message.includes('[rejected] (stale info)')) {
-    logger.info(
+    logger.warn(
       'Branch update was rejected because local copy is not up-to-date.'
     );
-    return null;
+    throw new ExternalHostError(err, 'git');
   }
   if (
     err.message.includes('denying non-fast-forward') ||


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

- Wrap to `ExternalHostError` and re-throw, which will lead `processBranch()` to skip the branch updating for this run.

## Context:

- Closes: #12124

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
