### PR TITLE
docs: Refine list of fields supporting handlebars templates

### DIFF
--- a/docs/usage/templates.md
+++ b/docs/usage/templates.md
@@ -5,7 +5,7 @@ description: Explain Renovate template fields
 
 # Template fields
 
-In order to provide flexible configuration, Renovate supports using "templates" for certain fields like `branchName`.
+In order to provide flexible configuration, Renovate supports using "templates" for certain fields like `addLabels`, `branchName`, `extractVersionTemplate`, `labels`.
 
 Renovate's templates use [handlebars](https://handlebarsjs.com/) under the hood.
 You can recognize templates when you see strings like `{{depName}}` in configuration fields.


### PR DESCRIPTION
## Changes

Refine list of fields supporting handlebars templates, as most fields don't mention they support templates, see https://docs.renovatebot.com/configuration-options/#addlabels https://docs.renovatebot.com/configuration-options/#labels https://docs.renovatebot.com/configuration-options/#extractversiontemplate

Actually, it would be much better to have a programmatic flag on each parameter to automatically document templates support, but this PR is a first step to testify of the need of better documentation (unless I missed it somewhere)

## Context

* Describe why you're making these changes if it's not already explained in a corresponding issue. * 

Trying to discover which fields support templates

<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
