### PR TITLE
refactor: cleanup http option interface

### DIFF
--- a/lib/util/http/gitea.ts
+++ b/lib/util/http/gitea.ts
@@ -9,9 +9,8 @@ export const setBaseUrl = (newBaseUrl: string): void => {
   baseUrl = newBaseUrl.replace(/\/*$/, '/'); // TODO #12875
 };
 
-export interface GiteaHttpOptions extends InternalHttpOptions {
+export interface GiteaHttpOptions extends HttpOptions {
   paginate?: boolean;
-  token?: string;
 }
 
 function getPaginationContainer<T = unknown>(body: unknown): T[] | null {

--- a/lib/util/http/github.ts
+++ b/lib/util/http/github.ts
@@ -18,6 +18,7 @@ import { parseLinkHeader } from '../url';
 import type { GotLegacyError } from './legacy';
 import type {
   GraphqlOptions,
+  HttpOptions,
   HttpPostOptions,
   HttpResponse,
   InternalHttpOptions,
@@ -30,15 +31,10 @@ export const setBaseUrl = (url: string): void => {
   baseUrl = url;
 };
 
-interface GithubInternalOptions extends InternalHttpOptions {
-  body?: string;
-}
-
-export interface GithubHttpOptions extends InternalHttpOptions {
+export interface GithubHttpOptions extends HttpOptions {
   paginate?: boolean | string;
   paginationField?: string;
   pageLimit?: number;
-  token?: string;
 }
 
 interface GithubGraphqlRepoData<T = unknown> {
@@ -274,7 +270,7 @@ export class GithubHttp extends Http<GithubHttpOptions, GithubHttpOptions> {
 
   protected override async request<T>(
     url: string | URL,
-    options?: GithubInternalOptions & GithubHttpOptions,
+    options?: InternalHttpOptions & GithubHttpOptions,
     okToRetry = true
   ): Promise<HttpResponse<T>> {
     const opts = {

--- a/lib/util/http/gitlab.ts
+++ b/lib/util/http/gitlab.ts
@@ -3,7 +3,7 @@ import { PlatformId } from '../../constants';
 import { logger } from '../../logger';
 import { ExternalHostError } from '../../types/errors/external-host-error';
 import { parseLinkHeader, parseUrl } from '../url';
-import type { HttpResponse, InternalHttpOptions } from './types';
+import type { HttpOptions, HttpResponse, InternalHttpOptions } from './types';
 import { Http } from '.';
 
 let baseUrl = 'https://gitlab.com/api/v4/';
@@ -11,13 +11,8 @@ export const setBaseUrl = (url: string): void => {
   baseUrl = url;
 };
 
-interface GitlabInternalOptions extends InternalHttpOptions {
-  body?: string;
-}
-
-export interface GitlabHttpOptions extends InternalHttpOptions {
+export interface GitlabHttpOptions extends HttpOptions {
   paginate?: boolean;
-  token?: string;
 }
 
 export class GitlabHttp extends Http<GitlabHttpOptions, GitlabHttpOptions> {
@@ -27,7 +22,7 @@ export class GitlabHttp extends Http<GitlabHttpOptions, GitlabHttpOptions> {
 
   protected override async request<T>(
     url: string | URL,
-    options?: GitlabInternalOptions & GitlabHttpOptions
+    options?: InternalHttpOptions & GitlabHttpOptions
   ): Promise<HttpResponse<T>> {
     const opts = {
       baseUrl,

--- a/lib/util/http/types.ts
+++ b/lib/util/http/types.ts
@@ -60,6 +60,8 @@ export interface HttpOptions {
   noAuth?: boolean;
 
   throwHttpErrors?: boolean;
+
+  token?: string;
   useCache?: boolean;
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
cleanup `HttpOptions` interface usage, no functional change
<!-- Describe what behavior is changed by this PR. -->

## Context
- #16900
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
