### PR TITLE
refactor(github): Remove unused `etag` support for PR cache

### DIFF
--- a/lib/modules/platform/github/api-cache.spec.ts
+++ b/lib/modules/platform/github/api-cache.spec.ts
@@ -205,23 +205,4 @@ describe('modules/platform/github/api-cache', () => {
       expect(needNextPage).toBeFalse();
     });
   });
-
-  describe('etag', () => {
-    it('returns null', () => {
-      const apiCache = new ApiCache({ items: {} });
-      expect(apiCache.etag).toBeNull();
-    });
-
-    it('sets and retrieves non-null value', () => {
-      const apiCache = new ApiCache({ items: {} });
-      apiCache.etag = 'foobar';
-      expect(apiCache.etag).toBe('foobar');
-    });
-
-    it('deletes value for null parameter', () => {
-      const apiCache = new ApiCache({ items: {} });
-      apiCache.etag = null;
-      expect(apiCache.etag).toBeNull();
-    });
-  });
 });

--- a/lib/modules/platform/github/api-cache.ts
+++ b/lib/modules/platform/github/api-cache.ts
@@ -5,18 +5,6 @@ import type { ApiPageCache, ApiPageItem } from './types';
 export class ApiCache<T extends ApiPageItem> {
   constructor(private cache: ApiPageCache<T>) {}
 
-  get etag(): string | null {
-    return this.cache.etag ?? null;
-  }
-
-  set etag(value: string | null) {
-    if (value === null) {
-      delete this.cache.etag;
-    } else {
-      this.cache.etag = value;
-    }
-  }
-
   /**
    * @returns Date formatted to use in HTTP headers
    */

--- a/lib/modules/platform/github/types.ts
+++ b/lib/modules/platform/github/types.ts
@@ -145,5 +145,4 @@ export interface ApiPageItem {
 export interface ApiPageCache<T extends ApiPageItem = ApiPageItem> {
   items: Record<number, T>;
   lastModified?: string;
-  etag?: string;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
