### PR TITLE
fix(http): clear queues after hostrules change

### DIFF
--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -22,6 +22,7 @@ const githubApiHost = 'https://api.github.com';
 jest.mock('delay');
 
 jest.mock('../../../util/host-rules');
+jest.mock('../../../util/http/queue');
 const hostRules: jest.Mocked<typeof _hostRules> = mocked(_hostRules);
 
 jest.mock('../../../util/git');

--- a/lib/util/http/queue.ts
+++ b/lib/util/http/queue.ts
@@ -1,12 +1,15 @@
 import PQueue from 'p-queue';
+import { logger } from '../../logger';
 import { parseUrl } from '../url';
 import { getRequestLimit } from './host-rules';
 
-const hostQueues = new Map<string | null, PQueue | null>();
+const hostQueues = new Map<string, PQueue | null>();
 
 export function getQueue(url: string): PQueue | null {
   const host = parseUrl(url)?.host;
   if (!host) {
+    // should never happen
+    logger.debug({ url }, 'No host');
     return null;
   }
 
@@ -15,7 +18,10 @@ export function getQueue(url: string): PQueue | null {
     queue = null; // null represents "no queue", as opposed to undefined
     const concurrency = getRequestLimit(url);
     if (concurrency) {
+      logger.debug({ concurrency, host }, 'Using queue');
       queue = new PQueue({ concurrency });
+    } else {
+      logger.debug({ host }, 'No concurency limits');
     }
   }
   hostQueues.set(host, queue);

--- a/lib/workers/global/index.ts
+++ b/lib/workers/global/index.ts
@@ -17,6 +17,7 @@ import { CONFIG_PRESETS_INVALID } from '../../constants/error-messages';
 import { pkg } from '../../expose.cjs';
 import { getProblems, logger, setMeta } from '../../logger';
 import * as hostRules from '../../util/host-rules';
+import * as queue from '../../util/http/queue';
 import * as repositoryWorker from '../repository';
 import { autodiscoverRepositories } from './autodiscover';
 import { parseConfigs } from './config/parse';
@@ -152,6 +153,10 @@ export async function start(): Promise<number> {
         repoConfig.hostRules.forEach((rule) => hostRules.add(rule));
         repoConfig.hostRules = [];
       }
+
+      // host rules can change concurrency
+      queue.clear();
+
       await repositoryWorker.renovateRepository(repoConfig);
       setMeta({});
     }

--- a/lib/workers/repository/init/merge.ts
+++ b/lib/workers/repository/init/merge.ts
@@ -21,6 +21,7 @@ import { getCache } from '../../../util/cache/repository';
 import { readLocalFile } from '../../../util/fs';
 import { getFileList } from '../../../util/git';
 import * as hostRules from '../../../util/host-rules';
+import * as queue from '../../../util/http/queue';
 import type { RepoFileConfig } from './types';
 
 async function detectConfigFile(): Promise<string | null> {
@@ -255,6 +256,8 @@ export async function mergeRenovateConfig(
         );
       }
     }
+    // host rules can change concurrency
+    queue.clear();
     delete resolvedConfig.hostRules;
   }
   returnConfig = mergeChildConfig(returnConfig, resolvedConfig);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
clear http queues after hostrule change, as the concurrency config is probably no longer valid
<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
