### PR TITLE
refactor(manager): pass through `UpdateArtifact` generic type

### DIFF
--- a/lib/modules/manager/flux/artifacts.ts
+++ b/lib/modules/manager/flux/artifacts.ts
@@ -5,11 +5,12 @@ import type { ExecOptions } from '../../../util/exec/types';
 import { readLocalFile } from '../../../util/fs';
 import type { UpdateArtifact, UpdateArtifactsResult } from '../types';
 import { isSystemManifest } from './common';
+import type { FluxManagerData } from './types';
 
 export async function updateArtifacts({
   packageFileName,
   updatedDeps,
-}: UpdateArtifact): Promise<UpdateArtifactsResult[] | null> {
+}: UpdateArtifact<FluxManagerData>): Promise<UpdateArtifactsResult[] | null> {
   const systemDep = updatedDeps[0];
   if (!isSystemManifest(packageFileName) || !systemDep?.newVersion) {
     return null;

--- a/lib/modules/manager/flux/extract.ts
+++ b/lib/modules/manager/flux/extract.ts
@@ -6,7 +6,12 @@ import { GithubReleasesDatasource } from '../../datasource/github-releases';
 import { HelmDatasource } from '../../datasource/helm';
 import type { ExtractConfig, PackageDependency, PackageFile } from '../types';
 import { isSystemManifest } from './common';
-import type { FluxManifest, FluxResource, ResourceFluxManifest } from './types';
+import type {
+  FluxManagerData,
+  FluxManifest,
+  FluxResource,
+  ResourceFluxManifest,
+} from './types';
 
 function readManifest(content: string, file: string): FluxManifest | null {
   if (isSystemManifest(file)) {
@@ -68,14 +73,14 @@ function readManifest(content: string, file: string): FluxManifest | null {
 function resolveManifest(
   manifest: FluxManifest,
   context: FluxManifest[]
-): PackageDependency[] | null {
+): PackageDependency<FluxManagerData>[] | null {
   const resourceManifests = context.filter(
     (manifest) => manifest.kind === 'resource'
   ) as ResourceFluxManifest[];
   const repositories = resourceManifests.flatMap(
     (manifest) => manifest.repositories
   );
-  let res: PackageDependency[] | null = null;
+  let res: PackageDependency<FluxManagerData>[] | null = null;
   switch (manifest.kind) {
     case 'system':
       res = [
@@ -91,7 +96,7 @@ function resolveManifest(
       break;
     case 'resource':
       res = manifest.releases.map((release) => {
-        const dep: PackageDependency = {
+        const dep: PackageDependency<FluxManagerData> = {
           depName: release.spec.chart.spec.chart,
           currentValue: release.spec.chart.spec.version,
           datasource: HelmDatasource.id,
@@ -122,7 +127,7 @@ function resolveManifest(
 export function extractPackageFile(
   content: string,
   packageFile: string
-): PackageFile | null {
+): PackageFile<FluxManagerData> | null {
   const manifest = readManifest(content, packageFile);
   if (!manifest) {
     return null;
@@ -134,9 +139,9 @@ export function extractPackageFile(
 export async function extractAllPackageFiles(
   _config: ExtractConfig,
   packageFiles: string[]
-): Promise<PackageFile[] | null> {
+): Promise<PackageFile<FluxManagerData>[] | null> {
   const manifests: FluxManifest[] = [];
-  const results: PackageFile[] = [];
+  const results: PackageFile<FluxManagerData>[] = [];
 
   for (const file of packageFiles) {
     const content = await readLocalFile(file, 'utf8');

--- a/lib/modules/manager/flux/types.ts
+++ b/lib/modules/manager/flux/types.ts
@@ -1,3 +1,7 @@
+export type FluxManagerData = {
+  components: string;
+};
+
 export interface KubernetesResource {
   apiVersion: string;
   metadata: {

--- a/lib/modules/manager/types.ts
+++ b/lib/modules/manager/types.ts
@@ -198,9 +198,9 @@ export interface UpdateArtifactsResult {
   file?: FileChange;
 }
 
-export interface UpdateArtifact {
+export interface UpdateArtifact<T = Record<string, any>> {
   packageFileName: string;
-  updatedDeps: PackageDependency[];
+  updatedDeps: PackageDependency<T>[];
   newPackageFileContent: string;
   config: UpdateArtifactsConfig;
 }

--- a/lib/modules/manager/types.ts
+++ b/lib/modules/manager/types.ts
@@ -198,7 +198,7 @@ export interface UpdateArtifactsResult {
   file?: FileChange;
 }
 
-export interface UpdateArtifact<T = Record<string, any>> {
+export interface UpdateArtifact<T = Record<string, unknown>> {
   packageFileName: string;
   updatedDeps: PackageDependency<T>[];
   newPackageFileContent: string;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Change the type of `UpdateArtifact` to pass through a generic type to `updatedDeps`

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->
Discovered this as part of some other feature I am working on. 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
