### PR TITLE
fix(github): Re-throw datasource cache errors

### DIFF
--- a/lib/modules/datasource/github-releases/cache/cache-base.spec.ts
+++ b/lib/modules/datasource/github-releases/cache/cache-base.spec.ts
@@ -251,12 +251,10 @@ describe('modules/datasource/github-releases/cache/cache-base', () => {
     ];
     const cache = new TestCache(http, { resetDeltaMinutes: 0 });
 
-    const res = await cache.getItems({ packageName: 'foo/bar' });
-
-    expect(sortItems(res)).toMatchObject([
-      { version: 'v1', bar: 'aaa' },
-      { version: 'v2', bar: 'bbb' },
-      { version: 'v3', bar: 'ccc' },
-    ]);
+    await expect(cache.getItems({ packageName: 'foo/bar' })).rejects.toThrow(
+      'Unknown error'
+    );
+    expect(packageCache.get).toHaveBeenCalled();
+    expect(packageCache.set).not.toHaveBeenCalled();
   });
 });

--- a/lib/modules/datasource/github-releases/cache/cache-base.ts
+++ b/lib/modules/datasource/github-releases/cache/cache-base.ts
@@ -1,5 +1,4 @@
 import { DateTime, DurationLikeObject } from 'luxon';
-import { logger } from '../../../../logger';
 import * as packageCache from '../../../../util/cache/package';
 import type {
   GithubGraphqlResponse,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Don't do any error handling just like in previous implementation
<!-- Describe what behavior is changed by this PR. -->

## Context

- Ref: #15645
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
