### PR TITLE
fix(package-rules): check for missing value

### DIFF
--- a/lib/util/package-rules.spec.ts
+++ b/lib/util/package-rules.spec.ts
@@ -665,7 +665,7 @@ describe('util/package-rules', () => {
         lockedVersion: '^1.0.0',
       },
     });
-    expect(res3.x).toBe(1);
+    expect(res3.x).toBeUndefined();
   });
 
   it('checks if matchCurrentVersion selector is valid and satisfies the condition on pinned to range overlap', () => {
@@ -933,5 +933,56 @@ describe('util/package-rules', () => {
     };
     const res = applyPackageRules({ ...config, ...dep });
     expect(res.x).toBe(1);
+  });
+
+  it('needs language to match', () => {
+    const config: TestConfig = {
+      packageRules: [
+        {
+          matchPackageNames: ['abc'],
+          matchLanguages: ['js'],
+          x: 1,
+        },
+      ],
+    };
+    const dep = {
+      depName: 'abc',
+    };
+    const res = applyPackageRules({ ...config, ...dep });
+    expect(res.x).toBeUndefined();
+  });
+
+  it('needs baseBranch to match', () => {
+    const config: TestConfig = {
+      packageRules: [
+        {
+          matchPackageNames: ['abc'],
+          matchBaseBranches: ['dev'],
+          x: 1,
+        },
+      ],
+    };
+    const dep = {
+      depName: 'abc',
+    };
+    const res = applyPackageRules({ ...config, ...dep });
+    expect(res.x).toBeUndefined();
+  });
+
+  it('needs manager to match', () => {
+    const config: TestConfig = {
+      packageRules: [
+        {
+          matchPackageNames: ['abc'],
+          matchManagers: ['npm'],
+          x: 1,
+        },
+      ],
+    };
+    const dep = {
+      depName: 'abc',
+    };
+    const res = applyPackageRules({ ...config, ...dep });
+    expect(res.x).toBeUndefined();
   });
 });

--- a/lib/util/package-rules.ts
+++ b/lib/util/package-rules.ts
@@ -93,14 +93,20 @@ function matchesRule(
     }
     positiveMatch = true;
   }
-  if (matchLanguages.length && language) {
+  if (matchLanguages.length) {
+    if (!language) {
+      return false;
+    }
     const isMatch = matchLanguages.includes(language);
     if (!isMatch) {
       return false;
     }
     positiveMatch = true;
   }
-  if (matchBaseBranches.length && baseBranch) {
+  if (matchBaseBranches.length) {
+    if (!baseBranch) {
+      return false;
+    }
     const isMatch = matchBaseBranches.some((matchBaseBranch): boolean => {
       const isAllowedPred = configRegexPredicate(matchBaseBranch);
       if (isAllowedPred) {
@@ -114,14 +120,20 @@ function matchesRule(
     }
     positiveMatch = true;
   }
-  if (matchManagers.length && manager) {
+  if (matchManagers.length) {
+    if (!manager) {
+      return false;
+    }
     const isMatch = matchManagers.includes(manager);
     if (!isMatch) {
       return false;
     }
     positiveMatch = true;
   }
-  if (matchDatasources.length && datasource) {
+  if (matchDatasources.length) {
+    if (!datasource) {
+      return false;
+    }
     const isMatch = matchDatasources.includes(datasource);
     if (!isMatch) {
       return false;
@@ -138,11 +150,13 @@ function matchesRule(
     positiveMatch = true;
   }
   if (
-    depName &&
-    (matchPackageNames.length ||
-      matchPackagePatterns.length ||
-      matchPackagePrefixes.length)
+    matchPackageNames.length ||
+    matchPackagePatterns.length ||
+    matchPackagePrefixes.length
   ) {
+    if (!depName) {
+      return false;
+    }
     let isMatch = matchPackageNames.includes(depName);
     // name match is "or" so we check patterns if we didn't match names
     if (!isMatch) {
@@ -169,8 +183,8 @@ function matchesRule(
     }
     positiveMatch = true;
   }
-  if (excludePackageNames.length && depName) {
-    const isMatch = excludePackageNames.includes(depName);
+  if (excludePackageNames.length) {
+    const isMatch = depName && excludePackageNames.includes(depName);
     if (isMatch) {
       return false;
     }
@@ -221,14 +235,17 @@ function matchesRule(
     }
     positiveMatch = true;
   }
-  if (matchCurrentVersion && currentValue) {
+  if (matchCurrentVersion) {
     const version = allVersioning.get(versioning);
     const matchCurrentVersionStr = matchCurrentVersion.toString();
     const matchCurrentVersionPred = configRegexPredicate(
       matchCurrentVersionStr
     );
     if (matchCurrentVersionPred) {
-      if (!unconstrainedValue && !matchCurrentVersionPred(currentValue)) {
+      if (
+        !unconstrainedValue &&
+        (!currentValue || !matchCurrentVersionPred(currentValue))
+      ) {
         return false;
       }
       positiveMatch = true;
@@ -237,7 +254,8 @@ function matchesRule(
       try {
         isMatch =
           unconstrainedValue ||
-          version.matches(matchCurrentVersionStr, currentValue);
+          (currentValue &&
+            version.matches(matchCurrentVersionStr, currentValue));
       } catch (err) {
         // Do nothing
       }

--- a/lib/util/package-rules.ts
+++ b/lib/util/package-rules.ts
@@ -254,8 +254,10 @@ function matchesRule(
       try {
         isMatch =
           unconstrainedValue ||
-          (currentValue &&
-            version.matches(matchCurrentVersionStr, currentValue));
+          !!(
+            currentValue &&
+            version.matches(matchCurrentVersionStr, currentValue)
+          );
       } catch (err) {
         // Do nothing
       }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Fixes packageRules logic so that rules can't match if the field to match is missing or empty.

## Context

Closes #15342,
Closes #15323

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
