### PR TITLE
feat(schema): Different options for error handling

### DIFF
--- a/lib/modules/platform/github/common.ts
+++ b/lib/modules/platform/github/common.ts
@@ -52,6 +52,6 @@ export function coerceRestPr(pr: GhRestPr): GhPr {
     result.closedAt = pr.closed_at;
   }
 
-  schema.match(platformSchemas.Pr, result, true);
+  schema.match(platformSchemas.Pr, result, 'warn');
   return result;
 }

--- a/lib/util/schema.ts
+++ b/lib/util/schema.ts
@@ -47,13 +47,17 @@ export function reportErrors(): void {
 export function match<T extends z.ZodSchema>(
   schema: T,
   input: unknown,
-  report = false
+  onError?: 'warn' | 'throw'
 ): input is z.infer<T> {
   const res = schema.safeParse(input);
   const { success } = res;
   if (!success) {
-    if (report) {
+    if (onError === 'warn') {
       collectError(schema, res.error);
+    }
+
+    if (onError === 'throw') {
+      throw res.error;
     }
 
     return false;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- By default, do nothing (useful when only type guard is needed)
- `warn` for error logging after repo run
- `throw` to re-throw `ZodError` immediately

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
