### PR TITLE
fix(gitlab): encode namespaced project paths in /api/v4/projects call

### DIFF
--- a/lib/platform/gitlab/index.ts
+++ b/lib/platform/gitlab/index.ts
@@ -161,7 +161,7 @@ export async function getRawFile(
   branchOrTag?: string
 ): Promise<string | null> {
   const escapedFileName = urlEscape(fileName);
-  const repo = urlEscape(repoName || config.repository);
+  const repo = urlEscape(repoName ?? config.repository);
   const url =
     `projects/${repo}/repository/files/${escapedFileName}?ref=` +
     (branchOrTag || `HEAD`);

--- a/lib/platform/gitlab/index.ts
+++ b/lib/platform/gitlab/index.ts
@@ -161,7 +161,7 @@ export async function getRawFile(
   branchOrTag?: string
 ): Promise<string | null> {
   const escapedFileName = urlEscape(fileName);
-  const repo = repoName ?? config.repository;
+  const repo = urlEscape(repoName || config.repository);
   const url =
     `projects/${repo}/repository/files/${escapedFileName}?ref=` +
     (branchOrTag || `HEAD`);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes

<!-- Describe what behavior is changed by this PR. -->

When making a GET call to Gitlab's `/api/v4/projects/:repo` endpoint, the `repo` now has forward slashes url encoded (`%2F%`) when using namespaced paths.  This aligns with Gitlab's [specifications](https://docs.gitlab.com/ee/api/index.html#namespaced-path-encoding) for namespaced project paths.  If they are not encoded, then Gitlab will respond with a 404.  

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

Closes #14268

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
