### PR TITLE
fix(github): Throw on GraphQL errors during cache fetching

### DIFF
--- a/lib/modules/datasource/github-releases/cache/cache-base.spec.ts
+++ b/lib/modules/datasource/github-releases/cache/cache-base.spec.ts
@@ -234,7 +234,7 @@ describe('modules/datasource/github-releases/cache/cache-base', () => {
     ]);
   });
 
-  it('throws for unknown errors', async () => {
+  it('throws for http errors', async () => {
     packageCache.get.mockResolvedValueOnce({
       items: {
         v1: { version: 'v1', releaseTimestamp: t1, bar: 'aaa' },

--- a/lib/modules/datasource/github-releases/cache/cache-base.ts
+++ b/lib/modules/datasource/github-releases/cache/cache-base.ts
@@ -203,7 +203,13 @@ export abstract class AbstractGithubDatasourceCache<
           });
           pagesRemained -= 1;
 
-          const data = graphqlRes.body.data;
+          const { data, errors } = graphqlRes.body;
+
+          const errorMessage = errors?.[0]?.message;
+          if (errorMessage) {
+            throw Error(errorMessage);
+          }
+
           if (data) {
             const {
               nodes: fetchedItems,

--- a/lib/util/http/github.ts
+++ b/lib/util/http/github.ts
@@ -50,7 +50,6 @@ export interface GithubGraphqlResponse<T = unknown> {
   errors?: {
     type?: string;
     message: string;
-    locations: unknown;
   }[];
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Throw with error message if GraphQL-related error is encountered
<!-- Describe what behavior is changed by this PR. -->

## Context

- Ref: #15645
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
