### PR TITLE
feat(github): Remove irrelevant fields from PR cache

### DIFF
--- a/lib/modules/platform/github/pr.ts
+++ b/lib/modules/platform/github/pr.ts
@@ -1,3 +1,4 @@
+import is from '@sindresorhus/is';
 import { PlatformId } from '../../../constants';
 import { logger } from '../../../logger';
 import { ExternalHostError } from '../../../types/errors/external-host-error';
@@ -9,14 +10,42 @@ import { ApiCache } from './api-cache';
 import { coerceRestPr } from './common';
 import type { ApiPageCache, GhRestPr } from './types';
 
+function removeUrlFields(input: unknown): void {
+  if (is.plainObject(input)) {
+    for (const [key, val] of Object.entries(input)) {
+      if ((key === 'url' || key.endsWith('_url')) && is.string(val)) {
+        delete input[key];
+      } else {
+        removeUrlFields(val);
+      }
+    }
+  }
+}
+
+function massageGhRestPr(ghPr: GhRestPr): GhRestPr {
+  removeUrlFields(ghPr);
+  delete ghPr?.head?.repo?.pushed_at;
+  delete ghPr?.base?.repo?.pushed_at;
+  delete ghPr?._links;
+  return ghPr;
+}
+
 function getPrApiCache(): ApiCache<GhRestPr> {
   const repoCache = getCache();
   repoCache.platform ??= {};
   repoCache.platform.github ??= {};
   repoCache.platform.github.prCache ??= { items: {} };
-  const prCache = new ApiCache(
-    repoCache.platform.github.prCache as ApiPageCache<GhRestPr>
-  );
+  const apiPageCache = repoCache.platform.github
+    .prCache as ApiPageCache<GhRestPr>;
+
+  const items = Object.values(apiPageCache.items);
+  if (items?.[0]?._links) {
+    for (const ghPr of items) {
+      massageGhRestPr(ghPr);
+    }
+  }
+
+  const prCache = new ApiCache(apiPageCache);
   return prCache;
 }
 
@@ -100,6 +129,10 @@ export async function getPrCache(
         page = page.filter(
           (ghPr) => ghPr?.user?.login && ghPr.user.login === username
         );
+      }
+
+      for (const ghPr of page) {
+        massageGhRestPr(ghPr);
       }
 
       needNextPageSync = prApiCache.reconcile(page);

--- a/lib/modules/platform/github/types.ts
+++ b/lib/modules/platform/github/types.ts
@@ -24,7 +24,15 @@ export interface GhRestPr {
   head: {
     ref: string;
     sha: string;
-    repo: { full_name: string };
+    repo: {
+      full_name: string;
+      pushed_at?: string;
+    };
+  };
+  base: {
+    repo: {
+      pushed_at?: string;
+    };
   };
   mergeable_state: string;
   number: number;
@@ -41,6 +49,7 @@ export interface GhRestPr {
   assignees?: { login?: string }[];
   requested_reviewers?: { login?: string }[];
   labels?: { name: string }[];
+  _links?: unknown;
 }
 
 export interface GhGraphQlPr {


### PR DESCRIPTION
## Changes

- Renove any API-related fields from response, i.e. `_links`, `url`, `*_url`
- Cleanup the previously stored cache items

## Context

- Ref: #15275

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
