### PR TITLE
fix(manager:npm): support yarn-path in repo sub-dir

### DIFF
--- a/lib/modules/manager/npm/post-update/yarn.spec.ts
+++ b/lib/modules/manager/npm/post-update/yarn.spec.ts
@@ -298,7 +298,21 @@ describe('modules/manager/npm/post-update/yarn', () => {
       GlobalConfig.set({ localDir: '/tmp/renovate' });
       expect(await yarnHelper.checkYarnrc('.')).toEqual({
         offlineMirror: true,
-        yarnPath: './.yarn/cli.js',
+        yarnPath: '.yarn/cli.js',
+      });
+    });
+
+    it('returns yarn path in subdir', async () => {
+      Fixtures.mock(
+        {
+          '.yarn/cli.js': '',
+          '.yarnrc': 'yarn-path "./.yarn/cli.js"\n',
+        },
+        'some-dir'
+      );
+      expect(await yarnHelper.checkYarnrc('some-dir')).toEqual({
+        offlineMirror: false,
+        yarnPath: 'some-dir/.yarn/cli.js',
       });
     });
 

--- a/lib/modules/manager/npm/post-update/yarn.ts
+++ b/lib/modules/manager/npm/post-update/yarn.ts
@@ -45,6 +45,10 @@ export async function checkYarnrc(
       if (pathLine) {
         yarnPath = pathLine.replace(regEx(/^yarn-path\s+"?(.+?)"?$/), '$1');
       }
+      if (yarnPath) {
+        // resolve binary relative to `yarnrc`
+        yarnPath = upath.join(lockFileDir, yarnPath);
+      }
       const yarnBinaryExists = yarnPath
         ? await localPathIsFile(yarnPath)
         : false;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- resolve `yarn-path` relative to `.yarnrc`
<!-- Describe what behavior is changed by this PR. -->

## Context
- found in #15414
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
