### PR TITLE
fix(gitlab): add Private-token to sanitization list

### DIFF
--- a/lib/util/sanitize.ts
+++ b/lib/util/sanitize.ts
@@ -15,6 +15,7 @@ export const redactedFields = [
   'gitPrivateKey',
   'forkToken',
   'password',
+  'Private-token',
 ];
 
 export function sanitize(input: string): string {


### PR DESCRIPTION
## Changes

    "Private-token"  is displayed redacted in the logs.

## Context

When logging request performed by renovate the "Private-token" is displayed in clear text


## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

