### PR TITLE
fix(bitbucket-server): fix typo in log message and spec file

### DIFF
--- a/lib/config/presets/bitbucket-server/index.spec.ts
+++ b/lib/config/presets/bitbucket-server/index.spec.ts
@@ -88,7 +88,7 @@ describe('config/presets/bitbucket-server/index', () => {
       ).rejects.toThrow(PRESET_DEP_NOT_FOUND);
     });
 
-    it('throws to big', async () => {
+    it('throws too big', async () => {
       httpMock
         .scope(bitbucketApiHost)
         .get(`${basePath}/some-filename.json`)

--- a/lib/config/presets/bitbucket-server/index.ts
+++ b/lib/config/presets/bitbucket-server/index.ts
@@ -43,7 +43,7 @@ export async function fetchJSONFile(
     throw new Error(PRESET_DEP_NOT_FOUND);
   }
   if (!res.body.isLastPage) {
-    logger.warn({ size: res.body.size }, 'Renovate config to big');
+    logger.warn({ size: res.body.size }, 'Renovate config too big');
     throw new Error(PRESET_INVALID_JSON);
   }
   return parsePreset(res.body.lines.map((l) => l.text).join(''));


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Fix typo in log message

## Context

Found in discussion: https://github.com/renovatebot/renovate/discussions/17458#discussion-4343139

Not closing any issue with this PR.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
