### PR TITLE
fix(elixir): latest Elixir build and bump default version

### DIFF
--- a/lib/modules/manager/regex/__fixtures__/Dockerfile
+++ b/lib/modules/manager/regex/__fixtures__/Dockerfile
@@ -106,9 +106,9 @@ RUN apt-get update && \
 
 # Elixir
 
-ENV ELIXIR_VERSION=1.8.2
+ENV ELIXIR_VERSION=1.11.4
 
-RUN curl -L https://github.com/elixir-lang/elixir/releases/download/v${ELIXIR_VERSION}/Precompiled.zip -o Precompiled.zip && \
+RUN curl -L https://repo.hex.pm/builds/elixir/v${ELIXIR_VERSION}.zip -o Precompiled.zip && \
   mkdir -p /opt/elixir-${ELIXIR_VERSION}/ && \
   unzip Precompiled.zip -d /opt/elixir-${ELIXIR_VERSION}/ && \
   rm Precompiled.zip


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Lately Elixir dependencies have been failing to upgrade because of the change of format in release assets.

GitHub releases are only recommended for developers to download.

Automations are recommended to use the builds from https://repo.hex.pm/.

Hence changing the URL.

Additionally bumping the default elixir version. Normally the latest 4 minor versions are supported by libs. The current latest minor is `1.14.0`, so I'm bumping the default to `1.11.4`.

## Context

Been getting this lately

### ⚠ Artifact update problem

Renovate failed to update an artifact related to this branch. You probably do not want to merge this PR as-is.

♻ Renovate will retry this branch, including artifacts, only when one of the following happens:

 - any of the package files in this branch needs updating, or 
 - the branch becomes conflicted, or
 - you click the rebase/retry checkbox if found above, or
 - you rename this PR's title to start with "rebase!" to trigger it manually

The artifact failure details are included below:

##### File name: mix.lock

```
Command failed: docker run --rm --name=renovate_sidecar --label=renovate_child -v "/mnt/renovate/gh/princemaple/songri-desk":"/mnt/renovate/gh/princemaple/songri-desk" -v "/tmp/renovate-cache":"/tmp/renovate-cache" -v "/tmp/containerbase":"/tmp/containerbase" -e BUILDPACK_CACHE_DIR -w "/mnt/renovate/gh/princemaple/songri-desk" docker.io/renovate/sidecar bash -l -c "install-tool erlang 24.3.4.0 && install-tool elixir v1.14.0 && mix deps.update jason"
curl: (22) The requested URL returned error: 404 
Download failed: https://github.com/elixir-lang/elixir/releases/download/v1.14.0/Precompiled.zip
```

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
