### PR TITLE
fix(gomod): explicitly match Gitlab ID for gitlab enterprise servers

### DIFF
--- a/lib/modules/datasource/go/base.spec.ts
+++ b/lib/modules/datasource/go/base.spec.ts
@@ -1,6 +1,7 @@
 import { Fixtures } from '../../../../test/fixtures';
 import * as httpMock from '../../../../test/http-mock';
 import { mocked } from '../../../../test/util';
+import { PlatformId } from '../../../constants';
 import * as _hostRules from '../../../util/host-rules';
 import { GithubTagsDatasource } from '../github-tags';
 import { GitlabTagsDatasource } from '../gitlab-tags';
@@ -202,7 +203,7 @@ describe('modules/datasource/go/base', () => {
       });
 
       it('supports GitLab EE deps', async () => {
-        hostRules.find.mockReturnValue({ token: 'some-token' });
+        hostRules.hostType.mockReturnValue(PlatformId.Gitlab);
         httpMock
           .scope('https://my.custom.domain')
           .get('/golang/myrepo?go-get=1')
@@ -220,7 +221,7 @@ describe('modules/datasource/go/base', () => {
       });
 
       it('supports GitLab EE deps in subgroup', async () => {
-        hostRules.find.mockReturnValue({ token: 'some-token' });
+        hostRules.hostType.mockReturnValue(PlatformId.Gitlab);
         httpMock
           .scope('https://my.custom.domain')
           .get('/golang/subgroup/myrepo?go-get=1')
@@ -238,7 +239,7 @@ describe('modules/datasource/go/base', () => {
       });
 
       it('supports GitLab EE deps in subgroup with version', async () => {
-        hostRules.find.mockReturnValue({ token: 'some-token' });
+        hostRules.hostType.mockReturnValue(PlatformId.Gitlab);
         httpMock
           .scope('https://my.custom.domain')
           .get('/golang/subgroup/myrepo/v2?go-get=1')
@@ -256,7 +257,7 @@ describe('modules/datasource/go/base', () => {
       });
 
       it('supports GitLab EE deps in private subgroup with vcs indicator', async () => {
-        hostRules.find.mockReturnValue({ token: 'some-token' });
+        hostRules.hostType.mockReturnValue(PlatformId.Gitlab);
         httpMock
           .scope('https://my.custom.domain')
           .get('/golang/subgroup/myrepo.git/v2?go-get=1')
@@ -274,7 +275,7 @@ describe('modules/datasource/go/base', () => {
       });
 
       it('supports GitLab EE monorepo deps in subgroup', async () => {
-        hostRules.find.mockReturnValue({ token: 'some-token' });
+        hostRules.hostType.mockReturnValue(PlatformId.Gitlab);
         httpMock
           .scope('https://my.custom.domain')
           .get('/golang/subgroup/myrepo/monorepo?go-get=1')

--- a/lib/modules/datasource/go/base.ts
+++ b/lib/modules/datasource/go/base.ts
@@ -137,11 +137,7 @@ export class BaseGoDatasource {
       };
     }
 
-    const opts = hostRules.find({
-      hostType: PlatformId.Gitlab,
-      url: goSourceUrl,
-    });
-    if (opts.token) {
+    if (hostRules.hostType({ url: goSourceUrl }) === PlatformId.Gitlab) {
       // get server base url from import url
       const parsedUrl = URL.parse(goSourceUrl);
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

This change checks for the correct hostType for a given URL to decide if it should try to match it as a Gitlab Enterprise repository for go modules hosted on URLs which do not include "gitlab".

This should fix #17570 

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

~~The `HostRuleSearchResult` does not return the `hostType`. The host-rules `find` method will match on hostnames only, if no matching `hostType` is set.~~

~~This means, that it is impossible to ask for a hostRule _only if_ it matches the `hostType`.~~

~~To be non-breaking, we use this value to match that the hostRule is actually a Gitlab host rule in the gomod datasource, otherwise there is no way of telling a Github Enterprise and Gitlab Enterprise configuration apart.~~

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
