### PR TITLE
fix(git): treat stale rejection as REPOSITORY_CHANGED

### DIFF
--- a/lib/util/git/error.ts
+++ b/lib/util/git/error.ts
@@ -22,7 +22,6 @@ export function checkForPlatformFailure(err: Error): Error | null {
     'early EOF',
     'fatal: bad config', // .gitmodules problem
     'expected flush after ref listing',
-    '[rejected] (stale info)',
   ];
   for (const errorStr of externalHostFailureStrings) {
     if (err.message.includes(errorStr)) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes

Catches `[rejected] (stale info)` during git push and throws `REPOSITORY_CHANGED`.

## Context

Lots of "unknown branch error" warns in the hosted app.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
