### PR TITLE
docs: add whitespaces around items with multiple allowed values

### DIFF
--- a/tools/docs/config.ts
+++ b/tools/docs/config.ts
@@ -141,6 +141,14 @@ function genTable(obj: [string, string][], type: string, def: any): string {
   return buildHtmlTable(data);
 }
 
+function stringifyArrays(el: Record<string, any>): void {
+  for (const [key, value] of Object.entries(el)) {
+    if (key !== 'default' && Array.isArray(value)) {
+      el[key] = value.join(', ');
+    }
+  }
+}
+
 export async function generateConfig(dist: string, bot = false): Promise<void> {
   let configFile = `configuration-options.md`;
   if (bot) {
@@ -162,6 +170,7 @@ export async function generateConfig(dist: string, bot = false): Promise<void> {
       }
       el.cli = getCliName(option);
       el.env = getEnvName(option);
+      stringifyArrays(el);
 
       configOptionsRaw[headerIndex] +=
         `\n${option.description}\n\n` +


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
`genTable` expects [string, string][] as input, but for some the value is Array[] which causes this bug, as Array.proto.toStrings joins with ",".

example:
![image](https://user-images.githubusercontent.com/97394622/173819859-5b4fb814-2791-4fec-b00e-dff2bbfe6808.png)

<!-- Describe what behavior is changed by this PR. -->

## Context
Closes #13349 
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
