### PR TITLE
docs(docker): explain how to get Renovate to fetch release notes

### DIFF
--- a/lib/modules/datasource/docker/readme.md
+++ b/lib/modules/datasource/docker/readme.md
@@ -3,3 +3,11 @@ This datasource identifies an image's source repository according to the [pre-de
 This datasource looks for the metadata of the **latest stable** image found on the Docker registry and uses the value of the label `org.opencontainers.image.source` and `org.label-schema.vcs-url` as the `sourceUrl`.
 
 The [Label Schema](https://label-schema.org/) is superseded by OCI annotations, therefore `org.opencontainers.image.source` label should be preferred.
+
+If you maintain a Docker image and want Renovate to find your changelogs, add a `org.opencontainers.image.source` field to your Dockerfile.
+The link must point to your GitHub or GitLab repository.
+Here's an example from our `renovate/renovate` Dockerfile:
+
+```dockerfile
+LABEL org.opencontainers.image.source="https://github.com/renovatebot/renovate"
+```


### PR DESCRIPTION
## Changes

- Explain that Docker image maintainers need to add a `org.opencontainers.image.source` that points to their repository if they want Renovate to fetch their release notes

## Context

Closes #15052.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
