### PR TITLE
fix(repo/config-migration): error fetching config file when repo cache is enabled

### DIFF
--- a/lib/workers/repository/config-migration/branch/migrated-data.spec.ts
+++ b/lib/workers/repository/config-migration/branch/migrated-data.spec.ts
@@ -119,7 +119,7 @@ describe('workers/repository/config-migration/branch/migrated-data', () => {
         rawNonMigratedJson5
       );
       MigratedDataFactory.reset();
-      await expect(MigratedDataFactory.getAsync()).resolves.toEqual(
+      await expect(MigratedDataFactory.getAsync('enabled')).resolves.toEqual(
         migratedDataJson5
       );
     });
@@ -140,7 +140,7 @@ describe('workers/repository/config-migration/branch/migrated-data', () => {
       mockedFunction(getCache).mockReturnValue(repoData);
       mockedFunction(platform.getRawFile).mockRejectedValue(null);
       MigratedDataFactory.reset();
-      await expect(MigratedDataFactory.getAsync()).resolves.toBeNull();
+      await expect(MigratedDataFactory.getAsync('enabled')).resolves.toBeNull();
     });
 
     it('format and migrate a JSON config file', async () => {

--- a/lib/workers/repository/config-migration/branch/migrated-data.ts
+++ b/lib/workers/repository/config-migration/branch/migrated-data.ts
@@ -3,6 +3,7 @@ import JSON5 from 'json5';
 import prettier from 'prettier';
 import { migrateConfig } from '../../../../config/migration';
 import { logger } from '../../../../logger';
+import { platform } from '../../../../modules/platform';
 import { readLocalFile } from '../../../../util/fs';
 import { getFileList } from '../../../../util/git';
 import { detectRepoFileConfig } from '../../init/merge';
@@ -99,7 +100,7 @@ export class MigratedDataFactory {
       delete migratedConfig.warnings;
 
       const filename = rc.configFileName ?? '';
-      const raw = await readLocalFile(filename, 'utf8');
+      const raw = await platform.getRawFile(filename);
 
       // indent defaults to 2 spaces
       // TODO #7154

--- a/lib/workers/repository/finalise/index.ts
+++ b/lib/workers/repository/finalise/index.ts
@@ -17,7 +17,9 @@ export async function finaliseRepo(
   branchList: string[]
 ): Promise<void> {
   if (config.configMigration) {
-    const migratedConfigData = await MigratedDataFactory.getAsync();
+    const migratedConfigData = await MigratedDataFactory.getAsync(
+      config.repositoryCache
+    );
     const migrationBranch = await checkConfigMigrationBranch(
       config,
       migratedConfigData!


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Use `platform.readLocalFile` to fetch repo config file.
currently we are using `fs.getLocalFile` which fails when `repoCache=enabled`. which in turn causes migration PR to not be created/autoclosed.

```
DEBUG: MigratedDataFactory.getAsync() Error initializing renovate MigratedData
{
  "err": {
    "message": "Expected a string",
    "stack": "TypeError: Expected a string\n    at module.exports (/home/ubuntu/renovateapp/node_modules/detect-indent/index.js:134:9)\n    at Function.build (/home/ubuntu/renovateapp/node_modules/renovate/dist/workers/repository/config-migration/branch/migrated-data.js:80:56)\n    at async Function.getAsync (/home/ubuntu/renovateapp/node_modules/renovate/dist/workers/repository/config-migration/branch/migrated-data.js:54:26)\n    at async finaliseRepo (/home/ubuntu/renovateapp/node_modules/renovate/dist/workers/repository/finalise/index.js:18:36)\n    at async Object.renovateRepository (/home/ubuntu/renovateapp/node_modules/renovate/dist/workers/repository/index.js:58:13)\n    at async renovateRepository (/home/ubuntu/renovateapp/app/worker/index.js:309:26)\n    at async /home/ubuntu/renovateapp/app/worker/index.js:569:5"
  }
}
DEBUG: checkConfigMigrationBranch()
DEBUG: checkConfigMigrationBranch() Config does not need migration
...
INFO: Autoclosing PR
{
  "branchName": "renovate/migrate-config",
  "prNo": 13,
  "prTitle": "Configure Renovate"
}
DEBUG: updatePr(13, Configure Renovate - autoclosed, body)
DEBUG: PR updated
{
  "pr": 13
}
DEBUG: Deleted remote branch
{
  "branchName": "renovate/migrate-config"
}
```
<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
