### PR TITLE
refactor(datasource/docker): Use cache decorators

### DIFF
--- a/lib/modules/datasource/docker/index.spec.ts
+++ b/lib/modules/datasource/docker/index.spec.ts
@@ -297,7 +297,7 @@ describe('modules/datasource/docker/index', () => {
         .reply(200)
         .head('/library/some-dep/manifests/latest')
         .reply(200, '', { 'docker-content-digest': 'some-digest' });
-      hostRules.find.mockReturnValueOnce({ insecureRegistry: true });
+      hostRules.find.mockReturnValue({ insecureRegistry: true });
       const res = await getDigest({
         datasource: 'docker',
         depName: 'some-dep',

--- a/lib/modules/datasource/docker/index.ts
+++ b/lib/modules/datasource/docker/index.ts
@@ -721,7 +721,6 @@ export class DockerDatasource extends Datasource {
     namespace: 'datasource-docker-tags',
     key: (registryHost: string, dockerRepository: string) =>
       `${registryHost}:${dockerRepository}`,
-    ttlMinutes: 30,
   })
   public async getTags(
     registryHost: string,
@@ -797,7 +796,6 @@ export class DockerDatasource extends Datasource {
       );
       return `${registryHost}:${dockerRepository}:${newTag}`;
     },
-    ttlMinutes: 30,
   })
   override async getDigest(
     { registryUrl, packageName }: GetReleasesConfig,

--- a/lib/modules/datasource/docker/index.ts
+++ b/lib/modules/datasource/docker/index.ts
@@ -8,7 +8,7 @@ import { HOST_DISABLED } from '../../../constants/error-messages';
 import { logger } from '../../../logger';
 import type { HostRule } from '../../../types';
 import { ExternalHostError } from '../../../types/errors/external-host-error';
-import * as packageCache from '../../../util/cache/package';
+import { cache } from '../../../util/cache/package/decorator';
 import * as hostRules from '../../../util/host-rules';
 import { Http, HttpError } from '../../../util/http';
 import type {
@@ -539,22 +539,18 @@ export class DockerDatasource extends Datasource {
    * This function will:
    *  - Return the labels for the requested image
    */
-  private async getLabels(
+  @cache({
+    namespace: 'datasource-docker-labels',
+    key: (registryHost: string, dockerRepository: string, tag: string) =>
+      `${registryHost}:${dockerRepository}:${tag}`,
+    ttlMinutes: 60,
+  })
+  public async getLabels(
     registryHost: string,
     dockerRepository: string,
     tag: string
   ): Promise<Record<string, string>> {
     logger.debug(`getLabels(${registryHost}, ${dockerRepository}, ${tag})`);
-    const cacheNamespace = 'datasource-docker-labels';
-    const cacheKey = `${registryHost}:${dockerRepository}:${tag}`;
-    const cachedResult = await packageCache.get<Record<string, string>>(
-      cacheNamespace,
-      cacheKey
-    );
-    // istanbul ignore if
-    if (cachedResult !== undefined) {
-      return cachedResult;
-    }
     try {
       let labels: Record<string, string> = {};
       const configDigest = await this.getConfigDigest(
@@ -591,8 +587,6 @@ export class DockerDatasource extends Datasource {
           'found labels in manifest'
         );
       }
-      const cacheMinutes = 60;
-      await packageCache.set(cacheNamespace, cacheKey, labels, cacheMinutes);
       return labels;
     } catch (err) /* istanbul ignore next: should be tested in future */ {
       if (err instanceof ExternalHostError) {
@@ -723,22 +717,17 @@ export class DockerDatasource extends Datasource {
     return tags;
   }
 
-  private async getTags(
+  @cache({
+    namespace: 'datasource-docker-tags',
+    key: (registryHost: string, dockerRepository: string) =>
+      `${registryHost}:${dockerRepository}`,
+    ttlMinutes: 30,
+  })
+  public async getTags(
     registryHost: string,
     dockerRepository: string
   ): Promise<string[] | null> {
     try {
-      const cacheNamespace = 'datasource-docker-tags';
-      const cacheKey = `${registryHost}:${dockerRepository}`;
-      const cachedResult = await packageCache.get<string[]>(
-        cacheNamespace,
-        cacheKey
-      );
-      // istanbul ignore if
-      if (cachedResult !== undefined) {
-        return cachedResult;
-      }
-
       const isQuay = regEx(/^https:\/\/quay\.io(?::[1-9][0-9]{0,4})?$/i).test(
         registryHost
       );
@@ -748,8 +737,6 @@ export class DockerDatasource extends Datasource {
       } else {
         tags = await this.getDockerApiTags(registryHost, dockerRepository);
       }
-      const cacheMinutes = 30;
-      await packageCache.set(cacheNamespace, cacheKey, tags, cacheMinutes);
       return tags;
     } catch (err) /* istanbul ignore next */ {
       if (err instanceof ExternalHostError) {
@@ -797,6 +784,21 @@ export class DockerDatasource extends Datasource {
    *  - Look up a sha256 digest for a tag on its registry
    *  - Return the digest as a string
    */
+  @cache({
+    namespace: 'datasource-docker-digest',
+    key: (
+      { registryUrl, packageName }: GetReleasesConfig,
+      newValue?: string
+    ) => {
+      const newTag = newValue || 'latest';
+      const { registryHost, dockerRepository } = getRegistryRepository(
+        packageName,
+        registryUrl
+      );
+      return `${registryHost}:${dockerRepository}:${newTag}`;
+    },
+    ttlMinutes: 30,
+  })
   override async getDigest(
     { registryUrl, packageName }: GetReleasesConfig,
     newValue?: string
@@ -809,18 +811,8 @@ export class DockerDatasource extends Datasource {
       `getDigest(${registryHost}, ${dockerRepository}, ${newValue})`
     );
     const newTag = newValue || 'latest';
-    const cacheNamespace = 'datasource-docker-digest';
-    const cacheKey = `${registryHost}:${dockerRepository}:${newTag}`;
     let digest: string = null;
     try {
-      const cachedResult = await packageCache.get<string>(
-        cacheNamespace,
-        cacheKey
-      );
-      // istanbul ignore if
-      if (cachedResult !== undefined) {
-        return cachedResult;
-      }
       let manifestResponse = await this.getManifestResponse(
         registryHost,
         dockerRepository,
@@ -859,8 +851,6 @@ export class DockerDatasource extends Datasource {
         'Unknown Error looking up docker image digest'
       );
     }
-    const cacheMinutes = 30;
-    await packageCache.set(cacheNamespace, cacheKey, digest, cacheMinutes);
     return digest;
   }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes

- Refactor all necessary code to be usable with decorator

## Context

- Ref: #14632

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
