### PR TITLE
fix(config): `unicodeEmoji` is a global only option

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2695,10 +2695,6 @@ When the `lockfileVersion` is higher than `1` in `package-lock.json`, remediatio
 
 This is considered a feature flag with the aim to remove it and default to this behavior once it has been more widely tested.
 
-## unicodeEmoji
-
-If enabled emoji shortcodes (`:warning:`) are replaced with their Unicode equivalents (`⚠️`).
-
 ## updateInternalDeps
 
 Renovate defaults to skipping any internal package dependencies within monorepos.

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -665,6 +665,10 @@ This is currently applicable to `npm` and `lerna`/`npm` only, and only used in c
 
 ## token
 
+## unicodeEmoji
+
+If enabled emoji shortcodes (`:warning:`) are replaced with their Unicode equivalents (`⚠️`).
+
 ## username
 
 You might need to set a `username` if you use:

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -2094,6 +2094,7 @@ const options: RenovateOptions[] = [
     description: 'Enable or disable Unicode emoji.',
     type: 'boolean',
     default: true,
+    globalOnly: true,
   },
   {
     name: 'gitLabIgnoreApprovals',

--- a/lib/modules/platform/bitbucket-server/index.md
+++ b/lib/modules/platform/bitbucket-server/index.md
@@ -13,7 +13,7 @@ Remember to set `platform=bitbucket-server` somewhere in your Renovate config fi
 
 If you're not using `@renovate-bot` as username then set your custom `username` for the bot account.
 
-If you use MySQL or MariaDB you must set `unicodeEmoji` to `false` in the bot config (`RENOVATE_CONFIG_FILE`) to prevent issues with emojis.
+If you use MySQL or MariaDB you must set `unicodeEmoji` to `false` in the global bot config (`RENOVATE_CONFIG_FILE`) to prevent issues with emojis.
 
 ## Unsupported platform features/concepts
 

--- a/lib/util/emoji.ts
+++ b/lib/util/emoji.ts
@@ -33,8 +33,8 @@ function lazyInitMappings(): void {
   }
 }
 
-export function setEmojiConfig(_config: RenovateConfig): void {
-  unicodeEmoji = !!_config.unicodeEmoji;
+export function setEmojiConfig(config: RenovateConfig): void {
+  unicodeEmoji = !!config.unicodeEmoji;
 }
 
 const shortCodeRegex = regEx(SHORTCODE_REGEX.source, 'g');


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
`unicodeEmoji` is a global only option
<!-- Describe what behavior is changed by this PR. -->

## Context
- https://github.com/renovatebot/renovate/discussions/15452#discussioncomment-2774116
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
