### PR TITLE
fix: Revert "feat: extend dryRun options to extract lookup full"

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -292,17 +292,6 @@ Like this:
 
 ## dryRun
 
-Use `dryRun` to preview the behavior of Renovate in logs, without making any changes to the repository files.
-
-You can choose from the following behaviors for the `dryRun` config option:
-
-- `null`: Default behavior - Performs a regular Renovate run including creating/updating/deleting branches and PRs
-- `"extract"`: Performs a very quick package file scan to identify the extracted dependencies
-- `"lookup"`: Performs a package file scan to identify the extracted dependencies and updates available
-- `"full"`: Performs a dry run by logging messages instead of creating/updating/deleting branches and PRs
-
-Information provided mainly in debug log level.
-
 ## endpoint
 
 ## executionTimeout

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -245,10 +245,9 @@ const options: RenovateOptions[] = [
     name: 'dryRun',
     description:
       'If enabled, perform a dry run by logging messages instead of creating/updating/deleting branches and PRs.',
-    type: 'string',
+    type: 'boolean',
     globalOnly: true,
-    allowedValues: ['extract', 'lookup', 'full'],
-    default: null,
+    default: false,
   },
   {
     name: 'printConfig',

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -11,7 +11,6 @@ export type RenovateConfigStage =
   | 'pr';
 
 export type RepositoryCacheConfig = 'disabled' | 'enabled' | 'reset';
-export type DryRunConfig = 'extract' | 'lookup' | 'full';
 
 export interface GroupConfig extends Record<string, unknown> {
   branchName?: string;
@@ -105,7 +104,7 @@ export interface RepoGlobalConfig {
   dockerChildPrefix?: string;
   dockerImagePrefix?: string;
   dockerUser?: string;
-  dryRun?: DryRunConfig;
+  dryRun?: boolean;
   executionTimeout?: number;
   exposeAllEnv?: boolean;
   migratePresets?: Record<string, string>;

--- a/lib/workers/global/config/parse/index.spec.ts
+++ b/lib/workers/global/config/parse/index.spec.ts
@@ -135,35 +135,5 @@ describe('workers/global/config/parse/index', () => {
       const parsed = await configParser.parseConfigs(defaultEnv, defaultArgv);
       expect(parsed.hostRules).toContainEqual({ matchHost: 'example.org' });
     });
-
-    it('env dryRun = true replaced to full', async () => {
-      const env: NodeJS.ProcessEnv = {
-        ...defaultEnv,
-        RENOVATE_DRY_RUN: 'true',
-      };
-      const parsedConfig = await configParser.parseConfigs(env, defaultArgv);
-      expect(parsedConfig).toContainEntries([['dryRun', 'full']]);
-    });
-
-    it('cli dryRun = true replaced to full', async () => {
-      defaultArgv = defaultArgv.concat(['--dry-run=true']);
-      const parsed = await configParser.parseConfigs(defaultEnv, defaultArgv);
-      expect(parsed).toContainEntries([['dryRun', 'full']]);
-    });
-
-    it('env dryRun = false replaced to null', async () => {
-      const env: NodeJS.ProcessEnv = {
-        ...defaultEnv,
-        RENOVATE_DRY_RUN: 'false',
-      };
-      const parsedConfig = await configParser.parseConfigs(env, defaultArgv);
-      expect(parsedConfig).toContainEntries([['dryRun', null]]);
-    });
-
-    it('cli dryRun = false replaced to null', async () => {
-      defaultArgv = defaultArgv.concat(['--dry-run=false']);
-      const parsed = await configParser.parseConfigs(defaultEnv, defaultArgv);
-      expect(parsed).toContainEntries([['dryRun', null]]);
-    });
   });
 });

