### PR TITLE
fix(github-tags): Use `releaseTimestamp` from `tagger` object

### DIFF
--- a/lib/modules/datasource/github-tags/cache.spec.ts
+++ b/lib/modules/datasource/github-tags/cache.spec.ts
@@ -28,6 +28,8 @@ describe('modules/datasource/github-tags/cache', () => {
             type: 'Tag',
             target: {
               hash: 'abc',
+            },
+            tagger: {
               releaseTimestamp: '2020-04-09T10:00:00.000Z',
             },
           },

--- a/lib/modules/datasource/github-tags/cache.ts
+++ b/lib/modules/datasource/github-tags/cache.ts
@@ -26,8 +26,10 @@ query ($owner: String!, $name: String!, $cursor: String, $count: Int!) {
             target {
               ... on Commit {
                 hash: oid
-                releaseTimestamp: committedDate
               }
+            }
+            tagger {
+              releaseTimestamp: date
             }
           }
         }
@@ -53,6 +55,8 @@ export interface FetchedTag {
         type: 'Tag';
         target: {
           hash: string;
+        };
+        tagger: {
           releaseTimestamp: string;
         };
       };
@@ -67,7 +71,7 @@ export class CacheableGithubTags extends AbstractGithubDatasourceCache<
   StoredTag,
   FetchedTag
 > {
-  readonly cacheNs = 'github-datasource-graphql-tags';
+  readonly cacheNs = 'github-datasource-graphql-tags-v2';
   readonly graphqlQuery = query;
 
   constructor(http: GithubHttp, opts: CacheOptions = {}) {
@@ -80,7 +84,8 @@ export class CacheableGithubTags extends AbstractGithubDatasourceCache<
       const { hash, releaseTimestamp } = target;
       return { version, hash, releaseTimestamp };
     } else if (target.type === 'Tag') {
-      const { hash, releaseTimestamp } = target.target;
+      const { hash } = target.target;
+      const { releaseTimestamp } = target.tagger;
       return { version, hash, releaseTimestamp };
     }
     return null;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Use `releaseTimestamp` from `tagger` object
- Don't using commit date
- ⚠️ **Reset all existing caches** ⚠️

## Context

- Closes: #16374
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
