### PR TITLE
chore: use “behind base branch” not “stale”

### DIFF
--- a/docs/usage/updating-rebasing.md
+++ b/docs/usage/updating-rebasing.md
@@ -59,6 +59,6 @@ The label name is configurable via the `rebaseLabel` option.
 If you apply a rebase label then Renovate will regenerate its commit for the branch, even if the branch has been modified.
 The rebase label is useful in situations like:
 
-- If a branch is stale but you don't have `rebaseWhen=behind-base-branch` enabled
+- If a branch is behind the base branch but you don't have `rebaseWhen=behind-base-branch` enabled
 - If a branch has been edited and you want to discard the edits and have Renovate create it again
 - If a branch was created with an error (e.g. lockfile generation) and you want Renovate to try again

--- a/lib/workers/repository/update/branch/index.ts
+++ b/lib/workers/repository/update/branch/index.ts
@@ -590,7 +590,7 @@ export async function processBranch(
         ['conflicted', 'never'].includes(config.rebaseWhen!)
       ) {
         logger.warn(
-          'Branch cannot automerge because it is stale and rebaseWhen setting disallows rebasing - raising a PR instead'
+          'Branch cannot automerge because it is behind base branch and rebaseWhen setting disallows rebasing - raising a PR instead'
         );
         config.forcePr = true;
         config.branchAutomergeFailureMessage = mergeStatus;

--- a/lib/workers/repository/update/branch/reuse.ts
+++ b/lib/workers/repository/update/branch/reuse.ts
@@ -63,7 +63,7 @@ export async function shouldReuseExistingBranch(
       (config.automerge || (await platform.getRepoForceRebase())))
   ) {
     if (await isBranchBehindBase(branchName)) {
-      logger.debug(`Branch is stale and needs rebasing`);
+      logger.debug(`Branch is behind base branch and needs rebasing`);
       // We can rebase the branch only if no PR or PR can be rebased
       if (await isBranchModified(branchName)) {
         logger.debug('Cannot rebase branch as it has been modified');
@@ -77,7 +77,7 @@ export async function shouldReuseExistingBranch(
     logger.debug('Branch is up-to-date');
   } else {
     logger.debug(
-      `Skipping stale branch check due to rebaseWhen=${config.rebaseWhen!}`
+      `Skipping behind base branch check due to rebaseWhen=${config.rebaseWhen!}`
     );
   }
 


### PR DESCRIPTION

## Changes

Terminology from stale to behind base branch

## Context

Old terminology

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
