### PR TITLE
fix(git): default branch fall back to remote show

### DIFF
--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -109,7 +109,17 @@ async function isDirectory(dir: string): Promise<boolean> {
 async function getDefaultBranch(git: SimpleGit): Promise<string> {
   // see https://stackoverflow.com/a/62352647/3005034
   try {
-    const res = await git.raw(['rev-parse', '--abbrev-ref', 'origin/HEAD']);
+    let res = await git.raw(['rev-parse', '--abbrev-ref', 'origin/HEAD']);
+    // istanbul ignore if
+    if (!res) {
+      logger.debug('Could not determine default branch using git rev-parse');
+      const headPrefix = 'HEAD branch: ';
+      res = (await git.raw(['remote', 'show', 'origin']))
+        .split('\n')
+        .map((line) => line.trim())
+        .find((line) => line.startsWith(headPrefix))
+        .replace(headPrefix, '');
+    }
     return res.replace('origin/', '').trim();
   } catch (err) /* istanbul ignore next */ {
     const errChecked = checkForPlatformFailure(err);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes

Adds a default branch fallback.

## Context

#14764

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
