### PR TITLE
feat(azure-pipelines)!: disable by default

### DIFF
--- a/lib/modules/manager/azure-pipelines/index.ts
+++ b/lib/modules/manager/azure-pipelines/index.ts
@@ -4,6 +4,7 @@ export { extractPackageFile } from './extract';
 
 export const defaultConfig = {
   fileMatch: ['azure.*pipelines?.*\\.ya?ml$'],
+  enabled: false,
 };
 
 export const supportedDatasources = [

--- a/lib/modules/manager/azure-pipelines/readme.md
+++ b/lib/modules/manager/azure-pipelines/readme.md
@@ -1,4 +1,18 @@
-The `azure-pipelines` manager extracts container and repository resources from the `resources` block as well as tasks from `steps` blocks.
+The `azure-pipelines` manager is disabled by default.
+This is because there's no way for Renovate to know whether new task versions are yet available with the Azure DevOps environment, so new versions proposed by Renovate could fail.
+
+To opt into running it, set the following:
+
+```json
+{
+  "azure-pipelines": {
+    "enabled": true
+  }
+}
+```
+
+It works by container and repository resources from the `resources` block as well as tasks from `steps` blocks.
+
 For example:
 
 ```yaml


### PR DESCRIPTION
Closes #15818

BREAKING CHANGE: azure-pipelines manager is now disabled by default.