### PR TITLE
refactore: bump is version and migrate to native nonEmptyStringAndNot…

### DIFF
--- a/lib/util/string.ts
+++ b/lib/util/string.ts
@@ -1,4 +1,3 @@
-import is from '@sindresorhus/is';
 import { logger } from '../logger';
 
 // Return true if the match string is found at index in content
@@ -23,11 +22,6 @@ export function replaceAt(
     newString +
     content.substr(index + oldString.length)
   );
-}
-
-// Return true if the input is non-empty and not whitespace string
-export function nonEmptyStringAndNotWhitespace(input: unknown): boolean {
-  return is.nonEmptyString(input) && !is.emptyStringOrWhitespace(input);
 }
 
 /**

--- a/lib/workers/pr/index.spec.ts
+++ b/lib/workers/pr/index.spec.ts
@@ -1,6 +1,6 @@
 import { getConfig, git, mocked, partial, platform } from '../../../test/util';
 import { PlatformId } from '../../constants';
-import type { Pr } from '../../platform/types';
+import type { Pr } from '../../platform';
 import { BranchStatus } from '../../types';
 import * as _limits from '../global/limits';
 import type { BranchConfig } from '../types';

--- a/lib/workers/pr/index.ts
+++ b/lib/workers/pr/index.ts
@@ -1,3 +1,4 @@
+import is from '@sindresorhus/is';
 import { GlobalConfig } from '../../config/global';
 import type { RenovateConfig } from '../../config/types';
 import {
@@ -14,7 +15,6 @@ import { sampleSize } from '../../util';
 import { stripEmojis } from '../../util/emoji';
 import { deleteBranch, getBranchLastCommitTime } from '../../util/git';
 import { regEx } from '../../util/regex';
-import { nonEmptyStringAndNotWhitespace } from '../../util/string';
 import * as template from '../../util/template';
 import { resolveBranchStatus } from '../branch/status-checks';
 import { Limit, incLimitedValue, isLimitReached } from '../global/limits';
@@ -59,9 +59,9 @@ export function prepareLabels(config: RenovateConfig): string[] {
   const labels = config.labels ?? [];
   const addLabels = config.addLabels ?? [];
   return [...new Set([...labels, ...addLabels])]
-    .filter(nonEmptyStringAndNotWhitespace)
+    .filter(is.nonEmptyStringAndNotWhitespace)
     .map((label) => template.compile(label, config))
-    .filter(nonEmptyStringAndNotWhitespace);
+    .filter(is.nonEmptyStringAndNotWhitespace);
 }
 
 export async function addAssigneesReviewers(

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "@iarna/toml": "2.2.5",
     "@renovatebot/pep440": "2.1.0",
     "@renovatebot/ruby-semver": "1.1.2",
-    "@sindresorhus/is": "4.4.0",
+    "@sindresorhus/is": "4.6.0",
     "@yarnpkg/core": "3.1.0",
     "@yarnpkg/parsers": "2.5.0",
     "auth-header": "1.0.0",


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes

- Update `sindresorhus/is`
- Migrate to native https://github.com/sindresorhus/is/blob/65ea91297ede74046b19a65c434411a39c16dacd/source/index.ts#L356

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
