### PR TITLE
chore(gitTimeOut): improve description

### DIFF
--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -733,7 +733,7 @@ const options: RenovateOptions[] = [
   {
     name: 'gitTimeout',
     description:
-      'Configure the timeout with a number of milliseconds to wait for a git task',
+      'Configure the timeout with a number of milliseconds to wait for a Git task.',
     type: 'integer',
     globalOnly: true,
     default: 10000,


### PR DESCRIPTION
## Changes

- Capitalize proper noun `Git`
- End sentence with full stop

## Context

Fixing up the `description` field for the `gitTimeOut` config option.
Not closing any issue with this.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
