### PR TITLE
fix: add stdout to error output for post update commands

### DIFF
--- a/lib/util/exec/common.ts
+++ b/lib/util/exec/common.ts
@@ -96,7 +96,7 @@ export function exec(cmd: string, opts: RawExecOptions): Promise<ExecResult> {
       }
       if (code !== 0) {
         reject(
-          new ExecError(`Command failed: ${cmd}\n${stringify(stderr)}`, {
+          new ExecError(`Command failed: ${cmd}\n${stringify(stdout)}\n${stringify(stderr)}`, {
             ...rejectInfo(),
             exitCode: code,
           })


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Updates the message in the ExecError thrown by post update commands to include stdout as well.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->
When renovate fails on a post upgrade command, it posts this back to a PR. If the command has printed anything to stdout, then the person addressing the failure may not know why it failed or when it failed, especially if stderr is empty.

This was discovered using a python utility that logs using `print` ([ref](https://github.com/reddit/baseplate.py-upgrader/blob/master/baseplate_py_upgrader/__init__.py#L129)) as a mechanism for printing info back to the user on the CLI without logging cruft around it.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [X] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
