### PR TITLE
feat(gitlab): Support for repo cache fetching

### DIFF
--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -2138,4 +2138,28 @@ These updates have all been created already. Click a checkbox below to force a r
       expect(filteredUsers).toMatchSnapshot();
     });
   });
+
+  describe('fetchRepoCache', () => {
+    it('fetches repo cache blob', async () => {
+      httpMock
+        .scope(gitlabApiHost)
+        .get(`/api/v4/projects/undefined/repository/blobs/111/raw`)
+        .reply(200, JSON.stringify({ foo: 'bar' }));
+
+      const res = await gitlab.fetchRepoCache({ blob: '111', commit: '222' });
+
+      expect(res).toEqual({ foo: 'bar' });
+    });
+
+    it('returns null on error', async () => {
+      httpMock
+        .scope(gitlabApiHost)
+        .get(`/api/v4/projects/undefined/repository/blobs/111/raw`)
+        .replyWithError('unknown error');
+
+      const res = await gitlab.fetchRepoCache({ blob: '111', commit: '222' });
+
+      expect(res).toBeNull();
+    });
+  });
 });

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -44,6 +44,7 @@ import type {
   PlatformPrOptions,
   PlatformResult,
   Pr,
+  RepoCacheConfig,
   RepoParams,
   RepoResult,
   UpdatePrConfig,
@@ -235,6 +236,20 @@ function getRepoUrl(
   const repoUrl = URL.parse(`${res.body.http_url_to_repo}`);
   repoUrl.auth = 'oauth2:' + opts.token;
   return URL.format(repoUrl);
+}
+
+export async function fetchRepoCache({
+  blob,
+}: RepoCacheConfig): Promise<Record<string, unknown> | null> {
+  try {
+    const { body } = await gitlabApi.get(
+      `projects/${config.repository}/repository/blobs/${blob}/raw`
+    );
+    return JSON.parse(body);
+  } catch (err) {
+    logger.debug({ err }, 'Failed to fetch repo cache blob');
+    return null;
+  }
 }
 
 // Initialize GitLab by getting base branch

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -247,7 +247,7 @@ export async function fetchRepoCache({
     );
     return JSON.parse(body);
   } catch (err) {
-    logger.debug({ err }, 'Failed to fetch repo cache blob');
+    logger.warn({ err }, 'Failed to fetch repo cache blob');
     return null;
   }
 }

--- a/lib/modules/platform/types.ts
+++ b/lib/modules/platform/types.ts
@@ -147,6 +147,11 @@ export type EnsureCommentRemovalConfig =
 
 export type EnsureIssueResult = 'updated' | 'created';
 
+export interface RepoCacheConfig {
+  commit: string;
+  blob: string;
+}
+
 export interface Platform {
   findIssue(title: string): Promise<Issue | null>;
   getIssueList(): Promise<Issue[]>;
@@ -196,4 +201,7 @@ export interface Platform {
   initPlatform(config: PlatformParams): Promise<PlatformResult>;
   filterUnavailableUsers?(users: string[]): Promise<string[]>;
   commitFiles?(config: CommitFilesConfig): Promise<CommitSha | null>;
+  fetchRepoCache?(
+    config: RepoCacheConfig
+  ): Promise<Record<string, unknown> | null>;
 }


### PR DESCRIPTION
## Changes

- Support for remote JSON blob fetching in GitLab platform

## Context

- Ref: #15118

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
