### PR TITLE
fix(pr): include uncompiled pr body note if failing

### DIFF
--- a/lib/workers/repository/update/pr/body/notes.spec.ts
+++ b/lib/workers/repository/update/pr/body/notes.spec.ts
@@ -37,11 +37,11 @@ describe('workers/repository/update/pr/body/notes', () => {
         {
           manager: 'some-manager',
           branchName: 'branch',
-          prBodyNotes: ['NOTE'],
+          prBodyNotes: ['{{NOTE}}'],
         },
       ],
     });
-    expect(res).not.toContain('NOTE');
+    expect(res).toContain('{{NOTE}}');
   });
 
   it('handles extra notes', () => {

--- a/lib/workers/repository/update/pr/body/notes.ts
+++ b/lib/workers/repository/update/pr/body/notes.ts
@@ -15,7 +15,8 @@ export function getPrNotes(config: BranchConfig): string {
             notes.push(res);
           }
         } catch (err) {
-          logger.warn({ note }, 'Error compiling upgrade note');
+          logger.debug({ err }, 'Error compiling upgrade note');
+          notes.push(note);
         }
       }
     }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Include uncompiled prBodyNotes and do not log a warning if compilation fails.

## Context

This compilation failing is usually from vulnerability notes.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
