### PR TITLE
fix(datasource/bitbucket-tags): use paging to fetch

### DIFF
--- a/lib/modules/datasource/bitbucket-tags/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/datasource/bitbucket-tags/__snapshots__/index.spec.ts.snap
@@ -86,7 +86,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://api.bitbucket.org/2.0/repositories/some/dep2/refs/tags",
+    "url": "https://api.bitbucket.org/2.0/repositories/some/dep2/refs/tags?pagelen=100",
   },
 ]
 `;

--- a/lib/modules/datasource/bitbucket-tags/index.spec.ts
+++ b/lib/modules/datasource/bitbucket-tags/index.spec.ts
@@ -28,7 +28,7 @@ describe('modules/datasource/bitbucket-tags/index', () => {
       };
       httpMock
         .scope('https://api.bitbucket.org')
-        .get('/2.0/repositories/some/dep2/refs/tags')
+        .get('/2.0/repositories/some/dep2/refs/tags?pagelen=100')
         .reply(200, body);
       const res = await getPkgReleases({
         datasource,

--- a/lib/modules/datasource/bitbucket-tags/index.ts
+++ b/lib/modules/datasource/bitbucket-tags/index.ts
@@ -1,7 +1,7 @@
 import { cache } from '../../../util/cache/package/decorator';
 import { BitbucketHttp } from '../../../util/http/bitbucket';
 import { ensureTrailingSlash } from '../../../util/url';
-import type * as utils from '../../platform/bitbucket/utils';
+import * as utils from '../../platform/bitbucket/utils';
 import { Datasource } from '../datasource';
 import type { DigestConfig, GetReleasesConfig, ReleaseResult } from '../types';
 import type { BitbucketCommit, BitbucketTag } from './types';
@@ -55,15 +55,12 @@ export class BitBucketTagsDatasource extends Datasource {
     packageName: repo,
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
     const url = `/2.0/repositories/${repo}/refs/tags`;
-
-    const bitbucketTags = (
-      await this.bitbucketHttp.getJson<utils.PagedResult<BitbucketTag>>(url)
-    ).body;
+    const bitbucketTags = await utils.accumulateValues(url);
 
     const dependency: ReleaseResult = {
       sourceUrl: BitBucketTagsDatasource.getSourceUrl(repo, registryUrl),
       registryUrl: BitBucketTagsDatasource.getRegistryURL(registryUrl),
-      releases: bitbucketTags.values.map(({ name, target }) => ({
+      releases: bitbucketTags.map(({ name, target }) => ({
         version: name,
         gitRef: name,
         releaseTimestamp: target?.date,

--- a/lib/modules/datasource/go/__snapshots__/releases-direct.spec.ts.snap
+++ b/lib/modules/datasource/go/__snapshots__/releases-direct.spec.ts.snap
@@ -120,7 +120,7 @@ Array [
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
     },
     "method": "GET",
-    "url": "https://api.bitbucket.org/2.0/repositories/golang/text/refs/tags",
+    "url": "https://api.bitbucket.org/2.0/repositories/golang/text/refs/tags?pagelen=100",
   },
 ]
 `;

--- a/lib/modules/datasource/go/releases-direct.spec.ts
+++ b/lib/modules/datasource/go/releases-direct.spec.ts
@@ -103,7 +103,7 @@ describe('modules/datasource/go/releases-direct', () => {
       });
       httpMock
         .scope('https://api.bitbucket.org/')
-        .get('/2.0/repositories/golang/text/refs/tags')
+        .get('/2.0/repositories/golang/text/refs/tags?pagelen=100')
         .reply(200, {
           pagelen: 2,
           page: 1,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes

<!-- Describe what behavior is changed by this PR. -->
The `bitbucket-tags` datasource should fetch all releases, not just the first page. 

## Context

Closes #14655 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
