### PR TITLE
fix(leiningen): Don't extract deps from commented vectors

### DIFF
--- a/lib/modules/manager/leiningen/__fixtures__/project.clj
+++ b/lib/modules/manager/leiningen/__fixtures__/project.clj
@@ -51,6 +51,7 @@
   ;; You can also strings like ["group-id/name" version] for instances
   ;; where the dependency name isn't a valid symbol literal.
   :dependencies [[org.clojure/clojure,"1.3.0"]
+                 #_[org.clojure/clojure "9.9.9"]
                  [org.jclouds/jclouds "1.0" :classifier "jdk15"]
                  [net.sf.ehcache/ehcache "2.3.1" :extension "pom"]
                  [log4j "1.2.15" :exclusions [[javax.mail/mail :extension "jar"]
@@ -59,6 +60,7 @@
                                               com.sun.jmx/jmxri]]
                  ["net.3scale/3scale-api" "3.0.2"]
                  [org.lwjgl.lwjgl/lwjgl "2.8.5"]
+                 #_[org.lwjgl.lwjgl/lwjgl "0.0.0"]
                  [org.lwjgl.lwjgl/lwjgl-platform "2.8.5"
                   :classifier "natives-osx"
                   ;; LWJGL stores natives in the root of the jar; this

--- a/lib/modules/manager/leiningen/extract.spec.ts
+++ b/lib/modules/manager/leiningen/extract.spec.ts
@@ -16,6 +16,7 @@ describe('modules/manager/leiningen/extract', () => {
     expect(extractFromVectors('')).toBeEmptyArray();
     expect(extractFromVectors('[]')).toBeEmptyArray();
     expect(extractFromVectors('[[]]')).toBeEmptyArray();
+    expect(extractFromVectors('[#_[foo/bar "1.2.3"]]')).toBeEmptyArray();
     expect(extractFromVectors('[[foo/bar "1.2.3"]]')).toEqual([
       {
         datasource: ClojureDatasource.id,

--- a/lib/modules/manager/leiningen/extract.ts
+++ b/lib/modules/manager/leiningen/extract.ts
@@ -174,7 +174,9 @@ function collectDeps(
   return result;
 }
 
-export function extractPackageFile(content: string): PackageFile {
+export function extractPackageFile(input: string): PackageFile {
+  const content = input.replace(regEx(/#_\[[^\]]*?\]/g), '');
+
   const registryUrls = extractLeinRepos(content);
   const vars = extractVariables(content);
 

--- a/lib/modules/manager/leiningen/extract.ts
+++ b/lib/modules/manager/leiningen/extract.ts
@@ -35,6 +35,7 @@ export function extractFromVectors(
   let vecPos = 0;
   let artifactId = '';
   let version = '';
+  let commentLevel = 0;
 
   const isSpace = (ch: string | null): boolean =>
     !!ch && regEx(/[\s,]/).test(ch);
@@ -43,7 +44,7 @@ export function extractFromVectors(
     s.replace(regEx(/^"/), '').replace(regEx(/"$/), '');
 
   const yieldDep = (): void => {
-    if (artifactId && version) {
+    if (!commentLevel && artifactId && version) {
       const depName = expandDepName(cleanStrLiteral(artifactId));
       if (version.startsWith('~')) {
         const varName = version.replace(regEx(/^~\s*/), '');
@@ -73,6 +74,11 @@ export function extractFromVectors(
   let prevChar: string | null = null;
   while (idx < str.length) {
     const char = str.charAt(idx);
+
+    if (str.substring(idx).startsWith('#_[')) {
+      commentLevel = balance;
+    }
+
     if (char === '[') {
       balance += 1;
       if (balance === 2) {
@@ -80,6 +86,13 @@ export function extractFromVectors(
       }
     } else if (char === ']') {
       balance -= 1;
+
+      if (commentLevel === balance) {
+        artifactId = '';
+        version = '';
+        commentLevel = 0;
+      }
+
       if (balance === 1) {
         yieldDep();
       } else if (balance === 0) {
@@ -174,9 +187,7 @@ function collectDeps(
   return result;
 }
 
-export function extractPackageFile(input: string): PackageFile {
-  const content = input.replace(regEx(/#_\[[^\]]*?\]/g), '');
-
+export function extractPackageFile(content: string): PackageFile {
   const registryUrls = extractLeinRepos(content);
   const vars = extractVariables(content);
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Handle common case of dependency commenting in Leiningen

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
