### PR TITLE
refactor(changelog): Unify argument lists for the call hierarchy

### DIFF
--- a/lib/workers/repository/update/pr/changelog/github/index.ts
+++ b/lib/workers/repository/update/pr/changelog/github/index.ts
@@ -10,7 +10,12 @@ import type {
 import { GithubHttp } from '../../../../../../util/http/github';
 import { fromBase64 } from '../../../../../../util/string';
 import { ensureTrailingSlash } from '../../../../../../util/url';
-import type { ChangeLogFile, ChangeLogNotes } from '../types';
+import type {
+  ChangeLogFile,
+  ChangeLogNotes,
+  ChangeLogProject,
+  ChangeLogRelease,
+} from '../types';
 
 export const id = 'github-changelog';
 const http = new GithubHttp(id);
@@ -107,10 +112,14 @@ export async function getReleaseNotesMd(
 }
 
 export async function getReleaseList(
-  apiBaseUrl: string,
-  repository: string
+  project: ChangeLogProject,
+  _release: ChangeLogRelease
 ): Promise<ChangeLogNotes[]> {
   logger.trace('github.getReleaseList()');
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+  const apiBaseUrl = project.apiBaseUrl!;
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+  const repository = project.repository!;
   const notesSourceUrl = `${ensureTrailingSlash(
     apiBaseUrl
   )}repos/${repository}/releases`;

--- a/lib/workers/repository/update/pr/changelog/gitlab/index.ts
+++ b/lib/workers/repository/update/pr/changelog/gitlab/index.ts
@@ -5,7 +5,12 @@ import type { GitlabTag } from '../../../../../../modules/datasource/gitlab-tags
 import type { GitlabTreeNode } from '../../../../../../types/platform/gitlab';
 import { GitlabHttp } from '../../../../../../util/http/gitlab';
 import { ensureTrailingSlash } from '../../../../../../util/url';
-import type { ChangeLogFile, ChangeLogNotes } from '../types';
+import type {
+  ChangeLogFile,
+  ChangeLogNotes,
+  ChangeLogProject,
+  ChangeLogRelease,
+} from '../types';
 
 export const id = 'gitlab-changelog';
 const http = new GitlabHttp(id);
@@ -91,11 +96,14 @@ export async function getReleaseNotesMd(
 }
 
 export async function getReleaseList(
-  apiBaseUrl: string,
-  repository: string
+  project: ChangeLogProject,
+  _release: ChangeLogRelease
 ): Promise<ChangeLogNotes[]> {
   logger.trace('gitlab.getReleaseNotesMd()');
-
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+  const apiBaseUrl = project.apiBaseUrl!;
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+  const repository = project.repository!;
   const urlEncodedRepo = encodeURIComponent(repository);
   const apiUrl = `${ensureTrailingSlash(
     apiBaseUrl

--- a/lib/workers/repository/update/pr/changelog/release-notes.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/release-notes.spec.ts
@@ -172,7 +172,10 @@ describe('workers/repository/update/pr/changelog/release-notes', () => {
 
   describe('getReleaseList()', () => {
     it('should return empty array if no apiBaseUrl', async () => {
-      const res = await getReleaseList({} as ChangeLogProject);
+      const res = await getReleaseList(
+        {} as ChangeLogProject,
+        {} as ChangeLogRelease
+      );
       expect(res).toBeEmptyArray();
     });
 
@@ -186,10 +189,13 @@ describe('workers/repository/update/pr/changelog/release-notes', () => {
         },
       ] as never);
 
-      const res = await getReleaseList({
-        ...githubProject,
-        repository: 'some/yet-other-repository',
-      });
+      const res = await getReleaseList(
+        {
+          ...githubProject,
+          repository: 'some/yet-other-repository',
+        },
+        {} as ChangeLogRelease
+      );
       expect(res).toMatchSnapshot([
         {
           notesSourceUrl:
@@ -218,10 +224,13 @@ describe('workers/repository/update/pr/changelog/release-notes', () => {
             body: 'some body #123, [#124](https://gitlab.com/some/yet-other-repository/issues/124)',
           },
         ]);
-      const res = await getReleaseList({
-        ...gitlabProject,
-        repository: 'some/yet-other-repository',
-      });
+      const res = await getReleaseList(
+        {
+          ...gitlabProject,
+          repository: 'some/yet-other-repository',
+        },
+        {} as ChangeLogRelease
+      );
       expect(res).toMatchSnapshot([
         {
           notesSourceUrl:
@@ -252,12 +261,15 @@ describe('workers/repository/update/pr/changelog/release-notes', () => {
             body: 'some body #123, [#124](https://my.custom.domain/some/yet-other-repository/issues/124)',
           },
         ]);
-      const res = await getReleaseList({
-        ...gitlabProject,
-        repository: 'some/yet-other-repository',
-        apiBaseUrl: 'https://my.custom.domain/api/v4/',
-        baseUrl: 'https://my.custom.domain/',
-      });
+      const res = await getReleaseList(
+        {
+          ...gitlabProject,
+          repository: 'some/yet-other-repository',
+          apiBaseUrl: 'https://my.custom.domain/api/v4/',
+          baseUrl: 'https://my.custom.domain/',
+        },
+        {} as ChangeLogRelease
+      );
       expect(res).toMatchSnapshot([
         {
           notesSourceUrl:


### PR DESCRIPTION
## Changes

- Pass `project` and `release` data

## Context

- This is prerequisite for fixing #15957

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
