### PR TITLE
feat: fixes and tests for autoreplace support for replacements

### DIFF
--- a/lib/workers/repository/update/branch/auto-replace.spec.ts
+++ b/lib/workers/repository/update/branch/auto-replace.spec.ts
@@ -4,7 +4,7 @@ import { GlobalConfig } from '../../../../config/global';
 import { WORKER_FILE_UPDATE_FAILED } from '../../../../constants/error-messages';
 import { extractPackageFile } from '../../../../modules/manager/html';
 import type { BranchUpgradeConfig } from '../../../types';
-import { doAutoReplace, doReplacementAutoReplace } from './auto-replace';
+import { doAutoReplace } from './auto-replace';
 
 const sampleHtml = Fixtures.get(
   'sample.html',
@@ -200,28 +200,12 @@ describe('workers/repository/update/branch/auto-replace', () => {
       upgrade.updateType = 'replacement';
       upgrade.depName = 'bitnami/redis';
       upgrade.newName = 'mcr.microsoft.com/oss/bitnami/redis';
+      upgrade.replaceString = 'bitnami/redis:6.0.8';
       upgrade.packageFile = 'Dockerfile';
-      const res = await doReplacementAutoReplace(
-        upgrade,
-        dockerfile,
-        reuseExistingBranch
-      );
+      upgrade.depIndex = 0;
+      upgrade.currentValue = '6.0.8';
+      const res = await doAutoReplace(upgrade, dockerfile, reuseExistingBranch);
       expect(res).toBe(dockerfile.replace(upgrade.depName, upgrade.newName));
-    });
-
-    it('handles already replaced', async () => {
-      const dockerfile = 'FROM library/ubuntu:20.04';
-      upgrade.manager = 'dockerfile';
-      upgrade.updateType = 'replacement';
-      upgrade.depName = 'library/alpine';
-      upgrade.newName = 'library/ubuntu';
-      upgrade.packageFile = 'Dockerfile';
-      const res = await doReplacementAutoReplace(
-        upgrade,
-        dockerfile,
-        reuseExistingBranch
-      );
-      expect(res).toBe(dockerfile);
     });
 
     it('updates with terraform replacement', async () => {
@@ -231,45 +215,641 @@ describe('workers/repository/update/branch/auto-replace', () => {
       upgrade.updateType = 'replacement';
       upgrade.depName = 'github.com/hashicorp/example';
       upgrade.newName = 'github.com/hashicorp/new-example';
-      upgrade.packageFile = 'modules.tf';
-      const res = await doReplacementAutoReplace(
-        upgrade,
-        hcl,
-        reuseExistingBranch
-      );
-      expect(res).toBe(hcl.replace(upgrade.depName, upgrade.newName));
-    });
-
-    it('fails with old name in depname', async () => {
-      const yml =
-        'image: "1111111111.dkr.ecr.us-east-1.amazonaws.com/my-repository:1"\n\n';
-      upgrade.manager = 'regex';
-      upgrade.updateType = 'replacement';
-      upgrade.depName =
-        '1111111111.dkr.ecr.us-east-1.amazonaws.com/my-repository';
-      upgrade.currentValue = '1';
-      upgrade.newName =
-        '1111111111.dkr.ecr.us-east-1.amazonaws.com/my-repository';
+      upgrade.currentValue = 'v1.0.0';
       upgrade.depIndex = 0;
-      upgrade.replaceString =
-        'image: "1111111111.dkr.ecr.us-east-1.amazonaws.com/my-repository:1"\n\n';
-      upgrade.packageFile = 'k8s/base/defaults.yaml';
-      upgrade.matchStrings = [
-        'image:\\s*\\\'?\\"?(?<depName>[^:]+):(?<currentValue>[^\\s\\\'\\"]+)\\\'?\\"?\\s*',
-      ];
-      const res = doReplacementAutoReplace(upgrade, yml, reuseExistingBranch);
-      await expect(res).rejects.toThrow(WORKER_FILE_UPDATE_FAILED);
+      upgrade.packageFile = 'modules.tf';
+      const res = await doAutoReplace(upgrade, hcl, reuseExistingBranch);
+      expect(res).toBe(hcl.replace(upgrade.depName, upgrade.newName));
     });
 
     it('rebases if the deps list has changed', async () => {
       upgrade.baseDeps = extractPackageFile(sampleHtml)?.deps;
       reuseExistingBranch = true;
-      const res = await doReplacementAutoReplace(
+      const res = await doAutoReplace(
         upgrade,
         'existing content',
         reuseExistingBranch
       );
       expect(res).toBeNull();
+    });
+  });
+
+  describe('doReplacementAutoReplaceNewDepName', () => {
+    let reuseExistingBranch: boolean;
+    let upgrade: BranchUpgradeConfig;
+
+    beforeEach(() => {
+      upgrade = {
+        ...JSON.parse(JSON.stringify(defaultConfig)),
+      };
+      reuseExistingBranch = false;
+    });
+
+    it('updates with ansible replacement', async () => {
+      const yml =
+        '- name: Container present\n' +
+        '  docker_container:\n' +
+        '    name: mycontainer\n' +
+        '    state: present\n' +
+        '    image: ubuntu:14.04\n' +
+        '    command: sleep infinity\n';
+      upgrade.manager = 'ansible';
+      upgrade.depName = 'ubuntu';
+      upgrade.currentValue = '14.04';
+      upgrade.replaceString = 'ubuntu:14.04';
+      upgrade.depIndex = 0;
+      upgrade.updateType = 'replacement';
+      upgrade.newName = 'alpine';
+      upgrade.newValue = '3.16';
+      upgrade.packageFile = 'tasks/main.yaml';
+      const res = await doAutoReplace(upgrade, yml, reuseExistingBranch);
+      expect(res).toBe(
+        yml
+          .replace(upgrade.depName, upgrade.newName)
+          .replace(upgrade.currentValue, upgrade.newValue)
+      );
+    });
+
+    it('updates with ansible-galaxy roles replacement', async () => {
+      const yml =
+        'roles:\n' + '  - name: geerlingguy.java\n' + '    version: 1.9.6\n';
+      upgrade.manager = 'ansible-galaxy';
+      upgrade.depName = 'geerlingguy.java';
+      upgrade.currentValue = '1.9.6';
+      upgrade.depIndex = 0;
+      upgrade.updateType = 'replacement';
+      upgrade.newName = 'cloudalchemy.node_exporter';
+      upgrade.newValue = '1.0.0';
+      upgrade.packageFile = 'requirements.yaml';
+      const res = await doAutoReplace(upgrade, yml, reuseExistingBranch);
+      expect(res).toBe(
+        yml
+          .replace(upgrade.depName, upgrade.newName)
+          .replace(upgrade.currentValue, upgrade.newValue)
+      );
+    });
+
+    it('updates with azure-pipeline image replacement', async () => {
+      const yml =
+        'resources:\n' +
+        '  containers:\n' +
+        '    - container: linux\n' +
+        '      image: ubuntu:16.04\n';
+      upgrade.manager = 'azure-pipelines';
+      upgrade.depName = 'ubuntu';
+      upgrade.currentValue = '16.04';
+      upgrade.replaceString = 'ubuntu:16.04';
+      upgrade.depIndex = 0;
+      upgrade.updateType = 'replacement';
+      upgrade.newName = 'alpine';
+      upgrade.newValue = '3.16';
+      upgrade.packageFile = 'azure-pipeline.yml';
+      const res = await doAutoReplace(upgrade, yml, reuseExistingBranch);
+      expect(res).toBe(
+        yml
+          .replace(upgrade.depName, upgrade.newName)
+          .replace(upgrade.currentValue, upgrade.newValue)
+      );
+    });
+
+    it('updates with batect image replacement', async () => {
+      const yml =
+        'containers:\n' + '  my-container:\n' + '    image: ubuntu:16.04\n';
+      upgrade.manager = 'batect';
+      upgrade.depName = 'ubuntu';
+      upgrade.currentValue = '16.04';
+      upgrade.replaceString = 'ubuntu:16.04';
+      upgrade.depIndex = 0;
+      upgrade.updateType = 'replacement';
+      upgrade.newName = 'alpine';
+      upgrade.newValue = '3.16';
+      upgrade.packageFile = 'batect.yml';
+      const res = await doAutoReplace(upgrade, yml, reuseExistingBranch);
+      expect(res).toBe(
+        yml
+          .replace(upgrade.depName, upgrade.newName)
+          .replace(upgrade.currentValue, upgrade.newValue)
+      );
+    });
+
+    it('updates with bitbucket-pipelines image replacement', async () => {
+      const yml = 'image: ubuntu:16.04\n';
+      upgrade.manager = 'bitbucket-pipelines';
+      upgrade.depName = 'ubuntu';
+      upgrade.currentValue = '16.04';
+      upgrade.replaceString = 'ubuntu:16.04';
+      upgrade.depIndex = 0;
+      upgrade.updateType = 'replacement';
+      upgrade.newName = 'alpine';
+      upgrade.newValue = '3.16';
+      upgrade.packageFile = 'bitbucket-pipelines.yml';
+      const res = await doAutoReplace(upgrade, yml, reuseExistingBranch);
+      expect(res).toBe(
+        yml
+          .replace(upgrade.depName, upgrade.newName)
+          .replace(upgrade.currentValue, upgrade.newValue)
+      );
+    });
+
+    it('updates with buildkite plugin replacement', async () => {
+      const yml =
+        'steps:\n' +
+        '  - command: test.sh\n' +
+        '    plugins:\n' +
+        '      - docker-compose#v3.10.0:\n';
+      upgrade.manager = 'buildkite';
+      upgrade.depName = 'docker-compose';
+      upgrade.currentValue = 'v3.10.0';
+      upgrade.depIndex = 0;
+      upgrade.updateType = 'replacement';
+      upgrade.newName = 'buildpipe';
+      upgrade.newValue = 'v0.10.1';
+      upgrade.packageFile = 'buildkite.yml';
+      const res = await doAutoReplace(upgrade, yml, reuseExistingBranch);
+      expect(res).toBe(
+        yml
+          .replace(upgrade.depName, upgrade.newName)
+          .replace(upgrade.currentValue, upgrade.newValue)
+      );
+    });
+
+    it('updates with bundler gem replacement', async () => {
+      const gemfile =
+        "source 'https://rubygems.org'\n" + '\n' + "gem 'rails', '~>7.0'";
+      upgrade.manager = 'bundler';
+      upgrade.depName = 'rails';
+      upgrade.currentValue = '~>7.0';
+      upgrade.depIndex = 0;
+      upgrade.updateType = 'replacement';
+      upgrade.newName = 'rack';
+      upgrade.newValue = '~>2.2';
+      upgrade.packageFile = 'Gemfile';
+      const res = await doAutoReplace(upgrade, gemfile, reuseExistingBranch);
+      expect(res).toBe(
+        gemfile
+          .replace(upgrade.depName, upgrade.newName)
+          .replace(upgrade.currentValue, upgrade.newValue)
+      );
+    });
+
+    it('updates with cake #addin replacement', async () => {
+      const build =
+        '#addin nuget:?package=Microsoft.Extensions.Logging&version=7.0.0-preview.7.22375.6&prerelease\n';
+      upgrade.manager = 'cake';
+      upgrade.depName = 'Microsoft.Extensions.Logging';
+      upgrade.currentValue = '7.0.0-preview.7.22375.6';
+      upgrade.depIndex = 0;
+      upgrade.updateType = 'replacement';
+      upgrade.newName = 'Newtonsoft.Json';
+      upgrade.newValue = '13.0.2-beta1';
+      upgrade.packageFile = 'build.cake';
+      const res = await doAutoReplace(upgrade, build, reuseExistingBranch);
+      expect(res).toBe(
+        build
+          .replace(upgrade.depName, upgrade.newName)
+          .replace(upgrade.currentValue, upgrade.newValue)
+      );
+    });
+
+    it('updates with cargo dependency replacement', async () => {
+      const cargo = '[dependencies]\n' + 'rand = "0.8.4"\n';
+      upgrade.manager = 'cargo';
+      upgrade.depName = 'rand';
+      upgrade.currentValue = '0.8.4';
+      upgrade.depIndex = 0;
+      upgrade.updateType = 'replacement';
+      upgrade.newName = 'syn';
+      upgrade.newValue = '1.0.99';
+      upgrade.packageFile = 'Cargo.toml';
+      const res = await doAutoReplace(upgrade, cargo, reuseExistingBranch);
+      expect(res).toBe(
+        cargo
+          .replace(upgrade.depName, upgrade.newName)
+          .replace(upgrade.currentValue, upgrade.newValue)
+      );
+    });
+
+    it('updates with cloudbuild replacement', async () => {
+      const yml =
+        'steps:\n' +
+        '- name: gcr.io/cloud-builders/docker\n' +
+        '- name: ubuntu:16.04\n';
+      upgrade.manager = 'cloudbuild';
+      upgrade.depName = 'ubuntu';
+      upgrade.replaceString = 'ubuntu:16.04';
+      upgrade.currentValue = '16.04';
+      upgrade.depIndex = 1;
+      upgrade.updateType = 'replacement';
+      upgrade.newName = 'alpine';
+      upgrade.newValue = '3.16';
+      upgrade.packageFile = 'cloudbuild.yml';
+      const res = await doAutoReplace(upgrade, yml, reuseExistingBranch);
+      expect(res).toBe(
+        yml
+          .replace(upgrade.depName, upgrade.newName)
+          .replace(upgrade.currentValue, upgrade.newValue)
+      );
+    });
+
+    it('updates with podfile pod replacement', async () => {
+      const podfile = "pod 'GoogleAnalytics', '3.20.0'";
+      upgrade.manager = 'cocoapods';
+      upgrade.depName = 'GoogleAnalytics';
+      upgrade.currentValue = '3.20.0';
+      upgrade.depIndex = 0;
+      upgrade.updateType = 'replacement';
+      upgrade.newName = 'Docker';
+      upgrade.newValue = '1.3.11';
+      upgrade.packageFile = 'Podfile';
+      const res = await doAutoReplace(upgrade, podfile, reuseExistingBranch);
+      expect(res).toBe(
+        podfile
+          .replace(upgrade.depName, upgrade.newName)
+          .replace(upgrade.currentValue, upgrade.newValue)
+      );
+    });
+
+    it('updates with composer require replacement', async () => {
+      const json =
+        '{\n' +
+        '    "require": {\n' +
+        '        "psr/log": "3.0.0"\n' +
+        '    }\n' +
+        '}';
+      upgrade.manager = 'composer';
+      upgrade.depName = 'psr/log';
+      upgrade.currentValue = '3.0.0';
+      upgrade.depIndex = 0;
+      upgrade.updateType = 'replacement';
+      upgrade.newName = 'symfony/console';
+      upgrade.newValue = 'v6.1.3';
+      upgrade.packageFile = 'composer.json';
+      const res = await doAutoReplace(upgrade, json, reuseExistingBranch);
+      expect(res).toBe(
+        json
+          .replace(upgrade.depName, upgrade.newName)
+          .replace(upgrade.currentValue, upgrade.newValue)
+      );
+    });
+
+    it('updates with edn deps replacement', async () => {
+      const edn = '{:deps\n' + ' {com.taoensso/timbre {:mvn/version "5.2.1"}}}';
+      upgrade.manager = 'deps-edn';
+      upgrade.depName = 'com.taoensso/timbre';
+      upgrade.currentValue = '5.2.1';
+      upgrade.depIndex = 0;
+      upgrade.replaceString = '{:mvn/version \\"5.2.1\\"}';
+      upgrade.updateType = 'replacement';
+      upgrade.newName = 'org.clojure-android/tools.nrepl';
+      upgrade.newValue = '0.2.6-lollipop';
+      upgrade.packageFile = 'deps.edn';
+      const res = await doAutoReplace(upgrade, edn, reuseExistingBranch);
+      expect(res).toBe(
+        edn
+          .replace(upgrade.depName, upgrade.newName)
+          .replace(upgrade.currentValue, upgrade.newValue)
+      );
+    });
+
+    it('updates with docker-compose image replacement', async () => {
+      const yml = 'services:\n' + '  test:\n' + '    image: "ubuntu:16.04"\n';
+      upgrade.manager = 'docker-compose';
+      upgrade.depName = 'ubuntu';
+      upgrade.replaceString = 'ubuntu:16.04';
+      upgrade.currentValue = '16.04';
+      upgrade.depIndex = 0;
+      upgrade.updateType = 'replacement';
+      upgrade.newName = 'alpine';
+      upgrade.newValue = '3.16';
+      upgrade.packageFile = 'docker-compose.yml';
+      const res = await doAutoReplace(upgrade, yml, reuseExistingBranch);
+      expect(res).toBe(
+        yml
+          .replace(upgrade.depName, upgrade.newName)
+          .replace(upgrade.currentValue, upgrade.newValue)
+      );
+    });
+
+    it('updates with Dockerfile image replacement', async () => {
+      const dockerfile = 'FROM ubuntu:16.04\n';
+      upgrade.manager = 'dockerfile';
+      upgrade.depName = 'ubuntu';
+      upgrade.replaceString = 'ubuntu:16.04';
+      upgrade.currentValue = '16.04';
+      upgrade.depIndex = 0;
+      upgrade.updateType = 'replacement';
+      upgrade.newName = 'alpine';
+      upgrade.newValue = '3.16';
+      upgrade.packageFile = 'Dockerfile';
+      const res = await doAutoReplace(upgrade, dockerfile, reuseExistingBranch);
+      expect(res).toBe(
+        dockerfile
+          .replace(upgrade.depName, upgrade.newName)
+          .replace(upgrade.currentValue, upgrade.newValue)
+      );
+    });
+
+    it('updates with droneci image replacement', async () => {
+      const yml = 'steps:\n' + '- name: test\n' + '  image: ubuntu:16.04\n';
+      upgrade.manager = 'droneci';
+      upgrade.depName = 'ubuntu';
+      upgrade.replaceString = 'ubuntu:16.04';
+      upgrade.currentValue = '16.04';
+      upgrade.depIndex = 0;
+      upgrade.updateType = 'replacement';
+      upgrade.newName = 'alpine';
+      upgrade.newValue = '3.16';
+      upgrade.packageFile = '.drone.yml';
+      const res = await doAutoReplace(upgrade, yml, reuseExistingBranch);
+      expect(res).toBe(
+        yml
+          .replace(upgrade.depName, upgrade.newName)
+          .replace(upgrade.currentValue, upgrade.newValue)
+      );
+    });
+
+    it('updates with gitlabci image replacement', async () => {
+      const yml = 'image: "ubuntu:16.04"\n';
+      upgrade.manager = 'gitlabci';
+      upgrade.depName = 'ubuntu';
+      upgrade.replaceString = 'ubuntu:16.04';
+      upgrade.currentValue = '16.04';
+      upgrade.depIndex = 0;
+      upgrade.updateType = 'replacement';
+      upgrade.newName = 'alpine';
+      upgrade.newValue = '3.16';
+      upgrade.packageFile = '.gitlab-ci.yml';
+      const res = await doAutoReplace(upgrade, yml, reuseExistingBranch);
+      expect(res).toBe(
+        yml
+          .replace(upgrade.depName, upgrade.newName)
+          .replace(upgrade.currentValue, upgrade.newValue)
+      );
+    });
+
+    it('updates with helm value image/repository replacement', async () => {
+      const yml =
+        'parser:\n' +
+        '  image:\n' +
+        '    repository: docker.io/securecodebox/parser-nmap\n' +
+        '    tag: 3.14.3\n';
+      upgrade.manager = 'helm-values';
+      upgrade.depName = 'docker.io/securecodebox/parser-nmap';
+      upgrade.replaceString = '3.14.3';
+      upgrade.currentValue = '3.14.3';
+      upgrade.depIndex = 0;
+      upgrade.updateType = 'replacement';
+      upgrade.newName = 'iteratec/juice-balancer';
+      upgrade.newValue = 'v5.1.0';
+      upgrade.packageFile = 'values.yml';
+      const res = await doAutoReplace(upgrade, yml, reuseExistingBranch);
+      expect(res).toBe(
+        yml
+          .replace(upgrade.depName, upgrade.newName)
+          .replace(upgrade.currentValue, upgrade.newValue)
+      );
+    });
+
+    it('updates with jenkins plugin replacement', async () => {
+      const txt = 'script-security:1175\n';
+      upgrade.manager = 'jenkins';
+      upgrade.depName = 'script-security';
+      upgrade.currentValue = '1175';
+      upgrade.depIndex = 0;
+      upgrade.updateType = 'replacement';
+      upgrade.newName = 'Mailer';
+      upgrade.newValue = '438.v02c7f0a_12fa_4';
+      upgrade.packageFile = 'plugins.txt';
+      const res = await doAutoReplace(upgrade, txt, reuseExistingBranch);
+      expect(res).toBe(
+        txt
+          .replace(upgrade.depName, upgrade.newName)
+          .replace(upgrade.currentValue, upgrade.newValue)
+      );
+    });
+
+    it('updates with meteor npm.depends replacement', async () => {
+      const js =
+        'Package.describe({\n' +
+        "\t'name': 'test',\n" +
+        '});\n' +
+        '\n' +
+        'Npm.depends({\n' +
+        "\t'xml2js': '0.2.0'\n" +
+        '});';
+      upgrade.manager = 'meteor';
+      upgrade.depName = 'xml2js';
+      upgrade.currentValue = '0.2.0';
+      upgrade.depIndex = 0;
+      upgrade.updateType = 'replacement';
+      upgrade.newName = 'connect';
+      upgrade.newValue = '2.7.10';
+      upgrade.packageFile = 'package.js';
+      const res = await doAutoReplace(upgrade, js, reuseExistingBranch);
+      expect(res).toBe(
+        js
+          .replace(upgrade.depName, upgrade.newName)
+          .replace(upgrade.currentValue, upgrade.newValue)
+      );
+    });
+
+    it('checks for replaceWithoutReplaceString double update', async () => {
+      const js =
+        'Package.describe({\n' +
+        "\t'name': 'test',\n" +
+        '});\n' +
+        '\n' +
+        'Npm.depends({\n' +
+        "\t'xml2js': '0.2.0',\n" +
+        "\t'xml2js': '0.2.0'\n" +
+        '});';
+      upgrade.manager = 'meteor';
+      upgrade.depName = 'xml2js';
+      upgrade.currentValue = '0.2.0';
+      upgrade.depIndex = 1;
+      upgrade.updateType = 'replacement';
+      upgrade.newName = 'connect';
+      upgrade.newValue = '2.7.10';
+      upgrade.packageFile = 'package.js';
+      const res = await doAutoReplace(upgrade, js, reuseExistingBranch);
+      expect(res).toBe(
+        'Package.describe({\n' +
+          "\t'name': 'test',\n" +
+          '});\n' +
+          '\n' +
+          'Npm.depends({\n' +
+          "\t'xml2js': '0.2.0',\n" +
+          "\t'connect': '2.7.10'\n" +
+          '});'
+      );
+    });
+
+    it('updates with mix deps replacement', async () => {
+      const exs =
+        'defmodule MyProject.MixProject do\n' +
+        '  use Mix.Project\n' +
+        '\n' +
+        '  def project() do\n' +
+        '    [\n' +
+        '      app: :my_project,\n' +
+        '      version: "0.0.1",\n' +
+        '      elixir: "~> 1.0",\n' +
+        '      deps: deps(),\n' +
+        '    ]\n' +
+        '  end\n' +
+        '\n' +
+        '  def application() do\n' +
+        '    []\n' +
+        '  end\n' +
+        '\n' +
+        '  defp deps() do\n' +
+        '    [\n' +
+        '      {:postgrex, "~> 0.8.1"}\n' +
+        '    ]\n' +
+        '  end\n' +
+        'end';
+      upgrade.manager = 'mix';
+      upgrade.depName = 'postgrex';
+      upgrade.currentValue = '~> 0.8.1';
+      upgrade.depIndex = 0;
+      upgrade.updateType = 'replacement';
+      upgrade.newName = 'jason';
+      upgrade.newValue = '~> 1.3.0';
+      upgrade.packageFile = 'mix.exs';
+      const res = await doAutoReplace(upgrade, exs, reuseExistingBranch);
+      expect(res).toBe(
+        exs
+          .replace(upgrade.depName, upgrade.newName)
+          .replace(upgrade.currentValue, upgrade.newValue)
+      );
+    });
+
+    it('updates with nuget tools replacement', async () => {
+      const json =
+        '{\n' +
+        '  "version": 1,\n' +
+        '  "isRoot": true,\n' +
+        '  "tools": {\n' +
+        '    "Microsoft.Extensions.Logging": {\n' +
+        '      "version": "7.0.0-preview.7.22375.6"\n' +
+        '    }\n' +
+        '  }\n' +
+        '}';
+      upgrade.manager = 'nuget';
+      upgrade.depName = 'Microsoft.Extensions.Logging';
+      upgrade.currentValue = '7.0.0-preview.7.22375.6';
+      upgrade.depIndex = 0;
+      upgrade.updateType = 'replacement';
+      upgrade.newName = 'Newtonsoft.Json';
+      upgrade.newValue = '13.0.2-beta1';
+      upgrade.packageFile = 'dotnet-tools.json';
+      const res = await doAutoReplace(upgrade, json, reuseExistingBranch);
+      expect(res).toBe(
+        json
+          .replace(upgrade.depName, upgrade.newName)
+          .replace(upgrade.currentValue, upgrade.newValue)
+      );
+    });
+
+    it('updates with pre-commit repo replacement', async () => {
+      const yml =
+        'repos:\n' +
+        '-   repo: https://github.com/pre-commit/pre-commit-hooks\n' +
+        '    rev: v4.3.0\n';
+      upgrade.manager = 'pre-commit';
+      upgrade.depName = 'pre-commit/pre-commit-hooks';
+      upgrade.currentValue = 'v4.3.0';
+      upgrade.depIndex = 0;
+      upgrade.updateType = 'replacement';
+      upgrade.newName = 'pre-commit/pygrep-hooks';
+      upgrade.newValue = 'v1.9.0';
+      upgrade.packageFile = '.pre-commit-config.yaml';
+      const res = await doAutoReplace(upgrade, yml, reuseExistingBranch);
+      expect(res).toBe(
+        yml
+          .replace(upgrade.depName, upgrade.newName)
+          .replace(upgrade.currentValue, upgrade.newValue)
+      );
+    });
+
+    it('updates with terraform image replacement', async () => {
+      const tf =
+        'resource "docker_image" "image" {\n' +
+        '  name = "ubuntu:16.04"\n' +
+        '}\n';
+      upgrade.manager = 'terraform';
+      upgrade.depName = 'ubuntu';
+      upgrade.replaceString = 'ubuntu:16.04';
+      upgrade.currentValue = '16.04';
+      upgrade.depIndex = 0;
+      upgrade.updateType = 'replacement';
+      upgrade.newName = 'alpine';
+      upgrade.newValue = '3.16';
+      upgrade.packageFile = 'test.tf';
+      const res = await doAutoReplace(upgrade, tf, reuseExistingBranch);
+      expect(res).toBe(
+        tf
+          .replace(upgrade.depName, upgrade.newName)
+          .replace(upgrade.currentValue, upgrade.newValue)
+      );
+    });
+
+    it('updates with terraform module replacement', async () => {
+      const tf =
+        'module "vpc" {\n' +
+        '  source  = "terraform-aws-modules/vpc/aws"\n' +
+        '  version = "3.14.2"\n' +
+        '}';
+      upgrade.manager = 'terraform';
+      upgrade.depName = 'terraform-aws-modules/vpc/aws';
+      upgrade.currentValue = '3.14.2';
+      upgrade.depIndex = 0;
+      upgrade.updateType = 'replacement';
+      upgrade.newName = 'cloudposse/label/null';
+      upgrade.newValue = '0.25.0';
+      upgrade.packageFile = 'module-test.tf';
+      const res = await doAutoReplace(upgrade, tf, reuseExistingBranch);
+      expect(res).toBe(
+        tf
+          .replace(upgrade.depName, upgrade.newName)
+          .replace(upgrade.currentValue, upgrade.newValue)
+      );
+    });
+
+    it('updates with setup-cfg replacement', async () => {
+      const tf = '[options]\n' + 'install_requires = sphinx ~=5.1.0\n';
+      upgrade.manager = 'setup-cfg';
+      upgrade.depName = 'sphinx';
+      upgrade.currentValue = '~=5.1.0';
+      upgrade.depIndex = 0;
+      upgrade.updateType = 'replacement';
+      upgrade.newName = 'postgres';
+      upgrade.newValue = '~=4.0.0';
+      upgrade.packageFile = 'setup.cfg';
+      const res = await doAutoReplace(upgrade, tf, reuseExistingBranch);
+      expect(res).toBe(
+        tf
+          .replace(upgrade.depName, upgrade.newName)
+          .replace(upgrade.currentValue, upgrade.newValue)
+      );
+    });
+
+    it('updates with nvm version replacement', async () => {
+      const tf = '12.3.4';
+      upgrade.manager = 'nvm';
+      upgrade.depName = 'node';
+      upgrade.currentValue = '12.3.4';
+      upgrade.depIndex = 0;
+      upgrade.updateType = 'replacement';
+      upgrade.newName = 'node';
+      upgrade.newValue = '16.5.4';
+      upgrade.packageFile = '.nvmrc';
+      const res = await doAutoReplace(upgrade, tf, reuseExistingBranch);
+      expect(res).toBe(
+        tf
+          .replace(upgrade.depName, upgrade.newName)
+          .replace(upgrade.currentValue, upgrade.newValue)
+      );
     });
   });
 });

