### PR TITLE
feat(terraform): Add init_container for deployments, cron_jobs and daemonset

### DIFF
--- a/lib/modules/manager/terraform/__fixtures__/kubernetes.tf
+++ b/lib/modules/manager/terraform/__fixtures__/kubernetes.tf
@@ -7,6 +7,11 @@ resource "kubernetes_cron_job_v1" "demo" {
         template {
           metadata {}
           spec {
+            init_container {
+              name    = "kaniko"
+              image   = "gcr.io/kaniko-project/executor:v1.7.0@sha256:8504bde9a9a8c9c4e9a4fe659703d265697a36ff13607b7669a4caa4407baa52"
+            }
+
             container {
               name    = "kaniko"
               image   = "gcr.io/kaniko-project/executor:v1.7.0@sha256:8504bde9a9a8c9c4e9a4fe659703d265697a36ff13607b7669a4caa4407baa52"
@@ -28,6 +33,11 @@ resource "kubernetes_cron_job" "demo" {
         template {
           metadata {}
           spec {
+            init_container {
+              name    = "kaniko"
+              image   = "gcr.io/kaniko-project/executor:v1.8.0@sha256:8504bde9a9a8c9c4e9a4fe659703d265697a36ff13607b7669a4caa4407baa52"
+            }
+
             container {
               name    = "kaniko"
               image   = "gcr.io/kaniko-project/executor:v1.8.0@sha256:8504bde9a9a8c9c4e9a4fe659703d265697a36ff13607b7669a4caa4407baa52"
@@ -46,6 +56,11 @@ resource "kubernetes_daemon_set_v1" "example" {
     template {
       metadata {}
       spec {
+        init_container {
+          image = "nginx:1.21.1"
+          name  = "example1"
+        }
+
         container {
           image = "nginx:1.21.1"
           name  = "example1"
@@ -61,6 +76,11 @@ resource "kubernetes_daemonset" "example" {
     template {
       metadata {}
       spec {
+        init_container {
+          image = "nginx:1.21.2"
+          name  = "example2"
+        }
+
         container {
           image = "nginx:1.21.2"
           name  = "example2"
@@ -76,6 +96,11 @@ resource "kubernetes_deployment" "example" {
     template {
       metadata {}
       spec {
+        init_container {
+          image = "nginx:1.21.3"
+          name  = "example3"
+        }
+
         container {
           image = "nginx:1.21.3"
           name  = "example3"
@@ -91,6 +116,11 @@ resource "kubernetes_deployment_v1" "example" {
     template {
       metadata {}
       spec {
+        init_container {
+          image = "nginx:1.21.4"
+          name  = "example4"
+        }
+
         container {
           image = "nginx:1.21.4"
           name  = "example4"


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

In PR #16029 you added the support to update kubernetes images for terraform resources.
init_containers are only implemented for StateFullSets, but not for Deployments, CronJobs or DaemonSets.

I added init_container for deployments, cron_jobs and daemonset to support terraform kubernetes image resources
I'm not 100% sure if this is enough.

## Context

- closes #16088 

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
