### PR TITLE
fix: behind-base cache logic

### DIFF
--- a/lib/util/cache/repository/types.ts
+++ b/lib/util/cache/repository/types.ts
@@ -32,6 +32,9 @@ export interface BranchCache {
   isModified: boolean;
   prNo: number | null;
   sha: string | null;
+  /**
+   * Parent commit branch sha
+   */
   parentSha: string | null;
   upgrades: BranchUpgradeCache[];
   branchFingerprint?: string;

--- a/lib/util/cache/repository/types.ts
+++ b/lib/util/cache/repository/types.ts
@@ -33,7 +33,7 @@ export interface BranchCache {
   prNo: number | null;
   sha: string | null;
   /**
-   * Parent commit branch sha
+   * Parent commit of branch sha(latest branch commit)
    */
   parentSha: string | null;
   upgrades: BranchUpgradeCache[];

--- a/lib/util/cache/repository/types.ts
+++ b/lib/util/cache/repository/types.ts
@@ -35,6 +35,7 @@ export interface BranchCache {
   parentSha: string | null;
   upgrades: BranchUpgradeCache[];
   branchFingerprint?: string;
+  baseBranchSha: string | null;
 }
 
 export interface RepoCacheData {

--- a/lib/util/git/behind-base-branch-cache.spec.ts
+++ b/lib/util/git/behind-base-branch-cache.spec.ts
@@ -2,9 +2,12 @@ import { mocked, partial } from '../../../test/util';
 import * as _repositoryCache from '../cache/repository';
 import type { BranchCache, RepoCacheData } from '../cache/repository/types';
 import { getCachedBehindBaseResult } from './behind-base-branch-cache';
+import * as _git from '.';
 
 jest.mock('../cache/repository');
+jest.mock('.');
 const repositoryCache = mocked(_repositoryCache);
+const git = mocked(_git);
 
 describe('util/git/behind-base-branch-cache', () => {
   let repoCache: RepoCacheData = {};
@@ -16,11 +19,11 @@ describe('util/git/behind-base-branch-cache', () => {
 
   describe('getCachedBehindBaseResult', () => {
     it('returns null if cache is not populated', () => {
-      expect(getCachedBehindBaseResult('foo', '111')).toBeNull();
+      expect(getCachedBehindBaseResult('foo', 'base_branch')).toBeNull();
     });
 
     it('returns null if branch not found', () => {
-      expect(getCachedBehindBaseResult('foo', '111')).toBeNull();
+      expect(getCachedBehindBaseResult('foo', 'base_branch')).toBeNull();
     });
 
     it('returns null if cache is partially defined', () => {
@@ -31,21 +34,23 @@ describe('util/git/behind-base-branch-cache', () => {
       });
       const repoCache: RepoCacheData = { branches: [branchCache] };
       repositoryCache.getCache.mockReturnValue(repoCache);
-      expect(getCachedBehindBaseResult(branchName, '111')).toBeNull();
+      expect(getCachedBehindBaseResult(branchName, 'base_branch')).toBeNull();
     });
 
     it('returns true if target SHA has changed', () => {
       repoCache.branches = [
         { branchName: 'foo', sha: 'aaa', baseBranchSha: '222' } as BranchCache,
       ];
-      expect(getCachedBehindBaseResult('foo', '111')).toBeTrue();
+      git.getBranchCommit.mockReturnValue('111');
+      expect(getCachedBehindBaseResult('foo', 'base_branch')).toBeTrue();
     });
 
     it('returns false if target SHA has not changed', () => {
       repoCache.branches = [
-        { branchName: 'foo', sha: 'aaa', baseBranchSha: '111' } as BranchCache,
+        { branchName: 'foo', sha: 'aaa', baseBranchSha: '222' } as BranchCache,
       ];
-      expect(getCachedBehindBaseResult('foo', '111')).toBeFalse();
+      git.getBranchCommit.mockReturnValue('222');
+      expect(getCachedBehindBaseResult('foo', 'base_branch')).toBeFalse();
     });
   });
 });

--- a/lib/util/git/behind-base-branch-cache.spec.ts
+++ b/lib/util/git/behind-base-branch-cache.spec.ts
@@ -36,14 +36,14 @@ describe('util/git/behind-base-branch-cache', () => {
 
     it('returns true if target SHA has changed', () => {
       repoCache.branches = [
-        { branchName: 'foo', sha: 'aaa', parentSha: '222' } as BranchCache,
+        { branchName: 'foo', sha: 'aaa', baseBranchSha: '222' } as BranchCache,
       ];
       expect(getCachedBehindBaseResult('foo', '111')).toBeTrue();
     });
 
     it('returns false if target SHA has not changed', () => {
       repoCache.branches = [
-        { branchName: 'foo', sha: 'aaa', parentSha: '111' } as BranchCache,
+        { branchName: 'foo', sha: 'aaa', baseBranchSha: '111' } as BranchCache,
       ];
       expect(getCachedBehindBaseResult('foo', '111')).toBeFalse();
     });

--- a/lib/util/git/behind-base-branch-cache.ts
+++ b/lib/util/git/behind-base-branch-cache.ts
@@ -1,8 +1,8 @@
 import { getCache } from '../cache/repository';
 import { getBranchCommit } from '.';
 
-// Compare cached parent Sha of a branch to the fetched base-branch sha to determine whether the branch is behind the base
-// Since cache is updated after each run, this will be sufficient to determine whether a branch is behind its parent.
+// Compare cached baseBranchSha of a branch and fetched baseBranchSha to determine if the branch is behind base
+// since we update cache on each run, it is sufficient to determine whether a branch is behind its parent
 export function getCachedBehindBaseResult(
   branchName: string,
   baseBranchName: string

--- a/lib/util/git/behind-base-branch-cache.ts
+++ b/lib/util/git/behind-base-branch-cache.ts
@@ -1,12 +1,14 @@
 import { getCache } from '../cache/repository';
+import { getBranchCommit } from '.';
 
 // Compare cached parent Sha of a branch to the fetched base-branch sha to determine whether the branch is behind the base
 // Since cache is updated after each run, this will be sufficient to determine whether a branch is behind its parent.
 export function getCachedBehindBaseResult(
   branchName: string,
-  currentBaseBranchSha: string
+  baseBranchName: string
 ): boolean | null {
   const cache = getCache();
+  const baseBranchSha = getBranchCommit(baseBranchName);
   const { branches = [] } = cache;
   const cachedBranch = branches?.find(
     (branch) => branch.branchName === branchName
@@ -16,5 +18,5 @@ export function getCachedBehindBaseResult(
     return null;
   }
 
-  return currentBaseBranchSha !== cachedBranch.baseBranchSha;
+  return baseBranchSha !== cachedBranch.baseBranchSha;
 }

--- a/lib/util/git/behind-base-branch-cache.ts
+++ b/lib/util/git/behind-base-branch-cache.ts
@@ -12,9 +12,9 @@ export function getCachedBehindBaseResult(
     (branch) => branch.branchName === branchName
   );
 
-  if (!cachedBranch?.parentSha) {
+  if (!cachedBranch?.baseBranchSha) {
     return null;
   }
 
-  return currentBaseBranchSha !== cachedBranch.parentSha;
+  return currentBaseBranchSha !== cachedBranch.baseBranchSha;
 }

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -261,16 +261,17 @@ describe('util/git/index', () => {
     });
 
     it('should return result even if non-default and not under branchPrefix', async () => {
-      const parentSha = 'SHA';
       const branchCache = partial<BranchCache>({
         branchName: 'develop',
-        parentSha: parentSha,
+        baseBranchSha: git.getBranchCommit(defaultBranch),
       });
       repoCache.getCache.mockReturnValueOnce({}).mockReturnValueOnce({
         branches: [branchCache],
       });
       expect(await git.isBranchBehindBase('develop', defaultBranch)).toBeTrue();
-      expect(await git.isBranchBehindBase('develop', defaultBranch)).toBeTrue(); // cache
+      expect(
+        await git.isBranchBehindBase('develop', defaultBranch)
+      ).toBeFalse(); // cache
     });
   });
 

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -249,13 +249,15 @@ describe('util/git/index', () => {
     it('should return false if same SHA as master', async () => {
       repoCache.getCache.mockReturnValueOnce({});
       expect(
-        await git.isBranchBehindBase('renovate/future_branch')
+        await git.isBranchBehindBase('renovate/future_branch', defaultBranch)
       ).toBeFalse();
     });
 
     it('should return true if SHA different from master', async () => {
       repoCache.getCache.mockReturnValueOnce({});
-      expect(await git.isBranchBehindBase('renovate/past_branch')).toBeTrue();
+      expect(
+        await git.isBranchBehindBase('renovate/past_branch', defaultBranch)
+      ).toBeTrue();
     });
 
     it('should return result even if non-default and not under branchPrefix', async () => {
@@ -267,8 +269,8 @@ describe('util/git/index', () => {
       repoCache.getCache.mockReturnValueOnce({}).mockReturnValueOnce({
         branches: [branchCache],
       });
-      expect(await git.isBranchBehindBase('develop')).toBeTrue();
-      expect(await git.isBranchBehindBase('develop')).toBeTrue(); // cache
+      expect(await git.isBranchBehindBase('develop', defaultBranch)).toBeTrue();
+      expect(await git.isBranchBehindBase('develop', defaultBranch)).toBeTrue(); // cache
     });
   });
 

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -558,10 +558,11 @@ export function getBranchList(): string[] {
   return Object.keys(config.branchCommits);
 }
 
-export async function isBranchBehindBase(branchName: string): Promise<boolean> {
-  const { currentBranchSha } = config;
-
-  let isBehind = getCachedBehindBaseResult(branchName, currentBranchSha);
+export async function isBranchBehindBase(
+  branchName: string,
+  baseBranch: string
+): Promise<boolean> {
+  let isBehind = getCachedBehindBaseResult(branchName, baseBranch);
   if (isBehind !== null) {
     return isBehind;
   }
@@ -573,7 +574,7 @@ export async function isBranchBehindBase(branchName: string): Promise<boolean> {
       '--remotes',
       '--verbose',
       '--contains',
-      config.currentBranchSha,
+      currentBranchSha,
     ]);
     isBehind = !branches.all.map(localName).includes(branchName);
     logger.debug(

--- a/lib/workers/repository/cache.ts
+++ b/lib/workers/repository/cache.ts
@@ -50,7 +50,7 @@ async function generateBranchCache(
   const { branchName } = branch;
   try {
     const baseBranchName = branch.baseBranch ?? branch.defaultBranch;
-    // TODO: (fix types) #7154
+    // TODO: fix types (#7154)
     const baseBranchSha = getBranchCommit(baseBranchName!) ?? null;
     const sha = getBranchCommit(branchName) ?? null;
     let prNo = null;

--- a/lib/workers/repository/cache.ts
+++ b/lib/workers/repository/cache.ts
@@ -49,6 +49,8 @@ async function generateBranchCache(
 ): Promise<BranchCache | null> {
   const { branchName } = branch;
   try {
+    const baseBranchName = branch.baseBranch ?? branch.defaultBranch;
+    const baseBranchSha = getBranchCommit(baseBranchName!) ?? null;
     const sha = getBranchCommit(branchName) ?? null;
     let prNo = null;
     let parentSha = null;
@@ -81,6 +83,7 @@ async function generateBranchCache(
       isModified,
       upgrades,
       branchFingerprint,
+      baseBranchSha,
     };
   } catch (error) {
     const err = error.err || error; // external host error nests err

--- a/lib/workers/repository/cache.ts
+++ b/lib/workers/repository/cache.ts
@@ -50,6 +50,7 @@ async function generateBranchCache(
   const { branchName } = branch;
   try {
     const baseBranchName = branch.baseBranch ?? branch.defaultBranch;
+    // TODO: (fix types) #7154
     const baseBranchSha = getBranchCommit(baseBranchName!) ?? null;
     const sha = getBranchCommit(branchName) ?? null;
     let prNo = null;

--- a/lib/workers/repository/onboarding/branch/rebase.ts
+++ b/lib/workers/repository/onboarding/branch/rebase.ts
@@ -31,7 +31,8 @@ export async function rebaseOnboardingBranch(
   // TODO #7154
   if (
     contents === existingContents &&
-    !(await isBranchBehindBase(config.onboardingBranch!))
+    // TODO: (fix types) #7154
+    !(await isBranchBehindBase(config.onboardingBranch!, config.defaultBranch!))
   ) {
     logger.debug('Onboarding branch is up to date');
     return null;

--- a/lib/workers/repository/onboarding/branch/rebase.ts
+++ b/lib/workers/repository/onboarding/branch/rebase.ts
@@ -20,7 +20,7 @@ export async function rebaseOnboardingBranch(
   config: RenovateConfig
 ): Promise<string | null> {
   logger.debug('Checking if onboarding branch needs rebasing');
-  // TODO: (fix types) #7154
+  // TODO: fix types (#7154)
   if (await isBranchModified(config.onboardingBranch!)) {
     logger.debug('Onboarding branch has been edited and cannot be rebased');
     return null;
@@ -28,7 +28,7 @@ export async function rebaseOnboardingBranch(
   const configFile = defaultConfigFile(config);
   const existingContents = await getFile(configFile, config.onboardingBranch);
   const contents = await getOnboardingConfigContents(config, configFile);
-  // TODO: (fix types) #7154
+  // TODO: fix types (#7154)
   if (
     contents === existingContents &&
     !(await isBranchBehindBase(config.onboardingBranch!, config.defaultBranch!))

--- a/lib/workers/repository/onboarding/branch/rebase.ts
+++ b/lib/workers/repository/onboarding/branch/rebase.ts
@@ -20,7 +20,7 @@ export async function rebaseOnboardingBranch(
   config: RenovateConfig
 ): Promise<string | null> {
   logger.debug('Checking if onboarding branch needs rebasing');
-  // TODO #7154
+  // TODO: (fix types) #7154
   if (await isBranchModified(config.onboardingBranch!)) {
     logger.debug('Onboarding branch has been edited and cannot be rebased');
     return null;
@@ -28,10 +28,9 @@ export async function rebaseOnboardingBranch(
   const configFile = defaultConfigFile(config);
   const existingContents = await getFile(configFile, config.onboardingBranch);
   const contents = await getOnboardingConfigContents(config, configFile);
-  // TODO #7154
+  // TODO: (fix types) #7154
   if (
     contents === existingContents &&
-    // TODO: (fix types) #7154
     !(await isBranchBehindBase(config.onboardingBranch!, config.defaultBranch!))
   ) {
     logger.debug('Onboarding branch is up to date');

--- a/lib/workers/repository/update/branch/reuse.ts
+++ b/lib/workers/repository/update/branch/reuse.ts
@@ -62,7 +62,8 @@ export async function shouldReuseExistingBranch(
     (config.rebaseWhen === 'auto' &&
       (config.automerge || (await platform.getRepoForceRebase())))
   ) {
-    if (await isBranchBehindBase(branchName)) {
+    // TODO: (fix types) #7154
+    if (await isBranchBehindBase(branchName, baseBranch!)) {
       logger.debug(`Branch is behind base branch and needs rebasing`);
       // We can rebase the branch only if no PR or PR can be rebased
       if (await isBranchModified(branchName)) {

--- a/lib/workers/repository/update/branch/reuse.ts
+++ b/lib/workers/repository/update/branch/reuse.ts
@@ -62,7 +62,7 @@ export async function shouldReuseExistingBranch(
     (config.rebaseWhen === 'auto' &&
       (config.automerge || (await platform.getRepoForceRebase())))
   ) {
-    // TODO: (fix types) #7154
+    // TODO: fix types (#7154)
     if (await isBranchBehindBase(branchName, baseBranch!)) {
       logger.debug(`Branch is behind base branch and needs rebasing`);
       // We can rebase the branch only if no PR or PR can be rebased


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- cache and use baseBranchSha instead of parentSha in cache logic
- updates tests and types
- use defaultBranch as baseBranch in onboardingBranch
<!-- Describe what behavior is changed by this PR. -->

## Context
- Closes: #17528 
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
