### PR TITLE
docs: document composer VCS repo name hint

### DIFF
--- a/lib/modules/manager/composer/readme.md
+++ b/lib/modules/manager/composer/readme.md
@@ -1,6 +1,7 @@
 Extracts dependencies from `composer.json` files, and keeps the associated `composer.lock` file updated too.
 
-If [VCS repositories](https://getcomposer.org/doc/05-repositories.md#vcs) are used Renovate needs a hint via the `name` property, which has to match the relevant package. E.g. the package `acme/foo` would need an entry in [repositories](https://getcomposer.org/doc/04-schema.md#repositories) similar to the following
+If you use [VCS repositories](https://getcomposer.org/doc/05-repositories.md#vcs) then Renovate needs a hint via the `name` property, which must match the relevant package.
+For example, the package `acme/foo` would need an entry in [repositories](https://getcomposer.org/doc/04-schema.md#repositories) similar to the following:
 
 ```json
 {

--- a/lib/modules/manager/composer/readme.md
+++ b/lib/modules/manager/composer/readme.md
@@ -1,1 +1,11 @@
 Extracts dependencies from `composer.json` files, and keeps the associated `composer.lock` file updated too.
+
+If [VCS repositories](https://getcomposer.org/doc/05-repositories.md#vcs) are used Renovate needs a hint via the `name` property, which has to match the relevant package. E.g. the package `acme/foo` would need an entry in [repositories](https://getcomposer.org/doc/04-schema.md#repositories) similar to the following
+
+```json
+{
+  "name": "acme/foo",
+  "type": "vcs",
+  "url": "http://vcs-of-acme.org/acme/foo.git"
+}
+```


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Adds info how to help Renovate extract Composer package info if [VCS repositories](https://getcomposer.org/doc/05-repositories.md#vcs) are used. I found this a while ago somewhere in a discussion which I didn't find now. But it basically works because of https://github.com/renovatebot/renovate/blob/32.10.2/lib/modules/manager/composer/extract.ts#L42

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->
We did already migrate to a "real" Composer repository and do not use this anymore, but I was reminded because somebody asked a similar thing in https://github.com/renovatebot/renovate/discussions/10504#discussioncomment-2473836 which was the pre-condition for me to use VCS repos with Bitbucket.

And this name property thing is really hard to figure out.

Not sure though where this really should be. Candidates
- https://docs.renovatebot.com/modules/manager/composer/
- https://docs.renovatebot.com/php/

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
