### PR TITLE
fix(git/cache): getCachedBranchParentShaResult returns unexpected undefined

### DIFF
--- a/lib/util/git/parent-sha-cache.ts
+++ b/lib/util/git/parent-sha-cache.ts
@@ -7,7 +7,7 @@ export function getCachedBranchParentShaResult(
   const { branches } = getCache();
   const branch = branches?.find((branch) => branch.branchName === branchName);
 
-  if (branchSha === branch?.sha) {
+  if (branch?.parentSha && branchSha === branch?.sha) {
     return branch.parentSha;
   }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context
`getBranchParentSha` will return unexpected `undefined` when repo cache is disabled.
similarly to 
- https://github.com/renovatebot/renovate/issues/16751

https://github.com/renovatebot/renovate/blob/17387fcf48e926b767989fe7c1c20ad5fbebab90/lib/util/git/index.ts#L467-L475

this happens because of L10- 
https://github.com/renovatebot/renovate/blob/17387fcf48e926b767989fe7c1c20ad5fbebab90/lib/util/git/parent-sha-cache.ts#L3-L11

as `branchSha` and cache in general are being set by `isModified` even if repo cache is disabled (parentSha is not)
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
