### PR TITLE
feat: use cache for getFile

### DIFF
--- a/lib/util/cache/repository/types.ts
+++ b/lib/util/cache/repository/types.ts
@@ -30,6 +30,7 @@ export interface BranchCache {
   sha: string | null;
   parentSha: string | null;
   upgrades: BranchUpgradeCache[];
+  contents?: Record<string, string>;
 }
 
 export interface RepoCacheData {

--- a/lib/util/git/get-file-cache.spec.ts
+++ b/lib/util/git/get-file-cache.spec.ts
@@ -1,0 +1,126 @@
+import { mocked } from '../../../test/util';
+import * as _repositoryCache from '../cache/repository';
+import type { BranchCache, RepoCacheData } from '../cache/repository/types';
+import { getCachedFile, setCachedFile } from './get-file-cache';
+
+jest.mock('../cache/repository');
+const repositoryCache = mocked(_repositoryCache);
+
+describe('util/git/get-file-cache', () => {
+  let repoCache: RepoCacheData = {};
+  const defaultBranchCache: BranchCache = {
+    automerge: false,
+    branchName: 'some-branch',
+    isModified: false,
+    prNo: null,
+    sha: null,
+    parentSha: null,
+    upgrades: [],
+    contents: {},
+  };
+
+  beforeEach(() => {
+    repoCache = {};
+    repositoryCache.getCache.mockReturnValue(repoCache);
+  });
+
+  describe('getCachedFile', () => {
+    it('returns null if cache is not populated', () => {
+      expect(getCachedFile('foo', '111', 'not-existing-file')).toBeNull();
+    });
+
+    it('returns null if target SHA has changed', () => {
+      repoCache.branches = [
+        { ...defaultBranchCache, branchName: 'foo', sha: 'aaa' } as BranchCache,
+      ];
+      expect(getCachedFile('foo', '111', 'not-existing-file')).toBeNull();
+    });
+
+    it('returns null if filePath not found', () => {
+      repoCache.branches = [
+        {
+          ...defaultBranchCache,
+          branchName: 'foo',
+          sha: '111',
+          contents: {
+            'some-file': 'some-content',
+          },
+        } as BranchCache,
+      ];
+      expect(getCachedFile('foo', '111', 'not-existing-file')).toBeNull();
+    });
+
+    it('returns null if content not cached', () => {
+      repoCache.branches = [
+        {
+          ...defaultBranchCache,
+          branchName: 'foo',
+          sha: '111',
+          contents: {
+            'existing-file': undefined as never,
+          },
+        },
+      ];
+      expect(getCachedFile('foo', '111', 'existing-file')).toBeNull();
+    });
+
+    it('returns content', () => {
+      repoCache.branches = [
+        {
+          ...defaultBranchCache,
+          branchName: 'foo',
+          sha: '111',
+          contents: {
+            'existing-file': 'content',
+          },
+        },
+      ];
+      expect(getCachedFile('foo', '111', 'existing-file')).toBe('content');
+    });
+  });
+
+  describe('setCachedFile', () => {
+    it('sets value for unpopulated cache', () => {
+      setCachedFile('foo', '111', 'some-file', 'some-content');
+      expect(repoCache).toEqual({
+        branches: [
+          {
+            branchName: 'foo',
+            sha: '111',
+            contents: { 'some-file': 'some-content' },
+          },
+        ],
+      });
+    });
+
+    // it('replaces value when SHA has changed', () => {
+    //   setCachedFile('foo', '111', false);
+    //   setCachedFile('foo', '121', false);
+    //   setCachedFile('foo', '131', false);
+    //   expect(repoCache).toEqual({
+    //     branches: [{ branchName: 'foo', sha: '131', isModified: false }],
+    //   });
+    // });
+
+    // it('replaces value when both value and SHA have changed', () => {
+    //   setCachedFile('foo', '111', false);
+    //   setCachedFile('foo', 'aaa', true);
+    //   expect(repoCache).toEqual({
+    //     branches: [{ branchName: 'foo', sha: 'aaa', isModified: true }],
+    //   });
+    // });
+
+    // it('handles multiple branches', () => {
+    //   setCachedFile('foo-1', '111', false);
+    //   setCachedFile('foo-2', 'aaa', true);
+    //   setCachedFile('foo-3', '222', false);
+    //   expect(repoCache).toEqual({
+    //     branches: [
+    //       { branchName: 'foo-1', sha: '111', isModified: false },
+    //       { branchName: 'foo-2', sha: 'aaa', isModified: true },
+    //       { branchName: 'foo-3', sha: '222', isModified: false },
+    //     ],
+    //   });
+    // });
+  });
+});

--- a/lib/util/git/get-file-cache.spec.ts
+++ b/lib/util/git/get-file-cache.spec.ts
@@ -93,34 +93,61 @@ describe('util/git/get-file-cache', () => {
       });
     });
 
