### PR TITLE
fix(presets): handle null values from azure

### DIFF
--- a/lib/config/presets/local/common.spec.ts
+++ b/lib/config/presets/local/common.spec.ts
@@ -1,0 +1,48 @@
+import { platform } from '../../../../test/util';
+import { ExternalHostError } from '../../../types/errors/external-host-error';
+import { PRESET_DEP_NOT_FOUND } from '../util';
+import { fetchJSONFile, getPresetFromEndpoint } from './common';
+
+describe('config/presets/local/common', () => {
+  describe('fetchJSONFile', () => {
+    it('throws for null', async () => {
+      platform.getRawFile.mockResolvedValueOnce(null);
+
+      await expect(fetchJSONFile('some/repo', 'default.json')).rejects.toThrow(
+        PRESET_DEP_NOT_FOUND
+      );
+    });
+
+    it('throws for ExternalHostError', async () => {
+      platform.getRawFile.mockRejectedValueOnce(
+        new ExternalHostError(new Error())
+      );
+
+      await expect(fetchJSONFile('some/repo', 'default.json')).rejects.toThrow(
+        ExternalHostError
+      );
+    });
+
+    it('throws for Error', async () => {
+      platform.getRawFile.mockRejectedValueOnce(new Error());
+
+      await expect(fetchJSONFile('some/repo', 'default.json')).rejects.toThrow(
+        PRESET_DEP_NOT_FOUND
+      );
+    });
+  });
+
+  describe('getPresetFromEndpoint', () => {
+    it('works', async () => {
+      platform.getRawFile.mockResolvedValueOnce('{}');
+      expect(
+        await getPresetFromEndpoint(
+          'some/repo',
+          'default.json',
+          undefined,
+          'dummy'
+        )
+      ).toEqual({});
+    });
+  });
+});

--- a/lib/config/presets/local/common.ts
+++ b/lib/config/presets/local/common.ts
@@ -13,7 +13,6 @@ export async function fetchJSONFile(
   try {
     raw = await platform.getRawFile(fileName, repo);
   } catch (err) {
-    // istanbul ignore if: not testable with nock
     if (err instanceof ExternalHostError) {
       throw err;
     }
@@ -26,8 +25,11 @@ export async function fetchJSONFile(
     throw new Error(PRESET_DEP_NOT_FOUND);
   }
 
-  // TODO: null check #7154
-  return parsePreset(raw!);
+  if (!raw) {
+    throw new Error(PRESET_DEP_NOT_FOUND);
+  }
+
+  return parsePreset(raw);
 }
 
 export function getPresetFromEndpoint(

--- a/lib/modules/platform/azure/index.spec.ts
+++ b/lib/modules/platform/azure/index.spec.ts
@@ -1,10 +1,12 @@
 import { Readable } from 'stream';
 import is from '@sindresorhus/is';
+import type { IGitApi } from 'azure-devops-node-api/GitApi';
 import {
   GitPullRequestMergeStrategy,
   GitStatusState,
   PullRequestStatus,
 } from 'azure-devops-node-api/interfaces/GitInterfaces.js';
+import { partial } from '../../../../test/util';
 import {
   REPOSITORY_ARCHIVED,
   REPOSITORY_NOT_FOUND,
@@ -167,13 +169,13 @@ describe('modules/platform/azure/index', () => {
     if (is.string(args)) {
       return azure.initRepo({
         repository: args,
-      } as any);
+      });
     }
 
     return azure.initRepo({
       repository: 'some/repo',
       ...args,
-    } as any);
+    });
   }
 
   describe('initRepo', () => {
@@ -1308,6 +1310,10 @@ describe('modules/platform/azure/index', () => {
   });
 
   describe('getJsonFile()', () => {
+    beforeEach(async () => {
+      await initRepo();
+    });
+
     it('returns file content', async () => {
       const data = { foo: 'bar' };
       azureApi.gitApi.mockImplementationOnce(
@@ -1395,6 +1401,16 @@ describe('modules/platform/azure/index', () => {
       const res = await azure.getJsonFile('file.json', 'foo/bar');
       expect(res).toEqual(data);
       expect(gitApiMock.getItemContent.mock.calls).toMatchSnapshot();
+    });
+
+    it('returns null', async () => {
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          getRepositories: jest.fn(() => Promise.resolve([])),
+        })
+      );
+      const res = await azure.getJsonFile('file.json', 'foo/bar');
+      expect(res).toBeNull();
     });
   });
 });

--- a/lib/modules/platform/azure/index.ts
+++ b/lib/modules/platform/azure/index.ts
@@ -134,13 +134,16 @@ export async function getRawFile(
     repoId = config.repoId;
   }
 
+  if (!repoId) {
+    return null;
+  }
+
   const versionDescriptor: GitVersionDescriptor = {
     version: branchOrTag,
   } as GitVersionDescriptor;
 
   const buf = await azureApiGit.getItemContent(
-    // TODO #7154
-    repoId!,
+    repoId,
     fileName,
     undefined,
     undefined,
@@ -161,8 +164,7 @@ export async function getJsonFile(
   branchOrTag?: string
 ): Promise<any | null> {
   const raw = await getRawFile(fileName, repoName, branchOrTag);
-  // TODO #7154
-  return JSON5.parse(raw!);
+  return raw ? JSON5.parse(raw) : null;
 }
 
 export async function initRepo({


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- handle missing `repoId` at azure
- handle null presets 
<!-- Describe what behavior is changed by this PR. -->

## Context
- fixes #16526
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
