### PR TITLE
fix(github): Catch errors inside `fetchPr` call

### DIFF
--- a/lib/modules/platform/github/common.ts
+++ b/lib/modules/platform/github/common.ts
@@ -8,6 +8,7 @@ import type { GhRestPr } from './types';
  * @see https://docs.github.com/en/rest/reference/pulls#list-pull-requests
  */
 export function coerceRestPr(pr: GhRestPr | null | undefined): Pr | null {
+  // istanbul ignore if
   if (!pr) {
     return null;
   }

--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -2504,7 +2504,7 @@ describe('modules/platform/github/index', () => {
         )
         .reply(200, [])
         .get('/repos/some/repo/pulls/1234')
-        .reply(200);
+        .reply(404);
       await github.initRepo({ repository: 'some/repo' });
       const pr = await github.getPr(1234);
       expect(pr).toBeNull();

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -590,7 +590,7 @@ async function fetchPr(prNo: number): Promise<Pr | null> {
     cachePr(result);
     return result;
   } catch (err) {
-    logger.debug({ err }, `fetchPr(${prNo}) error`);
+    logger.warn({ err, prNo }, `GitHub fetchPr error`);
     return null;
   }
 }

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -582,12 +582,17 @@ function cachePr(pr?: Pr | null): void {
 
 // Fetch fresh Pull Request and cache it when possible
 async function fetchPr(prNo: number): Promise<Pr | null> {
-  const { body: ghRestPr } = await githubApi.getJson<GhRestPr>(
-    `repos/${config.parentRepo ?? config.repository}/pulls/${prNo}`
-  );
-  const result = coerceRestPr(ghRestPr);
-  cachePr(result);
-  return result;
+  try {
+    const { body: ghRestPr } = await githubApi.getJson<GhRestPr>(
+      `repos/${config.parentRepo ?? config.repository}/pulls/${prNo}`
+    );
+    const result = coerceRestPr(ghRestPr);
+    cachePr(result);
+    return result;
+  } catch (err) {
+    logger.debug({ err }, `fetchPr(${prNo}) error`);
+    return null;
+  }
 }
 
 // Gets details for a PR


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
