### PR TITLE
refactor(packagist): Use cache decorator for datasource

### DIFF
--- a/lib/modules/datasource/packagist/index.ts
+++ b/lib/modules/datasource/packagist/index.ts
@@ -95,12 +95,15 @@ export class PackagistDatasource extends Datasource {
     return meta;
   }
 
-  static isPrivatePackage(regUrl: string): boolean {
+  private static isPrivatePackage(regUrl: string): boolean {
     const opts = PackagistDatasource.getHostOpts(regUrl);
     return !!opts.password || !!opts.headers?.authorization;
   }
 
-  static getPackagistFileUrl(regUrl: string, regFile: RegistryFile): string {
+  private static getPackagistFileUrl(
+    regUrl: string,
+    regFile: RegistryFile
+  ): string {
     const { key, sha256 } = regFile;
     const fileName = key.replace('%hash%', sha256);
     const url = `${regUrl}/${fileName}`;
@@ -115,7 +118,7 @@ export class PackagistDatasource extends Datasource {
       !PackagistDatasource.isPrivatePackage(regUrl),
     ttlMinutes: 1440,
   })
-  public async getPackagistFile(
+  async getPackagistFile(
     regUrl: string,
     regFile: RegistryFile
   ): Promise<PackagistFile> {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes

- Refactor all necessary code to be usable with decorator

## Context

- Ref: #14632

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
