### PR TITLE
feat(fvm): update to use flutter version datasource

### DIFF
--- a/lib/modules/manager/fvm/extract.spec.ts
+++ b/lib/modules/manager/fvm/extract.spec.ts
@@ -31,7 +31,7 @@ describe('modules/manager/fvm/extract', () => {
       expect(res.deps).toEqual([
         {
           currentValue: '2.10.1',
-          datasource: 'github-tags',
+          datasource: 'flutter-version',
           depName: 'flutter',
           packageName: 'flutter/flutter',
         },
@@ -46,7 +46,7 @@ describe('modules/manager/fvm/extract', () => {
       expect(res.deps).toEqual([
         {
           currentValue: 'stable',
-          datasource: 'github-tags',
+          datasource: 'flutter-version',
           depName: 'flutter',
           packageName: 'flutter/flutter',
         },

--- a/lib/modules/manager/fvm/extract.ts
+++ b/lib/modules/manager/fvm/extract.ts
@@ -1,6 +1,6 @@
 import is from '@sindresorhus/is';
 import { logger } from '../../../logger';
-import { GithubTagsDatasource } from '../../datasource/github-tags';
+import { FlutterVersionDatasource } from '../../datasource/flutter-version';
 import type { PackageDependency, PackageFile } from '../types';
 
 interface FvmConfig {
@@ -33,7 +33,7 @@ export function extractPackageFile(
   const dep: PackageDependency = {
     depName: 'flutter',
     currentValue: fvmConfig.flutterSdkVersion,
-    datasource: GithubTagsDatasource.id,
+    datasource: FlutterVersionDatasource.id,
     packageName: 'flutter/flutter',
   };
   return { deps: [dep] };

--- a/lib/modules/manager/fvm/index.ts
+++ b/lib/modules/manager/fvm/index.ts
@@ -1,9 +1,9 @@
-import { GithubTagsDatasource } from '../../datasource/github-tags';
+import { FlutterVersionDatasource } from '../../datasource/flutter-version';
 import * as semverVersioning from '../../versioning/semver';
 
 export { extractPackageFile } from './extract';
 
-export const supportedDatasources = [GithubTagsDatasource.id];
+export const supportedDatasources = [FlutterVersionDatasource.id];
 
 export const defaultConfig = {
   fileMatch: ['(^|\\/)\\.fvm\\/fvm_config\\.json$'],


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Update to use `FlutterVersionDatasource` instead of `GithubTagsDatasource` as the datasource for `fvm` manager

## Context

It seems like Flutter does not always release on their GitHub repo and their [website](https://docs.flutter.dev/development/tools/sdk/releases?tab=linux) at the same time. At the time of raising this PR, their GitHub repo has already [released](https://github.com/flutter/flutter/releases/tag/3.1.0) the tag 3.1.0, but they haven't published this SDK version on their website (see screenshot below).

![image](https://user-images.githubusercontent.com/12210067/170811189-b23a8cd5-6efb-4eda-bc96-093464c67b53.png)

This results in CI tools like [flutter-action](https://github.com/subosito/flutter-action) failing when Renovate creates a PR to update Flutter to 3.1.0, as the action will fail to download this version from the Flutter website. See [this](https://github.com/zeshuaro/appainter/pull/412) PR raised by Renovate for example where `flutter-action` failed to set up the SDK with Flutter 3.1.0.

The `FlutterVersionDatasource` fetches the versions from the Flutter website, which should resolve this issue.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository (see the repo [here](https://github.com/barriot/test-repo-2/pulls))

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
