### PR TITLE
docs: drop duplicate word

### DIFF
--- a/docs/usage/getting-started/use-cases.md
+++ b/docs/usage/getting-started/use-cases.md
@@ -57,7 +57,7 @@ Not all dependencies are detected by default, this can be because:
 - The package manager/file format is not supported, or
 - The file format is not a standard or is proprietary
 
-If your dependencies are not detected by default, you can use use our "regex" manager to set your own custom patterns to extract dependencies.
+If your dependencies are not detected by default, you can use our "regex" manager to set your own custom patterns to extract dependencies.
 You configure the regex manager by telling it:
 
 - Which file pattern(s) to match


### PR DESCRIPTION
## Changes

- Drop duplicate word

## Context

We're using the word `use` twice in a row. 🙈 

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
