### PR TITLE
refactor: rename isBranchStale -> isBranchBehindBase

### DIFF
--- a/lib/modules/platform/azure/index.spec.ts
+++ b/lib/modules/platform/azure/index.spec.ts
@@ -41,7 +41,7 @@ describe('modules/platform/azure/index', () => {
     logger = (await import('../../../logger')).logger as never;
     git = require('../../../util/git');
     git.branchExists.mockReturnValue(true);
-    git.isBehindBaseBranch.mockResolvedValue(false);
+    git.isBranchBehindBase.mockResolvedValue(false);
     hostRules.find.mockReturnValue({
       token: 'token',
     });

--- a/lib/modules/platform/azure/index.spec.ts
+++ b/lib/modules/platform/azure/index.spec.ts
@@ -41,7 +41,7 @@ describe('modules/platform/azure/index', () => {
     logger = (await import('../../../logger')).logger as never;
     git = require('../../../util/git');
     git.branchExists.mockReturnValue(true);
-    git.isBranchStale.mockResolvedValue(false);
+    git.isBehindBaseBranch.mockResolvedValue(false);
     hostRules.find.mockReturnValue({
       token: 'token',
     });

--- a/lib/modules/platform/bitbucket-server/index.spec.ts
+++ b/lib/modules/platform/bitbucket-server/index.spec.ts
@@ -209,7 +209,7 @@ describe('modules/platform/bitbucket-server/index', () => {
         bitbucket = await import('.');
         git = require('../../../util/git');
         git.branchExists.mockReturnValue(true);
-        git.isBehindBaseBranch.mockResolvedValue(false);
+        git.isBranchBehindBase.mockResolvedValue(false);
         git.getBranchCommit.mockReturnValue(
           '0d9c7726c3d628b7e28af234595cfd20febdbf8e'
         );

--- a/lib/modules/platform/bitbucket-server/index.spec.ts
+++ b/lib/modules/platform/bitbucket-server/index.spec.ts
@@ -209,7 +209,7 @@ describe('modules/platform/bitbucket-server/index', () => {
         bitbucket = await import('.');
         git = require('../../../util/git');
         git.branchExists.mockReturnValue(true);
-        git.isBranchStale.mockResolvedValue(false);
+        git.isBehindBaseBranch.mockResolvedValue(false);
         git.getBranchCommit.mockReturnValue(
           '0d9c7726c3d628b7e28af234595cfd20febdbf8e'
         );

--- a/lib/modules/platform/bitbucket/index.spec.ts
+++ b/lib/modules/platform/bitbucket/index.spec.ts
@@ -34,7 +34,7 @@ describe('modules/platform/bitbucket/index', () => {
     logger = (await import('../../../logger')).logger as any;
     git = require('../../../util/git');
     git.branchExists.mockReturnValue(true);
-    git.isBehindBaseBranch.mockResolvedValue(false);
+    git.isBranchBehindBase.mockResolvedValue(false);
     // clean up hostRules
     hostRules.clear();
     hostRules.find.mockReturnValue({

--- a/lib/modules/platform/bitbucket/index.spec.ts
+++ b/lib/modules/platform/bitbucket/index.spec.ts
@@ -34,7 +34,7 @@ describe('modules/platform/bitbucket/index', () => {
     logger = (await import('../../../logger')).logger as any;
     git = require('../../../util/git');
     git.branchExists.mockReturnValue(true);
-    git.isBranchStale.mockResolvedValue(false);
+    git.isBehindBaseBranch.mockResolvedValue(false);
     // clean up hostRules
     hostRules.clear();
     hostRules.find.mockReturnValue({

--- a/lib/modules/platform/gitea/index.spec.ts
+++ b/lib/modules/platform/gitea/index.spec.ts
@@ -179,7 +179,7 @@ describe('modules/platform/gitea/index', () => {
     helper = mocked(await import('./gitea-helper'));
     logger = mocked((await import('../../../logger')).logger);
     gitvcs = require('../../../util/git');
-    gitvcs.isBranchStale.mockResolvedValue(false);
+    gitvcs.isBehindBaseBranch.mockResolvedValue(false);
     gitvcs.getBranchCommit.mockReturnValue(mockCommitHash);
     hostRules = mocked(await import('../../../util/host-rules'));
     hostRules.clear();

--- a/lib/modules/platform/gitea/index.spec.ts
+++ b/lib/modules/platform/gitea/index.spec.ts
@@ -179,7 +179,7 @@ describe('modules/platform/gitea/index', () => {
     helper = mocked(await import('./gitea-helper'));
     logger = mocked((await import('../../../logger')).logger);
     gitvcs = require('../../../util/git');
-    gitvcs.isBehindBaseBranch.mockResolvedValue(false);
+    gitvcs.isBranchBehindBase.mockResolvedValue(false);
     gitvcs.getBranchCommit.mockReturnValue(mockCommitHash);
     hostRules = mocked(await import('../../../util/host-rules'));
     hostRules.clear();

--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -35,7 +35,7 @@ describe('modules/platform/github/index', () => {
     setBaseUrl(githubApiHost);
 
     git.branchExists.mockReturnValue(true);
-    git.isBehindBaseBranch.mockResolvedValue(true);
+    git.isBranchBehindBase.mockResolvedValue(true);
     git.getBranchCommit.mockReturnValue(
       '0d9c7726c3d628b7e28af234595cfd20febdbf8e'
     );

--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -35,7 +35,7 @@ describe('modules/platform/github/index', () => {
     setBaseUrl(githubApiHost);
 
     git.branchExists.mockReturnValue(true);
-    git.isBranchStale.mockResolvedValue(true);
+    git.isBehindBaseBranch.mockResolvedValue(true);
     git.getBranchCommit.mockReturnValue(
       '0d9c7726c3d628b7e28af234595cfd20febdbf8e'
     );

--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -36,7 +36,7 @@ describe('modules/platform/gitlab/index', () => {
     jest.mock('../../../util/git');
     git = require('../../../util/git');
     git.branchExists.mockReturnValue(true);
-    git.isBranchStale.mockResolvedValue(true);
+    git.isBehindBaseBranch.mockResolvedValue(true);
     git.getBranchCommit.mockReturnValue(
       '0d9c7726c3d628b7e28af234595cfd20febdbf8e'
     );

--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -36,7 +36,7 @@ describe('modules/platform/gitlab/index', () => {
     jest.mock('../../../util/git');
     git = require('../../../util/git');
     git.branchExists.mockReturnValue(true);
-    git.isBehindBaseBranch.mockResolvedValue(true);
+    git.isBranchBehindBase.mockResolvedValue(true);
     git.getBranchCommit.mockReturnValue(
       '0d9c7726c3d628b7e28af234595cfd20febdbf8e'
     );

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -234,18 +234,20 @@ describe('util/git/index', () => {
     });
   });
 
-  describe('isBranchStale()', () => {
+  describe('isBehindBaseBranch()', () => {
     it('should return false if same SHA as master', async () => {
-      expect(await git.isBranchStale('renovate/future_branch')).toBeFalse();
+      expect(
+        await git.isBehindBaseBranch('renovate/future_branch')
+      ).toBeFalse();
     });
 
     it('should return true if SHA different from master', async () => {
-      expect(await git.isBranchStale('renovate/past_branch')).toBeTrue();
+      expect(await git.isBehindBaseBranch('renovate/past_branch')).toBeTrue();
     });
 
     it('should return result even if non-default and not under branchPrefix', async () => {
-      expect(await git.isBranchStale('develop')).toBeTrue();
-      expect(await git.isBranchStale('develop')).toBeTrue(); // cache
+      expect(await git.isBehindBaseBranch('develop')).toBeTrue();
+      expect(await git.isBehindBaseBranch('develop')).toBeTrue(); // cache
     });
   });
 

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -234,20 +234,20 @@ describe('util/git/index', () => {
     });
   });
 
-  describe('isBehindBaseBranch()', () => {
+  describe('isBranchBehindBase()', () => {
     it('should return false if same SHA as master', async () => {
       expect(
-        await git.isBehindBaseBranch('renovate/future_branch')
+        await git.isBranchBehindBase('renovate/future_branch')
       ).toBeFalse();
     });
 
     it('should return true if SHA different from master', async () => {
-      expect(await git.isBehindBaseBranch('renovate/past_branch')).toBeTrue();
+      expect(await git.isBranchBehindBase('renovate/past_branch')).toBeTrue();
     });
 
     it('should return result even if non-default and not under branchPrefix', async () => {
-      expect(await git.isBehindBaseBranch('develop')).toBeTrue();
-      expect(await git.isBehindBaseBranch('develop')).toBeTrue(); // cache
+      expect(await git.isBranchBehindBase('develop')).toBeTrue();
+      expect(await git.isBranchBehindBase('develop')).toBeTrue(); // cache
     });
   });
 

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -538,7 +538,7 @@ export function getBranchList(): string[] {
   return Object.keys(config.branchCommits);
 }
 
-export async function isBranchStale(branchName: string): Promise<boolean> {
+export async function isBehindBaseBranch(branchName: string): Promise<boolean> {
   await syncGit();
   try {
     const { currentBranchSha, currentBranch } = config;
@@ -548,12 +548,14 @@ export async function isBranchStale(branchName: string): Promise<boolean> {
       '--contains',
       config.currentBranchSha,
     ]);
-    const isStale = !branches.all.map(localName).includes(branchName);
+    const isBehindBaseBranch = !branches.all
+      .map(localName)
+      .includes(branchName);
     logger.debug(
-      { isStale, currentBranch, currentBranchSha },
-      `isBranchStale=${isStale}`
+      { isBehindBaseBranch, currentBranch, currentBranchSha },
+      `isBehindBaseBranch=${isBehindBaseBranch}`
     );
-    return isStale;
+    return isBehindBaseBranch;
   } catch (err) /* istanbul ignore next */ {
     const errChecked = checkForPlatformFailure(err);
     if (errChecked) {

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -538,7 +538,7 @@ export function getBranchList(): string[] {
   return Object.keys(config.branchCommits);
 }
 
-export async function isBehindBaseBranch(branchName: string): Promise<boolean> {
+export async function isBranchBehindBase(branchName: string): Promise<boolean> {
   await syncGit();
   try {
     const { currentBranchSha, currentBranch } = config;
@@ -548,14 +548,12 @@ export async function isBehindBaseBranch(branchName: string): Promise<boolean> {
       '--contains',
       config.currentBranchSha,
     ]);
-    const isBehindBaseBranch = !branches.all
-      .map(localName)
-      .includes(branchName);
+    const isBehind = !branches.all.map(localName).includes(branchName);
     logger.debug(
-      { isBehindBaseBranch, currentBranch, currentBranchSha },
-      `isBehindBaseBranch=${isBehindBaseBranch}`
+      { isBehind, currentBranch, currentBranchSha },
+      `isBranchBehindBase=${isBehind}`
     );
-    return isBehindBaseBranch;
+    return isBehind;
   } catch (err) /* istanbul ignore next */ {
     const errChecked = checkForPlatformFailure(err);
     if (errChecked) {

--- a/lib/workers/repository/config-migration/branch/rebase.spec.ts
+++ b/lib/workers/repository/config-migration/branch/rebase.spec.ts
@@ -52,7 +52,7 @@ describe('workers/repository/config-migration/branch/rebase', () => {
     });
 
     it('rebases migration branch', async () => {
-      git.isBehindBaseBranch.mockResolvedValueOnce(true);
+      git.isBranchBehindBase.mockResolvedValueOnce(true);
       await rebaseMigrationBranch(config, migratedConfigData);
       expect(git.commitFiles).toHaveBeenCalledTimes(1);
     });
@@ -61,14 +61,14 @@ describe('workers/repository/config-migration/branch/rebase', () => {
       GlobalConfig.set({
         dryRun: 'full',
       });
-      git.isBehindBaseBranch.mockResolvedValueOnce(true);
+      git.isBranchBehindBase.mockResolvedValueOnce(true);
       await rebaseMigrationBranch(config, migratedConfigData);
       expect(git.commitFiles).toHaveBeenCalledTimes(0);
     });
 
     it('rebases via platform', async () => {
       config.platformCommit = true;
-      git.isBehindBaseBranch.mockResolvedValueOnce(true);
+      git.isBranchBehindBase.mockResolvedValueOnce(true);
       await rebaseMigrationBranch(config, migratedConfigData);
       expect(platform.commitFiles).toHaveBeenCalledTimes(1);
     });

--- a/lib/workers/repository/config-migration/branch/rebase.spec.ts
+++ b/lib/workers/repository/config-migration/branch/rebase.spec.ts
@@ -52,7 +52,7 @@ describe('workers/repository/config-migration/branch/rebase', () => {
     });
 
     it('rebases migration branch', async () => {
-      git.isBranchStale.mockResolvedValueOnce(true);
+      git.isBehindBaseBranch.mockResolvedValueOnce(true);
       await rebaseMigrationBranch(config, migratedConfigData);
       expect(git.commitFiles).toHaveBeenCalledTimes(1);
     });
@@ -61,14 +61,14 @@ describe('workers/repository/config-migration/branch/rebase', () => {
       GlobalConfig.set({
         dryRun: 'full',
       });
-      git.isBranchStale.mockResolvedValueOnce(true);
+      git.isBehindBaseBranch.mockResolvedValueOnce(true);
       await rebaseMigrationBranch(config, migratedConfigData);
       expect(git.commitFiles).toHaveBeenCalledTimes(0);
     });
 
     it('rebases via platform', async () => {
       config.platformCommit = true;
-      git.isBranchStale.mockResolvedValueOnce(true);
+      git.isBehindBaseBranch.mockResolvedValueOnce(true);
       await rebaseMigrationBranch(config, migratedConfigData);
       expect(platform.commitFiles).toHaveBeenCalledTimes(1);
     });

--- a/lib/workers/repository/config-migration/branch/rebase.ts
+++ b/lib/workers/repository/config-migration/branch/rebase.ts
@@ -4,7 +4,7 @@ import { logger } from '../../../../logger';
 import { commitAndPush } from '../../../../modules/platform/commit';
 import {
   getFile,
-  isBehindBaseBranch,
+  isBranchBehindBase,
   isBranchModified,
 } from '../../../../util/git';
 import { getMigrationBranchName } from '../common';
@@ -26,7 +26,7 @@ export async function rebaseMigrationBranch(
   const existingContents = await getFile(configFileName, branchName);
   if (
     contents === existingContents &&
-    !(await isBehindBaseBranch(branchName))
+    !(await isBranchBehindBase(branchName))
   ) {
     logger.debug('Migration branch is up to date');
     return null;

--- a/lib/workers/repository/config-migration/branch/rebase.ts
+++ b/lib/workers/repository/config-migration/branch/rebase.ts
@@ -2,7 +2,11 @@ import { GlobalConfig } from '../../../../config/global';
 import type { RenovateConfig } from '../../../../config/types';
 import { logger } from '../../../../logger';
 import { commitAndPush } from '../../../../modules/platform/commit';
-import { getFile, isBranchModified, isBranchStale } from '../../../../util/git';
+import {
+  getFile,
+  isBehindBaseBranch,
+  isBranchModified,
+} from '../../../../util/git';
 import { getMigrationBranchName } from '../common';
 import { ConfigMigrationCommitMessageFactory } from './commit-message';
 import type { MigratedData } from './migrated-data';
@@ -20,7 +24,10 @@ export async function rebaseMigrationBranch(
   const configFileName = migratedConfigData.filename;
   const contents = migratedConfigData.content;
   const existingContents = await getFile(configFileName, branchName);
-  if (contents === existingContents && !(await isBranchStale(branchName))) {
+  if (
+    contents === existingContents &&
+    !(await isBehindBaseBranch(branchName))
+  ) {
     logger.debug('Migration branch is up to date');
     return null;
   }

--- a/lib/workers/repository/onboarding/branch/rebase.spec.ts
+++ b/lib/workers/repository/onboarding/branch/rebase.spec.ts
@@ -44,7 +44,7 @@ describe('workers/repository/onboarding/branch/rebase', () => {
     });
 
     it('rebases onboarding branch', async () => {
-      git.isBranchStale.mockResolvedValueOnce(true);
+      git.isBehindBaseBranch.mockResolvedValueOnce(true);
       await rebaseOnboardingBranch(config);
       expect(git.commitFiles).toHaveBeenCalledTimes(1);
     });
@@ -52,13 +52,13 @@ describe('workers/repository/onboarding/branch/rebase', () => {
     it('rebases via platform', async () => {
       platform.commitFiles = jest.fn();
       config.platformCommit = true;
-      git.isBranchStale.mockResolvedValueOnce(true);
+      git.isBehindBaseBranch.mockResolvedValueOnce(true);
       await rebaseOnboardingBranch(config);
       expect(platform.commitFiles).toHaveBeenCalledTimes(1);
     });
 
     it('uses the onboardingConfigFileName if set', async () => {
-      git.isBranchStale.mockResolvedValueOnce(true);
+      git.isBehindBaseBranch.mockResolvedValueOnce(true);
       await rebaseOnboardingBranch({
         ...config,
         onboardingConfigFileName: '.github/renovate.json',
@@ -73,7 +73,7 @@ describe('workers/repository/onboarding/branch/rebase', () => {
     });
 
     it('falls back to "renovate.json" if onboardingConfigFileName is not set', async () => {
-      git.isBranchStale.mockResolvedValueOnce(true);
+      git.isBehindBaseBranch.mockResolvedValueOnce(true);
       await rebaseOnboardingBranch({
         ...config,
         onboardingConfigFileName: undefined,

--- a/lib/workers/repository/onboarding/branch/rebase.spec.ts
+++ b/lib/workers/repository/onboarding/branch/rebase.spec.ts
@@ -44,7 +44,7 @@ describe('workers/repository/onboarding/branch/rebase', () => {
     });
 
     it('rebases onboarding branch', async () => {
-      git.isBehindBaseBranch.mockResolvedValueOnce(true);
+      git.isBranchBehindBase.mockResolvedValueOnce(true);
       await rebaseOnboardingBranch(config);
       expect(git.commitFiles).toHaveBeenCalledTimes(1);
     });
@@ -52,13 +52,13 @@ describe('workers/repository/onboarding/branch/rebase', () => {
     it('rebases via platform', async () => {
       platform.commitFiles = jest.fn();
       config.platformCommit = true;
-      git.isBehindBaseBranch.mockResolvedValueOnce(true);
+      git.isBranchBehindBase.mockResolvedValueOnce(true);
       await rebaseOnboardingBranch(config);
       expect(platform.commitFiles).toHaveBeenCalledTimes(1);
     });
 
     it('uses the onboardingConfigFileName if set', async () => {
-      git.isBehindBaseBranch.mockResolvedValueOnce(true);
+      git.isBranchBehindBase.mockResolvedValueOnce(true);
       await rebaseOnboardingBranch({
         ...config,
         onboardingConfigFileName: '.github/renovate.json',
@@ -73,7 +73,7 @@ describe('workers/repository/onboarding/branch/rebase', () => {
     });
 
     it('falls back to "renovate.json" if onboardingConfigFileName is not set', async () => {
-      git.isBehindBaseBranch.mockResolvedValueOnce(true);
+      git.isBranchBehindBase.mockResolvedValueOnce(true);
       await rebaseOnboardingBranch({
         ...config,
         onboardingConfigFileName: undefined,

--- a/lib/workers/repository/onboarding/branch/rebase.ts
+++ b/lib/workers/repository/onboarding/branch/rebase.ts
@@ -5,7 +5,7 @@ import { logger } from '../../../../logger';
 import { commitAndPush } from '../../../../modules/platform/commit';
 import {
   getFile,
-  isBehindBaseBranch,
+  isBranchBehindBase,
   isBranchModified,
 } from '../../../../util/git';
 import { OnboardingCommitMessageFactory } from './commit-message';
@@ -31,7 +31,7 @@ export async function rebaseOnboardingBranch(
   // TODO #7154
   if (
     contents === existingContents &&
-    !(await isBehindBaseBranch(config.onboardingBranch!))
+    !(await isBranchBehindBase(config.onboardingBranch!))
   ) {
     logger.debug('Onboarding branch is up to date');
     return null;

--- a/lib/workers/repository/onboarding/branch/rebase.ts
+++ b/lib/workers/repository/onboarding/branch/rebase.ts
@@ -3,7 +3,11 @@ import { GlobalConfig } from '../../../../config/global';
 import type { RenovateConfig } from '../../../../config/types';
 import { logger } from '../../../../logger';
 import { commitAndPush } from '../../../../modules/platform/commit';
-import { getFile, isBranchModified, isBranchStale } from '../../../../util/git';
+import {
+  getFile,
+  isBehindBaseBranch,
+  isBranchModified,
+} from '../../../../util/git';
 import { OnboardingCommitMessageFactory } from './commit-message';
 import { getOnboardingConfigContents } from './config';
 
@@ -27,7 +31,7 @@ export async function rebaseOnboardingBranch(
   // TODO #7154
   if (
     contents === existingContents &&
-    !(await isBranchStale(config.onboardingBranch!))
+    !(await isBehindBaseBranch(config.onboardingBranch!))
   ) {
     logger.debug('Onboarding branch is up to date');
     return null;

--- a/lib/workers/repository/update/branch/reuse.spec.ts
+++ b/lib/workers/repository/update/branch/reuse.spec.ts
@@ -173,7 +173,7 @@ describe('workers/repository/update/branch/reuse', () => {
       config.automerge = true;
       config.automergeType = 'branch';
       git.branchExists.mockReturnValueOnce(true);
-      git.isBehindBaseBranch.mockResolvedValueOnce(true);
+      git.isBranchBehindBase.mockResolvedValueOnce(true);
       const res = await shouldReuseExistingBranch(config);
       expect(res.reuseExistingBranch).toBeFalse();
     });
@@ -181,7 +181,7 @@ describe('workers/repository/update/branch/reuse', () => {
     it('returns true if rebaseWhen=behind-base-branch but cannot rebase', async () => {
       config.rebaseWhen = 'behind-base-branch';
       git.branchExists.mockReturnValueOnce(true);
-      git.isBehindBaseBranch.mockResolvedValueOnce(true);
+      git.isBranchBehindBase.mockResolvedValueOnce(true);
       git.isBranchConflicted.mockResolvedValueOnce(true);
       platform.getBranchPr.mockResolvedValueOnce(pr);
       git.isBranchModified.mockResolvedValueOnce(true);
@@ -194,7 +194,7 @@ describe('workers/repository/update/branch/reuse', () => {
       config.automerge = true;
       config.automergeType = 'pr';
       git.branchExists.mockReturnValueOnce(true);
-      git.isBehindBaseBranch.mockResolvedValueOnce(true);
+      git.isBranchBehindBase.mockResolvedValueOnce(true);
       const res = await shouldReuseExistingBranch(config);
       expect(res.reuseExistingBranch).toBeFalse();
     });
@@ -203,7 +203,7 @@ describe('workers/repository/update/branch/reuse', () => {
       config.rebaseWhen = 'auto';
       platform.getRepoForceRebase.mockResolvedValueOnce(true);
       git.branchExists.mockReturnValueOnce(true);
-      git.isBehindBaseBranch.mockResolvedValueOnce(true);
+      git.isBranchBehindBase.mockResolvedValueOnce(true);
       const res = await shouldReuseExistingBranch(config);
       expect(res.reuseExistingBranch).toBeFalse();
     });
@@ -214,7 +214,7 @@ describe('workers/repository/update/branch/reuse', () => {
       git.branchExists.mockReturnValueOnce(true);
       const res = await shouldReuseExistingBranch(config);
       expect(res.reuseExistingBranch).toBeTrue();
-      expect(git.isBehindBaseBranch).not.toHaveBeenCalled();
+      expect(git.isBranchBehindBase).not.toHaveBeenCalled();
       expect(git.isBranchModified).not.toHaveBeenCalled();
     });
 
@@ -222,7 +222,7 @@ describe('workers/repository/update/branch/reuse', () => {
       config.rebaseWhen = 'conflicted';
       config.automerge = true;
       git.branchExists.mockReturnValueOnce(true);
-      git.isBehindBaseBranch.mockResolvedValueOnce(true);
+      git.isBranchBehindBase.mockResolvedValueOnce(true);
       const res = await shouldReuseExistingBranch(config);
       expect(res.reuseExistingBranch).toBeTrue();
     });

--- a/lib/workers/repository/update/branch/reuse.spec.ts
+++ b/lib/workers/repository/update/branch/reuse.spec.ts
@@ -173,7 +173,7 @@ describe('workers/repository/update/branch/reuse', () => {
       config.automerge = true;
       config.automergeType = 'branch';
       git.branchExists.mockReturnValueOnce(true);
-      git.isBranchStale.mockResolvedValueOnce(true);
+      git.isBehindBaseBranch.mockResolvedValueOnce(true);
       const res = await shouldReuseExistingBranch(config);
       expect(res.reuseExistingBranch).toBeFalse();
     });
@@ -181,7 +181,7 @@ describe('workers/repository/update/branch/reuse', () => {
     it('returns true if rebaseWhen=behind-base-branch but cannot rebase', async () => {
       config.rebaseWhen = 'behind-base-branch';
       git.branchExists.mockReturnValueOnce(true);
-      git.isBranchStale.mockResolvedValueOnce(true);
+      git.isBehindBaseBranch.mockResolvedValueOnce(true);
       git.isBranchConflicted.mockResolvedValueOnce(true);
       platform.getBranchPr.mockResolvedValueOnce(pr);
       git.isBranchModified.mockResolvedValueOnce(true);
@@ -194,7 +194,7 @@ describe('workers/repository/update/branch/reuse', () => {
       config.automerge = true;
       config.automergeType = 'pr';
       git.branchExists.mockReturnValueOnce(true);
-      git.isBranchStale.mockResolvedValueOnce(true);
+      git.isBehindBaseBranch.mockResolvedValueOnce(true);
       const res = await shouldReuseExistingBranch(config);
       expect(res.reuseExistingBranch).toBeFalse();
     });
@@ -203,7 +203,7 @@ describe('workers/repository/update/branch/reuse', () => {
       config.rebaseWhen = 'auto';
       platform.getRepoForceRebase.mockResolvedValueOnce(true);
       git.branchExists.mockReturnValueOnce(true);
-      git.isBranchStale.mockResolvedValueOnce(true);
+      git.isBehindBaseBranch.mockResolvedValueOnce(true);
       const res = await shouldReuseExistingBranch(config);
       expect(res.reuseExistingBranch).toBeFalse();
     });
@@ -214,7 +214,7 @@ describe('workers/repository/update/branch/reuse', () => {
       git.branchExists.mockReturnValueOnce(true);
       const res = await shouldReuseExistingBranch(config);
       expect(res.reuseExistingBranch).toBeTrue();
-      expect(git.isBranchStale).not.toHaveBeenCalled();
+      expect(git.isBehindBaseBranch).not.toHaveBeenCalled();
       expect(git.isBranchModified).not.toHaveBeenCalled();
     });
 
@@ -222,7 +222,7 @@ describe('workers/repository/update/branch/reuse', () => {
       config.rebaseWhen = 'conflicted';
       config.automerge = true;
       git.branchExists.mockReturnValueOnce(true);
-      git.isBranchStale.mockResolvedValueOnce(true);
+      git.isBehindBaseBranch.mockResolvedValueOnce(true);
       const res = await shouldReuseExistingBranch(config);
       expect(res.reuseExistingBranch).toBeTrue();
     });

--- a/lib/workers/repository/update/branch/reuse.ts
+++ b/lib/workers/repository/update/branch/reuse.ts
@@ -5,9 +5,9 @@ import { platform } from '../../../../modules/platform';
 import type { RangeStrategy } from '../../../../types';
 import {
   branchExists,
+  isBehindBaseBranch,
   isBranchConflicted,
   isBranchModified,
-  isBranchStale,
 } from '../../../../util/git';
 import type { BranchConfig } from '../../../types';
 
@@ -62,7 +62,7 @@ export async function shouldReuseExistingBranch(
     (config.rebaseWhen === 'auto' &&
       (config.automerge || (await platform.getRepoForceRebase())))
   ) {
-    if (await isBranchStale(branchName)) {
+    if (await isBehindBaseBranch(branchName)) {
       logger.debug(`Branch is stale and needs rebasing`);
       // We can rebase the branch only if no PR or PR can be rebased
       if (await isBranchModified(branchName)) {

--- a/lib/workers/repository/update/branch/reuse.ts
+++ b/lib/workers/repository/update/branch/reuse.ts
@@ -5,7 +5,7 @@ import { platform } from '../../../../modules/platform';
 import type { RangeStrategy } from '../../../../types';
 import {
   branchExists,
-  isBehindBaseBranch,
+  isBranchBehindBase,
   isBranchConflicted,
   isBranchModified,
 } from '../../../../util/git';
@@ -62,7 +62,7 @@ export async function shouldReuseExistingBranch(
     (config.rebaseWhen === 'auto' &&
       (config.automerge || (await platform.getRepoForceRebase())))
   ) {
-    if (await isBehindBaseBranch(branchName)) {
+    if (await isBranchBehindBase(branchName)) {
       logger.debug(`Branch is stale and needs rebasing`);
       // We can rebase the branch only if no PR or PR can be rebased
       if (await isBranchModified(branchName)) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- rename isBranchStale -> isBehindBaseBranch
<!-- Describe what behavior is changed by this PR. -->

## Context
- we use the term "stale" but that's too vague, what we mean by stale is "behind base branch" 
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