--- a/lib/workers/repository/update/branch/auto-replace.ts
+++ b/lib/workers/repository/update/branch/auto-replace.ts
@@ -44,7 +44,10 @@ export async function confirmIfDepVersionUpdated(
     return false;
   }
 
-  if (upgrade.depName !== newUpgrade.depName) {
+  if (
+    upgrade.depName !== newUpgrade.depName &&
+    upgrade.newName !== newUpgrade.depName
+  ) {
     logger.debug(
       {
         manager,
@@ -56,7 +59,7 @@ export async function confirmIfDepVersionUpdated(
     );
     return false;
   }
-  if (newUpgrade.currentValue !== newValue) {
+  if (newValue && newUpgrade.currentValue !== newValue) {
     logger.debug(
       {
         manager,
@@ -79,44 +82,6 @@ export async function confirmIfDepVersionUpdated(
   }
   // istanbul ignore next
   return false;
-}
-
-async function confirmIfDepReplacementUpdated(
-  upgrade: BranchUpgradeConfig,
-  newContent: string
-): Promise<boolean> {
-  const { manager, packageFile, newName } = upgrade;
-  const extractPackageFile = get(manager, 'extractPackageFile');
-  let newUpgrade: PackageDependency;
-  try {
-    const newExtract = await extractPackageFile(
-      newContent,
-      packageFile,
-      upgrade
-    );
-    // istanbul ignore if
-    if (!newExtract) {
-      logger.debug({ manager, packageFile }, 'Could not extract package file');
-      return false;
-    }
-    newUpgrade = newExtract.deps.find((d) => d.depName === newName);
-  } catch (err) /* istanbul ignore next */ {
-    logger.debug({ manager, packageFile, err }, 'Failed to parse newContent');
-  }
-
-  if (upgrade.depName === newUpgrade.depName) {
-    logger.debug(
-      {
-        manager,
-        packageFile,
-        currentDepName: upgrade.depName,
-        newDepName: newUpgrade.depName,
-      },
-      'depName mismatch'
-    );
-    return false;
-  }
-  return true;
 }
 
 function getDepsSignature(deps: PackageDependency[]): string {
@@ -180,6 +145,7 @@ export async function doAutoReplace(
   const {
     packageFile,
     depName,
+    newName,
     currentValue,
     newValue,
     currentDigest,
@@ -189,9 +155,21 @@ export async function doAutoReplace(
   if (reuseExistingBranch) {
     return await checkExistingBranch(upgrade, existingContent);
   }
+  const replaceWithoutReplaceString = Boolean(
+    newName &&
+      newName !== depName &&
+      (!upgrade.replaceString || upgrade.replaceString.indexOf(depName!) === -1)
+  );
   const replaceString = upgrade.replaceString ?? currentValue;
   logger.trace({ depName, replaceString }, 'autoReplace replaceString');
-  let searchIndex = existingContent.indexOf(replaceString!);
+  let searchIndex;
+  if (replaceWithoutReplaceString) {
+    const depIndex = existingContent.indexOf(depName!);
+    const valIndex = existingContent.indexOf(currentValue!);
+    searchIndex = depIndex < valIndex ? depIndex : valIndex;
+  } else {
+    searchIndex = existingContent.indexOf(replaceString!);
+  }
   if (searchIndex === -1) {
     logger.info(
       { packageFile, depName, existingContent, replaceString },
@@ -201,14 +179,20 @@ export async function doAutoReplace(
   }
   try {
     let newString: string;
-    if (autoReplaceStringTemplate) {
+    if (autoReplaceStringTemplate && !newName) {
       newString = compile(autoReplaceStringTemplate, upgrade, false);
     } else {
       newString = replaceString!;
-      if (currentValue) {
+      if (currentValue && newValue) {
         newString = newString.replace(
           regEx(escapeRegExp(currentValue), 'g'),
-          newValue!
+          newValue
+        );
+      }
+      if (depName && newName) {
+        newString = newString.replace(
+          regEx(escapeRegExp(depName), 'g'),
+          newName
         );
       }
       if (currentDigest && newDigest) {
@@ -222,89 +206,71 @@ export async function doAutoReplace(
       { packageFile, depName },
       `Starting search at index ${searchIndex}`
     );
+    let newContent = existingContent;
+    let nameReplaced = !newName;
+    let valueReplaced = !newValue;
     // Iterate through the rest of the file
-    for (; searchIndex < existingContent.length; searchIndex += 1) {
+    for (; searchIndex < newContent.length; searchIndex += 1) {
       // First check if we have a hit for the old version
-      if (matchAt(existingContent, searchIndex, replaceString!)) {
+      if (replaceWithoutReplaceString) {
+        // look for depName and currentValue
+        if (newName && matchAt(newContent, searchIndex, depName!)) {
+          logger.debug(
+            { packageFile, depName },
+            `Found depName at index ${searchIndex}`
+          );
+          // replace with newName
+          newContent = replaceAt(newContent, searchIndex, depName!, newName);
+          await writeLocalFile(upgrade.packageFile!, newContent);
+          nameReplaced = true;
+        } else if (
+          newValue &&
+          matchAt(newContent, searchIndex, currentValue!)
+        ) {
+          logger.debug(
+            { packageFile, currentValue },
+            `Found currentValue at index ${searchIndex}`
+          );
+          // Now test if the result matches
+          newContent = replaceAt(
+            newContent,
+            searchIndex,
+            currentValue!,
+            newValue
+          );
+          await writeLocalFile(upgrade.packageFile!, newContent);
+          valueReplaced = true;
+        } else if (nameReplaced && valueReplaced) {
+          if (await confirmIfDepVersionUpdated(upgrade, newContent)) {
+            return newContent;
+          }
+          await writeLocalFile(upgrade.packageFile!, existingContent);
+          newContent = existingContent;
+          nameReplaced = false;
+          valueReplaced = false;
+        }
+      } else if (matchAt(newContent, searchIndex, replaceString!)) {
         logger.debug(
           { packageFile, depName },
           `Found match at index ${searchIndex}`
         );
         // Now test if the result matches
-        const testContent = replaceAt(
-          existingContent,
+        newContent = replaceAt(
+          newContent,
           searchIndex,
           replaceString!,
           newString
         );
-        await writeLocalFile(upgrade.packageFile!, testContent);
-
-        if (await confirmIfDepUpdated(upgrade, testContent)) {
-          return testContent;
+        await writeLocalFile(upgrade.packageFile!, newContent);
+        if (await confirmIfDepVersionUpdated(upgrade, newContent)) {
+          return newContent;
         }
-        // istanbul ignore next
         await writeLocalFile(upgrade.packageFile!, existingContent);
+        newContent = existingContent;
       }
     }
   } catch (err) /* istanbul ignore next */ {
     logger.debug({ packageFile, depName, err }, 'doAutoReplace error');
-  }
-  // istanbul ignore next
-  throw new Error(WORKER_FILE_UPDATE_FAILED);
-}
-
-export async function doReplacementAutoReplace(
-  upgrade: BranchUpgradeConfig,
-  existingContent: string,
-  reuseExistingBranch: boolean
-): Promise<string | null> {
-  const { packageFile, depName, newName } = upgrade;
-  if (reuseExistingBranch) {
-    return await checkExistingBranch(upgrade, existingContent);
-  }
-  let searchIndex = existingContent.indexOf(depName);
-  if (searchIndex === -1) {
-    logger.info(
-      { packageFile, depName, existingContent },
-      'Cannot find depName in current file content. Was it already updated?'
-    );
-    return existingContent;
-  }
-  if (newName !== undefined) {
-    logger.debug(
-      { packageFile, depName },
-      `Starting search at index ${searchIndex}`
-    );
-    try {
-      // Iterate through the rest of the file
-      for (; searchIndex < existingContent.length; searchIndex += 1) {
-        // First check if we have a hit for the old version
-        if (matchAt(existingContent, searchIndex, depName)) {
-          logger.debug(
-            { packageFile, depName },
-            `Found match at index ${searchIndex}`
-          );
-          // Now test if the result matches
-          const testContent = replaceAt(
-            existingContent,
-            searchIndex,
-            depName,
-            newName
-          );
-          await writeLocalFile(upgrade.packageFile, testContent);
-          if (await confirmIfDepReplacementUpdated(upgrade, testContent)) {
-            return testContent;
-          }
-          // istanbul ignore next
-          await writeLocalFile(upgrade.packageFile, existingContent);
-        }
-      }
-    } catch (err) /* istanbul ignore next */ {
-      logger.debug(
-        { packageFile, depName, err },
-        'doReplacementAutoReplace error'
-      );
-    }
   }
   // istanbul ignore next
   throw new Error(WORKER_FILE_UPDATE_FAILED);

--- a/lib/workers/repository/update/branch/get-updated.spec.ts
+++ b/lib/workers/repository/update/branch/get-updated.spec.ts
@@ -506,13 +506,9 @@ describe('workers/repository/update/branch/get-updated', () => {
         packageFile: 'index.html',
         manager: 'html',
         updateType: 'replacement',
-        branchName: undefined,
+        branchName: undefined!,
       });
-      autoReplace.doAutoReplace.mockResolvedValueOnce('my-dep:1.0.0');
-      autoReplace.doReplacementAutoReplace.mockResolvedValueOnce(
-        'my-new-dep:1.0.0'
-      );
-
+      autoReplace.doAutoReplace.mockResolvedValueOnce('my-new-dep:1.0.0');
       const res = await getUpdatedPackageFiles(config);
       expect(res).toMatchSnapshot({
         updatedPackageFiles: [

--- a/lib/workers/repository/update/branch/get-updated.ts
+++ b/lib/workers/repository/update/branch/get-updated.ts
@@ -10,7 +10,7 @@ import type {
 import { getFile } from '../../../../util/git';
 import type { FileAddition, FileChange } from '../../../../util/git/types';
 import type { BranchConfig } from '../../../types';
-import { doAutoReplace, doReplacementAutoReplace } from './auto-replace';
+import { doAutoReplace } from './auto-replace';
 
 export interface PackageFilesResult {
   artifactErrors: ArtifactError[];
@@ -155,13 +155,6 @@ export async function getUpdatedPackageFiles(
           packageFileContent!,
           reuseExistingBranch
         );
-        if (upgrade.updateType === 'replacement' && res) {
-          res = await doReplacementAutoReplace(
-            upgrade,
-            res,
-            reuseExistingBranch
-          );
-        }
         if (res) {
           if (bumpPackageVersion && upgrade.bumpVersion) {
             const { bumpedContent } = await bumpPackageVersion(


### PR DESCRIPTION
As we are also interested in the replace feature, I had a look at the proposed code changes.
To make my changes more clear, I am creating this PR against @JamieMagee's [PR](https://github.com/renovatebot/renovate/pull/13211)
I hope this is also alright with you @JamieMagee.
After fixing building errors I added the name-replacement into the doAutoReplace function as they share most of their logic.
If you have any good ideas for better structure, I can refactor the code further.

I also crated a [gitlab demo-repo](https://gitlab.com/t.kulmburg/replacement-demo/-/blob/main/renovate.json) containing a dependency for all managers listed in the PR of @JamieMagee.
As can be seen in the [repo README](https://gitlab.com/t.kulmburg/replacement-demo/-/blob/main/README.md) and the [Renovate created merge requests](https://gitlab.com/t.kulmburg/replacement-demo/-/merge_requests), more then half of them are already working with my rather minimal changes.
I also added a brief description of the problems the other managers currently have.
To test the feature even further I added unit tests for Managers that worked in the demo-repo.

My question now would be how you would like to proceed with this topic in general.
Getting the feature to work for all supported managers will probably require a lot more work,
but supporting only the currently working ones will require a detailed documentation on the current status.

I am willing to spend some more time on this in the next days/weeks, so reviews would be appreciated.