### PR TITLE
fix(gradle): Treat `dev` qualifier as unstable

### DIFF
--- a/lib/modules/versioning/gradle/index.spec.ts
+++ b/lib/modules/versioning/gradle/index.spec.ts
@@ -181,6 +181,7 @@ describe('modules/versioning/gradle/index', () => {
     ${'Hoxton.SR'}                          | ${true}
     ${'Hoxton.SR1'}                         | ${true}
     ${'1.3.5-native-mt-1.3.71-release-429'} | ${false}
+    ${'1.0-dev'}                            | ${false}
   `('isStable("$input") === $expected', ({ input, expected }) => {
     expect(api.isStable(input)).toBe(expected);
   });

--- a/lib/modules/versioning/gradle/index.ts
+++ b/lib/modules/versioning/gradle/index.ts
@@ -75,6 +75,7 @@ const getPatch = (version: string): number | null => {
 const isGreaterThan = (a: string, b: string): boolean => compare(a, b) === 1;
 
 const unstable = new Set([
+  'dev',
   'a',
   'alpha',
   'b',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Add `dev` to other unstable qualifier list

## Context

- Closes: #18166
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
