### PR TITLE
docs: rewrite security sections

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -1,9 +1,12 @@
 # Contributing
 
-## Security
+## Security / Disclosure
 
-If you think you've found a **security issue**, please do not mention it in this repository.
-Instead, email renovate-disclosure@whitesourcesoftware.com with as much details as possible so that it can be handled confidentially.
+If you find any bug with Renovate that may be a security problem, then e-mail us at: [renovate-disclosure@whitesourcesoftware.com](mailto:renovate-disclosure@whitesourcesoftware.com).
+This way we can evaluate the bug and hopefully fix it before it gets abused.
+Please give us enough time to investigate the bug before you report it anywhere else.
+
+Please do not create GitHub issues for security-related doubts or problems.
 
 ## Support
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,7 @@
-# Security Policy
+# Security / Disclosure
 
-Please send an email to [renovate-disclosure@whitesourcesoftware.com](mailto:renovate-disclosure@whitesourcesoftware.com) describing what you have found.
-Please do not raise an issue in this repository or publicize your concern in any other forum without giving us adequate time to investigate first.
+If you find any bug with Renovate that may be a security problem, then e-mail us at: [renovate-disclosure@whitesourcesoftware.com](mailto:renovate-disclosure@whitesourcesoftware.com).
+This way we can evaluate the bug and hopefully fix it before it gets abused.
+Please give us enough time to investigate the bug before you report it anywhere else.
+
+Please do not create GitHub issues for security-related doubts or problems.

--- a/readme.md
+++ b/readme.md
@@ -108,7 +108,8 @@ If you want to contribute to Renovate or get a local copy running, please read t
 
 ## Security / Disclosure
 
-If you find any important bug with Renovate that may be a security problem, then e-mail us at: renovate-disclosure@whitesourcesoftware.com.
+If you find any bug with Renovate that may be a security problem, then e-mail us at: [renovate-disclosure@whitesourcesoftware.com](mailto:renovate-disclosure@whitesourcesoftware.com).
 This way we can evaluate the bug and hopefully fix it before it gets abused.
+Please give us enough time to investigate the bug before you report it anywhere else.
 
 Please do not create GitHub issues for security-related doubts or problems.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes

- Sync security section in all files in the main `renovatebot/renovate` repository
- Remove part that talks about `important` bug, even small bugs might be significant
- Use `mailto:` links so that the browser opens the user's mail program
- Add part about asking for enough time to all sections
- Use the same `h1` or `h2` heading names for all sections

## Context

Follow-up after PR https://github.com/renovatebot/renovate/pull/14683

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
