### PR TITLE
docs(readme): highlight good first issues

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -106,6 +106,7 @@ To run your own instance of Renovate you have several options:
 ## Contributing
 
 If you want to contribute to Renovate or get a local copy running, please read the instructions in [.github/contributing.md](.github/contributing.md).
+To get started look at the [list of good first issues](https://github.com/renovatebot/renovate/contribute).
 
 ## Security / Disclosure
 


### PR DESCRIPTION
## Changes

- Put good first issues in the contributing section of the readme

## Context

We're trying to get more people to contribute. We should highlight good first issues for newcomers.

GitHub created a nice overview page for us, which lists all the issues labeled `good first issue`.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
