### PR TITLE
docs(manager:regex): Improve regex manager documentation

### DIFF
--- a/docs/usage/modules/manager.md
+++ b/docs/usage/modules/manager.md
@@ -93,7 +93,7 @@ To disable all managers within a language like `python`, do this:
 ```
 
 Only languages declared by a Renovate manager are supported.
-Please check the [list of supported managers](https://docs.renovatebot.com/modules/manager/#supported-managers).
+Please check the [list of supported managers](#supported-managers).
 
 #### Limiting enabled managers
 

--- a/lib/modules/manager/regex/readme.md
+++ b/lib/modules/manager/regex/readme.md
@@ -47,7 +47,8 @@ RUN curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version ${YARN_VER
 You would need to capture the `currentValue` using a named capture group, like so: `ENV YARN_VERSION=(?<currentValue>.*?)\\n`.
 
 If you're looking for an online regex testing tool that supports capture groups, try [https://regex101.com/](<https://regex101.com/?flavor=javascript&flags=g&regex=ENV%20YARN_VERSION%3D(%3F%3CcurrentValue%3E.*%3F)%5Cn&testString=FROM%20node%3A12%0AENV%20YARN_VERSION%3D1.19.1%0ARUN%20curl%20-o-%20-L%20https%3A%2F%2Fyarnpkg.com%2Finstall.sh%20%7C%20bash%20-s%20--%20--version%20%24%7BYARN_VERSION%7D>).
-Be aware that backslashes (`'\'`) of the resulting regex have to still be escaped e.g `\n\s` --> `\\n\\s`.
+Be aware that backslashes (`'\'`) of the resulting regex have to still be escaped e.g. `\n\s` --> `\\n\\s`.
+You can use the Code Generator in the sidebar and copy the regex in the generated "Alternative syntax" comment into JSON.
 
 ### Configuration templates
 

