### PR TITLE
test(datasource): remove unnecessary optional chaining in tests

### DIFF
--- a/lib/modules/datasource/gradle-version/index.spec.ts
+++ b/lib/modules/datasource/gradle-version/index.spec.ts
@@ -6,7 +6,7 @@ import { ExternalHostError } from '../../../types/errors/external-host-error';
 import { id as versioning } from '../../versioning/gradle';
 import { GradleVersionDatasource } from '.';
 
-const allResponse = Fixtures?.get('all.json');
+const allResponse = Fixtures.get('all.json');
 
 let config: GetPkgReleasesConfig;
 

--- a/lib/modules/datasource/jenkins-plugins/index.spec.ts
+++ b/lib/modules/datasource/jenkins-plugins/index.spec.ts
@@ -4,8 +4,8 @@ import * as httpMock from '../../../../test/http-mock';
 import * as versioning from '../../versioning/docker';
 import { JenkinsPluginsDatasource } from '.';
 
-const jenkinsPluginsVersions = Fixtures?.getJson('plugin-versions.json');
-const jenkinsPluginsInfo = Fixtures?.getJson('update-center.actual.json');
+const jenkinsPluginsVersions = Fixtures.getJson('plugin-versions.json');
+const jenkinsPluginsInfo = Fixtures.getJson('update-center.actual.json');
 
 describe('modules/datasource/jenkins-plugins/index', () => {
   describe('getReleases', () => {

--- a/lib/modules/datasource/repology/index.spec.ts
+++ b/lib/modules/datasource/repology/index.spec.ts
@@ -48,12 +48,12 @@ const mockResolverCall = (
   }
 };
 
-const fixtureNginx = Fixtures?.get(`nginx.json`);
-const fixtureGccDefaults = Fixtures?.get(`gcc-defaults.json`);
-const fixtureGcc = Fixtures?.get(`gcc.json`);
-const fixturePulseaudio = Fixtures?.get(`pulseaudio.json`);
-const fixtureJdk = Fixtures?.get(`openjdk.json`);
-const fixturePython = Fixtures?.get(`python.json`);
+const fixtureNginx = Fixtures.get(`nginx.json`);
+const fixtureGccDefaults = Fixtures.get(`gcc-defaults.json`);
+const fixtureGcc = Fixtures.get(`gcc.json`);
+const fixturePulseaudio = Fixtures.get(`pulseaudio.json`);
+const fixtureJdk = Fixtures.get(`openjdk.json`);
+const fixturePython = Fixtures.get(`python.json`);
 
 describe('modules/datasource/repology/index', () => {
   describe('getReleases', () => {

--- a/lib/modules/datasource/rubygems/index.spec.ts
+++ b/lib/modules/datasource/rubygems/index.spec.ts
@@ -5,10 +5,10 @@ import * as rubyVersioning from '../../versioning/ruby';
 import { resetCache } from './get-rubygems-org';
 import { RubyGemsDatasource } from '.';
 
-const rubygemsOrgVersions = Fixtures?.get('rubygems-org.txt');
-const railsInfo = Fixtures?.getJson('rails/info.json');
-const railsVersions = Fixtures?.getJson('rails/versions.json');
-const railsDependencies = Fixtures?.getBinary('dependencies-rails.dat');
+const rubygemsOrgVersions = Fixtures.get('rubygems-org.txt');
+const railsInfo = Fixtures.getJson('rails/info.json');
+const railsVersions = Fixtures.getJson('rails/versions.json');
+const railsDependencies = Fixtures.getBinary('dependencies-rails.dat');
 const emptyMarshalArray = Buffer.from([4, 8, 91, 0]);
 
 describe('modules/datasource/rubygems/index', () => {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Change `Fixtures?.get...` to `Fixtures.get...`.

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

As pointed out at https://github.com/renovatebot/renovate/pull/16545#discussion_r919122247.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
