### PR TITLE
fix(manager): correctly escape the dot character in fileMatch

### DIFF
--- a/lib/config/index.spec.ts
+++ b/lib/config/index.spec.ts
@@ -95,7 +95,7 @@ describe('config/index', () => {
       const configParser = await import('./index');
       const config = configParser.getManagerConfig(parentConfig, 'npm');
       expect(config).toContainEntries([
-        ['fileMatch', ['(^|/)package.json$']],
+        ['fileMatch', ['(^|/)package\\.json$']],
         ['rollbackPrs', true],
       ]);
       expect(

--- a/lib/modules/manager/cargo/index.ts
+++ b/lib/modules/manager/cargo/index.ts
@@ -11,7 +11,7 @@ export { extractPackageFile, updateArtifacts };
 
 export const defaultConfig = {
   commitMessageTopic: 'Rust crate {{depName}}',
-  fileMatch: ['(^|/)Cargo.toml$'],
+  fileMatch: ['(^|/)Cargo\\.toml$'],
   versioning: cargoVersioning.id,
   rangeStrategy: 'bump',
 };

--- a/lib/modules/manager/circleci/index.ts
+++ b/lib/modules/manager/circleci/index.ts
@@ -8,7 +8,7 @@ export const displayName = 'CircleCI';
 export const url = 'https://circleci.com/docs/configuration-reference';
 
 export const defaultConfig = {
-  fileMatch: ['(^|/).circleci/config.yml$'],
+  fileMatch: ['(^|/)\\.circleci/config\\.yml$'],
 };
 
 export const supportedDatasources = [DockerDatasource.id, OrbDatasource.id];

--- a/lib/modules/manager/cloudbuild/index.ts
+++ b/lib/modules/manager/cloudbuild/index.ts
@@ -4,7 +4,7 @@ import { extractPackageFile } from './extract';
 export { extractPackageFile };
 
 export const defaultConfig = {
-  fileMatch: ['(^|/)cloudbuild.ya?ml'],
+  fileMatch: ['(^|/)cloudbuild\\.ya?ml'],
 };
 
 export const supportedDatasources = [DockerDatasource.id];

--- a/lib/modules/manager/composer/index.ts
+++ b/lib/modules/manager/composer/index.ts
@@ -18,7 +18,7 @@ export {
 };
 
 export const defaultConfig = {
-  fileMatch: ['(^|/)([\\w-]*)composer.json$'],
+  fileMatch: ['(^|/)([\\w-]*)composer\\.json$'],
   versioning: composerVersioningId,
 };
 

--- a/lib/modules/manager/droneci/index.ts
+++ b/lib/modules/manager/droneci/index.ts
@@ -7,7 +7,7 @@ export const language = ProgrammingLanguage.Docker;
 export { extractPackageFile };
 
 export const defaultConfig = {
-  fileMatch: ['(^|/).drone.yml$'],
+  fileMatch: ['(^|/)\\.drone\\.yml$'],
 };
 
 export const supportedDatasources = [DockerDatasource.id];

--- a/lib/modules/manager/fleet/index.ts
+++ b/lib/modules/manager/fleet/index.ts
@@ -4,7 +4,7 @@ import { HelmDatasource } from '../../datasource/helm';
 export { extractPackageFile } from './extract';
 
 export const defaultConfig = {
-  fileMatch: ['(^|/)fleet.ya?ml'],
+  fileMatch: ['(^|/)fleet\\.ya?ml'],
 };
 
 export const supportedDatasources = [GitTagsDatasource.id, HelmDatasource.id];

--- a/lib/modules/manager/git-submodules/index.ts
+++ b/lib/modules/manager/git-submodules/index.ts
@@ -8,7 +8,7 @@ export { default as updateArtifacts } from './artifacts';
 export const defaultConfig = {
   enabled: false,
   versioning: gitVersioning.id,
-  fileMatch: ['(^|/).gitmodules$'],
+  fileMatch: ['(^|/)\\.gitmodules$'],
 };
 
 export const supportedDatasources = [GitRefsDatasource.id];

--- a/lib/modules/manager/gomod/index.ts
+++ b/lib/modules/manager/gomod/index.ts
@@ -13,7 +13,7 @@ export const url = 'https://go.dev/ref/mod';
 export const language = ProgrammingLanguage.Golang;
 
 export const defaultConfig = {
-  fileMatch: ['(^|/)go.mod$'],
+  fileMatch: ['(^|/)go\\.mod$'],
 };
 
 export const supportedDatasources = [

--- a/lib/modules/manager/gradle-wrapper/index.ts
+++ b/lib/modules/manager/gradle-wrapper/index.ts
@@ -5,7 +5,7 @@ export { extractPackageFile } from './extract';
 export { updateArtifacts } from './artifacts';
 
 export const defaultConfig = {
-  fileMatch: ['(^|/)gradle/wrapper/gradle-wrapper.properties$'],
+  fileMatch: ['(^|/)gradle/wrapper/gradle-wrapper\\.properties$'],
   versioning,
 };
 

--- a/lib/modules/manager/helm-values/index.ts
+++ b/lib/modules/manager/helm-values/index.ts
@@ -3,7 +3,7 @@ export { extractPackageFile } from './extract';
 
 export const defaultConfig = {
   commitMessageTopic: 'helm values {{depName}}',
-  fileMatch: ['(^|/)values.yaml$'],
+  fileMatch: ['(^|/)values\\.yaml$'],
   pinDigests: false,
 };
 

--- a/lib/modules/manager/helmfile/index.ts
+++ b/lib/modules/manager/helmfile/index.ts
@@ -7,7 +7,7 @@ export const defaultConfig = {
     stable: 'https://charts.helm.sh/stable',
   },
   commitMessageTopic: 'helm chart {{depName}}',
-  fileMatch: ['(^|/)helmfile.yaml$'],
+  fileMatch: ['(^|/)helmfile\\.yaml$'],
 };
 
 export const supportedDatasources = [HelmDatasource.id, DockerDatasource.id];

--- a/lib/modules/manager/helmv3/index.ts
+++ b/lib/modules/manager/helmv3/index.ts
@@ -11,7 +11,7 @@ export const defaultConfig = {
     stable: 'https://charts.helm.sh/stable',
   },
   commitMessageTopic: 'helm chart {{depName}}',
-  fileMatch: ['(^|/)Chart.yaml$'],
+  fileMatch: ['(^|/)Chart\\.yaml$'],
 };
 
 export const supportedDatasources = [DockerDatasource.id, HelmDatasource.id];

--- a/lib/modules/manager/jsonnet-bundler/index.ts
+++ b/lib/modules/manager/jsonnet-bundler/index.ts
@@ -5,7 +5,7 @@ export { extractPackageFile } from './extract';
 export const supportsLockFileMaintenance = true;
 
 export const defaultConfig = {
-  fileMatch: ['(^|/)jsonnetfile.json$'],
+  fileMatch: ['(^|/)jsonnetfile\\.json$'],
   datasource: GitTagsDatasource.id,
 };
 

--- a/lib/modules/manager/meteor/index.ts
+++ b/lib/modules/manager/meteor/index.ts
@@ -6,7 +6,7 @@ export { extractPackageFile } from './extract';
 export const language = ProgrammingLanguage.JavaScript;
 
 export const defaultConfig = {
-  fileMatch: ['(^|/)package.js$'],
+  fileMatch: ['(^|/)package\\.js$'],
 };
 
 export const supportedDatasources = [NpmDatasource.id];

--- a/lib/modules/manager/nodenv/index.ts
+++ b/lib/modules/manager/nodenv/index.ts
@@ -10,7 +10,7 @@ export const url = 'https://github.com/nodenv/nodenv';
 export const language = ProgrammingLanguage.NodeJS;
 
 export const defaultConfig = {
-  fileMatch: ['(^|/).node-version$'],
+  fileMatch: ['(^|/)\\.node-version$'],
   versioning: nodeVersioning.id,
 };
 

--- a/lib/modules/manager/npm/index.ts
+++ b/lib/modules/manager/npm/index.ts
@@ -16,7 +16,7 @@ export const language = ProgrammingLanguage.JavaScript;
 export const supportsLockFileMaintenance = true;
 
 export const defaultConfig = {
-  fileMatch: ['(^|/)package.json$'],
+  fileMatch: ['(^|/)package\\.json$'],
   rollbackPrs: true,
   versioning: npmVersioning.id,
   digest: {

--- a/lib/modules/manager/pip_setup/index.ts
+++ b/lib/modules/manager/pip_setup/index.ts
@@ -6,7 +6,7 @@ export { extractPackageFile } from './extract';
 export const language = ProgrammingLanguage.Python;
 
 export const defaultConfig = {
-  fileMatch: ['(^|/)setup.py$'],
+  fileMatch: ['(^|/)setup\\.py$'],
 };
 
 export const supportedDatasources = [PypiDatasource.id];

--- a/lib/modules/manager/pyenv/index.ts
+++ b/lib/modules/manager/pyenv/index.ts
@@ -9,6 +9,6 @@ export const language = ProgrammingLanguage.Python;
 export const supportedDatasources = [DockerDatasource.id];
 
 export const defaultConfig = {
-  fileMatch: ['(^|/).python-version$'],
+  fileMatch: ['(^|/)\\.python-version$'],
   versioning: dockerVersioning.id,
 };

--- a/lib/modules/manager/travis/index.ts
+++ b/lib/modules/manager/travis/index.ts
@@ -9,7 +9,7 @@ export const language = ProgrammingLanguage.NodeJS;
 export const supportedDatasources = [GithubTagsDatasource.id];
 
 export const defaultConfig = {
-  fileMatch: ['^.travis.yml$'],
+  fileMatch: ['^\\.travis\\.yml$'],
   major: {
     enabled: false,
   },

--- a/lib/modules/manager/velaci/index.ts
+++ b/lib/modules/manager/velaci/index.ts
@@ -3,7 +3,7 @@ import { DockerDatasource } from '../../datasource/docker';
 export { extractPackageFile } from './extract';
 
 export const defaultConfig = {
-  fileMatch: ['(^|/).vela.ya?ml$'],
+  fileMatch: ['(^|/)\\.vela\\.ya?ml$'],
 };
 
 export const supportedDatasources = [DockerDatasource.id];

--- a/lib/workers/repository/extract/file-match.spec.ts
+++ b/lib/workers/repository/extract/file-match.spec.ts
@@ -53,7 +53,7 @@ describe('workers/repository/extract/file-match', () => {
       includePaths: [],
       ignorePaths: [],
       manager: 'npm',
-      fileMatch: ['(^|/)package.json$'],
+      fileMatch: ['(^|/)package\\.json$'],
     };
 
     it('returns npm files', () => {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Escapes `.` in file paths for `defaultConfig.fileMatch`.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
