### PR TITLE
fix: filter out rollback if followTag is true

### DIFF
--- a/lib/modules/manager/bazel/update.ts
+++ b/lib/modules/manager/bazel/update.ts
@@ -13,6 +13,10 @@ function updateWithNewVersion(
   currentValue: string,
   newValue: string
 ): string {
+  // istanbul ignore if
+  if (currentValue === newValue) {
+    return content;
+  }
   const replaceFrom = currentValue.replace(regEx(/^v/), '');
   const replaceTo = newValue.replace(regEx(/^v/), '');
   let newContent = content;

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -394,6 +394,12 @@ export async function lookupUpdates(
         (update) => update.newValue === currentValue
       );
     }
+    // Handle a weird edge case involving followTag and fallbacks
+    if (rollbackPrs && followTag) {
+      res.updates = res.updates.filter(
+        (update) => res.updates.length === 1 || update.updateType !== 'rollback'
+      );
+    }
   } catch (err) /* istanbul ignore next */ {
     if (err instanceof ExternalHostError || err.message === CONFIG_VALIDATION) {
       throw err;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Filters out a rollback tag if followTag=true and multiple updates exist

## Context

In certain edge cases we get duplicates

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
