### PR TITLE
fix(git): remove wrong submodule file filter

### DIFF
--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -208,7 +208,8 @@ describe('util/git/index', () => {
     it('should exclude submodules', async () => {
       const repo = Git(base.path);
       await repo.submoduleAdd(base.path, 'submodule');
-      await repo.commit('Add submodule');
+      await repo.submoduleAdd(base.path, 'file');
+      await repo.commit('Add submodules');
       await git.initRepo({
         cloneSubmodules: true,
         url: base.path,

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -529,7 +529,6 @@ export async function checkoutBranch(branchName: string): Promise<CommitSha> {
 export async function getFileList(): Promise<string[]> {
   await syncGit();
   const branch = config.currentBranch;
-  const submodules = await getSubmodules();
   let files: string;
   try {
     files = await git.raw(['ls-tree', '-r', branch]);
@@ -547,14 +546,12 @@ export async function getFileList(): Promise<string[]> {
   if (!files) {
     return [];
   }
+  // submodules are starting with `160000 commit`
   return files
     .split(newlineRegex)
     .filter(is.string)
     .filter((line) => line.startsWith('100'))
-    .map((line) => line.split(regEx(/\t/)).pop()!)
-    .filter((file) =>
-      submodules.every((submodule: string) => !file.startsWith(submodule))
-    );
+    .map((line) => line.split(regEx(/\t/)).pop()!);
 }
 
 export function getBranchList(): string[] {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Remove submodule filter, as it's not required. Submodules are filtered already because they are starting with `160000 commit`.
<!-- Describe what behavior is changed by this PR. -->

## Context
- fixes #16841
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
