### PR TITLE
fix(pod): Massage only registry URLs that matched the GitHub regex; leave CocoaPods CDN URLs untouched

### DIFF
--- a/lib/modules/datasource/pod/index.ts
+++ b/lib/modules/datasource/pod/index.ts
@@ -222,7 +222,6 @@ export class PodDatasource extends Datasource {
 
     const podName = packageName.replace(regEx(/\/.*$/), '');
     let baseUrl = registryUrl.replace(regEx(/\/+$/), '');
-    baseUrl = massageGithubUrl(baseUrl);
     // In order to not abuse github API limits, query CDN instead
     if (isDefaultRepo(baseUrl)) {
       [baseUrl] = this.defaultRegistryUrls;
@@ -231,6 +230,7 @@ export class PodDatasource extends Datasource {
     let result: ReleaseResult | null = null;
     const match = githubRegex.exec(baseUrl);
     if (match) {
+      baseUrl = massageGithubUrl(baseUrl);
       const { hostURL, account, repo } = match?.groups ?? {};
       const opts = { hostURL, account, repo };
       result = await this.getReleasesFromGithub(podName, opts);


### PR DESCRIPTION
## Changes

Massage only registry URLs that matched the GitHub regex; leave CocoaPods CDN URLs untouched.

## Context

CocoaPods CDN URLs were "massaged" (`massageGithubUrl`) as if they were GitHub repository URLs. Massaging involves - amongst other things - stripping parts of the URL. This caused our CDN URL to become invalid.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [X] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository