### PR TITLE
fix: don’t count duplicate package cache stats

### DIFF
--- a/lib/util/cache/package/index.ts
+++ b/lib/util/cache/package/index.ts
@@ -18,15 +18,19 @@ export async function get<T = any>(
     return undefined;
   }
   const globalKey = getGlobalKey(namespace, key);
+  let start = 0;
   if (memCache.get(globalKey) === undefined) {
     memCache.set(globalKey, cacheProxy.get(namespace, key));
+    start = Date.now();
   }
-  const start = Date.now();
   const result = await memCache.get(globalKey);
-  const durationMs = Math.round(Date.now() - start);
-  const cacheDurations = memCache.get<number[]>('package-cache-gets') ?? [];
-  cacheDurations.push(durationMs);
-  memCache.set('package-cache-gets', cacheDurations);
+  if (start) {
+    // Only count duration if it's not a duplicate
+    const durationMs = Math.round(Date.now() - start);
+    const cacheDurations = memCache.get<number[]>('package-cache-gets') ?? [];
+    cacheDurations.push(durationMs);
+    memCache.set('package-cache-gets', cacheDurations);
+  }
   return result;
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Only counts deduplicated requests to package file cache

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
