### PR TITLE
fix(bitbucket-server): Fix retrival of config files with oneline json5 comments

### DIFF
--- a/lib/config/presets/bitbucket-server/index.spec.ts
+++ b/lib/config/presets/bitbucket-server/index.spec.ts
@@ -60,7 +60,11 @@ describe('config/presets/bitbucket-server/index', () => {
         .query({ limit: 20000 })
         .reply(200, {
           isLastPage: true,
-          lines: [{ text: '{from:"api"' }, {text: '//some comment'}, { text: '}' }],
+          lines: [
+            { text: '{from:"api"' },
+            { text: '//some comment' },
+            { text: '}' },
+          ],
         });
 
       const res = await bitbucketServer.fetchJSONFile(

--- a/lib/config/presets/bitbucket-server/index.spec.ts
+++ b/lib/config/presets/bitbucket-server/index.spec.ts
@@ -53,6 +53,24 @@ describe('config/presets/bitbucket-server/index', () => {
       expect(res).toEqual({ from: 'api' });
     });
 
+    it('supports line comments in JSON5', async () => {
+      httpMock
+        .scope(bitbucketApiHost)
+        .get(`${basePath}/some-filename.json5`)
+        .query({ limit: 20000 })
+        .reply(200, {
+          isLastPage: true,
+          lines: [{ text: '{from:"api"' }, {text: '//some comment'}, { text: '}' }],
+        });
+
+      const res = await bitbucketServer.fetchJSONFile(
+        'some/repo',
+        'some-filename.json5',
+        bitbucketApiHost
+      );
+      expect(res).toEqual({ from: 'api' });
+    });
+
     it('handles branches/tags', async () => {
       httpMock
         .scope(bitbucketApiHost)

--- a/lib/config/presets/bitbucket-server/index.ts
+++ b/lib/config/presets/bitbucket-server/index.ts
@@ -46,7 +46,7 @@ export async function fetchJSONFile(
     logger.warn({ size: res.body.size }, 'Renovate config too big');
     throw new Error(PRESET_INVALID_JSON);
   }
-  return parsePreset(res.body.lines.map((l) => l.text).join(''));
+  return parsePreset(res.body.lines.map((l) => l.text).join('\n'));
 }
 
 export function getPresetFromEndpoint(

--- a/lib/modules/platform/bitbucket-server/index.spec.ts
+++ b/lib/modules/platform/bitbucket-server/index.spec.ts
@@ -2101,12 +2101,12 @@ Followed by some information.
         });
 
         it('returns file content in json5 format', async () => {
-          const json5Data = `
-          {
-            // json5 comment
-            foo: 'bar'
-          }
-        `;
+          const lines = [
+            { text: '{' },
+            { text: '  // json5 comment' },
+            { text: '  foo: "bar"' },
+            { text: '}' },
+          ];
           const scope = await initRepo();
           scope
             .get(
@@ -2114,7 +2114,7 @@ Followed by some information.
             )
             .reply(200, {
               isLastPage: true,
-              lines: [{ text: json5Data }],
+              lines: lines,
             });
           const res = await bitbucket.getJsonFile('file.json5');
           expect(res).toEqual({ foo: 'bar' });

--- a/lib/modules/platform/bitbucket-server/index.ts
+++ b/lib/modules/platform/bitbucket-server/index.ts
@@ -133,7 +133,7 @@ export async function getRawFile(
   const res = await bitbucketServerHttp.getJson<FileData>(fileUrl);
   const { isLastPage, lines, size } = res.body;
   if (isLastPage) {
-    return lines.map(({ text }) => text).join('');
+    return lines.map(({ text }) => text).join('\n');
   }
   const msg = `The file is too big (${size}B)`;
   logger.warn({ size }, msg);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

When retrieving rawFiles from bitbucket server (presets or other files), the retrieved lines are now concatenated with new line characters.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

- Closes #17321

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
