### PR TITLE
feat: package cache stats

### DIFF
--- a/lib/util/cache/package/index.ts
+++ b/lib/util/cache/package/index.ts
@@ -21,7 +21,12 @@ export async function get<T = any>(
   if (memCache.get(globalKey) === undefined) {
     memCache.set(globalKey, cacheProxy.get(namespace, key));
   }
+  const start = Date.now();
   const result = await memCache.get(globalKey);
+  const durationMs = Math.round(Date.now() - start);
+  const cacheRequests = memCache.get<number[]>('package-cache-requests') || [];
+  cacheRequests.push(durationMs);
+  memCache.set('package-cache-requests', cacheRequests);
   return result;
 }
 

--- a/lib/util/cache/package/index.ts
+++ b/lib/util/cache/package/index.ts
@@ -24,9 +24,9 @@ export async function get<T = any>(
   const start = Date.now();
   const result = await memCache.get(globalKey);
   const durationMs = Math.round(Date.now() - start);
-  const cacheRequests = memCache.get<number[]>('package-cache-requests') ?? [];
-  cacheRequests.push(durationMs);
-  memCache.set('package-cache-requests', cacheRequests);
+  const cacheDurations = memCache.get<number[]>('package-cache-gets') ?? [];
+  cacheDurations.push(durationMs);
+  memCache.set('package-cache-gets', cacheDurations);
   return result;
 }
 
@@ -41,7 +41,12 @@ export async function set(
   }
   const globalKey = getGlobalKey(namespace, key);
   memCache.set(globalKey, value);
+  const start = Date.now();
   await cacheProxy.set(namespace, key, value, minutes);
