### PR TITLE
docs: change disclosure link in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -110,7 +110,7 @@ To get started look at the [list of good first issues](https://github.com/renova
 
 ## Security / Disclosure
 
-If you find any bug with Renovate that may be a security problem, then e-mail us at: [renovate-disclosure@whitesourcesoftware.com](mailto:renovate-disclosure@whitesourcesoftware.com).
+If you find any bug with Renovate that may be a security problem, then e-mail us at: [renovate-disclosure@mend.io](mailto:renovate-disclosure@mend.io).
 This way we can evaluate the bug and hopefully fix it before it gets abused.
 Please give us enough time to investigate the bug before you report it anywhere else.
 


### PR DESCRIPTION
whitesourcesoftware.com was renamed to mend.io.

## Changes

The company `whitesourcesoftware.com` was renamed to `mend.io`

## Context

Probably old email address @whitesoftware.com will be deprecated at some stage

## Documentation (please check one with an [x])

- [x ] I have updated the documentation

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only
