### PR TITLE
refactor: Custom rebasing notice for `getPrBody()` function

### DIFF
--- a/lib/workers/repository/update/pr/body/index.spec.ts
+++ b/lib/workers/repository/update/pr/body/index.spec.ts
@@ -107,5 +107,19 @@ describe('workers/repository/update/pr/body/index', () => {
       });
       expect(res).toBe('PR BODY');
     });
+
+    it('supports custom rebasing message', async () => {
+      platform.massageMarkdown.mockImplementation((x) => x);
+      template.compile.mockImplementation((x) => x);
+      const res = await getPrBody(
+        {
+          branchName: 'some-branch',
+          upgrades: [],
+          prBodyTemplate: ['aaa', '**Rebasing**: FOO', 'bbb'].join('\n'),
+        },
+        { rebasingNotice: 'BAR' }
+      );
+      expect(res).toContain(['aaa', '**Rebasing**: BAR', 'bbb'].join('\n'));
+    });
   });
 });

--- a/lib/workers/repository/update/pr/body/index.ts
+++ b/lib/workers/repository/update/pr/body/index.ts
@@ -57,25 +57,42 @@ function massageUpdateMetadata(config: BranchConfig): void {
   });
 }
 
-export async function getPrBody(config: BranchConfig): Promise<string> {
-  massageUpdateMetadata(config);
+interface PrBodyConfig {
+  appendExtra?: string | null | undefined;
+  rebasingNotice?: string;
+}
+
+const rebasingRegex = regEx(/\*\*Rebasing\*\*: .*/);
+
+export async function getPrBody(
+  branchConfig: BranchConfig,
+  prBodyConfig?: PrBodyConfig
+): Promise<string> {
+  massageUpdateMetadata(branchConfig);
   const content = {
-    header: getPrHeader(config),
-    table: getPrUpdatesTable(config),
-    notes: getPrNotes(config) + getPrExtraNotes(config),
-    changelogs: getChangelogs(config),
-    configDescription: await getPrConfigDescription(config),
-    controls: await getControls(config),
-    footer: getPrFooter(config),
+    header: getPrHeader(branchConfig),
+    table: getPrUpdatesTable(branchConfig),
+    notes: getPrNotes(branchConfig) + getPrExtraNotes(branchConfig),
+    changelogs: getChangelogs(branchConfig),
+    configDescription: await getPrConfigDescription(branchConfig),
+    controls: await getControls(branchConfig),
+    footer: getPrFooter(branchConfig),
   };
 
   let prBody = '';
-  if (config.prBodyTemplate) {
-    const prBodyTemplate = config.prBodyTemplate;
+  if (branchConfig.prBodyTemplate) {
+    const prBodyTemplate = branchConfig.prBodyTemplate;
     prBody = template.compile(prBodyTemplate, content, false);
     prBody = prBody.trim();
     prBody = prBody.replace(regEx(/\n\n\n+/g), '\n\n');
     prBody = platform.massageMarkdown(prBody);
+
+    if (prBodyConfig?.rebasingNotice) {
+      prBody = prBody.replace(
+        rebasingRegex,
+        `**Rebasing**: ${prBodyConfig.rebasingNotice}`
+      );
+    }
   }
   return prBody;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Support second optional configuration parameter which allows to configure `** Rebasing **: ...` message

## Context

- Ref: #15276

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
