### PR TITLE
docs(configuration options): rewrite prHourlyLimit

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2158,20 +2158,28 @@ When you set prCreation to `not-pending` you're reducing the "noise" but get not
 
 ## prHourlyLimit
 
-This setting - if enabled - helps slow down Renovate, particularly during the onboarding phase. What may happen without this setting is:
+This config option slows down the _rate_ at which Renovate creates PRs.
 
-1. Onboarding PR is created
-2. User merges onboarding PR to activate Renovate
-3. Renovate creates a "Pin Dependencies" PR (if necessary)
-4. User merges Pin PR
-5. Renovate then creates every single upgrade PR necessary - potentially dozens
+Slowing Renovate down can be handy when you're onboarding a repository with a lot of dependencies.
+What may happen if you don't set a `prHourlyLimit`:
 
-The above can result in swamping CI systems, as well as a lot of retesting if branches need to be rebased every time one is merged.
-Instead, if `prHourlyLimit` is configure to a value like 1 or 2, it will mean that Renovate creates at most that many new PRs within each hourly period (:00-:59).
-So the project should still result in all PRs created perhaps within the first 24 hours maximum, but at a rate that may allow users to merge them once they pass tests.
-It does not place a limit on the number of _concurrently open_ PRs - only on the rate they are created.
+1. Renovate creates a Onboarding PR
+1. You merge the onboarding PR to activate Renovate
+1. Renovate creates a "Pin Dependencies" PR (if needed)
+1. You merge the "Pin Dependencies" PR
+1. Renovate creates every single upgrade PR needed, which can be a lot. This may cause:
+    - Renovate bot's PRs to overwhelm your CI systems
+    - a lot of test runs, because branches are rebased each time you merge a PR
 
-This limit is enforced on a per-repository basis.
+To prevent these problems you can set `prHourlyLimit` to a value like `1` or `2`.
+Renovate will only create that many PRs within each hourly period (`:00` through `:59`).
+You still get all the PRs in a reasonable time, perhaps over a day or so.
+Now you can merge the PRs at a do-able rate, once the tests pass.
+
+<!-- prettier-ignore -->
+!!! tip
+    The `prHourlyLimit` setting does _not_ limit the number of _concurrently open PRs_, only the _rate_ at which PRs are created.
+    The `prHourlyLimit` setting is enforced on a per-repository basis.
 
 ## prNotPendingHours
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2168,8 +2168,8 @@ What may happen if you don't set a `prHourlyLimit`:
 1. Renovate creates a "Pin Dependencies" PR (if needed)
 1. You merge the "Pin Dependencies" PR
 1. Renovate creates every single upgrade PR needed, which can be a lot. This may cause:
-    - Renovate bot's PRs to overwhelm your CI systems
-    - a lot of test runs, because branches are rebased each time you merge a PR
+   - Renovate bot's PRs to overwhelm your CI systems
+   - a lot of test runs, because branches are rebased each time you merge a PR
 
 To prevent these problems you can set `prHourlyLimit` to a value like `1` or `2`.
 Renovate will only create that many PRs within each hourly period (`:00` through `:59`).


### PR DESCRIPTION
## Changes

- Make it clearer that this option is about _rate_ limits, not concurrent limits
- Use `you` and `Renovate` to make clear _who_ does what
- Add possible problems into the first list
- Use `1.`'s to create the ordered list, don't bother manually numbering the list
- Create `tip` admonition for two important points:
  - Re-iterate that it's about _rate_ limiting
  - That `prHourlyLimit` is enforced per-repository

## Context

This needed a big rewrite. 😄 

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
