### PR TITLE
fix: set `mergeable`=`false` for `ignorePaths` config option

### DIFF
--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -742,6 +742,7 @@ const options: RenovateOptions[] = [
     description:
       'Skip any package file whose path matches one of these. Can be a string or glob pattern.',
     type: 'array',
+    mergeable: false,
     subType: 'string',
     stage: 'repository',
     default: ['**/node_modules/**', '**/bower_components/**'],


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes

- Add `mergeable` = `false` property for `ignorePaths` config option

## Context

Trying to fix a problem found in discussion: https://github.com/renovatebot/renovate/discussions/14941

Our [docs for the `ignorePaths` config option](https://docs.renovatebot.com/configuration-options/#ignorepaths) do not mention the `mergeable` key.

Please review if I'm making the change in the correct place/file. 😉 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
