### PR TITLE
fix(config): apply secrets to global hostRules

### DIFF
--- a/lib/workers/global/initialize.ts
+++ b/lib/workers/global/initialize.ts
@@ -9,6 +9,7 @@ import { setEmojiConfig } from '../../util/emoji';
 import { validateGitVersion } from '../../util/git';
 import * as hostRules from '../../util/host-rules';
 import { Limit, setMaxLimit } from './limits';
+import { applySecretsToConfig } from '../../config/secrets';
 
 async function setDirectories(input: AllConfig): Promise<AllConfig> {
   const config: AllConfig = { ...input };
@@ -46,6 +47,7 @@ async function checkVersions(): Promise<void> {
 function setGlobalHostRules(config: RenovateConfig): void {
   if (config.hostRules) {
     logger.debug('Setting global hostRules');
+    applySecretsToConfig(config, undefined, false);
     config.hostRules.forEach((rule) => hostRules.add(rule));
   }
 }

--- a/lib/workers/global/initialize.ts
+++ b/lib/workers/global/initialize.ts
@@ -1,6 +1,7 @@
 import os from 'os';
 import fs from 'fs-extra';
 import upath from 'upath';
+import { applySecretsToConfig } from '../../config/secrets';
 import type { AllConfig, RenovateConfig } from '../../config/types';
 import { logger } from '../../logger';
 import { initPlatform } from '../../modules/platform';
@@ -9,7 +10,6 @@ import { setEmojiConfig } from '../../util/emoji';
 import { validateGitVersion } from '../../util/git';
 import * as hostRules from '../../util/host-rules';
 import { Limit, setMaxLimit } from './limits';
-import { applySecretsToConfig } from '../../config/secrets';
 
 async function setDirectories(input: AllConfig): Promise<AllConfig> {
   const config: AllConfig = { ...input };


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Applies secrets to global hostRules before they are set.

## Context

Closes #16215

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
