### PR TITLE
fix(manager:nuget): use `upath` for cross-platform paths

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -71,7 +71,10 @@ module.exports = {
 
     // disallow direct `nock` module usage as it causes memory issues.
     // disallow `parse-link-header` to allow override ENV https://github.com/thlorenz/parse-link-header#environmental-variables
-    'no-restricted-imports': [2, { paths: ['nock', 'parse-link-header'] }],
+    'no-restricted-imports': [
+      2,
+      { paths: ['nock', 'parse-link-header', 'path'] },
+    ],
 
     // Makes no sense to allow type inference for expression parameters, but require typing the response
     '@typescript-eslint/explicit-function-return-type': [

--- a/lib/modules/manager/nuget/artifacts.ts
+++ b/lib/modules/manager/nuget/artifacts.ts
@@ -1,5 +1,5 @@
-import { join } from 'path';
 import { quote } from 'shlex';
+import { join } from 'upath';
 import { TEMPORARY_ERROR } from '../../../constants/error-messages';
 import { logger } from '../../../logger';
 import { exec } from '../../../util/exec';

--- a/tools/clean-cache.mjs
+++ b/tools/clean-cache.mjs
@@ -1,6 +1,6 @@
 import { tmpdir } from 'os';
-import { join } from 'path';
 import { remove } from 'fs-extra';
+import { join } from 'upath';
 
 // eslint-disable-next-line @typescript-eslint/no-floating-promises
 (async () => {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
there was a wrong `path.join` usage, wich isn't cross-platform safe. So `path` is now disallowed via lint, `upath` is a dropin cross-platform compatible replacement
<!-- Describe what behavior is changed by this PR. -->

## Context
failed windows tests on windows
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
