### PR TITLE
feat(pnpm): detect v7 support when updating lock file

### DIFF
--- a/lib/modules/manager/npm/post-update/pnpm.spec.ts
+++ b/lib/modules/manager/npm/post-update/pnpm.spec.ts
@@ -165,11 +165,17 @@ describe('modules/manager/npm/post-update/pnpm', () => {
   });
 
   it('uses skips pnpm v7 if lockfileVersion indicates <7', async () => {
-    fs.readLocalFile.mockResolvedValueOnce('{}'); // package.json
-    fs.readLocalFile.mockResolvedValueOnce('lockfileVersion: 5.3\n'); // pnpm-lock.yaml
-    fs.readLocalFile.mockResolvedValueOnce('lockfileVersion: 5.3\n'); // pnpm-lock.yaml
-    delete config.constraints.pnpm;
-    const res = await pnpmHelper.generateLockFile('some-folder', {}, config);
+    mockExecAll(exec);
+    const configTemp = partial<PostUpdateConfig>({});
+    fs.readLocalFile
+      .mockResolvedValueOnce('{}') // package.json
+      .mockResolvedValue('lockfileVersion: 5.3\n'); // pnpm-lock.yaml
+    const res = await pnpmHelper.generateLockFile(
+      'some-folder',
+      {},
+      configTemp,
+      []
+    );
     expect(fs.readLocalFile).toHaveBeenCalledTimes(3);
     expect(res.lockFile).toBe('lockfileVersion: 5.3\n');
   });

--- a/lib/modules/manager/npm/post-update/pnpm.spec.ts
+++ b/lib/modules/manager/npm/post-update/pnpm.spec.ts
@@ -163,4 +163,14 @@ describe('modules/manager/npm/post-update/pnpm', () => {
       },
     ]);
   });
+
+  it('uses skips pnpm v7 if lockfileVersion indicates <7', async () => {
+    fs.readLocalFile.mockResolvedValueOnce('{}'); // package.json
+    fs.readLocalFile.mockResolvedValueOnce('lockfileVersion: 5.3\n'); // pnpm-lock.yaml
+    fs.readLocalFile.mockResolvedValueOnce('lockfileVersion: 5.3\n'); // pnpm-lock.yaml
+    delete config.constraints.pnpm;
+    const res = await pnpmHelper.generateLockFile('some-folder', {}, config);
+    expect(fs.readLocalFile).toHaveBeenCalledTimes(3);
+    expect(res.lockFile).toBe('lockfileVersion: 5.3\n');
+  });
 });

--- a/lib/modules/manager/npm/post-update/pnpm.ts
+++ b/lib/modules/manager/npm/post-update/pnpm.ts
@@ -123,7 +123,7 @@ async function getPnpmContraint(
     const lockFileName = upath.join(lockFileDir, 'pnpm-lock.yaml');
     const content = await readLocalFile(lockFileName, 'utf8');
     if (content) {
-      const pnpmLock: PnpmLockFile = load(content);
+      const pnpmLock = load(content) as PnpmLockFile;
       if (
         is.number(pnpmLock.lockfileVersion) &&
         pnpmLock.lockfileVersion < 5.4

--- a/lib/modules/manager/npm/post-update/pnpm.ts
+++ b/lib/modules/manager/npm/post-update/pnpm.ts
@@ -1,3 +1,5 @@
+import is from '@sindresorhus/is';
+import { load } from 'js-yaml';
 import upath from 'upath';
 import { GlobalConfig } from '../../../../config/global';
 import { TEMPORARY_ERROR } from '../../../../constants/error-messages';
@@ -12,7 +14,7 @@ import { deleteLocalFile, readLocalFile } from '../../../../util/fs';
 import type { PostUpdateConfig, Upgrade } from '../../types';
 import type { NpmPackage } from '../extract/types';
 import { getNodeConstraint } from './node-version';
-import type { GenerateLockFileResult } from './types';
+import type { GenerateLockFileResult, PnpmLockFile } from './types';
 
 export async function generateLockFile(
   lockFileDir: string,
@@ -114,6 +116,19 @@ async function getPnpmContraint(
       const engines = packageJson?.engines;
       if (engines) {
         result = engines['pnpm'];
+      }
+    }
+  }
+  if (!result) {
+    const lockFileName = upath.join(lockFileDir, 'pnpm-lock.yaml');
+    const content = await readLocalFile(lockFileName, 'utf8');
+    if (content) {
+      const pnpmLock: PnpmLockFile = load(content);
+      if (
+        is.number(pnpmLock.lockfileVersion) &&
+        pnpmLock.lockfileVersion < 5.4
+      ) {
+        result = '<7';
       }
     }
   }

--- a/lib/modules/manager/npm/post-update/types.ts
+++ b/lib/modules/manager/npm/post-update/types.ts
@@ -28,3 +28,7 @@ export interface GenerateLockFileResult {
   stderr?: string;
   stdout?: string;
 }
+
+export interface PnpmLockFile {
+  lockfileVersion?: number;
+}


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

If no constraints are specified, Renovate will look at the `lockfileVersion` to determine if pnpm v7 should be used or not.

## Context

Closes #15469

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
