### PR TITLE
fix(manager/gradle): explicitly mention Gradle in updates to Gradle plugins

### DIFF
--- a/lib/modules/manager/gradle/extract.spec.ts
+++ b/lib/modules/manager/gradle/extract.spec.ts
@@ -268,7 +268,7 @@ describe('modules/manager/gradle/extract', () => {
             depName: 'io.gitlab.arturbosch.detekt',
             depType: 'plugin',
             currentValue: '1.17.0',
-            commitMessageTopic: 'plugin detekt',
+            commitMessageTopic: 'Gradle plugin detekt',
             packageName:
               'io.gitlab.arturbosch.detekt:io.gitlab.arturbosch.detekt.gradle.plugin',
             managerData: {
@@ -284,7 +284,7 @@ describe('modules/manager/gradle/extract', () => {
             depName: 'org.danilopianini.publish-on-central',
             depType: 'plugin',
             currentValue: '0.5.0',
-            commitMessageTopic: 'plugin publish-on-central',
+            commitMessageTopic: 'Gradle plugin publish-on-central',
             packageName:
               'org.danilopianini.publish-on-central:org.danilopianini.publish-on-central.gradle.plugin',
             managerData: {
@@ -299,7 +299,7 @@ describe('modules/manager/gradle/extract', () => {
           {
             depName: 'org.ajoberstar.grgit',
             depType: 'plugin',
-            commitMessageTopic: 'plugin grgit',
+            commitMessageTopic: 'Gradle plugin grgit',
             packageName:
               'org.ajoberstar.grgit:org.ajoberstar.grgit.gradle.plugin',
             managerData: {
@@ -391,7 +391,7 @@ describe('modules/manager/gradle/extract', () => {
             depName: 'org.jetbrains.kotlin.jvm',
             depType: 'plugin',
             currentValue: '1.5.21',
-            commitMessageTopic: 'plugin kotlinJvm',
+            commitMessageTopic: 'Gradle plugin kotlinJvm',
             packageName:
               'org.jetbrains.kotlin.jvm:org.jetbrains.kotlin.jvm.gradle.plugin',
             managerData: {
@@ -407,7 +407,7 @@ describe('modules/manager/gradle/extract', () => {
             depName: 'org.jetbrains.kotlin.plugin.serialization',
             depType: 'plugin',
             currentValue: '1.5.21',
-            commitMessageTopic: 'plugin kotlinSerialization',
+            commitMessageTopic: 'Gradle plugin kotlinSerialization',
             packageName:
               'org.jetbrains.kotlin.plugin.serialization:org.jetbrains.kotlin.plugin.serialization.gradle.plugin',
             managerData: {
@@ -423,7 +423,7 @@ describe('modules/manager/gradle/extract', () => {
             depName: 'org.danilopianini.multi-jvm-test-plugin',
             depType: 'plugin',
             currentValue: '0.3.0',
-            commitMessageTopic: 'plugin multiJvm',
+            commitMessageTopic: 'Gradle plugin multiJvm',
             packageName:
               'org.danilopianini.multi-jvm-test-plugin:org.danilopianini.multi-jvm-test-plugin.gradle.plugin',
             managerData: {

--- a/lib/modules/manager/gradle/extract/catalog.ts
+++ b/lib/modules/manager/gradle/extract/catalog.ts
@@ -255,7 +255,7 @@ export function parseCatalog(
       packageName: `${depName}:${depName}.gradle.plugin`,
       registryUrls: ['https://plugins.gradle.org/m2/'],
       currentValue,
-      commitMessageTopic: `plugin ${pluginName}`,
+      commitMessageTopic: `Gradle plugin ${pluginName}`,
       managerData: { fileReplacePosition },
     };
 


### PR DESCRIPTION
## Changes

"Gradle" is now explicitly mentioned when the update concerns Gradle plugins. 

## Context

Since many dependencies working with plugin-like systems may be present at once, the previous wording could have been confusing.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [X] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

*Note*: it is likely that the CI will fail, I'm fixing the tests afterwards, I want to see the red flags before the green ones.