### PR TITLE
fix(github): Disable caching for GitHub datasources

### DIFF
--- a/lib/modules/datasource/github-releases/index.spec.ts
+++ b/lib/modules/datasource/github-releases/index.spec.ts
@@ -1,6 +1,6 @@
 import { getDigest, getPkgReleases } from '..';
+import * as httpMock from '../../../../test/http-mock';
 import * as _hostRules from '../../../util/host-rules';
-import { CacheableGithubReleases } from './cache';
 import { GitHubReleaseMocker } from './test';
 import { GithubReleasesDatasource } from '.';
 
@@ -9,12 +9,20 @@ const hostRules: any = _hostRules;
 
 const githubApiHost = 'https://api.github.com';
 
-describe('modules/datasource/github-releases/index', () => {
-  const cacheGetItems = jest.spyOn(
-    CacheableGithubReleases.prototype,
-    'getItems'
-  );
+const responseBody = [
+  { tag_name: 'a', published_at: '2020-03-09T13:00:00Z' },
+  { tag_name: 'v', published_at: '2020-03-09T12:00:00Z' },
+  { tag_name: '1.0.0', published_at: '2020-03-09T11:00:00Z' },
+  { tag_name: 'v1.1.0', draft: false, published_at: '2020-03-09T10:00:00Z' },
+  { tag_name: '1.2.0', draft: true, published_at: '2020-03-09T10:00:00Z' },
+  {
+    tag_name: '2.0.0',
+    published_at: '2020-04-09T10:00:00Z',
+    prerelease: true,
+  },
+];
 
+describe('modules/datasource/github-releases/index', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     hostRules.hosts.mockReturnValue([]);
@@ -25,17 +33,10 @@ describe('modules/datasource/github-releases/index', () => {
 
   describe('getReleases', () => {
     it('returns releases', async () => {
-      cacheGetItems.mockResolvedValueOnce([
-        { version: 'a', releaseTimestamp: '2020-03-09T13:00:00Z' },
-        { version: 'v', releaseTimestamp: '2020-03-09T12:00:00Z' },
-        { version: '1.0.0', releaseTimestamp: '2020-03-09T11:00:00Z' },
-        { version: 'v1.1.0', releaseTimestamp: '2020-03-09T10:00:00Z' },
-        {
-          version: '2.0.0',
-          releaseTimestamp: '2020-04-09T10:00:00Z',
-          isStable: false,
-        },
-      ] as never);
+      httpMock
+        .scope(githubApiHost)
+        .get('/repos/some/dep/releases?per_page=100')
+        .reply(200, responseBody);
 
       const res = await getPkgReleases({
         datasource: GithubReleasesDatasource.id,

--- a/lib/modules/datasource/github-releases/index.ts
+++ b/lib/modules/datasource/github-releases/index.ts
@@ -208,7 +208,6 @@ export class GithubReleasesDatasource extends Datasource {
    *  - Sanitize the versions if desired (e.g. strip out leading 'v')
    *  - Return a dependency object containing sourceUrl string and releases array
    */
-  // istanbul ignore next
   async getReleases(config: GetReleasesConfig): Promise<ReleaseResult> {
     const { packageName: repo, registryUrl } = config;
     const apiBaseUrl = getApiBaseUrl(registryUrl);

--- a/lib/modules/datasource/github-releases/index.ts
+++ b/lib/modules/datasource/github-releases/index.ts
@@ -1,5 +1,4 @@
 // TODO: types (#7154)
-/* eslint-disable @typescript-eslint/restrict-template-expressions */
 import hasha from 'hasha';
 import { logger } from '../../../logger';
 import { GithubHttp } from '../../../util/http/github';

--- a/lib/modules/datasource/github-tags/index.spec.ts
+++ b/lib/modules/datasource/github-tags/index.spec.ts
@@ -84,7 +84,7 @@ describe('modules/datasource/github-tags/index', () => {
       expect(res).toBeNull();
     });
 
-    it('supports ghe', async () => {
+    it('supports GHE', async () => {
       httpMock
         .scope(githubEnterpriseApiHost)
         .get(`/api/v3/repos/${packageName}/git/refs/tags/${tag}`)

--- a/lib/modules/datasource/github-tags/index.spec.ts
+++ b/lib/modules/datasource/github-tags/index.spec.ts
@@ -1,7 +1,6 @@
 import { getPkgReleases } from '..';
 import * as httpMock from '../../../../test/http-mock';
 import * as _hostRules from '../../../util/host-rules';
-import { CacheableGithubTags } from './cache';
 import { GithubTagsDatasource } from '.';
 
 jest.mock('../../../util/host-rules');
@@ -11,11 +10,6 @@ const githubApiHost = 'https://api.github.com';
 const githubEnterpriseApiHost = 'https://git.enterprise.com';
 
 describe('modules/datasource/github-tags/index', () => {
-  const tagsCacheGetItems = jest.spyOn(
-    CacheableGithubTags.prototype,
-    'getItems'
-  );
-
   const github = new GithubTagsDatasource();
 
   beforeEach(() => {
@@ -28,6 +22,7 @@ describe('modules/datasource/github-tags/index', () => {
 
   describe('getDigest', () => {
     const packageName = 'some/dep';
+    const tag = 'v1.2.0';
 
     it('returns commit digest', async () => {
       httpMock
@@ -45,46 +40,69 @@ describe('modules/datasource/github-tags/index', () => {
         .scope(githubApiHost)
         .get(`/repos/${packageName}/commits?per_page=1`)
         .reply(200, []);
-
       const res = await github.getDigest({ packageName }, undefined);
-
       expect(res).toBeNull();
     });
 
-    it('returns tag digest', async () => {
-      tagsCacheGetItems.mockResolvedValueOnce([
-        { version: 'v1.0.0', releaseTimestamp: '2021-01-01', hash: 'aaa' },
-        { version: 'v2.0.0', releaseTimestamp: '2022-01-01', hash: 'bbb' },
-      ]);
-
-      const res = await github.getDigest({ packageName }, 'v2.0.0');
-
-      expect(res).toBe('bbb');
+    it('returns digest', async () => {
+      httpMock
+        .scope(githubApiHost)
+        .get(`/repos/${packageName}/commits?per_page=1`)
+        .reply(200, [{ sha: 'abcdef' }]);
+      const res = await github.getDigest({ packageName }, undefined);
+      expect(res).toBe('abcdef');
     });
 
-    it('returns null for missing tag', async () => {
-      tagsCacheGetItems.mockResolvedValueOnce([
-        { version: 'v1.0.0', releaseTimestamp: '2021-01-01', hash: 'aaa' },
-        { version: 'v2.0.0', releaseTimestamp: '2022-01-01', hash: 'bbb' },
-      ]);
+    it('returns tagged commit digest', async () => {
+      httpMock
+        .scope(githubApiHost)
+        .get(`/repos/${packageName}/git/refs/tags/${tag}`)
+        .reply(200, {
+          object: { type: 'tag', url: `${githubApiHost}/some-url` },
+        })
+        .get('/some-url')
+        .reply(200, { object: { type: 'commit', sha: 'ddd111' } });
+      const res = await github.getDigest({ packageName }, tag);
+      expect(res).toBe('ddd111');
+    });
 
-      const res = await github.getDigest({ packageName }, 'v3.0.0');
-
+    it('warns if unknown ref', async () => {
+      httpMock
+        .scope(githubApiHost)
+        .get(`/repos/${packageName}/git/refs/tags/${tag}`)
+        .reply(200, { object: { sha: 'ddd111' } });
+      const res = await github.getDigest({ packageName }, tag);
       expect(res).toBeNull();
     });
 
-    it('supports GHE', async () => {
+    it('returns null for missed tagged digest', async () => {
+      httpMock
+        .scope(githubApiHost)
+        .get(`/repos/${packageName}/git/refs/tags/${tag}`)
+        .reply(200, {});
+      const res = await github.getDigest({ packageName: 'some/dep' }, 'v1.2.0');
+      expect(res).toBeNull();
+    });
+
+    it('supports ghe', async () => {
       httpMock
         .scope(githubEnterpriseApiHost)
+        .get(`/api/v3/repos/${packageName}/git/refs/tags/${tag}`)
+        .reply(200, { object: { type: 'commit', sha: 'ddd111' } })
         .get(`/api/v3/repos/${packageName}/commits?per_page=1`)
         .reply(200, [{ sha: 'abcdef' }]);
 
-      const res = await github.getDigest(
+      const sha1 = await github.getDigest(
         { packageName, registryUrl: githubEnterpriseApiHost },
         undefined
       );
+      const sha2 = await github.getDigest(
+        { packageName: 'some/dep', registryUrl: githubEnterpriseApiHost },
+        'v1.2.0'
+      );
 
-      expect(res).toBe('abcdef');
+      expect(sha1).toBe('abcdef');
+      expect(sha2).toBe('ddd111');
     });
   });
 
@@ -100,31 +118,21 @@ describe('modules/datasource/github-tags/index', () => {
     const depName = 'some/dep2';
 
     it('returns tags', async () => {
-      tagsCacheGetItems.mockResolvedValueOnce([
-        { version: 'v1.0.0', releaseTimestamp: '2021-01-01', hash: '123' },
-        { version: 'v2.0.0', releaseTimestamp: '2022-01-01', hash: 'abc' },
-      ]);
-
+      const tags = [{ name: 'v1.0.0' }, { name: 'v1.1.0' }];
+      httpMock
+        .scope(githubApiHost)
+        .get(`/repos/${depName}/tags?per_page=100`)
+        .reply(200, tags);
       const res = await getPkgReleases({ datasource: github.id, depName });
 
       expect(res).toEqual({
         registryUrl: 'https://github.com',
-        sourceUrl: 'https://github.com/some/dep2',
         releases: [
-          {
-            gitRef: 'v1.0.0',
-            hash: '123',
-            releaseTimestamp: '2021-01-01T00:00:00.000Z',
-            version: 'v1.0.0',
-          },
-
-          {
-            gitRef: 'v2.0.0',
-            hash: 'abc',
-            releaseTimestamp: '2022-01-01T00:00:00.000Z',
-            version: 'v2.0.0',
-          },
+          { gitRef: 'v1.0.0', version: 'v1.0.0' },
+          { gitRef: 'v1.1.0', version: 'v1.1.0' },
         ],
+
+        sourceUrl: 'https://github.com/some/dep2',
       });
     });
   });

--- a/lib/modules/datasource/github-tags/index.ts
+++ b/lib/modules/datasource/github-tags/index.ts
@@ -73,7 +73,6 @@ export class GithubTagsDatasource extends GithubReleasesDatasource {
       : this.getCommit(registryUrl, repo!);
   }
 
-  // istanbul ignore next
   override async getReleases(
     config: GetReleasesConfig
   ): Promise<ReleaseResult> {

--- a/lib/modules/datasource/github-tags/index.ts
+++ b/lib/modules/datasource/github-tags/index.ts
@@ -1,43 +1,43 @@
 import { logger } from '../../../logger';
-import { cache } from '../../../util/cache/package/decorator';
 import { GithubReleasesDatasource } from '../github-releases';
 import { getApiBaseUrl, getSourceUrl } from '../github-releases/common';
 import type { DigestConfig, GetReleasesConfig, ReleaseResult } from '../types';
-import { CacheableGithubTags } from './cache';
+import type { GitHubTag, TagResponse } from './types';
 
 export class GithubTagsDatasource extends GithubReleasesDatasource {
   static override readonly id = 'github-tags';
 
-  private tagsCache: CacheableGithubTags;
-
   constructor() {
     super(GithubTagsDatasource.id);
-    this.tagsCache = new CacheableGithubTags(this.http);
   }
 
   async getTagCommit(
     registryUrl: string | undefined,
-    packageName: string,
+    githubRepo: string,
     tag: string
   ): Promise<string | null> {
-    let result: string | null = null;
-    const tagReleases = await this.tagsCache.getItems({
-      packageName,
-      registryUrl,
-    });
-    const tagRelease = tagReleases.find(({ version }) => version === tag);
-    if (tagRelease) {
-      result = tagRelease.hash;
+    const apiBaseUrl = getApiBaseUrl(registryUrl);
+    let digest: string | null = null;
+    try {
+      const url = `${apiBaseUrl}repos/${githubRepo}/git/refs/tags/${tag}`;
+      const res = (await this.http.getJson<TagResponse>(url)).body.object;
+      if (res.type === 'commit') {
+        digest = res.sha;
+      } else if (res.type === 'tag') {
+        digest = (await this.http.getJson<TagResponse>(res.url)).body.object
+          .sha;
+      } else {
+        logger.warn({ res }, 'Unknown git tag refs type');
+      }
+    } catch (err) {
+      logger.debug(
+        { githubRepo, err },
+        'Error getting tag commit from GitHub repo'
+      );
     }
-    return result;
+    return digest;
   }
 
-  @cache({
-    ttlMinutes: 10,
-    namespace: `datasource-${GithubTagsDatasource.id}`,
-    key: (registryUrl: string, githubRepo: string) =>
-      `${registryUrl}:${githubRepo}:commit`,
-  })
   async getCommit(
     registryUrl: string | undefined,
     githubRepo: string
@@ -73,16 +73,28 @@ export class GithubTagsDatasource extends GithubReleasesDatasource {
       : this.getCommit(registryUrl, repo!);
   }
 
+  // istanbul ignore next
   override async getReleases(
     config: GetReleasesConfig
   ): Promise<ReleaseResult> {
-    const tagReleases = await this.tagsCache.getItems(config);
+    const { registryUrl, packageName: repo } = config;
+    const apiBaseUrl = getApiBaseUrl(registryUrl);
+    // tag
+    const url = `${apiBaseUrl}repos/${repo}/tags?per_page=100`;
 
-    const tagsResult: ReleaseResult = {
-      sourceUrl: getSourceUrl(config.packageName, config.registryUrl),
-      releases: tagReleases.map((item) => ({ ...item, gitRef: item.version })),
+    const versions = (
+      await this.http.getJson<GitHubTag[]>(url, {
+        paginate: true,
+      })
+    ).body.map((o) => o.name);
+
+    const dependency: ReleaseResult = {
+      sourceUrl: getSourceUrl(repo, registryUrl),
+      releases: versions.map((version) => ({
+        version,
+        gitRef: version,
+      })),
     };
-
-    return tagsResult;
+    return dependency;
   }
 }

--- a/lib/modules/datasource/github-tags/types.ts
+++ b/lib/modules/datasource/github-tags/types.ts
@@ -1,0 +1,11 @@
+export interface TagResponse {
+  object: {
+    type: string;
+    url: string;
+    sha: string;
+  };
+}
+
+export interface GitHubTag {
+  name: string;
+}

--- a/lib/workers/repository/update/pr/changelog/github.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/github.spec.ts
@@ -1,7 +1,6 @@
 import * as httpMock from '../../../../../../test/http-mock';
 import { GlobalConfig } from '../../../../../config/global';
 import { PlatformId } from '../../../../../constants';
-import { CacheableGithubTags } from '../../../../../modules/datasource/github-tags/cache';
 import * as semverVersioning from '../../../../../modules/versioning/semver';
 import * as hostRules from '../../../../../util/host-rules';
 import type { BranchUpgradeConfig } from '../../../../types';
@@ -358,17 +357,15 @@ describe('workers/repository/update/pr/changelog/github', () => {
     });
 
     it('works with same version releases but different prefix', async () => {
-      const githubTagsMock = jest.spyOn(
-        CacheableGithubTags.prototype,
-        'getItems'
-      );
-
-      githubTagsMock.mockResolvedValue([
-        { version: 'v1.0.1' },
-        { version: '1.0.1' },
-        { version: 'correctPrefix/target@1.0.1' },
-        { version: 'wrongPrefix/target-1.0.1' },
-      ] as never);
+      httpMock
+        .scope('https://api.github.com/')
+        .get('/repos/chalk/chalk/tags?per_page=100')
+        .reply(200, [
+          { name: 'v1.0.1' },
+          { name: '1.0.1' },
+          { name: 'correctPrefix/target@1.0.1' },
+          { name: 'wrongPrefix/target-1.0.1' },
+        ]);
 
       const upgradeData: BranchUpgradeConfig = {
         manager: 'some-manager',

--- a/lib/workers/repository/update/pr/changelog/github/index.ts
+++ b/lib/workers/repository/update/pr/changelog/github/index.ts
@@ -115,6 +115,7 @@ export async function getReleaseList(
   release: ChangeLogRelease
 ): Promise<ChangeLogNotes[]> {
   logger.trace('github.getReleaseList()');
+  // TODO #7154
   const apiBaseUrl = project.apiBaseUrl!;
   const repository = project.repository;
   const url = `${ensureTrailingSlash(apiBaseUrl)}repos/${repository}/releases`;

--- a/lib/workers/repository/update/pr/changelog/github/index.ts
+++ b/lib/workers/repository/update/pr/changelog/github/index.ts
@@ -1,7 +1,7 @@
 import changelogFilenameRegex from 'changelog-filename-regex';
 import { logger } from '../../../../../../logger';
-import { CacheableGithubReleases } from '../../../../../../modules/datasource/github-releases/cache';
-import { CacheableGithubTags } from '../../../../../../modules/datasource/github-tags/cache';
+import type { GithubRelease } from '../../../../../../modules/datasource/github-releases/types';
+import type { GitHubTag } from '../../../../../../modules/datasource/github-tags/types';
 import type {
   GithubGitBlob,
   GithubGitTree,
@@ -19,8 +19,6 @@ import type {
 
 export const id = 'github-changelog';
 const http = new GithubHttp(id);
-const tagsCache = new CacheableGithubTags(http);
-const releasesCache = new CacheableGithubReleases(http);
 
 export async function getTags(
   endpoint: string,
@@ -28,17 +26,18 @@ export async function getTags(
 ): Promise<string[]> {
   logger.trace('github.getTags()');
   try {
-    const tags = await tagsCache.getItems({
-      registryUrl: endpoint,
-      packageName: repository,
+    const url = `${endpoint}repos/${repository}/tags?per_page=100`;
+    const res = await http.getJson<GitHubTag[]>(url, {
+      paginate: true,
     });
+    const tags = res.body;
 
     // istanbul ignore if
     if (!tags.length) {
       logger.debug({ repository }, 'repository has no Github tags');
     }
 
-    return tags.map(({ version }) => version).filter(Boolean);
+    return tags.map((tag) => tag.name).filter(Boolean);
   } catch (err) {
     logger.debug(
       { sourceRepo: repository, err },
@@ -116,26 +115,19 @@ export async function getReleaseList(
   release: ChangeLogRelease
 ): Promise<ChangeLogNotes[]> {
   logger.trace('github.getReleaseList()');
-  // TODO #7154
   const apiBaseUrl = project.apiBaseUrl!;
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-  const repository = project.repository!;
-  const notesSourceUrl = `${ensureTrailingSlash(
-    apiBaseUrl
-  )}repos/${repository}/releases`;
-  const items = await releasesCache.getItems(
-    {
-      registryUrl: apiBaseUrl,
-      packageName: repository,
-    },
-    release
-  );
-  return items.map(({ url, id, version: tag, name, description: body }) => ({
-    url,
-    notesSourceUrl,
-    id,
-    tag,
-    name,
-    body,
+  const repository = project.repository;
+  const url = `${ensureTrailingSlash(apiBaseUrl)}repos/${repository}/releases`;
+  const res = await http.getJson<GithubRelease[]>(`${url}?per_page=100`, {
+    paginate: true,
+  });
+
+  return res.body.map((release) => ({
+    url: release.html_url,
+    notesSourceUrl: url,
+    id: release.id,
+    tag: release.tag_name,
+    name: release.name,
+    body: release.body,
   }));
 }

--- a/lib/workers/repository/update/pr/changelog/index.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/index.spec.ts
@@ -2,8 +2,6 @@ import * as httpMock from '../../../../../../test/http-mock';
 import { partial } from '../../../../../../test/util';
 import { GlobalConfig } from '../../../../../config/global';
 import { PlatformId } from '../../../../../constants';
-import { CacheableGithubReleases } from '../../../../../modules/datasource/github-releases/cache';
-import { CacheableGithubTags } from '../../../../../modules/datasource/github-tags/cache';
 import * as semverVersioning from '../../../../../modules/versioning/semver';
 import * as hostRules from '../../../../../util/host-rules';
 import type { BranchConfig } from '../../../../types';
@@ -36,15 +34,6 @@ const upgrade: BranchConfig = partial<BranchConfig>({
 
 describe('workers/repository/update/pr/changelog/index', () => {
   describe('getChangeLogJSON', () => {
-    const githubReleasesMock = jest.spyOn(
-      CacheableGithubReleases.prototype,
-      'getItems'
-    );
-    const githubTagsMock = jest.spyOn(
-      CacheableGithubTags.prototype,
-      'getItems'
-    );
-
     beforeEach(() => {
       jest.resetAllMocks();
       hostRules.clear();
@@ -93,11 +82,14 @@ describe('workers/repository/update/pr/changelog/index', () => {
     });
 
     it('works without Github', async () => {
-      githubTagsMock.mockRejectedValueOnce(new Error('Unknown'));
-      githubReleasesMock.mockRejectedValueOnce(new Error('Unknown'));
       httpMock
         .scope(githubApiHost)
         .get('/repos/chalk/chalk')
+        .times(4)
+        .reply(500)
+        .get('/repos/chalk/chalk/tags?per_page=100')
+        .reply(500)
+        .get('/repos/chalk/chalk/releases?per_page=100')
         .times(4)
         .reply(500);
       expect(
@@ -125,16 +117,20 @@ describe('workers/repository/update/pr/changelog/index', () => {
     });
 
     it('uses GitHub tags', async () => {
-      httpMock.scope(githubApiHost).get(/.*/).reply(200, []).persist();
-      githubTagsMock.mockResolvedValue([
-        { version: '0.9.0' },
-        { version: '1.0.0' },
-        { version: '1.4.0' },
-        { version: 'v2.3.0' },
-        { version: '2.2.2' },
-        { version: 'v2.4.2' },
-      ] as never);
-      githubReleasesMock.mockResolvedValue([]);
+      httpMock
+        .scope(githubApiHost)
+        .get('/repos/chalk/chalk/tags?per_page=100')
+        .reply(200, [
+          { name: '0.9.0' },
+          { name: '1.0.0' },
+          { name: '1.4.0' },
+          { name: 'v2.3.0' },
+          { name: '2.2.2' },
+          { name: 'v2.4.2' },
+        ])
+        .persist()
+        .get(/.*/)
+        .reply(200, []);
       expect(
         await getChangeLogJSON({
           ...upgrade,
@@ -160,10 +156,6 @@ describe('workers/repository/update/pr/changelog/index', () => {
     });
 
     it('filters unnecessary warns', async () => {
-      githubTagsMock.mockRejectedValueOnce(new Error('Unknown Github Repo'));
-      githubReleasesMock.mockRejectedValueOnce(
-        new Error('Unknown Github Repo')
-      );
       httpMock.scope(githubApiHost).get(/.*/).reply(200, []).persist();
       const res = await getChangeLogJSON({
         ...upgrade,
@@ -190,8 +182,6 @@ describe('workers/repository/update/pr/changelog/index', () => {
     });
 
     it('supports node engines', async () => {
-      githubTagsMock.mockRejectedValueOnce([]);
-      githubReleasesMock.mockRejectedValueOnce([]);
       expect(
         await getChangeLogJSON({
           ...upgrade,
@@ -266,8 +256,6 @@ describe('workers/repository/update/pr/changelog/index', () => {
     });
 
     it('supports github enterprise and github.com changelog', async () => {
-      githubTagsMock.mockRejectedValueOnce([]);
-      githubReleasesMock.mockRejectedValueOnce([]);
       httpMock.scope(githubApiHost).persist().get(/.*/).reply(200, []);
       hostRules.add({
         hostType: PlatformId.Github,
@@ -300,8 +288,6 @@ describe('workers/repository/update/pr/changelog/index', () => {
     });
 
     it('supports github enterprise and github enterprise changelog', async () => {
-      githubTagsMock.mockRejectedValueOnce([]);
-      githubReleasesMock.mockRejectedValueOnce([]);
       httpMock
         .scope('https://github-enterprise.example.com')
         .persist()
@@ -340,8 +326,6 @@ describe('workers/repository/update/pr/changelog/index', () => {
     });
 
     it('supports github.com and github enterprise changelog', async () => {
-      githubTagsMock.mockRejectedValueOnce([]);
-      githubReleasesMock.mockRejectedValueOnce([]);
       httpMock
         .scope('https://github-enterprise.example.com')
         .persist()


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Returns GitHub tags/releases fetching to REST and disables caching.

## Context

Addresses performance regressions in the hosted app. Plan is:
- Revert GraphQL and convert to REST. No caching
- Switch to GraphQL, no caching
- Add caching back to GraphQL

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
