### PR TITLE
fix(gomod): Adjust regex used to disable replace directives

### DIFF
--- a/lib/modules/manager/gomod/artifacts.spec.ts
+++ b/lib/modules/manager/gomod/artifacts.spec.ts
@@ -28,10 +28,65 @@ require golang.org/x/foo v1.0.0
 require github.com/rarkins/foo abcdef1
 require gopkg.in/russross/blackfriday.v1 v1.0.0
 
+replace gopkg.in/russross/blackfriday.v1 ./blackfriday
+
 replace github.com/pkg/errors => ../errors
 
-replace (golang.org/x/foo => github.com/pravesht/gocql v0.0.0)
+replace github.com/aws/aws-sdk-go => github.com/aws/aws-sdk-go v1.15.22
 
+replace github.com/davecgh/go-spew v1.0.0 => github.com/davecgh/go-spew v1.0.1
+`;
+
+const gomod1Replaced = `module github.com/renovate-tests/gomod1
+
+require github.com/pkg/errors v0.7.0
+require github.com/aws/aws-sdk-go v1.15.21
+require github.com/davecgh/go-spew v1.0.0
+require golang.org/x/foo v1.0.0
+require github.com/rarkins/foo abcdef1
+require gopkg.in/russross/blackfriday.v1 v1.0.0
+
+replace gopkg.in/russross/blackfriday.v1 ./blackfriday
+
+// renovate-replace replace github.com/pkg/errors => ../errors
+
+replace github.com/aws/aws-sdk-go => github.com/aws/aws-sdk-go v1.15.22
+
+replace github.com/davecgh/go-spew v1.0.0 => github.com/davecgh/go-spew v1.0.1
+`;
+
+const gomod2 = `module github.com/renovate-tests/gomod2
+
+require github.com/pkg/errors v0.7.0
+require github.com/aws/aws-sdk-go v1.15.21
+require github.com/davecgh/go-spew v1.0.0
+require golang.org/x/foo v1.0.0
+require github.com/rarkins/foo abcdef1
+require gopkg.in/russross/blackfriday.v1 v1.0.0
+
+replace (
+  gopkg.in/russross/blackfriday.v1 => ./blackfriday
+  github.com/pkg/errors => ../errors
+  github.com/aws/aws-sdk-go => github.com/aws/aws-sdk-go v1.15.22
+  github.com/davecgh/go-spew v1.0.0 => github.com/davecgh/go-spew v1.0.1
+)
+`;
+
+const gomod2Replaced = `module github.com/renovate-tests/gomod2
+
+require github.com/pkg/errors v0.7.0
+require github.com/aws/aws-sdk-go v1.15.21
+require github.com/davecgh/go-spew v1.0.0
+require golang.org/x/foo v1.0.0
+require github.com/rarkins/foo abcdef1
+require gopkg.in/russross/blackfriday.v1 v1.0.0
+
+replace (
+  gopkg.in/russross/blackfriday.v1 => ./blackfriday
+  // renovate-replace github.com/pkg/errors => ../errors
+  github.com/aws/aws-sdk-go => github.com/aws/aws-sdk-go v1.15.22
+  github.com/davecgh/go-spew v1.0.0 => github.com/davecgh/go-spew v1.0.1
+)
 `;
 
 const adminConfig: RepoGlobalConfig = {
@@ -672,6 +727,18 @@ describe('modules/manager/gomod/artifacts', () => {
       { file: { type: 'addition', path: 'go.mod', contents: 'New go.mod' } },
     ]);
     expect(execSnapshots).toMatchSnapshot();
+  });
+
+  it('correctly disables inline parent directory replace directives', async () => {
+    expect(gomod.disableLocalParentReplaceDirective(gomod1)).toEqual(
+      gomod1Replaced
+    );
+  });
+
+  it('correctly disables block parent directory replace directives', async () => {
+    expect(gomod.disableLocalParentReplaceDirective(gomod2)).toEqual(
+      gomod2Replaced
+    );
   });
 
   it('skips updating import paths with gomodUpdateImportPaths on v0 to v1', async () => {

--- a/lib/modules/manager/gomod/artifacts.ts
+++ b/lib/modules/manager/gomod/artifacts.ts
@@ -136,6 +136,15 @@ function useModcacherw(goVersion: string): boolean {
   );
 }
 
+export function disableLocalParentReplaceDirective(
+  goModContent: string
+): string {
+  const replacementRegex = regEx(
+    /(\n\r?\s+)([^\s]+(?:\s+[^\s]+)?\s+=>\s+\.\.\/[^\s]+)(?:\n\r?)/g
+  );
+  return goModContent.replace(replacementRegex, '$1// renovate-replace $2\n');
+}
+
 export async function updateArtifacts({
   packageFileName: goModFileName,
   updatedDeps,
@@ -156,37 +165,7 @@ export async function updateArtifacts({
   const useVendor = (await readLocalFile(vendorModulesFileName)) !== null;
 
   try {
-    // Regex match inline replace directive, example:
-    // replace golang.org/x/net v1.2.3 => example.com/fork/net v1.4.5
-    // https://go.dev/ref/mod#go-mod-file-replace
-    const inlineReplaceRegEx = regEx(
-      /(\r?\n)(replace\s+[^\s]+\s+=>\s+\.\.\/.*)/g
-    );
-
-    // $1 will be matched with the (\r?n) group
-    // $2 will be matched with the inline replace match, example
-    // "// renovate-replace replace golang.org/x/net v1.2.3 => example.com/fork/net v1.4.5"
-    const inlineCommentOut = '$1// renovate-replace $2';
-
-    // Regex match replace directive block, example:
-    // replace (
-    //     golang.org/x/net v1.2.3 => example.com/fork/net v1.4.5
-    // )
-    const blockReplaceRegEx = regEx(/(\r?\n)replace\s*\([^)]+\s*\)/g);
-
-    /**
-     * replacerFunction for commenting out replace blocks
-     * @param match A string representing a golang replace directive block
-     * @returns A commented out block with // renovate-replace
-     */
-    const blockCommentOut = (match): string =>
-      match.replace(/(\r?\n)/g, '$1// renovate-replace ');
-
-    // Comment out golang replace directives
-    const massagedGoMod = newGoModContent
-      .replace(inlineReplaceRegEx, inlineCommentOut)
-      .replace(blockReplaceRegEx, blockCommentOut);
-
+    const massagedGoMod = disableLocalParentReplaceDirective(newGoModContent);
     if (massagedGoMod !== newGoModContent) {
       logger.debug('Removed some relative replace statements from go.mod');
     }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes

This PR splits the code that disables `replace` directives into a separate function to make it more easily tested (without all of the setup and teardown used by the other tests). Additionally, it changes the disabling logic by modifying the regex so that only relative replace directives are commented-out to fix a problem with Renovate PRs having a dirty `go mod tidy` for repos containing replace directives (normal ones, not relative paths).

## Context

In https://github.com/renovatebot/renovate/pull/14033, multi-line replace directives were disabled entirely to fix https://github.com/renovatebot/renovate/issues/11428. Looking through GitHub history, I found in https://github.com/renovatebot/renovate/issues/2596 that this logic (implemented in https://github.com/renovatebot/renovate/commit/9551ed75c0c1e4cc0401f4d82141db43e67d84d8) was originally only intended to disable replace directives that point to a parent directory (i.e. starts with `../`) so I believe the new regexes in #14033 are overly broad.

To explain my use case, my company uses Renovate on many repos. We also have CI checks which ensure that `go mod tidy` shows no changes. Due to the potential bug described in the previous paragraph, almost all Renovate PRs opened on Go repos containing any replace directive fail CI and therefore aren't working for us. I can provide some diffs to demonstrate the result of Renovate versus running `go mod tidy` locally or in CI. I have already verified that it's not a version mismatch using the same version of Go as Renovate.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
