### PR TITLE
fix(config): filter out invalid massaged packageRules

### DIFF
--- a/lib/config/massage.spec.ts
+++ b/lib/config/massage.spec.ts
@@ -46,6 +46,21 @@ describe('config/massage', () => {
       expect(res.packageRules).toHaveLength(3);
     });
 
+    it('filters packageRules with only match/exclude', () => {
+      const config: RenovateConfig = {
+        packageRules: [
+          {
+            matchBaseBranches: ['main'],
+            major: {
+              enabled: true,
+            },
+          },
+        ],
+      };
+      const res = massage.massageConfig(config);
+      expect(res.packageRules).toHaveLength(1);
+    });
+
     it('does not massage lockFileMaintenance', () => {
       const config: RenovateConfig = {
         packageRules: [

--- a/lib/config/massage.ts
+++ b/lib/config/massage.ts
@@ -40,7 +40,7 @@ export function massageConfig(config: RenovateConfig): RenovateConfig {
     }
   }
   if (is.nonEmptyArray(massagedConfig.packageRules)) {
-    const newRules: PackageRule[] = [];
+    let newRules: PackageRule[] = [];
     const updateTypes: UpdateType[] = [
       'major',
       'minor',
@@ -74,6 +74,17 @@ export function massageConfig(config: RenovateConfig): RenovateConfig {
         delete rule[updateType];
       });
     }
+    newRules = newRules.filter((rule) => {
+      if (
+        Object.keys(rule).every(
+          (key) => key.startsWith('match') || key.startsWith('exclude')
+        )
+      ) {
+        // Exclude rules which contain only match or exclude options
+        return false;
+      }
+      return true;
+    });
     massagedConfig.packageRules = newRules;
   }
   return massagedConfig;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Filters out massaged packageRules which contain only match/exclude

## Context

- Closes #16777

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
