### PR TITLE
fix: Referencing a preset on Azure DevOps with space in path doesn't work (#14845)

### DIFF
--- a/lib/config/presets/index.spec.ts
+++ b/lib/config/presets/index.spec.ts
@@ -457,6 +457,17 @@ describe('config/presets/index', () => {
         presetSource: 'local',
       });
     });
+    it('parses local with spaces in subdirectory', () => {
+      expect(
+        presets.parsePreset('local>A2B CD/A2B_Renovate//some dir/some-file')
+      ).toEqual({
+        repo: 'A2B CD/A2B_Renovate',
+        params: undefined,
+        presetName: 'some-file',
+        presetPath: 'some dir',
+        presetSource: 'local',
+      });
+    });
     it('parses local with sub preset and tag', () => {
       expect(
         presets.parsePreset(

--- a/lib/config/presets/index.ts
+++ b/lib/config/presets/index.ts
@@ -195,7 +195,6 @@ export async function getPreset(
   }
   const { presetSource, repo, presetPath, presetName, tag, params } =
     parsePreset(preset);
-  logger.debug(parsePreset(preset));
   let presetConfig = await presetSources[presetSource].getPreset({
     repo,
     presetPath,
@@ -203,7 +202,6 @@ export async function getPreset(
     baseConfig,
     tag,
   });
-  logger.debug(presetConfig);
   if (!presetConfig) {
     throw new Error(PRESET_DEP_NOT_FOUND);
   }

--- a/lib/config/presets/index.ts
+++ b/lib/config/presets/index.ts
@@ -38,7 +38,7 @@ const presetSources: Record<string, PresetApi> = {
 };
 
 const nonScopedPresetWithSubdirRegex = regEx(
-  /^(?<repo>~?[\w\-. /]+?)\/\/(?:(?<presetPath>[\w\-./]+)\/)?(?<presetName>[\w\-.]+)(?:#(?<tag>[\w\-./]+?))?$/
+  /^(?<repo>~?[\w\-. /]+?)\/\/(?:(?<presetPath>[\w\-. /]+)\/)?(?<presetName>[\w\-.]+)(?:#(?<tag>[\w\-./]+?))?$/
 );
 const gitPresetRegex = regEx(
   /^(?<repo>~?[\w\-. /]+)(?::(?<presetName>[\w\-.+/]+))?(?:#(?<tag>[\w\-./]+?))?$/
@@ -195,6 +195,7 @@ export async function getPreset(
   }
   const { presetSource, repo, presetPath, presetName, tag, params } =
     parsePreset(preset);
+  logger.debug(parsePreset(preset));
   let presetConfig = await presetSources[presetSource].getPreset({
     repo,
     presetPath,
@@ -202,6 +203,7 @@ export async function getPreset(
     baseConfig,
     tag,
   });
+  logger.debug(presetConfig);
   if (!presetConfig) {
     throw new Error(PRESET_DEP_NOT_FOUND);
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes

It's now allowed to have a space in the preset path.
<!-- Describe what behavior is changed by this PR. -->

## Context

See #14845
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
