### PR TITLE
fix: exclude unstable data from cache fingerprints

### DIFF
--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -382,6 +382,7 @@ const options: RenovateOptions[] = [
     globalOnly: true,
     type: 'string',
     default: null,
+    stage: 'global',
   },
   // Onboarding
   {

--- a/lib/util/fingerprint.ts
+++ b/lib/util/fingerprint.ts
@@ -2,5 +2,5 @@ import hasha from 'hasha';
 import { safeStringify } from './stringify';
 
 export function fingerprint(input: unknown): string {
-  return hasha(safeStringify(input), { algorithm: 'sha256' });
+  return hasha(safeStringify(input));
 }

--- a/lib/util/fingerprint.ts
+++ b/lib/util/fingerprint.ts
@@ -1,0 +1,6 @@
+import hasha from 'hasha';
+import { safeStringify } from './stringify';
+
+export function fingerprint(input: unknown): string {
+  return hasha(safeStringify(input), { algorithm: 'sha256' });
+}

--- a/lib/workers/repository/process/extract-update.spec.ts
+++ b/lib/workers/repository/process/extract-update.spec.ts
@@ -1,4 +1,5 @@
 import hasha from 'hasha';
+import stringify from 'safe-stable-stringify';
 import { git, mocked } from '../../../../test/util';
 import type { PackageFile } from '../../../modules/manager/types';
 import * as _repositoryCache from '../../../util/cache/repository';
@@ -71,7 +72,7 @@ describe('workers/repository/process/extract-update', () => {
         scan: {
           master: {
             sha: '123test',
-            configHash: hasha(JSON.stringify(config)),
+            configHash: hasha(stringify(config)),
             packageFiles,
           },
         },

--- a/lib/workers/repository/process/extract-update.spec.ts
+++ b/lib/workers/repository/process/extract-update.spec.ts
@@ -1,8 +1,7 @@
-import hasha from 'hasha';
-import stringify from 'safe-stable-stringify';
 import { git, mocked } from '../../../../test/util';
 import type { PackageFile } from '../../../modules/manager/types';
 import * as _repositoryCache from '../../../util/cache/repository';
+import { fingerprint } from '../../../util/fingerprint';
 import * as _branchify from '../updates/branchify';
 import { extract, lookup, update } from './extract-update';
 
@@ -72,7 +71,7 @@ describe('workers/repository/process/extract-update', () => {
         scan: {
           master: {
             sha: '123test',
-            configHash: hasha(stringify(config)),
+            configHash: fingerprint(config),
             packageFiles,
           },
         },

--- a/lib/workers/repository/process/extract-update.ts
+++ b/lib/workers/repository/process/extract-update.ts
@@ -1,12 +1,11 @@
 // TODO #7154
 import is from '@sindresorhus/is';
-import hasha from 'hasha';
-import stringify from 'safe-stable-stringify';
 import type { RenovateConfig } from '../../../config/types';
 import { logger } from '../../../logger';
 import type { PackageFile } from '../../../modules/manager/types';
 import { getCache } from '../../../util/cache/repository';
 import { checkGithubToken as ensureGithubToken } from '../../../util/check-token';
+import { fingerprint } from '../../../util/fingerprint';
 import { checkoutBranch, getBranchCommit } from '../../../util/git';
 import type { BranchConfig } from '../../types';
 import { extractAllDependencies } from '../extract';
@@ -75,7 +74,7 @@ export async function extract(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { packageRules, ...remainingConfig } = config;
   // Calculate hash excluding packageRules, because they're not applied during extract
-  const configHash = hasha(stringify(remainingConfig));
+  const configHash = fingerprint(remainingConfig);
   // istanbul ignore if
   if (
     cachedExtract?.sha === baseBranchSha &&

--- a/lib/workers/repository/process/extract-update.ts
+++ b/lib/workers/repository/process/extract-update.ts
@@ -1,6 +1,7 @@
 // TODO #7154
 import is from '@sindresorhus/is';
 import hasha from 'hasha';
+import stringify from 'safe-stable-stringify';
 import type { RenovateConfig } from '../../../config/types';
 import { logger } from '../../../logger';
 import type { PackageFile } from '../../../modules/manager/types';
@@ -71,7 +72,10 @@ export async function extract(
   const cache = getCache();
   cache.scan ||= {};
   const cachedExtract = cache.scan[baseBranch!];
-  const configHash = hasha(JSON.stringify(config));
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { packageRules, ...remainingConfig } = config;
+  // Calculate hash excluding packageRules, because they're not applied during extract
+  const configHash = hasha(stringify(remainingConfig));
   // istanbul ignore if
   if (
     cachedExtract?.sha === baseBranchSha &&

--- a/lib/workers/repository/process/write.spec.ts
+++ b/lib/workers/repository/process/write.spec.ts
@@ -166,21 +166,20 @@ describe('workers/repository/process/write', () => {
         result: BranchResult.Done,
         commitSha: 'some-value',
       });
-      const branchManagersFingerprint = fingerprint(
-        [
-          ...new Set(
-            branches[0].upgrades
-              .map((upgrade) => hashMap.get(upgrade.manager) ?? upgrade.manager)
-              .filter(is.string)
-          ),
-        ].sort()
-      );
+      const branch = branches[0];
+      const managers = [
+        ...new Set(
+          branch.upgrades
+            .map((upgrade) => hashMap.get(upgrade.manager) ?? upgrade.manager)
+            .filter(is.string)
+        ),
+      ].sort();
       const branchFingerprint = fingerprint({
-        branches: JSON.stringify(branches[0]),
-        branchManagersFingerprint,
+        branch,
+        managers,
       });
       expect(await writeUpdates(config, branches)).toBe('done');
-      expect(branches[0].branchFingerprint).toBe(branchFingerprint);
+      expect(branch.branchFingerprint).toBe(branchFingerprint);
     });
 
     it('caches same fingerprint when no commit is made', async () => {
@@ -196,18 +195,16 @@ describe('workers/repository/process/write', () => {
           ],
         },
       ]);
-      const branchManagersFingerprint = fingerprint(
-        [
-          ...new Set(
-            branches[0].upgrades
-              .map((upgrade) => hashMap.get(upgrade.manager) ?? upgrade.manager)
-              .filter(is.string)
-          ),
-        ].sort()
-      );
+      const managers = [
+        ...new Set(
+          branches[0].upgrades
+            .map((upgrade) => hashMap.get(upgrade.manager) ?? upgrade.manager)
+            .filter(is.string)
+        ),
+      ].sort();
       const branchFingerprint = fingerprint({
         branches: JSON.stringify(branches[0]),
-        branchManagersFingerprint,
+        managers,
       });
       repoCache.getCache.mockReturnValueOnce({
         branches: [

--- a/lib/workers/repository/process/write.ts
+++ b/lib/workers/repository/process/write.ts
@@ -1,11 +1,10 @@
 import is from '@sindresorhus/is';
-import hasha from 'hasha';
-import stringify from 'safe-stable-stringify';
 import type { RenovateConfig } from '../../../config/types';
 import { addMeta, logger, removeMeta } from '../../../logger';
 import { hashMap } from '../../../modules/manager';
 import { getCache } from '../../../util/cache/repository';
 import type { BranchCache } from '../../../util/cache/repository/types';
+import { fingerprint } from '../../../util/fingerprint';
 import { branchExists, getBranchCommit } from '../../../util/git';
 import { setBranchNewCommit } from '../../../util/git/set-branch-commit';
 import { Limit, incLimitedValue, setMaxLimit } from '../../global/limits';
@@ -124,7 +123,7 @@ export async function writeUpdates(
     // TODO: base branch name cannot be undefined - fix optional types (#7154)
     const branchState = syncBranchState(branchName, baseBranch!);
 
-    const branchManagersFingerprint = hasha(
+    const branchManagersFingerprint = fingerprint(
       [
         ...new Set(
           branch.upgrades
@@ -133,10 +132,10 @@ export async function writeUpdates(
         ),
       ].sort()
     );
-    const branchFingerprint = hasha([
-      stringify(branch),
+    const branchFingerprint = fingerprint({
+      branch,
       branchManagersFingerprint,
-    ]);
+    });
     branch.skipBranchUpdate = canSkipBranchUpdateCheck(
       branchState,
       branchFingerprint

--- a/lib/workers/repository/process/write.ts
+++ b/lib/workers/repository/process/write.ts
@@ -123,18 +123,16 @@ export async function writeUpdates(
     // TODO: base branch name cannot be undefined - fix optional types (#7154)
     const branchState = syncBranchState(branchName, baseBranch!);
 
-    const branchManagersFingerprint = fingerprint(
-      [
-        ...new Set(
-          branch.upgrades
-            .map((upgrade) => hashMap.get(upgrade.manager) ?? upgrade.manager)
-            .filter(is.string)
-        ),
-      ].sort()
-    );
+    const managers = [
+      ...new Set(
+        branch.upgrades
+          .map((upgrade) => hashMap.get(upgrade.manager) ?? upgrade.manager)
+          .filter(is.string)
+      ),
+    ].sort();
     const branchFingerprint = fingerprint({
       branch,
-      branchManagersFingerprint,
+      managers,
     });
     branch.skipBranchUpdate = canSkipBranchUpdateCheck(
       branchState,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Excludes `packageRules` config from the extract cache fingerprint so that our regular monorepo changes/improvements don't invalidate extract caches every time.

Also uses stable stringify so that ordering is not a problem in future.

## Context

Closes #18116

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
