### PR TITLE
refactor(github): Uniform names for github datasource types

### DIFF
--- a/lib/modules/datasource/github-releases/cache/cache-base.spec.ts
+++ b/lib/modules/datasource/github-releases/cache/cache-base.spec.ts
@@ -2,8 +2,8 @@ import { DateTime } from 'luxon';
 import { mocked } from '../../../../../test/util';
 import * as _packageCache from '../../../../util/cache/package';
 import type {
-  QueryResponse,
-  StoredItemBase,
+  GithubCachedItem,
+  GithubGraphqlRepoResponse,
 } from '../../../../util/github/types';
 import {
   GithubGraphqlResponse,
@@ -20,14 +20,14 @@ interface FetchedItem {
   foo: string;
 }
 
-interface StoredItem extends StoredItemBase {
+interface StoredItem extends GithubCachedItem {
   bar: string;
 }
 
 type GraphqlDataResponse = {
   statusCode: 200;
   headers: Record<string, string>;
-  body: GithubGraphqlResponse<QueryResponse<FetchedItem>>;
+  body: GithubGraphqlResponse<GithubGraphqlRepoResponse<FetchedItem>>;
 };
 
 type GraphqlResponse = GraphqlDataResponse | Error;

--- a/lib/modules/datasource/github-releases/cache/cache-base.ts
+++ b/lib/modules/datasource/github-releases/cache/cache-base.ts
@@ -6,10 +6,10 @@ import * as packageCache from '../../../../util/cache/package';
 import type {
   CacheOptions,
   ChangelogRelease,
+  GithubCachedItem,
   GithubDatasourceCache,
-  GithubQueryParams,
-  QueryResponse,
-  StoredItemBase,
+  GithubGraphqlRepoParams,
+  GithubGraphqlRepoResponse,
 } from '../../../../util/github/types';
 import { getApiBaseUrl } from '../../../../util/github/url';
 import type {
@@ -100,7 +100,7 @@ function isExpired(
 }
 
 export abstract class AbstractGithubDatasourceCache<
-  StoredItem extends StoredItemBase,
+  CachedItem extends GithubCachedItem,
   FetchedItem = unknown
 > {
   private updateDuration: DurationLikeObject;
@@ -163,16 +163,18 @@ export abstract class AbstractGithubDatasourceCache<
    * Transform `fetchedItem` for storing in the package cache.
    * @param fetchedItem Node obtained from GraphQL response
    */
-  abstract coerceFetched(fetchedItem: FetchedItem): StoredItem | null;
+  abstract coerceFetched(fetchedItem: FetchedItem): CachedItem | null;
 
   private async queryPayload(
     baseUrl: string,
-    variables: GithubQueryParams,
+    variables: GithubGraphqlRepoParams,
     options: GithubHttpOptions
-  ): Promise<QueryResponse<FetchedItem>['repository']['payload'] | Error> {
+  ): Promise<
+    GithubGraphqlRepoResponse<FetchedItem>['repository']['payload'] | Error
+  > {
     try {
       const graphqlRes = await this.http.postJson<
-        GithubGraphqlResponse<QueryResponse<FetchedItem>>
+        GithubGraphqlResponse<GithubGraphqlRepoResponse<FetchedItem>>
       >('/graphql', {
         ...options,
         baseUrl,
@@ -222,14 +224,14 @@ export abstract class AbstractGithubDatasourceCache<
   async getItemsImpl(
     releasesConfig: GetReleasesConfig,
     changelogRelease?: ChangelogRelease
-  ): Promise<StoredItem[]> {
+  ): Promise<CachedItem[]> {
     const { packageName, registryUrl } = releasesConfig;
 
     // The time meant to be used across the function
     const now = DateTime.now();
 
     // Initialize items and timestamps for the new cache
-    let cacheItems: Record<string, StoredItem> = {};
+    let cacheItems: Record<string, CachedItem> = {};
 
     // Add random minutes to the creation date in order to
     // provide back-off time during mass cache invalidation.
@@ -244,7 +246,7 @@ export abstract class AbstractGithubDatasourceCache<
     if (owner && name) {
       const baseUrl = this.getBaseUrl(registryUrl);
       const cacheKey = this.getCacheKey(registryUrl, packageName);
-      const cache = await packageCache.get<GithubDatasourceCache<StoredItem>>(
+      const cache = await packageCache.get<GithubDatasourceCache<CachedItem>>(
         this.cacheNs,
         cacheKey
       );
@@ -280,7 +282,7 @@ export abstract class AbstractGithubDatasourceCache<
           cacheItems
         )
       ) {
-        const variables: GithubQueryParams = {
+        const variables: GithubGraphqlRepoParams = {
           owner,
           name,
           cursor: null,
@@ -386,7 +388,7 @@ export abstract class AbstractGithubDatasourceCache<
           .diff(now, ['minutes'])
           .toObject();
         if (ttlMinutes && ttlMinutes > 0) {
-          const cacheValue: GithubDatasourceCache<StoredItem> = {
+          const cacheValue: GithubDatasourceCache<CachedItem> = {
             items: cacheItems,
             createdAt: cacheCreatedAt,
             updatedAt: now.toISO(),
@@ -413,12 +415,12 @@ export abstract class AbstractGithubDatasourceCache<
   getItems(
     releasesConfig: GetReleasesConfig,
     changelogRelease?: ChangelogRelease
-  ): Promise<StoredItem[]> {
+  ): Promise<CachedItem[]> {
     const { packageName, registryUrl } = releasesConfig;
     const cacheKey = this.getCacheKey(registryUrl, packageName);
     const promiseKey = `github-datasource-cache:${this.cacheNs}:${cacheKey}`;
     const res =
-      memCache.get<Promise<StoredItem[]>>(promiseKey) ??
+      memCache.get<Promise<CachedItem[]>>(promiseKey) ??
       this.getItemsImpl(releasesConfig, changelogRelease);
     memCache.set(promiseKey, res);
     return res;
@@ -430,7 +432,7 @@ export abstract class AbstractGithubDatasourceCache<
   }
 
   public getLastReleaseTimestamp(
-    items: Record<string, StoredItem>
+    items: Record<string, CachedItem>
   ): string | null {
     let result: string | null = null;
     let latest: DateTime | null = null;
@@ -454,7 +456,7 @@ export abstract class AbstractGithubDatasourceCache<
     changelogRelease: ChangelogRelease | undefined,
     now: DateTime,
     updateDuration: DurationLikeObject,
-    cacheItems: Record<string, StoredItem>
+    cacheItems: Record<string, CachedItem>
   ): boolean {
     if (!changelogRelease?.date) {
       return false;

--- a/lib/modules/datasource/github-releases/cache/index.spec.ts
+++ b/lib/modules/datasource/github-releases/cache/index.spec.ts
@@ -1,11 +1,12 @@
+import type { GithubGraphqlRelease } from '../../../../util/github/types';
 import { GithubHttp } from '../../../../util/http/github';
-import { CacheableGithubReleases, FetchedRelease } from '.';
+import { CacheableGithubReleases } from '.';
 
 describe('modules/datasource/github-releases/cache/index', () => {
   const http = new GithubHttp();
   const cache = new CacheableGithubReleases(http, { resetDeltaMinutes: 0 });
 
-  const fetchedItem: FetchedRelease = {
+  const fetchedItem: GithubGraphqlRelease = {
     version: '1.2.3',
     releaseTimestamp: '2020-04-09T10:00:00.000Z',
     isDraft: false,

--- a/lib/modules/datasource/github-releases/cache/index.ts
+++ b/lib/modules/datasource/github-releases/cache/index.ts
@@ -1,6 +1,7 @@
 import type {
   CacheOptions,
-  StoredItemBase,
+  GithubCachedRelease,
+  GithubGraphqlRelease,
 } from '../../../../util/github/types';
 import type { GithubHttp } from '../../../../util/http/github';
 import { AbstractGithubDatasourceCache } from './cache-base';
@@ -32,28 +33,9 @@ query ($owner: String!, $name: String!, $cursor: String, $count: Int!) {
 }
 `;
 
-export interface FetchedRelease {
-  version: string;
-  releaseTimestamp: string;
-  isDraft: boolean;
-  isPrerelease: boolean;
-  url: string;
-  id: number;
-  name: string;
-  description: string;
-}
-
-export interface StoredRelease extends StoredItemBase {
-  isStable?: boolean;
-  url: string;
-  id: number;
-  name: string;
-  description: string;
-}
-
 export class CacheableGithubReleases extends AbstractGithubDatasourceCache<
-  StoredRelease,
-  FetchedRelease
+  GithubCachedRelease,
+  GithubGraphqlRelease
 > {
   cacheNs = 'github-datasource-graphql-releases';
   graphqlQuery = query;
@@ -62,7 +44,7 @@ export class CacheableGithubReleases extends AbstractGithubDatasourceCache<
     super(http, opts);
   }
 
-  coerceFetched(item: FetchedRelease): StoredRelease | null {
+  coerceFetched(item: GithubGraphqlRelease): GithubCachedRelease | null {
     const {
       version,
       releaseTimestamp,
@@ -78,7 +60,7 @@ export class CacheableGithubReleases extends AbstractGithubDatasourceCache<
       return null;
     }
 
-    const result: StoredRelease = {
+    const result: GithubCachedRelease = {
       version,
       releaseTimestamp,
       url,

--- a/lib/modules/datasource/github-releases/digest.spec.ts
+++ b/lib/modules/datasource/github-releases/digest.spec.ts
@@ -1,6 +1,6 @@
 import hasha from 'hasha';
 import * as httpMock from '../../../../test/http-mock';
-import type { DigestAsset } from '../../../util/github/types';
+import type { GithubDigestFile } from '../../../util/github/types';
 import { GitHubReleaseMocker } from './test';
 
 import { GithubReleasesDatasource } from '.';
@@ -77,7 +77,7 @@ describe('modules/datasource/github-releases/digest', () => {
 
   describe('mapDigestAssetToRelease', () => {
     describe('with digest file', () => {
-      const digestAsset: DigestAsset = {
+      const digestAsset: GithubDigestFile = {
         assetName: 'SHASUMS.txt',
         currentVersion: 'v1.0.0',
         currentDigest: 'old-digest',
@@ -136,7 +136,7 @@ describe('modules/datasource/github-releases/digest', () => {
     });
 
     describe('with digested file', () => {
-      const digestAsset: DigestAsset = {
+      const digestAsset: GithubDigestFile = {
         assetName: 'asset.zip',
         currentVersion: 'v1.0.0',
         currentDigest: '0'.repeat(64),

--- a/lib/modules/datasource/github-releases/test/index.ts
+++ b/lib/modules/datasource/github-releases/test/index.ts
@@ -1,6 +1,6 @@
 import * as httpMock from '../../../../../test/http-mock';
 import { partial } from '../../../../../test/util';
-import type { GithubRelease } from '../../../../util/github/types';
+import type { GithubRestRelease } from '../../../../util/github/types';
 
 export class GitHubReleaseMocker {
   constructor(
@@ -8,15 +8,15 @@ export class GitHubReleaseMocker {
     private readonly packageName: string
   ) {}
 
-  release(version: string): GithubRelease {
+  release(version: string): GithubRestRelease {
     return this.withAssets(version, {});
   }
 
   withAssets(
     version: string,
     assets: { [key: string]: string }
-  ): GithubRelease {
-    const releaseData = partial<GithubRelease>({
+  ): GithubRestRelease {
+    const releaseData = partial<GithubRestRelease>({
       tag_name: version,
       published_at: '2020-03-09T11:00:00Z',
       prerelease: false,
@@ -46,7 +46,10 @@ export class GitHubReleaseMocker {
     return releaseData;
   }
 
-  withDigestFileAsset(version: string, ...digests: string[]): GithubRelease {
+  withDigestFileAsset(
+    version: string,
+    ...digests: string[]
+  ): GithubRestRelease {
     return this.withAssets(version, { 'SHASUMS.txt': digests.join('\n') });
   }
 }

--- a/lib/modules/datasource/github-tags/cache.spec.ts
+++ b/lib/modules/datasource/github-tags/cache.spec.ts
@@ -1,11 +1,12 @@
+import type { GithubGraphqlTag } from '../../../util/github/types';
 import { GithubHttp } from '../../../util/http/github';
-import { CacheableGithubTags, FetchedTag } from './cache';
+import { CacheableGithubTags } from './cache';
 
 describe('modules/datasource/github-tags/cache', () => {
   const http = new GithubHttp();
   const cache = new CacheableGithubTags(http, { resetDeltaMinutes: 0 });
 
-  const fetchedItem: FetchedTag = {
+  const fetchedItem: GithubGraphqlTag = {
     version: '1.2.3',
     target: {
       type: 'Commit',

--- a/lib/modules/datasource/github-tags/cache.ts
+++ b/lib/modules/datasource/github-tags/cache.ts
@@ -1,4 +1,8 @@
-import type { CacheOptions, StoredItemBase } from '../../../util/github/types';
+import type {
+  CacheOptions,
+  GithubCachedTag,
+  GithubGraphqlTag,
+} from '../../../util/github/types';
 import type { GithubHttp } from '../../../util/http/github';
 import { AbstractGithubDatasourceCache } from '../github-releases/cache/cache-base';
 
@@ -40,33 +44,9 @@ query ($owner: String!, $name: String!, $cursor: String, $count: Int!) {
 }
 `;
 
-export interface FetchedTag {
-  version: string;
-  target:
-    | {
-        type: 'Commit';
-        hash: string;
-        releaseTimestamp: string;
-      }
-    | {
-        type: 'Tag';
-        target: {
-          hash: string;
-        };
-        tagger: {
-          releaseTimestamp: string;
-        };
-      };
-}
-
-export interface StoredTag extends StoredItemBase {
-  hash: string;
-  releaseTimestamp: string;
-}
-
 export class CacheableGithubTags extends AbstractGithubDatasourceCache<
-  StoredTag,
-  FetchedTag
+  GithubCachedTag,
+  GithubGraphqlTag
 > {
   readonly cacheNs = 'github-datasource-graphql-tags-v2';
   readonly graphqlQuery = query;
@@ -75,7 +55,7 @@ export class CacheableGithubTags extends AbstractGithubDatasourceCache<
     super(http, opts);
   }
 
-  coerceFetched(item: FetchedTag): StoredTag | null {
+  coerceFetched(item: GithubGraphqlTag): GithubCachedTag | null {
     const { version, target } = item;
     if (target.type === 'Commit') {
       const { hash, releaseTimestamp } = target;

--- a/lib/modules/datasource/github-tags/index.ts
+++ b/lib/modules/datasource/github-tags/index.ts
@@ -1,5 +1,5 @@
 import { logger } from '../../../logger';
-import type { GitHubTag, TagResponse } from '../../../util/github/types';
+import type { GithubRestRef, GithubRestTag } from '../../../util/github/types';
 import { getApiBaseUrl, getSourceUrl } from '../../../util/github/url';
 import { GithubHttp } from '../../../util/http/github';
 import { Datasource } from '../datasource';
@@ -26,11 +26,11 @@ export class GithubTagsDatasource extends Datasource {
     let digest: string | null = null;
     try {
       const url = `${apiBaseUrl}repos/${githubRepo}/git/refs/tags/${tag}`;
-      const res = (await this.http.getJson<TagResponse>(url)).body.object;
+      const res = (await this.http.getJson<GithubRestRef>(url)).body.object;
       if (res.type === 'commit') {
         digest = res.sha;
       } else if (res.type === 'tag') {
-        digest = (await this.http.getJson<TagResponse>(res.url)).body.object
+        digest = (await this.http.getJson<GithubRestRef>(res.url)).body.object
           .sha;
       } else {
         logger.warn({ res }, 'Unknown git tag refs type');
@@ -88,7 +88,7 @@ export class GithubTagsDatasource extends Datasource {
     const url = `${apiBaseUrl}repos/${repo}/tags?per_page=100`;
 
     const versions = (
-      await this.http.getJson<GitHubTag[]>(url, {
+      await this.http.getJson<GithubRestTag[]>(url, {
         paginate: true,
       })
     ).body.map((o) => o.name);

--- a/lib/modules/datasource/hermit/index.ts
+++ b/lib/modules/datasource/hermit/index.ts
@@ -1,6 +1,6 @@
 import { logger } from '../../../logger';
 import { cache } from '../../../util/cache/package/decorator';
-import type { GithubRelease } from '../../../util/github/types';
+import type { GithubRestRelease } from '../../../util/github/types';
 import { getApiBaseUrl } from '../../../util/github/url';
 import { GithubHttp } from '../../../util/http/github';
 import { regEx } from '../../../util/regex';
@@ -118,7 +118,7 @@ export class HermitDatasource extends Datasource {
 
     const apiBaseUrl = getApiBaseUrl(`https://${host}`);
 
-    const indexRelease = await this.http.getJson<GithubRelease>(
+    const indexRelease = await this.http.getJson<GithubRestRelease>(
       `${apiBaseUrl}repos/${owner}/${repo}/releases/tags/index`
     );
 

--- a/lib/workers/repository/update/pr/changelog/github/index.ts
+++ b/lib/workers/repository/update/pr/changelog/github/index.ts
@@ -6,8 +6,8 @@ import type {
   GithubGitTreeNode,
 } from '../../../../../../types/platform/github';
 import type {
-  GitHubTag,
-  GithubRelease,
+  GithubRestRelease,
+  GithubRestTag,
 } from '../../../../../../util/github/types';
 import { GithubHttp } from '../../../../../../util/http/github';
 import { fromBase64 } from '../../../../../../util/string';
@@ -29,7 +29,7 @@ export async function getTags(
   logger.trace('github.getTags()');
   try {
     const url = `${endpoint}repos/${repository}/tags?per_page=100`;
-    const res = await http.getJson<GitHubTag[]>(url, {
+    const res = await http.getJson<GithubRestTag[]>(url, {
       paginate: true,
     });
     const tags = res.body;
@@ -121,7 +121,7 @@ export async function getReleaseList(
   const apiBaseUrl = project.apiBaseUrl!;
   const repository = project.repository;
   const url = `${ensureTrailingSlash(apiBaseUrl)}repos/${repository}/releases`;
-  const res = await http.getJson<GithubRelease[]>(`${url}?per_page=100`, {
+  const res = await http.getJson<GithubRestRelease[]>(`${url}?per_page=100`, {
     paginate: true,
   });
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
