### PR TITLE
chore: drop HonkingGoose from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,3 @@
-*.md                                   @HonkingGoose
-
 /lib/modules/manager/git-submodules/           @JamieMagee
 
 /lib/modules/platform/azure/                   @JamieMagee


### PR DESCRIPTION
## Changes

- Drop @HonkingGoose from CODEOWNERS

## Context

I'm going to do less for Renovate, so I'm removing myself from the CODEOWNERS file.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
