### PR TITLE
fix(maven): Support underscore (_) in versioning

### DIFF
--- a/lib/modules/versioning/maven/compare.spec.ts
+++ b/lib/modules/versioning/maven/compare.spec.ts
@@ -91,6 +91,7 @@ describe('modules/versioning/maven/compare', () => {
         ${'5.0.7'}              | ${'5.0.7.RELEASE'}
         ${'Hoxton.RELEASE'}     | ${'hoxton'}
         ${'Hoxton.SR1'}         | ${'hoxton.sr-1'}
+        ${'1_5ea'}              | ${'1.0_5ea'}
       `('$x == $y', ({ x, y }) => {
         expect(compare(x, y)).toBe(0);
         expect(compare(y, x)).toBe(0);
@@ -184,6 +185,8 @@ describe('modules/versioning/maven/compare', () => {
         ${'1-0.alpha'}                                  | ${'1'}
         ${'1-0.beta'}                                   | ${'1'}
         ${'1-0.alpha'}                                  | ${'1-0.beta'}
+        ${'1_5ea'}                                      | ${'1_c3b'}
+        ${'1_c3b'}                                      | ${'2'}
       `('$x < $y', ({ x, y }) => {
         expect(compare(x, y)).toBe(-1);
         expect(compare(y, x)).toBe(1);

--- a/lib/modules/versioning/maven/compare.ts
+++ b/lib/modules/versioning/maven/compare.ts
@@ -44,7 +44,7 @@ function isDigit(char: string): boolean {
 }
 
 function isLetter(char: string): boolean {
-  return regEx(/^[a-z]$/i).test(char);
+  return regEx(/^[a-z_]$/i).test(char);
 }
 
 function isTransition(prevChar: string, nextChar: string): boolean {
@@ -282,7 +282,7 @@ function isVersion(version: unknown): version is string {
   if (!version || typeof version !== 'string') {
     return false;
   }
-  if (!regEx(/^[a-z0-9.-]+$/i).test(version)) {
+  if (!regEx(/^[a-z_0-9.-]+$/i).test(version)) {
     return false;
   }
   if (regEx(/^[.-]/).test(version)) {

--- a/lib/modules/versioning/maven/index.spec.ts
+++ b/lib/modules/versioning/maven/index.spec.ts
@@ -29,6 +29,8 @@ describe('modules/versioning/maven/index', () => {
     ${'x1.0.0'}          | ${true}
     ${'2.1.1.RELEASE'}   | ${true}
     ${'Greenwich.SR1'}   | ${true}
+    ${'v1.0.0_2'}        | ${true}
+    ${'1.1.1-20_62b10c'} | ${true}
     ${'.1'}              | ${false}
     ${'1.'}              | ${false}
     ${'-1'}              | ${false}


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes

This PR allows maven versioning to treat underscores `_` the same as "letters". This follows the approach maven is doing, which treats all non-digits, `-` and `.` as "letters". 

## Context

This PR allows in a first step renovate to parse maven versions containing an underscore. 

The tests have been validating using the maven version comparision tool. 
E.g.: 
```bash
java -jar ./maven-artifact-3.8.5.jar 1_5ea 1_c3b 2
Display parameters as parsed by Maven (in canonical form and as a list of tokens) and comparison result:
1. 1_5ea -> 1-_-5-ea; tokens: [1, [_, [5, [ea]]]]
   1_5ea < 1_c3b
2. 1_c3b -> 1-_c-3-b; tokens: [1, [_c, [3, [b]]]]
   1_c3b < 2
3. 2 -> 2; tokens: [2]
```

fixes #14648

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
