### PR TITLE
feat(datasource/crate): fetch crate metadata from crates.io

### DIFF
--- a/lib/modules/datasource/crate/__fixtures__/amethyst.json
+++ b/lib/modules/datasource/crate/__fixtures__/amethyst.json
@@ -1,0 +1,33 @@
+{
+  "categories": null,
+  "crate": {
+    "badges": null,
+    "categories": null,
+    "created_at": "2016-01-04T03:42:04.120616+00:00",
+    "description": "Data-oriented game engine written in Rust",
+    "documentation": "https://docs.amethyst.rs/stable/amethyst",
+    "downloads": 121814,
+    "exact_match": false,
+    "homepage": "https://amethyst.rs/",
+    "id": "amethyst",
+    "keywords": null,
+    "links": {
+      "owner_team": "/api/v1/crates/amethyst/owner_team",
+      "owner_user": "/api/v1/crates/amethyst/owner_user",
+      "owners": "/api/v1/crates/amethyst/owners",
+      "reverse_dependencies": "/api/v1/crates/amethyst/reverse_dependencies",
+      "version_downloads": "/api/v1/crates/amethyst/downloads",
+      "versions": "/api/v1/crates/amethyst/versions"
+    },
+    "max_stable_version": null,
+    "max_version": "0.0.0",
+    "name": "amethyst",
+    "newest_version": "0.0.0",
+    "recent_downloads": null,
+    "repository": "https://github.com/amethyst/amethyst",
+    "updated_at": "2020-08-23T02:18:12.559064+00:00",
+    "versions": null
+  },
+  "keywords": null,
+  "versions": null
+}

--- a/lib/modules/datasource/crate/__fixtures__/libc.json
+++ b/lib/modules/datasource/crate/__fixtures__/libc.json
@@ -1,0 +1,33 @@
+{
+  "categories": null,
+  "crate": {
+    "badges": null,
+    "categories": null,
+    "created_at": "2015-01-15T20:22:13.100871+00:00",
+    "description": "Raw FFI bindings to platform libraries like libc.\n",
+    "documentation": "https://docs.rs/libc/",
+    "downloads": 106751998,
+    "exact_match": false,
+    "homepage": "https://github.com/rust-lang/libc",
+    "id": "libc",
+    "keywords": null,
+    "links": {
+      "owner_team": "/api/v1/crates/libc/owner_team",
+      "owner_user": "/api/v1/crates/libc/owner_user",
+      "owners": "/api/v1/crates/libc/owners",
+      "reverse_dependencies": "/api/v1/crates/libc/reverse_dependencies",
+      "version_downloads": "/api/v1/crates/libc/downloads",
+      "versions": "/api/v1/crates/libc/versions"
+    },
+    "max_stable_version": null,
+    "max_version": "0.0.0",
+    "name": "libc",
+    "newest_version": "0.0.0",
+    "recent_downloads": null,
+    "repository": "https://github.com/rust-lang/libc",
+    "updated_at": "2022-04-18T23:40:23.878438+00:00",
+    "versions": null
+  },
+  "keywords": null,
+  "versions": null
+}

--- a/lib/modules/datasource/crate/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/datasource/crate/__snapshots__/index.spec.ts.snap
@@ -33,6 +33,7 @@ Object {
 exports[`modules/datasource/crate/index getReleases processes real data: amethyst 1`] = `
 Object {
   "dependencyUrl": "https://crates.io/crates/amethyst",
+  "homepage": "https://amethyst.rs/",
   "registryUrl": "https://crates.io",
   "releases": Array [
     Object {
@@ -94,6 +95,7 @@ Object {
       "version": "0.10.1",
     },
   ],
+  "sourceUrl": "https://github.com/amethyst/amethyst",
 }
 `;
 
@@ -300,6 +302,7 @@ Object {
       "version": "0.2.51",
     },
   ],
