### PR TITLE
refactor(migrations): automergeMinor

### DIFF
--- a/lib/config/migration.ts
+++ b/lib/config/migration.ts
@@ -198,10 +198,6 @@ export function migrateConfig(
           }
         }
         delete migratedConfig.unpublishSafe;
-      } else if (key === 'automergeMinor') {
-        migratedConfig.minor = migratedConfig.minor || {};
-        migratedConfig.minor.automerge = !!val;
-        delete migratedConfig[key];
       } else if (key === 'automergeMajor') {
         migratedConfig.major = migratedConfig.major || {};
         migratedConfig.major.automerge = !!val;

--- a/lib/config/migrations/custom/automerge-minor-migration.spec.ts
+++ b/lib/config/migrations/custom/automerge-minor-migration.spec.ts
@@ -1,0 +1,47 @@
+import { AutomergeMinorMigration } from './automerge-minor-migration';
+
+describe('config/migrations/custom/automerge-minor-migration', () => {
+  it('should migrate value to object', () => {
+    expect(AutomergeMinorMigration).toMigrate(
+      {
+        automergeMinor: 'some-value',
+      },
+      {
+        minor: {
+          automerge: true,
+        },
+      }
+    );
+  });
+
+  it('should migrate value to object and concat with existing minor object', () => {
+    expect(AutomergeMinorMigration).toMigrate(
+      {
+        automergeMinor: 'some-value',
+        minor: {
+          matchFiles: ['test'],
+        },
+      },
+      {
+        minor: {
+          automerge: true,
+          matchFiles: ['test'],
+        },
+      }
+    );
+  });
+
+  it('should ignore non object minor value', () => {
+    expect(AutomergeMinorMigration).toMigrate(
+      {
+        automergeMinor: 'some-value',
+        minor: null,
+      },
+      {
+        minor: {
+          automerge: true,
+        },
+      }
+    );
+  });
+});

--- a/lib/config/migrations/custom/automerge-minor-migration.ts
+++ b/lib/config/migrations/custom/automerge-minor-migration.ts
@@ -1,0 +1,15 @@
+import is from '@sindresorhus/is';
+import { AbstractMigration } from '../base/abstract-migration';
+
+export class AutomergeMinorMigration extends AbstractMigration {
+  override readonly deprecated = true;
+  override readonly propertyName = 'automergeMinor';
+
+  override run(value: unknown): void {
+    const minor = this.get('minor');
+
+    const newMinor = is.object(minor) ? minor : {};
+    newMinor.automerge = Boolean(value);
+    this.setHard('minor', newMinor);
+  }
+}

--- a/lib/config/migrations/migrations-service.ts
+++ b/lib/config/migrations/migrations-service.ts
@@ -2,6 +2,7 @@ import { dequal } from 'dequal';
 import type { RenovateConfig } from '../types';
 import { RemovePropertyMigration } from './base/remove-property-migration';
 import { RenamePropertyMigration } from './base/rename-property-migration';
+import { AutomergeMinorMigration } from './custom/automerge-minor-migration';
 import { AutomergeTypeMigration } from './custom/automerge-type-migration';
 import { BinarySourceMigration } from './custom/binary-source-migration';
 import { CompatibilityMigration } from './custom/compatibility-migration';
@@ -55,6 +56,7 @@ export class MigrationsService {
   ]);
 
   static readonly customMigrations: ReadonlyArray<MigrationConstructor> = [
+    AutomergeMinorMigration,
     AutomergeTypeMigration,
     BinarySourceMigration,
     CompatibilityMigration,


### PR DESCRIPTION
## Changes:

One more migration from previously huge PR https://github.com/renovatebot/renovate/pull/12957

## Context:

1. https://github.com/renovatebot/renovate/issues/11459
2. Part of https://github.com/renovatebot/renovate/pull/12957 

## Documentation

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository