### PR TITLE
refactor(github): Stop using cannotMergeReason field

### DIFF
--- a/lib/modules/platform/github/__fixtures__/graphql/pullrequest-1.json
+++ b/lib/modules/platform/github/__fixtures__/graphql/pullrequest-1.json
@@ -9,7 +9,6 @@
             "baseRefName": "master",
             "headRefName": "renovate/major-got-packages",
             "title": "build(deps): update got packages (major)",
-            "mergeStateStatus": "CLEAN",
             "labels": {
               "nodes": [
                 {
@@ -22,8 +21,7 @@
             "number": 2500,
             "baseRefName": "master",
             "headRefName": "renovate/jest-monorepo",
-            "title": "chore(deps): update dependency jest to v23.6.0",
-            "mergeStateStatus": "DIRTY"
+            "title": "chore(deps): update dependency jest to v23.6.0"
           },
           {
             "number": 2079,
@@ -33,9 +31,7 @@
           {
             "number": 2086,
             "headRefName": "fix/deletePRafterDeleteBranch",
-            "title": "feat(azure): abandon pr after delete branch",
-            "mergeStateStatus": "BEHIND",
-            "reviews": { "nodes": [ ] }
+            "title": "feat(azure): abandon pr after delete branch"
           }
         ]
       }

--- a/lib/modules/platform/github/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/platform/github/__snapshots__/index.spec.ts.snap
@@ -3534,21 +3534,9 @@ Array [
                   "name": null,
                 },
               },
-              "mergeStateStatus": null,
               "number": null,
               "reviewRequests": Object {
                 "totalCount": null,
-              },
-              "reviews": Object {
-                "__args": Object {
-                  "first": "1",
-                  "states": Array [
-                    "CHANGES_REQUESTED",
-                  ],
-                },
-                "nodes": Object {
-                  "state": null,
-                },
               },
               "title": null,
             },
@@ -3570,7 +3558,7 @@ Array [
       "accept": "application/vnd.github.merge-info-preview+json, application/vnd.github.v3+json",
       "accept-encoding": "gzip, deflate, br",
       "authorization": "token 123test",
-      "content-length": "915",
+      "content-length": "771",
       "content-type": "application/json",
       "host": "api.github.com",
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
@@ -3842,21 +3830,9 @@ Array [
                   "name": null,
                 },
               },
-              "mergeStateStatus": null,
               "number": null,
               "reviewRequests": Object {
                 "totalCount": null,
-              },
-              "reviews": Object {
-                "__args": Object {
-                  "first": "1",
-                  "states": Array [
-                    "CHANGES_REQUESTED",
-                  ],
-                },
-                "nodes": Object {
-                  "state": null,
-                },
               },
               "title": null,
             },
@@ -3878,7 +3854,7 @@ Array [
       "accept": "application/vnd.github.merge-info-preview+json, application/vnd.github.v3+json",
       "accept-encoding": "gzip, deflate, br",
       "authorization": "token 123test",
-      "content-length": "915",
+      "content-length": "771",
       "content-type": "application/json",
       "host": "api.github.com",
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
@@ -4128,21 +4104,9 @@ Array [
                   "name": null,
                 },
               },
-              "mergeStateStatus": null,
               "number": null,
               "reviewRequests": Object {
                 "totalCount": null,
-              },
-              "reviews": Object {
-                "__args": Object {
-                  "first": "1",
-                  "states": Array [
-                    "CHANGES_REQUESTED",
-                  ],
-                },
-                "nodes": Object {
-                  "state": null,
-                },
               },
               "title": null,
             },
@@ -4164,7 +4128,7 @@ Array [
       "accept": "application/vnd.github.merge-info-preview+json, application/vnd.github.v3+json",
       "accept-encoding": "gzip, deflate, br",
       "authorization": "token 123test",
-      "content-length": "915",
+      "content-length": "771",
       "content-type": "application/json",
       "host": "api.github.com",
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
@@ -5335,21 +5299,9 @@ Array [
                   "name": null,
                 },
               },
-              "mergeStateStatus": null,
               "number": null,
               "reviewRequests": Object {
                 "totalCount": null,
-              },
-              "reviews": Object {
-                "__args": Object {
-                  "first": "1",
-                  "states": Array [
-                    "CHANGES_REQUESTED",
-                  ],
-                },
-                "nodes": Object {
-                  "state": null,
-                },
               },
               "title": null,
             },
@@ -5371,7 +5323,7 @@ Array [
       "accept": "application/vnd.github.merge-info-preview+json, application/vnd.github.v3+json",
       "accept-encoding": "gzip, deflate, br",
       "authorization": "token 123test",
-      "content-length": "915",
+      "content-length": "771",
       "content-type": "application/json",
       "host": "api.github.com",
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
@@ -5452,7 +5404,6 @@ Array [
 
 exports[`modules/platform/github/index getPr(prNo) should return PR from graphql result 1`] = `
 Object {
-  "cannotMergeReason": "pr.mergeStateStatus = DIRTY",
   "displayNumber": "Pull Request #2500",
   "hasAssignees": false,
   "hasReviewers": false,
@@ -5552,21 +5503,9 @@ Array [
                   "name": null,
                 },
               },
-              "mergeStateStatus": null,
               "number": null,
               "reviewRequests": Object {
                 "totalCount": null,
-              },
-              "reviews": Object {
-                "__args": Object {
-                  "first": "1",
-                  "states": Array [
-                    "CHANGES_REQUESTED",
-                  ],
-                },
-                "nodes": Object {
-                  "state": null,
-                },
               },
               "title": null,
             },
@@ -5588,7 +5527,7 @@ Array [
       "accept": "application/vnd.github.merge-info-preview+json, application/vnd.github.v3+json",
       "accept-encoding": "gzip, deflate, br",
       "authorization": "token 123test",
-      "content-length": "915",
+      "content-length": "771",
       "content-type": "application/json",
       "host": "api.github.com",
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
@@ -5699,21 +5638,9 @@ Array [
                   "name": null,
                 },
               },
-              "mergeStateStatus": null,
               "number": null,
               "reviewRequests": Object {
                 "totalCount": null,
-              },
-              "reviews": Object {
-                "__args": Object {
-                  "first": "1",
-                  "states": Array [
-                    "CHANGES_REQUESTED",
-                  ],
-                },
-                "nodes": Object {
-                  "state": null,
-                },
               },
               "title": null,
             },
@@ -5735,7 +5662,7 @@ Array [
       "accept": "application/vnd.github.merge-info-preview+json, application/vnd.github.v3+json",
       "accept-encoding": "gzip, deflate, br",
       "authorization": "token 123test",
-      "content-length": "915",
+      "content-length": "771",
       "content-type": "application/json",
       "host": "api.github.com",
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
@@ -5928,21 +5855,9 @@ Array [
                   "name": null,
                 },
               },
-              "mergeStateStatus": null,
               "number": null,
               "reviewRequests": Object {
                 "totalCount": null,
-              },
-              "reviews": Object {
-                "__args": Object {
-                  "first": "1",
-                  "states": Array [
-                    "CHANGES_REQUESTED",
-                  ],
-                },
-                "nodes": Object {
-                  "state": null,
-                },
               },
               "title": null,
             },
@@ -5964,7 +5879,7 @@ Array [
       "accept": "application/vnd.github.merge-info-preview+json, application/vnd.github.v3+json",
       "accept-encoding": "gzip, deflate, br",
       "authorization": "token 123test",
-      "content-length": "915",
+      "content-length": "771",
       "content-type": "application/json",
       "host": "api.github.com",
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
@@ -6156,21 +6071,9 @@ Array [
                   "name": null,
                 },
               },
-              "mergeStateStatus": null,
               "number": null,
               "reviewRequests": Object {
                 "totalCount": null,
-              },
-              "reviews": Object {
-                "__args": Object {
-                  "first": "1",
-                  "states": Array [
-                    "CHANGES_REQUESTED",
-                  ],
-                },
-                "nodes": Object {
-                  "state": null,
-                },
               },
               "title": null,
             },
@@ -6192,7 +6095,7 @@ Array [
       "accept": "application/vnd.github.merge-info-preview+json, application/vnd.github.v3+json",
       "accept-encoding": "gzip, deflate, br",
       "authorization": "token 123test",
-      "content-length": "915",
+      "content-length": "771",
       "content-type": "application/json",
       "host": "api.github.com",
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
@@ -6370,21 +6273,9 @@ Array [
                   "name": null,
                 },
               },
-              "mergeStateStatus": null,
               "number": null,
               "reviewRequests": Object {
                 "totalCount": null,
-              },
-              "reviews": Object {
-                "__args": Object {
-                  "first": "1",
-                  "states": Array [
-                    "CHANGES_REQUESTED",
-                  ],
-                },
-                "nodes": Object {
-                  "state": null,
-                },
               },
               "title": null,
             },
@@ -6406,7 +6297,7 @@ Array [
       "accept": "application/vnd.github.merge-info-preview+json, application/vnd.github.v3+json",
       "accept-encoding": "gzip, deflate, br",
       "authorization": "token 123test",
-      "content-length": "915",
+      "content-length": "771",
       "content-type": "application/json",
       "host": "api.github.com",
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",

--- a/lib/modules/platform/github/graphql.ts
+++ b/lib/modules/platform/github/graphql.ts
@@ -73,7 +73,6 @@ query($owner: String!, $name: String!, $count: Int, $cursor: String) {
         headRefName
         baseRefName
         title
-        mergeStateStatus
         labels(last: 100) {
           nodes {
             name
@@ -86,11 +85,6 @@ query($owner: String!, $name: String!, $count: Int, $cursor: String) {
           totalCount
         }
         body
-        reviews(first: 1, states: [CHANGES_REQUESTED]){
-          nodes{
-            state
-          }
-        }
       }
     }
   }

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -628,15 +628,6 @@ async function getOpenPrs(): Promise<PrList> {
         delete pr.headRefName;
         pr.targetBranch = pr.baseRefName;
         delete pr.baseRefName;
-        // https://developer.github.com/v4/enum/mergeablestate
-        const canMergeStates = ['BEHIND', 'CLEAN', 'HAS_HOOKS', 'UNSTABLE'];
-        const hasNegativeReview = pr.reviews?.nodes?.length > 0;
-        // istanbul ignore if
-        if (hasNegativeReview) {
-          pr.cannotMergeReason = `PR has a negative review`;
-        } else if (!canMergeStates.includes(pr.mergeStateStatus)) {
-          pr.cannotMergeReason = `pr.mergeStateStatus = ${pr.mergeStateStatus}`;
-        }
         if (pr.labels) {
           pr.labels = pr.labels.nodes.map((label) => label.name);
         }


### PR DESCRIPTION
## Changes

- Remove `cannotMergeReason` assignment in Github manager
- Stop querying `mergeStateStatus` and `reviews` GraphQL fields

## Context

- Ref: #14672

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

