### PR TITLE
fix(changelog): massage links case insensitive

### DIFF
--- a/lib/modules/platform/github/massage-markdown-links.spec.ts
+++ b/lib/modules/platform/github/massage-markdown-links.spec.ts
@@ -62,6 +62,7 @@ describe('modules/platform/github/massage-markdown-links', () => {
     ${'github.com/foo/bar/discussions/1'}                                                     | ${'[github.com/foo/bar/discussions/1](togithub.com/foo/bar/discussions/1)'}
     ${'github.com/foo/bar/issues/1'}                                                          | ${'[github.com/foo/bar/issues/1](togithub.com/foo/bar/issues/1)'}
     ${'github.com/foo/bar/pull/1'}                                                            | ${'[github.com/foo/bar/pull/1](togithub.com/foo/bar/pull/1)'}
+    ${'github.com/Foo/bar/pull/1'}                                                            | ${'[github.com/Foo/bar/pull/1](togithub.com/Foo/bar/pull/1)'}
     ${'www.github.com/foo/bar/discussions/1'}                                                 | ${'[www.github.com/foo/bar/discussions/1](www.togithub.com/foo/bar/discussions/1)'}
     ${'www.github.com/foo/bar/issues/1'}                                                      | ${'[www.github.com/foo/bar/issues/1](www.togithub.com/foo/bar/issues/1)'}
     ${'www.github.com/foo/bar/pull/1'}                                                        | ${'[www.github.com/foo/bar/pull/1](www.togithub.com/foo/bar/pull/1)'}

--- a/lib/modules/platform/github/massage-markdown-links.ts
+++ b/lib/modules/platform/github/massage-markdown-links.ts
@@ -22,6 +22,7 @@ function collectLinkPosition(input: string, matches: UrlMatch[]): Plugin {
   const transformer = (tree: Content): void => {
     const startOffset: number = tree.position?.start.offset ?? 0;
     const endOffset: number = tree.position?.end.offset ?? 0;
+
     if (tree.type === 'link') {
       const substr = input.slice(startOffset, endOffset);
       const url: string = tree.url;

--- a/lib/modules/platform/github/massage-markdown-links.ts
+++ b/lib/modules/platform/github/massage-markdown-links.ts
@@ -22,7 +22,6 @@ function collectLinkPosition(input: string, matches: UrlMatch[]): Plugin {
   const transformer = (tree: Content): void => {
     const startOffset: number = tree.position?.start.offset ?? 0;
     const endOffset: number = tree.position?.end.offset ?? 0;
-
     if (tree.type === 'link') {
       const substr = input.slice(startOffset, endOffset);
       const url: string = tree.url;
@@ -35,7 +34,7 @@ function collectLinkPosition(input: string, matches: UrlMatch[]): Plugin {
         });
       }
     } else if (tree.type === 'text') {
-      const globalUrlReg = new RegExp(urlRegex, 'g');
+      const globalUrlReg = new RegExp(urlRegex, 'gi');
       const urlMatches = [...tree.value.matchAll(globalUrlReg)];
       for (const match of urlMatches) {
         const [url] = match;


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Fixes changelog massaging to be case insensitive

## Context

Closes #14804

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
