### PR TITLE
fix(semantic commit message): stop lowercasing conventional commits

### DIFF
--- a/lib/workers/repository/updates/generate.spec.ts
+++ b/lib/workers/repository/updates/generate.spec.ts
@@ -480,11 +480,11 @@ describe('workers/repository/updates/generate', () => {
       ];
       const res = generateBranchConfig(branch);
       expect(res.prTitle).toBe(
-        'chore(package): Update dependency some-dep to v1.2.0'
+        'chore(package): update dependency some-dep to v1.2.0'
       );
     });
 
-    it('supports uppercase in semantic commit scope', () => {
+    it('supports uppercase in semantic-commit prefix', () => {
       // TODO #7154 incompatible types
       const branch: BranchUpgradeConfig[] = [
         {
@@ -505,8 +505,31 @@ describe('workers/repository/updates/generate', () => {
       ];
       const res = generateBranchConfig(branch);
       expect(res.prTitle).toBe(
-        'chore(PACKAGE): Update dependency some-dep to v1.2.0'
+        'chore(PACKAGE): update dependency some-dep to v1.2.0'
       );
+    });
+
+    it('works correctly with empty semantic prefix', () => {
+      // TODO #7154 incompatible types
+      const branch: BranchUpgradeConfig[] = [
+        {
+          ...defaultConfig,
+          manager: 'some-manager',
+          depName: 'some-dep',
+          semanticCommits: 'enabled',
+          semanticCommitType: '',
+          semanticCommitScope: '',
+          newValue: '1.2.0',
+          isSingleVersion: true,
+          newVersion: '1.2.0',
+          foo: 1,
+          group: {
+            foo: 2,
+          },
+        } as BranchUpgradeConfig,
+      ];
+      const res = generateBranchConfig(branch);
+      expect(res.prTitle).toBe('update dependency some-dep to v1.2.0');
     });
 
     it('scopes monorepo commits', () => {
@@ -531,7 +554,7 @@ describe('workers/repository/updates/generate', () => {
         } as BranchUpgradeConfig,
       ];
       const res = generateBranchConfig(branch);
-      expect(res.prTitle).toBe('chore(): Update dependency some-dep to v1.2.0');
+      expect(res.prTitle).toBe('chore(): update dependency some-dep to v1.2.0');
     });
 
     it('scopes monorepo commits with nested package files using parent directory', () => {
@@ -558,7 +581,7 @@ describe('workers/repository/updates/generate', () => {
       ];
       const res = generateBranchConfig(branch);
       expect(res.prTitle).toBe(
-        'chore(bar): Update dependency some-dep to v1.2.0'
+        'chore(bar): update dependency some-dep to v1.2.0'
       );
     });
 
@@ -585,7 +608,7 @@ describe('workers/repository/updates/generate', () => {
       ];
       const res = generateBranchConfig(branch);
       expect(res.prTitle).toBe(
-        'chore(foo/bar): Update dependency some-dep to v1.2.0'
+        'chore(foo/bar): update dependency some-dep to v1.2.0'
       );
     });
 

--- a/lib/workers/repository/updates/generate.spec.ts
+++ b/lib/workers/repository/updates/generate.spec.ts
@@ -480,7 +480,32 @@ describe('workers/repository/updates/generate', () => {
       ];
       const res = generateBranchConfig(branch);
       expect(res.prTitle).toBe(
-        'chore(package): update dependency some-dep to v1.2.0'
+        'chore(package): Update dependency some-dep to v1.2.0'
+      );
+    });
+
+    it('supports uppercase in semantic commit scope', () => {
+      // TODO #7154 incompatible types
+      const branch: BranchUpgradeConfig[] = [
+        {
+          ...defaultConfig,
+          manager: 'some-manager',
+          depName: 'some-dep',
+          semanticCommits: 'enabled',
+          semanticCommitType: 'chore',
+          semanticCommitScope: 'PACKAGE',
+          newValue: '1.2.0',
+          isSingleVersion: true,
+          newVersion: '1.2.0',
+          foo: 1,
+          group: {
+            foo: 2,
+          },
+        } as BranchUpgradeConfig,
+      ];
+      const res = generateBranchConfig(branch);
+      expect(res.prTitle).toBe(
+        'chore(PACKAGE): Update dependency some-dep to v1.2.0'
       );
     });
 
@@ -506,7 +531,7 @@ describe('workers/repository/updates/generate', () => {
         } as BranchUpgradeConfig,
       ];
       const res = generateBranchConfig(branch);
-      expect(res.prTitle).toBe('chore(): update dependency some-dep to v1.2.0');
+      expect(res.prTitle).toBe('chore(): Update dependency some-dep to v1.2.0');
     });
 
     it('scopes monorepo commits with nested package files using parent directory', () => {
@@ -533,7 +558,7 @@ describe('workers/repository/updates/generate', () => {
       ];
       const res = generateBranchConfig(branch);
       expect(res.prTitle).toBe(
-        'chore(bar): update dependency some-dep to v1.2.0'
+        'chore(bar): Update dependency some-dep to v1.2.0'
       );
     });
 
@@ -560,7 +585,7 @@ describe('workers/repository/updates/generate', () => {
       ];
       const res = generateBranchConfig(branch);
       expect(res.prTitle).toBe(
-        'chore(foo/bar): update dependency some-dep to v1.2.0'
+        'chore(foo/bar): Update dependency some-dep to v1.2.0'
       );
     });
 

--- a/lib/workers/repository/updates/generate.ts
+++ b/lib/workers/repository/updates/generate.ts
@@ -178,9 +178,6 @@ export function generateBranchConfig(
         )})`;
       }
       upgrade.commitMessagePrefix = CommitMessage.formatPrefix(semanticPrefix!);
-      upgrade.toLowerCase =
-        regEx(/[A-Z]/).exec(upgrade.semanticCommitType!) === null &&
-        !upgrade.semanticCommitType!.startsWith(':');
     }
     // Compile a few times in case there are nested templates
     upgrade.commitMessage = template.compile(

--- a/lib/workers/types.ts
+++ b/lib/workers/types.ts
@@ -62,6 +62,8 @@ export interface BranchUpgradeConfig
   repoName?: string;
   minimumConfidence?: MergeConfidence;
   sourceDirectory?: string;
+  useSemanticCommit?: boolean;
+  toLowerCase?: boolean;
 
   updatedPackageFiles?: FileChange[];
   updatedArtifacts?: FileChange[];


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

The semantic-commit prefix is no longer lowercased while preserving the lowercased subject to not cause breaking changes for potential regex checks on the users end.

## Context

Fixes https://github.com/renovatebot/renovate/issues/16839
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
