### PR TITLE
docs: prevent line ending problems when self-hosting on Windows

### DIFF
--- a/docs/development/best-practices.md
+++ b/docs/development/best-practices.md
@@ -173,5 +173,12 @@ Use [Named Capturing Groups](https://www.regular-expressions.info/named.html) wh
 
 ### Windows
 
-We recommend you set [`core.autocrlf = input`](https://git-scm.com/docs/gitattributes#_text) in your `gitConfig`, or the carriage return `\r\n` might confuse Renovate bot.
+We recommend you set [`core.autocrlf = input`](https://git-scm.com/docs/gitattributes#_text) in your Git config.
+You can do this by running this Git command:
+
+```bash
+$ git config --global core.autocrlf input
+```
+
+This prevents the carriage return `\r\n` which may confuse Renovate bot.
 You can also set the line endings in your repository by adding `* text=auto eol=lf` to your `.gitattributes` file.

--- a/docs/development/best-practices.md
+++ b/docs/development/best-practices.md
@@ -177,7 +177,7 @@ We recommend you set [`core.autocrlf = input`](https://git-scm.com/docs/gitattri
 You can do this by running this Git command:
 
 ```bash
-$ git config --global core.autocrlf input
+git config --global core.autocrlf input
 ```
 
 This prevents the carriage return `\r\n` which may confuse Renovate bot.

--- a/docs/usage/getting-started/installing-onboarding.md
+++ b/docs/usage/getting-started/installing-onboarding.md
@@ -45,7 +45,7 @@ We recommend you set [`core.autocrlf = input`](https://git-scm.com/docs/gitattri
 You can do this by running this Git command:
 
 ```bash
-$ git config --global core.autocrlf input
+git config --global core.autocrlf input
 ```
 
 This prevents the carriage return `\r\n` which may confuse Renovate bot.

--- a/docs/usage/getting-started/installing-onboarding.md
+++ b/docs/usage/getting-started/installing-onboarding.md
@@ -39,6 +39,18 @@ Once you're done selecting repositories for Renovate to run on, click the green 
 Unfortunately Mend's hosted GitLab app needed to be taken offline indefinitely until a viable security model for bots on GitLab.com is available.
 For more details on GitLab security for bots, please see the [GitLab Bot Security](../gitlab-bot-security.md) doc.
 
+### Self-hosting on Windows
+
+We recommend you set [`core.autocrlf = input`](https://git-scm.com/docs/gitattributes#_text) in your Git config.
+You can do this by running this Git command:
+
+```bash
+$ git config --global core.autocrlf input
+```
+
+This prevents the carriage return `\r\n` which may confuse Renovate bot.
+You can also set the line endings in your repository by adding `* text=auto eol=lf` to your `.gitattributes` file.
+
 ## Repository onboarding
 
 Once you have enabled Renovate on a repository, you will get a "Configure Renovate" Pull Request looking something like this:

--- a/docs/usage/getting-started/running.md
+++ b/docs/usage/getting-started/running.md
@@ -16,6 +16,8 @@ Self-hosting Renovate means that you are the "administrator" of the bot, which e
 - You ensure it's running regularly,
 - You ensure Renovate bot itself is updated
 
+Read our section on [Self-hosting on Windows](./installing-onboarding.md#self-hosting-on-windows) to prevent line endings from confusing Renovate bot.
+
 ### Available distributions
 
 #### npm package (CLI)


### PR DESCRIPTION
## Changes

- Add new sections to our usage docs:
  - Explain how to prevent line ending problems on Windows
- Sync our development docs with the new usage docs

## Context

Closes #6745.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
