### PR TITLE
chore(types): fix typos in comments

### DIFF
--- a/lib/types/later.d.ts
+++ b/lib/types/later.d.ts
@@ -95,7 +95,7 @@ declare module '@breejs/later' {
 
     /*
      * Custom Time Periods and Modifiers
-     * For acces to custom time periods created as extension to the later static type
+     * For access to custom time periods created as extension to the later static type
      * and modifiers created on the later modifier static type.
      */
     [timeperiodAndModifierName: string]: number[] | undefined;
@@ -117,7 +117,7 @@ declare module '@breejs/later' {
      */
     parse: {
       /**
-       * Create schedule data by paring a human readable string.
+       * Create schedule data by parsing a human readable string.
        *
        * @param [input] - A string value to parse.
        */


### PR DESCRIPTION
## Changes

- Fixing two typos in comment for `@breejs/later` type

## Context

While I was fixing these typos, I was thinking: "Should we try to upstream this file again?".

@JamieMagee wanted to upstream the type definitions to `DefinitelyTyped`:

- https://github.com/renovatebot/renovate/pull/7565#issuecomment-717199562
- https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56048

It looks like there were some problems with getting that PR into the DefinetelyTyped project?

It feels like the types for `@breejs/later` should live outside of our main Renovate repository. That why I'm asking if we want to re-try upstreaming the file. 😉 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
