### PR TITLE
refactor(maven): Use explicit cacheability flag for datasource

### DIFF
--- a/lib/modules/datasource/maven/index.ts
+++ b/lib/modules/datasource/maven/index.ts
@@ -112,7 +112,7 @@ export class MavenDatasource extends Datasource {
       return cachedVersions;
     }
 
-    const { authorization, xml: mavenMetadata } = await downloadMavenXml(
+    const { isCacheable, xml: mavenMetadata } = await downloadMavenXml(
       this.http,
       metadataUrl
     );
@@ -125,7 +125,7 @@ export class MavenDatasource extends Datasource {
       (acc, version) => ({ ...acc, [version]: null }),
       {}
     );
-    if (!authorization) {
+    if (isCacheable) {
       await packageCache.set(cacheNamespace, cacheKey, releaseMap, 30);
     }
     return releaseMap;

--- a/lib/modules/datasource/maven/types.ts
+++ b/lib/modules/datasource/maven/types.ts
@@ -9,7 +9,7 @@ export interface MavenDependency {
 }
 
 export interface MavenXml {
-  authorization?: boolean;
+  isCacheable?: boolean;
   xml?: XmlDocument;
 }
 

--- a/lib/modules/datasource/maven/util.ts
+++ b/lib/modules/datasource/maven/util.ts
@@ -185,7 +185,7 @@ export async function downloadMavenXml(
     isCacheable = true;
   }
 
-  return { isCacheable: isCacheable, xml: new XmlDocument(rawContent) };
+  return { isCacheable, xml: new XmlDocument(rawContent) };
 }
 
 export function getDependencyParts(packageName: string): MavenDependency {

--- a/lib/modules/datasource/maven/util.ts
+++ b/lib/modules/datasource/maven/util.ts
@@ -150,6 +150,9 @@ export async function downloadMavenXml(
   if (!pkgUrl) {
     return {};
   }
+
+  let isCacheable = false;
+
   let rawContent: string | undefined;
   let authorization: boolean | undefined;
   let statusCode: number | undefined;
@@ -178,7 +181,11 @@ export async function downloadMavenXml(
     return {};
   }
 
-  return { authorization, xml: new XmlDocument(rawContent) };
+  if (!authorization) {
+    isCacheable = true;
+  }
+
+  return { isCacheable: isCacheable, xml: new XmlDocument(rawContent) };
 }
 
 export function getDependencyParts(packageName: string): MavenDependency {


### PR DESCRIPTION
## Changes

- Use `authorization` flag internally
- Expose `isCacheable` instead

## Context

- Ref: #13825

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
