### PR TITLE
fix: Elevate Git/GitHub error debug logging to error logging

### DIFF
--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -78,7 +78,7 @@ export async function gitRetry<T>(gitFunc: () => Promise<T>): Promise<T> {
       return res;
     } catch (err) {
       lastError = err;
-      logger.debug({ err }, `Git function thrown`);
+      logger.error({ err }, `Git function thrown`);
       // Try to transform the Error to ExternalHostError
       const errChecked = checkForPlatformFailure(err);
       if (errChecked instanceof ExternalHostError) {
@@ -216,7 +216,7 @@ async function fetchBranchCommits(): Promise<void> {
     if (errChecked) {
       throw errChecked;
     }
-    logger.debug({ err }, 'git error');
+    logger.error({ err }, 'git error');
     if (err.message?.includes('Please ask the owner to check their account')) {
       throw new Error(REPOSITORY_DISABLED);
     }
@@ -395,7 +395,7 @@ export async function syncGit(): Promise<void> {
       };
       await gitRetry(() => emptyDirAndClone());
     } catch (err) /* istanbul ignore next */ {
-      logger.debug({ err }, 'git clone error');
+      logger.error({ err }, 'git clone error');
       if (err.message?.includes('No space left on device')) {
         throw new Error(SYSTEM_INSUFFICIENT_DISK_SPACE);
       }
@@ -630,7 +630,7 @@ export async function isBranchModified(branchName: string): Promise<boolean> {
     ).trim();
   } catch (err) /* istanbul ignore next */ {
     if (err.message?.includes('fatal: bad revision')) {
-      logger.debug(
+      logger.error(
         { err },
         'Remote branch not found when checking last commit author - aborting run'
       );
@@ -776,7 +776,7 @@ export async function mergeBranch(branchName: string): Promise<void> {
     await gitRetry(() => git.push('origin', config.currentBranch));
     incLimitedValue(Limit.Commits);
   } catch (err) {
-    logger.debug(
+    logger.error(
       {
         baseBranch: config.currentBranch,
         baseSha: config.currentBranchSha,

--- a/lib/util/http/github.ts
+++ b/lib/util/http/github.ts
@@ -73,44 +73,44 @@ function handleGotError(
     err.code === 'EAI_AGAIN' ||
     err.code === 'ECONNRESET'
   ) {
-    logger.debug({ err }, 'GitHub failure: RequestError');
+    logger.error({ err }, 'GitHub failure: RequestError');
     return new ExternalHostError(err, PlatformId.Github);
   }
   if (err.name === 'ParseError') {
-    logger.debug({ err }, '');
+    logger.error({ err }, '');
     return new ExternalHostError(err, PlatformId.Github);
   }
   if (err.statusCode && err.statusCode >= 500 && err.statusCode < 600) {
-    logger.debug({ err }, 'GitHub failure: 5xx');
+    logger.error({ err }, 'GitHub failure: 5xx');
     return new ExternalHostError(err, PlatformId.Github);
   }
   if (
     err.statusCode === 403 &&
     message.startsWith('You have triggered an abuse detection mechanism')
   ) {
-    logger.debug({ err }, 'GitHub failure: abuse detection');
+    logger.error({ err }, 'GitHub failure: abuse detection');
     return new Error(PLATFORM_RATE_LIMIT_EXCEEDED);
   }
   if (
     err.statusCode === 403 &&
     message.startsWith('You have exceeded a secondary rate limit')
   ) {
-    logger.debug({ err }, 'GitHub failure: secondary rate limit');
+    logger.error({ err }, 'GitHub failure: secondary rate limit');
     return new Error(PLATFORM_RATE_LIMIT_EXCEEDED);
   }
   if (err.statusCode === 403 && message.includes('Upgrade to GitHub Pro')) {
-    logger.debug({ path }, 'Endpoint needs paid GitHub plan');
+    logger.error({ path }, 'Endpoint needs paid GitHub plan');
     return err;
   }
   if (err.statusCode === 403 && message.includes('rate limit exceeded')) {
-    logger.debug({ err }, 'GitHub failure: rate limit');
+    logger.error({ err }, 'GitHub failure: rate limit');
     return new Error(PLATFORM_RATE_LIMIT_EXCEEDED);
   }
   if (
     err.statusCode === 403 &&
     message.startsWith('Resource not accessible by integration')
   ) {
-    logger.debug(
+    logger.error(
       { err },
       'GitHub failure: Resource not accessible by integration'
     );
@@ -118,7 +118,7 @@ function handleGotError(
   }
   if (err.statusCode === 401 && message.includes('Bad credentials')) {
     const rateLimit = err.headers?.['x-ratelimit-limit'] ?? -1;
-    logger.debug(
+    logger.error(
       {
         token: maskToken(opts.token),
         err,
@@ -136,7 +136,7 @@ function handleGotError(
     ) {
       return err;
     } else if (err.body?.errors?.find((e: any) => e.code === 'invalid')) {
-      logger.debug({ err }, 'Received invalid response - aborting');
+      logger.error({ err }, 'Received invalid response - aborting');
       return new Error(REPOSITORY_CHANGED);
     } else if (
       err.body?.errors?.find((e: any) =>
@@ -145,7 +145,7 @@ function handleGotError(
     ) {
       return err;
     }
-    logger.debug({ err }, '422 Error thrown from GitHub');
+    logger.error({ err }, '422 Error thrown from GitHub');
     return new ExternalHostError(err, PlatformId.Github);
   }
   if (
@@ -155,9 +155,9 @@ function handleGotError(
     return err;
   }
   if (err.statusCode === 404) {
-    logger.debug({ url: path }, 'GitHub 404');
+    logger.error({ url: path }, 'GitHub 404');
   } else {
-    logger.debug({ err }, 'Unknown GitHub error');
+    logger.error({ err }, 'Unknown GitHub error');
   }
   return err;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This will elevate error messages logged using `logger.debug` in GitHub/Git logic (specifically `lib/util/http/github.ts` and `lib/util/git/index.ts`) to instead log these errors via `logger.error` to accurately reflect that the errors are in fact unexpected errors.

## Context

These changes will make it easier to stay updated on Git/GitHub issues occurring when using Renovate. 

Git/GitHub error messages reflect actual errors happening when Renovate attempts to update/process repositories and will be labelled as such in this PR. 

Labeling these errors accurately makes it possible to accurately label/alert on these errors in log processors (such as DataDog) to let teams be alerted when Renovate has issues processing repositories within an organisation. 

Currently, these errors drown in the debug output Renovate logs in normal operation which makes it hard to determine when action needs to be taken (e.g. when self-hosting Renovate which we are in [Pleo](https://pleo.io/en)).  

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required _(please let me know if this is not the case!)_

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [X] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
