### PR TITLE
feat(preset): extend NestJS monorepo

### DIFF
--- a/lib/config/presets/internal/monorepo.ts
+++ b/lib/config/presets/internal/monorepo.ts
@@ -147,6 +147,8 @@ const repoGroups = {
   nest: [
     'https://github.com/nestjs/nest',
     'https://github.com/nestjs/passport',
+    'https://github.com/nestjs/schematics',
+    'https://github.com/nestjs/terminus',
   ],
   netty: 'https://github.com/netty/netty',
   neutrino: [


### PR DESCRIPTION
There are several additional `@nestjs` packages in the [NestJS GitHub Org](https://github.com/nestjs) that are currently not grouped, but follow the same major versioning and should be upgraded together.

It would also be possible to match against the org itself, but there are packages that don't follow the same major version as the core package (e.g. `@nestjs/swagger`) and I'm not sure if this would cause issues. (The extended list might not be complete anyways, because we're not familiar with all packages.)