### PR TITLE
fix(docker): support nvcr.io tag listing

### DIFF
--- a/lib/modules/datasource/docker/index.spec.ts
+++ b/lib/modules/datasource/docker/index.spec.ts
@@ -545,6 +545,27 @@ describe('modules/datasource/docker/index', () => {
       expect(res).toBe('some-digest');
     });
 
+    it('supports token with no service', async () => {
+      httpMock
+        .scope(baseUrl)
+        .get('/')
+        .reply(401, '', {
+          'www-authenticate':
+            'Bearer realm="https://auth.docker.io/token",scope=""',
+        })
+        .head('/library/some-other-dep/manifests/8.0.0-alpine')
+        .reply(200, {}, { 'docker-content-digest': 'some-digest' });
+      httpMock
+        .scope(authUrl)
+        .get('/token?service=&scope=repository:library/some-other-dep:pull')
+        .reply(200, { access_token: 'test' });
+      const res = await getDigest(
+        { datasource: 'docker', depName: 'some-other-dep' },
+        '8.0.0-alpine'
+      );
+      expect(res).toBe('some-digest');
+    });
+
     it('supports scoped names', async () => {
       httpMock
         .scope(baseUrl)

--- a/lib/modules/datasource/docker/index.ts
+++ b/lib/modules/datasource/docker/index.ts
@@ -140,7 +140,6 @@ export async function getAuthHeaders(
     if (
       authenticateHeader.scheme.toUpperCase() !== 'BEARER' ||
       !is.string(authenticateHeader.params.realm) ||
-      !is.string(authenticateHeader.params.service) ||
       parseUrl(authenticateHeader.params.realm) === null
     ) {
       logger.trace(
@@ -159,7 +158,11 @@ export async function getAuthHeaders(
       scope = authenticateHeader.params.scope;
     }
 
-    const authUrl = `${authenticateHeader.params.realm}?service=${authenticateHeader.params.service}&scope=${scope}`;
+    let service = authenticateHeader.params.service;
+    if (!is.string(service)) {
+      service = '';
+    }
+    const authUrl = `${authenticateHeader.params.realm}?service=${service}&scope=${scope}`;
     logger.trace(
       { registryHost, dockerRepository, authUrl },
       `Obtaining docker registry token`


### PR DESCRIPTION
## Changes

Support nvcr.io image registry tag listing.

## Context

Updating an nvcr.io image (`nvidia/k8s-device-plugin` in my particular case) fails with the following error:
> DEBUG: Failed to get authHeaders for getTags lookup
> DEBUG: Failed to look up dependency nvcr.io/nvidia/k8s-device-plugin (nvcr.io/nvidia/k8s-device-plugin)(packageFile="[...]/Dockerfile", dependency="nvcr.io/nvidia/k8s-device-plugin")

nvcr.io seems to deviate slightly from other image registries in that it does not return a `service` with the `Www-authenticate` header:

```
$ curl -v https://nvcr.io/v2/ |& grep Www
< Www-Authenticate: Bearer realm="https://nvcr.io/proxy_auth",scope=""
```

Returning an empty service query param back works fine:

```
$ curl -I 'https://nvcr.io/proxy_auth?service=&scope=repository:nvcr.io/nvidia/k8s-device-plugin:pull'
HTTP/1.1 200
...
```

The original change was made in https://github.com/renovatebot/renovate/pull/11942 and does not explain why `service` must be a string.

- closes #17304

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository