### PR TITLE
refactor(migrations): suppressNotifications

### DIFF
--- a/lib/config/migration.ts
+++ b/lib/config/migration.ts
@@ -46,14 +46,7 @@ export function migrateConfig(
     ];
     const { migratePresets } = GlobalConfig.get();
     for (const [key, val] of Object.entries(newConfig)) {
-      if (key === 'suppressNotifications') {
-        if (is.nonEmptyArray(val) && val.includes('prEditNotification')) {
-          migratedConfig.suppressNotifications =
-            migratedConfig.suppressNotifications.filter(
-              (item) => item !== 'prEditNotification'
-            );
-        }
-      } else if (key === 'matchStrings' && is.array(val)) {
+      if (key === 'matchStrings' && is.array(val)) {
         migratedConfig.matchStrings = val
           .map(
             (matchString) =>

--- a/lib/config/migrations/custom/suppress-notifications-migration.spec.ts
+++ b/lib/config/migrations/custom/suppress-notifications-migration.spec.ts
@@ -1,0 +1,38 @@
+import { SuppressNotificationsMigration } from './suppress-notifications-migration';
+
+describe('config/migrations/custom/suppress-notifications-migration', () => {
+  it('should remomve prEditNotification from array', () => {
+    expect(SuppressNotificationsMigration).toMigrate(
+      {
+        suppressNotifications: ['test', 'prEditNotification'],
+      },
+      {
+        suppressNotifications: ['test'],
+      }
+    );
+  });
+
+  it('should not migrate array without prEditNotification', () => {
+    expect(SuppressNotificationsMigration).toMigrate(
+      {
+        suppressNotifications: ['test'],
+      },
+      {
+        suppressNotifications: ['test'],
+      },
+      false
+    );
+  });
+
+  it('should not migrate empty array', () => {
+    expect(SuppressNotificationsMigration).toMigrate(
+      {
+        suppressNotifications: [],
+      },
+      {
+        suppressNotifications: [],
+      },
+      false
+    );
+  });
+});

--- a/lib/config/migrations/custom/suppress-notifications-migration.ts
+++ b/lib/config/migrations/custom/suppress-notifications-migration.ts
@@ -1,0 +1,13 @@
+import is from '@sindresorhus/is';
+import { AbstractMigration } from '../base/abstract-migration';
+
+export class SuppressNotificationsMigration extends AbstractMigration {
+  override readonly propertyName = 'suppressNotifications';
+
+  override run(value: unknown): void {
+    if (is.nonEmptyArray(value) && value.includes('prEditNotification')) {
+      const newValue = value.filter((item) => item !== 'prEditNotification');
+      this.rewrite(newValue);
+    }
+  }
+}

--- a/lib/config/migrations/migrations-service.ts
+++ b/lib/config/migrations/migrations-service.ts
@@ -17,6 +17,7 @@ import { RebaseStalePrsMigration } from './custom/rebase-stale-prs-migration';
 import { RenovateForkMigration } from './custom/renovate-fork-migration';
 import { RequiredStatusChecksMigration } from './custom/required-status-checks-migration';
 import { SemanticCommitsMigration } from './custom/semantic-commits-migration';
+import { SuppressNotificationsMigration } from './custom/suppress-notifications-migration';
 import { TrustLevelMigration } from './custom/trust-level-migration';
 import { UpgradeInRangeMigration } from './custom/upgrade-in-range-migration';
 import { VersionStrategyMigration } from './custom/version-strategy-migration';
@@ -68,6 +69,7 @@ export class MigrationsService {
     RenovateForkMigration,
     RequiredStatusChecksMigration,
     SemanticCommitsMigration,
+    SuppressNotificationsMigration,
     TrustLevelMigration,
     UpgradeInRangeMigration,
     VersionStrategyMigration,


### PR DESCRIPTION
## Changes:

One more migration from previously huge PR https://github.com/renovatebot/renovate/pull/12957

## Context:

1. https://github.com/renovatebot/renovate/issues/11459
2. Part of https://github.com/renovatebot/renovate/pull/12957 

## Documentation

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository