### PR TITLE
Mention /modules/manager in matchManger config options docs

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -1690,6 +1690,8 @@ Use this field to restrict rules to a particular package manager. e.g.
 }
 ```
 
+See https://docs.renovatebot.com/modules/manager for a full list of supported managers.
+
 ### matchDatasources
 
 Use this field to restrict rules to a particular datasource. e.g.

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -1690,7 +1690,7 @@ Use this field to restrict rules to a particular package manager. e.g.
 }
 ```
 
-See https://docs.renovatebot.com/modules/manager for a full list of supported managers.
+For the full list of available managers, see the [Supported Managers](https://docs.renovatebot.com/modules/manager/#supported-managers) documentation.
 
 ### matchDatasources
 


### PR DESCRIPTION
## Changes

Please forgive the lack of backing issue or PR template adherence. I just found this to be a little inconvenient in the docs today. 😄 