### PR TITLE
refactor: move error-warning.ts

### DIFF
--- a/lib/workers/repository/errors-warnings.spec.ts
+++ b/lib/workers/repository/errors-warnings.spec.ts
@@ -1,8 +1,8 @@
-import { RenovateConfig, getConfig } from '../../../../../test/util';
-import type { PackageFile } from '../../../../modules/manager/types';
+import { RenovateConfig, getConfig } from '../../../test/util';
+import type { PackageFile } from '../../modules/manager/types';
 import { getDepWarnings, getErrors, getWarnings } from './errors-warnings';
 
-describe('workers/repository/onboarding/pr/errors-warnings', () => {
+describe('workers/repository/errors-warnings', () => {
   describe('getWarnings()', () => {
     let config: RenovateConfig;
 

--- a/lib/workers/repository/errors-warnings.ts
+++ b/lib/workers/repository/errors-warnings.ts
@@ -1,7 +1,7 @@
-import type { RenovateConfig } from '../../../../config/types';
-import { logger } from '../../../../logger';
-import type { PackageFile } from '../../../../modules/manager/types';
-import { emojify } from '../../../../util/emoji';
+import type { RenovateConfig } from '../../config/types';
+import { logger } from '../../logger';
+import type { PackageFile } from '../../modules/manager/types';
+import { emojify } from '../../util/emoji';
 
 export function getWarnings(config: RenovateConfig): string {
   if (!config.warnings.length) {

--- a/lib/workers/repository/onboarding/pr/index.ts
+++ b/lib/workers/repository/onboarding/pr/index.ts
@@ -13,12 +13,12 @@ import {
 } from '../../../../util/git';
 import * as template from '../../../../util/template';
 import type { BranchConfig } from '../../../types';
+import { getDepWarnings, getErrors, getWarnings } from '../../errors-warnings';
 import { getPlatformPrOptions } from '../../update/pr';
 import { prepareLabels } from '../../update/pr/labels';
 import { addParticipants } from '../../update/pr/participants';
 import { getBaseBranchDesc } from './base-branch';
 import { getConfigDesc } from './config-description';
-import { getDepWarnings, getErrors, getWarnings } from './errors-warnings';
 import { getPrList } from './pr-list';
 
 export async function ensureOnboardingPr(

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -48,7 +48,7 @@
     "lib/workers/repository/onboarding/branch/rebase.ts",
     "lib/workers/repository/onboarding/pr/base-branch.ts",
     "lib/workers/repository/onboarding/pr/config-description.ts",
-    "lib/workers/repository/onboarding/pr/errors-warnings.ts",
+    "lib/workers/repository/errors-warnings.ts",
     "lib/workers/repository/onboarding/pr/index.ts",
     "lib/workers/repository/onboarding/pr/pr-list.ts",
     "lib/workers/repository/process/deprecated.ts",


### PR DESCRIPTION
…tory/

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
move error-warning from `repository/onboarding/pr/` to `repository/`

<!-- Describe what behavior is changed by this PR. -->

## Context
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
