### PR TITLE
fix(github): Use long pages for initial PR lsit fetch

### DIFF
--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -583,8 +583,8 @@ describe('modules/platform/github/index', () => {
       updated_at: t3,
     };
 
-    const pagePath = (x: number) =>
-      `/repos/some/repo/pulls?per_page=20&state=all&sort=updated&direction=desc&page=${x}`;
+    const pagePath = (x: number, perPage = 100) =>
+      `/repos/some/repo/pulls?per_page=${perPage}&state=all&sort=updated&direction=desc&page=${x}`;
     const pageLink = (x: number) =>
       `<${githubApiHost}${pagePath(x)}>; rel="next"`;
 
@@ -637,15 +637,15 @@ describe('modules/platform/github/index', () => {
       const res1 = await github.getPrList();
 
       scope
-        .get(pagePath(1))
+        .get(pagePath(1, 20))
         .reply(200, [{ ...pr3, updated_at: t4, title: 'PR #3 (updated)' }], {
           link: `${pageLink(2)}`,
         })
-        .get(pagePath(2))
+        .get(pagePath(2, 20))
         .reply(200, [{ ...pr2, updated_at: t4, title: 'PR #2 (updated)' }], {
           link: `${pageLink(3)}`,
         })
-        .get(pagePath(3))
+        .get(pagePath(3, 20))
         .reply(200, [{ ...pr1, updated_at: t4, title: 'PR #1 (updated)' }]);
 
       await github.initRepo({ repository: 'some/repo' } as never);
@@ -692,7 +692,7 @@ describe('modules/platform/github/index', () => {
     it('removes url data from existing cache', async () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
-      scope.get(pagePath(1)).reply(200, [
+      scope.get(pagePath(1, 20)).reply(200, [
         {
           ...pr1,
           url: 'https://example.com',
@@ -731,7 +731,7 @@ describe('modules/platform/github/index', () => {
       initRepoMock(scope, 'some/repo');
       scope
         .get(
-          '/repos/some/repo/pulls?per_page=20&state=all&sort=updated&direction=desc&page=1'
+          '/repos/some/repo/pulls?per_page=100&state=all&sort=updated&direction=desc&page=1'
         )
         .reply(200, []);
 
@@ -747,7 +747,7 @@ describe('modules/platform/github/index', () => {
       initRepoMock(scope, 'some/repo');
       scope
         .get(
-          '/repos/some/repo/pulls?per_page=20&state=all&sort=updated&direction=desc&page=1'
+          '/repos/some/repo/pulls?per_page=100&state=all&sort=updated&direction=desc&page=1'
         )
         .reply(200, [
           {
@@ -780,7 +780,7 @@ describe('modules/platform/github/index', () => {
       initRepoMock(scope, 'some/repo');
       scope
         .get(
-          '/repos/some/repo/pulls?per_page=20&state=all&sort=updated&direction=desc&page=1'
+          '/repos/some/repo/pulls?per_page=100&state=all&sort=updated&direction=desc&page=1'
         )
         .reply(200, [
           {
@@ -822,7 +822,7 @@ describe('modules/platform/github/index', () => {
       initRepoMock(scope, 'some/repo');
       scope
         .get(
-          '/repos/some/repo/pulls?per_page=20&state=all&sort=updated&direction=desc&page=1'
+          '/repos/some/repo/pulls?per_page=100&state=all&sort=updated&direction=desc&page=1'
         )
         .reply(200, [
           {
@@ -851,7 +851,7 @@ describe('modules/platform/github/index', () => {
       initRepoMock(scope, 'some/repo');
       scope
         .get(
-          '/repos/some/repo/pulls?per_page=20&state=all&sort=updated&direction=desc&page=1'
+          '/repos/some/repo/pulls?per_page=100&state=all&sort=updated&direction=desc&page=1'
         )
         .reply(200, [
           {
@@ -879,7 +879,7 @@ describe('modules/platform/github/index', () => {
       initRepoMock(scope, 'some/repo');
       scope
         .get(
-          '/repos/some/repo/pulls?per_page=20&state=all&sort=updated&direction=desc&page=1'
+          '/repos/some/repo/pulls?per_page=100&state=all&sort=updated&direction=desc&page=1'
         )
         .reply(200, [
           {
@@ -907,7 +907,7 @@ describe('modules/platform/github/index', () => {
         .patch('/repos/forked/repo/git/refs/heads/master')
         .reply(200)
         .get(
-          '/repos/some/repo/pulls?per_page=20&state=all&sort=updated&direction=desc&page=1'
+          '/repos/some/repo/pulls?per_page=100&state=all&sort=updated&direction=desc&page=1'
         )
         .reply(200, [
           {
@@ -1993,7 +1993,7 @@ describe('modules/platform/github/index', () => {
       const scope = httpMock
         .scope(githubApiHost)
         .get(
-          '/repos/some/repo/pulls?per_page=20&state=all&sort=updated&direction=desc&page=1'
+          '/repos/some/repo/pulls?per_page=100&state=all&sort=updated&direction=desc&page=1'
         )
         .reply(200, [
           {
@@ -2035,7 +2035,7 @@ describe('modules/platform/github/index', () => {
       initRepoMock(scope, 'some/repo');
       scope
         .get(
-          '/repos/some/repo/pulls?per_page=20&state=all&sort=updated&direction=desc&page=1'
+          '/repos/some/repo/pulls?per_page=100&state=all&sort=updated&direction=desc&page=1'
         )
         .reply(200, [
           {
@@ -2059,7 +2059,7 @@ describe('modules/platform/github/index', () => {
       initRepoMock(scope, 'some/repo');
       scope
         .get(
-          '/repos/some/repo/pulls?per_page=20&state=all&sort=updated&direction=desc&page=1'
+          '/repos/some/repo/pulls?per_page=100&state=all&sort=updated&direction=desc&page=1'
         )
         .reply(200, [
           {
@@ -2310,7 +2310,7 @@ describe('modules/platform/github/index', () => {
       initRepoMock(scope, 'some/repo');
       scope
         .get(
-          '/repos/some/repo/pulls?per_page=20&state=all&sort=updated&direction=desc&page=1'
+          '/repos/some/repo/pulls?per_page=100&state=all&sort=updated&direction=desc&page=1'
         )
         .reply(200, [
           {
@@ -2345,7 +2345,7 @@ describe('modules/platform/github/index', () => {
       initRepoMock(scope, 'some/repo');
       scope
         .get(
-          '/repos/some/repo/pulls?per_page=20&state=all&sort=updated&direction=desc&page=1'
+          '/repos/some/repo/pulls?per_page=100&state=all&sort=updated&direction=desc&page=1'
         )
         .reply(200, [
           {
@@ -2370,7 +2370,7 @@ describe('modules/platform/github/index', () => {
       initRepoMock(scope, 'some/repo');
       scope
         .get(
-          '/repos/some/repo/pulls?per_page=20&state=all&sort=updated&direction=desc&page=1'
+          '/repos/some/repo/pulls?per_page=100&state=all&sort=updated&direction=desc&page=1'
         )
         .reply(200, [
           {
@@ -2396,7 +2396,7 @@ describe('modules/platform/github/index', () => {
       initRepoMock(scope, 'some/repo');
       scope
         .get(
-          '/repos/some/repo/pulls?per_page=20&state=all&sort=updated&direction=desc&page=1'
+          '/repos/some/repo/pulls?per_page=100&state=all&sort=updated&direction=desc&page=1'
         )
         .reply(200, [])
         .get('/repos/some/repo/pulls/1234')
@@ -2411,7 +2411,7 @@ describe('modules/platform/github/index', () => {
       initRepoMock(scope, 'some/repo');
       scope
         .get(
-          '/repos/some/repo/pulls?per_page=20&state=all&sort=updated&direction=desc&page=1'
+          '/repos/some/repo/pulls?per_page=100&state=all&sort=updated&direction=desc&page=1'
         )
         .reply(200, [])
         .get('/repos/some/repo/pulls/1234')
@@ -2439,7 +2439,7 @@ describe('modules/platform/github/index', () => {
       initRepoMock(scope, 'some/repo');
       scope
         .get(
-          '/repos/some/repo/pulls?per_page=20&state=all&sort=updated&direction=desc&page=1'
+          '/repos/some/repo/pulls?per_page=100&state=all&sort=updated&direction=desc&page=1'
         )
         .reply(200, [])
         .get('/repos/some/repo/pulls/1234')
@@ -2467,7 +2467,7 @@ describe('modules/platform/github/index', () => {
       initRepoMock(scope, 'some/repo');
       scope
         .get(
-          '/repos/some/repo/pulls?per_page=20&state=all&sort=updated&direction=desc&page=1'
+          '/repos/some/repo/pulls?per_page=100&state=all&sort=updated&direction=desc&page=1'
         )
         .reply(200, [])
         .get('/repos/some/repo/pulls/1234')
@@ -2525,7 +2525,7 @@ describe('modules/platform/github/index', () => {
       initRepoMock(scope, 'some/repo');
       scope
         .get(
-          '/repos/some/repo/pulls?per_page=20&state=all&sort=updated&direction=desc&page=1'
+          '/repos/some/repo/pulls?per_page=100&state=all&sort=updated&direction=desc&page=1'
         )
         .reply(200, [
           {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Initial fetching with page size of 20 is the bug, this PR fixes it.

## Context

- Ref: #15280

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
