### PR TITLE
feat(gitea): Support for repo cache fetching

### DIFF
--- a/lib/modules/platform/gitea/gitea-helper.spec.ts
+++ b/lib/modules/platform/gitea/gitea-helper.spec.ts
@@ -759,4 +759,42 @@ describe('modules/platform/gitea/gitea-helper', () => {
       expect(res).toEqual(otherMockBranch);
     });
   });
+
+  describe('fetchRepoCache', () => {
+    it('fetches blob content', async () => {
+      httpMock
+        .scope(baseUrl)
+        .get(`/repos/${mockRepo.full_name}/git/blobs/111`)
+        .reply(200, { content: toBase64(JSON.stringify({ foo: 'bar' })) });
+      const res = await ght.fetchRepoCache(mockRepo.full_name, {
+        blob: '111',
+        commit: '222',
+      });
+      expect(res).toEqual({ foo: 'bar' });
+    });
+
+    it('returns null for invalid content', async () => {
+      httpMock
+        .scope(baseUrl)
+        .get(`/repos/${mockRepo.full_name}/git/blobs/111`)
+        .reply(200, { content: toBase64('foo=bar') });
+      const res = await ght.fetchRepoCache(mockRepo.full_name, {
+        blob: '111',
+        commit: '222',
+      });
+      expect(res).toBeNull();
+    });
+
+    it('returns null for errors', async () => {
+      httpMock
+        .scope(baseUrl)
+        .get(`/repos/${mockRepo.full_name}/git/blobs/111`)
+        .replyWithError('unknown');
+      const res = await ght.fetchRepoCache(mockRepo.full_name, {
+        blob: '111',
+        commit: '222',
+      });
+      expect(res).toBeNull();
+    });
+  });
 });

--- a/lib/modules/platform/gitea/gitea-helper.ts
+++ b/lib/modules/platform/gitea/gitea-helper.ts
@@ -607,7 +607,7 @@ export async function fetchRepoCache(
     const { body } = await giteaHttp.getJson<{ content: string }>(url);
     return JSON.parse(fromBase64(body.content));
   } catch (err) {
-    logger.debug({ err }, 'Failed to fetch repo cache blob');
+    logger.warn({ err }, 'Failed to fetch repo cache blob');
   }
   return null;
 }

--- a/lib/modules/platform/gitea/gitea-helper.ts
+++ b/lib/modules/platform/gitea/gitea-helper.ts
@@ -605,11 +605,7 @@ export async function fetchRepoCache(
   try {
     const url = `repos/${repoPath}/git/blobs/${blob}`;
     const { body } = await giteaHttp.getJson<{ content: string }>(url);
-    const rawContent = body?.content;
-    if (rawContent) {
-      return JSON.parse(fromBase64(rawContent));
-    }
-    logger.debug('Failed to obtain repo cache blob content');
+    return JSON.parse(fromBase64(body.content));
   } catch (err) {
     logger.debug({ err }, 'Failed to fetch repo cache blob');
   }

--- a/lib/modules/platform/gitea/index.spec.ts
+++ b/lib/modules/platform/gitea/index.spec.ts
@@ -18,6 +18,7 @@ import type { logger as _logger } from '../../../logger';
 import { BranchStatus, PrState } from '../../../types';
 import type * as _git from '../../../util/git';
 import { setBaseUrl } from '../../../util/http/gitea';
+import { toBase64 } from '../../../util/string';
 import type { PlatformResult } from '../types';
 import type * as ght from './gitea-helper';
 
@@ -1597,6 +1598,21 @@ describe('modules/platform/gitea/index', () => {
       helper.getRepoContents.mockRejectedValueOnce(new Error('some error'));
       await initFakeRepo({ full_name: 'some/repo' });
       await expect(gitea.getJsonFile('file.json')).rejects.toThrow();
+    });
+  });
+
+  describe('fetchRepoCache', () => {
+    it('fetches blob content', async () => {
+      helper.fetchRepoCache.mockResolvedValueOnce({ foo: 'bar' });
+      await initFakeRepo({ full_name: 'some/repo' });
+
+      const res = await gitea.fetchRepoCache({ blob: '111', commit: '222' });
+
+      expect(res).toEqual({ foo: 'bar' });
+      expect(helper.fetchRepoCache).toHaveBeenCalledWith('some/repo', {
+        blob: '111',
+        commit: '222',
+      });
     });
   });
 });

--- a/lib/modules/platform/gitea/index.spec.ts
+++ b/lib/modules/platform/gitea/index.spec.ts
@@ -18,7 +18,6 @@ import type { logger as _logger } from '../../../logger';
 import { BranchStatus, PrState } from '../../../types';
 import type * as _git from '../../../util/git';
 import { setBaseUrl } from '../../../util/http/gitea';
-import { toBase64 } from '../../../util/string';
 import type { PlatformResult } from '../types';
 import type * as ght from './gitea-helper';
 

--- a/lib/modules/platform/gitea/index.ts
+++ b/lib/modules/platform/gitea/index.ts
@@ -31,6 +31,7 @@ import type {
   PlatformParams,
   PlatformResult,
   Pr,
+  RepoCacheConfig,
   RepoParams,
   RepoResult,
   UpdatePrConfig,
@@ -230,6 +231,13 @@ const platform: Platform = {
       return JSON5.parse(raw);
     }
     return JSON.parse(raw);
+  },
+
+  async fetchRepoCache(
+    cacheConfig: RepoCacheConfig
+  ): Promise<Record<string, unknown> | null> {
+    const result = await helper.fetchRepoCache(config.repository, cacheConfig);
+    return result;
   },
 
   async initRepo({
@@ -879,6 +887,7 @@ export const {
   ensureCommentRemoval,
   ensureIssue,
   ensureIssueClosing,
+  fetchRepoCache,
   findIssue,
   findPr,
   getBranchPr,

--- a/lib/modules/platform/types.ts
+++ b/lib/modules/platform/types.ts
@@ -147,6 +147,11 @@ export type EnsureCommentRemovalConfig =
 
 export type EnsureIssueResult = 'updated' | 'created';
 
+export interface RepoCacheConfig {
+  commit: string;
+  blob: string;
+}
+
 export interface Platform {
   findIssue(title: string): Promise<Issue | null>;
   getIssueList(): Promise<Issue[]>;
@@ -196,4 +201,7 @@ export interface Platform {
   initPlatform(config: PlatformParams): Promise<PlatformResult>;
   filterUnavailableUsers?(users: string[]): Promise<string[]>;
   commitFiles?(config: CommitFilesConfig): Promise<CommitSha | null>;
+  fetchRepoCache?(
+    config: RepoCacheConfig
+  ): Promise<Record<string, unknown> | null>;
 }


### PR DESCRIPTION
## Changes

- Support for remote JSON blob fetching in gitea platform

## Context

- Ref: #15118

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
