### PR TITLE
docs(self-hosted configuration): improve username config option section

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -631,7 +631,16 @@ This is currently applicable to `npm` and `lerna`/`npm` only, and only used in c
 
 ## username
 
-Mandatory if a GitHub app token is in use using the CLI.
+You might need to set a custom `username` if you use:
+
+- The Bitbucket platform, or
+- use the GitHub App with CLI (required)
+
+If you're using a Personal Access Token (PAT) to authenticate then we recommend you keep the `username` at its default value.
+
+<!-- prettier-ignore  -->
+!!! caution
+    If you use a Personal Access Token (PAT) and want to set a custom `username` (not recommended!), then make sure that Renovate's `username` matches the PAT username.
 
 ## writeDiscoveredRepos
 

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -638,10 +638,6 @@ You might need to set a `username` if you use:
 
 If you're using a Personal Access Token (PAT) to authenticate then you should not specify `username`.
 
-<!-- prettier-ignore  -->
-!!! caution
-    If you use a Personal Access Token (PAT) and want to set a custom `username` (not recommended!), then make sure that Renovate's `username` matches the PAT username.
-
 ## writeDiscoveredRepos
 
 Optional parameter which allows to write the discovered repositories into a JSON file instead of renovating them.

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -631,12 +631,12 @@ This is currently applicable to `npm` and `lerna`/`npm` only, and only used in c
 
 ## username
 
-You might need to set a custom `username` if you use:
+You might need to set a `username` if you use:
 
 - The Bitbucket platform, or
 - use the GitHub App with CLI (required)
 
-If you're using a Personal Access Token (PAT) to authenticate then we recommend you keep the `username` at its default value.
+If you're using a Personal Access Token (PAT) to authenticate then you should not specify `username`.
 
 <!-- prettier-ignore  -->
 !!! caution


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes

- Cover the only two usecases where you might want to change the `username`
- Add recommendation that if you use a PAT you should keep the `username` as-is

## Context

Improvements based on suggestion by @rarkins in this comment https://github.com/renovatebot/renovate/discussions/14639#discussioncomment-2357163

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
