### PR TITLE
refactor(decorator): extract general purpose decorator methods

### DIFF
--- a/lib/util/cache/package/decorator.ts
+++ b/lib/util/cache/package/decorator.ts
@@ -1,61 +1,6 @@
 import is from '@sindresorhus/is';
+import { Decorator, decorate } from '../../decorator';
 import * as packageCache from '.';
-
-type Handler<T> = (parameters: DecoratorParameters<T>) => Promise<unknown>;
-type Method<T> = (this: T, ...args: any[]) => Promise<any>;
-type Decorator<T> = <U extends T>(
-  target: U,
-  key: keyof U,
-  descriptor: TypedPropertyDescriptor<Method<T>>
-) => TypedPropertyDescriptor<Method<T>>;
-
-interface DecoratorParameters<T, U extends any[] = any[]> {
-  /**
-   * Current call arguments.
-   */
-  args: U;
-
-  /**
-   * A callback to call the decorated method with the current arguments.
-   */
-  callback(): unknown;
-
-  /**
-   * Current call context.
-   */
-  instance: T;
-}
-
-/**
- * Applies decorating function to intercept decorated method calls.
- * @param fn - The decorating function.
- */
-function decorate<T>(fn: Handler<T>): Decorator<T> {
-  const result: Decorator<T> = (
-    target,
-    key,
-    /* TODO: Can descriptor be undefined ? */
-    descriptor = Object.getOwnPropertyDescriptor(target, key) ?? {
-      enumerable: true,
-      configurable: true,
-      writable: true,
-    }
-  ) => {
-    const { value } = descriptor;
-
-    return Object.assign(descriptor, {
-      value(this: T, ...args: any[]) {
-        return fn({
-          args,
-          instance: this,
-          callback: () => value?.apply(this, args),
-        });
-      },
-    });
-  };
-
-  return result;
-}
 
 type HashFunction<T extends any[] = any[]> = (...args: T) => string;
 type BooleanFunction<T extends any[] = any[]> = (...args: T) => boolean;

--- a/lib/util/decorator/index.spec.ts
+++ b/lib/util/decorator/index.spec.ts
@@ -1,0 +1,32 @@
+import { Decorator, decorate } from '.';
+
+interface WrapParameters {
+  mock: jest.Mock;
+}
+
+function wrap<T>({ mock }: WrapParameters): Decorator<T> {
+  return decorate(async ({ args, instance, callback }) => {
+    mock('before');
+    await callback();
+    mock('after');
+  });
+}
+
+describe('util/decorator/index', () => {
+  it('wraps a function', async () => {
+    const mock = jest.fn();
+    class MyClass {
+      @wrap({ mock })
+      async underTest() {
+        await Promise.resolve();
+      }
+    }
+
+    const myClass = new MyClass();
+    await myClass.underTest();
+
+    expect(mock).toHaveBeenCalledTimes(2);
+    expect(mock).toHaveBeenNthCalledWith(1, 'before');
+    expect(mock).toHaveBeenNthCalledWith(2, 'after');
+  });
+});

--- a/lib/util/decorator/index.ts
+++ b/lib/util/decorator/index.ts
@@ -1,0 +1,57 @@
+export type Handler<T> = (
+  parameters: DecoratorParameters<T>
+) => Promise<unknown>;
+export type Method<T> = (this: T, ...args: any[]) => Promise<any>;
+export type Decorator<T> = <U extends T>(
+  target: U,
+  key: keyof U,
+  descriptor: TypedPropertyDescriptor<Method<T>>
+) => TypedPropertyDescriptor<Method<T>>;
+
+export interface DecoratorParameters<T, U extends any[] = any[]> {
+  /**
+   * Current call arguments.
+   */
+  args: U;
+
+  /**
+   * A callback to call the decorated method with the current arguments.
+   */
+  callback(): unknown;
+
+  /**
+   * Current call context.
+   */
+  instance: T;
+}
+
+/**
+ * Applies decorating function to intercept decorated method calls.
+ * @param fn - The decorating function.
+ */
+export function decorate<T>(fn: Handler<T>): Decorator<T> {
+  const result: Decorator<T> = (
+    target,
+    key,
+    /* TODO: Can descriptor be undefined ? */
+    descriptor = Object.getOwnPropertyDescriptor(target, key) ?? {
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    }
+  ) => {
+    const { value } = descriptor;
+
+    return Object.assign(descriptor, {
+      value(this: T, ...args: any[]) {
+        return fn({
+          args,
+          instance: this,
+          callback: () => value?.apply(this, args),
+        });
+      },
+    });
+  };
+
+  return result;
+}


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Extracts the general purpose decorator methods from the `cache` module into their own module. This makes it easier to write other decorators.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

https://github.com/renovatebot/renovate/pull/15731/files#r883261949

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
