### PR TITLE
refactor(gitea): cleanup types

### DIFF
--- a/lib/config/presets/gitea/index.ts
+++ b/lib/config/presets/gitea/index.ts
@@ -1,8 +1,6 @@
 import { logger } from '../../../logger';
-import {
-  RepoContents,
-  getRepoContents,
-} from '../../../modules/platform/gitea/gitea-helper';
+import { getRepoContents } from '../../../modules/platform/gitea/gitea-helper';
+import type { RepoContents } from '../../../modules/platform/gitea/types';
 import { ExternalHostError } from '../../../types/errors/external-host-error';
 import { fromBase64 } from '../../../util/string';
 import type { Preset, PresetConfig } from '../types';

--- a/lib/modules/platform/gitea/gitea-helper.spec.ts
+++ b/lib/modules/platform/gitea/gitea-helper.spec.ts
@@ -2,7 +2,49 @@ import * as httpMock from '../../../../test/http-mock';
 import { PrState } from '../../../types';
 import { setBaseUrl } from '../../../util/http/gitea';
 import { toBase64 } from '../../../util/string';
-import * as ght from './gitea-helper';
+import {
+  closeIssue,
+  closePR,
+  createComment,
+  createCommitStatus,
+  createIssue,
+  createPR,
+  deleteComment,
+  getBranch,
+  getCombinedCommitStatus,
+  getComments,
+  getCurrentUser,
+  getIssue,
+  getOrgLabels,
+  getPR,
+  getRepo,
+  getRepoContents,
+  getRepoLabels,
+  getVersion,
+  mergePR,
+  requestPrReviewers,
+  searchIssues,
+  searchPRs,
+  searchRepos,
+  unassignLabel,
+  updateComment,
+  updateIssue,
+  updateIssueLabels,
+  updatePR,
+} from './gitea-helper';
+import type {
+  Branch,
+  Comment,
+  Commit,
+  CommitStatus,
+  CommitStatusType,
+  Issue,
+  Label,
+  PR,
+  Repo,
+  RepoContents,
+  User,
+} from './types';
 
 describe('modules/platform/gitea/gitea-helper', () => {
   const giteaApiHost = 'https://gitea.renovatebot.com/';
@@ -10,21 +52,21 @@ describe('modules/platform/gitea/gitea-helper', () => {
 
   const mockCommitHash = '0d9c7726c3d628b7e28af234595cfd20febdbf8e';
 
-  const mockUser: ght.User = {
+  const mockUser: User = {
     id: 1,
     username: 'admin',
     full_name: 'The Administrator',
     email: 'admin@example.com',
   };
 
-  const otherMockUser: ght.User & Required<Pick<ght.User, 'full_name'>> = {
+  const otherMockUser: User & Required<Pick<User, 'full_name'>> = {
     ...mockUser,
     username: 'renovate',
     full_name: 'Renovate Bot',
     email: 'renovate@example.com',
   };
 
-  const mockRepo: ght.Repo = {
+  const mockRepo: Repo = {
     allow_rebase: true,
     allow_rebase_explicit: true,
     allow_merge_commits: true,
@@ -45,26 +87,26 @@ describe('modules/platform/gitea/gitea-helper', () => {
     },
   };
 
-  const otherMockRepo: ght.Repo = {
+  const otherMockRepo: Repo = {
     ...mockRepo,
     full_name: 'other/repo',
     clone_url: 'https://gitea.renovatebot.com/other/repo.git',
   };
 
-  const mockLabel: ght.Label = {
+  const mockLabel: Label = {
     id: 100,
     name: 'some-label',
     description: 'just a label',
     color: '#000000',
   };
 
-  const otherMockLabel: ght.Label = {
+  const otherMockLabel: Label = {
     ...mockLabel,
     id: 200,
     name: 'other-label',
   };
 
-  const mockPR: ght.PR = {
+  const mockPR: PR = {
     number: 13,
     state: PrState.Open,
     title: 'Some PR',
@@ -81,7 +123,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
     closed_at: '2020-04-01T19:19:22Z',
   };
 
-  const mockIssue: ght.Issue = {
+  const mockIssue: Issue = {
     number: 7,
     state: 'open',
     title: 'Some Issue',
@@ -90,12 +132,12 @@ describe('modules/platform/gitea/gitea-helper', () => {
     labels: [],
   };
 
-  const mockComment: ght.Comment = {
+  const mockComment: Comment = {
     id: 31,
     body: 'some-comment',
   };
 
-  const mockCommitStatus: ght.CommitStatus = {
+  const mockCommitStatus: CommitStatus = {
     id: 121,
     status: 'success',
     context: 'some-context',
@@ -104,14 +146,14 @@ describe('modules/platform/gitea/gitea-helper', () => {
     created_at: '2020-03-25T00:00:00Z',
   };
 
-  const otherMockCommitStatus: ght.CommitStatus = {
+  const otherMockCommitStatus: CommitStatus = {
     ...mockCommitStatus,
     id: 242,
     status: 'error',
     context: 'other-context',
   };
 
-  const mockCommit: ght.Commit = {
+  const mockCommit: Commit = {
     id: mockCommitHash,
     author: {
       name: otherMockUser.full_name,
@@ -120,23 +162,23 @@ describe('modules/platform/gitea/gitea-helper', () => {
     },
   };
 
-  const mockBranch: ght.Branch = {
+  const mockBranch: Branch = {
     name: 'some-branch',
     commit: mockCommit,
   };
 
-  const otherMockBranch: ght.Branch = {
+  const otherMockBranch: Branch = {
     ...mockBranch,
     name: 'other/branch/with/slashes',
   };
 
-  const mockContents: ght.RepoContents = {
+  const mockContents: RepoContents = {
     path: 'dummy.txt',
     content: toBase64('top secret'),
     contentString: 'top secret',
   };
 
-  const otherMockContents: ght.RepoContents = {
+  const otherMockContents: RepoContents = {
     ...mockContents,
     path: 'nested/path/dummy.txt',
   };
@@ -150,7 +192,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
     it('should call /api/v1/user endpoint', async () => {
       httpMock.scope(baseUrl).get('/user').reply(200, mockUser);
 
-      const res = await ght.getCurrentUser();
+      const res = await getCurrentUser();
       expect(res).toEqual(mockUser);
     });
   });
@@ -160,7 +202,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
       const version = '1.13.01.14.0+dev-754-g5d2b7ba63';
       httpMock.scope(baseUrl).get('/version').reply(200, { version });
 
-      const res = await ght.getVersion();
+      const res = await getVersion();
 
       expect(res).toEqual(version);
     });
@@ -176,7 +218,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
           data: [mockRepo, otherMockRepo],
         });
 
-      const res = await ght.searchRepos({});
+      const res = await searchRepos({});
       expect(res).toEqual([mockRepo, otherMockRepo]);
     });
 
@@ -189,7 +231,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
           data: [otherMockRepo],
         });
 
-      const res = await ght.searchRepos({
+      const res = await searchRepos({
         uid: 13,
         archived: false,
       });
@@ -202,7 +244,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
         data: [],
       });
 
-      await expect(ght.searchRepos({})).rejects.toThrow();
+      await expect(searchRepos({})).rejects.toThrow();
     });
   });
 
@@ -213,7 +255,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
         .get(`/repos/${mockRepo.full_name}`)
         .reply(200, mockRepo);
 
-      const res = await ght.getRepo(mockRepo.full_name);
+      const res = await getRepo(mockRepo.full_name);
       expect(res).toEqual(mockRepo);
     });
   });
@@ -227,10 +269,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
         .get(`/repos/${mockRepo.full_name}/contents/${mockContents.path}`)
         .reply(200, { ...mockContents, contentString: undefined });
 
-      const res = await ght.getRepoContents(
-        mockRepo.full_name,
-        mockContents.path
-      );
+      const res = await getRepoContents(mockRepo.full_name, mockContents.path);
       expect(res).toEqual(mockContents);
     });
 
@@ -242,7 +281,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
         )
         .reply(200, { ...mockContents, contentString: undefined });
 
-      const res = await ght.getRepoContents(
+      const res = await getRepoContents(
         mockRepo.full_name,
         mockContents.path,
         mockCommitHash
@@ -258,7 +297,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
         .get(`/repos/${mockRepo.full_name}/contents/${escapedPath}`)
         .reply(200, otherMockContents);
 
-      const res = await ght.getRepoContents(
+      const res = await getRepoContents(
         mockRepo.full_name,
         otherMockContents.path
       );
@@ -275,10 +314,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
           contentString: undefined,
         });
 
-      const res = await ght.getRepoContents(
-        mockRepo.full_name,
-        mockContents.path
-      );
+      const res = await getRepoContents(mockRepo.full_name, mockContents.path);
       expect(res).toEqual({
         ...mockContents,
         content: undefined,
@@ -294,7 +330,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
         .post(`/repos/${mockRepo.full_name}/pulls`)
         .reply(200, mockPR);
 
-      const res = await ght.createPR(mockRepo.full_name, {
+      const res = await createPR(mockRepo.full_name, {
         state: mockPR.state,
         title: mockPR.title,
         body: mockPR.body,
@@ -309,7 +345,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
 
   describe('updatePR', () => {
     it('should call /api/v1/repos/[repo]/pulls/[pull] endpoint', async () => {
-      const updatedMockPR: ght.PR = {
+      const updatedMockPR: PR = {
         ...mockPR,
         state: PrState.Closed,
         title: 'new-title',
@@ -321,7 +357,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
         .patch(`/repos/${mockRepo.full_name}/pulls/${mockPR.number}`)
         .reply(200, updatedMockPR);
 
-      const res = await ght.updatePR(mockRepo.full_name, mockPR.number, {
+      const res = await updatePR(mockRepo.full_name, mockPR.number, {
         state: PrState.Closed,
         title: 'new-title',
         body: 'new-body',
@@ -339,7 +375,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
         .patch(`/repos/${mockRepo.full_name}/pulls/${mockPR.number}`)
         .reply(200);
 
-      const res = await ght.closePR(mockRepo.full_name, mockPR.number);
+      const res = await closePR(mockRepo.full_name, mockPR.number);
       expect(res).toBeUndefined();
     });
   });
@@ -351,7 +387,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
         .post(`/repos/${mockRepo.full_name}/pulls/${mockPR.number}/merge`)
         .reply(200);
 
-      const res = await ght.mergePR(mockRepo.full_name, mockPR.number, {
+      const res = await mergePR(mockRepo.full_name, mockPR.number, {
         Do: 'rebase',
       });
       expect(res).toBeUndefined();
@@ -365,7 +401,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
         .get(`/repos/${mockRepo.full_name}/pulls/${mockPR.number}`)
         .reply(200, mockPR);
 
-      const res = await ght.getPR(mockRepo.full_name, mockPR.number);
+      const res = await getPR(mockRepo.full_name, mockPR.number);
       expect(res).toEqual(mockPR);
     });
   });
@@ -380,7 +416,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
         .reply(200);
 
       await expect(
-        ght.requestPrReviewers(mockRepo.full_name, mockPR.number, {})
+        requestPrReviewers(mockRepo.full_name, mockPR.number, {})
       ).toResolve();
     });
   });
@@ -392,7 +428,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
         .get(`/repos/${mockRepo.full_name}/pulls`)
         .reply(200, [mockPR]);
 
-      const res = await ght.searchPRs(mockRepo.full_name, {});
+      const res = await searchPRs(mockRepo.full_name, {});
       expect(res).toEqual([mockPR]);
     });
 
@@ -404,7 +440,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
         )
         .reply(200, [mockPR]);
 
-      const res = await ght.searchPRs(mockRepo.full_name, {
+      const res = await searchPRs(mockRepo.full_name, {
         state: PrState.Open,
         labels: [mockLabel.id, otherMockLabel.id],
       });
@@ -419,7 +455,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
         .post(`/repos/${mockRepo.full_name}/issues`)
         .reply(200, mockIssue);
 
-      const res = await ght.createIssue(mockRepo.full_name, {
+      const res = await createIssue(mockRepo.full_name, {
         state: mockIssue.state,
         title: mockIssue.title,
         body: mockIssue.body,
@@ -431,7 +467,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
 
   describe('updateIssue', () => {
     it('should call /api/v1/repos/[repo]/issues/[issue] endpoint', async () => {
-      const updatedMockIssue: ght.Issue = {
+      const updatedMockIssue: Issue = {
         ...mockIssue,
         state: 'closed',
         title: 'new-title',
@@ -444,7 +480,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
         .patch(`/repos/${mockRepo.full_name}/issues/${mockIssue.number}`)
         .reply(200, updatedMockIssue);
 
-      const res = await ght.updateIssue(mockRepo.full_name, mockIssue.number, {
+      const res = await updateIssue(mockRepo.full_name, mockIssue.number, {
         state: 'closed',
         title: 'new-title',
         body: 'new-body',
@@ -456,7 +492,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
 
   describe('updateIssueLabels', () => {
     it('should call /api/v1/repos/[repo]/issues/[issue]/labels endpoint', async () => {
-      const updatedMockLabels: Partial<ght.Label>[] = [
+      const updatedMockLabels: Partial<Label>[] = [
         { id: 1, name: 'Renovate' },
         { id: 3, name: 'Maintenance' },
       ];
@@ -466,7 +502,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
         .put(`/repos/${mockRepo.full_name}/issues/${mockIssue.number}/labels`)
         .reply(200, updatedMockLabels);
 
-      const res = await ght.updateIssueLabels(
+      const res = await updateIssueLabels(
         mockRepo.full_name,
         mockIssue.number,
         {
@@ -484,7 +520,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
         .patch(`/repos/${mockRepo.full_name}/issues/${mockIssue.number}`)
         .reply(200);
 
-      const res = await ght.closeIssue(mockRepo.full_name, mockIssue.number);
+      const res = await closeIssue(mockRepo.full_name, mockIssue.number);
       expect(res).toBeUndefined();
     });
   });
@@ -496,7 +532,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
         .get(`/repos/${mockRepo.full_name}/issues?type=issues`)
         .reply(200, [mockIssue]);
 
-      const res = await ght.searchIssues(mockRepo.full_name, {});
+      const res = await searchIssues(mockRepo.full_name, {});
       expect(res).toEqual([mockIssue]);
     });
 
@@ -506,7 +542,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
         .get(`/repos/${mockRepo.full_name}/issues?state=open&type=issues`)
         .reply(200, [mockIssue]);
 
-      const res = await ght.searchIssues(mockRepo.full_name, {
+      const res = await searchIssues(mockRepo.full_name, {
         state: 'open',
       });
       expect(res).toEqual([mockIssue]);
@@ -520,7 +556,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
         .get(`/repos/${mockRepo.full_name}/issues/${mockIssue.number}`)
         .reply(200, mockIssue);
 
-      const res = await ght.getIssue(mockRepo.full_name, mockIssue.number);
+      const res = await getIssue(mockRepo.full_name, mockIssue.number);
       expect(res).toEqual(mockIssue);
     });
   });
@@ -532,7 +568,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
         .get(`/repos/${mockRepo.full_name}/labels`)
         .reply(200, [mockLabel, otherMockLabel]);
 
-      const res = await ght.getRepoLabels(mockRepo.full_name);
+      const res = await getRepoLabels(mockRepo.full_name);
       expect(res).toEqual([mockLabel, otherMockLabel]);
     });
   });
@@ -544,7 +580,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
         .get(`/orgs/${mockRepo.owner.username}/labels`)
         .reply(200, [mockLabel, otherMockLabel]);
 
-      const res = await ght.getOrgLabels(mockRepo.owner.username);
+      const res = await getOrgLabels(mockRepo.owner.username);
       expect(res).toEqual([mockLabel, otherMockLabel]);
     });
   });
@@ -558,7 +594,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
         )
         .reply(200);
 
-      const res = await ght.unassignLabel(
+      const res = await unassignLabel(
         mockRepo.full_name,
         mockIssue.number,
         mockLabel.id
@@ -576,7 +612,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
         )
         .reply(200, mockComment);
 
-      const res = await ght.createComment(
+      const res = await createComment(
         mockRepo.full_name,
         mockIssue.number,
         mockComment.body
@@ -587,7 +623,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
 
   describe('updateComment', () => {
     it('should call /api/v1/repos/[repo]/issues/comments/[comment] endpoint', async () => {
-      const updatedMockComment: ght.Comment = {
+      const updatedMockComment: Comment = {
         ...mockComment,
         body: 'new-body',
       };
@@ -597,7 +633,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
         .patch(`/repos/${mockRepo.full_name}/issues/comments/${mockComment.id}`)
         .reply(200, updatedMockComment);
 
-      const res = await ght.updateComment(
+      const res = await updateComment(
         mockRepo.full_name,
         mockComment.id,
         'new-body'
@@ -615,7 +651,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
         )
         .reply(200);
 
-      const res = await ght.deleteComment(mockRepo.full_name, mockComment.id);
+      const res = await deleteComment(mockRepo.full_name, mockComment.id);
       expect(res).toBeUndefined();
     });
   });
@@ -627,7 +663,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
         .get(`/repos/${mockRepo.full_name}/issues/${mockIssue.number}/comments`)
         .reply(200, [mockComment]);
 
-      const res = await ght.getComments(mockRepo.full_name, mockIssue.number);
+      const res = await getComments(mockRepo.full_name, mockIssue.number);
       expect(res).toEqual([mockComment]);
     });
   });
@@ -639,16 +675,12 @@ describe('modules/platform/gitea/gitea-helper', () => {
         .post(`/repos/${mockRepo.full_name}/statuses/${mockCommitHash}`)
         .reply(200, mockCommitStatus);
 
-      const res = await ght.createCommitStatus(
-        mockRepo.full_name,
-        mockCommitHash,
-        {
-          state: mockCommitStatus.status,
-          context: mockCommitStatus.context,
-          description: mockCommitStatus.description,
-          target_url: mockCommitStatus.target_url,
-        }
-      );
+      const res = await createCommitStatus(mockRepo.full_name, mockCommitHash, {
+        state: mockCommitStatus.status,
+        context: mockCommitStatus.context,
+        description: mockCommitStatus.description,
+        target_url: mockCommitStatus.target_url,
+      });
       expect(res).toEqual(mockCommitStatus);
     });
   });
@@ -660,7 +692,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
         .get(`/repos/${mockRepo.full_name}/commits/${mockBranch.name}/statuses`)
         .reply(200, [mockCommitStatus, otherMockCommitStatus]);
 
-      const res = await ght.getCombinedCommitStatus(
+      const res = await getCombinedCommitStatus(
         mockRepo.full_name,
         mockBranch.name
       );
@@ -670,9 +702,9 @@ describe('modules/platform/gitea/gitea-helper', () => {
 
     it('should properly determine worst commit status', async () => {
       const statuses: {
-        status: ght.CommitStatusType;
+        status: CommitStatusType;
         created_at: string;
-        expected: ght.CommitStatusType;
+        expected: CommitStatusType;
       }[] = [
         {
           status: 'unknown',
@@ -706,7 +738,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
         },
       ];
 
-      const commitStatuses: ght.CommitStatus[] = [
+      const commitStatuses: CommitStatus[] = [
         { ...mockCommitStatus, status: 'unknown' },
       ];
 
@@ -727,7 +759,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
 
         // Expect to get the current state back as the worst status, as all previous commit statuses
         // should be less important than the one which just got added
-        const res = await ght.getCombinedCommitStatus(
+        const res = await getCombinedCommitStatus(
           mockRepo.full_name,
           mockBranch.name
         );
@@ -743,7 +775,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
         .get(`/repos/${mockRepo.full_name}/branches/${mockBranch.name}`)
         .reply(200, mockBranch);
 
-      const res = await ght.getBranch(mockRepo.full_name, mockBranch.name);
+      const res = await getBranch(mockRepo.full_name, mockBranch.name);
       expect(res).toEqual(mockBranch);
     });
 
@@ -755,7 +787,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
         .get(`/repos/${mockRepo.full_name}/branches/${escapedBranchName}`)
         .reply(200, otherMockBranch);
 
-      const res = await ght.getBranch(mockRepo.full_name, otherMockBranch.name);
+      const res = await getBranch(mockRepo.full_name, otherMockBranch.name);
       expect(res).toEqual(otherMockBranch);
     });
   });

--- a/lib/modules/platform/gitea/gitea-helper.ts
+++ b/lib/modules/platform/gitea/gitea-helper.ts
@@ -1,197 +1,37 @@
 import { BranchStatus, PrState } from '../../../types';
 import { GiteaHttp, GiteaHttpOptions } from '../../../util/http/gitea';
 import { getQueryString } from '../../../util/url';
-import type { PrReviewersParams } from './types';
+import type {
+  Branch,
+  CombinedCommitStatus,
+  Comment,
+  CommentCreateParams,
+  CommentUpdateParams,
+  CommitStatus,
+  CommitStatusCreateParams,
+  CommitStatusType,
+  Issue,
+  IssueCreateParams,
+  IssueSearchParams,
+  IssueUpdateLabelsParams,
+  IssueUpdateParams,
+  Label,
+  PR,
+  PRCreateParams,
+  PRMergeParams,
+  PRSearchParams,
+  PRUpdateParams,
+  PrReviewersParams,
+  Repo,
+  RepoContents,
+  RepoSearchParams,
+  RepoSearchResults,
+  User,
+} from './types';
 
 const giteaHttp = new GiteaHttp();
 
 const API_PATH = '/api/v1';
-
-export type PRState = PrState.Open | PrState.Closed | PrState.All;
-export type IssueState = 'open' | 'closed' | 'all';
-export type CommitStatusType =
-  | 'pending'
-  | 'success'
-  | 'error'
-  | 'failure'
-  | 'warning'
-  | 'unknown';
-export type PRMergeMethod = 'merge' | 'rebase' | 'rebase-merge' | 'squash';
-
-export interface PR {
-  number: number;
-  state: PRState;
-  title: string;
-  body: string;
-  mergeable: boolean;
-  created_at: string;
-  closed_at: string;
-  diff_url: string;
-  base?: {
-    ref: string;
-  };
-  head?: {
-    label: string;
-    sha: string;
-    repo?: Repo;
-  };
-  assignee?: {
-    login?: string;
-  };
-  assignees?: any[];
-  user?: { username?: string };
-}
-
-export interface Issue {
-  number: number;
-  state: IssueState;
-  title: string;
-  body: string;
-  assignees: User[];
-  labels: Label[];
-}
-
-export interface User {
-  id: number;
-  email: string;
-  full_name?: string;
-  username: string;
-}
-
-export interface Repo {
-  allow_merge_commits: boolean;
-  allow_rebase: boolean;
-  allow_rebase_explicit: boolean;
-  allow_squash_merge: boolean;
-  archived: boolean;
-  clone_url?: string;
-  ssh_url?: string;
-  default_branch: string;
-  empty: boolean;
-  fork: boolean;
-  full_name: string;
-  mirror: boolean;
-  owner: User;
-  permissions: RepoPermission;
-}
-
-export interface RepoPermission {
-  admin: boolean;
-  pull: boolean;
-  push: boolean;
-}
-
-export interface RepoSearchResults {
-  ok: boolean;
-  data: Repo[];
-}
-
-export interface RepoContents {
-  path: string;
-  content?: string;
-  contentString?: string;
-}
-
-export interface Comment {
-  id: number;
-  body: string;
-}
-
-export interface Label {
-  id: number;
-  name: string;
-  description: string;
-  color: string;
-}
-
-export interface Branch {
-  name: string;
-  commit: Commit;
-}
-
-export interface Commit {
-  id: string;
-  author: CommitUser;
-}
-
-export interface CommitUser {
-  name: string;
-  email: string;
-  username: string;
-}
-
-export interface CommitStatus {
-  id: number;
-  status: CommitStatusType;
-  context: string;
-  description: string;
-  target_url: string;
-  created_at: string;
-}
-
-export interface CombinedCommitStatus {
-  worstStatus: CommitStatusType;
-  statuses: CommitStatus[];
-}
-
-export type RepoSearchParams = {
-  uid?: number;
-  archived?: boolean;
-};
-
-export type IssueCreateParams = Partial<IssueUpdateLabelsParams> &
-  IssueUpdateParams;
-
-export type IssueUpdateParams = {
-  title?: string;
-  body?: string;
-  state?: IssueState;
-  assignees?: string[];
-};
-
-export type IssueUpdateLabelsParams = {
-  labels?: number[];
-};
-
-export type IssueSearchParams = {
-  state?: IssueState;
-};
-
-export type PRCreateParams = {
-  base?: string;
-  head?: string;
-} & PRUpdateParams;
-
-export type PRUpdateParams = {
-  title?: string;
-  body?: string;
-  assignees?: string[];
-  labels?: number[];
-  state?: PRState;
-};
-
-export type PRSearchParams = {
-  state?: PRState;
-  labels?: number[];
-};
-
-export interface PRMergeParams {
-  Do: PRMergeMethod;
-  merge_when_checks_succeed?: boolean;
-}
-
-export type CommentCreateParams = CommentUpdateParams;
-
-export type CommentUpdateParams = {
-  body: string;
-};
-
-export type CommitStatusCreateParams = {
-  context?: string;
-  description?: string;
-  state?: CommitStatusType;
-  target_url?: string;
-};
 
 const urlEscape = (raw: string): string => encodeURIComponent(raw);
 const commitStatusStates: CommitStatusType[] = [

--- a/lib/modules/platform/gitea/index.ts
+++ b/lib/modules/platform/gitea/index.ts
@@ -36,6 +36,15 @@ import type {
 } from '../types';
 import { smartTruncate } from '../utils/pr-body';
 import * as helper from './gitea-helper';
+import type {
+  CombinedCommitStatus,
+  Comment,
+  IssueState,
+  Label,
+  PR,
+  PRMergeMethod,
+  Repo,
+} from './types';
 import {
   getMergeMethod,
   getRepoUrl,
@@ -45,11 +54,11 @@ import {
 
 interface GiteaRepoConfig {
   repository: string;
-  mergeMethod: helper.PRMergeMethod;
+  mergeMethod: PRMergeMethod;
 
   prList: Promise<Pr[]> | null;
   issueList: Promise<Issue[]> | null;
-  labelList: Promise<helper.Label[]> | null;
+  labelList: Promise<Label[]> | null;
   defaultBranch: string;
   cloneSubmodules: boolean;
 }
@@ -66,7 +75,7 @@ let config: GiteaRepoConfig = {} as any;
 let botUserID: number;
 let botUserName: string;
 
-function toRenovateIssue(data: helper.Issue): Issue {
+function toRenovateIssue(data: Issue): Issue {
   return {
     number: data.number,
     state: data.state,
@@ -76,7 +85,7 @@ function toRenovateIssue(data: helper.Issue): Issue {
 }
 
 // TODO #7154
-function toRenovatePR(data: helper.PR): Pr | null {
+function toRenovatePR(data: PR): Pr | null {
   if (!data) {
     return null;
   }
@@ -136,20 +145,20 @@ function matchesState(actual: string, expected: string): boolean {
 }
 
 function findCommentByTopic(
-  comments: helper.Comment[],
+  comments: Comment[],
   topic: string
-): helper.Comment | null {
+): Comment | null {
   return comments.find((c) => c.body.startsWith(`### ${topic}\n\n`)) ?? null;
 }
 
 function findCommentByContent(
-  comments: helper.Comment[],
+  comments: Comment[],
   content: string
-): helper.Comment | null {
+): Comment | null {
   return comments.find((c) => c.body.trim() === content) ?? null;
 }
 
-function getLabelList(): Promise<helper.Label[]> {
+function getLabelList(): Promise<Label[]> {
   if (config.labelList === null) {
     const repoLabels = helper
       .getRepoLabels(config.repository, {
@@ -171,11 +180,11 @@ function getLabelList(): Promise<helper.Label[]> {
       .catch((err) => {
         // Will fail if owner of repo is not org or Gitea version < 1.12
         logger.debug(`Unable to fetch organization labels`);
-        return [] as helper.Label[];
+        return [] as Label[];
       });
 
     config.labelList = Promise.all([repoLabels, orgLabels]).then((labels) =>
-      ([] as helper.Label[]).concat(...labels)
+      ([] as Label[]).concat(...labels)
     );
   }
 
@@ -252,7 +261,7 @@ const platform: Platform = {
     cloneSubmodules,
     gitUrl,
   }: RepoParams): Promise<RepoResult> {
-    let repo: helper.Repo;
+    let repo: Repo;
 
     config = {} as any;
     config.repository = repository;
@@ -371,7 +380,7 @@ const platform: Platform = {
   },
 
   async getBranchStatus(branchName: string): Promise<BranchStatus> {
-    let ccs: helper.CombinedCommitStatus;
+    let ccs: CombinedCommitStatus;
     try {
       ccs = await helper.getCombinedCommitStatus(config.repository, branchName);
     } catch (err) {
@@ -742,9 +751,7 @@ const platform: Platform = {
           {
             body,
             title,
-            state: shouldReOpen
-              ? 'open'
-              : (activeIssue.state as helper.IssueState),
+            state: shouldReOpen ? 'open' : (activeIssue.state as IssueState),
           }
         );
 
@@ -824,7 +831,7 @@ const platform: Platform = {
       const commentList = await helper.getComments(config.repository, issue);
 
       // Search comment by either topic or exact body
-      let comment: helper.Comment | null = null;
+      let comment: Comment | null = null;
       if (topic) {
         comment = findCommentByTopic(commentList, topic);
         body = `### ${topic}\n\n${body}`;
@@ -867,7 +874,7 @@ const platform: Platform = {
     logger.debug(`Ensuring comment "${key}" in #${issue} is removed`);
     const commentList = await helper.getComments(config.repository, issue);
 
-    let comment: helper.Comment | null = null;
+    let comment: Comment | null = null;
     if (deleteConfig.type === 'by-topic') {
       comment = findCommentByTopic(commentList, deleteConfig.topic);
     } else if (deleteConfig.type === 'by-content') {

--- a/lib/modules/platform/gitea/types.ts
+++ b/lib/modules/platform/gitea/types.ts
@@ -1,4 +1,192 @@
-export type PrReviewersParams = {
+import type { PrState } from '../../../types';
+
+export interface PrReviewersParams {
   reviewers?: string[];
   team_reviewers?: string[];
-};
+}
+
+export type PRState = PrState.Open | PrState.Closed | PrState.All;
+export type IssueState = 'open' | 'closed' | 'all';
+export type CommitStatusType =
+  | 'pending'
+  | 'success'
+  | 'error'
+  | 'failure'
+  | 'warning'
+  | 'unknown';
+export type PRMergeMethod = 'merge' | 'rebase' | 'rebase-merge' | 'squash';
+
+export interface PR {
+  number: number;
+  state: PRState;
+  title: string;
+  body: string;
+  mergeable: boolean;
+  created_at: string;
+  closed_at: string;
+  diff_url: string;
+  base?: {
+    ref: string;
+  };
+  head?: {
+    label: string;
+    sha: string;
+    repo?: Repo;
+  };
+  assignee?: {
+    login?: string;
+  };
+  assignees?: any[];
+  user?: { username?: string };
+}
+
+export interface Issue {
+  number: number;
+  state: IssueState;
+  title: string;
+  body: string;
+  assignees: User[];
+  labels: Label[];
+}
+
+export interface User {
+  id: number;
+  email: string;
+  full_name?: string;
+  username: string;
+}
+
+export interface Repo {
+  allow_merge_commits: boolean;
+  allow_rebase: boolean;
+  allow_rebase_explicit: boolean;
+  allow_squash_merge: boolean;
+  archived: boolean;
+  clone_url?: string;
+  ssh_url?: string;
+  default_branch: string;
+  empty: boolean;
+  fork: boolean;
+  full_name: string;
+  mirror: boolean;
+  owner: User;
+  permissions: RepoPermission;
+}
+
+export interface RepoPermission {
+  admin: boolean;
+  pull: boolean;
+  push: boolean;
+}
+
+export interface RepoSearchResults {
+  ok: boolean;
+  data: Repo[];
+}
+
+export interface RepoContents {
+  path: string;
+  content?: string;
+  contentString?: string;
+}
+
+export interface Comment {
+  id: number;
+  body: string;
+}
+
+export interface Label {
+  id: number;
+  name: string;
+  description: string;
+  color: string;
+}
+
+export interface Branch {
+  name: string;
+  commit: Commit;
+}
+
+export interface Commit {
+  id: string;
+  author: CommitUser;
+}
+
+export interface CommitUser {
+  name: string;
+  email: string;
+  username: string;
+}
+
+export interface CommitStatus {
+  id: number;
+  status: CommitStatusType;
+  context: string;
+  description: string;
+  target_url: string;
+  created_at: string;
+}
+
+export interface CombinedCommitStatus {
+  worstStatus: CommitStatusType;
+  statuses: CommitStatus[];
+}
+
+export interface RepoSearchParams {
+  uid?: number;
+  archived?: boolean;
+}
+
+export type IssueCreateParams = Partial<IssueUpdateLabelsParams> &
+  IssueUpdateParams;
+
+export interface IssueUpdateParams {
+  title?: string;
+  body?: string;
+  state?: IssueState;
+  assignees?: string[];
+}
+
+export interface IssueUpdateLabelsParams {
+  labels?: number[];
+}
+
+export interface IssueSearchParams {
+  state?: IssueState;
+}
+
+export interface PRCreateParams extends PRUpdateParams {
+  base?: string;
+  head?: string;
+}
+
+export interface PRUpdateParams {
+  title?: string;
+  body?: string;
+  assignees?: string[];
+  labels?: number[];
+  state?: PRState;
+}
+
+export interface PRSearchParams {
+  state?: PRState;
+  labels?: number[];
+}
+
+export interface PRMergeParams {
+  Do: PRMergeMethod;
+  merge_when_checks_succeed?: boolean;
+}
+
+export type CommentCreateParams = CommentUpdateParams;
+
+export interface CommentUpdateParams {
+  body: string;
+}
+
+export interface CommitStatusCreateParams {
+  context?: string;
+  description?: string;
+  state?: CommitStatusType;
+  target_url?: string;
+}

--- a/lib/modules/platform/gitea/utils.spec.ts
+++ b/lib/modules/platform/gitea/utils.spec.ts
@@ -1,6 +1,6 @@
 import { partial } from '../../../../test/util';
 import { CONFIG_GIT_URL_UNAVAILABLE } from '../../../constants/error-messages';
-import type { Repo } from './gitea-helper';
+import type { Repo } from './types';
 import { getMergeMethod, getRepoUrl, trimTrailingApiPath } from './utils';
 
 describe('modules/platform/gitea/utils', () => {

--- a/lib/modules/platform/gitea/utils.ts
+++ b/lib/modules/platform/gitea/utils.ts
@@ -6,7 +6,7 @@ import * as hostRules from '../../../util/host-rules';
 import { regEx } from '../../../util/regex';
 import { parseUrl } from '../../../util/url';
 import type { GitUrlOption } from '../types';
-import type { PRMergeMethod, Repo } from './gitea-helper';
+import type { PRMergeMethod, Repo } from './types';
 
 export function smartLinks(body: string): string {
   return body?.replace(regEx(/\]\(\.\.\/pull\//g), '](pulls/');


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- move all types to `./types.ts`
- convert types to interfaces where possible
<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
