### PR TITLE
fix: validate depName is a string

### DIFF
--- a/lib/workers/repository/process/fetch.spec.ts
+++ b/lib/workers/repository/process/fetch.spec.ts
@@ -77,17 +77,19 @@ describe('workers/repository/process/fetch', () => {
               { depName: ' ' },
               { depName: null },
               { depName: undefined },
+              { depName: { oh: 'no' } as unknown as string },
             ],
           },
         ],
       };
       await fetchUpdates(config, packageFiles);
-      expect(packageFiles.docker[0].deps[0].skipReason).toBe('missing-depname');
+      expect(packageFiles.docker[0].deps[0].skipReason).toBe('invalid-name');
       expect(packageFiles.docker[0].deps[1].skipReason).toBeUndefined();
-      expect(packageFiles.docker[0].deps[2].skipReason).toBe('missing-depname');
-      expect(packageFiles.docker[0].deps[3].skipReason).toBe('missing-depname');
-      expect(packageFiles.docker[0].deps[4].skipReason).toBe('missing-depname');
-      expect(packageFiles.docker[0].deps[5].skipReason).toBe('missing-depname');
+      expect(packageFiles.docker[0].deps[2].skipReason).toBe('invalid-name');
+      expect(packageFiles.docker[0].deps[3].skipReason).toBe('invalid-name');
+      expect(packageFiles.docker[0].deps[4].skipReason).toBe('invalid-name');
+      expect(packageFiles.docker[0].deps[5].skipReason).toBe('invalid-name');
+      expect(packageFiles.docker[0].deps[6].skipReason).toBe('invalid-name');
     });
   });
 });

--- a/lib/workers/repository/process/fetch.ts
+++ b/lib/workers/repository/process/fetch.ts
@@ -16,8 +16,11 @@ async function fetchDepUpdates(
 ): Promise<PackageDependency> {
   let dep = clone(indep);
   dep.updates = [];
-  if (!is.nonEmptyString(dep.depName?.trim())) {
-    dep.skipReason = 'missing-depname';
+  if (is.string(dep.depName)) {
+    dep.depName = dep.depName.trim();
+  }
+  if (!is.nonEmptyString(dep.depName)) {
+    dep.skipReason = 'invalid-name';
   }
   if (dep.skipReason) {
     return dep;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes

Makes sure `depName` is a string before trimming it.

## Context

Closes #14338

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
