### PR TITLE
fix(manager/nuget): skip invalid xml files

### DIFF
--- a/lib/modules/manager/nuget/package-tree.spec.ts
+++ b/lib/modules/manager/nuget/package-tree.spec.ts
@@ -155,12 +155,10 @@ describe('modules/manager/nuget/package-tree', () => {
       );
     });
 
-    it('throws error on invalid xml file', async () => {
+    it('skips on invalid xml file', async () => {
       git.getFileList.mockResolvedValue(['foo/bar.csproj']);
       Fixtures.mock({ '/tmp/repo/foo/bar.csproj': '<invalid' });
-      await expect(getDependentPackageFiles('foo/bar.csproj')).rejects.toThrow(
-        'Invalid xml file: foo/bar.csproj'
-      );
+      expect(await getDependentPackageFiles('foo/bar.csproj')).toEqual([]);
     });
   });
 });

--- a/lib/modules/manager/nuget/package-tree.ts
+++ b/lib/modules/manager/nuget/package-tree.ts
@@ -40,7 +40,7 @@ export async function getDependentPackageFiles(
   for (const f of packageFiles) {
     const doc = await readFileAsXmlDocument(f);
     if (!doc) {
-      throw new Error(`Invalid xml file: ${f}`);
+      continue;
     }
 
     const projectReferenceAttributes = doc


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Skip invalid xml files instead of throwing an error.
<!-- Describe what behavior is changed by this PR. -->

## Context
- #16754
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
