### PR TITLE
fix: fix failed hermit binary source tests due to findUp module acts differently in windows

### DIFF
--- a/lib/util/exec/hermit.spec.ts
+++ b/lib/util/exec/hermit.spec.ts
@@ -26,13 +26,13 @@ describe('util/exec/hermit', () => {
     });
 
     it('should find the closest hermit cwd to the given path', async () => {
-      findUp.mockResolvedValue(upath.join(localDir, 'nested/bin/hermit'));
+      findUp.mockResolvedValueOnce(upath.join(localDir, 'nested/bin/hermit'));
       const nestedCwd = 'nested/other/directory';
 
       expect(await findHermitCwd(nestedCwd)).toBe(`${localDir}/nested/bin`);
       expect(await findHermitCwd('nested')).toBe(`${localDir}/nested/bin`);
 
-      findUp.mockResolvedValue(upath.join(localDir, 'bin/hermit'));
+      findUp.mockResolvedValueOnce(upath.join(localDir, 'bin/hermit'));
       expect(await findHermitCwd('')).toBe(`${localDir}/bin`);
       expect(await findHermitCwd('other/directory')).toBe(`${localDir}/bin`);
     });
@@ -51,7 +51,7 @@ describe('util/exec/hermit', () => {
     });
 
     it('should return hermit environment variables when hermit env returns successfully', async () => {
-      findUp.mockResolvedValue(upath.join(localDir, 'bin/hermit'));
+      findUp.mockResolvedValueOnce(upath.join(localDir, 'bin/hermit'));
       mockExecAll({
         stdout: `GOBIN=/usr/src/app/repository-a/.hermit/go/bin
 PATH=/usr/src/app/repository-a/bin

--- a/lib/util/exec/hermit.spec.ts
+++ b/lib/util/exec/hermit.spec.ts
@@ -30,16 +30,17 @@ describe('util/exec/hermit', () => {
       const nestedCwd = 'nested/other/directory';
 
       expect(await findHermitCwd(nestedCwd)).toBe(`${localDir}/nested/bin`);
+      findUp.mockResolvedValueOnce(upath.join(localDir, 'nested/bin/hermit'));
       expect(await findHermitCwd('nested')).toBe(`${localDir}/nested/bin`);
 
       findUp.mockResolvedValueOnce(upath.join(localDir, 'bin/hermit'));
       expect(await findHermitCwd('')).toBe(`${localDir}/bin`);
+      findUp.mockResolvedValueOnce(upath.join(localDir, 'bin/hermit'));
       expect(await findHermitCwd('other/directory')).toBe(`${localDir}/bin`);
     });
 
     it('should throw error when hermit cwd is not found', async () => {
       const err = new Error('hermit not found for other/directory');
-      findUp.mockResolvedValue('');
 
       await expect(findHermitCwd('other/directory')).rejects.toThrow(err);
     });

--- a/lib/util/exec/hermit.spec.ts
+++ b/lib/util/exec/hermit.spec.ts
@@ -46,6 +46,10 @@ describe('util/exec/hermit', () => {
   });
 
   describe('getHermitEnvs', () => {
+    beforeEach(() => {
+      GlobalConfig.set({ localDir });
+    });
+
     it('should return hermit environment variables when hermit env returns successfully', async () => {
       findUp.mockResolvedValue(upath.join(localDir, 'bin/hermit'));
       mockExecAll({


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
This PR fixes failed hermit binary source tests. It uses the same way as how `findUpLocal` tests sets up the `find-up` mocks in [`lib/util/fs/index.spec.ts`](https://github.com/renovatebot/renovate/blob/main/lib/util/fs/index.spec.ts#L367)

The failed tests result is in the following.
https://github.com/renovatebot/renovate/runs/7685608162?check_suite_focus=true#step:7:306

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

This happens after the merge of https://github.com/renovatebot/renovate/pull/16259/

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [X] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
