### PR TITLE
fix: Revert "fix: move update internal deps to worker logic"

### DIFF
--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -216,7 +216,7 @@ export interface RenovateConfig
 
   repoIsOnboarded?: boolean;
   repoIsActivated?: boolean;
-  updateInternalDeps?: boolean;
+
   updateType?: UpdateType;
 
   warnings?: ValidationMessage[];

--- a/lib/modules/manager/npm/extract/__snapshots__/monorepo.spec.ts.snap
+++ b/lib/modules/manager/npm/extract/__snapshots__/monorepo.spec.ts.snap
@@ -6,11 +6,9 @@ Array [
     "deps": Array [
       Object {
         "depName": "@org/a",
-        "isInternal": true,
       },
       Object {
         "depName": "@org/b",
-        "isInternal": true,
       },
       Object {
         "depName": "@org/c",
@@ -34,7 +32,6 @@ Array [
     "deps": Array [
       Object {
         "depName": "@org/b",
-        "isInternal": true,
       },
       Object {
         "depName": "@org/c",
@@ -75,11 +72,11 @@ Array [
     "deps": Array [
       Object {
         "depName": "@org/a",
-        "isInternal": true,
+        "skipReason": "internal-package",
       },
       Object {
         "depName": "@org/b",
-        "isInternal": true,
+        "skipReason": "internal-package",
       },
       Object {
         "depName": "@org/c",
@@ -103,7 +100,7 @@ Array [
     "deps": Array [
       Object {
         "depName": "@org/b",
-        "isInternal": true,
+        "skipReason": "internal-package",
       },
       Object {
         "depName": "@org/c",

--- a/lib/modules/manager/npm/extract/index.spec.ts
+++ b/lib/modules/manager/npm/extract/index.spec.ts
@@ -752,7 +752,7 @@ describe('modules/manager/npm/extract/index', () => {
 
   describe('.postExtract()', () => {
     it('runs', async () => {
-      await expect(npmExtract.postExtract([])).resolves.not.toThrow();
+      await expect(npmExtract.postExtract([], false)).resolves.not.toThrow();
     });
   });
 });

--- a/lib/modules/manager/npm/extract/index.ts
+++ b/lib/modules/manager/npm/extract/index.ts
@@ -472,8 +472,11 @@ export async function extractPackageFile(
   };
 }
 
-export async function postExtract(packageFiles: PackageFile[]): Promise<void> {
-  await detectMonorepos(packageFiles);
+export async function postExtract(
+  packageFiles: PackageFile[],
+  updateInternalDeps: boolean
+): Promise<void> {
+  await detectMonorepos(packageFiles, updateInternalDeps);
   await getLockedVersions(packageFiles);
 }
 
@@ -497,8 +500,7 @@ export async function extractAllPackageFiles(
       logger.debug({ packageFile }, 'packageFile has no content');
     }
   }
-
-  await postExtract(npmFiles);
+  await postExtract(npmFiles, !!config.updateInternalDeps);
   return npmFiles;
 }
 

--- a/lib/modules/manager/npm/extract/monorepo.spec.ts
+++ b/lib/modules/manager/npm/extract/monorepo.spec.ts
@@ -48,12 +48,12 @@ describe('modules/manager/npm/extract/monorepo', () => {
           packageJsonName: '@org/b',
         },
       ] as any;
-      await detectMonorepos(packageFiles);
+      await detectMonorepos(packageFiles, false);
       expect(packageFiles).toMatchSnapshot();
       expect(packageFiles[1].managerData.lernaJsonFile).toBe('lerna.json');
       expect(
         packageFiles.some((packageFile) =>
-          packageFile.deps?.some((dep) => dep.isInternal)
+          packageFile.deps?.some((dep) => dep.skipReason)
         )
       ).toBeTrue();
     });
@@ -102,14 +102,14 @@ describe('modules/manager/npm/extract/monorepo', () => {
           packageJsonName: '@org/b',
         },
       ] as any;
-      await detectMonorepos(packageFiles);
+      await detectMonorepos(packageFiles, true);
       expect(packageFiles).toMatchSnapshot();
       expect(packageFiles[1].managerData.lernaJsonFile).toBe('lerna.json');
       expect(
         packageFiles.some((packageFile) =>
-          packageFile.deps?.some((dep) => dep.isInternal)
+          packageFile.deps?.some((dep) => dep.skipReason)
         )
-      ).toBeTrue();
+      ).toBeFalse();
     });
 
     it('uses yarn workspaces package settings with lerna', async () => {
@@ -132,7 +132,7 @@ describe('modules/manager/npm/extract/monorepo', () => {
           packageJsonName: '@org/b',
         },
       ];
-      await detectMonorepos(packageFiles);
+      await detectMonorepos(packageFiles, false);
       expect(packageFiles).toMatchSnapshot();
       expect(packageFiles[1].managerData.lernaJsonFile).toBe('lerna.json');
     });
@@ -154,7 +154,7 @@ describe('modules/manager/npm/extract/monorepo', () => {
           packageJsonName: '@org/b',
         },
       ];
-      await detectMonorepos(packageFiles);
+      await detectMonorepos(packageFiles, false);
       expect(packageFiles).toMatchSnapshot([
         {},
         { npmrc: '@org:registry=//registry.some.org\n' },
@@ -184,7 +184,7 @@ describe('modules/manager/npm/extract/monorepo', () => {
           skipInstalls: true,
         },
       ];
-      await detectMonorepos(packageFiles);
+      await detectMonorepos(packageFiles, false);
       expect(packageFiles).toMatchSnapshot([
         {},
         { managerData: { yarnZeroInstall: true }, skipInstalls: false },

--- a/lib/modules/manager/types.ts
+++ b/lib/modules/manager/types.ts
@@ -21,6 +21,7 @@ export interface ExtractConfig {
   npmrc?: string;
   npmrcMerge?: boolean;
   skipInstalls?: boolean;
+  updateInternalDeps?: boolean;
 }
 
 export interface RegexManagerTemplates {
@@ -171,7 +172,6 @@ export interface PackageDependency<T = Record<string, any>> extends Package<T> {
   editFile?: string;
   separateMinorPatch?: boolean;
   extractVersion?: string;
-  isInternal?: boolean;
 }
 
 export interface Upgrade<T = Record<string, any>>

--- a/lib/workers/repository/extract/index.spec.ts
+++ b/lib/workers/repository/extract/index.spec.ts
@@ -40,30 +40,6 @@ describe('workers/repository/extract/index', () => {
       expect(logger.debug).toHaveBeenCalled();
     });
 
-    it('adds skipReason to internal deps when updateInternalDeps is false/undefined', async () => {
-      config.enabledManagers = ['npm'];
-      managerFiles.getManagerPackageFiles.mockResolvedValue([
-        {
-          deps: [{ depName: 'a', isInternal: true }, { depName: 'b' }],
-        },
-      ]);
-      expect(await extractAllDependencies(config)).toEqual({
-        npm: [
-          {
-            deps: [
-              {
-                depName: 'a',
-                isInternal: true,
-                skipReason: 'internal-package',
-              },
-              { depName: 'b' },
-            ],
-          },
-        ],
-      });
-      expect(logger.debug).toHaveBeenCalled();
-    });
-
     it('checks custom managers', async () => {
       managerFiles.getManagerPackageFiles.mockResolvedValue([{} as never]);
       config.regexManagers = [{ fileMatch: ['README'], matchStrings: [''] }];

--- a/lib/workers/repository/extract/index.ts
+++ b/lib/workers/repository/extract/index.ts
@@ -47,16 +47,6 @@ export async function extractAllDependencies(
   const extractResults = await Promise.all(
     extractList.map(async (managerConfig) => {
       const packageFiles = await getManagerPackageFiles(managerConfig);
-      for (const p of packageFiles) {
-        //istanbul ignore if
-        if (p.deps) {
-          for (const dep of p.deps) {
-            if (!config.updateInternalDeps && dep.isInternal) {
-              dep.skipReason = 'internal-package';
-            }
-          }
-        }
-      }
       return { manager: managerConfig.manager, packageFiles };
     })
   );


### PR DESCRIPTION
- Reverts renovatebot/renovate#15745
- fixes https://github.com/renovatebot/docker-renovate/issues/273