### PR TITLE
fix(github): filter our non-OPEN vulnerability alerts

### DIFF
--- a/lib/modules/platform/github/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/platform/github/__snapshots__/index.spec.ts.snap
@@ -6605,6 +6605,7 @@ Array [
             },
             "edges": Object {
               "node": Object {
+                "dismissReason": null,
                 "securityAdvisory": Object {
                   "description": null,
                   "identifiers": Object {
@@ -6641,7 +6642,7 @@ Array [
       "accept": "application/vnd.github.vixen-preview+json, application/vnd.github.v3+json",
       "accept-encoding": "gzip, deflate, br",
       "authorization": "token 123test",
-      "content-length": "676",
+      "content-length": "701",
       "content-type": "application/json",
       "host": "api.github.com",
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
@@ -6672,6 +6673,7 @@ Array [
             },
             "edges": Object {
               "node": Object {
+                "dismissReason": null,
                 "securityAdvisory": Object {
                   "description": null,
                   "identifiers": Object {
@@ -6708,7 +6710,7 @@ Array [
       "accept": "application/vnd.github.vixen-preview+json, application/vnd.github.v3+json",
       "accept-encoding": "gzip, deflate, br",
       "authorization": "token 123test",
-      "content-length": "676",
+      "content-length": "701",
       "content-type": "application/json",
       "host": "api.github.com",
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
@@ -6739,6 +6741,7 @@ Array [
             },
             "edges": Object {
               "node": Object {
+                "dismissReason": null,
                 "securityAdvisory": Object {
                   "description": null,
                   "identifiers": Object {
@@ -6775,7 +6778,7 @@ Array [
       "accept": "application/vnd.github.vixen-preview+json, application/vnd.github.v3+json",
       "accept-encoding": "gzip, deflate, br",
       "authorization": "token 123test",
-      "content-length": "676",
+      "content-length": "701",
       "content-type": "application/json",
       "host": "api.github.com",
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
@@ -6806,6 +6809,7 @@ Array [
             },
             "edges": Object {
               "node": Object {
+                "dismissReason": null,
                 "securityAdvisory": Object {
                   "description": null,
                   "identifiers": Object {
@@ -6842,7 +6846,7 @@ Array [
       "accept": "application/vnd.github.vixen-preview+json, application/vnd.github.v3+json",
       "accept-encoding": "gzip, deflate, br",
       "authorization": "token 123test",
-      "content-length": "676",
+      "content-length": "701",
       "content-type": "application/json",
       "host": "api.github.com",
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",

--- a/lib/modules/platform/github/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/platform/github/__snapshots__/index.spec.ts.snap
@@ -6605,7 +6605,6 @@ Array [
             },
             "edges": Object {
               "node": Object {
-                "dismissReason": null,
                 "securityAdvisory": Object {
                   "description": null,
                   "identifiers": Object {
@@ -6627,6 +6626,7 @@ Array [
                   },
                   "vulnerableVersionRange": null,
                 },
+                "state": null,
                 "vulnerableManifestFilename": null,
                 "vulnerableManifestPath": null,
                 "vulnerableRequirements": null,
@@ -6641,7 +6641,7 @@ Array [
       "accept": "application/vnd.github.vixen-preview+json, application/vnd.github.v3+json",
       "accept-encoding": "gzip, deflate, br",
       "authorization": "token 123test",
-      "content-length": "684",
+      "content-length": "676",
       "content-type": "application/json",
       "host": "api.github.com",
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
@@ -6672,7 +6672,6 @@ Array [
             },
             "edges": Object {
               "node": Object {
-                "dismissReason": null,
                 "securityAdvisory": Object {
                   "description": null,
                   "identifiers": Object {
@@ -6694,6 +6693,7 @@ Array [
                   },
                   "vulnerableVersionRange": null,
                 },
+                "state": null,
                 "vulnerableManifestFilename": null,
                 "vulnerableManifestPath": null,
                 "vulnerableRequirements": null,
@@ -6708,7 +6708,7 @@ Array [
       "accept": "application/vnd.github.vixen-preview+json, application/vnd.github.v3+json",
       "accept-encoding": "gzip, deflate, br",
       "authorization": "token 123test",
-      "content-length": "684",
+      "content-length": "676",
       "content-type": "application/json",
       "host": "api.github.com",
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
@@ -6739,7 +6739,6 @@ Array [
             },
             "edges": Object {
               "node": Object {
-                "dismissReason": null,
                 "securityAdvisory": Object {
                   "description": null,
                   "identifiers": Object {
@@ -6761,6 +6760,7 @@ Array [
                   },
                   "vulnerableVersionRange": null,
                 },
+                "state": null,
                 "vulnerableManifestFilename": null,
                 "vulnerableManifestPath": null,
                 "vulnerableRequirements": null,
@@ -6775,7 +6775,7 @@ Array [
       "accept": "application/vnd.github.vixen-preview+json, application/vnd.github.v3+json",
       "accept-encoding": "gzip, deflate, br",
       "authorization": "token 123test",
-      "content-length": "684",
+      "content-length": "676",
       "content-type": "application/json",
       "host": "api.github.com",
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
@@ -6806,7 +6806,6 @@ Array [
             },
             "edges": Object {
               "node": Object {
-                "dismissReason": null,
                 "securityAdvisory": Object {
                   "description": null,
                   "identifiers": Object {
@@ -6828,6 +6827,7 @@ Array [
                   },
                   "vulnerableVersionRange": null,
                 },
+                "state": null,
                 "vulnerableManifestFilename": null,
                 "vulnerableManifestPath": null,
                 "vulnerableRequirements": null,
@@ -6842,7 +6842,7 @@ Array [
       "accept": "application/vnd.github.vixen-preview+json, application/vnd.github.v3+json",
       "accept-encoding": "gzip, deflate, br",
       "authorization": "token 123test",
-      "content-length": "684",
+      "content-length": "676",
       "content-type": "application/json",
       "host": "api.github.com",
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",

--- a/lib/modules/platform/github/graphql.ts
+++ b/lib/modules/platform/github/graphql.ts
@@ -133,7 +133,7 @@ query($owner: String!, $name: String!) {
     vulnerabilityAlerts(last: 100) {
       edges {
         node {
-          dismissReason
+          state
           vulnerableManifestFilename
           vulnerableManifestPath
           vulnerableRequirements

--- a/lib/modules/platform/github/graphql.ts
+++ b/lib/modules/platform/github/graphql.ts
@@ -134,6 +134,7 @@ query($owner: String!, $name: String!) {
       edges {
         node {
           state
+          dismissReason
           vulnerableManifestFilename
           vulnerableManifestPath
           vulnerableRequirements

--- a/lib/types/vulnerability-alert.ts
+++ b/lib/types/vulnerability-alert.ts
@@ -14,7 +14,7 @@ export interface SecurityAdvisory {
   severity: 'HIGH' | 'MODERATE' | string;
 }
 export interface VulnerabilityAlert {
-  dismissReason?: string | null;
+  state?: string | null;
   securityAdvisory: SecurityAdvisory;
   securityVulnerability: SecurityVulnerability;
   vulnerableManifestFilename: string;

--- a/lib/types/vulnerability-alert.ts
+++ b/lib/types/vulnerability-alert.ts
@@ -15,6 +15,7 @@ export interface SecurityAdvisory {
 }
 export interface VulnerabilityAlert {
   state?: string | null;
+  dismissReason?: string | null;
   securityAdvisory: SecurityAdvisory;
   securityVulnerability: SecurityVulnerability;
   vulnerableManifestFilename: string;

--- a/lib/workers/repository/init/vulnerability.spec.ts
+++ b/lib/workers/repository/init/vulnerability.spec.ts
@@ -42,7 +42,7 @@ describe('workers/repository/init/vulnerability', () => {
       platform.getVulnerabilityAlerts.mockResolvedValue([
         partial<VulnerabilityAlert>({}),
         {
-          dismissReason: null,
+          state: 'OPEN',
           vulnerableManifestFilename: 'package-lock.json',
           vulnerableManifestPath: 'backend/package-lock.json',
           vulnerableRequirements: '= 1.8.2',
@@ -63,7 +63,7 @@ describe('workers/repository/init/vulnerability', () => {
         },
         {
           // this will be ignored
-          dismissReason: null,
+          state: 'OPEN',
           vulnerableManifestFilename: 'package-lock.json',
           vulnerableManifestPath: 'backend/package-lock.json',
           securityAdvisory: {
@@ -77,7 +77,7 @@ describe('workers/repository/init/vulnerability', () => {
           vulnerableRequirements: '= 5.0.1',
         },
         {
-          dismissReason: 'some reason',
+          state: 'FIXED',
           vulnerableManifestFilename: 'package-lock.json',
           vulnerableManifestPath: 'package-lock.json',
           vulnerableRequirements: '= 1.8.2',
@@ -100,7 +100,7 @@ describe('workers/repository/init/vulnerability', () => {
           },
         },
         {
-          dismissReason: null,
+          state: 'OPEN',
           vulnerableManifestFilename: 'requirements.txt',
           vulnerableManifestPath: 'requirements.txt',
           vulnerableRequirements: '= 1.6.7',
@@ -123,7 +123,7 @@ describe('workers/repository/init/vulnerability', () => {
           },
         },
         {
-          dismissReason: null,
+          state: 'OPEN',
           vulnerableManifestFilename: 'requirements.txt',
           vulnerableManifestPath: 'requirements.txt',
           vulnerableRequirements: '= 1.6.7',
@@ -145,7 +145,7 @@ describe('workers/repository/init/vulnerability', () => {
           },
         },
         {
-          dismissReason: null,
+          state: 'OPEN',
           vulnerableManifestFilename: 'requirements.txt',
           vulnerableManifestPath: 'requirements.txt',
           vulnerableRequirements: '= 1.6.7',
@@ -168,7 +168,7 @@ describe('workers/repository/init/vulnerability', () => {
           },
         },
         {
-          dismissReason: null,
+          state: 'OPEN',
           vulnerableManifestFilename: 'requirements.txt',
           vulnerableManifestPath: 'requirements.txt',
           vulnerableRequirements: '= 1.6.7',
@@ -191,7 +191,7 @@ describe('workers/repository/init/vulnerability', () => {
           },
         },
         {
-          dismissReason: null,
+          state: 'OPEN',
           vulnerableManifestFilename: 'requirements.txt',
           vulnerableManifestPath: 'requirements.txt',
           vulnerableRequirements: '= 1.6.7',
@@ -214,7 +214,7 @@ describe('workers/repository/init/vulnerability', () => {
           },
         },
         {
-          dismissReason: null,
+          state: 'OPEN',
           vulnerableManifestFilename: 'requirements.txt',
           vulnerableManifestPath: 'requirements.txt',
           vulnerableRequirements: '= 1.6.7',
@@ -237,7 +237,7 @@ describe('workers/repository/init/vulnerability', () => {
           },
         },
         {
-          dismissReason: null,
+          state: 'OPEN',
           vulnerableManifestFilename: 'requirements.txt',
           vulnerableManifestPath: 'requirements.txt',
           vulnerableRequirements: '= 1.6.7',
@@ -260,7 +260,7 @@ describe('workers/repository/init/vulnerability', () => {
           },
         },
         {
-          dismissReason: null,
+          state: 'OPEN',
           vulnerableManifestFilename: 'pom.xml',
           vulnerableManifestPath: 'pom.xml',
           vulnerableRequirements: '= 2.4.2',

--- a/lib/workers/repository/init/vulnerability.ts
+++ b/lib/workers/repository/init/vulnerability.ts
@@ -145,7 +145,7 @@ export async function detectVulnerabilityAlerts(
         logger.debug('Invalid firstPatchedVersion: ' + firstPatchedVersion);
       }
       alertDetails.fileType = fileType;
-    } catch (err) {
+    } catch (err) /* istanbul ignore next */ {
       logger.warn({ err }, 'Error parsing vulnerability alert');
     }
   }

--- a/lib/workers/repository/init/vulnerability.ts
+++ b/lib/workers/repository/init/vulnerability.ts
@@ -1,3 +1,4 @@
+import is from '@sindresorhus/is';
 import type { PackageRule, RenovateConfig } from '../../../config/types';
 import { NO_VULNERABILITY_ALERTS } from '../../../constants/error-messages';
 import { logger } from '../../../logger';
@@ -79,7 +80,10 @@ export async function detectVulnerabilityAlerts(
       continue;
     }
     try {
-      if (alert.state !== 'OPEN') {
+      if (
+        alert.dismissReason ||
+        (is.string(alert.state) && alert.state !== 'OPEN')
+      ) {
         continue;
       }
       if (!alert.securityVulnerability.firstPatchedVersion) {

--- a/lib/workers/repository/init/vulnerability.ts
+++ b/lib/workers/repository/init/vulnerability.ts
@@ -149,7 +149,7 @@ export async function detectVulnerabilityAlerts(
         logger.debug('Invalid firstPatchedVersion: ' + firstPatchedVersion);
       }
       alertDetails.fileType = fileType;
-    } catch (err) /* istanbul ignore next */ {
+    } catch (err) {
       logger.warn({ err }, 'Error parsing vulnerability alert');
     }
   }

--- a/lib/workers/repository/init/vulnerability.ts
+++ b/lib/workers/repository/init/vulnerability.ts
@@ -79,7 +79,7 @@ export async function detectVulnerabilityAlerts(
       continue;
     }
     try {
-      if (alert.dismissReason) {
+      if (alert.state !== 'OPEN') {
         continue;
       }
       if (!alert.securityVulnerability.firstPatchedVersion) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes

Changes from `dismissReason` filtering of vulnerability alerts to `state` filtering, so that `FIXED` alerts are also taken into consideration.

## Context

Closes #14316
Replaces #14431

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
