### PR TITLE
fix: log sidecar sha

### DIFF
--- a/lib/util/exec/docker/index.ts
+++ b/lib/util/exec/docker/index.ts
@@ -25,10 +25,7 @@ export async function prefetchDockerImage(taggedImage: string): Promise<void> {
     const res = await rawExec(`docker pull ${taggedImage}`, {
       encoding: 'utf-8',
     });
-    let imageDigest = 'unknown';
-    if (digestRegex.test(res.stdout)) {
-      imageDigest = digestRegex.exec(res.stdout)[1];
-    }
+    const imageDigest = digestRegex.exec(res?.stdout)?.[1] ?? 'unknown';
     logger.debug(
       `Finished fetching Docker image ${taggedImage}@${imageDigest}`
     );

--- a/lib/util/exec/docker/index.ts
+++ b/lib/util/exec/docker/index.ts
@@ -9,16 +9,30 @@ import { ensureTrailingSlash } from '../../url';
 import { rawExec } from '../common';
 import type { DockerOptions, Opt, VolumeOption, VolumesPair } from '../types';
 
-const prefetchedImages = new Set<string>();
+const prefetchedImages = new Map<string, string>();
+
+const digestRegex = regEx('Digest: (.*?)\n');
 
 export async function prefetchDockerImage(taggedImage: string): Promise<void> {
   if (prefetchedImages.has(taggedImage)) {
-    logger.debug(`Docker image is already prefetched: ${taggedImage}`);
+    logger.debug(
+      `Docker image is already prefetched: ${taggedImage}@${prefetchedImages.get(
+        taggedImage
+      )}`
+    );
   } else {
     logger.debug(`Fetching Docker image: ${taggedImage}`);
-    prefetchedImages.add(taggedImage);
-    await rawExec(`docker pull ${taggedImage}`, { encoding: 'utf-8' });
-    logger.debug(`Finished fetching Docker image`);
+    const res = await rawExec(`docker pull ${taggedImage}`, {
+      encoding: 'utf-8',
+    });
+    let imageDigest = 'unknown';
+    if (digestRegex.test(res.stdout)) {
+      imageDigest = digestRegex.exec(res.stdout)[1];
+    }
+    logger.debug(
+      `Finished fetching Docker image ${taggedImage}@${imageDigest}`
+    );
+    prefetchedImages.set(taggedImage, imageDigest);
   }
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Logs sha256 of sidecar images.

## Context

Helping debug issues such as #15493

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
