### PR TITLE
fix(github): Don't append `/api/v3/` to the endpoint twice

### DIFF
--- a/lib/modules/datasource/github-releases/cache/cache-base.ts
+++ b/lib/modules/datasource/github-releases/cache/cache-base.ts
@@ -181,7 +181,7 @@ export abstract class AbstractGithubDatasourceCache<
     // so that soft update mechanics is immediately starting.
     let cacheUpdatedAt = now.minus(this.updateDuration).toISO();
 
-    const baseUrl = getApiBaseUrl(registryUrl).replace('/v3/', '/'); // Replace for GHE
+    const baseUrl = getApiBaseUrl(registryUrl).replace(/\/v3\/$/, '/'); // Replace for GHE
 
     const [owner, name] = packageName.split('/');
     if (owner && name) {

--- a/lib/modules/datasource/github-releases/common.spec.ts
+++ b/lib/modules/datasource/github-releases/common.spec.ts
@@ -20,8 +20,12 @@ describe('modules/datasource/github-releases/common', () => {
     });
 
     it('supports local github installations', () => {
-      const apiUrl = getApiBaseUrl('https://gh.my-company.com/');
-      expect(apiUrl).toBe('https://gh.my-company.com/api/v3/');
+      expect(getApiBaseUrl('https://gh.my-company.com/')).toBe(
+        'https://gh.my-company.com/api/v3/'
+      );
+      expect(getApiBaseUrl('https://gh.my-company.com/api/v3/')).toBe(
+        'https://gh.my-company.com/api/v3/'
+      );
     });
   });
 });

--- a/lib/modules/datasource/github-releases/common.ts
+++ b/lib/modules/datasource/github-releases/common.ts
@@ -10,9 +10,19 @@ export function getSourceUrlBase(registryUrl: string | undefined): string {
 
 export function getApiBaseUrl(registryUrl: string | undefined): string {
   const sourceUrlBase = getSourceUrlBase(registryUrl);
-  return [defaultSourceUrlBase, defaultApiBaseUrl].includes(sourceUrlBase)
-    ? defaultApiBaseUrl
-    : `${sourceUrlBase}api/v3/`;
+
+  if (
+    sourceUrlBase === defaultSourceUrlBase ||
+    sourceUrlBase === defaultApiBaseUrl
+  ) {
+    return defaultApiBaseUrl;
+  }
+
+  if (sourceUrlBase.endsWith('/api/v3/')) {
+    return sourceUrlBase;
+  }
+
+  return `${sourceUrlBase}api/v3/`;
 }
 
 export function getSourceUrl(


### PR DESCRIPTION
## Changes

- Make `getApiBaseUrl()` to ensure `/api/v3/` is present no more than once in the resulting URL

## Context

- Closes: #16073

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
