### PR TITLE
docs(configuration options): split list

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2170,9 +2170,12 @@ What may happen if you don't set a `prHourlyLimit`:
 1. You merge the onboarding PR to activate Renovate
 1. Renovate creates a "Pin Dependencies" PR (if needed)
 1. You merge the "Pin Dependencies" PR
-1. Renovate creates every single upgrade PR needed, which can be a lot. This may cause:
-   - Renovate bot's PRs to overwhelm your CI systems
-   - a lot of test runs, because branches are rebased each time you merge a PR
+1. Renovate creates every single upgrade PR needed, which can be a lot.
+ 
+The above may cause:
+
+- Renovate bot's PRs to overwhelm your CI systems
+- a lot of test runs, because branches are rebased each time you merge a PR
 
 To prevent these problems you can set `prHourlyLimit` to a value like `1` or `2`.
 Renovate will only create that many PRs within each hourly period (`:00` through `:59`).

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2171,7 +2171,7 @@ What may happen if you don't set a `prHourlyLimit`:
 1. Renovate creates a "Pin Dependencies" PR (if needed)
 1. You merge the "Pin Dependencies" PR
 1. Renovate creates every single upgrade PR needed, which can be a lot
- 
+
 The above may cause:
 
 - Renovate bot's PRs to overwhelm your CI systems

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2170,7 +2170,7 @@ What may happen if you don't set a `prHourlyLimit`:
 1. You merge the onboarding PR to activate Renovate
 1. Renovate creates a "Pin Dependencies" PR (if needed)
 1. You merge the "Pin Dependencies" PR
-1. Renovate creates every single upgrade PR needed, which can be a lot.
+1. Renovate creates every single upgrade PR needed, which can be a lot
  
 The above may cause:
 


### PR DESCRIPTION
## Changes

- Split list into two parts

## Context

Fixing up this PR:

- #17707

The original layout looks good on the GitHub preview, but it breaks in the published docs (the lists keeps numbering instead of adding bullet points). 🙈 

I'm splitting the list into two parts, which should display correctly. 😄

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
