### PR TITLE
fix(datasource:docker): wrong scope for ghcr.io

### DIFF
--- a/lib/modules/datasource/docker/index.ts
+++ b/lib/modules/datasource/docker/index.ts
@@ -136,7 +136,11 @@ export async function getAuthHeaders(
     }
 
     let scope = `repository:${dockerRepository}:pull`;
-    if (is.string(authenticateHeader.params.scope)) {
+    // repo isn't known to server yet, so causing wrong scope `repository:user/image:pull`
+    if (
+      is.string(authenticateHeader.params.scope) &&
+      !apiCheckUrl.endsWith('/v2/')
+    ) {
       scope = authenticateHeader.params.scope;
     }
 

--- a/test/http-mock.ts
+++ b/test/http-mock.ts
@@ -49,11 +49,11 @@ export function clear(throwOnPending = true): void {
   const missing = missingLog;
   requestLog = [];
   missingLog = [];
-  if (!isDone && throwOnPending) {
-    throw new Error(`Pending mocks!\n * ${pending.join('\n * ')}`);
-  }
   if (missing.length && throwOnPending) {
     throw new Error(`Missing mocks!\n * ${missing.join('\n * ')}`);
+  }
+  if (!isDone && throwOnPending) {
+    throw new Error(`Pending mocks!\n * ${pending.join('\n * ')}`);
   }
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

ghcr.io returns a wrong scope when calling `/v2/` endpoint. 
<!-- Describe what behavior is changed by this PR. -->

## Context
- #15683
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
