### PR TITLE
docs(self-hosted configuration): rewrite cacheDir section

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -147,13 +147,13 @@ Unsupported tools will fall back to `binarySource=global`.
 
 ## cacheDir
 
-By default Renovate uses a temporary directory like `/tmp/renovate/cache` to store cache data.
+By default Renovate stores cache data in a temporary directory like `/tmp/renovate/cache`.
 Use the `cacheDir` option to override this default.
 
-The `baseDir` and `cacheDir` option do not need to point to the same directory.
-You can use one directory for the repo data, and another for the the cache data.
+The `baseDir` and `cacheDir` option may point to different directories.
+You can use one directory for the repo data, and another for the cache data.
 
-e.g.
+For example:
 
 ```json
 {


### PR DESCRIPTION
## Changes

- Rewrite `cacheDir` section:
  - Remove double negative, and put the point positively
  - Remove double `the` word
  - Replace `e.g.` with `For example`

## Context

Fixing up some problems with the text that I found while running the Vale linter on my fork.
I'm not closing any issue with this PR.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
