### PR TITLE
feat(github): Different cache update frequency for fresh packages

### DIFF
--- a/lib/modules/datasource/github-releases/cache/cache-base.spec.ts
+++ b/lib/modules/datasource/github-releases/cache/cache-base.spec.ts
@@ -344,4 +344,14 @@ describe('modules/datasource/github-releases/cache/cache-base', () => {
     expect(packageCache.get).toHaveBeenCalled();
     expect(packageCache.set).not.toHaveBeenCalled();
   });
+
+  it('finds latest release timestamp correctly', () => {
+    const cache = new TestCache(http);
+    const ts = cache.getLastReleaseTimestamp({
+      v2: { bar: 'bbb', releaseTimestamp: t2, version: 'v2' },
+      v3: { bar: 'ccc', releaseTimestamp: t3, version: 'v3' },
+      v1: { bar: 'aaa', releaseTimestamp: t1, version: 'v1' },
+    });
+    expect(ts).toEqual(t3);
+  });
 });

--- a/lib/modules/datasource/github-releases/cache/cache-base.spec.ts
+++ b/lib/modules/datasource/github-releases/cache/cache-base.spec.ts
@@ -115,6 +115,7 @@ describe('modules/datasource/github-releases/cache/cache-base', () => {
       {
         createdAt: now.toISO(),
         updatedAt: now.toISO(),
+        lastReleasedAt: t3,
         items: {
           v1: { bar: 'aaa', releaseTimestamp: t1, version: 'v1' },
           v2: { bar: 'bbb', releaseTimestamp: t2, version: 'v2' },
@@ -174,6 +175,7 @@ describe('modules/datasource/github-releases/cache/cache-base', () => {
       {
         createdAt: t3,
         updatedAt: now.toISO(),
+        lastReleasedAt: t3,
         items: {
           v1: { bar: 'aaa', releaseTimestamp: t1, version: 'v1' },
           v2: { bar: 'bbb', releaseTimestamp: t2, version: 'v2' },
@@ -181,6 +183,69 @@ describe('modules/datasource/github-releases/cache/cache-base', () => {
         },
       },
       6 * 24 * 60
+    );
+  });
+
+  it('does not update non-fresh packages earlier than 120 minutes ago', async () => {
+    const releaseTimestamp = now.minus({ days: 7 }).toISO();
+    const createdAt = now.minus({ minutes: 119 }).toISO();
+    packageCache.get.mockResolvedValueOnce({
+      items: { v1: { version: 'v1', releaseTimestamp, bar: 'aaa' } },
+      createdAt: createdAt,
+      updatedAt: createdAt,
+    });
+    responses = [
+      resp([
+        { name: 'v1', createdAt: releaseTimestamp, foo: 'aaa' },
+        { name: 'v2', createdAt: now.toISO(), foo: 'bbb' },
+      ]),
+    ];
+    const cache = new TestCache(http, { resetDeltaMinutes: 0 });
+
+    const res = await cache.getItems({ packageName: 'foo/bar' });
+
+    expect(sortItems(res)).toMatchObject([
+      { version: 'v1', releaseTimestamp, bar: 'aaa' },
+    ]);
+    expect(httpPostJson).not.toHaveBeenCalled();
+  });
+
+  it('updates non-fresh packages after 120 minutes', async () => {
+    const releaseTimestamp = now.minus({ days: 7 }).toISO();
+    const recentTimestamp = now.toISO();
+    const createdAt = now.minus({ minutes: 120 }).toISO();
+    packageCache.get.mockResolvedValueOnce({
+      items: { v1: { version: 'v1', releaseTimestamp, bar: 'aaa' } },
+      createdAt: createdAt,
+      updatedAt: createdAt,
+    });
+    responses = [
+      resp([
+        { name: 'v1', createdAt: releaseTimestamp, foo: 'aaa' },
+        { name: 'v2', createdAt: recentTimestamp, foo: 'bbb' },
+      ]),
+    ];
+    const cache = new TestCache(http, { resetDeltaMinutes: 0 });
+
+    const res = await cache.getItems({ packageName: 'foo/bar' });
+
+    expect(sortItems(res)).toMatchObject([
+      { version: 'v1', releaseTimestamp, bar: 'aaa' },
+      { version: 'v2', releaseTimestamp: recentTimestamp, bar: 'bbb' },
+    ]);
+    expect(packageCache.set).toHaveBeenCalledWith(
+      'test-cache',
+      'https://api.github.com/:foo:bar',
+      {
+        createdAt: createdAt,
+        items: {
+          v1: { bar: 'aaa', releaseTimestamp, version: 'v1' },
+          v2: { bar: 'bbb', releaseTimestamp: recentTimestamp, version: 'v2' },
+        },
+        lastReleasedAt: recentTimestamp,
+        updatedAt: recentTimestamp,
+      },
+      60 * 24 * 7 - 120
     );
   });
 

--- a/lib/modules/datasource/github-releases/cache/cache-base.ts
+++ b/lib/modules/datasource/github-releases/cache/cache-base.ts
@@ -341,7 +341,7 @@ export abstract class AbstractGithubDatasourceCache<
     return Math.floor(rnd * this.resetDeltaMinutes);
   }
 
-  private getLastReleaseTimestamp(
+  public getLastReleaseTimestamp(
     items: Record<string, StoredItem>
   ): string | null {
     let result: string | null = null;
@@ -354,6 +354,7 @@ export abstract class AbstractGithubDatasourceCache<
       latest ??= timestamp;
 
       if (timestamp > latest) {
+        result = releaseTimestamp;
         latest = timestamp;
       }
     }

--- a/lib/modules/datasource/github-releases/cache/cache-base.ts
+++ b/lib/modules/datasource/github-releases/cache/cache-base.ts
@@ -283,6 +283,10 @@ export abstract class AbstractGithubDatasourceCache<
                 checkedVersions.add(version);
 
                 lastReleasedAt ??= releaseTimestamp;
+                // It may be tempting to optimize the code and
+                // remove the check, as we're fetching fresh releases here.
+                // That's wrong, because some items are already cached,
+                // and they obviously aren't latest.
                 if (
                   DateTime.fromISO(releaseTimestamp) >
                   DateTime.fromISO(lastReleasedAt)

--- a/lib/modules/datasource/github-releases/cache/types.ts
+++ b/lib/modules/datasource/github-releases/cache/types.ts
@@ -50,6 +50,9 @@ export interface GithubDatasourceCache<StoredItem extends StoredItemBase> {
 
   /** Cache soft updates are performed depending on `updatedAt` value. */
   updatedAt: string;
+
+  /** Latest release timestamp (`releaseTimestamp`) of all releases. */
+  lastReleasedAt?: string;
 }
 
 /**
@@ -60,6 +63,25 @@ export interface CacheOptions {
    * How many minutes to wait until next cache update
    */
   updateAfterMinutes?: number;
+
+  /**
+   * If package was released recently, we assume higher
+   * probability of having one more release soon.
+   *
+   * In this case, we use `updateAfterMinutesFresh` option.
+   */
+  packageFreshDays?: number;
+
+  /**
+   * If package was released recently, we assume higher
+   * probability of having one more release soon.
+   *
+   * In this case, this option will be used
+   * instead of `updateAfterMinutes`.
+   *
+   * Fresh period is configured via `freshDays` option.
+   */
+  updateAfterMinutesFresh?: number;
 
   /**
    * How many days to wait until full cache reset (for single package).


### PR DESCRIPTION
## Changes

- `updateAfterMinutes` is set to 120
- `updateAfterMinutesFresh` is set to 30
- `packageFreshDays` is set to 7

For example, Renovate repository would be checked each 30 minutes, since we have frequent release cycle.

For monthly release cycles, it would refresh each 120 minutes in most cases.

## Context

- Ref: #15645

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository
