### PR TITLE
fix: Ignore .Net 7

### DIFF
--- a/lib/config/presets/internal/workarounds.ts
+++ b/lib/config/presets/internal/workarounds.ts
@@ -13,7 +13,6 @@ export const presets: Record<string, Preset> = {
       'workarounds:typesNodeVersioning',
       'workarounds:reduceRepologyServerLoad',
       'workarounds:doNotUpgradeFromAlpineStableToEdge',
-      'workarounds:ignoreDotnet7Preview',
     ],
   },
   mavenCommonsAncientVersion: {

--- a/lib/config/presets/internal/workarounds.ts
+++ b/lib/config/presets/internal/workarounds.ts
@@ -13,7 +13,7 @@ export const presets: Record<string, Preset> = {
       'workarounds:typesNodeVersioning',
       'workarounds:reduceRepologyServerLoad',
       'workarounds:doNotUpgradeFromAlpineStableToEdge',
-      'workarounds:ignoreDotNet7',
+      'workarounds:ignoreDotnet7Preview',
     ],
   },
   mavenCommonsAncientVersion: {
@@ -89,7 +89,7 @@ export const presets: Record<string, Preset> = {
       },
     ],
   },
-  ignoreDotNet7: {
+  ignoreDotnet7Preview: {
     description: 'Ignore dotnet 7 preview releases',
     packageRules: [
       {

--- a/lib/config/presets/internal/workarounds.ts
+++ b/lib/config/presets/internal/workarounds.ts
@@ -13,7 +13,7 @@ export const presets: Record<string, Preset> = {
       'workarounds:typesNodeVersioning',
       'workarounds:reduceRepologyServerLoad',
       'workarounds:doNotUpgradeFromAlpineStableToEdge',
-      'workarounds:ignoreDotNet7'
+      'workarounds:ignoreDotNet7',
     ],
   },
   mavenCommonsAncientVersion: {

--- a/lib/config/presets/internal/workarounds.ts
+++ b/lib/config/presets/internal/workarounds.ts
@@ -13,6 +13,7 @@ export const presets: Record<string, Preset> = {
       'workarounds:typesNodeVersioning',
       'workarounds:reduceRepologyServerLoad',
       'workarounds:doNotUpgradeFromAlpineStableToEdge',
+      'workarounds:ignoreDotNet7'
     ],
   },
   mavenCommonsAncientVersion: {
@@ -85,6 +86,16 @@ export const presets: Record<string, Preset> = {
         matchPackageNames: ['alpine'],
         matchCurrentVersion: '<20000000',
         allowedVersions: '<20000000',
+      },
+    ],
+  },
+  ignoreDotNet7: {
+    description: 'Ignore dotnet 7 preview releases',
+    packageRules: [
+      {
+        matchDatasources: ['docker'],
+        matchPackagePrefixes: ['mcr.microsoft.com/dotnet/'],
+        allowedVersions: '!/^7\\.0/',
       },
     ],
   },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes

Ignore the Dot Net 7 Docker images.

<!-- Describe what behavior is changed by this PR. -->

## Context

Dot Net 7 is in preview, but for some reason, Microsoft creates the following tags:
```
    "7.0",
    "7.0-alpine",
    "7.0-alpine-amd64",
    "7.0-alpine-arm32v7",
    "7.0-alpine-arm64v8",
    "7.0-alpine3.15",
    "7.0-alpine3.15-amd64",
    "7.0-alpine3.15-arm32v7",
    "7.0-alpine3.15-arm64v8",
    "7.0-bullseye-slim",
    "7.0-bullseye-slim-amd64",
    "7.0-bullseye-slim-arm32v7",
    "7.0-bullseye-slim-arm64v8",
    "7.0-cbl-mariner1.0",
    "7.0-cbl-mariner1.0-amd64",
    "7.0-focal",
    "7.0-focal-amd64",
    "7.0-focal-arm32v7",
    "7.0-focal-arm64v8",
    "7.0-nanoserver-1809",
    "7.0-nanoserver-ltsc2022",
    "7.0-windowsservercore-ltsc2019",
    "7.0-windowsservercore-ltsc2022",
    "7.0.100-preview.1",
    "7.0.100-preview.1-alpine3.15",
    "7.0.100-preview.1-alpine3.15-amd64",
    "7.0.100-preview.1-alpine3.15-arm32v7",
    "7.0.100-preview.1-alpine3.15-arm64v8",
    "7.0.100-preview.1-bullseye-slim",
    "7.0.100-preview.1-bullseye-slim-amd64",
    "7.0.100-preview.1-bullseye-slim-arm32v7",
    "7.0.100-preview.1-bullseye-slim-arm64v8",
    "7.0.100-preview.1-cbl-mariner1.0",
    "7.0.100-preview.1-cbl-mariner1.0-amd64",
    "7.0.100-preview.1-focal",
    "7.0.100-preview.1-focal-amd64",
    "7.0.100-preview.1-focal-arm32v7",
    "7.0.100-preview.1-focal-arm64v8",
    "7.0.100-preview.1-nanoserver-1809",
    "7.0.100-preview.1-nanoserver-ltsc2022",
    "7.0.100-preview.1-windowsservercore-ltsc2019",
    "7.0.100-preview.1-windowsservercore-ltsc2022",
```

I am unsure why Microsoft doesn't tag them all as preview, but they don't. They did the same thing for 5 and 6 when it was in preview. There is probably a better way to blacklist renovate opening these PRs until it goes stable and the rule is removed (or likely updated to blacklist 8), but this appeared to work.

7 is targeting to be released in November.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [X] No unit tests but ran on a real repository, or https://github.com/busches/dotnet-renovate/compare/d45c0e8840f25688d44b44e7d7f6967021be7c01..dbf59fdd910eaac24f6392839c6cb6cf26adcd9f
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
