### PR TITLE
fix(npm): return null for latest lerna

### DIFF
--- a/lib/modules/manager/npm/post-update/lerna.spec.ts
+++ b/lib/modules/manager/npm/post-update/lerna.spec.ts
@@ -239,19 +239,19 @@ describe('modules/manager/npm/post-update/lerna', () => {
       const pkg = {
         deps: [{ depName: 'something-else', currentValue: '1.2.3' }],
       };
-      expect(lernaHelper.getLernaVersion(pkg)).toBe('latest');
+      expect(lernaHelper.getLernaVersion(pkg)).toBeNull();
     });
 
     it('returns latest if pkg has no deps at all', () => {
       const pkg = {};
-      expect(lernaHelper.getLernaVersion(pkg)).toBe('latest');
+      expect(lernaHelper.getLernaVersion(pkg)).toBeNull();
     });
 
     it('returns latest if specified lerna version is not a valid semVer range', () => {
       const pkg = {
         deps: [{ depName: 'lerna', currentValue: '[a.b.c;' }],
       };
-      expect(lernaHelper.getLernaVersion(pkg)).toBe('latest');
+      expect(lernaHelper.getLernaVersion(pkg)).toBeNull();
     });
   });
 });

--- a/lib/modules/manager/npm/post-update/lerna.ts
+++ b/lib/modules/manager/npm/post-update/lerna.ts
@@ -16,7 +16,7 @@ import type { GenerateLockFileResult } from './types';
 // Exported for testability
 export function getLernaVersion(
   lernaPackageFile: Partial<PackageFile>
-): string {
+): string | null {
   const lernaDep = lernaPackageFile.deps?.find((d) => d.depName === 'lerna');
   if (!lernaDep?.currentValue || !semver.validRange(lernaDep.currentValue)) {
     logger.warn(
@@ -24,7 +24,7 @@ export function getLernaVersion(
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       `Could not detect lerna version in ${lernaPackageFile.packageFile}, using 'latest'`
     );
-    return 'latest';
+    return null;
   }
   return lernaDep.currentValue;
 }
@@ -102,7 +102,7 @@ export async function generateLockFiles(
       extraEnv.NPM_EMAIL = env.NPM_EMAIL;
     }
     const lernaVersion = getLernaVersion(lernaPackageFile);
-    logger.debug('Using lerna version ' + lernaVersion);
+    logger.debug(`Using lerna version ${lernaVersion ?? 'latest'}`);
     toolConstraints.push({ toolName: 'lerna', constraint: lernaVersion });
     cmd.push('lerna info || echo "Ignoring lerna info failure"');
     cmd.push(`${lernaClient} install ${cmdOptions}`);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
do not return `latest` for lerna, instead return `null` 
<!-- Describe what behavior is changed by this PR. -->

## Context
- fixes #17314
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
