### PR TITLE
chore(bug report template): add description to platform version field

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -47,6 +47,14 @@ body:
     id: platform-version-if-selfhosting
     attributes:
       label: If you're self-hosting Renovate, tell us what version of the platform you run.
+      description: |
+        This field is for the version number of your _platform_, so one of these:
+          - GitHub (.com and Enterprise)
+          - GitLab (.com and CE/EE)
+          - Bitbucket Cloud
+          - Bitbucket Server
+          - Azure DevOps
+          - Gitea
     validations:
       required: false
 


### PR DESCRIPTION
## Changes

- Add `description` field to the platform version input field
  - List all supported platforms

## Context

Bug reporters are filling out the the version of the Renovate _bot_ in the _platform version_ field. So it's clear that the form doesn't explain what we need well enough. 😄 

My changes should make the input field for the platform version easier to understand.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
