### PR TITLE
refactor(migrations): ignoreNpmrcFile

### DIFF
--- a/lib/config/migration.ts
+++ b/lib/config/migration.ts
@@ -122,11 +122,6 @@ export function migrateConfig(
           regEx(/{{depNameShort}}/g),
           '{{depName}}'
         );
-      } else if (key === 'ignoreNpmrcFile') {
-        delete migratedConfig.ignoreNpmrcFile;
-        if (!is.string(migratedConfig.npmrc)) {
-          migratedConfig.npmrc = '';
-        }
       } else if (
         key === 'branchPrefix' &&
         is.string(val) &&

--- a/lib/config/migrations/custom/ignore-npmrc-file-migration.spec.ts
+++ b/lib/config/migrations/custom/ignore-npmrc-file-migration.spec.ts
@@ -23,4 +23,16 @@ describe('config/migrations/custom/ignore-npmrc-file-migration', () => {
       }
     );
   });
+
+  it('should change npmrc field if it not represents string value', () => {
+    expect(IgnoreNpmrcFileMigration).toMigrate(
+      {
+        ignoreNpmrcFile: true,
+        npmrc: true,
+      } as any,
+      {
+        npmrc: '',
+      }
+    );
+  });
 });

--- a/lib/config/migrations/custom/ignore-npmrc-file-migration.spec.ts
+++ b/lib/config/migrations/custom/ignore-npmrc-file-migration.spec.ts
@@ -1,0 +1,26 @@
+import { IgnoreNpmrcFileMigration } from './ignore-npmrc-file-migration';
+
+describe('config/migrations/custom/ignore-npmrc-file-migration', () => {
+  it('should init npmrc field', () => {
+    expect(IgnoreNpmrcFileMigration).toMigrate(
+      {
+        ignoreNpmrcFile: true,
+      },
+      {
+        npmrc: '',
+      }
+    );
+  });
+
+  it('should not change npmrc field if it represents string value', () => {
+    expect(IgnoreNpmrcFileMigration).toMigrate(
+      {
+        ignoreNpmrcFile: true,
+        npmrc: '',
+      },
+      {
+        npmrc: '',
+      }
+    );
+  });
+});

--- a/lib/config/migrations/custom/ignore-npmrc-file-migration.ts
+++ b/lib/config/migrations/custom/ignore-npmrc-file-migration.ts
@@ -1,0 +1,15 @@
+import is from '@sindresorhus/is';
+import { AbstractMigration } from '../base/abstract-migration';
+
+export class IgnoreNpmrcFileMigration extends AbstractMigration {
+  override readonly deprecated = true;
+  override readonly propertyName = 'ignoreNpmrcFile';
+
+  override run(): void {
+    const npmrc = this.get('npmrc');
+
+    if (!is.string(npmrc)) {
+      this.setHard('npmrc', '');
+    }
+  }
+}

--- a/lib/config/migrations/migrations-service.ts
+++ b/lib/config/migrations/migrations-service.ts
@@ -16,6 +16,7 @@ import { EnabledManagersMigration } from './custom/enabled-managers-migration';
 import { GoModTidyMigration } from './custom/go-mod-tidy-migration';
 import { HostRulesMigration } from './custom/host-rules-migration';
 import { IgnoreNodeModulesMigration } from './custom/ignore-node-modules-migration';
+import { IgnoreNpmrcFileMigration } from './custom/ignore-npmrc-file-migration';
 import { PackageNameMigration } from './custom/package-name-migration';
 import { PackagePatternMigration } from './custom/package-pattern-migration';
 import { PackagesMigration } from './custom/packages-migration';
@@ -78,6 +79,7 @@ export class MigrationsService {
     GoModTidyMigration,
     HostRulesMigration,
     IgnoreNodeModulesMigration,
+    IgnoreNpmrcFileMigration,
     PackageNameMigration,
     PackagePatternMigration,
     PackagesMigration,


### PR DESCRIPTION
## Changes:

One more migration from previously huge PR https://github.com/renovatebot/renovate/pull/12957

## Context:

1. https://github.com/renovatebot/renovate/issues/11459
2. Part of https://github.com/renovatebot/renovate/pull/12957 

## Documentation

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository