### PR TITLE
fix(github): Never return null results for `getReleases`

### DIFF
--- a/lib/modules/datasource/github-releases/index.ts
+++ b/lib/modules/datasource/github-releases/index.ts
@@ -237,26 +237,22 @@ export class GithubReleasesDatasource extends Datasource {
    *  - Sanitize the versions if desired (e.g. strip out leading 'v')
    *  - Return a dependency object containing sourceUrl string and releases array
    */
-  async getReleases(config: GetReleasesConfig): Promise<ReleaseResult | null> {
-    let result: ReleaseResult | null = null;
+  async getReleases(config: GetReleasesConfig): Promise<ReleaseResult> {
     const releases = await this.releasesCache.getItems(config);
-    if (releases.length) {
-      result = {
-        sourceUrl: getSourceUrl(config.packageName, config.registryUrl),
-        releases: releases.map((item) => {
-          const { version, releaseTimestamp, isStable } = item;
-          const result: Release = {
-            version,
-            gitRef: version,
-            releaseTimestamp,
-          };
-          if (isStable !== undefined) {
-            result.isStable = isStable;
-          }
-          return result;
-        }),
-      };
-    }
-    return result;
+    return {
+      sourceUrl: getSourceUrl(config.packageName, config.registryUrl),
+      releases: releases.map((item) => {
+        const { version, releaseTimestamp, isStable } = item;
+        const result: Release = {
+          version,
+          gitRef: version,
+          releaseTimestamp,
+        };
+        if (isStable !== undefined) {
+          result.isStable = isStable;
+        }
+        return result;
+      }),
+    };
   }
 }

--- a/lib/modules/datasource/github-tags/index.ts
+++ b/lib/modules/datasource/github-tags/index.ts
@@ -85,11 +85,6 @@ export class GithubTagsDatasource extends GithubReleasesDatasource {
   ): Promise<ReleaseResult | null> {
     const tagReleases = await this.tagsCache.getItems(config);
 
-    // istanbul ignore if
-    if (!tagReleases.length) {
-      return null;
-    }
-
     const tagsResult: ReleaseResult = {
       sourceUrl: getSourceUrl(config.packageName, config.registryUrl),
       releases: tagReleases.map((item) => ({ ...item, gitRef: item.version })),
@@ -113,8 +108,8 @@ export class GithubTagsDatasource extends GithubReleasesDatasource {
       });
 
       tagsResult.releases = mergedReleases;
-    } catch (e) {
-      // no-op
+    } catch (err) /* istanbul ignore next */ {
+      logger.debug({ err }, `Error fetching additional info for GitHub tags`);
     }
 
     return tagsResult;

--- a/lib/modules/datasource/github-tags/index.ts
+++ b/lib/modules/datasource/github-tags/index.ts
@@ -82,7 +82,7 @@ export class GithubTagsDatasource extends GithubReleasesDatasource {
 
   override async getReleases(
     config: GetReleasesConfig
-  ): Promise<ReleaseResult | null> {
+  ): Promise<ReleaseResult> {
     const tagReleases = await this.tagsCache.getItems(config);
 
     const tagsResult: ReleaseResult = {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Return `releases: []` instead of the whole result to be `null`
<!-- Describe what behavior is changed by this PR. -->

## Context

- Ref: #15645

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
