### PR TITLE
Draft: fix: resolve members in groups from CODEOWNERS

### DIFF
--- a/lib/modules/platform/gitlab/http.ts
+++ b/lib/modules/platform/gitlab/http.ts
@@ -1,6 +1,6 @@
 import { logger } from '../../../logger';
 import { GitlabHttp } from '../../../util/http/gitlab';
-import type { GitlabUserStatus } from './types';
+import type { GitLabUser, GitlabUserStatus } from './types';
 
 export const gitlabApi = new GitlabHttp();
 
@@ -8,6 +8,12 @@ export async function getUserID(username: string): Promise<number> {
   return (
     await gitlabApi.getJson<{ id: number }[]>(`users?username=${username}`)
   ).body[0].id;
+}
+
+export async function getMemberUserIDs(group: string): Promise<number[]> {
+  const groupEncoded = encodeURIComponent(group);
+  const members = (await gitlabApi.getJson<GitLabUser[]>(`groups/${groupEncoded}/members`)).body;
+  return members.map((u) => u.id)
 }
 
 export async function isUserBusy(user: string): Promise<boolean> {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Resolves groups in CODEOWNERS 

## Context

Closes https://github.com/renovatebot/renovate/issues/14777

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
