### PR TITLE
refactor(changelog): Relocate in-range release fetching

### DIFF
--- a/lib/workers/repository/update/pr/changelog/index.ts
+++ b/lib/workers/repository/update/pr/changelog/index.ts
@@ -2,7 +2,6 @@ import { logger } from '../../../../../logger';
 import { detectPlatform } from '../../../../../modules/platform/util';
 import * as allVersioning from '../../../../../modules/versioning';
 import type { BranchUpgradeConfig } from '../../../../types';
-import { getInRangeReleases } from './releases';
 import * as sourceGithub from './source-github';
 import * as sourceGitlab from './source-gitlab';
 import type { ChangeLogResult } from './types';
@@ -10,9 +9,9 @@ import type { ChangeLogResult } from './types';
 export * from './types';
 
 export async function getChangeLogJSON(
-  args: BranchUpgradeConfig
+  config: BranchUpgradeConfig
 ): Promise<ChangeLogResult | null> {
-  const { sourceUrl, versioning, currentVersion, newVersion } = args;
+  const { sourceUrl, versioning, currentVersion, newVersion } = config;
   try {
     if (!(sourceUrl && currentVersion && newVersion)) {
       return null;
@@ -24,7 +23,6 @@ export async function getChangeLogJSON(
     logger.debug(
       `Fetching changelog: ${sourceUrl} (${currentVersion} -> ${newVersion})`
     );
-    const releases = args.releases || (await getInRangeReleases(args));
 
     let res: ChangeLogResult | null = null;
 
@@ -32,10 +30,10 @@ export async function getChangeLogJSON(
 
     switch (platform) {
       case 'gitlab':
-        res = await sourceGitlab.getChangeLogJSON({ ...args, releases });
+        res = await sourceGitlab.getChangeLogJSON(config);
         break;
       case 'github':
-        res = await sourceGithub.getChangeLogJSON({ ...args, releases });
+        res = await sourceGithub.getChangeLogJSON(config);
         break;
 
       default:
@@ -48,7 +46,7 @@ export async function getChangeLogJSON(
 
     return res;
   } catch (err) /* istanbul ignore next */ {
-    logger.error({ config: args, err }, 'getChangeLogJSON error');
+    logger.error({ config: config, err }, 'getChangeLogJSON error');
     return null;
   }
 }

--- a/lib/workers/repository/update/pr/changelog/index.ts
+++ b/lib/workers/repository/update/pr/changelog/index.ts
@@ -46,7 +46,7 @@ export async function getChangeLogJSON(
 
     return res;
   } catch (err) /* istanbul ignore next */ {
-    logger.error({ config: config, err }, 'getChangeLogJSON error');
+    logger.error({ config, err }, 'getChangeLogJSON error');
     return null;
   }
 }

--- a/lib/workers/repository/update/pr/changelog/source-github.ts
+++ b/lib/workers/repository/update/pr/changelog/source-github.ts
@@ -11,6 +11,7 @@ import { regEx } from '../../../../../util/regex';
 import type { BranchUpgradeConfig } from '../../../../types';
 import { getTags } from './github';
 import { addReleaseNotes } from './release-notes';
+import { getInRangeReleases } from './releases';
 import { ChangeLogError, ChangeLogRelease, ChangeLogResult } from './types';
 
 function getCachedTags(
@@ -28,16 +29,18 @@ function getCachedTags(
   return promisedRes;
 }
 
-export async function getChangeLogJSON({
-  versioning,
-  currentVersion,
-  newVersion,
-  sourceUrl,
-  sourceDirectory,
-  releases,
-  depName,
-  manager,
-}: BranchUpgradeConfig): Promise<ChangeLogResult | null> {
+export async function getChangeLogJSON(
+  config: BranchUpgradeConfig
+): Promise<ChangeLogResult | null> {
+  const {
+    versioning,
+    currentVersion,
+    newVersion,
+    sourceUrl,
+    sourceDirectory,
+    depName,
+    manager,
+  } = config;
   if (sourceUrl === 'https://github.com/DefinitelyTyped/DefinitelyTyped') {
     logger.trace('No release notes for @types');
     return null;
@@ -48,12 +51,12 @@ export async function getChangeLogJSON({
   const url = sourceUrl.startsWith('https://github.com/')
     ? 'https://api.github.com/'
     : sourceUrl;
-  const config = hostRules.find({
+  const { token } = hostRules.find({
     hostType: PlatformId.Github,
     url,
   });
   // istanbul ignore if
-  if (!config.token) {
+  if (!token) {
     if (host.endsWith('github.com')) {
       if (!GlobalConfig.get().githubTokenWarn) {
         logger.debug(
@@ -85,6 +88,7 @@ export async function getChangeLogJSON({
     logger.debug({ sourceUrl }, 'Invalid github URL found');
     return null;
   }
+  const releases = config.releases || (await getInRangeReleases(config));
   if (!releases?.length) {
     logger.debug('No releases');
     return null;

--- a/lib/workers/repository/update/pr/changelog/source-gitlab.ts
+++ b/lib/workers/repository/update/pr/changelog/source-gitlab.ts
@@ -8,6 +8,7 @@ import { regEx } from '../../../../../util/regex';
 import type { BranchUpgradeConfig } from '../../../../types';
 import { getTags } from './gitlab';
 import { addReleaseNotes } from './release-notes';
+import { getInRangeReleases } from './releases';
 import type { ChangeLogRelease, ChangeLogResult } from './types';
 
 const cacheNamespace = 'changelog-gitlab-release';
@@ -28,16 +29,18 @@ function getCachedTags(
   return promisedRes;
 }
 
-export async function getChangeLogJSON({
-  versioning,
-  currentVersion,
-  newVersion,
-  sourceUrl,
-  releases,
-  depName,
-  manager,
-  sourceDirectory,
-}: BranchUpgradeConfig): Promise<ChangeLogResult | null> {
+export async function getChangeLogJSON(
+  config: BranchUpgradeConfig
+): Promise<ChangeLogResult | null> {
+  const {
+    versioning,
+    currentVersion,
+    newVersion,
+    sourceUrl,
+    depName,
+    manager,
+    sourceDirectory,
+  } = config;
   logger.trace('getChangeLogJSON for gitlab');
   const version = allVersioning.get(versioning);
   const { protocol, host, pathname } = URL.parse(sourceUrl);
@@ -52,6 +55,7 @@ export async function getChangeLogJSON({
     logger.info({ sourceUrl }, 'Invalid gitlab URL found');
     return null;
   }
+  const releases = config.releases || (await getInRangeReleases(config));
   if (!releases?.length) {
     logger.debug('No releases');
     return null;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes


## Context

- Ref: #7154
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
