### PR TITLE
fix(config): don't skip migration PR if closed PR found

### DIFF
--- a/lib/workers/repository/config-migration/pr/index.spec.ts
+++ b/lib/workers/repository/config-migration/pr/index.spec.ts
@@ -86,21 +86,6 @@ describe('workers/repository/config-migration/pr/index', () => {
       expect(platform.createPr).toHaveBeenCalledTimes(0);
     });
 
-    it('Founds a closed PR and exit', async () => {
-      platform.getBranchPr.mockResolvedValueOnce(null);
-      platform.findPr.mockResolvedValueOnce(
-        mock<Pr>({
-          title: 'Config Migration',
-        })
-      );
-      await ensureConfigMigrationPr(config, migratedData);
-      expect(platform.updatePr).toHaveBeenCalledTimes(0);
-      expect(platform.createPr).toHaveBeenCalledTimes(0);
-      expect(logger.debug).toHaveBeenCalledWith(
-        'Found closed migration PR, exiting...'
-      );
-    });
-
     it('Dry runs and does not update out of date PR', async () => {
       GlobalConfig.set({
         dryRun: 'full',

--- a/lib/workers/repository/config-migration/pr/index.ts
+++ b/lib/workers/repository/config-migration/pr/index.ts
@@ -4,7 +4,6 @@ import type { RenovateConfig } from '../../../../config/types';
 import { logger } from '../../../../logger';
 import { platform } from '../../../../modules/platform';
 import { hashBody } from '../../../../modules/platform/pr-body';
-import { PrState } from '../../../../types';
 import { emojify } from '../../../../util/emoji';
 import { deleteBranch } from '../../../../util/git';
 import * as template from '../../../../util/template';
@@ -27,11 +26,6 @@ export async function ensureConfigMigrationPr(
   const branchName = getMigrationBranchName(config);
   const prTitle = 'Migrate Renovate config';
   const existingPr = await platform.getBranchPr(branchName);
-  const closedPr = await platform.findPr({
-    branchName,
-    prTitle,
-    state: PrState.Closed,
-  });
   const filename = migratedConfigData.filename;
   logger.debug('Filling in config migration PR template');
   let prBody = `The Renovate config in this repository needs migrating. Typically this is because one or more configuration options you are using have been renamed.
@@ -81,10 +75,6 @@ ${
       });
       logger.info({ pr: existingPr.number }, 'Migration PR updated');
     }
-    return;
-  }
-  if (closedPr) {
-    logger.debug('Found closed migration PR, exiting...');
     return;
   }
   logger.debug('Creating migration PR');


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Removes current logic which skips creating a migration PR if a previous one was closed.

## Context

There may be many migrations needed over time. If a user wants to ignore it, they should disable the feature.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