+  const durationMs = Math.round(Date.now() - start);
+  const cacheDurations = memCache.get<number[]>('package-cache-sets') ?? [];
+  cacheDurations.push(durationMs);
+  memCache.set('package-cache-sets', cacheDurations);
 }
 
 export async function init(config: AllConfig): Promise<void> {

--- a/lib/util/cache/package/index.ts
+++ b/lib/util/cache/package/index.ts
@@ -24,7 +24,7 @@ export async function get<T = any>(
   const start = Date.now();
   const result = await memCache.get(globalKey);
   const durationMs = Math.round(Date.now() - start);
-  const cacheRequests = memCache.get<number[]>('package-cache-requests') || [];
+  const cacheRequests = memCache.get<number[]>('package-cache-requests') ?? [];
   cacheRequests.push(durationMs);
   memCache.set('package-cache-requests', cacheRequests);
   return result;

--- a/lib/workers/repository/stats.spec.ts
+++ b/lib/workers/repository/stats.spec.ts
@@ -124,13 +124,8 @@ describe('workers/repository/stats', () => {
           },
         }
       `);
-      expect(log.debug.mock.calls[1][0]).toMatchInlineSnapshot(`
+      expect(log.debug.mock.calls[2][0]).toMatchInlineSnapshot(`
         {
-          "cacheStats": {
-            "cacheAverageMs": 20,
-            "cacheCount": 3,
-            "cacheMaximumMs": 30,
-          },
           "hostStats": {
             "api.github.com": {
               "queueAvgMs": 2,

--- a/lib/workers/repository/stats.spec.ts
+++ b/lib/workers/repository/stats.spec.ts
@@ -124,6 +124,13 @@ describe('workers/repository/stats', () => {
           },
         }
       `);
+      expect(log.debug.mock.calls[1][0]).toMatchInlineSnapshot(`
+        {
+          "requestCount": 3,
+          "responseAvgMs": 20,
+          "responseMaxMs": 30,
+        }
+      `);
       expect(log.debug.mock.calls[2][0]).toMatchInlineSnapshot(`
         {
           "hostStats": {

--- a/lib/workers/repository/stats.spec.ts
+++ b/lib/workers/repository/stats.spec.ts
@@ -63,7 +63,7 @@ describe('workers/repository/stats', () => {
       memCache.get.mockImplementationOnce(() => httpStats as any);
       expect(printRequestStats()).toBeUndefined();
       expect(log.trace).toHaveBeenCalledOnce();
-      expect(log.debug).toHaveBeenCalledTimes(2);
+      expect(log.debug).toHaveBeenCalledTimes(3);
       expect(log.trace.mock.calls[0][0]).toMatchInlineSnapshot(`
         {
           "allRequests": [

--- a/lib/workers/repository/stats.spec.ts
+++ b/lib/workers/repository/stats.spec.ts
@@ -12,7 +12,10 @@ const log = logger.logger as jest.Mocked<Logger>;
 describe('workers/repository/stats', () => {
   describe('printRequestStats()', () => {
     it('runs', () => {
-      const stats: RequestStats[] = [
+      const cacheStats: number[] = [10, 20, 30];
+      // TODO: fix types, jest is using wrong overload (#7154)
+      memCache.get.mockImplementationOnce(() => cacheStats as any);
+      const httpStats: RequestStats[] = [
         {
           method: 'get',
           url: 'https://api.github.com/api/v3/user',
@@ -57,7 +60,7 @@ describe('workers/repository/stats', () => {
         },
       ];
       // TODO: fix types, jest is using wrong overload (#7154)
-      memCache.get.mockImplementationOnce(() => stats as any);
+      memCache.get.mockImplementationOnce(() => httpStats as any);
       expect(printRequestStats()).toBeUndefined();
       expect(log.trace).toHaveBeenCalledOnce();
       expect(log.debug).toHaveBeenCalledTimes(2);
@@ -123,6 +126,11 @@ describe('workers/repository/stats', () => {
       `);
       expect(log.debug.mock.calls[1][0]).toMatchInlineSnapshot(`
         {
+          "cacheStats": {
+            "cacheAverageMs": 20,
+            "cacheCount": 3,
+            "cacheMaximumMs": 30,
+          },
           "hostStats": {
             "api.github.com": {
               "queueAvgMs": 2,

--- a/lib/workers/repository/stats.spec.ts
+++ b/lib/workers/repository/stats.spec.ts
@@ -12,9 +12,12 @@ const log = logger.logger as jest.Mocked<Logger>;
 describe('workers/repository/stats', () => {
   describe('printRequestStats()', () => {
     it('runs', () => {
-      const cacheStats: number[] = [10, 20, 30];
+      const getStats: number[] = [10, 20, 30];
       // TODO: fix types, jest is using wrong overload (#7154)
-      memCache.get.mockImplementationOnce(() => cacheStats as any);
+      memCache.get.mockImplementationOnce(() => getStats as any);
+      const setStats: number[] = [20, 80];
+      // TODO: fix types, jest is using wrong overload (#7154)
+      memCache.get.mockImplementationOnce(() => setStats as any);
       const httpStats: RequestStats[] = [
         {
           method: 'get',
@@ -126,9 +129,16 @@ describe('workers/repository/stats', () => {
       `);
       expect(log.debug.mock.calls[1][0]).toMatchInlineSnapshot(`
         {
-          "requestCount": 3,
-          "responseAvgMs": 20,
-          "responseMaxMs": 30,
+          "get": {
+            "avgMs": 20,
+            "count": 3,
+            "maxMs": 30,
+          },
+          "set": {
+            "avgMs": 50,
+            "count": 2,
+            "maxMs": 80,
+          },
         }
       `);
       expect(log.debug.mock.calls[2][0]).toMatchInlineSnapshot(`

--- a/lib/workers/repository/stats.ts
+++ b/lib/workers/repository/stats.ts
@@ -20,6 +20,7 @@ export function printRequestStats(): void {
     packageCacheStats.cacheMaximumMs =
       packageCacheRequests[packageCacheRequests.length - 1];
   }
+  logger.debug(packageCacheStats, 'Package cache statistics');
   const httpRequests = memCache.get<RequestStats[]>('http-requests');
   // istanbul ignore next
   if (!httpRequests) {
@@ -86,8 +87,5 @@ export function printRequestStats(): void {
     const queueAvgMs = Math.round(queueSum / requestCount);
     hostStats[hostname] = { requestCount, requestAvgMs, queueAvgMs };
   }
-  logger.debug(
-    { urls, packageCacheStats, hostStats, totalRequests },
-    'http statistics'
-  );
+  logger.debug({ urls, hostStats, totalRequests }, 'http statistics');
 }

--- a/lib/workers/repository/stats.ts
+++ b/lib/workers/repository/stats.ts
@@ -8,16 +8,16 @@ export function printRequestStats(): void {
     memCache.get<number[]>('package-cache-requests') || []
   ).sort();
   const packageCacheStats = {
-    cacheCount: packageCacheRequests.length,
-    cacheAverageMs: 0,
-    cacheMaximumMs: 0,
+    requestCount: packageCacheRequests.length,
+    responseAvgMs: 0,
+    responseMaxMs: 0,
   };
-  if (packageCacheStats.cacheCount) {
-    packageCacheStats.cacheAverageMs = Math.round(
+  if (packageCacheStats.requestCount) {
+    packageCacheStats.responseAvgMs = Math.round(
       packageCacheRequests.reduce((a, b) => a + b, 0) /
         packageCacheRequests.length
     );
-    packageCacheStats.cacheMaximumMs =
+    packageCacheStats.responseMaxMs =
       packageCacheRequests[packageCacheRequests.length - 1];
   }
   logger.debug(packageCacheStats, 'Package cache statistics');

--- a/lib/workers/repository/stats.ts
+++ b/lib/workers/repository/stats.ts
@@ -5,7 +5,7 @@ import type { RequestStats } from '../../util/http/types';
 
 export function printRequestStats(): void {
   const packageCacheRequests = (
-    memCache.get<number[]>('package-cache-requests') || []
+    memCache.get<number[]>('package-cache-requests') ?? []
   ).sort();
   const packageCacheStats = {
     requestCount: packageCacheRequests.length,

--- a/lib/workers/repository/stats.ts
+++ b/lib/workers/repository/stats.ts
@@ -4,6 +4,22 @@ import * as memCache from '../../util/cache/memory';
 import type { RequestStats } from '../../util/http/types';
 
 export function printRequestStats(): void {
+  const packageCacheRequests = (
+    memCache.get<number[]>('package-cache-requests') || []
+  ).sort();
+  const packageCacheStats = {
+    cacheCount: packageCacheRequests.length,
+    cacheAverageMs: 0,
+    cacheMaximumMs: 0,
+  };
+  if (packageCacheStats.cacheCount) {
+    packageCacheStats.cacheAverageMs = Math.round(
+      packageCacheRequests.reduce((a, b) => a + b, 0) /
+        packageCacheRequests.length
+    );
+    packageCacheStats.cacheMaximumMs =
+      packageCacheRequests[packageCacheRequests.length - 1];
+  }
   const httpRequests = memCache.get<RequestStats[]>('http-requests');
   // istanbul ignore next
   if (!httpRequests) {
@@ -70,5 +86,8 @@ export function printRequestStats(): void {
     const queueAvgMs = Math.round(queueSum / requestCount);
     hostStats[hostname] = { requestCount, requestAvgMs, queueAvgMs };
   }
-  logger.debug({ urls, hostStats, totalRequests }, 'http statistics');
+  logger.debug(
+    { urls, packageCacheStats, hostStats, totalRequests },
+    'http statistics'
+  );
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds new stats recording/printing for the package cache (which defaults to file-based, but can also be Redis).

## Context

I suspect we're seeing a lot of delay from the production Redis, so this is a good stat to gather.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
