### PR TITLE
feat(datasource): add getMetadata function

### DIFF
--- a/lib/modules/datasource/datasource.ts
+++ b/lib/modules/datasource/datasource.ts
@@ -33,6 +33,8 @@ export abstract class Datasource implements DatasourceApi {
 
   getDigest?(config: DigestConfig, newValue?: string): Promise<string | null>;
 
+  getMetadata?(config: GetReleasesConfig): Promise<ReleaseResult | null>;
+
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   handleSpecificErrors(err: HttpError): void {}
 

--- a/lib/modules/datasource/datasource.ts
+++ b/lib/modules/datasource/datasource.ts
@@ -5,7 +5,7 @@ import type {
   DatasourceApi,
   DigestConfig,
   GetReleasesConfig,
-  MetadataResult,
+  PackageMetadata,
   ReleaseResult,
 } from './types';
 
@@ -34,7 +34,7 @@ export abstract class Datasource implements DatasourceApi {
 
   getDigest?(config: DigestConfig, newValue?: string): Promise<string | null>;
 
-  getMetadata?(config: GetReleasesConfig): Promise<MetadataResult | null>;
+  getMetadata?(config: GetReleasesConfig): Promise<PackageMetadata | null>;
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   handleSpecificErrors(err: HttpError): void {}

--- a/lib/modules/datasource/datasource.ts
+++ b/lib/modules/datasource/datasource.ts
@@ -5,6 +5,7 @@ import type {
   DatasourceApi,
   DigestConfig,
   GetReleasesConfig,
+  MetadataResult,
   ReleaseResult,
 } from './types';
 
@@ -33,7 +34,7 @@ export abstract class Datasource implements DatasourceApi {
 
   getDigest?(config: DigestConfig, newValue?: string): Promise<string | null>;
 
-  getMetadata?(config: GetReleasesConfig): Promise<ReleaseResult | null>;
+  getMetadata?(config: GetReleasesConfig): Promise<MetadataResult | null>;
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   handleSpecificErrors(err: HttpError): void {}

--- a/lib/modules/datasource/types.ts
+++ b/lib/modules/datasource/types.ts
@@ -74,6 +74,7 @@ export interface DatasourceApi extends ModuleApi {
   id: string;
   getDigest?(config: DigestConfig, newValue?: string): Promise<string | null>;
   getReleases(config: GetReleasesConfig): Promise<ReleaseResult | null>;
+  getMetadata?(config: GetReleasesConfig): Promise<ReleaseResult | null>;
   defaultRegistryUrls?: string[];
   defaultVersioning?: string;
   defaultConfig?: Record<string, unknown>;

--- a/lib/modules/datasource/types.ts
+++ b/lib/modules/datasource/types.ts
@@ -70,11 +70,16 @@ export interface ReleaseResult {
   replacementVersion?: string;
 }
 
+export type MetadataResult = Pick<
+  ReleaseResult,
+  'changelogUrl' | 'dependencyUrl' | 'homepage' | 'sourceUrl'
+>;
+
 export interface DatasourceApi extends ModuleApi {
   id: string;
   getDigest?(config: DigestConfig, newValue?: string): Promise<string | null>;
   getReleases(config: GetReleasesConfig): Promise<ReleaseResult | null>;
-  getMetadata?(config: GetReleasesConfig): Promise<ReleaseResult | null>;
+  getMetadata?(config: GetReleasesConfig): Promise<MetadataResult | null>;
   defaultRegistryUrls?: string[];
   defaultVersioning?: string;
   defaultConfig?: Record<string, unknown>;

--- a/lib/modules/datasource/types.ts
+++ b/lib/modules/datasource/types.ts
@@ -54,10 +54,9 @@ export interface Release {
   sourceDirectory?: string;
 }
 
-export interface ReleaseResult {
+export interface PackageMetadata {
   deprecationMessage?: string;
   isPrivate?: boolean;
-  releases: Release[];
   tags?: Record<string, string>;
   // URL metadata
   changelogUrl?: string;
@@ -70,16 +69,15 @@ export interface ReleaseResult {
   replacementVersion?: string;
 }
 
-export type MetadataResult = Pick<
-  ReleaseResult,
-  'changelogUrl' | 'dependencyUrl' | 'homepage' | 'sourceUrl'
->;
+export interface ReleaseResult extends PackageMetadata {
+  releases: Release[];
+}
 
 export interface DatasourceApi extends ModuleApi {
   id: string;
   getDigest?(config: DigestConfig, newValue?: string): Promise<string | null>;
   getReleases(config: GetReleasesConfig): Promise<ReleaseResult | null>;
-  getMetadata?(config: GetReleasesConfig): Promise<MetadataResult | null>;
+  getMetadata?(config: GetReleasesConfig): Promise<PackageMetadata | null>;
   defaultRegistryUrls?: string[];
   defaultVersioning?: string;
   defaultConfig?: Record<string, unknown>;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes

Adds a new, optional, `getMetadata` function to the `DatasourceApi` interface

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

- #11024

I'd like input on what the return type should be. It's currently `Promise<ReleaseResult | null>`, but I think this is too broad. I would prefer something like:

```ts
type MetadataResult = Pick<ReleaseResult, 'changelogUrl' | 'dependencyUrl' | 'homepage' | 'sourceUrl'>;
getMetadata?(config: GetReleasesConfig): Promise<MetadataResult | null>;
```

But then it's a type, not an interface. Thoughts?

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
