### PR TITLE
fix(git): remove default gitTimeout

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -367,8 +367,6 @@ This reduces the chance of unintended consequences with global Git configs on sh
 
 To handle the case where the underlying Git processes appear to hang, configure the timeout with the number of milliseconds to wait after last received content on either `stdOut` or `stdErr` streams before sending a `SIGINT` kill message.
 
-The value must be between `2000` and `60000` (milliseconds) inclusive.
-
 ## gitUrl
 
 Override the default resolution for Git remote, e.g. to switch GitLab from HTTPS to SSH-based.

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -736,7 +736,7 @@ const options: RenovateOptions[] = [
       'Configure the timeout with a number of milliseconds to wait for a Git task.',
     type: 'integer',
     globalOnly: true,
-    default: 10000,
+    default: 0,
   },
   {
     name: 'enabledManagers',

--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -739,18 +739,5 @@ describe('config/validation', () => {
         },
       ]);
     });
-
-    it.each([
-      [
-        'invalid value',
-        {
-          gitTimeout: 'string',
-        },
-      ],
-      ['out of range', { gitTimeout: 1000 }],
-    ])('checks invalid git timeout values', async (_case, config) => {
-      const { errors } = await configValidation.validateConfig(config);
-      expect(errors).toHaveLength(1);
-    });
   });
 });

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -128,19 +128,6 @@ export async function validateConfig(
       });
       continue;
     }
-    if (key === 'gitTimeout') {
-      if (!is.number(val)) {
-        errors.push({
-          topic: 'Config Error',
-          message: `GitTimeout must be set to an integer value`,
-        });
-      } else if (!(val >= 2000 && val <= 60000)) {
-        errors.push({
-          topic: 'Config Error',
-          message: `GitTimeout value must be within 2 to 60 seconds`,
-        });
-      }
-    }
     if (parentPath && topLevelObjects.includes(key)) {
       errors.push({
         topic: 'Configuration Error',

--- a/lib/util/git/config.spec.ts
+++ b/lib/util/git/config.spec.ts
@@ -9,9 +9,6 @@ describe('util/git/config', () => {
   it('uses "close" events, ignores "exit" events from child processes', () => {
     expect(simpleGitConfig()).toEqual({
       completion: { onClose: true, onExit: false },
-      timeout: {
-        block: 10000,
-      },
     });
   });
 

--- a/lib/util/git/config.ts
+++ b/lib/util/git/config.ts
@@ -18,13 +18,16 @@ export function getNoVerify(): GitNoVerifyOption[] {
 }
 
 export function simpleGitConfig(): Partial<SimpleGitOptions> {
-  return {
+  const config: Partial<SimpleGitOptions> = {
     completion: {
       onClose: true,
       onExit: false,
     },
-    timeout: {
-      block: GlobalConfig.get('gitTimeout') ?? 10000,
-    },
   };
+  // https://github.com/steveukx/git-js/pull/591
+  const gitTimeout = GlobalConfig.get('gitTimeout');
+  if (is.number(gitTimeout) && gitTimeout > 0) {
+    config.timeout = { block: gitTimeout };
+  }
+  return config;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Sets default `gitTimeout` value to `0`.

## Context

Closes #15179, Closes #15177

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
