### PR TITLE
refactor(maven): removed use of the url lib.

### DIFF
--- a/lib/modules/datasource/maven/util.ts
+++ b/lib/modules/datasource/maven/util.ts
@@ -17,7 +17,9 @@ import type {
   MavenXml,
 } from './types';
 
-const getHost = (x: string): string => parseUrl(x)?.host;
+function getHost (x: string): string | null {
+  return parseUrl(x)?.host ?? null;
+}
 
 function isMavenCentral(pkgUrl: URL | string): boolean {
   const host = typeof pkgUrl === 'string' ? pkgUrl : pkgUrl.host;

--- a/lib/modules/datasource/maven/util.ts
+++ b/lib/modules/datasource/maven/util.ts
@@ -6,7 +6,7 @@ import { ExternalHostError } from '../../../types/errors/external-host-error';
 import type { Http } from '../../../util/http';
 import type { HttpResponse } from '../../../util/http/types';
 import { regEx } from '../../../util/regex';
-import {parseUrl} from "../../../util/url";
+import { parseUrl } from '../../../util/url';
 import { normalizeDate } from '../metadata';
 
 import type { ReleaseResult } from '../types';

--- a/lib/modules/datasource/maven/util.ts
+++ b/lib/modules/datasource/maven/util.ts
@@ -1,4 +1,3 @@
-import url from 'url';
 import { DateTime } from 'luxon';
 import { XmlDocument } from 'xmldoc';
 import { HOST_DISABLED } from '../../../constants/error-messages';
@@ -7,6 +6,7 @@ import { ExternalHostError } from '../../../types/errors/external-host-error';
 import type { Http } from '../../../util/http';
 import type { HttpResponse } from '../../../util/http/types';
 import { regEx } from '../../../util/regex';
+import {parseUrl} from "../../../util/url";
 import { normalizeDate } from '../metadata';
 
 import type { ReleaseResult } from '../types';
@@ -17,9 +17,9 @@ import type {
   MavenXml,
 } from './types';
 
-const getHost = (x: string): string => new url.URL(x).host;
+const getHost = (x: string): string => parseUrl(x).host;
 
-function isMavenCentral(pkgUrl: url.URL | string): boolean {
+function isMavenCentral(pkgUrl: URL | string): boolean {
   const host = typeof pkgUrl === 'string' ? pkgUrl : pkgUrl.host;
   return getHost(MAVEN_REPO) === host;
 }
@@ -58,7 +58,7 @@ function isUnsupportedHostError(err: { name: string }): boolean {
 
 export async function downloadHttpProtocol(
   http: Http,
-  pkgUrl: url.URL | string
+  pkgUrl: URL | string
 ): Promise<Partial<HttpResponse>> {
   let raw: HttpResponse;
   try {
@@ -99,7 +99,7 @@ export async function downloadHttpProtocol(
 
 export async function checkHttpResource(
   http: Http,
-  pkgUrl: url.URL | string
+  pkgUrl: URL | string
 ): Promise<HttpResourceCheckResult> {
   try {
     const res = await http.head(pkgUrl.toString());
@@ -136,13 +136,13 @@ export function getMavenUrl(
   dependency: MavenDependency,
   repoUrl: string,
   path: string
-): url.URL {
-  return new url.URL(`${dependency.dependencyUrl}/${path}`, repoUrl);
+): URL {
+  return new URL(`${dependency.dependencyUrl}/${path}`, repoUrl);
 }
 
 export async function downloadMavenXml(
   http: Http,
-  pkgUrl: url.URL | null
+  pkgUrl: URL | null
 ): Promise<MavenXml> {
   /* istanbul ignore if */
   if (!pkgUrl) {

--- a/lib/modules/datasource/maven/util.ts
+++ b/lib/modules/datasource/maven/util.ts
@@ -17,7 +17,7 @@ import type {
   MavenXml,
 } from './types';
 
-function getHost (x: string): string | null {
+function getHost(x: string): string | null {
   return parseUrl(x)?.host ?? null;
 }
 

--- a/lib/modules/datasource/maven/util.ts
+++ b/lib/modules/datasource/maven/util.ts
@@ -17,8 +17,8 @@ import type {
   MavenXml,
 } from './types';
 
-function getHost(x: string): string | null {
-  return parseUrl(x)?.host ?? null;
+function getHost(url: string): string | null {
+  return parseUrl(url)?.host ?? null;
 }
 
 function isMavenCentral(pkgUrl: URL | string): boolean {

--- a/lib/modules/datasource/maven/util.ts
+++ b/lib/modules/datasource/maven/util.ts
@@ -17,7 +17,7 @@ import type {
   MavenXml,
 } from './types';
 
-const getHost = (x: string): string => parseUrl(x).host;
+const getHost = (x: string): string => parseUrl(x)?.host;
 
 function isMavenCentral(pkgUrl: URL | string): boolean {
   const host = typeof pkgUrl === 'string' ? pkgUrl : pkgUrl.host;

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "Jamie Magee <jamie.magee@gmail.com>",
     "Jan Sauer <jan@jansauer.de>",
     "Jean-Yves Couët <jycouet@gmail.com>",
+    "Kenneth Jørgensen <kenneth@autonomouslogic.com>",
     "Kevin James <KevinJames@thekev.in>",
     "Klaus Meinhardt <klaus.meinhardt1@gmail.com>",
     "Matt Lavin <matt.lavin@gmail.com>",


### PR DESCRIPTION
## Changes

Removed the use of the deprecated `url` library, as requested in https://github.com/renovatebot/renovate/pull/14938#discussion_r848768378.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
