### PR TITLE
feat(changelogs): defer fetching until required

### DIFF
--- a/lib/workers/repository/index.ts
+++ b/lib/workers/repository/index.ts
@@ -9,7 +9,6 @@ import { deleteLocalFile, privateCacheDir } from '../../util/fs';
 import * as queue from '../../util/http/queue';
 import { addSplit, getSplits, splitInit } from '../../util/split';
 import { setBranchCache } from './cache';
-import { embedChangelogs } from './changelog';
 import { ensureDependencyDashboard } from './dependency-dashboard';
 import handleError from './error';
 import { finaliseRepo } from './finalise';
@@ -49,13 +48,6 @@ export async function renovateRepository(
     ) {
       await ensureOnboardingPr(config, packageFiles, branches);
       addSplit('onboarding');
-      if (config.fetchReleaseNotes && config.repoIsOnboarded) {
-        logger.info('Fetching changelogs');
-        for (const branch of branches) {
-          await embedChangelogs(branch.upgrades);
-        }
-      }
-      addSplit('changelogs');
       const res = await updateRepo(config, branches);
       setMeta({ repository: config.repository });
       addSplit('update');

--- a/lib/workers/repository/update/branch/index.spec.ts
+++ b/lib/workers/repository/update/branch/index.spec.ts
@@ -3,6 +3,7 @@ import {
   fs,
   git,
   mocked,
+  mockedFunction,
   partial,
   platform,
 } from '../../../../../test/util';
@@ -24,6 +25,7 @@ import * as _sanitize from '../../../../util/sanitize';
 import * as _limits from '../../../global/limits';
 import type { BranchConfig, BranchUpgradeConfig } from '../../../types';
 import { BranchResult } from '../../../types';
+import { needsChangelogs } from '../../changelog';
 import type { Pr } from '../../onboarding/branch/check';
 import * as _prWorker from '../pr';
 import type { ResultWithPr } from '../pr';
@@ -652,12 +654,16 @@ describe('workers/repository/update/branch/index', () => {
         artifactErrors: [],
         updatedArtifacts: [partial<FileChange>({})],
       } as WriteExistingFilesResult);
+
+      mockedFunction(needsChangelogs).mockReturnValueOnce(true);
+
       expect(
         await branchWorker.processBranch({
           ...config,
           ignoreTests: true,
           prCreation: 'not-pending',
           commitBody: '[skip-ci]',
+          fetchReleaseNotes: true,
         })
       ).toEqual({
         branchExists: true,

--- a/lib/workers/repository/update/branch/index.ts
+++ b/lib/workers/repository/update/branch/index.ts
@@ -43,6 +43,7 @@ import {
 import * as template from '../../../../util/template';
 import { Limit, isLimitReached } from '../../../global/limits';
 import { BranchConfig, BranchResult, PrBlockedBy } from '../../../types';
+import { embedChangelog, needsChangelogs } from '../../changelog';
 // import { embedChangelog, needsChangelogs } from '../../changelog';
 import { ensurePr, getPlatformPrOptions, updatePrDebugData } from '../pr';
 import { checkAutoMerge } from '../pr/automerge';
@@ -487,10 +488,11 @@ export async function processBranch(
 
     // compile commit message with body, which maybe needs changelogs
     if (config.commitBody) {
-      // TODO: defer fetching changelogs (#17020)
-      // if (config.fetchReleaseNotes && needsChangelogs(config, ['commitBody'])) {
-      //   await embedChangelog(config);
-      // }
+      if (config.fetchReleaseNotes && needsChangelogs(config, ['commitBody'])) {
+        // we only need first upgrade, the others are only needed on PR update
+        // we add it to first, so PR fetch can skip fetching for that update
+        await embedChangelog(config.upgrades[0]);
+      }
       // changelog is on first upgrade
       config.commitMessage = `${config.commitMessage!}\n\n${template.compile(
         config.commitBody,

--- a/lib/workers/repository/update/pr/index.spec.ts
+++ b/lib/workers/repository/update/pr/index.spec.ts
@@ -91,6 +91,8 @@ describe('workers/repository/update/pr/index', () => {
         platform.createPr.mockResolvedValueOnce(pr);
         limits.isLimitReached.mockReturnValueOnce(true);
 
+        config.fetchReleaseNotes = true;
+
         const res = await ensurePr(config);
 
         expect(res).toEqual({ type: 'without-pr', prBlockedBy: 'RateLimited' });

--- a/lib/workers/repository/update/pr/index.ts
+++ b/lib/workers/repository/update/pr/index.ts
@@ -27,6 +27,7 @@ import type {
   BranchUpgradeConfig,
   PrBlockedBy,
 } from '../../../types';
+import { embedChangelogs } from '../../changelog';
 // import { embedChangelogs } from '../../changelog';
 import { resolveBranchStatus } from '../branch/status-checks';
 import { getPrBody } from './body';
@@ -195,11 +196,10 @@ export async function ensurePr(
     }`;
   }
 
-  // TODO: defer fetching changelogs (#17020)
-  // if (config.fetchReleaseNotes) {
-  //   // fetch changelogs when not already done;
-  //   await embedChangelogs(upgrades);
-  // }
+  if (config.fetchReleaseNotes) {
+    // fetch changelogs when not already done;
+    await embedChangelogs(upgrades);
+  }
 
   // Get changelog and then generate template strings
   for (const upgrade of upgrades) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- defer changelog fetching until required (for PR update or template compilation)
<!-- Describe what behavior is changed by this PR. -->

## Context
- closes #17020
- test: https://github.com/renovate-reproductions/docker-node-versioning-issue
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
