### PR TITLE
fix(manager:npm): fix yarn lockfile version replacement

### DIFF
--- a/lib/modules/manager/npm/update/locked-dependency/yarn-lock/replace.spec.ts
+++ b/lib/modules/manager/npm/update/locked-dependency/yarn-lock/replace.spec.ts
@@ -32,7 +32,7 @@ describe('modules/manager/npm/update/locked-dependency/yarn-lock/replace', () =>
       expect(addedSections).toHaveLength(1);
       expect(removedSections).toHaveLength(1);
       expect(addedSections[0].value).toMatchInlineSnapshot(`
-        "  version: \\"0.2.5\\"
+        "  version \\"0.2.5\\"
         "
       `);
       expect(removedSections[0].value).toMatchInlineSnapshot(`
@@ -57,7 +57,7 @@ describe('modules/manager/npm/update/locked-dependency/yarn-lock/replace', () =>
       expect(addedSections).toHaveLength(1);
       expect(removedSections).toHaveLength(1);
       expect(addedSections[0].value).toMatchInlineSnapshot(`
-              "  version: \\"4.4.0\\"
+              "  version \\"4.4.0\\"
               "
           `);
       expect(removedSections[0].value).toMatchInlineSnapshot(`
@@ -84,7 +84,7 @@ describe('modules/manager/npm/update/locked-dependency/yarn-lock/replace', () =>
       expect(removedSections).toHaveLength(1);
       expect(addedSections[0].value).toMatchInlineSnapshot(`
                   "express@4.4.0:
-                    version: \\"4.4.0\\"
+                    version \\"4.4.0\\"
                   "
               `);
       expect(removedSections[0].value).toMatchInlineSnapshot(`
@@ -110,7 +110,7 @@ describe('modules/manager/npm/update/locked-dependency/yarn-lock/replace', () =>
       expect(addedSections).toHaveLength(1);
       expect(removedSections).toHaveLength(1);
       expect(addedSections[0].value).toMatchInlineSnapshot(`
-        "  version: \\"2.2.0\\"
+        "  version \\"2.2.0\\"
         "
       `);
       expect(removedSections[0].value).toMatchInlineSnapshot(`
@@ -136,7 +136,7 @@ describe('modules/manager/npm/update/locked-dependency/yarn-lock/replace', () =>
       expect(addedSections).toHaveLength(1);
       expect(removedSections).toHaveLength(1);
       expect(addedSections[0].value).toMatchInlineSnapshot(`
-        "  version: \\"0.48.1\\"
+        "  version \\"0.48.1\\"
         "
       `);
       expect(removedSections[0].value).toMatchInlineSnapshot(`

--- a/lib/modules/manager/npm/update/locked-dependency/yarn-lock/replace.ts
+++ b/lib/modules/manager/npm/update/locked-dependency/yarn-lock/replace.ts
@@ -35,6 +35,6 @@ export function replaceConstraintVersion(
   }
   return lockFileContent.replace(
     regEx(matchString),
-    `${constraintLine}  version: "${newVersion}"\n$5`
+    `${constraintLine}  version "${newVersion}"\n$5`
   );
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
 Removes the `:` after the version. It makes the lockfile invalid. If you check the other sample lockfiles, there is no `:` after the version.
<!-- Describe what behavior is changed by this PR. -->

## Context

- #15058
- https://github.com/renovate-reproductions/yarn-lockfile-update/pull/6
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
