### PR TITLE
docs: lazy-load images

### DIFF
--- a/docs/usage/dependency-pinning.md
+++ b/docs/usage/dependency-pinning.md
@@ -142,7 +142,7 @@ You can add a package rule in our Renovate configuration to group these together
 Since both `yarn` and `npm@5` both support lock files, it's a common question to ask "Why should I pin dependencies if I'm already using a lock file?".
 It's a good question!
 
-![broken-lockfile](assets/images/broken-lockfile.jpg)
+![broken-lockfile](assets/images/broken-lockfile.jpg){ loading=lazy }
 
 Lock files are a great companion to SemVer ranges _or_ pinning dependencies, because these files lock (pin) deeper into your dependency tree than you see in `package.json`.
 
@@ -158,7 +158,7 @@ If a lock file gets out of sync with its `package.json`, it can no longer be gua
 
 The lock file has only delayed the inevitable problem, and provides much less visibility than `package.json`, because it's not designed to be human readable and is quite dense.
 
-![all-dead](assets/images/all-dead.jpg)
+![all-dead](assets/images/all-dead.jpg){ loading=lazy }
 
 If the `package.json` has a range, and a new in-range version is released that would break the build, then essentially your `package.json` is in a state of "broken", even if the lock file is still holding things together.
 

--- a/docs/usage/getting-started/installing-onboarding.md
+++ b/docs/usage/getting-started/installing-onboarding.md
@@ -17,11 +17,11 @@ Installing/enabling Mend's Renovate GitHub App is simple.
 
 First, navigate to [https://github.com/apps/renovate](https://github.com/apps/renovate) and click the Install button:
 
-![Github App Install button](../assets/images/github-app-install.png)
+![Github App Install button](../assets/images/github-app-install.png){ loading=lazy }
 
 The only choice you need to make is whether to run Renovate on all repositories or on selected repositories:
 
-![Github App repositories](../assets/images/github-app-choose-repos.png)
+![Github App repositories](../assets/images/github-app-choose-repos.png){ loading=lazy }
 
 Renovate will ignore any repositories that don't have known package files, as well as any forks, so you can enable Renovate for all your repositories with no problems.
 That said, most people run Renovate on selected repositories.
@@ -55,7 +55,7 @@ You can also set the line endings in your repository by adding `* text=auto eol=
 
 Once you have enabled Renovate on a repository, you will get a "Configure Renovate" Pull Request looking something like this:
 
-![Onboarding](../assets/images/onboarding.png)
+![Onboarding](../assets/images/onboarding.png){ loading=lazy }
 
 ### No risk onboarding
 

--- a/docs/usage/key-concepts/automerge.md
+++ b/docs/usage/key-concepts/automerge.md
@@ -27,7 +27,7 @@ For example, if you have Jest or Mocha as a development dependency, and it has a
 If you have a linter like ESLint or TSLint and its update passes... automerge them!
 If you have an API with 100% test coverage and Express is updated... automerge it!
 
-![Automerged PR](/assets/images/automerged-pr.png)
+![Automerged PR](/assets/images/automerged-pr.png){ loading=lazy }
 
 ## Configuration examples
 

--- a/lib/modules/platform/azure/index.md
+++ b/lib/modules/platform/azure/index.md
@@ -20,12 +20,12 @@ Remember to set `platform=azure` somewhere in your Renovate config file.
 ### Setting up a new pipeline
 
 Create a brand new pipeline within Azure DevOps, and select your source:
-![Azure DevOps create new pipeline](/assets/images/azure-devops-setup-1.png)
+![Azure DevOps create new pipeline](/assets/images/azure-devops-setup-1.png){ loading=lazy }
 
 Then select your repository.
 
 Within _Configure your pipeline_ select: **Starter pipeline**
-![Azure DevOps starter pipeline template](/assets/images/azure-devops-setup-2.png)
+![Azure DevOps starter pipeline template](/assets/images/azure-devops-setup-2.png){ loading=lazy }
 
 Replace _all_ content in the starter pipeline with:
 


### PR DESCRIPTION
## Changes

- Lazy-load more images [^docs]

## Context

We're already using this feature in the Swissquote article. But there are more images that we should lazily load.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

[^docs]: https://squidfunk.github.io/mkdocs-material/reference/images/#image-lazy-loading