### PR TITLE
fix(changelogs): embed to upgrade instead of branch config

### DIFF
--- a/lib/workers/repository/index.ts
+++ b/lib/workers/repository/index.ts
@@ -51,7 +51,9 @@ export async function renovateRepository(
       addSplit('onboarding');
       if (config.fetchReleaseNotes && config.repoIsOnboarded) {
         logger.info('Fetching changelogs');
-        await embedChangelogs(branches);
+        for (const branch of branches) {
+          await embedChangelogs(branch.upgrades);
+        }
       }
       addSplit('changelogs');
       const res = await updateRepo(config, branches);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
changelogs need to be on upgrade not branch config
<!-- Describe what behavior is changed by this PR. -->

## Context
- https://github.com/renovate-reproductions/docker-node-versioning-issue/pull/1
- regression of #17073
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
