### PR TITLE
fix(manager:npm): wrong lockfile token replacement

### DIFF
--- a/lib/modules/manager/npm/post-update/index.ts
+++ b/lib/modules/manager/npm/post-update/index.ts
@@ -526,17 +526,17 @@ export async function getAdditionalFiles(
     NODE_ENV: 'dev',
   };
 
-  let token = '';
+  let token: string | undefined;
   try {
-    ({ token = '' } = hostRules.find({
+    ({ token } = hostRules.find({
       hostType: config.platform,
       url: 'https://api.github.com/',
     }));
-    token += '@';
+    token = token ? `${token}@` : token;
   } catch (err) {
     logger.warn({ err }, 'Error getting token for packageFile');
   }
-  const tokenRe = regEx(`${token}`, 'g', false);
+  const tokenRe = regEx(`${token ?? ''}`, 'g', false);
   const localDir = GlobalConfig.get('localDir')!;
   for (const npmLock of dirs.npmLockDirs) {
     const lockFileDir = upath.dirname(npmLock);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
regression from null check refactoring, so it now replaces all `@` when no token found for github api.
It now sets token correctly to empty string again if no token was found.
<!-- Describe what behavior is changed by this PR. -->

## Context
- fixes #15211
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
