### PR TITLE
feat(npm): support custom registryUrls

### DIFF
--- a/lib/config/presets/npm/index.ts
+++ b/lib/config/presets/npm/index.ts
@@ -1,5 +1,8 @@
 import { logger } from '../../../logger';
-import { resolvePackage } from '../../../modules/datasource/npm/npmrc';
+import {
+  resolvePackageUrl,
+  resolveRegistryUrl,
+} from '../../../modules/datasource/npm/npmrc';
 import type { NpmResponse } from '../../../modules/datasource/npm/types';
 import { Http } from '../../../util/http';
 import type { Preset, PresetConfig } from '../types';
@@ -19,7 +22,8 @@ export async function getPreset({
 }: PresetConfig): Promise<Preset> {
   let dep;
   try {
-    const { packageUrl } = resolvePackage(pkg);
+    const registryUrl = resolveRegistryUrl(pkg);
+    const packageUrl = resolvePackageUrl(registryUrl, pkg);
     // istanbul ignore if
     if (!packageUrl.startsWith('https://registry.npmjs.org/')) {
       logger.warn(

--- a/lib/modules/datasource/index.ts
+++ b/lib/modules/datasource/index.ts
@@ -250,7 +250,9 @@ async function fetchReleases(
     if (is.string(config.npmrc)) {
       setNpmrc(config.npmrc);
     }
-    registryUrls = [resolveRegistryUrl(config.packageName)];
+    if (!is.nonEmptyArray(registryUrls)) {
+      registryUrls = [resolveRegistryUrl(config.packageName)];
+    }
   }
   const datasource = getDatasourceFor(datasourceName);
   registryUrls = resolveRegistryUrls(

--- a/lib/modules/datasource/npm/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/datasource/npm/__snapshots__/index.spec.ts.snap
@@ -19,7 +19,7 @@ Array [
 exports[`modules/datasource/npm/index should fetch package info from custom registry 1`] = `
 Object {
   "name": "foobar",
-  "registryUrl": "https://npm.mycustomregistry.com/",
+  "registryUrl": "https://npm.mycustomregistry.com",
   "releases": Array [
     Object {
       "releaseTimestamp": "2018-05-06T05:21:53.000Z",
@@ -561,7 +561,7 @@ Array [
 exports[`modules/datasource/npm/index should use host rules by baseUrl if provided 1`] = `
 Object {
   "name": "foobar",
-  "registryUrl": "https://npm.mycustomregistry.com/_packaging/mycustomregistry/npm/registry/",
+  "registryUrl": "https://npm.mycustomregistry.com/_packaging/mycustomregistry/npm/registry",
   "releases": Array [
     Object {
       "releaseTimestamp": "2018-05-06T05:21:53.000Z",
@@ -600,7 +600,7 @@ Array [
 exports[`modules/datasource/npm/index should use host rules by hostName if provided 1`] = `
 Object {
   "name": "foobar",
-  "registryUrl": "https://npm.mycustomregistry.com/",
+  "registryUrl": "https://npm.mycustomregistry.com",
   "releases": Array [
     Object {
       "releaseTimestamp": "2018-05-06T05:21:53.000Z",

--- a/lib/modules/datasource/npm/get.spec.ts
+++ b/lib/modules/datasource/npm/get.spec.ts
@@ -3,7 +3,7 @@ import { ExternalHostError } from '../../../types/errors/external-host-error';
 import * as hostRules from '../../../util/host-rules';
 import { Http } from '../../../util/http';
 import { getDependency, resetMemCache } from './get';
-import { resolvePackage, setNpmrc } from './npmrc';
+import { resolveRegistryUrl, setNpmrc } from './npmrc';
 
 function getPath(s = ''): string {
   const [x] = s.split('\n');
@@ -44,7 +44,7 @@ describe('modules/datasource/npm/get', () => {
         .reply(200, { name: '@myco/test' });
 
       setNpmrc(npmrc);
-      const { registryUrl } = resolvePackage('@myco/test');
+      const registryUrl = resolveRegistryUrl('@myco/test');
       await getDependency(http, registryUrl, '@myco/test');
 
       const trace = httpMock.getTrace();
@@ -77,7 +77,7 @@ describe('modules/datasource/npm/get', () => {
         .get(getPath(npmrc))
         .reply(200, { name: '@myco/test' });
       setNpmrc(npmrc);
-      const { registryUrl } = resolvePackage('@myco/test');
+      const registryUrl = resolveRegistryUrl('@myco/test');
       await getDependency(http, registryUrl, '@myco/test');
 
       const trace = httpMock.getTrace();
@@ -101,7 +101,7 @@ describe('modules/datasource/npm/get', () => {
         .get(getPath(npmrc))
         .reply(200, { name: '@myco/test' });
       setNpmrc(npmrc);
-      const { registryUrl } = resolvePackage('@myco/test');
+      const registryUrl = resolveRegistryUrl('@myco/test');
       await getDependency(http, registryUrl, '@myco/test');
 
       const trace = httpMock.getTrace();
@@ -128,7 +128,7 @@ describe('modules/datasource/npm/get', () => {
       .get(getPath(npmrc))
       .reply(200, { name: '@myco/test' });
     setNpmrc(npmrc);
-    const { registryUrl } = resolvePackage('@myco/test');
+    const registryUrl = resolveRegistryUrl('@myco/test');
     await getDependency(http, registryUrl, '@myco/test');
     expect(httpMock.getTrace()).toMatchSnapshot();
   });
@@ -150,7 +150,7 @@ describe('modules/datasource/npm/get', () => {
       .get('/renovate')
       .reply(200, { name: 'renovate' });
     setNpmrc(npmrc);
-    const { registryUrl } = resolvePackage('renovate');
+    const registryUrl = resolveRegistryUrl('renovate');
     await getDependency(http, registryUrl, 'renovate');
     expect(httpMock.getTrace()).toMatchSnapshot();
   });
@@ -173,7 +173,7 @@ describe('modules/datasource/npm/get', () => {
       .get('/renovate')
       .reply(200, { name: 'renovate' });
     setNpmrc(npmrc);
-    const { registryUrl } = resolvePackage('renovate');
+    const registryUrl = resolveRegistryUrl('renovate');
     await getDependency(http, registryUrl, 'renovate');
     expect(httpMock.getTrace()).toMatchSnapshot();
   });
@@ -187,7 +187,7 @@ describe('modules/datasource/npm/get', () => {
       .scope('https://test.org')
       .get('/none')
       .reply(200, { name: '@myco/test' });
-    let { registryUrl } = resolvePackage('none');
+    let registryUrl = resolveRegistryUrl('none');
     expect(await getDependency(http, registryUrl, 'none')).toBeNull();
 
     httpMock
@@ -199,7 +199,7 @@ describe('modules/datasource/npm/get', () => {
         versions: { '1.0.0': {} },
         'dist-tags': { latest: '1.0.0' },
       });
-    ({ registryUrl } = resolvePackage('@myco/test'));
+    registryUrl = resolveRegistryUrl('@myco/test');
     expect(await getDependency(http, registryUrl, '@myco/test')).toBeDefined();
 
     httpMock
@@ -210,23 +210,23 @@ describe('modules/datasource/npm/get', () => {
         versions: { '1.0.0': {} },
         'dist-tags': { latest: '1.0.0' },
       });
-    ({ registryUrl } = resolvePackage('@myco/test2'));
+    registryUrl = resolveRegistryUrl('@myco/test2');
     expect(await getDependency(http, registryUrl, '@myco/test2')).toBeDefined();
 
     httpMock.scope('https://test.org').get('/error-401').reply(401);
-    ({ registryUrl } = resolvePackage('error-401'));
+    registryUrl = resolveRegistryUrl('error-401');
     expect(await getDependency(http, registryUrl, 'error-401')).toBeNull();
 
     httpMock.scope('https://test.org').get('/error-402').reply(402);
-    ({ registryUrl } = resolvePackage('error-402'));
+    registryUrl = resolveRegistryUrl('error-402');
     expect(await getDependency(http, registryUrl, 'error-402')).toBeNull();
 
     httpMock.scope('https://test.org').get('/error-404').reply(404);
-    ({ registryUrl } = resolvePackage('error-404'));
+    registryUrl = resolveRegistryUrl('error-404');
     expect(await getDependency(http, registryUrl, 'error-404')).toBeNull();
 
     httpMock.scope('https://test.org').get('/error4').reply(200, null);
-    ({ registryUrl } = resolvePackage('error4'));
+    registryUrl = resolveRegistryUrl('error4');
     expect(await getDependency(http, registryUrl, 'error4')).toBeNull();
 
     setNpmrc();
@@ -234,7 +234,7 @@ describe('modules/datasource/npm/get', () => {
       .scope('https://registry.npmjs.org')
       .get('/npm-parse-error')
       .reply(200, 'not-a-json');
-    ({ registryUrl } = resolvePackage('npm-parse-error'));
+    registryUrl = resolveRegistryUrl('npm-parse-error');
     await expect(
       getDependency(http, registryUrl, 'npm-parse-error')
     ).rejects.toThrow(ExternalHostError);
@@ -263,7 +263,7 @@ describe('modules/datasource/npm/get', () => {
         versions: { '1.0.0': {} },
         'dist-tags': { latest: '1.0.0' },
       });
-    const { registryUrl } = resolvePackage('@neutrinojs/react');
+    const registryUrl = resolveRegistryUrl('@neutrinojs/react');
     const dep = await getDependency(http, registryUrl, '@neutrinojs/react');
 
     expect(dep.sourceUrl).toBe('https://github.com/neutrinojs/neutrino');
@@ -314,7 +314,7 @@ describe('modules/datasource/npm/get', () => {
         },
         'dist-tags': { latest: '2.0.0' },
       });
-    const { registryUrl } = resolvePackage('vue');
+    const registryUrl = resolveRegistryUrl('vue');
     const dep = await getDependency(http, registryUrl, 'vue');
 
     expect(dep.sourceUrl).toBe('https://github.com/vuejs/vue.git');
@@ -340,7 +340,7 @@ describe('modules/datasource/npm/get', () => {
         versions: { '1.0.0': {} },
         'dist-tags': { latest: '1.0.0' },
       });
-    const { registryUrl } = resolvePackage('@neutrinojs/react');
+    const registryUrl = resolveRegistryUrl('@neutrinojs/react');
     const dep = await getDependency(http, registryUrl, '@neutrinojs/react');
 
     expect(dep.sourceUrl).toBe('https://github.com/neutrinojs/neutrino');
@@ -378,7 +378,7 @@ describe('modules/datasource/npm/get', () => {
         versions: { '1.0.0': {} },
         'dist-tags': { latest: '1.0.0' },
       });
-    const { registryUrl } = resolvePackage('@neutrinojs/react');
+    const registryUrl = resolveRegistryUrl('@neutrinojs/react');
     const dep = await getDependency(http, registryUrl, '@neutrinojs/react');
 
     expect(dep.sourceUrl).toBe(

--- a/lib/modules/datasource/npm/get.ts
+++ b/lib/modules/datasource/npm/get.ts
@@ -6,7 +6,6 @@ import * as packageCache from '../../../util/cache/package';
 import type { Http } from '../../../util/http';
 import { joinUrlParts } from '../../../util/url';
 import { id } from './common';
-import { resolvePackage } from './npmrc';
 import type { NpmDependency, NpmRelease, NpmResponse } from './types';
 
 let memcache: Record<string, string> = {};
@@ -53,6 +52,7 @@ function getPackageSource(repository: any): PackageSource {
 
 export async function getDependency(
   http: Http,
+  registryUrl: string,
   packageName: string
 ): Promise<NpmDependency | null> {
   logger.trace(`npm.getDependency(${packageName})`);
@@ -63,7 +63,6 @@ export async function getDependency(
     return JSON.parse(memcache[packageName]) as NpmDependency;
   }
 
-  const { registryUrl } = resolvePackage(packageName);
   const packageUrl = joinUrlParts(registryUrl, packageName.replace('/', '%2F'));
 
   // Now check the persistent cache

--- a/lib/modules/datasource/npm/get.ts
+++ b/lib/modules/datasource/npm/get.ts
@@ -4,6 +4,7 @@ import { logger } from '../../../logger';
 import { ExternalHostError } from '../../../types/errors/external-host-error';
 import * as packageCache from '../../../util/cache/package';
 import type { Http } from '../../../util/http';
+import { joinUrlParts } from '../../../util/url';
 import { id } from './common';
 import { resolvePackage } from './npmrc';
 import type { NpmDependency, NpmRelease, NpmResponse } from './types';
@@ -62,7 +63,8 @@ export async function getDependency(
     return JSON.parse(memcache[packageName]) as NpmDependency;
   }
 
-  const { packageUrl, registryUrl } = resolvePackage(packageName);
+  const { registryUrl } = resolvePackage(packageName);
+  const packageUrl = joinUrlParts(registryUrl, packageName.replace('/', '%2F'));
 
   // Now check the persistent cache
   const cacheNamespace = 'datasource-npm';

--- a/lib/modules/datasource/npm/index.ts
+++ b/lib/modules/datasource/npm/index.ts
@@ -4,7 +4,7 @@ import { Datasource } from '../datasource';
 import type { GetReleasesConfig, ReleaseResult } from '../types';
 import { id } from './common';
 import { getDependency } from './get';
-import { resolvePackage, setNpmrc } from './npmrc';
+import { resolveRegistryUrl, setNpmrc } from './npmrc';
 
 export { resetMemCache, resetCache } from './get';
 export { setNpmrc } from './npmrc';
@@ -29,7 +29,7 @@ export class NpmDatasource extends Datasource {
     if (is.string(npmrc)) {
       setNpmrc(npmrc);
     }
-    const { registryUrl } = resolvePackage(packageName);
+    const registryUrl = resolveRegistryUrl(packageName);
     const res = await getDependency(this.http, registryUrl, packageName);
     if (res) {
       res.tags = res['dist-tags'];

--- a/lib/modules/datasource/npm/index.ts
+++ b/lib/modules/datasource/npm/index.ts
@@ -4,7 +4,7 @@ import { Datasource } from '../datasource';
 import type { GetReleasesConfig, ReleaseResult } from '../types';
 import { id } from './common';
 import { getDependency } from './get';
-import { setNpmrc } from './npmrc';
+import { resolvePackage, setNpmrc } from './npmrc';
 
 export { resetMemCache, resetCache } from './get';
 export { setNpmrc } from './npmrc';
@@ -29,7 +29,8 @@ export class NpmDatasource extends Datasource {
     if (is.string(npmrc)) {
       setNpmrc(npmrc);
     }
-    const res = await getDependency(this.http, packageName);
+    const { registryUrl } = resolvePackage(packageName);
+    const res = await getDependency(this.http, registryUrl, packageName);
     if (res) {
       res.tags = res['dist-tags'];
       delete res['dist-tags'];

--- a/lib/modules/datasource/npm/index.ts
+++ b/lib/modules/datasource/npm/index.ts
@@ -1,20 +1,18 @@
-import is from '@sindresorhus/is';
 import * as npmVersioning from '../../versioning/npm';
 import { Datasource } from '../datasource';
 import type { GetReleasesConfig, ReleaseResult } from '../types';
 import { id } from './common';
 import { getDependency } from './get';
-import { resolveRegistryUrl, setNpmrc } from './npmrc';
 
 export { resetMemCache, resetCache } from './get';
 export { setNpmrc } from './npmrc';
 
-export const customRegistrySupport = false;
-
 export class NpmDatasource extends Datasource {
   static readonly id = id;
 
-  override readonly customRegistrySupport = false;
+  override readonly customRegistrySupport = true;
+
+  override readonly registryStrategy = 'first';
 
   override readonly defaultVersioning = npmVersioning.id;
 
@@ -24,12 +22,8 @@ export class NpmDatasource extends Datasource {
 
   async getReleases({
     packageName,
-    npmrc,
+    registryUrl,
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
-    if (is.string(npmrc)) {
-      setNpmrc(npmrc);
-    }
-    const registryUrl = resolveRegistryUrl(packageName);
     const res = await getDependency(this.http, registryUrl, packageName);
     if (res) {
       res.tags = res['dist-tags'];

--- a/lib/modules/datasource/npm/npmrc.ts
+++ b/lib/modules/datasource/npm/npmrc.ts
@@ -10,7 +10,7 @@ import { regEx } from '../../../util/regex';
 import { fromBase64 } from '../../../util/string';
 import { ensureTrailingSlash, validateUrl } from '../../../util/url';
 import { defaultRegistryUrls } from './common';
-import type { NpmrcRules, PackageResolution } from './types';
+import type { NpmrcRules } from './types';
 
 let npmrc: Record<string, any> = {};
 let npmrcRaw = '';
@@ -179,11 +179,12 @@ export function resolveRegistryUrl(packageName: string): string {
   return registryUrl;
 }
 
-export function resolvePackage(packageName: string): PackageResolution {
-  const registryUrl = resolveRegistryUrl(packageName);
-  const packageUrl = url.resolve(
+export function resolvePackageUrl(
+  registryUrl: string,
+  packageName: string
+): string {
+  return url.resolve(
     ensureTrailingSlash(registryUrl),
     encodeURIComponent(packageName).replace(regEx(/^%40/), '@')
   );
-  return { packageUrl, registryUrl };
 }

--- a/lib/modules/datasource/npm/types.ts
+++ b/lib/modules/datasource/npm/types.ts
@@ -47,8 +47,3 @@ export interface NpmDependency extends ReleaseResult {
 }
 
 export type Npmrc = Record<string, any>;
-
-export interface PackageResolution {
-  packageUrl: string;
-  registryUrl: string;
-}

--- a/lib/modules/datasource/types.ts
+++ b/lib/modules/datasource/types.ts
@@ -18,7 +18,6 @@ export interface DigestConfig {
 }
 
 export interface GetReleasesConfig {
-  npmrc?: string;
   packageName: string;
   registryUrl?: string;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes

Refactors `npmrc` handling from `datasource/npm` into `datasource/index` so that custom `registryUrls` can be supported.

## Context

Closes #10110

Helps #9145

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
