### PR TITLE
refactor(cache): Explicit types for different cache revisions

### DIFF
--- a/lib/util/cache/repository/common.ts
+++ b/lib/util/cache/repository/common.ts
@@ -1,5 +1,9 @@
 import is from '@sindresorhus/is';
-import type { RepoCacheData, RepoCacheRecord } from './types';
+import type {
+  RepoCacheRecordV10,
+  RepoCacheRecordV11,
+  RepoCacheRecordV12,
+} from './types';
 
 // Increment this whenever there could be incompatibilities between old and new cache structure
 export const CACHE_REVISION = 12;
@@ -7,7 +11,7 @@ export const CACHE_REVISION = 12;
 export function isValidRev10(
   input: unknown,
   repo?: string
-): input is RepoCacheData & { repository?: string; revision?: number } {
+): input is RepoCacheRecordV10 {
   return (
     is.plainObject(input) &&
     is.safeInteger(input.revision) &&
@@ -20,7 +24,7 @@ export function isValidRev10(
 export function isValidRev11(
   input: unknown,
   repo?: string
-): input is { repository: string; revision: number; data: RepoCacheData } {
+): input is RepoCacheRecordV11 {
   return (
     is.plainObject(input) &&
     is.safeInteger(input.revision) &&
@@ -34,7 +38,7 @@ export function isValidRev11(
 export function isValidRev12(
   input: unknown,
   repo?: string
-): input is RepoCacheRecord {
+): input is RepoCacheRecordV12 {
   return (
     is.plainObject(input) &&
     is.safeInteger(input.revision) &&

--- a/lib/util/cache/repository/types.ts
+++ b/lib/util/cache/repository/types.ts
@@ -47,12 +47,25 @@ export interface RepoCacheData {
   prComments?: Record<number, Record<string, string>>;
 }
 
-export interface RepoCacheRecord {
+export interface RepoCacheRecordV10 extends RepoCacheData {
+  repository?: string;
+  revision?: number;
+}
+
+export interface RepoCacheRecordV11 {
+  repository: string;
+  revision: number;
+  data: RepoCacheData;
+}
+
+export interface RepoCacheRecordV12 {
   repository: string;
   revision: number;
   payload: string;
   hash: string;
 }
+
+export type RepoCacheRecord = RepoCacheRecordV12;
 
 export interface RepoCache {
   load(): Promise<void>;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Repository cache can be stored indefinitely. Because of that it's a good idea to have explicit types resembling evolution of its data structure.

## Context

- Ref: #17247
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
