### PR TITLE
docs(faq): update major platform feature support

### DIFF
--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -40,11 +40,11 @@ If you're self hosting Renovate, use the latest release if possible.
 
 Some major platform features are not supported at all by Renovate.
 
-| Feature name                            | Platform               | See Renovate issue(s)                                                                                                                                                                                                                                       |
-| --------------------------------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Jira issues                             | BitBucket              | [#3796](https://github.com/renovatebot/renovate/issues/3796)                                                                                                                                                                                                |
-| Merge trains                            | GitLab                 | [#5573](https://github.com/renovatebot/renovate/issues/5573)                                                                                                                                                                                                |
-| Configurable merge strategy and message | Only BitBucket for now | [#10867](https://github.com/renovatebot/renovate/issues/10867) [#10868](https://github.com/renovatebot/renovate/issues/10868) [#10869](https://github.com/renovatebot/renovate/issues/10869) [#10870](https://github.com/renovatebot/renovate/issues/10870) |
+| Feature name                            | Platform                         | See Renovate issue(s)                                                                                                                                                                        |
+| --------------------------------------- | -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Jira issues                             | BitBucket                        | [#3796](https://github.com/renovatebot/renovate/issues/3796)                                                                                                                                 |
+| Merge trains                            | GitLab                           | [#5573](https://github.com/renovatebot/renovate/issues/5573)                                                                                                                                 |
+| Configurable merge strategy and message | Only BitBucket and Gitea for now | [#10867](https://github.com/renovatebot/renovate/issues/10867) [#10869](https://github.com/renovatebot/renovate/issues/10869) [#10870](https://github.com/renovatebot/renovate/issues/10870) |
 
 ## What is this `main` branch I see in the documentation?
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Update the "Configurable merge strategy and message" row in the table:
  - Drop link to closed issue
  - Mention Gitea support

## Context

Looks like Gitea now has _Configurable merge strategy_:

- #10868
- #16851

Does the Gitea platform support _configurable merge messages_ now?

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
