### PR TITLE
feat(gradle): add support for simple extra properties

### DIFF
--- a/lib/modules/manager/gradle/parser.spec.ts
+++ b/lib/modules/manager/gradle/parser.spec.ts
@@ -19,6 +19,7 @@ describe('modules/manager/gradle/parser', () => {
       ${'version = "1.2.3"'}         | ${'version'}         | ${'1.2.3'}
       ${'set("version", "1.2.3")'}   | ${'version'}         | ${'1.2.3'}
       ${'versions.foobar = "1.2.3"'} | ${'versions.foobar'} | ${'1.2.3'}
+      ${'ext.foo.bar = "1.2.3"'}     | ${'foo.bar'}         | ${'1.2.3'}
     `('$input', ({ input, name, value }) => {
       const { vars } = parseGradle(input);
       expect(vars).toContainKey(name);

--- a/lib/modules/manager/gradle/parser.ts
+++ b/lib/modules/manager/gradle/parser.ts
@@ -388,6 +388,18 @@ function processLibraryDep(input: SyntaxHandlerInput): SyntaxHandlerOutput {
 
 const matcherConfigs: SyntaxMatchConfig[] = [
   {
+    // ext.foo.bar = 'baz'
+    matchers: [
+      { matchType: TokenType.Word, matchValue: 'ext' },
+      { matchType: TokenType.Dot },
+      { matchType: TokenType.Word, tokenMapKey: 'keyToken' },
+      { matchType: TokenType.Assignment },
+      { matchType: TokenType.String, tokenMapKey: 'valToken' },
+      endOfInstruction,
+    ],
+    handler: handleAssignment,
+  },
+  {
     // foo.bar = 'baz'
     matchers: [
       { matchType: TokenType.Word, tokenMapKey: 'objectToken' },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Adds parsing support for simple [extra properties](https://docs.gradle.org/current/userguide/writing_build_scripts.html#sec:extra_properties) that are declared using the `ext` prefix. 

Minimal reproduction repository:
- https://github.com/Churro/renovate-gradle-ext/blob/master/build.gradle
- https://github.com/Churro/renovate-gradle-ext/pull/1

<!-- Describe what behavior is changed by this PR. -->

## Context

- Related to in https://github.com/renovatebot/renovate/issues/15359 but not solving the problem described there. 
  - Parsing library versions in `ext` hierarchies like the one exemplified in that issue will probably only work once https://github.com/zharinov/good-enough-parser is integrated

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
