### PR TITLE
feat(vulnerabilities): add feature-flagged support for osv

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -1432,6 +1432,20 @@ A use case for the latter is if you are a Renovate bot admin and wish to provide
 If `false` (default), it means that defining `config.npmrc` will result in any `.npmrc` file in the repo being overridden and its values ignored.
 If configured to `true`, it means that any `.npmrc` file in the repo will have `config.npmrc` prepended to it before running `npm`.
 
+## osvVulnerabilityAlerts
+
+Set this to `true` to enable [OSV](https://osv.dev/) vulnerability alerts.
+OSV vulnerabilities are only supported for top-level dependencies.
+OSV vulnerabilities are supported for the following datasources:
+
+- [`crate`](https://docs.renovatebot.com/modules/datasource/#crate-datasource)
+- [`go`](https://docs.renovatebot.com/modules/datasource/#go-datasource)
+- [`maven`](https://docs.renovatebot.com/modules/datasource/#maven-datasource)
+- [`npm`](https://docs.renovatebot.com/modules/datasource/#npm-datasource)
+- [`nuget`](https://docs.renovatebot.com/modules/datasource/#nuget-datasource)
+- [`pypi`](https://docs.renovatebot.com/modules/datasource/#pypi-datasource)
+- [`rubygems`](https://docs.renovatebot.com/modules/datasource/#rubygems-datasource)
+
 ## packageRules
 
 `packageRules` is a powerful feature that lets you apply rules to individual packages or to groups of packages using regex pattern matching.

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -1611,6 +1611,14 @@ const options: RenovateOptions[] = [
     supportedPlatforms: ['github'],
   },
   {
+    name: 'osvVulnerabilityAlerts',
+    description: 'Use vulnerability alerts from `osv.dev`.',
+    type: 'boolean',
+    default: false,
+    experimental: true,
+    experimentalIssues: [6562],
+  },
+  {
     name: 'pruneBranchAfterAutomerge',
     description: 'Set to `true` to enable branch pruning after automerging.',
     type: 'boolean',

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -239,6 +239,7 @@ export interface RenovateConfig
 
   warnings?: ValidationMessage[];
   vulnerabilityAlerts?: RenovateSharedConfig;
+  osvVulnerabilityAlerts?: boolean;
   regexManagers?: RegExManager[];
 
   fetchReleaseNotes?: boolean;

--- a/lib/workers/repository/process/extract-update.ts
+++ b/lib/workers/repository/process/extract-update.ts
@@ -13,6 +13,7 @@ import { branchifyUpgrades } from '../updates/branchify';
 import { raiseDeprecationWarnings } from './deprecated';
 import { fetchUpdates } from './fetch';
 import { sortBranches } from './sort';
+import { Vulnerabilities } from './vulnerabilities';
 import { WriteUpdateResult, writeUpdates } from './write';
 
 export interface ExtractResult {
@@ -121,10 +122,25 @@ export async function extract(
   return packageFiles;
 }
 
+async function fetchVulnerabilities(
+  config: RenovateConfig,
+  packageFiles: Record<string, PackageFile[]>
+): Promise<void> {
+  if (config.osvVulnerabilityAlerts) {
+    try {
+      const vulnerabilities = await Vulnerabilities.create();
+      await vulnerabilities.fetchVulnerabilities(config, packageFiles);
+    } catch (err) {
+      logger.warn({ err }, 'Unable to read vulnerability information');
+    }
+  }
+}
+
 export async function lookup(
   config: RenovateConfig,
   packageFiles: Record<string, PackageFile[]>
 ): Promise<ExtractResult> {
+  await fetchVulnerabilities(config, packageFiles);
   await fetchUpdates(config, packageFiles);
   await raiseDeprecationWarnings(config, packageFiles);
   const { branches, branchList } = await branchifyUpgrades(

--- a/lib/workers/repository/process/vulnerabilities.spec.ts
+++ b/lib/workers/repository/process/vulnerabilities.spec.ts
@@ -1,6 +1,6 @@
-import type { Ecosystem, OsvOffline } from '@renovatebot/osv-offline';
+import type { Osv, OsvOffline } from '@renovatebot/osv-offline';
 import { mockFn } from 'jest-mock-extended';
-import { getConfig } from '../../../../test/util';
+import { RenovateConfig, getConfig } from '../../../../test/util';
 import type { PackageFile } from '../../../modules/manager/types';
 import { Vulnerabilities } from './vulnerabilities';
 
@@ -33,28 +33,134 @@ describe('workers/repository/process/vulnerabilities', () => {
   });
 
   describe('fetchVulnerabilities()', () => {
-    const config = getConfig();
-    const packageFiles: Record<string, PackageFile[]> = {
-      npm: [{ deps: [{ depName: 'lodash' }] }],
-    };
+    let config: RenovateConfig;
     let vulnerabilities: Vulnerabilities;
+    const lodashVulnerability: Osv.Vulnerability = {
+      id: 'GHSA-x5rq-j2xg-h7qm',
+      modified: new Date(),
+      affected: [
+        {
+          ranges: [
+            {
+              type: 'SEMVER',
+              events: [{ introduced: '0.0.0' }, { fixed: '4.17.11' }],
+            },
+          ],
+          package: { name: 'lodash', ecosystem: 'npm' },
+        },
+      ],
+      references: [
+        {
+          type: 'ADVISORY',
+          url: 'https://nvd.nist.gov/vuln/detail/CVE-2019-1010266',
+        },
+      ],
+    };
 
     beforeAll(async () => {
       createMock.mockResolvedValue({
-        getVulnerabilities: (ecosystem: Ecosystem, packageName: string) =>
-          getVulnerabilitiesMock(ecosystem, packageName),
+        getVulnerabilities: getVulnerabilitiesMock,
       });
       vulnerabilities = await Vulnerabilities.create();
     });
 
-    it('works', async () => {
-      getVulnerabilitiesMock.mockResolvedValue([
+    beforeEach(() => {
+      config = getConfig();
+      // Why does this not reset?
+      config.packageRules = [];
+    });
+
+    it('returns no packageRules when no vulnerabilities', async () => {
+      const packageFiles: Record<string, PackageFile[]> = {
+        npm: [
+          {
+            deps: [
+              { depName: 'lodash', currentValue: '4.17.10', datasource: 'npm' },
+            ],
+          },
+        ],
+      };
+      getVulnerabilitiesMock.mockResolvedValueOnce([]);
+
+      await vulnerabilities.fetchVulnerabilities(config, packageFiles);
+
+      expect(config.packageRules).toHaveLength(0);
+    });
+
+    it('returns no packageRules for unsupported datasource', async () => {
+      const packageFiles: Record<string, PackageFile[]> = {
+        dockerfile: [{ deps: [{ depName: 'node', datasource: 'docker' }] }],
+      };
+
+      await vulnerabilities.fetchVulnerabilities(config, packageFiles);
+
+      expect(config.packageRules).toHaveLength(0);
+    });
+
+    it('filters out not applicable vulnerabilities', async () => {
+      const packageFiles: Record<string, PackageFile[]> = {
+        npm: [
+          {
+            deps: [
+              { depName: 'lodash', currentValue: '4.17.11', datasource: 'npm' },
+            ],
+          },
+        ],
+      };
+      getVulnerabilitiesMock.mockResolvedValueOnce([lodashVulnerability]);
+
+      await vulnerabilities.fetchVulnerabilities(config, packageFiles);
+
+      expect(config.packageRules).toHaveLength(0);
+    });
+
+    it('returns a single packageRule', async () => {
+      const packageFiles: Record<string, PackageFile[]> = {
+        npm: [
+          {
+            deps: [
+              { depName: 'lodash', currentValue: '4.17.10', datasource: 'npm' },
+            ],
+          },
+        ],
+      };
+      getVulnerabilitiesMock.mockResolvedValueOnce([lodashVulnerability]);
+
+      await vulnerabilities.fetchVulnerabilities(config, packageFiles);
+
+      expect(config.packageRules).toHaveLength(1);
+      expect(config.packageRules).toIncludeAllPartialMembers([
         {
-          id: 'ABCD',
+          allowedVersions: '4.17.11',
+          isVulnerabilityAlert: true,
+          matchPackageNames: ['lodash'],
+        },
+      ]);
+    });
+
+    it('returns multiple packageRules when multiple vulnerabilities', async () => {
+      const packageFiles: Record<string, PackageFile[]> = {
+        npm: [
+          {
+            deps: [
+              { depName: 'lodash', currentValue: '4.17.10', datasource: 'npm' },
+            ],
+          },
+        ],
+      };
+      getVulnerabilitiesMock.mockResolvedValueOnce([
+        lodashVulnerability,
+        {
+          id: 'GHSA-p6mc-m468-83gw',
           modified: new Date(),
           affected: [
             {
-              ranges: [{ type: 'SEMVER', events: [{ fixed: '1.2.3' }] }],
+              ranges: [
+                {
+                  type: 'SEMVER',
+                  events: [{ introduced: '0' }, { fixed: '4.17.20' }],
+                },
+              ],
               package: { name: 'lodash', ecosystem: 'npm' },
             },
           ],
@@ -63,7 +169,43 @@ describe('workers/repository/process/vulnerabilities', () => {
 
       await vulnerabilities.fetchVulnerabilities(config, packageFiles);
 
+      expect(config.packageRules).toHaveLength(2);
+      expect(config.packageRules).toIncludeAllPartialMembers([
+        {
+          allowedVersions: '4.17.11',
+          isVulnerabilityAlert: true,
+          matchPackageNames: ['lodash'],
+        },
+        {
+          allowedVersions: '4.17.20',
+          isVulnerabilityAlert: true,
+          matchPackageNames: ['lodash'],
+        },
+      ]);
+    });
+
+    it('returns a single packageRule for regex manager', async () => {
+      const packageFiles: Record<string, PackageFile[]> = {
+        regex: [
+          {
+            deps: [
+              { depName: 'lodash', currentValue: '4.17.10', datasource: 'npm' },
+            ],
+          },
+        ],
+      };
+      getVulnerabilitiesMock.mockResolvedValueOnce([lodashVulnerability]);
+
+      await vulnerabilities.fetchVulnerabilities(config, packageFiles);
+
       expect(config.packageRules).toHaveLength(1);
+      expect(config.packageRules).toIncludeAllPartialMembers([
+        {
+          allowedVersions: '4.17.11',
+          isVulnerabilityAlert: true,
+          matchPackageNames: ['lodash'],
+        },
+      ]);
     });
   });
 });

--- a/lib/workers/repository/process/vulnerabilities.ts
+++ b/lib/workers/repository/process/vulnerabilities.ts
@@ -1,5 +1,6 @@
 // TODO #7154
 import { Ecosystem, Osv, OsvOffline } from '@renovatebot/osv-offline';
+import is from '@sindresorhus/is';
 import { getManagerConfig, mergeChildConfig } from '../../../config';
 import type { PackageRule, RenovateConfig } from '../../../config/types';
 import { logger } from '../../../logger';
@@ -7,30 +8,23 @@ import type {
   PackageDependency,
   PackageFile,
 } from '../../../modules/manager/types';
+import semverCoerced from '../../../modules/versioning/semver-coerced';
 import * as p from '../../../util/promises';
 
 export class Vulnerabilities {
   private osvOffline: OsvOffline | undefined;
 
-  private static readonly managerEcosystemMap: Record<
+  private static readonly datasourceEcosystemMap: Record<
     string,
     Ecosystem | undefined
   > = {
-    bundler: 'RubyGems',
-    cargo: 'crates.io',
-    gomod: 'Go',
-    gradle: 'Maven',
+    crate: 'crates.io',
+    go: 'Go',
     maven: 'Maven',
-    meteor: 'npm',
     npm: 'npm',
     nuget: 'NuGet',
-    'pip-compile': 'PyPI',
-    pip_requirements: 'PyPI',
-    pip_setup: 'PyPI',
-    pipenv: 'PyPI',
-    poetry: 'PyPI',
-    'setup-cfg': 'PyPI',
-    sbt: 'Maven',
+    pypi: 'PyPI',
+    rubygems: 'RubyGems',
   };
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -50,9 +44,7 @@ export class Vulnerabilities {
     config: RenovateConfig,
     packageFiles: Record<string, PackageFile[]>
   ): Promise<void> {
-    const managers = Object.keys(packageFiles).filter(
-      (manager) => Vulnerabilities.managerEcosystemMap[manager] !== undefined
-    );
+    const managers = Object.keys(packageFiles);
     const allManagerJobs = managers.map((manager) =>
       this.fetchManagerVulnerabilities(config, packageFiles, manager)
     );
@@ -67,7 +59,11 @@ export class Vulnerabilities {
     const managerConfig = getManagerConfig(config, manager);
     const queue = packageFiles[manager].map(
       (pFile) => (): Promise<void> =>
-        this.fetchManagerPackagerFileUpdates(config, managerConfig, pFile)
+        this.fetchManagerPackageFileVulnerabilities(
+          config,
+          managerConfig,
+          pFile
+        )
     );
     logger.trace(
       { manager, queueLength: queue.length },
@@ -77,7 +73,7 @@ export class Vulnerabilities {
     logger.trace({ manager }, 'fetchManagerUpdates finished');
   }
 
-  private async fetchManagerPackagerFileUpdates(
+  private async fetchManagerPackageFileVulnerabilities(
     config: RenovateConfig,
     managerConfig: RenovateConfig,
     pFile: PackageFile
@@ -91,11 +87,14 @@ export class Vulnerabilities {
     );
     logger.trace(
       { manager, packageFile, queueLength: queue.length },
-      'fetchManagerPackagerFileUpdates starting with concurrency'
+      'fetchManagerPackageFileVulnerabilities starting with concurrency'
     );
 
     config.packageRules?.push(...(await p.all(queue)).flat());
-    logger.trace({ packageFile }, 'fetchManagerPackagerFileUpdates finished');
+    logger.trace(
+      { packageFile },
+      'fetchManagerPackageFileVulnerabilities finished'
+    );
   }
 
   private async fetchDependencyVulnerabilities(
@@ -103,39 +102,114 @@ export class Vulnerabilities {
     packageDependency: PackageDependency
   ): Promise<PackageRule[]> {
     const ecosystem =
-      Vulnerabilities.managerEcosystemMap[packageFileConfig.manager!];
+      Vulnerabilities.datasourceEcosystemMap[packageDependency.datasource!];
+    if (!ecosystem) {
+      return [];
+    }
 
-    const vulnerabilities = await this.osvOffline?.getVulnerabilities(
-      ecosystem!,
+    let vulnerabilities = await this.osvOffline?.getVulnerabilities(
+      ecosystem,
       packageDependency.depName!
     );
+    if (is.nullOrUndefined(vulnerabilities) || is.emptyArray(vulnerabilities)) {
+      return [];
+    }
+    vulnerabilities = this.filterVulnerabilities(
+      vulnerabilities,
+      packageDependency
+    );
     return this.convertToPackageRule(
+      packageFileConfig,
       vulnerabilities ?? [],
       packageDependency.depName!,
-      ecosystem!
+      ecosystem
     );
   }
 
+  private filterVulnerabilities(
+    vulnerabilities: Osv.Vulnerability[],
+    packageDependency: PackageDependency
+  ): Osv.Vulnerability[] {
+    return vulnerabilities.filter((vulnerability) => {
+      return vulnerability.affected?.some((affected) => {
+        return (
+          affected.package?.ecosystem ===
+            Vulnerabilities.datasourceEcosystemMap[
+              packageDependency.datasource!
+            ] &&
+          affected.package?.name === packageDependency.depName &&
+          affected.ranges?.some(
+            (range) =>
+              semverCoerced.isGreaterThan(
+                packageDependency.currentValue!,
+                range.events.find((event) =>
+                  is.nonEmptyString(event.introduced)
+                )?.introduced ?? ''
+              ) &&
+              semverCoerced.isGreaterThan(
+                range.events.find((event) => is.nonEmptyString(event.fixed))
+                  ?.fixed ?? '',
+                packageDependency.currentValue!
+              )
+          )
+        );
+      });
+    });
+  }
+
   private convertToPackageRule(
+    packageFileConfig: RenovateConfig & PackageFile,
     vulnerabilities: Osv.Vulnerability[],
     dependencyName: string,
     ecosystem: Ecosystem
   ): PackageRule[] {
-    return vulnerabilities
-      .flatMap((vulnerability) => vulnerability.affected)
-      .filter(
-        (vulnerability) =>
-          vulnerability?.package?.name === dependencyName &&
-          vulnerability?.package?.ecosystem === ecosystem
-      )
-      .map(
-        (affected): PackageRule => ({
-          matchPackageNames: [dependencyName],
-          allowedVersions: affected?.ranges?.[0].events.find(
-            (event) => event.fixed !== undefined
-          )!.fixed,
-          isVulnerabilityAlert: true,
-        })
-      );
+    const rules: PackageRule[] = [];
+
+    vulnerabilities.forEach((vulnerability) => {
+      vulnerability.affected?.forEach((affected) => {
+        if (
+          affected.package?.ecosystem === ecosystem &&
+          affected.package.name === dependencyName
+        ) {
+          rules.push({
+            matchPackageNames: [dependencyName],
+            // TODO: Multiple ranges
+            allowedVersions: affected?.ranges?.[0].events.find((event) =>
+              is.nonEmptyString(event.fixed)
+            )!.fixed,
+            isVulnerabilityAlert: true,
+            prBodyNotes: Vulnerabilities.generatePrBodyNotes(
+              dependencyName,
+              vulnerability
+            ),
+            force: {
+              ...packageFileConfig.vulnerabilityAlerts,
+            },
+          });
+        }
+      });
+    });
+
+    return rules;
+  }
+
+  private static generatePrBodyNotes(
+    dependencyName: string,
+    vulnerability: Osv.Vulnerability
+  ): string[] {
+    return [
+      `## ${dependencyName} - ${vulnerability.id}`,
+      `${vulnerability.summary ?? ''}`,
+      '<details><summary>More information</summary>',
+      `## Details\n${vulnerability.details ?? 'No details'}
+## Severity\n${vulnerability.severity?.[0].score ?? 'No severity'}
+## References\n${
+        vulnerability.references
+          ?.map((ref) => {
+            return `- ${ref.url}`;
+          })
+          .join('\n') ?? 'No references'
+      }</details>`,
+    ];
   }
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Added `osvVulnerabilityAlerts` option as `experimental` and default `false`
- Lookup vulnerabilities for top-level packages during lookup phase

Examples:

- https://github.com/JamieMagee/renovate-vulnerabilities-test/pull/7
- https://github.com/JamieMagee/renovate-vulnerabilities-test/pull/10
- https://github.com/JamieMagee/renovate-vulnerabilities-test/pull/11

NOTE: This does not provide vulnerability updates for transitive dependencies. GitHub Security Advisories does do this, but currently Renovate does not extract dependencies from lockfiles, for example `package-lock.json`. So, at this point in the Renovate run we cannot lookup vulnerabilities for transitive dependencies.

## Context

#6562

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

(Will provide updated documentation once the feature is listed)

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