-    // it('replaces value when SHA has changed', () => {
-    //   setCachedFile('foo', '111', false);
-    //   setCachedFile('foo', '121', false);
-    //   setCachedFile('foo', '131', false);
-    //   expect(repoCache).toEqual({
-    //     branches: [{ branchName: 'foo', sha: '131', isModified: false }],
-    //   });
-    // });
+    it('replaces SHA when it has changed', () => {
+      setCachedFile('foo', '111', 'some-file', 'old-content');
+      setCachedFile('foo', '121', 'some-file', 'old-content');
+      expect(repoCache).toEqual({
+        branches: [
+          {
+            branchName: 'foo',
+            sha: '121',
+            contents: { 'some-file': 'old-content' },
+          },
+        ],
+      });
+    });
 
-    // it('replaces value when both value and SHA have changed', () => {
-    //   setCachedFile('foo', '111', false);
-    //   setCachedFile('foo', 'aaa', true);
-    //   expect(repoCache).toEqual({
-    //     branches: [{ branchName: 'foo', sha: 'aaa', isModified: true }],
-    //   });
-    // });
+    it('replaces value and SHA when both have changed', () => {
+      setCachedFile('foo', '111', 'some-file', 'old-content');
+      setCachedFile('foo', '121', 'some-file', 'new-content');
+      expect(repoCache).toEqual({
+        branches: [
+          {
+            branchName: 'foo',
+            sha: '121',
+            contents: { 'some-file': 'new-content' },
+          },
+        ],
+      });
+    });
 
-    // it('handles multiple branches', () => {
-    //   setCachedFile('foo-1', '111', false);
-    //   setCachedFile('foo-2', 'aaa', true);
-    //   setCachedFile('foo-3', '222', false);
-    //   expect(repoCache).toEqual({
-    //     branches: [
-    //       { branchName: 'foo-1', sha: '111', isModified: false },
-    //       { branchName: 'foo-2', sha: 'aaa', isModified: true },
-    //       { branchName: 'foo-3', sha: '222', isModified: false },
-    //     ],
-    //   });
-    // });
+    it('handles multiple branches and filePaths', () => {
+      setCachedFile('foo-1', '111', 'some-file', 'content');
+      setCachedFile('foo-2', '121', 'some-file', 'content');
+      setCachedFile('foo-3', '222', 'file-1', 'file-1-content');
+      setCachedFile('foo-3', '222', 'file-2', 'file-2-content');
+      expect(repoCache).toEqual({
+        branches: [
+          {
+            branchName: 'foo-1',
+            sha: '111',
+            contents: { 'some-file': 'content' },
+          },
+          {
+            branchName: 'foo-2',
+            sha: '121',
+            contents: { 'some-file': 'content' },
+          },
+          {
+            branchName: 'foo-3',
+            sha: '222',
+            contents: {
+              'file-1': 'file-1-content',
+              'file-2': 'file-2-content',
+            },
+          },
+        ],
+      });
+    });
   });
 });

--- a/lib/util/git/get-file-cache.ts
+++ b/lib/util/git/get-file-cache.ts
@@ -1,0 +1,43 @@
+import { getCache } from '../cache/repository';
+import type { BranchCache } from '../cache/repository/types';
+
+export function getCachedFile(
+  branchName: string,
+  branchSha: string,
+  filePath: string
+): string | null {
+  const { branches = [] } = getCache();
+  const branch = branches?.find((branch) => branch.branchName === branchName);
+  const fileContent = branch?.contents?.[filePath];
+
+  if (branch?.sha !== branchSha || fileContent === undefined) {
+    return null;
+  }
+  return fileContent;
+}
+
+export function setCachedFile(
+  branchName: string,
+  branchSha: string,
+  filePath: string,
+  content: string
+): void {
+  const cache = getCache();
+  cache.branches ??= [];
+  const { branches } = cache;
+  const branch =
+    branches?.find((branch) => branch.branchName === branchName) ??
+    ({ branchName: branchName } as BranchCache);
+
+  // if branch not present add it to cache
+  if (branch.sha === undefined) {
+    branches.push(branch);
+  }
+
+  if (branch.sha !== branchSha) {
+    branch.sha = branchSha;
+  }
+
+  branch.contents ||= {};
+  branch.contents[filePath] = content;
+}

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -11,6 +11,7 @@ import * as _repoCache from '../cache/repository';
 import type { BranchCache } from '../cache/repository/types';
 import { newlineRegex, regEx } from '../regex';
 import * as _conflictsCache from './conflicts-cache';
