### PR TITLE
fix: new Sharp package changelog location

### DIFF
--- a/lib/modules/datasource/metadata-manual.ts
+++ b/lib/modules/datasource/metadata-manual.ts
@@ -10,7 +10,7 @@ export const manualChangelogUrls: Record<string, Record<string, string>> = {
       'https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/CHANGELOG.md',
     'react-native':
       'https://github.com/react-native-community/react-native-releases/blob/master/CHANGELOG.md',
-    sharp: 'https://github.com/lovell/sharp/blob/master/docs/changelog.md',
+    sharp: 'https://github.com/lovell/sharp/blob/main/docs/changelog.md',
     'tailwindcss-classnames':
       'https://github.com/muhammadsammy/tailwindcss-classnames/blob/master/CHANGELOG.md',
     'zone.js':


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Update Sharp changelog location in `manualChangelogUrls`

## Context

Sharp have updated their main branch from `master` to `main`

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
