### PR TITLE
fix(config/preset): Update dotNetCore Docker Group

### DIFF
--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -127,7 +127,7 @@ const staticGroups = {
     packageRules: [
       {
         matchDatasources: ['docker'],
-        matchPackagePrefixes: ['mcr.microsoft.com/dotnet/core/'],
+        matchPackagePrefixes: ['mcr.microsoft.com/dotnet/'],
         groupName: '.NET Core Docker containers',
       },
     ],


### PR DESCRIPTION
## Changes

Instead of grouping the dotnet docker images that match `dotnet/core/*`, this now groups anything under `dotnet/*`

## Context
Currently this only groups tags under `dotnet/core/*`, but they stopped using this path with dotnet 5 preview. See https://mcr.microsoft.com/v2/dotnet/core/sdk/tags/list.

They now put all the versions just under `dotnet/*`, see https://hub.docker.com/_/microsoft-dotnet-sdk.

Most repos will use `dotnet/sdk` to build and then `dotnet/aspnet` as the runtime, see the official example: https://docs.docker.com/samples/dotnetcore/#create-a-dockerfile-for-an-aspnet-core-application
 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [X] No unit tests but ran on a real repository, or https://github.com/busches/dotnet-renovate/pull/9
- [ ] Both unit tests + ran on a real repository