### PR TITLE
feat(github-tags): Add defaultRegistryUrls to github tags

### DIFF
--- a/lib/datasource/github-tags/index.spec.ts
+++ b/lib/datasource/github-tags/index.spec.ts
@@ -20,6 +20,12 @@ describe('datasource/github-tags/index', () => {
     });
   });
 
+  describe('defaultRegistryUrls', () => {
+    it('returns https://github.com', () => {
+      expect(github.defaultRegistryUrls).toBe(['https://github.com']);
+    });
+  });
+
   describe('getDigest', () => {
     const lookupName = 'some/dep';
     const tag = 'v1.2.0';

--- a/lib/datasource/github-tags/index.ts
+++ b/lib/datasource/github-tags/index.ts
@@ -12,6 +12,8 @@ export class GithubTagsDatasource extends GithubReleasesDatasource {
     super(GithubTagsDatasource.id);
   }
 
+  override readonly defaultRegistryUrls = ['https://github.com'];
+
   @cache({
     ttlMinutes: 120,
     namespace: `datasource-${GithubTagsDatasource.id}`,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes

By changing the defaultRegistryUrls for github-tags datasource, we allow renovate to fetch the changelog associated to the github tags it opens the PR for.

## Context

We are renovate users and we would like to get the changelog fetched in our PR opened for kustomize. 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [X] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
