### PR TITLE
refactor(github): Consume pages entirely during tags/releases caching

### DIFF
--- a/lib/modules/datasource/github-releases/cache/cache-base.spec.ts
+++ b/lib/modules/datasource/github-releases/cache/cache-base.spec.ts
@@ -270,7 +270,7 @@ describe('modules/datasource/github-releases/cache/cache-base', () => {
 
     expect(sortItems(res)).toMatchObject([
       { version: 'v1', bar: 'aaa' },
-      { version: 'v2', bar: 'bbb' },
+      { version: 'v2', bar: 'yyy' },
       { version: 'v3', bar: 'zzz' },
     ]);
   });

--- a/lib/modules/datasource/github-releases/cache/cache-base.ts
+++ b/lib/modules/datasource/github-releases/cache/cache-base.ts
@@ -288,7 +288,6 @@ export abstract class AbstractGithubDatasourceCache<
                   )
                 ) {
                   stopIteration = true;
-                  break;
                 }
 
                 cacheItems[version] = newStoredItem;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Update data with expired stability threshold from already fetched pages, just in case

## Context

- Ref: #16374

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
