### PR TITLE
refactor(replacements): added support for multiple args for addPrestes

### DIFF
--- a/lib/config/presets/internal/auto-generate-replacements.ts
+++ b/lib/config/presets/internal/auto-generate-replacements.ts
@@ -3,7 +3,7 @@ import type { Preset } from '../types';
 
 export type Replacement = [string[], string];
 
-export interface AutoPackageRules {
+export interface ReplacementRule {
   matchCurrentVersion: string;
   matchDatasources: string[];
   replacements: Replacement[];
@@ -13,39 +13,46 @@ export interface AutoPackageRules {
 export interface PresetTemplate {
   title: string;
   description: string;
-  packageRules: AutoPackageRules;
+  packageRules: ReplacementRule[];
 }
 
-function generatePackageRules({
-  matchCurrentVersion,
-  matchDatasources,
-  replacements,
-  replacementVersion,
-}: AutoPackageRules): PackageRule[] {
+function generatePackageRules(
+  replacementRules: ReplacementRule[]
+): PackageRule[] {
   const rules: PackageRule[] = [];
-  for (const replacement of replacements) {
-    const [matchPackageNames, replacementName] = replacement;
-    rules.push({
+  for (const replacementRule of replacementRules) {
+    const {
       matchCurrentVersion,
       matchDatasources,
-      matchPackageNames,
-      replacementName,
+      replacements,
       replacementVersion,
-    });
+    } = replacementRule;
+    for (const replacement of replacements) {
+      const [matchPackageNames, replacementName] = replacement;
+      rules.push({
+        matchCurrentVersion,
+        matchDatasources,
+        matchPackageNames,
+        replacementName,
+        replacementVersion,
+      });
+    }
   }
   return rules;
 }
 
 export function addPresets(
   presets: Record<string, Preset>,
-  template: PresetTemplate
+  ...templates: PresetTemplate[]
 ): void {
-  const { title, description, packageRules } = template;
-  presets[title] = {
-    description,
-    packageRules: generatePackageRules(packageRules),
-  };
   const ext = presets.all?.extends ?? [];
-  ext.push(`replacements:${title}`);
+  for (const template of templates) {
+    const { title, description, packageRules } = template;
+    presets[title] = {
+      description,
+      packageRules: generatePackageRules(packageRules),
+    };
+    ext.push(`replacements:${title}`);
+  }
   ext.sort();
 }

--- a/lib/config/presets/internal/replacements.ts
+++ b/lib/config/presets/internal/replacements.ts
@@ -578,12 +578,14 @@ const muiReplacement: Replacement[] = [
 const mui: PresetTemplate = {
   description:
     'The `material-ui` monorepo org was renamed from `@material-ui` to `@mui`.',
-  packageRules: {
-    matchCurrentVersion: '>=4.0.0 <5.0.0',
-    matchDatasources: ['npm'],
-    replacements: muiReplacement,
-    replacementVersion: '5.0.0',
-  },
+  packageRules: [
+    {
+      matchCurrentVersion: '>=4.0.0 <5.0.0',
+      matchDatasources: ['npm'],
+      replacements: muiReplacement,
+      replacementVersion: '5.0.0',
+    },
+  ],
   title: 'material-ui-to-mui',
 };
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- `addPresets` function now supports multiple templates as input
- `PresetTemplate` now supports a `packageRule` array as it is more inline with actual `packageRule` design and usage

 
<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Ran on a real repository

Debug mode of a real repo run:
left view- runtime `presets` obj, middle view - the breakpoint, right view - the actual replacement template for mui.
![image](https://user-images.githubusercontent.com/97394622/194033933-4d6d010e-9920-4589-851f-7bf91f253014.png)


<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
