### PR TITLE
fix(cli): Restore --dry-run cli switch behaviour

### DIFF
--- a/lib/workers/global/config/parse/cli.ts
+++ b/lib/workers/global/config/parse/cli.ts
@@ -16,18 +16,18 @@ export function getCliName(option: ParseConfigOptions): string {
 export function getConfig(input: string[]): AllConfig {
   // massage migrated configuration keys
   const argv = input
-    .map(
-      (a) =>
-        a
-          .replace('--endpoints=', '--host-rules=')
-          .replace('--expose-env=true', '--trust-level=high')
-          .replace('--expose-env', '--trust-level=high')
-          .replace('--renovate-fork', '--include-forks')
-          .replace('"platform":"', '"hostType":"')
-          .replace('"endpoint":"', '"matchHost":"')
-          .replace('"host":"', '"matchHost":"')
-          .replace('--azure-auto-complete', '--platform-automerge') // migrate: azureAutoComplete
-          .replace('--git-lab-automerge', '--platform-automerge') // migrate: gitLabAutomerge
+    .map((a) =>
+      a
+        .replace('--endpoints=', '--host-rules=')
+        .replace('--expose-env=true', '--trust-level=high')
+        .replace('--expose-env', '--trust-level=high')
+        .replace('--renovate-fork', '--include-forks')
+        .replace('"platform":"', '"hostType":"')
+        .replace('"endpoint":"', '"matchHost":"')
+        .replace('"host":"', '"matchHost":"')
+        .replace('--azure-auto-complete', '--platform-automerge') // migrate: azureAutoComplete
+        .replace('--git-lab-automerge', '--platform-automerge') // migrate: gitLabAutomerge
+        .replace(/^--dry-run$/, '--dry-run=true')
     )
     .filter((a) => !a.startsWith('--git-fs'));
   const options = getOptions();

--- a/lib/workers/global/config/parse/index.spec.ts
+++ b/lib/workers/global/config/parse/index.spec.ts
@@ -151,6 +151,12 @@ describe('workers/global/config/parse/index', () => {
       expect(parsed).toContainEntries([['dryRun', 'full']]);
     });
 
+    it('cli dryRun replaced to full', async () => {
+      defaultArgv = defaultArgv.concat(['--dry-run']);
+      const parsed = await configParser.parseConfigs(defaultEnv, defaultArgv);
+      expect(parsed).toContainEntries([['dryRun', 'full']]);
+    });
+
     it('env dryRun = false replaced to null', async () => {
       const env: NodeJS.ProcessEnv = {
         ...defaultEnv,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Restores the `--dry-run` CLI option behaviour.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

Unfortunately, #14555 broke the simple command switch.

```
$ renovate --dry-run $RENOVATE_EXTRA_FLAGS
error: option '--dry-run <string>' argument missing
```

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
