### PR TITLE
fix(cache/repository): don't log error for non-existant files

### DIFF
--- a/lib/util/cache/repository/impl/local.spec.ts
+++ b/lib/util/cache/repository/impl/local.spec.ts
@@ -37,15 +37,23 @@ describe('util/cache/repository/impl/local', () => {
 
   it('skip when receives non-string data', async () => {
     const localRepoCache = CacheFactory.get('some/repo', 'local');
+    fs.cachePathExists.mockResolvedValueOnce(true);
     await localRepoCache.load(); // readCacheFile is mocked but has no return value set - therefore returns undefined
     expect(logger.debug).toHaveBeenCalledWith(
       "RepoCacheBase.load() - expecting data of type 'string' received 'undefined' instead - skipping"
     );
   });
 
+  it('skip when not found', async () => {
+    const localRepoCache = CacheFactory.get('some/repo', 'local');
+    await localRepoCache.load(); // readCacheFile is mocked but has no return value set - therefore returns undefined
+    expect(logger.debug).not.toHaveBeenCalledWith();
+  });
+
   it('loads previously stored cache from disk', async () => {
     const data: RepoCacheData = { semanticCommits: 'enabled' };
     const cacheRecord = await createCacheRecord(data);
+    fs.cachePathExists.mockResolvedValueOnce(true);
     fs.readCacheFile.mockResolvedValue(JSON.stringify(cacheRecord));
     const localRepoCache = CacheFactory.get('some/repo', 'local');
 
@@ -55,6 +63,7 @@ describe('util/cache/repository/impl/local', () => {
   });
 
   it('migrates revision from 10 to 12', async () => {
+    fs.cachePathExists.mockResolvedValueOnce(true);
     fs.readCacheFile.mockResolvedValue(
       JSON.stringify({
         revision: 10,
@@ -75,6 +84,7 @@ describe('util/cache/repository/impl/local', () => {
   });
 
   it('migrates revision from 11 to 12', async () => {
+    fs.cachePathExists.mockResolvedValueOnce(true);
     fs.readCacheFile.mockResolvedValue(
       JSON.stringify({
         revision: 11,
@@ -95,6 +105,7 @@ describe('util/cache/repository/impl/local', () => {
   });
 
   it('does not migrate from older revisions to 11', async () => {
+    fs.cachePathExists.mockResolvedValueOnce(true);
     fs.readCacheFile.mockResolvedValueOnce(
       JSON.stringify({
         revision: 9,
@@ -110,6 +121,7 @@ describe('util/cache/repository/impl/local', () => {
   });
 
   it('handles invalid data', async () => {
+    fs.cachePathExists.mockResolvedValueOnce(true);
     fs.readCacheFile.mockResolvedValue(JSON.stringify({ foo: 'bar' }));
     const localRepoCache = CacheFactory.get('some/repo', 'local');
 
@@ -119,6 +131,7 @@ describe('util/cache/repository/impl/local', () => {
   });
 
   it('handles file read error', async () => {
+    fs.cachePathExists.mockResolvedValueOnce(true);
     fs.readCacheFile.mockRejectedValue(new Error('unknown error'));
     const localRepoCache = CacheFactory.get('some/repo', 'local');
 
@@ -129,6 +142,7 @@ describe('util/cache/repository/impl/local', () => {
   });
 
   it('handles invalid json', async () => {
+    fs.cachePathExists.mockResolvedValueOnce(true);
     fs.readCacheFile.mockResolvedValue('{1');
     const localRepoCache = CacheFactory.get('some/repo', 'local');
 
@@ -139,6 +153,7 @@ describe('util/cache/repository/impl/local', () => {
 
   it('resets if repository does not match', async () => {
     const cacheRecord = createCacheRecord({ semanticCommits: 'enabled' });
+    fs.cachePathExists.mockResolvedValueOnce(true);
     fs.readCacheFile.mockResolvedValueOnce(JSON.stringify(cacheRecord));
 
     const localRepoCache = CacheFactory.get('some/repo', 'local');
@@ -150,6 +165,7 @@ describe('util/cache/repository/impl/local', () => {
   it('saves modified cache data to file', async () => {
     const oldCacheRecord = createCacheRecord({ semanticCommits: 'enabled' });
     const cacheType = 'protocol://domain/path';
+    fs.cachePathExists.mockResolvedValueOnce(true);
     fs.readCacheFile.mockResolvedValueOnce(JSON.stringify(oldCacheRecord));
     const localRepoCache = CacheFactory.get('some/repo', cacheType);
     await localRepoCache.load();

--- a/lib/util/cache/repository/impl/local.ts
+++ b/lib/util/cache/repository/impl/local.ts
@@ -1,7 +1,7 @@
 import upath from 'upath';
 import { GlobalConfig } from '../../../../config/global';
 import { logger } from '../../../../logger';
-import { outputCacheFile, readCacheFile } from '../../../fs';
+import { cachePathExists, outputCacheFile, readCacheFile } from '../../../fs';
 import type { RepoCacheRecord } from '../types';
 import { RepoCacheBase } from './base';
 
@@ -13,6 +13,10 @@ export class RepoCacheLocal extends RepoCacheBase {
   protected async read(): Promise<string | null> {
     const cacheFileName = this.getCacheFileName();
     try {
+      // suppress debug logs with errros
+      if (!(await cachePathExists(cacheFileName))) {
+        return null;
+      }
       return await readCacheFile(cacheFileName, 'utf8');
     } catch (err) {
       logger.debug({ err, cacheFileName }, 'Repository local cache not found');

--- a/lib/util/fs/index.spec.ts
+++ b/lib/util/fs/index.spec.ts
@@ -5,6 +5,7 @@ import { join, resolve } from 'upath';
 import { mockedFunction } from '../../../test/util';
 import { GlobalConfig } from '../../config/global';
 import {
+  cachePathExists,
   chmodLocalFile,
   createCacheWriteStream,
   deleteLocalFile,
@@ -423,6 +424,14 @@ describe('util/fs/index', () => {
       await rmCache(`foo/bar`);
       expect(await fs.pathExists(`${cacheDir}/foo/bar/file.txt`)).toBeFalse();
       expect(await fs.pathExists(`${cacheDir}/foo/bar`)).toBeFalse();
+    });
+  });
+
+  describe('cachePathExists', () => {
+    it('reads file', async () => {
+      await fs.outputFile(`${cacheDir}/foo/bar/file.txt`, 'foobar');
+      expect(await cachePathExists(`foo/bar/file.txt1`)).toBeFalse();
+      expect(await cachePathExists(`foo/bar/file.txt`)).toBeTrue();
     });
   });
 

--- a/lib/util/fs/index.ts
+++ b/lib/util/fs/index.ts
@@ -246,6 +246,16 @@ export async function rmCache(path: string): Promise<void> {
   await fs.rm(fullPath, { recursive: true });
 }
 
+export async function cachePathExists(pathName: string): Promise<boolean> {
+  const path = ensureCachePath(pathName);
+  try {
+    const s = await fs.stat(path);
+    return !!s;
+  } catch (_) {
+    return false;
+  }
+}
+
 export async function readCacheFile(fileName: string): Promise<Buffer>;
 export async function readCacheFile(
   fileName: string,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- don't log a debug message with an error, if the repo cache file doesn't exist.
<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
