### PR TITLE
docs(ruby): replace caveats with warnings

### DIFF
--- a/docs/usage/ruby.md
+++ b/docs/usage/ruby.md
@@ -15,7 +15,7 @@ Renovate supports upgrading dependencies in Bundler's Gemfiles and their accompa
 1. A PR is created which updates the `Gemfile` and `Gemfile.lock` in a single commit
 1. If the source repository has a "changelog" file or uses GitHub releases, then Release Notes for each version are embedded in the generated PR
 
-## Caveats
+## Warnings
 
 Renovate doesn't update dependencies without a version constraint.
 Example: `gem 'some-gem', '~> 1.2.3'` will update `some-gem` if a new version matching the constraint is available, but `gem 'some-gem'` won't.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes

- Replace heading `caveats` with `warnings`

## Context

Use a simpler word.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
