### PR TITLE
fix(git-refs): gracefully ignore git-refs auth error

### DIFF
--- a/lib/modules/datasource/git-refs/index.ts
+++ b/lib/modules/datasource/git-refs/index.ts
@@ -51,7 +51,7 @@ export class GitRefsDatasource extends GitDatasource {
       releases: uniqueRefs.map((ref) => ({
         version: ref,
         gitRef: ref,
-        newDigest: rawRefs.find((rawRef) => rawRef.value === ref)?.hash,
+        newDigest: rawRefs!.find((rawRef) => rawRef.value === ref)?.hash,
       })),
     };
 

--- a/lib/modules/datasource/git-refs/index.ts
+++ b/lib/modules/datasource/git-refs/index.ts
@@ -1,3 +1,4 @@
+import { logger } from '../../../logger';
 import { cache } from '../../../util/cache/package/decorator';
 import { regEx } from '../../../util/regex';
 import type { DigestConfig, GetReleasesConfig, ReleaseResult } from '../types';
@@ -23,7 +24,13 @@ export class GitRefsDatasource extends GitDatasource {
   override async getReleases({
     packageName,
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
-    const rawRefs: RawRefs[] | null = await this.getRawRefs({ packageName });
+    let rawRefs: RawRefs[] | null = null;
+
+    try {
+      rawRefs = await this.getRawRefs({ packageName });
+    } catch (err) /* istanbul ignore next */ {
+      logger.debug({ err }, 'Error getting git-refs');
+    }
 
     if (!rawRefs) {
       return null;


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Catches git-refs auth errors gracefully.

## Context

Closes #16616

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
