### PR TITLE
fix(gradle): resolve escaped registry URLs in gradle.properties

### DIFF
--- a/lib/modules/manager/gradle/extract.spec.ts
+++ b/lib/modules/manager/gradle/extract.spec.ts
@@ -232,7 +232,7 @@ describe('modules/manager/gradle/extract', () => {
 
     mockFs({
       'build.gradle': buildFile,
-      'gradle.properties': 'repositoryBaseURL: https://dummy.org/whatever',
+      'gradle.properties': 'repositoryBaseURL: https\\://dummy.org/whatever',
     });
 
     const res = await extractAllPackageFiles({} as ExtractConfig, [

--- a/lib/modules/manager/gradle/parser.ts
+++ b/lib/modules/manager/gradle/parser.ts
@@ -298,6 +298,7 @@ function processCustomRegistryUrl({
 
   try {
     if (registryUrl) {
+      registryUrl = registryUrl.replace(regEx(/\\/g), '');
       const { host, protocol } = url.parse(registryUrl);
       if (host && protocol) {
         return { urls: [registryUrl] };


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Replaces backslashes in Gradle registry URLs that may be introduced by escaping characters in `gradle.properties`

<!-- Describe what behavior is changed by this PR. -->

## Context

`gradle.properties` files follow the [convention of properties files](https://en.wikipedia.org/wiki/.properties) in which backslashes can be used for escaping characters. Currently, if this is used with registry URLs, e.g., `https\://foo.bar`, `url.parse(registryUrl);` does not work since `\` is not allowed in URLs. The effect is that `processCustomRegistryUrl()` returns null and the registry URL is ignored.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
