### PR TITLE
feat: use private gitlab pypi registry together with gitlab host

### DIFF
--- a/docs/usage/getting-started/private-packages.md
+++ b/docs/usage/getting-started/private-packages.md
@@ -327,6 +327,39 @@ For those found, a command similar to the following is run: `dotnet nuget add so
 
 For every poetry source, a `hostRules` search is done and then any found credentials are added to env like `POETRY_HTTP_BASIC_X_USERNAME` and `POETRY_HTTP_BASIC_X_PASSWORD`.
 
+```json
+{
+  "hostRules": [
+    {
+      "matchHost": "pypi.example.com",
+      "username": "pypi-user",
+      "password": "pypi-password"
+    }
+  ]
+}
+```
+
+<!-- prettier-ignore -->
+!!! note
+    Environment variables are build from the poetry source `name` configured in the section `[[tool.poetry.source]]` of
+    the project's `pyproject.toml` file.
+
+When using renovate on Gitlab hosted projects which depend on Python dependencies also hosted on Gitlab's private pypi registries, use a distinct
+`hostType`:
+
+```json
+{
+  "hostRules": [
+    {
+      "matchHost": "gitlab.example.com",
+      "hostType": "pypi",
+      "username": "gitlab-ci-token", // CI credentials will work on self-hosted renovate
+      "password": "$CI_JOB_TOKEN" // use any other username/password in other cases
+    }
+  ]
+}
+```
+
 ## WhiteSource Renovate Hosted App Encryption
 
 The popular [Renovate App on GitHub](https://github.com/apps/renovate) is hosted by WhiteSource.

--- a/lib/manager/poetry/artifacts.ts
+++ b/lib/manager/poetry/artifacts.ts
@@ -107,7 +107,8 @@ function getSourceCredentialVars(
   const envVars: Record<string, string> = {};
 
   for (const source of poetrySources) {
-    const matchingHostRule = find({ url: source.url });
+    const matchingHostRule =
+      find({ hostType: 'pypi', url: source.url }) || find({ url: source.url });
     const formattedSourceName = source.name.toUpperCase();
     if (matchingHostRule.username) {
       envVars[`POETRY_HTTP_BASIC_${formattedSourceName}_USERNAME`] =


### PR DESCRIPTION
## Changes:

Use Gitlab Pypi registries as private poetry sources to renovate projects hosted on the same Gitlab instance. 

## Context:

To configure poetry credentials for private pypi registries hosted on a Gitlab instance, I can create a `hostRules` entry like this:

```json
"hostRules": [
    {
      "matchHost": "https://gitlab.example.com/api/v4/projects/123/packages/pypi/simple/",
      "username": "gitlab-user",
      "password": "gitlab-token"
    }
]
```

However, if I want to renovate several projects using dependencies hosted on several registries, I would need a dedicated entry for each of those projects.

This PR add the possibility to use a dedicated hostRule only relevant for Gitlab hosted pypi registries. 

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository