### PR TITLE
fix(config): move endpoint, platform to GlobalConfig

### DIFF
--- a/lib/config/global.ts
+++ b/lib/config/global.ts
@@ -23,6 +23,8 @@ export class GlobalConfig {
     'privateKey',
     'privateKeyOld',
     'gitTimeout',
+    'platform',
+    'endpoint',
   ];
 
   private static config: RepoGlobalConfig = {};

--- a/lib/config/presets/index.spec.ts
+++ b/lib/config/presets/index.spec.ts
@@ -287,7 +287,6 @@ describe('config/presets/index', () => {
 
       expect(res.labels).toEqual(['self-hosted resolved']);
       expect(local.getPreset.mock.calls).toHaveLength(1);
-      expect(local.getPreset.mock.calls[0][0].baseConfig).toBeDefined();
       expect(res).toMatchSnapshot();
     });
 
@@ -308,26 +307,6 @@ describe('config/presets/index', () => {
         endpoint: 'https://dummy.example.com/api/v4',
         labels: ['self-hosted resolved'],
       });
-      expect(local.getPreset.mock.calls).toMatchObject([
-        [
-          {
-            baseConfig: {
-              platform: 'gitlab',
-              endpoint: 'https://dummy.example.com/api/v4',
-              extends: ['local>username/preset-repo'],
-            },
-          },
-        ],
-        [
-          {
-            baseConfig: {
-              platform: 'gitlab',
-              endpoint: 'https://dummy.example.com/api/v4',
-              extends: ['local>username/preset-repo'],
-            },
-          },
-        ],
-      ]);
     });
   });
 

--- a/lib/config/presets/index.ts
+++ b/lib/config/presets/index.ts
@@ -222,7 +222,6 @@ export async function getPreset(
     repo,
     presetPath,
     presetName,
-    baseConfig,
     tag,
   });
   if (!presetConfig) {

--- a/lib/config/presets/local/index.spec.ts
+++ b/lib/config/presets/local/index.spec.ts
@@ -1,4 +1,5 @@
 import { mocked } from '../../../../test/util';
+import { GlobalConfig } from '../../global';
 import * as _azure from '../azure';
 import * as _bitbucket from '../bitbucket';
 import * as _bitbucketServer from '../bitbucket-server';
@@ -34,62 +35,66 @@ describe('config/presets/local/index', () => {
   });
 
   describe('getPreset()', () => {
+    beforeEach(() => {
+      GlobalConfig.reset();
+    });
+
     it('throws for unsupported platform', async () => {
+      GlobalConfig.set({
+        platform: 'unsupported-platform',
+      });
       await expect(async () => {
         await local.getPreset({
           repo: 'some/repo',
           presetName: 'default',
-          baseConfig: {
-            platform: 'unsupported-platform',
-          },
         });
       }).rejects.toThrow();
     });
 
     it('throws for missing platform', async () => {
+      GlobalConfig.set({
+        platform: undefined,
+      });
       await expect(async () => {
         await local.getPreset({
           repo: 'some/repo',
           presetName: 'default',
-          baseConfig: {
-            platform: undefined,
-          },
         });
       }).rejects.toThrow();
     });
 
     it('forwards to azure', async () => {
+      GlobalConfig.set({
+        platform: 'azure',
+      });
       const content = await local.getPreset({
         repo: 'some/repo',
         presetName: 'default',
-        baseConfig: {
-          platform: 'azure',
-        },
       });
       expect(azure.getPresetFromEndpoint.mock.calls).toMatchSnapshot();
       expect(content).toEqual({ resolved: 'preset' });
     });
 
     it('forwards to bitbucket', async () => {
+      GlobalConfig.set({
+        platform: 'bitbucket',
+      });
       const content = await local.getPreset({
         repo: 'some/repo',
         presetName: 'default',
-        baseConfig: {
-          platform: 'bitbucket',
-        },
       });
       expect(bitbucket.getPresetFromEndpoint.mock.calls).toMatchSnapshot();
       expect(content).toEqual({ resolved: 'preset' });
     });
 
     it('forwards to custom bitbucket-server', async () => {
+      GlobalConfig.set({
+        platform: 'bitbucket-server',
+        endpoint: 'https://git.example.com',
+      });
       const content = await local.getPreset({
         repo: 'some/repo',
         presetName: 'default',
-        baseConfig: {
-          platform: 'bitbucket-server',
-          endpoint: 'https://git.example.com',
-        },
       });
       expect(
         bitbucketServer.getPresetFromEndpoint.mock.calls
@@ -98,126 +103,124 @@ describe('config/presets/local/index', () => {
     });
 
     it('forwards to gitea', async () => {
+      GlobalConfig.set({
+        platform: 'gitea',
+      });
       const content = await local.getPreset({
         repo: 'some/repo',
-        baseConfig: {
-          platform: 'gitea',
-        },
       });
       expect(gitea.getPresetFromEndpoint.mock.calls).toMatchSnapshot();
       expect(content).toEqual({ resolved: 'preset' });
     });
 
     it('forwards to custom gitea', async () => {
+      GlobalConfig.set({
+        platform: 'gitea',
+        endpoint: 'https://api.gitea.example.com',
+      });
       const content = await local.getPreset({
         repo: 'some/repo',
         presetName: 'default',
-        baseConfig: {
-          platform: 'gitea',
-          endpoint: 'https://api.gitea.example.com',
-        },
       });
       expect(gitea.getPresetFromEndpoint.mock.calls).toMatchSnapshot();
       expect(content).toEqual({ resolved: 'preset' });
     });
 
     it('forwards to github', async () => {
+      GlobalConfig.set({
+        platform: 'github',
+      });
       const content = await local.getPreset({
         repo: 'some/repo',
-        baseConfig: {
-          platform: 'github',
-        },
       });
       expect(github.getPresetFromEndpoint.mock.calls).toMatchSnapshot();
       expect(content).toEqual({ resolved: 'preset' });
     });
 
     it('forwards to custom github', async () => {
+      GlobalConfig.set({
+        platform: 'github',
+        endpoint: 'https://api.github.example.com',
+      });
       const content = await local.getPreset({
         repo: 'some/repo',
         presetName: 'default',
-        baseConfig: {
-          platform: 'github',
-          endpoint: 'https://api.github.example.com',
-        },
       });
       expect(github.getPresetFromEndpoint.mock.calls).toMatchSnapshot();
       expect(content).toEqual({ resolved: 'preset' });
     });
 
     it('forwards to github with a tag', async () => {
+      GlobalConfig.set({
+        platform: 'github',
+      });
       const content = await local.getPreset({
         repo: 'some/repo',
         tag: 'someTag',
-        baseConfig: {
-          platform: 'github',
-        },
       });
       expect(github.getPresetFromEndpoint.mock.calls).toMatchSnapshot();
       expect(content).toEqual({ resolved: 'preset' });
     });
 
     it('forwards to custom github with a tag', async () => {
+      GlobalConfig.set({
+        platform: 'github',
+        endpoint: 'https://api.github.example.com',
+      });
       const content = await local.getPreset({
         repo: 'some/repo',
         presetName: 'default',
         tag: 'someTag',
-        baseConfig: {
-          platform: 'github',
-          endpoint: 'https://api.github.example.com',
-        },
       });
       expect(github.getPresetFromEndpoint.mock.calls).toMatchSnapshot();
       expect(content).toEqual({ resolved: 'preset' });
     });
 
     it('forwards to gitlab', async () => {
+      GlobalConfig.set({
+        platform: 'GitLab',
+      });
       const content = await local.getPreset({
         repo: 'some/repo',
         presetName: 'default',
-        baseConfig: {
-          platform: 'GitLab',
-        },
       });
       expect(gitlab.getPresetFromEndpoint.mock.calls).toMatchSnapshot();
       expect(content).toEqual({ resolved: 'preset' });
     });
 
     it('forwards to custom gitlab', async () => {
+      GlobalConfig.set({
+        platform: 'gitlab',
+        endpoint: 'https://gitlab.example.com/api/v4',
+      });
       const content = await local.getPreset({
         repo: 'some/repo',
         presetName: 'default',
-        baseConfig: {
-          platform: 'gitlab',
-          endpoint: 'https://gitlab.example.com/api/v4',
-        },
       });
       expect(gitlab.getPresetFromEndpoint.mock.calls).toMatchSnapshot();
       expect(content).toEqual({ resolved: 'preset' });
     });
 
     it('forwards to gitlab with a tag', async () => {
+      GlobalConfig.set({ platform: 'GitLab' });
       const content = await local.getPreset({
         repo: 'some/repo',
         presetName: 'default',
         tag: 'someTag',
-        baseConfig: {
-          platform: 'GitLab',
-        },
       });
       expect(gitlab.getPresetFromEndpoint.mock.calls).toMatchSnapshot();
       expect(content).toEqual({ resolved: 'preset' });
     });
 
     it('forwards to custom gitlab with a tag', async () => {
+      GlobalConfig.set({
+        platform: 'gitlab',
+        endpoint: 'https://gitlab.example.com/api/v4',
+      });
       const content = await local.getPreset({
         repo: 'some/repo',
         presetName: 'default',
         tag: 'someTag',
-        baseConfig: {
-          platform: 'gitlab',
-          endpoint: 'https://gitlab.example.com/api/v4',
-        },
       });
       expect(gitlab.getPresetFromEndpoint.mock.calls).toMatchSnapshot();
       expect(content).toEqual({ resolved: 'preset' });

--- a/lib/config/presets/local/index.ts
+++ b/lib/config/presets/local/index.ts
@@ -1,4 +1,5 @@
 import { PlatformId } from '../../../constants';
+import { GlobalConfig } from '../../global';
 import * as azure from '../azure';
 import * as bitbucket from '../bitbucket';
 import * as bitbucketServer from '../bitbucket-server';
@@ -21,9 +22,8 @@ export function getPreset({
   presetName = 'default',
   presetPath,
   tag,
-  baseConfig,
 }: PresetConfig): Promise<Preset | undefined> {
-  const { platform, endpoint } = baseConfig ?? {};
+  const { platform, endpoint } = GlobalConfig.get();
   if (!platform) {
     throw new Error(`Missing platform config for local preset.`);
   }
@@ -31,8 +31,7 @@ export function getPreset({
   if (!resolver) {
     throw new Error(
       // TODO: can be undefined? #7154
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-      `Unsupported platform '${baseConfig!.platform}' for local preset.`
+      `Unsupported platform '${platform}' for local preset.`
     );
   }
   return resolver.getPresetFromEndpoint(

--- a/lib/config/presets/types.ts
+++ b/lib/config/presets/types.ts
@@ -7,7 +7,6 @@ export type PresetConfig = {
   repo: string;
   presetPath?: string;
   presetName?: string;
-  baseConfig?: RenovateConfig;
   tag?: string;
 };
 

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -51,7 +51,6 @@ export interface RenovateSharedConfig {
   hashedBranchLength?: number;
   npmrc?: string;
   npmrcMerge?: boolean;
-  platform?: string;
   postUpgradeTasks?: PostUpgradeTasks;
   prBodyColumns?: string[];
   prBodyDefinitions?: Record<string, string>;
@@ -95,6 +94,8 @@ export interface GlobalOnlyConfig {
   privateKeyPathOld?: string;
   redisUrl?: string;
   repositories?: RenovateRepository[];
+  platform?: string;
+  endpoint?: string;
 }
 
 // Config options used within the repository worker, but not user configurable
@@ -120,11 +121,11 @@ export interface RepoGlobalConfig {
   privateKeyOld?: string;
   localDir?: string;
   cacheDir?: string;
+  platform?: string;
+  endpoint?: string;
 }
 
 export interface LegacyAdminConfig {
-  endpoint?: string;
-
   localDir?: string;
 
   logContext?: string;
@@ -137,7 +138,6 @@ export interface LegacyAdminConfig {
   onboardingConfig?: RenovateSharedConfig;
   onboardingConfigFileName?: string;
 
-  platform?: string;
   requireConfig?: RequiredConfig;
 }
 export type ExecutionMode = 'branch' | 'update';

--- a/lib/modules/manager/gitlabci-include/extract.spec.ts
+++ b/lib/modules/manager/gitlabci-include/extract.spec.ts
@@ -1,4 +1,5 @@
 import { loadFixture } from '../../../../test/util';
+import { GlobalConfig } from '../../../config/global';
 import { extractPackageFile } from './extract';
 
 const yamlFileMultiConfig = loadFixture('gitlab-ci.1.yaml');
@@ -45,9 +46,8 @@ describe('modules/manager/gitlabci-include/extract', () => {
       ];
 
       for (const endpoint of endpoints) {
-        const res = extractPackageFile(yamlFileMultiConfig, '.gitlab-ci.yml', {
-          endpoint,
-        });
+        GlobalConfig.set({ platform: 'gitlab', endpoint });
+        const res = extractPackageFile(yamlFileMultiConfig);
         expect(res.deps[0].registryUrls[0]).toBe('http://gitlab.test');
       }
     });

--- a/lib/modules/manager/gitlabci-include/extract.spec.ts
+++ b/lib/modules/manager/gitlabci-include/extract.spec.ts
@@ -9,32 +9,22 @@ const yamlWithEmptyIncludeConfig = loadFixture('gitlab-ci.3.yaml');
 describe('modules/manager/gitlabci-include/extract', () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty', () => {
-      expect(
-        extractPackageFile('nothing here', '.gitlab-ci.yml', {})
-      ).toBeNull();
+      expect(extractPackageFile('nothing here')).toBeNull();
     });
 
     it('returns null for include block without any actual includes', () => {
-      const res = extractPackageFile(
-        yamlWithEmptyIncludeConfig,
-        '.gitlab-ci.yml',
-        {}
-      );
+      const res = extractPackageFile(yamlWithEmptyIncludeConfig);
       expect(res).toBeNull();
     });
 
     it('extracts single include block', () => {
-      const res = extractPackageFile(
-        yamlFileSingleConfig,
-        '.gitlab-ci.yml',
-        {}
-      );
+      const res = extractPackageFile(yamlFileSingleConfig);
       expect(res.deps).toMatchSnapshot();
       expect(res.deps).toHaveLength(1);
     });
 
     it('extracts multiple include blocks', () => {
-      const res = extractPackageFile(yamlFileMultiConfig, '.gitlab-ci.yml', {});
+      const res = extractPackageFile(yamlFileMultiConfig);
       expect(res.deps).toMatchSnapshot();
       expect(res.deps).toHaveLength(3);
     });

--- a/lib/modules/manager/gitlabci-include/extract.ts
+++ b/lib/modules/manager/gitlabci-include/extract.ts
@@ -5,7 +5,7 @@ import { logger } from '../../../logger';
 import { regEx } from '../../../util/regex';
 import { GitlabTagsDatasource } from '../../datasource/gitlab-tags';
 import { replaceReferenceTags } from '../gitlabci/utils';
-import type { ExtractConfig, PackageDependency, PackageFile } from '../types';
+import type { PackageDependency, PackageFile } from '../types';
 
 function extractDepFromIncludeFile(includeObj: {
   file: any;

--- a/lib/modules/manager/gitlabci-include/extract.ts
+++ b/lib/modules/manager/gitlabci-include/extract.ts
@@ -1,5 +1,6 @@
 import is from '@sindresorhus/is';
 import { load } from 'js-yaml';
+import { GlobalConfig } from '../../../config/global';
 import { logger } from '../../../logger';
 import { regEx } from '../../../util/regex';
 import { GitlabTagsDatasource } from '../../datasource/gitlab-tags';
@@ -24,12 +25,9 @@ function extractDepFromIncludeFile(includeObj: {
   return dep;
 }
 
-export function extractPackageFile(
-  content: string,
-  _packageFile: string,
-  config: ExtractConfig
-): PackageFile | null {
+export function extractPackageFile(content: string): PackageFile | null {
   const deps: PackageDependency[] = [];
+  const { platform, endpoint } = GlobalConfig.get();
   try {
     // TODO: fix me (#9610)
     const doc: any = load(replaceReferenceTags(content), {
@@ -44,10 +42,8 @@ export function extractPackageFile(
     for (const includeObj of includes) {
       if (includeObj?.file && includeObj.project) {
         const dep = extractDepFromIncludeFile(includeObj);
-        if (config.endpoint) {
-          dep.registryUrls = [
-            config.endpoint.replace(regEx(/\/api\/v4\/?/), ''),
-          ];
+        if (platform === 'gitlab' && endpoint) {
+          dep.registryUrls = [endpoint.replace(regEx(/\/api\/v4\/?/), '')];
         }
         deps.push(dep);
       }

--- a/lib/modules/manager/npm/post-update/index.ts
+++ b/lib/modules/manager/npm/post-update/index.ts
@@ -269,7 +269,7 @@ export async function writeUpdatedPackageFiles(
     const massagedFile = JSON.parse(packageFile.contents.toString());
     try {
       const { token } = hostRules.find({
-        hostType: config.platform,
+        hostType: 'github',
         url: 'https://api.github.com/',
       });
       for (const upgrade of config.upgrades) {
@@ -507,7 +507,7 @@ export async function getAdditionalFiles(
   let token: string | undefined;
   try {
     ({ token } = hostRules.find({
-      hostType: config.platform,
+      hostType: 'github',
       url: 'https://api.github.com/',
     }));
     token = token ? /* istanbul ignore next */ `${token}@` : token;

--- a/lib/modules/manager/types.ts
+++ b/lib/modules/manager/types.ts
@@ -16,7 +16,6 @@ export interface ManagerData<T> {
 
 export interface ExtractConfig {
   registryUrls?: string[];
-  endpoint?: string;
   aliases?: Record<string, string>;
   npmrc?: string;
   npmrcMerge?: boolean;
@@ -297,7 +296,6 @@ export interface PostUpdateConfig<T = Record<string, any>>
   skipInstalls?: boolean;
   ignoreScripts?: boolean;
 
-  platform?: string;
   upgrades: Upgrade[];
   npmLock?: string;
   yarnLock?: string;

--- a/lib/util/cache/repository/index.spec.ts
+++ b/lib/util/cache/repository/index.spec.ts
@@ -13,7 +13,7 @@ describe('util/cache/repository/index', () => {
   beforeEach(() => {
     resetCache();
     jest.resetAllMocks();
-    GlobalConfig.set({ cacheDir: '/tmp/cache' });
+    GlobalConfig.set({ cacheDir: '/tmp/cache', platform: 'github' });
   });
 
   const config: RenovateConfig = {

--- a/lib/util/cache/repository/init.ts
+++ b/lib/util/cache/repository/init.ts
@@ -1,3 +1,4 @@
+import { GlobalConfig } from '../../../config/global';
 import type { RenovateConfig } from '../../../config/types';
 import { LocalRepoCache } from './impl/local';
 import { resetCache, setCache } from '.';
@@ -7,12 +8,9 @@ import { resetCache, setCache } from '.';
  */
 export async function initRepoCache(config: RenovateConfig): Promise<void> {
   resetCache();
-  if (
-    config.platform &&
-    config.repository &&
-    config.repositoryCache === 'enabled'
-  ) {
-    const localCache = new LocalRepoCache(config.platform, config.repository);
+  const { platform } = GlobalConfig.get();
+  if (platform && config.repository && config.repositoryCache === 'enabled') {
+    const localCache = new LocalRepoCache(platform, config.repository);
     await localCache.load();
     setCache(localCache);
   }

--- a/lib/workers/global/index.ts
+++ b/lib/workers/global/index.ts
@@ -32,7 +32,7 @@ export async function getRepositoryConfig(
     globalConfig,
     is.string(repository) ? { repository } : repository
   );
-  const { platform } = GlobalConfig.get();
+  const platform = GlobalConfig.get('platform');
   repoConfig.localDir = upath.join(
     repoConfig.baseDir,
     `./repos/${platform}/${repoConfig.repository}`

--- a/lib/workers/global/index.ts
+++ b/lib/workers/global/index.ts
@@ -5,6 +5,7 @@ import semver from 'semver';
 import upath from 'upath';
 import * as configParser from '../../config';
 import { mergeChildConfig } from '../../config';
+import { GlobalConfig } from '../../config/global';
 import { resolveConfigPresets } from '../../config/presets';
 import { validateConfigSecrets } from '../../config/secrets';
 import type {
@@ -31,9 +32,10 @@ export async function getRepositoryConfig(
     globalConfig,
     is.string(repository) ? { repository } : repository
   );
+  const { platform } = GlobalConfig.get();
   repoConfig.localDir = upath.join(
     repoConfig.baseDir,
-    `./repos/${repoConfig.platform}/${repoConfig.repository}`
+    `./repos/${platform}/${repoConfig.repository}`
   );
   await fs.ensureDir(repoConfig.localDir);
   delete repoConfig.baseDir;

--- a/lib/workers/repository/init/index.ts
+++ b/lib/workers/repository/init/index.ts
@@ -18,7 +18,7 @@ function initializeConfig(config: RenovateConfig): RenovateConfig {
 
 function warnOnUnsupportedOptions(config: RenovateConfig): void {
   if (config.filterUnavailableUsers && !platform.filterUnavailableUsers) {
-    const { platform } = GlobalConfig.get();
+    const platform = GlobalConfig.get('platform');
     logger.warn(
       `Configuration option 'filterUnavailableUsers' is not supported on the current platform '${platform}'.`
     );

--- a/lib/workers/repository/init/index.ts
+++ b/lib/workers/repository/init/index.ts
@@ -1,3 +1,4 @@
+import { GlobalConfig } from '../../../config/global';
 import { applySecretsToConfig } from '../../../config/secrets';
 import type { RenovateConfig } from '../../../config/types';
 import { logger } from '../../../logger';
@@ -17,8 +18,9 @@ function initializeConfig(config: RenovateConfig): RenovateConfig {
 
 function warnOnUnsupportedOptions(config: RenovateConfig): void {
   if (config.filterUnavailableUsers && !platform.filterUnavailableUsers) {
+    const { platform } = GlobalConfig.get();
     logger.warn(
-      `Configuration option 'filterUnavailableUsers' is not supported on the current platform '${config.platform}'.`
+      `Configuration option 'filterUnavailableUsers' is not supported on the current platform '${platform}'.`
     );
   }
 }

--- a/lib/workers/repository/onboarding/branch/config.spec.ts
+++ b/lib/workers/repository/onboarding/branch/config.spec.ts
@@ -14,6 +14,7 @@ describe('workers/repository/onboarding/branch/config', () => {
   beforeAll(() => {
     GlobalConfig.set({
       localDir: '',
+      platform: 'github',
     });
   });
 

--- a/lib/workers/repository/onboarding/branch/config.ts
+++ b/lib/workers/repository/onboarding/branch/config.ts
@@ -1,3 +1,4 @@
+import { GlobalConfig } from '../../../../config/global';
 import { getPreset } from '../../../../config/presets/local';
 import { PRESET_DEP_NOT_FOUND } from '../../../../config/presets/util';
 import type {
@@ -24,7 +25,7 @@ async function getOnboardingConfig(
   // Check for org/renovate-config
   try {
     const repo = `${orgName}/renovate-config`;
-    await getPreset({ repo, baseConfig: config });
+    await getPreset({ repo });
     orgPreset = `local>${repo}`;
   } catch (err) {
     if (
@@ -37,13 +38,13 @@ async function getOnboardingConfig(
 
   if (!orgPreset) {
     // Check for org/.{{platform}}
+    const { platform } = GlobalConfig.get();
     try {
-      const repo = `${orgName}/.${config.platform}`;
+      const repo = `${orgName}/.${platform}`;
       const presetName = 'renovate-config';
       await getPreset({
         repo,
         presetName,
-        baseConfig: config,
       });
       orgPreset = `local>${repo}:${presetName}`;
     } catch (err) {

--- a/lib/workers/repository/onboarding/branch/config.ts
+++ b/lib/workers/repository/onboarding/branch/config.ts
@@ -38,7 +38,7 @@ async function getOnboardingConfig(
 
   if (!orgPreset) {
     // Check for org/.{{platform}}
-    const { platform } = GlobalConfig.get();
+    const platform = GlobalConfig.get('platform');
     try {
       const repo = `${orgName}/.${platform}`;
       const presetName = 'renovate-config';

--- a/lib/workers/types.ts
+++ b/lib/workers/types.ts
@@ -37,7 +37,6 @@ export interface BranchUpgradeConfig
   currentDigest?: string;
   currentDigestShort?: string;
   currentValue?: string;
-  endpoint?: string;
   excludeCommitPaths?: string[];
   githubName?: string;
   group?: GroupConfig;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Moves `platform` and `endpoint` to `GlobalConfig`.

## Context

Closes #15859

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
