### PR TITLE
docs(shareable config presets): update shorthand description

### DIFF
--- a/docs/usage/config-presets.md
+++ b/docs/usage/config-presets.md
@@ -103,8 +103,8 @@ It mostly uses Renovate config defaults but adds a few smart customisations such
 
 <!-- prettier-ignore -->
 !!! note
-    The `:xyz` naming convention (with `:` prefix) is a special shorthand for the `default:` presets.
-    e.g. `:xyz` is equivalent to `default:xyz`.
+    The `:xyz` naming convention (with `:` prefix) is shorthand for the `config:` presets.
+    This means that `:xyz` is the same as `config:xyz`.
 
 ## How to Use Preset Configs
 


### PR DESCRIPTION
**Edit:** Ignore this PR, I misunderstood some things. 🙈 

---

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Update our shorthand description
- `:xyz` now points to `config:xyz`
- Rewrite text

## Context

Relevant snippet from my comment https://github.com/renovatebot/renovate/issues/12024#issuecomment-1182889890:

> Is there a `default:base`?

It looks like we once _had_ a `default:base` preset, but we _renamed_ it to `config:base`. See line 18:

https://github.com/renovatebot/renovate/blob/3c8d1d6076e2e776ebc366274e97198d9e69bce4/lib/config/presets/common.ts#L1-L25

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
