### PR TITLE
fix(http): cache head requests

### DIFF
--- a/lib/util/http/index.ts
+++ b/lib/util/http/index.ts
@@ -167,8 +167,8 @@ export class Http<GetOptions = HttpOptions, PostOptions = HttpPostOptions> {
       };
       const queue = getQueue(url);
       resPromise = queue?.add(queueTask) ?? queueTask();
-      if (options.method === 'get') {
-        memCache.set(cacheKey, resPromise); // always set if it's a get
+      if (options.method === 'get' || options.method === 'head') {
+        memCache.set(cacheKey, resPromise); // always set if it's a get or a head
       }
     }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Caching head requests is broken, as the response never get's to memcache.
<!-- Describe what behavior is changed by this PR. -->

## Context

found while working on docker datasource fix
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
