### PR TITLE
fix: set `newVersion` for pin updates

### DIFF
--- a/lib/workers/repository/process/lookup/__snapshots__/index.spec.ts.snap
+++ b/lib/workers/repository/process/lookup/__snapshots__/index.spec.ts.snap
@@ -6,6 +6,7 @@ Array [
     "isPin": true,
     "newMajor": 0,
     "newValue": "0.4.4",
+    "newVersion": "0.4.4",
     "updateType": "pin",
   },
   Object {
@@ -40,6 +41,7 @@ Array [
     "isPin": true,
     "newMajor": 0,
     "newValue": "==0.9.4",
+    "newVersion": "0.9.4",
     "updateType": "pin",
   },
   Object {
@@ -311,6 +313,7 @@ Array [
     "isPin": true,
     "newMajor": 0,
     "newValue": "0.9.7",
+    "newVersion": "0.9.7",
     "updateType": "pin",
   },
   Object {
@@ -357,6 +360,7 @@ Array [
     "isPin": true,
     "newMajor": 1,
     "newValue": "1.4.1",
+    "newVersion": "1.4.1",
     "updateType": "pin",
   },
 ]
@@ -452,6 +456,7 @@ Array [
     "isPin": true,
     "newMajor": 0,
     "newValue": "0.4.4",
+    "newVersion": "0.4.4",
     "updateType": "pin",
   },
   Object {
@@ -1119,6 +1124,7 @@ Array [
     "isPin": true,
     "newMajor": 0,
     "newValue": "0.4.4",
+    "newVersion": "0.4.4",
     "updateType": "pin",
   },
   Object {
@@ -1148,6 +1154,7 @@ Array [
     "isPin": true,
     "newMajor": 0,
     "newValue": "0.4.4",
+    "newVersion": "0.4.4",
     "updateType": "pin",
   },
   Object {
@@ -1207,6 +1214,7 @@ Array [
     "isPin": true,
     "newMajor": 1,
     "newValue": "1.3.0",
+    "newVersion": "1.3.0",
     "updateType": "pin",
   },
   Object {
@@ -1447,6 +1455,7 @@ Array [
     "isPin": true,
     "newMajor": 1,
     "newValue": "1.0.1",
+    "newVersion": "1.0.1",
     "updateType": "pin",
   },
   Object {
@@ -1547,6 +1556,7 @@ Array [
     "isPin": true,
     "newMajor": 1,
     "newValue": "1.3.0",
+    "newVersion": "1.3.0",
     "updateType": "pin",
   },
   Object {
@@ -1596,6 +1606,7 @@ Array [
     "isPin": true,
     "newMajor": 1,
     "newValue": "1.0.0",
+    "newVersion": "1.0.0",
     "updateType": "pin",
   },
   Object {

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -206,20 +206,21 @@ export async function lookupUpdates(
       res.currentVersion = currentVersion!;
       if (
         currentValue &&
-        // TODO #7154
-        currentVersion! &&
+        currentVersion &&
         rangeStrategy === 'pin' &&
         !versioning.isSingleVersion(currentValue)
       ) {
         res.updates.push({
           updateType: 'pin',
           isPin: true,
+          // TODO: newValue can be null! (#7154)
           newValue: versioning.getNewValue({
             currentValue,
             rangeStrategy,
             currentVersion,
             newVersion: currentVersion,
           })!,
+          newVersion: currentVersion,
           newMajor: versioning.getMajor(currentVersion)!,
         });
       }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
set `newVersion` for pin PR's
<!-- Describe what behavior is changed by this PR. -->

## Context
- fixes #17125
- test: https://github.com/renovate-reproductions/17125-renovate-badges-test/pull/1
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
