### PR TITLE
fix(config): validate integer types

### DIFF
--- a/lib/config/__snapshots__/validation.spec.ts.snap
+++ b/lib/config/__snapshots__/validation.spec.ts.snap
@@ -54,6 +54,10 @@ Array [
     "topic": "Configuration Error",
   },
   Object {
+    "message": "Configuration option \`prCommitsPerRunLimit\` should be an integer. Found: false (boolean)",
+    "topic": "Configuration Error",
+  },
+  Object {
     "message": "Configuration option \`semanticCommitType\` should be a string",
     "topic": "Configuration Error",
   },

--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -195,6 +195,7 @@ describe('config/validation', () => {
         schedule: ['every 15 mins every weekday'],
         timezone: 'Asia',
         labels: 5 as any,
+        prCommitsPerRunLimit: false as any,
         semanticCommitType: 7 as any,
         lockFileMaintenance: false as any,
         extends: [':timezone(Europe/Brussel)'],
@@ -220,7 +221,7 @@ describe('config/validation', () => {
       );
       expect(warnings).toHaveLength(1);
       expect(errors).toMatchSnapshot();
-      expect(errors).toHaveLength(12);
+      expect(errors).toHaveLength(13);
     });
 
     it('selectors outside packageRules array trigger errors', async () => {

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -256,6 +256,15 @@ export async function validateConfig(
               )} (${typeof val})`,
             });
           }
+        } else if (type === 'integer') {
+          if (!is.number(val)) {
+            errors.push({
+              topic: 'Configuration Error',
+              message: `Configuration option \`${currentPath}\` should be an integer. Found: ${JSON.stringify(
+                val
+              )} (${typeof val})`,
+            });
+          }
         } else if (type === 'array' && val) {
           if (is.array(val)) {
             for (const [subIndex, subval] of val.entries()) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds integer type validation for config.

## Context

[Discovered it's missing during ](https://github.com/renovatebot/renovate/pull/15200#discussion_r854495527)

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
