### PR TITLE
refactor(migrations): separateMajorReleases

### DIFF
--- a/lib/config/migration.ts
+++ b/lib/config/migration.ts
@@ -136,9 +136,6 @@ export function migrateConfig(
         } else {
           migratedConfig.semanticCommitScope = null;
         }
-      } else if (key === 'separateMajorReleases') {
-        delete migratedConfig.separateMultipleMajor;
-        migratedConfig.separateMajorMinor = val;
       } else if (is.string(val) && val.startsWith('{{semanticPrefix}}')) {
         migratedConfig[key] = val.replace(
           '{{semanticPrefix}}',

--- a/lib/config/migrations/base/abstract-migration.ts
+++ b/lib/config/migrations/base/abstract-migration.ts
@@ -21,6 +21,10 @@ export abstract class AbstractMigration implements Migration {
     return this.migratedConfig[key] ?? this.originalConfig[key];
   }
 
+  protected has<Key extends keyof RenovateConfig>(key: Key): boolean {
+    return key in this.originalConfig;
+  }
+
   protected setSafely<Key extends keyof RenovateConfig>(
     key: Key,
     value: RenovateConfig[Key]

--- a/lib/config/migrations/custom/separate-major-release-migration.spec.ts
+++ b/lib/config/migrations/custom/separate-major-release-migration.spec.ts
@@ -1,0 +1,15 @@
+import { SeparateMajorReleasesMigration } from './separate-major-release-migration';
+
+describe('config/migrations/custom/separate-major-release-migration', () => {
+  it('should migrate', () => {
+    expect(SeparateMajorReleasesMigration).toMigrate(
+      {
+        separateMajorReleases: true,
+      },
+      {
+        separateMajorMinor: true,
+        separateMajorReleases: true,
+      }
+    );
+  });
+});

--- a/lib/config/migrations/custom/separate-major-release-migration.ts
+++ b/lib/config/migrations/custom/separate-major-release-migration.ts
@@ -1,0 +1,9 @@
+import { AbstractMigration } from '../base/abstract-migration';
+
+export class SeparateMajorReleasesMigration extends AbstractMigration {
+  override readonly propertyName = 'separateMajorReleases';
+
+  override run(value: unknown): void {
+    this.setSafely('separateMajorMinor', value);
+  }
+}

--- a/lib/config/migrations/custom/separate-multiple-major-migration.spec.ts
+++ b/lib/config/migrations/custom/separate-multiple-major-migration.spec.ts
@@ -1,0 +1,27 @@
+import { SeparateMultipleMajorMigration } from './separate-multiple-major-migration';
+
+describe('config/migrations/custom/separate-multiple-major-migration', () => {
+  it('should remove if separateMajorReleases exists', () => {
+    expect(SeparateMultipleMajorMigration).toMigrate(
+      {
+        separateMajorReleases: true,
+        separateMultipleMajor: true,
+      },
+      {
+        separateMajorReleases: true,
+      }
+    );
+  });
+
+  it('should skip if separateMajorReleases does not exist', () => {
+    expect(SeparateMultipleMajorMigration).toMigrate(
+      {
+        separateMultipleMajor: true,
+      },
+      {
+        separateMultipleMajor: true,
+      },
+      false
+    );
+  });
+});

--- a/lib/config/migrations/custom/separate-multiple-major-migration.ts
+++ b/lib/config/migrations/custom/separate-multiple-major-migration.ts
@@ -1,0 +1,11 @@
+import { AbstractMigration } from '../base/abstract-migration';
+
+export class SeparateMultipleMajorMigration extends AbstractMigration {
+  override readonly propertyName = 'separateMultipleMajor';
+
+  override run(): void {
+    if (this.has('separateMajorReleases')) {
+      this.delete();
+    }
+  }
+}

--- a/lib/config/migrations/migrations-service.ts
+++ b/lib/config/migrations/migrations-service.ts
@@ -30,6 +30,8 @@ import { RenovateForkMigration } from './custom/renovate-fork-migration';
 import { RequiredStatusChecksMigration } from './custom/required-status-checks-migration';
 import { ScheduleMigration } from './custom/schedule-migration';
 import { SemanticCommitsMigration } from './custom/semantic-commits-migration';
+import { SeparateMajorReleasesMigration } from './custom/separate-major-release-migration';
+import { SeparateMultipleMajorMigration } from './custom/separate-multiple-major-migration';
 import { SuppressNotificationsMigration } from './custom/suppress-notifications-migration';
 import { TrustLevelMigration } from './custom/trust-level-migration';
 import { UnpublishSafeMigration } from './custom/unpublish-safe-migration';
@@ -96,6 +98,8 @@ export class MigrationsService {
     RequiredStatusChecksMigration,
     ScheduleMigration,
     SemanticCommitsMigration,
+    SeparateMajorReleasesMigration,
+    SeparateMultipleMajorMigration,
     SuppressNotificationsMigration,
     TrustLevelMigration,
     UnpublishSafeMigration,


### PR DESCRIPTION
## Changes:

One more migration from previously huge PR https://github.com/renovatebot/renovate/pull/12957

## Context:

1. https://github.com/renovatebot/renovate/issues/11459
2. Part of https://github.com/renovatebot/renovate/pull/12957 

## Documentation

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository