### PR TITLE
chore: use valid SPDX license identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "Markus Siebert <mail@markussiebert.com>",
     "Sergey Vedmak <serg.vedmak@gmail.com>"
   ],
-  "license": "AGPL-3.0",
+  "license": "AGPL-3.0-only",
   "bugs": {
     "url": "https://github.com/renovatebot/renovate/issues"
   },

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@
 Automated dependency updates.
 Multi-platform and multi-language.
 
-[![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://raw.githubusercontent.com/renovatebot/renovate/main/license)
+[![License: AGPL-3.0-only](https://img.shields.io/badge/license-%20%09AGPL--3.0--only-blue.svg)](https://raw.githubusercontent.com/renovatebot/renovate/main/license)
 [![codecov](https://codecov.io/gh/renovatebot/renovate/branch/main/graph/badge.svg)](https://codecov.io/gh/renovatebot/renovate)
 [![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovatebot.com/)
 [![Build status](https://github.com/renovatebot/renovate/workflows/build/badge.svg)](https://github.com/renovatebot/renovate/actions)


### PR DESCRIPTION
## Changes

- Update to a valid SPDX identifier, as our current `AGPL-3.0` identifier has been deprecated as of version `3.1` of the SPDX license list [^SPDX-License-List]
- _Optional:_ Update `shields.io` badge in README file

## Context

Closes #17464.

If you don't want me to change the badge, let me know and I'll revert it.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

[^SPDX-License-List]: https://spdx.org/licenses/
