### PR TITLE
docs(flux): OCI HelmRepository sources are currently unsupported

### DIFF
--- a/lib/modules/manager/flux/readme.md
+++ b/lib/modules/manager/flux/readme.md
@@ -4,9 +4,11 @@ This manager parses [Flux](https://fluxcd.io/) YAML manifests and:
 2. Extracts `github-releases` dependencies from system manifests (`flux-system/gotk-components.yaml` files) and regenerates them when new versions of Flux are available
 
 The `flux` manager will only extract `helm` dependencies for `HelmRelease` resources linked to `HelmRepository` sources.
-`HelmRelease` resources linked to other kinds of sources like `GitRepository` or `Bucket` will be ignored.
+The following configurations are currently unsupported:
+* OCI `HelmRepository` sources (those with `type: oci`)
+* `HelmRelease` resources linked to other kinds of sources like `GitRepository` or `Bucket`
 
-For the `flux` manager to properly link `HelmRelease` and `HelmRepository` resources, _both_ of the following conditions must be met:
+In addition, for the `flux` manager to properly link `HelmRelease` and `HelmRepository` resources, _both_ of the following conditions must be met:
 
 1. The `HelmRelease` resource must either have its `metadata.namespace` property set or its `spec.chart.spec.sourceRef.namespace` property set
 2. The referenced `HelmRepository` resource must have its `metadata.namespace` property set

--- a/lib/modules/manager/flux/readme.md
+++ b/lib/modules/manager/flux/readme.md
@@ -5,8 +5,9 @@ This manager parses [Flux](https://fluxcd.io/) YAML manifests and:
 
 The `flux` manager will only extract `helm` dependencies for `HelmRelease` resources linked to `HelmRepository` sources.
 The following configurations are currently unsupported:
-* OCI `HelmRepository` sources (those with `type: oci`)
-* `HelmRelease` resources linked to other kinds of sources like `GitRepository` or `Bucket`
+
+- OCI `HelmRepository` sources (those with `type: oci`)
+- `HelmRelease` resources linked to other kinds of sources like `GitRepository` or `Bucket`
 
 In addition, for the `flux` manager to properly link `HelmRelease` and `HelmRepository` resources, _both_ of the following conditions must be met:
 


### PR DESCRIPTION
Flux introduced a feature a week ago in [v0.31.0](https://github.com/fluxcd/flux2/releases/tag/v0.31.0) to pull Helm charts from OCI container registries. Since I haven't tested this (and am not sure whether the `helm` datasource supports OCI URLs), I'm just updating the docs to reflect that OCI `HelmRepository` sources are currently unsupported.

If anyone wants to test this scenario, feel free - I don't currently pull any Helm charts from container registries myself.