### PR TITLE
docs: always show `mergeable` flag

### DIFF
--- a/tools/docs/config.ts
+++ b/tools/docs/config.ts
@@ -76,7 +76,7 @@ export async function generateConfig(dist: string, bot = false): Promise<void> {
     .filter((option) => option.releaseStatus !== 'unpublished')
     .forEach((option) => {
       // TODO: fix types (#9610)
-      const el: Record<string, any> = { ...option };
+      const el: Record<string, any> = { mergeable: false, ...option };
       let headerIndex = configOptionsRaw.indexOf(`## ${option.name}`);
       if (headerIndex === -1) {
         headerIndex = configOptionsRaw.indexOf(`### ${option.name}`);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
 always show `mergeable` flag on docs, but i'm not sure if we really need it. 🤔 
<!-- Describe what behavior is changed by this PR. -->

## Context
- closes #15042
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
