### PR TITLE
refactor(platform/github): cache prs made by renovate

### DIFF
--- a/lib/modules/platform/github/common.ts
+++ b/lib/modules/platform/github/common.ts
@@ -51,5 +51,9 @@ export function coerceRestPr(pr: GhRestPr | null | undefined): Pr | null {
     result.closedAt = pr.closed_at;
   }
 
+  if (pr.user?.login?.endsWith('[bot]')) {
+    result.byRenovate = true;
+  }
+
   return result;
 }

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -611,7 +611,7 @@ export async function getPrList(): Promise<Pr[]> {
     // TODO: check null `repo` #7154
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     const prCache = await getPrCache(githubApi, repo!, username);
-    config.prList = Object.values(prCache);
+    config.prList = Object.values(prCache).filter((pr) => !pr.byRenovate);
   }
 
   return config.prList;

--- a/lib/modules/platform/github/pr.ts
+++ b/lib/modules/platform/github/pr.ts
@@ -114,7 +114,9 @@ export async function getPrCache(
 
       if (username) {
         page = page.filter(
-          (ghPr) => ghPr?.user?.login && ghPr.user.login === username
+          (ghPr) =>
+            ghPr?.user?.login &&
+            (ghPr.user.login === username || ghPr.user.login.endsWith('[bot]'))
         );
       }
 

--- a/lib/modules/platform/types.ts
+++ b/lib/modules/platform/types.ts
@@ -64,6 +64,7 @@ export interface Pr {
   targetBranch?: string;
   title: string;
   isDraft?: boolean;
+  byRenovate?: boolean;
 }
 
 /**


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Saves PR done by renovate[bot] to github cache.
<!-- Describe what behavior is changed by this PR. -->

## Context
needed for and might block #15308
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
