### PR TITLE
fix(composer): Revert "feat(manager/composer): support git-tags hostRules for github.com when updating artifacts"

### DIFF
--- a/docs/usage/getting-started/private-packages.md
+++ b/docs/usage/getting-started/private-packages.md
@@ -179,21 +179,6 @@ The following details the most common/popular manager artifacts updating and how
 
 Any `hostRules` token for `github.com` or `gitlab.com` are found and written out to `COMPOSER_AUTH` in env for Composer to parse.
 Any `hostRules` with `hostType=packagist` are also included.
-For dependencies on `github.com` without a packagist server, a hostRule with `hostType=git-tags` should be used with a personal access token (not an application token).
-Do not add a hostRule with `hostType=github` because it can override the default renovate application token for everything else and cause unwanted side effects.
-
-The repository in `composer.json` should have the `vcs` type with a `https` url. Ex:
-
-```json
-{
-  "repositories": [
-    {
-      "type": "vcs",
-      "url": "https://github.com/organization/private-repository"
-    }
-  ]
-}
-```
 
 ### gomod
 

--- a/lib/modules/manager/composer/artifacts.spec.ts
+++ b/lib/modules/manager/composer/artifacts.spec.ts
@@ -8,7 +8,6 @@ import * as docker from '../../../util/exec/docker';
 import type { StatusResult } from '../../../util/git/types';
 import * as hostRules from '../../../util/host-rules';
 import * as _datasource from '../../datasource';
-import { GitTagsDatasource } from '../../datasource/git-tags';
 import { PackagistDatasource } from '../../datasource/packagist';
 import type { UpdateArtifactsConfig } from '../types';
 import * as composer from '.';
@@ -114,13 +113,7 @@ describe('modules/manager/composer/artifacts', () => {
     hostRules.add({
       hostType: PlatformId.Github,
       matchHost: 'api.github.com',
-      token: 'ghp_github-token',
-    });
-    // This rule should not affect the result the Github rule has priority to avoid breaking changes.
-    hostRules.add({
-      hostType: GitTagsDatasource.id,
-      matchHost: 'github.com',
-      token: 'ghp_git-tags-token',
+      token: 'github-token',
     });
     hostRules.add({
       hostType: PlatformId.Gitlab,
@@ -172,87 +165,8 @@ describe('modules/manager/composer/artifacts', () => {
           cwd: '/tmp/github/some/repo',
           env: {
             COMPOSER_AUTH:
-              '{"github-oauth":{"github.com":"ghp_git-tags-token"},' +
-              '"gitlab-token":{"gitlab.com":"gitlab-token"},' +
-              '"gitlab-domains":["gitlab.com"],' +
-              '"http-basic":{' +
-              '"packagist.renovatebot.com":{"username":"some-username","password":"some-password"},' +
-              '"artifactory.yyyyyyy.com":{"username":"some-other-username","password":"some-other-password"}' +
-              '},' +
-              '"bearer":{"packages-bearer.example.com":"abcdef0123456789"}}',
+              '{"github-oauth":{"github.com":"github-token"},"gitlab-token":{"gitlab.com":"gitlab-token"},"gitlab-domains":["gitlab.com"],"http-basic":{"packagist.renovatebot.com":{"username":"some-username","password":"some-password"},"artifactory.yyyyyyy.com":{"username":"some-other-username","password":"some-other-password"}},"bearer":{"packages-bearer.example.com":"abcdef0123456789"}}',
             COMPOSER_CACHE_DIR: '/tmp/renovate/cache/others/composer',
-          },
-        },
-      },
-    ]);
-  });
-
-  it('git-tags hostRule for github.com set github-token in COMPOSER_AUTH', async () => {
-    hostRules.add({
-      hostType: GitTagsDatasource.id,
-      matchHost: 'github.com',
-      token: 'ghp_token',
-    });
-    fs.readLocalFile.mockResolvedValueOnce('{}');
-    const execSnapshots = mockExecAll();
-    fs.readLocalFile.mockResolvedValueOnce('{}');
-    const authConfig = {
-      ...config,
-      registryUrls: ['https://packagist.renovatebot.com'],
-    };
-    git.getRepoStatus.mockResolvedValueOnce(repoStatus);
-    expect(
-      await composer.updateArtifacts({
-        packageFileName: 'composer.json',
-        updatedDeps: [],
-        newPackageFileContent: '{}',
-        config: authConfig,
-      })
-    ).toBeNull();
-
-    expect(execSnapshots).toMatchObject([
-      {
-        options: {
-          env: {
-            COMPOSER_AUTH: '{"github-oauth":{"github.com":"ghp_token"}}',
-          },
-        },
-      },
-    ]);
-  });
-
-  it('Skip github application access token hostRules in COMPOSER_AUTH', async () => {
-    hostRules.add({
-      hostType: PlatformId.Github,
-      matchHost: 'api.github.com',
-      token: 'ghs_token',
-    });
-    hostRules.add({
-      hostType: GitTagsDatasource.id,
-      matchHost: 'github.com',
-      token: 'ghp_token',
-    });
-    fs.readLocalFile.mockResolvedValueOnce('{}');
-    const execSnapshots = mockExecAll();
-    fs.readLocalFile.mockResolvedValueOnce('{}');
-    const authConfig = {
-      ...config,
-      registryUrls: ['https://packagist.renovatebot.com'],
-    };
-    git.getRepoStatus.mockResolvedValueOnce(repoStatus);
-    expect(
-      await composer.updateArtifacts({
-        packageFileName: 'composer.json',
-        updatedDeps: [],
-        newPackageFileContent: '{}',
-        config: authConfig,
-      })
-    ).toBeNull();
-    expect(execSnapshots).toMatchObject([
-      {
-        options: {
-          env: {
-            COMPOSER_AUTH: '{"github-oauth":{"github.com":"ghp_token"}}',
           },
         },
       },

--- a/lib/modules/manager/composer/artifacts.ts
+++ b/lib/modules/manager/composer/artifacts.ts
@@ -19,14 +19,12 @@ import {
 import { getRepoStatus } from '../../../util/git';
 import * as hostRules from '../../../util/host-rules';
 import { regEx } from '../../../util/regex';
-import { GitTagsDatasource } from '../../datasource/git-tags';
 import { PackagistDatasource } from '../../datasource/packagist';
 import type { UpdateArtifact, UpdateArtifactsResult } from '../types';
 import type { AuthJson, ComposerLock } from './types';
 import {
   composerVersioningId,
   extractConstraints,
-  findGithubPersonalAccessToken,
   getComposerArguments,
   getPhpConstraint,
   requireComposerDependencyInstallation,
@@ -35,23 +33,13 @@ import {
 function getAuthJson(): string | null {
   const authJson: AuthJson = {};
 
-  const githubToken = findGithubPersonalAccessToken({
+  const githubCredentials = hostRules.find({
     hostType: PlatformId.Github,
     url: 'https://api.github.com/',
   });
-  if (githubToken) {
+  if (githubCredentials?.token) {
     authJson['github-oauth'] = {
-      'github.com': githubToken,
-    };
-  }
-
-  const gitTagsGithubToken = findGithubPersonalAccessToken({
-    hostType: GitTagsDatasource.id,
-    url: 'https://github.com',
-  });
-  if (gitTagsGithubToken) {
-    authJson['github-oauth'] = {
-      'github.com': gitTagsGithubToken,
+      'github.com': githubCredentials.token.replace('x-access-token:', ''),
     };
   }
 

--- a/lib/modules/manager/composer/utils.spec.ts
+++ b/lib/modules/manager/composer/utils.spec.ts
@@ -1,21 +1,13 @@
 import { GlobalConfig } from '../../../config/global';
-import * as hostRules from '../../../util/host-rules';
-import { GitTagsDatasource } from '../../datasource/git-tags';
 import {
   extractConstraints,
-  findGithubPersonalAccessToken,
   getComposerArguments,
-  isPersonalAccessToken,
   requireComposerDependencyInstallation,
 } from './utils';
 
 jest.mock('../../datasource');
 
 describe('modules/manager/composer/utils', () => {
-  beforeEach(() => {
-    hostRules.clear();
-  });
-
   describe('extractConstraints', () => {
     it('returns from require', () => {
       expect(
@@ -294,61 +286,6 @@ describe('modules/manager/composer/utils', () => {
           packages: [{ name: 'symfony/console', version: '5.4.0' }],
         })
       ).toBeFalse();
-    });
-  });
-
-  describe('findGithubPersonalAccessToken', () => {
-    it('returns the token string when hostRule match search with a valid personal access token', () => {
-      const TOKEN_STRING = 'ghp_TOKEN';
-      hostRules.add({
-        hostType: GitTagsDatasource.id,
-        matchHost: 'github.com',
-        token: TOKEN_STRING,
-      });
-      expect(
-        findGithubPersonalAccessToken({
-          hostType: GitTagsDatasource.id,
-          url: 'https://github.com',
-        })
-      ).toEqual(TOKEN_STRING);
-    });
-
-    it('returns undefined when hostRule match search with a invalid personal access token', () => {
-      const TOKEN_STRING = 'NOT_A_PERSONAL_ACCESS_TOKEN';
-      hostRules.add({
-        hostType: GitTagsDatasource.id,
-        matchHost: 'github.com',
-        token: TOKEN_STRING,
-      });
-      expect(
-        findGithubPersonalAccessToken({
-          hostType: GitTagsDatasource.id,
-          url: 'https://github.com',
-        })
-      ).toBeUndefined();
-    });
-
-    it('returns undefined when no hostRule match search', () => {
-      expect(
-        findGithubPersonalAccessToken({
-          hostType: GitTagsDatasource.id,
-          url: 'https://github.com',
-        })
-      ).toBeUndefined();
-    });
-  });
-
-  describe('isPersonalAccessToken', () => {
-    it('returns true when string is a github personnal access token', () => {
-      expect(isPersonalAccessToken('ghp_XXXXXX')).toBeTrue();
-    });
-
-    it('returns false when string is a github application token', () => {
-      expect(isPersonalAccessToken('ghs_XXXXXX')).toBeFalse();
-    });
-
-    it('returns false when string is not a token at all', () => {
-      expect(isPersonalAccessToken('XXXXXX')).toBeFalse();
     });
   });
 });

--- a/lib/modules/manager/composer/utils.ts
+++ b/lib/modules/manager/composer/utils.ts
@@ -4,8 +4,6 @@ import { quote } from 'shlex';
 import { GlobalConfig } from '../../../config/global';
 import { logger } from '../../../logger';
 import type { ToolConstraint } from '../../../util/exec/types';
-import { HostRuleSearch, find as findHostRule } from '../../../util/host-rules';
-import { regEx } from '../../../util/regex';
 import { api, id as composerVersioningId } from '../../versioning/composer';
 import type { UpdateArtifactsConfig } from '../types';
 import type { ComposerConfig, ComposerLock } from './types';
@@ -110,18 +108,4 @@ export function extractConstraints(
     res.composer = `^${major}.${minor}`;
   }
   return res;
-}
-
-export function findGithubPersonalAccessToken(
-  search: HostRuleSearch
-): string | undefined {
-  const token = findHostRule(search)?.token;
-  if (token && isPersonalAccessToken(token)) {
-    return token;
-  }
-  return undefined;
-}
-
-export function isPersonalAccessToken(token: string): boolean {
-  return regEx(/^ghp_/).test(token);
 }


### PR DESCRIPTION
Reverts renovatebot/renovate#16193

Closes #17778