### PR TITLE
docs: add information about adding a new datasource to api.ts

### DIFF
--- a/lib/datasource/readme.md
+++ b/lib/datasource/readme.md
@@ -7,6 +7,8 @@ Datasources are used in Renovate primarily to fetch released versions of package
 New datasources _must_ follow the class-based programming style.
 Use the `adoptium-java` datasource as a reference.
 
+Add the datasource to the API in [`api.ts`](api.ts) so that the new datasource is usable. If you encounter `Pending mocks!` errors in the jest tests and your mocked URLs are correct, ensure the datasource is correctly registered.
+
 ## getReleases
 
 The minimum exported interface for a datasource is a function called `getReleases` that takes a lookup config as input.


### PR DESCRIPTION
## Changes

This adds a hint about adding new datasources to `lib/datasource/api.ts`.

## Context

While working on #14257, I debugged for about an hour why all jest tests showed `Pending mocks!` as the URLs looked correct.

As the warning in https://github.com/renovatebot/renovate/blob/f1b3f320eefef474028dbb94089ab39716ed6560/lib/datasource/index.ts#L243 does not get printed in the tests, I was debugging this issue quite a while until I found it when attaching a debugger to the tests (the VSCode launch targets are great for that, thanks for providing them!).

This hint in the documentation would've pointed me to the error far quicker than it took me.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
