### PR TITLE
fix(npm): use lower case %2f encoding

### DIFF
--- a/lib/modules/datasource/npm/get.spec.ts
+++ b/lib/modules/datasource/npm/get.spec.ts
@@ -8,7 +8,7 @@ import { resolveRegistryUrl, setNpmrc } from './npmrc';
 function getPath(s = ''): string {
   const [x] = s.split('\n');
   const prePath = x.replace(/^.*https:\/\/test\.org/, '');
-  return `${prePath}/@myco%2Ftest`;
+  return `${prePath}/@myco%2ftest`;
 }
 
 const http = new Http('npm');
@@ -186,7 +186,7 @@ describe('modules/datasource/npm/get', () => {
 
     httpMock
       .scope('https://test.org')
-      .get('/@myco%2Ftest')
+      .get('/@myco%2ftest')
       .reply(200, {
         name: '@myco/test',
         repository: {},
@@ -198,7 +198,7 @@ describe('modules/datasource/npm/get', () => {
 
     httpMock
       .scope('https://test.org')
-      .get('/@myco%2Ftest2')
+      .get('/@myco%2ftest2')
       .reply(200, {
         name: '@myco/test2',
         versions: { '1.0.0': {} },
@@ -247,7 +247,7 @@ describe('modules/datasource/npm/get', () => {
       .scope('https://test.org', {
         reqheaders: { authorization: 'Bearer XXX' },
       })
-      .get('/@neutrinojs%2Freact')
+      .get('/@neutrinojs%2freact')
       .reply(200, {
         name: '@neutrinojs/react',
         repository: {
@@ -274,7 +274,7 @@ describe('modules/datasource/npm/get', () => {
             "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
           },
           "method": "GET",
-          "url": "https://test.org/@neutrinojs%2Freact",
+          "url": "https://test.org/@neutrinojs%2freact",
         },
       ]
     `);
@@ -285,7 +285,7 @@ describe('modules/datasource/npm/get', () => {
 
     httpMock
       .scope('https://test.org')
-      .get('/@neutrinojs%2Freact')
+      .get('/@neutrinojs%2freact')
       .reply(200, {
         name: '@neutrinojs/react',
         repository: {
@@ -344,7 +344,7 @@ describe('modules/datasource/npm/get', () => {
 
     httpMock
       .scope('https://test.org')
-      .get('/@neutrinojs%2Freact')
+      .get('/@neutrinojs%2freact')
       .reply(200, {
         name: '@neutrinojs/react',
         repository: {
@@ -372,7 +372,7 @@ describe('modules/datasource/npm/get', () => {
             "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
           },
           "method": "GET",
-          "url": "https://test.org/@neutrinojs%2Freact",
+          "url": "https://test.org/@neutrinojs%2freact",
         },
       ]
     `);
@@ -383,7 +383,7 @@ describe('modules/datasource/npm/get', () => {
 
     httpMock
       .scope('https://test.org')
-      .get('/@neutrinojs%2Freact')
+      .get('/@neutrinojs%2freact')
       .reply(200, {
         name: '@neutrinojs/react',
         repository: {
@@ -412,7 +412,7 @@ describe('modules/datasource/npm/get', () => {
             "user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
           },
           "method": "GET",
-          "url": "https://test.org/@neutrinojs%2Freact",
+          "url": "https://test.org/@neutrinojs%2freact",
         },
       ]
     `);

--- a/lib/modules/datasource/npm/get.ts
+++ b/lib/modules/datasource/npm/get.ts
@@ -63,7 +63,7 @@ export async function getDependency(
     return JSON.parse(memcache[packageName]) as NpmDependency;
   }
 
-  const packageUrl = joinUrlParts(registryUrl, packageName.replace('/', '%2F'));
+  const packageUrl = joinUrlParts(registryUrl, packageName.replace('/', '%2f'));
 
   // Now check the persistent cache
   const cacheNamespace = 'datasource-npm';


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

fixes #15942. This changes the casing for url encoding for npm to lowercase. 

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->
When resolving npm packages from Proget, Renovate url encodes the package name by replacing the `/` with `%2F`. This then results in a 404 being returned by proget. When changing this to `%2f` a 200 response is returned. 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
