### PR TITLE
refactor(workers): Prefer interface over type

### DIFF
--- a/lib/workers/repository/init/types.ts
+++ b/lib/workers/repository/init/types.ts
@@ -1,7 +1,7 @@
-export type RepoConfigError = {
+export interface RepoConfigError {
   validationError: string;
   validationMessage: string;
-};
+}
 
 export interface RepoFileConfig {
   configFileName?: string;

--- a/lib/workers/repository/process/extract-update.ts
+++ b/lib/workers/repository/process/extract-update.ts
@@ -14,11 +14,11 @@ import { fetchUpdates } from './fetch';
 import { sortBranches } from './sort';
 import { WriteUpdateResult, writeUpdates } from './write';
 
-export type ExtractResult = {
+export interface ExtractResult {
   branches: BranchConfig[];
   branchList: string[];
   packageFiles: Record<string, PackageFile[]>;
-};
+}
 
 export interface StatsResult {
   fileCount: number;

--- a/lib/workers/repository/update/branch/execute-post-upgrade-commands.ts
+++ b/lib/workers/repository/update/branch/execute-post-upgrade-commands.ts
@@ -18,10 +18,10 @@ import { sanitize } from '../../../../util/sanitize';
 import { compile } from '../../../../util/template';
 import type { BranchConfig, BranchUpgradeConfig } from '../../../types';
 
-export type PostUpgradeCommandsExecutionResult = {
+export interface PostUpgradeCommandsExecutionResult {
   updatedArtifacts: FileChange[];
   artifactErrors: ArtifactError[];
-};
+}
 
 export async function postUpgradeCommandsExecutor(
   filteredUpgradeCommands: BranchUpgradeConfig[],

--- a/lib/workers/repository/update/branch/status-checks.ts
+++ b/lib/workers/repository/update/branch/status-checks.ts
@@ -51,10 +51,10 @@ async function setStatusCheck(
   }
 }
 
-export type StabilityConfig = RenovateConfig & {
+export interface StabilityConfig extends RenovateConfig {
   stabilityStatus?: BranchStatus;
   branchName: string;
-};
+}
 
 export async function setStability(config: StabilityConfig): Promise<void> {
   if (!config.stabilityStatus) {
@@ -74,10 +74,10 @@ export async function setStability(config: StabilityConfig): Promise<void> {
   );
 }
 
-export type ConfidenceConfig = RenovateConfig & {
+export interface ConfidenceConfig extends RenovateConfig {
   confidenceStatus?: BranchStatus;
   minimumConfidence?: MergeConfidence;
-};
+}
 
 export async function setConfidence(config: ConfidenceConfig): Promise<void> {
   if (

--- a/lib/workers/repository/update/pr/automerge.ts
+++ b/lib/workers/repository/update/pr/automerge.ts
@@ -27,11 +27,11 @@ export enum PrAutomergeBlockReason {
   OffSchedule = 'off schedule',
 }
 
-export type AutomergePrResult = {
+export interface AutomergePrResult {
   automerged: boolean;
   branchRemoved?: boolean;
   prAutomergeBlockReason?: PrAutomergeBlockReason;
-};
+}
 
 export async function checkAutoMerge(
   pr: Pr,

--- a/lib/workers/repository/update/pr/index.ts
+++ b/lib/workers/repository/update/pr/index.ts
@@ -51,15 +51,15 @@ export function getPlatformPrOptions(
   };
 }
 
-export type ResultWithPr = {
+export interface ResultWithPr {
   type: 'with-pr';
   pr: Pr;
-};
+}
 
-export type ResultWithoutPr = {
+export interface ResultWithoutPr {
   type: 'without-pr';
   prBlockedBy: PrBlockedBy;
-};
+}
 
 export type EnsurePrResult = ResultWithPr | ResultWithoutPr;
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Use `interface` over `type` for `lib/workers` types where possible.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

https://github.com/renovatebot/renovate/blob/main/docs/development/best-practices.md#general

> Prefer `interface` over `type` for TypeScript type declarations

- #16707 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
