### PR TITLE
fix(gradle): Don't skip files matched via custom pattern

### DIFF
--- a/lib/modules/manager/gradle/extract.ts
+++ b/lib/modules/manager/gradle/extract.ts
@@ -12,7 +12,6 @@ import type {
 } from './types';
 import {
   getVars,
-  isGradleFile,
   isPropsFile,
   isTOMLFile,
   reorderFiles,
@@ -68,7 +67,7 @@ export async function extractAllPackageFiles(
       } else if (isTOMLFile(packageFile)) {
         const updatesFromCatalog = parseCatalog(packageFile, content);
         extractedDeps.push(...updatesFromCatalog);
-      } else if (isGradleFile(packageFile)) {
+      } else {
         const vars = getVars(registry, dir);
         const {
           deps,

--- a/lib/modules/manager/gradle/utils.ts
+++ b/lib/modules/manager/gradle/utils.ts
@@ -101,7 +101,6 @@ export function interpolateString(
 
 const gradleVersionsFileRegex = regEx('^versions\\.gradle(?:\\.kts)?$', 'i');
 const gradleBuildFileRegex = regEx('^build\\.gradle(?:\\.kts)?$', 'i');
-const gradleFileRegex = regEx('\\.gradle(?:\\.kts)?$', 'i');
 
 export function isGradleVersionsFile(path: string): boolean {
   const filename = upath.basename(path);
@@ -111,11 +110,6 @@ export function isGradleVersionsFile(path: string): boolean {
 export function isGradleBuildFile(path: string): boolean {
   const filename = upath.basename(path);
   return gradleBuildFileRegex.test(filename);
-}
-
-export function isGradleFile(path: string): boolean {
-  const filename = upath.basename(path);
-  return gradleFileRegex.test(filename);
 }
 
 export function isPropsFile(path: string): boolean {


### PR DESCRIPTION
## Changes

- Stop skipping non-`build.gradle` files and parse them in the same way

## Context

- Fixes: #14940

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
