### PR TITLE
fix(buildkite): Catch '?' yaml syntax for plugins

### DIFF
--- a/lib/modules/manager/buildkite/__fixtures__/pipeline8.yml
+++ b/lib/modules/manager/buildkite/__fixtures__/pipeline8.yml
@@ -1,0 +1,4 @@
+steps:
+  - plugins:
+      - ? ssh://git@github.company.com/some-org/some-plugin.git#v3.2.7
+        : enforce_peer_deps: false

--- a/lib/modules/manager/buildkite/extract.spec.ts
+++ b/lib/modules/manager/buildkite/extract.spec.ts
@@ -60,5 +60,16 @@ describe('modules/manager/buildkite/extract', () => {
       };
       expect(res).toEqual([expectedPackageDependency]);
     });
+
+    it('extracts plugin with preceding ?', () => {
+      const res = extractPackageFile(Fixtures.get('pipeline8.yml'))?.deps;
+      const expectedPackageDependency: PackageDependency = {
+        currentValue: 'v3.2.7',
+        datasource: 'github-tags',
+        depName: 'some-org/some-plugin',
+        registryUrls: ['https://github.company.com'],
+      };
+      expect(res).toEqual([expectedPackageDependency]);
+    });
   });
 });

--- a/lib/modules/manager/buildkite/extract.ts
+++ b/lib/modules/manager/buildkite/extract.ts
@@ -13,7 +13,7 @@ export function extractPackageFile(content: string): PackageFile | null {
     for (const line of lines) {
       // Search each line for plugin names
       const depLineMatch = regEx(
-        /^[\s-]*(?<depName>[^#\s]+)#(?<currentValue>[^:]+)/
+        /^[\s-?]*(?<depName>[^#\s]+)#(?<currentValue>[^:]+)/
       ).exec(line);
 
       if (depLineMatch?.groups) {

--- a/lib/modules/manager/buildkite/extract.ts
+++ b/lib/modules/manager/buildkite/extract.ts
@@ -13,7 +13,7 @@ export function extractPackageFile(content: string): PackageFile | null {
     for (const line of lines) {
       // Search each line for plugin names
       const depLineMatch = regEx(
-        /^[\s-?]*(?<depName>[^#\s]+)#(?<currentValue>[^:]+)/
+        /^[\s-?]*(\?\s)?(?<depName>[^#\s]+)#(?<currentValue>[^:]+)/
       ).exec(line);
 
       if (depLineMatch?.groups) {

--- a/lib/modules/manager/buildkite/extract.ts
+++ b/lib/modules/manager/buildkite/extract.ts
@@ -13,7 +13,7 @@ export function extractPackageFile(content: string): PackageFile | null {
     for (const line of lines) {
       // Search each line for plugin names
       const depLineMatch = regEx(
-        /^[\s-]*(\?\s)?(?<depName>[^#\s]+)#(?<currentValue>[^:]+)/
+        /^\s*(?:-\s+(?:\?\s+)?)?(?<depName>[^#\s]+)#(?<currentValue>[^:]+)/
       ).exec(line);
 
       if (depLineMatch?.groups) {

--- a/lib/modules/manager/buildkite/extract.ts
+++ b/lib/modules/manager/buildkite/extract.ts
@@ -13,7 +13,7 @@ export function extractPackageFile(content: string): PackageFile | null {
     for (const line of lines) {
       // Search each line for plugin names
       const depLineMatch = regEx(
-        /^[\s-?]*(\?\s)?(?<depName>[^#\s]+)#(?<currentValue>[^:]+)/
+        /^[\s-]*(\?\s)?(?<depName>[^#\s]+)#(?<currentValue>[^:]+)/
       ).exec(line);
 
       if (depLineMatch?.groups) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Modify the buildkite dependency line matcher to allow for plugins of the form: 
`- ? ssh://git@github.company.com/some-org/some-plugin.git#v3.2.7`

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->
Renovate is not opening PRs on repositories that specify buildkite plugins in the above-mentioned form.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