+  "sourceUrl": "https://github.com/rust-lang/libc",
 }
 `;
 

--- a/lib/modules/datasource/crate/index.spec.ts
+++ b/lib/modules/datasource/crate/index.spec.ts
@@ -64,7 +64,7 @@ function mockCratesApiCallFor(crateName: string, response?: httpMock.Body) {
   httpMock
     .scope(API_BASE_URL)
     .get(`/crates/${crateName}?include=`)
-    .reply(response ? 200 : 404, response ?? '');
+    .reply(response ? 200 : 404, response);
 }
 
 describe('modules/datasource/crate/index', () => {

--- a/lib/modules/datasource/crate/index.spec.ts
+++ b/lib/modules/datasource/crate/index.spec.ts
@@ -15,6 +15,8 @@ import { CrateDatasource } from '.';
 jest.mock('simple-git');
 const simpleGit: jest.Mock<Partial<SimpleGit>> = _simpleGit as never;
 
+const API_BASE_URL = CrateDatasource.CRATES_IO_API_BASE_URL;
+
 const baseUrl =
   'https://raw.githubusercontent.com/rust-lang/crates.io-index/master/';
 
@@ -56,6 +58,13 @@ function setupErrorGitMock(): { mockClone: jest.Mock<any, any> } {
   });
 
   return { mockClone };
+}
+
+function mockCratesApiCallFor(crateName: string, response?: httpMock.Body) {
+  httpMock
+    .scope(API_BASE_URL)
+    .get(`/crates/${crateName}?include=`)
+    .reply(response ? 200 : 404, response ?? '');
 }
 
 describe('modules/datasource/crate/index', () => {
@@ -133,6 +142,7 @@ describe('modules/datasource/crate/index', () => {
     });
 
     it('returns null for empty result', async () => {
+      mockCratesApiCallFor('non_existent_crate');
       httpMock.scope(baseUrl).get('/no/n_/non_existent_crate').reply(200, {});
       expect(
         await getPkgReleases({
@@ -144,6 +154,7 @@ describe('modules/datasource/crate/index', () => {
     });
 
     it('returns null for missing fields', async () => {
+      mockCratesApiCallFor('non_existent_crate');
       httpMock
         .scope(baseUrl)
         .get('/no/n_/non_existent_crate')
@@ -158,6 +169,7 @@ describe('modules/datasource/crate/index', () => {
     });
 
     it('returns null for empty list', async () => {
+      mockCratesApiCallFor('non_existent_crate');
       httpMock.scope(baseUrl).get('/no/n_/non_existent_crate').reply(200, '\n');
       expect(
         await getPkgReleases({
@@ -207,6 +219,8 @@ describe('modules/datasource/crate/index', () => {
     });
 
     it('processes real data: libc', async () => {
+      mockCratesApiCallFor('libc', Fixtures.get('libc.json'));
+
       httpMock
         .scope(baseUrl)
         .get('/li/bc/libc')
@@ -222,6 +236,8 @@ describe('modules/datasource/crate/index', () => {
     });
 
     it('processes real data: amethyst', async () => {
+      mockCratesApiCallFor('amethyst', Fixtures.get('amethyst.json'));
+
       httpMock
         .scope(baseUrl)
         .get('/am/et/amethyst')

--- a/lib/modules/datasource/crate/types.ts
+++ b/lib/modules/datasource/crate/types.ts
@@ -27,3 +27,10 @@ export interface CrateRecord {
   vers: string;
   yanked: boolean;
 }
+
+export interface CrateMetadata {
+  description: string | null;
+  documentation: string | null;
+  homepage: string | null;
+  repository: string | null;
+}

--- a/test/http-mock.ts
+++ b/test/http-mock.ts
@@ -5,7 +5,7 @@ import nock from 'nock';
 import { makeGraphqlSnapshot } from './graphql-snapshot';
 
 // eslint-disable-next-line no-restricted-imports
-export type { Scope, ReplyHeaders } from 'nock';
+export type { Scope, ReplyHeaders, Body } from 'nock';
 
 interface RequestLogItem {
   headers: Record<string, string>;


### PR DESCRIPTION
## Changes

This PR adds changelogs to Rust crate update PRs by downloading crate metadata from crates.io. It is using a fast path on the crates.io server to avoid unnecessary database requests (see code comment) and work around the regular request per second limitation. Since the metadata rarely changes, it will be cached for 24 hours to avoid unnecessary API requests.

<img width="734" alt="Bildschirmfoto 2022-04-21 um 00 23 21" src="https://user-images.githubusercontent.com/141300/164401044-cf5091b3-1fec-454f-97bd-f66d86e0cbcf.png">

Example PR from this branch: https://github.com/Turbo87/renovate-crates-test/pull/3

## Context

Closes https://github.com/renovatebot/renovate/issues/3486

Note that I have seen https://github.com/renovatebot/renovate/pull/14841, but since the discussion there was not concluded yet, I've implemented it only for the crates.io datasource for now.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

