### PR TITLE
fix(maven): Allow whitespaces after comma in ranges

### DIFF
--- a/lib/modules/versioning/maven/compare.spec.ts
+++ b/lib/modules/versioning/maven/compare.spec.ts
@@ -255,12 +255,16 @@ describe('modules/versioning/maven/compare', () => {
     });
 
     test.each`
-      input          | leftType             | leftValue | leftBracket | rightType            | rightValue | rightBracket
-      ${'[1.0]'}     | ${'INCLUDING_POINT'} | ${'1.0'}  | ${'['}      | ${'INCLUDING_POINT'} | ${'1.0'}   | ${']'}
-      ${'(,1.0]'}    | ${'EXCLUDING_POINT'} | ${null}   | ${'('}      | ${'INCLUDING_POINT'} | ${'1.0'}   | ${']'}
-      ${'[1.2,1.3]'} | ${'INCLUDING_POINT'} | ${'1.2'}  | ${'['}      | ${'INCLUDING_POINT'} | ${'1.3'}   | ${']'}
-      ${'[1.0,2.0)'} | ${'INCLUDING_POINT'} | ${'1.0'}  | ${'['}      | ${'EXCLUDING_POINT'} | ${'2.0'}   | ${')'}
-      ${'[1.5,)'}    | ${'INCLUDING_POINT'} | ${'1.5'}  | ${'['}      | ${'EXCLUDING_POINT'} | ${null}    | ${')'}
+      input           | leftType             | leftValue | leftBracket | rightType            | rightValue | rightBracket
+      ${'[1.0]'}      | ${'INCLUDING_POINT'} | ${'1.0'}  | ${'['}      | ${'INCLUDING_POINT'} | ${'1.0'}   | ${']'}
+      ${'(,1.0]'}     | ${'EXCLUDING_POINT'} | ${null}   | ${'('}      | ${'INCLUDING_POINT'} | ${'1.0'}   | ${']'}
+      ${'(, 1.0]'}    | ${'EXCLUDING_POINT'} | ${null}   | ${'('}      | ${'INCLUDING_POINT'} | ${'1.0'}   | ${']'}
+      ${'[1.2,1.3]'}  | ${'INCLUDING_POINT'} | ${'1.2'}  | ${'['}      | ${'INCLUDING_POINT'} | ${'1.3'}   | ${']'}
+      ${'[1.2, 1.3]'} | ${'INCLUDING_POINT'} | ${'1.2'}  | ${'['}      | ${'INCLUDING_POINT'} | ${'1.3'}   | ${']'}
+      ${'[1.0,2.0)'}  | ${'INCLUDING_POINT'} | ${'1.0'}  | ${'['}      | ${'EXCLUDING_POINT'} | ${'2.0'}   | ${')'}
+      ${'[1.0,2.0)'}  | ${'INCLUDING_POINT'} | ${'1.0'}  | ${'['}      | ${'EXCLUDING_POINT'} | ${'2.0'}   | ${')'}
+      ${'[1.5,)'}     | ${'INCLUDING_POINT'} | ${'1.5'}  | ${'['}      | ${'EXCLUDING_POINT'} | ${null}    | ${')'}
+      ${'[1.5, )'}    | ${'INCLUDING_POINT'} | ${'1.5'}  | ${'['}      | ${'EXCLUDING_POINT'} | ${null}    | ${')'}
     `(
       'parseRange("$input")',
       ({
@@ -283,7 +287,9 @@ describe('modules/versioning/maven/compare', () => {
           },
         ];
         expect(parseRange(input)).toEqual(parseResult);
-        expect(rangeToStr(parseResult as never)).toEqual(input);
+        expect(rangeToStr(parseResult as never)).toEqual(
+          input.replace(/\s*/g, '')
+        );
       }
     );
 

--- a/lib/modules/versioning/maven/compare.ts
+++ b/lib/modules/versioning/maven/compare.ts
@@ -313,7 +313,7 @@ function parseRange(rangeStr: string): Range[] | null {
     };
   }
 
-  const commaSplit = rangeStr.split(',');
+  const commaSplit = rangeStr.split(/\s*,\s*/);
   let ranges: Range[] | null = [];
   let interval = emptyInterval();
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes

- Allow both `[1.0.0,2.0.0)` and `[1.0.0, 2.0.0)` forms of range

## Context

- Closes: #14921

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
