### PR TITLE
refactor: fix null-check

### DIFF
--- a/lib/modules/manager/npm/extract/index.ts
+++ b/lib/modules/manager/npm/extract/index.ts
@@ -181,7 +181,7 @@ export async function extractPackageFile(
   function extractDependency(
     depType: string,
     depName: string,
-    input: string
+    input?: string
   ): PackageDependency {
     const dep: PackageDependency = {};
     if (!validateNpmPackageName(depName).validForOldPackages) {
@@ -347,7 +347,7 @@ export async function extractPackageFile(
    */
   function extractOverrideDepsRec(
     parents: string[],
-    child: NpmManagerData
+    child?: NpmManagerData
   ): PackageDependency[] {
     const deps: PackageDependency[] = [];
     if (!child || is.emptyObject(child)) {
@@ -355,7 +355,7 @@ export async function extractPackageFile(
     }
     for (const [overrideName, versionValue] of Object.entries(child)) {
       if (is.string(versionValue)) {
-        // special handling for "." override depenency name
+        // special handling for "." override dependency name
         // "." means the constraint is applied to the parent dep
         const currDepName =
           overrideName === '.' ? parents[parents.length - 1] : overrideName;

--- a/lib/modules/manager/npm/update/dependency/index.ts
+++ b/lib/modules/manager/npm/update/dependency/index.ts
@@ -217,7 +217,7 @@ export function updateDependency({
           newFileContent,
           'resolutions',
           depKey,
-          parsedContents.resolutions[depKey],
+          parsedContents.resolutions[depKey]!,
           // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
           newValue!
         );


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- update some type definitions and asserstions
<!-- Describe what behavior is changed by this PR. -->

## Context
- #15810 
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
