### PR TITLE
fix(git): revert gitTimeout

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -363,12 +363,6 @@ Before the first commit in a repository, Renovate will:
 The `git` commands are run locally in the cloned repo instead of globally.
 This reduces the chance of unintended consequences with global Git configs on shared systems.
 
-## gitTimeout
-
-To handle the case where the underlying Git processes appear to hang, configure the timeout with the number of milliseconds to wait after last received content on either `stdOut` or `stdErr` streams before sending a `SIGINT` kill message.
-
-The value must be between `2000` and `6000` (milliseconds) inclusive.
-
 ## gitUrl
 
 Override the default resolution for Git remote, e.g. to switch GitLab from HTTPS to SSH-based.

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -367,7 +367,7 @@ This reduces the chance of unintended consequences with global Git configs on sh
 
 To handle the case where the underlying Git processes appear to hang, configure the timeout with the number of milliseconds to wait after last received content on either `stdOut` or `stdErr` streams before sending a `SIGINT` kill message.
 
-The value must be between `2000` and `60000` (milliseconds) inclusive.
+The value must be between `2000` and `6000` (milliseconds) inclusive.
 
 ## gitUrl
 

--- a/lib/config/global.ts
+++ b/lib/config/global.ts
@@ -22,7 +22,6 @@ export class GlobalConfig {
     'migratePresets',
     'privateKey',
     'privateKeyOld',
-    'gitTimeout',
   ];
 
   private static config: RepoGlobalConfig = {};

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -733,7 +733,7 @@ const options: RenovateOptions[] = [
   {
     name: 'gitTimeout',
     description:
-      'Configure the timeout with a number of milliseconds to wait for a Git task.',
+      'Configure the timeout with a number of milliseconds to wait for a git task',
     type: 'integer',
     globalOnly: true,
     default: 10000,

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -731,14 +731,6 @@ const options: RenovateOptions[] = [
     stage: 'repository',
   },
   {
-    name: 'gitTimeout',
-    description:
-      'Configure the timeout with a number of milliseconds to wait for a git task',
-    type: 'integer',
-    globalOnly: true,
-    default: 10000,
-  },
-  {
     name: 'enabledManagers',
     description:
       'A list of package managers to enable. If defined, then all managers not on the list are disabled.',

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -107,7 +107,6 @@ export interface RepoGlobalConfig {
   dockerUser?: string;
   dryRun?: DryRunConfig;
   executionTimeout?: number;
-  gitTimeout?: number;
   exposeAllEnv?: boolean;
   githubTokenWarn?: boolean;
   migratePresets?: Record<string, string>;

--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -739,18 +739,5 @@ describe('config/validation', () => {
         },
       ]);
     });
-
-    it.each([
-      [
-        'invalid value',
-        {
-          gitTimeout: 'string',
-        },
-      ],
-      ['out of range', { gitTimeout: 1000 }],
-    ])('checks invalid git timeout values', async (_case, config) => {
-      const { errors } = await configValidation.validateConfig(config);
-      expect(errors).toHaveLength(1);
-    });
   });
 });

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -128,19 +128,6 @@ export async function validateConfig(
       });
       continue;
     }
-    if (key === 'gitTimeout') {
-      if (!is.number(val)) {
-        errors.push({
-          topic: 'Config Error',
-          message: `GitTimeout must be set to an integer value`,
-        });
-      } else if (!(val >= 2000 && val <= 60000)) {
-        errors.push({
-          topic: 'Config Error',
-          message: `GitTimeout value must be within 2 to 60 seconds`,
-        });
-      }
-    }
     if (parentPath && topLevelObjects.includes(key)) {
       errors.push({
         topic: 'Configuration Error',

--- a/lib/modules/manager/git-submodules/extract.ts
+++ b/lib/modules/manager/git-submodules/extract.ts
@@ -36,11 +36,7 @@ async function getUrl(
 const headRefRe = regEx(/ref: refs\/heads\/(?<branch>\w+)\s/);
 
 async function getDefaultBranch(subModuleUrl: string): Promise<string> {
-  const val = await Git(simpleGitConfig()).listRemote([
-    '--symref',
-    subModuleUrl,
-    'HEAD',
-  ]);
+  const val = await Git().listRemote(['--symref', subModuleUrl, 'HEAD']);
   return headRefRe.exec(val)?.groups?.branch ?? 'master';
 }
 
@@ -50,7 +46,7 @@ async function getBranch(
   subModuleUrl: string
 ): Promise<string> {
   return (
-    (await Git(simpleGitConfig()).raw([
+    (await Git().raw([
       'config',
       '--file',
       gitModulesPath,
@@ -95,7 +91,7 @@ export default async function extractPackageFile(
   config: ExtractConfig
 ): Promise<PackageFile | null> {
   const { localDir } = GlobalConfig.get();
-  const git = Git(localDir, simpleGitConfig());
+  const git = Git(localDir);
   const gitModulesPath = upath.join(localDir, fileName);
 
   const depNames = await getModules(git, gitModulesPath);

--- a/lib/util/git/config.spec.ts
+++ b/lib/util/git/config.spec.ts
@@ -1,27 +1,9 @@
-import { GlobalConfig } from '../../config/global';
 import { simpleGitConfig } from './config';
 
 describe('util/git/config', () => {
-  beforeEach(() => {
-    GlobalConfig.reset();
-  });
-
   it('uses "close" events, ignores "exit" events from child processes', () => {
     expect(simpleGitConfig()).toEqual({
       completion: { onClose: true, onExit: false },
-      timeout: {
-        block: 10000,
-      },
-    });
-  });
-
-  it('uses timeout value from GlobalConfig', () => {
-    GlobalConfig.set({ gitTimeout: 50000 });
-    expect(simpleGitConfig()).toEqual({
-      completion: { onClose: true, onExit: false },
-      timeout: {
-        block: 50000,
-      },
     });
   });
 });

--- a/lib/util/git/config.ts
+++ b/lib/util/git/config.ts
@@ -1,6 +1,5 @@
 import is from '@sindresorhus/is';
 import type { SimpleGitOptions } from 'simple-git';
-import { GlobalConfig } from '../../config/global';
 import type { GitNoVerifyOption } from './types';
 
 let noVerify: GitNoVerifyOption[] = ['push', 'commit'];
@@ -22,9 +21,6 @@ export function simpleGitConfig(): Partial<SimpleGitOptions> {
     completion: {
       onClose: true,
       onExit: false,
-    },
-    timeout: {
-      block: GlobalConfig.get('gitTimeout') ?? 10000,
     },
   };
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Reverts git timeout behavior.

## Context

Closes #15177, Closes #15179


## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
This reverts commit a8930b7.