### PR TITLE
feat: redis repository cache

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -606,9 +606,14 @@ Elements in the `repositories` array can be an object if you wish to define addi
 
 ## repositoryCache
 
-Set this to `"enabled"` to have Renovate maintain a JSON file cache per-repository to speed up extractions.
-Set to `"reset"` if you ever need to bypass the cache and have it overwritten.
-JSON files will be stored inside the `cacheDir` beside the existing file-based package cache.
+Renovate supports a per-repository cache to speed up dependency extractions.
+Set this to `"local"` to have Renovate maintain a local JSON file cache inside the `cacheDir` beside the existing file-based package cache.
+Set this to a Redis URL (like `redis://localhost`) to use Redis for the cache. It's recommended that you use a separate Redis database or instance from the `redisUrl` as this will contain sensitive data.
+Set to `"disabled"` if you don't want to use a repository cache for extractions.
+
+<!-- prettier-ignore -->
+!!! warning
+  The `"enabled"` option is deprecated; use `"local"` instead.
 
 ## requireConfig
 

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -10,7 +10,12 @@ export type RenovateConfigStage =
   | 'branch'
   | 'pr';
 
-export type RepositoryCacheConfig = 'disabled' | 'enabled' | 'reset';
+export type RepositoryCacheConfig =
+  | 'disabled'
+  | 'enabled'
+  | 'reset'
+  | 'local'
+  | string;
 export type DryRunConfig = 'extract' | 'lookup' | 'full';
 export type RequiredConfig = 'required' | 'optional' | 'ignored';
 

--- a/lib/util/cache/package/redis.ts
+++ b/lib/util/cache/package/redis.ts
@@ -73,7 +73,7 @@ export async function init(url: string): Promise<void> {
   if (!url) {
     return;
   }
-  logger.debug('Redis cache init');
+  logger.debug('Redis package cache init');
   client = createClient({
     url,
     socket: {

--- a/lib/util/cache/repository/impl/base.ts
+++ b/lib/util/cache/repository/impl/base.ts
@@ -1,17 +1,80 @@
+import { promisify } from 'util';
+import zlib from 'zlib';
+import hasha from 'hasha';
+import { logger } from '../../../../logger';
+import {
+  CACHE_REVISION,
+  isValidRev10,
+  isValidRev11,
+  isValidRev12,
+} from '../common';
+import type { RepoCacheRecord } from '../types';
 import type { RepoCache, RepoCacheData } from '../types';
 
-export class RepoCacheBase implements RepoCache {
-  protected data: RepoCacheData = {};
+const compress = promisify(zlib.brotliCompress);
+const decompress = promisify(zlib.brotliDecompress);
 
-  // istanbul ignore next
+export abstract class RepoCacheBase implements RepoCache {
+  private data: RepoCacheData = {};
+  private oldHash: string | null = null;
+
+  constructor(protected repository: string) {}
+
   async load(): Promise<void> {
-    await Promise.resolve();
+    try {
+      const rawCache = await this.readFromCache();
+      if (!rawCache) {
+        return;
+      }
+      const oldCache = JSON.parse(rawCache);
+
+      if (isValidRev12(oldCache, this.repository)) {
+        const compressed = Buffer.from(oldCache.payload, 'base64');
+        const uncompressed = await decompress(compressed);
+        const jsonStr = uncompressed.toString('utf8');
+        this.data = JSON.parse(jsonStr);
+        this.oldHash = oldCache.hash;
+        logger.debug('Repository cache is valid');
+        return;
+      }
+
+      if (isValidRev11(oldCache, this.repository)) {
+        this.data = oldCache.data;
+        logger.debug('Repository cache is migrated from 11 revision');
+        return;
+      }
+
+      if (isValidRev10(oldCache, this.repository)) {
+        delete oldCache.repository;
+        delete oldCache.revision;
+        this.data = oldCache;
+        logger.debug('Repository cache is migrated from 10 revision');
+        return;
+      }
+
+      logger.debug('Repository cache is invalid');
+    } catch (err) {
+      logger.debug('Repository cache not found');
+    }
   }
 
-  // istanbul ignore next
+  protected abstract readFromCache(): Promise<string | undefined>;
+
   async save(): Promise<void> {
-    await Promise.resolve();
+    const revision = CACHE_REVISION;
+    const repository = this.repository;
+    const data = this.getData();
+    const jsonStr = JSON.stringify(data);
+    const hash = await hasha.async(jsonStr, { algorithm: 'sha256' });
+    if (hash !== this.oldHash) {
+      const compressed = await compress(jsonStr);
+      const payload = compressed.toString('base64');
+      const record: RepoCacheRecord = { revision, repository, payload, hash };
+      await this.writeToCache(JSON.stringify(record));
+    }
   }
+
+  protected abstract writeToCache(data: string): Promise<void>;
 
   getData(): RepoCacheData {
     return this.data;

--- a/lib/util/cache/repository/impl/local.ts
+++ b/lib/util/cache/repository/impl/local.ts
@@ -1,27 +1,12 @@
-import { promisify } from 'util';
-import zlib from 'zlib';
-import hasha from 'hasha';
 import upath from 'upath';
 import { GlobalConfig } from '../../../../config/global';
 import { logger } from '../../../../logger';
 import { outputCacheFile, readCacheFile } from '../../../fs';
-import {
-  CACHE_REVISION,
-  isValidRev10,
-  isValidRev11,
-  isValidRev12,
-} from '../common';
-import type { RepoCacheRecord } from '../types';
 import { RepoCacheBase } from './base';
 
-const compress = promisify(zlib.brotliCompress);
-const decompress = promisify(zlib.brotliDecompress);
-
 export class LocalRepoCache extends RepoCacheBase {
-  private oldHash: string | null = null;
-
-  constructor(private platform: string, private repository: string) {
-    super();
+  constructor(private platform: string, repository: string) {
+    super(repository);
   }
 
   public getCacheFileName(): string {
@@ -32,55 +17,18 @@ export class LocalRepoCache extends RepoCacheBase {
     return upath.join(cacheDir, repoCachePath, platform, fileName);
   }
 
-  override async load(): Promise<void> {
+  protected async readFromCache(): Promise<string | undefined> {
     const cacheFileName = this.getCacheFileName();
     try {
-      const cacheFileName = this.getCacheFileName();
-      const rawCache = await readCacheFile(cacheFileName, 'utf8');
-      const oldCache = JSON.parse(rawCache);
-
-      if (isValidRev12(oldCache, this.repository)) {
-        const compressed = Buffer.from(oldCache.payload, 'base64');
-        const uncompressed = await decompress(compressed);
-        const jsonStr = uncompressed.toString('utf8');
-        this.data = JSON.parse(jsonStr);
-        this.oldHash = oldCache.hash;
-        logger.debug('Repository cache is valid');
-        return;
-      }
-
-      if (isValidRev11(oldCache, this.repository)) {
-        this.data = oldCache.data;
-        logger.debug('Repository cache is migrated from 11 revision');
-        return;
-      }
-
-      if (isValidRev10(oldCache, this.repository)) {
-        delete oldCache.repository;
-        delete oldCache.revision;
-        this.data = oldCache;
-        logger.debug('Repository cache is migrated from 10 revision');
-        return;
-      }
-
-      logger.debug('Repository cache is invalid');
+      return await readCacheFile(cacheFileName, 'utf8');
     } catch (err) {
       logger.debug({ cacheFileName }, 'Repository cache not found');
+      return undefined;
     }
   }
 
-  override async save(): Promise<void> {
+  protected async writeToCache(data: string): Promise<void> {
     const cacheFileName = this.getCacheFileName();
-    const revision = CACHE_REVISION;
-    const repository = this.repository;
-    const data = this.getData();
-    const jsonStr = JSON.stringify(data);
-    const hash = await hasha.async(jsonStr, { algorithm: 'sha256' });
-    if (hash !== this.oldHash) {
-      const compressed = await compress(jsonStr);
-      const payload = compressed.toString('base64');
-      const record: RepoCacheRecord = { revision, repository, payload, hash };
-      await outputCacheFile(cacheFileName, JSON.stringify(record));
-    }
+    return await outputCacheFile(cacheFileName, data);
   }
 }

--- a/lib/util/cache/repository/impl/memory.spec.ts
+++ b/lib/util/cache/repository/impl/memory.spec.ts
@@ -1,0 +1,29 @@
+import { MemoryRepoCache } from './memory';
+
+describe('util/cache/repository/impl/memory', () => {
+  it('returns empty object on creation', () => {
+    const cache = new MemoryRepoCache();
+    expect(cache.getData()).toBeEmpty();
+  });
+
+  it('does not lose data on load', async () => {
+    const cache = new MemoryRepoCache();
+    const data = cache.getData();
+    data.semanticCommits = 'enabled';
+    expect(cache.getData()).toEqual(data);
+
+    await cache.load();
+    expect(cache.getData()).toEqual(data);
+  });
+
+  it('does not persist data on save', async () => {
+    const cache = new MemoryRepoCache();
+    const data = cache.getData();
+    data.semanticCommits = 'enabled';
+    await cache.save();
+
+    const newCache = new MemoryRepoCache();
+    await newCache.load();
+    expect(newCache.getData()).toBeEmpty();
+  });
+});

--- a/lib/util/cache/repository/impl/memory.ts
+++ b/lib/util/cache/repository/impl/memory.ts
@@ -1,0 +1,19 @@
+import type { RepoCache, RepoCacheData } from '../types';
+
+export class MemoryRepoCache implements RepoCache {
+  private data: RepoCacheData = {};
+
+  // istanbul ignore next
+  async load(): Promise<void> {
+    await Promise.resolve();
+  }
+
+  // istanbul ignore next
+  async save(): Promise<void> {
+    await Promise.resolve();
+  }
+
+  getData(): RepoCacheData {
+    return this.data;
+  }
+}

--- a/lib/util/cache/repository/impl/redis.ts
+++ b/lib/util/cache/repository/impl/redis.ts
@@ -1,0 +1,48 @@
+import { createClient } from 'redis';
+import { logger } from '../../../../logger';
+import { RepoCacheBase } from './base';
+
+let client: ReturnType<typeof createClient> | undefined;
+
+const NAMESPACE = 'repository';
+
+export class RedisRepoCache extends RepoCacheBase {
+  constructor(private platform: string, repository: string) {
+    super(repository);
+  }
+
+  protected getCacheKey(): string {
+    return [NAMESPACE, this.platform, this.repository].join('.');
+  }
+
+  protected async readFromCache(): Promise<string | undefined> {
+    const cacheKey = this.getCacheKey();
+    try {
+      return (await client?.get(cacheKey)) ?? undefined;
+    } catch (err) {
+      logger.debug({ cacheKey }, 'Repository cache not found');
+      return undefined;
+    }
+  }
+
+  protected async writeToCache(data: string): Promise<void> {
+    await client?.set(this.getCacheKey(), data);
+  }
+}
+
+export async function initRedisClient(url: string): Promise<void> {
+  if (!url) {
+    return;
+  }
+  logger.debug('Redis repository cache init');
+  client = createClient({
+    url,
+    socket: {
+      reconnectStrategy: (retries) => {
+        // Reconnect after this time
+        return Math.min(retries * 100, 3000);
+      },
+    },
+  });
+  await client.connect();
+}

--- a/lib/util/cache/repository/index.ts
+++ b/lib/util/cache/repository/index.ts
@@ -1,10 +1,10 @@
-import { RepoCacheBase } from './impl/base';
+import { MemoryRepoCache } from './impl/memory';
 import type { RepoCache, RepoCacheData } from './types';
 
-let repoCache: RepoCache = new RepoCacheBase();
+let repoCache: RepoCache = new MemoryRepoCache();
 
 export function resetCache(): void {
-  setCache(new RepoCacheBase());
+  setCache(new MemoryRepoCache());
 }
 
 export function setCache(cache: RepoCache): void {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds support for Redis-backed repository caching.

## Context

See https://github.com/renovatebot/renovate/discussions/16497

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
