### PR TITLE
fix: set global config before validating local presets

### DIFF
--- a/lib/workers/global/index.ts
+++ b/lib/workers/global/index.ts
@@ -118,6 +118,9 @@ export async function start(): Promise<number> {
     // initialize all submodules
     config = await globalInitialize(config);
 
+    // Set platform and endpoint in case local presets are used
+    GlobalConfig.set({ platform: config.platform, endpoint: config.endpoint });
+
     await validatePresets(config);
 
     checkEnv();


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Calls `GlobalConfig.set()` with endpoint and platform prior to validating presets in global worker.

## Context

Closes #15925

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
