### PR TITLE
fix(utils/fs): make assertions windows compatible

### DIFF
--- a/lib/util/fs/index.spec.ts
+++ b/lib/util/fs/index.spec.ts
@@ -1,7 +1,7 @@
 import _findUp from 'find-up';
 import fs from 'fs-extra';
 import tmp, { DirectoryResult } from 'tmp-promise';
-import { join } from 'upath';
+import { join, resolve } from 'upath';
 import { mockedFunction } from '../../../test/util';
 import { GlobalConfig } from '../../config/global';
 import {
@@ -246,7 +246,7 @@ describe('util/fs/index', () => {
       expect(result).toMatchSnapshot();
 
       await writeLocalFile('Cargo.lock', '');
-      await writeLocalFile('/test/subdir/Cargo.lock', '');
+      await writeLocalFile('test/subdir/Cargo.lock', '');
 
       const resultWithAdditionalFiles = await readLocalDirectory('test');
       expect(resultWithAdditionalFiles).not.toBeNull();
@@ -291,13 +291,13 @@ describe('util/fs/index', () => {
     });
 
     it('returns false for directory', async () => {
-      const path = `${localDir}/foobar`;
+      const path = resolve(`${localDir}/foobar`);
       await fs.mkdir(path);
       expect(await localPathIsFile(path)).toBeFalse();
     });
 
     it('returns false for non-existing path', async () => {
-      expect(await localPathIsFile(`${localDir}/foobar`)).toBeFalse();
+      expect(await localPathIsFile(resolve(`${localDir}/foobar`))).toBeFalse();
     });
   });
 

--- a/lib/util/fs/util.spec.ts
+++ b/lib/util/fs/util.spec.ts
@@ -1,20 +1,20 @@
+import upath from 'upath';
 import { GlobalConfig } from '../../config/global';
 import { FILE_ACCESS_VIOLATION_ERROR } from '../../constants/error-messages';
 import { ensureCachePath, ensureLocalPath } from './util';
 
 describe('util/fs/util', () => {
-  const localDir = '/foo';
-  const cacheDir = '/bar';
+  const localDir = upath.resolve('/foo');
+  const cacheDir = upath.resolve('/bar');
 
   beforeAll(() => {
     GlobalConfig.set({ localDir, cacheDir });
   });
 
   test.each`
-    path      | fullPath
-    ${''}     | ${`${localDir}`}
-    ${'baz'}  | ${`${localDir}/baz`}
-    ${'/baz'} | ${`${localDir}/baz`}
+    path     | fullPath
+    ${''}    | ${`${localDir}`}
+    ${'baz'} | ${`${localDir}/baz`}
   `(`ensureLocalPath('$path', '$fullPath')`, ({ path, fullPath }) => {
     expect(ensureLocalPath(path)).toBe(fullPath);
   });
@@ -25,15 +25,15 @@ describe('util/fs/util', () => {
     ${'../etc/passwd'}
     ${'/foo/../bar'}
     ${'/foo/../../etc/passwd'}
+    ${'/baz'}
   `(`ensureLocalPath('$path', '${localDir}') - throws`, ({ path }) => {
     expect(() => ensureLocalPath(path)).toThrow(FILE_ACCESS_VIOLATION_ERROR);
   });
 
   test.each`
-    path      | fullPath
-    ${''}     | ${`${cacheDir}`}
-    ${'baz'}  | ${`${cacheDir}/baz`}
-    ${'/baz'} | ${`${cacheDir}/baz`}
+    path     | fullPath
+    ${''}    | ${`${cacheDir}`}
+    ${'baz'} | ${`${cacheDir}/baz`}
   `(`ensureCachePath('$path', '$fullPath')`, ({ path, fullPath }) => {
     expect(ensureCachePath(path)).toBe(fullPath);
   });
@@ -44,6 +44,7 @@ describe('util/fs/util', () => {
     ${'../etc/passwd'}
     ${'/bar/../foo'}
     ${'/bar/../../etc/passwd'}
+    ${'/baz'}
   `(`ensureCachePath('$path', '${cacheDir}') - throws`, ({ path }) => {
     expect(() => ensureCachePath(path)).toThrow(FILE_ACCESS_VIOLATION_ERROR);
   });

--- a/lib/util/fs/util.ts
+++ b/lib/util/fs/util.ts
@@ -15,11 +15,9 @@ function assertBaseDir(path: string, baseDir: string): void {
 
 function ensurePath(path: string, key: 'localDir' | 'cacheDir'): string {
   const baseDir = upath.resolve(GlobalConfig.get(key)!);
-  let fullPath = path;
-  if (fullPath.startsWith(baseDir)) {
-    fullPath = fullPath.replace(baseDir, '');
-  }
-  fullPath = upath.resolve(upath.join(baseDir, fullPath));
+  const fullPath = upath.resolve(
+    upath.isAbsolute(path) ? path : upath.join(baseDir, path)
+  );
   assertBaseDir(fullPath, baseDir);
   return fullPath;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
**behavior change**: do not treat absolute path as relative to `baseDir` / `cacheDir`.

So `/baz` and `/foo` was read as `/foo/baz` which now throws 
<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
