### PR TITLE
fix: Disable token warning on githubTokenWarn=true

### DIFF
--- a/lib/util/check-token.spec.ts
+++ b/lib/util/check-token.spec.ts
@@ -1,4 +1,5 @@
 import { hostRules, logger } from '../../test/util';
+import { GlobalConfig } from '../config/global';
 import { GithubReleasesDatasource } from '../modules/datasource/github-releases';
 import { GithubTagsDatasource } from '../modules/datasource/github-tags';
 import type { PackageFile } from '../modules/manager/types';
@@ -11,6 +12,7 @@ describe('util/check-token', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     memCache.reset();
+    GlobalConfig.set({ githubTokenWarn: true });
   });
 
   it('does nothing if data is empty', () => {
@@ -28,6 +30,20 @@ describe('util/check-token', () => {
       url: 'https://api.github.com',
     });
     expect(logger.logger.trace).toHaveBeenCalledWith('GitHub token is found');
+    expect(logger.logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('returns early if token warnings are disabled', () => {
+    GlobalConfig.set({ githubTokenWarn: false });
+    hostRules.find.mockReturnValueOnce({});
+    checkGithubToken({});
+    expect(hostRules.find).toHaveBeenCalledWith({
+      hostType: 'github',
+      url: 'https://api.github.com',
+    });
+    expect(logger.logger.trace).toHaveBeenCalledWith(
+      'GitHub token warning is disabled'
+    );
     expect(logger.logger.warn).not.toHaveBeenCalled();
   });
 

--- a/lib/util/check-token.ts
+++ b/lib/util/check-token.ts
@@ -1,3 +1,4 @@
+import { GlobalConfig } from '../config/global';
 import { PlatformId } from '../constants';
 import { logger } from '../logger';
 import { GithubReleasesDatasource } from '../modules/datasource/github-releases';
@@ -19,13 +20,19 @@ export function checkGithubToken(
     return;
   }
 
+  if (!GlobalConfig.get('githubTokenWarn')) {
+    logger.trace('GitHub token warning is disabled');
+    return;
+  }
+
   const githubDeps: string[] = [];
   for (const files of Object.values(packageFiles ?? {})) {
     for (const file of files ?? []) {
       for (const dep of file.deps ?? []) {
         if (
-          dep.datasource === GithubTagsDatasource.id ||
-          dep.datasource === GithubReleasesDatasource.id
+          !dep.skipReason &&
+          (dep.datasource === GithubTagsDatasource.id ||
+            dep.datasource === GithubReleasesDatasource.id)
         ) {
           dep.skipReason = 'github-token-required';
           if (dep.depName) {

--- a/lib/workers/repository/update/pr/changelog/source-github.ts
+++ b/lib/workers/repository/update/pr/changelog/source-github.ts
@@ -59,7 +59,7 @@ export async function getChangeLogJSON(
   // istanbul ignore if
   if (!token) {
     if (host!.endsWith('.github.com') || host === 'github.com') {
-      if (!GlobalConfig.get().githubTokenWarn) {
+      if (!GlobalConfig.get('githubTokenWarn')) {
         logger.debug(
           { manager, depName, sourceUrl },
           'GitHub token warning has been suppressed. Skipping release notes retrieval'


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

- Ref: #14882
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
