### PR TITLE
docs: use relative links for development docs

### DIFF
--- a/docs/development/configuration.md
+++ b/docs/development/configuration.md
@@ -66,6 +66,6 @@ If you add configuration options to your `package.json` then these will override
 
 ## Configuration Options
 
-Please read [our list of user-facing configuration options](../usage/configuration-options.md).
+Please read [our list of user-facing configuration options](https://docs.renovatebot.com/configuration-options/).
 
 For further options when running your own instance of Renovate, please see the full config options file at `lib/config/options/index.ts`.

--- a/docs/development/configuration.md
+++ b/docs/development/configuration.md
@@ -66,6 +66,6 @@ If you add configuration options to your `package.json` then these will override
 
 ## Configuration Options
 
-Please see [https://docs.renovatebot.com/configuration-options/](https://docs.renovatebot.com/configuration-options/) for a list of user-facing configuration options.
+Please read [our list of user-facing configuration options](../usage/configuration-options.md).
 
 For further options when running your own instance of Renovate, please see the full config options file at `lib/config/options/index.ts`.

--- a/docs/development/issue-labeling.md
+++ b/docs/development/issue-labeling.md
@@ -18,10 +18,10 @@ These labels should also map approximately to our Conventional Commit scopes.
 
 You should know about platforms, package managers, datasources and versioning to label issues effectively.
 
-- To learn about platforms, read the [Renovate docs on Platforms](https://docs.renovatebot.com/modules/platform/).
-- To learn about managers, read the [Renovate docs on Managers](https://docs.renovatebot.com/modules/manager/).
-- To learn about datasources, read the [Renovate docs on Datasources](https://docs.renovatebot.com/modules/datasource/).
-- To learn more about versioning, read the [Renovate docs on Versioning](https://docs.renovatebot.com/modules/versioning/).
+- To learn about platforms, read the [Renovate docs on Platforms](../usage/modules/platform.md)
+- To learn about managers, read the [Renovate docs on Managers](../usage//modules/manager.md)
+- To learn about datasources, read the [Renovate docs on Datasources](../usage/modules/datasource.md)
+- To learn more about versioning, read the [Renovate docs on Versioning](../usage/modules/versioning.md)
 
 Most issues should have a label relating to either a platform, manager, datasource, versioning or worker topic.
 

--- a/docs/development/issue-labeling.md
+++ b/docs/development/issue-labeling.md
@@ -18,10 +18,10 @@ These labels should also map approximately to our Conventional Commit scopes.
 
 You should know about platforms, package managers, datasources and versioning to label issues effectively.
 
-- To learn about platforms, read the [Renovate docs on Platforms](../usage/modules/platform.md)
-- To learn about managers, read the [Renovate docs on Managers](../usage//modules/manager.md)
-- To learn about datasources, read the [Renovate docs on Datasources](../usage/modules/datasource.md)
-- To learn more about versioning, read the [Renovate docs on Versioning](../usage/modules/versioning.md)
+- To learn about platforms, read the [Renovate docs on Platforms](https://docs.renovatebot.com/modules/platform/)
+- To learn about managers, read the [Renovate docs on Managers](https://docs.renovatebot.com/modules/manager/)
+- To learn about datasources, read the [Renovate docs on Datasources](https://docs.renovatebot.com/modules/datasource/)
+- To learn more about versioning, read the [Renovate docs on Versioning](https://docs.renovatebot.com/modules/versioning/)
 
 Most issues should have a label relating to either a platform, manager, datasource, versioning or worker topic.
 

--- a/docs/development/new-package-manager-template.md
+++ b/docs/development/new-package-manager-template.md
@@ -23,7 +23,7 @@
 
 ### What type of package files and names does it use?
 
-### What [fileMatch](https://renovatebot.com/docs/configuration-options/#filematch) pattern(s) should be used?
+### What [fileMatch](../usage/configuration-options.md/#filematch) pattern(s) should be used?
 
 ### Is it likely that many users would need to extend this pattern for custom file names?
 

--- a/docs/development/triage-guide.md
+++ b/docs/development/triage-guide.md
@@ -56,7 +56,7 @@ Don't be afraid to ask for help.
 ### Apply labels to issues
 
 All issues should have labels attached to them.
-Read the [issue-labeling guide](https://github.com/renovatebot/renovate/blob/main/docs/development/issue-labeling.md) to get all the necessary info.
+Read the [issue-labeling guide](./issue-labeling.md) to get all the necessary info.
 
 In general try to make a good-faith effort to label issues correctly.
 


### PR DESCRIPTION
## Changes

- Replaces hardcoded links with relative links where possible
- Improve link names
- Remove `.` at the end of list items

## Context

Helps with #13400, but doesn't close it.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository