### PR TITLE
test(manager/nuget): add tests covering more complex project references

### DIFF
--- a/lib/modules/manager/nuget/__fixtures__/three-two-linear-references/one/one.csproj
+++ b/lib/modules/manager/nuget/__fixtures__/three-two-linear-references/one/one.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Serilog" Version="2.11.0" />
+  </ItemGroup>
+
+</Project>

--- a/lib/modules/manager/nuget/__fixtures__/three-two-linear-references/one/packages.lock.json
+++ b/lib/modules/manager/nuget/__fixtures__/three-two-linear-references/one/packages.lock.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net6.0": {
+      "Serilog": {
+        "type": "Direct",
+        "requested": "[2.11.0, )",
+        "resolved": "2.11.0",
+        "contentHash": "ysv+hBzTul6Dp+Hvm10FlhJO3yMQcFKSAleus+LpiIzvNstpeV4Z7gGuIZ1OPNfIMulSHOjmLuGAEDKzpnV8ZQ=="
+      }
+    }
+  }
+}

--- a/lib/modules/manager/nuget/__fixtures__/three-two-linear-references/three/packages.lock.json
+++ b/lib/modules/manager/nuget/__fixtures__/three-two-linear-references/three/packages.lock.json
@@ -1,0 +1,26 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net6.0": {
+      "Serilog": {
+        "type": "Direct",
+        "requested": "[2.11.0, )",
+        "resolved": "2.11.0",
+        "contentHash": "ysv+hBzTul6Dp+Hvm10FlhJO3yMQcFKSAleus+LpiIzvNstpeV4Z7gGuIZ1OPNfIMulSHOjmLuGAEDKzpnV8ZQ=="
+      },
+      "one": {
+        "type": "Project",
+        "dependencies": {
+          "Serilog": "2.11.0"
+        }
+      },
+      "two": {
+        "type": "Project",
+        "dependencies": {
+          "Serilog": "2.11.0",
+          "one": "1.0.0"
+        }
+      }
+    }
+  }
+}

--- a/lib/modules/manager/nuget/__fixtures__/three-two-linear-references/three/three.csproj
+++ b/lib/modules/manager/nuget/__fixtures__/three-two-linear-references/three/three.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Serilog" Version="2.11.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../two/two.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/lib/modules/manager/nuget/__fixtures__/three-two-linear-references/two/packages.lock.json
+++ b/lib/modules/manager/nuget/__fixtures__/three-two-linear-references/two/packages.lock.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net6.0": {
+      "Serilog": {
+        "type": "Direct",
+        "requested": "[2.11.0, )",
+        "resolved": "2.11.0",
+        "contentHash": "ysv+hBzTul6Dp+Hvm10FlhJO3yMQcFKSAleus+LpiIzvNstpeV4Z7gGuIZ1OPNfIMulSHOjmLuGAEDKzpnV8ZQ=="
+      },
+      "one": {
+        "type": "Project",
+        "dependencies": {
+          "Serilog": "2.11.0"
+        }
+      }
+    }
+  }
+}

--- a/lib/modules/manager/nuget/__fixtures__/three-two-linear-references/two/two.csproj
+++ b/lib/modules/manager/nuget/__fixtures__/three-two-linear-references/two/two.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Serilog" Version="2.11.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../one/one.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/lib/modules/manager/nuget/__fixtures__/three-two-treelike-references/one/one.csproj
+++ b/lib/modules/manager/nuget/__fixtures__/three-two-treelike-references/one/one.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Serilog" Version="2.11.0" />
+  </ItemGroup>
+
+</Project>

--- a/lib/modules/manager/nuget/__fixtures__/three-two-treelike-references/one/packages.lock.json
+++ b/lib/modules/manager/nuget/__fixtures__/three-two-treelike-references/one/packages.lock.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net6.0": {
+      "Serilog": {
+        "type": "Direct",
+        "requested": "[2.11.0, )",
+        "resolved": "2.11.0",
+        "contentHash": "ysv+hBzTul6Dp+Hvm10FlhJO3yMQcFKSAleus+LpiIzvNstpeV4Z7gGuIZ1OPNfIMulSHOjmLuGAEDKzpnV8ZQ=="
+      }
+    }
+  }
+}

--- a/lib/modules/manager/nuget/__fixtures__/three-two-treelike-references/three/packages.lock.json
+++ b/lib/modules/manager/nuget/__fixtures__/three-two-treelike-references/three/packages.lock.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net6.0": {
+      "Serilog": {
+        "type": "Direct",
+        "requested": "[2.11.0, )",
+        "resolved": "2.11.0",
+        "contentHash": "ysv+hBzTul6Dp+Hvm10FlhJO3yMQcFKSAleus+LpiIzvNstpeV4Z7gGuIZ1OPNfIMulSHOjmLuGAEDKzpnV8ZQ=="
+      },
+      "one": {
+        "type": "Project",
+        "dependencies": {
+          "Serilog": "2.11.0"
+        }
+      }
+    }
+  }
+}

