### PR TITLE
fix(util/promises): Disable `stopOnError` option by default

### DIFF
--- a/lib/util/promises.spec.ts
+++ b/lib/util/promises.spec.ts
@@ -1,0 +1,81 @@
+import { ExternalHostError } from '../types/errors/external-host-error';
+import * as p from './promises';
+
+describe('util/promises', () => {
+  describe('all', () => {
+    it('works', async () => {
+      const queue = p.all([
+        () => Promise.resolve(1),
+        () => Promise.resolve(2),
+        () => Promise.resolve(3),
+      ]);
+      await expect(queue).resolves.toEqual([1, 2, 3]);
+    });
+  });
+
+  describe('map', () => {
+    it('works', async () => {
+      const queue = p.map([1, 2, 3], (x) => Promise.resolve(x + 1));
+      await expect(queue).resolves.toEqual([2, 3, 4]);
+    });
+  });
+
+  describe('Error handling', () => {
+    it('throws first ExternalHostError found', async () => {
+      const unknownErr = new Error('fail');
+      const hostErr = new ExternalHostError(unknownErr);
+      let res: Error | string[] | null = null;
+      try {
+        res = await p.all([
+          () => Promise.resolve('ok'),
+          () => Promise.reject(unknownErr),
+          () => Promise.reject(hostErr),
+        ]);
+      } catch (err) {
+        res = err;
+      }
+      expect(res).toBe(hostErr);
+    });
+
+    it('throws first error if error messages are all the same', async () => {
+      const err1 = new Error('some error');
+      const err2 = new Error('some error');
+      const err3 = new Error('some error');
+      let res: Error | string[] | null = null;
+      try {
+        res = await p.all([
+          () => Promise.reject(err1),
+          () => Promise.reject(err2),
+          () => Promise.reject(err3),
+        ]);
+      } catch (err) {
+        res = err;
+      }
+      expect(res).toBe(err1);
+    });
+
+    it('throws aggregate error for different error messages', async () => {
+      await expect(
+        p.map([1, 2, 3], (x) => Promise.reject(new Error(`error ${x}`)))
+      ).rejects.toHaveProperty('name', 'AggregateError');
+    });
+
+    it('re-throws when stopOnError=true', async () => {
+      const unknownErr = new Error('fail');
+      let res: Error | string[] | null = null;
+      try {
+        res = await p.all(
+          [
+            () => Promise.resolve('ok'),
+            () => Promise.resolve('ok'),
+            () => Promise.reject(unknownErr),
+          ],
+          { stopOnError: true }
+        );
+      } catch (err) {
+        res = err;
+      }
+      expect(res).toBe(unknownErr);
+    });
+  });
+});

--- a/lib/util/promises.ts
+++ b/lib/util/promises.ts
@@ -1,6 +1,7 @@
 import AggregateError from 'aggregate-error';
 import pAll from 'p-all';
 import pMap from 'p-map';
+import { logger } from '../logger';
 import { ExternalHostError } from '../types/errors/external-host-error';
 
 type PromiseFactory<T> = () => Promise<T>;
@@ -13,6 +14,8 @@ function handleError(err: any): never {
   if (!(err instanceof AggregateError)) {
     throw err;
   }
+
+  logger.debug({ err }, 'Aggregate error is thrown');
 
   const errors = [...err];
 

--- a/lib/util/promises.ts
+++ b/lib/util/promises.ts
@@ -1,28 +1,20 @@
-import is from '@sindresorhus/is';
+import AggregateError from 'aggregate-error';
 import pAll from 'p-all';
 import pMap from 'p-map';
 import { ExternalHostError } from '../types/errors/external-host-error';
 
 type PromiseFactory<T> = () => Promise<T>;
 
-interface AggregateError {
-  _errors: Error[];
-}
-
-function isAggregateError(err: any): err is AggregateError {
-  return is.array(err?._errors, is.error);
-}
-
 function isExternalHostError(err: any): err is ExternalHostError {
   return err instanceof ExternalHostError;
 }
 
 function handleError(err: any): never {
-  if (!isAggregateError(err)) {
+  if (!(err instanceof AggregateError)) {
     throw err;
   }
 
-  const errors = err._errors;
+  const errors = [...err];
 
   const hostError = errors.find(isExternalHostError);
   if (hostError) {

--- a/lib/util/promises.ts
+++ b/lib/util/promises.ts
@@ -1,27 +1,74 @@
+import is from '@sindresorhus/is';
 import pAll from 'p-all';
 import pMap from 'p-map';
+import { ExternalHostError } from '../types/errors/external-host-error';
 
 type PromiseFactory<T> = () => Promise<T>;
 
-export function all<T>(
+interface AggregateError {
+  _errors: Error[];
+}
+
+function isAggregateError(err: any): err is AggregateError {
+  return is.array(err?._errors, is.error);
+}
+
+function isExternalHostError(err: any): err is ExternalHostError {
+  return err instanceof ExternalHostError;
+}
+
+function handleError(err: any): never {
+  if (!isAggregateError(err)) {
+    throw err;
+  }
+
+  const errors = err._errors;
+
+  const hostError = errors.find(isExternalHostError);
+  if (hostError) {
+    throw hostError;
+  }
+
+  if (
+    errors.length === 1 ||
+    new Set(errors.map(({ message }) => message)).size === 1
+  ) {
+    const [error] = errors;
+    throw error;
+  }
+
+  throw err;
+}
+
+export async function all<T>(
   tasks: PromiseFactory<T>[],
   options?: pAll.Options
 ): Promise<T[]> {
-  return pAll(tasks, {
-    concurrency: 5,
-    ...options,
-    stopOnError: true,
-  });
+  try {
+    const res = await pAll(tasks, {
+      concurrency: 5,
+      stopOnError: false,
+      ...options,
+    });
+    return res;
+  } catch (err) {
+    return handleError(err);
+  }
 }
 
-export function map<Element, NewElement>(
+export async function map<Element, NewElement>(
   input: Iterable<Element>,
   mapper: pMap.Mapper<Element, NewElement>,
   options?: pMap.Options
 ): Promise<NewElement[]> {
-  return pMap(input, mapper, {
-    concurrency: 5,
-    ...options,
-    stopOnError: true,
-  });
+  try {
+    const res = await pMap(input, mapper, {
+      concurrency: 5,
+      stopOnError: false,
+      ...options,
+    });
+    return res;
+  } catch (err) {
+    return handleError(err);
+  }
 }

--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
     "@yarnpkg/core": "3.2.4",
     "@yarnpkg/parsers": "2.5.1",
     "agentkeepalive": "4.2.1",
+    "aggregate-error": "3.1.0",
     "auth-header": "1.0.0",
     "azure-devops-node-api": "11.2.0",
     "bunyan": "1.8.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3181,7 +3181,7 @@ agentkeepalive@4.2.1, agentkeepalive@^4.2.1:
     depd "^1.1.2"
     humanize-ms "^1.2.1"
 
-aggregate-error@^3.0.0:
+aggregate-error@3.1.0, aggregate-error@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.1.0.tgz#92670ff50f5359bdb7a3e0d40d0ec30c5737687a"
   integrity sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Wait for all promises to settle
- Throw the first relevant error when possible
- Throw aggregate error as the last resort

## Context

- Closes #17647
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
