### PR TITLE
refactor: Make invalid schema reporting optional

### DIFF
--- a/lib/modules/platform/github/common.ts
+++ b/lib/modules/platform/github/common.ts
@@ -1,6 +1,6 @@
 import is from '@sindresorhus/is';
 import { PrState } from '../../../types';
-import { checkSchema } from '../../../util/schema';
+import * as schema from '../../../util/schema';
 import { getPrBodyStruct } from '../pr-body';
 import * as platformSchemas from '../schemas';
 import type { GhPr, GhRestPr } from './types';
@@ -52,6 +52,6 @@ export function coerceRestPr(pr: GhRestPr): GhPr {
     result.closedAt = pr.closed_at;
   }
 
-  checkSchema(platformSchemas.Pr, result);
+  schema.match(platformSchemas.Pr, result, true);
   return result;
 }

--- a/lib/util/schema.spec.ts
+++ b/lib/util/schema.spec.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { logger } from '../../test/util';
 import * as memCache from './cache/memory';
-import { checkSchema, reportErrors } from './schema';
+import * as schema from './schema';
 
 describe('util/schema', () => {
   beforeEach(() => {
@@ -10,33 +10,41 @@ describe('util/schema', () => {
   });
 
   it('validates data', () => {
-    const schema = z.object({ foo: z.string() });
+    const testSchema = z.object({ foo: z.string() });
     const validData = { foo: 'bar' };
 
-    const res = checkSchema(schema, validData);
+    const res = schema.match(testSchema, validData);
     expect(res).toBeTrue();
-
-    reportErrors();
-    expect(logger.logger.warn).not.toHaveBeenCalledOnce();
   });
 
-  it('reports nothing if there are no any reports', () => {
-    reportErrors();
+  it('returns false for invalid data', () => {
+    const testSchema = z.object({ foo: z.string() });
+    const invalidData = { foo: 123 };
+
+    const res = schema.match(testSchema, invalidData);
+    expect(res).toBeFalse();
+
+    schema.reportErrors();
     expect(logger.logger.warn).not.toHaveBeenCalled();
   });
 
-  it('reports same warning once', () => {
-    const schema = z.object(
+  it('reports nothing if there are no any reports', () => {
+    schema.reportErrors();
+    expect(logger.logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('reports same warning one time', () => {
+    const testSchema = z.object(
       { foo: z.string() },
       { description: 'Some test schema' }
     );
     const invalidData = { foo: 42 };
 
-    checkSchema(schema, invalidData);
-    checkSchema(schema, invalidData);
-    checkSchema(schema, invalidData);
-    checkSchema(schema, invalidData);
-    reportErrors();
+    schema.match(testSchema, invalidData, true);
+    schema.match(testSchema, invalidData, true);
+    schema.match(testSchema, invalidData, true);
+    schema.match(testSchema, invalidData, true);
+    schema.reportErrors();
 
     expect(logger.logger.warn).toHaveBeenCalledOnce();
     expect(logger.logger.warn.mock.calls[0]).toMatchObject([
@@ -46,11 +54,11 @@ describe('util/schema', () => {
   });
 
   it('reports unspecified schema', () => {
-    const schema = z.object({ foo: z.string() });
+    const testSchema = z.object({ foo: z.string() });
     const invalidData = { foo: 42 };
 
-    checkSchema(schema, invalidData);
-    reportErrors();
+    schema.match(testSchema, invalidData, true);
+    schema.reportErrors();
 
     expect(logger.logger.warn).toHaveBeenCalledOnce();
     expect(logger.logger.warn.mock.calls[0]).toMatchObject([

--- a/lib/util/schema.ts
+++ b/lib/util/schema.ts
@@ -44,14 +44,18 @@ export function reportErrors(): void {
   memCache.set('schema-errors', null);
 }
 
-export function checkSchema<T extends z.ZodSchema>(
+export function match<T extends z.ZodSchema>(
   schema: T,
-  input: unknown
+  input: unknown,
+  report = false
 ): input is z.infer<T> {
   const res = schema.safeParse(input);
   const { success } = res;
   if (!success) {
-    collectError(schema, res.error);
+    if (report) {
+      collectError(schema, res.error);
+    }
+
     return false;
   }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This allows us to validate and leverage type guarding even if we don't need any reporting

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
