### PR TITLE
fix(kustomize): accept kustomization files without header

### DIFF
--- a/lib/modules/manager/kustomize/extract.spec.ts
+++ b/lib/modules/manager/kustomize/extract.spec.ts
@@ -34,6 +34,22 @@ describe('modules/manager/kustomize/extract', () => {
     const file = parseKustomize('');
     expect(file).toBeNull();
   });
+  it('should return null when header has invalid resource kind', () => {
+    const file = parseKustomize(`
+      kind: NoKustomization
+      bases:
+      - github.com/fluxcd/flux/deploy?ref=1.19.0
+    `);
+    expect(file).toBeNull();
+  });
+  it('should fall back to default resource kind when header is missing', () => {
+    const file = parseKustomize(`
+      bases:
+      - github.com/fluxcd/flux/deploy?ref=1.19.0
+    `);
+    expect(file).not.toBeNull();
+    expect(file.kind).toBe('Kustomization');
+  });
   describe('extractBase', () => {
     it('should return null for a local base', () => {
       const res = extractResource('./service-1');

--- a/lib/modules/manager/kustomize/extract.ts
+++ b/lib/modules/manager/kustomize/extract.ts
@@ -133,12 +133,9 @@ export function parseKustomize(content: string): Kustomize | null {
     return null;
   }
 
-  const pkgKindKustomization = 'Kustomization';
-  const pkgKindComponent = 'Component';
+  pkg.kind ??= 'Kustomization';
 
-  pkg.kind = pkg.kind || pkgKindKustomization;
-
-  if (![pkgKindKustomization, pkgKindComponent].includes(pkg.kind)) {
+  if (!['Kustomization', 'Component'].includes(pkg.kind)) {
     return null;
   }
 

--- a/lib/modules/manager/kustomize/extract.ts
+++ b/lib/modules/manager/kustomize/extract.ts
@@ -133,7 +133,12 @@ export function parseKustomize(content: string): Kustomize | null {
     return null;
   }
 
-  if (!['Kustomization', 'Component'].includes(pkg.kind)) {
+  const pkgKindKustomization = 'Kustomization';
+  const pkgKindComponent = 'Component';
+
+  pkg.kind = pkg.kind || pkgKindKustomization;
+
+  if (![pkgKindKustomization, pkgKindComponent].includes(pkg.kind)) {
     return null;
   }
 

--- a/lib/modules/manager/kustomize/readme.md
+++ b/lib/modules/manager/kustomize/readme.md
@@ -21,7 +21,6 @@ This manager uses three `depType`s to allow a fine-grained control of which depe
 
 **Limitations**
 
-- Needs to have `kind: Kustomization` or `kind: Component` defined
 - Currently this hasn't been tested using HTTPS to fetch the repos
 - The keys for the image tags can be in any order
 

--- a/lib/modules/manager/kustomize/types.ts
+++ b/lib/modules/manager/kustomize/types.ts
@@ -12,7 +12,7 @@ export interface HelmChart {
 }
 
 export interface Kustomize {
-  kind: string;
+  kind?: string;
   bases?: string[]; // deprecated since kustomize v2.1.0
   resources?: string[];
   components?: string[];


### PR DESCRIPTION
## Changes

Changes the behavior of the kustomize manager to accept a missing header and assume the default resource kind `Kustomization`.

## Context

Fixes #14524

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

🛠 with ❤️ by [Siemens](https://opensource.siemens.com/)