### PR TITLE
fix: union types for ensurePR

### DIFF
--- a/lib/workers/branch/index.spec.ts
+++ b/lib/workers/branch/index.spec.ts
@@ -99,6 +99,7 @@ describe('workers/branch/index', () => {
 
       platform.massageMarkdown.mockImplementation((prBody) => prBody);
       prWorker.ensurePr.mockResolvedValue({
+        type: 'with-pr',
         pr: partial<Pr>({
           title: '',
           sourceBranch: '',
@@ -381,6 +382,7 @@ describe('workers/branch/index', () => {
       });
       git.branchExists.mockReturnValue(true);
       prWorker.ensurePr.mockResolvedValueOnce({
+        type: 'without-pr',
         prBlockedBy: 'RateLimited',
       });
       limits.isLimitReached.mockReturnValue(false);
@@ -503,6 +505,7 @@ describe('workers/branch/index', () => {
       commit.commitFilesToBranch.mockResolvedValueOnce(null);
       automerge.tryBranchAutomerge.mockResolvedValueOnce('failed');
       prWorker.ensurePr.mockResolvedValueOnce({
+        type: 'without-pr',
         prBlockedBy: 'NeedsApproval',
       });
       expect(await branchWorker.processBranch(config)).toEqual({
@@ -524,6 +527,7 @@ describe('workers/branch/index', () => {
       commit.commitFilesToBranch.mockResolvedValueOnce(null);
       automerge.tryBranchAutomerge.mockResolvedValueOnce('failed');
       prWorker.ensurePr.mockResolvedValueOnce({
+        type: 'without-pr',
         prBlockedBy: 'AwaitingTests',
       });
       expect(await branchWorker.processBranch(config)).toEqual({
@@ -545,6 +549,7 @@ describe('workers/branch/index', () => {
       commit.commitFilesToBranch.mockResolvedValueOnce(null);
       automerge.tryBranchAutomerge.mockResolvedValueOnce('no automerge');
       prWorker.ensurePr.mockResolvedValueOnce({
+        type: 'without-pr',
         prBlockedBy: 'BranchAutomerge',
       });
       expect(await branchWorker.processBranch(config)).toEqual({
@@ -566,6 +571,7 @@ describe('workers/branch/index', () => {
       commit.commitFilesToBranch.mockResolvedValueOnce(null);
       automerge.tryBranchAutomerge.mockResolvedValueOnce('failed');
       prWorker.ensurePr.mockResolvedValueOnce({
+        type: 'without-pr',
         prBlockedBy: 'Error',
       });
       expect(await branchWorker.processBranch(config)).toEqual({
@@ -587,6 +593,7 @@ describe('workers/branch/index', () => {
       commit.commitFilesToBranch.mockResolvedValueOnce(null);
       automerge.tryBranchAutomerge.mockResolvedValueOnce('failed');
       prWorker.ensurePr.mockResolvedValueOnce({
+        type: 'without-pr',
         prBlockedBy: 'whoops' as any,
       });
       expect(await branchWorker.processBranch(config)).toEqual({

--- a/lib/workers/branch/index.spec.ts
+++ b/lib/workers/branch/index.spec.ts
@@ -21,7 +21,7 @@ import * as _mergeConfidence from '../../util/merge-confidence';
 import * as _sanitize from '../../util/sanitize';
 import * as _limits from '../global/limits';
 import * as _prWorker from '../pr';
-import type { EnsurePrResult } from '../pr';
+import type { ResultWithPr } from '../pr';
 import * as _prAutomerge from '../pr/automerge';
 import type { Pr } from '../repository/onboarding/branch/check';
 import type { BranchConfig, BranchUpgradeConfig } from '../types';
@@ -637,8 +637,9 @@ describe('workers/branch/index', () => {
       git.branchExists.mockReturnValue(true);
       automerge.tryBranchAutomerge.mockResolvedValueOnce('failed');
       prWorker.ensurePr.mockResolvedValueOnce({
+        type: 'with-pr',
         pr: {},
-      } as EnsurePrResult);
+      } as ResultWithPr);
       prAutomerge.checkAutoMerge.mockResolvedValueOnce({ automerged: true });
       commit.commitFilesToBranch.mockResolvedValueOnce(null);
       await branchWorker.processBranch({ ...config, automerge: true });
@@ -657,8 +658,9 @@ describe('workers/branch/index', () => {
       git.branchExists.mockReturnValue(true);
       automerge.tryBranchAutomerge.mockResolvedValueOnce('stale');
       prWorker.ensurePr.mockResolvedValueOnce({
+        type: 'with-pr',
         pr: {},
-      } as EnsurePrResult);
+      } as ResultWithPr);
       prAutomerge.checkAutoMerge.mockResolvedValueOnce({ automerged: false });
       commit.commitFilesToBranch.mockResolvedValueOnce(null);
       await branchWorker.processBranch({
@@ -681,8 +683,9 @@ describe('workers/branch/index', () => {
       git.branchExists.mockReturnValue(true);
       automerge.tryBranchAutomerge.mockResolvedValueOnce('failed');
       prWorker.ensurePr.mockResolvedValueOnce({
+        type: 'with-pr',
         pr: {},
-      } as EnsurePrResult);
+      } as ResultWithPr);
       prAutomerge.checkAutoMerge.mockResolvedValueOnce({ automerged: true });
       commit.commitFilesToBranch.mockResolvedValueOnce(null);
       await branchWorker.processBranch(config);
@@ -701,8 +704,9 @@ describe('workers/branch/index', () => {
       git.branchExists.mockReturnValue(true);
       automerge.tryBranchAutomerge.mockResolvedValueOnce('failed');
       prWorker.ensurePr.mockResolvedValueOnce({
+        type: 'with-pr',
         pr: {},
-      } as EnsurePrResult);
+      } as ResultWithPr);
       prAutomerge.checkAutoMerge.mockResolvedValueOnce({ automerged: true });
       config.releaseTimestamp = '2018-04-26T05:15:51.877Z';
       commit.commitFilesToBranch.mockResolvedValueOnce(null);
@@ -722,8 +726,9 @@ describe('workers/branch/index', () => {
       git.branchExists.mockReturnValue(true);
       automerge.tryBranchAutomerge.mockResolvedValueOnce('failed');
       prWorker.ensurePr.mockResolvedValueOnce({
+        type: 'with-pr',
         pr: {},
-      } as EnsurePrResult);
+      } as ResultWithPr);
       prAutomerge.checkAutoMerge.mockResolvedValueOnce({ automerged: true });
       config.releaseTimestamp = new Date().toISOString();
       commit.commitFilesToBranch.mockResolvedValueOnce(null);
@@ -743,8 +748,9 @@ describe('workers/branch/index', () => {
       git.branchExists.mockReturnValue(false);
       automerge.tryBranchAutomerge.mockResolvedValueOnce('failed');
       prWorker.ensurePr.mockResolvedValueOnce({
+        type: 'with-pr',
         pr: {},
-      } as EnsurePrResult);
+      } as ResultWithPr);
       prAutomerge.checkAutoMerge.mockResolvedValueOnce({ automerged: true });
       config.releaseTimestamp = new Date().toISOString();
       await expect(branchWorker.processBranch(config)).rejects.toThrow(
@@ -763,8 +769,9 @@ describe('workers/branch/index', () => {
       git.branchExists.mockReturnValue(true);
       automerge.tryBranchAutomerge.mockResolvedValueOnce('failed');
       prWorker.ensurePr.mockResolvedValueOnce({
+        type: 'with-pr',
         pr: {},
-      } as EnsurePrResult);
+      } as ResultWithPr);
       prAutomerge.checkAutoMerge.mockResolvedValueOnce({ automerged: true });
       commit.commitFilesToBranch.mockResolvedValueOnce(null);
       await branchWorker.processBranch(config);
@@ -897,8 +904,9 @@ describe('workers/branch/index', () => {
       git.isBranchModified.mockResolvedValueOnce(true);
       schedule.isScheduledNow.mockReturnValueOnce(false);
       prWorker.ensurePr.mockResolvedValueOnce({
+        type: 'with-pr',
         pr: {},
-      } as EnsurePrResult);
+      } as ResultWithPr);
       commit.commitFilesToBranch.mockResolvedValueOnce(null);
       GlobalConfig.set({ ...adminConfig, dryRun: true });
       expect(

--- a/lib/workers/pr/index.spec.ts
+++ b/lib/workers/pr/index.spec.ts
@@ -764,7 +764,7 @@ describe('workers/pr/index', () => {
       config.upgrades.push(config.upgrades[0]);
       const result = await prWorker.ensurePr(config);
       isResultWithPr(result);
-      expect(result).toMatchObject({ displayNumber: 'New Pull Request' });
+      expect(result.pr).toMatchObject({ displayNumber: 'New Pull Request' });
     });
     it('should create privateRepo PR if success', async () => {
       platform.getBranchStatus.mockResolvedValueOnce(BranchStatus.green);

--- a/lib/workers/pr/index.ts
+++ b/lib/workers/pr/index.ts
@@ -217,14 +217,14 @@ export async function ensurePr(
       logger.debug(`Branch tests failed, so will create PR`);
     } else {
       // Branch should be automerged, so we don't want to create a PR
-      return { prBlockedBy: 'BranchAutomerge' };
+      return { type: 'without-pr', prBlockedBy: 'BranchAutomerge' };
     }
   }
   if (config.prCreation === 'status-success') {
     logger.debug('Checking branch combined status');
     if ((await getBranchStatus()) !== BranchStatus.green) {
       logger.debug(`Branch status isn't green - not creating PR`);
-      return { prBlockedBy: 'AwaitingTests' };
+      return { type: 'without-pr', prBlockedBy: 'AwaitingTests' };
     }
     logger.debug('Branch status success');
   } else if (
@@ -232,7 +232,7 @@ export async function ensurePr(
     !existingPr &&
     dependencyDashboardCheck !== 'approvePr'
   ) {
-    return { prBlockedBy: 'NeedsApproval' };
+    return { type: 'without-pr', prBlockedBy: 'NeedsApproval' };
   } else if (
     config.prCreation === 'not-pending' &&
     !existingPr &&
@@ -257,6 +257,7 @@ export async function ensurePr(
           `Branch is ${elapsedHours} hours old - skipping PR creation`
         );
         return {
+          type: 'without-pr',
           prBlockedBy: 'AwaitingTests',
         };
       }
@@ -385,7 +386,7 @@ export async function ensurePr(
           noWhitespaceOrHeadings(stripEmojis(prBody))
       ) {
         logger.debug(`${existingPr.displayNumber} does not need updating`);
-        return { pr: existingPr };
+        return { type: 'with-pr', pr: existingPr };
       }
       // PR must need updating
       if (existingPrTitle !== newPrTitle) {
@@ -417,9 +418,7 @@ export async function ensurePr(
         });
         logger.info({ pr: existingPr.number, prTitle }, `PR updated`);
       }
-      return {
-        pr: existingPr,
-      };
+      return { type: 'with-pr', pr: existingPr };
     }
     logger.debug({ branch: branchName, prTitle }, `Creating PR`);
     // istanbul ignore if
@@ -439,7 +438,7 @@ export async function ensurePr(
           !config.isVulnerabilityAlert
         ) {
           logger.debug('Skipping PR - limit reached');
-          return { prBlockedBy: 'RateLimited' };
+          return { type: 'without-pr', prBlockedBy: 'RateLimited' };
         }
         pr = await platform.createPr({
           sourceBranch: branchName,
@@ -463,7 +462,7 @@ export async function ensurePr(
         )
       ) {
         logger.warn('A pull requests already exists');
-        return { prBlockedBy: 'Error' };
+        return { type: 'without-pr', prBlockedBy: 'Error' };
       }
       if (err.statusCode === 502) {
         logger.warn(
@@ -476,7 +475,7 @@ export async function ensurePr(
           await deleteBranch(branchName);
         }
       }
-      return { prBlockedBy: 'Error' };
+      return { type: 'without-pr', prBlockedBy: 'Error' };
     }
     if (
       config.branchAutomergeFailureMessage &&
@@ -514,7 +513,7 @@ export async function ensurePr(
       await addAssigneesReviewers(config, pr);
     }
     logger.debug(`Created ${pr.displayNumber}`);
-    return { pr };
+    return { type: 'with-pr', pr };
   } catch (err) {
     // istanbul ignore if
     if (
@@ -529,8 +528,8 @@ export async function ensurePr(
     logger.error({ err }, 'Failed to ensure PR: ' + prTitle);
   }
   if (existingPr) {
-    return { pr: existingPr };
+    return { type: 'with-pr', pr: existingPr };
   }
   // istanbul ignore next
-  return { prBlockedBy: 'Error' };
+  return { type: 'without-pr', prBlockedBy: 'Error' };
 }

--- a/lib/workers/pr/index.ts
+++ b/lib/workers/pr/index.ts
@@ -145,12 +145,12 @@ export function getPlatformPrOptions(
 }
 
 export type ResultWithPr = {
+  type: 'with-pr';
   pr: Pr;
-  prBlockedBy?: never;
 };
 
 export type ResultWithoutPr = {
-  pr?: never;
+  type: 'without-pr';
   prBlockedBy: PrBlockedBy;
 };
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Implement propert discriminated unions for `ensurePr`. These changes are required for TypeScript 4.6

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

I heard that TypeScript 4.6 can break existing codebases with some of the new features[^1]. Attempting an update to 4.6-rc on Renovate resulted in the following errors:

```
$ yarn compile:ts
yarn run v1.22.17
$ tsc -p tsconfig.app.json
lib/workers/branch/index.ts:690:74 - error TS2339: Property 'number' does not exist on type 'never'.

690               `DRY-RUN: Would ensure lock file error comment in PR #${pr.number}`
                                                                             ~~~~~~

lib/workers/branch/index.ts:694:26 - error TS2339: Property 'number' does not exist on type 'never'.

694               number: pr.number,
                             ~~~~~~


Found 2 errors in the same file, starting at: lib/workers/branch/index.ts:690

error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

The control flow logic for `if(pr) {` no longer seemed to work for `never`. I could have changed this to `undefined` and it would work, but I instead opted for a discriminated union.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->

[^1]: https://devblogs.microsoft.com/typescript/announcing-typescript-4-6-beta