### PR TITLE
fix(npm): allow for missing dist-tags/latest

### DIFF
--- a/lib/config/presets/npm/index.ts
+++ b/lib/config/presets/npm/index.ts
@@ -31,11 +31,11 @@ export async function getPreset({
       );
     }
     const body = (await http.getJson<NpmResponse>(packageUrl)).body;
-    dep = body.versions[body['dist-tags'].latest];
+    dep = body.versions[body['dist-tags']?.latest];
   } catch (err) {
     throw new Error(PRESET_DEP_NOT_FOUND);
   }
-  if (!dep['renovate-config']) {
+  if (!dep?.['renovate-config']) {
     throw new Error(PRESET_RENOVATE_CONFIG_NOT_FOUND);
   }
   const presetConfig = dep['renovate-config'][presetName];

--- a/lib/modules/datasource/npm/get.spec.ts
+++ b/lib/modules/datasource/npm/get.spec.ts
@@ -286,6 +286,27 @@ describe('modules/datasource/npm/get', () => {
     `);
   });
 
+  it('handles missing dist-tags latest', async () => {
+    setNpmrc('registry=https://test.org\n_authToken=XXX');
+
+    httpMock
+      .scope('https://test.org')
+      .get('/@neutrinojs%2Freact')
+      .reply(200, {
+        name: '@neutrinojs/react',
+        repository: {
+          type: 'git',
+          url: 'https://github.com/neutrinojs/neutrino/tree/master/packages/react',
+        },
+        versions: { '1.0.0': {} },
+      });
+    const registryUrl = resolveRegistryUrl('@neutrinojs/react');
+    const dep = await getDependency(http, registryUrl, '@neutrinojs/react');
+
+    expect(dep.sourceUrl).toBe('https://github.com/neutrinojs/neutrino');
+    expect(dep.sourceDirectory).toBe('packages/react');
+  });
+
   it('handles mixed sourceUrls in releases', async () => {
     setNpmrc('registry=https://test.org\n_authToken=XXX');
 

--- a/lib/modules/datasource/npm/get.ts
+++ b/lib/modules/datasource/npm/get.ts
@@ -87,9 +87,9 @@ export async function getDependency(
       return null;
     }
 
-    const latestVersion = res.versions[res['dist-tags'].latest];
-    res.repository = res.repository || latestVersion.repository;
-    res.homepage = res.homepage || latestVersion.homepage;
+    const latestVersion = res.versions[res['dist-tags']?.latest];
+    res.repository = res.repository || latestVersion?.repository;
+    res.homepage = res.homepage || latestVersion?.homepage;
 
     const { sourceUrl, sourceDirectory } = getPackageSource(res.repository);
 
@@ -105,7 +105,7 @@ export async function getDependency(
       registryUrl,
     };
 
-    if (latestVersion.deprecated) {
+    if (latestVersion?.deprecated) {
       dep.deprecationMessage = `On registry \`${registryUrl}\`, the "latest" version of dependency \`${packageName}\` has the following deprecation notice:\n\n\`${latestVersion.deprecated}\`\n\nMarking the latest version of an npm package as deprecated results in the entire package being considered deprecated, so contact the package author you think this is a mistake.`;
       dep.deprecationSource = id;
     }

--- a/lib/modules/datasource/npm/types.ts
+++ b/lib/modules/datasource/npm/types.ts
@@ -42,7 +42,7 @@ export interface NpmDependency extends ReleaseResult {
   homepage: string;
   sourceUrl: string;
   versions: Record<string, any>;
-  'dist-tags': Record<string, string>;
+  'dist-tags'?: Record<string, string>;
   sourceDirectory?: string;
 }
 


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes

Fixes npm datasource so that it can handle a missing dist-tags/latest field.

## Context

Closes #14814

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
