### PR TITLE
fix: check hashedBranchLength

### DIFF
--- a/lib/workers/repository/updates/branch-name.ts
+++ b/lib/workers/repository/updates/branch-name.ts
@@ -57,7 +57,7 @@ export function generateBranchName(update: RenovateConfig): void {
 
   if (update.hashedBranchLength) {
     let hashLength = update.hashedBranchLength - update.branchPrefix.length;
-    if (hashLength <= MIN_HASH_LENGTH) {
+    if (hashLength < MIN_HASH_LENGTH) {
       logger.warn(
         `\`hashedBranchLength\` must allow for at least ${MIN_HASH_LENGTH} characters hashing in addition to \`branchPrefix\`. Using ${MIN_HASH_LENGTH} character hash instead.`
       );


### PR DESCRIPTION
## Changes

Fix check set minimum hashedBranchLength 

## Context

You can't set `(hashedBranchLength - branchPrefix.length) == 6` without warning, because the wrong check

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

