### PR TITLE
refactor(lib/config): change secrets/replaceSecretsInObject function name to camel case

### DIFF
--- a/lib/config/secrets.ts
+++ b/lib/config/secrets.ts
@@ -83,7 +83,7 @@ function replaceSecretsInString(
   });
 }
 
-function replaceSecretsinObject(
+function replaceSecretsInObject(
   config_: RenovateConfig,
   secrets: Record<string, string>,
   deleteSecrets: boolean
@@ -94,7 +94,7 @@ function replaceSecretsinObject(
   }
   for (const [key, value] of Object.entries(config)) {
     if (is.plainObject(value)) {
-      config[key] = replaceSecretsinObject(value, secrets, deleteSecrets);
+      config[key] = replaceSecretsInObject(value, secrets, deleteSecrets);
     }
     if (is.string(value)) {
       config[key] = replaceSecretsInString(key, value, secrets);
@@ -102,7 +102,7 @@ function replaceSecretsinObject(
     if (is.array(value)) {
       for (const [arrayIndex, arrayItem] of value.entries()) {
         if (is.plainObject(arrayItem)) {
-          value[arrayIndex] = replaceSecretsinObject(
+          value[arrayIndex] = replaceSecretsInObject(
             arrayItem,
             secrets,
             deleteSecrets
@@ -128,5 +128,5 @@ export function applySecretsToConfig(
     }
   }
   // TODO: fix types (#9610)
-  return replaceSecretsinObject(config, secrets as never, deleteSecrets);
+  return replaceSecretsInObject(config, secrets as never, deleteSecrets);
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes

<!-- Describe what behavior is changed by this PR. -->
change secrets/replaceSecretsInObject function name to camel case

## Context

We need to use Camel Case and in this function "replaceSecretsInObject" we don't have Camel case naming convention.  

- Closes #13861
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
