### PR TITLE
refactor(github): Sort cached PR list

### DIFF
--- a/lib/modules/platform/github/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/platform/github/__snapshots__/index.spec.ts.snap
@@ -14,20 +14,6 @@ Object {
 }
 `;
 
-exports[`modules/platform/github/index getBranchPr(branchName) should cache and return the PR object in fork mode 1`] = `
-Object {
-  "bodyStruct": Object {
-    "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-  },
-  "displayNumber": "Pull Request #90",
-  "number": 90,
-  "sourceBranch": "somebranch",
-  "sourceRepo": "other/repo",
-  "state": "open",
-  "title": "Some title",
-}
-`;
-
 exports[`modules/platform/github/index getBranchPr(branchName) should reopen and cache autoclosed PR 1`] = `
 Object {
   "bodyStruct": Object {

--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -650,7 +650,7 @@ describe('modules/platform/github/index', () => {
 
       const res = await github.getPrList();
 
-      expect(res).toMatchObject([{ number: 1 }, { number: 2 }, { number: 3 }]);
+      expect(res).toMatchObject([{ number: 3 }, { number: 2 }, { number: 1 }]);
     });
 
     it('synchronizes cache', async () => {
@@ -687,14 +687,14 @@ describe('modules/platform/github/index', () => {
       const res2 = await github.getPrList();
 
       expect(res1).toMatchObject([
-        { number: 1, title: 'PR #1' },
-        { number: 2, title: 'PR #2' },
         { number: 3, title: 'PR #3' },
+        { number: 2, title: 'PR #2' },
+        { number: 1, title: 'PR #1' },
       ]);
       expect(res2).toMatchObject([
-        { number: 1, title: 'PR #1 (updated)' },
-        { number: 2, title: 'PR #2 (updated)' },
         { number: 3, title: 'PR #3 (updated)' },
+        { number: 2, title: 'PR #2 (updated)' },
+        { number: 1, title: 'PR #1 (updated)' },
       ]);
     });
 
@@ -1008,43 +1008,6 @@ describe('modules/platform/github/index', () => {
       } as any);
       const pr = await github.getBranchPr('somebranch');
       expect(pr).toBeNull();
-    });
-
-    it('should cache and return the PR object in fork mode', async () => {
-      const scope = httpMock.scope(githubApiHost);
-      forkInitRepoMock(scope, 'some/repo', true);
-      scope
-        .patch('/repos/forked/repo/git/refs/heads/master')
-        .reply(200)
-        .get(
-          '/repos/some/repo/pulls?per_page=100&state=all&sort=updated&direction=desc&page=1'
-        )
-        .reply(200, [
-          {
-            number: 90,
-            base: { sha: '1234' },
-            head: { ref: 'somebranch', repo: { full_name: 'other/repo' } },
-            state: PrState.Open,
-            title: 'Some title',
-          },
-          {
-            number: 91,
-            base: { sha: '1234' },
-            head: { ref: 'somebranch', repo: { full_name: 'some/repo' } },
-            state: PrState.Open,
-            title: 'Wrong PR',
-          },
-        ]);
-      await github.initRepo({
-        repository: 'some/repo',
-        forkMode: true,
-      } as any);
-
-      const pr = await github.getBranchPr('somebranch');
-      const pr2 = await github.getBranchPr('somebranch');
-
-      expect(pr).toMatchSnapshot({ number: 90 });
-      expect(pr2).toEqual(pr);
     });
   });
 

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -617,7 +617,9 @@ export async function getPrList(): Promise<Pr[]> {
         : null;
     // TODO: check null `repo` (#7154)
     const prCache = await getPrCache(githubApi, repo!, username);
-    config.prList = Object.values(prCache);
+    config.prList = Object.values(prCache).sort(
+      ({ number: a }, { number: b }) => (a > b ? -1 : 1)
+    );
   }
 
   return config.prList;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

- Closes: #16812

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
