### PR TITLE
refactor(manager/jenkins): correct type-check for version

### DIFF
--- a/lib/modules/manager/jenkins/extract.ts
+++ b/lib/modules/manager/jenkins/extract.ts
@@ -19,7 +19,7 @@ function getDependency(plugin: JenkinsPlugin): PackageDependency {
 
   if (plugin.source?.version) {
     dep.currentValue = plugin.source.version.toString();
-    if (typeof plugin.source.version !== 'string') {
+    if (!is.string(plugin.source.version)) {
       dep.skipReason = 'invalid-version';
       logger.warn(
         { dep },

--- a/lib/modules/manager/jenkins/types.ts
+++ b/lib/modules/manager/jenkins/types.ts
@@ -3,7 +3,7 @@ export interface JenkinsPluginRenovate {
 }
 
 export interface JenkinsPluginSource {
-  version?: string;
+  version?: string | number;
   url?: string;
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Add `number` as a possible type for Jenkins plugin version

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->
Previously, the version property could be not-defined, or string. Therefore the `if (plugin.source?.version) {` narrowed the type to `string`, but that doesn't reflect reality where the type can be a `number` as well

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
