### PR TITLE
fix(yarn): check stdout for disk space error

### DIFF
--- a/lib/modules/manager/npm/post-update/yarn.ts
+++ b/lib/modules/manager/npm/post-update/yarn.ts
@@ -281,17 +281,19 @@ export async function generateLockFile(
       },
       'lock file error'
     );
-    if (err.stderr) {
-      if (err.stderr.includes('ENOSPC: no space left on device')) {
-        throw new Error(SYSTEM_INSUFFICIENT_DISK_SPACE);
-      }
-      if (
-        err.stderr.includes('The registry may be down.') ||
-        err.stderr.includes('getaddrinfo ENOTFOUND registry.yarnpkg.com') ||
-        err.stderr.includes('getaddrinfo ENOTFOUND registry.npmjs.org')
-      ) {
-        throw new ExternalHostError(err, NpmDatasource.id);
-      }
+    const stdouterr = String(err.stdout) + String(err.stderr);
+    if (
+      stdouterr.includes('ENOSPC: no space left on device') ||
+      stdouterr.includes('Out of diskspace')
+    ) {
+      throw new Error(SYSTEM_INSUFFICIENT_DISK_SPACE);
+    }
+    if (
+      stdouterr.includes('The registry may be down.') ||
+      stdouterr.includes('getaddrinfo ENOTFOUND registry.yarnpkg.com') ||
+      stdouterr.includes('getaddrinfo ENOTFOUND registry.npmjs.org')
+    ) {
+      throw new ExternalHostError(err, NpmDatasource.id);
     }
     return { error: true, stderr: err.stderr, stdout: err.stdout };
   }


### PR DESCRIPTION

## Changes


Checks both stdout and stderr for Yarn disk space and registry errors.



## Context

Closes #16536


## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
