### PR TITLE
chore(stale action): close stale issues as not planned

### DIFF
--- a/.github/workflows/stale-action.yml
+++ b/.github/workflows/stale-action.yml
@@ -36,6 +36,9 @@ jobs:
           days-before-issue-close: 7
           close-issue-message: 'This bug report has been closed as we need a reproduction to work on this. If the original poster or anybody else with the same problem discovers that they can reproduce it, please create a new issue, and reference this issue.'
 
-          # Never label/close any pull requests
+          # Close stale issues as "not planned" on GitHub.
+          close-issue-reason: 'not_planned'
+
+          # Never label/close any pull requests.
           days-before-pr-close: -1
           days-before-pr-stale: -1


### PR DESCRIPTION
## Changes

- Stale bot now closes stale issues with the reason "not-planned"

## Context

GitHub recently released "issue closed reasons". When closing an issue you can choose to:

- Close as completed (Done, closed, fixed, resolved)
- Close as not planned (Won't fix, can't repro, duplicate, stale)

With [`actions/stale` v5.1.0](https://github.com/actions/stale/releases/tag/v5.1.0) you can now set the `close-issue-reason`.

I think the stale action should always close issues as "Close as not planned", because we need the reproduction to work on the issue.

## References

- [GitHub Docs, closing an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/closing-an-issue)
- [`actions/stale` readme, `close-issue-reason` ](https://github.com/actions/stale#close-issue-reason)

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository