### PR TITLE
fix(datasource/docker): remove default group commit message topic 

### DIFF
--- a/lib/modules/datasource/docker/index.ts
+++ b/lib/modules/datasource/docker/index.ts
@@ -362,9 +362,6 @@ const defaultConfig = {
       branchTopic: 'digests-pin',
     },
   },
-  group: {
-    commitMessageTopic: '{{{groupName}}} Docker tags',
-  },
 };
 
 function findLatestStable(tags: string[]): string | null {


### PR DESCRIPTION
## Changes

remove default group commit message topic configuration to avoid unexpected `Docker tags` commit suffixes depending on grouping configuration

<!-- Describe what behavior is changed by this PR. -->

## Context

- fixes #17366

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
