### PR TITLE
refactor(lib/workers): fix null-check for tests

### DIFF
--- a/lib/config/migration.ts
+++ b/lib/config/migration.ts
@@ -59,7 +59,7 @@ export function migrateConfig(config: RenovateConfig): MigratedConfig {
               const payload = migrateConfig(
                 packageFile as RenovateConfig
               ).migratedConfig;
-              for (const subrule of payload.packageRules || []) {
+              for (const subrule of payload.packageRules ?? []) {
                 subrule.paths = [(packageFile as any).packageFile];
                 migratedConfig.packageRules.push(subrule);
               }
@@ -157,7 +157,7 @@ export function migrateConfig(config: RenovateConfig): MigratedConfig {
         // validated non-null
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
         delete migratedConfig.node!.enabled;
-        migratedConfig.travis = migratedConfig.travis || {};
+        migratedConfig.travis = migratedConfig.travis ?? {};
         migratedConfig.travis.enabled = true;
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
         if (Object.keys(migratedConfig.node!).length) {
@@ -259,7 +259,7 @@ export function migrateConfig(config: RenovateConfig): MigratedConfig {
     }
     if (is.nonEmptyObject(migratedConfig['gradle-lite'])) {
       migratedConfig.gradle = mergeChildConfig(
-        migratedConfig.gradle || {},
+        migratedConfig.gradle ?? {},
         migratedConfig['gradle-lite']
       );
     }

--- a/lib/workers/global/index.spec.ts
+++ b/lib/workers/global/index.spec.ts
@@ -176,7 +176,7 @@ describe('workers/global/index', () => {
         endpoint: 'https://github.com/',
         writeDiscoveredRepos: '/tmp/renovate-output.json',
       });
-      fs.writeFile.mockReturnValueOnce(null);
+      fs.writeFile.mockReturnValueOnce(null as never);
 
       expect(await globalWorker.start()).toBe(0);
       expect(fs.writeFile).toHaveBeenCalledTimes(1);

--- a/lib/workers/global/index.spec.ts
+++ b/lib/workers/global/index.spec.ts
@@ -176,7 +176,7 @@ describe('workers/global/index', () => {
         endpoint: 'https://github.com/',
         writeDiscoveredRepos: '/tmp/renovate-output.json',
       });
-      fs.writeFile.mockReturnValueOnce(null as never);
+      fs.writeFile.mockResolvedValueOnce();
 
       expect(await globalWorker.start()).toBe(0);
       expect(fs.writeFile).toHaveBeenCalledTimes(1);

--- a/lib/workers/repository/config-migration/branch/index.spec.ts
+++ b/lib/workers/repository/config-migration/branch/index.spec.ts
@@ -37,7 +37,7 @@ describe('workers/repository/config-migration/branch/index', () => {
 
     it('Exits when Migration is not needed', async () => {
       await expect(
-        checkConfigMigrationBranch(config, null)
+        checkConfigMigrationBranch(config, null as never)
       ).resolves.toBeNull();
       expect(logger.debug).toHaveBeenCalledWith(
         'checkConfigMigrationBranch() Config does not need migration'

--- a/lib/workers/repository/config-migration/branch/index.spec.ts
+++ b/lib/workers/repository/config-migration/branch/index.spec.ts
@@ -20,7 +20,7 @@ jest.mock('./rebase');
 jest.mock('./create');
 jest.mock('../../../../util/git');
 
-const migratedData: MigratedData = Fixtures.getJson('./migrated-data.json');
+const migratedData = Fixtures.getJson<MigratedData>('./migrated-data.json');
 
 describe('workers/repository/config-migration/branch/index', () => {
   describe('checkConfigMigrationBranch', () => {
@@ -37,7 +37,7 @@ describe('workers/repository/config-migration/branch/index', () => {
 
     it('Exits when Migration is not needed', async () => {
       await expect(
-        checkConfigMigrationBranch(config, null as never)
+        checkConfigMigrationBranch(config, null)
       ).resolves.toBeNull();
       expect(logger.debug).toHaveBeenCalledWith(
         'checkConfigMigrationBranch() Config does not need migration'

--- a/lib/workers/repository/config-migration/branch/index.ts
+++ b/lib/workers/repository/config-migration/branch/index.ts
@@ -10,7 +10,7 @@ import { rebaseMigrationBranch } from './rebase';
 
 export async function checkConfigMigrationBranch(
   config: RenovateConfig,
-  migratedConfigData: MigratedData
+  migratedConfigData: MigratedData | null
 ): Promise<string | null> {
   logger.debug('checkConfigMigrationBranch()');
   if (!migratedConfigData) {

--- a/lib/workers/repository/config-migration/branch/migrated-data.spec.ts
+++ b/lib/workers/repository/config-migration/branch/migrated-data.spec.ts
@@ -1,6 +1,6 @@
 import detectIndent from 'detect-indent';
 import { Fixtures } from '../../../../../test/fixtures';
-import { mockedFunction } from '../../../../../test/util';
+import { RenovateConfig, mockedFunction } from '../../../../../test/util';
 
 import { migrateConfig } from '../../../../config/migration';
 import { readLocalFile } from '../../../../util/fs';
@@ -40,7 +40,7 @@ describe('workers/repository/config-migration/branch/migrated-data', () => {
     it('Calls getAsync a first when migration not needed', async () => {
       mockedFunction(migrateConfig).mockReturnValueOnce({
         isMigrated: false,
-        migratedConfig: null,
+        migratedConfig: <RenovateConfig>{},
       });
       await expect(MigratedDataFactory.getAsync()).resolves.toBeNull();
     });
@@ -62,12 +62,12 @@ describe('workers/repository/config-migration/branch/migrated-data', () => {
     describe('MigratedData class', () => {
       it('gets the filename from the class instance', async () => {
         const data = await MigratedDataFactory.getAsync();
-        expect(data.filename).toBe('renovate.json');
+        expect(data?.filename).toBe('renovate.json');
       });
 
       it('gets the content from the class instance', async () => {
         const data = await MigratedDataFactory.getAsync();
-        expect(data.content).toBe(migratedData.content);
+        expect(data?.content).toBe(migratedData.content);
       });
     });
 
@@ -80,9 +80,9 @@ describe('workers/repository/config-migration/branch/migrated-data', () => {
 
     it('Resets the factory and gets a new value with default indentation', async () => {
       mockedFunction(detectIndent).mockReturnValueOnce({
-        type: null,
+        type: null as never,
         amount: 0,
-        indent: null,
+        indent: null as never,
       });
       MigratedDataFactory.reset();
       await expect(MigratedDataFactory.getAsync()).resolves.toEqual(
@@ -103,7 +103,7 @@ describe('workers/repository/config-migration/branch/migrated-data', () => {
 
     it('Returns nothing due to fs error', async () => {
       mockedFunction(detectRepoFileConfig).mockResolvedValueOnce({
-        configFileName: null,
+        configFileName: undefined,
       });
       mockedFunction(readLocalFile).mockRejectedValueOnce(null);
       MigratedDataFactory.reset();

--- a/lib/workers/repository/config-migration/branch/migrated-data.spec.ts
+++ b/lib/workers/repository/config-migration/branch/migrated-data.spec.ts
@@ -1,6 +1,6 @@
 import detectIndent from 'detect-indent';
 import { Fixtures } from '../../../../../test/fixtures';
-import { RenovateConfig, mockedFunction } from '../../../../../test/util';
+import { mockedFunction } from '../../../../../test/util';
 
 import { migrateConfig } from '../../../../config/migration';
 import { readLocalFile } from '../../../../util/fs';
@@ -40,7 +40,7 @@ describe('workers/repository/config-migration/branch/migrated-data', () => {
     it('Calls getAsync a first when migration not needed', async () => {
       mockedFunction(migrateConfig).mockReturnValueOnce({
         isMigrated: false,
-        migratedConfig: <RenovateConfig>{},
+        migratedConfig: {},
       });
       await expect(MigratedDataFactory.getAsync()).resolves.toBeNull();
     });
@@ -80,9 +80,9 @@ describe('workers/repository/config-migration/branch/migrated-data', () => {
 
     it('Resets the factory and gets a new value with default indentation', async () => {
       mockedFunction(detectIndent).mockReturnValueOnce({
-        type: null as never,
+        type: undefined,
         amount: 0,
-        indent: null as never,
+        indent: '',
       });
       MigratedDataFactory.reset();
       await expect(MigratedDataFactory.getAsync()).resolves.toEqual(

--- a/lib/workers/repository/config-migration/branch/migrated-data.spec.ts
+++ b/lib/workers/repository/config-migration/branch/migrated-data.spec.ts
@@ -82,7 +82,8 @@ describe('workers/repository/config-migration/branch/migrated-data', () => {
       mockedFunction(detectIndent).mockReturnValueOnce({
         type: undefined,
         amount: 0,
-        indent: '',
+        // TODO: incompatible types (#7154)
+        indent: null as never,
       });
       MigratedDataFactory.reset();
       await expect(MigratedDataFactory.getAsync()).resolves.toEqual(

--- a/lib/workers/repository/config-migration/pr/index.spec.ts
+++ b/lib/workers/repository/config-migration/pr/index.spec.ts
@@ -61,7 +61,7 @@ describe('workers/repository/config-migration/pr/index', () => {
 
     it('creates PR with default PR title', async () => {
       await ensureConfigMigrationPr(
-        { ...config, onboardingPrTitle: null },
+        { ...config, onboardingPrTitle: '' },
         migratedData
       );
       expect(platform.getBranchPr).toHaveBeenCalledTimes(1);

--- a/lib/workers/repository/config-migration/pr/index.spec.ts
+++ b/lib/workers/repository/config-migration/pr/index.spec.ts
@@ -229,7 +229,7 @@ describe('workers/repository/config-migration/pr/index', () => {
     });
 
     it('deletes branch when PR already exists but cannot find it', async () => {
-      err.response.body = {
+      response.body = {
         errors: [{ message: 'A pull request already exists' }],
       };
       platform.createPr.mockRejectedValue(err);

--- a/lib/workers/repository/dependency-dashboard.spec.ts
+++ b/lib/workers/repository/dependency-dashboard.spec.ts
@@ -517,7 +517,7 @@ describe('workers/repository/dependency-dashboard', () => {
       config.dependencyDashboard = true;
       config.dependencyDashboardChecks = { branchName2: 'approve-branch' };
       config.dependencyDashboardIssue = 1;
-      platform.getIssue.mockResolvedValueOnce({
+      platform.getIssue?.mockResolvedValueOnce({
         title: 'Dependency Dashboard',
         body: `This issue contains a list of Renovate updates and their statuses.
 

--- a/lib/workers/repository/dependency-dashboard.spec.ts
+++ b/lib/workers/repository/dependency-dashboard.spec.ts
@@ -5,6 +5,7 @@ import {
   RenovateConfig,
   getConfig,
   logger,
+  mockedFunction,
   platform,
 } from '../../../test/util';
 import { GlobalConfig } from '../../config/global';
@@ -517,7 +518,8 @@ describe('workers/repository/dependency-dashboard', () => {
       config.dependencyDashboard = true;
       config.dependencyDashboardChecks = { branchName2: 'approve-branch' };
       config.dependencyDashboardIssue = 1;
-      platform.getIssue?.mockResolvedValueOnce({
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+      mockedFunction(platform.getIssue!).mockResolvedValueOnce({
         title: 'Dependency Dashboard',
         body: `This issue contains a list of Renovate updates and their statuses.
 

--- a/lib/workers/repository/errors-warnings.spec.ts
+++ b/lib/workers/repository/errors-warnings.spec.ts
@@ -45,7 +45,7 @@ describe('workers/repository/errors-warnings', () => {
             packageFile: 'package.json',
             deps: [
               {
-                warnings: [{ message: 'Warning 1', topic: undefined }],
+                warnings: [{ message: 'Warning 1', topic: '' }],
               },
               {},
             ],
@@ -54,7 +54,7 @@ describe('workers/repository/errors-warnings', () => {
             packageFile: 'backend/package.json',
             deps: [
               {
-                warnings: [{ message: 'Warning 1', topic: undefined }],
+                warnings: [{ message: 'Warning 1', topic: '' }],
               },
             ],
           },
@@ -64,7 +64,7 @@ describe('workers/repository/errors-warnings', () => {
             packageFile: 'Dockerfile',
             deps: [
               {
-                warnings: [{ message: 'Warning 2', topic: undefined }],
+                warnings: [{ message: 'Warning 2', topic: '' }],
               },
             ],
           },

--- a/lib/workers/repository/extract/file-match.spec.ts
+++ b/lib/workers/repository/extract/file-match.spec.ts
@@ -64,7 +64,7 @@ describe('workers/repository/extract/file-match', () => {
     });
 
     it('deduplicates', () => {
-      config.fileMatch.push('package.json');
+      config.fileMatch?.push('package.json');
       const res = fileMatch.getMatchingFiles(config, fileList);
       expect(res).toMatchSnapshot();
       expect(res).toHaveLength(2);

--- a/lib/workers/repository/extract/index.spec.ts
+++ b/lib/workers/repository/extract/index.spec.ts
@@ -42,7 +42,7 @@ describe('workers/repository/extract/index', () => {
 
     it('warns if packageFiles is null', async () => {
       config.enabledManagers = ['npm'];
-      managerFiles.getManagerPackageFiles.mockResolvedValue([]);
+      managerFiles.getManagerPackageFiles.mockResolvedValue(null);
       expect(await extractAllDependencies(config)).toEqual({});
     });
 

--- a/lib/workers/repository/extract/index.spec.ts
+++ b/lib/workers/repository/extract/index.spec.ts
@@ -42,7 +42,7 @@ describe('workers/repository/extract/index', () => {
 
     it('warns if packageFiles is null', async () => {
       config.enabledManagers = ['npm'];
-      managerFiles.getManagerPackageFiles.mockResolvedValue(null);
+      managerFiles.getManagerPackageFiles.mockResolvedValue([]);
       expect(await extractAllDependencies(config)).toEqual({});
     });
 

--- a/lib/workers/repository/extract/manager-files.ts
+++ b/lib/workers/repository/extract/manager-files.ts
@@ -11,7 +11,7 @@ import type { WorkerExtractConfig } from '../../types';
 
 export async function getManagerPackageFiles(
   config: WorkerExtractConfig
-): Promise<PackageFile[]> {
+): Promise<PackageFile[] | null> {
   const { enabled, manager, fileList } = config;
   logger.trace(`getPackageFiles(${manager})`);
   if (!enabled) {
@@ -42,8 +42,7 @@ export async function getManagerPackageFiles(
         }
       }
     }
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-    return allPackageFiles!;
+    return allPackageFiles;
   }
   const packageFiles: PackageFile[] = [];
   for (const packageFile of fileList) {

--- a/lib/workers/repository/finalise/prune.spec.ts
+++ b/lib/workers/repository/finalise/prune.spec.ts
@@ -28,7 +28,7 @@ describe('workers/repository/finalise/prune', () => {
 
     it('returns if no branchList', async () => {
       delete config.branchList;
-      await cleanup.pruneStaleBranches(config, config.branchList ?? []);
+      await cleanup.pruneStaleBranches(config, config.branchList as never);
       expect(git.getBranchList).toHaveBeenCalledTimes(0);
     });
 

--- a/lib/workers/repository/finalise/prune.spec.ts
+++ b/lib/workers/repository/finalise/prune.spec.ts
@@ -28,7 +28,7 @@ describe('workers/repository/finalise/prune', () => {
 
     it('returns if no branchList', async () => {
       delete config.branchList;
-      await cleanup.pruneStaleBranches(config, config.branchList);
+      await cleanup.pruneStaleBranches(config, config.branchList ?? []);
       expect(git.getBranchList).toHaveBeenCalledTimes(0);
     });
 

--- a/lib/workers/repository/finalise/prune.spec.ts
+++ b/lib/workers/repository/finalise/prune.spec.ts
@@ -28,7 +28,7 @@ describe('workers/repository/finalise/prune', () => {
 
     it('returns if no branchList', async () => {
       delete config.branchList;
-      await cleanup.pruneStaleBranches(config, config.branchList as never);
+      await cleanup.pruneStaleBranches(config, config.branchList);
       expect(git.getBranchList).toHaveBeenCalledTimes(0);
     });
 

--- a/lib/workers/repository/finalise/prune.ts
+++ b/lib/workers/repository/finalise/prune.ts
@@ -91,7 +91,7 @@ async function cleanUpBranches(
 
 export async function pruneStaleBranches(
   config: RenovateConfig,
-  branchList: string[]
+  branchList: string[] | null | undefined
 ): Promise<void> {
   logger.debug('Removing any stale branches');
   logger.trace({ config }, `pruneStaleBranches`);

--- a/lib/workers/repository/init/merge.spec.ts
+++ b/lib/workers/repository/init/merge.spec.ts
@@ -186,14 +186,14 @@ describe('workers/repository/init/merge', () => {
       migrateAndValidate.migrateAndValidate.mockResolvedValueOnce({
         errors: [{ topic: 'dep', message: 'test error' }],
       });
-      let e: Error;
+      let e: Error | undefined;
       try {
         await mergeRenovateConfig(config);
       } catch (err) {
         e = err;
       }
       expect(e).toBeDefined();
-      expect(e.toString()).toBe('Error: config-validation');
+      expect(e?.toString()).toBe('Error: config-validation');
     });
 
     it('migrates nested config', async () => {

--- a/lib/workers/repository/init/semantic.spec.ts
+++ b/lib/workers/repository/init/semantic.spec.ts
@@ -20,7 +20,6 @@ describe('workers/repository/init/semantic', () => {
     });
 
     it('detects false if unknown', async () => {
-      config.semanticCommits = null;
       git.getCommitMessages.mockResolvedValueOnce(['foo', 'bar']);
       git.getCommitMessages.mockResolvedValueOnce([
         'fix: foo',
@@ -33,7 +32,6 @@ describe('workers/repository/init/semantic', () => {
     });
 
     it('detects true if known', async () => {
-      config.semanticCommits = null;
       git.getCommitMessages.mockResolvedValue(['fix: foo', 'refactor: bar']);
       const res = await detectSemanticCommits();
       expect(res).toBe('enabled');

--- a/lib/workers/repository/init/semantic.spec.ts
+++ b/lib/workers/repository/init/semantic.spec.ts
@@ -20,6 +20,7 @@ describe('workers/repository/init/semantic', () => {
     });
 
     it('detects false if unknown', async () => {
+      config.semanticCommits = undefined;
       git.getCommitMessages.mockResolvedValueOnce(['foo', 'bar']);
       git.getCommitMessages.mockResolvedValueOnce([
         'fix: foo',
@@ -32,6 +33,7 @@ describe('workers/repository/init/semantic', () => {
     });
 
     it('detects true if known', async () => {
+      config.semanticCommits = undefined;
       git.getCommitMessages.mockResolvedValue(['fix: foo', 'refactor: bar']);
       const res = await detectSemanticCommits();
       expect(res).toBe('enabled');

--- a/lib/workers/repository/init/vulnerability.spec.ts
+++ b/lib/workers/repository/init/vulnerability.spec.ts
@@ -24,12 +24,14 @@ describe('workers/repository/init/vulnerability', () => {
 
     it('returns if alerts are disabled', async () => {
       // TODO #7154
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
       config.vulnerabilityAlerts!.enabled = false;
       expect(await detectVulnerabilityAlerts(config)).toEqual(config);
     });
 
     it('returns if no alerts', async () => {
       // TODO #7154
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
       delete config.vulnerabilityAlerts!.enabled;
       platform.getVulnerabilityAlerts.mockResolvedValue([]);
       expect(await detectVulnerabilityAlerts(config)).toEqual(config);
@@ -45,6 +47,7 @@ describe('workers/repository/init/vulnerability', () => {
 
     it('returns alerts and remediations', async () => {
       config.transitiveRemediation = true;
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
       delete config.vulnerabilityAlerts!.enabled;
       platform.getVulnerabilityAlerts.mockResolvedValue([
         partial<VulnerabilityAlert>({}),

--- a/lib/workers/repository/init/vulnerability.spec.ts
+++ b/lib/workers/repository/init/vulnerability.spec.ts
@@ -4,6 +4,7 @@ import {
   partial,
   platform,
 } from '../../../../test/util';
+import type { RenovateSharedConfig } from '../../../config/types';
 import { NO_VULNERABILITY_ALERTS } from '../../../constants/error-messages';
 import type { VulnerabilityAlert } from '../../../types';
 import { detectVulnerabilityAlerts } from './vulnerability';
@@ -23,11 +24,13 @@ describe('workers/repository/init/vulnerability', () => {
     });
 
     it('returns if alerts are disabled', async () => {
+      config.vulnerabilityAlerts = {};
       config.vulnerabilityAlerts.enabled = false;
       expect(await detectVulnerabilityAlerts(config)).toEqual(config);
     });
 
     it('returns if no alerts', async () => {
+      config.vulnerabilityAlerts = <RenovateSharedConfig>{};
       delete config.vulnerabilityAlerts.enabled;
       platform.getVulnerabilityAlerts.mockResolvedValue([]);
       expect(await detectVulnerabilityAlerts(config)).toEqual(config);
@@ -43,7 +46,7 @@ describe('workers/repository/init/vulnerability', () => {
 
     it('returns alerts and remediations', async () => {
       config.transitiveRemediation = true;
-      delete config.vulnerabilityAlerts.enabled;
+      delete config.vulnerabilityAlerts?.enabled;
       platform.getVulnerabilityAlerts.mockResolvedValue([
         partial<VulnerabilityAlert>({}),
         {
@@ -73,7 +76,7 @@ describe('workers/repository/init/vulnerability', () => {
           vulnerableManifestPath: 'backend/package-lock.json',
           securityAdvisory: {
             references: [],
-            severity: null,
+            severity: '',
           },
           securityVulnerability: {
             package: { ecosystem: 'NPM', name: 'yargs-parser' },

--- a/lib/workers/repository/init/vulnerability.spec.ts
+++ b/lib/workers/repository/init/vulnerability.spec.ts
@@ -4,7 +4,6 @@ import {
   partial,
   platform,
 } from '../../../../test/util';
-import type { RenovateSharedConfig } from '../../../config/types';
 import { NO_VULNERABILITY_ALERTS } from '../../../constants/error-messages';
 import type { VulnerabilityAlert } from '../../../types';
 import { detectVulnerabilityAlerts } from './vulnerability';
@@ -30,7 +29,7 @@ describe('workers/repository/init/vulnerability', () => {
     });
 
     it('returns if no alerts', async () => {
-      config.vulnerabilityAlerts = <RenovateSharedConfig>{};
+      config.vulnerabilityAlerts = {};
       delete config.vulnerabilityAlerts.enabled;
       platform.getVulnerabilityAlerts.mockResolvedValue([]);
       expect(await detectVulnerabilityAlerts(config)).toEqual(config);

--- a/lib/workers/repository/init/vulnerability.spec.ts
+++ b/lib/workers/repository/init/vulnerability.spec.ts
@@ -23,14 +23,14 @@ describe('workers/repository/init/vulnerability', () => {
     });
 
     it('returns if alerts are disabled', async () => {
-      config.vulnerabilityAlerts = {};
-      config.vulnerabilityAlerts.enabled = false;
+      // TODO #7154
+      config.vulnerabilityAlerts!.enabled = false;
       expect(await detectVulnerabilityAlerts(config)).toEqual(config);
     });
 
     it('returns if no alerts', async () => {
-      config.vulnerabilityAlerts = {};
-      delete config.vulnerabilityAlerts.enabled;
+      // TODO #7154
+      delete config.vulnerabilityAlerts!.enabled;
       platform.getVulnerabilityAlerts.mockResolvedValue([]);
       expect(await detectVulnerabilityAlerts(config)).toEqual(config);
     });
@@ -45,7 +45,7 @@ describe('workers/repository/init/vulnerability', () => {
 
     it('returns alerts and remediations', async () => {
       config.transitiveRemediation = true;
-      delete config.vulnerabilityAlerts?.enabled;
+      delete config.vulnerabilityAlerts!.enabled;
       platform.getVulnerabilityAlerts.mockResolvedValue([
         partial<VulnerabilityAlert>({}),
         {

--- a/lib/workers/repository/model/semantic-commit-message.spec.ts
+++ b/lib/workers/repository/model/semantic-commit-message.spec.ts
@@ -29,7 +29,7 @@ describe('workers/repository/model/semantic-commit-message', () => {
     const instance = SemanticCommitMessage.fromString('feat: ticket 123');
 
     expect(SemanticCommitMessage.is(instance)).toBeTrue();
-    expect(instance.toJSON()).toEqual({
+    expect(instance?.toJSON()).toEqual({
       body: '',
       footer: '',
       scope: '',
@@ -44,7 +44,7 @@ describe('workers/repository/model/semantic-commit-message', () => {
     );
 
     expect(SemanticCommitMessage.is(instance)).toBeTrue();
-    expect(instance.toJSON()).toEqual({
+    expect(instance?.toJSON()).toEqual({
       body: '',
       footer: '',
       scope: 'dashboard',
@@ -57,7 +57,7 @@ describe('workers/repository/model/semantic-commit-message', () => {
     const instance = SemanticCommitMessage.fromString('fix(deps): ');
 
     expect(SemanticCommitMessage.is(instance)).toBeTrue();
-    expect(instance.toJSON()).toEqual({
+    expect(instance?.toJSON()).toEqual({
       body: '',
       footer: '',
       scope: 'deps',

--- a/lib/workers/repository/onboarding/branch/index.spec.ts
+++ b/lib/workers/repository/onboarding/branch/index.spec.ts
@@ -77,9 +77,9 @@ describe('workers/repository/onboarding/branch/index', () => {
       fs.readLocalFile.mockResolvedValue('{}');
       await checkOnboardingBranch(config);
       const file = git.commitFiles.mock.calls[0][0].files[0] as FileAddition;
-      const contents = file.contents?.toString() ?? '';
+      const contents = file.contents?.toString();
       expect(contents).toBeJsonString();
-      expect(JSON.parse(contents)).toEqual({
+      expect(JSON.parse(contents!)).toEqual({
         $schema: 'https://docs.renovatebot.com/renovate-schema.json',
       });
     });
@@ -110,9 +110,9 @@ describe('workers/repository/onboarding/branch/index', () => {
         configFileNames[0]
       );
       const file = git.commitFiles.mock.calls[0][0].files[0] as FileAddition;
-      const contents = file.contents?.toString() ?? '';
+      const contents = file.contents?.toString();
       expect(contents).toBeJsonString();
-      expect(JSON.parse(contents)).toEqual({
+      expect(JSON.parse(contents!)).toEqual({
         $schema: 'https://docs.renovatebot.com/renovate-schema.json',
         extends: ['some/renovate-config'],
       });

--- a/lib/workers/repository/onboarding/branch/index.spec.ts
+++ b/lib/workers/repository/onboarding/branch/index.spec.ts
@@ -79,6 +79,7 @@ describe('workers/repository/onboarding/branch/index', () => {
       const file = git.commitFiles.mock.calls[0][0].files[0] as FileAddition;
       const contents = file.contents?.toString();
       expect(contents).toBeJsonString();
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
       expect(JSON.parse(contents!)).toEqual({
         $schema: 'https://docs.renovatebot.com/renovate-schema.json',
       });
@@ -112,6 +113,7 @@ describe('workers/repository/onboarding/branch/index', () => {
       const file = git.commitFiles.mock.calls[0][0].files[0] as FileAddition;
       const contents = file.contents?.toString();
       expect(contents).toBeJsonString();
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
       expect(JSON.parse(contents!)).toEqual({
         $schema: 'https://docs.renovatebot.com/renovate-schema.json',
         extends: ['some/renovate-config'],

--- a/lib/workers/repository/onboarding/branch/index.spec.ts
+++ b/lib/workers/repository/onboarding/branch/index.spec.ts
@@ -77,7 +77,7 @@ describe('workers/repository/onboarding/branch/index', () => {
       fs.readLocalFile.mockResolvedValue('{}');
       await checkOnboardingBranch(config);
       const file = git.commitFiles.mock.calls[0][0].files[0] as FileAddition;
-      const contents = file.contents.toString();
+      const contents = file.contents?.toString() ?? '';
       expect(contents).toBeJsonString();
       expect(JSON.parse(contents)).toEqual({
         $schema: 'https://docs.renovatebot.com/renovate-schema.json',
@@ -110,7 +110,7 @@ describe('workers/repository/onboarding/branch/index', () => {
         configFileNames[0]
       );
       const file = git.commitFiles.mock.calls[0][0].files[0] as FileAddition;
-      const contents = file.contents.toString();
+      const contents = file.contents?.toString() ?? '';
       expect(contents).toBeJsonString();
       expect(JSON.parse(contents)).toEqual({
         $schema: 'https://docs.renovatebot.com/renovate-schema.json',

--- a/lib/workers/repository/onboarding/pr/index.spec.ts
+++ b/lib/workers/repository/onboarding/pr/index.spec.ts
@@ -224,7 +224,7 @@ describe('workers/repository/onboarding/pr/index', () => {
       });
 
       it('deletes branch when PR already exists but cannot find it', async () => {
-        err.response.body = {
+        response.body = {
           errors: [{ message: 'A pull request already exists' }],
         };
         platform.createPr.mockRejectedValueOnce(err);

--- a/lib/workers/repository/process/fetch.spec.ts
+++ b/lib/workers/repository/process/fetch.spec.ts
@@ -80,7 +80,7 @@ describe('workers/repository/process/fetch', () => {
               { depName: 'abcd' },
               { currentValue: '2.8.11', datasource: 'docker' },
               { depName: ' ' },
-              { depName: undefined },
+              {},
               { depName: undefined },
               { depName: { oh: 'no' } as unknown as string },
             ],

--- a/lib/workers/repository/process/fetch.spec.ts
+++ b/lib/workers/repository/process/fetch.spec.ts
@@ -80,7 +80,7 @@ describe('workers/repository/process/fetch', () => {
               { depName: 'abcd' },
               { currentValue: '2.8.11', datasource: 'docker' },
               { depName: ' ' },
-              { depName: null },
+              { depName: undefined },
               { depName: undefined },
               { depName: { oh: 'no' } as unknown as string },
             ],

--- a/lib/workers/repository/process/fetch.ts
+++ b/lib/workers/repository/process/fetch.ts
@@ -52,7 +52,7 @@ async function fetchDepUpdates(
         ...(await lookupUpdates(depConfig as LookupUpdateConfig)),
       };
     }
-    dep.updates = dep.updates || [];
+    dep.updates = dep.updates ?? [];
   }
   return dep;
 }

--- a/lib/workers/repository/process/limits.spec.ts
+++ b/lib/workers/repository/process/limits.spec.ts
@@ -130,7 +130,7 @@ describe('workers/repository/process/limits', () => {
 
     it('returns prConcurrentLimit if errored', () => {
       config.branchConcurrentLimit = 2;
-      const res = limits.getConcurrentBranchesRemaining(config, null);
+      const res = limits.getConcurrentBranchesRemaining(config, []);
       expect(res).toBe(2);
     });
   });

--- a/lib/workers/repository/process/limits.spec.ts
+++ b/lib/workers/repository/process/limits.spec.ts
@@ -130,7 +130,8 @@ describe('workers/repository/process/limits', () => {
 
     it('returns prConcurrentLimit if errored', () => {
       config.branchConcurrentLimit = 2;
-      const res = limits.getConcurrentBranchesRemaining(config, []);
+      // TODO: #7154
+      const res = limits.getConcurrentBranchesRemaining(config, null as never);
       expect(res).toBe(2);
     });
   });

--- a/lib/workers/repository/process/limits.ts
+++ b/lib/workers/repository/process/limits.ts
@@ -116,6 +116,7 @@ export function getConcurrentBranchesRemaining(
 
       return concurrentRemaining;
     } catch (err) {
+      // TODO: #7154 should never throw
       logger.error({ err }, 'Error checking concurrent branches');
       return limit;
     }

--- a/lib/workers/repository/process/vulnerabilities.spec.ts
+++ b/lib/workers/repository/process/vulnerabilities.spec.ts
@@ -12,7 +12,9 @@ jest.mock('@jamiemagee/osv-offline', () => {
   return {
     __esModule: true,
     OsvOffline: class {
-      static create = () => createMock();
+      static create() {
+        return createMock();
+      }
     },
   };
 });

--- a/lib/workers/repository/update/branch/artifacts.spec.ts
+++ b/lib/workers/repository/update/branch/artifacts.spec.ts
@@ -10,7 +10,7 @@ describe('workers/repository/update/branch/artifacts', () => {
   beforeEach(() => {
     GlobalConfig.set({});
     jest.resetAllMocks();
-    config = {
+    config = <BranchConfig>{
       ...getConfig(),
       manager: 'some-manager',
       branchName: 'renovate/pin',
@@ -40,6 +40,7 @@ describe('workers/repository/update/branch/artifacts', () => {
     });
 
     it('skips status (no errors)', async () => {
+      config.artifactErrors = [];
       platform.getBranchStatusCheck.mockResolvedValueOnce(null);
       config.artifactErrors.length = 0;
       await setArtifactErrorStatus(config);

--- a/lib/workers/repository/update/branch/artifacts.spec.ts
+++ b/lib/workers/repository/update/branch/artifacts.spec.ts
@@ -10,13 +10,14 @@ describe('workers/repository/update/branch/artifacts', () => {
   beforeEach(() => {
     GlobalConfig.set({});
     jest.resetAllMocks();
-    config = <BranchConfig>{
+    // TODO #7154 incompatible types
+    config = {
       ...getConfig(),
       manager: 'some-manager',
       branchName: 'renovate/pin',
       upgrades: [],
       artifactErrors: [{ lockFile: 'some' }],
-    };
+    } as BranchConfig;
   });
 
   describe('setArtifactsErrorStatus', () => {
@@ -40,9 +41,8 @@ describe('workers/repository/update/branch/artifacts', () => {
     });
 
     it('skips status (no errors)', async () => {
-      config.artifactErrors = [];
       platform.getBranchStatusCheck.mockResolvedValueOnce(null);
-      config.artifactErrors.length = 0;
+      config.artifactErrors = [];
       await setArtifactErrorStatus(config);
       expect(platform.setBranchStatus).not.toHaveBeenCalled();
     });

--- a/lib/workers/repository/update/branch/check-existing.spec.ts
+++ b/lib/workers/repository/update/branch/check-existing.spec.ts
@@ -10,11 +10,12 @@ describe('workers/repository/update/branch/check-existing', () => {
     let config: BranchConfig;
 
     beforeEach(() => {
-      config = <BranchConfig>{
+      // TODO #7154 incompatible types
+      config = {
         ...defaultConfig,
         branchName: 'some-branch',
         prTitle: 'some-title',
-      };
+      } as BranchConfig;
       jest.resetAllMocks();
     });
 

--- a/lib/workers/repository/update/branch/check-existing.spec.ts
+++ b/lib/workers/repository/update/branch/check-existing.spec.ts
@@ -10,11 +10,11 @@ describe('workers/repository/update/branch/check-existing', () => {
     let config: BranchConfig;
 
     beforeEach(() => {
-      config = partial<BranchConfig>({
+      config = <BranchConfig>{
         ...defaultConfig,
         branchName: 'some-branch',
         prTitle: 'some-title',
-      });
+      };
       jest.resetAllMocks();
     });
 

--- a/lib/workers/repository/update/branch/commit.spec.ts
+++ b/lib/workers/repository/update/branch/commit.spec.ts
@@ -60,6 +60,7 @@ describe('workers/repository/update/branch/commit', () => {
       expect(platform.commitFiles).toHaveBeenCalledTimes(1);
       // TODO #7154
       expect(
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
         mockedFunction(platform.commitFiles!).mock.calls
       ).toMatchSnapshot();
     });

--- a/lib/workers/repository/update/branch/commit.spec.ts
+++ b/lib/workers/repository/update/branch/commit.spec.ts
@@ -1,9 +1,4 @@
-import {
-  defaultConfig,
-  git,
-  partial,
-  platform,
-} from '../../../../../test/util';
+import { defaultConfig, git, platform } from '../../../../../test/util';
 import { GlobalConfig } from '../../../../config/global';
 import type { BranchConfig } from '../../../types';
 import { commitFilesToBranch } from './commit';
@@ -15,7 +10,7 @@ describe('workers/repository/update/branch/commit', () => {
     let config: BranchConfig;
 
     beforeEach(() => {
-      config = partial<BranchConfig>({
+      config = <BranchConfig>{
         ...defaultConfig,
         branchName: 'renovate/some-branch',
         commitMessage: 'some commit message',
@@ -24,7 +19,8 @@ describe('workers/repository/update/branch/commit', () => {
         semanticCommitScope: 'b',
         updatedPackageFiles: [],
         updatedArtifacts: [],
-      });
+        upgrades: [],
+      };
       jest.resetAllMocks();
       git.commitFiles.mockResolvedValueOnce('123test');
       platform.commitFiles = jest.fn();
@@ -37,7 +33,7 @@ describe('workers/repository/update/branch/commit', () => {
     });
 
     it('commits files', async () => {
-      config.updatedPackageFiles.push({
+      config.updatedPackageFiles?.push({
         type: 'addition',
         path: 'package.json',
         contents: 'some contents',
@@ -48,7 +44,7 @@ describe('workers/repository/update/branch/commit', () => {
     });
 
     it('commits via platform', async () => {
-      config.updatedPackageFiles.push({
+      config.updatedPackageFiles?.push({
         type: 'addition',
         path: 'package.json',
         contents: 'some contents',
@@ -56,12 +52,12 @@ describe('workers/repository/update/branch/commit', () => {
       config.platformCommit = true;
       await commitFilesToBranch(config);
       expect(platform.commitFiles).toHaveBeenCalledTimes(1);
-      expect(platform.commitFiles.mock.calls).toMatchSnapshot();
+      expect((platform.commitFiles as jest.Mock).mock.calls).toMatchSnapshot();
     });
 
     it('dry runs', async () => {
       GlobalConfig.set({ dryRun: 'full' });
-      config.updatedPackageFiles.push({
+      config.updatedPackageFiles?.push({
         type: 'addition',
         path: 'package.json',
         contents: 'some contents',

--- a/lib/workers/repository/update/branch/commit.spec.ts
+++ b/lib/workers/repository/update/branch/commit.spec.ts
@@ -1,4 +1,9 @@
-import { defaultConfig, git, platform } from '../../../../../test/util';
+import {
+  defaultConfig,
+  git,
+  mockedFunction,
+  platform,
+} from '../../../../../test/util';
 import { GlobalConfig } from '../../../../config/global';
 import type { BranchConfig } from '../../../types';
 import { commitFilesToBranch } from './commit';
@@ -10,7 +15,8 @@ describe('workers/repository/update/branch/commit', () => {
     let config: BranchConfig;
 
     beforeEach(() => {
-      config = <BranchConfig>{
+      // TODO #7154 incompatible types
+      config = {
         ...defaultConfig,
         branchName: 'renovate/some-branch',
         commitMessage: 'some commit message',
@@ -20,7 +26,7 @@ describe('workers/repository/update/branch/commit', () => {
         updatedPackageFiles: [],
         updatedArtifacts: [],
         upgrades: [],
-      };
+      } as BranchConfig;
       jest.resetAllMocks();
       git.commitFiles.mockResolvedValueOnce('123test');
       platform.commitFiles = jest.fn();
@@ -52,7 +58,10 @@ describe('workers/repository/update/branch/commit', () => {
       config.platformCommit = true;
       await commitFilesToBranch(config);
       expect(platform.commitFiles).toHaveBeenCalledTimes(1);
-      expect((platform.commitFiles as jest.Mock).mock.calls).toMatchSnapshot();
+      // TODO #7154
+      expect(
+        mockedFunction(platform.commitFiles!).mock.calls
+      ).toMatchSnapshot();
     });
 
     it('dry runs', async () => {

--- a/lib/workers/repository/update/branch/execute-post-upgrade-commands.spec.ts
+++ b/lib/workers/repository/update/branch/execute-post-upgrade-commands.spec.ts
@@ -35,6 +35,17 @@ describe('workers/repository/update/branch/execute-post-upgrade-commands', () =>
         modified: [],
         not_added: [],
         deleted: [],
+        conflicted: [],
+        renamed: [],
+        staged: [],
+        created: [],
+        detached: false,
+        tracking: '',
+        current: '',
+        behind: 0,
+        ahead: 0,
+        files: [],
+        isClean: () => false,
       } as StatusResult);
       GlobalConfig.set({
         localDir: __dirname,

--- a/lib/workers/repository/update/branch/execute-post-upgrade-commands.spec.ts
+++ b/lib/workers/repository/update/branch/execute-post-upgrade-commands.spec.ts
@@ -1,4 +1,4 @@
-import { fs, git } from '../../../../../test/util';
+import { fs, git, partial } from '../../../../../test/util';
 import { GlobalConfig } from '../../../../config/global';
 import type { StatusResult } from '../../../../util/git/types';
 import type { BranchConfig, BranchUpgradeConfig } from '../../../types';
@@ -31,22 +31,13 @@ describe('workers/repository/update/branch/execute-post-upgrade-commands', () =>
         upgrades: [],
         branchName: 'main',
       };
-      git.getRepoStatus.mockResolvedValueOnce({
-        modified: [],
-        not_added: [],
-        deleted: [],
-        conflicted: [],
-        renamed: [],
-        staged: [],
-        created: [],
-        detached: false,
-        tracking: '',
-        current: '',
-        behind: 0,
-        ahead: 0,
-        files: [],
-        isClean: () => false,
-      } as StatusResult);
+      git.getRepoStatus.mockResolvedValueOnce(
+        partial<StatusResult>({
+          modified: [],
+          not_added: [],
+          deleted: [],
+        })
+      );
       GlobalConfig.set({
         localDir: __dirname,
         allowedPostUpgradeCommands: ['some-command'],

--- a/lib/workers/repository/update/branch/get-updated.spec.ts
+++ b/lib/workers/repository/update/branch/get-updated.spec.ts
@@ -41,7 +41,7 @@ describe('workers/repository/update/branch/get-updated', () => {
       config.upgrades.push({
         packageFile: 'index.html',
         manager: 'html',
-        branchName: undefined,
+        branchName: '',
       });
       autoReplace.doAutoReplace.mockResolvedValueOnce('updated-file');
       const res = await getUpdatedPackageFiles(config);
@@ -56,7 +56,7 @@ describe('workers/repository/update/branch/get-updated', () => {
       config.upgrades.push({
         packageFile: 'index.html',
         manager: 'html',
-        branchName: undefined,
+        branchName: '',
       });
       autoReplace.doAutoReplace.mockResolvedValueOnce('existing content');
       const res = await getUpdatedPackageFiles(config);
@@ -69,7 +69,7 @@ describe('workers/repository/update/branch/get-updated', () => {
     });
 
     it('handles autoreplace failure', async () => {
-      config.upgrades.push({ manager: 'html', branchName: undefined });
+      config.upgrades.push({ manager: 'html', branchName: '' });
       autoReplace.doAutoReplace.mockResolvedValueOnce(null);
       await expect(getUpdatedPackageFiles(config)).rejects.toThrow();
     });
@@ -79,7 +79,7 @@ describe('workers/repository/update/branch/get-updated', () => {
       config.upgrades.push({
         packageFile: 'index.html',
         manager: 'html',
-        branchName: undefined,
+        branchName: '',
       });
       autoReplace.doAutoReplace.mockResolvedValueOnce(null);
       autoReplace.doAutoReplace.mockResolvedValueOnce('updated-file');
@@ -133,7 +133,7 @@ describe('workers/repository/update/branch/get-updated', () => {
       config.upgrades.push({
         packageFile: 'composer.json',
         manager: 'composer',
-        branchName: undefined,
+        branchName: '',
       });
       autoReplace.doAutoReplace.mockResolvedValueOnce('some new content');
       composer.updateArtifacts.mockResolvedValueOnce([
@@ -278,7 +278,7 @@ describe('workers/repository/update/branch/get-updated', () => {
       config.reuseExistingBranch = true;
       config.upgrades.push({
         manager: 'composer',
-        branchName: undefined,
+        branchName: '',
       });
       autoReplace.doAutoReplace.mockResolvedValueOnce('some new content');
       composer.updateArtifacts.mockResolvedValueOnce([
@@ -318,7 +318,7 @@ describe('workers/repository/update/branch/get-updated', () => {
       config.upgrades.push({
         packageFile: 'composer.json',
         manager: 'composer',
-        branchName: undefined,
+        branchName: '',
         isLockfileUpdate: true,
       });
       composer.updateLockedDependency.mockReturnValueOnce({
@@ -356,7 +356,7 @@ describe('workers/repository/update/branch/get-updated', () => {
       config.upgrades.push({
         packageFile: 'abc.tf',
         manager: 'terraform',
-        branchName: undefined,
+        branchName: '',
         isLockfileUpdate: true,
       });
       terraform.updateArtifacts.mockResolvedValueOnce([
@@ -392,7 +392,7 @@ describe('workers/repository/update/branch/get-updated', () => {
         packageFile: 'package.json',
         lockFiles: ['package-lock.json'],
         manager: 'npm',
-        branchName: undefined,
+        branchName: '',
         isLockfileUpdate: true,
       });
       npm.updateLockedDependency.mockResolvedValue({
@@ -415,7 +415,7 @@ describe('workers/repository/update/branch/get-updated', () => {
         packageFile: 'package.json',
         lockFile: 'package-lock.json',
         manager: 'npm',
-        branchName: undefined,
+        branchName: '',
         isLockfileUpdate: true,
       });
       npm.updateLockedDependency.mockResolvedValueOnce({
@@ -438,7 +438,7 @@ describe('workers/repository/update/branch/get-updated', () => {
         packageFile: 'package.json',
         lockFile: 'package-lock.json',
         manager: 'npm',
-        branchName: undefined,
+        branchName: '',
         isLockfileUpdate: true,
       });
       git.getFile.mockResolvedValue('some content');
@@ -460,7 +460,7 @@ describe('workers/repository/update/branch/get-updated', () => {
     it('bumps versions in updateDependency managers', async () => {
       config.upgrades.push({
         packageFile: 'package.json',
-        branchName: undefined,
+        branchName: '',
         bumpVersion: 'patch',
         manager: 'npm',
       });
@@ -481,7 +481,7 @@ describe('workers/repository/update/branch/get-updated', () => {
     it('bumps versions in autoReplace managers', async () => {
       config.upgrades.push({
         packageFile: 'Chart.yaml',
-        branchName: undefined,
+        branchName: '',
         bumpVersion: 'patch',
         manager: 'helmv3',
       });

--- a/lib/workers/repository/update/branch/index.spec.ts
+++ b/lib/workers/repository/update/branch/index.spec.ts
@@ -1,4 +1,3 @@
-import { exec, mockExecAll } from '../../../../../test/exec-util';
 import {
   defaultConfig,
   fs,
@@ -18,6 +17,7 @@ import * as _npmPostExtract from '../../../../modules/manager/npm/post-update';
 import type { WriteExistingFilesResult } from '../../../../modules/manager/npm/post-update/types';
 import { hashBody } from '../../../../modules/platform/pr-body';
 import { PrState } from '../../../../types';
+import * as _exec from '../../../../util/exec';
 import type { FileChange, StatusResult } from '../../../../util/git/types';
 import * as _mergeConfidence from '../../../../util/merge-confidence';
 import * as _sanitize from '../../../../util/sanitize';
@@ -63,6 +63,7 @@ const commit = mocked(_commit);
 const mergeConfidence = mocked(_mergeConfidence);
 const prAutomerge = mocked(_prAutomerge);
 const prWorker = mocked(_prWorker);
+const exec = mocked(_exec);
 const sanitize = mocked(_sanitize);
 const limits = mocked(_limits);
 
@@ -99,7 +100,6 @@ describe('workers/repository/update/branch/index', () => {
         warnings: [],
         upgrades: [{ depName: 'some-dep-name' }] as BranchUpgradeConfig[],
       } as BranchConfig;
-      mockExecAll(exec);
       schedule.isScheduledNow.mockReturnValue(true);
       commit.commitFilesToBranch.mockResolvedValue('123test');
 
@@ -1270,7 +1270,7 @@ describe('workers/repository/update/branch/index', () => {
         localDir: '/localDir',
       });
 
-      mockExecAll(exec, new Error('Meh, this went wrong!'));
+      exec.exec.mockRejectedValue(new Error('Meh, this went wrong!'));
 
       await branchWorker.processBranch({
         ...config,
@@ -1376,7 +1376,7 @@ describe('workers/repository/update/branch/index', () => {
         prNo: undefined,
         result: 'done',
       });
-      expect(exec).toHaveBeenCalledWith('echo {{{versioning}}}', {
+      expect(exec.exec).toHaveBeenCalledWith('echo {{{versioning}}}', {
         cwd: '/localDir',
       });
     });
@@ -1500,13 +1500,13 @@ describe('workers/repository/update/branch/index', () => {
         prNo: undefined,
         result: 'done',
       });
-      expect(exec).toHaveBeenNthCalledWith(1, 'echo some-dep-name-1', {
+      expect(exec.exec).toHaveBeenNthCalledWith(1, 'echo some-dep-name-1', {
         cwd: '/localDir',
       });
-      expect(exec).toHaveBeenNthCalledWith(2, 'echo some-dep-name-2', {
+      expect(exec.exec).toHaveBeenNthCalledWith(2, 'echo some-dep-name-2', {
         cwd: '/localDir',
       });
-      expect(exec).toHaveBeenCalledTimes(2);
+      expect(exec.exec).toHaveBeenCalledTimes(2);
       const calledWithConfig = commit.commitFilesToBranch.mock.calls[0][0];
       const updatedArtifacts = calledWithConfig.updatedArtifacts;
       expect(findFileContent(updatedArtifacts, 'modified_file')).toBe(
@@ -1644,10 +1644,10 @@ describe('workers/repository/update/branch/index', () => {
         prNo: undefined,
         result: 'done',
       });
-      expect(exec).toHaveBeenNthCalledWith(1, 'echo hardcoded-string', {
+      expect(exec.exec).toHaveBeenNthCalledWith(1, 'echo hardcoded-string', {
         cwd: '/localDir',
       });
-      expect(exec).toHaveBeenCalledTimes(1);
+      expect(exec.exec).toHaveBeenCalledTimes(1);
       expect(
         findFileContent(
           commit.commitFilesToBranch.mock.calls[0][0].updatedArtifacts,

--- a/lib/workers/repository/update/branch/index.spec.ts
+++ b/lib/workers/repository/update/branch/index.spec.ts
@@ -99,6 +99,7 @@ describe('workers/repository/update/branch/index', () => {
         warnings: [],
         upgrades: [{ depName: 'some-dep-name' }] as BranchUpgradeConfig[],
       } as BranchConfig;
+      mockExecAll(exec);
       schedule.isScheduledNow.mockReturnValue(true);
       commit.commitFilesToBranch.mockResolvedValue('123test');
 

--- a/lib/workers/repository/update/branch/index.spec.ts
+++ b/lib/workers/repository/update/branch/index.spec.ts
@@ -1,3 +1,4 @@
+import { exec, mockExecAll } from '../../../../../test/exec-util';
 import {
   defaultConfig,
   fs,
@@ -15,10 +16,8 @@ import {
 import { logger } from '../../../../logger';
 import * as _npmPostExtract from '../../../../modules/manager/npm/post-update';
 import type { WriteExistingFilesResult } from '../../../../modules/manager/npm/post-update/types';
-import type { ArtifactError } from '../../../../modules/manager/types';
 import { hashBody } from '../../../../modules/platform/pr-body';
 import { PrState } from '../../../../types';
-import * as _exec from '../../../../util/exec';
 import type { FileChange, StatusResult } from '../../../../util/git/types';
 import * as _mergeConfidence from '../../../../util/merge-confidence';
 import * as _sanitize from '../../../../util/sanitize';
@@ -64,16 +63,18 @@ const commit = mocked(_commit);
 const mergeConfidence = mocked(_mergeConfidence);
 const prAutomerge = mocked(_prAutomerge);
 const prWorker = mocked(_prWorker);
-const exec = mocked(_exec);
 const sanitize = mocked(_sanitize);
 const limits = mocked(_limits);
 
 const adminConfig: RepoGlobalConfig = { localDir: '', cacheDir: '' };
 
-function findFileContent(files: FileChange[], path: string): string | null {
-  const f = files.find((file) => file.path === path);
+function findFileContent(
+  files: FileChange[] | undefined,
+  path: string
+): string | null {
+  const f = files?.find((file) => file.path === path);
   if (f?.type === 'addition' && f.contents) {
-    return f?.contents.toString();
+    return f.contents.toString();
   }
   return null;
 }
@@ -96,7 +97,7 @@ describe('workers/repository/update/branch/index', () => {
         branchName: 'renovate/some-branch',
         errors: [],
         warnings: [],
-        upgrades: [{ depName: 'some-dep-name' }] as BranchConfig['upgrades'],
+        upgrades: [{ depName: 'some-dep-name' }] as BranchUpgradeConfig[],
       } as BranchConfig;
       schedule.isScheduledNow.mockReturnValue(true);
       commit.commitFilesToBranch.mockResolvedValue('123test');
@@ -471,8 +472,8 @@ describe('workers/repository/update/branch/index', () => {
         updatedPackageFiles: [{}],
       } as PackageFilesResult);
       npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
-        artifactErrors: <ArtifactError[]>[],
-        updatedArtifacts: <FileChange[]>[{}],
+        artifactErrors: [],
+        updatedArtifacts: [partial<FileChange>({})],
       } as WriteExistingFilesResult);
       git.branchExists.mockReturnValue(true);
       commit.commitFilesToBranch.mockResolvedValueOnce(null);
@@ -487,8 +488,8 @@ describe('workers/repository/update/branch/index', () => {
         updatedPackageFiles: [{}],
       } as PackageFilesResult);
       npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
-        artifactErrors: <ArtifactError[]>[],
-        updatedArtifacts: <FileChange[]>[{}],
+        artifactErrors: [],
+        updatedArtifacts: [partial<FileChange>({})],
       } as WriteExistingFilesResult);
       git.branchExists.mockReturnValue(false);
       automerge.tryBranchAutomerge.mockResolvedValueOnce('automerged');
@@ -505,8 +506,8 @@ describe('workers/repository/update/branch/index', () => {
         updatedPackageFiles: [{}],
       } as PackageFilesResult);
       npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
-        artifactErrors: <ArtifactError[]>[],
-        updatedArtifacts: <FileChange[]>[{}],
+        artifactErrors: [],
+        updatedArtifacts: [partial<FileChange>({})],
       } as WriteExistingFilesResult);
       git.branchExists.mockReturnValue(true);
       commit.commitFilesToBranch.mockResolvedValueOnce(null);
@@ -523,8 +524,8 @@ describe('workers/repository/update/branch/index', () => {
         updatedPackageFiles: [{}],
       } as PackageFilesResult);
       npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
-        artifactErrors: <ArtifactError[]>[],
-        updatedArtifacts: <FileChange[]>[{}],
+        artifactErrors: [],
+        updatedArtifacts: [partial<FileChange>({})],
       } as WriteExistingFilesResult);
       git.branchExists.mockReturnValue(true);
       commit.commitFilesToBranch.mockResolvedValueOnce(null);
@@ -546,8 +547,8 @@ describe('workers/repository/update/branch/index', () => {
         updatedPackageFiles: [{}],
       } as PackageFilesResult);
       npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
-        artifactErrors: <ArtifactError[]>[],
-        updatedArtifacts: <FileChange[]>[{}],
+        artifactErrors: [],
+        updatedArtifacts: [partial<FileChange>({})],
       } as WriteExistingFilesResult);
       git.branchExists.mockReturnValue(true);
       commit.commitFilesToBranch.mockResolvedValueOnce(null);
@@ -569,8 +570,8 @@ describe('workers/repository/update/branch/index', () => {
         updatedPackageFiles: [{}],
       } as PackageFilesResult);
       npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
-        artifactErrors: <ArtifactError[]>[],
-        updatedArtifacts: <FileChange[]>[{}],
+        artifactErrors: [],
+        updatedArtifacts: [partial<FileChange>({})],
       } as WriteExistingFilesResult);
       git.branchExists.mockReturnValue(true);
       commit.commitFilesToBranch.mockResolvedValueOnce(null);
@@ -592,8 +593,8 @@ describe('workers/repository/update/branch/index', () => {
         updatedPackageFiles: [{}],
       } as PackageFilesResult);
       npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
-        artifactErrors: <ArtifactError[]>[],
-        updatedArtifacts: <FileChange[]>[{}],
+        artifactErrors: [],
+        updatedArtifacts: [partial<FileChange>({})],
       } as WriteExistingFilesResult);
       git.branchExists.mockReturnValue(true);
       commit.commitFilesToBranch.mockResolvedValueOnce(null);
@@ -615,8 +616,8 @@ describe('workers/repository/update/branch/index', () => {
         updatedPackageFiles: [{}],
       } as PackageFilesResult);
       npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
-        artifactErrors: <ArtifactError[]>[],
-        updatedArtifacts: <FileChange[]>[{}],
+        artifactErrors: [],
+        updatedArtifacts: [partial<FileChange>({})],
       } as WriteExistingFilesResult);
       git.branchExists.mockReturnValue(true);
       commit.commitFilesToBranch.mockResolvedValueOnce(null);
@@ -638,8 +639,8 @@ describe('workers/repository/update/branch/index', () => {
         updatedPackageFiles: [{}],
       } as PackageFilesResult);
       npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
-        artifactErrors: <ArtifactError[]>[],
-        updatedArtifacts: <FileChange[]>[{}],
+        artifactErrors: [],
+        updatedArtifacts: [partial<FileChange>({})],
       } as WriteExistingFilesResult);
       expect(
         await branchWorker.processBranch({
@@ -662,8 +663,8 @@ describe('workers/repository/update/branch/index', () => {
         updatedPackageFiles: [{}],
       } as PackageFilesResult);
       npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
-        artifactErrors: <ArtifactError[]>[],
-        updatedArtifacts: <FileChange[]>[{}],
+        artifactErrors: [],
+        updatedArtifacts: [partial<FileChange>({})],
       } as WriteExistingFilesResult);
       git.branchExists.mockReturnValue(true);
       automerge.tryBranchAutomerge.mockResolvedValueOnce('failed');
@@ -684,8 +685,8 @@ describe('workers/repository/update/branch/index', () => {
         updatedPackageFiles: [{}],
       } as PackageFilesResult);
       npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
-        artifactErrors: <ArtifactError[]>[],
-        updatedArtifacts: <FileChange[]>[{}],
+        artifactErrors: [],
+        updatedArtifacts: [partial<FileChange>({})],
       } as WriteExistingFilesResult);
       git.branchExists.mockReturnValue(true);
       automerge.tryBranchAutomerge.mockResolvedValueOnce('stale');
@@ -885,8 +886,8 @@ describe('workers/repository/update/branch/index', () => {
         updatedPackageFiles: [{}],
       } as PackageFilesResult);
       npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
-        artifactErrors: <ArtifactError[]>[],
-        updatedArtifacts: <FileChange[]>[{}],
+        artifactErrors: [],
+        updatedArtifacts: [partial<FileChange>({})],
       } as WriteExistingFilesResult);
       git.branchExists.mockReturnValue(true);
       automerge.tryBranchAutomerge.mockResolvedValueOnce('failed');
@@ -934,8 +935,8 @@ describe('workers/repository/update/branch/index', () => {
         artifactErrors: [{}],
       } as PackageFilesResult);
       npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
-        artifactErrors: <ArtifactError[]>[],
-        updatedArtifacts: <FileChange[]>[{}],
+        artifactErrors: [],
+        updatedArtifacts: [partial<FileChange>({})],
       } as WriteExistingFilesResult);
       git.branchExists.mockReturnValue(true);
       platform.getBranchPr.mockResolvedValueOnce({
@@ -970,8 +971,8 @@ describe('workers/repository/update/branch/index', () => {
         artifactErrors: [{}],
       } as PackageFilesResult);
       npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
-        artifactErrors: <ArtifactError[]>[],
-        updatedArtifacts: <FileChange[]>[{}],
+        artifactErrors: [],
+        updatedArtifacts: [partial<FileChange>({})],
       } as WriteExistingFilesResult);
       git.branchExists.mockReturnValue(true);
       platform.getBranchPr.mockResolvedValueOnce({
@@ -1003,14 +1004,16 @@ describe('workers/repository/update/branch/index', () => {
     });
 
     it('branch pr no schedule', async () => {
-      getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce({
-        updatedPackageFiles: [],
-        artifactErrors: [],
-        updatedArtifacts: [],
-      } as PackageFilesResult);
+      getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce(
+        partial<PackageFilesResult>({
+          updatedPackageFiles: [partial<FileChange>({})],
+          artifactErrors: [],
+          updatedArtifacts: [],
+        })
+      );
       npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
-        artifactErrors: <ArtifactError[]>[],
-        updatedArtifacts: <FileChange[]>[{}],
+        artifactErrors: [],
+        updatedArtifacts: [partial<FileChange>({})],
       } as WriteExistingFilesResult);
       git.branchExists.mockReturnValue(true);
       platform.getBranchPr.mockResolvedValueOnce({
@@ -1039,14 +1042,16 @@ describe('workers/repository/update/branch/index', () => {
     });
 
     it('skips branch update if stopUpdatingLabel presents', async () => {
-      getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce({
-        updatedPackageFiles: [],
-        artifactErrors: [],
-        updatedArtifacts: [],
-      } as PackageFilesResult);
+      getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce(
+        partial<PackageFilesResult>({
+          updatedPackageFiles: [partial<FileChange>({})],
+          artifactErrors: [],
+          updatedArtifacts: [],
+        })
+      );
       npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
-        artifactErrors: <ArtifactError[]>[],
-        updatedArtifacts: <FileChange[]>[{}],
+        artifactErrors: [],
+        updatedArtifacts: [partial<FileChange>({})],
       } as WriteExistingFilesResult);
       git.branchExists.mockReturnValue(true);
       platform.getBranchPr.mockResolvedValueOnce({
@@ -1075,14 +1080,16 @@ describe('workers/repository/update/branch/index', () => {
     });
 
     it('updates branch if stopUpdatingLabel presents and PR rebase/retry box checked', async () => {
-      getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce({
-        updatedPackageFiles: [],
-        artifactErrors: [],
-        updatedArtifacts: [],
-      } as PackageFilesResult);
+      getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce(
+        partial<PackageFilesResult>({
+          updatedPackageFiles: [partial<FileChange>({})],
+          artifactErrors: [],
+          updatedArtifacts: [],
+        })
+      );
       npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
-        artifactErrors: <ArtifactError[]>[],
-        updatedArtifacts: <FileChange[]>[{}],
+        artifactErrors: [],
+        updatedArtifacts: [partial<FileChange>({})],
       } as WriteExistingFilesResult);
       git.branchExists.mockReturnValue(true);
       platform.getBranchPr.mockResolvedValueOnce({
@@ -1144,22 +1151,13 @@ describe('workers/repository/update/branch/index', () => {
         },
       } as Pr);
       git.isBranchModified.mockResolvedValueOnce(true);
-      git.getRepoStatus.mockResolvedValueOnce({
-        modified: ['modified_file'],
-        not_added: [],
-        deleted: ['deleted_file'],
-        conflicted: [],
-        renamed: [],
-        staged: [],
-        created: [],
-        detached: false,
-        tracking: '',
-        current: '',
-        behind: 0,
-        ahead: 0,
-        files: [],
-        isClean: () => false,
-      } as StatusResult);
+      git.getRepoStatus.mockResolvedValueOnce(
+        partial<StatusResult>({
+          modified: ['modified_file'],
+          not_added: [],
+          deleted: ['deleted_file'],
+        })
+      );
       fs.readLocalFile.mockResolvedValueOnce('modified file content');
       fs.localPathExists
         .mockResolvedValueOnce(true)
@@ -1244,22 +1242,13 @@ describe('workers/repository/update/branch/index', () => {
         },
       } as never);
       git.isBranchModified.mockResolvedValueOnce(true);
-      git.getRepoStatus.mockResolvedValueOnce({
-        modified: ['modified_file'],
-        not_added: [],
-        deleted: ['deleted_file'],
-        conflicted: [],
-        renamed: [],
-        staged: [],
-        created: [],
-        detached: false,
-        tracking: '',
-        current: '',
-        behind: 0,
-        ahead: 0,
-        files: [],
-        isClean: () => false,
-      } as StatusResult);
+      git.getRepoStatus.mockResolvedValueOnce(
+        partial<StatusResult>({
+          modified: ['modified_file'],
+          not_added: [],
+          deleted: ['deleted_file'],
+        })
+      );
 
       fs.readLocalFile.mockResolvedValueOnce('modified file content');
       fs.localPathExists
@@ -1280,7 +1269,7 @@ describe('workers/repository/update/branch/index', () => {
         localDir: '/localDir',
       });
 
-      exec.exec.mockRejectedValue(new Error('Meh, this went wrong!'));
+      mockExecAll(exec, new Error('Meh, this went wrong!'));
 
       await branchWorker.processBranch({
         ...config,
@@ -1336,22 +1325,13 @@ describe('workers/repository/update/branch/index', () => {
         },
       } as Pr);
       git.isBranchModified.mockResolvedValueOnce(true);
-      git.getRepoStatus.mockResolvedValueOnce({
-        modified: ['modified_file'],
-        not_added: [],
-        deleted: ['deleted_file'],
-        conflicted: [],
-        renamed: [],
-        staged: [],
-        created: [],
-        detached: false,
-        tracking: '',
-        current: '',
-        behind: 0,
-        ahead: 0,
-        files: [],
-        isClean: () => false,
-      } as StatusResult);
+      git.getRepoStatus.mockResolvedValueOnce(
+        partial<StatusResult>({
+          modified: ['modified_file'],
+          not_added: [],
+          deleted: ['deleted_file'],
+        })
+      );
 
       fs.readLocalFile.mockResolvedValueOnce('modified file content');
       fs.localPathExists
@@ -1395,7 +1375,7 @@ describe('workers/repository/update/branch/index', () => {
         prNo: undefined,
         result: 'done',
       });
-      expect(exec.exec).toHaveBeenCalledWith('echo {{{versioning}}}', {
+      expect(exec).toHaveBeenCalledWith('echo {{{versioning}}}', {
         cwd: '/localDir',
       });
     });
@@ -1432,38 +1412,20 @@ describe('workers/repository/update/branch/index', () => {
       } as Pr);
       git.isBranchModified.mockResolvedValueOnce(true);
       git.getRepoStatus
-        .mockResolvedValueOnce({
-          modified: ['modified_file', 'modified_then_deleted_file'],
-          not_added: [],
-          deleted: ['deleted_file', 'deleted_then_created_file'],
-          conflicted: [],
-          renamed: [],
-          staged: [],
-          created: [],
-          detached: false,
-          tracking: '',
-          current: '',
-          behind: 0,
-          ahead: 0,
-          files: [],
-          isClean: () => false,
-        } as StatusResult)
-        .mockResolvedValueOnce({
-          modified: ['modified_file', 'deleted_then_created_file'],
-          not_added: [],
-          deleted: ['deleted_file', 'modified_then_deleted_file'],
-          conflicted: [],
-          renamed: [],
-          staged: [],
-          created: [],
-          detached: false,
-          tracking: '',
-          current: '',
-          behind: 0,
-          ahead: 0,
-          files: [],
-          isClean: () => false,
-        } as StatusResult);
+        .mockResolvedValueOnce(
+          partial<StatusResult>({
+            modified: ['modified_file', 'modified_then_deleted_file'],
+            not_added: [],
+            deleted: ['deleted_file', 'deleted_then_created_file'],
+          })
+        )
+        .mockResolvedValueOnce(
+          partial<StatusResult>({
+            modified: ['modified_file', 'deleted_then_created_file'],
+            not_added: [],
+            deleted: ['deleted_file', 'modified_then_deleted_file'],
+          })
+        );
 
       fs.readLocalFile
         .mockResolvedValueOnce('modified file content' as never)
@@ -1537,20 +1499,20 @@ describe('workers/repository/update/branch/index', () => {
         prNo: undefined,
         result: 'done',
       });
-      expect(exec.exec).toHaveBeenNthCalledWith(1, 'echo some-dep-name-1', {
+      expect(exec).toHaveBeenNthCalledWith(1, 'echo some-dep-name-1', {
         cwd: '/localDir',
       });
-      expect(exec.exec).toHaveBeenNthCalledWith(2, 'echo some-dep-name-2', {
+      expect(exec).toHaveBeenNthCalledWith(2, 'echo some-dep-name-2', {
         cwd: '/localDir',
       });
-      expect(exec.exec).toHaveBeenCalledTimes(2);
+      expect(exec).toHaveBeenCalledTimes(2);
       const calledWithConfig = commit.commitFilesToBranch.mock.calls[0][0];
       const updatedArtifacts = calledWithConfig.updatedArtifacts;
-      expect(findFileContent(updatedArtifacts ?? [], 'modified_file')).toBe(
+      expect(findFileContent(updatedArtifacts, 'modified_file')).toBe(
         'modified file content again'
       );
       expect(
-        findFileContent(updatedArtifacts ?? [], 'deleted_then_created_file')
+        findFileContent(updatedArtifacts, 'deleted_then_created_file')
       ).toBe('this file was once deleted');
       expect(
         updatedArtifacts?.find(
@@ -1602,22 +1564,13 @@ describe('workers/repository/update/branch/index', () => {
         },
       } as Pr);
       git.isBranchModified.mockResolvedValueOnce(true);
-      git.getRepoStatus.mockResolvedValueOnce({
-        modified: ['modified_file', 'modified_then_deleted_file'],
-        not_added: [],
-        deleted: ['deleted_file', 'deleted_then_created_file'],
-        conflicted: [],
-        renamed: [],
-        staged: [],
-        created: [],
-        detached: false,
-        tracking: '',
-        current: '',
-        behind: 0,
-        ahead: 0,
-        files: [],
-        isClean: () => false,
-      } as StatusResult);
+      git.getRepoStatus.mockResolvedValueOnce(
+        partial<StatusResult>({
+          modified: ['modified_file', 'modified_then_deleted_file'],
+          not_added: [],
+          deleted: ['deleted_file', 'deleted_then_created_file'],
+        })
+      );
 
       fs.readLocalFile
         .mockResolvedValueOnce('modified file content')
@@ -1690,13 +1643,13 @@ describe('workers/repository/update/branch/index', () => {
         prNo: undefined,
         result: 'done',
       });
-      expect(exec.exec).toHaveBeenNthCalledWith(1, 'echo hardcoded-string', {
+      expect(exec).toHaveBeenNthCalledWith(1, 'echo hardcoded-string', {
         cwd: '/localDir',
       });
-      expect(exec.exec).toHaveBeenCalledTimes(1);
+      expect(exec).toHaveBeenCalledTimes(1);
       expect(
         findFileContent(
-          commit.commitFilesToBranch.mock.calls[0][0].updatedArtifacts ?? [],
+          commit.commitFilesToBranch.mock.calls[0][0].updatedArtifacts,
           'modified_file'
         )
       ).toBe('modified file content');

--- a/lib/workers/repository/update/branch/index.spec.ts
+++ b/lib/workers/repository/update/branch/index.spec.ts
@@ -15,6 +15,7 @@ import {
 import { logger } from '../../../../logger';
 import * as _npmPostExtract from '../../../../modules/manager/npm/post-update';
 import type { WriteExistingFilesResult } from '../../../../modules/manager/npm/post-update/types';
+import type { ArtifactError } from '../../../../modules/manager/types';
 import { hashBody } from '../../../../modules/platform/pr-body';
 import { PrState } from '../../../../types';
 import * as _exec from '../../../../util/exec';
@@ -71,8 +72,8 @@ const adminConfig: RepoGlobalConfig = { localDir: '', cacheDir: '' };
 
 function findFileContent(files: FileChange[], path: string): string | null {
   const f = files.find((file) => file.path === path);
-  if (f.type === 'addition') {
-    return f.contents.toString();
+  if (f?.type === 'addition' && f.contents) {
+    return f?.contents.toString();
   }
   return null;
 }
@@ -95,7 +96,7 @@ describe('workers/repository/update/branch/index', () => {
         branchName: 'renovate/some-branch',
         errors: [],
         warnings: [],
-        upgrades: [{ depName: 'some-dep-name' }],
+        upgrades: [{ depName: 'some-dep-name' }] as BranchConfig['upgrades'],
       } as BranchConfig;
       schedule.isScheduledNow.mockReturnValue(true);
       commit.commitFilesToBranch.mockResolvedValue('123test');
@@ -470,8 +471,8 @@ describe('workers/repository/update/branch/index', () => {
         updatedPackageFiles: [{}],
       } as PackageFilesResult);
       npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
-        artifactErrors: [],
-        updatedArtifacts: [{}],
+        artifactErrors: <ArtifactError[]>[],
+        updatedArtifacts: <FileChange[]>[{}],
       } as WriteExistingFilesResult);
       git.branchExists.mockReturnValue(true);
       commit.commitFilesToBranch.mockResolvedValueOnce(null);
@@ -486,8 +487,8 @@ describe('workers/repository/update/branch/index', () => {
         updatedPackageFiles: [{}],
       } as PackageFilesResult);
       npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
-        artifactErrors: [],
-        updatedArtifacts: [{}],
+        artifactErrors: <ArtifactError[]>[],
+        updatedArtifacts: <FileChange[]>[{}],
       } as WriteExistingFilesResult);
       git.branchExists.mockReturnValue(false);
       automerge.tryBranchAutomerge.mockResolvedValueOnce('automerged');
@@ -504,8 +505,8 @@ describe('workers/repository/update/branch/index', () => {
         updatedPackageFiles: [{}],
       } as PackageFilesResult);
       npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
-        artifactErrors: [],
-        updatedArtifacts: [{}],
+        artifactErrors: <ArtifactError[]>[],
+        updatedArtifacts: <FileChange[]>[{}],
       } as WriteExistingFilesResult);
       git.branchExists.mockReturnValue(true);
       commit.commitFilesToBranch.mockResolvedValueOnce(null);
@@ -522,8 +523,8 @@ describe('workers/repository/update/branch/index', () => {
         updatedPackageFiles: [{}],
       } as PackageFilesResult);
       npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
-        artifactErrors: [],
-        updatedArtifacts: [{}],
+        artifactErrors: <ArtifactError[]>[],
+        updatedArtifacts: <FileChange[]>[{}],
       } as WriteExistingFilesResult);
       git.branchExists.mockReturnValue(true);
       commit.commitFilesToBranch.mockResolvedValueOnce(null);
@@ -545,8 +546,8 @@ describe('workers/repository/update/branch/index', () => {
         updatedPackageFiles: [{}],
       } as PackageFilesResult);
       npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
-        artifactErrors: [],
-        updatedArtifacts: [{}],
+        artifactErrors: <ArtifactError[]>[],
+        updatedArtifacts: <FileChange[]>[{}],
       } as WriteExistingFilesResult);
       git.branchExists.mockReturnValue(true);
       commit.commitFilesToBranch.mockResolvedValueOnce(null);
@@ -568,8 +569,8 @@ describe('workers/repository/update/branch/index', () => {
         updatedPackageFiles: [{}],
       } as PackageFilesResult);
       npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
-        artifactErrors: [],
-        updatedArtifacts: [{}],
+        artifactErrors: <ArtifactError[]>[],
+        updatedArtifacts: <FileChange[]>[{}],
       } as WriteExistingFilesResult);
       git.branchExists.mockReturnValue(true);
       commit.commitFilesToBranch.mockResolvedValueOnce(null);
@@ -591,8 +592,8 @@ describe('workers/repository/update/branch/index', () => {
         updatedPackageFiles: [{}],
       } as PackageFilesResult);
       npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
-        artifactErrors: [],
-        updatedArtifacts: [{}],
+        artifactErrors: <ArtifactError[]>[],
+        updatedArtifacts: <FileChange[]>[{}],
       } as WriteExistingFilesResult);
       git.branchExists.mockReturnValue(true);
       commit.commitFilesToBranch.mockResolvedValueOnce(null);
@@ -614,8 +615,8 @@ describe('workers/repository/update/branch/index', () => {
         updatedPackageFiles: [{}],
       } as PackageFilesResult);
       npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
-        artifactErrors: [],
-        updatedArtifacts: [{}],
+        artifactErrors: <ArtifactError[]>[],
+        updatedArtifacts: <FileChange[]>[{}],
       } as WriteExistingFilesResult);
       git.branchExists.mockReturnValue(true);
       commit.commitFilesToBranch.mockResolvedValueOnce(null);
@@ -637,8 +638,8 @@ describe('workers/repository/update/branch/index', () => {
         updatedPackageFiles: [{}],
       } as PackageFilesResult);
       npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
-        artifactErrors: [],
-        updatedArtifacts: [{}],
+        artifactErrors: <ArtifactError[]>[],
+        updatedArtifacts: <FileChange[]>[{}],
       } as WriteExistingFilesResult);
       expect(
         await branchWorker.processBranch({
@@ -661,8 +662,8 @@ describe('workers/repository/update/branch/index', () => {
         updatedPackageFiles: [{}],
       } as PackageFilesResult);
       npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
-        artifactErrors: [],
-        updatedArtifacts: [{}],
+        artifactErrors: <ArtifactError[]>[],
+        updatedArtifacts: <FileChange[]>[{}],
       } as WriteExistingFilesResult);
       git.branchExists.mockReturnValue(true);
       automerge.tryBranchAutomerge.mockResolvedValueOnce('failed');
@@ -683,8 +684,8 @@ describe('workers/repository/update/branch/index', () => {
         updatedPackageFiles: [{}],
       } as PackageFilesResult);
       npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
-        artifactErrors: [],
-        updatedArtifacts: [{}],
+        artifactErrors: <ArtifactError[]>[],
+        updatedArtifacts: <FileChange[]>[{}],
       } as WriteExistingFilesResult);
       git.branchExists.mockReturnValue(true);
       automerge.tryBranchAutomerge.mockResolvedValueOnce('stale');
@@ -884,8 +885,8 @@ describe('workers/repository/update/branch/index', () => {
         updatedPackageFiles: [{}],
       } as PackageFilesResult);
       npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
-        artifactErrors: [],
-        updatedArtifacts: [{}],
+        artifactErrors: <ArtifactError[]>[],
+        updatedArtifacts: <FileChange[]>[{}],
       } as WriteExistingFilesResult);
       git.branchExists.mockReturnValue(true);
       automerge.tryBranchAutomerge.mockResolvedValueOnce('failed');
@@ -933,8 +934,8 @@ describe('workers/repository/update/branch/index', () => {
         artifactErrors: [{}],
       } as PackageFilesResult);
       npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
-        artifactErrors: [],
-        updatedArtifacts: [{}],
+        artifactErrors: <ArtifactError[]>[],
+        updatedArtifacts: <FileChange[]>[{}],
       } as WriteExistingFilesResult);
       git.branchExists.mockReturnValue(true);
       platform.getBranchPr.mockResolvedValueOnce({
@@ -969,8 +970,8 @@ describe('workers/repository/update/branch/index', () => {
         artifactErrors: [{}],
       } as PackageFilesResult);
       npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
-        artifactErrors: [],
-        updatedArtifacts: [{}],
+        artifactErrors: <ArtifactError[]>[],
+        updatedArtifacts: <FileChange[]>[{}],
       } as WriteExistingFilesResult);
       git.branchExists.mockReturnValue(true);
       platform.getBranchPr.mockResolvedValueOnce({
@@ -1003,12 +1004,13 @@ describe('workers/repository/update/branch/index', () => {
 
     it('branch pr no schedule', async () => {
       getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce({
-        updatedPackageFiles: [{}],
+        updatedPackageFiles: [],
         artifactErrors: [],
+        updatedArtifacts: [],
       } as PackageFilesResult);
       npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
-        artifactErrors: [],
-        updatedArtifacts: [{}],
+        artifactErrors: <ArtifactError[]>[],
+        updatedArtifacts: <FileChange[]>[{}],
       } as WriteExistingFilesResult);
       git.branchExists.mockReturnValue(true);
       platform.getBranchPr.mockResolvedValueOnce({
@@ -1038,12 +1040,13 @@ describe('workers/repository/update/branch/index', () => {
 
     it('skips branch update if stopUpdatingLabel presents', async () => {
       getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce({
-        updatedPackageFiles: [{}],
+        updatedPackageFiles: [],
         artifactErrors: [],
+        updatedArtifacts: [],
       } as PackageFilesResult);
       npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
-        artifactErrors: [],
-        updatedArtifacts: [{}],
+        artifactErrors: <ArtifactError[]>[],
+        updatedArtifacts: <FileChange[]>[{}],
       } as WriteExistingFilesResult);
       git.branchExists.mockReturnValue(true);
       platform.getBranchPr.mockResolvedValueOnce({
@@ -1073,12 +1076,13 @@ describe('workers/repository/update/branch/index', () => {
 
     it('updates branch if stopUpdatingLabel presents and PR rebase/retry box checked', async () => {
       getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce({
-        updatedPackageFiles: [{}],
+        updatedPackageFiles: [],
         artifactErrors: [],
+        updatedArtifacts: [],
       } as PackageFilesResult);
       npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
-        artifactErrors: [],
-        updatedArtifacts: [{}],
+        artifactErrors: <ArtifactError[]>[],
+        updatedArtifacts: <FileChange[]>[{}],
       } as WriteExistingFilesResult);
       git.branchExists.mockReturnValue(true);
       platform.getBranchPr.mockResolvedValueOnce({
@@ -1118,6 +1122,7 @@ describe('workers/repository/update/branch/index', () => {
       getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce({
         updatedPackageFiles: [updatedPackageFile],
         artifactErrors: [],
+        updatedArtifacts: [],
       } as PackageFilesResult);
       npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
         artifactErrors: [],
@@ -1143,6 +1148,17 @@ describe('workers/repository/update/branch/index', () => {
         modified: ['modified_file'],
         not_added: [],
         deleted: ['deleted_file'],
+        conflicted: [],
+        renamed: [],
+        staged: [],
+        created: [],
+        detached: false,
+        tracking: '',
+        current: '',
+        behind: 0,
+        ahead: 0,
+        files: [],
+        isClean: () => false,
       } as StatusResult);
       fs.readLocalFile.mockResolvedValueOnce('modified file content');
       fs.localPathExists
@@ -1232,6 +1248,17 @@ describe('workers/repository/update/branch/index', () => {
         modified: ['modified_file'],
         not_added: [],
         deleted: ['deleted_file'],
+        conflicted: [],
+        renamed: [],
+        staged: [],
+        created: [],
+        detached: false,
+        tracking: '',
+        current: '',
+        behind: 0,
+        ahead: 0,
+        files: [],
+        isClean: () => false,
       } as StatusResult);
 
       fs.readLocalFile.mockResolvedValueOnce('modified file content');
@@ -1287,6 +1314,7 @@ describe('workers/repository/update/branch/index', () => {
       getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce({
         updatedPackageFiles: [updatedPackageFile],
         artifactErrors: [],
+        updatedArtifacts: [],
       } as PackageFilesResult);
       npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
         artifactErrors: [],
@@ -1312,6 +1340,17 @@ describe('workers/repository/update/branch/index', () => {
         modified: ['modified_file'],
         not_added: [],
         deleted: ['deleted_file'],
+        conflicted: [],
+        renamed: [],
+        staged: [],
+        created: [],
+        detached: false,
+        tracking: '',
+        current: '',
+        behind: 0,
+        ahead: 0,
+        files: [],
+        isClean: () => false,
       } as StatusResult);
 
       fs.readLocalFile.mockResolvedValueOnce('modified file content');
@@ -1370,6 +1409,7 @@ describe('workers/repository/update/branch/index', () => {
       getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce({
         updatedPackageFiles: [updatedPackageFile],
         artifactErrors: [],
+        updatedArtifacts: [],
       } as PackageFilesResult);
       npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
         artifactErrors: [],
@@ -1396,11 +1436,33 @@ describe('workers/repository/update/branch/index', () => {
           modified: ['modified_file', 'modified_then_deleted_file'],
           not_added: [],
           deleted: ['deleted_file', 'deleted_then_created_file'],
+          conflicted: [],
+          renamed: [],
+          staged: [],
+          created: [],
+          detached: false,
+          tracking: '',
+          current: '',
+          behind: 0,
+          ahead: 0,
+          files: [],
+          isClean: () => false,
         } as StatusResult)
         .mockResolvedValueOnce({
           modified: ['modified_file', 'deleted_then_created_file'],
           not_added: [],
           deleted: ['deleted_file', 'modified_then_deleted_file'],
+          conflicted: [],
+          renamed: [],
+          staged: [],
+          created: [],
+          detached: false,
+          tracking: '',
+          current: '',
+          behind: 0,
+          ahead: 0,
+          files: [],
+          isClean: () => false,
         } as StatusResult);
 
       fs.readLocalFile
@@ -1484,25 +1546,25 @@ describe('workers/repository/update/branch/index', () => {
       expect(exec.exec).toHaveBeenCalledTimes(2);
       const calledWithConfig = commit.commitFilesToBranch.mock.calls[0][0];
       const updatedArtifacts = calledWithConfig.updatedArtifacts;
-      expect(findFileContent(updatedArtifacts, 'modified_file')).toBe(
+      expect(findFileContent(updatedArtifacts ?? [], 'modified_file')).toBe(
         'modified file content again'
       );
       expect(
-        findFileContent(updatedArtifacts, 'deleted_then_created_file')
+        findFileContent(updatedArtifacts ?? [], 'deleted_then_created_file')
       ).toBe('this file was once deleted');
       expect(
-        updatedArtifacts.find(
+        updatedArtifacts?.find(
           (f) => f.type === 'deletion' && f.path === 'deleted_then_created_file'
         )
       ).toBeUndefined();
       expect(
-        updatedArtifacts.find(
+        updatedArtifacts?.find(
           (f) =>
             f.type === 'addition' && f.path === 'modified_then_deleted_file'
         )
       ).toBeUndefined();
       expect(
-        updatedArtifacts.find(
+        updatedArtifacts?.find(
           (f) =>
             f.type === 'deletion' && f.path === 'modified_then_deleted_file'
         )
@@ -1518,6 +1580,7 @@ describe('workers/repository/update/branch/index', () => {
       getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce({
         updatedPackageFiles: [updatedPackageFile],
         artifactErrors: [],
+        updatedArtifacts: [],
       } as PackageFilesResult);
       npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
         artifactErrors: [],
@@ -1543,6 +1606,17 @@ describe('workers/repository/update/branch/index', () => {
         modified: ['modified_file', 'modified_then_deleted_file'],
         not_added: [],
         deleted: ['deleted_file', 'deleted_then_created_file'],
+        conflicted: [],
+        renamed: [],
+        staged: [],
+        created: [],
+        detached: false,
+        tracking: '',
+        current: '',
+        behind: 0,
+        ahead: 0,
+        files: [],
+        isClean: () => false,
       } as StatusResult);
 
       fs.readLocalFile
@@ -1622,7 +1696,7 @@ describe('workers/repository/update/branch/index', () => {
       expect(exec.exec).toHaveBeenCalledTimes(1);
       expect(
         findFileContent(
-          commit.commitFilesToBranch.mock.calls[0][0].updatedArtifacts,
+          commit.commitFilesToBranch.mock.calls[0][0].updatedArtifacts ?? [],
           'modified_file'
         )
       ).toBe('modified file content');

--- a/lib/workers/repository/update/branch/reuse.spec.ts
+++ b/lib/workers/repository/update/branch/reuse.spec.ts
@@ -35,7 +35,7 @@ describe('workers/repository/update/branch/reuse', () => {
 
     it('returns true if no PR', async () => {
       git.branchExists.mockReturnValueOnce(true);
-      platform.getBranchPr.mockReturnValue(null);
+      platform.getBranchPr.mockReturnValue(null as never);
       const res = await shouldReuseExistingBranch(config);
       expect(res.reuseExistingBranch).toBeTrue();
     });

--- a/lib/workers/repository/update/branch/reuse.spec.ts
+++ b/lib/workers/repository/update/branch/reuse.spec.ts
@@ -35,7 +35,7 @@ describe('workers/repository/update/branch/reuse', () => {
 
     it('returns true if no PR', async () => {
       git.branchExists.mockReturnValueOnce(true);
-      platform.getBranchPr.mockReturnValue(null as never);
+      platform.getBranchPr.mockResolvedValue(null);
       const res = await shouldReuseExistingBranch(config);
       expect(res.reuseExistingBranch).toBeTrue();
     });

--- a/lib/workers/repository/update/pr/automerge.spec.ts
+++ b/lib/workers/repository/update/pr/automerge.spec.ts
@@ -8,8 +8,6 @@ import * as prAutomerge from './automerge';
 
 jest.mock('../../../../util/git');
 
-const defaultConfig = getConfig();
-
 describe('workers/repository/update/pr/automerge', () => {
   describe('checkAutoMerge(pr, config)', () => {
     const spy = jest.spyOn(schedule, 'isScheduledNow');
@@ -17,9 +15,10 @@ describe('workers/repository/update/pr/automerge', () => {
     let pr: Pr;
 
     beforeEach(() => {
-      config = <BranchConfig>{
-        ...defaultConfig,
-      };
+      // TODO #7154 incompatible types
+      config = {
+        ...getConfig(),
+      } as BranchConfig;
       pr = partial<Pr>({});
     });
 

--- a/lib/workers/repository/update/pr/automerge.spec.ts
+++ b/lib/workers/repository/update/pr/automerge.spec.ts
@@ -17,9 +17,9 @@ describe('workers/repository/update/pr/automerge', () => {
     let pr: Pr;
 
     beforeEach(() => {
-      config = partial<BranchConfig>({
+      config = <BranchConfig>{
         ...defaultConfig,
-      });
+      };
       pr = partial<Pr>({});
     });
 

--- a/lib/workers/repository/update/pr/body/updates-table.spec.ts
+++ b/lib/workers/repository/update/pr/body/updates-table.spec.ts
@@ -85,7 +85,7 @@ describe('workers/repository/update/pr/body/updates-table', () => {
       displayFrom: '^6.2.3',
       displayTo: '6.2.3',
     };
-    const upgrade3: BranchUpgradeConfig = undefined;
+    const upgrade3 = undefined as never;
     const configObj: BranchConfig = {
       manager: 'some-manager',
       branchName: 'some-branch',

--- a/lib/workers/repository/update/pr/body/updates-table.spec.ts
+++ b/lib/workers/repository/update/pr/body/updates-table.spec.ts
@@ -85,6 +85,7 @@ describe('workers/repository/update/pr/body/updates-table', () => {
       displayFrom: '^6.2.3',
       displayTo: '6.2.3',
     };
+    // TODO #7154 allow or filter undefined
     const upgrade3 = undefined as never;
     const configObj: BranchConfig = {
       manager: 'some-manager',

--- a/lib/workers/repository/update/pr/changelog/github.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/github.spec.ts
@@ -11,7 +11,7 @@ jest.mock('../../../../../modules/datasource/npm');
 
 const upgrade: BranchUpgradeConfig = {
   manager: 'some-manager',
-  branchName: undefined,
+  branchName: '',
   depName: 'renovate',
   endpoint: 'https://api.github.com/',
   versioning: semverVersioning.id,
@@ -53,7 +53,7 @@ describe('workers/repository/update/pr/changelog/github', () => {
       expect(
         await getChangeLogJSON({
           ...upgrade,
-          currentVersion: null,
+          currentVersion: undefined,
         })
       ).toBeNull();
     });
@@ -313,7 +313,7 @@ describe('workers/repository/update/pr/changelog/github', () => {
 
       const upgradeData: BranchUpgradeConfig = {
         manager: 'some-manager',
-        branchName: undefined,
+        branchName: '',
         depName: 'correctPrefix/target',
         endpoint: 'https://api.github.com/',
         versioning: 'npm',

--- a/lib/workers/repository/update/pr/changelog/gitlab.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/gitlab.spec.ts
@@ -9,7 +9,7 @@ jest.mock('../../../../../modules/datasource/npm');
 
 const upgrade: BranchUpgradeConfig = {
   manager: 'some-manager',
-  branchName: undefined,
+  branchName: '',
   endpoint: 'https://gitlab.com/api/v4/ ',
   depName: 'renovate',
   versioning: semverVersioning.id,
@@ -51,7 +51,7 @@ describe('workers/repository/update/pr/changelog/gitlab', () => {
       expect(
         await getChangeLogJSON({
           ...upgrade,
-          currentVersion: null,
+          currentVersion: undefined,
         })
       ).toBeNull();
     });

--- a/lib/workers/repository/update/pr/changelog/index.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/index.spec.ts
@@ -59,7 +59,7 @@ describe('workers/repository/update/pr/changelog/index', () => {
       expect(
         await getChangeLogJSON({
           ...upgrade,
-          currentVersion: null,
+          currentVersion: undefined,
         })
       ).toBeNull();
     });

--- a/lib/workers/repository/update/pr/changelog/release-notes.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/release-notes.spec.ts
@@ -98,7 +98,9 @@ describe('workers/repository/update/pr/changelog/release-notes', () => {
       expect(
         await addReleaseNotes(input as never, {} as BranchUpgradeConfig)
       ).toEqual(input);
-      expect(await addReleaseNotes(null, {} as BranchUpgradeConfig)).toBeNull();
+      expect(
+        await addReleaseNotes(null as never, {} as BranchUpgradeConfig)
+      ).toBeNull();
       expect(
         await addReleaseNotes(
           { versions: [] } as never,
@@ -974,7 +976,7 @@ describe('workers/repository/update/pr/changelog/release-notes', () => {
             gitRef: '15.3.0',
           } as ChangeLogRelease
         );
-        versionOneNotes = res;
+        versionOneNotes = res!;
 
         expect(res).toMatchSnapshot({
           notesSourceUrl:
@@ -1004,7 +1006,7 @@ describe('workers/repository/update/pr/changelog/release-notes', () => {
             gitRef: '15.2.0',
           } as ChangeLogRelease
         );
-        versionTwoNotes = res;
+        versionTwoNotes = res!;
 
         expect(res).toMatchSnapshot({
           notesSourceUrl:
@@ -1034,7 +1036,7 @@ describe('workers/repository/update/pr/changelog/release-notes', () => {
             gitRef: '4.33.0',
           } as ChangeLogRelease
         );
-        versionTwoNotes = res;
+        versionTwoNotes = res!;
 
         expect(res).toMatchSnapshot({
           notesSourceUrl:
@@ -1070,7 +1072,7 @@ describe('workers/repository/update/pr/changelog/release-notes', () => {
             gitRef: '4.33.0',
           } as ChangeLogRelease
         );
-        versionTwoNotes = res;
+        versionTwoNotes = res!;
 
         expect(res).toMatchSnapshot({
           notesSourceUrl:

--- a/lib/workers/repository/update/pr/changelog/release-notes.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/release-notes.spec.ts
@@ -98,6 +98,7 @@ describe('workers/repository/update/pr/changelog/release-notes', () => {
       expect(
         await addReleaseNotes(input as never, {} as BranchUpgradeConfig)
       ).toEqual(input);
+      // TODO #7154
       expect(
         await addReleaseNotes(null as never, {} as BranchUpgradeConfig)
       ).toBeNull();

--- a/lib/workers/repository/update/pr/changelog/release-notes.ts
+++ b/lib/workers/repository/update/pr/changelog/release-notes.ts
@@ -374,6 +374,7 @@ export function releaseNotesCacheMinutes(releaseDate?: string | Date): number {
   return 14495; // 5 minutes shy of 10 days
 }
 
+// TODO #7154 allow `null` and `undefined`
 export async function addReleaseNotes(
   input: ChangeLogResult,
   config: BranchUpgradeConfig

--- a/lib/workers/repository/update/pr/code-owners.spec.ts
+++ b/lib/workers/repository/update/pr/code-owners.spec.ts
@@ -82,7 +82,7 @@ describe('workers/repository/update/pr/code-owners', () => {
           if (path === codeOwnerFilePath) {
             return Promise.resolve(['* @mike'].join('\n'));
           }
-          return Promise.resolve<string>('');
+          return Promise.resolve(null);
         });
         git.getBranchFiles.mockResolvedValueOnce(['README.md']);
         const codeOwners = await codeOwnersForPr(pr);

--- a/lib/workers/repository/update/pr/code-owners.spec.ts
+++ b/lib/workers/repository/update/pr/code-owners.spec.ts
@@ -82,7 +82,7 @@ describe('workers/repository/update/pr/code-owners', () => {
           if (path === codeOwnerFilePath) {
             return Promise.resolve(['* @mike'].join('\n'));
           }
-          return Promise.resolve<string>(null);
+          return Promise.resolve<string>('');
         });
         git.getBranchFiles.mockResolvedValueOnce(['README.md']);
         const codeOwners = await codeOwnersForPr(pr);

--- a/lib/workers/repository/update/pr/labels.spec.ts
+++ b/lib/workers/repository/update/pr/labels.spec.ts
@@ -50,10 +50,10 @@ describe('workers/repository/update/pr/labels', () => {
 
     it('null labels ignored', () => {
       const result = prepareLabels({
-        labels: ['labelA', null],
+        labels: ['labelA', null] as never,
         // an empty space between two commas in an array is categorized as a null value
         // eslint-disable-next-line no-sparse-arrays
-        addLabels: ['labelB', '', undefined, , ,],
+        addLabels: ['labelB', '', undefined, , ,] as never,
       });
       expect(result).toBeArrayOfSize(2);
       expect(result).toEqual(['labelA', 'labelB']);

--- a/lib/workers/repository/update/pr/labels.spec.ts
+++ b/lib/workers/repository/update/pr/labels.spec.ts
@@ -49,6 +49,7 @@ describe('workers/repository/update/pr/labels', () => {
     });
 
     it('null labels ignored', () => {
+      // TODO #7154
       const result = prepareLabels({
         labels: ['labelA', null] as never,
         // an empty space between two commas in an array is categorized as a null value

--- a/lib/workers/repository/updates/flatten.spec.ts
+++ b/lib/workers/repository/updates/flatten.spec.ts
@@ -1,5 +1,4 @@
 import { RenovateConfig, getConfig } from '../../../../test/util';
-import type { PackageRule } from '../../../config/types';
 
 import { ProgrammingLanguage } from '../../../constants';
 import { flattenUpdates } from './flatten';
@@ -16,8 +15,8 @@ beforeEach(() => {
 describe('workers/repository/updates/flatten', () => {
   describe('flattenUpdates()', () => {
     it('flattens', async () => {
-      config.lockFileMaintenance = <PackageRule>{};
-      config.lockFileMaintenance.enabled = true;
+      // TODO #7154
+      config.lockFileMaintenance!.enabled = true;
       config.packageRules = [
         {
           matchUpdateTypes: ['minor'],

--- a/lib/workers/repository/updates/flatten.spec.ts
+++ b/lib/workers/repository/updates/flatten.spec.ts
@@ -1,4 +1,5 @@
 import { RenovateConfig, getConfig } from '../../../../test/util';
+import type { PackageRule } from '../../../config/types';
 
 import { ProgrammingLanguage } from '../../../constants';
 import { flattenUpdates } from './flatten';
@@ -15,6 +16,7 @@ beforeEach(() => {
 describe('workers/repository/updates/flatten', () => {
   describe('flattenUpdates()', () => {
     it('flattens', async () => {
+      config.lockFileMaintenance = <PackageRule>{};
       config.lockFileMaintenance.enabled = true;
       config.packageRules = [
         {

--- a/lib/workers/repository/updates/generate.spec.ts
+++ b/lib/workers/repository/updates/generate.spec.ts
@@ -1,7 +1,6 @@
-import { defaultConfig, partial } from '../../../../test/util';
+import { defaultConfig } from '../../../../test/util';
 import type { UpdateType } from '../../../config/types';
 import { NpmDatasource } from '../../../modules/datasource/npm';
-import type { LookupUpdate } from '../../../modules/manager/types';
 import type { BranchUpgradeConfig } from '../../types';
 import { generateBranchConfig } from './generate';
 
@@ -187,7 +186,7 @@ describe('workers/repository/updates/generate', () => {
           automerge: false,
         },
       ];
-      const res = generateBranchConfig(branch);
+      const res = generateBranchConfig(<BranchUpgradeConfig[]>branch);
       expect(res.foo).toBe(2);
       expect(res.groupName).toBeDefined();
       expect(res.releaseTimestamp).toBe('2017-02-07T20:01:41+00:00');
@@ -405,16 +404,16 @@ describe('workers/repository/updates/generate', () => {
 
     it('pins digest to table', () => {
       const branch = [
-        partial<LookupUpdate & BranchUpgradeConfig>({
+        {
           ...defaultConfig,
           depName: 'foo-image',
           newDigest: 'abcdefg987612345',
           currentDigest: '',
           updateType: 'pinDigest',
           isPinDigest: true,
-        }),
+        },
       ];
-      const res = generateBranchConfig(branch);
+      const res = generateBranchConfig(<BranchUpgradeConfig[]>branch);
       expect(res.upgrades[0].displayFrom).toBe('');
       expect(res.upgrades[0].displayTo).toBe('abcdefg');
     });
@@ -461,7 +460,7 @@ describe('workers/repository/updates/generate', () => {
 
     it('uses semantic commits', () => {
       const branch = [
-        partial<BranchUpgradeConfig>({
+        {
           ...defaultConfig,
           manager: 'some-manager',
           depName: 'some-dep',
@@ -475,9 +474,9 @@ describe('workers/repository/updates/generate', () => {
           group: {
             foo: 2,
           },
-        }),
+        },
       ];
-      const res = generateBranchConfig(branch);
+      const res = generateBranchConfig(<BranchUpgradeConfig[]>branch);
       expect(res.prTitle).toBe(
         'chore(package): update dependency some-dep to v1.2.0'
       );
@@ -485,7 +484,7 @@ describe('workers/repository/updates/generate', () => {
 
     it('scopes monorepo commits', () => {
       const branch = [
-        partial<BranchUpgradeConfig>({
+        {
           ...defaultConfig,
           manager: 'some-manager',
           depName: 'some-dep',
@@ -501,15 +500,15 @@ describe('workers/repository/updates/generate', () => {
           group: {
             foo: 2,
           },
-        }),
+        },
       ];
-      const res = generateBranchConfig(branch);
+      const res = generateBranchConfig(<BranchUpgradeConfig[]>branch);
       expect(res.prTitle).toBe('chore(): update dependency some-dep to v1.2.0');
     });
 
     it('scopes monorepo commits with nested package files using parent directory', () => {
       const branch = [
-        partial<BranchUpgradeConfig>({
+        {
           ...defaultConfig,
           commitBodyTable: false,
           manager: 'some-manager',
@@ -526,9 +525,9 @@ describe('workers/repository/updates/generate', () => {
           group: {
             foo: 2,
           },
-        }),
+        },
       ];
-      const res = generateBranchConfig(branch);
+      const res = generateBranchConfig(<BranchUpgradeConfig[]>branch);
       expect(res.prTitle).toBe(
         'chore(bar): update dependency some-dep to v1.2.0'
       );
@@ -536,7 +535,7 @@ describe('workers/repository/updates/generate', () => {
 
     it('scopes monorepo commits with nested package files using base directory', () => {
       const branch = [
-        partial<BranchUpgradeConfig>({
+        {
           ...defaultConfig,
           manager: 'some-manager',
           depName: 'some-dep',
@@ -552,9 +551,9 @@ describe('workers/repository/updates/generate', () => {
           group: {
             foo: 2,
           },
-        }),
+        },
       ];
-      const res = generateBranchConfig(branch);
+      const res = generateBranchConfig(<BranchUpgradeConfig[]>branch);
       expect(res.prTitle).toBe(
         'chore(foo/bar): update dependency some-dep to v1.2.0'
       );
@@ -562,7 +561,7 @@ describe('workers/repository/updates/generate', () => {
 
     it('adds commit message body', () => {
       const branch = [
-        partial<BranchUpgradeConfig>({
+        {
           ...defaultConfig,
           manager: 'some-manager',
           depName: 'some-dep',
@@ -570,24 +569,24 @@ describe('workers/repository/updates/generate', () => {
           newValue: '1.2.0',
           isSingleVersion: true,
           newVersion: '1.2.0',
-        }),
+        },
       ];
-      const res = generateBranchConfig(branch);
+      const res = generateBranchConfig(<BranchUpgradeConfig[]>branch);
       expect(res.commitMessage).toMatchSnapshot();
       expect(res.commitMessage).toContain('\n');
     });
 
     it('supports manual prTitle', () => {
       const branch = [
-        partial<BranchUpgradeConfig>({
+        {
           ...defaultConfig,
           manager: 'some-manager',
           depName: 'some-dep',
           prTitle: 'Upgrade {{depName}}',
           toLowerCase: true,
-        }),
+        },
       ];
-      const res = generateBranchConfig(branch);
+      const res = generateBranchConfig(<BranchUpgradeConfig[]>branch);
       expect(res.prTitle).toBe('upgrade some-dep');
     });
 
@@ -598,7 +597,7 @@ describe('workers/repository/updates/generate', () => {
           commitBodyTable: true,
           datasource: NpmDatasource.id,
           depName: '@types/some-dep',
-          groupName: null,
+          groupName: null as never,
           branchName: 'some-branch',
           prTitle: 'some-title',
           currentValue: '0.5.7',
@@ -612,7 +611,7 @@ describe('workers/repository/updates/generate', () => {
           datasource: NpmDatasource.id,
           manager: 'some-manager',
           depName: 'some-dep',
-          groupName: null,
+          groupName: null as never,
           branchName: 'some-branch',
           prTitle: 'some-title',
           newValue: '0.6.0',
@@ -623,7 +622,7 @@ describe('workers/repository/updates/generate', () => {
           datasource: NpmDatasource.id,
           manager: 'some-manager',
           depName: 'some-dep',
-          groupName: null,
+          groupName: null as never,
           branchName: 'some-branch',
           prTitle: 'some-other-title',
           newValue: '1.0.0',
@@ -661,7 +660,7 @@ describe('workers/repository/updates/generate', () => {
         {
           manager: 'some-manager',
           depName: 'some-dep',
-          groupName: null,
+          groupName: null as never,
           branchName: 'some-branch',
           prTitle: 'some-title',
           newValue: '0.6.0',
@@ -673,7 +672,7 @@ describe('workers/repository/updates/generate', () => {
           datasource: NpmDatasource.id,
           manager: 'some-manager',
           depName: 'some-dep',
-          groupName: null,
+          groupName: null as never,
           branchName: 'some-branch',
           prTitle: 'some-other-title',
           newValue: '1.0.0',
@@ -683,7 +682,7 @@ describe('workers/repository/updates/generate', () => {
         {
           manager: 'some-manager',
           depName: '@types/some-dep',
-          groupName: null,
+          groupName: null as never,
           branchName: 'some-branch',
           prTitle: 'some-title',
           newValue: '0.5.7',
@@ -718,7 +717,7 @@ describe('workers/repository/updates/generate', () => {
     });
 
     it('handles upgrades', () => {
-      const branch: BranchUpgradeConfig[] = [
+      const branch = [
         {
           manager: 'some-manager',
           depName: 'some-dep',
@@ -766,7 +765,7 @@ describe('workers/repository/updates/generate', () => {
           fileReplacePosition: 0,
         },
       ];
-      const res = generateBranchConfig(branch);
+      const res = generateBranchConfig(<BranchUpgradeConfig[]>branch);
       expect(res.prTitle).toMatchSnapshot('some-title (patch)');
     });
 

--- a/lib/workers/repository/updates/generate.spec.ts
+++ b/lib/workers/repository/updates/generate.spec.ts
@@ -403,7 +403,8 @@ describe('workers/repository/updates/generate', () => {
     });
 
     it('pins digest to table', () => {
-      const branch = [
+      // TODO #7154 incompatible types
+      const branch: BranchUpgradeConfig[] = [
         {
           ...defaultConfig,
           depName: 'foo-image',
@@ -411,9 +412,9 @@ describe('workers/repository/updates/generate', () => {
           currentDigest: '',
           updateType: 'pinDigest',
           isPinDigest: true,
-        },
+        } as BranchUpgradeConfig,
       ];
-      const res = generateBranchConfig(<BranchUpgradeConfig[]>branch);
+      const res = generateBranchConfig(branch);
       expect(res.upgrades[0].displayFrom).toBe('');
       expect(res.upgrades[0].displayTo).toBe('abcdefg');
     });

--- a/lib/workers/repository/updates/generate.spec.ts
+++ b/lib/workers/repository/updates/generate.spec.ts
@@ -11,7 +11,7 @@ beforeEach(() => {
 describe('workers/repository/updates/generate', () => {
   describe('generateBranchConfig()', () => {
     it('does not group single upgrade', () => {
-      const branch = [
+      const branch: BranchUpgradeConfig[] = [
         {
           manager: 'some-manager',
           depName: 'some-dep',
@@ -32,7 +32,7 @@ describe('workers/repository/updates/generate', () => {
     });
 
     it('handles lockFileMaintenance', () => {
-      const branch = [
+      const branch: BranchUpgradeConfig[] = [
         {
           manager: 'some-manager',
           branchName: 'some-branch',
@@ -56,7 +56,7 @@ describe('workers/repository/updates/generate', () => {
     });
 
     it('handles lockFileUpdate', () => {
-      const branch = [
+      const branch: BranchUpgradeConfig[] = [
         {
           manager: 'some-manager',
           branchName: 'some-branch',
@@ -96,7 +96,7 @@ describe('workers/repository/updates/generate', () => {
     });
 
     it('does not group same upgrades', () => {
-      const branch = [
+      const branch: BranchUpgradeConfig[] = [
         {
           manager: 'some-manager',
           depName: 'some-dep',
@@ -126,7 +126,7 @@ describe('workers/repository/updates/generate', () => {
     });
 
     it('groups multiple upgrades same version', () => {
-      const branch = [
+      const branch: BranchUpgradeConfig[] = [
         {
           manager: 'some-manager',
           depName: 'some-dep',
@@ -186,7 +186,7 @@ describe('workers/repository/updates/generate', () => {
           automerge: false,
         },
       ];
-      const res = generateBranchConfig(<BranchUpgradeConfig[]>branch);
+      const res = generateBranchConfig(branch);
       expect(res.foo).toBe(2);
       expect(res.groupName).toBeDefined();
       expect(res.releaseTimestamp).toBe('2017-02-07T20:01:41+00:00');
@@ -198,7 +198,7 @@ describe('workers/repository/updates/generate', () => {
     });
 
     it('groups major updates with different versions but same newValue, no recreateClosed', () => {
-      const branch = [
+      const branch: BranchUpgradeConfig[] = [
         {
           manager: 'some-manager',
           depName: 'some-dep',
@@ -234,7 +234,7 @@ describe('workers/repository/updates/generate', () => {
     });
 
     it('groups multiple upgrades different version', () => {
-      const branch = [
+      const branch: BranchUpgradeConfig[] = [
         {
           manager: 'some-manager',
           depName: 'depB',
@@ -277,7 +277,7 @@ describe('workers/repository/updates/generate', () => {
     });
 
     it('groups multiple upgrades different version but same value', () => {
-      const branch = [
+      const branch: BranchUpgradeConfig[] = [
         {
           manager: 'some-manager',
           depName: 'depB',
@@ -320,7 +320,7 @@ describe('workers/repository/updates/generate', () => {
     });
 
     it('groups multiple upgrades different value but same version', () => {
-      const branch = [
+      const branch: BranchUpgradeConfig[] = [
         {
           manager: 'some-manager',
           depName: 'depB',
@@ -363,7 +363,7 @@ describe('workers/repository/updates/generate', () => {
     });
 
     it('groups multiple digest updates', () => {
-      const branch = [
+      const branch: BranchUpgradeConfig[] = [
         {
           manager: 'some-manager',
           depName: 'foo/bar',
@@ -419,7 +419,7 @@ describe('workers/repository/updates/generate', () => {
     });
 
     it('fixes different messages', () => {
-      const branch = [
+      const branch: BranchUpgradeConfig[] = [
         {
           manager: 'some-manager',
           depName: 'depA',
@@ -459,7 +459,8 @@ describe('workers/repository/updates/generate', () => {
     });
 
     it('uses semantic commits', () => {
-      const branch = [
+      // TODO #7154 incompatible types
+      const branch: BranchUpgradeConfig[] = [
         {
           ...defaultConfig,
           manager: 'some-manager',
@@ -474,16 +475,17 @@ describe('workers/repository/updates/generate', () => {
           group: {
             foo: 2,
           },
-        },
+        } as BranchUpgradeConfig,
       ];
-      const res = generateBranchConfig(<BranchUpgradeConfig[]>branch);
+      const res = generateBranchConfig(branch);
       expect(res.prTitle).toBe(
         'chore(package): update dependency some-dep to v1.2.0'
       );
     });
 
     it('scopes monorepo commits', () => {
-      const branch = [
+      // TODO #7154 incompatible types
+      const branch: BranchUpgradeConfig[] = [
         {
           ...defaultConfig,
           manager: 'some-manager',
@@ -500,14 +502,15 @@ describe('workers/repository/updates/generate', () => {
           group: {
             foo: 2,
           },
-        },
+        } as BranchUpgradeConfig,
       ];
-      const res = generateBranchConfig(<BranchUpgradeConfig[]>branch);
+      const res = generateBranchConfig(branch);
       expect(res.prTitle).toBe('chore(): update dependency some-dep to v1.2.0');
     });
 
     it('scopes monorepo commits with nested package files using parent directory', () => {
-      const branch = [
+      // TODO #7154 incompatible types
+      const branch: BranchUpgradeConfig[] = [
         {
           ...defaultConfig,
           commitBodyTable: false,
@@ -525,16 +528,17 @@ describe('workers/repository/updates/generate', () => {
           group: {
             foo: 2,
           },
-        },
+        } as BranchUpgradeConfig,
       ];
-      const res = generateBranchConfig(<BranchUpgradeConfig[]>branch);
+      const res = generateBranchConfig(branch);
       expect(res.prTitle).toBe(
         'chore(bar): update dependency some-dep to v1.2.0'
       );
     });
 
     it('scopes monorepo commits with nested package files using base directory', () => {
-      const branch = [
+      // TODO #7154 incompatible types
+      const branch: BranchUpgradeConfig[] = [
         {
           ...defaultConfig,
           manager: 'some-manager',
@@ -551,16 +555,17 @@ describe('workers/repository/updates/generate', () => {
           group: {
             foo: 2,
           },
-        },
+        } as BranchUpgradeConfig,
       ];
-      const res = generateBranchConfig(<BranchUpgradeConfig[]>branch);
+      const res = generateBranchConfig(branch);
       expect(res.prTitle).toBe(
         'chore(foo/bar): update dependency some-dep to v1.2.0'
       );
     });
 
     it('adds commit message body', () => {
-      const branch = [
+      // TODO #7154 incompatible types
+      const branch: BranchUpgradeConfig[] = [
         {
           ...defaultConfig,
           manager: 'some-manager',
@@ -569,24 +574,25 @@ describe('workers/repository/updates/generate', () => {
           newValue: '1.2.0',
           isSingleVersion: true,
           newVersion: '1.2.0',
-        },
+        } as BranchUpgradeConfig,
       ];
-      const res = generateBranchConfig(<BranchUpgradeConfig[]>branch);
+      const res = generateBranchConfig(branch);
       expect(res.commitMessage).toMatchSnapshot();
       expect(res.commitMessage).toContain('\n');
     });
 
     it('supports manual prTitle', () => {
-      const branch = [
+      // TODO #7154 incompatible types
+      const branch: BranchUpgradeConfig[] = [
         {
           ...defaultConfig,
           manager: 'some-manager',
           depName: 'some-dep',
           prTitle: 'Upgrade {{depName}}',
           toLowerCase: true,
-        },
+        } as BranchUpgradeConfig,
       ];
-      const res = generateBranchConfig(<BranchUpgradeConfig[]>branch);
+      const res = generateBranchConfig(branch);
       expect(res.prTitle).toBe('upgrade some-dep');
     });
 
@@ -717,7 +723,8 @@ describe('workers/repository/updates/generate', () => {
     });
 
     it('handles upgrades', () => {
-      const branch = [
+      // TODO #7154 incompatible types
+      const branch: BranchUpgradeConfig[] = [
         {
           manager: 'some-manager',
           depName: 'some-dep',
@@ -764,8 +771,8 @@ describe('workers/repository/updates/generate', () => {
           updateType: 'patch' as UpdateType,
           fileReplacePosition: 0,
         },
-      ];
-      const res = generateBranchConfig(<BranchUpgradeConfig[]>branch);
+      ] as BranchUpgradeConfig[];
+      const res = generateBranchConfig(branch);
       expect(res.prTitle).toMatchSnapshot('some-title (patch)');
     });
 
@@ -828,7 +835,7 @@ describe('workers/repository/updates/generate', () => {
     });
 
     it('passes through pendingChecks', () => {
-      const branch = [
+      const branch: BranchUpgradeConfig[] = [
         {
           manager: 'some-manager',
           depName: 'some-dep',
@@ -852,7 +859,7 @@ describe('workers/repository/updates/generate', () => {
     });
 
     it('filters pendingChecks', () => {
-      const branch = [
+      const branch: BranchUpgradeConfig[] = [
         {
           manager: 'some-manager',
           depName: 'some-dep',
@@ -875,7 +882,7 @@ describe('workers/repository/updates/generate', () => {
     });
 
     it('displays pending versions', () => {
-      const branch = [
+      const branch: BranchUpgradeConfig[] = [
         {
           manager: 'some-manager',
           depName: 'some-dep',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "strict": true,
-    "noImplicitAny": true /* TODO: fix me */,
-    "strictNullChecks": true /* TODO: fix me */,
+    "noImplicitAny": false /* TODO: fix me */,
+    "strictNullChecks": false /* TODO: fix me */,
     "outDir": "./dist",
     /* https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping */
     "target": "es2020",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "strict": true,
-    "noImplicitAny": false /* TODO: fix me */,
-    "strictNullChecks": false /* TODO: fix me */,
+    "noImplicitAny": true /* TODO: fix me */,
+    "strictNullChecks": true /* TODO: fix me */,
     "outDir": "./dist",
     /* https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping */
     "target": "es2020",

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -12,7 +12,7 @@
     "**/__mocks__/*",
     "coverage",
     "config.js",
-    "tmp"
+    "tmp",
     // TODO: fixme
   ]
 }

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -12,12 +12,7 @@
     "**/__mocks__/*",
     "coverage",
     "config.js",
-    "tmp",
+    "tmp"
     // TODO: fixme
-    "lib/renovate.spec.ts",
-    "lib/workers/repository/dependency-dashboard.spec.ts",
-    "lib/workers/repository/config-migration/pr/index.spec.ts",
-    "lib/workers/repository/onboarding/pr/index.spec.ts",
-    "lib/workers/repository/process/vulnerabilities.spec.ts"
   ]
 }

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -14,7 +14,10 @@
     "config.js",
     "tmp",
     // TODO: fixme
-    "lib/workers/**/*.spec.ts",
-    "lib/renovate.spec.ts"
+    "lib/renovate.spec.ts",
+    "lib/workers/repository/dependency-dashboard.spec.ts",
+    "lib/workers/repository/config-migration/pr/index.spec.ts",
+    "lib/workers/repository/onboarding/pr/index.spec.ts",
+    "lib/workers/repository/process/vulnerabilities.spec.ts"
   ]
 }

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -12,7 +12,7 @@
     "**/__mocks__/*",
     "coverage",
     "config.js",
-    "tmp",
+    "tmp"
     // TODO: fixme
   ]
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- Implement null-check for test files
<!-- Describe what behavior is changed by this PR. -->

## Context
- #7154
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

