### PR TITLE
fix(npm): correct matchDatasources casing

### DIFF
--- a/lib/modules/datasource/npm/npmrc.spec.ts
+++ b/lib/modules/datasource/npm/npmrc.spec.ts
@@ -134,7 +134,7 @@ describe('modules/datasource/npm/npmrc', () => {
           ],
           "packageRules": Array [
             Object {
-              "matchDataSources": Array [
+              "matchDatasources": Array [
                 "npm",
               ],
               "matchPackagePrefixes": Array [

--- a/lib/modules/datasource/npm/npmrc.ts
+++ b/lib/modules/datasource/npm/npmrc.ts
@@ -85,14 +85,14 @@ export function convertNpmrcToRules(npmrc: Record<string, any>): NpmrcRules {
     rules.hostRules?.push(hostRule);
   }
   // Generate packageRules
-  const matchDataSources = ['npm'];
+  const matchDatasources = ['npm'];
   const { registry } = npmrc;
   // packageRules order matters, so look for a default registry first
   if (is.nonEmptyString(registry)) {
     if (validateUrl(registry)) {
       // Default registry
       rules.packageRules?.push({
-        matchDataSources,
+        matchDatasources,
         registryUrls: [registry],
       });
     } else {
@@ -110,7 +110,7 @@ export function convertNpmrcToRules(npmrc: Record<string, any>): NpmrcRules {
       const scope = keyParts.join(':');
       if (validateUrl(value)) {
         rules.packageRules?.push({
-          matchDataSources,
+          matchDatasources,
           matchPackagePrefixes: [scope + '/'],
           registryUrls: [value],
         });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Fixes `matchDataSources` - `matchDatasources`

## Context

Found by accident

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
