### PR TITLE
fix(manager:npm): patch local yarn v1 binary

### DIFF
--- a/lib/modules/datasource/clojure/index.spec.ts
+++ b/lib/modules/datasource/clojure/index.spec.ts
@@ -95,7 +95,7 @@ function mockGenericPackage(opts: MockOpts = {}) {
         .map((x) => parseInt(x, 10))
         .map((x) => (x < 10 ? `0${x}` : `${x}`));
       const timestamp = `2020-01-01T${major}:${minor}:${patch}.000Z`;
-      const headers = version.startsWith('0.')
+      const headers: httpMock.ReplyHeaders = version.startsWith('0.')
         ? {}
         : { 'Last-Modified': timestamp };
       scope
@@ -237,7 +237,6 @@ describe('modules/datasource/clojure/index', () => {
     const { releases } = await get(
       'org.example:package',
       'ftp://protocol_error_repo',
-      's3://protocol_error_repo',
       base
     );
 

--- a/lib/modules/datasource/maven/index.spec.ts
+++ b/lib/modules/datasource/maven/index.spec.ts
@@ -96,7 +96,7 @@ function mockGenericPackage(opts: MockOpts = {}) {
         .map((x) => parseInt(x, 10))
         .map((x) => (x < 10 ? `0${x}` : `${x}`));
       const timestamp = `2020-01-01T${major}:${minor}:${patch}.000Z`;
-      const headers = version.startsWith('0.')
+      const headers: httpMock.ReplyHeaders = version.startsWith('0.')
         ? {}
         : { 'Last-Modified': timestamp };
       scope
@@ -297,7 +297,6 @@ describe('modules/datasource/maven/index', () => {
     const { releases } = await get(
       'org.example:package',
       'ftp://protocol_error_repo',
-      's3://protocol_error_repo',
       base
     );
 

--- a/lib/modules/manager/flux/artifacts.spec.ts
+++ b/lib/modules/manager/flux/artifacts.spec.ts
@@ -29,7 +29,7 @@ describe('modules/manager/flux/artifacts', () => {
           },
         },
       ],
-      newPackageFileContent: undefined,
+      newPackageFileContent: '',
       config: {},
     });
 
@@ -42,16 +42,18 @@ describe('modules/manager/flux/artifacts', () => {
         },
       },
     ]);
-    expect(snapshots[0].cmd).toBe(
-      'flux install --export --components source-controller,kustomize-controller,helm-controller,notification-controller > clusters/my-cluster/flux-system/gotk-components.yaml'
-    );
+    expect(snapshots).toMatchObject([
+      {
+        cmd: 'flux install --export --components source-controller,kustomize-controller,helm-controller,notification-controller > clusters/my-cluster/flux-system/gotk-components.yaml',
+      },
+    ]);
   });
 
   it('ignores non-system manifests', async () => {
     const res = await updateArtifacts({
       packageFileName: 'not-a-system-manifest.yaml',
       updatedDeps: [{ newVersion: '1.0.1' }],
-      newPackageFileContent: undefined,
+      newPackageFileContent: '',
       config: {},
     });
 
@@ -59,23 +61,29 @@ describe('modules/manager/flux/artifacts', () => {
   });
 
   it('ignores unchanged system manifests', async () => {
+    const execSnapshots = mockExecAll(exec, { stdout: '', stderr: '' });
     fs.readLocalFile.mockResolvedValueOnce('old');
     fs.readLocalFile.mockResolvedValueOnce('old');
     const res = await updateArtifacts({
       packageFileName: 'clusters/my-cluster/flux-system/gotk-components.yaml',
       updatedDeps: [{ newVersion: '1.0.1' }],
-      newPackageFileContent: undefined,
+      newPackageFileContent: '',
       config: {},
     });
 
     expect(res).toBeNull();
+    expect(execSnapshots).toMatchObject([
+      {
+        cmd: 'flux install --export > clusters/my-cluster/flux-system/gotk-components.yaml',
+      },
+    ]);
   });
 
   it('ignores system manifests without a new version', async () => {
     const res = await updateArtifacts({
       packageFileName: 'clusters/my-cluster/flux-system/gotk-components.yaml',
       updatedDeps: [{ newVersion: undefined }],
-      newPackageFileContent: undefined,
+      newPackageFileContent: '',
       config: {},
     });
 
@@ -87,7 +95,7 @@ describe('modules/manager/flux/artifacts', () => {
     const res = await updateArtifacts({
       packageFileName: 'clusters/my-cluster/flux-system/gotk-components.yaml',
       updatedDeps: [{ newVersion: '1.0.1' }],
-      newPackageFileContent: undefined,
+      newPackageFileContent: '',
       config: {},
     });
 
@@ -108,7 +116,7 @@ describe('modules/manager/flux/artifacts', () => {
     const res = await updateArtifacts({
       packageFileName: 'clusters/my-cluster/flux-system/gotk-components.yaml',
       updatedDeps: [{ newVersion: '1.0.1' }],
-      newPackageFileContent: undefined,
+      newPackageFileContent: '',
       config: {},
     });
 

--- a/lib/modules/manager/npm/post-update/yarn.spec.ts
+++ b/lib/modules/manager/npm/post-update/yarn.spec.ts
@@ -9,6 +9,7 @@ import {
 import { Fixtures } from '../../../../../test/fixtures';
 import { env, mockedFunction, partial } from '../../../../../test/util';
 import { GlobalConfig } from '../../../../config/global';
+import * as docker from '../../../../util/exec/docker';
 import { getPkgReleases } from '../../../datasource';
 import type { PostUpdateConfig } from '../../types';
 import type { NpmManagerData } from '../types';
@@ -34,14 +35,16 @@ const fixSnapshots = (snapshots: ExecSnapshots): ExecSnapshots =>
 const plocktest1PackageJson = Fixtures.get('plocktest1/package.json', '..');
 const plocktest1YarnLockV1 = Fixtures.get('plocktest1/yarn.lock', '..');
 
+jest.spyOn(docker, 'removeDockerContainer').mockResolvedValue();
+env.getChildProcessEnv.mockReturnValue(envMock.basic);
+
 describe('modules/manager/npm/post-update/yarn', () => {
   beforeEach(() => {
-    Fixtures.reset();
-    jest.clearAllMocks();
-    jest.resetModules();
-    env.getChildProcessEnv.mockReturnValue(envMock.basic);
-    GlobalConfig.set({ localDir: '.' });
     delete process.env.BUILDPACK;
+    jest.clearAllMocks();
+    Fixtures.reset();
+    docker.resetPrefetchedImages();
+    GlobalConfig.set({ localDir: '.' });
   });
 
   it.each([
@@ -369,11 +372,11 @@ describe('modules/manager/npm/post-update/yarn', () => {
     ]);
   });
 
-  it('patches local yarn (docker)', async () => {
+  it('patches local yarn', async () => {
     // sanity check for later refactorings
     expect(plocktest1YarnLockV1).toBeTruthy();
     expect(plocktest1PackageJson).toBeTruthy();
-    GlobalConfig.set({ localDir: '.', binarySource: 'docker' });
+    GlobalConfig.set({ localDir: '.' });
     Fixtures.mock(
       {
         'package.json': plocktest1PackageJson,
@@ -394,10 +397,43 @@ describe('modules/manager/npm/post-update/yarn', () => {
     const config = partial<PostUpdateConfig<NpmManagerData>>({});
     const res = await yarnHelper.generateLockFile('some-dir', {}, config);
     expect(res.lockFile).toBe(plocktest1YarnLockV1);
+    const options = { encoding: 'utf-8', cwd: 'some-dir' };
+    expect(execSnapshots).toMatchObject([
+      {
+        cmd: `sed -i 's/ steps,/ steps.slice(0,1),/' some-dir/.yarn/cli.js || true`,
+        options,
+      },
+      {
+        cmd: 'yarn install --ignore-engines --ignore-platform --network-timeout 100000 --ignore-scripts',
+        options,
+      },
+    ]);
+  });
+
+  it('patches local yarn (docker)', async () => {
+    // sanity check for later refactorings
+    expect(plocktest1YarnLockV1).toBeTruthy();
+    expect(plocktest1PackageJson).toBeTruthy();
+    GlobalConfig.set({ localDir: '.', binarySource: 'docker' });
+    Fixtures.mock(
+      {
+        'package.json': plocktest1PackageJson,
+        '.yarn/cli.js': '',
+        'yarn.lock': plocktest1YarnLockV1,
+        '.yarnrc': 'yarn-path ./.yarn/cli.js\n',
+      },
+      'some-dir'
+    );
+    mockedFunction(getPkgReleases).mockResolvedValueOnce({
+      releases: [{ version: '1.22.18' }],
+    });
+    const execSnapshots = mockExecAll(exec, { stdout: '', stderr: '' });
+    const config = partial<PostUpdateConfig<NpmManagerData>>({});
+    const res = await yarnHelper.generateLockFile('some-dir', {}, config);
+    expect(res.lockFile).toBe(plocktest1YarnLockV1);
     const options = { encoding: 'utf-8' };
     expect(execSnapshots).toMatchObject([
       { cmd: 'docker pull renovate/node', options },
-      { cmd: 'docker ps --filter name=renovate_node -aq', options },
       {
         cmd:
           `docker run --rm --name=renovate_node --label=renovate_child -v ".":"." -e CI -w "some-dir" renovate/node ` +

--- a/lib/modules/manager/npm/post-update/yarn.ts
+++ b/lib/modules/manager/npm/post-update/yarn.ts
@@ -141,7 +141,7 @@ export async function generateLockFile(
           // The following change causes Yarn 1.x to exit gracefully after updating the lock file but without installing node_modules
           yarnTool.toolName = 'yarn-slim';
           if (yarnPath) {
-            preCommands.push(getOptimizeCommand(yarnPath) + ' || true');
+            commands.push(getOptimizeCommand(yarnPath) + ' || true');
           }
         }
       } else if (isYarnModeAvailable) {

--- a/test/exec-util.ts
+++ b/test/exec-util.ts
@@ -9,6 +9,7 @@ type CallOptions = ExecOptions | null | undefined;
 
 export type ExecResult = { stdout: string; stderr: string } | Error;
 
+// TODO: fix type #7154
 export type ExecMock = jest.Mock<typeof _exec>;
 export const exec: ExecMock = _exec as any;
 
@@ -99,3 +100,9 @@ export const envMock = {
   full: fullEnvMock,
   filtered: filteredEnvMock,
 };
+
+// reset exec mock, otherwise there can be some left over from previous test
+beforeEach(() => {
+  // maybe not mocked
+  exec.mockReset?.();
+});


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- always patch local yarn v1 binary when required to speedup run
- other test changes are somehow related to the exec mock change
- some strict null check fixes
<!-- Describe what behavior is changed by this PR. -->

## Context
- found in #15414
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
