### PR TITLE
fix(gomod): default to not massaging replace statements

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -1881,7 +1881,7 @@ This way Renovate can use GitHub's [Commit signing support for bots and other Gi
 
 ## postUpdateOptions
 
-- `gomodNoMassage`: Skip massaging `replace` directives before calling `go` commands
+- `gomodMassage`: Enable massaging `replace` directives before calling `go` commands
 - `gomodTidy`: Run `go mod tidy` after Go module updates. This is implicitly enabled for major module updates when `gomodUpdateImportPaths` is enabled
 - `gomodTidy1.17`: Run `go mod tidy -compat=1.17` after Go module updates.
 - `gomodUpdateImportPaths`: Update source import paths on major module updates, using [mod](https://github.com/marwan-at-work/mod)

--- a/docs/usage/golang.md
+++ b/docs/usage/golang.md
@@ -30,12 +30,13 @@ To install Renovate Bot itself, either enable the [Renovate App](https://github.
 
 ### Replace massaging
 
-Renovate's default behavior is to massage any `replace` statements it finds prior to running `go` commands, and then massage them back afterwards.
-This was originally done because relative `replace` statements outside of the current repo will not work when Renovate clones the repo locally.
+Renovate can massage `replace` statements it finds prior to running `go` commands, and then massage them back afterwards.
+This capability was added - and originally default behavior - because relative `replace` statements outside of the current repo will not work when Renovate clones the repo locally.
 
 On the other hand, this massaging of `replace` statements may lead to unexpected results, especially because `go mod tidy` may not fully tidy the `go.sum` if it is missing the `replace` directives in `go.mod`.
+It has therefore been disabled by default.
 
-To disable this default behavior, and retain all `replace` statements when running `go` commands, add `gomodNoMassage` to your `postUpdateOptions` array.
+To enable this replace massaging behavior, add `gomodMassage` to your `postUpdateOptions` array.
 
 ### Module Tidying
 

--- a/lib/config/migrations/custom/post-update-options-migration.spec.ts
+++ b/lib/config/migrations/custom/post-update-options-migration.spec.ts
@@ -1,0 +1,14 @@
+import { PostUpdateOptionsMigration } from './post-update-options-migration';
+
+describe('config/migrations/custom/post-update-options-migration', () => {
+  it('should migrate properly', () => {
+    expect(PostUpdateOptionsMigration).toMigrate(
+      {
+        postUpdateOptions: ['gomodTidy', 'gomodNoMassage'],
+      },
+      {
+        postUpdateOptions: ['gomodTidy'],
+      }
+    );
+  });
+});

--- a/lib/config/migrations/custom/post-update-options-migration.ts
+++ b/lib/config/migrations/custom/post-update-options-migration.ts
@@ -1,0 +1,16 @@
+import is from '@sindresorhus/is';
+import { AbstractMigration } from '../base/abstract-migration';
+
+export class PostUpdateOptionsMigration extends AbstractMigration {
+  override readonly propertyName = 'postUpdateOptions';
+
+  override run(value: unknown): void {
+    if (Array.isArray(value)) {
+      const newValue = value
+        .filter(is.nonEmptyString)
+        .filter((option) => option !== 'gomodNoMassage');
+
+      this.rewrite(newValue);
+    }
+  }
+}

--- a/lib/config/migrations/migrations-service.ts
+++ b/lib/config/migrations/migrations-service.ts
@@ -28,6 +28,7 @@ import { PackagePatternMigration } from './custom/package-pattern-migration';
 import { PackagesMigration } from './custom/packages-migration';
 import { PathRulesMigration } from './custom/path-rules-migration';
 import { PinVersionsMigration } from './custom/pin-versions-migration';
+import { PostUpdateOptionsMigration } from './custom/post-update-options-migration';
 import { RaiseDeprecationWarningsMigration } from './custom/raise-deprecation-warnings-migration';
 import { RebaseConflictedPrs } from './custom/rebase-conflicted-prs-migration';
 import { RebaseStalePrsMigration } from './custom/rebase-stale-prs-migration';
@@ -100,6 +101,7 @@ export class MigrationsService {
     PackagesMigration,
     PathRulesMigration,
     PinVersionsMigration,
+    PostUpdateOptionsMigration,
     RaiseDeprecationWarningsMigration,
     RebaseConflictedPrs,
     RebaseStalePrsMigration,

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -1820,7 +1820,7 @@ const options: RenovateOptions[] = [
     type: 'array',
     default: [],
     allowedValues: [
-      'gomodNoMassage',
+      'gomodMassage',
       'gomodUpdateImportPaths',
       'gomodTidy',
       'gomodTidy1.17',

--- a/lib/modules/manager/gomod/artifacts.spec.ts
+++ b/lib/modules/manager/gomod/artifacts.spec.ts
@@ -42,6 +42,7 @@ const adminConfig: RepoGlobalConfig = {
 
 const config: UpdateArtifactsConfig = {
   constraints: { go: '1.14' },
+  postUpdateOptions: ['gomodMassage'],
 };
 
 const goEnv = {

--- a/lib/modules/manager/gomod/artifacts.ts
+++ b/lib/modules/manager/gomod/artifacts.ts
@@ -160,7 +160,7 @@ export async function updateArtifacts({
 
   let massagedGoMod = newGoModContent;
 
-  if (!config.postUpdateOptions?.includes('gomodNoMassage')) {
+  if (config.postUpdateOptions?.includes('gomodMassage')) {
     // Regex match inline replace directive, example:
     // replace golang.org/x/net v1.2.3 => example.com/fork/net v1.4.5
     // https://go.dev/ref/mod#go-mod-file-replace

--- a/lib/modules/manager/gomod/readme.md
+++ b/lib/modules/manager/gomod/readme.md
@@ -4,7 +4,7 @@ You might be interested in the following `postUpdateOptions`:
    1. This is implicitly enabled for major updates if the user has enabled the option `gomodUpdateImportPaths`
 1. `gomodTidy1.17` - if you'd like Renovate to run `go mod tidy -compat=1.17` after every update before raising the PR.
 1. `gomodUpdateImportPaths` - if you'd like Renovate to update your source import paths on major updates before raising the PR.
-1. `gomodNoMassage` - to skip massaging of `replace` statements.
+1. `gomodMassage` - to enable massaging of all `replace` statements prior to running `go` so that they will be ignored.
 
 When Renovate is running using `binarySource=docker` (such as in the hosted Mend Renovate app) then it will pick the latest compatible version of Go to run, i.e. the latest `1.x` release.
 Therefore even if the `go.mod` has a version like `go 1.14`, you will see Renovate treating that as a `^1.14` constraint and not `=1.14`.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Changes Renovate default behavior to *not* massage replace statements in `go.mod`.

## Context

Closes #6213

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
