### PR TITLE
fix(config): add missing `globalOnly` flags

### DIFF
--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -241,6 +241,7 @@ const options: RenovateOptions[] = [
     stage: 'global',
     type: 'boolean',
     default: true,
+    globalOnly: true,
   },
   {
     name: 'draftPR',
@@ -281,6 +282,7 @@ const options: RenovateOptions[] = [
       'If set, this Redis URL will be used for caching instead of the file system.',
     stage: 'global',
     type: 'string',
+    globalOnly: true,
   },
   {
     name: 'baseDir',
@@ -288,6 +290,7 @@ const options: RenovateOptions[] = [
       'The base directory for Renovate to store local files, including repository files and cache. If left empty, Renovate will create its own temporary directory to use.',
     stage: 'global',
     type: 'string',
+    globalOnly: true,
   },
   {
     name: 'cacheDir',
@@ -341,6 +344,7 @@ const options: RenovateOptions[] = [
     description: 'Log file path.',
     stage: 'global',
     type: 'string',
+    globalOnly: true,
   },
   {
     name: 'logFileLevel',
@@ -348,6 +352,7 @@ const options: RenovateOptions[] = [
     stage: 'global',
     type: 'string',
     default: 'debug',
+    globalOnly: true,
   },
   {
     name: 'logContext',
@@ -689,6 +694,7 @@ const options: RenovateOptions[] = [
     stage: 'global',
     type: 'boolean',
     default: false,
+    globalOnly: true,
   },
   {
     name: 'autodiscoverFilter',
@@ -696,6 +702,7 @@ const options: RenovateOptions[] = [
     stage: 'global',
     type: 'string',
     default: null,
+    globalOnly: true,
   },
   {
     name: 'prCommitsPerRunLimit',
@@ -704,6 +711,7 @@ const options: RenovateOptions[] = [
     stage: 'global',
     type: 'integer',
     default: 0,
+    globalOnly: true,
   },
   {
     name: 'repositories',
@@ -711,6 +719,7 @@ const options: RenovateOptions[] = [
     stage: 'global',
     type: 'array',
     cli: false,
+    globalOnly: true,
   },
   {
     name: 'baseBranches',

--- a/test/website-docs.spec.ts
+++ b/test/website-docs.spec.ts
@@ -33,7 +33,6 @@ describe('website-docs', () => {
     .match(/\n## (.*?)\n/g)
     ?.map((match) => match.substring(4, match.length - 1));
   const expectedOptions = options
-    .filter((option) => option.stage !== 'global')
     .filter((option) => option.releaseStatus !== 'unpublished')
     .filter((option) => !option.globalOnly)
     .filter((option) => !option.parent)
@@ -42,7 +41,7 @@ describe('website-docs', () => {
     .sort();
 
   const selfHostExpectedOptions = options
-    .filter((option) => !!option.globalOnly || option.stage === 'global')
+    .filter((option) => !!option.globalOnly)
     .map((option) => option.name)
     .sort();
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
add missing `globalOnly` flag for some global renovate options.
<!-- Describe what behavior is changed by this PR. -->

## Context
- #16183
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
