### PR TITLE
refactor: extract getLockFileContentMap() into fs utils

### DIFF
--- a/lib/modules/manager/nuget/artifacts.spec.ts
+++ b/lib/modules/manager/nuget/artifacts.spec.ts
@@ -50,6 +50,7 @@ describe('modules/manager/nuget/artifacts', () => {
   it('aborts if no lock file found', async () => {
     const execSnapshots = mockExecAll();
     fs.getSiblingFileName.mockReturnValueOnce('packages.lock.json');
+    fs.getFileContentMap.mockResolvedValueOnce({ 'packages.lock.json': null });
     expect(
       await nuget.updateArtifacts({
         packageFileName: 'project.csproj',
@@ -66,8 +67,13 @@ describe('modules/manager/nuget/artifacts', () => {
     fs.getSiblingFileName.mockReturnValueOnce(
       'path/with space/packages.lock.json'
     );
-    git.getFile.mockResolvedValueOnce('Current packages.lock.json');
-    fs.readLocalFile.mockResolvedValueOnce('Current packages.lock.json');
+    fs.getFileContentMap
+      .mockResolvedValueOnce({
+        'path/with space/packages.lock.json': 'Current packages.lock.json',
+      })
+      .mockResolvedValueOnce({
+        'path/with space/packages.lock.json': 'Current packages.lock.json',
+      });
     expect(
       await nuget.updateArtifacts({
         packageFileName: 'path/with space/project.csproj',
@@ -82,8 +88,13 @@ describe('modules/manager/nuget/artifacts', () => {
   it('updates lock file', async () => {
     const execSnapshots = mockExecAll();
     fs.getSiblingFileName.mockReturnValueOnce('packages.lock.json');
-    git.getFile.mockResolvedValueOnce('Current packages.lock.json');
-    fs.readLocalFile.mockResolvedValueOnce('New packages.lock.json');
+    fs.getFileContentMap
+      .mockResolvedValueOnce({
+        'packages.lock.json': 'Current packages.lock.json',
+      })
+      .mockResolvedValueOnce({
+        'packages.lock.json': 'New packages.lock.json',
+      });
     expect(
       await nuget.updateArtifacts({
         packageFileName: 'project.csproj',
@@ -98,8 +109,13 @@ describe('modules/manager/nuget/artifacts', () => {
   it('does not update lock file when non-proj file is changed', async () => {
     const execSnapshots = mockExecAll();
     fs.getSiblingFileName.mockReturnValueOnce('packages.lock.json');
-    git.getFile.mockResolvedValueOnce('Current packages.lock.json');
-    fs.readLocalFile.mockResolvedValueOnce('New packages.lock.json');
+    fs.getFileContentMap
+      .mockResolvedValueOnce({
+        'packages.lock.json': 'Current packages.lock.json',
+      })
+      .mockResolvedValueOnce({
+        'packages.lock.json': 'New packages.lock.json',
+      });
     expect(
       await nuget.updateArtifacts({
         packageFileName: 'otherfile.props',
@@ -114,8 +130,13 @@ describe('modules/manager/nuget/artifacts', () => {
   it('does not update lock file when no deps changed', async () => {
     const execSnapshots = mockExecAll();
     fs.getSiblingFileName.mockReturnValueOnce('packages.lock.json');
-    git.getFile.mockResolvedValueOnce('Current packages.lock.json');
-    fs.readLocalFile.mockResolvedValueOnce('New packages.lock.json');
+    fs.getFileContentMap
+      .mockResolvedValueOnce({
+        'packages.lock.json': 'Current packages.lock.json',
+      })
+      .mockResolvedValueOnce({
+        'packages.lock.json': 'New packages.lock.json',
+      });
     expect(
       await nuget.updateArtifacts({
         packageFileName: 'project.csproj',
@@ -130,8 +151,13 @@ describe('modules/manager/nuget/artifacts', () => {
   it('performs lock file maintenance', async () => {
     const execSnapshots = mockExecAll();
     fs.getSiblingFileName.mockReturnValueOnce('packages.lock.json');
-    git.getFile.mockResolvedValueOnce('Current packages.lock.json');
-    fs.readLocalFile.mockResolvedValueOnce('New packages.lock.json');
+    fs.getFileContentMap
+      .mockResolvedValueOnce({
+        'packages.lock.json': 'Current packages.lock.json',
+      })
+      .mockResolvedValueOnce({
+        'packages.lock.json': 'New packages.lock.json',
+      });
     expect(
       await nuget.updateArtifacts({
         packageFileName: 'project.csproj',
@@ -150,8 +176,13 @@ describe('modules/manager/nuget/artifacts', () => {
     GlobalConfig.set({ ...adminConfig, binarySource: 'docker' });
     const execSnapshots = mockExecAll();
     fs.getSiblingFileName.mockReturnValueOnce('packages.lock.json');
-    git.getFile.mockResolvedValueOnce('Current packages.lock.json');
-    fs.readLocalFile.mockResolvedValueOnce('New packages.lock.json');
+    fs.getFileContentMap
+      .mockResolvedValueOnce({
+        'packages.lock.json': 'Current packages.lock.json',
+      })
+      .mockResolvedValueOnce({
+        'packages.lock.json': 'New packages.lock.json',
+      });
     expect(
       await nuget.updateArtifacts({
         packageFileName: 'project.csproj',
@@ -167,8 +198,13 @@ describe('modules/manager/nuget/artifacts', () => {
     GlobalConfig.set({ ...adminConfig, binarySource: 'global' });
     const execSnapshots = mockExecAll();
     fs.getSiblingFileName.mockReturnValueOnce('packages.lock.json');
-    git.getFile.mockResolvedValueOnce('Current packages.lock.json');
-    fs.readLocalFile.mockResolvedValueOnce('New packages.lock.json');
+    fs.getFileContentMap
+      .mockResolvedValueOnce({
+        'packages.lock.json': 'Current packages.lock.json',
+      })
+      .mockResolvedValueOnce({
+        'packages.lock.json': 'New packages.lock.json',
+      });
     expect(
       await nuget.updateArtifacts({
         packageFileName: 'project.csproj',
@@ -182,7 +218,9 @@ describe('modules/manager/nuget/artifacts', () => {
 
   it('catches errors', async () => {
     fs.getSiblingFileName.mockReturnValueOnce('packages.lock.json');
-    git.getFile.mockResolvedValueOnce('Current packages.lock.json');
+    fs.getFileContentMap.mockResolvedValueOnce({
+      'packages.lock.json': 'Current packages.lock.json',
+    });
     fs.writeLocalFile.mockImplementationOnce(() => {
       throw new Error('not found');
     });
@@ -206,8 +244,13 @@ describe('modules/manager/nuget/artifacts', () => {
   it('authenticates at registries', async () => {
     const execSnapshots = mockExecAll();
     fs.getSiblingFileName.mockReturnValueOnce('packages.lock.json');
-    git.getFile.mockResolvedValueOnce('Current packages.lock.json');
-    fs.readLocalFile.mockResolvedValueOnce('New packages.lock.json');
+    fs.getFileContentMap
+      .mockResolvedValueOnce({
+        'packages.lock.json': 'Current packages.lock.json',
+      })
+      .mockResolvedValueOnce({
+        'packages.lock.json': 'New packages.lock.json',
+      });
     getConfiguredRegistries.mockResolvedValueOnce([
       {
         name: 'myRegistry',
@@ -240,8 +283,13 @@ describe('modules/manager/nuget/artifacts', () => {
   it('strips protocol version from feed url', async () => {
     const execSnapshots = mockExecAll();
     fs.getSiblingFileName.mockReturnValueOnce('packages.lock.json');
-    git.getFile.mockResolvedValueOnce('Current packages.lock.json');
-    fs.readLocalFile.mockResolvedValueOnce('New packages.lock.json');
+    fs.getFileContentMap
+      .mockResolvedValueOnce({
+        'packages.lock.json': 'Current packages.lock.json',
+      })
+      .mockResolvedValueOnce({
+        'packages.lock.json': 'New packages.lock.json',
+      });
     getConfiguredRegistries.mockResolvedValueOnce([
       {
         name: 'myRegistry',

--- a/lib/util/fs/index.spec.ts
+++ b/lib/util/fs/index.spec.ts
@@ -1,6 +1,5 @@
 import _findUp from 'find-up';
 import fs from 'fs-extra';
-import Git from 'simple-git';
 import tmp, { DirectoryResult } from 'tmp-promise';
 import { join, resolve } from 'upath';
 import { git, mockedFunction } from '../../../test/util';
@@ -37,6 +36,7 @@ import {
 
 jest.mock('../exec/env');
 jest.mock('find-up');
+jest.mock('../git');
 
 const findUp = mockedFunction(_findUp);
 
@@ -482,15 +482,7 @@ describe('util/fs/index', () => {
         file1: 'foobar',
       };
 
-      const repo = Git(tmpDir);
-      await repo.init();
-      await fs.outputFile(`${tmpDir}/file1`, fileContentMap.file1);
-      await repo.add(Object.keys(fileContentMap));
-      await repo.commit('some message');
-      await git.initRepo({
-        url: tmpDir,
-      });
-
+      git.getFile.mockResolvedValueOnce('foobar');
       const res = await getFileContentMap(Object.keys(fileContentMap));
       expect(res).toStrictEqual(fileContentMap);
     });

--- a/lib/util/fs/index.ts
+++ b/lib/util/fs/index.ts
@@ -6,6 +6,7 @@ import fs from 'fs-extra';
 import upath from 'upath';
 import { GlobalConfig } from '../../config/global';
 import { logger } from '../../logger';
+import { getFile } from '../git';
 import { ensureCachePath, ensureLocalPath } from './util';
 
 export const pipeline = util.promisify(stream.pipeline);
@@ -284,4 +285,19 @@ export function readSystemFile(
   encoding?: string
 ): Promise<string | Buffer> {
   return encoding ? fs.readFile(fileName, encoding) : fs.readFile(fileName);
+}
+
+export async function getFileContentMap(
+  fileNames: string[],
+  local = false
+): Promise<Record<string, string | null>> {
+  const fileContentMap: Record<string, string | null> = {};
+
+  for (const fileName of fileNames) {
+    fileContentMap[fileName] = local
+      ? await readLocalFile(fileName, 'utf8')
+      : await getFile(fileName);
+  }
+
+  return fileContentMap;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Extract `getLockFileContentMap()` from nuget manager into fs util, renaming it to `getFileContentMap()`.
<!-- Describe what behavior is changed by this PR. -->

## Context

https://github.com/renovatebot/renovate/pull/17949#discussion_r979346631

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
