### PR TITLE
fix(platform/github): rewrite debug message

### DIFF
--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -2309,7 +2309,7 @@ describe('modules/platform/github/index', () => {
         expect(logger.logger.debug).toHaveBeenNthCalledWith(
           10,
           { prNumber: 123 },
-          'GitHub-native automerge: not supported on this GHE version. Requires >=3.3.0'
+          'GitHub-native automerge: not supported on this version of GHE. Use 3.3.0 or newer.'
         );
       });
 

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -1355,7 +1355,7 @@ async function tryPrAutomerge(
     if (semver.satisfies(platformConfig.gheVersion!, '<3.3.0')) {
       logger.debug(
         { prNumber },
-        'GitHub-native automerge: not supported on this GHE version. Requires >=3.3.0'
+        'GitHub-native automerge: not supported on this version of GHE. Use 3.3.0 or newer.'
       );
       return;
     }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Rewrite GitHub platform debug message

## Context

Make the GitHub debug message consistent with the one for Gitea.
Found this while reviewing a PR: https://github.com/renovatebot/renovate/pull/16885#discussion_r934257592

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
