### PR TITLE
docs: improve description for internal presets

### DIFF
--- a/lib/config/presets/__snapshots__/index.spec.ts.snap
+++ b/lib/config/presets/__snapshots__/index.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`config/presets/index getPreset gets linters 1`] = `
 Object {
   "description": Array [
-    "All lint-related packages",
+    "All lint-related packages.",
   ],
   "extends": Array [
     "packages:emberTemplateLint",
@@ -28,10 +28,10 @@ Object {
   "automergeType": "pr",
   "branchPrefix": "renovate/",
   "description": Array [
-    "Use <code>renovate/</code> as prefix for all branch names",
-    "If semantic commits detected, use semantic commit type <code>fix</code> for dependencies and <code>chore</code> for all others",
-    "Require all status checks to pass before any automerging",
-    "Pin dependency versions for <code>devDependencies</code> and retain SemVer ranges for others",
+    "Prefix \`renovate/\` to all branch names.",
+    "If Renovate detects semantic commits, it will use semantic commit type \`fix\` for dependencies and \`chore\` for all others.",
+    "Require all status checks to pass before any automerging.",
+    "Pin dependency versions for \`devDependencies\` and retain SemVer ranges for others.",
   ],
   "ignoreTests": false,
   "ignoreUnstable": true,
@@ -127,7 +127,7 @@ Object {
 exports[`config/presets/index resolvePreset resolves linters 1`] = `
 Object {
   "description": Array [
-    "All lint-related packages",
+    "All lint-related packages.",
   ],
   "matchPackageNames": Array [
     "@types/eslint",
@@ -150,13 +150,13 @@ Object {
 exports[`config/presets/index resolvePreset resolves nested groups 1`] = `
 Object {
   "description": Array [
-    "Update lint packages automatically if tests pass",
+    "Update lint packages automatically if tests pass.",
   ],
   "packageRules": Array [
     Object {
       "automerge": true,
       "description": Array [
-        "All lint-related packages",
+        "All lint-related packages.",
       ],
       "matchPackageNames": Array [
         "@types/eslint",

--- a/lib/config/presets/index.spec.ts
+++ b/lib/config/presets/index.spec.ts
@@ -907,7 +907,7 @@ describe('config/presets/index', () => {
         {}
       );
       expect(res).toEqual({
-        description: ['Group eslint packages into same branch/PR'],
+        description: ['Group `eslint` packages into same branch/PR.'],
         packageRules: [
           {
             extends: ['packages:eslint'],
@@ -920,7 +920,7 @@ describe('config/presets/index', () => {
     it('handles missing params', async () => {
       const res = await presets.getPreset(':group()', {});
       expect(res).toEqual({
-        description: ['Group {{arg1}} packages into same branch/PR'],
+        description: ['Group `{{arg1}}` packages into same branch/PR.'],
         packageRules: [
           {
             extends: [],
@@ -934,7 +934,7 @@ describe('config/presets/index', () => {
       const res = await presets.getPreset(':pinVersions(foo, bar)', {});
       expect(res).toEqual({
         description: [
-          'Use version pinning (maintain a single version only and not SemVer ranges)',
+          'Use version pinning (maintain a single version only and not SemVer ranges).',
         ],
         rangeStrategy: 'pin',
       });

--- a/lib/config/presets/index.spec.ts
+++ b/lib/config/presets/index.spec.ts
@@ -858,40 +858,40 @@ describe('config/presets/index', () => {
     it('handles renamed monorepos', async () => {
       const res = await presets.getPreset('monorepo:opentelemetry', {});
       expect(res).toMatchInlineSnapshot(`
-Object {
-  "description": Array [
-    "opentelemetry-js monorepo",
-  ],
-  "matchSourceUrlPrefixes": Array [
-    "https://github.com/open-telemetry/opentelemetry-js",
-  ],
-}
-`);
+        Object {
+          "description": Array [
+            "opentelemetry-js monorepo",
+          ],
+          "matchSourceUrlPrefixes": Array [
+            "https://github.com/open-telemetry/opentelemetry-js",
+          ],
+        }
+      `);
     });
 
     it('handles renamed monorepo groups', async () => {
       const res = await presets.getPreset('group:opentelemetryMonorepo', {});
       expect(res).toMatchInlineSnapshot(`
-Object {
-  "packageRules": Array [
-    Object {
-      "description": Array [
-        "Group packages from opentelemetry-js monorepo together",
-      ],
-      "extends": Array [
-        "monorepo:opentelemetry-js",
-      ],
-      "groupName": "opentelemetry-js monorepo",
-      "matchUpdateTypes": Array [
-        "digest",
-        "patch",
-        "minor",
-        "major",
-      ],
-    },
-  ],
-}
-`);
+        Object {
+          "packageRules": Array [
+            Object {
+              "description": Array [
+                "Group packages from opentelemetry-js monorepo together.",
+              ],
+              "extends": Array [
+                "monorepo:opentelemetry-js",
+              ],
+              "groupName": "opentelemetry-js monorepo",
+              "matchUpdateTypes": Array [
+                "digest",
+                "patch",
+                "minor",
+                "major",
+              ],
+            },
+          ],
+        }
+      `);
     });
 
     it('gets linters', async () => {

--- a/lib/config/presets/internal/compatibility.ts
+++ b/lib/config/presets/internal/compatibility.ts
@@ -3,7 +3,7 @@ import type { Preset } from '../types';
 export const presets: Record<string, Preset> = {
   additionalBranchPrefix: {
     description:
-      'Backwards-compatibility preset to restore additionalBranchPrefix settings for multiple managers which were removed in v25',
+      'Backwards-compatibility preset to restore `additionalBranchPrefix` settings for multiple managers which were removed in Renovate `v25`.',
     buildkite: {
       additionalBranchPrefix: 'buildkite-',
     },

--- a/lib/config/presets/internal/config.ts
+++ b/lib/config/presets/internal/config.ts
@@ -2,7 +2,7 @@ import type { Preset } from '../types';
 
 export const presets: Record<string, Preset> = {
   base: {
-    description: 'Default base configuration for all languages',
+    description: 'Default base configuration for all languages.',
     extends: [
       ':dependencyDashboard',
       ':semanticPrefixFixDepsChoreOthers',
@@ -16,16 +16,16 @@ export const presets: Record<string, Preset> = {
     ],
   },
   'js-app': {
-    description: 'Default configuration for webapps',
+    description: 'Default configuration for webapps.',
     extends: ['config:base', ':pinAllExceptPeerDependencies'],
   },
   'js-lib': {
-    description: 'Default configuration for libraries',
+    description: 'Default configuration for libraries.',
     extends: ['config:base', ':pinOnlyDevDependencies'],
   },
   semverAllMonthly: {
     description:
-      'Preserve SemVer ranges and update everything together once a month',
+      'Preserve SemVer ranges and update everything together once a month.',
     separateMajorMinor: false,
     extends: [
       ':preserveSemverRanges',

--- a/lib/config/presets/internal/default.ts
+++ b/lib/config/presets/internal/default.ts
@@ -10,7 +10,7 @@ export const presets: Record<string, Preset> = {
     enabled: false,
   },
   disableMajorUpdates: {
-    description: 'Disables `major` updates.',
+    description: 'Disable `major` updates.',
     major: {
       enabled: false,
     },

--- a/lib/config/presets/internal/default.ts
+++ b/lib/config/presets/internal/default.ts
@@ -2,21 +2,21 @@ import type { Preset } from '../types';
 
 export const presets: Record<string, Preset> = {
   enableRenovate: {
-    description: 'Enable Renovate',
+    description: 'Enable Renovate.',
     enabled: true,
   },
   disableRenovate: {
-    description: 'Disable Renovate',
+    description: 'Disable Renovate.',
     enabled: false,
   },
   disableMajorUpdates: {
-    description: 'Disables major updates',
+    description: 'Disables `major` updates.',
     major: {
       enabled: false,
     },
   },
   disableDomain: {
-    description: 'Disable requests to a particular domain',
+    description: 'Disable requests to a particular domain.',
     hostRules: [
       {
         matchHost: '{{arg0}}',
@@ -25,7 +25,7 @@ export const presets: Record<string, Preset> = {
     ],
   },
   disableHost: {
-    description: 'Disable requests to a particular host',
+    description: 'Disable requests to a particular host.',
     hostRules: [
       {
         matchHost: 'https://{{arg0}}',
@@ -34,14 +34,14 @@ export const presets: Record<string, Preset> = {
     ],
   },
   enablePreCommit: {
-    description: 'Enable the pre-commit manager',
+    description: 'Enable the pre-commit manager.',
     'pre-commit': {
       enabled: true,
     },
   },
   ignoreModulesAndTests: {
     description:
-      'Ignore `node_modules`, `bower_components`, `vendor` and various test/tests directories',
+      'Ignore `node_modules`, `bower_components`, `vendor` and various test/tests directories.',
     ignorePaths: [
       '**/node_modules/**',
       '**/bower_components/**',
@@ -55,22 +55,21 @@ export const presets: Record<string, Preset> = {
   },
   includeNodeModules: {
     description:
-      'Include <code>package.json</code> files found within <code>node_modules</code> folders or <code>bower_components</code>.',
+      'Include `package.json` files found within `node_modules` folders or `bower_components`.',
     ignorePaths: [],
   },
   pinVersions: {
     description:
-      'Use version pinning (maintain a single version only and not SemVer ranges)',
+      'Use version pinning (maintain a single version only and not SemVer ranges).',
     rangeStrategy: 'pin',
   },
   preserveSemverRanges: {
     description:
-      'Preserve (but continue to upgrade) any existing SemVer ranges',
+      'Preserve (but continue to upgrade) any existing SemVer ranges.',
     packageRules: [{ matchPackagePatterns: ['*'], rangeStrategy: 'replace' }],
   },
   pinAllExceptPeerDependencies: {
-    description:
-      'Pin dependency versions for all except <code>peerDependencies</code>',
+    description: 'Pin dependency versions for all except `peerDependencies`.',
     packageRules: [
       {
         matchPackagePatterns: ['*'],
@@ -84,7 +83,7 @@ export const presets: Record<string, Preset> = {
   },
   pinDependencies: {
     description:
-      'Pin dependency versions where <code>depType=dependencies</code>. Usually applies only to non-dev dependencies in <code>package.json</code>',
+      'Pin dependency versions where `depType=dependencies`. Usually applies only to non-dev dependencies in `package.json`.',
     packageRules: [
       {
         matchDepTypes: ['dependencies'],
@@ -93,7 +92,7 @@ export const presets: Record<string, Preset> = {
     ],
   },
   pinDevDependencies: {
-    description: 'Pin dependency versions for <code>devDependencies</code>',
+    description: 'Pin dependency versions for `devDependencies`.',
     packageRules: [
       {
         matchDepTypes: ['devDependencies'],
@@ -103,7 +102,7 @@ export const presets: Record<string, Preset> = {
   },
   pinOnlyDevDependencies: {
     description:
-      'Pin dependency versions for <code>devDependencies</code> and retain SemVer ranges for others',
+      'Pin dependency versions for `devDependencies` and retain SemVer ranges for others.',
     packageRules: [
       {
         matchPackagePatterns: ['*'],
@@ -120,52 +119,51 @@ export const presets: Record<string, Preset> = {
     ],
   },
   autodetectPinVersions: {
-    description: 'Autodetect whether to pin dependencies or maintain ranges',
+    description: 'Autodetect whether to pin dependencies or maintain ranges.',
     rangeStrategy: 'auto',
   },
   separateMajorReleases: {
     description:
-      'Separate major versions of dependencies into individual branches/PRs',
+      'Separate `major` versions of dependencies into individual branches/PRs.',
     separateMajorMinor: true,
   },
   separateMultipleMajorReleases: {
     description:
-      'Separate each available major versions of dependencies into individual branches/PRs',
+      'Separate each available `major` versions of dependencies into individual branches/PRs.',
     separateMajorMinor: true,
     separateMultipleMajor: true,
   },
   separatePatchReleases: {
     description:
-      'Separate patch and minor releases of dependencies into separate PRs',
+      'Separate `patch` and `minor` releases of dependencies into separate PRs.',
     separateMinorPatch: true,
   },
   combinePatchMinorReleases: {
     description:
-      'Do not separate patch and minor upgrades into separate PRs for the same dependency',
+      'Do not separate `patch` and `minor` upgrades into separate PRs for the same dependency.',
     separateMinorPatch: false,
   },
   renovatePrefix: {
-    description: 'Use <code>renovate/</code> as prefix for all branch names',
+    description: 'Use `renovate/` as prefix for all branch names.',
     branchPrefix: 'renovate/',
   },
   semanticCommitType: {
     description:
-      'Use <code>{{arg0}}</code> as semantic commit type for commit messages and PR titles',
+      'Use `{{arg0}}` as semantic commit type for commit messages and PR titles.',
     semanticCommitType: '{{arg0}}',
   },
   semanticPrefixChore: {
     description:
-      'Use <code>chore</code> as semantic commit type for commit messages and PR titles',
+      'Use `chore` as semantic commit type for commit messages and PR titles.',
     extends: [':semanticCommitType(chore)'],
   },
   semanticPrefixFix: {
     description:
-      'Use <code>fix</code> as semantic commit type for commit messages and PR titles',
+      'Use `fix` as semantic commit type for commit messages and PR titles.',
     extends: [':semanticCommitType(fix)'],
   },
   disablePeerDependencies: {
-    description:
-      'Do not renovate <code>peerDependencies</code> versions/ranges',
+    description: 'Do not renovate `peerDependencies` versions/ranges.',
     packageRules: [
       {
         matchDepTypes: ['peerDependencies'],
@@ -174,7 +172,7 @@ export const presets: Record<string, Preset> = {
     ],
   },
   disableDevDependencies: {
-    description: 'Do not renovate <code>devDependencies</code> versions/ranges',
+    description: 'Do not renovate `devDependencies` versions/ranges.',
     packageRules: [
       {
         matchDepTypes: ['devDependencies'],
@@ -183,14 +181,14 @@ export const presets: Record<string, Preset> = {
     ],
   },
   disableDigestUpdates: {
-    description: 'Disable digest and Git hash updates',
+    description: 'Disable digest and Git hash updates.',
     digest: {
       enabled: false,
     },
   },
   semanticPrefixFixDepsChoreOthers: {
     description:
-      'If semantic commits detected, use semantic commit type <code>fix</code> for dependencies and <code>chore</code> for all others',
+      'If semantic commits detected, use semantic commit type `fix` for dependencies and `chore` for all others.',
     packageRules: [
       {
         matchPackagePatterns: ['*'],
@@ -216,7 +214,7 @@ export const presets: Record<string, Preset> = {
   },
   semanticCommitTypeAll: {
     description:
-      'If semantic commits detected, use semantic commit type <code>{{arg0}}</code> for all',
+      'If semantic commits detected, use semantic commit type `{{arg0}}` for all.',
     packageRules: [
       {
         matchPackagePatterns: ['*'],
@@ -226,64 +224,64 @@ export const presets: Record<string, Preset> = {
   },
   rebaseStalePrs: {
     description:
-      'Rebase existing PRs any time the base branch has been updated',
+      'Rebase existing PRs any time the base branch has been updated.',
     rebaseWhen: 'behind-base-branch',
   },
   prImmediately: {
-    description: 'Raise PRs immediately (after branch is created)',
+    description: 'Raise PRs immediately (after branch is created).',
     prCreation: 'immediate',
   },
   prNotPending: {
     description:
-      'Wait until branch tests have passed or failed before creating the PR',
+      'Wait for branch tests to pass or fail before creating the PR.',
     prCreation: 'not-pending',
   },
   prHourlyLimitNone: {
-    description: 'Removes rate limit for PR creation per hour',
+    description: 'Removes rate limit for PR creation per hour.',
     prHourlyLimit: 0,
   },
   prHourlyLimit1: {
-    description: 'Rate limit PR creation to a maximum of one per hour',
+    description: 'Rate limit PR creation to a maximum of one per hour.',
     prHourlyLimit: 1,
   },
   prHourlyLimit2: {
-    description: 'Rate limit PR creation to a maximum of two per hour',
+    description: 'Rate limit PR creation to a maximum of two per hour.',
     prHourlyLimit: 2,
   },
   prHourlyLimit4: {
-    description: 'Rate limit PR creation to a maximum of four per hour',
+    description: 'Rate limit PR creation to a maximum of four per hour.',
     prHourlyLimit: 4,
   },
   prConcurrentLimitNone: {
-    description: 'Remove limit for open PRs at any time',
+    description: 'Remove limit for open PRs at any time.',
     prConcurrentLimit: 0,
   },
   prConcurrentLimit10: {
-    description: 'Limit to maximum 10 open PRs at any time',
+    description: 'Limit to maximum 10 open PRs at any time.',
     prConcurrentLimit: 10,
   },
   prConcurrentLimit20: {
-    description: 'Limit to maximum 20 open PRs at any time',
+    description: 'Limit to maximum 20 open PRs at any time.',
     prConcurrentLimit: 20,
   },
   disableRateLimiting: {
-    description: 'Remove hourly and concurrent rate limits',
+    description: 'Remove hourly and concurrent rate limits.',
     prConcurrentLimit: 0,
     prHourlyLimit: 0,
   },
   automergeDisabled: {
     description:
-      'Disable automerging feature - wait for humans to merge all PRs',
+      'Disable automerging feature - wait for humans to merge all PRs.',
     automerge: false,
   },
   automergeDigest: {
-    description: 'Automerge digest upgrades if they pass tests',
+    description: 'Automerge `digest` upgrades if they pass tests.',
     digest: {
       automerge: true,
     },
   },
   automergePatch: {
-    description: 'Automerge patch upgrades if they pass tests',
+    description: 'Automerge `patch` upgrades if they pass tests.',
     separateMinorPatch: true,
     patch: {
       automerge: true,
@@ -296,7 +294,7 @@ export const presets: Record<string, Preset> = {
     },
   },
   automergeMinor: {
-    description: 'Automerge patch and minor upgrades if they pass tests',
+    description: 'Automerge `patch` and `minor` upgrades if they pass tests.',
     minor: {
       automerge: true,
     },
@@ -311,43 +309,45 @@ export const presets: Record<string, Preset> = {
     },
   },
   automergeMajor: {
-    description: 'Automerge all upgrades (including major) if they pass tests',
+    description:
+      'Automerge all upgrades (including `major`) if they pass tests.',
     automerge: true,
   },
   automergeAll: {
-    description: 'Automerge all upgrades (including major) if they pass tests',
+    description:
+      'Automerge all upgrades (including `major`) if they pass tests.',
     automerge: true,
   },
   automergeBranch: {
     description:
-      'If automerging, push the new commit directly to base branch (no PR)',
+      'If automerging, push the new commit directly to the base branch (no PR).',
     automergeType: 'branch',
   },
   automergePr: {
-    description: 'Raise a PR first before any automerging',
+    description: 'Raise a PR first before any automerging.',
     automergeType: 'pr',
   },
   automergeRequireAllStatusChecks: {
-    description: 'Require all status checks to pass before any automerging',
+    description: 'Require all status checks to pass before any automerging.',
     ignoreTests: false,
   },
   skipStatusChecks: {
-    description: 'Skip status checks and automerge right away',
+    description: 'Skip status checks and automerge right away.',
     ignoreTests: true,
   },
   maintainLockFilesDisabled: {
     description:
-      'Update existing lock files only when <code>package.json</code> is modified',
+      'Update existing lock files only when `package.json` is modified.',
     lockFileMaintenance: {
       enabled: false,
     },
   },
   pinDigestsDisabled: {
-    description: 'Disable pinning of Docker dependency digests',
+    description: 'Disable pinning of Docker dependency digests.',
     pinDigests: false,
   },
   maintainLockFilesWeekly: {
-    description: 'Run lock file maintenance (updates) early Monday mornings',
+    description: 'Run lock file maintenance (updates) early Monday mornings.',
     lockFileMaintenance: {
       enabled: true,
       extends: ['schedule:weekly'],
@@ -355,7 +355,7 @@ export const presets: Record<string, Preset> = {
   },
   maintainLockFilesMonthly: {
     description:
-      'Run lock file maintenance (updates) on the first day of each month',
+      'Run lock file maintenance (updates) on the first day of each month.',
     lockFileMaintenance: {
       enabled: true,
       extends: ['schedule:monthly'],
@@ -363,23 +363,23 @@ export const presets: Record<string, Preset> = {
   },
   ignoreUnstable: {
     description:
-      'Upgrade to unstable versions only if the existing version is unstable',
+      'Upgrade to unstable versions only if the existing version is unstable.',
     ignoreUnstable: true,
   },
   respectLatest: {
-    description: 'Upgrade versions up to the "latest" tag in npm registry',
+    description: 'Upgrade versions up to the "latest" tag in the npm registry.',
     respectLatest: true,
   },
   updateNotScheduled: {
-    description: 'Keep existing branches updated even when not scheduled',
+    description: 'Keep existing branches updated even when not scheduled.',
     updateNotScheduled: true,
   },
   noUnscheduledUpdates: {
-    description: 'Make no updates to branches when not scheduled',
+    description: 'Only update branches when scheduled.',
     updateNotScheduled: false,
   },
   automergeLinters: {
-    description: 'Update lint packages automatically if tests pass',
+    description: 'Update lint packages automatically if tests pass.',
     packageRules: [
       {
         extends: ['packages:linters'],
@@ -388,7 +388,7 @@ export const presets: Record<string, Preset> = {
     ],
   },
   automergeTesters: {
-    description: 'Update testing packages automatically if tests pass',
+    description: 'Update testing packages automatically if tests pass.',
     packageRules: [
       {
         extends: ['packages:test'],
@@ -397,7 +397,7 @@ export const presets: Record<string, Preset> = {
     ],
   },
   automergeTypes: {
-    description: 'Update `@types/*` packages automatically if tests pass',
+    description: 'Update `@types/*` packages automatically if tests pass.',
     packageRules: [
       {
         matchPackagePrefixes: ['@types/'],
@@ -406,7 +406,7 @@ export const presets: Record<string, Preset> = {
     ],
   },
   doNotPinPackage: {
-    description: 'Disable version pinning for <code>{{arg0}}</code>',
+    description: 'Disable version pinning for `{{arg0}}`.',
     packageRules: [
       {
         matchPackageNames: ['{{arg0}}'],
@@ -415,7 +415,7 @@ export const presets: Record<string, Preset> = {
     ],
   },
   pinSkipCi: {
-    description: 'Add [skip ci] to commit message body whenever pinning',
+    description: 'Add [skip ci] to commit message body whenever pinning.',
     pin: {
       commitBody: '[skip ci]',
     },
@@ -425,19 +425,19 @@ export const presets: Record<string, Preset> = {
     commitBody: 'Signed-off-by: {{{gitAuthor}}}',
   },
   npm: {
-    description: 'Keep <code>package.json</code> npm dependencies updated',
+    description: 'Keep `package.json` npm dependencies updated.',
     npm: {
       enabled: true,
     },
   },
   gomod: {
-    description: 'Enable Go modules support',
+    description: 'Enable Go modules support.',
     gomod: {
       enabled: true,
     },
   },
   onlyNpm: {
-    description: 'Renovate only npm dependencies',
+    description: 'Renovate only npm dependencies.',
     docker: {
       enabled: false,
     },
@@ -446,19 +446,19 @@ export const presets: Record<string, Preset> = {
     },
   },
   docker: {
-    description: 'Keep Dockerfile FROM sources updated',
+    description: 'Keep Dockerfile `FROM` sources updated.',
     docker: {
       enabled: true,
     },
   },
   meteor: {
-    description: 'Keep Meteor Npm.depends packages updated',
+    description: 'Keep Meteor Npm.depends packages updated.',
     meteor: {
       enabled: true,
     },
   },
   group: {
-    description: 'Group {{arg1}} packages into same branch/PR',
+    description: 'Group `{{arg1}}` packages into same branch/PR.',
     packageRules: [
       {
         extends: ['{{arg0}}'],
@@ -467,70 +467,69 @@ export const presets: Record<string, Preset> = {
     ],
   },
   label: {
-    description: 'Apply label <code>{{arg0}}</code> to PRs',
+    description: 'Apply label `{{arg0}}` to PRs.',
     labels: ['{{arg0}}'],
   },
   labels: {
-    description:
-      'Apply labels <code>{{arg0}}</code> and <code>{{arg1}}</code> to PRs',
+    description: 'Apply labels `{{arg0}}` and `{{arg1}}` to PRs.',
     labels: ['{{arg0}}', '{{arg1}}'],
   },
   assignee: {
-    description: 'Assign PRs to <code>{{arg0}}</code>',
+    description: 'Assign PRs to `{{arg0}}`.',
     assignees: ['{{arg0}}'],
   },
   reviewer: {
-    description: 'Add <code>{{arg0}}</code> as reviewer for PRs',
+    description: 'Add `{{arg0}}` as reviewer for PRs.',
     reviewers: ['{{arg0}}'],
   },
   assignAndReview: {
-    description: 'Set <code>{{arg0}}</code> as assignee and reviewer of PRs',
+    description: 'Set `{{arg0}}` as assignee and reviewer of PRs.',
     extends: [':assignee({{arg0}})', ':reviewer({{arg0}})'],
   },
   enableVulnerabilityAlerts: {
-    description: 'Raise PR when vulnerability alerts are detected',
+    description: 'Raise PR when vulnerability alerts are detected.',
     vulnerabilityAlerts: {
       enabled: true,
     },
   },
   enableVulnerabilityAlertsWithLabel: {
     description:
-      'Raise PR when vulnerability alerts are detected with label <code>{{arg0}}</code>',
+      'Raise PR when vulnerability alerts are detected with label `{{arg0}}`.',
     vulnerabilityAlerts: {
       enabled: true,
       labels: ['{{arg0}}'],
     },
   },
   disableVulnerabilityAlerts: {
-    description: 'Disable vulnerability alerts completely',
+    description: 'Disable vulnerability alerts completely.',
     vulnerabilityAlerts: {
       enabled: false,
     },
   },
   semanticCommits: {
-    description: 'Use semantic prefixes for commit messages and PR titles',
+    description: 'Use semantic prefixes for commit messages and PR titles.',
     semanticCommits: 'enabled',
   },
   semanticCommitsDisabled: {
-    description: 'Disable semantic prefixes for commit messages and PR titles',
+    description: 'Disable semantic prefixes for commit messages and PR titles.',
     semanticCommits: 'disabled',
   },
   disableLockFiles: {
-    description: 'Disable lock file updates',
+    description: 'Disable lock file updates.',
     updateLockFiles: false,
   },
   semanticCommitScope: {
     description:
-      'Use semantic commit scope <code>{{arg0}}</code> for all commits and PR titles',
+      'Use semantic commit scope `{{arg0}}` for all commits and PR titles.',
     semanticCommitScope: '{{arg0}}',
   },
   semanticCommitScopeDisabled: {
-    description: 'Disable semantic commit scope for all commits and PR titles',
+    description: 'Disable semantic commit scope for all commits and PR titles.',
     semanticCommitScope: null,
   },
   widenPeerDependencies: {
     description:
-      'Always widen peerDependencies SemVer ranges when updating, instead of replacing',
+      'Always widen `peerDependencies` SemVer ranges when updating, instead of replacing.',
     packageRules: [
       {
         matchDepTypes: ['peerDependencies'],
@@ -539,24 +538,24 @@ export const presets: Record<string, Preset> = {
     ],
   },
   dependencyDashboard: {
-    description: 'Enable Renovate Dependency Dashboard creation',
+    description: 'Enable Renovate Dependency Dashboard creation.',
     dependencyDashboard: true,
   },
   disableDependencyDashboard: {
-    description: 'Disable Renovate Dependency Dashboard creation',
+    description: 'Disable Renovate Dependency Dashboard creation.',
     dependencyDashboard: false,
   },
   dependencyDashboardApproval: {
-    description: 'Enable Renovate Dependency Dashboard approval workflow',
+    description: 'Enable Renovate Dependency Dashboard approval workflow.',
     dependencyDashboardApproval: true,
   },
   timezone: {
-    description: 'Evaluate schedules according to timezone {{arg0}}',
+    description: 'Evaluate schedules according to timezone `{{arg0}}`.',
     timezone: '{{arg0}}',
   },
   pathSemanticCommitType: {
     description:
-      'Use semanticCommitType {{arg0}} for all package files matching path {{arg1}}',
+      'Use semanticCommitType `{{arg0}}` for all package files matching path `{{arg1}}`.',
     packageRules: [
       {
         matchPaths: ['{{arg0}}'],
@@ -566,7 +565,7 @@ export const presets: Record<string, Preset> = {
   },
   followTag: {
     description:
-      'For package <code>{{arg0}}</code>, strictly follow release tag <code>{{arg1}}</code>',
+      'For package `{{arg0}}`, strictly follow release tag `{{arg1}}`.',
     packageRules: [
       {
         matchPackageNames: ['{{arg0}}'],
@@ -576,7 +575,7 @@ export const presets: Record<string, Preset> = {
   },
   githubComToken: {
     description:
-      'Use provided token for github.com lookups. Do not configure this if you are already running on github.com',
+      'Use provided token for `github.com` lookups. Do not configure this if you are already running on `github.com`.',
     hostRules: [
       {
         matchHost: 'github.com',
@@ -587,7 +586,7 @@ export const presets: Record<string, Preset> = {
     ],
   },
   disablePrControls: {
-    description: 'Remove the checkbox controls from PRs',
+    description: 'Remove the checkbox controls from PRs.',
     prBodyTemplate:
       '{{{header}}}{{{table}}}{{{notes}}}{{{changelogs}}}{{{configDescription}}}{{{footer}}}',
   },

--- a/lib/config/presets/internal/default.ts
+++ b/lib/config/presets/internal/default.ts
@@ -69,7 +69,7 @@ export const presets: Record<string, Preset> = {
     packageRules: [{ matchPackagePatterns: ['*'], rangeStrategy: 'replace' }],
   },
   pinAllExceptPeerDependencies: {
-    description: 'Pin dependency versions for all except `peerDependencies`.',
+    description: 'Pin all dependency versions except `peerDependencies`.',
     packageRules: [
       {
         matchPackagePatterns: ['*'],
@@ -129,7 +129,7 @@ export const presets: Record<string, Preset> = {
   },
   separateMultipleMajorReleases: {
     description:
-      'Separate each available `major` versions of dependencies into individual branches/PRs.',
+      'Separate each `major` version of dependencies into individual branches/PRs.',
     separateMajorMinor: true,
     separateMultipleMajor: true,
   },
@@ -144,7 +144,7 @@ export const presets: Record<string, Preset> = {
     separateMinorPatch: false,
   },
   renovatePrefix: {
-    description: 'Use `renovate/` as prefix for all branch names.',
+    description: 'Prefix `renovate/` to all branch names.',
     branchPrefix: 'renovate/',
   },
   semanticCommitType: {
@@ -181,14 +181,14 @@ export const presets: Record<string, Preset> = {
     ],
   },
   disableDigestUpdates: {
-    description: 'Disable digest and Git hash updates.',
+    description: 'Disable `digest` and Git hash updates.',
     digest: {
       enabled: false,
     },
   },
   semanticPrefixFixDepsChoreOthers: {
     description:
-      'If semantic commits detected, use semantic commit type `fix` for dependencies and `chore` for all others.',
+      'If Renovate detects semantic commits, it will use semantic commit type `fix` for dependencies and `chore` for all others.',
     packageRules: [
       {
         matchPackagePatterns: ['*'],
@@ -214,7 +214,7 @@ export const presets: Record<string, Preset> = {
   },
   semanticCommitTypeAll: {
     description:
-      'If semantic commits detected, use semantic commit type `{{arg0}}` for all.',
+      'If Renovate detects semantic commits, it will use semantic commit type `{{arg0}}` for all commits.',
     packageRules: [
       {
         matchPackagePatterns: ['*'],
@@ -415,7 +415,7 @@ export const presets: Record<string, Preset> = {
     ],
   },
   pinSkipCi: {
-    description: 'Add [skip ci] to commit message body whenever pinning.',
+    description: 'Add `[skip ci]` to commit message body whenever pinning.',
     pin: {
       commitBody: '[skip ci]',
     },

--- a/lib/config/presets/internal/docker.ts
+++ b/lib/config/presets/internal/docker.ts
@@ -2,7 +2,7 @@ import type { Preset } from '../types';
 
 export const presets: Record<string, Preset> = {
   disable: {
-    description: 'Disable Docker updates',
+    description: 'Disable Docker updates.',
     docker: {
       enabled: false,
     },
@@ -14,7 +14,7 @@ export const presets: Record<string, Preset> = {
     },
   },
   enableMajor: {
-    description: 'Enable Docker major updates',
+    description: 'Enable Docker `major` updates.',
     packageRules: [
       {
         matchDatasources: ['docker'],
@@ -24,7 +24,7 @@ export const presets: Record<string, Preset> = {
     ],
   },
   disableMajor: {
-    description: 'Disable Docker major updates',
+    description: 'Disable Docker `major` updates.',
     packageRules: [
       {
         matchDatasources: ['docker'],
@@ -34,7 +34,7 @@ export const presets: Record<string, Preset> = {
     ],
   },
   pinDigests: {
-    description: 'Pin Docker digests',
+    description: 'Pin Docker digests.',
     docker: {
       pinDigests: true,
     },

--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -5,7 +5,7 @@ const nonPinUpdateTypes = ['digest', 'patch', 'minor', 'major'];
 
 const staticGroups = {
   all: {
-    description: 'Group all updates together',
+    description: 'Group all updates together.',
     groupName: 'all dependencies',
     separateMajorMinor: false,
     groupSlug: 'all',
@@ -21,7 +21,7 @@ const staticGroups = {
     },
   },
   allNonMajor: {
-    description: 'Group all minor and patch updates together',
+    description: 'Group all `minor` and `patch` updates together.',
     packageRules: [
       {
         matchPackagePatterns: ['*'],
@@ -33,7 +33,7 @@ const staticGroups = {
   },
   nodeJs: {
     description:
-      "Group anything that looks like Node.js together so that it's updated together",
+      "Group anything that looks like Node.js together so that it's updated together.",
     packageRules: [
       {
         matchDatasources: ['docker'],
@@ -46,7 +46,7 @@ const staticGroups = {
   },
   recommended: {
     description:
-      'Use curated list of recommended non-monorepo package groupings',
+      'Use curated list of recommended non-monorepo package groupings.',
     extends: [
       'group:nodeJs',
       'group:allApollographql',
@@ -97,7 +97,7 @@ const staticGroups = {
     ignoreDeps: [],
   },
   allApollographql: {
-    description: 'Group all packages published by Apollo GraphQL together',
+    description: 'Group all packages published by Apollo GraphQL together.',
     packageRules: [
       {
         extends: 'packages:apollographql',
@@ -106,7 +106,7 @@ const staticGroups = {
     ],
   },
   codemirror: {
-    description: 'Group CodeMirror packages together',
+    description: 'Group CodeMirror packages together.',
     packageRules: [
       {
         groupName: 'CodeMirror',
@@ -115,7 +115,7 @@ const staticGroups = {
     ],
   },
   definitelyTyped: {
-    description: 'Group all @types packages together',
+    description: 'Group all `@types` packages together.',
     packageRules: [
       {
         groupName: 'definitelyTyped',
@@ -124,7 +124,7 @@ const staticGroups = {
     ],
   },
   dotNetCore: {
-    description: '.NET Core Docker containers',
+    description: '.NET Core Docker containers.',
     packageRules: [
       {
         matchDatasources: ['docker'],
@@ -134,7 +134,7 @@ const staticGroups = {
     ],
   },
   fortawesome: {
-    description: 'Group all packages by Font Awesome together',
+    description: 'Group all packages by Font Awesome together.',
     packageRules: [
       {
         groupName: 'Font Awesome',
@@ -143,7 +143,7 @@ const staticGroups = {
     ],
   },
   fusionjs: {
-    description: 'Group Fusion.js packages together',
+    description: 'Group Fusion.js packages together.',
     matchPackageNames: [
       'fusion-cli',
       'fusion-core',
@@ -153,7 +153,7 @@ const staticGroups = {
     matchPackagePrefixes: ['fusion-plugin-', 'fusion-react', '^usion-apollo'],
   },
   glimmer: {
-    description: 'Group Glimmer.js packages together',
+    description: 'Group Glimmer.js packages together.',
     packageRules: [
       {
         groupName: 'Glimmer.js packages',
@@ -163,7 +163,7 @@ const staticGroups = {
     ],
   },
   illuminate: {
-    description: 'Group PHP Illuminate packages together',
+    description: 'Group PHP Illuminate packages together.',
     packageRules: [
       {
         matchPackagePrefixes: ['illuminate/'],
@@ -173,7 +173,7 @@ const staticGroups = {
     ],
   },
   symfony: {
-    description: 'Group PHP Symfony packages together',
+    description: 'Group PHP Symfony packages together.',
     packageRules: [
       {
         matchPackagePrefixes: ['symfony/'],
@@ -183,7 +183,7 @@ const staticGroups = {
     ],
   },
   phpstan: {
-    description: 'Group PHPStan packages together',
+    description: 'Group PHPStan packages together.',
     packageRules: [
       {
         matchDatasources: ['packagist'],
@@ -193,7 +193,7 @@ const staticGroups = {
     ],
   },
   polymer: {
-    description: 'Group all @polymer packages together',
+    description: 'Group all `@polymer` packages together.',
     packageRules: [
       {
         groupName: 'polymer packages',
@@ -202,7 +202,7 @@ const staticGroups = {
     ],
   },
   hibernateCore: {
-    description: 'Group Java Hibernate Core packages',
+    description: 'Group Java Hibernate Core packages.',
     packageRules: [
       {
         matchPackagePrefixes: ['org.hibernate:'],
@@ -211,7 +211,7 @@ const staticGroups = {
     ],
   },
   hibernateValidator: {
-    description: 'Group Java Hibernate Validator packages',
+    description: 'Group Java Hibernate Validator packages.',
     packageRules: [
       {
         matchPackagePrefixes: ['org.hibernate.validator:'],
@@ -220,7 +220,7 @@ const staticGroups = {
     ],
   },
   hibernateOgm: {
-    description: 'Group Java Hibernate OGM packages',
+    description: 'Group Java Hibernate OGM packages.',
     packageRules: [
       {
         matchPackagePrefixes: ['org.hibernate.ogm:'],
@@ -229,7 +229,7 @@ const staticGroups = {
     ],
   },
   hibernateCommons: {
-    description: 'Group Java Hibernate Commons packages',
+    description: 'Group Java Hibernate Commons packages.',
     packageRules: [
       {
         matchPackagePrefixes: ['org.hibernate.common:'],
@@ -238,7 +238,7 @@ const staticGroups = {
     ],
   },
   resilience4j: {
-    description: 'Group Java Resilience4j packages',
+    description: 'Group Java Resilience4j packages.',
     packageRules: [
       {
         matchPackagePrefixes: ['io.github.resilience4j:'],
@@ -247,7 +247,7 @@ const staticGroups = {
     ],
   },
   springAmqp: {
-    description: 'Group Java Spring AMQP packages',
+    description: 'Group Java Spring AMQP packages.',
     packageRules: [
       {
         groupName: 'spring amqp',
@@ -256,7 +256,7 @@ const staticGroups = {
     ],
   },
   springAndroid: {
-    description: 'Group Java Spring Android packages',
+    description: 'Group Java Spring Android packages.',
     packageRules: [
       {
         groupName: 'spring android',
@@ -265,7 +265,7 @@ const staticGroups = {
     ],
   },
   springBatch: {
-    description: 'Group Java Spring Batch packages',
+    description: 'Group Java Spring Batch packages.',
     packageRules: [
       {
         groupName: 'spring batch',
@@ -274,7 +274,7 @@ const staticGroups = {
     ],
   },
   springBoot: {
-    description: 'Group Java Spring Boot packages',
+    description: 'Group Java Spring Boot packages.',
     packageRules: [
       {
         groupName: 'spring boot',
@@ -284,7 +284,7 @@ const staticGroups = {
     ],
   },
   springCloud: {
-    description: 'Group Java Spring Cloud packages',
+    description: 'Group Java Spring Cloud packages.',
     packageRules: [
       {
         groupName: 'spring cloud',
@@ -293,7 +293,7 @@ const staticGroups = {
     ],
   },
   springCore: {
-    description: 'Group Java Spring Core packages',
+    description: 'Group Java Spring Core packages.',
     packageRules: [
       {
         groupName: 'spring core',
@@ -302,7 +302,7 @@ const staticGroups = {
     ],
   },
   springData: {
-    description: 'Group Java Spring Data packages',
+    description: 'Group Java Spring Data packages.',
     packageRules: [
       {
         groupName: 'spring data',
@@ -311,7 +311,7 @@ const staticGroups = {
     ],
   },
   springHateoas: {
-    description: 'Group Java Spring HATEOAS packages',
+    description: 'Group Java Spring HATEOAS packages.',
     packageRules: [
       {
         groupName: 'spring hateoas',
@@ -320,7 +320,7 @@ const staticGroups = {
     ],
   },
   springIntegration: {
-    description: 'Group Java Spring Integration packages',
+    description: 'Group Java Spring Integration packages.',
     packageRules: [
       {
         groupName: 'spring integration',
@@ -329,7 +329,7 @@ const staticGroups = {
     ],
   },
   springKafka: {
-    description: 'Group Java Spring Kafka packages',
+    description: 'Group Java Spring Kafka packages.',
     packageRules: [
       {
         groupName: 'spring kafka',
@@ -338,7 +338,7 @@ const staticGroups = {
     ],
   },
   springLdap: {
-    description: 'Group Java Spring LDAP packages',
+    description: 'Group Java Spring LDAP packages.',
     packageRules: [
       {
         groupName: 'spring ldap',
@@ -347,7 +347,7 @@ const staticGroups = {
     ],
   },
   springMobile: {
-    description: 'Group Java Spring Mobile packages',
+    description: 'Group Java Spring Mobile packages.',
     packageRules: [
       {
         groupName: 'spring mobile',
@@ -356,7 +356,7 @@ const staticGroups = {
     ],
   },
   springOsgi: {
-    description: 'Group Java Spring OSGi packages',
+    description: 'Group Java Spring OSGi packages.',
     packageRules: [
       {
         groupName: 'spring osgi',
@@ -365,7 +365,7 @@ const staticGroups = {
     ],
   },
   springRestDocs: {
-    description: 'Group Java Spring REST Docs packages',
+    description: 'Group Java Spring REST Docs packages.',
     packageRules: [
       {
         groupName: 'spring restdocs',
@@ -374,7 +374,7 @@ const staticGroups = {
     ],
   },
   springRoo: {
-    description: 'Group Java Spring Roo packages',
+    description: 'Group Java Spring Roo packages.',
     packageRules: [
       {
         groupName: 'spring roo',
@@ -383,7 +383,7 @@ const staticGroups = {
     ],
   },
   springScala: {
-    description: 'Group Java Spring Scala packages',
+    description: 'Group Java Spring Scala packages.',
     packageRules: [
       {
         groupName: 'spring scala',
@@ -392,7 +392,7 @@ const staticGroups = {
     ],
   },
   springSecurity: {
-    description: 'Group Java Spring Security packages',
+    description: 'Group Java Spring Security packages.',
     packageRules: [
       {
         groupName: 'spring security',
@@ -401,7 +401,7 @@ const staticGroups = {
     ],
   },
   springSession: {
-    description: 'Group Java Spring Session packages',
+    description: 'Group Java Spring Session packages.',
     packageRules: [
       {
         groupName: 'spring session',
@@ -410,7 +410,7 @@ const staticGroups = {
     ],
   },
   springShell: {
-    description: 'Group Java Spring Shell packages',
+    description: 'Group Java Spring Shell packages.',
     packageRules: [
       {
         groupName: 'spring shell',
@@ -419,7 +419,7 @@ const staticGroups = {
     ],
   },
   springSocial: {
-    description: 'Group Java Spring Social packages',
+    description: 'Group Java Spring Social packages.',
     packageRules: [
       {
         groupName: 'spring social',
@@ -428,7 +428,7 @@ const staticGroups = {
     ],
   },
   springStatemachine: {
-    description: 'Group Java Spring Statemachine packages',
+    description: 'Group Java Spring Statemachine packages.',
     packageRules: [
       {
         groupName: 'spring statemachine',
@@ -437,7 +437,7 @@ const staticGroups = {
     ],
   },
   springWebflow: {
-    description: 'Group Java Spring WebFlow packages',
+    description: 'Group Java Spring WebFlow packages.',
     packageRules: [
       {
         groupName: 'spring webflow',
@@ -446,7 +446,7 @@ const staticGroups = {
     ],
   },
   springWs: {
-    description: 'Group Java Spring WS packages',
+    description: 'Group Java Spring WS packages.',
     packageRules: [
       {
         groupName: 'spring ws',
@@ -455,7 +455,7 @@ const staticGroups = {
     ],
   },
   socketio: {
-    description: 'Group socket.io packages',
+    description: 'Group socket.io packages.',
     packageRules: [
       {
         groupName: 'socket.io packages',
@@ -464,7 +464,7 @@ const staticGroups = {
     ],
   },
   postcss: {
-    description: 'Group PostCSS packages together',
+    description: 'Group PostCSS packages together.',
     packageRules: [
       {
         extends: 'packages:postcss',
@@ -473,7 +473,7 @@ const staticGroups = {
     ],
   },
   jekyllEcosystem: {
-    description: 'Group Jekyll and related Ruby packages together',
+    description: 'Group Jekyll and related Ruby packages together.',
     packageRules: [
       {
         matchSourceUrlPrefixes: [
@@ -485,7 +485,7 @@ const staticGroups = {
     ],
   },
   rubyOmniauth: {
-    description: 'Group OmniAuth packages together',
+    description: 'Group OmniAuth packages together.',
     packageRules: [
       {
         matchDatasources: ['rubygems'],
@@ -495,7 +495,7 @@ const staticGroups = {
     ],
   },
   goOpenapi: {
-    description: 'Group go-openapi packages together',
+    description: 'Group `go-openapi` packages together.',
     packageRules: [
       {
         matchDatasources: ['go'],
@@ -506,7 +506,7 @@ const staticGroups = {
     ],
   },
   kubernetes: {
-    description: 'Group kubernetes packages together',
+    description: 'Group Kubernetes packages together.',
     packageRules: [
       {
         matchDatasources: ['go'],
@@ -545,7 +545,7 @@ const staticGroups = {
     ],
   },
   googleapis: {
-    description: 'Group googleapis packages together',
+    description: 'Group `googleapis` packages together.',
     packageRules: [
       {
         extends: 'packages:googleapis',
@@ -554,7 +554,7 @@ const staticGroups = {
     ],
   },
   linters: {
-    description: 'Group various lint packages together',
+    description: 'Group various lint packages together.',
     packageRules: [
       {
         extends: 'packages:linters',
@@ -563,7 +563,7 @@ const staticGroups = {
     ],
   },
   jsUnitTest: {
-    description: 'Group JS unit test packages together',
+    description: 'Group JavaScript unit test packages together.',
     packageRules: [
       {
         extends: 'packages:jsUnitTest',
@@ -572,7 +572,8 @@ const staticGroups = {
     ],
   },
   jsUnitTestNonMajor: {
-    description: 'Group JS unit test packages together',
+    description:
+      'Group JavaScipt unit test packages together for non-major updates.',
     packageRules: [
       {
         extends: 'packages:jsUnitTest',
@@ -582,7 +583,7 @@ const staticGroups = {
     ],
   },
   unitTest: {
-    description: 'Group all unit test packages together',
+    description: 'Group all unit test packages together.',
     packageRules: [
       {
         extends: 'packages:unitTest',
@@ -591,7 +592,7 @@ const staticGroups = {
     ],
   },
   unitTestNonMajor: {
-    description: 'Group all unit test packages together',
+    description: 'Group all unit test packages together for non-major updates.',
     packageRules: [
       {
         extends: 'packages:unitTest',
@@ -601,7 +602,7 @@ const staticGroups = {
     ],
   },
   jsTest: {
-    description: 'Group JS test packages together',
+    description: 'Group JS test packages together.',
     packageRules: [
       {
         extends: 'packages:jsTest',
@@ -610,7 +611,7 @@ const staticGroups = {
     ],
   },
   jsTestMonMajor: {
-    description: 'Group non-major JS test package updates together',
+    description: 'Group non-major JS test package updates together.',
     packageRules: [
       {
         extends: 'packages:jsTest',
@@ -620,7 +621,7 @@ const staticGroups = {
     ],
   },
   test: {
-    description: 'Group all test packages together',
+    description: 'Group all test packages together.',
     packageRules: [
       {
         extends: 'packages:test',
@@ -629,7 +630,7 @@ const staticGroups = {
     ],
   },
   testNonMajor: {
-    description: 'Group all non-major test package updates together',
+    description: 'Group all non-major test package updates together.',
     packageRules: [
       {
         extends: 'packages:test',
@@ -639,7 +640,7 @@ const staticGroups = {
     ],
   },
   jestPlusTSJest: {
-    description: 'Add ts-jest major update to Jest monorepo',
+    description: 'Add `ts-jest` `major` update to Jest monorepo.',
     packageRules: [
       {
         matchSourceUrlPrefixes: ['https://github.com/kulshekhar/ts-jest'],
@@ -649,7 +650,7 @@ const staticGroups = {
     ],
   },
   jestPlusTypes: {
-    description: 'Add @types/jest update to Jest monorepo',
+    description: 'Add `@types/jest` update to Jest monorepo.',
     packageRules: [
       {
         matchPackageNames: ['@types/jest'],
@@ -669,7 +670,7 @@ for (const monorepo of Object.keys(monorepos.presets)) {
   config[name] = {
     packageRules: [
       {
-        description: `Group packages from ${monorepo} monorepo together`,
+        description: `Group packages from ${monorepo} monorepo together.`, // Check me on on adding a full stop here
         extends: `monorepo:${monorepo}`,
         matchUpdateTypes: nonPinUpdateTypes,
         groupName: `${monorepo} monorepo`,
@@ -678,7 +679,7 @@ for (const monorepo of Object.keys(monorepos.presets)) {
   };
 }
 config.monorepos = {
-  description: 'Group known monorepo packages together',
+  description: 'Group known monorepo packages together.', // Check me on on adding a full stop here
   ignoreDeps: [],
   extends: monorepoNames,
 };

--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -670,7 +670,7 @@ for (const monorepo of Object.keys(monorepos.presets)) {
   config[name] = {
     packageRules: [
       {
-        description: `Group packages from ${monorepo} monorepo together.`, // Check me on on adding a full stop here
+        description: `Group packages from ${monorepo} monorepo together.`,
         extends: `monorepo:${monorepo}`,
         matchUpdateTypes: nonPinUpdateTypes,
         groupName: `${monorepo} monorepo`,
@@ -679,7 +679,7 @@ for (const monorepo of Object.keys(monorepos.presets)) {
   };
 }
 config.monorepos = {
-  description: 'Group known monorepo packages together.', // Check me on on adding a full stop here
+  description: 'Group known monorepo packages together.',
   ignoreDeps: [],
   extends: monorepoNames,
 };

--- a/lib/config/presets/internal/helpers.ts
+++ b/lib/config/presets/internal/helpers.ts
@@ -2,7 +2,7 @@ import type { Preset } from '../types';
 
 export const presets: Record<string, Preset> = {
   disableTypesNodeMajor: {
-    description: 'Disable major updates to <code>@types/node</code>',
+    description: 'Disable `major` updates to `@types/node`.',
     packageRules: [
       {
         matchPackageNames: ['@types/node'],
@@ -12,17 +12,15 @@ export const presets: Record<string, Preset> = {
     ],
   },
   followTypescriptNext: {
-    description:
-      'Keep <code>typescript</code> version in sync with the <code>next</code> tag',
+    description: 'Keep `typescript` version in sync with the `next` tag.',
     extends: [':followTag(typescript, next)'],
   },
   followTypescriptRc: {
-    description:
-      'Keep <code>typescript</code> version in sync with the <code>rc</code> tag',
+    description: 'Keep `typescript` version in sync with the `rc` tag.',
     extends: [':followTag(typescript, rc)'],
   },
   pinGitHubActionDigests: {
-    description: 'Pin <code>github-action</code> digests',
+    description: 'Pin `github-action` digests.',
     packageRules: [
       {
         matchDepTypes: ['action'],

--- a/lib/config/presets/internal/npm.ts
+++ b/lib/config/presets/internal/npm.ts
@@ -3,7 +3,7 @@ import type { Preset } from '../types';
 export const presets: Record<string, Preset> = {
   unpublishSafe: {
     description:
-      'Set a status check pending for 3 days from release timestamp to guard against npm unpublishing',
+      'Wait until the npm package is three days old before raising the update, this prevents npm unpublishing a package you already upgraded to.',
     npm: {
       stabilityDays: 3,
     },

--- a/lib/config/presets/internal/packages.ts
+++ b/lib/config/presets/internal/packages.ts
@@ -2,7 +2,7 @@ import type { Preset } from '../types';
 
 export const presets: Record<string, Preset> = {
   angularJs: {
-    description: 'All AngularJS packages',
+    description: 'All AngularJS packages.',
     matchPackageNames: [
       'angular',
       'angular-animate',
@@ -11,38 +11,38 @@ export const presets: Record<string, Preset> = {
     ],
   },
   react: {
-    description: 'All React packages',
+    description: 'All React packages.',
     matchPackageNames: ['@types/react'],
     matchPackagePrefixes: ['react'],
   },
   apollographql: {
-    description: 'All packages published by Apollo GraphQL',
+    description: 'All packages published by Apollo GraphQL.',
     matchSourceUrlPrefixes: ['https://github.com/apollographql/'],
   },
   mapbox: {
-    description: 'All Mapbox-related packages',
+    description: 'All Mapbox-related packages.',
     matchPackagePrefixes: ['leaflet', 'mapbox'],
   },
   emberTemplateLint: {
-    description: 'All ember-template-lint packages',
+    description: 'All ember-template-lint packages.',
     matchPackagePrefixes: ['ember-template-lint'],
   },
   eslint: {
-    description: 'All ESLint packages',
+    description: 'All ESLint packages.',
     matchPackageNames: ['@types/eslint', 'babel-eslint'],
     matchPackagePrefixes: ['@typescript-eslint/', 'eslint'],
   },
   stylelint: {
-    description: 'All Stylelint packages',
+    description: 'All Stylelint packages.',
     matchPackagePrefixes: ['stylelint'],
   },
   tslint: {
-    description: 'All TSLint packages',
+    description: 'All TSLint packages.',
     matchPackageNames: ['codelyzer'],
     matchPackagePatterns: ['\\btslint\\b'],
   },
   linters: {
-    description: 'All lint-related packages',
+    description: 'All lint-related packages.',
     extends: [
       'packages:emberTemplateLint',
       'packages:eslint',
@@ -52,12 +52,12 @@ export const presets: Record<string, Preset> = {
     matchPackageNames: ['remark-lint'],
   },
   postcss: {
-    description: 'All PostCSS packages',
+    description: 'All PostCSS packages.',
     matchPackageNames: ['postcss'],
     matchPackagePrefixes: ['postcss-'],
   },
   jsUnitTest: {
-    description: 'Unit test packages for JavaScript',
+    description: 'Unit test packages for JavaScript.',
     matchPackageNames: [
       '@types/chai',
       '@types/ember-mocha',
@@ -94,24 +94,24 @@ export const presets: Record<string, Preset> = {
     ],
   },
   unitTest: {
-    description: 'All unit test packages',
+    description: 'All unit test packages.',
     extends: ['packages:jsUnitTest'],
   },
   jsTest: {
-    description: 'JavaScript test packages',
+    description: 'JavaScript test packages.',
     extends: ['packages:jsUnitTest'],
   },
   test: {
-    description: 'Test packages',
+    description: 'Test packages.',
     extends: ['packages:unitTest'],
   },
   gatsby: {
-    description: 'All packages published by Gatsby',
+    description: 'All packages published by Gatsby.',
     extends: ['monorepo:gatsby'],
   },
   googleapis: {
     matchDatasources: ['npm'],
-    description: 'All googleapis packages',
+    description: 'All `googleapis` packages.',
     matchPackagePrefixes: ['@google-cloud/'],
   },
 };

--- a/lib/config/presets/internal/preview.ts
+++ b/lib/config/presets/internal/preview.ts
@@ -2,13 +2,13 @@ import type { Preset } from '../types';
 
 export const presets: Record<string, Preset> = {
   dockerCompose: {
-    description: 'Enable Docker Compose image updating',
+    description: 'Enable Docker Compose image updating.',
     'docker-compose': {
       enabled: true,
     },
   },
   dockerVersions: {
-    description: 'Upgrade Docker tags to newer versions',
+    description: 'Upgrade Docker tags to newer versions.',
     docker: {
       major: {
         enabled: true,
@@ -19,7 +19,7 @@ export const presets: Record<string, Preset> = {
     },
   },
   buildkite: {
-    description: 'Enable Buildkite functionality',
+    description: 'Enable Buildkite functionality.',
     buildkite: {
       enabled: true,
     },

--- a/lib/config/presets/internal/regex-managers.ts
+++ b/lib/config/presets/internal/regex-managers.ts
@@ -2,7 +2,7 @@ import type { Preset } from '../types';
 
 export const presets: Record<string, Preset> = {
   dockerfileVersions: {
-    description: 'Update _VERSION variables in Dockerfiles',
+    description: 'Update `_VERSION` variables in Dockerfiles.',
     regexManagers: [
       {
         fileMatch: ['(^|/|\\.)Dockerfile$', '(^|/)Dockerfile[^/]*$'],

--- a/lib/config/presets/internal/replacements.ts
+++ b/lib/config/presets/internal/replacements.ts
@@ -8,7 +8,7 @@ import {
 /* eslint sort-keys: ["error", "asc", {"caseSensitive": false, "natural": true}] */
 export const presets: Record<string, Preset> = {
   all: {
-    description: 'All replacements',
+    description: 'All replacements.',
     extends: [
       'replacements:babel-eslint-to-eslint-parser',
       'replacements:cucumber-to-scoped',
@@ -22,7 +22,7 @@ export const presets: Record<string, Preset> = {
     ],
   },
   'babel-eslint-to-eslint-parser': {
-    description: 'babel-eslint was renamed under the @babel scope',
+    description: '`babel-eslint` was renamed under the `@babel` scope.',
     packageRules: [
       {
         matchCurrentVersion: '>=7.11.0',
@@ -34,7 +34,7 @@ export const presets: Record<string, Preset> = {
     ],
   },
   'cucumber-to-scoped': {
-    description: 'cucumber became scoped',
+    description: '`cucumber` became scoped.',
     packageRules: [
       {
         matchDatasources: ['npm'],
@@ -45,7 +45,7 @@ export const presets: Record<string, Preset> = {
     ],
   },
   'hapi-to-scoped': {
-    description: 'hapi became scoped',
+    description: '`hapi` became scoped.',
     packageRules: [
       {
         matchCurrentVersion: '>=18.0.0',
@@ -57,7 +57,7 @@ export const presets: Record<string, Preset> = {
     ],
   },
   'jade-to-pug': {
-    description: 'Jade was renamed to Pug',
+    description: 'Jade was renamed to Pug.',
     packageRules: [
       {
         matchDatasources: ['npm'],
@@ -68,7 +68,7 @@ export const presets: Record<string, Preset> = {
     ],
   },
   'joi-to-scoped': {
-    description: 'joi became scoped under the hapi organization',
+    description: '`joi` became scoped under the `hapi` organization.',
     packageRules: [
       {
         matchCurrentVersion: '>=14.0.0 <14.4.0',
@@ -80,7 +80,7 @@ export const presets: Record<string, Preset> = {
     ],
   },
   'joi-to-unscoped': {
-    description: 'joi was moved out of the hapi organization',
+    description: '`joi` was moved out of the `hapi` organization.',
     packageRules: [
       {
         matchCurrentVersion: '>=17.0.0',
@@ -93,7 +93,7 @@ export const presets: Record<string, Preset> = {
   },
   'redux-devtools-extension-to-scope': {
     description:
-      'the redux-devtools-extension package was renamed to @redux-devtools/extension',
+      'The `redux-devtools-extension` package was renamed to `@redux-devtools/extension`.',
     packageRules: [
       {
         matchDatasources: ['npm'],
@@ -105,7 +105,7 @@ export const presets: Record<string, Preset> = {
   },
   'renovate-pep440-to-renovatebot-pep440': {
     description:
-      'the @renovate/pep440 package was renamed to @renovatebot/pep440',
+      'The `@renovate/pep440` package was renamed to `@renovatebot/pep440`.',
     packageRules: [
       {
         matchDatasources: ['npm'],
@@ -116,7 +116,7 @@ export const presets: Record<string, Preset> = {
     ],
   },
   'rollup-node-resolve-to-scoped': {
-    description: 'the node-resolve plugin for rollup became scoped',
+    description: 'The node-resolve plugin for rollup became scoped.',
     packageRules: [
       {
         matchDatasources: ['npm'],
@@ -127,7 +127,7 @@ export const presets: Record<string, Preset> = {
     ],
   },
   'xmldom-to-scoped': {
-    description: 'the xmldom package is now published as @xmldom/xmldom',
+    description: 'The `xmldom` package is now published as `@xmldom/xmldom`.',
     packageRules: [
       {
         matchDatasources: ['npm'],
@@ -155,7 +155,7 @@ const muiReplacement: Replacement[] = [
 
 const mui: PresetTemplate = {
   description:
-    'the material-ui monorepo org was renamed from @material-ui to @mui/',
+    'The `material-ui` monorepo org was renamed from `@material-ui` to `@mui`.',
   packageRules: {
     matchCurrentVersion: '>=4.0.0 <5.0.0',
     matchDatasources: ['npm'],

--- a/lib/config/presets/internal/schedule.ts
+++ b/lib/config/presets/internal/schedule.ts
@@ -2,40 +2,40 @@ import type { Preset } from '../types';
 
 export const presets: Record<string, Preset> = {
   earlyMondays: {
-    description: 'Weekly schedule on early monday mornings',
+    description: 'Weekly schedule on early Monday mornings.',
     schedule: ['before 3am on Monday'],
   },
   daily: {
-    description: 'Schedule daily',
+    description: 'Schedule daily.',
     schedule: ['before 2am'],
   },
   weekly: {
-    description: 'Schedule weekly',
+    description: 'Schedule weekly.',
     extends: ['schedule:earlyMondays'],
   },
   monthly: {
-    description: 'Schedule monthly',
+    description: 'Schedule monthly.',
     schedule: ['before 3am on the first day of the month'],
   },
   quarterly: {
-    description: 'Schedule quarterly',
+    description: 'Schedule quarterly.',
     schedule: ['every 3 months on the first day of the month'],
   },
   yearly: {
-    description: 'Schedule once a year (not recommended)',
+    description: 'Schedule once a year (not recommended).',
     schedule: ['every 12 months on the first day of the month'],
   },
   weekends: {
-    description: 'Schedule for weekends',
+    description: 'Schedule for weekends.',
     schedule: ['every weekend'],
   },
   weekdays: {
-    description: 'Schedule for weekdays',
+    description: 'Schedule for weekdays.',
     schedule: ['every weekday'],
   },
   nonOfficeHours: {
     description:
-      'Schedule for typical non-office hours (night time and weekends)',
+      'Schedule for typical non-office hours (night time and weekends).',
     schedule: [
       'after 10pm every weekday',
       'before 5am every weekday',

--- a/lib/config/presets/internal/workarounds.ts
+++ b/lib/config/presets/internal/workarounds.ts
@@ -3,7 +3,7 @@ import type { Preset } from '../types';
 export const presets: Record<string, Preset> = {
   all: {
     description: [
-      'A collection of workarounds for known problems with packages',
+      'A collection of workarounds for known problems with packages.',
     ],
     extends: [
       'workarounds:mavenCommonsAncientVersion',
@@ -17,7 +17,7 @@ export const presets: Record<string, Preset> = {
     ignoreDeps: [],
   },
   mavenCommonsAncientVersion: {
-    description: 'Fix some problems with very old Maven commons versions',
+    description: 'Fix some problems with very old Maven commons versions.',
     packageRules: [
       {
         matchDatasources: ['maven', 'sbt-package'],
@@ -27,7 +27,7 @@ export const presets: Record<string, Preset> = {
     ],
   },
   ignoreSpringCloudNumeric: {
-    description: 'Ignore spring cloud 1.x releases',
+    description: 'Ignore spring cloud `1.x` releases.',
     packageRules: [
       {
         matchDatasources: ['maven'],
@@ -39,7 +39,7 @@ export const presets: Record<string, Preset> = {
     ],
   },
   ignoreWeb3jCoreWithOldReleaseTimestamp: {
-    description: 'Ignore web3j 5.0.0 release',
+    description: 'Ignore `web3j` `5.0.0` release.',
     packageRules: [
       {
         matchDatasources: ['maven'],
@@ -49,7 +49,7 @@ export const presets: Record<string, Preset> = {
     ],
   },
   ignoreHttp4sDigestMilestones: {
-    description: 'Ignore http4s digest-based 1.x milestones',
+    description: 'Ignore `http4s` digest-based `1.x` milestones.',
     packageRules: [
       {
         matchManagers: ['sbt'],
@@ -59,7 +59,7 @@ export const presets: Record<string, Preset> = {
     ],
   },
   typesNodeVersioning: {
-    description: 'Use node versioning for @types/node',
+    description: 'Use node versioning for `@types/node`.',
     packageRules: [
       {
         matchManagers: ['npm'],
@@ -70,7 +70,7 @@ export const presets: Record<string, Preset> = {
   },
   reduceRepologyServerLoad: {
     description:
-      'Limit concurrent requests to reduce load on Repology servers until we can fix this properly, see issue 10133',
+      'Limit concurrent requests to reduce load on Repology servers until we can fix this properly, see issue `#10133`.',
     hostRules: [
       {
         matchHost: 'repology.org',
@@ -79,7 +79,7 @@ export const presets: Record<string, Preset> = {
     ],
   },
   doNotUpgradeFromAlpineStableToEdge: {
-    description: 'Do not upgrade from Alpine stable to edge',
+    description: 'Do not upgrade from Alpine stable to edge.',
     packageRules: [
       {
         matchDatasources: ['docker'],


### PR DESCRIPTION
## Changes

- Improve `description` field for internal presets:
  - Use full stop at end of sentences
  - Replace `<code>` `</code>` elements with backticks
  - Use `monospaced` font for package names
  - Use `monospaced` font for versions like `major`, `minor`, `patch`
  - Use `monospaced` font for version numbers like `v25`
  - Put your points positively
  - Expand abbreviation `JS` -> `JavaScript`
  - Capitalize the first word of a sentence

## Context

Closes #16321.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository