### PR TITLE
docs(reviewers): Permission required for self-hosted Github App

### DIFF
--- a/docs/usage/getting-started/running.md
+++ b/docs/usage/getting-started/running.md
@@ -174,6 +174,7 @@ When creating the GitHub App give it the following permissions:
 - Commit statuses: Read & write
 - Dependabot alerts: Read-only
 - Workflows: Read & write
+- Members: Read
 
 Other values like Homepage URL, User authorization callback URL and webhooks can be disabled or filled with dummy values.
 


### PR DESCRIPTION



## Changes

In the documenation, Added `Members: Read` as a required permission for GitHub App

## Context

With the Self-Hosted Github app, Members was required to add team reviewers when I used it.
After adding this permission, we could add team reviewers again.
This could be required for other scenarios. Only the Self-Hosted Github App + Team reviewers was tested for this.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
