### PR TITLE
feat(gradle): always add depType to extracted dependencies

### DIFF
--- a/lib/modules/manager/gradle/__snapshots__/extract.spec.ts.snap
+++ b/lib/modules/manager/gradle/__snapshots__/extract.spec.ts.snap
@@ -8,6 +8,7 @@ Array [
       Object {
         "currentValue": "1.2.3",
         "depName": "foo:bar",
+        "depType": "dependencies",
         "fileReplacePosition": 4,
         "groupName": "baz",
         "managerData": Object {

--- a/lib/modules/manager/gradle/extract.spec.ts
+++ b/lib/modules/manager/gradle/extract.spec.ts
@@ -802,4 +802,33 @@ describe('modules/manager/gradle/extract', () => {
       { packageFile: 'build.gradle' },
     ]);
   });
+
+  it('ensures depType is assigned', async () => {
+    const fsMock = {
+      'build.gradle':
+        "id 'org.sonarqube' version '3.1.1'\n\"io.jsonwebtoken:jjwt-api:0.11.2\"",
+      'buildSrc/build.gradle': '"com.google.protobuf:protobuf-java:3.18.2"',
+    };
+
+    mockFs(fsMock);
+
+    const res = await extractAllPackageFiles(
+      {} as ExtractConfig,
+      Object.keys(fsMock)
+    );
+
+    expect(res).toMatchObject([
+      {
+        packageFile: 'build.gradle',
+        deps: [
+          { depName: 'org.sonarqube', depType: 'plugin' },
+          { depName: 'io.jsonwebtoken:jjwt-api', depType: 'dependencies' },
+        ],
+      },
+      {
+        packageFile: 'buildSrc/build.gradle',
+        deps: [{ depType: 'devDependencies' }],
+      },
+    ]);
+  });
 });

--- a/lib/modules/manager/gradle/extract.ts
+++ b/lib/modules/manager/gradle/extract.ts
@@ -113,6 +113,12 @@ export async function extractAllPackageFiles(
         ...new Set([...registryUrls, ...(dep.registryUrls ?? [])]),
       ];
 
+      if (!dep.depType) {
+        dep.depType = key.startsWith('buildSrc')
+          ? 'devDependencies'
+          : 'dependencies';
+      }
+
       const depAlreadyInPkgFile = pkgFile.deps.some(
         (item) =>
           item.depName === dep.depName &&


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Ensures that `depType` is added to each gradle dependency. So far, `depType` is only added for gradle plugins. For regular dependencies, this attribute was missing, making it infeasible to use `matchDepTypes` in package rules. 

Notes:
* It is not feasible to use `implementation`, `api`, `testImplementation`, etc. as `depType` (see [dicussion here](https://github.com/renovatebot/renovate/discussions/12831)). The gradle manager in renovate doesn't even capture these configurations. Moreover, they are not actual dependency types but configurations that are specified to the Java plugin (see [here](https://docs.gradle.org/current/userguide/java_plugin.html#sec:java_plugin_and_dependency_management)).
* Besides, with classic gradle builds, dev- / build- / compile-time deps can be located in a `buildScript` block or the `buildSrc` folder. The former can't be determined with the current gradle manager implementation, as dependencies are extracted independent from their position in the AST. 
* I deliberately chose _devDependencies_ for deps in `buildSrc`, as this would make it compatible with the `disableDevDependencies` preset. If you think, _compile_ or whatever else fits better, I'd be open for suggestions.

<!-- Describe what behavior is changed by this PR. -->

## Context

* Closes https://github.com/renovatebot/renovate/issues/4316

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
