### PR TITLE
fix: don't throw if a PR body contains a standalone unicode modifier

### DIFF
--- a/lib/util/emoji.spec.ts
+++ b/lib/util/emoji.spec.ts
@@ -82,5 +82,10 @@ describe('util/emoji', () => {
       setEmojiConfig({ unicodeEmoji: false });
       expect(stripEmojis(`foo ${x} bar`)).toBe(`foo ${y} bar`);
     });
+
+    it('does not throw on standalone modifiers', () => {
+      // This is based on a string from an actual PR description.
+      expect(stripEmojis("foo '🏻' bar")).toBe("foo '' bar");
+    });
   });
 });

--- a/lib/util/emoji.ts
+++ b/lib/util/emoji.ts
@@ -93,9 +93,13 @@ export function unemojify(text: string): string {
 
 function stripEmoji(emoji: string): string {
   const hexCode = stripHexCode(fromUnicodeToHexcode(emoji));
-  const codePoint = fromHexcodeToCodepoint(hexCode);
-  const result = fromCodepointToUnicode(codePoint);
-  return result;
+  // `hexCode` could be empty if `emoji` is a modifier character that isn't
+  // modifying anything
+  if (hexCode) {
+    const codePoint = fromHexcodeToCodepoint(hexCode);
+    return fromCodepointToUnicode(codePoint);
+  }
+  return '';
 }
 
 export function stripEmojis(input: string): string {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

If the title or body of any PR queried and processed by Renovate contained a unicode modifier character (such as a [skin tone modifier](https://emojipedia.org/emoji/%F0%9F%8F%BB/)) that wasn't modifying anything, the `stripEmojis` utility would throw an uncaught exception.

This PR adds a check for that case and returns an empty string instead. I'd be open to other suggestions for what to return since technically this is a tiny amount of data loss, but based on how the PR body and title are used (and extreme rarity of this case) I'm guessing that's okay.

## Context

This came up in an actual Azure DevOps repo where I was testing Renovate because someone had made a PR which modified some code affecting skin tone modifiers, and used one of the modifiers (without a corresponding modified emoji) in the description.

This issue is more likely to be hit with Azure DevOps currently because Renovate queries and processes *all PRs ever* instead of only PRs by the Renovate user.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
