### PR TITLE
docs(issue labeling): sync labels

### DIFF
--- a/docs/development/issue-labeling.md
+++ b/docs/development/issue-labeling.md
@@ -112,11 +112,11 @@ Keep in mind that an issue can be both affecting a platform and a self hosted in
 
     core:automerge
     core:changelogs
+    core:config
     core:dashboard
+    core:git
     core:onboarding
     core:schedule
-    core:config
-    core:git
 
 </details>
 
@@ -137,10 +137,10 @@ Use a `datasource:` label when it is applicable specifically to particular datas
 <details>
     <summary>Worker</summary>
 
-    worker:global
     worker:branch
-    worker:repository
+    worker:global
     worker:pr
+    worker:repository
 
 </details>
 

--- a/docs/development/issue-labeling.md
+++ b/docs/development/issue-labeling.md
@@ -115,6 +115,8 @@ Keep in mind that an issue can be both affecting a platform and a self hosted in
     core:dashboard
     core:onboarding
     core:schedule
+    core:config
+    core:git
 
 </details>
 
@@ -135,9 +137,9 @@ Use a `datasource:` label when it is applicable specifically to particular datas
 <details>
     <summary>Worker</summary>
 
-    worker:branch
     worker:global
-    worker:onboarding
+    worker:branch
+    worker:repository
     worker:pr
 
 </details>


### PR DESCRIPTION
## Changes

- Sync labels so they match the `renovatebot/renovate` labels

## Context

Drive-by PR, not closing any issue.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository