### PR TITLE
fix(onboarding): use default preset only if truthy

### DIFF
--- a/lib/workers/repository/onboarding/branch/config.ts
+++ b/lib/workers/repository/onboarding/branch/config.ts
@@ -26,8 +26,9 @@ async function getOnboardingConfig(
   // Check for org/renovate-config
   try {
     const repo = `${orgName}/renovate-config`;
-    await getPreset({ repo });
-    orgPreset = `local>${repo}`;
+    if (await getPreset({ repo })) {
+      orgPreset = `local>${repo}`;
+    }
   } catch (err) {
     if (
       err.message !== PRESET_DEP_NOT_FOUND &&
@@ -43,11 +44,14 @@ async function getOnboardingConfig(
     try {
       const repo = `${orgName}/.${platform}`;
       const presetName = 'renovate-config';
-      await getPreset({
-        repo,
-        presetName,
-      });
-      orgPreset = `local>${repo}:${presetName}`;
+      if (
+        await getPreset({
+          repo,
+          presetName,
+        })
+      ) {
+        orgPreset = `local>${repo}:${presetName}`;
+      }
     } catch (err) {
       if (
         err.message !== PRESET_DEP_NOT_FOUND &&
@@ -59,6 +63,9 @@ async function getOnboardingConfig(
   }
 
   if (orgPreset) {
+    logger.debug(
+      `Found org preset ${orgPreset} - using it in onboarding config`
+    );
     onboardingConfig = {
       $schema: 'https://docs.renovatebot.com/renovate-schema.json',
       extends: [orgPreset],


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Uses default org preset only if truthy.

## Context

Closes #16526

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
