### PR TITLE
docs(readme): rewrite security section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -108,5 +108,7 @@ If you want to contribute to Renovate or get a local copy running, please read t
 
 ## Security / Disclosure
 
-If you discover any important bug with Renovate that may pose a security problem, please disclose it confidentially to renovate-disclosure@whitesourcesoftware.com first, so that it can be assessed and hopefully fixed prior to being exploited.
-Please do not raise GitHub issues for security-related doubts or problems.
+If you find any important bug with Renovate that may be a security problem, then e-mail us at: renovate-disclosure@whitesourcesoftware.com.
+This way we can evaluate the bug and hopefully fix it before it gets abused.
+
+Please do not create GitHub issues for security-related doubts or problems.


### PR DESCRIPTION
## Changes

Simplify security section:

- Use simpler words
- Split long sentence
- Add newline to separate two points (email vs github issue)

## Context

We use this text in multiple places, so it should be easy to read and understand.

Once this PR gets merged, I'll make more PRs to fix the other security statements. 😉 

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository