### PR TITLE
test(manager/pipenv): migrate all manage fs.readFile to fs.readLocalFile

### DIFF
--- a/lib/manager/pipenv/artifacts.spec.ts
+++ b/lib/manager/pipenv/artifacts.spec.ts
@@ -1,26 +1,19 @@
-import { exec as _exec } from 'child_process';
-import _fs from 'fs-extra';
 import { join } from 'upath';
-import { envMock, mockExecAll } from '../../../test/exec-util';
-import { git, mocked } from '../../../test/util';
+import { envMock, exec, mockExecAll } from '../../../test/exec-util';
+import { env, fs, git } from '../../../test/util';
 import { GlobalConfig } from '../../config/global';
 import type { RepoGlobalConfig } from '../../config/types';
 import * as docker from '../../util/exec/docker';
-import * as _env from '../../util/exec/env';
 import type { StatusResult } from '../../util/git/types';
 import type { UpdateArtifactsConfig } from '../types';
 import * as pipenv from './artifacts';
 
-jest.mock('fs-extra');
 jest.mock('child_process');
 jest.mock('../../util/exec/env');
 jest.mock('../../util/git');
+jest.mock('../../util/fs');
 jest.mock('../../util/host-rules');
 jest.mock('../../util/http');
-
-const fs: jest.Mocked<typeof _fs> = _fs as any;
-const exec: jest.Mock<typeof _exec> = _exec as any;
-const env = mocked(_env);
 
 const adminConfig: RepoGlobalConfig = {
   // `join` fixes Windows CI
@@ -61,11 +54,15 @@ describe('manager/pipenv/artifacts', () => {
       })
     ).toBeNull();
   });
