### PR TITLE
fix(http): don't cache request errors/exceptions

### DIFF
--- a/lib/util/http/index.ts
+++ b/lib/util/http/index.ts
@@ -175,6 +175,7 @@ export class Http<GetOptions = HttpOptions, PostOptions = HttpPostOptions> {
       res.authorization = !!options?.headers?.authorization;
       return cloneResponse(res);
     } catch (err) {
+      memCache.set(cacheKey, undefined);
       const { abortOnError, abortIgnoreStatusCodes } = options;
       if (abortOnError && !abortIgnoreStatusCodes?.includes(err.statusCode)) {
         throw new ExternalHostError(err);


### PR DESCRIPTION
## Changes

HTTP requests have an opt-out caching behavior for all GET and HEAD requests.
This PR evicts the cache entry for a given request when the request ends up failing/throwing, allowing a retry to go through down the line.

## Context

We use Renovate to handle upgrades in projects with dependencies stored in a private `npm` packages repository.
Said repository reliability is less than stellar, and we've observed different failure-modes while trying to download/install packages, such as gateway timeouts (504s), throttling (429s) and temporary request denials (403s).

Recently, our Renovate dashboards started showing warnings re: dependency lookup on private packages, all with a similar error.
These dependencies were being updated regularly until then.
From the renovate logs:

```js
DEBUG: Failed to look up dependency @xxx/yyy (@xxx/yyy) (packageFile="package.json", dependency="@xxx/yyy")
DEBUG: Unknown npm lookup error
{
  "err": {
    "name": "HTTPError",
    "code": "ERR_NON_2XX_3XX_RESPONSE",
    ...
    "message": "Response code 504 (Gateway Timeout)",
```

Requesting Renovate to run again on the repositories led to the same error, even after days.
The credentials were configured correctly, and were being successfully used both locally and in other CI tasks. 
On the occasional CI failures caused by errors while downloading packages, a retry worked. 

Given the above, we suspected we had gotten unlucky and a temporary downtime ended up being cached. 
Through inspection (and luck, to balance things out!), we found such a cache on Renovate.

- [x] No documentation update is required
- [x] I have verified these changes via newly added/modified unit tests