### PR TITLE
fix(buildpack): execute `preCommads` on install mode

### DIFF
--- a/lib/modules/manager/pipenv/artifacts.spec.ts
+++ b/lib/modules/manager/pipenv/artifacts.spec.ts
@@ -16,6 +16,8 @@ jest.mock('../../../util/host-rules');
 jest.mock('../../../util/http');
 jest.mock('../../datasource');
 
+process.env.BUILDPACK = 'true';
+
 const getPkgReleases = mockedFunction(_getPkgReleases);
 
 const adminConfig: RepoGlobalConfig = {
@@ -148,6 +150,33 @@ describe('modules/manager/pipenv/artifacts', () => {
       })
     ).not.toBeNull();
     expect(execSnapshots).toMatchSnapshot();
+  });
+
+  it('supports install mode', async () => {
+    GlobalConfig.set({ ...adminConfig, binarySource: 'install' });
+    pipFileLock._meta.requires.python_version = '3.7';
+    fs.ensureCacheDir.mockResolvedValueOnce(
+      '/tmp/renovate/cache/others/pipenv'
+    );
+    fs.readLocalFile.mockResolvedValueOnce(JSON.stringify(pipFileLock));
+    const execSnapshots = mockExecAll();
+    git.getRepoStatus.mockResolvedValue({
+      modified: ['Pipfile.lock'],
+    } as StatusResult);
+    fs.readLocalFile.mockResolvedValueOnce('new lock');
+    expect(
+      await pipenv.updateArtifacts({
+        packageFileName: 'Pipfile',
+        updatedDeps: [],
+        newPackageFileContent: 'some new content',
+        config,
+      })
+    ).not.toBeNull();
+    expect(execSnapshots).toMatchObject([
+      { cmd: 'install-tool python 3.10.2' },
+      { cmd: 'pip install --user pipenv' },
+      { cmd: 'pipenv lock', options: { cwd: '/tmp/github/some/repo' } },
+    ]);
   });
 
   it('catches errors', async () => {

--- a/lib/util/exec/buildpack.ts
+++ b/lib/util/exec/buildpack.ts
@@ -122,8 +122,11 @@ export function isDynamicInstall(
     );
     return false;
   }
-  return !!toolConstraints?.every((toolConstraint) =>
-    supportsDynamicInstall(toolConstraint.toolName)
+  return (
+    !toolConstraints ||
+    toolConstraints.every((toolConstraint) =>
+      supportsDynamicInstall(toolConstraint.toolName)
+    )
   );
 }
 

--- a/lib/util/exec/index.spec.ts
+++ b/lib/util/exec/index.spec.ts
@@ -846,6 +846,20 @@ describe('util/exec/index', () => {
     await expect(promise).rejects.toThrow('No tool releases found.');
   });
 
+  it('Supports binarySource=install preCommands', async () => {
+    process.env = processEnv;
+    const actualCmd: string[] = [];
+    cpExec.mockImplementation((execCmd) => {
+      actualCmd.push(execCmd);
+      return Promise.resolve({ stdout: '', stderr: '' });
+    });
+
+    GlobalConfig.set({ ...globalConfig, binarySource: 'install' });
+    process.env.BUILDPACK = 'true';
+    await exec('foobar', { preCommands: ['install-pip foobar'] });
+    expect(actualCmd).toEqual([`install-pip foobar`, `foobar`]);
+  });
+
   it('only calls removeDockerContainer in catch block is useDocker is set', async () => {
     cpExec.mockImplementation(() => {
       throw new Error('some error occurred');

--- a/lib/util/exec/index.ts
+++ b/lib/util/exec/index.ts
@@ -140,6 +140,7 @@ async function prepareRawExec(
     logger.debug('Using buildpack dynamic installs');
     rawCommands = [
       ...(await generateInstallCommands(opts.toolConstraints)),
+      ...(opts.preCommands ?? []),
       ...rawCommands,
     ];
   } else if (isHermit()) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- execute `preCommands` to install python tools on install mode 
<!-- Describe what behavior is changed by this PR. -->

## Context
- #13683
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
