### PR TITLE
refactor: split global/repo sanitizations

### DIFF
--- a/lib/modules/platform/azure/util.ts
+++ b/lib/modules/platform/azure/util.ts
@@ -142,7 +142,7 @@ export function getStorageExtraCloneOpts(config: HostRule): GitOptions {
     authType = 'bearer';
     authValue = config.token;
   }
-  addSecretForSanitizing(authValue);
+  addSecretForSanitizing(authValue, 'global');
   return {
     '-c': `http.extraheader=AUTHORIZATION: ${authType} ${authValue}`,
   };

--- a/lib/util/sanitize.spec.ts
+++ b/lib/util/sanitize.spec.ts
@@ -19,7 +19,7 @@ describe('util/sanitize', () => {
     const token = '123testtoken';
     const username = 'userabc';
     const password = 'password123';
-    addSecretForSanitizing(token);
+    addSecretForSanitizing(token, 'global');
     const hashed = toBase64(`${username}:${password}`);
     addSecretForSanitizing(hashed);
     addSecretForSanitizing(password);

--- a/lib/util/sanitize.ts
+++ b/lib/util/sanitize.ts
@@ -1,7 +1,8 @@
 import is from '@sindresorhus/is';
 import { toBase64 } from './string';
 
-const secrets = new Set<string>();
+const globalSecrets = new Set<string>();
+const repoSecrets = new Set<string>();
 
 export const redactedFields = [
   'authorization',
@@ -21,20 +22,23 @@ export function sanitize(input: string): string {
     return input;
   }
   let output: string = input;
-  secrets.forEach((secret) => {
-    while (output.includes(secret)) {
-      output = output.replace(secret, '**redacted**');
-    }
+  [globalSecrets, repoSecrets].forEach((secrets) => {
+    secrets.forEach((secret) => {
+      while (output.includes(secret)) {
+        output = output.replace(secret, '**redacted**');
+      }
+    });
   });
   return output;
 }
 
 const GITHUB_APP_TOKEN_PREFIX = 'x-access-token:';
 
-export function addSecretForSanitizing(secret: string): void {
+export function addSecretForSanitizing(secret: string, type = 'repo'): void {
   if (!is.nonEmptyString(secret)) {
     return;
   }
+  const secrets = type === 'repo' ? repoSecrets : globalSecrets;
   secrets.add(secret);
   secrets.add(toBase64(secret));
   if (secret.startsWith(GITHUB_APP_TOKEN_PREFIX)) {
@@ -44,6 +48,7 @@ export function addSecretForSanitizing(secret: string): void {
   }
 }
 
-export function clearSanitizedSecretsList(): void {
+export function clearSanitizedSecretsList(type = 'repo'): void {
+  const secrets = type === 'repo' ? repoSecrets : globalSecrets;
   secrets.clear();
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes

Refactors sanitization to include global concept, which isn't cleared per-repo.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