--- a/lib/modules/manager/regex/readme.md
+++ b/lib/modules/manager/regex/readme.md
@@ -14,7 +14,7 @@ In order for Renovate to look up a dependency and decide about updates, it then 
 
 - The dependency's name
 - Which [`datasource`](https://docs.renovatebot.com/modules/datasource/#supported-datasources) to look up (e.g. [npm](https://docs.renovatebot.com/modules/datasource/#npm-datasource), [Docker](https://docs.renovatebot.com/modules/datasource/#docker-datasource), [GitHub tags](https://docs.renovatebot.com/modules/datasource/#github-tags-datasource))
-- Which [version scheme](https://docs.renovatebot.com/modules/versioning/#supported-versioning) to apply (defaults to [`semver`](https://docs.renovatebot.com/modules/versioning/#semantic-versioning), but also may be other values like [`pep440`](https://docs.renovatebot.com/modules/versioning/#pep440-versioning))
+- Which [version scheme](https://docs.renovatebot.com/modules/versioning/) to apply (defaults to [`semver`](https://docs.renovatebot.com/modules/versioning/#semantic-versioning), but also may be [other values](https://docs.renovatebot.com/modules/versioning/#supported-versioning) like [`pep440`](https://docs.renovatebot.com/modules/versioning/#pep440-versioning))
 
 <!-- prettier-ignore -->
 !!! note

--- a/lib/modules/manager/regex/readme.md
+++ b/lib/modules/manager/regex/readme.md
@@ -13,21 +13,24 @@ The first two required fields are `fileMatch` and `matchStrings`. `fileMatch` wo
 In order for Renovate to look up a dependency and decide about updates, it then needs the following information about each dependency:
 
 - The dependency's name
-- Which `datasource` to look up (e.g. npm, Docker, GitHub tags, etc)
-- Which version scheme to apply (defaults to `semver`, but also may be other values like `pep440`)
+- Which [`datasource`](https://docs.renovatebot.com/modules/datasource/#supported-datasources) to look up (e.g. [npm](https://docs.renovatebot.com/modules/datasource/#npm-datasource), [Docker](https://docs.renovatebot.com/modules/datasource/#docker-datasource), [GitHub tags](https://docs.renovatebot.com/modules/datasource/#github-tags-datasource), [etc.](https://docs.renovatebot.com/modules/datasource/#supported-datasources))
+- Which [version scheme](https://docs.renovatebot.com/modules/versioning/#supported-versioning) to apply (defaults to [`semver`](https://docs.renovatebot.com/modules/versioning/#semantic-versioning), but also may be other values like [`pep440`](https://docs.renovatebot.com/modules/versioning/#pep440-versioning))
+
+Note: capture groups below are similar to [available fields](https://docs.renovatebot.com/templates/#other-available-fields), but these available fields are not available in templates below, because most of those are coming from managers, and `regex` is a manager.
 
 Configuration-wise, it works like this:
 
 - You must capture the `currentValue` of the dependency in a named capture group
-- You must have either a `depName` capture group or a `depNameTemplate` config field
-- You can optionally have a `packageName` capture group or a `packageNameTemplate` if it differs from `depName`
-- You must have either a `datasource` capture group or a `datasourceTemplate` config field
-- You can optionally have a `depType` capture group or a `depTypeTemplate` config field
-- You can optionally have a `versioning` capture group or a `versioningTemplate` config field. If neither are present, `semver` will be used as the default
-- You can optionally have an `extractVersion` capture group or an `extractVersionTemplate` config field
-- You can optionally have a `currentDigest` capture group.
-- You can optionally have a `registryUrl` capture group or a `registryUrlTemplate` config field
-  - If it's a valid URL, it will be converted to the `registryUrls` field as a single-length array.
+- You must have either a `depName` capture group or a [`depNameTemplate` config field](https://docs.renovatebot.com/configuration-options/#depnametemplate)
+- You can optionally have a `packageName` capture group or a [`packageNameTemplate` config field] if it differs from `depName`
+- You must have either a [`datasource` capture group](https://docs.renovatebot.com/modules/datasource/#supported-datasources) or a [`datasourceTemplate` config field](https://docs.renovatebot.com/configuration-options/#datasourcetemplate)
+- You can optionally have a `depType` capture group or a [`depTypeTemplate` config field](https://docs.renovatebot.com/configuration-options/#deptypetemplate)  
+  See [manager specific documentation pages](https://docs.renovatebot.com/modules/manager/#supported-managers) for recommended values, other values are also possible.
+- You can optionally have a [`versioning` capture group](https://docs.renovatebot.com/modules/versioning/#supported-versioning) or a [`versioningTemplate` config field](https://docs.renovatebot.com/configuration-options/#versioningtemplate). If neither are present, `semver` will be used as the default
+- You can optionally have an `extractVersion` capture group or an [`extractVersionTemplate` config field](https://docs.renovatebot.com/configuration-options/#extractversiontemplate)
+- You can optionally have a [`currentDigest` capture group](https://docs.renovatebot.com/configuration-options/#digest).
+- You can optionally have a [`registryUrl` capture group](https://docs.renovatebot.com/configuration-options/#registryurls) or a [`registryUrlTemplate` config field](https://docs.renovatebot.com/configuration-options/#registryurltemplate)
+  - If it's a valid URL, it will be converted to the [`registryUrls` field](https://docs.renovatebot.com/configuration-options/#registryurls) as a single-length array.
 
 ### Regular Expression Capture Groups
 
@@ -44,8 +47,7 @@ RUN curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version ${YARN_VER
 You would need to capture the `currentValue` using a named capture group, like so: `ENV YARN_VERSION=(?<currentValue>.*?)\\n`.
 
 If you're looking for an online regex testing tool that supports capture groups, try [https://regex101.com/](<https://regex101.com/?flavor=javascript&flags=g&regex=ENV%20YARN_VERSION%3D(%3F%3CcurrentValue%3E.*%3F)%5Cn&testString=FROM%20node%3A12%0AENV%20YARN_VERSION%3D1.19.1%0ARUN%20curl%20-o-%20-L%20https%3A%2F%2Fyarnpkg.com%2Finstall.sh%20%7C%20bash%20-s%20--%20--version%20%24%7BYARN_VERSION%7D>).
-Be aware that backslashes (`'\'`) of the resulting regex have to still be escaped e.g. `\n\s` --> `\\n\\s`.
-You can use the Code Generator in the sidebar and copy the regex in the generated "Alternative syntax" comment into JSON.
+Be aware that backslashes (`'\'`) of the resulting regex have to still be escaped e.g `\n\s` --> `\\n\\s`.
 
 ### Configuration templates
 

--- a/lib/modules/manager/regex/readme.md
+++ b/lib/modules/manager/regex/readme.md
@@ -13,7 +13,7 @@ The first two required fields are `fileMatch` and `matchStrings`. `fileMatch` wo
 In order for Renovate to look up a dependency and decide about updates, it then needs the following information about each dependency:
 
 - The dependency's name
-- Which [`datasource`](https://docs.renovatebot.com/modules/datasource/#supported-datasources) to look up (e.g. [npm](https://docs.renovatebot.com/modules/datasource/#npm-datasource), [Docker](https://docs.renovatebot.com/modules/datasource/#docker-datasource), [GitHub tags](https://docs.renovatebot.com/modules/datasource/#github-tags-datasource), [etc.](https://docs.renovatebot.com/modules/datasource/#supported-datasources))
+- Which [`datasource`](https://docs.renovatebot.com/modules/datasource/#supported-datasources) to look up (e.g. [npm](https://docs.renovatebot.com/modules/datasource/#npm-datasource), [Docker](https://docs.renovatebot.com/modules/datasource/#docker-datasource), [GitHub tags](https://docs.renovatebot.com/modules/datasource/#github-tags-datasource))
 - Which [version scheme](https://docs.renovatebot.com/modules/versioning/#supported-versioning) to apply (defaults to [`semver`](https://docs.renovatebot.com/modules/versioning/#semantic-versioning), but also may be other values like [`pep440`](https://docs.renovatebot.com/modules/versioning/#pep440-versioning))
 
 Note: capture groups below are similar to [available fields](https://docs.renovatebot.com/templates/#other-available-fields), but these available fields are not available in templates below, because most of those are coming from managers, and `regex` is a manager.
@@ -24,7 +24,7 @@ Configuration-wise, it works like this:
 - You must have either a `depName` capture group or a [`depNameTemplate` config field](https://docs.renovatebot.com/configuration-options/#depnametemplate)
 - You can optionally have a `packageName` capture group or a [`packageNameTemplate` config field] if it differs from `depName`
 - You must have either a [`datasource` capture group](https://docs.renovatebot.com/modules/datasource/#supported-datasources) or a [`datasourceTemplate` config field](https://docs.renovatebot.com/configuration-options/#datasourcetemplate)
-- You can optionally have a `depType` capture group or a [`depTypeTemplate` config field](https://docs.renovatebot.com/configuration-options/#deptypetemplate)  
+- You can optionally have a `depType` capture group or a [`depTypeTemplate` config field](https://docs.renovatebot.com/configuration-options/#deptypetemplate)
   See [manager specific documentation pages](https://docs.renovatebot.com/modules/manager/#supported-managers) for recommended values, other values are also possible.
 - You can optionally have a [`versioning` capture group](https://docs.renovatebot.com/modules/versioning/#supported-versioning) or a [`versioningTemplate` config field](https://docs.renovatebot.com/configuration-options/#versioningtemplate). If neither are present, `semver` will be used as the default
 - You can optionally have an `extractVersion` capture group or an [`extractVersionTemplate` config field](https://docs.renovatebot.com/configuration-options/#extractversiontemplate)

--- a/lib/modules/manager/regex/readme.md
+++ b/lib/modules/manager/regex/readme.md
@@ -24,12 +24,12 @@ Configuration-wise, it works like this:
 
 - You must capture the `currentValue` of the dependency in a named capture group
 - You must have either a `depName` capture group or a [`depNameTemplate` config field](https://docs.renovatebot.com/configuration-options/#depnametemplate)
-- You can optionally have a `packageName` capture group or a [`packageNameTemplate` config field] if it differs from `depName`
+- You can optionally have a `packageName` capture group or a [`packageNameTemplate` config field](https://docs.renovatebot.com/configuration-options/#packagenametemplate) if it differs from `depName`
 - You must have either a [`datasource` capture group](https://docs.renovatebot.com/modules/datasource/#supported-datasources) or a [`datasourceTemplate` config field](https://docs.renovatebot.com/configuration-options/#datasourcetemplate)
 - You can optionally have a `depType` capture group or a [`depTypeTemplate` config field](https://docs.renovatebot.com/configuration-options/#deptypetemplate)
   See [manager specific documentation pages](https://docs.renovatebot.com/modules/manager/#supported-managers) for recommended values, other values are also possible.
 - You can optionally have a [`versioning` capture group](https://docs.renovatebot.com/modules/versioning/#supported-versioning) or a [`versioningTemplate` config field](https://docs.renovatebot.com/configuration-options/#versioningtemplate). If neither are present, `semver` will be used as the default
-- You can optionally have an `extractVersion` capture group or an [`extractVersionTemplate` config field](https://docs.renovatebot.com/configuration-options/#extractversiontemplate)
+- You can optionally have an [`extractVersion`](https://docs.renovatebot.com/configuration-options/#extractversion) capture group or an [`extractVersionTemplate` config field](https://docs.renovatebot.com/configuration-options/#extractversiontemplate)
 - You can optionally have a [`currentDigest` capture group](https://docs.renovatebot.com/configuration-options/#digest).
 - You can optionally have a [`registryUrl` capture group](https://docs.renovatebot.com/configuration-options/#registryurls) or a [`registryUrlTemplate` config field](https://docs.renovatebot.com/configuration-options/#registryurltemplate)
   - If it's a valid URL, it will be converted to the [`registryUrls` field](https://docs.renovatebot.com/configuration-options/#registryurls) as a single-length array.

--- a/lib/modules/manager/regex/readme.md
+++ b/lib/modules/manager/regex/readme.md
@@ -31,8 +31,7 @@ Configuration-wise, it works like this:
 - You can optionally have a [`versioning` capture group](https://docs.renovatebot.com/modules/versioning/#supported-versioning) or a [`versioningTemplate` config field](https://docs.renovatebot.com/configuration-options/#versioningtemplate). If neither are present, `semver` will be used as the default
 - You can optionally have an [`extractVersion`](https://docs.renovatebot.com/configuration-options/#extractversion) capture group or an [`extractVersionTemplate` config field](https://docs.renovatebot.com/configuration-options/#extractversiontemplate)
 - You can optionally have a [`currentDigest` capture group](https://docs.renovatebot.com/configuration-options/#digest).
-- You can optionally have a [`registryUrl` capture group](https://docs.renovatebot.com/configuration-options/#registryurls) or a [`registryUrlTemplate` config field](https://docs.renovatebot.com/configuration-options/#registryurltemplate)
-  - If it's a valid URL, it will be converted to the [`registryUrls` field](https://docs.renovatebot.com/configuration-options/#registryurls) as a single-length array.
+- You can optionally have a [`registryUrl` capture group](https://docs.renovatebot.com/configuration-options/#registryurls) or a [`registryUrlTemplate` config field](https://docs.renovatebot.com/configuration-options/#registryurltemplate). If it is a valid URL, it will be converted to the [`registryUrls` field](https://docs.renovatebot.com/configuration-options/#registryurls) as a single-length array.
 
 ### Regular Expression Capture Groups
 

--- a/lib/modules/manager/regex/readme.md
+++ b/lib/modules/manager/regex/readme.md
@@ -16,7 +16,9 @@ In order for Renovate to look up a dependency and decide about updates, it then 
 - Which [`datasource`](https://docs.renovatebot.com/modules/datasource/#supported-datasources) to look up (e.g. [npm](https://docs.renovatebot.com/modules/datasource/#npm-datasource), [Docker](https://docs.renovatebot.com/modules/datasource/#docker-datasource), [GitHub tags](https://docs.renovatebot.com/modules/datasource/#github-tags-datasource))
 - Which [version scheme](https://docs.renovatebot.com/modules/versioning/#supported-versioning) to apply (defaults to [`semver`](https://docs.renovatebot.com/modules/versioning/#semantic-versioning), but also may be other values like [`pep440`](https://docs.renovatebot.com/modules/versioning/#pep440-versioning))
 
-Note: capture groups below are similar to [available fields](https://docs.renovatebot.com/templates/#other-available-fields), but these available fields are not available in templates below, because most of those are coming from managers, and `regex` is a manager.
+<!-- prettier-ignore -->
+!!! note
+The capture groups below are similar to [available fields](https://docs.renovatebot.com/templates/#other-available-fields), but these available fields are not available in templates below, because most of those are coming from managers, and `regex` is a manager.
 
 Configuration-wise, it works like this:
 

--- a/lib/modules/manager/regex/readme.md
+++ b/lib/modules/manager/regex/readme.md
@@ -29,7 +29,7 @@ Configuration-wise, it works like this:
 - You can optionally have a `depType` capture group or a [`depTypeTemplate` config field](https://docs.renovatebot.com/configuration-options/#deptypetemplate)
   See [manager specific documentation pages](https://docs.renovatebot.com/modules/manager/#supported-managers) for recommended values, other values are also possible.
 - You can optionally have a [`versioning` capture group](https://docs.renovatebot.com/modules/versioning/#supported-versioning) or a [`versioningTemplate` config field](https://docs.renovatebot.com/configuration-options/#versioningtemplate). If neither are present, `semver` will be used as the default
-- You can optionally have an [`extractVersion`](https://docs.renovatebot.com/configuration-options/#extractversion) capture group or an [`extractVersionTemplate` config field](https://docs.renovatebot.com/configuration-options/#extractversiontemplate)
+- You can optionally have an [`extractVersion` capture group](https://docs.renovatebot.com/configuration-options/#extractversion) or an [`extractVersionTemplate` config field](https://docs.renovatebot.com/configuration-options/#extractversiontemplate)
 - You can optionally have a [`currentDigest` capture group](https://docs.renovatebot.com/configuration-options/#digest).
 - You can optionally have a [`registryUrl` capture group](https://docs.renovatebot.com/configuration-options/#registryurls) or a [`registryUrlTemplate` config field](https://docs.renovatebot.com/configuration-options/#registryurltemplate). If it is a valid URL, it will be converted to the [`registryUrls` field](https://docs.renovatebot.com/configuration-options/#registryurls) as a single-length array.
 


### PR DESCRIPTION
## Changes

While the [page for regex manager](https://docs.renovatebot.com/modules/manager/regex/) gives a list of possible fields, it's very unclear what the values should be for each of those fields.

[**Live rendered preview**](https://github.com/TWiStErRob/renovate/blob/patch-2/lib/modules/manager/regex/readme.md) for this branch (always HEAD).

## Context

I wanted to simply match `const val VERSION_KOTLIN: String = "1.4.32"` kotlin code and use it as a Gradle `org.jetbrains.kotlin:kotlin-stdlib` dependency. I'm hoping that these links would help others to faster navigate the docs. I'm willing to improve further, because even the linked pages only contain some basic descriptions, but not much about the actual potential values of each, or where to find those.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository