### PR TITLE
fix(gitea): filter mirror repos on autodiscover

### DIFF
--- a/lib/modules/platform/gitea/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/platform/gitea/__snapshots__/index.spec.ts.snap
@@ -199,13 +199,6 @@ exports[`modules/platform/gitea/index getPrList should return list of pull reque
 ]
 `;
 
-exports[`modules/platform/gitea/index getRepos should return an array of repos 1`] = `
-[
-  "a/b",
-  "c/d",
-]
-`;
-
 exports[`modules/platform/gitea/index initPlatform() should support custom endpoint 1`] = `
 {
   "endpoint": "https://gitea.renovatebot.com/",

--- a/lib/modules/platform/gitea/index.spec.ts
+++ b/lib/modules/platform/gitea/index.spec.ts
@@ -76,6 +76,7 @@ describe('modules/platform/gitea/index', () => {
   const mockRepos: Repo[] = [
     partial<Repo>({ full_name: 'a/b' }),
     partial<Repo>({ full_name: 'c/d' }),
+    partial<Repo>({ full_name: 'e/f', mirror: true }),
   ];
 
   const mockPRs: MockPr[] = [
@@ -303,7 +304,7 @@ describe('modules/platform/gitea/index', () => {
       helper.searchRepos.mockResolvedValueOnce(mockRepos);
 
       const repos = await gitea.getRepos();
-      expect(repos).toMatchSnapshot();
+      expect(repos).toEqual(['a/b', 'c/d']);
     });
   });
 

--- a/lib/modules/platform/gitea/index.ts
+++ b/lib/modules/platform/gitea/index.ts
@@ -346,7 +346,7 @@ const platform: Platform = {
         uid: botUserID,
         archived: false,
       });
-      return repos.map((r) => r.full_name);
+      return repos.filter((r) => !r.mirror).map((r) => r.full_name);
     } catch (err) {
       logger.error({ err }, 'Gitea getRepos() error');
       throw err;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
filter mirror repos early like on other platforms, will be skipped on initRepo anyways
https://github.com/renovatebot/renovate/blob/50ae0049cb0b6d57f7ae8a3e153d1d72605bf3c5/lib/modules/platform/gitea/index.ts#L286-L291
<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