--- a/lib/workers/global/config/parse/index.ts
+++ b/lib/workers/global/config/parse/index.ts
@@ -22,27 +22,6 @@ export async function parseConfigs(
   const cliConfig = cliParser.getConfig(argv);
   const envConfig = envParser.getConfig(env);
 
-  if (cliConfig?.dryRun === 'true') {
-    logger.warn('cli config dryRun property has been changed to full');
-    cliConfig.dryRun = 'full';
-  }
-  if (envConfig?.dryRun === 'true') {
-    logger.warn('env config dryRun property has been changed to full');
-    envConfig.dryRun = 'full';
-  }
-  if (cliConfig?.dryRun === 'false' || cliConfig?.dryRun === 'null') {
-    logger.warn(
-      'cli config dryRun property has been changed to null, running with normal mode.'
-    );
-    cliConfig.dryRun = null;
-  }
-  if (envConfig?.dryRun === 'false' || envConfig?.dryRun === 'null') {
-    logger.warn(
-      'env config dryRun property has been changed to null, running with normal mode.'
-    );
-    envConfig.dryRun = null;
-  }
-
   let config: AllConfig = mergeChildConfig(fileConfig, envConfig);
   config = mergeChildConfig(config, cliConfig);
 

--- a/lib/workers/repository/dependency-dashboard.spec.ts
+++ b/lib/workers/repository/dependency-dashboard.spec.ts
@@ -32,7 +32,7 @@ async function dryRun(
   ensureIssueCalls = 0
 ) {
   jest.clearAllMocks();
-  GlobalConfig.set({ dryRun: 'full' });
+  GlobalConfig.set({ dryRun: true });
   await dependencyDashboard.ensureDependencyDashboard(config, branches);
   expect(platform.ensureIssueClosing).toHaveBeenCalledTimes(
     ensureIssueClosingCalls

--- a/lib/workers/repository/dependency-dashboard.ts
+++ b/lib/workers/repository/dependency-dashboard.ts
@@ -350,7 +350,7 @@ export async function ensureDependencyDashboard(
       { title: config.dependencyDashboardTitle },
       'DRY-RUN: Would ensure Dependency Dashboard'
     );
-  } else if (!GlobalConfig.get('dryRun')) {
+  } else {
     await platform.ensureIssue({
       title: config.dependencyDashboardTitle,
       reuseTitle,

--- a/lib/workers/repository/error-config.spec.ts
+++ b/lib/workers/repository/error-config.spec.ts
@@ -32,7 +32,7 @@ describe('workers/repository/error-config', () => {
       error.validationSource = 'package.json';
       error.validationMessage = 'some-message';
       platform.ensureIssue.mockResolvedValueOnce('created');
-      GlobalConfig.set({ dryRun: 'full' });
+      GlobalConfig.set({ dryRun: true });
       const res = await raiseConfigWarningIssue(config, error);
       expect(res).toBeUndefined();
     });
@@ -57,7 +57,7 @@ describe('workers/repository/error-config', () => {
         number: 1,
         state: PrState.Open,
       });
-      GlobalConfig.set({ dryRun: 'full' });
+      GlobalConfig.set({ dryRun: true });
       const res = await raiseConfigWarningIssue(config, error);
       expect(res).toBeUndefined();
     });

--- a/lib/workers/repository/finalise/prune.spec.ts
+++ b/lib/workers/repository/finalise/prune.spec.ts
@@ -69,7 +69,7 @@ describe('workers/repository/finalise/prune', () => {
     });
     it('does nothing on dryRun', async () => {
       config.branchList = ['renovate/a', 'renovate/b'];
-      GlobalConfig.set({ dryRun: 'full' });
+      GlobalConfig.set({ dryRun: true });
       git.getBranchList.mockReturnValueOnce(
         config.branchList.concat(['renovate/c'])
       );
@@ -107,7 +107,7 @@ describe('workers/repository/finalise/prune', () => {
     });
     it('skips comment if dry run', async () => {
       config.branchList = ['renovate/a', 'renovate/b'];
-      GlobalConfig.set({ dryRun: 'full' });
+      GlobalConfig.set({ dryRun: true });
       git.getBranchList.mockReturnValueOnce(
         config.branchList.concat(['renovate/c'])
       );
@@ -122,7 +122,7 @@ describe('workers/repository/finalise/prune', () => {
     });
     it('dry run delete branch no PR', async () => {
       config.branchList = ['renovate/a', 'renovate/b'];
-      GlobalConfig.set({ dryRun: 'full' });
+      GlobalConfig.set({ dryRun: true });
       git.getBranchList.mockReturnValueOnce(
         config.branchList.concat(['renovate/c'])
       );

--- a/lib/workers/repository/index.ts
+++ b/lib/workers/repository/index.ts
@@ -42,28 +42,23 @@ export async function renovateRepository(
     const { branches, branchList, packageFiles } = await extractDependencies(
       config
     );
-    if (
-      GlobalConfig.get('dryRun') !== 'lookup' &&
-      GlobalConfig.get('dryRun') !== 'extract'
-    ) {
-      await ensureOnboardingPr(config, packageFiles, branches);
-      const res = await updateRepo(config, branches);
-      setMeta({ repository: config.repository });
-      addSplit('update');
-      await setBranchCache(branches);
-      if (res === 'automerged') {
-        if (canRetry) {
-          logger.info('Renovating repository again after automerge result');
-          const recursiveRes = await renovateRepository(repoConfig, false);
-          return recursiveRes;
-        }
-        logger.debug(`Automerged but already retried once`);
-      } else {
-        await ensureDependencyDashboard(config, branches);
+    await ensureOnboardingPr(config, packageFiles, branches);
+    const res = await updateRepo(config, branches);
+    setMeta({ repository: config.repository });
+    addSplit('update');
+    await setBranchCache(branches);
+    if (res === 'automerged') {
+      if (canRetry) {
+        logger.info('Renovating repository again after automerge result');
+        const recursiveRes = await renovateRepository(repoConfig, false);
+        return recursiveRes;
       }
-      await finaliseRepo(config, branchList);
-      repoResult = processResult(config, res);
+      logger.debug(`Automerged but already retried once`);
+    } else {
+      await ensureDependencyDashboard(config, branches);
     }
+    await finaliseRepo(config, branchList);
+    repoResult = processResult(config, res);
   } catch (err) /* istanbul ignore next */ {
     setMeta({ repository: config.repository });
     const errorRes = await handleError(config, err);

--- a/lib/workers/repository/onboarding/pr/index.spec.ts
+++ b/lib/workers/repository/onboarding/pr/index.spec.ts
@@ -159,7 +159,7 @@ describe('workers/repository/onboarding/pr/index', () => {
       expect(platform.createPr).toHaveBeenCalledTimes(1);
     });
     it('dryrun of updates PR when modified', async () => {
-      GlobalConfig.set({ dryRun: 'full' });
+      GlobalConfig.set({ dryRun: true });
       config.baseBranch = 'some-branch';
       platform.getBranchPr.mockResolvedValueOnce(
         partial<Pr>({
@@ -178,7 +178,7 @@ describe('workers/repository/onboarding/pr/index', () => {
       );
     });
     it('dryrun of creates PR', async () => {
-      GlobalConfig.set({ dryRun: 'full' });
+      GlobalConfig.set({ dryRun: true });
       await ensureOnboardingPr(config, packageFiles, branches);
       expect(logger.info).toHaveBeenCalledWith(
         'DRY-RUN: Would check branch renovate/configure'

--- a/lib/workers/repository/process/index.spec.ts
+++ b/lib/workers/repository/process/index.spec.ts
@@ -5,11 +5,9 @@ import {
   mocked,
   platform,
 } from '../../../../test/util';
-import { GlobalConfig } from '../../../config/global';
 import { CONFIG_VALIDATION } from '../../../constants/error-messages';
 import { getCache } from '../../../util/cache/repository';
 import * as _extractUpdate from './extract-update';
-import { lookup } from './extract-update';
 import { extractDependencies, updateRepo } from '.';
 
 jest.mock('../../../util/git');
@@ -99,18 +97,6 @@ describe('workers/repository/process/index', () => {
       await expect(extractDependencies(config)).rejects.toThrow(
         CONFIG_VALIDATION
       );
-    });
-    it('processes baseBranches dryRun extract', async () => {
-      extract.mockResolvedValue({} as never);
-      GlobalConfig.set({ dryRun: 'extract' });
-      const res = await extractDependencies(config);
-      await updateRepo(config, res.branches);
-      expect(res).toEqual({
-        branchList: [],
-        branches: [],
-        packageFiles: {},
-      });
-      expect(lookup).toHaveBeenCalledTimes(0);
     });
   });
 });

--- a/lib/workers/repository/process/index.ts
+++ b/lib/workers/repository/process/index.ts
@@ -1,5 +1,4 @@
 import { mergeChildConfig } from '../../../config';
-import { GlobalConfig } from '../../../config/global';
 import type { RenovateConfig } from '../../../config/types';
 import { CONFIG_VALIDATION } from '../../../constants/error-messages';
 import { logger } from '../../../logger';
@@ -104,11 +103,6 @@ export async function extractDependencies(
     logger.debug('No baseBranches');
     const packageFiles = await extract(config);
     addSplit('extract');
-    if (GlobalConfig.get('dryRun') === 'extract') {
-      res.packageFiles = packageFiles;
-      logger.info({ packageFiles }, 'Extracted dependencies');
-      return res;
-    }
     res = await lookup(config, packageFiles);
   }
   addSplit('lookup');

--- a/lib/workers/repository/process/write.spec.ts
+++ b/lib/workers/repository/process/write.spec.ts
@@ -1,5 +1,4 @@
 import { RenovateConfig, getConfig, git, mocked } from '../../../../test/util';
-import { GlobalConfig } from '../../../config/global';
 import { Limit, isLimitReached } from '../../global/limits';
 import { BranchConfig, BranchResult } from '../../types';
 import * as _branchWorker from '../update/branch';
@@ -49,7 +48,6 @@ describe('workers/repository/process/write', () => {
         branchExists: false,
         result: BranchResult.Automerged,
       });
-      GlobalConfig.set({ dryRun: 'full' });
       const res = await writeUpdates(config, branches);
       expect(res).toBe('automerged');
       expect(branchWorker.processBranch).toHaveBeenCalledTimes(4);
@@ -64,7 +62,6 @@ describe('workers/repository/process/write', () => {
       git.branchExists.mockReturnValueOnce(true);
       limits.getBranchesRemaining.mockResolvedValueOnce(1);
       expect(isLimitReached(Limit.Branches)).toBeFalse();
-      GlobalConfig.set({ dryRun: 'full' });
       await writeUpdates({ config }, branches);
       expect(isLimitReached(Limit.Branches)).toBeTrue();
     });

--- a/lib/workers/repository/update/branch/artifacts.spec.ts
+++ b/lib/workers/repository/update/branch/artifacts.spec.ts
@@ -31,7 +31,7 @@ describe('workers/repository/update/branch/artifacts', () => {
     });
 
     it('skips status (dry-run)', async () => {
-      GlobalConfig.set({ dryRun: 'full' });
+      GlobalConfig.set({ dryRun: true });
       platform.getBranchStatusCheck.mockResolvedValueOnce(null);
       await setArtifactErrorStatus(config);
       expect(platform.setBranchStatus).not.toHaveBeenCalled();

--- a/lib/workers/repository/update/branch/automerge.spec.ts
+++ b/lib/workers/repository/update/branch/automerge.spec.ts
@@ -63,7 +63,7 @@ describe('workers/repository/update/branch/automerge', () => {
     it('returns true if automerge succeeds (dry-run)', async () => {
       config.automerge = true;
       config.automergeType = 'branch';
-      GlobalConfig.set({ dryRun: 'full' });
+      GlobalConfig.set({ dryRun: true });
       platform.getBranchStatus.mockResolvedValueOnce(BranchStatus.green);
       expect(await tryBranchAutomerge(config)).toBe('automerged');
     });

--- a/lib/workers/repository/update/branch/commit.spec.ts
+++ b/lib/workers/repository/update/branch/commit.spec.ts
@@ -55,7 +55,7 @@ describe('workers/repository/update/branch/commit', () => {
       expect(platform.commitFiles.mock.calls).toMatchSnapshot();
     });
     it('dry runs', async () => {
-      GlobalConfig.set({ dryRun: 'full' });
+      GlobalConfig.set({ dryRun: true });
       config.updatedPackageFiles.push({
         type: 'addition',
         path: 'package.json',

--- a/lib/workers/repository/update/branch/index.spec.ts
+++ b/lib/workers/repository/update/branch/index.spec.ts
@@ -487,7 +487,7 @@ describe('workers/repository/update/branch/index', () => {
       git.branchExists.mockReturnValue(true);
       commit.commitFilesToBranch.mockResolvedValueOnce(null);
       automerge.tryBranchAutomerge.mockResolvedValueOnce('automerged');
-      GlobalConfig.set({ ...adminConfig, dryRun: 'full' });
+      GlobalConfig.set({ ...adminConfig, dryRun: true });
       await branchWorker.processBranch(config);
       expect(automerge.tryBranchAutomerge).toHaveBeenCalledTimes(1);
       expect(prWorker.ensurePr).toHaveBeenCalledTimes(0);
@@ -831,7 +831,7 @@ describe('workers/repository/update/branch/index', () => {
       checkExisting.prAlreadyExisted.mockResolvedValueOnce({
         state: PrState.Closed,
       } as Pr);
-      GlobalConfig.set({ ...adminConfig, dryRun: 'full' });
+      GlobalConfig.set({ ...adminConfig, dryRun: true });
       expect(await branchWorker.processBranch(config)).toEqual({
         branchExists: false,
         prNo: undefined,
@@ -845,7 +845,7 @@ describe('workers/repository/update/branch/index', () => {
         state: PrState.Open,
       } as Pr);
       git.isBranchModified.mockResolvedValueOnce(true);
-      GlobalConfig.set({ ...adminConfig, dryRun: 'full' });
+      GlobalConfig.set({ ...adminConfig, dryRun: true });
       expect(await branchWorker.processBranch(config)).toEqual({
         branchExists: true,
         prNo: undefined,
@@ -871,7 +871,7 @@ describe('workers/repository/update/branch/index', () => {
       git.isBranchModified.mockResolvedValueOnce(true);
       schedule.isScheduledNow.mockReturnValueOnce(false);
       commit.commitFilesToBranch.mockResolvedValueOnce(null);
-      GlobalConfig.set({ ...adminConfig, dryRun: 'full' });
+      GlobalConfig.set({ ...adminConfig, dryRun: true });
       expect(
         await branchWorker.processBranch({
           ...config,
@@ -908,7 +908,7 @@ describe('workers/repository/update/branch/index', () => {
         pr: {},
       } as ResultWithPr);
       commit.commitFilesToBranch.mockResolvedValueOnce(null);
-      GlobalConfig.set({ ...adminConfig, dryRun: 'full' });
+      GlobalConfig.set({ ...adminConfig, dryRun: true });
       expect(
         await branchWorker.processBranch({
           ...config,

--- a/lib/workers/repository/update/pr/automerge.spec.ts
+++ b/lib/workers/repository/update/pr/automerge.spec.ts
@@ -1,5 +1,4 @@
 import { getConfig, git, mocked, partial } from '../../../../../test/util';
-import { GlobalConfig } from '../../../../config/global';
 import { Pr, platform as _platform } from '../../../../modules/platform';
 import { BranchStatus } from '../../../../types';
 import type { BranchConfig } from '../../../types';
@@ -104,52 +103,6 @@ describe('workers/repository/update/pr/automerge', () => {
         automerged: false,
         prAutomergeBlockReason: 'Conflicted',
       });
-      expect(platform.mergePr).toHaveBeenCalledTimes(0);
-    });
-    it('dryRun full should not automerge', async () => {
-      config.automerge = true;
-      GlobalConfig.set({ dryRun: 'full' });
-      platform.getBranchStatus.mockResolvedValueOnce(BranchStatus.green);
-      const res = await prAutomerge.checkAutoMerge(pr, config);
-      expect(res).toEqual({
-        automerged: false,
-        prAutomergeBlockReason: 'DryRun',
-      });
-      expect(platform.mergePr).toHaveBeenCalledTimes(0);
-    });
-    it('dryRun lookup should not automerge', async () => {
-      const expectedResult = {
-        automerged: false,
-        prAutomergeBlockReason: 'DryRun',
-      };
-      platform.getBranchStatus.mockResolvedValueOnce(BranchStatus.green);
-      GlobalConfig.set({ dryRun: 'lookup' });
-      const res = await prAutomerge.checkAutoMerge(pr, config);
-      expect(res).toEqual(expectedResult);
-      expect(platform.mergePr).toHaveBeenCalledTimes(0);
-    });
-    it('dryRun lookup pr-comment', async () => {
-      config.automergeType = 'pr-comment';
-      const expectedResult = {
-        automerged: false,
-        prAutomergeBlockReason: 'DryRun',
-      };
-      platform.getBranchStatus.mockResolvedValueOnce(BranchStatus.green);
-      GlobalConfig.set({ dryRun: 'lookup' });
-      const res = await prAutomerge.checkAutoMerge(pr, config);
-      expect(res).toEqual(expectedResult);
-      expect(platform.mergePr).toHaveBeenCalledTimes(0);
-    });
-    it('dryRun full pr-comment', async () => {
-      config.automergeType = 'pr-comment';
-      const expectedResult = {
-        automerged: false,
-        prAutomergeBlockReason: 'DryRun',
-      };
-      platform.getBranchStatus.mockResolvedValueOnce(BranchStatus.green);
-      GlobalConfig.set({ dryRun: 'full' });
-      const res = await prAutomerge.checkAutoMerge(pr, config);
-      expect(res).toEqual(expectedResult);
       expect(platform.mergePr).toHaveBeenCalledTimes(0);
     });
   });


### PR DESCRIPTION
Reverts renovatebot/renovate#14555

Dry run is not fully migrated and breaks some workflows.