### PR TITLE
refactor: move repository/config-migration to the main worker flow

### DIFF
--- a/lib/workers/repository/config-migration/index.spec.ts
+++ b/lib/workers/repository/config-migration/index.spec.ts
@@ -1,0 +1,55 @@
+import { Fixtures } from '../../../../test/fixtures';
+import { defaultConfig, mockedFunction } from '../../../../test/util';
+import type { BranchConfig } from '../../types';
+import { checkConfigMigrationBranch } from './branch';
+import { MigratedDataFactory } from './branch/migrated-data';
+import { ensureConfigMigrationPr } from './pr';
+import { configMigration } from './index';
+
+jest.mock('./pr');
+jest.mock('./branch');
+jest.mock('./branch/migrated-data');
+
+const content = Fixtures.getJson('./migrated-data.json', './branch');
+const filename = 'renovate.json';
+const branchName = 'renovate/config-migration';
+const config = {
+  ...defaultConfig,
+  configMigration: true,
+};
+
+describe('workers/repository/config-migration/index', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockedFunction(MigratedDataFactory.getAsync).mockResolvedValue({
+      filename,
+      content,
+    });
+  });
+
+  it('does nothing when config migration is disabled', async () => {
+    await configMigration({ ...config, configMigration: false }, [], []);
+    expect(MigratedDataFactory.getAsync).toHaveBeenCalledTimes(0);
+    expect(checkConfigMigrationBranch).toHaveBeenCalledTimes(0);
+    expect(ensureConfigMigrationPr).toHaveBeenCalledTimes(0);
+  });
+
+  it('ensures config migration PR when migrated', async () => {
+    const branches: BranchConfig[] = [];
+    const branchList: string[] = [];
+    mockedFunction(checkConfigMigrationBranch).mockResolvedValue(branchName);
+    await configMigration(config, branches, branchList);
+    expect(branches).toContainEqual({ branchName } as BranchConfig);
+    expect(branchList).toContainEqual(branchName);
+    expect(ensureConfigMigrationPr).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips pr creation when migration is not needed', async () => {
+    const branches: BranchConfig[] = [];
+    const branchList: string[] = [];
+    mockedFunction(checkConfigMigrationBranch).mockResolvedValue(null);
+    await configMigration(config, branches, branchList);
+    expect(checkConfigMigrationBranch).toHaveBeenCalledTimes(1);
+    expect(ensureConfigMigrationPr).toHaveBeenCalledTimes(0);
+  });
+});

--- a/lib/workers/repository/config-migration/index.ts
+++ b/lib/workers/repository/config-migration/index.ts
@@ -1,0 +1,25 @@
+import type { RenovateConfig } from '../../../config/types';
+import type { BranchConfig } from '../../types';
+import { checkConfigMigrationBranch } from './branch';
+import { MigratedDataFactory } from './branch/migrated-data';
+import { ensureConfigMigrationPr } from './pr';
+
+export async function configMigration(
+  config: RenovateConfig,
+  branches: BranchConfig[],
+  branchList: string[]
+): Promise<void> {
+  if (config.configMigration) {
+    const migratedConfigData = await MigratedDataFactory.getAsync();
+    const migrationBranch = await checkConfigMigrationBranch(
+      config,
+      migratedConfigData
+    ); // null if migration not needed
+    if (migrationBranch) {
+      branchList.push(migrationBranch);
+      branches.push({ branchName: migrationBranch } as BranchConfig);
+      await ensureConfigMigrationPr(config, migratedConfigData!);
+    }
+    MigratedDataFactory.reset();
+  }
+}

--- a/lib/workers/repository/dependency-dashboard.ts
+++ b/lib/workers/repository/dependency-dashboard.ts
@@ -65,7 +65,7 @@ function getListItem(branch: BranchConfig, type: string): string {
     item += branch.prTitle;
   }
   const uniquePackages = [
-    ...new Set(branch.upgrades.map((upgrade) => `\`${upgrade.depName}\``)),
+    ...new Set(branch.upgrades?.map((upgrade) => `\`${upgrade.depName}\``)),
   ];
   if (uniquePackages.length < 2) {
     return item + '\n';

--- a/lib/workers/repository/finalise/index.ts
+++ b/lib/workers/repository/finalise/index.ts
@@ -4,9 +4,6 @@ import { logger } from '../../../logger';
 import { platform } from '../../../modules/platform';
 import * as repositoryCache from '../../../util/cache/repository';
 import { clearRenovateRefs } from '../../../util/git';
-import { checkConfigMigrationBranch } from '../config-migration/branch';
-import { MigratedDataFactory } from '../config-migration/branch/migrated-data';
-import { ensureConfigMigrationPr } from '../config-migration/pr';
 import { PackageFiles } from '../package-files';
 import { pruneStaleBranches } from './prune';
 import { runRenovateRepoStats } from './repository-statistics';
@@ -16,18 +13,6 @@ export async function finaliseRepo(
   config: RenovateConfig,
   branchList: string[]
 ): Promise<void> {
-  if (config.configMigration) {
-    const migratedConfigData = await MigratedDataFactory.getAsync();
-    const migrationBranch = await checkConfigMigrationBranch(
-      config,
-      migratedConfigData!
-    ); // null if migration not needed
-    if (migrationBranch) {
-      branchList.push(migrationBranch);
-      await ensureConfigMigrationPr(config, migratedConfigData!);
-    }
-    MigratedDataFactory.reset();
-  }
   await repositoryCache.saveCache();
   await pruneStaleBranches(config, branchList);
   await platform.ensureIssueClosing(

--- a/lib/workers/repository/finalise/index.ts
+++ b/lib/workers/repository/finalise/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
 import type { RenovateConfig } from '../../../config/types';
 import { logger } from '../../../logger';
 import { platform } from '../../../modules/platform';

--- a/lib/workers/repository/index.ts
+++ b/lib/workers/repository/index.ts
@@ -9,6 +9,7 @@ import { deleteLocalFile, privateCacheDir } from '../../util/fs';
 import * as queue from '../../util/http/queue';
 import { addSplit, getSplits, splitInit } from '../../util/split';
 import { setBranchCache } from './cache';
+import { configMigration } from './config-migration';
 import { ensureDependencyDashboard } from './dependency-dashboard';
 import handleError from './error';
 import { finaliseRepo } from './finalise';
@@ -50,6 +51,7 @@ export async function renovateRepository(
       const res = await updateRepo(config, branches);
       setMeta({ repository: config.repository });
       addSplit('update');
+      await configMigration(config, branches, branchList);
       await setBranchCache(branches);
       if (res === 'automerged') {
         if (canRetry) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
In the current state, we cant use repository cache in the migration flow.
This is because the cache is set before the finalize flow which contains the migration, therefore we cant cache the migration branch.

In this PR we move the migration flow to the worker's main flow, just before the cache is set.

related discussion in:
 - https://github.com/renovatebot/renovate/pull/16664
## Context
closes #16736 
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Unit tests

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
