### PR TITLE
fix(git): Don't call redundant fetch after git-based commit creation

### DIFF
--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -376,6 +376,28 @@ describe('util/git/index', () => {
       });
       expect(commit).not.toBeNull();
     });
+    it('uses right commit SHA', async () => {
+      const files: FileChange[] = [
+        {
+          type: 'addition',
+          path: 'some-existing-file',
+          contents: 'updated content',
+        },
+        {
+          type: 'addition',
+          path: 'some-other-existing-file',
+          contents: 'other updated content',
+        },
+      ];
+      const commitConfig = {
+        branchName: 'renovate/something',
+        files,
+        message: 'Update something',
+      };
+      const commitSha = await git.commitFiles(commitConfig);
+      const remoteSha = await git.fetchCommit(commitConfig);
+      expect(commitSha).toEqual(remoteSha);
+    });
     it('updates git submodules', async () => {
       const files: FileChange[] = [
         {

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -906,7 +906,6 @@ export async function prepareCommit({
       { deletedFiles, ignoredFiles, result: commitRes },
       `git commit`
     );
-    const commitSha = commitRes?.commit || 'unknown';
     if (!force && !(await hasDiff(`origin/${branchName}`))) {
       logger.debug(
         { branchName, deletedFiles, addedModifiedFiles, ignoredFiles },
@@ -915,6 +914,7 @@ export async function prepareCommit({
       return null;
     }
 
+    const commitSha = (await git.revparse([branchName])).trim();
     const result: CommitResult = {
       parentCommitSha,
       commitSha,
@@ -980,13 +980,17 @@ export async function fetchCommit({
 }
 
 export async function commitFiles(
-  config: CommitFilesConfig
+  commitConfig: CommitFilesConfig
 ): Promise<CommitSha | null> {
-  const commitResult = await prepareCommit(config);
+  const commitResult = await prepareCommit(commitConfig);
   if (commitResult) {
-    const pushResult = await pushCommit(config);
+    const pushResult = await pushCommit(commitConfig);
     if (pushResult) {
-      return fetchCommit(config);
+      const { branchName } = commitConfig;
+      const { commitSha } = commitResult;
+      config.branchCommits[branchName] = commitSha;
+      config.branchIsModified[branchName] = false;
+      return commitSha;
     }
   }
   return null;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes

- Don't use `fetchCommit()`
- Instead, use SHA from `prepareCommit()` result

## Context

- Fixes #14791

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
