### PR TITLE
fix(manager/bundler): fix recursive resolved dependencies

### DIFF
--- a/lib/modules/manager/bundler/artifacts.ts
+++ b/lib/modules/manager/bundler/artifacts.ts
@@ -18,12 +18,7 @@ import { getRepoStatus } from '../../../util/git';
 import { regEx } from '../../../util/regex';
 import { addSecretForSanitizing } from '../../../util/sanitize';
 import { isValid } from '../../versioning/ruby';
-import { createDependency } from '../regex/utils';
-import type {
-  PackageDependency,
-  UpdateArtifact,
-  UpdateArtifactsResult,
-} from '../types';
+import type { UpdateArtifact, UpdateArtifactsResult } from '../types';
 import { getBundlerConstraint, getRubyConstraint } from './common';
 import {
   findAllAuthenticatable,
@@ -44,12 +39,6 @@ function buildBundleHostVariable(hostRule: HostRule): Record<string, string> {
   );
   return {
     [varName]: `${getAuthenticationHeaderValue(hostRule)}`,
-  };
-}
-
-function createDependency(name: string): PackageDependency {
-  return {
-    depName: name,
   };
 }
 
@@ -230,10 +219,12 @@ export async function updateArtifacts(
           { resolveMatches, updatedDeps },
           'Found new resolve matches - reattempting recursively'
         );
-        const resolvedDeps: PackageDependency[] = resolveMatches.map((match) =>
-          createDependency(match)
-        );
-        const newUpdatedDeps = [...new Set([...updatedDeps, ...resolvedDeps])];
+        const newUpdatedDeps = [
+          ...new Set([
+            ...updatedDeps,
+            ...resolveMatches.map((match) => ({ depName: match })),
+          ]),
+        ];
         return updateArtifacts({
           packageFileName,
           updatedDeps: newUpdatedDeps,


### PR DESCRIPTION
## Changes

Closes https://github.com/renovatebot/renovate/issues/15949. 

## Context

I believe the problem in the related issue was caused by `resolveMatches` being an array of strings, and `updatedDeps` being an array of `PackageDependency`. So when it correctly found the resolved dependencies and added them to retry again, it ended up as undefined because it had no `depName` attribute.

I believe this also fixed the TODO I removed. First time ever writing Typescript, apologies and thanks for any feedback.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository