### PR TITLE
refactor(platform/github): Simplify test mocks

### DIFF
--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -1,34 +1,35 @@
 import { DateTime } from 'luxon';
 import * as httpMock from '../../../../test/http-mock';
-import { loadFixture, mocked } from '../../../../test/util';
+import { loadFixture, logger, mocked } from '../../../../test/util';
 import {
   REPOSITORY_NOT_FOUND,
   REPOSITORY_RENAMED,
 } from '../../../constants/error-messages';
-import type * as _logger from '../../../logger';
 import { BranchStatus, PrState, VulnerabilityAlert } from '../../../types';
-import type * as _git from '../../../util/git';
+import * as _git from '../../../util/git';
+import * as _hostRules from '../../../util/host-rules';
+import { setBaseUrl } from '../../../util/http/github';
 import { toBase64 } from '../../../util/string';
-import type { CreatePRConfig, Platform } from '../types';
+import type { CreatePRConfig } from '../types';
+import * as github from '.';
 
 const githubApiHost = 'https://api.github.com';
 
+jest.mock('delay');
+
+jest.mock('../../../util/host-rules');
+const hostRules: jest.Mocked<typeof _hostRules> = mocked(_hostRules);
+
+jest.mock('../../../util/git');
+const git: jest.Mocked<typeof _git> = mocked(_git);
+
 describe('modules/platform/github/index', () => {
-  let github: Platform;
-  let hostRules: jest.Mocked<typeof import('../../../util/host-rules')>;
-  let git: jest.Mocked<typeof _git>;
-  let logger: jest.Mocked<typeof _logger>;
-  beforeEach(async () => {
-    // reset module
-    jest.resetModules();
-    jest.unmock('.');
-    jest.mock('delay');
-    jest.mock('../../../util/host-rules');
-    github = await import('.');
-    hostRules = mocked(await import('../../../util/host-rules'));
-    jest.mock('../../../util/git');
-    git = mocked(await import('../../../util/git'));
-    logger = mocked(await import('../../../logger'));
+  beforeEach(() => {
+    jest.resetAllMocks();
+    github.resetConfigs();
+
+    setBaseUrl(githubApiHost);
+
     git.branchExists.mockReturnValue(true);
     git.isBranchStale.mockResolvedValue(true);
     git.getBranchCommit.mockReturnValue(

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -78,13 +78,12 @@ import type {
 } from './types';
 import { getUserDetails, getUserEmail } from './user';
 
-let githubApi = new githubHttp.GithubHttp();
+const githubApi = new githubHttp.GithubHttp();
 
 let config: LocalRepoConfig;
 let platformConfig: PlatformConfig;
 
 export function resetConfigs(): void {
-  githubApi = new githubHttp.GithubHttp();
   config = {} as never;
   platformConfig = {
     hostType: PlatformId.Github,

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -76,19 +76,27 @@ import type {
   PlatformConfig,
   PrList,
 } from './types';
-import { UserDetails, getUserDetails, getUserEmail } from './user';
+import { getUserDetails, getUserEmail } from './user';
 
-const githubApi = new githubHttp.GithubHttp();
+let githubApi = new githubHttp.GithubHttp();
 
-let config: LocalRepoConfig = {} as any;
+let config: LocalRepoConfig;
+let platformConfig: PlatformConfig;
 
-const platformConfig: PlatformConfig = {
-  hostType: PlatformId.Github,
-  endpoint: 'https://api.github.com/',
-};
+export function resetConfigs(): void {
+  githubApi = new githubHttp.GithubHttp();
+  config = {} as never;
+  platformConfig = {
+    hostType: PlatformId.Github,
+    endpoint: 'https://api.github.com/',
+  };
+}
 
-const escapeHash = (input: string): string =>
-  input ? input.replace(regEx(/#/g), '%23') : input;
+resetConfigs();
+
+function escapeHash(input: string): string {
+  return input ? input.replace(regEx(/#/g), '%23') : input;
+}
 
 export async function detectGhe(token: string): Promise<void> {
   platformConfig.isGhe =
@@ -127,20 +135,28 @@ export async function initPlatform({
 
   await detectGhe(token);
 
-  let userDetails: UserDetails;
   let renovateUsername: string;
   if (username) {
     renovateUsername = username;
   } else {
-    userDetails = await getUserDetails(platformConfig.endpoint, token);
-    renovateUsername = userDetails.username;
+    platformConfig.userDetails ??= await getUserDetails(
+      platformConfig.endpoint,
+      token
+    );
+    renovateUsername = platformConfig.userDetails.username;
   }
   let discoveredGitAuthor: string;
   if (!gitAuthor) {
-    userDetails = await getUserDetails(platformConfig.endpoint, token);
-    const userEmail = await getUserEmail(platformConfig.endpoint, token);
-    if (userEmail) {
-      discoveredGitAuthor = `${userDetails.name} <${userEmail}>`;
+    platformConfig.userDetails ??= await getUserDetails(
+      platformConfig.endpoint,
+      token
+    );
+    platformConfig.userEmail ??= await getUserEmail(
+      platformConfig.endpoint,
+      token
+    );
+    if (platformConfig.userEmail) {
+      discoveredGitAuthor = `${platformConfig.userDetails.name} <${platformConfig.userEmail}>`;
     }
   }
   logger.debug({ platformConfig, renovateUsername }, 'Platform config');
@@ -218,8 +234,6 @@ export async function getJsonFile(
   }
   return JSON.parse(raw);
 }
-
-let existingRepos;
 
 // Initialize GitHub by getting base branch and SHA
 export async function initRepo({
@@ -352,18 +366,16 @@ export async function initRepo({
     config.parentRepo = config.repository;
     config.repository = null;
     // Get list of existing repos
-    existingRepos =
-      existingRepos ||
-      (
-        await githubApi.getJson<{ full_name: string }[]>(
-          'user/repos?per_page=100',
-          {
-            token: forkToken || opts.token,
-            paginate: true,
-            pageLimit: 100,
-          }
-        )
-      ).body.map((r) => r.full_name);
+    platformConfig.existingRepos ??= (
+      await githubApi.getJson<{ full_name: string }[]>(
+        'user/repos?per_page=100',
+        {
+          token: forkToken || opts.token,
+          paginate: true,
+          pageLimit: 100,
+        }
+      )
+    ).body.map((r) => r.full_name);
     try {
       const forkedRepo = await githubApi.postJson<{
         full_name: string;
@@ -424,7 +436,7 @@ export async function initRepo({
       logger.debug({ err }, 'Error forking repository');
       throw new Error(REPOSITORY_CANNOT_FORK);
     }
-    if (existingRepos.includes(config.repository)) {
+    if (platformConfig.existingRepos.includes(config.repository)) {
       logger.debug(
         { repository_fork: config.repository },
         'Found existing fork'
@@ -456,7 +468,7 @@ export async function initRepo({
       }
     } else {
       logger.debug({ repository_fork: config.repository }, 'Created fork');
-      existingRepos.push(config.repository);
+      platformConfig.existingRepos.push(config.repository);
       // Wait an arbitrary 30s to hopefully give GitHub enough time for forking to complete
       await delay(30000);
     }

--- a/lib/modules/platform/github/types.ts
+++ b/lib/modules/platform/github/types.ts
@@ -52,12 +52,20 @@ export interface GhGraphQlPr extends GhPr {
   labels: string[] & { nodes?: { name: string }[] };
 }
 
+export interface UserDetails {
+  username: string;
+  name: string;
+}
+
 export interface PlatformConfig {
   hostType: string;
   endpoint: string;
   isGhe?: boolean;
   gheVersion?: string | null;
   isGHApp?: boolean;
+  existingRepos?: string[];
+  userDetails?: UserDetails;
+  userEmail?: string | null;
 }
 
 export interface LocalRepoConfig {

--- a/lib/modules/platform/github/user.ts
+++ b/lib/modules/platform/github/user.ts
@@ -1,22 +1,13 @@
 import { logger } from '../../../logger';
 import * as githubHttp from '../../../util/http/github';
+import type { UserDetails } from './types';
 
 const githubApi = new githubHttp.GithubHttp();
-
-export interface UserDetails {
-  username: string;
-  name: string;
-}
-
-let userDetails: UserDetails;
 
 export async function getUserDetails(
   endpoint: string,
   token: string
 ): Promise<UserDetails> {
-  if (userDetails) {
-    return userDetails;
-  }
   try {
     const userData = (
       await githubApi.getJson<{ login: string; name: string }>(
@@ -26,18 +17,15 @@ export async function getUserDetails(
         }
       )
     ).body;
-    userDetails = {
+    return {
       username: userData.login,
       name: userData.name,
     };
-    return userDetails;
   } catch (err) {
     logger.debug({ err }, 'Error authenticating with GitHub');
     throw new Error('Init: Authentication failure');
   }
 }
-
-let userEmail: string | null;
 
 export async function getUserEmail(
   endpoint: string,
@@ -49,8 +37,7 @@ export async function getUserEmail(
         token,
       })
     ).body;
-    userEmail = emails?.[0].email ?? null;
-    return userEmail;
+    return emails?.[0].email ?? null;
   } catch (err) {
     logger.debug(
       'Cannot read user/emails endpoint on GitHub to retrieve gitAuthor'


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes

- Stop importing modules for each unit test.
- Introduce `resetConfigs()` function that clears `config` and `platformConfig`
- Consolidate `userDetails` and `userEmail` into `platformConfig`
- Also consolidate `existingRepos` array into `platformConfig`

## Context

When running jest with `-t` key, mock for `git` module stops working.
It leads to real `initRepo` calls and VSCode prompts to enter credentials, which makes debug experience quite complicated.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
