### PR TITLE
fix(java): add sapmachine to LTS workaround

### DIFF
--- a/lib/config/presets/internal/workarounds.ts
+++ b/lib/config/presets/internal/workarounds.ts
@@ -132,7 +132,7 @@ export const presets: Record<string, Preset> = {
           'adoptopenjdk',
           'openjdk',
           'java',
-          'sapmachine'
+          'sapmachine',
         ],
         versioning:
           'regex:^(?<major>\\d+)?(\\.(?<minor>\\d+))?(\\.(?<patch>\\d+))?([\\._+](?<build>\\d+))?(-(?<compatibility>.*))?$',

--- a/lib/config/presets/internal/workarounds.ts
+++ b/lib/config/presets/internal/workarounds.ts
@@ -132,6 +132,7 @@ export const presets: Record<string, Preset> = {
           'adoptopenjdk',
           'openjdk',
           'java',
+          'sapmachine'
         ],
         versioning:
           'regex:^(?<major>\\d+)?(\\.(?<minor>\\d+))?(\\.(?<patch>\\d+))?([\\._+](?<build>\\d+))?(-(?<compatibility>.*))?$',


### PR DESCRIPTION
Just read the changelog and saw that Sapmachine was missing.

## Changes

Sapmachine is another build of the OpenJDK, that should be included in the workaround.

## Context

More information about Sapmachine
[Website](https://sap.github.io/SapMachine/)
[Dockerhub](https://hub.docker.com/_/sapmachine)

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

Screenshots of Dockerfile and Dependency Dashboard, just as a sanity check :)
![Screenshot from 2022-10-05 10-09-58](https://user-images.githubusercontent.com/1809629/194012470-1ac0cd2a-0672-4794-a4de-040c2a22fac7.png)
![Screenshot from 2022-10-05 10-10-24](https://user-images.githubusercontent.com/1809629/194012485-edfc6bc3-ba4f-45eb-a23b-47dc9e1553e5.png)