+
   it('returns null if unchanged', async () => {
     pipFileLock._meta.requires.python_full_version = '3.7.6';
-    fs.readFile.mockResolvedValueOnce(JSON.stringify(pipFileLock) as any);
+    fs.ensureCacheDir.mockResolvedValueOnce(
+      '/tmp/renovate/cache/others/pipenv'
+    );
+    fs.readLocalFile.mockResolvedValueOnce(JSON.stringify(pipFileLock));
     const execSnapshots = mockExecAll(exec);
-    fs.readFile.mockReturnValueOnce(JSON.stringify(pipFileLock) as any);
+    fs.readLocalFile.mockResolvedValueOnce(JSON.stringify(pipFileLock));
     expect(
       await pipenv.updateArtifacts({
         packageFileName: 'Pipfile',
@@ -76,10 +73,14 @@ describe('manager/pipenv/artifacts', () => {
     ).toBeNull();
     expect(execSnapshots).toMatchSnapshot();
   });
+
   it('handles no constraint', async () => {
-    fs.readFile.mockResolvedValueOnce('unparseable pipfile lock' as any);
+    fs.ensureCacheDir.mockResolvedValueOnce(
+      '/tmp/renovate/cache/others/pipenv'
+    );
+    fs.readLocalFile.mockResolvedValueOnce('unparseable pipfile lock');
     const execSnapshots = mockExecAll(exec);
-    fs.readFile.mockReturnValueOnce('unparseable pipfile lock' as any);
+    fs.readLocalFile.mockResolvedValueOnce('unparseable pipfile lock');
     expect(
       await pipenv.updateArtifacts({
         packageFileName: 'Pipfile',
@@ -90,13 +91,17 @@ describe('manager/pipenv/artifacts', () => {
     ).toBeNull();
     expect(execSnapshots).toMatchSnapshot();
   });
+
   it('returns updated Pipfile.lock', async () => {
-    fs.readFile.mockResolvedValueOnce('current pipfile.lock' as any);
+    fs.ensureCacheDir.mockResolvedValueOnce(
+      '/tmp/renovate/cache/others/pipenv'
+    );
+    fs.readLocalFile.mockResolvedValueOnce('current pipfile.lock');
     const execSnapshots = mockExecAll(exec);
     git.getRepoStatus.mockResolvedValue({
       modified: ['Pipfile.lock'],
     } as StatusResult);
-    fs.readFile.mockReturnValueOnce('New Pipfile.lock' as any);
+    fs.readLocalFile.mockResolvedValueOnce('New Pipfile.lock');
     expect(
       await pipenv.updateArtifacts({
         packageFileName: 'Pipfile',
@@ -107,15 +112,19 @@ describe('manager/pipenv/artifacts', () => {
     ).not.toBeNull();
     expect(execSnapshots).toMatchSnapshot();
   });
+
   it('supports docker mode', async () => {
     GlobalConfig.set(dockerAdminConfig);
     pipFileLock._meta.requires.python_version = '3.7';
-    fs.readFile.mockResolvedValueOnce(JSON.stringify(pipFileLock) as any);
+    fs.ensureCacheDir.mockResolvedValueOnce(
+      '/tmp/renovate/cache/others/pipenv'
+    );
+    fs.readLocalFile.mockResolvedValueOnce(JSON.stringify(pipFileLock));
     const execSnapshots = mockExecAll(exec);
     git.getRepoStatus.mockResolvedValue({
       modified: ['Pipfile.lock'],
     } as StatusResult);
-    fs.readFile.mockReturnValueOnce('new lock' as any);
+    fs.readLocalFile.mockResolvedValueOnce('new lock');
     expect(
       await pipenv.updateArtifacts({
         packageFileName: 'Pipfile',
@@ -126,9 +135,13 @@ describe('manager/pipenv/artifacts', () => {
     ).not.toBeNull();
     expect(execSnapshots).toMatchSnapshot();
   });
+
   it('catches errors', async () => {
-    fs.readFile.mockResolvedValueOnce('Current Pipfile.lock' as any);
-    fs.outputFile.mockImplementationOnce(() => {
+    fs.ensureCacheDir.mockResolvedValueOnce(
+      '/tmp/renovate/cache/others/pipenv'
+    );
+    fs.readLocalFile.mockResolvedValueOnce('Current Pipfile.lock');
+    fs.writeLocalFile.mockImplementationOnce(() => {
       throw new Error('not found');
     });
     expect(
@@ -142,13 +155,17 @@ describe('manager/pipenv/artifacts', () => {
       { artifactError: { lockFile: 'Pipfile.lock', stderr: 'not found' } },
     ]);
   });
+
   it('returns updated Pipenv.lock when doing lockfile maintenance', async () => {
-    fs.readFile.mockResolvedValueOnce('Current Pipfile.lock' as any);
+    fs.ensureCacheDir.mockResolvedValueOnce(
+      '/tmp/renovate/cache/others/pipenv'
+    );
+    fs.readLocalFile.mockResolvedValueOnce('Current Pipfile.lock');
     const execSnapshots = mockExecAll(exec);
     git.getRepoStatus.mockResolvedValue({
       modified: ['Pipfile.lock'],
     } as StatusResult);
-    fs.readFile.mockReturnValueOnce('New Pipfile.lock' as any);
+    fs.readLocalFile.mockResolvedValueOnce('New Pipfile.lock');
     expect(
       await pipenv.updateArtifacts({
         packageFileName: 'Pipfile',
@@ -159,15 +176,19 @@ describe('manager/pipenv/artifacts', () => {
     ).not.toBeNull();
     expect(execSnapshots).toMatchSnapshot();
   });
+
   it('uses pipenv version from Pipfile', async () => {
+    fs.ensureCacheDir.mockResolvedValueOnce(
+      '/tmp/renovate/cache/others/pipenv'
+    );
     GlobalConfig.set(dockerAdminConfig);
     pipFileLock.default.pipenv.version = '==2020.8.13';
-    fs.readFile.mockResolvedValueOnce(JSON.stringify(pipFileLock) as any);
+    fs.readLocalFile.mockResolvedValueOnce(JSON.stringify(pipFileLock));
     const execSnapshots = mockExecAll(exec);
     git.getRepoStatus.mockResolvedValue({
       modified: ['Pipfile.lock'],
     } as StatusResult);
-    fs.readFile.mockReturnValueOnce('new lock' as any);
+    fs.readLocalFile.mockResolvedValueOnce('new lock');
     expect(
       await pipenv.updateArtifacts({
         packageFileName: 'Pipfile',
@@ -178,15 +199,19 @@ describe('manager/pipenv/artifacts', () => {
     ).not.toBeNull();
     expect(execSnapshots).toMatchSnapshot();
   });
+
   it('uses pipenv version from Pipfile dev packages', async () => {
     GlobalConfig.set(dockerAdminConfig);
     pipFileLock.develop.pipenv.version = '==2020.8.13';
-    fs.readFile.mockResolvedValueOnce(JSON.stringify(pipFileLock) as any);
+    fs.ensureCacheDir.mockResolvedValueOnce(
+      '/tmp/renovate/cache/others/pipenv'
+    );
+    fs.readLocalFile.mockResolvedValueOnce(JSON.stringify(pipFileLock));
     const execSnapshots = mockExecAll(exec);
     git.getRepoStatus.mockResolvedValue({
       modified: ['Pipfile.lock'],
     } as StatusResult);
-    fs.readFile.mockReturnValueOnce('new lock' as any);
+    fs.readLocalFile.mockResolvedValueOnce('new lock');
     expect(
       await pipenv.updateArtifacts({
         packageFileName: 'Pipfile',
@@ -197,15 +222,19 @@ describe('manager/pipenv/artifacts', () => {
     ).not.toBeNull();
     expect(execSnapshots).toMatchSnapshot();
   });
+
   it('uses pipenv version from config', async () => {
     GlobalConfig.set(dockerAdminConfig);
     pipFileLock.default.pipenv.version = '==2020.8.13';
-    fs.readFile.mockResolvedValueOnce(JSON.stringify(pipFileLock) as any);
+    fs.ensureCacheDir.mockResolvedValueOnce(
+      '/tmp/renovate/cache/others/pipenv'
+    );
+    fs.readLocalFile.mockResolvedValueOnce(JSON.stringify(pipFileLock));
     const execSnapshots = mockExecAll(exec);
     git.getRepoStatus.mockResolvedValue({
       modified: ['Pipfile.lock'],
     } as StatusResult);
-    fs.readFile.mockReturnValueOnce('new lock' as any);
+    fs.readLocalFile.mockResolvedValueOnce('new lock');
     expect(
       await pipenv.updateArtifacts({
         packageFileName: 'Pipfile',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Migrate all manage fs.readFile to fs.readLocalFile #7049

<!-- Describe what behavior is changed by this PR. -->

## Context:

Part of https://github.com/renovatebot/renovate/issues/7049, related to PR https://github.com/renovatebot/renovate/pull/12987
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
