### PR TITLE
feat(platform/bitbucket): update to use effective default reviewers

### DIFF
--- a/lib/modules/platform/bitbucket/index.spec.ts
+++ b/lib/modules/platform/bitbucket/index.spec.ts
@@ -696,11 +696,29 @@ describe('modules/platform/bitbucket/index', () => {
 
   describe('createPr()', () => {
     it('posts PR', async () => {
+      const projectReviewer = {
+        type: 'default_reviewer',
+        reviewer_type: 'project',
+        user: {
+          display_name: 'Bob Smith',
+          uuid: '{d2238482-2e9f-48b3-8630-de22ccb9e42f}',
+          account_id: '123',
+        },
+      };
+      const repoReviewer = {
+        type: 'default_reviewer',
+        reviewer_type: 'repository',
+        user: {
+          display_name: 'Jane Smith',
+          uuid: '{90b6646d-1724-4a64-9fd9-539515fe94e9}',
+          account_id: '456',
+        },
+      };
       const scope = await initRepoMock();
       scope
-        .get('/2.0/repositories/some/repo/default-reviewers')
+        .get('/2.0/repositories/some/repo/effective-default-reviewers')
         .reply(200, {
-          values: [{ uuid: '{1234-5678}' }],
+          values: [projectReviewer, repoReviewer],
         })
         .post('/2.0/repositories/some/repo/pullrequests')
         .reply(200, { id: 5 });
@@ -718,18 +736,22 @@ describe('modules/platform/bitbucket/index', () => {
 
     it('removes inactive reviewers when updating pr', async () => {
       const inactiveReviewer = {
-        display_name: 'Bob Smith',
-        uuid: '{d2238482-2e9f-48b3-8630-de22ccb9e42f}',
-        account_id: '123',
+        user: {
+          display_name: 'Bob Smith',
+          uuid: '{d2238482-2e9f-48b3-8630-de22ccb9e42f}',
+          account_id: '123',
+        },
       };
       const activeReviewer = {
-        display_name: 'Jane Smith',
-        uuid: '{90b6646d-1724-4a64-9fd9-539515fe94e9}',
-        account_id: '456',
+        user: {
+          display_name: 'Jane Smith',
+          uuid: '{90b6646d-1724-4a64-9fd9-539515fe94e9}',
+          account_id: '456',
+        },
       };
       const scope = await initRepoMock();
       scope
-        .get('/2.0/repositories/some/repo/default-reviewers')
+        .get('/2.0/repositories/some/repo/effective-default-reviewers')
         .reply(200, {
           values: [activeReviewer, inactiveReviewer],
         })
@@ -767,18 +789,22 @@ describe('modules/platform/bitbucket/index', () => {
 
     it('removes default reviewers no longer member of the workspace when creating pr', async () => {
       const notMemberReviewer = {
-        display_name: 'Bob Smith',
-        uuid: '{d2238482-2e9f-48b3-8630-de22ccb9e42f}',
-        account_id: '123',
+        user: {
+          display_name: 'Bob Smith',
+          uuid: '{d2238482-2e9f-48b3-8630-de22ccb9e42f}',
+          account_id: '123',
+        },
       };
       const memberReviewer = {
-        display_name: 'Jane Smith',
-        uuid: '{90b6646d-1724-4a64-9fd9-539515fe94e9}',
-        account_id: '456',
+        user: {
+          display_name: 'Jane Smith',
+          uuid: '{90b6646d-1724-4a64-9fd9-539515fe94e9}',
+          account_id: '456',
+        },
       };
       const scope = await initRepoMock();
       scope
-        .get('/2.0/repositories/some/repo/default-reviewers')
+        .get('/2.0/repositories/some/repo/effective-default-reviewers')
         .reply(200, {
           values: [memberReviewer, notMemberReviewer],
         })
@@ -819,13 +845,15 @@ describe('modules/platform/bitbucket/index', () => {
 
     it('throws exception when unable to check default reviewers workspace membership', async () => {
       const reviewer = {
-        display_name: 'Bob Smith',
-        uuid: '{d2238482-2e9f-48b3-8630-de22ccb9e42f}',
-        account_id: '123',
+        user: {
+          display_name: 'Bob Smith',
+          uuid: '{d2238482-2e9f-48b3-8630-de22ccb9e42f}',
+          account_id: '123',
+        },
       };
       const scope = await initRepoMock();
       scope
-        .get('/2.0/repositories/some/repo/default-reviewers')
+        .get('/2.0/repositories/some/repo/effective-default-reviewers')
         .reply(200, {
           values: [reviewer],
         })
@@ -861,13 +889,15 @@ describe('modules/platform/bitbucket/index', () => {
 
     it('rethrows exception when PR create error due to unknown reviewers error', async () => {
       const reviewer = {
-        display_name: 'Jane Smith',
-        uuid: '{90b6646d-1724-4a64-9fd9-539515fe94e9}',
+        user: {
+          display_name: 'Jane Smith',
+          uuid: '{90b6646d-1724-4a64-9fd9-539515fe94e9}',
+        },
       };
 
       const scope = await initRepoMock();
       scope
-        .get('/2.0/repositories/some/repo/default-reviewers')
+        .get('/2.0/repositories/some/repo/effective-default-reviewers')
         .reply(200, {
           values: [reviewer],
         })
@@ -896,13 +926,15 @@ describe('modules/platform/bitbucket/index', () => {
 
     it('rethrows exception when PR create error not due to reviewers field', async () => {
       const reviewer = {
-        display_name: 'Jane Smith',
-        uuid: '{90b6646d-1724-4a64-9fd9-539515fe94e9}',
+        user: {
+          display_name: 'Jane Smith',
+          uuid: '{90b6646d-1724-4a64-9fd9-539515fe94e9}',
+        },
       };
 
       const scope = await initRepoMock();
       scope
-        .get('/2.0/repositories/some/repo/default-reviewers')
+        .get('/2.0/repositories/some/repo/effective-default-reviewers')
         .reply(200, {
           values: [reviewer],
         })

--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -35,6 +35,7 @@ import * as comments from './comments';
 import * as utils from './utils';
 import {
   Account,
+  EffectiveReviewer,
   PrResponse,
   RepoInfoBody,
   mergeBodyTransformer,
@@ -738,12 +739,12 @@ export async function createPr({
 
   if (platformOptions?.bbUseDefaultReviewers) {
     const reviewersResponse = (
-      await bitbucketHttp.getJson<utils.PagedResult<Account>>(
-        `/2.0/repositories/${config.repository}/default-reviewers`
+      await bitbucketHttp.getJson<utils.PagedResult<EffectiveReviewer>>(
+        `/2.0/repositories/${config.repository}/effective-default-reviewers`
       )
     ).body;
-    reviewers = reviewersResponse.values.map((reviewer: Account) => ({
-      uuid: reviewer.uuid,
+    reviewers = reviewersResponse.values.map((reviewer: EffectiveReviewer) => ({
+      uuid: reviewer.user.uuid,
     }));
   }
 

--- a/lib/modules/platform/bitbucket/utils.ts
+++ b/lib/modules/platform/bitbucket/utils.ts
@@ -201,3 +201,9 @@ export interface Account {
   nickname?: string;
   account_status?: string;
 }
+
+export interface EffectiveReviewer {
+  type: string;
+  reviewer_type: string;
+  user: Account;
+}


### PR DESCRIPTION
## Changes

Migrates the existing logic to use a new **Effective Default Reviewers** Bitbucket Cloud API endpoint.

This endpoint returns a union of the repository-level reviewers, as well as the any project-level reviewers 

<!-- Describe what behavior is changed by this PR. -->

## Context

Atlassian recently released Project Settings in Bitbucket Cloud ([announcement article](https://bitbucket.org/blog/project-settings-are-now-available-in-bitbucket-cloud)).  This new featureset allows project-level default reviewers to be defined, so that they can be inherited by all repositories inside the project.


Behavior in current release of Renovate is mixed:
* ✅ repository-level default reviewers only, behaves as expected.
* ✅ project-level default reviewers only.  Renovate creates a PR without any reviewers, but Bitbucket Cloud is "smart enough" to attach the project-level reviewers
* ⚠️ mixture of project-level and repository-level default reviewers.  Renovate PRs only have repository-level reviewers.  Any project-level reviewers are omitted



<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
