### PR TITLE
refactor(github): Explicit coerce functions for PR list responses

### DIFF
--- a/lib/modules/platform/github/__fixtures__/graphql/pullrequests-open.json
+++ b/lib/modules/platform/github/__fixtures__/graphql/pullrequests-open.json
@@ -21,7 +21,14 @@
             "number": 2500,
             "baseRefName": "master",
             "headRefName": "renovate/jest-monorepo",
-            "title": "chore(deps): update dependency jest to v23.6.0"
+            "title": "chore(deps): update dependency jest to v23.6.0",
+            "body": "Some body",
+            "assignees": {
+              "totalCount": 1
+            },
+            "reviewRequests": {
+              "totalCount": 2
+            }
           },
           {
             "number": 2079,

--- a/lib/modules/platform/github/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/platform/github/__snapshots__/index.spec.ts.snap
@@ -142,20 +142,6 @@ Array [
 `;
 
 exports[`modules/platform/github/index createPr() should create a draftPR if set in the settings 1`] = `
-Object {
-  "displayNumber": "Pull Request #123",
-  "head": Object {
-    "repo": Object {
-      "full_name": "some/repo",
-    },
-  },
-  "number": 123,
-  "sourceBranch": "some-branch",
-  "sourceRepo": "some/repo",
-}
-`;
-
-exports[`modules/platform/github/index createPr() should create a draftPR if set in the settings 2`] = `
 Array [
   Object {
     "graphql": Object {
@@ -226,20 +212,6 @@ Array [
 `;
 
 exports[`modules/platform/github/index createPr() should create and return a PR object 1`] = `
-Object {
-  "displayNumber": "Pull Request #123",
-  "head": Object {
-    "repo": Object {
-      "full_name": "some/repo",
-    },
-  },
-  "number": 123,
-  "sourceBranch": "some-branch",
-  "sourceRepo": "some/repo",
-}
-`;
-
-exports[`modules/platform/github/index createPr() should create and return a PR object 2`] = `
 Array [
   Object {
     "graphql": Object {
@@ -327,20 +299,6 @@ Array [
 `;
 
 exports[`modules/platform/github/index createPr() should use defaultBranch 1`] = `
-Object {
-  "displayNumber": "Pull Request #123",
-  "head": Object {
-    "repo": Object {
-      "full_name": "some/repo",
-    },
-  },
-  "number": 123,
-  "sourceBranch": "some-branch",
-  "sourceRepo": "some/repo",
-}
-`;
-
-exports[`modules/platform/github/index createPr() should use defaultBranch 2`] = `
 Array [
   Object {
     "graphql": Object {
@@ -519,74 +477,6 @@ Array [
     "url": "https://api.github.com/graphql",
   },
   Object {
-    "graphql": Object {
-      "query": Object {
-        "__vars": Object {
-          "$count": "Int",
-          "$cursor": "String",
-          "$name": "String!",
-          "$owner": "String!",
-        },
-        "repository": Object {
-          "__args": Object {
-            "name": "$name",
-            "owner": "$owner",
-          },
-          "pullRequests": Object {
-            "__args": Object {
-              "after": "$cursor",
-              "first": "$count",
-              "orderBy": Object {
-                "direction": "DESC",
-                "field": "UPDATED_AT",
-              },
-              "states": Array [
-                "CLOSED",
-                "MERGED",
-              ],
-            },
-            "nodes": Object {
-              "comments": Object {
-                "__args": Object {
-                  "last": "100",
-                },
-                "nodes": Object {
-                  "body": null,
-                  "databaseId": null,
-                },
-              },
-              "headRefName": null,
-              "number": null,
-              "state": null,
-              "title": null,
-            },
-            "pageInfo": Object {
-              "endCursor": null,
-              "hasNextPage": null,
-            },
-          },
-        },
-      },
-      "variables": Object {
-        "count": 100,
-        "cursor": null,
-        "name": "repo",
-        "owner": "some",
-      },
-    },
-    "headers": Object {
-      "accept": "application/vnd.github.v3+json",
-      "accept-encoding": "gzip, deflate, br",
-      "authorization": "token 123test",
-      "content-length": "674",
-      "content-type": "application/json",
-      "host": "api.github.com",
-      "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
-    },
-    "method": "POST",
-    "url": "https://api.github.com/graphql",
-  },
-  Object {
     "headers": Object {
       "accept": "application/vnd.github.v3+json",
       "accept-encoding": "gzip, deflate, br",
@@ -659,74 +549,6 @@ Array [
       "accept-encoding": "gzip, deflate, br",
       "authorization": "token 123test",
       "content-length": "395",
-      "content-type": "application/json",
-      "host": "api.github.com",
-      "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
-    },
-    "method": "POST",
-    "url": "https://api.github.com/graphql",
-  },
-  Object {
-    "graphql": Object {
-      "query": Object {
-        "__vars": Object {
-          "$count": "Int",
-          "$cursor": "String",
-          "$name": "String!",
-          "$owner": "String!",
-        },
-        "repository": Object {
-          "__args": Object {
-            "name": "$name",
-            "owner": "$owner",
-          },
-          "pullRequests": Object {
-            "__args": Object {
-              "after": "$cursor",
-              "first": "$count",
-              "orderBy": Object {
-                "direction": "DESC",
-                "field": "UPDATED_AT",
-              },
-              "states": Array [
-                "CLOSED",
-                "MERGED",
-              ],
-            },
-            "nodes": Object {
-              "comments": Object {
-                "__args": Object {
-                  "last": "100",
-                },
-                "nodes": Object {
-                  "body": null,
-                  "databaseId": null,
-                },
-              },
-              "headRefName": null,
-              "number": null,
-              "state": null,
-              "title": null,
-            },
-            "pageInfo": Object {
-              "endCursor": null,
-              "hasNextPage": null,
-            },
-          },
-        },
-      },
-      "variables": Object {
-        "count": 100,
-        "cursor": null,
-        "name": "repo",
-        "owner": "some",
-      },
-    },
-    "headers": Object {
-      "accept": "application/vnd.github.v3+json",
-      "accept-encoding": "gzip, deflate, br",
-      "authorization": "token 123test",
-      "content-length": "674",
       "content-type": "application/json",
       "host": "api.github.com",
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
@@ -952,74 +774,6 @@ Array [
     "url": "https://api.github.com/graphql",
   },
   Object {
-    "graphql": Object {
-      "query": Object {
-        "__vars": Object {
-          "$count": "Int",
-          "$cursor": "String",
-          "$name": "String!",
-          "$owner": "String!",
-        },
-        "repository": Object {
-          "__args": Object {
-            "name": "$name",
-            "owner": "$owner",
-          },
-          "pullRequests": Object {
-            "__args": Object {
-              "after": "$cursor",
-              "first": "$count",
-              "orderBy": Object {
-                "direction": "DESC",
-                "field": "UPDATED_AT",
-              },
-              "states": Array [
-                "CLOSED",
-                "MERGED",
-              ],
-            },
-            "nodes": Object {
-              "comments": Object {
-                "__args": Object {
-                  "last": "100",
-                },
-                "nodes": Object {
-                  "body": null,
-                  "databaseId": null,
-                },
-              },
-              "headRefName": null,
-              "number": null,
-              "state": null,
-              "title": null,
-            },
-            "pageInfo": Object {
-              "endCursor": null,
-              "hasNextPage": null,
-            },
-          },
-        },
-      },
-      "variables": Object {
-        "count": 100,
-        "cursor": null,
-        "name": "repo",
-        "owner": "some",
-      },
-    },
-    "headers": Object {
-      "accept": "application/vnd.github.v3+json",
-      "accept-encoding": "gzip, deflate, br",
-      "authorization": "token 123test",
-      "content-length": "674",
-      "content-type": "application/json",
-      "host": "api.github.com",
-      "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
-    },
-    "method": "POST",
-    "url": "https://api.github.com/graphql",
-  },
-  Object {
     "headers": Object {
       "accept": "application/vnd.github.v3+json",
       "accept-encoding": "gzip, deflate, br",
@@ -1081,74 +835,6 @@ Array [
     "url": "https://api.github.com/graphql",
   },
   Object {
-    "graphql": Object {
-      "query": Object {
-        "__vars": Object {
-          "$count": "Int",
-          "$cursor": "String",
-          "$name": "String!",
-          "$owner": "String!",
-        },
-        "repository": Object {
-          "__args": Object {
-            "name": "$name",
-            "owner": "$owner",
-          },
-          "pullRequests": Object {
-            "__args": Object {
-              "after": "$cursor",
-              "first": "$count",
-              "orderBy": Object {
-                "direction": "DESC",
-                "field": "UPDATED_AT",
-              },
-              "states": Array [
-                "CLOSED",
-                "MERGED",
-              ],
-            },
-            "nodes": Object {
-              "comments": Object {
-                "__args": Object {
-                  "last": "100",
-                },
-                "nodes": Object {
-                  "body": null,
-                  "databaseId": null,
-                },
-              },
-              "headRefName": null,
-              "number": null,
-              "state": null,
-              "title": null,
-            },
-            "pageInfo": Object {
-              "endCursor": null,
-              "hasNextPage": null,
-            },
-          },
-        },
-      },
-      "variables": Object {
-        "count": 100,
-        "cursor": null,
-        "name": "repo",
-        "owner": "some",
-      },
-    },
-    "headers": Object {
-      "accept": "application/vnd.github.v3+json",
-      "accept-encoding": "gzip, deflate, br",
-      "authorization": "token 123test",
-      "content-length": "674",
-      "content-type": "application/json",
-      "host": "api.github.com",
-      "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
-    },
-    "method": "POST",
-    "url": "https://api.github.com/graphql",
-  },
-  Object {
     "headers": Object {
       "accept": "application/vnd.github.v3+json",
       "accept-encoding": "gzip, deflate, br",
@@ -1202,74 +888,6 @@ Array [
       "accept-encoding": "gzip, deflate, br",
       "authorization": "token 123test",
       "content-length": "395",
-      "content-type": "application/json",
-      "host": "api.github.com",
-      "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
-    },
-    "method": "POST",
-    "url": "https://api.github.com/graphql",
-  },
-  Object {
-    "graphql": Object {
-      "query": Object {
-        "__vars": Object {
-          "$count": "Int",
-          "$cursor": "String",
-          "$name": "String!",
-          "$owner": "String!",
-        },
-        "repository": Object {
-          "__args": Object {
-            "name": "$name",
-            "owner": "$owner",
-          },
-          "pullRequests": Object {
-            "__args": Object {
-              "after": "$cursor",
-              "first": "$count",
-              "orderBy": Object {
-                "direction": "DESC",
-                "field": "UPDATED_AT",
-              },
-              "states": Array [
-                "CLOSED",
-                "MERGED",
-              ],
-            },
-            "nodes": Object {
-              "comments": Object {
-                "__args": Object {
-                  "last": "100",
-                },
-                "nodes": Object {
-                  "body": null,
-                  "databaseId": null,
-                },
-              },
-              "headRefName": null,
-              "number": null,
-              "state": null,
-              "title": null,
-            },
-            "pageInfo": Object {
-              "endCursor": null,
-              "hasNextPage": null,
-            },
-          },
-        },
-      },
-      "variables": Object {
-        "count": 100,
-        "cursor": null,
-        "name": "repo",
-        "owner": "some",
-      },
-    },
-    "headers": Object {
-      "accept": "application/vnd.github.v3+json",
-      "accept-encoding": "gzip, deflate, br",
-      "authorization": "token 123test",
-      "content-length": "674",
       "content-type": "application/json",
       "host": "api.github.com",
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
@@ -1342,74 +960,6 @@ Array [
       "accept-encoding": "gzip, deflate, br",
       "authorization": "token 123test",
       "content-length": "395",
-      "content-type": "application/json",
-      "host": "api.github.com",
-      "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
-    },
-    "method": "POST",
-    "url": "https://api.github.com/graphql",
-  },
-  Object {
-    "graphql": Object {
-      "query": Object {
-        "__vars": Object {
-          "$count": "Int",
-          "$cursor": "String",
-          "$name": "String!",
-          "$owner": "String!",
-        },
-        "repository": Object {
-          "__args": Object {
-            "name": "$name",
-            "owner": "$owner",
-          },
-          "pullRequests": Object {
-            "__args": Object {
-              "after": "$cursor",
-              "first": "$count",
-              "orderBy": Object {
-                "direction": "DESC",
-                "field": "UPDATED_AT",
-              },
-              "states": Array [
-                "CLOSED",
-                "MERGED",
-              ],
-            },
-            "nodes": Object {
-              "comments": Object {
-                "__args": Object {
-                  "last": "100",
-                },
-                "nodes": Object {
-                  "body": null,
-                  "databaseId": null,
-                },
-              },
-              "headRefName": null,
-              "number": null,
-              "state": null,
-              "title": null,
-            },
-            "pageInfo": Object {
-              "endCursor": null,
-              "hasNextPage": null,
-            },
-          },
-        },
-      },
-      "variables": Object {
-        "count": 100,
-        "cursor": null,
-        "name": "repo",
-        "owner": "some",
-      },
-    },
-    "headers": Object {
-      "accept": "application/vnd.github.v3+json",
-      "accept-encoding": "gzip, deflate, br",
-      "authorization": "token 123test",
-      "content-length": "674",
       "content-type": "application/json",
       "host": "api.github.com",
       "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
@@ -3382,23 +2932,12 @@ Array [
 
 exports[`modules/platform/github/index getBranchPr(branchName) should reopen an autoclosed PR 1`] = `
 Object {
-  "additions": 1,
-  "base": Object {
-    "sha": "1234",
-  },
-  "commits": 1,
-  "deletions": 1,
   "displayNumber": "Pull Request #91",
-  "head": Object {
-    "ref": "somebranch",
-    "repo": Object {
-      "full_name": "some/repo",
-    },
-  },
   "number": 91,
-  "sha": undefined,
   "sourceBranch": "somebranch",
+  "sourceRepo": "some/repo",
   "state": "open",
+  "title": "Some title",
 }
 `;
 
@@ -3711,23 +3250,12 @@ Array [
 
 exports[`modules/platform/github/index getBranchPr(branchName) should return the PR object 1`] = `
 Object {
-  "additions": 1,
-  "base": Object {
-    "sha": "1234",
-  },
-  "commits": 1,
-  "deletions": 1,
   "displayNumber": "Pull Request #91",
-  "head": Object {
-    "ref": "somebranch",
-    "repo": Object {
-      "full_name": "some/repo",
-    },
-  },
   "number": 91,
-  "sha": undefined,
   "sourceBranch": "somebranch",
+  "sourceRepo": "some/repo",
   "state": "open",
+  "title": "Some title",
 }
 `;
 
@@ -3946,23 +3474,12 @@ Array [
 
 exports[`modules/platform/github/index getBranchPr(branchName) should return the PR object in fork mode 1`] = `
 Object {
-  "additions": 1,
-  "base": Object {
-    "sha": "1234",
-  },
-  "commits": 1,
-  "deletions": 1,
   "displayNumber": "Pull Request #90",
-  "head": Object {
-    "ref": "somebranch",
-    "repo": Object {
-      "full_name": "other/repo",
-    },
-  },
   "number": 90,
-  "sha": undefined,
   "sourceBranch": "somebranch",
+  "sourceRepo": "other/repo",
   "state": "open",
+  "title": "Some title",
 }
 `;
 
@@ -5191,18 +4708,6 @@ Array [
 exports[`modules/platform/github/index getPr(prNo) should return PR from closed graphql result 1`] = `
 Object {
   "body": "dummy body",
-  "comments": Array [
-    Object {
-      "body": ":tada: This PR is included in version 13.63.5 :tada:
-
-The release is available on:
-- [npm package (@latest dist-tag)](https://www.npmjs.com/package/renovate)
-- [GitHub release](https://github.com/renovatebot/renovate/releases/tag/13.63.5)
-
-Your **[semantic-release](https://github.com/semantic-release/semantic-release)** bot :package::rocket:",
-      "id": 420006957,
-    },
-  ],
   "displayNumber": "Pull Request #2499",
   "number": 2499,
   "sourceBranch": "renovate/delay-4.x",
@@ -5404,9 +4909,10 @@ Array [
 
 exports[`modules/platform/github/index getPr(prNo) should return PR from graphql result 1`] = `
 Object {
+  "body": "Some body",
   "displayNumber": "Pull Request #2500",
-  "hasAssignees": false,
-  "hasReviewers": false,
+  "hasAssignees": true,
+  "hasReviewers": true,
   "number": 2500,
   "sourceBranch": "renovate/jest-monorepo",
   "state": "open",
@@ -5540,13 +5046,18 @@ Array [
 
 exports[`modules/platform/github/index getPr(prNo) should return a PR object - 0 1`] = `
 Object {
-  "base": Object {
-    "sha": "1234",
-  },
-  "displayNumber": "Pull Request #1",
-  "merged_at": "sometime",
-  "number": 1,
-  "state": "closed",
+  "createdAt": "01-01-2022",
+  "displayNumber": "Pull Request #1234",
+  "hasAssignees": true,
+  "labels": Array [
+    "foo",
+    "bar",
+  ],
+  "number": 1234,
+  "sha": "def",
+  "sourceBranch": "some/branch",
+  "state": "merged",
+  "title": "Some title",
 }
 `;
 
@@ -5754,16 +5265,13 @@ Array [
 
 exports[`modules/platform/github/index getPr(prNo) should return a PR object - 1 1`] = `
 Object {
-  "base": Object {
-    "sha": "1234",
-  },
-  "commits": 1,
-  "displayNumber": "Pull Request #1",
-  "mergeable_state": "dirty",
-  "number": 1,
-  "sha": undefined,
-  "sourceBranch": undefined,
+  "displayNumber": "Pull Request #1234",
+  "hasAssignees": true,
+  "hasReviewers": true,
+  "number": 1234,
+  "sourceBranch": "some/branch",
   "state": "open",
+  "title": "Some title",
 }
 `;
 
@@ -5971,15 +5479,11 @@ Array [
 
 exports[`modules/platform/github/index getPr(prNo) should return a PR object - 2 1`] = `
 Object {
-  "base": Object {
-    "sha": "5678",
-  },
-  "commits": 1,
-  "displayNumber": "Pull Request #1",
-  "number": 1,
-  "sha": undefined,
-  "sourceBranch": undefined,
+  "displayNumber": "Pull Request #1234",
+  "number": 1234,
+  "sourceBranch": "some/branch",
   "state": "open",
+  "title": "Some title",
 }
 `;
 

--- a/lib/modules/platform/github/common.ts
+++ b/lib/modules/platform/github/common.ts
@@ -1,0 +1,82 @@
+import is from '@sindresorhus/is';
+import { PrState } from '../../../types';
+import type { Pr } from '../types';
+import type { GhGraphQlPr, GhRestPr } from './types';
+
+/**
+ * @see https://developer.github.com/v4/object/pullrequest/
+ */
+export function coerceGraphqlPr(pr: GhGraphQlPr): Pr {
+  const result: Pr = {
+    number: pr.number,
+    displayNumber: `Pull Request #${pr.number}`,
+    title: pr.title,
+    state: pr.state ? pr.state.toLowerCase() : PrState.Open,
+    sourceBranch: pr.headRefName,
+    body: pr.body ? pr.body : 'dummy body',
+  };
+
+  if (pr.baseRefName) {
+    result.targetBranch = pr.baseRefName;
+  }
+
+  if (pr.assignees) {
+    result.hasAssignees = !!(pr.assignees.totalCount > 0);
+  }
+
+  if (pr.reviewRequests) {
+    result.hasReviewers = !!(pr.reviewRequests.totalCount > 0);
+  }
+
+  if (pr.labels) {
+    result.labels = pr.labels.nodes.map((label) => label.name);
+  }
+
+  return result;
+}
+
+/**
+ * @see https://docs.github.com/en/rest/reference/pulls#list-pull-requests
+ */
+export function coerceRestPr(pr: GhRestPr): Pr {
+  const result: Pr = {
+    displayNumber: `Pull Request #${pr.number}`,
+    number: pr.number,
+    sourceBranch: pr.head?.ref,
+    title: pr.title,
+    state:
+      pr.state === PrState.Closed && is.string(pr.merged_at)
+        ? PrState.Merged
+        : pr.state,
+  };
+
+  if (pr.head?.sha) {
+    result.sha = pr.head.sha;
+  }
+
+  if (pr.head?.repo?.full_name) {
+    result.sourceRepo = pr.head.repo.full_name;
+  }
+
+  if (pr.labels) {
+    result.labels = pr.labels.map(({ name }) => name);
+  }
+
+  if (pr.assignee || is.nonEmptyArray(pr.assignees)) {
+    result.hasAssignees = true;
+  }
+
+  if (pr.requested_reviewers) {
+    result.hasReviewers = true;
+  }
+
+  if (pr.created_at) {
+    result.createdAt = pr.created_at;
+  }
+
+  if (pr.closed_at) {
+    result.closedAt = pr.closed_at;
+  }
+
+  return result;
+}

--- a/lib/modules/platform/github/common.ts
+++ b/lib/modules/platform/github/common.ts
@@ -28,7 +28,7 @@ export function coerceGraphqlPr(pr: GhGraphQlPr): Pr {
     result.hasReviewers = !!(pr.reviewRequests.totalCount > 0);
   }
 
-  if (pr.labels) {
+  if (pr.labels?.nodes) {
     result.labels = pr.labels.nodes.map((label) => label.name);
   }
 

--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -40,7 +40,7 @@ describe('modules/platform/github/index', () => {
     });
   });
 
-  const graphqlOpenPullRequests = loadFixture('graphql/pullrequest-1.json');
+  const graphqlOpenPullRequests = loadFixture('graphql/pullrequests-open.json');
   const graphqlClosedPullRequests = loadFixture(
     'graphql/pullrequests-closed.json'
   );
@@ -593,6 +593,7 @@ describe('modules/platform/github/index', () => {
           },
           head: { ref: 'somebranch', repo: { full_name: 'some/repo' } },
           state: PrState.Open,
+          title: 'Some title',
         });
 
       await github.initRepo({
@@ -641,6 +642,7 @@ describe('modules/platform/github/index', () => {
           },
           head: { ref: 'somebranch', repo: { full_name: 'some/repo' } },
           state: PrState.Open,
+          title: 'Some title',
         });
 
       await github.initRepo({
@@ -758,6 +760,7 @@ describe('modules/platform/github/index', () => {
           },
           head: { ref: 'somebranch', repo: { full_name: 'other/repo' } },
           state: PrState.Open,
+          title: 'Some title',
         })
         .patch('/repos/forked/repo/git/refs/heads/master')
         .reply(200);
@@ -1671,23 +1674,20 @@ describe('modules/platform/github/index', () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
       scope
-        .post('/graphql')
-        .reply(200, {
-          data: { repository: { pullRequests: { pageInfo: {} } } },
-        })
         .get('/repos/some/repo/issues/42/comments?per_page=100')
         .reply(200, [])
         .post('/repos/some/repo/issues/42/comments')
         .reply(200);
-
       await github.initRepo({
         repository: 'some/repo',
       } as any);
+
       await github.ensureComment({
         number: 42,
         topic: 'some-subject',
         content: 'some\ncontent',
       });
+
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
     it('adds comment if found in closed PR list', async () => {
@@ -1701,21 +1701,20 @@ describe('modules/platform/github/index', () => {
       await github.initRepo({
         repository: 'some/repo',
       } as any);
+      await github.getClosedPrs();
+
       await github.ensureComment({
         number: 2499,
         topic: 'some-subject',
         content: 'some\ncontent',
       });
+
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
     it('add updates comment if necessary', async () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
       scope
-        .post('/graphql')
-        .reply(200, {
-          data: { repository: { pullRequests: { pageInfo: {} } } },
-        })
         .get('/repos/some/repo/issues/42/comments?per_page=100')
         .reply(200, [{ id: 1234, body: '### some-subject\n\nblablabla' }])
         .patch('/repos/some/repo/issues/comments/1234')
@@ -1723,51 +1722,49 @@ describe('modules/platform/github/index', () => {
       await github.initRepo({
         repository: 'some/repo',
       } as any);
+
       await github.ensureComment({
         number: 42,
         topic: 'some-subject',
         content: 'some\ncontent',
       });
+
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
     it('skips comment', async () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
       scope
-        .post('/graphql')
-        .reply(200, {
-          data: { repository: { pullRequests: { pageInfo: {} } } },
-        })
         .get('/repos/some/repo/issues/42/comments?per_page=100')
         .reply(200, [{ id: 1234, body: '### some-subject\n\nsome\ncontent' }]);
       await github.initRepo({
         repository: 'some/repo',
       } as any);
+
       await github.ensureComment({
         number: 42,
         topic: 'some-subject',
         content: 'some\ncontent',
       });
+
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
     it('handles comment with no description', async () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
       scope
-        .post('/graphql')
-        .reply(200, {
-          data: { repository: { pullRequests: { pageInfo: {} } } },
-        })
         .get('/repos/some/repo/issues/42/comments?per_page=100')
         .reply(200, [{ id: 1234, body: '!merge' }]);
       await github.initRepo({
         repository: 'some/repo',
       } as any);
+
       await github.ensureComment({
         number: 42,
         topic: null,
         content: '!merge',
       });
+
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
   });
@@ -1776,40 +1773,36 @@ describe('modules/platform/github/index', () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
       scope
-        .post('/graphql')
-        .reply(200, {
-          data: { repository: { pullRequests: { pageInfo: {} } } },
-        })
         .get('/repos/some/repo/issues/42/comments?per_page=100')
         .reply(200, [{ id: 1234, body: '### some-subject\n\nblablabla' }])
         .delete('/repos/some/repo/issues/comments/1234')
         .reply(200);
       await github.initRepo({ repository: 'some/repo', token: 'token' } as any);
+
       await github.ensureCommentRemoval({
         type: 'by-topic',
         number: 42,
         topic: 'some-subject',
       });
+
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
     it('deletes comment by content if found', async () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
       scope
-        .post('/graphql')
-        .reply(200, {
-          data: { repository: { pullRequests: { pageInfo: {} } } },
-        })
         .get('/repos/some/repo/issues/42/comments?per_page=100')
         .reply(200, [{ id: 1234, body: 'some-content' }])
         .delete('/repos/some/repo/issues/comments/1234')
         .reply(200);
       await github.initRepo({ repository: 'some/repo', token: 'token' } as any);
+
       await github.ensureCommentRemoval({
         type: 'by-content',
         number: 42,
         content: 'some-content',
       });
+
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
   });
@@ -1923,7 +1916,7 @@ describe('modules/platform/github/index', () => {
         prBody: 'Hello world',
         labels: ['deps', 'renovate'],
       });
-      expect(pr).toMatchSnapshot();
+      expect(pr).toMatchObject({ number: 123 });
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
     it('should use defaultBranch', async () => {
@@ -1941,7 +1934,7 @@ describe('modules/platform/github/index', () => {
         prBody: 'Hello world',
         labels: null,
       });
-      expect(pr).toMatchSnapshot();
+      expect(pr).toMatchObject({ number: 123 });
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
     it('should create a draftPR if set in the settings', async () => {
@@ -1949,7 +1942,7 @@ describe('modules/platform/github/index', () => {
       initRepoMock(scope, 'some/repo');
       scope.post('/repos/some/repo/pulls').reply(200, {
         number: 123,
-        head: { repo: { full_name: 'some/repo' } },
+        head: { repo: { full_name: 'some/repo' }, ref: 'some-branch' },
       });
       await github.initRepo({ repository: 'some/repo', token: 'token' } as any);
       const pr = await github.createPr({
@@ -1960,7 +1953,7 @@ describe('modules/platform/github/index', () => {
         labels: null,
         draftPR: true,
       });
-      expect(pr).toMatchSnapshot();
+      expect(pr).toMatchObject({ number: 123 });
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
     describe('automerge', () => {
@@ -2164,10 +2157,15 @@ describe('modules/platform/github/index', () => {
       scope
         .get('/repos/some/repo/pulls/1234')
         .reply(200, {
-          number: 1,
+          number: 1234,
           state: PrState.Closed,
-          base: { sha: '1234' },
+          base: { sha: 'abc' },
+          head: { sha: 'def', ref: 'some/branch' },
           merged_at: 'sometime',
+          title: 'Some title',
+          labels: [{ name: 'foo' }, { name: 'bar' }],
+          assignee: { login: 'foobar' },
+          created_at: '01-01-2022',
         })
         .post('/graphql')
         .twice()
@@ -2177,7 +2175,7 @@ describe('modules/platform/github/index', () => {
         token: 'token',
       } as any);
       const pr = await github.getPr(1234);
-      expect(pr).toMatchSnapshot();
+      expect(pr).toMatchSnapshot({ state: 'merged' });
       expect(httpMock.getTrace()).toMatchSnapshot();
     });
     it(`should return a PR object - 1`, async () => {
@@ -2186,11 +2184,15 @@ describe('modules/platform/github/index', () => {
       scope
         .get('/repos/some/repo/pulls/1234')
         .reply(200, {
-          number: 1,
+          number: 1234,
           state: PrState.Open,
           mergeable_state: 'dirty',
           base: { sha: '1234' },
+          head: { ref: 'some/branch' },
           commits: 1,
+          title: 'Some title',
+          assignees: [{ login: 'foo' }],
+          requested_reviewers: [{ login: 'bar' }],
         })
         .post('/graphql')
         .twice()
@@ -2209,10 +2211,12 @@ describe('modules/platform/github/index', () => {
       scope
         .get('/repos/some/repo/pulls/1234')
         .reply(200, {
-          number: 1,
+          number: 1234,
           state: PrState.Open,
           base: { sha: '5678' },
+          head: { ref: 'some/branch' },
           commits: 1,
+          title: 'Some title',
         })
         .post('/graphql')
         .twice()

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -54,6 +54,7 @@ import type {
   UpdatePrConfig,
 } from '../types';
 import { smartTruncate } from '../utils/pr-body';
+import { coerceGraphqlPr, coerceRestPr } from './common';
 import {
   closedPrsQuery,
   enableAutoMergeMutation,
@@ -359,6 +360,7 @@ export async function initRepo({
   config.openPrList = null;
   config.closedPrList = null;
   config.branchPrs = [];
+  config.prComments = {};
 
   config.forkMode = !!forkMode;
   if (forkMode) {
@@ -553,7 +555,7 @@ export async function getRepoForceRebase(): Promise<boolean> {
   return config.repoForceRebase;
 }
 
-async function getClosedPrs(): Promise<PrList> {
+export async function getClosedPrs(): Promise<PrList> {
   if (!config.closedPrList) {
     config.closedPrList = {};
     try {
@@ -574,19 +576,15 @@ async function getClosedPrs(): Promise<PrList> {
         logger.debug('getClosedPrs(): no graphql data');
         return {};
       }
-      for (const pr of nodes) {
-        // https://developer.github.com/v4/object/pullrequest/
-        pr.displayNumber = `Pull Request #${pr.number}`;
-        pr.state = pr.state.toLowerCase();
-        pr.sourceBranch = pr.headRefName;
-        delete pr.headRefName;
-        pr.comments = pr.comments.nodes.map((comment) => ({
-          id: comment.databaseId,
-          body: comment.body,
-        }));
-        pr.body = 'dummy body'; // just in case
+      for (const gqlPr of nodes) {
+        const pr = coerceGraphqlPr(gqlPr);
         config.closedPrList[pr.number] = pr;
         prNumbers.push(pr.number);
+        if (gqlPr.comments?.nodes) {
+          config.prComments[pr.number] = gqlPr.comments.nodes.map(
+            ({ databaseId: id, body }) => ({ id, body })
+          );
+        }
       }
       prNumbers.sort();
       logger.debug({ prNumbers }, 'Retrieved closed PR list with graphql');
@@ -620,22 +618,8 @@ async function getOpenPrs(): Promise<PrList> {
         logger.debug('getOpenPrs(): no graphql data');
         return {};
       }
-      for (const pr of nodes) {
-        // https://developer.github.com/v4/object/pullrequest/
-        pr.displayNumber = `Pull Request #${pr.number}`;
-        pr.state = PrState.Open;
-        pr.sourceBranch = pr.headRefName;
-        delete pr.headRefName;
-        pr.targetBranch = pr.baseRefName;
-        delete pr.baseRefName;
-        if (pr.labels) {
-          pr.labels = pr.labels.nodes.map((label) => label.name);
-        }
-        pr.hasAssignees = !!(pr.assignees?.totalCount > 0);
-        delete pr.assignees;
-        pr.hasReviewers = !!(pr.reviewRequests?.totalCount > 0);
-        delete pr.reviewRequests;
-        delete pr.mergeStateStatus;
+      for (const gqlPr of nodes) {
+        const pr = coerceGraphqlPr(gqlPr);
         config.openPrList[pr.number] = pr;
         prNumbers.push(pr.number);
       }
@@ -669,21 +653,12 @@ export async function getPr(prNo: number): Promise<Pr | null> {
     { prNo },
     'PR not found in open or closed PRs list - trying to fetch it directly'
   );
-  const pr = (
+  const ghRestPr = (
     await githubApi.getJson<GhRestPr>(
       `repos/${config.parentRepo || config.repository}/pulls/${prNo}`
     )
   ).body;
-  if (!pr) {
-    return null;
-  }
-  // Harmonise PR values
-  pr.displayNumber = `Pull Request #${pr.number}`;
-  if (pr.state === PrState.Open) {
-    pr.sourceBranch = pr.head ? pr.head.ref : undefined;
-    pr.sha = pr.head ? pr.head.sha : undefined;
-  }
-  return pr;
+  return ghRestPr ? coerceRestPr(ghRestPr) : null;
 }
 
 function matchesState(state: string, desiredState: string): boolean {
@@ -723,22 +698,7 @@ export async function getPrList(): Promise<Pr[]> {
             ? pr.user.login === config.renovateUsername
             : true)
       )
-      .map(
-        (pr) =>
-          ({
-            number: pr.number,
-            sourceBranch: pr.head.ref,
-            sha: pr.head.sha,
-            title: pr.title,
-            state:
-              pr.state === PrState.Closed && pr.merged_at?.length
-                ? /* istanbul ignore next */ PrState.Merged
-                : pr.state,
-            createdAt: pr.created_at,
-            closedAt: pr.closed_at,
-            sourceRepo: pr.head?.repo?.full_name,
-          } as never)
-      );
+      .map(coerceRestPr);
     logger.debug(`Retrieved ${config.prList.length} Pull Requests`);
   }
   return config.prList;
@@ -1323,10 +1283,10 @@ async function deleteComment(commentId: number): Promise<void> {
 }
 
 async function getComments(issueNo: number): Promise<Comment[]> {
-  const pr = (await getClosedPrs())[issueNo];
-  if (pr) {
+  const cachedComments = config.prComments[issueNo];
+  if (cachedComments) {
     logger.debug('Returning closed PR list comments');
-    return pr.comments;
+    return cachedComments;
   }
   // GET /repos/:owner/:repo/issues/:number/comments
   logger.debug(`Getting comments for #${issueNo}`);
@@ -1510,25 +1470,24 @@ export async function createPr({
     options.body.maintainer_can_modify = true;
   }
   logger.debug({ title, head, base, draft: draftPR }, 'Creating PR');
-  const pr = (
+  const ghRestPr = (
     await githubApi.postJson<GhRestPr>(
       `repos/${config.parentRepo || config.repository}/pulls`,
       options
     )
   ).body;
   logger.debug(
-    { branch: sourceBranch, pr: pr.number, draft: draftPR },
+    { branch: sourceBranch, pr: ghRestPr.number, draft: draftPR },
     'PR created'
   );
+  const { node_id } = ghRestPr;
+  const pr = coerceRestPr(ghRestPr);
   // istanbul ignore if
   if (config.prList) {
     config.prList.push(pr);
   }
-  pr.displayNumber = `Pull Request #${pr.number}`;
-  pr.sourceBranch = sourceBranch;
-  pr.sourceRepo = pr.head.repo.full_name;
   await addLabels(pr.number, labels);
-  await tryPrAutomerge(pr.number, pr.node_id, platformOptions);
+  await tryPrAutomerge(pr.number, node_id, platformOptions);
   return pr;
 }
 

--- a/lib/modules/platform/github/types.ts
+++ b/lib/modules/platform/github/types.ts
@@ -52,7 +52,7 @@ export interface GhGraphQlPr {
   assignees?: { totalCount: number };
   reviewRequests?: { totalCount: number };
   comments?: {
-    nodes: {
+    nodes?: {
       databaseId: number;
       body: string;
     }[];

--- a/lib/modules/platform/github/types.ts
+++ b/lib/modules/platform/github/types.ts
@@ -20,11 +20,7 @@ export interface Comment {
   body: string;
 }
 
-export interface GhPr extends Pr {
-  comments: Comment[];
-}
-
-export interface GhRestPr extends GhPr {
+export interface GhRestPr {
   head: {
     ref: string;
     sha: string;
@@ -39,17 +35,28 @@ export interface GhRestPr extends GhPr {
   closed_at: string;
   user?: { login?: string };
   node_id: string;
+  assignee?: { login?: string };
+  assignees?: { login?: string }[];
+  requested_reviewers?: { login?: string }[];
+  labels?: { name: string }[];
 }
 
-export interface GhGraphQlPr extends GhPr {
-  reviewRequests: any;
-  assignees: any;
-  mergeStateStatus: string;
-  reviews: any;
-  baseRefName: string;
+export interface GhGraphQlPr {
+  number: number;
+  title: string;
+  body?: string;
+  state?: string;
   headRefName: string;
-  comments: Comment[] & { nodes?: { databaseId: number; body: string }[] };
-  labels: string[] & { nodes?: { name: string }[] };
+  baseRefName?: string;
+  labels?: { nodes?: { name: string }[] };
+  assignees?: { totalCount: number };
+  reviewRequests?: { totalCount: number };
+  comments?: {
+    nodes: {
+      databaseId: number;
+      body: string;
+    }[];
+  };
 }
 
 export interface UserDetails {
@@ -78,7 +85,8 @@ export interface LocalRepoConfig {
   forkToken?: string;
   closedPrList: PrList | null;
   openPrList: PrList | null;
-  prList: GhPr[] | null;
+  prList: Pr[] | null;
+  prComments: Record<number, Comment[]>;
   issueList: any[] | null;
   mergeMethod: 'rebase' | 'squash' | 'merge';
   defaultBranch: string;
@@ -93,7 +101,7 @@ export interface LocalRepoConfig {
 }
 
 export type BranchProtection = any;
-export type PrList = Record<number, GhPr>;
+export type PrList = Record<number, Pr>;
 
 export interface GhRepo {
   isFork: boolean;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes

- Coerce functions for both REST/GraphQL
- Separate cached comments from PR interface
- Fix tests

## Context

- Ref: #14617

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
