### PR TITLE
docs(configuration options): remove duplicate line

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2496,8 +2496,6 @@ See [GitHub](https://help.github.com/en/github/creating-cloning-and-archiving-re
 
 ## reviewersSampleSize
 
-Take a random sample of given size from reviewers.
-
 ## rollback
 
 Add to this object if you wish to define rules that apply only to PRs that roll back versions.


### PR DESCRIPTION
## Changes

- Remove duplicate line

## Context

We're duplicating the `description` text from the code in our docs.

https://github.com/renovatebot/renovate/blob/8e540f051a7170f7063c4e8d1f1f283e45b5f907/lib/config/options/index.ts#L1788-L1793

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
