### PR TITLE
fix(manager:terraform): resources can contain blocks

### DIFF
--- a/lib/modules/manager/terraform/__fixtures__/tfeWorkspace.tf
+++ b/lib/modules/manager/terraform/__fixtures__/tfeWorkspace.tf
@@ -9,3 +9,15 @@ resource "tfe_workspace" "test_workspace" {
   name         = "test-workspace"
   organization = "renovate-fixtures"
 }
+
+resource "tfe_workspace" "workspace_with_block" {
+  vcs_repo {
+    identifier         = "organization/repository"
+    oauth_token_id     = "invalidToken"
+  }
+
+  name         = "lifecycle-workspace"
+  organization = "renovate-fixtures"
+
+  terraform_version = "1.1.9"
+}

--- a/lib/modules/manager/terraform/__snapshots__/extract.spec.ts.snap
+++ b/lib/modules/manager/terraform/__snapshots__/extract.spec.ts.snap
@@ -460,6 +460,13 @@ Object {
     Object {
       "skipReason": "no-version",
     },
+    Object {
+      "currentValue": "1.1.9",
+      "datasource": "github-tags",
+      "depName": "hashicorp/terraform",
+      "depType": "tfe_workspace",
+      "extractVersion": "v(?<version>.*)$",
+    },
   ],
 }
 `;

--- a/lib/modules/manager/terraform/extract.spec.ts
+++ b/lib/modules/manager/terraform/extract.spec.ts
@@ -109,7 +109,7 @@ describe('modules/manager/terraform/extract', () => {
         {}
       );
       expect(res).toMatchSnapshot();
-      expect(res.deps).toHaveLength(2);
+      expect(res.deps).toHaveLength(3);
       expect(res.deps.filter((dep) => dep.skipReason)).toHaveLength(1);
     });
   });

--- a/lib/modules/manager/terraform/providers.ts
+++ b/lib/modules/manager/terraform/providers.ts
@@ -40,7 +40,7 @@ export function extractTerraformProvider(
 
     // istanbul ignore else
     if (is.string(line)) {
-      // `{` will be counted wit +1 and `}` with -1. Therefore if we reach braceCounter == 0. We have found the end of the terraform block
+      // `{` will be counted with +1 and `}` with -1. Therefore if we reach braceCounter == 0. We have found the end of the terraform block
       const openBrackets = (line.match(regEx(/\{/g)) || []).length;
       const closedBrackets = (line.match(regEx(/\}/g)) || []).length;
       braceCounter = braceCounter + openBrackets - closedBrackets;

--- a/lib/modules/manager/terraform/resources.ts
+++ b/lib/modules/manager/terraform/resources.ts
@@ -1,7 +1,7 @@
 import is from '@sindresorhus/is';
-import { HelmDatasource } from '../../datasource/helm';
 import { logger } from '../../../logger';
 import { regEx } from '../../../util/regex';
+import { HelmDatasource } from '../../datasource/helm';
 import { getDep } from '../dockerfile/extract';
 import type { PackageDependency } from '../types';
 import { TerraformDependencyTypes, TerraformResourceTypes } from './common';
@@ -26,7 +26,7 @@ export function extractTerraformResource(
   lines: string[]
 ): ExtractionResult {
   let lineNumber = startingLine;
-  let line = lines[lineNumber];
+  const line = lines[lineNumber];
   const deps: PackageDependency<ResourceManagerData>[] = [];
   const managerData: ResourceManagerData = {
     terraformDependencyType: TerraformDependencyTypes.resource,

--- a/lib/modules/manager/terraform/resources.ts
+++ b/lib/modules/manager/terraform/resources.ts
@@ -57,7 +57,7 @@ export function extractTerraformResource(
 
     // istanbul ignore else
     if (is.string(line)) {
-      // `{` will be counted wit +1 and `}` with -1. Therefore if we reach braceCounter == 0. We have found the end of the terraform block
+      // `{` will be counted with +1 and `}` with -1. Therefore if we reach braceCounter == 0. We have found the end of the terraform block
       const openBrackets = (line.match(regEx(/\{/g)) || []).length;
       const closedBrackets = (line.match(regEx(/\}/g)) || []).length;
       braceCounter = braceCounter + openBrackets - closedBrackets;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

terraform resource extraction does not stop at the first closing brace `}` anymore, but tracks the number of braces.

## Context

This is required to correctly parse resources that contain blocks. An example of a block that fails without this change has been added to the fixtures to verify the change.

The code required to parse the brackets has been taken over from `providers.ts` which already implements that behaviour.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
