### PR TITLE
chore: disable word suggestions in Markdown files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,9 @@
   "[json]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
+  "[md]": {
+    "editor.wordBasedSuggestions": false
+  },
   "files.associations": {
     "Dockerfile.*": "dockerfile",
     ".releaserc": "json"


### PR DESCRIPTION
## Changes

- Disable word suggestions in Markdown files in the VS Code editor

## Context

I don't like the word suggestion feature while I'm writing Markdown. Most of the times the suggested words don't even make sense. And it's really easy to accidentally tab select the wrong word while writing. 😄 

https://github.com/Microsoft/vscode/issues/58523

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
