### PR TITLE
feat(github): Support for repo cache fetching

### DIFF
--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -2994,4 +2994,32 @@ describe('modules/platform/github/index', () => {
       expect(res).toBe('0abcdef');
     });
   });
+
+  describe('fetchRepoCache', () => {
+    it('fetches repo cache blob', async () => {
+      const scope = httpMock
+        .scope(githubApiHost)
+        .get('/repos/some/repo/git/blobs/111')
+        .reply(200, { content: toBase64(JSON.stringify({ foo: 'bar' })) });
+      initRepoMock(scope, 'some/repo');
+      await github.initRepo({ repository: 'some/repo', token: 'token' } as any);
+
+      const res = await github.fetchRepoCache({ blob: '111', commit: '222' });
+
+      expect(res).toEqual({ foo: 'bar' });
+    });
+
+    it('returns null on error', async () => {
+      const scope = httpMock
+        .scope(githubApiHost)
+        .get('/repos/some/repo/git/blobs/111')
+        .replyWithError('unknown error');
+      initRepoMock(scope, 'some/repo');
+      await github.initRepo({ repository: 'some/repo', token: 'token' } as any);
+
+      const res = await github.fetchRepoCache({ blob: '111', commit: '222' });
+
+      expect(res).toBeNull();
+    });
+  });
 });

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -49,6 +49,7 @@ import type {
   PlatformPrOptions,
   PlatformResult,
   Pr,
+  RepoCacheConfig,
   RepoParams,
   RepoResult,
   UpdatePrConfig,
@@ -232,6 +233,20 @@ export async function getJsonFile(
     return JSON5.parse(raw);
   }
   return JSON.parse(raw);
+}
+
+export async function fetchRepoCache({
+  blob,
+}: RepoCacheConfig): Promise<Record<string, unknown> | null> {
+  try {
+    const { body } = await githubApi.getJson<{ content: string }>(
+      `repos/${config.repository}/git/blobs/${blob}`
+    );
+    return JSON.parse(fromBase64(body.content));
+  } catch (err) {
+    logger.debug({ err }, 'Failed to fetch repo cache blob');
+    return null;
+  }
 }
 
 // Initialize GitHub by getting base branch and SHA

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -244,7 +244,7 @@ export async function fetchRepoCache({
     );
     return JSON.parse(fromBase64(body.content));
   } catch (err) {
-    logger.debug({ err }, 'Failed to fetch repo cache blob');
+    logger.warn({ err }, 'Failed to fetch repo cache blob');
     return null;
   }
 }

--- a/lib/modules/platform/types.ts
+++ b/lib/modules/platform/types.ts
@@ -147,6 +147,11 @@ export type EnsureCommentRemovalConfig =
 
 export type EnsureIssueResult = 'updated' | 'created';
 
+export interface RepoCacheConfig {
+  commit: string;
+  blob: string;
+}
+
 export interface Platform {
   findIssue(title: string): Promise<Issue | null>;
   getIssueList(): Promise<Issue[]>;
@@ -196,4 +201,7 @@ export interface Platform {
   initPlatform(config: PlatformParams): Promise<PlatformResult>;
   filterUnavailableUsers?(users: string[]): Promise<string[]>;
   commitFiles?(config: CommitFilesConfig): Promise<CommitSha | null>;
+  fetchRepoCache?(
+    config: RepoCacheConfig
+  ): Promise<Record<string, unknown> | null>;
 }


### PR DESCRIPTION
## Changes

- Support for remote JSON blob fetching in GitHub platform

## Context

- Ref: #15118

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
