### PR TITLE
fix(package-rules): matchCurrentVersion with locked versions

### DIFF
--- a/lib/util/package-rules/current-version.spec.ts
+++ b/lib/util/package-rules/current-version.spec.ts
@@ -39,5 +39,46 @@ describe('util/package-rules/current-version', () => {
       );
       expect(result).toBeFalse();
     });
+
+    it('return false for regex version non match', () => {
+      const result = matcher.matches(
+        {
+          versioning: 'ruby',
+          currentValue: '"~> 1.1.0"',
+          lockedVersion: '1.1.4',
+        },
+        {
+          matchCurrentVersion: '/^v?[~ -]?0/',
+        }
+      );
+      expect(result).toBeFalse();
+    });
+
+    it('return true for regex version match', () => {
+      const result = matcher.matches(
+        {
+          versioning: 'ruby',
+          currentValue: '"~> 0.1.0"',
+          lockedVersion: '0.1.0',
+        },
+        {
+          matchCurrentVersion: '/^v?[~ -]?0/',
+        }
+      );
+      expect(result).toBeTrue();
+    });
+
+    it('return false for regex value match', () => {
+      const result = matcher.matches(
+        {
+          versioning: 'ruby',
+          currentValue: '"~> 0.1.0"',
+        },
+        {
+          matchCurrentVersion: '/^v?[~ -]?0/',
+        }
+      );
+      expect(result).toBeFalse();
+    });
   });
 });

--- a/lib/util/package-rules/current-version.ts
+++ b/lib/util/package-rules/current-version.ts
@@ -18,12 +18,8 @@ export class CurrentVersionMatcher extends Matcher {
     if (is.undefined(matchCurrentVersion)) {
       return null;
     }
-
-    if (is.nullOrUndefined(currentValue)) {
-      return false;
-    }
-
-    const isUnconstrainedValue = !!lockedVersion;
+    const isUnconstrainedValue =
+      !!lockedVersion && is.nullOrUndefined(currentValue);
     const version = allVersioning.get(versioning);
     const matchCurrentVersionStr = matchCurrentVersion.toString();
     const matchCurrentVersionPred = configRegexPredicate(
@@ -31,13 +27,20 @@ export class CurrentVersionMatcher extends Matcher {
     );
 
     if (matchCurrentVersionPred) {
-      return !(!isUnconstrainedValue && !matchCurrentVersionPred(currentValue));
+      const compareVersion = lockedVersion ?? currentVersion ?? currentValue;
+      return (
+        !is.nullOrUndefined(compareVersion) &&
+        matchCurrentVersionPred(compareVersion)
+      );
     }
     if (version.isVersion(matchCurrentVersionStr)) {
       try {
         return (
           isUnconstrainedValue ||
-          version.matches(matchCurrentVersionStr, currentValue)
+          !!(
+            currentValue &&
+            version.matches(matchCurrentVersionStr, currentValue)
+          )
         );
       } catch (err) {
         return false;
@@ -47,7 +50,7 @@ export class CurrentVersionMatcher extends Matcher {
     const compareVersion = version.isVersion(currentValue)
       ? currentValue // it's a version so we can match against it
       : lockedVersion ?? currentVersion; // need to match against this currentVersion, if available
-    if (is.undefined(compareVersion)) {
+    if (is.nullOrUndefined(compareVersion)) {
       return false;
     }
     if (version.isVersion(compareVersion)) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Fixes `isUnconstrainedValue` to avoid `false` values when locked versions exist.

## Context

Closes #17670

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
