### PR TITLE
fix(datasource/helm): remove default group commit message topic

### DIFF
--- a/lib/modules/datasource/helm/index.ts
+++ b/lib/modules/datasource/helm/index.ts
@@ -21,9 +21,6 @@ export class HelmDatasource extends Datasource {
 
   override readonly defaultConfig = {
     commitMessageTopic: 'Helm release {{depName}}',
-    group: {
-      commitMessageTopic: '{{{groupName}}} Helm releases',
-    },
   };
 
   override readonly defaultVersioning = helmVersioning.id;


### PR DESCRIPTION
## Changes

remove default group commit message topic configuration to avoid unexpected "Helm releases" commit suffixes depending on grouping configuration

## Context

- fixes #17366

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
