### PR TITLE
docs(troubleshooting): improve link style

### DIFF
--- a/docs/usage/troubleshooting.md
+++ b/docs/usage/troubleshooting.md
@@ -57,7 +57,7 @@ We recommend you follow this process:
 1. Find all relevant `DEBUG` or `INFO` messages from before and after the problem occurred
 1. Copy/paste the relevant parts of the logs into your discussion post or bug report
 
-If you cannot fix the problem yourself after reading the logs, and reading - or searching through - our documentation, search the [renovatebot/renovate discussion](https://github.com/renovatebot/renovate/discussions) forum to see if somebody has asked a similar or related question.
+If you cannot fix the problem yourself after reading the logs, and reading - or searching through - our documentation, search the [`renovatebot/renovate` discussion](https://github.com/renovatebot/renovate/discussions) forum to see if somebody has asked a similar or related question.
 
 If none of these steps have helped you, then create a new discussion post to get help from the Renovate maintainers.
 


### PR DESCRIPTION
## Changes

- Use `monospace` styling for the link to the `renovatebot/renovate` repository discussion

## Context

The Vale linter complains about the word `renovatebot`, this is because we should spell it as `Renovate bot` or just `Renovate`. To shut up the Vale linter, I'm using `monospace` syntax, as it doesn't check "code" segments.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository