### PR TITLE
fix(manager/npm): support yarn update without yarnPath

### DIFF
--- a/lib/modules/manager/npm/post-update/index.spec.ts
+++ b/lib/modules/manager/npm/post-update/index.spec.ts
@@ -1,7 +1,7 @@
 // TODO: add tests
 import upath from 'upath';
 import { Fixtures } from '../../../../../test/fixtures';
-import { fs, git, partial } from '../../../../../test/util';
+import { fs, git, logger, partial } from '../../../../../test/util';
 import { GlobalConfig } from '../../../../config/global';
 import type { FileChange } from '../../../../util/git/types';
 import type { PostUpdateConfig } from '../../types';
@@ -301,6 +301,22 @@ describe('modules/manager/npm/post-update/index', () => {
       );
       expect(existingYarnrcYmlContent).toMatch(oldYarnrcYml);
       expect(updatedArtifacts).toBeEmpty();
+    });
+
+    it('should support Yarn with corepack', async () => {
+      git.getFile.mockResolvedValueOnce('');
+      fs.readLocalFile.mockResolvedValueOnce('');
+      fs.readLocalFile.mockResolvedValueOnce('');
+      const updatedArtifacts: FileChange[] = [];
+      const yarnrcYmlContent = await updateYarnBinary(
+        lockFileDir,
+        updatedArtifacts,
+        ''
+      );
+      expect(yarnrcYmlContent).toBe('');
+      expect(updatedArtifacts).toEqual([]);
+      expect(logger.logger.debug).not.toHaveBeenCalled();
+      expect(logger.logger.error).not.toHaveBeenCalled();
     });
   });
 

--- a/lib/modules/manager/npm/post-update/index.ts
+++ b/lib/modules/manager/npm/post-update/index.ts
@@ -36,6 +36,7 @@ import type {
   ArtifactError,
   DetermineLockFileDirsResult,
   WriteExistingFilesResult,
+  YarnRcYmlFile,
 } from './types';
 import * as yarn from './yarn';
 
@@ -408,6 +409,7 @@ async function updateYarnOffline(
   }
 }
 
+// TODO: move to ./yarn.ts
 // exported for testing
 export async function updateYarnBinary(
   lockFileDir: string,
@@ -423,8 +425,15 @@ export async function updateYarnBinary(
       return existingYarnrcYmlContent;
     }
 
-    const oldYarnPath = (load(yarnrcYml) as Record<string, string>).yarnPath;
-    const newYarnPath = (load(newYarnrcYml) as Record<string, string>).yarnPath;
+    const oldYarnPath = (load(yarnrcYml) as YarnRcYmlFile)?.yarnPath;
+    const newYarnPath = (load(newYarnrcYml) as YarnRcYmlFile)?.yarnPath;
+    if (
+      !is.nonEmptyStringAndNotWhitespace(oldYarnPath) ||
+      !is.nonEmptyStringAndNotWhitespace(newYarnPath)
+    ) {
+      return existingYarnrcYmlContent;
+    }
+
     const oldYarnFullPath = upath.join(lockFileDir, oldYarnPath);
     const newYarnFullPath = upath.join(lockFileDir, newYarnPath);
     logger.debug({ oldYarnPath, newYarnPath }, 'Found updated Yarn binary');

--- a/lib/modules/manager/npm/post-update/types.ts
+++ b/lib/modules/manager/npm/post-update/types.ts
@@ -32,3 +32,7 @@ export interface GenerateLockFileResult {
 export interface PnpmLockFile {
   lockfileVersion?: number;
 }
+
+export interface YarnRcYmlFile {
+  yarnPath?: string | null;
+}


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- skip updating `.yarnrc.yml` whichout `yarnPath`
- https://github.com/renovate-reproductions/14797-renovate-corepack-yarn/pull/9
<!-- Describe what behavior is changed by this PR. -->

## Context
- fixes #16733
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
