### PR TITLE
docs(development): fix brand name spelling

### DIFF
--- a/docs/development/remote-development.md
+++ b/docs/development/remote-development.md
@@ -23,7 +23,7 @@ You'll use the same code editor and have the same config as all other developers
 - Start work in a fresh environment every time
 - Reproducible development environment
 - Similar config for all developers
-- Use VSCode in the browser
+- Use VS Code in the browser
 
 ### Drawbacks
 


### PR DESCRIPTION
## Changes

- Change `VSCode` to `VS Code`, to match the spelling on their own website

## Context

Drive-by PR, not closing any issue with this.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository