### PR TITLE
docs: use term GitHub Enterprise Server

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -744,7 +744,7 @@ Set this to `false` if you want to disable release notes fetching.
 
 Renovate can fetch release notes when they are hosted on one of these platforms:
 
-- GitHub (.com and Enterprise)
+- GitHub (.com and Enterprise Server)
 - GitLab (.com and CE/EE)
 
 <!-- prettier-ignore -->

--- a/docs/usage/examples/self-hosting.md
+++ b/docs/usage/examples/self-hosting.md
@@ -247,7 +247,7 @@ module.exports = {
 Here change the `logFile` and `repositories` to something appropriate.
 Also replace `gitlab-token` value with the one created during the previous step.
 
-If running against GitHub Enterprise, change the above `gitlab` values to the equivalent GitHub ones.
+If running against GitHub Enterprise Server, change the above `gitlab` values to the equivalent GitHub ones.
 
 You can save this file as anything you want and then use `RENOVATE_CONFIG_FILE` env variable to tell Renovate where to find it.
 
@@ -269,7 +269,7 @@ renovate
 <!-- prettier-ignore -->
 !!! note
     The GitHub.com token in env is necessary in order to retrieve Release Notes that are usually hosted on github.com.
-    You don't need to add it if you are already running the bot against github.com, but you do need to add it if you're using GitHub Enterprise, GitLab, Azure DevOps, or Bitbucket.
+    You don't need to add it if you are already running the bot against github.com, but you do need to add it if you're using GitHub Enterprise Server, GitLab, Azure DevOps, or Bitbucket.
 
 You should save and test out this script manually first, and add it to cron once you've verified it.
 

--- a/lib/modules/platform/github/index.md
+++ b/lib/modules/platform/github/index.md
@@ -1,4 +1,4 @@
-# GitHub and GitHub Enterprise
+# GitHub and GitHub Enterprise Server
 
 ## Authentication
 

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ Multi-platform and multi-language.
 
 Renovate works on the following platforms:
 
-- GitHub (.com and Enterprise)
+- GitHub (.com and Enterprise Server)
 - GitLab (.com and CE/EE)
 - Bitbucket Cloud
 - Bitbucket Server


### PR DESCRIPTION
## Changes

- Use the term `GitHub Enterprise Server` to refer to the GitHub self-hosted instance

## Context

Closes #15032.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository