### PR TITLE
refactor: use containerbase not buildpack terminology

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -136,7 +136,7 @@ But you can tell Renovate to use "sidecar" containers for third-party tools by s
 For this to work, `docker` needs to be installed and the Docker socket available to Renovate.
 Now Renovate uses `docker run` to create containers like Node.js or Python to run tools in as-needed.
 
-Additionally, when Renovate is run inside a container built using [`containerbase/buildpack`](https://github.com/containerbase/buildpack), such as the official Renovate images on Docker Hub, then `binarySource=install` can be used.
+Additionally, when Renovate is run inside a container built using [`containerbase`](https://github.com/containerbase), such as the official Renovate images on Docker Hub, then `binarySource=install` can be used.
 This mode means that Renovate will dynamically install the version of tools available, if supported.
 
 Supported tools for dynamic install are:

--- a/lib/modules/manager/cargo/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/modules/manager/cargo/__snapshots__/artifacts.spec.ts.snap
@@ -89,7 +89,7 @@ exports[`modules/manager/cargo/artifacts returns updated Cargo.lock with docker 
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
       "env": {
-        "BUILDPACK_CACHE_DIR": "/tmp/cache/buildpack",
+        "BUILDPACK_CACHE_DIR": "/tmp/cache/containerbase",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",

--- a/lib/modules/manager/cocoapods/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/modules/manager/cocoapods/__snapshots__/artifacts.spec.ts.snap
@@ -14,7 +14,7 @@ exports[`modules/manager/cocoapods/artifacts dynamically selects Docker image ta
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
       "env": {
-        "BUILDPACK_CACHE_DIR": "/tmp/cache/buildpack",
+        "BUILDPACK_CACHE_DIR": "/tmp/cache/containerbase",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",
@@ -44,7 +44,7 @@ exports[`modules/manager/cocoapods/artifacts falls back to the \`latest\` Docker
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
       "env": {
-        "BUILDPACK_CACHE_DIR": "/tmp/cache/buildpack",
+        "BUILDPACK_CACHE_DIR": "/tmp/cache/containerbase",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",
@@ -140,7 +140,7 @@ exports[`modules/manager/cocoapods/artifacts returns updated Podfile 2`] = `
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
       "env": {
-        "BUILDPACK_CACHE_DIR": "/tmp/cache/buildpack",
+        "BUILDPACK_CACHE_DIR": "/tmp/cache/containerbase",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",
@@ -202,7 +202,7 @@ exports[`modules/manager/cocoapods/artifacts returns updated Podfile and Pods fi
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
       "env": {
-        "BUILDPACK_CACHE_DIR": "/tmp/cache/buildpack",
+        "BUILDPACK_CACHE_DIR": "/tmp/cache/containerbase",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",

--- a/lib/modules/manager/composer/artifacts.spec.ts
+++ b/lib/modules/manager/composer/artifacts.spec.ts
@@ -369,7 +369,7 @@ describe('modules/manager/composer/artifacts', () => {
         options: {
           cwd: '/tmp/github/some/repo',
           env: {
-            BUILDPACK_CACHE_DIR: '/tmp/renovate/cache/buildpack',
+            BUILDPACK_CACHE_DIR: '/tmp/renovate/cache/containerbase',
             COMPOSER_CACHE_DIR: '/tmp/renovate/cache/others/composer',
           },
         },
@@ -425,7 +425,7 @@ describe('modules/manager/composer/artifacts', () => {
         options: {
           cwd: '/tmp/github/some/repo',
           env: {
-            BUILDPACK_CACHE_DIR: '/tmp/renovate/cache/buildpack',
+            BUILDPACK_CACHE_DIR: '/tmp/renovate/cache/containerbase',
             COMPOSER_CACHE_DIR: '/tmp/renovate/cache/others/composer',
           },
         },

--- a/lib/modules/manager/flux/readme.md
+++ b/lib/modules/manager/flux/readme.md
@@ -19,7 +19,7 @@ Namespaces will not be inferred from the context (e.g. from the parent `Kustomiz
 Updating system manifests requires that either:
 
 1. The `flux` tool is pre-installed, or
-2. You run a Docker image based on [containerbase/buildpack](https://github.com/containerbase/buildpack), such as the official Renovate images, and have `binarySource=install` configured
+2. You run a Docker image based on [containerbase](https://github.com/containerbase), such as the official Renovate images, and have `binarySource=install` configured
 
 By default, the `flux` manager will only match `flux-system/gotk-components.yaml` (i.e. system manifest) files.
 This is because there is no commonly accepted file/directory naming convention for Flux manifests and we don't want to check every single `*.yaml` file in repositories just in case some of them have Flux definitions.

--- a/lib/modules/manager/gomod/artifacts.spec.ts
+++ b/lib/modules/manager/gomod/artifacts.spec.ts
@@ -306,7 +306,7 @@ describe('modules/manager/gomod/artifacts', () => {
         options: {
           cwd: '/tmp/github/some/repo',
           env: {
-            BUILDPACK_CACHE_DIR: '/tmp/renovate/cache/buildpack',
+            BUILDPACK_CACHE_DIR: '/tmp/renovate/cache/containerbase',
           },
         },
       },
@@ -345,7 +345,7 @@ describe('modules/manager/gomod/artifacts', () => {
         options: {
           cwd: '/tmp/github/some/repo',
           env: {
-            BUILDPACK_CACHE_DIR: '/tmp/renovate/cache/buildpack',
+            BUILDPACK_CACHE_DIR: '/tmp/renovate/cache/containerbase',
           },
         },
       },
@@ -460,7 +460,7 @@ describe('modules/manager/gomod/artifacts', () => {
         options: {
           cwd: '/tmp/github/some/repo',
           env: {
-            BUILDPACK_CACHE_DIR: '/tmp/renovate/cache/buildpack',
+            BUILDPACK_CACHE_DIR: '/tmp/renovate/cache/containerbase',
             GIT_CONFIG_COUNT: '6',
             GIT_CONFIG_KEY_0:
               'url.https://ssh:some-token@github.com/.insteadOf',

--- a/lib/modules/manager/helmv3/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/modules/manager/helmv3/__snapshots__/artifacts.spec.ts.snap
@@ -574,7 +574,7 @@ exports[`modules/manager/helmv3/artifacts returns updated Chart.lock with docker
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
       "env": {
-        "BUILDPACK_CACHE_DIR": "/tmp/renovate/cache/buildpack",
+        "BUILDPACK_CACHE_DIR": "/tmp/renovate/cache/containerbase",
         "HELM_EXPERIMENTAL_OCI": "1",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
@@ -734,7 +734,7 @@ exports[`modules/manager/helmv3/artifacts sets repositories from registryAliases
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
       "env": {
-        "BUILDPACK_CACHE_DIR": "/tmp/renovate/cache/buildpack",
+        "BUILDPACK_CACHE_DIR": "/tmp/renovate/cache/containerbase",
         "HELM_EXPERIMENTAL_OCI": "1",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",

--- a/lib/modules/manager/mix/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/modules/manager/mix/__snapshots__/artifacts.spec.ts.snap
@@ -26,7 +26,7 @@ exports[`modules/manager/mix/artifacts authenticates to private repositories 2`]
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
       "env": {
-        "BUILDPACK_CACHE_DIR": "/tmp/cache/buildpack",
+        "BUILDPACK_CACHE_DIR": "/tmp/cache/containerbase",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",
@@ -85,7 +85,7 @@ exports[`modules/manager/mix/artifacts returns updated mix.lock 1`] = `
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
       "env": {
-        "BUILDPACK_CACHE_DIR": "/tmp/cache/buildpack",
+        "BUILDPACK_CACHE_DIR": "/tmp/cache/containerbase",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",

--- a/lib/modules/manager/nuget/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/modules/manager/nuget/__snapshots__/artifacts.spec.ts.snap
@@ -154,7 +154,7 @@ exports[`modules/manager/nuget/artifacts supports docker mode 1`] = `
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
       "env": {
-        "BUILDPACK_CACHE_DIR": "/tmp/renovate/cache/buildpack",
+        "BUILDPACK_CACHE_DIR": "/tmp/renovate/cache/containerbase",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",

--- a/lib/modules/manager/pipenv/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/modules/manager/pipenv/__snapshots__/artifacts.spec.ts.snap
@@ -116,7 +116,7 @@ exports[`modules/manager/pipenv/artifacts supports docker mode 1`] = `
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
       "env": {
-        "BUILDPACK_CACHE_DIR": "/tmp/renovate/cache/buildpack",
+        "BUILDPACK_CACHE_DIR": "/tmp/renovate/cache/containerbase",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",
@@ -154,7 +154,7 @@ exports[`modules/manager/pipenv/artifacts uses pipenv version from Pipfile 1`] =
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
       "env": {
-        "BUILDPACK_CACHE_DIR": "/tmp/renovate/cache/buildpack",
+        "BUILDPACK_CACHE_DIR": "/tmp/renovate/cache/containerbase",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",
@@ -191,7 +191,7 @@ exports[`modules/manager/pipenv/artifacts uses pipenv version from Pipfile dev p
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
       "env": {
-        "BUILDPACK_CACHE_DIR": "/tmp/renovate/cache/buildpack",
+        "BUILDPACK_CACHE_DIR": "/tmp/renovate/cache/containerbase",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",
@@ -228,7 +228,7 @@ exports[`modules/manager/pipenv/artifacts uses pipenv version from config 1`] = 
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
       "env": {
-        "BUILDPACK_CACHE_DIR": "/tmp/renovate/cache/buildpack",
+        "BUILDPACK_CACHE_DIR": "/tmp/renovate/cache/containerbase",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",

--- a/lib/util/exec/containerbase.spec.ts
+++ b/lib/util/exec/containerbase.spec.ts
@@ -5,14 +5,14 @@ import {
   generateInstallCommands,
   isDynamicInstall,
   resolveConstraint,
-} from './buildpack';
+} from './containerbase';
 import type { ToolConstraint } from './types';
 
 jest.mock('../../modules/datasource');
 
 const datasource = mocked(_datasource);
 
-describe('util/exec/buildpack', () => {
+describe('util/exec/containerbase', () => {
   describe('isDynamicInstall()', () => {
     beforeEach(() => {
       GlobalConfig.reset();
@@ -23,7 +23,7 @@ describe('util/exec/buildpack', () => {
       expect(isDynamicInstall()).toBeFalse();
     });
 
-    it('returns false if not buildpack', () => {
+    it('returns false if not containerbase', () => {
       GlobalConfig.set({ binarySource: 'install' });
       expect(isDynamicInstall()).toBeFalse();
     });

--- a/lib/util/exec/containerbase.ts
+++ b/lib/util/exec/containerbase.ts
@@ -125,7 +125,7 @@ export function isDynamicInstall(
   }
   if (!isBuildpack()) {
     logger.warn(
-      'binarySource=install is only compatible with images derived from containerbase/buildpack'
+      'binarySource=install is only compatible with images derived from github.com/containerbase'
     );
     return false;
   }

--- a/lib/util/exec/index.spec.ts
+++ b/lib/util/exec/index.spec.ts
@@ -76,11 +76,11 @@ describe('util/exec/index', () => {
 
   const buildpackEnv = {
     ...envMock.basic,
-    BUILDPACK_CACHE_DIR: `${cacheDir}buildpack`,
+    BUILDPACK_CACHE_DIR: `${cacheDir}containerbase`,
   };
   const buildpackEnvFiltered = {
     ...envMock.filtered,
-    BUILDPACK_CACHE_DIR: `${cacheDir}buildpack`,
+    BUILDPACK_CACHE_DIR: `${cacheDir}containerbase`,
   };
 
   const testInputs: [string, TestInput][] = [

--- a/lib/util/exec/index.ts
+++ b/lib/util/exec/index.ts
@@ -3,8 +3,8 @@ import upath from 'upath';
 import { GlobalConfig } from '../../config/global';
 import { TEMPORARY_ERROR } from '../../constants/error-messages';
 import { logger } from '../../logger';
-import { generateInstallCommands, isDynamicInstall } from './buildpack';
 import { rawExec } from './common';
+import { generateInstallCommands, isDynamicInstall } from './containerbase';
 import { generateDockerCommand, removeDockerContainer } from './docker';
 import { getChildProcessEnv } from './env';
 import { getHermitEnvs, isHermit } from './hermit';
@@ -104,7 +104,7 @@ async function prepareRawExec(
   const { customEnvVariables, cacheDir, binarySource } = GlobalConfig.get();
 
   if (binarySource === 'docker' || binarySource === 'install') {
-    const buildPackCacheDir = upath.join(cacheDir, 'buildpack');
+    const buildPackCacheDir = upath.join(cacheDir, 'containerbase');
     opts.env ??= {};
     opts.env.BUILDPACK_CACHE_DIR = buildPackCacheDir;
   }
@@ -137,7 +137,7 @@ async function prepareRawExec(
     );
     rawCommands = [dockerCommand];
   } else if (isDynamicInstall(opts.toolConstraints)) {
-    logger.debug('Using buildpack dynamic installs');
+    logger.debug('Using containerbase dynamic installs');
     rawCommands = [
       ...(await generateInstallCommands(opts.toolConstraints)),
       ...(opts.preCommands ?? []),

--- a/lib/workers/global/initialize.spec.ts
+++ b/lib/workers/global/initialize.spec.ts
@@ -24,7 +24,7 @@ describe('workers/global/initialize', () => {
       await expect(globalInitialize(config)).toResolve();
     });
 
-    it('supports buildpack', async () => {
+    it('supports containerbase', async () => {
       const config: AllConfig = { binarySource: 'docker' };
       git.validateGitVersion.mockResolvedValueOnce(true);
       await expect(globalInitialize(config)).toResolve();

--- a/lib/workers/global/initialize.ts
+++ b/lib/workers/global/initialize.ts
@@ -29,7 +29,7 @@ async function setDirectories(input: AllConfig): Promise<AllConfig> {
   }
   await fs.ensureDir(config.cacheDir);
   if (config.binarySource === 'docker' || config.binarySource === 'install') {
-    await fs.ensureDir(upath.join(config.cacheDir, 'buildpack'));
+    await fs.ensureDir(upath.join(config.cacheDir, 'containerbase'));
   }
   return config;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Removes buildpack terminology and directory use, replaces with containerbase.

## Context

Avoid confusion with CNCF buildpacks.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
