### PR TITLE
fix(pep440): version range narrows when using tilde

### DIFF
--- a/lib/versioning/pep440/index.spec.ts
+++ b/lib/versioning/pep440/index.spec.ts
@@ -149,6 +149,9 @@ describe('versioning/pep440/index', () => {
     ${'!=1.2.3'}          | ${'replace'}     | ${'1.0.0'}     | ${'1.2.3'} | ${null}
     ${'!=1.2.3'}          | ${'pin'}         | ${'1.0.0'}     | ${'1.2.3'} | ${'==1.2.3'}
     ${'~=1.1.0,!=1.1.1'}  | ${'unsupported'} | ${'1.0.0'}     | ${'1.2.3'} | ${'~=1.2.3,!=1.1.1'}
+    ${'~=7.2'}            | ${'replace'}     | ${'7.2.0'}     | ${'8.0.1'} | ${'~=8.0'}
+    ${'~=7.2'}            | ${'replace'}     | ${'7.2.0'}     | ${'8'}     | ${'~=8.0'}
+    ${'~=7.2.0'}          | ${'replace'}     | ${'7.2.0'}     | ${'8.2'}   | ${'~=8.2.0'}
   `(
     'getNewValue("$currentValue", "$rangeStrategy", "$currentVersion", "$newVersion") === "$expected"',
     ({ currentValue, rangeStrategy, currentVersion, newVersion, expected }) => {

--- a/lib/versioning/pep440/range.ts
+++ b/lib/versioning/pep440/range.ts
@@ -218,8 +218,27 @@ function updateRangeValue(
     const futureVersion = getFutureVersion(range.version, newVersion, 0);
     return range.operator + futureVersion + '.*';
   }
-
-  if (['==', '~=', '<='].includes(range.operator)) {
+  if (range.operator === '~=') {
+    const baseVersion = parseVersion(range.version)?.release ?? [];
+    const futureVersion = parseVersion(newVersion)?.release ?? [];
+    const baseLen = baseVersion.length;
+    const newVerLen = futureVersion.length;
+    // trim redundant trailing version specifiers
+    if (baseLen < newVerLen) {
+      return (
+        range.operator + futureVersion.slice(0, baseVersion.length).join('.')
+      );
+    }
+    // pad with specifiers
+    if (baseLen > newVerLen) {
+      for (let i = baseLen - newVerLen - 1; i >= 0; i--) {
+        futureVersion.push(0);
+      }
+      return range.operator + futureVersion.join('.');
+    }
+    return range.operator + newVersion;
+  }
+  if (['==', '<='].includes(range.operator)) {
     return range.operator + newVersion;
   }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes
Now padding and trimming when accepted version has less/more version specifiers than the original range.
<!-- Describe what behavior is changed by this PR. -->

## Context
Closes #10354 
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
