### PR TITLE
refactor(cache): Restore each revision with own separate method

### DIFF
--- a/lib/util/cache/repository/impl/base.ts
+++ b/lib/util/cache/repository/impl/base.ts
@@ -64,19 +64,19 @@ export abstract class RepoCacheBase implements RepoCache {
 
       if (isValidRev12(oldCache, this.repository)) {
         await this.restoreFromRev12(oldCache);
-        logger.debug('Repository cache is restored from 12 revision');
+        logger.debug('Repository cache is restored from revision 12');
         return;
       }
 
       if (isValidRev11(oldCache, this.repository)) {
         this.restoreFromRev11(oldCache);
-        logger.debug('Repository cache is restored from 11 revision');
+        logger.debug('Repository cache is restored from revision 11');
         return;
       }
 
       if (isValidRev10(oldCache, this.repository)) {
         this.restoreFromRev10(oldCache);
-        logger.debug('Repository cache is restored from 10 revision');
+        logger.debug('Repository cache is restored from revision 10');
         return;
       }
 

--- a/lib/util/cache/repository/impl/base.ts
+++ b/lib/util/cache/repository/impl/base.ts
@@ -10,7 +10,14 @@ import {
   isValidRev11,
   isValidRev12,
 } from '../common';
-import type { RepoCache, RepoCacheData, RepoCacheRecord } from '../types';
+import type {
+  RepoCache,
+  RepoCacheData,
+  RepoCacheRecord,
+  RepoCacheRecordV10,
+  RepoCacheRecordV11,
+  RepoCacheRecordV12,
+} from '../types';
 
 const compress = promisify(zlib.brotliCompress);
 const decompress = promisify(zlib.brotliDecompress);
@@ -26,6 +33,24 @@ export abstract class RepoCacheBase implements RepoCache {
 
   protected abstract write(data: RepoCacheRecord): Promise<void>;
 
+  private async restoreFromRev12(oldCache: RepoCacheRecordV12): Promise<void> {
+    const compressed = Buffer.from(oldCache.payload, 'base64');
+    const uncompressed = await decompress(compressed);
+    const jsonStr = uncompressed.toString('utf8');
+    this.data = JSON.parse(jsonStr);
+    this.oldHash = oldCache.hash;
+  }
+
+  private restoreFromRev11(oldCache: RepoCacheRecordV11): void {
+    this.data = oldCache.data;
+  }
+
+  private restoreFromRev10(oldCache: RepoCacheRecordV10): void {
+    delete oldCache.repository;
+    delete oldCache.revision;
+    this.data = oldCache;
+  }
+
   async load(): Promise<void> {
     try {
       const data = await this.read();
@@ -35,29 +60,23 @@ export abstract class RepoCacheBase implements RepoCache {
         );
         return;
       }
-      const oldCache = JSON.parse(data);
+      const oldCache = JSON.parse(data) as unknown;
 
       if (isValidRev12(oldCache, this.repository)) {
-        const compressed = Buffer.from(oldCache.payload, 'base64');
-        const uncompressed = await decompress(compressed);
-        const jsonStr = uncompressed.toString('utf8');
-        this.data = JSON.parse(jsonStr);
-        this.oldHash = oldCache.hash;
-        logger.debug('Repository cache is valid');
+        await this.restoreFromRev12(oldCache);
+        logger.debug('Repository cache is restored from 12 revision');
         return;
       }
 
       if (isValidRev11(oldCache, this.repository)) {
-        this.data = oldCache.data;
-        logger.debug('Repository cache is migrated from 11 revision');
+        this.restoreFromRev11(oldCache);
+        logger.debug('Repository cache is restored from 11 revision');
         return;
       }
 
       if (isValidRev10(oldCache, this.repository)) {
-        delete oldCache.repository;
-        delete oldCache.revision;
-        this.data = oldCache;
-        logger.debug('Repository cache is migrated from 10 revision');
+        this.restoreFromRev10(oldCache);
+        logger.debug('Repository cache is restored from 10 revision');
         return;
       }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Extract methods for cache restore
- Change messages for debug log messages

## Context

- Ref: #17247
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
