### PR TITLE
chore: update link to semantic commit bot repo

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,4 +1,4 @@
-# Semantic Commit bot: https://github.com/zeke/semantic-pull-requests
+# Semantic Commit bot: https://github.com/Ezard/semantic-prs
 
 # Always validate the PR title, and ignore the commits
 titleOnly: true


### PR DESCRIPTION
## Changes

- Update link to semantic commit bot repo

## Context

I think we're using the `ezard` version of the semantic commit bot now that the `zeke` version is no longer maintained according to [their README](https://github.com/zeke/semantic-pull-requests/blob/main/README.md)?

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
