### PR TITLE
build: update gitignore to ignore any config.js* files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /node_modules
-/config.js
+/config.js*
 /coverage
 /dist
 /tmp


### PR DESCRIPTION
## Changes

Update `.gitignore` to exclude config.js*

## Context

I have several config.js files which I switch between to test different platforms(eg: bitbucket vs github) and configurations

I keep these named as `config.js.github`, `config.js.bitbucket` etc

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
