### PR TITLE
refactor(datasource): Make `GitDatasource` class abstract

### DIFF
--- a/lib/modules/datasource/git-refs/base.ts
+++ b/lib/modules/datasource/git-refs/base.ts
@@ -16,7 +16,7 @@ const headMatch = regEx(/(?<hash>.*?)\s+HEAD/);
 export abstract class GitDatasource extends Datasource {
   static id = 'git';
 
-  constructor(public override readonly id = GitDatasource.id) {
+  constructor(public override readonly id) {
     super(id);
   }
 

--- a/lib/modules/datasource/git-refs/base.ts
+++ b/lib/modules/datasource/git-refs/base.ts
@@ -16,7 +16,7 @@ const headMatch = regEx(/(?<hash>.*?)\s+HEAD/);
 export abstract class GitDatasource extends Datasource {
   static id = 'git';
 
-  constructor(public override readonly id) {
+  constructor(public override readonly id: string) {
     super(id);
   }
 

--- a/lib/modules/datasource/git-refs/base.ts
+++ b/lib/modules/datasource/git-refs/base.ts
@@ -5,6 +5,7 @@ import { cache } from '../../../util/cache/package/decorator';
 import { simpleGitConfig } from '../../../util/git/config';
 import { getRemoteUrlWithToken } from '../../../util/git/url';
 import { newlineRegex, regEx } from '../../../util/regex';
+import { Datasource } from '../datasource';
 import type { GetReleasesConfig } from '../types';
 import type { RawRefs } from './types';
 
@@ -12,22 +13,25 @@ const refMatch = regEx(/(?<hash>.*?)\s+refs\/(?<type>.*?)\/(?<value>.*)/);
 const headMatch = regEx(/(?<hash>.*?)\s+HEAD/);
 
 // TODO: extract to a separate directory structure (#10532)
-export class GitDatasource {
+export abstract class GitDatasource extends Datasource {
   static id = 'git';
+
+  constructor(public override readonly id = GitDatasource.id) {
+    super(id);
+  }
 
   @cache({
     namespace: `datasource-${GitDatasource.id}`,
     key: ({ packageName }: GetReleasesConfig) => packageName,
   })
-  static async getRawRefs(
-    { packageName }: GetReleasesConfig,
-    hostType: string
-  ): Promise<RawRefs[] | null> {
+  async getRawRefs({
+    packageName,
+  }: GetReleasesConfig): Promise<RawRefs[] | null> {
     const git = simpleGit(simpleGitConfig());
 
     // fetch remote tags
     const lsRemote = await git.listRemote([
-      getRemoteUrlWithToken(packageName, hostType),
+      getRemoteUrlWithToken(packageName, this.id),
     ]);
     if (!lsRemote) {
       return null;

--- a/lib/modules/datasource/git-refs/base.ts
+++ b/lib/modules/datasource/git-refs/base.ts
@@ -16,7 +16,7 @@ const headMatch = regEx(/(?<hash>.*?)\s+HEAD/);
 export abstract class GitDatasource extends Datasource {
   static id = 'git';
 
-  constructor(public override readonly id: string) {
+  constructor(id: string) {
     super(id);
   }
 

--- a/lib/modules/datasource/git-refs/index.ts
+++ b/lib/modules/datasource/git-refs/index.ts
@@ -1,6 +1,5 @@
 import { cache } from '../../../util/cache/package/decorator';
 import { regEx } from '../../../util/regex';
-import { Datasource } from '../datasource';
 import type { DigestConfig, GetReleasesConfig, ReleaseResult } from '../types';
 import { GitDatasource } from './base';
 import type { RawRefs } from './types';
@@ -8,8 +7,8 @@ import type { RawRefs } from './types';
 // git will prompt for known hosts or passwords, unless we activate BatchMode
 process.env.GIT_SSH_COMMAND = 'ssh -o BatchMode=yes';
 
-export class GitRefsDatasource extends Datasource {
-  static readonly id = 'git-refs';
+export class GitRefsDatasource extends GitDatasource {
+  static override readonly id = 'git-refs';
 
   constructor() {
     super(GitRefsDatasource.id);
@@ -24,10 +23,7 @@ export class GitRefsDatasource extends Datasource {
   override async getReleases({
     packageName,
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
-    const rawRefs: RawRefs[] | null = await GitDatasource.getRawRefs(
-      { packageName },
-      this.id
-    );
+    const rawRefs: RawRefs[] | null = await this.getRawRefs({ packageName });
 
     if (!rawRefs) {
       return null;
@@ -59,10 +55,7 @@ export class GitRefsDatasource extends Datasource {
     { packageName }: DigestConfig,
     newValue?: string
   ): Promise<string | null> {
-    const rawRefs: RawRefs[] | null = await GitDatasource.getRawRefs(
-      { packageName },
-      this.id
-    );
+    const rawRefs: RawRefs[] | null = await this.getRawRefs({ packageName });
 
     // istanbul ignore if
     if (!rawRefs) {

--- a/lib/modules/datasource/git-tags/index.ts
+++ b/lib/modules/datasource/git-tags/index.ts
@@ -1,11 +1,10 @@
 import { cache } from '../../../util/cache/package/decorator';
 import { regEx } from '../../../util/regex';
-import { Datasource } from '../datasource';
 import { GitDatasource } from '../git-refs/base';
 import type { DigestConfig, GetReleasesConfig, ReleaseResult } from '../types';
 
-export class GitTagsDatasource extends Datasource {
-  static readonly id = 'git-tags';
+export class GitTagsDatasource extends GitDatasource {
+  static override readonly id = 'git-tags';
 
   constructor() {
     super(GitTagsDatasource.id);
@@ -20,7 +19,7 @@ export class GitTagsDatasource extends Datasource {
   async getReleases({
     packageName,
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
-    const rawRefs = await GitDatasource.getRawRefs({ packageName }, this.id);
+    const rawRefs = await this.getRawRefs({ packageName });
 
     if (rawRefs === null) {
       return null;
@@ -49,7 +48,7 @@ export class GitTagsDatasource extends Datasource {
     { packageName }: DigestConfig,
     newValue?: string
   ): Promise<string | null> {
-    const rawRefs = await GitDatasource.getRawRefs({ packageName }, this.id);
+    const rawRefs = await this.getRawRefs({ packageName });
     const findValue = newValue || 'HEAD';
     const ref = rawRefs?.find((rawRef) => rawRef.value === findValue);
     if (ref) {

--- a/lib/workers/repository/process/lookup/index.spec.ts
+++ b/lib/workers/repository/process/lookup/index.spec.ts
@@ -4,7 +4,6 @@ import { getConfig, mocked, partial } from '../../../../../test/util';
 import { CONFIG_VALIDATION } from '../../../../constants/error-messages';
 import { DockerDatasource } from '../../../../modules/datasource/docker';
 import { GitRefsDatasource } from '../../../../modules/datasource/git-refs';
-import { GitDatasource } from '../../../../modules/datasource/git-refs/base';
 import { GithubReleasesDatasource } from '../../../../modules/datasource/github-releases';
 import { GithubTagsDatasource } from '../../../../modules/datasource/github-tags';
 import { NpmDatasource } from '../../../../modules/datasource/npm';
@@ -1645,6 +1644,13 @@ describe('workers/repository/process/lookup/index', () => {
     it('handles git submodule update', async () => {
       jest.mock('../../../../modules/datasource/git-refs', () => ({
         GitRefsDatasource: jest.fn(() => ({
+          getRawRefs: jest.fn().mockResolvedValueOnce([
+            {
+              value: 'HEAD',
+              hash: '4b825dc642cb6eb9a060e54bf8d69288fbee4904',
+              type: '',
+            },
+          ]),
           getReleases: jest.fn().mockResolvedValue({
             releases: [
               {
@@ -1657,14 +1663,6 @@ describe('workers/repository/process/lookup/index', () => {
             .mockResolvedValue('4b825dc642cb6eb9a060e54bf8d69288fbee4904'),
         })),
       }));
-
-      jest.spyOn(GitDatasource, 'getRawRefs').mockResolvedValueOnce([
-        {
-          value: 'HEAD',
-          hash: '4b825dc642cb6eb9a060e54bf8d69288fbee4904',
-          type: '',
-        },
-      ]);
 
       config.depName = 'some-path';
       config.versioning = gitVersioningId;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Make `GitDatasource` abstract instead of just wrapper for single static method

## Context

- Ref: #10532
- Ref: #15349

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
