### PR TITLE
docs: render default objects and arrays in config

### DIFF
--- a/tools/docs/config.ts
+++ b/tools/docs/config.ts
@@ -28,7 +28,12 @@ function genTable(obj: [string, string][], type: string, def: any): string {
     }
     if (
       !ignoredKeys.includes(el[0]) ||
-      (el[0] === 'default' && typeof el[1] !== 'object' && name !== 'prBody')
+      (el[0] === 'default' && typeof el[1] !== 'object' && name !== 'prBody') ||
+      // only show array and object defaults if they are not null and are not empty
+      (el[0] === 'default' &&
+        (type === 'array' || type === 'object') &&
+        el[1] !== null &&
+        Object.keys(el[1]).length > 0)
     ) {
       if (type === 'string' && el[0] === 'default') {
         el[1] = `\`"${el[1]}"\``;
@@ -42,6 +47,10 @@ function genTable(obj: [string, string][], type: string, def: any): string {
       }
       if (type === 'string' && el[0] === 'default' && el[1].length > 200) {
         el[1] = `[template]`;
+      }
+      // objects and arrays should be printed in JSON notation
+      if ((type === 'object' || type === 'array') && el[0] === 'default') {
+        el[1] = `\`${JSON.stringify(el[1])}\``;
       }
       data.push(el);
     }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This PR adds that arrays and objects are printed as well. This is especially helpful to understand what to configure. 

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

Currently the defaults for the configuration are only shown on the website, if the config option is a primitive type.
Complex types, like arrays or objects are not displayed and it is hard to guess what subtypes/keys they contain. 

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The difference in rendering of the configuration.md files can be seen in this commit: https://github.com/Shegox/renovate-docs-objects/commit/7b02ecf05f38a7a267c2605349f44825d6eb2bf6

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
