### PR TITLE
feat(util/exec): enable process group handling on process termination

### DIFF
--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -58,3 +58,7 @@ If set, Renovate will enable `forcePathStyle` when instantiating the AWS s3 clie
 > Whether to force path style URLs for S3 objects (e.g., `https://s3.amazonaws.com//` instead of `https://.s3.amazonaws.com/`
 
 Source: [AWS s3 documentation - Interface BucketEndpointInputConfig](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-s3/interfaces/bucketendpointinputconfig.html)
+
+## `RENOVATE_X_EXEC_GPID_HANDLE`
+
+If set, Renovate will terminate the whole process group of a terminated child process spawned by Renovate.

--- a/lib/util/exec/common.spec.ts
+++ b/lib/util/exec/common.spec.ts
@@ -33,6 +33,7 @@ interface StubArgs {
   stdout?: string;
   stderr?: string;
   timeout?: number;
+  pid?: number;
 }
 
 function getReadable(
@@ -66,6 +67,7 @@ function getSpawnStub(args: StubArgs): ChildProcess {
     stderr,
     encoding,
     timeout,
+    pid = 31415,
   } = args;
   const listeners: Events = {};
 
@@ -140,6 +142,7 @@ function getSpawnStub(args: StubArgs): ChildProcess {
     emit,
     unref,
     kill,
+    pid,
   } as ChildProcess;
 }
 
@@ -279,6 +282,53 @@ describe('util/exec/common', () => {
         message: 'stderr maxBuffer exceeded',
         stderr: '',
         stdout: '',
+      });
+    });
+  });
+
+  describe('handle gpid', () => {
+    const killSpy = jest.spyOn(process, 'kill');
+
+    afterEach(() => {
+      delete process.env.RENOVATE_X_EXEC_GPID_HANDLE;
+      jest.restoreAllMocks();
+    });
+
+    it('calls process.kill on the gpid', async () => {
+      process.env.RENOVATE_X_EXEC_GPID_HANDLE = 'true';
+      const cmd = 'ls -l';
+      const exitSignal = 'SIGTERM';
+      const stub = getSpawnStub({ cmd, exitCode: null, exitSignal });
+      spawn.mockImplementationOnce((cmd, opts) => stub);
+      killSpy.mockImplementationOnce((pid, signal) => true);
+      await expect(
+        exec(cmd, partial<RawExecOptions>({ encoding: 'utf8' }))
+      ).rejects.toMatchObject({
+        cmd,
+        signal: exitSignal,
+        message: `Command failed: ${cmd}\nInterrupted by ${exitSignal}`,
+      });
+      expect(process.kill).toHaveBeenCalledWith(
+        -(stub.pid as number),
+        exitSignal
+      );
+    });
+
+    it('handles process.kill call on non existent gpid', async () => {
+      process.env.RENOVATE_X_EXEC_GPID_HANDLE = 'true';
+      const cmd = 'ls -l';
+      const exitSignal = 'SIGTERM';
+      const stub = getSpawnStub({ cmd, exitCode: null, exitSignal });
+      spawn.mockImplementationOnce((cmd, opts) => stub);
+      killSpy.mockImplementationOnce((pid, signal) => {
+        throw new Error();
+      });
+      await expect(
+        exec(cmd, partial<RawExecOptions>({ encoding: 'utf8' }))
+      ).rejects.toMatchObject({
+        cmd,
+        signal: exitSignal,
+        message: `Command failed: ${cmd}\nInterrupted by ${exitSignal}`,
       });
     });
   });

--- a/lib/util/exec/common.spec.ts
+++ b/lib/util/exec/common.spec.ts
@@ -308,10 +308,7 @@ describe('util/exec/common', () => {
         signal: exitSignal,
         message: `Command failed: ${cmd}\nInterrupted by ${exitSignal}`,
       });
-      expect(process.kill).toHaveBeenCalledWith(
-        -(stub.pid as number),
-        exitSignal
-      );
+      expect(process.kill).toHaveBeenCalledWith(-stub.pid!, exitSignal);
     });
 
     it('handles process.kill call on non existent gpid', async () => {

--- a/lib/util/exec/common.ts
+++ b/lib/util/exec/common.ts
@@ -122,14 +122,14 @@ export function exec(cmd: string, opts: RawExecOptions): Promise<ExecResult> {
 
 function kill(cp: ChildProcess, signal: NodeJS.Signals): boolean {
   try {
-    if (process.env.RENOVATE_X_EXEC_GPID_HANDLE) {
+    if (cp.pid && process.env.RENOVATE_X_EXEC_GPID_HANDLE) {
       /**
        * If `pid` is negative, but not `-1`, signal shall be sent to all processes
        * (excluding an unspecified set of system processes),
        * whose process group ID (pgid) is equal to the absolute value of pid,
        * and for which the process has permission to send a signal.
        */
-      return process.kill(-(cp.pid as number), signal);
+      return process.kill(-cp.pid, signal);
     } else {
       // destroying stdio is needed for unref to work
       // https://nodejs.org/api/child_process.html#subprocessunref

--- a/lib/util/exec/common.ts
+++ b/lib/util/exec/common.ts
@@ -122,25 +122,25 @@ export function exec(cmd: string, opts: RawExecOptions): Promise<ExecResult> {
 
 function kill(cp: ChildProcess, signal: NodeJS.Signals): boolean {
   try {
-    // TODO: will be enabled in #16654
-    /**
-     * If `pid` is negative, but not `-1`, signal shall be sent to all processes
-     * (excluding an unspecified set of system processes),
-     * whose process group ID (pgid) is equal to the absolute value of pid,
-     * and for which the process has permission to send a signal.
-     */
-    // process.kill(-(cp.pid as number), signal);
-
-    // destroying stdio is needed for unref to work
-    // https://nodejs.org/api/child_process.html#subprocessunref
-    // https://github.com/nodejs/node/blob/4d5ff25a813fd18939c9f76b17e36291e3ea15c3/lib/child_process.js#L412-L426
-    cp.stderr?.destroy();
-    cp.stdout?.destroy();
-    cp.unref();
-    return cp.kill(signal);
+    if (process.env.RENOVATE_X_EXEC_GPID_HANDLE) {
+      /**
+       * If `pid` is negative, but not `-1`, signal shall be sent to all processes
+       * (excluding an unspecified set of system processes),
+       * whose process group ID (pgid) is equal to the absolute value of pid,
+       * and for which the process has permission to send a signal.
+       */
+      return process.kill(-(cp.pid as number), signal);
+    } else {
+      // destroying stdio is needed for unref to work
+      // https://nodejs.org/api/child_process.html#subprocessunref
+      // https://github.com/nodejs/node/blob/4d5ff25a813fd18939c9f76b17e36291e3ea15c3/lib/child_process.js#L412-L426
+      cp.stderr?.destroy();
+      cp.stdout?.destroy();
+      cp.unref();
+      return cp.kill(signal);
+    }
   } catch (err) {
     // cp is a single node tree, therefore -pid is invalid as there is no such pgid,
-    // istanbul ignore next: will be covered once we use process.kill
     return false;
   }
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
* Added an experimental env var - `RENOVATE_X_EXEC_GPID_HANDLE`
* Enable gpid hack when above is set

<!-- Describe what behavior is changed by this PR. -->

## Context
closes #16654 
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Unit tests only

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
