### PR TITLE
fix(config): link to `configMigration` issue

### DIFF
--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -132,6 +132,7 @@ const options: RenovateOptions[] = [
     experimental: true,
     experimentalDescription:
       'Config migration PRs are still being improved, in particular to reduce the amount of reordering and whitespace changes.',
+    experimentalIssues: 16359,
   },
   {
     name: 'productLinks',

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -132,7 +132,7 @@ const options: RenovateOptions[] = [
     experimental: true,
     experimentalDescription:
       'Config migration PRs are still being improved, in particular to reduce the amount of reordering and whitespace changes.',
-    experimentalIssues: 16359,
+    experimentalIssues: [16359],
   },
   {
     name: 'productLinks',


### PR DESCRIPTION
## Changes

- Add link to #16359

## Context

> Yes, once I merge #16355 please then add `experimentalIssues` linking to a new issue you create called something like "Enable config migration by default"

I think this is what you wanted me to do?
 
I think we use the `experimentalIssues` field to auto-generate some docs?

https://github.com/renovatebot/renovate/blob/2b43f273bf0737ccf29b27cf55ecec69403bfdf1/tools/docs/config.ts#L167-L176

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
