### PR TITLE
feat: add maven metadata.xml support for sbt-package

### DIFF
--- a/lib/modules/datasource/sbt-package/index.ts
+++ b/lib/modules/datasource/sbt-package/index.ts
@@ -6,6 +6,7 @@ import { ensureTrailingSlash } from '../../../util/url';
 import * as ivyVersioning from '../../versioning/ivy';
 import { compare } from '../../versioning/maven/compare';
 import { Datasource } from '../datasource';
+import { MavenDatasource } from '../maven';
 import { MAVEN_REPO } from '../maven/common';
 import { downloadHttpProtocol } from '../maven/util';
 import type { GetReleasesConfig, ReleaseResult } from '../types';
@@ -189,6 +190,12 @@ export class SbtPackageDatasource extends Datasource {
           dependencyUrl,
           releases: versions.map((v) => ({ version: v })),
         };
+      } else {
+        // Try to find new releases with the maven datasource implementation
+        return await new MavenDatasource().getReleases({
+          packageName,
+          registryUrl,
+        });
       }
     }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

As discussed in https://github.com/renovatebot/renovate/issues/16761 the sbt-package datasource doesn't support all the ways how the maven datasource tries to get the latest version of a dependency. Due to the fact that most sbt-packages are actually stored in a maven repository we can just try to resolve the latest versions by using the code of the maven datasource in case the sbt-package code did not find any versions.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

Closes #16761

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
