### PR TITLE
fix(npm): remove memcache

### DIFF
--- a/lib/modules/datasource/npm/get.spec.ts
+++ b/lib/modules/datasource/npm/get.spec.ts
@@ -2,7 +2,7 @@ import * as httpMock from '../../../../test/http-mock';
 import { ExternalHostError } from '../../../types/errors/external-host-error';
 import * as hostRules from '../../../util/host-rules';
 import { Http } from '../../../util/http';
-import { getDependency, resetMemCache } from './get';
+import { getDependency } from './get';
 import { resolveRegistryUrl, setNpmrc } from './npmrc';
 
 function getPath(s = ''): string {
@@ -16,7 +16,6 @@ const http = new Http('npm');
 describe('modules/datasource/npm/get', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    resetMemCache();
     hostRules.clear();
     setNpmrc();
   });

--- a/lib/modules/datasource/npm/index.spec.ts
+++ b/lib/modules/datasource/npm/index.spec.ts
@@ -4,7 +4,7 @@ import * as httpMock from '../../../../test/http-mock';
 import { GlobalConfig } from '../../../config/global';
 import { EXTERNAL_HOST_ERROR } from '../../../constants/error-messages';
 import * as hostRules from '../../../util/host-rules';
-import { NpmDatasource, resetCache, setNpmrc } from '.';
+import { NpmDatasource, setNpmrc } from '.';
 
 const datasource = NpmDatasource.id;
 
@@ -17,7 +17,6 @@ describe('modules/datasource/npm/index', () => {
     jest.resetAllMocks();
     GlobalConfig.reset();
     hostRules.clear();
-    resetCache();
     setNpmrc();
     npmResponse = {
       name: 'foobar',

--- a/lib/modules/datasource/npm/index.spec.ts
+++ b/lib/modules/datasource/npm/index.spec.ts
@@ -299,18 +299,6 @@ describe('modules/datasource/npm/index', () => {
     expect(res).toMatchSnapshot();
   });
 
-  it('should cache package info from npm', async () => {
-    httpMock
-      .scope('https://registry.npmjs.org')
-      .get('/foobar')
-      .reply(200, npmResponse);
-    const npmrc = '//registry.npmjs.org/:_authToken=abcdefghijklmnopqrstuvwxyz';
-    const res1 = await getPkgReleases({ datasource, depName: 'foobar', npmrc });
-    const res2 = await getPkgReleases({ datasource, depName: 'foobar', npmrc });
-    expect(res1).not.toBeNull();
-    expect(res1).toEqual(res2);
-  });
-
   it('should fetch package info from custom registry', async () => {
     httpMock
       .scope('https://npm.mycustomregistry.com', {})

--- a/lib/modules/datasource/npm/index.ts
+++ b/lib/modules/datasource/npm/index.ts
@@ -4,7 +4,6 @@ import type { GetReleasesConfig, ReleaseResult } from '../types';
 import { id } from './common';
 import { getDependency } from './get';
 
-export { resetMemCache, resetCache } from './get';
 export { setNpmrc } from './npmrc';
 
 export class NpmDatasource extends Datasource {

--- a/lib/workers/repository/init/cache.ts
+++ b/lib/workers/repository/init/cache.ts
@@ -10,7 +10,6 @@ export async function resetCaches(): Promise<void> {
   memCache.reset();
   repositoryCache.resetCache();
   await fs.remove(privateCacheDir());
-  npmApi.resetMemCache();
 }
 
 export async function initializeCaches(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Removes the npm datasource's custom memcache.

## Context

It should not be necessary if the datasource layer is already performing caching.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
