### PR TITLE
chore: improve bug and feature request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,6 +2,13 @@ name: Bug report
 description: You've found a bug with Renovate.
 labels: ['type:bug', 'status:requirements', 'priority-5-triage']
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Before you begin to fill out the form, make sure you have actually found a bug.
+        If you're not sure then create a [discussion](https://github.com/renovatebot/renovate/discussions) first.
+        If you have questions or want help with Renovate, then also create a [discussion](https://github.com/renovatebot/renovate/discussions).
+
   - type: dropdown
     id: how-are-you-running-renovate
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,7 +6,7 @@ body:
     id: what-would-you-like-renovate-to-be-able-to-do
     attributes:
       label: What would you like Renovate to be able to do?
-      placeholder: "Tell us what requirements you need solving, and be sure to mention too if this is part of any bigger problem you're trying to solve."
+      description: Tell us what requirements you need solving, and be sure to mention too if this is part of any bigger problem you're trying to solve.
     validations:
       required: true
 
@@ -14,7 +14,9 @@ body:
     id: implementation-idea-textbox
     attributes:
       label: If you have any ideas on how this should be implemented, please tell us here.
-      placeholder: "In case you've already dug into existing options or source code and have ideas, mention them here. Try to keep implementation ideas separate from requirements."
+      description: |
+        In case you've already dug into existing options or source code and have ideas, mention them here.
+        Try to keep implementation ideas separate from requirements.
     validations:
       required: true
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes

- Improve bug report template:
  - Ask reader if they're sure they have a bug, else create discussion first
  - Redirect questions/help to discussion as well
  - Add links to the discussions start page
- Improve feature request template:
  - Move text out of `placeholder` box and into the `description` that's always visible

## Context

Not closing any existing issue with this.
You can see the improved templates on my fork's [`chore/improve-templates`](https://github.com/HonkingGoose/renovate/tree/chore/improve-templates/.github/ISSUE_TEMPLATE) branch.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
