### PR TITLE
docs: replace appropriate with correct

### DIFF
--- a/docs/development/triage-guide.md
+++ b/docs/development/triage-guide.md
@@ -29,7 +29,7 @@ Take the following steps on an incoming feature request:
 1. If poster is asking a configuration question, or has not made a convincing case that it's really a feature request, then convert to discussion, add either a response or at least a note that it's been converted, and issue can be deleted by an admin.
 1. Determine if this is a duplicate of a open issue, if duplicate: link to earlier issue, apply `duplicate` label and close the issue.
 1. Make a best-effort judgement if this is a reasonable feature to put into Renovate. If in doubt, let the core maintainers decide.
-1. Make a initial judgement of the priority, and add the appropriate priority label.
+1. Make a initial judgement of the priority, and add the correct priority label.
 1. If we need the original poster or somebody else to respond to a query of ours, apply the `status:waiting-on-response` label.
 1. If it's an easy feature for somebody new to Renovate to help us with apply the `good first issue` label.
 1. If the feature is hard to start work on without outside help apply the `help wanted` label.

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -333,7 +333,7 @@ For `sbt` note that Renovate will update the version string only for packages th
 
 Enabling this option will mean that any detected Git submodules will be cloned at time of repository clone.
 
-Important: private submodules aren't supported by Renovate, unless the underlying `ssh` layer already has the appropriate permissions.
+Important: private submodules aren't supported by Renovate, unless the underlying `ssh` layer already has the correct permissions.
 
 ## commitBody
 
@@ -888,7 +888,7 @@ As a result of the above, the branchName would be `renovate/dev-dependencies` in
 ## hashedBranchLength
 
 Some code hosting systems have restrictions on the branch name lengths, this option lets you get around these restrictions.
-You can set the `hashedBranchLength` option to a number of characters that works for your system and then Renovate will generate branch names with the appropriate length by hashing `additionalBranchPrefix` and `branchTopic`, and then truncating the hash so that the full branch name (including `branchPrefix`) has the right number of characters.
+You can set the `hashedBranchLength` option to a number of characters that works for your system and then Renovate will generate branch names with the correct length by hashing `additionalBranchPrefix` and `branchTopic`, and then truncating the hash so that the full branch name (including `branchPrefix`) has the right number of characters.
 
 Example: If you have set `branchPrefix: "deps-"` and `hashedBranchLength: 12` it will result in a branch name like `deps-5bf36ec` instead of the traditional pretty branch name like `deps-react-17.x`.
 

--- a/docs/usage/examples/self-hosting.md
+++ b/docs/usage/examples/self-hosting.md
@@ -15,7 +15,7 @@ If you want to use these package managers to update your lockfiles, you must ens
 npm install -g yarn pnpm
 ```
 
-The same goes for any other third-party binary tool like `gradle` or `poetry` - you need to make sure it is installed and the appropriate version before running Renovate.
+The same goes for any other third-party binary tool like `gradle` or `poetry` - you need to make sure it is installed and the correct version before running Renovate.
 
 ### Docker
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes

- Replace `appropriate` with `correct`

## Context

Use simpler word.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
