### PR TITLE
refactor(fs): Use utf-8 as the default file encoding

### DIFF
--- a/lib/modules/manager/batect/extract.ts
+++ b/lib/modules/manager/batect/extract.ts
@@ -159,7 +159,7 @@ export async function extractAllPackageFiles(
     filesToExamine.delete(packageFile);
     filesAlreadyExamined.add(packageFile);
 
-    const content = await readLocalFile(packageFile, 'utf8');
+    const content = await readLocalFile(packageFile);
     // TODO #7154
     const result = extractPackageFile(content!, packageFile);
 

--- a/lib/modules/manager/bundler/artifacts.ts
+++ b/lib/modules/manager/bundler/artifacts.ts
@@ -12,6 +12,7 @@ import { exec } from '../../../util/exec';
 import type { ExecOptions } from '../../../util/exec/types';
 import {
   ensureCacheDir,
+  readLocalBlob,
   readLocalFile,
   writeLocalFile,
 } from '../../../util/fs';
@@ -56,7 +57,7 @@ export async function updateArtifacts(
     throw new Error(existingError);
   }
   const lockFileName = `${packageFileName}.lock`;
-  const existingLockFileContent = await readLocalFile(lockFileName, 'utf8');
+  const existingLockFileContent = await readLocalFile(lockFileName);
   if (!existingLockFileContent) {
     logger.debug('No Gemfile.lock found');
     return null;
@@ -164,7 +165,7 @@ export async function updateArtifacts(
       return null;
     }
     logger.debug('Returning updated Gemfile.lock');
-    const lockFileContent = await readLocalFile(lockFileName);
+    const lockFileContent = await readLocalBlob(lockFileName);
     return [
       {
         file: {

--- a/lib/modules/manager/bundler/common.ts
+++ b/lib/modules/manager/bundler/common.ts
@@ -34,7 +34,7 @@ export async function getRubyConstraint(
       packageFileName,
       '.ruby-version'
     );
-    const rubyVersionFileContent = await readLocalFile(rubyVersionFile, 'utf8');
+    const rubyVersionFileContent = await readLocalFile(rubyVersionFile);
     if (rubyVersionFileContent) {
       logger.debug('Using ruby version specified in .ruby-version');
       return rubyVersionFileContent

--- a/lib/modules/manager/bundler/extract.ts
+++ b/lib/modules/manager/bundler/extract.ts
@@ -185,7 +185,7 @@ export async function extractPackageFile(
 
   if (fileName) {
     const gemfileLock = fileName + '.lock';
-    const lockContent = await readLocalFile(gemfileLock, 'utf8');
+    const lockContent = await readLocalFile(gemfileLock);
     if (lockContent) {
       logger.debug({ packageFile: fileName }, 'Found Gemfile.lock file');
       res.lockFiles = [gemfileLock];

--- a/lib/modules/manager/cargo/artifacts.ts
+++ b/lib/modules/manager/cargo/artifacts.ts
@@ -5,7 +5,7 @@ import { exec } from '../../../util/exec';
 import type { ExecOptions } from '../../../util/exec/types';
 import {
   findLocalSiblingOrParent,
-  readLocalFile,
+  readLocalBlob,
   writeLocalFile,
 } from '../../../util/fs';
 import type { UpdateArtifact, UpdateArtifactsResult } from '../types';
@@ -55,7 +55,7 @@ export async function updateArtifacts({
     'Cargo.lock'
   );
   const existingLockFileContent = lockFileName
-    ? await readLocalFile(lockFileName)
+    ? await readLocalBlob(lockFileName)
     : null;
   if (!existingLockFileContent || !lockFileName) {
     logger.debug('No Cargo.lock found');
@@ -66,7 +66,7 @@ export async function updateArtifacts({
     logger.debug('Updating ' + lockFileName);
     await cargoUpdate(packageFileName, isLockFileMaintenance);
     logger.debug('Returning updated Cargo.lock');
-    const newCargoLockContent = await readLocalFile(lockFileName);
+    const newCargoLockContent = await readLocalBlob(lockFileName);
     if (existingLockFileContent === newCargoLockContent) {
       logger.debug('Cargo.lock is unchanged');
       return null;

--- a/lib/modules/manager/cargo/extract.ts
+++ b/lib/modules/manager/cargo/extract.ts
@@ -93,7 +93,7 @@ function extractFromSection(
 async function readCargoConfig(): Promise<CargoConfig | null> {
   for (const configName of ['config.toml', 'config']) {
     const path = `.cargo/${configName}`;
-    const payload = await readLocalFile(path, 'utf8');
+    const payload = await readLocalFile(path);
     if (payload) {
       try {
         return parse(payload) as CargoConfig;

--- a/lib/modules/manager/cocoapods/artifacts.ts
+++ b/lib/modules/manager/cocoapods/artifacts.ts
@@ -7,6 +7,7 @@ import type { ExecOptions } from '../../../util/exec/types';
 import {
   ensureCacheDir,
   getSiblingFileName,
+  readLocalBlob,
   readLocalFile,
   writeLocalFile,
 } from '../../../util/fs';
@@ -58,7 +59,7 @@ export async function updateArtifacts({
     ];
   }
 
-  const existingLockFileContent = await readLocalFile(lockFileName, 'utf8');
+  const existingLockFileContent = await readLocalFile(lockFileName);
   if (!existingLockFileContent) {
     logger.debug(`Lockfile not found: ${lockFileName}`);
     return null;
@@ -110,7 +111,7 @@ export async function updateArtifacts({
     return null;
   }
   logger.debug(`Returning updated lockfile: ${lockFileName}`);
-  const lockFileContent = await readLocalFile(lockFileName);
+  const lockFileContent = await readLocalBlob(lockFileName);
   const res: UpdateArtifactsResult[] = [
     {
       file: {
@@ -123,14 +124,14 @@ export async function updateArtifacts({
 
   const podsDir = upath.join(upath.dirname(packageFileName), 'Pods');
   const podsManifestFileName = upath.join(podsDir, 'Manifest.lock');
-  if (await readLocalFile(podsManifestFileName, 'utf8')) {
+  if (await readLocalFile(podsManifestFileName)) {
     for (const f of status.modified.concat(status.not_added)) {
       if (f.startsWith(podsDir)) {
         res.push({
           file: {
             type: 'addition',
             path: f,
-            contents: await readLocalFile(f),
+            contents: await readLocalBlob(f),
           },
         });
       }

--- a/lib/modules/manager/composer/artifacts.ts
+++ b/lib/modules/manager/composer/artifacts.ts
@@ -13,6 +13,7 @@ import {
   ensureLocalDir,
   getSiblingFileName,
   localPathExists,
+  readLocalBlob,
   readLocalFile,
   writeLocalFile,
 } from '../../../util/fs';
@@ -83,7 +84,7 @@ export async function updateArtifacts({
   logger.debug(`composer.updateArtifacts(${packageFileName})`);
 
   const lockFileName = packageFileName.replace(regEx(/\.json$/), '.lock');
-  const existingLockFileContent = await readLocalFile(lockFileName, 'utf8');
+  const existingLockFileContent = await readLocalFile(lockFileName);
   if (!existingLockFileContent) {
     logger.debug('No composer.lock found');
     return null;
@@ -161,7 +162,7 @@ export async function updateArtifacts({
         file: {
           type: 'addition',
           path: lockFileName,
-          contents: await readLocalFile(lockFileName),
+          contents: await readLocalBlob(lockFileName),
         },
       },
     ];
@@ -177,7 +178,7 @@ export async function updateArtifacts({
           file: {
             type: 'addition',
             path: f,
-            contents: await readLocalFile(f),
+            contents: await readLocalBlob(f),
           },
         });
       }

--- a/lib/modules/manager/composer/extract.ts
+++ b/lib/modules/manager/composer/extract.ts
@@ -95,7 +95,7 @@ export async function extractPackageFile(
 
   // handle lockfile
   const lockfilePath = fileName.replace(regEx(/\.json$/), '.lock');
-  const lockContents = await readLocalFile(lockfilePath, 'utf8');
+  const lockContents = await readLocalFile(lockfilePath);
   let lockParsed: ComposerLock | undefined;
   if (lockContents) {
     logger.debug({ packageFile: fileName }, 'Found composer lock file');

--- a/lib/modules/manager/flux/artifacts.ts
+++ b/lib/modules/manager/flux/artifacts.ts
@@ -2,7 +2,7 @@ import { quote } from 'shlex';
 import { logger } from '../../../logger';
 import { exec } from '../../../util/exec';
 import type { ExecOptions } from '../../../util/exec/types';
-import { readLocalFile } from '../../../util/fs';
+import { readLocalBlob } from '../../../util/fs';
 import type { UpdateArtifact, UpdateArtifactsResult } from '../types';
 import { isSystemManifest } from './common';
 
@@ -14,7 +14,7 @@ export async function updateArtifacts({
   if (!isSystemManifest(packageFileName) || !systemDep?.newVersion) {
     return null;
   }
-  const existingFileContent = await readLocalFile(packageFileName);
+  const existingFileContent = await readLocalBlob(packageFileName);
   try {
     logger.debug(`Updating Flux system manifests`);
     const args: string[] = ['--export'];
@@ -35,7 +35,7 @@ export async function updateArtifacts({
     };
     const result = await exec(cmd, execOptions);
 
-    const newFileContent = await readLocalFile(packageFileName);
+    const newFileContent = await readLocalBlob(packageFileName);
     if (!newFileContent) {
       logger.debug('Cannot read new flux file content');
       return [

--- a/lib/modules/manager/flux/extract.ts
+++ b/lib/modules/manager/flux/extract.ts
@@ -139,7 +139,7 @@ export async function extractAllPackageFiles(
   const results: PackageFile[] = [];
 
   for (const file of packageFiles) {
-    const content = await readLocalFile(file, 'utf8');
+    const content = await readLocalFile(file);
     // TODO #7154
     const manifest = readManifest(content!, file);
     if (manifest) {

--- a/lib/modules/manager/gitlabci/extract.ts
+++ b/lib/modules/manager/gitlabci/extract.ts
@@ -127,7 +127,7 @@ export async function extractAllPackageFiles(
   while (filesToExamine.length > 0) {
     const file = filesToExamine.pop()!;
 
-    const content = await readLocalFile(file, 'utf8');
+    const content = await readLocalFile(file);
     if (!content) {
       logger.debug({ file }, 'Empty or non existent gitlabci file');
 

--- a/lib/modules/manager/gomod/artifacts.ts
+++ b/lib/modules/manager/gomod/artifacts.ts
@@ -8,6 +8,7 @@ import { exec } from '../../../util/exec';
 import type { ExecOptions } from '../../../util/exec/types';
 import {
   ensureCacheDir,
+  readLocalBlob,
   readLocalFile,
   writeLocalFile,
 } from '../../../util/fs';
@@ -146,7 +147,7 @@ export async function updateArtifacts({
   logger.debug(`gomod.updateArtifacts(${goModFileName})`);
 
   const sumFileName = goModFileName.replace(regEx(/\.mod$/), '.sum');
-  const existingGoSumContent = await readLocalFile(sumFileName);
+  const existingGoSumContent = await readLocalBlob(sumFileName);
   if (!existingGoSumContent) {
     logger.debug('No go.sum found');
     return null;
@@ -154,7 +155,7 @@ export async function updateArtifacts({
 
   const vendorDir = upath.join(upath.dirname(goModFileName), 'vendor/');
   const vendorModulesFileName = upath.join(vendorDir, 'modules.txt');
-  const useVendor = (await readLocalFile(vendorModulesFileName)) !== null;
+  const useVendor = (await readLocalBlob(vendorModulesFileName)) !== null;
 
   let massagedGoMod = newGoModContent;
 
@@ -306,7 +307,7 @@ export async function updateArtifacts({
         file: {
           type: 'addition',
           path: sumFileName,
-          contents: await readLocalFile(sumFileName),
+          contents: await readLocalBlob(sumFileName),
         },
       },
     ];
@@ -320,7 +321,7 @@ export async function updateArtifacts({
             file: {
               type: 'addition',
               path: f,
-              contents: await readLocalFile(f),
+              contents: await readLocalBlob(f),
             },
           });
         }
@@ -334,7 +335,7 @@ export async function updateArtifacts({
             file: {
               type: 'addition',
               path: f,
-              contents: await readLocalFile(f),
+              contents: await readLocalBlob(f),
             },
           });
         }
@@ -350,7 +351,7 @@ export async function updateArtifacts({
     }
 
     // TODO #7154
-    const finalGoModContent = (await readLocalFile(goModFileName, 'utf8'))!
+    const finalGoModContent = (await readLocalFile(goModFileName))!
       .replace(regEx(/\/\/ renovate-replace /g), '')
       .replace(regEx(/renovate-replace-bracket/g), ')');
     if (finalGoModContent !== newGoModContent) {

--- a/lib/modules/manager/gradle-wrapper/artifacts.ts
+++ b/lib/modules/manager/gradle-wrapper/artifacts.ts
@@ -4,7 +4,7 @@ import { TEMPORARY_ERROR } from '../../../constants/error-messages';
 import { logger } from '../../../logger';
 import { exec } from '../../../util/exec';
 import type { ExecOptions } from '../../../util/exec/types';
-import { readLocalFile, writeLocalFile } from '../../../util/fs';
+import { readLocalBlob, writeLocalFile } from '../../../util/fs';
 import { getRepoStatus } from '../../../util/git';
 import type { StatusResult } from '../../../util/git/types';
 import { Http } from '../../../util/http';
@@ -29,7 +29,7 @@ async function addIfUpdated(
       file: {
         type: 'addition',
         path: fileProjectPath,
-        contents: await readLocalFile(fileProjectPath),
+        contents: await readLocalBlob(fileProjectPath),
       },
     };
   }

--- a/lib/modules/manager/gradle/extract.ts
+++ b/lib/modules/manager/gradle/extract.ts
@@ -53,7 +53,7 @@ export async function extractAllPackageFiles(
 
     try {
       // TODO #7154
-      const content = (await readLocalFile(packageFile, 'utf8'))!;
+      const content = (await readLocalFile(packageFile))!;
       const dir = upath.dirname(toAbsolutePath(packageFile));
 
       const updateVars = (newVars: PackageVariables): void => {

--- a/lib/modules/manager/gradle/parser.ts
+++ b/lib/modules/manager/gradle/parser.ts
@@ -1050,7 +1050,7 @@ async function parseInlineScriptFile(
   }
 
   const scriptFilePath = getSiblingFileName(packageFile, scriptFile);
-  const scriptFileContent = await readLocalFile(scriptFilePath, 'utf8');
+  const scriptFileContent = await readLocalFile(scriptFilePath);
   if (!scriptFileContent) {
     logger.warn({ scriptFilePath }, `Failed to process Gradle file`);
     return null;

--- a/lib/modules/manager/helmv3/artifacts.ts
+++ b/lib/modules/manager/helmv3/artifacts.ts
@@ -118,7 +118,7 @@ export async function updateArtifacts({
   }
 
   const lockFileName = getSiblingFileName(packageFileName, 'Chart.lock');
-  const existingLockFileContent = await readLocalFile(lockFileName, 'utf8');
+  const existingLockFileContent = await readLocalFile(lockFileName);
   if (!existingLockFileContent) {
     logger.debug('No Chart.lock found');
     return null;
@@ -157,7 +157,7 @@ export async function updateArtifacts({
     };
     await helmCommands(execOptions, packageFileName, repositories);
     logger.debug('Returning updated Chart.lock');
-    const newHelmLockContent = await readLocalFile(lockFileName, 'utf8');
+    const newHelmLockContent = await readLocalFile(lockFileName);
     if (existingLockFileContent === newHelmLockContent) {
       logger.debug('Chart.lock is unchanged');
       return null;

--- a/lib/modules/manager/jsonnet-bundler/artifacts.ts
+++ b/lib/modules/manager/jsonnet-bundler/artifacts.ts
@@ -3,7 +3,7 @@ import { TEMPORARY_ERROR } from '../../../constants/error-messages';
 import { logger } from '../../../logger';
 import { exec } from '../../../util/exec';
 import type { ExecOptions, ToolConstraint } from '../../../util/exec/types';
-import { readLocalFile } from '../../../util/fs';
+import { readLocalBlob, readLocalFile } from '../../../util/fs';
 import { getRepoStatus } from '../../../util/git';
 import { regEx } from '../../../util/regex';
 import type {
@@ -27,7 +27,7 @@ export async function updateArtifacts(
   logger.trace({ packageFileName }, 'jsonnet-bundler.updateArtifacts()');
 
   const lockFileName = packageFileName.replace(regEx(/\.json$/), '.lock.json');
-  const existingLockFileContent = await readLocalFile(lockFileName, 'utf8');
+  const existingLockFileContent = await readLocalFile(lockFileName);
 
   if (!existingLockFileContent) {
     logger.debug('No jsonnetfile.lock.json found');
@@ -73,7 +73,7 @@ export async function updateArtifacts(
         file: {
           type: 'addition',
           path: f,
-          contents: await readLocalFile(f),
+          contents: await readLocalBlob(f),
         },
       });
     }
@@ -82,7 +82,7 @@ export async function updateArtifacts(
         file: {
           type: 'addition',
           path: f,
-          contents: await readLocalFile(f),
+          contents: await readLocalBlob(f),
         },
       });
     }

--- a/lib/modules/manager/maven/extract.ts
+++ b/lib/modules/manager/maven/extract.ts
@@ -449,7 +449,7 @@ export async function extractAllPackageFiles(
   const additionalRegistryUrls: string[] = [];
 
   for (const packageFile of packageFiles) {
-    const content = await readLocalFile(packageFile, 'utf8');
+    const content = await readLocalFile(packageFile);
     if (!content) {
       logger.trace({ packageFile }, 'packageFile has no content');
       continue;

--- a/lib/modules/manager/mix/artifacts.ts
+++ b/lib/modules/manager/mix/artifacts.ts
@@ -42,7 +42,7 @@ export async function updateArtifacts({
     ];
   }
 
-  const existingLockFileContent = await readLocalFile(lockFileName, 'utf8');
+  const existingLockFileContent = await readLocalFile(lockFileName);
   if (!existingLockFileContent) {
     logger.debug('No mix.lock found');
     return null;
@@ -112,7 +112,7 @@ export async function updateArtifacts({
     ];
   }
 
-  const newMixLockContent = await readLocalFile(lockFileName, 'utf8');
+  const newMixLockContent = await readLocalFile(lockFileName);
   if (existingLockFileContent === newMixLockContent) {
     logger.debug('mix.lock is unchanged');
     return null;

--- a/lib/modules/manager/npm/extract/index.ts
+++ b/lib/modules/manager/npm/extract/index.ts
@@ -89,7 +89,7 @@ export async function extractPackageFile(
     string
   ][]) {
     const filePath = getSiblingFileName(fileName, val);
-    if (await readLocalFile(filePath, 'utf8')) {
+    if (await readLocalFile(filePath)) {
       lockFiles[key] = filePath;
     } else {
       lockFiles[key] = undefined;
@@ -101,7 +101,7 @@ export async function extractPackageFile(
 
   let npmrc: string | undefined;
   const npmrcFileName = getSiblingFileName(fileName, '.npmrc');
-  let repoNpmrc = await readLocalFile(npmrcFileName, 'utf8');
+  let repoNpmrc = await readLocalFile(npmrcFileName);
   if (is.string(repoNpmrc)) {
     if (is.string(config.npmrc) && !config.npmrcMerge) {
       logger.debug(
@@ -153,7 +153,7 @@ export async function extractPackageFile(
   try {
     lernaJsonFile = getSiblingFileName(fileName, 'lerna.json');
     // TODO #7154
-    lernaJson = JSON.parse((await readLocalFile(lernaJsonFile, 'utf8'))!);
+    lernaJson = JSON.parse((await readLocalFile(lernaJsonFile))!);
   } catch (err) /* istanbul ignore next */ {
     logger.warn({ err }, 'Could not parse lerna.json');
   }
@@ -483,7 +483,7 @@ export async function extractAllPackageFiles(
 ): Promise<PackageFile[]> {
   const npmFiles: PackageFile[] = [];
   for (const packageFile of packageFiles) {
-    const content = await readLocalFile(packageFile, 'utf8');
+    const content = await readLocalFile(packageFile);
     // istanbul ignore else
     if (content) {
       const deps = await extractPackageFile(content, packageFile, config);

--- a/lib/modules/manager/npm/extract/npm.ts
+++ b/lib/modules/manager/npm/extract/npm.ts
@@ -4,7 +4,7 @@ import type { LockFile, LockFileEntry } from './types';
 
 export async function getNpmLock(filePath: string): Promise<LockFile> {
   // TODO #7154
-  const lockRaw = (await readLocalFile(filePath, 'utf8'))!;
+  const lockRaw = (await readLocalFile(filePath))!;
   try {
     const lockParsed = JSON.parse(lockRaw);
     const lockedVersions: Record<string, string> = {};

--- a/lib/modules/manager/npm/extract/pnpm.ts
+++ b/lib/modules/manager/npm/extract/pnpm.ts
@@ -18,7 +18,7 @@ export async function extractPnpmFilters(
 ): Promise<string[] | undefined> {
   try {
     // TODO #7154
-    const contents = load((await readLocalFile(fileName, 'utf8'))!, {
+    const contents = load((await readLocalFile(fileName))!, {
       json: true,
     }) as PnpmWorkspaceFile;
     if (

--- a/lib/modules/manager/npm/extract/yarn.ts
+++ b/lib/modules/manager/npm/extract/yarn.ts
@@ -11,7 +11,7 @@ import type { LockFile } from './types';
 
 export async function getYarnLock(filePath: string): Promise<LockFile> {
   // TODO #7154
-  const yarnLockRaw = (await readLocalFile(filePath, 'utf8'))!;
+  const yarnLockRaw = (await readLocalFile(filePath))!;
   try {
     const parsed = parseSyml(yarnLockRaw);
     const lockedVersions: Record<string, string> = {};
@@ -58,7 +58,7 @@ export function getZeroInstallPaths(yarnrcYml: string): string[] {
 }
 
 export async function isZeroInstall(yarnrcYmlPath: string): Promise<boolean> {
-  const yarnrcYml = await readLocalFile(yarnrcYmlPath, 'utf8');
+  const yarnrcYml = await readLocalFile(yarnrcYmlPath);
   if (is.string(yarnrcYml)) {
     const paths = getZeroInstallPaths(yarnrcYml);
     for (const p of paths) {

--- a/lib/modules/manager/npm/post-update/index.ts
+++ b/lib/modules/manager/npm/post-update/index.ts
@@ -12,6 +12,7 @@ import {
   ensureCacheDir,
   getParentDir,
   getSiblingFileName,
+  readLocalBlob,
   readLocalFile,
   writeLocalFile,
 } from '../../../../util/fs';
@@ -304,7 +305,7 @@ async function getNpmrcContent(dir: string): Promise<string | null> {
   const npmrcFilePath = upath.join(dir, '.npmrc');
   let originalNpmrcContent: string | null = null;
   try {
-    originalNpmrcContent = await readLocalFile(npmrcFilePath, 'utf8');
+    originalNpmrcContent = await readLocalFile(npmrcFilePath);
     logger.debug('npmrc file found in repository');
   } catch /* istanbul ignore next */ {
     logger.debug('No npmrc file found in repository');
@@ -391,7 +392,7 @@ async function updateYarnOffline(
           updatedArtifacts.push({
             type: 'addition',
             path: f,
-            contents: await readLocalFile(f),
+            contents: await readLocalBlob(f),
           });
         }
       }
@@ -416,7 +417,7 @@ export async function updateYarnBinary(
   try {
     const yarnrcYmlFilename = upath.join(lockFileDir, '.yarnrc.yml');
     yarnrcYml ||= (await getFile(yarnrcYmlFilename)) ?? undefined;
-    const newYarnrcYml = await readLocalFile(yarnrcYmlFilename, 'utf8');
+    const newYarnrcYml = await readLocalFile(yarnrcYmlFilename);
     if (!is.string(yarnrcYml) || !is.string(newYarnrcYml)) {
       return existingYarnrcYmlContent;
     }
@@ -441,7 +442,7 @@ export async function updateYarnBinary(
       {
         type: 'addition',
         path: newYarnFullPath,
-        contents: await readLocalFile(newYarnFullPath, 'utf8'),
+        contents: await readLocalFile(newYarnFullPath),
         isExecutable: true,
       }
     );
@@ -589,7 +590,7 @@ export async function getAdditionalFiles(
     // istanbul ignore if: needs test
     if (additionalYarnRcYml) {
       yarnRcYmlFilename = getSiblingFileName(yarnLock, '.yarnrc.yml');
-      existingYarnrcYmlContent = await readLocalFile(yarnRcYmlFilename, 'utf8');
+      existingYarnrcYmlContent = await readLocalFile(yarnRcYmlFilename);
       if (existingYarnrcYmlContent) {
         try {
           const existingYarnrRcYml = load(existingYarnrcYmlContent) as Record<
@@ -829,13 +830,9 @@ export async function getAdditionalFiles(
           logger.trace('Checking against ' + lockFilePath);
           try {
             const newContent =
-              (await readLocalFile(lockFilePath, 'utf8')) ??
+              (await readLocalFile(lockFilePath)) ??
               (await readLocalFile(
-                lockFilePath.replace(
-                  'npm-shrinkwrap.json',
-                  'package-lock.json'
-                ),
-                'utf8'
+                lockFilePath.replace('npm-shrinkwrap.json', 'package-lock.json')
               ));
             // istanbul ignore if: needs test
             if (newContent === existingContent) {

--- a/lib/modules/manager/npm/post-update/node-version.ts
+++ b/lib/modules/manager/npm/post-update/node-version.ts
@@ -7,7 +7,7 @@ import type { PostUpdateConfig, Upgrade } from '../../types';
 async function getNodeFile(filename: string): Promise<string | null> {
   try {
     // TODO #7154
-    const constraint = (await readLocalFile(filename, 'utf8'))!
+    const constraint = (await readLocalFile(filename))!
       .split(newlineRegex)[0]
       .replace(regEx(/^v/), '');
     if (semver.validRange(constraint)) {

--- a/lib/modules/manager/npm/post-update/npm.ts
+++ b/lib/modules/manager/npm/post-update/npm.ts
@@ -135,10 +135,7 @@ export async function generateLockFile(
 
     // Read the result
     // TODO #7154
-    lockFile = (await readLocalFile(
-      upath.join(lockFileDir, filename),
-      'utf8'
-    ))!;
+    lockFile = (await readLocalFile(upath.join(lockFileDir, filename)))!;
 
     // Massage lockfile counterparts of package.json that were modified
     // because npm install was called with an explicit version for rangeStrategy=update-lockfile

--- a/lib/modules/manager/npm/post-update/pnpm.ts
+++ b/lib/modules/manager/npm/post-update/pnpm.ts
@@ -78,7 +78,7 @@ export async function generateLockFile(
     }
 
     await exec(`${cmd} ${args}`, execOptions);
-    lockFile = await readLocalFile(lockFileName, 'utf8');
+    lockFile = await readLocalFile(lockFileName);
   } catch (err) /* istanbul ignore next */ {
     if (err.message === TEMPORARY_ERROR) {
       throw err;
@@ -103,7 +103,7 @@ async function getPnpmContraint(
 ): Promise<string | undefined> {
   let result: string | undefined;
   const rootPackageJson = upath.join(lockFileDir, 'package.json');
-  const content = await readLocalFile(rootPackageJson, 'utf8');
+  const content = await readLocalFile(rootPackageJson);
   if (content) {
     const packageJson: NpmPackage = JSON.parse(content);
     const packageManager = packageJson?.packageManager;
@@ -122,7 +122,7 @@ async function getPnpmContraint(
   }
   if (!result) {
     const lockFileName = upath.join(lockFileDir, 'pnpm-lock.yaml');
-    const content = await readLocalFile(lockFileName, 'utf8');
+    const content = await readLocalFile(lockFileName);
     if (content) {
       const pnpmLock = load(content) as PnpmLockFile;
       if (

--- a/lib/modules/manager/npm/post-update/yarn.ts
+++ b/lib/modules/manager/npm/post-update/yarn.ts
@@ -34,10 +34,7 @@ export async function checkYarnrc(
   let offlineMirror = false;
   let yarnPath: string | null = null;
   try {
-    const yarnrc = await readLocalFile(
-      upath.join(lockFileDir, '.yarnrc'),
-      'utf8'
-    );
+    const yarnrc = await readLocalFile(upath.join(lockFileDir, '.yarnrc'));
     if (is.string(yarnrc)) {
       const mirrorLine = yarnrc
         .split(newlineRegex)
@@ -271,7 +268,7 @@ export async function generateLockFile(
     await exec(commands, execOptions);
 
     // Read the result
-    lockFile = await readLocalFile(lockFileName, 'utf8');
+    lockFile = await readLocalFile(lockFileName);
   } catch (err) /* istanbul ignore next */ {
     if (err.message === TEMPORARY_ERROR) {
       throw err;

--- a/lib/modules/manager/nuget/artifacts.ts
+++ b/lib/modules/manager/nuget/artifacts.ts
@@ -104,7 +104,7 @@ async function getLockFileContentMap(
 
   for (const lockFileName of lockFileNames) {
     lockFileContentMap[lockFileName] = local
-      ? await readLocalFile(lockFileName, 'utf8')
+      ? await readLocalFile(lockFileName)
       : await getFile(lockFileName);
   }
 

--- a/lib/modules/manager/nuget/package-tree.ts
+++ b/lib/modules/manager/nuget/package-tree.ts
@@ -39,7 +39,7 @@ export async function getDependentPackageFiles(
   }
 
   for (const f of packageFiles) {
-    const packageFileContent = await readLocalFile(f, 'utf8');
+    const packageFileContent = await readLocalFile(f);
 
     // TODO #7154
     const doc = new xmldoc.XmlDocument(packageFileContent!);

--- a/lib/modules/manager/nuget/util.ts
+++ b/lib/modules/manager/nuget/util.ts
@@ -11,7 +11,7 @@ async function readFileAsXmlDocument(
 ): Promise<XmlDocument | undefined> {
   try {
     // TODO #7154
-    return new XmlDocument((await readLocalFile(file, 'utf8'))!);
+    return new XmlDocument((await readLocalFile(file))!);
   } catch (err) {
     logger.debug({ err }, `failed to parse '${file}' as XML document`);
     return undefined;

--- a/lib/modules/manager/pip-compile/artifacts.ts
+++ b/lib/modules/manager/pip-compile/artifacts.ts
@@ -99,7 +99,7 @@ export async function updateArtifacts({
   logger.debug(
     `pipCompile.updateArtifacts(${inputFileName}->${outputFileName})`
   );
-  const existingOutput = await readLocalFile(outputFileName, 'utf8');
+  const existingOutput = await readLocalFile(outputFileName);
   if (!existingOutput) {
     logger.debug('No pip-compile output file found');
     return null;
@@ -139,7 +139,7 @@ export async function updateArtifacts({
         file: {
           type: 'addition',
           path: outputFileName,
-          contents: await readLocalFile(outputFileName, 'utf8'),
+          contents: await readLocalFile(outputFileName),
         },
       },
     ];

--- a/lib/modules/manager/pip_requirements/artifacts.ts
+++ b/lib/modules/manager/pip_requirements/artifacts.ts
@@ -47,7 +47,7 @@ export async function updateArtifacts({
       preCommands: ['pip install hashin'],
     };
     await exec(cmd, execOptions);
-    const newContent = await readLocalFile(packageFileName, 'utf8');
+    const newContent = await readLocalFile(packageFileName);
     if (newContent === newPackageFileContent) {
       logger.debug(`${packageFileName} is unchanged`);
       return null;

--- a/lib/modules/manager/pipenv/artifacts.ts
+++ b/lib/modules/manager/pipenv/artifacts.ts
@@ -79,7 +79,7 @@ export async function updateArtifacts({
   logger.debug(`pipenv.updateArtifacts(${pipfileName})`);
 
   const lockFileName = pipfileName + '.lock';
-  const existingLockFileContent = await readLocalFile(lockFileName, 'utf8');
+  const existingLockFileContent = await readLocalFile(lockFileName);
   if (!existingLockFileContent) {
     logger.debug('No Pipfile.lock found');
     return null;
@@ -119,7 +119,7 @@ export async function updateArtifacts({
         file: {
           type: 'addition',
           path: lockFileName,
-          contents: await readLocalFile(lockFileName, 'utf8'),
+          contents: await readLocalFile(lockFileName),
         },
       },
     ];

--- a/lib/modules/manager/poetry/artifacts.ts
+++ b/lib/modules/manager/poetry/artifacts.ts
@@ -146,11 +146,11 @@ export async function updateArtifacts({
   }
   // Try poetry.lock first
   let lockFileName = getSiblingFileName(packageFileName, 'poetry.lock');
-  let existingLockFileContent = await readLocalFile(lockFileName, 'utf8');
+  let existingLockFileContent = await readLocalFile(lockFileName);
   if (!existingLockFileContent) {
     // Try pyproject.lock next
     lockFileName = getSiblingFileName(packageFileName, 'pyproject.lock');
-    existingLockFileContent = await readLocalFile(lockFileName, 'utf8');
+    existingLockFileContent = await readLocalFile(lockFileName);
     if (!existingLockFileContent) {
       logger.debug(`No lock file found`);
       return null;
@@ -195,7 +195,7 @@ export async function updateArtifacts({
       toolConstraints: [toolConstraint],
     };
     await exec(cmd, execOptions);
-    const newPoetryLockContent = await readLocalFile(lockFileName, 'utf8');
+    const newPoetryLockContent = await readLocalFile(lockFileName);
     if (existingLockFileContent === newPoetryLockContent) {
       logger.debug(`${lockFileName} is unchanged`);
       return null;

--- a/lib/modules/manager/poetry/extract.ts
+++ b/lib/modules/manager/poetry/extract.ts
@@ -116,7 +116,7 @@ export async function extractPackageFile(
   // handle the lockfile
   const lockfileName = getSiblingFileName(fileName, 'poetry.lock');
   // TODO #7154
-  const lockContents = (await readLocalFile(lockfileName, 'utf8'))!;
+  const lockContents = (await readLocalFile(lockfileName))!;
 
   const lockfileMapping = extractLockFileEntries(lockContents);
 

--- a/lib/modules/manager/terraform/lockfile/hash.ts
+++ b/lib/modules/manager/terraform/lockfile/hash.ts
@@ -73,7 +73,7 @@ export class TerraformProviderHash {
       `Downloading archive and generating hash for ${build.name}-${build.version}...`
     );
     const readStream = TerraformProviderHash.http.stream(build.url);
-    const writeStream = fs.createWriteStream(downloadFileName);
+    const writeStream = fs.createCacheWriteStream(downloadFileName);
 
     try {
       await fs.pipeline(readStream, writeStream);

--- a/lib/modules/manager/terraform/lockfile/util.ts
+++ b/lib/modules/manager/terraform/lockfile/util.ts
@@ -27,7 +27,7 @@ export function findLockFile(packageFilePath: string): string {
 }
 
 export function readLockFile(lockFilePath: string): Promise<string | null> {
-  return readLocalFile(lockFilePath, 'utf8');
+  return readLocalFile(lockFilePath);
 }
 
 export function extractLocks(lockFileContent: string): ProviderLock[] | null {

--- a/lib/util/fs/index.spec.ts
+++ b/lib/util/fs/index.spec.ts
@@ -22,6 +22,7 @@ import {
   outputCacheFile,
   privateCacheDir,
   readCacheFile,
+  readLocalBlob,
   readLocalDirectory,
   readLocalFile,
   readSystemFile,
@@ -87,11 +88,11 @@ describe('util/fs/index', () => {
 
   describe('readLocalFile', () => {
     it('reads buffer', async () => {
-      expect(await readLocalFile(__filename)).toBeInstanceOf(Buffer);
+      expect(await readLocalBlob(__filename)).toBeInstanceOf(Buffer);
     });
 
     it('reads string', async () => {
-      expect(typeof (await readLocalFile(__filename, 'utf8'))).toBe('string');
+      expect(typeof (await readLocalFile(__filename))).toBe('string');
     });
 
     it('does not throw', async () => {

--- a/lib/util/fs/index.spec.ts
+++ b/lib/util/fs/index.spec.ts
@@ -1,23 +1,32 @@
 import _findUp from 'find-up';
 import fs from 'fs-extra';
-import { withDir } from 'tmp-promise';
+import tmp, { DirectoryResult } from 'tmp-promise';
 import { join } from 'upath';
 import { envMock } from '../../../test/exec-util';
 import { env, mockedFunction } from '../../../test/util';
 import { GlobalConfig } from '../../config/global';
 import {
   chmodLocalFile,
+  createCacheWriteStream,
+  deleteLocalFile,
   ensureCacheDir,
+  ensureDir,
   ensureLocalDir,
   findLocalSiblingOrParent,
   findUpLocal,
   getParentDir,
   getSiblingFileName,
+  listCacheDir,
   localPathExists,
   localPathIsFile,
   outputCacheFile,
+  privateCacheDir,
+  readCacheFile,
   readLocalDirectory,
   readLocalFile,
+  readSystemFile,
+  renameLocalFile,
+  rmCache,
   statLocalFile,
   writeLocalFile,
 } from '.';
@@ -28,6 +37,19 @@ jest.mock('find-up');
 const findUp = mockedFunction(_findUp);
 
 describe('util/fs/index', () => {
+  let dirResult: DirectoryResult;
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    GlobalConfig.set({ localDir: '' });
+    dirResult = await tmp.dir({ unsafeCleanup: true });
+    tmpDir = dirResult.path;
+  });
+
+  afterEach(async () => {
+    await dirResult.cleanup();
+  });
+
   describe('getParentDir', () => {
     test.each`
       dir            | expected
@@ -64,10 +86,6 @@ describe('util/fs/index', () => {
   });
 
   describe('readLocalFile', () => {
-    beforeEach(() => {
-      GlobalConfig.set({ localDir: '' });
-    });
-
     it('reads buffer', async () => {
       expect(await readLocalFile(__filename)).toBeInstanceOf(Buffer);
     });
@@ -82,124 +100,68 @@ describe('util/fs/index', () => {
     });
   });
 
-  describe('localPathExists', () => {
-    it('returns true for file', async () => {
-      expect(await localPathExists(__filename)).toBeTrue();
-    });
+  describe('writeLocalFile', () => {
+    it('outputs file', async () => {
+      const localDir = tmpDir;
+      GlobalConfig.set({ localDir });
+      await writeLocalFile('foo/bar/file.txt', 'foobar');
 
-    it('returns true for directory', async () => {
-      expect(await localPathExists(getParentDir(__filename))).toBeTrue();
-    });
-
-    it('returns false', async () => {
-      expect(await localPathExists(__filename.replace('.ts', '.txt'))).toBe(
-        false
-      );
+      const path = `${localDir}/foo/bar/file.txt`;
+      expect(await fs.pathExists(path)).toBeTrue();
+      expect(await fs.readFile(path, 'utf8')).toBe('foobar');
     });
   });
 
-  describe('findLocalSiblingOrParent', () => {
-    it('returns path for file', async () => {
-      await withDir(
-        async (localDir) => {
-          GlobalConfig.set({
-            localDir: localDir.path,
-          });
+  describe('deleteLocalFile', () => {
+    it('deletes file', async () => {
+      const localDir = tmpDir;
+      GlobalConfig.set({ localDir });
+      const filePath = `${localDir}/foo/bar/file.txt`;
+      await fs.outputFile(filePath, 'foobar');
 
-          await writeLocalFile('crates/one/Cargo.toml', '');
-          await writeLocalFile('Cargo.lock', '');
-
-          expect(
-            await findLocalSiblingOrParent(
-              'crates/one/Cargo.toml',
-              'Cargo.lock'
-            )
-          ).toBe('Cargo.lock');
-          expect(
-            await findLocalSiblingOrParent(
-              'crates/one/Cargo.toml',
-              'Cargo.mock'
-            )
-          ).toBeNull();
-
-          await writeLocalFile('crates/one/Cargo.lock', '');
-
-          expect(
-            await findLocalSiblingOrParent(
-              'crates/one/Cargo.toml',
-              'Cargo.lock'
-            )
-          ).toBe('crates/one/Cargo.lock');
-          expect(
-            await findLocalSiblingOrParent('crates/one', 'Cargo.lock')
-          ).toBe('Cargo.lock');
-          expect(
-            await findLocalSiblingOrParent(
-              'crates/one/Cargo.toml',
-              'Cargo.mock'
-            )
-          ).toBeNull();
-        },
-        {
-          unsafeCleanup: true,
-        }
-      );
-    });
-
-    it('immediately returns null when either path is absolute', async () => {
-      expect(await findLocalSiblingOrParent('/etc/hosts', 'other')).toBeNull();
-      expect(await findLocalSiblingOrParent('other', '/etc/hosts')).toBeNull();
+      expect(await fs.pathExists(filePath)).toBeTrue();
+      await deleteLocalFile('foo/bar/file.txt');
+      expect(await fs.pathExists(filePath)).toBeFalse();
     });
   });
 
-  describe('readLocalDirectory', () => {
-    it('returns dir content', async () => {
-      await withDir(
-        async (localDir) => {
-          GlobalConfig.set({
-            localDir: localDir.path,
-          });
-          await writeLocalFile('test/Cargo.toml', '');
-          await writeLocalFile('test/Cargo.lock', '');
+  describe('renameLocalFile', () => {
+    it('renames file', async () => {
+      const localDir = tmpDir;
+      GlobalConfig.set({ localDir });
+      const sourcePath = `${localDir}/foo.txt`;
+      const targetPath = `${localDir}/bar.txt`;
+      await fs.outputFile(sourcePath, 'foobar');
 
-          const result = await readLocalDirectory('test');
-          expect(result).not.toBeNull();
-          expect(result).toBeArrayOfSize(2);
-          expect(result).toMatchSnapshot();
-
-          await writeLocalFile('Cargo.lock', '');
-          await writeLocalFile('/test/subdir/Cargo.lock', '');
-
-          const resultWithAdditionalFiles = await readLocalDirectory('test');
-          expect(resultWithAdditionalFiles).not.toBeNull();
-          expect(resultWithAdditionalFiles).toBeArrayOfSize(3);
-          expect(resultWithAdditionalFiles).toMatchSnapshot();
-        },
-        {
-          unsafeCleanup: true,
-        }
-      );
+      expect(await fs.pathExists(sourcePath)).toBeTrue();
+      expect(await fs.pathExists(targetPath)).toBeFalse();
+      await renameLocalFile('foo.txt', 'bar.txt');
+      expect(await fs.pathExists(sourcePath)).toBeFalse();
+      expect(await fs.pathExists(targetPath)).toBeTrue();
     });
+  });
 
-    it('return empty array for non existing directory', async () => {
-      await withDir(
-        async (localDir) => {
-          GlobalConfig.set({
-            localDir: localDir.path,
-          });
-          await expect(readLocalDirectory('somedir')).rejects.toThrow();
-        },
-        {
-          unsafeCleanup: true,
-        }
-      );
+  describe('ensureDir', () => {
+    it('creates directory', async () => {
+      const localDir = tmpDir;
+      GlobalConfig.set({ localDir });
+      const path = `${localDir}/foo/bar`;
+
+      await ensureDir(path);
+      const stat = await fs.stat(path);
+      expect(stat.isDirectory()).toBeTrue();
     });
+  });
 
-    it('return empty array for a existing but empty directory', async () => {
-      await ensureLocalDir('somedir');
-      const result = await readLocalDirectory('somedir');
-      expect(result).not.toBeNull();
-      expect(result).toBeArrayOfSize(0);
+  describe('ensureLocalDir', () => {
+    it('creates local directory', async () => {
+      const localDir = tmpDir;
+      GlobalConfig.set({ localDir });
+      const path = `${localDir}/foo/bar`;
+
+      await ensureLocalDir('foo/bar');
+      const stat = await fs.stat(path);
+      expect(stat.isDirectory()).toBeTrue();
     });
   });
 
@@ -224,23 +186,123 @@ describe('util/fs/index', () => {
     }
 
     it('prefers environment variables over global config', async () => {
-      await withDir(
-        async (tmpDir) => {
-          const { dirFromEnv } = setupMock(tmpDir.path);
-          const res = await ensureCacheDir('bundler');
-          expect(res).toEqual(dirFromEnv);
-          expect(await fs.pathExists(dirFromEnv)).toBeTrue();
-        },
-        { unsafeCleanup: true }
+      const { dirFromEnv } = setupMock(tmpDir);
+      const res = await ensureCacheDir('bundler');
+      expect(res).toEqual(dirFromEnv);
+      expect(await fs.pathExists(dirFromEnv)).toBeTrue();
+    });
+  });
+
+  describe('privateCacheDir', () => {
+    it('returns cache dir', () => {
+      GlobalConfig.set({ cacheDir: '/tmp/foo/bar' });
+      expect(privateCacheDir()).toBe(`/tmp/foo/bar/__renovate-private-cache`);
+    });
+  });
+
+  describe('localPathExists', () => {
+    it('returns true for file', async () => {
+      expect(await localPathExists(__filename)).toBeTrue();
+    });
+
+    it('returns true for directory', async () => {
+      expect(await localPathExists(getParentDir(__filename))).toBeTrue();
+    });
+
+    it('returns false', async () => {
+      expect(await localPathExists(__filename.replace('.ts', '.txt'))).toBe(
+        false
       );
     });
   });
 
-  describe('localPathIsFile', () => {
-    beforeEach(() => {
-      GlobalConfig.set({ localDir: '' });
+  describe('findLocalSiblingOrParent', () => {
+    it('returns path for file', async () => {
+      const localDir = tmpDir;
+      GlobalConfig.set({ localDir });
+
+      await writeLocalFile('crates/one/Cargo.toml', 'foo');
+      await writeLocalFile('Cargo.lock', 'bar');
+
+      expect(
+        await findLocalSiblingOrParent('crates/one/Cargo.toml', 'Cargo.lock')
+      ).toBe('Cargo.lock');
+      expect(
+        await findLocalSiblingOrParent('crates/one/Cargo.toml', 'Cargo.mock')
+      ).toBeNull();
+
+      await writeLocalFile('crates/one/Cargo.lock', '');
+
+      expect(
+        await findLocalSiblingOrParent('crates/one/Cargo.toml', 'Cargo.lock')
+      ).toBe('crates/one/Cargo.lock');
+      expect(await findLocalSiblingOrParent('crates/one', 'Cargo.lock')).toBe(
+        'Cargo.lock'
+      );
+      expect(
+        await findLocalSiblingOrParent('crates/one/Cargo.toml', 'Cargo.mock')
+      ).toBeNull();
     });
 
+    it('immediately returns null when either path is absolute', async () => {
+      expect(await findLocalSiblingOrParent('/etc/hosts', 'other')).toBeNull();
+      expect(await findLocalSiblingOrParent('other', '/etc/hosts')).toBeNull();
+    });
+  });
+
+  describe('readLocalDirectory', () => {
+    it('returns dir content', async () => {
+      const localDir = tmpDir;
+      GlobalConfig.set({ localDir });
+      await writeLocalFile('test/Cargo.toml', '');
+      await writeLocalFile('test/Cargo.lock', '');
+
+      const result = await readLocalDirectory('test');
+      expect(result).not.toBeNull();
+      expect(result).toBeArrayOfSize(2);
+      expect(result).toMatchSnapshot();
+
+      await writeLocalFile('Cargo.lock', '');
+      await writeLocalFile('/test/subdir/Cargo.lock', '');
+
+      const resultWithAdditionalFiles = await readLocalDirectory('test');
+      expect(resultWithAdditionalFiles).not.toBeNull();
+      expect(resultWithAdditionalFiles).toBeArrayOfSize(3);
+      expect(resultWithAdditionalFiles).toMatchSnapshot();
+    });
+
+    it('return empty array for non existing directory', async () => {
+      const localDir = tmpDir;
+      GlobalConfig.set({ localDir });
+      await expect(readLocalDirectory('somedir')).rejects.toThrow();
+    });
+
+    it('return empty array for a existing but empty directory', async () => {
+      await ensureLocalDir('somedir');
+      const result = await readLocalDirectory('somedir');
+      expect(result).not.toBeNull();
+      expect(result).toBeArrayOfSize(0);
+    });
+  });
+
+  describe('createCacheWriteStream', () => {
+    it('creates write stream', async () => {
+      const path = `${tmpDir}/file.txt`;
+      await fs.outputFile(path, 'foo');
+
+      const stream = createCacheWriteStream(path);
+      expect(stream).toBeInstanceOf(fs.WriteStream);
+
+      const write = new Promise((resolve, reject) => {
+        stream.write('bar');
+        stream.close(resolve);
+      });
+      await write;
+      expect(await fs.readFile(path, 'utf8')).toBe('bar');
+    });
+  });
+
+  describe('localPathIsFile', () => {
     it('returns true for file', async () => {
       expect(await localPathIsFile(__filename)).toBeTrue();
     });
@@ -280,60 +342,88 @@ describe('util/fs/index', () => {
     });
   });
 
-  describe('statLocalFile', () => {
-    it('works', async () => {
-      await withDir(
-        async (tmpDir) => {
-          GlobalConfig.set({ localDir: tmpDir.path });
+  describe('chmodLocalFile', () => {
+    it('changes file mode', async () => {
+      const localDir = tmpDir;
+      GlobalConfig.set({ localDir });
+      await writeLocalFile('foo', 'bar');
+      let stat = await statLocalFile('foo');
+      const oldMode = stat!.mode & 0o777;
+      const newMode = oldMode & 0o555; // Remove `write` attributes (Windows-compatible)
 
-          expect(await statLocalFile('foo')).toBeNull();
+      await chmodLocalFile('foo', newMode);
+      stat = await statLocalFile('foo');
+      expect(stat!.mode & 0o777).toBe(newMode);
 
-          await writeLocalFile('foo', 'bar');
-          const stat = await statLocalFile('foo');
-          expect(stat).toBeDefined();
-          expect(stat!.isFile()).toBeTrue();
-        },
-        { unsafeCleanup: true }
-      );
+      await chmodLocalFile('foo', oldMode);
+      stat = await statLocalFile('foo');
+      expect(stat!.mode & 0o777).toBe(oldMode);
     });
   });
 
-  describe('chmodLocalFile', () => {
-    it('works', async () => {
-      await withDir(
-        async (tmpDir) => {
-          GlobalConfig.set({ localDir: tmpDir.path });
-          await writeLocalFile('foo', 'bar');
-          let stat = await statLocalFile('foo');
-          const oldMode = stat!.mode & 0o777;
-          const newMode = oldMode & 0o555; // Remove `write` attributes (Windows-compatible)
+  describe('statLocalFile', () => {
+    it('returns stat object', async () => {
+      const localDir = tmpDir;
+      GlobalConfig.set({ localDir });
 
-          await chmodLocalFile('foo', newMode);
-          stat = await statLocalFile('foo');
-          expect(stat!.mode & 0o777).toBe(newMode);
+      expect(await statLocalFile('foo')).toBeNull();
 
-          await chmodLocalFile('foo', oldMode);
-          stat = await statLocalFile('foo');
-          expect(stat!.mode & 0o777).toBe(oldMode);
-        },
-        { unsafeCleanup: true }
+      await writeLocalFile('foo', 'bar');
+      const stat = await statLocalFile('foo');
+      expect(stat).toBeTruthy();
+      expect(stat!.isFile()).toBeTrue();
+    });
+  });
+
+  describe('listCacheDir', () => {
+    it('lists directory', async () => {
+      const cacheDir = tmpDir;
+      GlobalConfig.set({ cacheDir });
+      await fs.outputFile(`${cacheDir}/foo/bar.txt`, 'foobar');
+      expect(await listCacheDir(`${cacheDir}/foo`)).toEqual(['bar.txt']);
+    });
+  });
+
+  describe('rmCache', () => {
+    it('removes cache dir', async () => {
+      const cacheDir = tmpDir;
+      GlobalConfig.set({ cacheDir });
+      await fs.outputFile(`${cacheDir}/foo/bar/file.txt`, 'foobar');
+      await rmCache(`${cacheDir}/foo/bar`);
+      expect(await fs.pathExists(`${cacheDir}/foo/bar/file.txt`)).toBeFalse();
+      expect(await fs.pathExists(`${cacheDir}/foo/bar`)).toBeFalse();
+    });
+  });
+
+  describe('readCacheFile', () => {
+    it('reads file', async () => {
+      const cacheDir = tmpDir;
+      GlobalConfig.set({ cacheDir });
+      await fs.outputFile(`${cacheDir}/foo/bar/file.txt`, 'foobar');
+      expect(await readCacheFile(`${cacheDir}/foo/bar/file.txt`, 'utf8')).toBe(
+        'foobar'
+      );
+      expect(await readCacheFile(`${cacheDir}/foo/bar/file.txt`)).toEqual(
+        Buffer.from('foobar')
       );
     });
   });
 
   describe('outputCacheFile', () => {
-    it('works', async () => {
-      await withDir(
-        async ({ path }) => {
-          const fsOutputFile = jest.spyOn(fs, 'outputFile');
-          const file = join(path, 'some-file');
-          await outputCacheFile(file, 'foobar');
-          const res = await fs.readFile(file, 'utf8');
-          expect(res).toBe('foobar');
-          expect(fsOutputFile).toHaveBeenCalledWith(file, 'foobar', {});
-        },
-        { unsafeCleanup: true }
-      );
+    it('outputs file', async () => {
+      const file = join(tmpDir, 'some-file');
+      await outputCacheFile(file, 'foobar');
+      const res = await fs.readFile(file, 'utf8');
+      expect(res).toBe('foobar');
+    });
+  });
+
+  describe('readSystemFile', () => {
+    it('reads file', async () => {
+      const path = `${tmpDir}/file.txt`;
+      await fs.outputFile(path, 'foobar', { encoding: 'utf8' });
+      expect(await readSystemFile(path, 'utf8')).toBe('foobar');
+      expect(await readSystemFile(path)).toEqual(Buffer.from('foobar'));
     });
   });
 });

--- a/lib/util/fs/index.ts
+++ b/lib/util/fs/index.ts
@@ -22,22 +22,22 @@ export function getSiblingFileName(
   return upath.join(subDirectory, siblingName);
 }
 
-export async function readLocalFile(fileName: string): Promise<Buffer | null>;
-export async function readLocalFile(
-  fileName: string,
-  encoding: 'utf8'
-): Promise<string | null>;
-export async function readLocalFile(
-  fileName: string,
-  encoding?: string
-): Promise<string | Buffer | null> {
+export async function readLocalFile(fileName: string): Promise<string | null> {
   const { localDir } = GlobalConfig.get();
   const localFileName = upath.join(localDir, fileName);
   try {
-    const fileContent = encoding
-      ? await fs.readFile(localFileName, encoding)
-      : await fs.readFile(localFileName);
-    return fileContent;
+    return await fs.readFile(localFileName, 'utf8');
+  } catch (err) {
+    logger.trace({ err }, 'Error reading local file');
+    return null;
+  }
+}
+
+export async function readLocalBlob(fileName: string): Promise<Buffer | null> {
+  const { localDir } = GlobalConfig.get();
+  const localFileName = upath.join(localDir, fileName);
+  try {
+    return await fs.readFile(localFileName);
   } catch (err) {
     logger.trace({ err }, 'Error reading local file');
     return null;

--- a/lib/util/fs/index.ts
+++ b/lib/util/fs/index.ts
@@ -61,7 +61,6 @@ export async function deleteLocalFile(fileName: string): Promise<void> {
   }
 }
 
-// istanbul ignore next
 export async function renameLocalFile(
   fromFile: string,
   toFile: string
@@ -70,14 +69,12 @@ export async function renameLocalFile(
   await fs.move(upath.join(localDir, fromFile), upath.join(localDir, toFile));
 }
 
-// istanbul ignore next
 export async function ensureDir(dirName: string): Promise<void> {
   if (is.nonEmptyString(dirName)) {
     await fs.ensureDir(dirName);
   }
 }
 
-// istanbul ignore next
 export async function ensureLocalDir(dirName: string): Promise<void> {
   const { localDir } = GlobalConfig.get();
   const localDirName = upath.join(localDir, dirName);
@@ -151,7 +148,7 @@ export async function readLocalDirectory(path: string): Promise<string[]> {
   return fileList;
 }
 
-export function createWriteStream(path: string): fs.WriteStream {
+export function createCacheWriteStream(path: string): fs.WriteStream {
   return fs.createWriteStream(path);
 }
 
@@ -216,12 +213,10 @@ export async function statLocalFile(
   }
 }
 
-// istanbul ignore next
 export function listCacheDir(path: string): Promise<string[]> {
   return fs.readdir(path);
 }
 
-// istanbul ignore next
 export async function rmCache(path: string): Promise<void> {
   await fs.rm(path, { recursive: true });
 }

--- a/lib/workers/repository/config-migration/branch/migrated-data.ts
+++ b/lib/workers/repository/config-migration/branch/migrated-data.ts
@@ -48,7 +48,7 @@ export class MigratedDataFactory {
       delete migratedConfig.warnings;
 
       const filename = rc.configFileName ?? '';
-      const raw = await readLocalFile(filename, 'utf8');
+      const raw = await readLocalFile(filename);
 
       // indent defaults to 2 spaces
       // TODO #7154

--- a/lib/workers/repository/extract/manager-files.ts
+++ b/lib/workers/repository/extract/manager-files.ts
@@ -46,7 +46,7 @@ export async function getManagerPackageFiles(
   }
   const packageFiles: PackageFile[] = [];
   for (const packageFile of fileList) {
-    const content = await readLocalFile(packageFile, 'utf8');
+    const content = await readLocalFile(packageFile);
     // istanbul ignore else
     if (content) {
       const res = await extractPackageFile(

--- a/lib/workers/repository/init/merge.ts
+++ b/lib/workers/repository/init/merge.ts
@@ -41,9 +41,7 @@ export async function detectRepoFileConfig(): Promise<RepoFileConfig> {
     for (const fileName of configFileNames) {
       if (fileName === 'package.json') {
         try {
-          const pJson = JSON.parse(
-            (await readLocalFile('package.json', 'utf8'))!
-          );
+          const pJson = JSON.parse((await readLocalFile('package.json'))!);
           if (pJson.renovate) {
             logger.debug('Using package.json for global renovate config');
             return 'package.json';
@@ -70,7 +68,7 @@ export async function detectRepoFileConfig(): Promise<RepoFileConfig> {
     // We already know it parses
     configFileParsed = JSON.parse(
       // TODO #7154
-      (await readLocalFile('package.json', 'utf8'))!
+      (await readLocalFile('package.json'))!
     ).renovate;
     if (is.string(configFileParsed)) {
       logger.debug('Massaging string renovate config to extends array');
@@ -78,7 +76,7 @@ export async function detectRepoFileConfig(): Promise<RepoFileConfig> {
     }
     logger.debug({ config: configFileParsed }, 'package.json>renovate config');
   } else {
-    let rawFileContents = await readLocalFile(configFileName, 'utf8');
+    let rawFileContents = await readLocalFile(configFileName);
     // istanbul ignore if
     if (!is.string(rawFileContents)) {
       logger.warn({ configFileName }, 'Null contents when reading config file');

--- a/lib/workers/repository/onboarding/branch/check.ts
+++ b/lib/workers/repository/onboarding/branch/check.ts
@@ -31,7 +31,7 @@ const configFileExists = async (): Promise<boolean> => {
 const packageJsonConfigExists = async (): Promise<boolean> => {
   try {
     // TODO #7154
-    const pJson = JSON.parse((await readLocalFile('package.json', 'utf8'))!);
+    const pJson = JSON.parse((await readLocalFile('package.json'))!);
     if (pJson.renovate) {
       return true;
     }

--- a/lib/workers/repository/update/branch/execute-post-upgrade-commands.ts
+++ b/lib/workers/repository/update/branch/execute-post-upgrade-commands.ts
@@ -8,7 +8,7 @@ import type { ArtifactError } from '../../../../modules/manager/types';
 import { exec } from '../../../../util/exec';
 import {
   localPathIsFile,
-  readLocalFile,
+  readLocalBlob,
   writeLocalFile,
 } from '../../../../util/fs';
 import { getRepoStatus } from '../../../../util/git';
@@ -111,7 +111,7 @@ export async function postUpgradeCommandsExecutor(
               { file: relativePath, pattern },
               'Post-upgrade file saved'
             );
-            const existingContent = await readLocalFile(relativePath);
+            const existingContent = await readLocalBlob(relativePath);
             const existingUpdatedArtifacts = updatedArtifacts.find(
               (ua) => ua.path === relativePath
             );

--- a/lib/workers/repository/update/pr/code-owners.spec.ts
+++ b/lib/workers/repository/update/pr/code-owners.spec.ts
@@ -63,9 +63,7 @@ describe('workers/repository/update/pr/code-owners', () => {
     });
 
     it('returns empty array when error occurs', async () => {
-      fs.readLocalFile.mockImplementationOnce((_, __) => {
-        throw new Error();
-      });
+      fs.readLocalFile.mockRejectedValueOnce(new Error());
       const codeOwners = await codeOwnersForPr(pr);
       expect(codeOwners).toBeEmptyArray();
     });
@@ -78,7 +76,7 @@ describe('workers/repository/update/pr/code-owners', () => {
     ];
     codeOwnerFilePaths.forEach((codeOwnerFilePath) => {
       it(`detects code owner file at '${codeOwnerFilePath}'`, async () => {
-        fs.readLocalFile.mockImplementation((path, _) => {
+        fs.readLocalFile.mockImplementation((path) => {
           if (path === codeOwnerFilePath) {
             return Promise.resolve(['* @mike'].join('\n'));
           }

--- a/lib/workers/repository/update/pr/code-owners.ts
+++ b/lib/workers/repository/update/pr/code-owners.ts
@@ -9,10 +9,10 @@ export async function codeOwnersForPr(pr: Pr): Promise<string[]> {
   logger.debug('Searching for CODEOWNERS file');
   try {
     const codeOwnersFile =
-      (await readLocalFile('CODEOWNERS', 'utf8')) ??
-      (await readLocalFile('.github/CODEOWNERS', 'utf8')) ??
-      (await readLocalFile('.gitlab/CODEOWNERS', 'utf8')) ??
-      (await readLocalFile('docs/CODEOWNERS', 'utf8'));
+      (await readLocalFile('CODEOWNERS')) ??
+      (await readLocalFile('.github/CODEOWNERS')) ??
+      (await readLocalFile('.gitlab/CODEOWNERS')) ??
+      (await readLocalFile('docs/CODEOWNERS'));
 
     if (!codeOwnersFile) {
       logger.debug('No CODEOWNERS file found');


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Provide `utf8` encoding under the hood
- Never return `Buffer`s, since we don't use them anyway
<!-- Describe what behavior is changed by this PR. -->

## Context

- Ref: #16313
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
