### PR TITLE
docs: remove heading for conda datasource

### DIFF
--- a/lib/datasource/conda/readme.md
+++ b/lib/datasource/conda/readme.md
@@ -1,5 +1,3 @@
-# Conda
-
 This datasource returns releases from the specified [conda](https://docs.conda.io/en/latest/) registry.
 
 The default registry is `https://api.anaconda.org/package/`, which queries a specific conda channel for a specific package.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes

Removes the H1 heading in the conda datasource documentation.

## Context

Fixes https://github.com/renovatebot/renovate/pull/14257#issuecomment-1057046470

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
