### PR TITLE
feat(manager/gradle): support repository content filtering of predefined registry

### DIFF
--- a/lib/modules/manager/gradle/parser.spec.ts
+++ b/lib/modules/manager/gradle/parser.spec.ts
@@ -93,6 +93,7 @@ describe('modules/manager/gradle/parser', () => {
       ${'mavenCentral()'}                             | ${MAVEN_REPO}
       ${'jcenter()'}                                  | ${JCENTER_REPO}
       ${'google()'}                                   | ${GOOGLE_REPO}
+      ${'google { content { includeGroup "foo" } }'}  | ${GOOGLE_REPO}
       ${'gradlePluginPortal()'}                       | ${GRADLE_PLUGIN_PORTAL_REPO}
       ${'maven("https://foo.bar/baz/qux")'}           | ${'https://foo.bar/baz/qux'}
       ${'maven { url = uri("https://foo.bar/baz") }'} | ${'https://foo.bar/baz'}

--- a/lib/modules/manager/gradle/parser.ts
+++ b/lib/modules/manager/gradle/parser.ts
@@ -460,6 +460,26 @@ const matcherConfigs: SyntaxMatchConfig[] = [
     handler: processPredefinedRegistryUrl,
   },
   {
+    // mavenCentral { content {
+    matchers: [
+      {
+        matchType: TokenType.Word,
+        matchValue: ['mavenCentral', 'jcenter', 'google', 'gradlePluginPortal'],
+        tokenMapKey: 'registryName',
+      },
+      { matchType: TokenType.LeftBrace },
+      {
+        matchType: TokenType.Word,
+        matchValue: ['content'],
+      },
+      {
+        matchType: TokenType.LeftBrace,
+        lookahead: true,
+      },
+    ],
+    handler: processPredefinedRegistryUrl,
+  },
+  {
     // maven("https://repository.mycompany.com/m2/repository")
     matchers: [
       {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Renovate supports [repository content filtering](https://docs.gradle.org/current/userguide/declaring_repositories.html#sec:repository-content-filtering) of predefined registry now.

By adding a new matcher for `registryName { content {`, Renovate matches repository content filtering of the predefined registry like below.

```groovy
google { 
     content { 
         includeGroupByRegex "androidx\\..*" 
         includeGroupByRegex "com\\.android.*" 
         includeGroupByRegex "com\\.google\\..*" 
     } 
 } 
```

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

Closes #14589 

https://github.com/wada811/RenovateSupportsRepositoyContentFiltering

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
