### PR TITLE
refactor(platform:bitbucket): strict null checks

### DIFF
--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -48,7 +48,7 @@ const defaults = { endpoint: BITBUCKET_PROD_ENDPOINT };
 
 const pathSeparator = '/';
 
-let renovateUserUuid: string;
+let renovateUserUuid: string | null = null;
 
 export async function initPlatform({
   endpoint,
@@ -136,7 +136,8 @@ export async function getJsonFile(
   repoName?: string,
   branchOrTag?: string
 ): Promise<any | null> {
-  const raw = await getRawFile(fileName, repoName, branchOrTag);
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+  const raw = (await getRawFile(fileName, repoName, branchOrTag)) as string;
   if (fileName.endsWith('.json5')) {
     return JSON5.parse(raw);
   }
@@ -191,7 +192,8 @@ export async function initRepo({
   // Converts API hostnames to their respective HTTP git hosts:
   // `api.bitbucket.org`  to `bitbucket.org`
   // `api-staging.<host>` to `staging.<host>`
-  const hostnameWithoutApiPrefix = regEx(/api[.|-](.+)/).exec(hostname)[1];
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+  const hostnameWithoutApiPrefix = regEx(/api[.|-](.+)/).exec(hostname!)?.[1];
 
   const url = git.getUrl({
     protocol: 'https',
@@ -261,7 +263,7 @@ export async function findPr({
   if (pr) {
     logger.debug(`Found PR #${pr.number}`);
   }
-  return pr;
+  return pr ?? null;
 }
 
 // Gets details for a PR
@@ -297,7 +299,9 @@ interface BranchResponse {
 }
 
 // Return the commit SHA for a branch
-async function getBranchCommit(branchName: string): Promise<string | null> {
+async function getBranchCommit(
+  branchName: string
+): Promise<string | undefined> {
   try {
     const branch = (
       await bitbucketHttp.getJson<BranchResponse>(
@@ -309,7 +313,7 @@ async function getBranchCommit(branchName: string): Promise<string | null> {
     return branch.target.hash;
   } catch (err) /* istanbul ignore next */ {
     logger.debug({ err }, `getBranchCommit('${branchName}') failed'`);
-    return null;
+    return undefined;
   }
 }
 
@@ -373,7 +377,8 @@ export async function getBranchStatusCheck(
 ): Promise<BranchStatus | null> {
   const statuses = await getStatus(branchName);
   const bbState = statuses.find((status) => status.key === context)?.state;
-  return bbToRenovateStatusMapping[bbState] || null;
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+  return bbToRenovateStatusMapping[bbState!] || null;
 }
 
 export async function setBranchStatus({
@@ -428,7 +433,7 @@ async function findOpenIssues(title: string): Promise<BbIssue[]> {
   }
 }
 
-export async function findIssue(title: string): Promise<Issue> {
+export async function findIssue(title: string): Promise<Issue | null> {
   logger.debug(`findIssue(${title})`);
 
   /* istanbul ignore if */
@@ -485,7 +490,7 @@ export async function ensureIssue({
   }
   try {
     let issues = await findOpenIssues(title);
-    if (!issues.length) {
+    if (!issues.length && reuseTitle) {
       issues = await findOpenIssues(reuseTitle);
     }
     if (issues.length) {
@@ -496,7 +501,7 @@ export async function ensureIssue({
       const [issue] = issues;
       if (
         issue.title !== title ||
-        String(issue.content.raw).trim() !== description.trim()
+        String(issue.content?.raw).trim() !== description.trim()
       ) {
         logger.debug('Issue updated');
         await bitbucketHttp.putJson(
@@ -593,7 +598,8 @@ export async function addReviewers(
 ): Promise<void> {
   logger.debug(`Adding reviewers '${reviewers.join(', ')}' to #${prId}`);
 
-  const { title } = await getPr(prId);
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+  const { title } = (await getPr(prId)) as Pr;
 
   const body = {
     title,
@@ -636,7 +642,7 @@ export function ensureCommentRemoval(
 async function sanitizeReviewers(
   reviewers: Account[],
   err: any
-): Promise<Account[]> {
+): Promise<Account[] | undefined> {
   if (err.statusCode === 400 && err.body?.error?.fields?.reviewers) {
     const sanitizedReviewers: Account[] = [];
 

--- a/lib/modules/platform/bitbucket/utils.ts
+++ b/lib/modules/platform/bitbucket/utils.ts
@@ -70,14 +70,14 @@ const bitbucketMergeStrategies: Map<MergeStrategy, BitbucketMergeStrategy> =
   ]);
 
 export function mergeBodyTransformer(
-  mergeStrategy: MergeStrategy
+  mergeStrategy: MergeStrategy | undefined
 ): MergeRequestBody {
   const body: MergeRequestBody = {
     close_source_branch: true,
   };
 
   // The `auto` strategy will use the strategy configured inside Bitbucket.
-  if (mergeStrategy !== 'auto') {
+  if (mergeStrategy && mergeStrategy !== 'auto') {
     body.merge_strategy = bitbucketMergeStrategies.get(mergeStrategy);
   }
 

--- a/lib/util/sanitize.ts
+++ b/lib/util/sanitize.ts
@@ -17,9 +17,10 @@ export const redactedFields = [
   'password',
 ];
 
-export function sanitize(input: string): string {
+export function sanitize(input: string | null | undefined): string {
   if (!input) {
-    return input;
+    // TODO: is that right? Changing return type causes a lot of changes
+    return '';
   }
   let output: string = input;
   [globalSecrets, repoSecrets].forEach((secrets) => {

--- a/lib/util/sanitize.ts
+++ b/lib/util/sanitize.ts
@@ -17,10 +17,16 @@ export const redactedFields = [
   'password',
 ];
 
-export function sanitize(input: string | null | undefined): string {
+// TODO: returns null or undefined only when input is null or undefined.
+export function sanitize(input: string): string;
+export function sanitize(
+  input: string | null | undefined
+): string | null | undefined;
+export function sanitize(
+  input: string | null | undefined
+): string | null | undefined {
   if (!input) {
-    // TODO: is that right? Changing return type causes a lot of changes
-    return '';
+    return input;
   }
   let output: string = input;
   [globalSecrets, repoSecrets].forEach((secrets) => {

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -39,7 +39,6 @@
     "lib/config/validation.ts",
     "lib/modules/datasource/github-releases/test/index.ts",
     "lib/modules/platform/api.ts",
-    "lib/modules/platform/bitbucket/index.ts",
     "lib/modules/platform/bitbucket-server/index.ts",
     "lib/modules/platform/bitbucket-server/utils.ts",
     "lib/modules/platform/comment.ts",


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- as title
<!-- Describe what behavior is changed by this PR. -->

## Context
- https://github.com/renovatebot/renovate/issues/7154
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
