### PR TITLE
fix(git): add symbolic link file support to prepareCommit

### DIFF
--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -373,6 +373,21 @@ describe('util/git/index', () => {
       expect(commit).not.toBeNull();
     });
 
+    it('link file', async () => {
+      const file: FileChange = {
+        type: 'addition',
+        path: 'link-to-future',
+        contents: 'future_file',
+        isSymlink: true,
+      };
+      const commit = await git.commitFiles({
+        branchName: 'renovate/future_branch',
+        files: [file],
+        message: 'Create a link',
+      });
+      expect(commit).not.toBeNull();
+    });
+
     it('deletes file', async () => {
       const file: FileChange = {
         type: 'deletion',

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -376,8 +376,8 @@ describe('util/git/index', () => {
     it('link file', async () => {
       const file: FileChange = {
         type: 'addition',
-        path: 'link-to-future',
-        contents: 'future_file',
+        path: 'future_link',
+        contents: 'past_file',
         isSymlink: true,
       };
       const commit = await git.commitFiles({
@@ -385,7 +385,16 @@ describe('util/git/index', () => {
         files: [file],
         message: 'Create a link',
       });
-      expect(commit).not.toBeNull();
+      expect(commit).toBeString();
+      const tmpGit = Git(tmpDir.path);
+      const lsTree = await tmpGit.raw(['ls-tree', commit!]);
+      const files = lsTree
+        .trim()
+        .split(newlineRegex)
+        .map((x) => x.split(/\s/))
+        .map(([mode, type, _hash, name]) => [mode, type, name]);
+      expect(files).toContainEqual(['100644', 'blob', 'past_file']);
+      expect(files).toContainEqual(['120000', 'blob', 'future_link']);
     });
 
     it('deletes file', async () => {

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -862,9 +862,13 @@ export async function prepareCommit({
           }
           // some file systems including Windows don't support the mode
           // so the index should be manually updated after adding the file
-          await fs.outputFile(upath.join(localDir, fileName), contents, {
-            mode: file.isExecutable ? 0o777 : 0o666,
-          });
+          if (file.isSymlink) {
+            await fs.symlink(file.contents, upath.join(localDir, fileName));
+          } else {
+            await fs.outputFile(upath.join(localDir, fileName), contents, {
+              mode: file.isExecutable ? 0o777 : 0o666,
+            });
+          }
         }
         try {
           // istanbul ignore next

--- a/lib/util/git/types.ts
+++ b/lib/util/git/types.ts
@@ -52,6 +52,8 @@ export interface FileAddition {
    * The executable bit
    */
   isExecutable?: boolean;
+
+  isSymlink?: boolean;
 }
 
 export interface FileDeletion {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As part of the Hermit manager feature from #16250, this PR contains the changes that adds symbolic link file support to prepareCommit function in git.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->
Issue: #16119 
PR: #16250 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [X] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
