### PR TITLE
Group RustCrypto crate updates.

### DIFF
--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -646,6 +646,16 @@ const staticGroups = {
       },
     ],
   },
+  rustCrypto: {
+    description: 'Group RustCrypto crates' ,
+    packagesRules: [
+      {
+        matchDatasources: ['crate'],
+        matchSourceUrlPrefixes: ['https://github.com/RustCrypto'],
+        groupName: 'crypto crates',
+      }
+    ]
+  }
 };
 
 const config: any = { ...staticGroups };


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes

Add group for RustCrypto crates.

## Context

The RustCrypto org hosts multiple repos containing multiple crates which depend on each other, so they should be updated together.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

Tried on a real repository, but this does not seem to work since I guess the source URL for crates seems to be `https://crates.io/crates/<crate>` instead of the GitHub repository.

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
