### PR TITLE
docs(use cases): link to Swissquote article

### DIFF
--- a/docs/usage/getting-started/use-cases.md
+++ b/docs/usage/getting-started/use-cases.md
@@ -200,3 +200,8 @@ The typical workflow for a company is:
 - Set that repository as the default `extends` value when onboarding new repositories
 
 This means that repositories get the centralized config by default, and any changes made to the centralized config repository are propagated to other repositories immediately.
+
+## How others use Renovate
+
+You can learn a lot by seeing how others use Renovate.
+Check out the [Swissquote user story](../user-stories/swissquote.md).


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Link to Swissquote user story from a new section in the Use Cases page

## Context

I think the Use Cases page is a good place to link to the new Swissquote user story. That way people can see how others use Renovate.

The announcement bar on the docs site links to the Swissquote article now, but it will show something else later. So we should link to the article in suitable places. 😄

Related issue:

- #17148

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
