### PR TITLE
fix: assign default versioning before applying package rules

### DIFF
--- a/lib/modules/datasource/index.spec.ts
+++ b/lib/modules/datasource/index.spec.ts
@@ -12,6 +12,7 @@ import type { DatasourceApi, GetReleasesConfig, ReleaseResult } from './types';
 import {
   getDatasourceList,
   getDatasources,
+  getDefaultVersioning,
   getDigest,
   getPkgReleases,
   supportsDigests,
@@ -107,6 +108,12 @@ describe('modules/datasource/index', () => {
 
   afterEach(() => {
     datasources.delete(datasource);
+  });
+
+  describe('getDefaultVersioning()', () => {
+    it('returns semver if undefined', () => {
+      expect(getDefaultVersioning(undefined)).toBe('semver');
+    });
   });
 
   describe('Validations', () => {

--- a/lib/modules/datasource/index.ts
+++ b/lib/modules/datasource/index.ts
@@ -230,7 +230,12 @@ function resolveRegistryUrls(
   return massageRegistryUrls(resolvedUrls);
 }
 
-export function getDefaultVersioning(datasourceName: string): string {
+export function getDefaultVersioning(
+  datasourceName: string | undefined
+): string {
+  if (!datasourceName) {
+    return 'semver';
+  }
   const datasource = getDatasourceFor(datasourceName);
   // istanbul ignore if: wrong regex manager config?
   if (!datasource) {

--- a/lib/workers/repository/process/fetch.ts
+++ b/lib/workers/repository/process/fetch.ts
@@ -4,7 +4,10 @@ import pAll from 'p-all';
 import { getManagerConfig, mergeChildConfig } from '../../../config';
 import type { RenovateConfig } from '../../../config/types';
 import { logger } from '../../../logger';
-import { getDefaultConfig } from '../../../modules/datasource';
+import {
+  getDefaultConfig,
+  getDefaultVersioning,
+} from '../../../modules/datasource';
 import type {
   PackageDependency,
   PackageFile,
@@ -39,6 +42,7 @@ async function fetchDepUpdates(
   let depConfig = mergeChildConfig(packageFileConfig, dep);
   const datasourceDefaultConfig = await getDefaultConfig(depConfig.datasource!);
   depConfig = mergeChildConfig(depConfig, datasourceDefaultConfig);
+  depConfig.versioning ??= getDefaultVersioning(depConfig.datasource);
   depConfig = applyPackageRules(depConfig);
   if (depConfig.ignoreDeps!.includes(depName!)) {
     logger.debug({ dependency: depName }, 'Dependency is ignored');


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Applies datasource default versioning after extraction, immediately before applying package rules.

## Context

Fixing a remediation problem. See comment below

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
