### PR TITLE
docs(about us): move HonkingGoose to contributions

### DIFF
--- a/docs/usage/about-us.md
+++ b/docs/usage/about-us.md
@@ -21,7 +21,6 @@ Renovate is maintained by:
 
 Next up, we have these people who help maintain parts of Renovate:
 
-- [@HonkingGoose](https://github.com/HonkingGoose) master of the docs and community manager
 - [@zharinov](https://github.com/zharinov) focused on parsing, Gradle and Maven
 - [@secustor](https://github.com/secustor) worked on Terraform and Helm
 - [@fgreinacher](https://github.com/fgreinacher) worked on NuGet
@@ -32,6 +31,7 @@ Next up, we have these people who help maintain parts of Renovate:
 We want to highlight these valuable contributions, even if they are one-offs.
 Some features made a lot of people happy, and efficient!
 
+- [@HonkingGoose](https://github.com/HonkingGoose) worked on the docs and was community manager
 - [@ikesyo](https://github.com/ikesyo) regularly helpful
 - [@astellingwerf](https://github.com/astellingwerf) reviews PRs
 - [@danports](https://github.com/danports) worked on the Flux manager, and other managers. Feel free to ping `@danports` for any Flux-related issue or PR


### PR DESCRIPTION
## Changes

- Move myself from "maintainers of features" to valuable contributions

## Context

I'm going to have less time for this project soon. So I'd like to move myself to valuable contributions, to make clear that I used to work on this a lot, but will have less time soon.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
