### PR TITLE
fix(core/exec): use nodejs style error messages when throwing

### DIFF
--- a/lib/util/exec/common.spec.ts
+++ b/lib/util/exec/common.spec.ts
@@ -184,7 +184,7 @@ describe('util/exec/common', () => {
         exec(cmd, partial<RawExecOptions>({ encoding: 'utf8' }))
       ).rejects.toMatchObject({
         cmd,
-        message: 'Process exited with exit code "1"',
+        message: `Command failed: ${cmd}\n${stderr}`,
         exitCode,
         stderr,
       });
@@ -200,7 +200,7 @@ describe('util/exec/common', () => {
       ).rejects.toMatchObject({
         cmd,
         signal: exitSignal,
-        message: 'Process signaled with "SIGTERM"',
+        message: `Command failed: ${cmd}\n`,
       });
     });
 

--- a/lib/util/exec/common.spec.ts
+++ b/lib/util/exec/common.spec.ts
@@ -200,7 +200,7 @@ describe('util/exec/common', () => {
       ).rejects.toMatchObject({
         cmd,
         signal: exitSignal,
-        message: `Command failed: ${cmd}\n`,
+        message: `Command failed: ${cmd}\nInterrupted by ${exitSignal}`,
       });
     });
 

--- a/lib/util/exec/common.ts
+++ b/lib/util/exec/common.ts
@@ -84,14 +84,23 @@ export function exec(cmd: string, opts: RawExecOptions): Promise<ExecResult> {
       if (NONTERM.includes(signal)) {
         return;
       }
-      const message = `Command failed: ${cmd}\n${stringify(stderr)}`;
       if (signal) {
         kill(cp, signal);
-        reject(new ExecError(message, { ...rejectInfo(), signal }));
+        reject(
+          new ExecError(`Command failed: ${cmd}\nInterrupted by ${signal}`, {
+            ...rejectInfo(),
+            signal,
+          })
+        );
         return;
       }
       if (code !== 0) {
-        reject(new ExecError(message, { ...rejectInfo(), exitCode: code }));
+        reject(
+          new ExecError(`Command failed: ${cmd}\n${stringify(stderr)}`, {
+            ...rejectInfo(),
+            exitCode: code,
+          })
+        );
         return;
       }
       resolve({

--- a/lib/util/exec/common.ts
+++ b/lib/util/exec/common.ts
@@ -76,6 +76,7 @@ export function exec(cmd: string, opts: RawExecOptions): Promise<ExecResult> {
     // handle process events
     cp.on('error', (error) => {
       kill(cp, 'SIGTERM');
+      // rethrowing, use originally emitted error message
       reject(new ExecError(error.message, rejectInfo(), error));
     });
 
@@ -83,15 +84,13 @@ export function exec(cmd: string, opts: RawExecOptions): Promise<ExecResult> {
       if (NONTERM.includes(signal)) {
         return;
       }
-
+      const message = `Command failed: ${cmd}\n${stringify(stderr)}`;
       if (signal) {
-        const message = `Process signaled with "${signal}"`;
         kill(cp, signal);
         reject(new ExecError(message, { ...rejectInfo(), signal }));
         return;
       }
       if (code !== 0) {
-        const message = `Process exited with exit code "${code}"`;
         reject(new ExecError(message, { ...rejectInfo(), exitCode: code }));
         return;
       }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Use nodejs style error messages when throwing ourselves.
When rethrowing we already reusing the thrown message, so no changes there.

source - 
https://github.com/nodejs/node/blob/7abbbf2ff32b14da47ee4a8e345adb6e424b8689/lib/child_process.js#L409-L415

https://github.com/nodejs/node/blob/7abbbf2ff32b14da47ee4a8e345adb6e424b8689/lib/internal/errors.js#L847-L859

<!-- Describe what behavior is changed by this PR. -->

## Context
Closes #16933
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
