### PR TITLE
docs(self hosted config): repositories array can be object

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -564,7 +564,7 @@ Example url: `redis://localhost`.
 
 ## repositories
 
-If you define a `repositories` array in your global config then its elements can each be an object:
+Elements in the `repositories` array can be an object if you wish to define additional settings:
 
 ```js
 {

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -568,7 +568,10 @@ If define a `repositories` array in then your global config then its elements ca
 
 ```js
 {
-  repositories: [ { repository: 'g/r', bumpVersion: true } ],
+  repositories: [
+    { repository: 'g/r1', bumpVersion: true },
+    'g/r2'
+  ],
 }
 ```
 

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -564,7 +564,7 @@ Example url: `redis://localhost`.
 
 ## repositories
 
-If define a `repositories` array in then your global config then its elements can each be an object:
+If define a `repositories` array in your global config then its elements can each be an object:
 
 ```js
 {

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -564,7 +564,7 @@ Example url: `redis://localhost`.
 
 ## repositories
 
-If you use a `config.js` file, then the `repositories` array can be an object:
+If define a `repositories` array in then your global config then its elements can each be an object:
 
 ```js
 {

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -564,6 +564,14 @@ Example url: `redis://localhost`.
 
 ## repositories
 
+If you use a `config.js` file, then the `repositories` array can be an object:
+
+```js
+{
+  repositories: [ { repository: 'g/r', bumpVersion: true } ],
+}
+```
+
 ## repositoryCache
 
 Set this to `"enabled"` to have Renovate maintain a JSON file cache per-repository to speed up extractions.

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -564,7 +564,7 @@ Example url: `redis://localhost`.
 
 ## repositories
 
-If define a `repositories` array in your global config then its elements can each be an object:
+If you define a `repositories` array in your global config then its elements can each be an object:
 
 ```js
 {


### PR DESCRIPTION
## Changes

- Explains that `repositories` array can be object

## Context

Requested to add this to the docs by @viceice in: https://github.com/renovatebot/renovate/discussions/14412#discussioncomment-2251331

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository