### PR TITLE
chore: Modify TODOs to make them compatible with Catana

### DIFF
--- a/lib/modules/datasource/sbt-plugin/index.spec.ts
+++ b/lib/modules/datasource/sbt-plugin/index.spec.ts
@@ -137,7 +137,7 @@ describe('modules/datasource/sbt-plugin/index', () => {
         );
     });
 
-    // TODO: fix mocks
+    // TODO(on: '2022-8-24', to: 'viceice') fix mocks
     afterEach(() => httpMock.clear(false));
 
     it('returns null in case of errors', async () => {

--- a/lib/modules/manager/bundler/artifacts.ts
+++ b/lib/modules/manager/bundler/artifacts.ts
@@ -123,7 +123,7 @@ export async function updateArtifacts(
     const bundlerHostRulesAuthCommands: string[] = bundlerHostRules.reduce(
       (authCommands: string[], hostRule) => {
         if (hostRule.resolvedHost?.includes('-')) {
-          // TODO: fix me, hostrules can missing all auth
+          // TODO(on: '2023-01-18', to: 'viceice') fix me, hostrules can missing all auth
           const creds = getAuthenticationHeaderValue(hostRule);
           authCommands.push(`${hostRule.resolvedHost} ${creds}`);
           // sanitize the authentication


### PR DESCRIPTION
Hi 👋 !

I’m a big fan of Renovate. Thank you so much for your work on maintaining and improving it!

I recently contacted @rarkins because I’m building a tool to help projects and organizations manage and surface TODO comments written in a codebase.
Rhys was very kind to accept using Catana on the Renovate project to prove its value.
Also, thank you very much @JamieMagee for your initial response!

--------------------------

### A short intro to Catana

Catana tries to solve the problem of forgotten TODOs and the increase of technical debt.
Catana helps **surface, assign, and remember to address TODOs** using a trigger system.

A trigger is a condition, when met, makes your TODO addressable.
When a TODO becomes addressable, Catana notifies its assignee.
Catana has a few built-in triggers: When a date is reached, when a GitHub Issue is closed, and [more](https://docs.catana.dev/).

💡 The [Catana landing page](https://catana.dev/) and the [associated GitHub application](https://github.com/apps/catana-dev) have more explanations on how it can help you and your team. I’m also more than happy to answer questions if you have any!

### Renovate 

Catana is currently in beta, I'm trying to validate if it fits the needs of large open source projects and implements the missing pieces based on maintainers' feedback.
The **Renovate codebase has around 600 TODOs** in various files written in different programming languages. It’s a candidate I could only dream of to prove Catana's value ❤️ .

### Why this Pull Request

Catana has a couple of conventions on TODOs (requires an assignee and an event to make a TODO addressable).
I offered to work on modifying the existing TODOs in Renovate to make them compatible. But I **first wanted to make a small change** to introduce myself and highlight what Catana can do and how it can help.

I randomly took two TODOs that were originally introduced by @viceice (hi! 👋) and assigned him on them. 
Worth noting that an assignee on a TODO doesn’t necessarily have to fix the TODO. Another team member can tackle it too. **He or she is the one who receives the notification** (through a GitHub Issue) when the TODO becomes addressable.

I chose the dates on which the team will be reminded randomly (one in the past, one in the future), so that **you can see how Catana works once this PR is merged and whether you'd like to continue giving Catana a try.**

### I would love to have your feedback 

I know Catana is not yet perfect, but I want it to be, and I can’t do it without the developer community! I’m working full-time on Catana, and I’d really love to get any (as small as they are) feedback, suggestions, or feature ideas you’d like to see in such a tool 🤗 .
One thing that I’ll start implementing is TODO grouping (There are around 200 TODOs linked to #7154, Catana is not yet suited for this yet).

Thanks if you read until here 😅 , and thank you for your support!