### PR TITLE
fix(platform:github): filter discovered null repos

### DIFF
--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -176,6 +176,7 @@ describe('modules/platform/github/index', () => {
           {
             full_name: 'c/d',
           },
+          null,
         ]);
       const repos = await github.getRepos();
       expect(repos).toMatchSnapshot();
@@ -200,6 +201,7 @@ describe('modules/platform/github/index', () => {
             {
               full_name: 'c/d',
             },
+            null,
           ],
         });
 

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -180,13 +180,15 @@ export async function getRepos(): Promise<string[]> {
         paginationField: 'repositories',
         paginate: 'all',
       });
-      return res.body.repositories.map((repo) => repo.full_name);
+      return res.body.repositories
+        .filter(is.nonEmptyObject)
+        .map((repo) => repo.full_name);
     } else {
       const res = await githubApi.getJson<{ full_name: string }[]>(
         `user/repos?per_page=100`,
         { paginate: 'all' }
       );
-      return res.body.map((repo) => repo.full_name);
+      return res.body.filter(is.nonEmptyObject).map((repo) => repo.full_name);
     }
   } catch (err) /* istanbul ignore next */ {
     logger.error({ err }, `GitHub getRepos error`);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
 Filter null repos
<!-- Describe what behavior is changed by this PR. -->

## Context

- #15087
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
