### PR TITLE
docs(self-hosted config): improve unicodeEmoji section

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -686,7 +686,8 @@ This is currently applicable to `npm` and `lerna`/`npm` only, and only used in c
 
 ## unicodeEmoji
 
-If enabled emoji shortcodes (`:warning:`) are replaced with their Unicode equivalents (`⚠️`).
+If enabled emoji shortcodes are replaced with their Unicode equivalents.
+For example: `:warning:` will be replaced with `⚠️`.
 
 ## username
 


### PR DESCRIPTION
## Changes

- Improve the `unicodeEmoji` section
  - Put `:warning:` -> :warning: example on new line
  - Drop `()` characters

## Context

Drive-by PR. Not closing any issue with this.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository