### PR TITLE
fix(manager/docker): use correct autoreplace string for registry aliases

### DIFF
--- a/lib/modules/manager/dockerfile/extract.spec.ts
+++ b/lib/modules/manager/dockerfile/extract.spec.ts
@@ -1151,16 +1151,17 @@ describe('modules/manager/dockerfile/extract', () => {
       `);
     });
 
-    const defaultAutoReplaceStringTemplate =
-      '{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}';
+    const versionAndDigestTemplate =
+      '{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}';
+    const defaultAutoReplaceStringTemplate = `{{depName}}${versionAndDigestTemplate}`;
 
     it.each`
       name                         | registryAliases                                         | imageName                     | dep
-      ${'multiple aliases'}        | ${{ foo: 'foo.registry.com', bar: 'bar.registry.com' }} | ${'foo/image:1.0'}            | ${{ depName: 'foo.registry.com/image', currentValue: '1.0', autoReplaceStringTemplate: `foo/${defaultAutoReplaceStringTemplate}` }}
-      ${'aliased variable'}        | ${{ $CI_REGISTRY: 'registry.com' }}                     | ${'$CI_REGISTRY/image:1.0'}   | ${{ depName: 'registry.com/image', currentValue: '1.0', autoReplaceStringTemplate: `$CI_REGISTRY/${defaultAutoReplaceStringTemplate}` }}
-      ${'variables with brackets'} | ${{ '${CI_REGISTRY}': 'registry.com' }}                 | ${'${CI_REGISTRY}/image:1.0'} | ${{ depName: 'registry.com/image', currentValue: '1.0', autoReplaceStringTemplate: `$\{CI_REGISTRY}/${defaultAutoReplaceStringTemplate}` }}
-      ${'not aliased variable'}    | ${{}}                                                   | ${'$CI_REGISTRY/image:1.0'}   | ${{ autoReplaceStringTemplate: `${defaultAutoReplaceStringTemplate}` }}
-      ${'plain image'}             | ${{}}                                                   | ${'registry.com/image:1.0'}   | ${{ depName: 'registry.com/image', currentValue: '1.0', autoReplaceStringTemplate: `${defaultAutoReplaceStringTemplate}` }}
+      ${'multiple aliases'}        | ${{ foo: 'foo.registry.com', bar: 'bar.registry.com' }} | ${'foo/image:1.0'}            | ${{ depName: 'foo.registry.com/image', currentValue: '1.0', autoReplaceStringTemplate: `foo/image${versionAndDigestTemplate}` }}
+      ${'aliased variable'}        | ${{ $CI_REGISTRY: 'registry.com' }}                     | ${'$CI_REGISTRY/image:1.0'}   | ${{ depName: 'registry.com/image', currentValue: '1.0', autoReplaceStringTemplate: `$CI_REGISTRY/image${versionAndDigestTemplate}` }}
+      ${'variables with brackets'} | ${{ '${CI_REGISTRY}': 'registry.com' }}                 | ${'${CI_REGISTRY}/image:1.0'} | ${{ depName: 'registry.com/image', currentValue: '1.0', autoReplaceStringTemplate: `$\{CI_REGISTRY}/image${versionAndDigestTemplate}` }}
+      ${'not aliased variable'}    | ${{}}                                                   | ${'$CI_REGISTRY/image:1.0'}   | ${{ autoReplaceStringTemplate: defaultAutoReplaceStringTemplate }}
+      ${'plain image'}             | ${{}}                                                   | ${'registry.com/image:1.0'}   | ${{ depName: 'registry.com/image', currentValue: '1.0', autoReplaceStringTemplate: defaultAutoReplaceStringTemplate }}
     `(
       'supports registry aliases - $name',
       ({

--- a/lib/modules/manager/dockerfile/extract.spec.ts
+++ b/lib/modules/manager/dockerfile/extract.spec.ts
@@ -1152,8 +1152,9 @@ describe('modules/manager/dockerfile/extract', () => {
     });
 
     const versionAndDigestTemplate =
-      '{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}';
-    const defaultAutoReplaceStringTemplate = `{{depName}}${versionAndDigestTemplate}`;
+      ':{{#if newValue}}{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}';
+    const defaultAutoReplaceStringTemplate =
+      '{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}';
 
     it.each`
       name                         | registryAliases                                         | imageName                     | dep

--- a/lib/modules/manager/dockerfile/extract.ts
+++ b/lib/modules/manager/dockerfile/extract.ts
@@ -30,17 +30,17 @@ function getAutoReplaceTemplate(dep: PackageDependency): string | undefined {
   let template = dep.replaceString;
 
   if (dep.currentValue) {
-    let placeholder = '{{#if newValue}}:{{newValue}}{{/if}}';
+    let placeholder = '{{#if newValue}}{{newValue}}{{/if}}';
     if (!dep.currentDigest) {
       placeholder += '{{#if newDigest}}@{{newDigest}}{{/if}}';
     }
-    template = template?.replace(`:${dep.currentValue}`, placeholder);
+    template = template?.replace(dep.currentValue, placeholder);
   }
 
   if (dep.currentDigest) {
     template = template?.replace(
-      `@${dep.currentDigest}`,
-      '{{#if newDigest}}@{{newDigest}}{{/if}}'
+      dep.currentDigest,
+      '{{#if newDigest}}{{newDigest}}{{/if}}'
     );
   }
 

--- a/lib/modules/manager/dockerfile/extract.ts
+++ b/lib/modules/manager/dockerfile/extract.ts
@@ -30,17 +30,17 @@ function getAutoReplaceTemplate(dep: PackageDependency): string | undefined {
   let template = dep.replaceString;
 
   if (dep.currentValue) {
-    let placeholder = '{{#if newValue}}{{newValue}}{{/if}}';
+    let placeholder = '{{#if newValue}}:{{newValue}}{{/if}}';
     if (!dep.currentDigest) {
       placeholder += '{{#if newDigest}}@{{newDigest}}{{/if}}';
     }
-    template = template?.replace(dep.currentValue, placeholder);
+    template = template?.replace(`:${dep.currentValue}`, placeholder);
   }
 
   if (dep.currentDigest) {
     template = template?.replace(
-      dep.currentDigest,
-      '{{#if newDigest}}{{newDigest}}{{/if}}'
+      `@${dep.currentDigest}`,
+      '{{#if newDigest}}@{{newDigest}}{{/if}}'
     );
   }
 
@@ -166,7 +166,7 @@ export function getDep(
   // Resolve registry aliases first so that we don't need special casing later on:
   for (const [name, value] of Object.entries(registryAliases ?? {})) {
     const escapedName = escapeRegExp(name);
-    const groups = regEx(`(?<prefix>${escapedName}/)(?<depName>.+)`).exec(
+    const groups = regEx(`(?<prefix>${escapedName})/(?<depName>.+)`).exec(
       currentFrom
     )?.groups;
     if (groups) {
@@ -174,7 +174,7 @@ export function getDep(
         ...getDep(`${value}/${groups.depName}`),
         replaceString: currentFrom,
       };
-      dep.autoReplaceStringTemplate = `${groups.prefix}${dep.autoReplaceStringTemplate}`;
+      dep.autoReplaceStringTemplate = getAutoReplaceTemplate(dep)!;
       return dep;
     }
   }

--- a/lib/modules/manager/gitlabci/extract.spec.ts
+++ b/lib/modules/manager/gitlabci/extract.spec.ts
@@ -245,7 +245,7 @@ describe('modules/manager/gitlabci/extract', () => {
       expect(res?.deps).toEqual([
         {
           autoReplaceStringTemplate:
-            '$CI_REGISTRY/{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
+            '$CI_REGISTRY/renovate/renovate{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
           currentDigest: undefined,
           currentValue: '31.65.1-slim',
           datasource: 'docker',
@@ -255,7 +255,7 @@ describe('modules/manager/gitlabci/extract', () => {
         },
         {
           autoReplaceStringTemplate:
-            'foo/{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
+            'foo/mariadb{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
           currentDigest: undefined,
           currentValue: '10.4.11',
           datasource: 'docker',
@@ -265,7 +265,7 @@ describe('modules/manager/gitlabci/extract', () => {
         },
         {
           autoReplaceStringTemplate:
-            '$CI_REGISTRY/{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
+            '$CI_REGISTRY/other/image1{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
           currentDigest: undefined,
           currentValue: '1.0.0',
           datasource: 'docker',

--- a/lib/modules/manager/gitlabci/extract.spec.ts
+++ b/lib/modules/manager/gitlabci/extract.spec.ts
@@ -245,7 +245,7 @@ describe('modules/manager/gitlabci/extract', () => {
       expect(res?.deps).toEqual([
         {
           autoReplaceStringTemplate:
-            '$CI_REGISTRY/renovate/renovate{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
+            '$CI_REGISTRY/renovate/renovate:{{#if newValue}}{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
           currentDigest: undefined,
           currentValue: '31.65.1-slim',
           datasource: 'docker',
@@ -255,7 +255,7 @@ describe('modules/manager/gitlabci/extract', () => {
         },
         {
           autoReplaceStringTemplate:
-            'foo/mariadb{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
+            'foo/mariadb:{{#if newValue}}{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
           currentDigest: undefined,
           currentValue: '10.4.11',
           datasource: 'docker',
@@ -265,7 +265,7 @@ describe('modules/manager/gitlabci/extract', () => {
         },
         {
           autoReplaceStringTemplate:
-            '$CI_REGISTRY/other/image1{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
+            '$CI_REGISTRY/other/image1:{{#if newValue}}{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
           currentDigest: undefined,
           currentValue: '1.0.0',
           datasource: 'docker',

--- a/lib/modules/manager/gitlabci/utils.spec.ts
+++ b/lib/modules/manager/gitlabci/utils.spec.ts
@@ -3,8 +3,9 @@ import { getGitlabDep } from './utils';
 
 describe('modules/manager/gitlabci/utils', () => {
   describe('getGitlabDep', () => {
-    const defaultAutoReplaceStringTemplate =
-      '{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}';
+    const versionAndDigestTemplate =
+      '{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}';
+    const defaultAutoReplaceStringTemplate = `{{depName}}${versionAndDigestTemplate}`;
 
     it.each`
       name                           | imagePrefix
@@ -45,11 +46,11 @@ describe('modules/manager/gitlabci/utils', () => {
 
     it.each`
       name                         | registryAliases                                         | imageName                     | dep
-      ${'multiple aliases'}        | ${{ foo: 'foo.registry.com', bar: 'bar.registry.com' }} | ${'foo/image:1.0'}            | ${{ depName: 'foo.registry.com/image', currentValue: '1.0', autoReplaceStringTemplate: `foo/${defaultAutoReplaceStringTemplate}` }}
-      ${'aliased variable'}        | ${{ $CI_REGISTRY: 'registry.com' }}                     | ${'$CI_REGISTRY/image:1.0'}   | ${{ depName: 'registry.com/image', currentValue: '1.0', autoReplaceStringTemplate: `$CI_REGISTRY/${defaultAutoReplaceStringTemplate}` }}
-      ${'variables with brackets'} | ${{ '${CI_REGISTRY}': 'registry.com' }}                 | ${'${CI_REGISTRY}/image:1.0'} | ${{ depName: 'registry.com/image', currentValue: '1.0', autoReplaceStringTemplate: `$\{CI_REGISTRY}/${defaultAutoReplaceStringTemplate}` }}
-      ${'not aliased variable'}    | ${{}}                                                   | ${'$CI_REGISTRY/image:1.0'}   | ${{ autoReplaceStringTemplate: `${defaultAutoReplaceStringTemplate}` }}
-      ${'plain image'}             | ${{}}                                                   | ${'registry.com/image:1.0'}   | ${{ depName: 'registry.com/image', currentValue: '1.0', autoReplaceStringTemplate: `${defaultAutoReplaceStringTemplate}` }}
+      ${'multiple aliases'}        | ${{ foo: 'foo.registry.com', bar: 'bar.registry.com' }} | ${'foo/image:1.0'}            | ${{ depName: 'foo.registry.com/image', currentValue: '1.0', autoReplaceStringTemplate: `foo/image${versionAndDigestTemplate}` }}
+      ${'aliased variable'}        | ${{ $CI_REGISTRY: 'registry.com' }}                     | ${'$CI_REGISTRY/image:1.0'}   | ${{ depName: 'registry.com/image', currentValue: '1.0', autoReplaceStringTemplate: `$CI_REGISTRY/image${versionAndDigestTemplate}` }}
+      ${'variables with brackets'} | ${{ '${CI_REGISTRY}': 'registry.com' }}                 | ${'${CI_REGISTRY}/image:1.0'} | ${{ depName: 'registry.com/image', currentValue: '1.0', autoReplaceStringTemplate: `$\{CI_REGISTRY}/image${versionAndDigestTemplate}` }}
+      ${'not aliased variable'}    | ${{}}                                                   | ${'$CI_REGISTRY/image:1.0'}   | ${{ autoReplaceStringTemplate: defaultAutoReplaceStringTemplate }}
+      ${'plain image'}             | ${{}}                                                   | ${'registry.com/image:1.0'}   | ${{ depName: 'registry.com/image', currentValue: '1.0', autoReplaceStringTemplate: defaultAutoReplaceStringTemplate }}
     `(
       'supports registry aliases - $name',
       ({

--- a/lib/modules/manager/gitlabci/utils.spec.ts
+++ b/lib/modules/manager/gitlabci/utils.spec.ts
@@ -4,8 +4,9 @@ import { getGitlabDep } from './utils';
 describe('modules/manager/gitlabci/utils', () => {
   describe('getGitlabDep', () => {
     const versionAndDigestTemplate =
-      '{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}';
-    const defaultAutoReplaceStringTemplate = `{{depName}}${versionAndDigestTemplate}`;
+      ':{{#if newValue}}{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}';
+    const defaultAutoReplaceStringTemplate =
+      '{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}';
 
     it.each`
       name                           | imagePrefix


### PR DESCRIPTION
## Changes

Ensure the autoreplace template contains the alias, not the resolved value.

## Context

Follow-up from #16227

While setting up registry aliases in our instance I noticed that there is a depname mismatch due to a wrong autoreplace template:

```json
{"manager":"gitlabci","currentDepName":"registry.ourgitlab.com/renovate-bot-test/acceptance-test","newDepName":"registry.ourgitlab.com/registry.ourgitlab.com/renovate-bot-test/acceptance-test","msg":"depName mismatch"}
```

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->

🛠 with ❤️ by [Siemens](https://opensource.siemens.com/)