### PR TITLE
fix: Set `stopOnError` to false for `p-all` and `p-map`

### DIFF
--- a/lib/modules/datasource/galaxy-collection/index.ts
+++ b/lib/modules/datasource/galaxy-collection/index.ts
@@ -109,7 +109,7 @@ export class GalaxyCollectionDatasource extends Datasource {
               return null;
             }
           }),
-      { concurrency: 5 } // allow 5 requests at maximum in parallel
+      { concurrency: 5, stopOnError: false } // allow 5 requests at maximum in parallel
     );
     // filter failed versions
     const filteredReleases = enrichedReleases.filter(is.truthy);

--- a/lib/modules/datasource/go/releases-goproxy.ts
+++ b/lib/modules/datasource/go/releases-goproxy.ts
@@ -60,7 +60,10 @@ export class GoProxyDatasource extends Datasource {
             return { version };
           }
         });
-        const releases = await pAll(queue, { concurrency: 5 });
+        const releases = await pAll(queue, {
+          concurrency: 5,
+          stopOnError: false,
+        });
         if (releases.length) {
           const datasource = await BaseGoDatasource.getDatasource(packageName);
           const sourceUrl = getSourceUrl(datasource);

--- a/lib/modules/datasource/maven/index.ts
+++ b/lib/modules/datasource/maven/index.ts
@@ -268,7 +268,7 @@ export class MavenDatasource extends Datasource {
           res !== 'not-found' && res !== 'error' ? release : null;
       });
 
-      await pAll(queue, { concurrency: 5 });
+      await pAll(queue, { concurrency: 5, stopOnError: false });
 
       if (!isCacheValid) {
         // Store new TTL flag for 24 hours if the previous one is invalidated

--- a/lib/modules/datasource/nuget/v3.ts
+++ b/lib/modules/datasource/nuget/v3.ts
@@ -122,7 +122,7 @@ export async function getReleases(
     (page) => (): Promise<CatalogEntry[]> => getCatalogEntry(http, page)
   );
   const catalogEntries = (
-    await pAll(catalogPagesQueue, { concurrency: 5 })
+    await pAll(catalogPagesQueue, { concurrency: 5, stopOnError: false })
   ).flat();
 
   let homepage: string | null = null;

--- a/lib/modules/datasource/packagist/index.ts
+++ b/lib/modules/datasource/packagist/index.ts
@@ -182,7 +182,10 @@ export class PackagistDatasource extends Datasource {
         (file) => (): Promise<PackagistFile> =>
           this.getPackagistFile(regUrl, file)
       );
-      const resolvedFiles = await pAll(queue, { concurrency: 5 });
+      const resolvedFiles = await pAll(queue, {
+        concurrency: 5,
+        stopOnError: false,
+      });
       for (const res of resolvedFiles) {
         for (const [name, val] of Object.entries(res.providers)) {
           providerPackages[name] = val.sha256;

--- a/lib/modules/datasource/terraform-provider/index.ts
+++ b/lib/modules/datasource/terraform-provider/index.ts
@@ -254,7 +254,7 @@ export class TerraformProviderDatasource extends TerraformDatasource {
           return null;
         }
       },
-      { concurrency: 4 }
+      { concurrency: 4, stopOnError: false }
     );
 
     const filteredResult = result.filter(is.truthy);

--- a/lib/modules/manager/hermit/artifacts.ts
+++ b/lib/modules/manager/hermit/artifacts.ts
@@ -126,7 +126,7 @@ async function getUpdateResult(
 
       return getAddResult(path, contents);
     },
-    { concurrency: 5 }
+    { concurrency: 5, stopOnError: false }
   );
 
   const deleted = hermitChanges.deleted.map(getDeleteResult);
@@ -140,7 +140,7 @@ async function getUpdateResult(
         getAddResult(path, contents), // add a new link
       ];
     },
-    { concurrency: 5 }
+    { concurrency: 5, stopOnError: false }
   );
 
   const renamed = await pMap(
@@ -152,7 +152,7 @@ async function getUpdateResult(
 
       return [getDeleteResult(from), getAddResult(to, toContents)];
     },
-    { concurrency: 5 }
+    { concurrency: 5, stopOnError: false }
   );
 
   return [

--- a/lib/modules/manager/terraform/lockfile/hash.ts
+++ b/lib/modules/manager/terraform/lockfile/hash.ts
@@ -97,7 +97,7 @@ export class TerraformProviderHash {
     return pMap(
       builds,
       (build) => this.calculateSingleHash(build, cacheDir),
-      { concurrency: 4 } // allow to look up 4 builds for this version in parallel
+      { concurrency: 4, stopOnError: false } // allow to look up 4 builds for this version in parallel
     );
   }
 

--- a/lib/modules/manager/terraform/lockfile/index.ts
+++ b/lib/modules/manager/terraform/lockfile/index.ts
@@ -56,7 +56,7 @@ async function updateAllLocks(
       };
       return update;
     },
-    { concurrency: 4 } // allow to look up 4 lock in parallel
+    { concurrency: 4, stopOnError: false } // allow to look up 4 lock in parallel
   );
 
   return updates.filter(is.truthy);

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -1016,7 +1016,7 @@ export async function addReviewers(
   try {
     newReviewerIDs = await pAll(
       newReviewers.map((r) => () => getUserID(r)),
-      { concurrency: 5 }
+      { concurrency: 5, stopOnError: false }
     );
   } catch (err) {
     logger.warn({ err }, 'Failed to get IDs of the new reviewers');

--- a/lib/util/http/github.ts
+++ b/lib/util/http/github.ts
@@ -335,7 +335,10 @@ export class GithubHttp extends Http<GithubHttpOptions, GithubHttpOptions> {
               );
             }
           );
-          const pages = await pAll(queue, { concurrency: 5 });
+          const pages = await pAll(queue, {
+            concurrency: 5,
+            stopOnError: false,
+          });
           if (opts.paginationField && is.plainObject(result.body)) {
             const paginatedResult = result.body[opts.paginationField];
             if (is.array<T>(paginatedResult)) {

--- a/lib/workers/repository/changelog/index.ts
+++ b/lib/workers/repository/changelog/index.ts
@@ -19,7 +19,7 @@ export async function embedChangelog(
 export async function embedChangelogs(
   branches: BranchUpgradeConfig[]
 ): Promise<void> {
-  await pMap(branches, embedChangelog, { concurrency: 10 });
+  await pMap(branches, embedChangelog, { concurrency: 10, stopOnError: false });
 }
 
 export function needsChangelogs(

--- a/lib/workers/repository/process/fetch.ts
+++ b/lib/workers/repository/process/fetch.ts
@@ -96,7 +96,7 @@ async function fetchManagerPackagerFileUpdates(
     'fetchManagerPackagerFileUpdates starting with concurrency'
   );
 
-  pFile.deps = await pAll(queue, { concurrency: 5 });
+  pFile.deps = await pAll(queue, { concurrency: 5, stopOnError: false });
   logger.trace({ packageFile }, 'fetchManagerPackagerFileUpdates finished');
 }
 
@@ -114,7 +114,7 @@ async function fetchManagerUpdates(
     { manager, queueLength: queue.length },
     'fetchManagerUpdates starting'
   );
-  await pAll(queue, { concurrency: 5 });
+  await pAll(queue, { concurrency: 5, stopOnError: false });
   logger.trace({ manager }, 'fetchManagerUpdates finished');
 }
 

--- a/lib/workers/repository/process/vulnerabilities.ts
+++ b/lib/workers/repository/process/vulnerabilities.ts
@@ -73,7 +73,7 @@ export class Vulnerabilities {
       { manager, queueLength: queue.length },
       'fetchManagerUpdates starting'
     );
-    await pAll(queue, { concurrency: 5 });
+    await pAll(queue, { concurrency: 5, stopOnError: false });
     logger.trace({ manager }, 'fetchManagerUpdates finished');
   }
 
@@ -95,7 +95,7 @@ export class Vulnerabilities {
     );
 
     config.packageRules?.push(
-      ...(await pAll(queue, { concurrency: 5 })).flat()
+      ...(await pAll(queue, { concurrency: 5, stopOnError: false })).flat()
     );
     logger.trace({ packageFile }, 'fetchManagerPackagerFileUpdates finished');
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

- Closes: #17647
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
