### PR TITLE
fix: respect latest when selecting tool versions

### DIFF
--- a/lib/util/exec/buildpack.ts
+++ b/lib/util/exec/buildpack.ts
@@ -142,7 +142,7 @@ export async function resolveConstraint(
   const pkgReleases = await getPkgReleases(toolConfig);
   const releases = pkgReleases?.releases ?? [];
 
-  if (!releases.length) {
+  if (!releases?.length) {
     throw new Error('No tool releases found.');
   }
 
@@ -180,7 +180,7 @@ export async function resolveConstraint(
     );
   }
 
-  const highestVersion = releases.pop().version;
+  const highestVersion = releases.pop()?.version;
   logger.warn(
     { toolName, constraint, highestVersion },
     'No matching or stable tool versions found - using an unstable version'

--- a/lib/util/exec/buildpack.ts
+++ b/lib/util/exec/buildpack.ts
@@ -1,3 +1,4 @@
+import is from '@sindresorhus/is';
 import { quote } from 'shlex';
 import { GlobalConfig } from '../../config/global';
 import { logger } from '../../logger';
@@ -100,6 +101,22 @@ export function isDynamicInstall(
   );
 }
 
+function isStable(
+  version: string,
+  versioning: allVersioning.VersioningApi,
+  latest?: string
+): boolean {
+  if (!versioning.isStable(version)) {
+    return false;
+  }
+  if (is.string(latest)) {
+    if (versioning.isGreaterThan(version, latest)) {
+      return false;
+    }
+  }
+  return true;
+}
+
 export async function resolveConstraint(
   toolConstraint: ToolConstraint
 ): Promise<string> {
@@ -124,27 +141,51 @@ export async function resolveConstraint(
 
   const pkgReleases = await getPkgReleases(toolConfig);
   const releases = pkgReleases?.releases ?? [];
-  const versions = releases.map((r) => r.version);
-  const resolvedVersion = versions
-    .filter((v) =>
-      constraint ? versioning.matches(v, constraint) : versioning.isStable(v)
-    )
-    .pop();
 
-  if (resolvedVersion) {
-    logger.debug({ toolName, constraint, resolvedVersion }, 'Resolved version');
-    return resolvedVersion;
-  }
-
-  const latestVersion = versions.filter((v) => versioning.isStable(v)).pop();
-  if (!latestVersion) {
+  if (!releases.length) {
     throw new Error('No tool releases found.');
   }
-  logger.warn(
-    { toolName, constraint, latestVersion },
-    'No matching tool versions found for constraint - using latest version'
+
+  const matchingReleases = releases.filter(
+    (r) => !constraint || versioning.matches(r.version, constraint)
   );
-  return latestVersion;
+
+  const stableMatchingVersion = matchingReleases
+    .filter((r) => isStable(r.version, versioning, pkgReleases?.tags?.latest))
+    .pop()?.version;
+  if (stableMatchingVersion) {
+    logger.debug(
+      { toolName, constraint, resolvedVersion: stableMatchingVersion },
+      'Resolved stable matching version'
+    );
+    return stableMatchingVersion;
+  }
+
+  const unstableMatchingVersion = matchingReleases.pop()?.version;
+  if (unstableMatchingVersion) {
+    logger.debug(
+      { toolName, constraint, resolvedVersion: unstableMatchingVersion },
+      'Resolved unstable matching version'
+    );
+    return unstableMatchingVersion;
+  }
+
+  const stableVersion = releases
+    .filter((r) => isStable(r.version, versioning, pkgReleases?.tags?.latest))
+    .pop()?.version;
+  if (stableVersion) {
+    logger.warn(
+      { toolName, constraint, stableVersion },
+      'No matching tool versions found for constraint - using latest stable version'
+    );
+  }
+
+  const highestVersion = releases.pop().version;
+  logger.warn(
+    { toolName, constraint, highestVersion },
+    'No matching or stable tool versions found - using an unstable version'
+  );
+  return highestVersion;
 }
 
 export async function generateInstallCommands(

--- a/lib/util/exec/buildpack.ts
+++ b/lib/util/exec/buildpack.ts
@@ -180,7 +180,7 @@ export async function resolveConstraint(
     );
   }
 
-  const highestVersion = releases.pop()?.version;
+  const highestVersion = releases.pop()!.version;
   logger.warn(
     { toolName, constraint, highestVersion },
     'No matching or stable tool versions found - using an unstable version'


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds logic to honor `latest` tag for tool version resolution.

## Context

We don't want `>=1.22.0` to pick v2 of Yarn.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
