### PR TITLE
fix(docker): filter duplicate dependency findings

### DIFF
--- a/lib/modules/manager/dockerfile/extract.spec.ts
+++ b/lib/modules/manager/dockerfile/extract.spec.ts
@@ -1158,6 +1158,15 @@ describe('modules/manager/dockerfile/extract', () => {
     });
   });
 
+  it('filters dependency duplicates', () => {
+    const res = extractPackageFile(
+      'ARG PYTHON_VERS=3.10-slim\nFROM python:${PYTHON_VERS} AS builder\nFROM python:${PYTHON_VERS}\n',
+      '',
+      {}
+    )?.deps;
+    expect(res).toHaveLength(1);
+  });
+
   describe('getDep()', () => {
     it('rejects null', () => {
       expect(getDep(null)).toEqual({ skipReason: 'invalid-value' });

--- a/lib/modules/manager/dockerfile/extract.ts
+++ b/lib/modules/manager/dockerfile/extract.ts
@@ -389,9 +389,15 @@ export function extractPackageFile(
   if (!deps.length) {
     return null;
   }
-  for (const d of deps) {
+
+  const deduplicatedDeps = [
+    ...new Map(deps.map((v) => [JSON.stringify(v), v])).values(),
+  ];
+
+  for (const d of deduplicatedDeps) {
     d.depType = 'stage';
   }
-  deps[deps.length - 1].depType = 'final';
-  return { deps };
+  deduplicatedDeps[deduplicatedDeps.length - 1].depType = 'final';
+
+  return { deps: deduplicatedDeps };
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds filtering of duplicated dependency findings in Dockerfile manager.

<!-- Describe what behavior is changed by this PR. -->

## Context

Closes #18022

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

Test repository: https://github.com/renovate-demo/18022-dockerfile-duplicate/pull/1

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
