### PR TITLE
fix(clojure): Prioritize Maven-based deps over git-based ones

### DIFF
--- a/lib/modules/manager/deps-edn/__fixtures__/deps.edn
+++ b/lib/modules/manager/deps-edn/__fixtures__/deps.edn
@@ -3,6 +3,7 @@
 ,,,,persistent-sorted-set,{:mvn/version,"0.1.2"}
     invalid/package! {:mvn/version "1.2.3"}
     invalid/version nil
+    io.github.nextjournal/clerk {:mvn/version "0.7.418"}
   }
 
   :aliases {

--- a/lib/modules/manager/deps-edn/__snapshots__/extract.spec.ts.snap
+++ b/lib/modules/manager/deps-edn/__snapshots__/extract.spec.ts.snap
@@ -15,6 +15,18 @@ Array [
     "replaceString": "{:mvn/version,\\"0.1.2\\"}",
   },
   Object {
+    "currentValue": "0.7.418",
+    "datasource": "clojure",
+    "depName": "io.github.nextjournal/clerk",
+    "packageName": "io.github.nextjournal:clerk",
+    "registryUrls": Array [
+      "https://deps.com/foo/bar",
+      "https://my.auth.com/repo",
+      "s3://my-bucket/maven/releases",
+    ],
+    "replaceString": "{:mvn/version \\"0.7.418\\"}",
+  },
+  Object {
     "currentValue": "1.9.0",
     "datasource": "clojure",
     "depName": "org.clojure/clojure",

--- a/lib/modules/manager/deps-edn/__snapshots__/parser.spec.ts.snap
+++ b/lib/modules/manager/deps-edn/__snapshots__/parser.spec.ts.snap
@@ -123,6 +123,9 @@ Object {
       "mvn/version": "1.2.3",
     },
     "invalid/version": "nil",
+    "io.github.nextjournal/clerk": Object {
+      "mvn/version": "0.7.418",
+    },
     "persistent-sorted-set": Object {
       "mvn/version": "0.1.2",
     },

--- a/lib/modules/manager/deps-edn/extract.spec.ts
+++ b/lib/modules/manager/deps-edn/extract.spec.ts
@@ -20,6 +20,11 @@ describe('modules/manager/deps-edn/extract', () => {
             's3://my-bucket/maven/releases',
           ],
         },
+        {
+          depName: 'io.github.nextjournal/clerk',
+          currentValue: '0.7.418',
+          datasource: 'clojure',
+        },
         { depName: 'org.clojure/clojure', currentValue: '1.9.0' },
         { depName: 'org.clojure/clojure', currentValue: '1.10.0' },
         { depName: 'org.clojure/clojurescript', currentValue: '1.10.520' },

--- a/lib/modules/manager/deps-edn/extract.ts
+++ b/lib/modules/manager/deps-edn/extract.ts
@@ -151,6 +151,15 @@ function extractDependency(
     dep.depType = depType;
   }
 
+  const mvnVersion = val['mvn/version'];
+  if (is.string(mvnVersion)) {
+    dep.datasource = ClojureDatasource.id;
+    dep.currentValue = mvnVersion;
+    dep.packageName = packageName.replace('/', ':');
+    dep.registryUrls = [...mavenRegistries];
+    return dep;
+  }
+
   resolveGitPackageFromEdnVal(dep, val);
   resolveGitPackageFromEdnKey(dep, key);
 
@@ -166,15 +175,6 @@ function extractDependency(
       dep.currentDigestShort = gitSha.slice(0, 7);
     }
 
-    return dep;
-  }
-
-  const mvnVersion = val['mvn/version'];
-  if (is.string(mvnVersion)) {
-    dep.datasource = ClojureDatasource.id;
-    dep.currentValue = mvnVersion;
-    dep.packageName = packageName.replace('/', ':');
-    dep.registryUrls = [...mavenRegistries];
     return dep;
   }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Dependencies can have `io.github.blabla` while still referring to Maven (`:mvn/version`). For this cases, Maven datasource should have higher priority.

## Context

- Ref: #15507

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
