### PR TITLE
refactor: remove unnecessarily long paths in imports and mocks

### DIFF
--- a/lib/manager/buildkite/extract.spec.ts
+++ b/lib/manager/buildkite/extract.spec.ts
@@ -1,5 +1,5 @@
 import { Fixtures } from '../../../test/fixtures';
-import type { PackageDependency } from '../../manager/types';
+import type { PackageDependency } from '../types';
 import { extractPackageFile } from './extract';
 
 describe('manager/buildkite/extract', () => {

--- a/lib/manager/bundler/artifacts.spec.ts
+++ b/lib/manager/bundler/artifacts.spec.ts
@@ -19,11 +19,11 @@ const bundlerHostRules = mocked(_bundlerHostRules);
 
 jest.mock('fs-extra');
 jest.mock('child_process');
-jest.mock('../../../lib/util/exec/env');
-jest.mock('../../../lib/datasource');
-jest.mock('../../../lib/util/fs');
-jest.mock('../../../lib/util/git');
-jest.mock('../../../lib/util/host-rules');
+jest.mock('../../util/exec/env');
+jest.mock('../../datasource');
+jest.mock('../../util/fs');
+jest.mock('../../util/git');
+jest.mock('../../util/host-rules');
 jest.mock('./host-rules');
 
 const adminConfig: RepoGlobalConfig = {

--- a/lib/manager/composer/artifacts.spec.ts
+++ b/lib/manager/composer/artifacts.spec.ts
@@ -14,7 +14,7 @@ import * as composer from './artifacts';
 
 jest.mock('child_process');
 jest.mock('../../util/exec/env');
-jest.mock('../../../lib/datasource');
+jest.mock('../../datasource');
 jest.mock('../../util/fs');
 jest.mock('../../util/git');
 

--- a/lib/manager/composer/utils.spec.ts
+++ b/lib/manager/composer/utils.spec.ts
@@ -5,7 +5,7 @@ import {
   requireComposerDependencyInstallation,
 } from './utils';
 
-jest.mock('../../../lib/datasource');
+jest.mock('../../datasource');
 
 describe('manager/composer/utils', () => {
   describe('extractContraints', () => {

--- a/lib/manager/npm/post-update/lerna.spec.ts
+++ b/lib/manager/npm/post-update/lerna.spec.ts
@@ -7,7 +7,7 @@ import * as _lernaHelper from './lerna';
 
 jest.mock('child_process');
 jest.mock('../../../util/exec/env');
-jest.mock('../../../manager/npm/post-update/node-version');
+jest.mock('../../npm/post-update/node-version');
 
 const exec: jest.Mock<typeof _exec> = _exec as any;
 const env = mocked(_env);

--- a/lib/util/exec/buildpack.spec.ts
+++ b/lib/util/exec/buildpack.spec.ts
@@ -8,7 +8,7 @@ import {
 } from './buildpack';
 import type { ToolConstraint } from './types';
 
-jest.mock('../../../lib/datasource');
+jest.mock('../../datasource');
 
 const datasource = mocked(_datasource);
 

--- a/lib/util/exec/index.spec.ts
+++ b/lib/util/exec/index.spec.ts
@@ -13,7 +13,7 @@ import { exec } from '.';
 const cpExec: jest.Mock<typeof _cpExec> = _cpExec as any;
 
 jest.mock('child_process');
-jest.mock('../../../lib/datasource');
+jest.mock('../../datasource');
 
 interface TestInput {
   processEnv: Record<string, string>;

--- a/lib/util/fs/index.spec.ts
+++ b/lib/util/fs/index.spec.ts
@@ -18,7 +18,7 @@ import {
   writeLocalFile,
 } from '.';
 
-jest.mock('../../util/exec/env');
+jest.mock('../exec/env');
 jest.mock('find-up');
 
 const findUp = mockedFunction(_findUp);

--- a/lib/util/git/conflicts-cache.spec.ts
+++ b/lib/util/git/conflicts-cache.spec.ts
@@ -1,12 +1,12 @@
 import { mocked } from '../../../test/util';
-import * as _repositoryCache from '../../util/cache/repository';
+import * as _repositoryCache from '../cache/repository';
 import type { Cache } from '../cache/repository/types';
 import {
   getCachedConflictResult,
   setCachedConflictResult,
 } from './conflicts-cache';
 
-jest.mock('../../util/cache/repository');
+jest.mock('../cache/repository');
 const repositoryCache = mocked(_repositoryCache);
 
 describe('util/git/conflicts-cache', () => {

--- a/lib/util/http/github.spec.ts
+++ b/lib/util/http/github.spec.ts
@@ -9,12 +9,12 @@ import {
   REPOSITORY_CHANGED,
 } from '../../constants/error-messages';
 import { GithubReleasesDatasource } from '../../datasource/github-releases';
-import * as _repositoryCache from '../../util/cache/repository';
-import type { Cache } from '../../util/cache/repository/types';
+import * as _repositoryCache from '../cache/repository';
+import type { Cache } from '../cache/repository/types';
 import * as hostRules from '../host-rules';
 import { GithubHttp, setBaseUrl } from './github';
 
-jest.mock('../../util/cache/repository');
+jest.mock('../cache/repository');
 const repositoryCache = mocked(_repositoryCache);
 
 const githubApiHost = 'https://api.github.com';

--- a/lib/util/http/github.ts
+++ b/lib/util/http/github.ts
@@ -10,7 +10,7 @@ import {
 } from '../../constants/error-messages';
 import { logger } from '../../logger';
 import { ExternalHostError } from '../../types/errors/external-host-error';
-import { getCache } from '../../util/cache/repository';
+import { getCache } from '../cache/repository';
 import { maskToken } from '../mask';
 import { range } from '../range';
 import { regEx } from '../regex';

--- a/lib/workers/pr/changelog/github.spec.ts
+++ b/lib/workers/pr/changelog/github.spec.ts
@@ -5,7 +5,7 @@ import * as semverVersioning from '../../../versioning/semver';
 import type { BranchUpgradeConfig } from '../../types';
 import { ChangeLogError, getChangeLogJSON } from '.';
 
-jest.mock('../../../../lib/datasource/npm');
+jest.mock('../../../datasource/npm');
 
 const upgrade: BranchUpgradeConfig = {
   branchName: undefined,

--- a/lib/workers/pr/changelog/gitlab.spec.ts
+++ b/lib/workers/pr/changelog/gitlab.spec.ts
@@ -5,7 +5,7 @@ import * as semverVersioning from '../../../versioning/semver';
 import type { BranchUpgradeConfig } from '../../types';
 import { getChangeLogJSON } from '.';
 
-jest.mock('../../../../lib/datasource/npm');
+jest.mock('../../../datasource/npm');
 
 const upgrade: BranchUpgradeConfig = {
   branchName: undefined,

--- a/lib/workers/repository/onboarding/branch/index.spec.ts
+++ b/lib/workers/repository/onboarding/branch/index.spec.ts
@@ -23,7 +23,7 @@ import { checkOnboardingBranch } from '.';
 const rebase: any = _rebase;
 const configModule: any = _config;
 
-jest.mock('../../../../workers/repository/onboarding/branch/rebase');
+jest.mock('../../../repository/onboarding/branch/rebase');
 jest.mock('../../../../util/cache/repository');
 jest.mock('../../../../util/fs');
 jest.mock('../../../../util/git');


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
