### PR TITLE
ci: create update-data scheduled workflow

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -1,0 +1,39 @@
+name: 'Update static data'
+on:
+  schedule:
+    - cron: '0 0 * * 0' # Every Sunday at midnight
+  workflow_dispatch:
+
+env:
+  NODE_VERSION: 14
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-data:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
+
+      - name: Set up Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@2fddd8803e2f5c9604345a0b591c3020ee971a93 # tag=v3.4.1
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: yarn
+
+      - name: Installing dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Update data
+        run: yarn run update-static-data
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@923ad837f191474af6b1721408744feb989a4c27 # tag=v4.0.4
+        with:
+          author: 'Renovate Bot <renovate@whitesourcesoftware.com>'
+          branch: 'chore/update-static-data'
+          commit-message: 'ci(data): automatic update of static data'
+          committer: 'Renovate Bot <renovate@whitesourcesoftware.com>'
+          title: 'ci(data): automatic update of static data'

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 env:
-  NODE_VERSION: 14
+  NODE_VERSION: 16
 
 permissions:
   contents: write

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -34,6 +34,6 @@ jobs:
         with:
           author: 'Renovate Bot <renovate@whitesourcesoftware.com>'
           branch: 'chore/update-static-data'
-          commit-message: 'ci(data): automatic update of static data'
+          commit-message: 'fix(data): automatic update of static data'
           committer: 'Renovate Bot <renovate@whitesourcesoftware.com>'
-          title: 'ci(data): automatic update of static data'
+          title: 'fix(data): automatic update of static data'

--- a/docs/development/static-data.md
+++ b/docs/development/static-data.md
@@ -1,0 +1,9 @@
+# Static Data
+
+Some data used by Renovate is stored in the repository and bundled with Renovate.
+This is either because the data changes infrequently or would be infeasible to parse on every run.
+
+## Updating static data
+
+Static data is updated weekly with a [GitHub Actions workflow](https://github.com/renovate/renovate/actions/workflows/update-data.yml).
+You can also update it manually by running `yarn run update-static-data`.

--- a/package.json
+++ b/package.json
@@ -51,8 +51,9 @@
     "test-schema": "run-s create-json-schema",
     "tsc": "tsc",
     "type-check": "run-s generate:* \"tsc --noEmit {@}\" --",
-    "update:distro-info": "node tools/distro-json-generate.mjs",
-    "update:azure-pipelines-tasks": "node tools/azure-pipelines-tasks-json-generate.mjs",
+    "update-static-data": "run-s update-static-data:*",
+    "update-static-data:distro-info": "node tools/distro-json-generate.mjs",
+    "update-static-data:azure-pipelines-tasks": "node tools/azure-pipelines-tasks-json-generate.mjs",
     "verify": "node tools/verify.mjs"
   },
   "repository": {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Adds a scheduled, and on demand, GitHub Actions workflow to update static data in the Renovate repository.

TODO:
- [x] Document this workflow
- [x] Test this workflow
	- https://github.com/JamieMagee/renovate/pull/2

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->
#17050

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
