### PR TITLE
refactor: add option endpoint to global config

### DIFF
--- a/lib/config/global.ts
+++ b/lib/config/global.ts
@@ -23,6 +23,7 @@ export class GlobalConfig {
     'privateKey',
     'privateKeyOld',
     'gitTimeout',
+    'endpoint',
   ];
 
   private static config: RepoGlobalConfig = {};

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -95,6 +95,7 @@ export interface GlobalOnlyConfig {
   privateKeyPathOld?: string;
   redisUrl?: string;
   repositories?: RenovateRepository[];
+  endpoint?: string;
 }
 
 // Config options used within the repository worker, but not user configurable
@@ -120,6 +121,7 @@ export interface RepoGlobalConfig {
   privateKeyOld?: string;
   localDir?: string;
   cacheDir?: string;
+  endpoint?: string;
 }
 
 export interface LegacyAdminConfig {

--- a/lib/workers/repository/index.spec.ts
+++ b/lib/workers/repository/index.spec.ts
@@ -1,6 +1,7 @@
 import { mock } from 'jest-mock-extended';
 
 import { RenovateConfig, getConfig, mocked } from '../../../test/util';
+import { GlobalConfig } from '../../config/global';
 import * as _process from './process';
 import type { ExtractResult } from './process/extract-update';
 import { renovateRepository } from '.';
@@ -23,6 +24,16 @@ describe('workers/repository/index', () => {
     it('runs', async () => {
       process.extractDependencies.mockResolvedValue(mock<ExtractResult>());
       const res = await renovateRepository(config);
+      expect(res).toBeUndefined();
+    });
+
+    it('shows endpoint', async () => {
+      process.extractDependencies.mockResolvedValue(mock<ExtractResult>());
+      const res = await renovateRepository({
+        ...config,
+        endpoint: 'https://github.com',
+      });
+      expect(GlobalConfig.get().endpoint).toBe('https://github.com');
       expect(res).toBeUndefined();
     });
   });

--- a/lib/workers/repository/index.spec.ts
+++ b/lib/workers/repository/index.spec.ts
@@ -1,7 +1,6 @@
 import { mock } from 'jest-mock-extended';
 
 import { RenovateConfig, getConfig, mocked } from '../../../test/util';
-import { GlobalConfig } from '../../config/global';
 import * as _process from './process';
 import type { ExtractResult } from './process/extract-update';
 import { renovateRepository } from '.';
@@ -19,7 +18,6 @@ describe('workers/repository/index', () => {
 
     beforeEach(() => {
       config = getConfig();
-      GlobalConfig.set({ localDir: '' });
     });
 
     it('runs', async () => {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- add `endpoint` as an option in `GlobalConfig` and as a property in `RepoGlobalConfig`, `GlobalOnlyConfig`
- add minimal test for endpoint

<!-- Describe what behavior is changed by this PR. -->

## Context

- Ref: #15800 

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
