### PR TITLE
docs(automerge): add `platformAutomerge` section

### DIFF
--- a/docs/usage/key-concepts/automerge.md
+++ b/docs/usage/key-concepts/automerge.md
@@ -82,6 +82,27 @@ Non-major updates in SemVer ecosystems shouldn't have breaking changes (if they 
 
 The `matchCurrentVersion` setting above is a rule to exclude any dependencies which are pre-1.0.0 because those can make breaking changes at _any_ time according to the SemVer spec.
 
+### Faster merges with platform-native automerge
+
+You can speed up merges by letting Renovate use your platform's native automerge.
+The config option is called `platformAutomerge`.
+If `automerge=true` and `automergeType=pr` then you can set `platformAutomerge=true`.
+
+For example:
+
+```json
+{
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true,
+    "automergeType": "pr",
+    "platformAutomerge": true
+  }
+}
+```
+
+For more information read [`platformAutomerge`](https://docs.renovatebot.com/configuration-options/#platformautomerge).
+
 ## Automerging and scheduling
 
 Automerging is particularly beneficial if you have configured a schedule, because Renovate on its own may be able to automerge the majority of your updates.


### PR DESCRIPTION
## Changes

- Add new section that covers the `platformAutomerge` feature:
  - Short intro
  - Example
  - Refer to `platformAutomerge` docs 

## Context

Closes #14558.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
