### PR TITLE
fix(github): Return remote commit hash for `platformCommit=true`

### DIFF
--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -1693,8 +1693,8 @@ export async function commitFiles(
   config: CommitFilesConfig
 ): Promise<CommitSha | null> {
   const commitResult = await git.prepareCommit(config); // Commit locally and don't push
+  const { branchName, files } = config;
   if (!commitResult) {
-    const { branchName, files } = config;
     logger.debug(
       { branchName, files: files.map(({ path }) => path) },
       `Platform-native commit: unable to prepare for commit`
@@ -1706,7 +1706,9 @@ export async function commitFiles(
   if (!pushResult) {
     return null;
   }
-  // Because the branch commit was done remotely via REST API, now we git fetch it locally.
-  // We also do this step when committing/pushing using local git tooling.
-  return git.fetchCommit(config);
+  // Replace locally created branch with the remotely created one
+  // and return the remote commit SHA
+  await git.resetToCommit(commitResult.parentCommitSha);
+  const commitSha = await git.fetchCommit(config);
+  return commitSha;
 }

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -233,6 +233,11 @@ async function resetToBranch(branchName: string): Promise<void> {
   await git.raw(['clean', '-fd']);
 }
 
+export async function resetToCommit(commit: string): Promise<void> {
+  logger.debug(`resetToCommit(${commit})`);
+  await git.raw(['reset', '--hard', commit]);
+}
+
 async function deleteLocalBranch(branchName: string): Promise<void> {
   await git.branch(['-D', branchName]);
 }
@@ -975,7 +980,7 @@ export async function fetchCommit({
   logger.debug(`Fetching branch ${branchName}`);
   try {
     const ref = `refs/heads/${branchName}:refs/remotes/origin/${branchName}`;
-    await gitRetry(() => git.fetch(['origin', ref, '--force']));
+    await gitRetry(() => git.pull(['origin', ref, '--force']));
     const commit = (await git.revparse([branchName])).trim();
     config.branchCommits[branchName] = commit;
     config.branchIsModified[branchName] = false;

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -233,6 +233,7 @@ async function resetToBranch(branchName: string): Promise<void> {
   await git.raw(['clean', '-fd']);
 }
 
+// istanbul ignore next
 export async function resetToCommit(commit: string): Promise<void> {
   logger.debug(`resetToCommit(${commit})`);
   await git.raw(['reset', '--hard', commit]);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Ensure remotely created commit is present locally after API-based commit
<!-- Describe what behavior is changed by this PR. -->

## Context

- Closes: #16384
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
