### PR TITLE
refactor(fs): Add tests for every filesystem function

### DIFF
--- a/lib/modules/manager/terraform/lockfile/hash.ts
+++ b/lib/modules/manager/terraform/lockfile/hash.ts
@@ -73,7 +73,7 @@ export class TerraformProviderHash {
       `Downloading archive and generating hash for ${build.name}-${build.version}...`
     );
     const readStream = TerraformProviderHash.http.stream(build.url);
-    const writeStream = fs.createWriteStream(downloadFileName);
+    const writeStream = fs.createCacheWriteStream(downloadFileName);
 
     try {
       await fs.pipeline(readStream, writeStream);

--- a/lib/util/fs/index.spec.ts
+++ b/lib/util/fs/index.spec.ts
@@ -1,23 +1,32 @@
 import _findUp from 'find-up';
 import fs from 'fs-extra';
-import { withDir } from 'tmp-promise';
+import tmp, { DirectoryResult } from 'tmp-promise';
 import { join } from 'upath';
 import { envMock } from '../../../test/exec-util';
 import { env, mockedFunction } from '../../../test/util';
 import { GlobalConfig } from '../../config/global';
 import {
   chmodLocalFile,
+  createCacheWriteStream,
+  deleteLocalFile,
   ensureCacheDir,
+  ensureDir,
   ensureLocalDir,
   findLocalSiblingOrParent,
   findUpLocal,
   getParentDir,
   getSiblingFileName,
+  listCacheDir,
   localPathExists,
   localPathIsFile,
   outputCacheFile,
+  privateCacheDir,
+  readCacheFile,
   readLocalDirectory,
   readLocalFile,
+  readSystemFile,
+  renameLocalFile,
+  rmCache,
   statLocalFile,
   writeLocalFile,
 } from '.';
@@ -28,6 +37,19 @@ jest.mock('find-up');
 const findUp = mockedFunction(_findUp);
 
 describe('util/fs/index', () => {
+  let dirResult: DirectoryResult;
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    GlobalConfig.set({ localDir: '' });
+    dirResult = await tmp.dir({ unsafeCleanup: true });
+    tmpDir = dirResult.path;
+  });
+
+  afterEach(async () => {
+    await dirResult.cleanup();
+  });
+
   describe('getParentDir', () => {
     test.each`
       dir            | expected
@@ -64,10 +86,6 @@ describe('util/fs/index', () => {
   });
 
   describe('readLocalFile', () => {
-    beforeEach(() => {
-      GlobalConfig.set({ localDir: '' });
-    });
-
     it('reads buffer', async () => {
       expect(await readLocalFile(__filename)).toBeInstanceOf(Buffer);
     });
@@ -82,124 +100,68 @@ describe('util/fs/index', () => {
     });
   });
 
-  describe('localPathExists', () => {
-    it('returns true for file', async () => {
-      expect(await localPathExists(__filename)).toBeTrue();
-    });
+  describe('writeLocalFile', () => {
+    it('outputs file', async () => {
+      const localDir = tmpDir;
+      GlobalConfig.set({ localDir });
+      await writeLocalFile('foo/bar/file.txt', 'foobar');
 
-    it('returns true for directory', async () => {
-      expect(await localPathExists(getParentDir(__filename))).toBeTrue();
-    });
-
-    it('returns false', async () => {
-      expect(await localPathExists(__filename.replace('.ts', '.txt'))).toBe(
-        false
-      );
+      const path = `${localDir}/foo/bar/file.txt`;
+      expect(await fs.pathExists(path)).toBeTrue();
+      expect(await fs.readFile(path, 'utf8')).toBe('foobar');
     });
   });
 
-  describe('findLocalSiblingOrParent', () => {
-    it('returns path for file', async () => {
-      await withDir(
-        async (localDir) => {
-          GlobalConfig.set({
-            localDir: localDir.path,
-          });
+  describe('deleteLocalFile', () => {
+    it('deletes file', async () => {
+      const localDir = tmpDir;
+      GlobalConfig.set({ localDir });
+      const filePath = `${localDir}/foo/bar/file.txt`;
+      await fs.outputFile(filePath, 'foobar');
 
-          await writeLocalFile('crates/one/Cargo.toml', '');
-          await writeLocalFile('Cargo.lock', '');
-
-          expect(
-            await findLocalSiblingOrParent(
-              'crates/one/Cargo.toml',
-              'Cargo.lock'
-            )
-          ).toBe('Cargo.lock');
-          expect(
-            await findLocalSiblingOrParent(
-              'crates/one/Cargo.toml',
-              'Cargo.mock'
-            )
-          ).toBeNull();
-
-          await writeLocalFile('crates/one/Cargo.lock', '');
-
-          expect(
-            await findLocalSiblingOrParent(
-              'crates/one/Cargo.toml',
-              'Cargo.lock'
-            )
-          ).toBe('crates/one/Cargo.lock');
-          expect(
-            await findLocalSiblingOrParent('crates/one', 'Cargo.lock')
-          ).toBe('Cargo.lock');
-          expect(
-            await findLocalSiblingOrParent(
-              'crates/one/Cargo.toml',
-              'Cargo.mock'
-            )
-          ).toBeNull();
-        },
-        {
-          unsafeCleanup: true,
-        }
-      );
-    });
-
-    it('immediately returns null when either path is absolute', async () => {
-      expect(await findLocalSiblingOrParent('/etc/hosts', 'other')).toBeNull();
-      expect(await findLocalSiblingOrParent('other', '/etc/hosts')).toBeNull();
+      expect(await fs.pathExists(filePath)).toBeTrue();
+      await deleteLocalFile('foo/bar/file.txt');
+      expect(await fs.pathExists(filePath)).toBeFalse();
     });
   });
 
-  describe('readLocalDirectory', () => {
-    it('returns dir content', async () => {
-      await withDir(
-        async (localDir) => {
-          GlobalConfig.set({
-            localDir: localDir.path,
-          });
-          await writeLocalFile('test/Cargo.toml', '');
-          await writeLocalFile('test/Cargo.lock', '');
+  describe('renameLocalFile', () => {
+    it('renames file', async () => {
+      const localDir = tmpDir;
+      GlobalConfig.set({ localDir });
+      const sourcePath = `${localDir}/foo.txt`;
+      const targetPath = `${localDir}/bar.txt`;
+      await fs.outputFile(sourcePath, 'foobar');
 
-          const result = await readLocalDirectory('test');
-          expect(result).not.toBeNull();
-          expect(result).toBeArrayOfSize(2);
-          expect(result).toMatchSnapshot();
-
-          await writeLocalFile('Cargo.lock', '');
-          await writeLocalFile('/test/subdir/Cargo.lock', '');
-
-          const resultWithAdditionalFiles = await readLocalDirectory('test');
-          expect(resultWithAdditionalFiles).not.toBeNull();
-          expect(resultWithAdditionalFiles).toBeArrayOfSize(3);
-          expect(resultWithAdditionalFiles).toMatchSnapshot();
-        },
-        {
-          unsafeCleanup: true,
-        }
-      );
+      expect(await fs.pathExists(sourcePath)).toBeTrue();
+      expect(await fs.pathExists(targetPath)).toBeFalse();
+      await renameLocalFile('foo.txt', 'bar.txt');
+      expect(await fs.pathExists(sourcePath)).toBeFalse();
+      expect(await fs.pathExists(targetPath)).toBeTrue();
     });
+  });
 
-    it('return empty array for non existing directory', async () => {
-      await withDir(
-        async (localDir) => {
-          GlobalConfig.set({
-            localDir: localDir.path,
-          });
-          await expect(readLocalDirectory('somedir')).rejects.toThrow();
-        },
-        {
-          unsafeCleanup: true,
-        }
-      );
+  describe('ensureDir', () => {
+    it('creates directory', async () => {
+      const localDir = tmpDir;
+      GlobalConfig.set({ localDir });
+      const path = `${localDir}/foo/bar`;
+
+      await ensureDir(path);
+      const stat = await fs.stat(path);
+      expect(stat.isDirectory()).toBeTrue();
     });
+  });
 
-    it('return empty array for a existing but empty directory', async () => {
-      await ensureLocalDir('somedir');
-      const result = await readLocalDirectory('somedir');
-      expect(result).not.toBeNull();
-      expect(result).toBeArrayOfSize(0);
+  describe('ensureLocalDir', () => {
+    it('creates local directory', async () => {
+      const localDir = tmpDir;
+      GlobalConfig.set({ localDir });
+      const path = `${localDir}/foo/bar`;
+
+      await ensureLocalDir('foo/bar');
+      const stat = await fs.stat(path);
+      expect(stat.isDirectory()).toBeTrue();
     });
   });
 
@@ -224,23 +186,123 @@ describe('util/fs/index', () => {
     }
 
     it('prefers environment variables over global config', async () => {
-      await withDir(
-        async (tmpDir) => {
-          const { dirFromEnv } = setupMock(tmpDir.path);
-          const res = await ensureCacheDir('bundler');
-          expect(res).toEqual(dirFromEnv);
-          expect(await fs.pathExists(dirFromEnv)).toBeTrue();
-        },
-        { unsafeCleanup: true }
+      const { dirFromEnv } = setupMock(tmpDir);
+      const res = await ensureCacheDir('bundler');
+      expect(res).toEqual(dirFromEnv);
+      expect(await fs.pathExists(dirFromEnv)).toBeTrue();
+    });
+  });
+
+  describe('privateCacheDir', () => {
+    it('returns cache dir', () => {
+      GlobalConfig.set({ cacheDir: '/tmp/foo/bar' });
+      expect(privateCacheDir()).toBe(`/tmp/foo/bar/__renovate-private-cache`);
+    });
+  });
+
+  describe('localPathExists', () => {
+    it('returns true for file', async () => {
+      expect(await localPathExists(__filename)).toBeTrue();
+    });
+
+    it('returns true for directory', async () => {
+      expect(await localPathExists(getParentDir(__filename))).toBeTrue();
+    });
+
+    it('returns false', async () => {
+      expect(await localPathExists(__filename.replace('.ts', '.txt'))).toBe(
+        false
       );
     });
   });
 
-  describe('localPathIsFile', () => {
-    beforeEach(() => {
-      GlobalConfig.set({ localDir: '' });
+  describe('findLocalSiblingOrParent', () => {
+    it('returns path for file', async () => {
+      const localDir = tmpDir;
+      GlobalConfig.set({ localDir });
+
+      await writeLocalFile('crates/one/Cargo.toml', 'foo');
+      await writeLocalFile('Cargo.lock', 'bar');
+
+      expect(
+        await findLocalSiblingOrParent('crates/one/Cargo.toml', 'Cargo.lock')
+      ).toBe('Cargo.lock');
+      expect(
+        await findLocalSiblingOrParent('crates/one/Cargo.toml', 'Cargo.mock')
+      ).toBeNull();
+
+      await writeLocalFile('crates/one/Cargo.lock', '');
+
+      expect(
+        await findLocalSiblingOrParent('crates/one/Cargo.toml', 'Cargo.lock')
+      ).toBe('crates/one/Cargo.lock');
+      expect(await findLocalSiblingOrParent('crates/one', 'Cargo.lock')).toBe(
+        'Cargo.lock'
+      );
+      expect(
+        await findLocalSiblingOrParent('crates/one/Cargo.toml', 'Cargo.mock')
+      ).toBeNull();
     });
 
+    it('immediately returns null when either path is absolute', async () => {
+      expect(await findLocalSiblingOrParent('/etc/hosts', 'other')).toBeNull();
+      expect(await findLocalSiblingOrParent('other', '/etc/hosts')).toBeNull();
+    });
+  });
+
+  describe('readLocalDirectory', () => {
+    it('returns dir content', async () => {
+      const localDir = tmpDir;
+      GlobalConfig.set({ localDir });
+      await writeLocalFile('test/Cargo.toml', '');
+      await writeLocalFile('test/Cargo.lock', '');
+
+      const result = await readLocalDirectory('test');
+      expect(result).not.toBeNull();
+      expect(result).toBeArrayOfSize(2);
+      expect(result).toMatchSnapshot();
+
+      await writeLocalFile('Cargo.lock', '');
+      await writeLocalFile('/test/subdir/Cargo.lock', '');
+
+      const resultWithAdditionalFiles = await readLocalDirectory('test');
+      expect(resultWithAdditionalFiles).not.toBeNull();
+      expect(resultWithAdditionalFiles).toBeArrayOfSize(3);
+      expect(resultWithAdditionalFiles).toMatchSnapshot();
+    });
+
+    it('return empty array for non existing directory', async () => {
+      const localDir = tmpDir;
+      GlobalConfig.set({ localDir });
+      await expect(readLocalDirectory('somedir')).rejects.toThrow();
+    });
+
+    it('return empty array for a existing but empty directory', async () => {
+      await ensureLocalDir('somedir');
+      const result = await readLocalDirectory('somedir');
+      expect(result).not.toBeNull();
+      expect(result).toBeArrayOfSize(0);
+    });
+  });
+
+  describe('createCacheWriteStream', () => {
+    it('creates write stream', async () => {
+      const path = `${tmpDir}/file.txt`;
+      await fs.outputFile(path, 'foo');
+
+      const stream = createCacheWriteStream(path);
+      expect(stream).toBeInstanceOf(fs.WriteStream);
+
+      const write = new Promise((resolve, reject) => {
+        stream.write('bar');
+        stream.close(resolve);
+      });
+      await write;
+      expect(await fs.readFile(path, 'utf8')).toBe('bar');
+    });
+  });
+
+  describe('localPathIsFile', () => {
     it('returns true for file', async () => {
       expect(await localPathIsFile(__filename)).toBeTrue();
     });
@@ -280,60 +342,88 @@ describe('util/fs/index', () => {
     });
   });
 
-  describe('statLocalFile', () => {
-    it('works', async () => {
-      await withDir(
-        async (tmpDir) => {
-          GlobalConfig.set({ localDir: tmpDir.path });
+  describe('chmodLocalFile', () => {
+    it('changes file mode', async () => {
+      const localDir = tmpDir;
+      GlobalConfig.set({ localDir });
+      await writeLocalFile('foo', 'bar');
+      let stat = await statLocalFile('foo');
+      const oldMode = stat!.mode & 0o777;
+      const newMode = oldMode & 0o555; // Remove `write` attributes (Windows-compatible)
 
-          expect(await statLocalFile('foo')).toBeNull();
+      await chmodLocalFile('foo', newMode);
+      stat = await statLocalFile('foo');
+      expect(stat!.mode & 0o777).toBe(newMode);
 
-          await writeLocalFile('foo', 'bar');
-          const stat = await statLocalFile('foo');
-          expect(stat).toBeDefined();
-          expect(stat!.isFile()).toBeTrue();
-        },
-        { unsafeCleanup: true }
-      );
+      await chmodLocalFile('foo', oldMode);
+      stat = await statLocalFile('foo');
+      expect(stat!.mode & 0o777).toBe(oldMode);
     });
   });
 
-  describe('chmodLocalFile', () => {
-    it('works', async () => {
-      await withDir(
-        async (tmpDir) => {
-          GlobalConfig.set({ localDir: tmpDir.path });
-          await writeLocalFile('foo', 'bar');
-          let stat = await statLocalFile('foo');
-          const oldMode = stat!.mode & 0o777;
-          const newMode = oldMode & 0o555; // Remove `write` attributes (Windows-compatible)
+  describe('statLocalFile', () => {
+    it('returns stat object', async () => {
+      const localDir = tmpDir;
+      GlobalConfig.set({ localDir });
 
-          await chmodLocalFile('foo', newMode);
-          stat = await statLocalFile('foo');
-          expect(stat!.mode & 0o777).toBe(newMode);
+      expect(await statLocalFile('foo')).toBeNull();
 
-          await chmodLocalFile('foo', oldMode);
-          stat = await statLocalFile('foo');
-          expect(stat!.mode & 0o777).toBe(oldMode);
-        },
-        { unsafeCleanup: true }
+      await writeLocalFile('foo', 'bar');
+      const stat = await statLocalFile('foo');
+      expect(stat).toBeTruthy();
+      expect(stat!.isFile()).toBeTrue();
+    });
+  });
+
+  describe('listCacheDir', () => {
+    it('lists directory', async () => {
+      const cacheDir = tmpDir;
+      GlobalConfig.set({ cacheDir });
+      await fs.outputFile(`${cacheDir}/foo/bar.txt`, 'foobar');
+      expect(await listCacheDir(`${cacheDir}/foo`)).toEqual(['bar.txt']);
+    });
+  });
+
+  describe('rmCache', () => {
+    it('removes cache dir', async () => {
+      const cacheDir = tmpDir;
+      GlobalConfig.set({ cacheDir });
+      await fs.outputFile(`${cacheDir}/foo/bar/file.txt`, 'foobar');
+      await rmCache(`${cacheDir}/foo/bar`);
+      expect(await fs.pathExists(`${cacheDir}/foo/bar/file.txt`)).toBeFalse();
+      expect(await fs.pathExists(`${cacheDir}/foo/bar`)).toBeFalse();
+    });
+  });
+
+  describe('readCacheFile', () => {
+    it('reads file', async () => {
+      const cacheDir = tmpDir;
+      GlobalConfig.set({ cacheDir });
+      await fs.outputFile(`${cacheDir}/foo/bar/file.txt`, 'foobar');
+      expect(await readCacheFile(`${cacheDir}/foo/bar/file.txt`, 'utf8')).toBe(
+        'foobar'
+      );
+      expect(await readCacheFile(`${cacheDir}/foo/bar/file.txt`)).toEqual(
+        Buffer.from('foobar')
       );
     });
   });
 
   describe('outputCacheFile', () => {
-    it('works', async () => {
-      await withDir(
-        async ({ path }) => {
-          const fsOutputFile = jest.spyOn(fs, 'outputFile');
-          const file = join(path, 'some-file');
-          await outputCacheFile(file, 'foobar');
-          const res = await fs.readFile(file, 'utf8');
-          expect(res).toBe('foobar');
-          expect(fsOutputFile).toHaveBeenCalledWith(file, 'foobar', {});
-        },
-        { unsafeCleanup: true }
-      );
+    it('outputs file', async () => {
+      const file = join(tmpDir, 'some-file');
+      await outputCacheFile(file, 'foobar');
+      const res = await fs.readFile(file, 'utf8');
+      expect(res).toBe('foobar');
+    });
+  });
+
+  describe('readSystemFile', () => {
+    it('reads file', async () => {
+      const path = `${tmpDir}/file.txt`;
+      await fs.outputFile(path, 'foobar', { encoding: 'utf8' });
+      expect(await readSystemFile(path, 'utf8')).toBe('foobar');
+      expect(await readSystemFile(path)).toEqual(Buffer.from('foobar'));
     });
   });
 });

--- a/lib/util/fs/index.ts
+++ b/lib/util/fs/index.ts
@@ -61,7 +61,6 @@ export async function deleteLocalFile(fileName: string): Promise<void> {
   }
 }
 
-// istanbul ignore next
 export async function renameLocalFile(
   fromFile: string,
   toFile: string
@@ -70,14 +69,12 @@ export async function renameLocalFile(
   await fs.move(upath.join(localDir, fromFile), upath.join(localDir, toFile));
 }
 
-// istanbul ignore next
 export async function ensureDir(dirName: string): Promise<void> {
   if (is.nonEmptyString(dirName)) {
     await fs.ensureDir(dirName);
   }
 }
 
-// istanbul ignore next
 export async function ensureLocalDir(dirName: string): Promise<void> {
   const { localDir } = GlobalConfig.get();
   const localDirName = upath.join(localDir, dirName);
@@ -151,7 +148,7 @@ export async function readLocalDirectory(path: string): Promise<string[]> {
   return fileList;
 }
 
-export function createWriteStream(path: string): fs.WriteStream {
+export function createCacheWriteStream(path: string): fs.WriteStream {
   return fs.createWriteStream(path);
 }
 
@@ -216,12 +213,10 @@ export async function statLocalFile(
   }
 }
 
-// istanbul ignore next
 export function listCacheDir(path: string): Promise<string[]> {
   return fs.readdir(path);
 }
 
-// istanbul ignore next
 export async function rmCache(path: string): Promise<void> {
   await fs.rm(path, { recursive: true });
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Add tests and fix coverage
- Refactor `createWriteStream` to `createCacheWriteStream`

## Context

- Ref: #16313
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
