### PR TITLE
ci(jest): use built-in github action reporter

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -25,7 +25,7 @@ const config: InitialOptionsTsJest = {
     },
   },
   modulePathIgnorePatterns: ['<rootDir>/dist/', '/__fixtures__/'],
-  reporters: ci ? ['default', 'jest-github-actions-reporter'] : ['default'],
+  reporters: ci ? ['default', 'github-actions'] : ['default'],
   setupFilesAfterEnv: [
     'jest-extended/all',
     'expect-more-jest',

--- a/package.json
+++ b/package.json
@@ -280,7 +280,6 @@
     "husky": "8.0.1",
     "jest": "28.1.1",
     "jest-extended": "2.0.0",
-    "jest-github-actions-reporter": "1.0.3",
     "jest-junit": "13.2.0",
     "jest-mock-extended": "2.0.6",
     "jest-silent-reporter": "0.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@actions/core@1.8.2", "@actions/core@^1.2.0", "@actions/core@^1.2.6":
+"@actions/core@1.8.2", "@actions/core@^1.2.6":
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.8.2.tgz#67539d669ae9b751430469e9ae4d83e0525973ac"
   integrity sha512-FXcBL7nyik8K5ODeCKlxi+vts7torOkoDAKfeh61EAkAy1HAvwn9uVzZBY0f15YcQTcZZ2/iSGBFHEuioZWfDA==
@@ -5946,13 +5946,6 @@ jest-get-type@^28.0.2:
   version "28.0.2"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-28.0.2.tgz#34622e628e4fdcd793d46db8a242227901fcf203"
   integrity sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==
-
-jest-github-actions-reporter@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/jest-github-actions-reporter/-/jest-github-actions-reporter-1.0.3.tgz#6aa2b3a6599352e1043bbe42628a7f73a1ce48c2"
-  integrity sha512-IwLAKLSWLN8ZVfcfEEv6rfeWb78wKDeOhvOmH9KKXayKsKLSCwceopBcB+KUtwxfB5wYnT8Y9s2eZ+WdhA5yng==
-  dependencies:
-    "@actions/core" "^1.2.0"
 
 jest-haste-map@^28.1.1:
   version "28.1.1"


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Replace `jest-github-actions-reporter` with the Jest 28 built-in GitHub action reporter `github-actions` [^jest-reporter]

## Context

Relevant quote: [^jest-blog]

> ### GitHub Actions Reporter
> 
> Jest now ships with a reporter to be used on GitHub Actions, which will use annotations to print test errors inline.
> 
> You can activate this reporter by passing `github-actions` in the [`reporters` configuration option](/docs/configuration#reporters-arraymodulename--modulename-options).

Closes #15353.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

[^jest-blog]: [Jest 28 blog, GitHub Actions reporter](https://jestjs.io/docs/configuration#reporters-arraymodulename--modulename-options)
[^jest-reporter]: [Jest `reporters` configuration docs](https://jestjs.io/docs/configuration#reporters-arraymodulename--modulename-options)