### PR TITLE
fix(manager/nuget): Skip dep if version is undefined

### DIFF
--- a/lib/modules/manager/nuget/__fixtures__/sample.csproj
+++ b/lib/modules/manager/nuget/__fixtures__/sample.csproj
@@ -34,6 +34,7 @@
     <PackageReference Include="NotUpdatable3" Version="(1.2.3, 3.2.1)" />
     <PackageReference Include="NotUpdatable3" Version="[1.2.3, 3.2.1]" />
     <PackageReference Include="NotUpdatable3" Version="[1.2.3, 3.2.1)" />
+    <PackageReference Include="NotUpdatable3" />
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="1.0.0" />

--- a/lib/modules/manager/nuget/extract.ts
+++ b/lib/modules/manager/nuget/extract.ts
@@ -1,3 +1,4 @@
+import is from '@sindresorhus/is';
 import { XmlDocument, XmlElement, XmlNode } from 'xmldoc';
 import { logger } from '../../../logger';
 import { getSiblingFileName, localPathExists } from '../../../util/fs';
@@ -48,10 +49,9 @@ function extractDepsFromXml(xmlNode: XmlDocument): PackageDependency[] {
         child.valueWithPath('Version') ??
         attr?.VersionOverride ??
         child.valueWithPath('VersionOverride');
-      const currentValue = checkVersion
-
-        ?.exec(version)
-        ?.groups?.currentValue?.trim();
+      const currentValue = is.nonEmptyStringAndNotWhitespace(version)
+        ? checkVersion.exec(version)?.groups?.currentValue?.trim()
+        : undefined;
       if (depName && currentValue) {
         results.push({
           datasource: NugetDatasource.id,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Skip referenceds without a version, currently typescript isn't correctly type `version`, so `undefined` is passed to regex and is then passed as `'undefined'` to `currentValue`.
<!-- Describe what behavior is changed by this PR. -->

## Context
- sample https://github.com/visualon/featureide.net/issues/2
![image](https://user-images.githubusercontent.com/1798109/180773779-4b77b812-80ab-425e-aae0-e285df57ecbd.png)

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