+import * as _getFileCache from './get-file-cache';
 import * as _modifiedCache from './modified-cache';
 import * as _parentShaCache from './parent-sha-cache';
 import type { FileChange } from './types';
@@ -18,12 +19,14 @@ import * as git from '.';
 import { setNoVerify } from '.';
 
 jest.mock('./conflicts-cache');
+jest.mock('./get-file-cache');
 jest.mock('./modified-cache');
 jest.mock('./parent-sha-cache');
 jest.mock('delay');
 jest.mock('../cache/repository');
 const repoCache = mocked(_repoCache);
 const conflictsCache = mocked(_conflictsCache);
+const getFileCache = mocked(_getFileCache);
 const modifiedCache = mocked(_modifiedCache);
 const parentShaCache = mocked(_parentShaCache);
 // Class is no longer exported
@@ -391,16 +394,19 @@ describe('util/git/index', () => {
 
   describe('getFile(filePath, branchName)', () => {
     it('gets the file', async () => {
+      getFileCache.getCachedFile.mockReturnValue(null);
       const res = await git.getFile('master_file');
       expect(res).toBe(defaultBranch);
     });
 
     it('short cuts 404', async () => {
+      getFileCache.getCachedFile.mockReturnValue(null);
       const res = await git.getFile('some-missing-path');
       expect(res).toBeNull();
     });
 
     it('returns null for 404', async () => {
+      getFileCache.getCachedFile.mockReturnValue(null);
       expect(await git.getFile('some-path', 'some-branch')).toBeNull();
     });
   });

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -394,20 +394,25 @@ describe('util/git/index', () => {
 
   describe('getFile(filePath, branchName)', () => {
     it('gets the file', async () => {
-      getFileCache.getCachedFile.mockReturnValue(null);
+      getFileCache.getCachedFile.mockReturnValueOnce(null);
       const res = await git.getFile('master_file');
       expect(res).toBe(defaultBranch);
     });
 
     it('short cuts 404', async () => {
-      getFileCache.getCachedFile.mockReturnValue(null);
+      getFileCache.getCachedFile.mockReturnValueOnce(null);
       const res = await git.getFile('some-missing-path');
       expect(res).toBeNull();
     });
 
     it('returns null for 404', async () => {
-      getFileCache.getCachedFile.mockReturnValue(null);
+      getFileCache.getCachedFile.mockReturnValueOnce(null);
       expect(await git.getFile('some-path', 'some-branch')).toBeNull();
+    });
+
+    it('returns cached content', async () => {
+      getFileCache.getCachedFile.mockReturnValueOnce('content');
+      expect(await git.getFile('some-path', 'some-branch')).toBe('content');
     });
   });
 

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -37,6 +37,7 @@ import {
   setCachedConflictResult,
 } from './conflicts-cache';
 import { checkForPlatformFailure, handleCommitError } from './error';
+import { getCachedFile, setCachedFile } from './get-file-cache';
 import {
   getCachedModifiedResult,
   setCachedModifiedResult,
@@ -52,7 +53,6 @@ import type {
   StorageConfig,
   TreeItem,
 } from './types';
-import { getCachedFile } from './get-file-cache';
 
 export { setNoVerify } from './config';
 export { setPrivateKey } from './private-key';
@@ -844,6 +844,12 @@ export async function getFile(
   await syncGit();
   try {
     content = await git.show(['origin/' + branchName + ':' + filePath]);
+    setCachedFile(
+      branchName,
+      config.branchCommits[branchName],
+      filePath,
+      content
+    );
     return content;
   } catch (err) {
     const errChecked = checkForPlatformFailure(err);

--- a/lib/workers/repository/update/branch/index.ts
+++ b/lib/workers/repository/update/branch/index.ts
@@ -278,7 +278,6 @@ export async function processBranch(
         'Branch + PR exists but is not scheduled -- will update if necessary'
       );
     }
-    await checkoutBranch(config.baseBranch!);
     //stability checks
     if (
       config.upgrades.some(
@@ -372,6 +371,7 @@ export async function processBranch(
     // TODO: types (#7154)
     logger.debug(`Using reuseExistingBranch: ${config.reuseExistingBranch!}`);
     const res = await getUpdatedPackageFiles(config);
+    await checkoutBranch(config.baseBranch!);
     // istanbul ignore if
     if (res.artifactErrors && config.artifactErrors) {
       res.artifactErrors = config.artifactErrors.concat(res.artifactErrors);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
 - store content of a file (packageFile and lockFile) in cache and use it when valid
 - moved `checkoutBranch` function call after `getUpdatedPackageFiles` function
<!-- Describe what behavior is changed by this PR. -->

## Context
- prevent cloning when possible when dealing with git
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
