### PR TITLE
fix(npm): add trailing newline when composing lockfiles

### DIFF
--- a/lib/modules/manager/npm/__snapshots__/utils.spec.ts.snap
+++ b/lib/modules/manager/npm/__snapshots__/utils.spec.ts.snap
@@ -13,5 +13,6 @@ exports[`modules/manager/npm/utils composeLockFile composes lockfile string out 
   },
   \\"requires\\": true,
   \\"version\\": \\"1.0.0\\"
-}"
+}
+"
 `;

--- a/lib/modules/manager/npm/post-update/__snapshots__/npm.spec.ts.snap
+++ b/lib/modules/manager/npm/post-update/__snapshots__/npm.spec.ts.snap
@@ -176,7 +176,8 @@ exports[`modules/manager/npm/post-update/npm performs lock file updates retainin
       \\"integrity\\": \\"sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==\\"
     }
   }
-}"
+}
+"
 `;
 
 exports[`modules/manager/npm/post-update/npm performs lock file updates retaining the package.json counterparts 2`] = `

--- a/lib/modules/manager/npm/utils.spec.ts
+++ b/lib/modules/manager/npm/utils.spec.ts
@@ -53,5 +53,12 @@ describe('modules/manager/npm/utils', () => {
       const lockFileComposed = composeLockFile(lockFile, '  ');
       expect(lockFileComposed).toMatchSnapshot();
     });
+
+    it('adds trailing newline to match npms behaviour and avoid diffs', () => {
+      const lockFile = loadFixture('lockfile-parsing/package-lock.json');
+      const { detectedIndent, lockFileParsed } = parseLockFile(lockFile);
+      const lockFileComposed = composeLockFile(lockFileParsed, detectedIndent);
+      expect(lockFileComposed).toBe(lockFile);
+    });
   });
 });

--- a/lib/modules/manager/npm/utils.ts
+++ b/lib/modules/manager/npm/utils.ts
@@ -16,5 +16,5 @@ export function parseLockFile(lockFile: string): ParseLockFileResult {
 }
 
 export function composeLockFile(lockFile: LockFile, indent: string): string {
-  return JSON.stringify(lockFile, null, indent);
+  return JSON.stringify(lockFile, null, indent) + '\n';
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Adds a trailing newline to npm lockfile strings composed from objects.

I tested this with npm itself, the lockfile will only ever result having one trailing newline. Meaning npm makes one newline out of multiple ones (in case of manual edits).

And `JSON.parse` and `detectIndent` basically ignore leading and trailing newlines, meaning if `JSON.stringify` is called there will never be a trailing newline. And simply appending `"\n"` leads to the same behaviour as npm has.

## Context
Follow-up of https://github.com/renovatebot/renovate/pull/14586 and https://github.com/renovatebot/renovate/pull/14720
Final fix for https://github.com/renovatebot/renovate/issues/14584

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
