### PR TITLE
fix(composer): add support for github vulnerability alerts

### DIFF
--- a/lib/workers/repository/init/vulnerability.ts
+++ b/lib/workers/repository/init/vulnerability.ts
@@ -3,6 +3,7 @@ import { NO_VULNERABILITY_ALERTS } from '../../../constants/error-messages';
 import { MavenDatasource } from '../../../datasource/maven';
 import { NpmDatasource } from '../../../datasource/npm';
 import { NugetDatasource } from '../../../datasource/nuget';
+import { PackagistDatasource } from '../../../datasource/packagist';
 import { PypiDatasource } from '../../../datasource/pypi';
 import { RubyGemsDatasource } from '../../../datasource/rubygems';
 import { logger } from '../../../logger';
@@ -11,6 +12,7 @@ import type { SecurityAdvisory } from '../../../types';
 import { sanitizeMarkdown } from '../../../util/markdown';
 import { regEx } from '../../../util/regex';
 import * as allVersioning from '../../../versioning';
+import * as composerVersioning from '../../../versioning/composer';
 import * as mavenVersioning from '../../../versioning/maven';
 import * as npmVersioning from '../../../versioning/npm';
 import * as pep440Versioning from '../../../versioning/pep440';
@@ -60,6 +62,7 @@ export async function detectVulnerabilityAlerts(
   }
   const config = { ...input };
   const versionings: Record<string, string> = {
+    packagist: composerVersioning.id,
     maven: mavenVersioning.id,
     npm: npmVersioning.id,
     nuget: semverVersioning.id,
@@ -87,6 +90,7 @@ export async function detectVulnerabilityAlerts(
         continue;
       }
       const datasourceMapping: Record<string, string> = {
+        COMPOSER: PackagistDatasource.id,
         MAVEN: MavenDatasource.id,
         NPM: NpmDatasource.id,
         NUGET: NugetDatasource.id,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes

Processes GitHub vulnerability alerts for Composer.

## Context

#14299

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
