### PR TITLE
fix(changelog): extractVersion check

### DIFF
--- a/lib/workers/repository/update/pr/changelog/release-notes.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/release-notes.spec.ts
@@ -621,6 +621,34 @@ describe('workers/repository/update/pr/changelog/release-notes', () => {
         body: 'some body\n',
       });
     });
+
+    it('fallback to extractVersion', async () => {
+      githubReleasesMock.mockResolvedValueOnce([
+        {
+          version: `app-1.0.0`,
+          url: 'correct/url/tag.com',
+          description: 'some body',
+        },
+      ] as never);
+      const res = await getReleaseNotes(
+        {
+          ...githubProject,
+          repository: 'some/other-repository',
+          depName: 'exampleDep',
+        },
+        '1.0.0',
+        { extractVersion: 'app-(?<version>[0-9.]*)' } as BranchUpgradeConfig
+      );
+      expect(res).toEqual({
+        url: 'correct/url/tag.com',
+        notesSourceUrl:
+          'https://api.github.com/repos/some/other-repository/releases',
+        id: undefined,
+        tag: 'app-1.0.0',
+        name: undefined,
+        body: 'some body\n',
+      });
+    });
   });
 
   describe('getReleaseNotesMd()', () => {

--- a/lib/workers/repository/update/pr/changelog/release-notes.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/release-notes.spec.ts
@@ -636,7 +636,10 @@ describe('workers/repository/update/pr/changelog/release-notes', () => {
           repository: 'some/other-repository',
           depName: 'exampleDep',
         },
-        '1.0.0',
+        {
+          version: '1.0.0',
+          gitRef: '1.0.0',
+        } as ChangeLogRelease,
         { extractVersion: 'app-(?<version>[0-9.]*)' } as BranchUpgradeConfig
       );
       expect(res).toEqual({

--- a/lib/workers/repository/update/pr/changelog/release-notes.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/release-notes.spec.ts
@@ -5,6 +5,7 @@ import { CacheableGithubReleases } from '../../../../../modules/datasource/githu
 import { clone } from '../../../../../util/clone';
 import * as _hostRules from '../../../../../util/host-rules';
 import { toBase64 } from '../../../../../util/string';
+import type { BranchUpgradeConfig } from '../../../../types';
 import {
   addReleaseNotes,
   getReleaseList,
@@ -94,9 +95,16 @@ describe('workers/repository/update/pr/changelog/release-notes', () => {
   describe('addReleaseNotes()', () => {
     it('returns input if invalid', async () => {
       const input = { a: 1 };
-      expect(await addReleaseNotes(input as never)).toEqual(input);
-      expect(await addReleaseNotes(null)).toBeNull();
-      expect(await addReleaseNotes({ versions: [] } as never)).toStrictEqual({
+      expect(
+        await addReleaseNotes(input as never, {} as BranchUpgradeConfig)
+      ).toEqual(input);
+      expect(await addReleaseNotes(null, {} as BranchUpgradeConfig)).toBeNull();
+      expect(
+        await addReleaseNotes(
+          { versions: [] } as never,
+          {} as BranchUpgradeConfig
+        )
+      ).toStrictEqual({
         versions: [],
       });
     });
@@ -110,7 +118,9 @@ describe('workers/repository/update/pr/changelog/release-notes', () => {
         },
         versions: [{ version: '3.10.0', compare: { url: '' } }],
       };
-      expect(await addReleaseNotes(input as never)).toEqual({
+      expect(
+        await addReleaseNotes(input as never, {} as BranchUpgradeConfig)
+      ).toEqual({
         a: 1,
         hasReleaseNotes: false,
         project: {
@@ -140,7 +150,7 @@ describe('workers/repository/update/pr/changelog/release-notes', () => {
           { version: '20.26.0', compare: { url: '' } } as ChangeLogRelease,
         ],
       } as ChangeLogResult;
-      expect(await addReleaseNotes(input)).toEqual({
+      expect(await addReleaseNotes(input, {} as BranchUpgradeConfig)).toEqual({
         a: 1,
         hasReleaseNotes: false,
         project: {
@@ -280,7 +290,8 @@ describe('workers/repository/update/pr/changelog/release-notes', () => {
         {
           version: '1.0.0',
           gitRef: '1.0.0',
-        } as ChangeLogRelease
+        } as ChangeLogRelease,
+        {} as BranchUpgradeConfig
       );
       expect(res).toBeNull();
     });
@@ -303,7 +314,8 @@ describe('workers/repository/update/pr/changelog/release-notes', () => {
         {
           version: '1.0.1',
           gitRef: '1.0.1',
-        } as ChangeLogRelease
+        } as ChangeLogRelease,
+        {} as BranchUpgradeConfig
       );
       expect(res).toEqual({
         body: 'some body [#123](https://github.com/some/other-repository/issues/123), [#124](https://github.com/some/yet-other-repository/issues/124)\n',
@@ -334,7 +346,8 @@ describe('workers/repository/update/pr/changelog/release-notes', () => {
         {
           version: '1.0.1',
           gitRef: '1.0.1',
-        } as ChangeLogRelease
+        } as ChangeLogRelease,
+        {} as BranchUpgradeConfig
       );
       expect(res).toEqual({
         body: 'some body [#123](https://github.com/some/other-repository/issues/123), [#124](https://github.com/some/yet-other-repository/issues/124)\n',
@@ -366,7 +379,8 @@ describe('workers/repository/update/pr/changelog/release-notes', () => {
         {
           version: '1.0.1',
           gitRef: '1.0.1',
-        } as ChangeLogRelease
+        } as ChangeLogRelease,
+        {} as BranchUpgradeConfig
       );
       expect(res).toEqual({
         body: 'some body [#123](https://github.com/some/other-repository/issues/123), [#124](https://github.com/some/yet-other-repository/issues/124)\n',
@@ -398,7 +412,8 @@ describe('workers/repository/update/pr/changelog/release-notes', () => {
         {
           version: '1.0.1',
           gitRef: '1.0.1',
-        } as ChangeLogRelease
+        } as ChangeLogRelease,
+        {} as BranchUpgradeConfig
       );
       expect(res).toEqual({
         body: 'some body [#123](https://github.com/some/other-repository/issues/123), [#124](https://github.com/some/yet-other-repository/issues/124)\n',
@@ -429,7 +444,8 @@ describe('workers/repository/update/pr/changelog/release-notes', () => {
         {
           version: '1.0.1',
           gitRef: '1.0.1',
-        } as ChangeLogRelease
+        } as ChangeLogRelease,
+        {} as BranchUpgradeConfig
       );
       expect(res).toEqual({
         body: 'some body [#123](https://github.com/some/other-repository/issues/123), [#124](https://github.com/some/yet-other-repository/issues/124)\n',
@@ -466,7 +482,8 @@ describe('workers/repository/update/pr/changelog/release-notes', () => {
         {
           version: '1.0.1',
           gitRef: '1.0.1',
-        } as ChangeLogRelease
+        } as ChangeLogRelease,
+        {} as BranchUpgradeConfig
       );
       expect(res).toEqual({
         body: 'some body #123, [#124](https://gitlab.com/some/yet-other-repository/issues/124)',
@@ -502,7 +519,8 @@ describe('workers/repository/update/pr/changelog/release-notes', () => {
         {
           version: '1.0.1',
           gitRef: '1.0.1',
-        } as ChangeLogRelease
+        } as ChangeLogRelease,
+        {} as BranchUpgradeConfig
       );
       expect(res).toEqual({
         body: 'some body #123, [#124](https://gitlab.com/some/yet-other-repository/issues/124)',
@@ -538,7 +556,8 @@ describe('workers/repository/update/pr/changelog/release-notes', () => {
         {
           version: '1.0.1',
           gitRef: '1.0.1',
-        } as ChangeLogRelease
+        } as ChangeLogRelease,
+        {} as BranchUpgradeConfig
       );
       expect(res).toEqual({
         body: 'some body #123, [#124](https://gitlab.com/some/yet-other-repository/issues/124)',
@@ -561,7 +580,8 @@ describe('workers/repository/update/pr/changelog/release-notes', () => {
         {
           version: '1.0.1',
           gitRef: '1.0.1',
-        } as ChangeLogRelease
+        } as ChangeLogRelease,
+        {} as BranchUpgradeConfig
       );
       expect(res).toBeNull();
     });
@@ -588,7 +608,8 @@ describe('workers/repository/update/pr/changelog/release-notes', () => {
         {
           version: '1.0.0',
           gitRef: '1.0.0',
-        } as ChangeLogRelease
+        } as ChangeLogRelease,
+        {} as BranchUpgradeConfig
       );
       expect(res).toEqual({
         url: 'correct/url/tag.com',

--- a/lib/workers/repository/update/pr/changelog/source-github.ts
+++ b/lib/workers/repository/update/pr/changelog/source-github.ts
@@ -177,7 +177,7 @@ export async function getChangeLogJSON(
     versions: changelogReleases,
   };
 
-  res = await addReleaseNotes(res);
+  res = await addReleaseNotes(res, config);
 
   return res;
 }

--- a/lib/workers/repository/update/pr/changelog/source-gitlab.ts
+++ b/lib/workers/repository/update/pr/changelog/source-gitlab.ts
@@ -145,7 +145,7 @@ export async function getChangeLogJSON(
     versions: changelogReleases,
   };
 
-  res = await addReleaseNotes(res);
+  res = await addReleaseNotes(res, config);
 
   return res;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Retrieving changelog when using `config.extractVersion`.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->
- https://github.com/renovatebot/renovate/pull/15869#discussion_r893152360

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
