### PR TITLE
feat(manager/terraform): support multiple container images

### DIFF
--- a/lib/modules/manager/terraform/__fixtures__/kubernetes.tf
+++ b/lib/modules/manager/terraform/__fixtures__/kubernetes.tf
@@ -11,6 +11,10 @@ resource "kubernetes_cron_job_v1" "demo" {
               name    = "kaniko"
               image   = "gcr.io/kaniko-project/executor:v1.7.0@sha256:8504bde9a9a8c9c4e9a4fe659703d265697a36ff13607b7669a4caa4407baa52"
             }
+            container {
+              name    = "node"
+              image   = "node:14"
+            }
           }
         }
       }
@@ -126,6 +130,7 @@ resource "kubernetes_job" "demo_invalid" {
         }
       }
     }
+    image   = "nginx:1.21.6"
   }
 }
 

--- a/lib/modules/manager/terraform/extract.spec.ts
+++ b/lib/modules/manager/terraform/extract.spec.ts
@@ -107,14 +107,19 @@ describe('modules/manager/terraform/extract', () => {
 
     it('extracts kubernetes resources', async () => {
       const res = await extractPackageFile(kubernetes, 'kubernetes.tf', {});
-      expect(res.deps).toHaveLength(16);
-      expect(res.deps.filter((dep) => dep.skipReason)).toHaveLength(2);
+      expect(res.deps).toHaveLength(18);
+      expect(res.deps.filter((dep) => dep.skipReason)).toHaveLength(1);
       expect(res.deps).toMatchObject([
         {
           depName: 'gcr.io/kaniko-project/executor',
           currentValue: 'v1.7.0',
           currentDigest:
             'sha256:8504bde9a9a8c9c4e9a4fe659703d265697a36ff13607b7669a4caa4407baa52',
+          depType: 'kubernetes_cron_job_v1',
+        },
+        {
+          depName: 'node',
+          currentValue: '14',
           depType: 'kubernetes_cron_job_v1',
         },
         {
@@ -149,7 +154,6 @@ describe('modules/manager/terraform/extract', () => {
           currentValue: '1.21.5',
           depType: 'kubernetes_job',
         },
-        { skipReason: 'invalid-dependency-specification' },
         { skipReason: 'invalid-value' },
         {
           depName: 'nginx',
@@ -177,9 +181,19 @@ describe('modules/manager/terraform/extract', () => {
           depType: 'kubernetes_replication_controller_v1',
         },
         {
+          depName: 'nginx',
+          currentValue: '1.21.11',
+          depType: 'kubernetes_stateful_set',
+        },
+        {
           depName: 'prom/prometheus',
           currentValue: 'v2.2.1',
           depType: 'kubernetes_stateful_set',
+        },
+        {
+          depName: 'nginx',
+          currentValue: '1.21.12',
+          depType: 'kubernetes_stateful_set_v1',
         },
         {
           depName: 'prom/prometheus',

--- a/lib/modules/manager/terraform/extract/kubernetes.ts
+++ b/lib/modules/manager/terraform/extract/kubernetes.ts
@@ -1,0 +1,76 @@
+import is from '@sindresorhus/is';
+import { logger } from '../../../../logger';
+import { regEx } from '../../../../util/regex';
+import type { PackageDependency } from '../../types';
+import { TerraformDependencyTypes } from '../common';
+import type { ExtractionResult, ResourceManagerData } from '../types';
+import { keyValueExtractionRegex } from '../util';
+
+export function extractTerraformKubernetesResource(
+  startingLine: number,
+  lines: string[],
+  resourceType: string
+): ExtractionResult {
+  let lineNumber = startingLine;
+  const deps: PackageDependency<ResourceManagerData>[] = [];
+
+  /**
+   * Iterates over all lines of the resource to extract the relevant key value pairs,
+   * e.g. the chart name for helm charts or the terraform_version for tfe_workspace
+   */
+  let braceCounter = 0;
+  let inContainer = -1;
+  do {
+    // istanbul ignore if
+    if (lineNumber > lines.length - 1) {
+      logger.debug(`Malformed Terraform file detected.`);
+    }
+
+    const line = lines[lineNumber];
+
+    // istanbul ignore else
+    if (is.string(line)) {
+      // `{` will be counted with +1 and `}` with -1. Therefore if we reach braceCounter == 0. We have found the end of the terraform block
+      const openBrackets = (line.match(regEx(/\{/g)) || []).length;
+      const closedBrackets = (line.match(regEx(/\}/g)) || []).length;
+      braceCounter = braceCounter + openBrackets - closedBrackets;
+
+      if (line.match(regEx(/^\s*(?:init_)?container(?:\s*\{|$)/s))) {
+        inContainer = braceCounter;
+      } else if (braceCounter < inContainer) {
+        inContainer = -1;
+      }
+
+      const managerData: ResourceManagerData = {
+        terraformDependencyType: TerraformDependencyTypes.resource,
+        resourceType,
+      };
+      const dep: PackageDependency<ResourceManagerData> = {
+        managerData,
+      };
+
+      const kvMatch = keyValueExtractionRegex.exec(line);
+      if (kvMatch?.groups && inContainer > 0) {
+        switch (kvMatch.groups.key) {
+          case 'image':
+            managerData[kvMatch.groups.key] = kvMatch.groups.value;
+            managerData.sourceLine = lineNumber;
+            deps.push(dep);
+            break;
+          default:
+            /* istanbul ignore next */
+            break;
+        }
+      }
+    } else {
+      // stop - something went wrong
+      braceCounter = 0;
+      inContainer = -1;
+    }
+    lineNumber += 1;
+  } while (braceCounter !== 0);
+
+  // remove last lineNumber addition to not skip a line after the last bracket
+  lineNumber -= 1;
+  return { lineNumber, dependencies: deps };
+}

--- a/lib/modules/manager/terraform/lockfile/index.spec.ts
+++ b/lib/modules/manager/terraform/lockfile/index.spec.ts
@@ -3,8 +3,8 @@ import { fs, loadFixture, mocked } from '../../../../../test/util';
 import { GlobalConfig } from '../../../../config/global';
 import { getPkgReleases } from '../../../datasource';
 import type { UpdateArtifactsConfig } from '../../types';
+import { updateArtifacts } from '../index';
 import { TerraformProviderHash } from './hash';
-import { updateArtifacts } from './index';
 
 // auto-mock fs
 jest.mock('../../../../util/fs');

--- a/lib/modules/manager/terraform/resources.ts
+++ b/lib/modules/manager/terraform/resources.ts
@@ -5,6 +5,7 @@ import { HelmDatasource } from '../../datasource/helm';
 import { getDep } from '../dockerfile/extract';
 import type { PackageDependency } from '../types';
 import { TerraformDependencyTypes, TerraformResourceTypes } from './common';
+import { extractTerraformKubernetesResource } from './extract/kubernetes';
 import { analyseTerraformVersion } from './required-version';
 import type { ExtractionResult, ResourceManagerData } from './types';
 import {
@@ -45,6 +46,14 @@ export function extractTerraformResource(
     Object.keys(TerraformResourceTypes).some((key) => {
       return TerraformResourceTypes[key].includes(resourceType);
     });
+
+  if (isKnownType && resourceType.startsWith('kubernetes_')) {
+    return extractTerraformKubernetesResource(
+      startingLine,
+      lines,
+      resourceType
+    );
+  }
 
   managerData.resourceType = isKnownType
     ? resourceType


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Kubernets resources can have multiple `container` and `init_container`, so we can have multiple dependencies.
So we've now a specialized extraction function for them.
<!-- Describe what behavior is changed by this PR. -->

## Context
- closes #16088
- closes #16096 
- sample PR renovate-reproductions/16096-renovate-init-container#2
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
