### PR TITLE
fix(npm): properly handle lock file maintenance for nested independent yarn workspaces

### DIFF
--- a/lib/modules/manager/npm/post-update/__snapshots__/yarn.spec.ts.snap
+++ b/lib/modules/manager/npm/post-update/__snapshots__/yarn.spec.ts.snap
@@ -365,6 +365,234 @@ Array [
 ]
 `;
 
+exports[`modules/manager/npm/post-update/yarn performs lock file maintenance in subdirectory independent workspaces using yarn v1.22.0 1`] = `
+Array [
+  Object {
+    "cmd": "yarn install --ignore-engines --ignore-platform --network-timeout 100000 --ignore-scripts",
+    "options": Object {
+      "cwd": "some-dir/sub_workspace",
+      "encoding": "utf-8",
+      "env": Object {
+        "CI": "true",
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+  Object {
+    "cmd": "npx yarn-deduplicate --strategy fewer",
+    "options": Object {
+      "cwd": "some-dir/sub_workspace",
+      "encoding": "utf-8",
+      "env": Object {
+        "CI": "true",
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+  Object {
+    "cmd": "yarn install --ignore-engines --ignore-platform --network-timeout 100000 --ignore-scripts",
+    "options": Object {
+      "cwd": "some-dir/sub_workspace",
+      "encoding": "utf-8",
+      "env": Object {
+        "CI": "true",
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+  Object {
+    "cmd": "npx yarn-deduplicate --strategy highest",
+    "options": Object {
+      "cwd": "some-dir/sub_workspace",
+      "encoding": "utf-8",
+      "env": Object {
+        "CI": "true",
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+  Object {
+    "cmd": "yarn install --ignore-engines --ignore-platform --network-timeout 100000 --ignore-scripts",
+    "options": Object {
+      "cwd": "some-dir/sub_workspace",
+      "encoding": "utf-8",
+      "env": Object {
+        "CI": "true",
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+]
+`;
+
+exports[`modules/manager/npm/post-update/yarn performs lock file maintenance in subdirectory independent workspaces using yarn v2.1.0 1`] = `
+Array [
+  Object {
+    "cmd": "yarn install",
+    "options": Object {
+      "cwd": "some-dir/sub_workspace",
+      "encoding": "utf-8",
+      "env": Object {
+        "CI": "true",
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+        "YARN_ENABLE_GLOBAL_CACHE": "1",
+        "YARN_ENABLE_IMMUTABLE_INSTALLS": "false",
+        "YARN_ENABLE_SCRIPTS": "0",
+        "YARN_HTTP_TIMEOUT": "100000",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+]
+`;
+
+exports[`modules/manager/npm/post-update/yarn performs lock file maintenance in subdirectory independent workspaces using yarn v2.2.0 1`] = `
+Array [
+  Object {
+    "cmd": "yarn install",
+    "options": Object {
+      "cwd": "some-dir/sub_workspace",
+      "encoding": "utf-8",
+      "env": Object {
+        "CI": "true",
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+        "YARN_ENABLE_GLOBAL_CACHE": "1",
+        "YARN_ENABLE_IMMUTABLE_INSTALLS": "false",
+        "YARN_ENABLE_SCRIPTS": "0",
+        "YARN_HTTP_TIMEOUT": "100000",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+  Object {
+    "cmd": "yarn dedupe --strategy highest",
+    "options": Object {
+      "cwd": "some-dir/sub_workspace",
+      "encoding": "utf-8",
+      "env": Object {
+        "CI": "true",
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+        "YARN_ENABLE_GLOBAL_CACHE": "1",
+        "YARN_ENABLE_IMMUTABLE_INSTALLS": "false",
+        "YARN_ENABLE_SCRIPTS": "0",
+        "YARN_HTTP_TIMEOUT": "100000",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+]
+`;
+
+exports[`modules/manager/npm/post-update/yarn performs lock file maintenance in subdirectory independent workspaces using yarn v3.0.0 1`] = `
+Array [
+  Object {
+    "cmd": "yarn install --mode=update-lockfile",
+    "options": Object {
+      "cwd": "some-dir/sub_workspace",
+      "encoding": "utf-8",
+      "env": Object {
+        "CI": "true",
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+        "YARN_ENABLE_GLOBAL_CACHE": "1",
+        "YARN_ENABLE_IMMUTABLE_INSTALLS": "false",
+        "YARN_HTTP_TIMEOUT": "100000",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+  Object {
+    "cmd": "yarn dedupe --strategy highest --mode=update-lockfile",
+    "options": Object {
+      "cwd": "some-dir/sub_workspace",
+      "encoding": "utf-8",
+      "env": Object {
+        "CI": "true",
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+        "YARN_ENABLE_GLOBAL_CACHE": "1",
+        "YARN_ENABLE_IMMUTABLE_INSTALLS": "false",
+        "YARN_HTTP_TIMEOUT": "100000",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+]
+`;
+
 exports[`modules/manager/npm/post-update/yarn performs lock file maintenance using yarn v1.22.0 1`] = `
 Array [
   Object {

--- a/lib/modules/manager/npm/post-update/yarn.ts
+++ b/lib/modules/manager/npm/post-update/yarn.ts
@@ -16,7 +16,6 @@ import type {
   ToolConstraint,
 } from '../../../../util/exec/types';
 import {
-  deleteLocalFile,
   localPathIsFile,
   readLocalFile,
   writeLocalFile,
@@ -251,12 +250,19 @@ export async function generateLockFile(
       logger.debug(
         `Removing ${lockFileName} first due to lock file maintenance upgrade`
       );
+
+      // Note: Instead of just deleting the `yarn.lock` file, we just wipe it
+      // and keep an empty lock file. Deleting the lock file could result in different
+      // Yarn semantics. e.g. Yarn 2+ will error when `yarn install` is executed in
+      // a subdirectory which is not part of a Yarn workspace. Yarn suggests to create
+      // an empty lock file if a subdirectory should be treated as its own workspace.
+      // https://github.com/yarnpkg/berry/blob/20612e82d26ead5928cc27bf482bb8d62dde87d3/packages/yarnpkg-core/sources/Project.ts#L284.
       try {
-        await deleteLocalFile(lockFileName);
+        await writeLocalFile(lockFileName, '');
       } catch (err) /* istanbul ignore next */ {
         logger.debug(
           { err, lockFileName },
-          'Error removing yarn.lock for lock file maintenance'
+          'Error clearing `yarn.lock` for lock file maintenance'
         );
       }
     }


### PR DESCRIPTION
If a separate Yarn "project" is nested inside a project, `yarn install`
cannot be simply run with Yarn Berry 2+ if there is no lock file.

This check/enforcement makes sense because Yarn 2+ wants to make sure
you either add this as a workspace using their workspaces feature, or
you explicitly opt-in into a dedicated/independent "sub workspace".

Currently when Renovate processes such an independent/isolated
sub-workspace, it removes the `yarn.lock` for lock file maintancen. This
will then result in the enforcement error when `yarn install` is
executed to actually re-generate the lock file.

See Yarn's error:

```
Usage Error: The nearest package directory (/tmp/renovate/repos/github/angular/dev-infra/tools/ts_proto) doesn't seem to be part of the project declared in /tmp/renovate/repos/github/angular/dev-infra.

- If /tmp/renovate/repos/github/angular/dev-infra isn't intended to be a project, remove any yarn.lock and/or package.json file there.
- If /tmp/renovate/repos/github/angular/dev-infra is intended to be a project, it might be that you forgot to list tools/ts_proto in its workspace configuration.
- Finally, if /tmp/renovate/repos/github/angular/dev-infra is fine and you intend tools/ts_proto to be treated as a completely separate project (not even a workspace), create an empty yarn.lock file in it.
```

We can fix this, preserving the original decision (of the subdirectory
being an independent workspace), by not deleting the lock file, but
rather by just wiping it (to trigger the full regeneration).

Example error PR without the fix:
https://github.com/angular/dev-infra/pull/676#issuecomment-1173434652.

## How I've tested my work (please tick one)

I have verified these changes via:

- [X] Code inspection only, or
- [X] Newly added/modified unit tests


**Note**: *Not actually tested in a full runtime, just unit tests which mock out the actual Yarn install though..*

