### PR TITLE
fix: wrong commit message title for groups

### DIFF
--- a/lib/workers/repository/updates/branch-name.spec.ts
+++ b/lib/workers/repository/updates/branch-name.spec.ts
@@ -198,6 +198,24 @@ describe('workers/repository/updates/branch-name', () => {
       expect(upgrade.branchName).toBe('dep-df9ca0');
     });
 
+    it('hashedBranchLength no topic', () => {
+      const upgrade: RenovateConfig = {
+        hashedBranchLength: 3,
+        branchPrefix: 'dep-',
+        depNameSanitized: 'jest',
+        newMajor: '42',
+        groupName: 'some group name',
+        group: {
+          branchName:
+            '{{{branchPrefix}}}{{{additionalBranchPrefix}}}{{{branchTopic}}}',
+          additionalBranchPrefix:
+            '{{{depNameSanitized}}}-{{{newMajor}}}{{#if isPatch}}.{{{newMinor}}}{{/if}}.x{{#if isLockfileUpdate}}-lockfile{{/if}}',
+        },
+      };
+      generateBranchName(upgrade);
+      expect(upgrade.branchName).toBe('dep-cf83e1');
+    });
+
     it('enforces valid git branch name', () => {
       const fixtures = [
         {

--- a/lib/workers/repository/updates/branch-name.ts
+++ b/lib/workers/repository/updates/branch-name.ts
@@ -67,12 +67,12 @@ export function generateBranchName(update: RenovateConfig): void {
     }
 
     const additionalBranchPrefix = template.compile(
-      String(update.additionalBranchPrefix || ''),
+      String(update.additionalBranchPrefix ?? ''),
       update
     );
 
     const branchTopic = template.compile(
-      String(update.branchTopic || ''),
+      String(update.branchTopic ?? ''),
       update
     );
 

--- a/lib/workers/repository/updates/generate.spec.ts
+++ b/lib/workers/repository/updates/generate.spec.ts
@@ -242,9 +242,10 @@ describe('workers/repository/updates/generate', () => {
           depName: 'depB',
           groupName: 'some-group',
           branchName: 'some-branch',
-          prTitle: 'some-title',
+          commitMessage:
+            '{{{groupName}}} {{{commitMessageExtra}}} {{{commitMessageSuffix}}}',
           commitMessageExtra:
-            'to {{#if isMajor}}{{prettyNewMajor}}{{else}}{{#unless isRange}}v{{/unless}}{{newValue}}{{/if}}',
+            'to {{#if isMajor}}{{prettyNewMajor}}{{else}}{{prettyNewVersion}}{{/if}}',
           foo: 1,
           newValue: '5.1.2',
           newVersion: '5.1.2',
@@ -252,15 +253,18 @@ describe('workers/repository/updates/generate', () => {
             foo: 2,
           },
           releaseTimestamp: '2017-02-07T20:01:41+00:00',
+          updateType: 'minor',
+          separateMinorPatch: true,
         },
         {
           manager: 'some-manager',
           depName: 'depA',
           groupName: 'some-group',
           branchName: 'some-branch',
-          prTitle: 'some-title',
+          commitMessage:
+            '{{{groupName}}} {{{commitMessageExtra}}} {{{commitMessageSuffix}}}',
           commitMessageExtra:
-            'to {{#if isMajor}}{{prettyNewMajor}}{{else}}{{#unless isRange}}v{{/unless}}{{newValue}}{{/if}}',
+            'to {{#if isMajor}}{{prettyNewMajor}}{{else}}{{prettyNewVersion}}{{/if}}',
           foo: 1,
           newValue: '1.1.0',
           newVersion: '1.1.0',
@@ -268,14 +272,20 @@ describe('workers/repository/updates/generate', () => {
             foo: 2,
           },
           releaseTimestamp: '2017-02-08T20:01:41+00:00',
+          updateType: 'minor',
+          separateMinorPatch: true,
         },
       ];
       const res = generateBranchConfig(branch);
-      expect(res.foo).toBe(2);
-      expect(res.singleVersion).toBeUndefined();
-      expect(res.recreateClosed).toBeTrue();
-      expect(res.groupName).toBeDefined();
-      expect(res.releaseTimestamp).toBe('2017-02-08T20:01:41+00:00');
+      expect(res).toMatchObject({
+        foo: 2,
+        isGroup: true,
+        recreateClosed: true,
+        prTitle: 'some-group (minor)',
+        commitMessage: 'some-group',
+        groupName: 'some-group',
+        releaseTimestamp: '2017-02-08T20:01:41+00:00',
+      });
     });
 
     it('groups multiple upgrades different version but same value', () => {

--- a/lib/workers/repository/updates/generate.ts
+++ b/lib/workers/repository/updates/generate.ts
@@ -74,7 +74,7 @@ export function generateBranchConfig(
   const newValue: string[] = [];
   const toVersions: string[] = [];
   const toValues = new Set<string>();
-  branchUpgrades.forEach((upg) => {
+  for (const upg of branchUpgrades) {
     if (!depNames.includes(upg.depName!)) {
       depNames.push(upg.depName!);
     }
@@ -82,20 +82,27 @@ export function generateBranchConfig(
       toVersions.push(upg.newVersion!);
     }
     toValues.add(upg.newValue!);
+    // prettify newVersion and newMajor for printing
+    if (upg.newVersion) {
+      upg.prettyNewVersion = upg.newVersion.startsWith('v')
+        ? upg.newVersion
+        : `v${upg.newVersion}`;
+    }
+    if (upg.newMajor) {
+      upg.prettyNewMajor = `v${upg.newMajor}`;
+    }
     if (upg.commitMessageExtra) {
       const extra = template.compile(upg.commitMessageExtra, upg);
       if (!newValue.includes(extra)) {
         newValue.push(extra);
       }
     }
-  });
+  }
   const groupEligible =
     depNames.length > 1 ||
     toVersions.length > 1 ||
     (!toVersions[0] && newValue.length > 1);
-  if (newValue.length > 1 && !groupEligible) {
-    branchUpgrades[0].commitMessageExtra = `to v${toVersions[0]}`;
-  }
+
   const typesGroup =
     depNames.length > 1 && !hasGroupName && isTypesGroup(branchUpgrades);
   logger.trace(`groupEligible: ${groupEligible}`);
@@ -104,6 +111,12 @@ export function generateBranchConfig(
   let releaseTimestamp: string;
   for (const branchUpgrade of branchUpgrades) {
     let upgrade: BranchUpgradeConfig = { ...branchUpgrade };
+
+    // needs to be done for each upgrade, as we reorder them below
+    if (newValue.length > 1 && !groupEligible) {
+      upgrade.commitMessageExtra = `to v${toVersions[0]}`;
+    }
+
     if (upgrade.currentDigest) {
       upgrade.currentDigestShort =
         upgrade.currentDigestShort ??
@@ -182,15 +195,7 @@ export function generateBranchConfig(
         regEx(/[A-Z]/).exec(upgrade.semanticCommitType!) === null &&
         !upgrade.semanticCommitType!.startsWith(':');
     }
-    // prettify newVersion and newMajor for printing
-    if (upgrade.newVersion) {
-      upgrade.prettyNewVersion = upgrade.newVersion.startsWith('v')
-        ? upgrade.newVersion
-        : `v${upgrade.newVersion}`;
-    }
-    if (upgrade.newMajor) {
-      upgrade.prettyNewMajor = `v${upgrade.newMajor}`;
-    }
+
     // Compile a few times in case there are nested templates
     upgrade.commitMessage = template.compile(
       upgrade.commitMessage ?? '',
@@ -372,7 +377,7 @@ export function generateBranchConfig(
     config.updateType = 'major';
   }
   config.constraints = {};
-  for (const upgrade of config.upgrades || []) {
+  for (const upgrade of config.upgrades) {
     if (upgrade.constraints) {
       config.constraints = { ...config.constraints, ...upgrade.constraints };
     }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
properly generate template fields in right order
<!-- Describe what behavior is changed by this PR. -->

## Context
- closes #16925
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
