### PR TITLE
fix(manager/kustomize): support yml extension for kustomization file

### DIFF
--- a/lib/manager/kustomize/index.ts
+++ b/lib/manager/kustomize/index.ts
@@ -5,7 +5,7 @@ import { HelmDatasource } from '../../datasource/helm';
 export { extractPackageFile } from './extract';
 
 export const defaultConfig = {
-  fileMatch: ['(^|/)kustomization\\.yaml'],
+  fileMatch: ['(^|/)kustomization\\.ya?ml'],
   pinDigests: false,
 };
 

--- a/lib/manager/kustomize/index.ts
+++ b/lib/manager/kustomize/index.ts
@@ -5,7 +5,7 @@ import { HelmDatasource } from '../../datasource/helm';
 export { extractPackageFile } from './extract';
 
 export const defaultConfig = {
-  fileMatch: ['(^|/)kustomization\\.ya?ml'],
+  fileMatch: ['(^|/)kustomization\\.ya?ml$'],
   pinDigests: false,
 };
 


### PR DESCRIPTION
## Changes

Extend the regex for the kustomize manager to support `kustomization.yml` in addition to `kustomization.yaml`.

## Context

This is supported by Kubernetes/Kustomize but not by Renovate.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
