### PR TITLE
chore: delete prettifier.yml

### DIFF
--- a/.github/prettifier.yml
+++ b/.github/prettifier.yml
@@ -1,4 +1,0 @@
-commitMessage: 'Apply prettier formatting fix'
-excludeBranches:
-  - main
-pullsOnly: true


### PR DESCRIPTION
## Changes

- Delete `prettifier.yml`

## Context

I remember we tried a "auto-prettier" bot that would fix up bad PRs automatically by running `prettier --write` on them. I think that bot only worked on PRs from within the repository, so not on outside forks.

I think we don't use the bot/app anymore, so maybe we can drop the config file?

Found the PR that added the bot:

- https://github.com/renovatebot/renovate/pull/7602

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