--- a/lib/modules/manager/nuget/__fixtures__/three-two-treelike-references/three/three.csproj
+++ b/lib/modules/manager/nuget/__fixtures__/three-two-treelike-references/three/three.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Serilog" Version="2.11.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../one/one.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/lib/modules/manager/nuget/__fixtures__/three-two-treelike-references/two/packages.lock.json
+++ b/lib/modules/manager/nuget/__fixtures__/three-two-treelike-references/two/packages.lock.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net6.0": {
+      "Serilog": {
+        "type": "Direct",
+        "requested": "[2.11.0, )",
+        "resolved": "2.11.0",
+        "contentHash": "ysv+hBzTul6Dp+Hvm10FlhJO3yMQcFKSAleus+LpiIzvNstpeV4Z7gGuIZ1OPNfIMulSHOjmLuGAEDKzpnV8ZQ=="
+      },
+      "one": {
+        "type": "Project",
+        "dependencies": {
+          "Serilog": "2.11.0"
+        }
+      }
+    }
+  }
+}

--- a/lib/modules/manager/nuget/__fixtures__/three-two-treelike-references/two/two.csproj
+++ b/lib/modules/manager/nuget/__fixtures__/three-two-treelike-references/two/two.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Serilog" Version="2.11.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../one/one.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/lib/modules/manager/nuget/package-tree.spec.ts
+++ b/lib/modules/manager/nuget/package-tree.spec.ts
@@ -63,6 +63,55 @@ describe('modules/manager/nuget/package-tree', () => {
       ]);
     });
 
+    it('returns two projects for three projects with two linear references', async () => {
+      git.getFileList.mockResolvedValue(['one/one.csproj', 'two/two.csproj', 'three/three.csproj']);
+      Fixtures.mock({
+        '/tmp/repo/one/one.csproj': Fixtures.get(
+          'three-two-linear-references/one/one.csproj'
+        ),
+        '/tmp/repo/two/two.csproj': Fixtures.get(
+          'three-two-linear-references/two/two.csproj'
+        ),
+        '/tmp/repo/three/three.csproj': Fixtures.get(
+          'three-two-linear-references/three/three.csproj'
+        ),
+      });
+
+      expect(await getDependentPackageFiles('one/one.csproj')).toEqual([
+        'two/two.csproj',
+        'three/three.csproj',
+      ]);
+
+      expect(await getDependentPackageFiles('two/two.csproj')).toEqual([
+        'three/three.csproj',
+      ]);
+
+      expect(await getDependentPackageFiles('three/three.csproj')).toEqual([]);
+    });
+
+    it('returns two projects for three projects with two tree-like references', async () => {
+      git.getFileList.mockResolvedValue(['one/one.csproj', 'two/two.csproj', 'three/three.csproj']);
+      Fixtures.mock({
+        '/tmp/repo/one/one.csproj': Fixtures.get(
+          'three-two-treelike-references/one/one.csproj'
+        ),
+        '/tmp/repo/two/two.csproj': Fixtures.get(
+          'three-two-treelike-references/two/two.csproj'
+        ),
+        '/tmp/repo/three/three.csproj': Fixtures.get(
+          'three-two-treelike-references/three/three.csproj'
+        ),
+      });
+
+      expect(await getDependentPackageFiles('one/one.csproj')).toEqual([
+        'two/two.csproj',
+        'three/three.csproj',
+      ]);
+
+      expect(await getDependentPackageFiles('two/two.csproj')).toEqual([]);
+      expect(await getDependentPackageFiles('three/three.csproj')).toEqual([]);
+    });
+
     it('throws error on circular reference', async () => {
       git.getFileList.mockResolvedValue(['one/one.csproj', 'two/two.csproj']);
       Fixtures.mock({

--- a/lib/modules/manager/nuget/package-tree.spec.ts
+++ b/lib/modules/manager/nuget/package-tree.spec.ts
@@ -64,7 +64,11 @@ describe('modules/manager/nuget/package-tree', () => {
     });
 
     it('returns two projects for three projects with two linear references', async () => {
-      git.getFileList.mockResolvedValue(['one/one.csproj', 'two/two.csproj', 'three/three.csproj']);
+      git.getFileList.mockResolvedValue([
+        'one/one.csproj',
+        'two/two.csproj',
+        'three/three.csproj',
+      ]);
       Fixtures.mock({
         '/tmp/repo/one/one.csproj': Fixtures.get(
           'three-two-linear-references/one/one.csproj'
@@ -90,7 +94,11 @@ describe('modules/manager/nuget/package-tree', () => {
     });
 
     it('returns two projects for three projects with two tree-like references', async () => {
-      git.getFileList.mockResolvedValue(['one/one.csproj', 'two/two.csproj', 'three/three.csproj']);
+      git.getFileList.mockResolvedValue([
+        'one/one.csproj',
+        'two/two.csproj',
+        'three/three.csproj',
+      ]);
       Fixtures.mock({
         '/tmp/repo/one/one.csproj': Fixtures.get(
           'three-two-treelike-references/one/one.csproj'


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds various test cases to the NuGet package tree resolver.

## Context

I'm hunting down a bug where lockfiles for more complex project layouts are not updated. \
Figured I might as well write some tests to validate certain chunks of behavior.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
