### PR TITLE
feat(gitlab): Use thread instead of comment for blocking comment

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -113,7 +113,7 @@ Alias values must be properly formatted URIs.
 
 ## artifactUpdateWarningAsThread
 
-By default, Renovate will create a warning comment when an artifact update occurs.
+By default, Renovate will create a warning comment when an artifact update fails.
 By configuring this setting to `true`, Renovatebot will instead create a thread when an artifact update occurs. This requires explicit acknowlegement of the issue when your repository is configured to have all threads resolved before merging.
 
 ## assignAutomerge

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -111,6 +111,11 @@ The above managers include this default alias:
 
 Alias values must be properly formatted URIs.
 
+## artifactUpdateWarningAsThread
+
+By default, Renovate will create a warning comment when an artifact update occurs.
+By configuring this setting to `true`, Renovatebot will instead create a thread when an artifact update occurs. This requires explicit acknowlegement of the issue when your repository is configured to have all threads resolved before merging.
+
 ## assignAutomerge
 
 By default, Renovate will not assign reviewers and assignees to an automerge-enabled PR unless it fails status checks.

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -114,7 +114,7 @@ Alias values must be properly formatted URIs.
 ## artifactUpdateWarningAsThread
 
 By default, Renovate will create a warning comment when an artifact update fails.
-By configuring this setting to `true`, Renovatebot will instead create a thread when an artifact update occurs. This requires explicit acknowlegement of the issue when your repository is configured to have all threads resolved before merging.
+By configuring this setting to `true`, Renovate will instead create a thread when such an artifact update warning occurs.
 
 ## assignAutomerge
 

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -2319,6 +2319,14 @@ const options: RenovateOptions[] = [
     default: false,
     supportedPlatforms: ['github'],
   },
+  {
+    name: 'artifactUpdateWarningAsThread',
+    description:
+      'If enabled, an artifact update problem is created as a thread instead of a comment.',
+    type: 'boolean',
+    default: false,
+    supportedPlatforms: ['gitlab'],
+  },
 ];
 
 export function getOptions(): RenovateOptions[] {

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -73,6 +73,7 @@ export interface RenovateSharedConfig {
   unicodeEmoji?: boolean;
   gitIgnoredAuthors?: string[];
   platformCommit?: boolean;
+  artifactUpdateWarningAsThread?: boolean;
 }
 
 // Config options used only within the global worker

--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -1119,6 +1119,8 @@ describe('modules/platform/gitlab/index', () => {
       scope
         .get('/api/v4/projects/some%2Frepo/merge_requests/42/notes')
         .reply(200, [])
+        .get('/api/v4/projects/some%2Frepo/merge_requests/42/discussions')
+        .reply(200, [])
         .post('/api/v4/projects/some%2Frepo/merge_requests/42/notes')
         .reply(200);
       await expect(
@@ -1134,6 +1136,8 @@ describe('modules/platform/gitlab/index', () => {
       const scope = await initRepo();
       scope
         .get('/api/v4/projects/some%2Frepo/merge_requests/42/notes')
+        .reply(200, [])
+        .get('/api/v4/projects/some%2Frepo/merge_requests/42/discussions')
         .reply(200, [])
         .post('/api/v4/projects/some%2Frepo/merge_requests/42/discussions')
         .reply(200);
@@ -1152,6 +1156,8 @@ describe('modules/platform/gitlab/index', () => {
       scope
         .get('/api/v4/projects/some%2Frepo/merge_requests/42/notes')
         .reply(200, [{ id: 1234, body: '### some-subject\n\nblablabla' }])
+        .get('/api/v4/projects/some%2Frepo/merge_requests/42/discussions')
+        .reply(200, [])
         .put('/api/v4/projects/some%2Frepo/merge_requests/42/notes/1234')
         .reply(200);
       await expect(
@@ -1167,7 +1173,9 @@ describe('modules/platform/gitlab/index', () => {
       const scope = await initRepo();
       scope
         .get('/api/v4/projects/some%2Frepo/merge_requests/42/notes')
-        .reply(200, [{ id: 1234, body: '### some-subject\n\nsome\ncontent' }]);
+        .reply(200, [{ id: 1234, body: '### some-subject\n\nsome\ncontent' }])
+        .get('/api/v4/projects/some%2Frepo/merge_requests/42/discussions')
+        .reply(200, []);
       await expect(
         gitlab.ensureComment({
           number: 42,
@@ -1181,7 +1189,9 @@ describe('modules/platform/gitlab/index', () => {
       const scope = await initRepo();
       scope
         .get('/api/v4/projects/some%2Frepo/merge_requests/42/notes')
-        .reply(200, [{ id: 1234, body: '!merge' }]);
+        .reply(200, [{ id: 1234, body: '!merge' }])
+        .get('/api/v4/projects/some%2Frepo/merge_requests/42/discussions')
+        .reply(200, []);
       await expect(
         gitlab.ensureComment({
           number: 42,

--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -1119,8 +1119,6 @@ describe('modules/platform/gitlab/index', () => {
       scope
         .get('/api/v4/projects/some%2Frepo/merge_requests/42/notes')
         .reply(200, [])
-        .get('/api/v4/projects/some%2Frepo/merge_requests/42/discussions')
-        .reply(200, [])
         .post('/api/v4/projects/some%2Frepo/merge_requests/42/notes')
         .reply(200);
       await expect(
@@ -1175,8 +1173,6 @@ describe('modules/platform/gitlab/index', () => {
       scope
         .get('/api/v4/projects/some%2Frepo/merge_requests/42/notes')
         .reply(200, [{ id: 1234, body: '### some-subject\n\nblablabla' }])
-        .get('/api/v4/projects/some%2Frepo/merge_requests/42/discussions')
-        .reply(200, [])
         .put('/api/v4/projects/some%2Frepo/merge_requests/42/notes/1234')
         .reply(200);
       await expect(
@@ -1193,8 +1189,6 @@ describe('modules/platform/gitlab/index', () => {
       scope
         .get('/api/v4/projects/some%2Frepo/merge_requests/42/notes')
         .reply(200, [{ id: 1234, body: '### some-subject\n\nsome\ncontent' }])
-        .get('/api/v4/projects/some%2Frepo/merge_requests/42/discussions')
-        .reply(200, []);
       await expect(
         gitlab.ensureComment({
           number: 42,
@@ -1209,8 +1203,6 @@ describe('modules/platform/gitlab/index', () => {
       scope
         .get('/api/v4/projects/some%2Frepo/merge_requests/42/notes')
         .reply(200, [{ id: 1234, body: '!merge' }])
-        .get('/api/v4/projects/some%2Frepo/merge_requests/42/discussions')
-        .reply(200, []);
       await expect(
         gitlab.ensureComment({
           number: 42,

--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -1151,6 +1151,25 @@ describe('modules/platform/gitlab/index', () => {
       ).toResolve();
     });
 
+    it('update thread', async () => {
+      const scope = await initRepo();
+      scope
+        .get('/api/v4/projects/some%2Frepo/merge_requests/42/notes')
+        .reply(200, [])
+        .get('/api/v4/projects/some%2Frepo/merge_requests/42/discussions')
+        .reply(200, [{ id: 1234, notes: [ { id: 4321, body: '### some-subject\n\nblablabla' } ] }])
+        .put('/api/v4/projects/some%2Frepo/merge_requests/42/discussions/1234/notes/4321')
+        .reply(200);
+      await expect(
+        gitlab.ensureComment({
+          number: 42,
+          topic: 'some-subject',
+          content: 'some\ncontent',
+          blocksMerge: true,
+        })
+      ).toResolve();
+    });
+
     it('add updates comment if necessary', async () => {
       const scope = await initRepo();
       scope

--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -1130,6 +1130,23 @@ describe('modules/platform/gitlab/index', () => {
       ).toResolve();
     });
 
+    it('add thread if comment should block merge', async () => {
+      const scope = await initRepo();
+      scope
+        .get('/api/v4/projects/some%2Frepo/merge_requests/42/notes')
+        .reply(200, [])
+        .post('/api/v4/projects/some%2Frepo/merge_requests/42/discussions')
+        .reply(200);
+      await expect(
+        gitlab.ensureComment({
+          number: 42,
+          topic: 'some-subject',
+          content: 'some\ncontent',
+          blocksMerge: true,
+        })
+      ).toResolve();
+    });
+
     it('add updates comment if necessary', async () => {
       const scope = await initRepo();
       scope

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -1128,7 +1128,7 @@ export async function ensureComment({
         .replace(regEx(/PR/g), 'MR')
     : topic;
   const comments = await getComments(number);
-  const discussions = await getDiscussions(number);
+  const discussions = blocksMerge ? await getDiscussions(number) : [];
   let body: string;
   let commentId: number | undefined;
   let discussionId: string | undefined;

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -1090,6 +1090,21 @@ async function editComment(
   );
 }
 
+async function editDiscussion(
+  issueNo: number,
+  discussionId: string,
+  noteId: number,
+  body: string
+): Promise<void> {
+  // PUT /projects/:id/merge_requests/:merge_request_iid/discussions/:discussion_id/notes/:note_id
+  await gitlabApi.putJson(
+    `projects/${config.repository}/merge_requests/${issueNo}/discussions/${discussionId}/notes/${noteId}`,
+    {
+      body: {body},
+    }
+  );
+}
+
 async function deleteComment(
   issueNo: number,
   commentId: number
@@ -1172,6 +1187,11 @@ export async function ensureComment({
       'Added comment'
     );
   } else if (commentNeedsUpdating && discussionId) {
+    await editDiscussion(number, discussionId, noteId, body);
+    logger.debug(
+      { repository: config.repository, issueNo: number },
+      'Updated discussion'
+    );
   } else if (commentNeedsUpdating && commentId) {
     await editComment(number, commentId, body);
     logger.debug(

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -55,10 +55,10 @@ import { getMR, updateMR } from './merge-request';
 import type {
   GitLabMergeRequest,
   GitlabComment,
+  GitlabDiscussion,
   GitlabIssue,
   MergeMethod,
   RepoResponse,
-  GitlabDiscussion,
 } from './types';
 
 let config: {

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -1047,7 +1047,7 @@ async function getComments(issueNo: number): Promise<GitlabComment[]> {
 
 async function getDiscussions(issueNo: number): Promise<GitlabDiscussion[]> {
   // GET projects/:id/merge_requests/:merge_request_iid/discussions
-  logger.debug(`Getting discussions for #${issueNo}`);
+  logger.trace(`Getting discussions for #${issueNo}`);
   const url = `projects/${config.repository}/merge_requests/${issueNo}/discussions`;
   const discussions = (
     await gitlabApi.getJson<GitlabDiscussion[]>(url, { paginate: true })

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -1052,7 +1052,7 @@ async function getDiscussions(issueNo: number): Promise<GitlabDiscussion[]> {
   const discussions = (
     await gitlabApi.getJson<GitlabDiscussion[]>(url, { paginate: true })
   ).body;
-  logger.debug(`Found ${discussions.length} discussions`);
+  logger.trace(`Found ${discussions.length} discussions`);
   return discussions;
 }
 

--- a/lib/modules/platform/gitlab/types.ts
+++ b/lib/modules/platform/gitlab/types.ts
@@ -11,6 +11,11 @@ export interface GitlabComment {
   id: number;
 }
 
+export interface GitlabDiscussion {
+  notes: GitlabComment[];
+  id: string;
+}
+
 export interface GitLabUser {
   id: number;
   username: string;

--- a/lib/modules/platform/types.ts
+++ b/lib/modules/platform/types.ts
@@ -134,6 +134,7 @@ export interface EnsureCommentConfig {
   number: number;
   topic: string | null;
   content: string;
+  blocksMerge?: boolean;
 }
 
 export interface EnsureCommentRemovalConfigByTopic {

--- a/lib/workers/repository/update/branch/index.ts
+++ b/lib/workers/repository/update/branch/index.ts
@@ -717,7 +717,7 @@ export async function processBranch(
               number: pr.number,
               topic: artifactErrorTopic,
               content,
-              blocksMerge: true,
+              blocksMerge: config.artifactUpdateWarningAsThread ?? false,
             });
           }
         }

--- a/lib/workers/repository/update/branch/index.ts
+++ b/lib/workers/repository/update/branch/index.ts
@@ -717,6 +717,7 @@ export async function processBranch(
               number: pr.number,
               topic: artifactErrorTopic,
               content,
+              blocksMerge: true,
             });
           }
         }


### PR DESCRIPTION
Gitlab has the possibility to create either a standard comment, or a thread. A thread can be resolved, and, depending on the configuration of the repository, can even block the merge itself. By using a thread when the merge request indicates that it probably should not be merged as-is, the developer has to perform an addional action before the merge request can be merged. This makes it less likely that the developer missed the warning message.

@see https://docs.gitlab.com/ee/user/discussions/

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
