### PR TITLE
fix: switch changelog urls from http to https

### DIFF
--- a/lib/modules/datasource/metadata-manual.ts
+++ b/lib/modules/datasource/metadata-manual.ts
@@ -23,7 +23,7 @@ export const manualChangelogUrls: Record<string, Record<string, string>> = {
     django: 'https://github.com/django/django/tree/master/docs/releases',
     djangorestframework:
       'https://www.django-rest-framework.org/community/release-notes/',
-    flake8: 'http://flake8.pycqa.org/en/latest/release-notes/index.html',
+    flake8: 'https://flake8.pycqa.org/en/latest/release-notes/index.html',
     'django-storages':
       'https://github.com/jschneier/django-storages/blob/master/CHANGELOG.rst',
     hypothesis:
@@ -32,8 +32,8 @@ export const manualChangelogUrls: Record<string, Record<string, string>> = {
     mypy: 'https://mypy-lang.blogspot.com/',
     phonenumbers:
       'https://github.com/daviddrysdale/python-phonenumbers/blob/dev/python/HISTORY.md',
-    psycopg2: 'http://initd.org/psycopg/articles/tag/release/',
-    'psycopg2-binary': 'http://initd.org/psycopg/articles/tag/release/',
+    psycopg2: 'https://initd.org/psycopg/articles/tag/release/',
+    'psycopg2-binary': 'https://initd.org/psycopg/articles/tag/release/',
     pycountry:
       'https://github.com/flyingcircusio/pycountry/blob/master/HISTORY.txt',
     'django-debug-toolbar':


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Switch the remaining changelog URLs from HTTP to HTTPS

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

I noticed the flake8 url in a PR, and decided to fix the others as well.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
