### PR TITLE
chore: add VsCode debug config with clean cache

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,6 +17,20 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "debug (clean cache)",
+      "program": "${workspaceFolder}/lib/renovate.ts",
+      "env": {
+        "LOG_LEVEL": "debug"
+      },
+      "preLaunchTask": "npm: clean-cache",
+      "console": "integratedTerminal",
+      "runtimeArgs": ["-r", "ts-node/register/transpile-only"],
+      "protocol": "inspector",
+      "skipFiles": ["<node_internals>/**/*.js"]
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "Jest Current File",
       "program": "${workspaceFolder}/node_modules/.bin/jest",
       "args": [


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This PR adds an additional debug config, which executes the `clean-cache` command to clean the cache before running.

<!-- Describe what behavior is changed by this PR. -->

## Context
When debugging datasources it is quite important to have a clean cache to verify if things are working. I noticed that while manually executing `clean-cache` beforehand solves that, this PR packages it in a handy launch command, which you can directly execute from the VsCode debug console. It copies the `launch` command completely and just adds a `preLaunchTask` to clean the cache.

The task `npm: clean-cache` is [a vscode notion](https://code.visualstudio.com/docs/editor/tasks) for automatically created tasks based on the commands from the `package.json`. It does actually execute `yarn run clean-cache` underneath:
<img width="717" alt="image" src="https://user-images.githubusercontent.com/16856448/185084628-4e6874ed-539b-4fcb-baa5-d4f77bc57e2b.png">
 

Based on the discussion in https://renovatebot.slack.com/archives/CAFH752JU/p1660038460461659

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

Tested in my local development setup without any negative impacts.

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
