### PR TITLE
refactor: move dependencyDashboardRebaseAllOpen parameter closely to worker

### DIFF
--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -212,7 +212,6 @@ export interface RenovateConfig
   dependencyDashboardAutoclose?: boolean;
   dependencyDashboardChecks?: Record<string, string>;
   dependencyDashboardIssue?: number;
-  dependencyDashboardRebaseAllOpen?: boolean;
   dependencyDashboardTitle?: string;
   dependencyDashboardHeader?: string;
   dependencyDashboardFooter?: string;

--- a/lib/workers/repository/dependency-dashboard.ts
+++ b/lib/workers/repository/dependency-dashboard.ts
@@ -7,7 +7,7 @@ import { getProblems, logger } from '../../logger';
 import { platform } from '../../modules/platform';
 import { regEx } from '../../util/regex';
 import * as template from '../../util/template';
-import { BranchConfig, BranchResult } from '../types';
+import { BranchConfig, BranchResult, SelectAllConfig } from '../types';
 import { PackageFiles } from './package-files';
 
 interface DependencyDashboard {
@@ -36,7 +36,9 @@ function parseDashboardIssue(issueBody: string): DependencyDashboard {
   return { dependencyDashboardChecks, dependencyDashboardRebaseAllOpen };
 }
 
-export async function readDashboardBody(config: RenovateConfig): Promise<void> {
+export async function readDashboardBody(
+  config: SelectAllConfig
+): Promise<void> {
   config.dependencyDashboardChecks = {};
   const stringifiedConfig = JSON.stringify(config);
   if (
@@ -97,7 +99,7 @@ function appendRepoProblems(config: RenovateConfig, issueBody: string): string {
 }
 
 export async function ensureDependencyDashboard(
-  config: RenovateConfig,
+  config: SelectAllConfig,
   allBranches: BranchConfig[]
 ): Promise<void> {
   // legacy/migrated issue

--- a/lib/workers/types.ts
+++ b/lib/workers/types.ts
@@ -145,3 +145,9 @@ export interface DepWarnings {
   warnings: string[];
   warningFiles: string[];
 }
+
+export interface SelectAllConfig extends RenovateConfig {
+  dependencyDashboardRebaseAllOpen?: boolean;
+  dependencyDashboardAllPending?: boolean;
+  dependencyDashboardAllRateLimited?: boolean;
+}


### PR DESCRIPTION
…worker

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
move dependencyDashboardRebaseAllOpen parameter closely to worker

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
