### PR TITLE
refactor(manager): consistently write as `export const language = ...`

### DIFF
--- a/lib/modules/manager/bundler/index.ts
+++ b/lib/modules/manager/bundler/index.ts
@@ -7,7 +7,7 @@ import { extractPackageFile } from './extract';
 import { getRangeStrategy } from './range';
 import { updateLockedDependency } from './update-locked';
 
-const language = ProgrammingLanguage.Ruby;
+export const language = ProgrammingLanguage.Ruby;
 export const supportsLockFileMaintenance = true;
 
 /*
@@ -19,7 +19,6 @@ export {
   extractPackageFile, // Mandatory unless extractAllPackageFiles is used instead
   updateArtifacts, // Optional
   getRangeStrategy, // Optional
-  language, // Optional
   updateLockedDependency,
 };
 

--- a/lib/modules/manager/cargo/index.ts
+++ b/lib/modules/manager/cargo/index.ts
@@ -4,10 +4,10 @@ import * as cargoVersioning from '../../versioning/cargo';
 import { updateArtifacts } from './artifacts';
 import { extractPackageFile } from './extract';
 
-const language = ProgrammingLanguage.Rust;
+export const language = ProgrammingLanguage.Rust;
 export const supportsLockFileMaintenance = true;
 
-export { extractPackageFile, updateArtifacts, language };
+export { extractPackageFile, updateArtifacts };
 
 export const defaultConfig = {
   commitMessageTopic: 'Rust crate {{depName}}',

--- a/lib/modules/manager/composer/index.ts
+++ b/lib/modules/manager/composer/index.ts
@@ -7,13 +7,12 @@ import { getRangeStrategy } from './range';
 import { updateLockedDependency } from './update-locked';
 import { composerVersioningId } from './utils';
 
-const language = ProgrammingLanguage.PHP;
+export const language = ProgrammingLanguage.PHP;
 export const supportsLockFileMaintenance = true;
 
 export {
   extractPackageFile,
   updateArtifacts,
-  language,
   getRangeStrategy,
   updateLockedDependency,
 };

--- a/lib/modules/manager/docker-compose/index.ts
+++ b/lib/modules/manager/docker-compose/index.ts
@@ -2,9 +2,9 @@ import { ProgrammingLanguage } from '../../../constants';
 import { DockerDatasource } from '../../datasource/docker';
 import { extractPackageFile } from './extract';
 
-const language = ProgrammingLanguage.Docker;
+export const language = ProgrammingLanguage.Docker;
 
-export { extractPackageFile, language };
+export { extractPackageFile };
 
 export const defaultConfig = {
   fileMatch: ['(^|/)(?:docker-)?compose[^/]*\\.ya?ml$'],

--- a/lib/modules/manager/dockerfile/index.ts
+++ b/lib/modules/manager/dockerfile/index.ts
@@ -2,9 +2,9 @@ import { ProgrammingLanguage } from '../../../constants';
 import { DockerDatasource } from '../../datasource/docker';
 import { extractPackageFile } from './extract';
 
-const language = ProgrammingLanguage.Docker;
+export const language = ProgrammingLanguage.Docker;
 
-export { extractPackageFile, language };
+export { extractPackageFile };
 
 export const defaultConfig = {
   fileMatch: ['(^|/|\\.)Dockerfile$', '(^|/)Dockerfile[^/]*$'],

--- a/lib/modules/manager/droneci/index.ts
+++ b/lib/modules/manager/droneci/index.ts
@@ -2,9 +2,9 @@ import { ProgrammingLanguage } from '../../../constants';
 import { DockerDatasource } from '../../datasource/docker';
 import { extractPackageFile } from './extract';
 
-const language = ProgrammingLanguage.Docker;
+export const language = ProgrammingLanguage.Docker;
 
-export { extractPackageFile, language };
+export { extractPackageFile };
 
 export const defaultConfig = {
   fileMatch: ['(^|/).drone.yml$'],

--- a/lib/modules/manager/gitlabci/index.ts
+++ b/lib/modules/manager/gitlabci/index.ts
@@ -2,9 +2,9 @@ import { ProgrammingLanguage } from '../../../constants';
 import { DockerDatasource } from '../../datasource/docker';
 import { extractAllPackageFiles, extractPackageFile } from './extract';
 
-const language = ProgrammingLanguage.Docker;
+export const language = ProgrammingLanguage.Docker;
 
-export { extractAllPackageFiles, extractPackageFile, language };
+export { extractAllPackageFiles, extractPackageFile };
 
 export const defaultConfig = {
   fileMatch: ['\\.gitlab-ci\\.yml$'],


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Instead of

```ts
const language = ...
export { language }
```

use `export const language = ...` for consistency.

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

`export const language = ...` is majority (22 of 29).

Other non-function properties of `ManagerApi` are also written as `export const supportsLockFileMaintenance = true`.

https://github.com/renovatebot/renovate/blob/245953cc0da01cb1e0d0c11e4c4f8f33632101aa/lib/modules/manager/types.ts#L241-L246

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
