### PR TITLE
feat(git): log cloned status at end of run

### DIFF
--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -367,6 +367,10 @@ export async function cloneSubmodules(shouldClone: boolean): Promise<void> {
   }
 }
 
+export function isCloned(): boolean {
+  return gitInitialized;
+}
+
 export async function syncGit(): Promise<void> {
   if (gitInitialized) {
     return;

--- a/lib/workers/repository/index.ts
+++ b/lib/workers/repository/index.ts
@@ -6,6 +6,7 @@ import { pkg } from '../../expose.cjs';
 import { logger, setMeta } from '../../logger';
 import { removeDanglingContainers } from '../../util/exec/docker';
 import { deleteLocalFile, privateCacheDir } from '../../util/fs';
+import { isCloned } from '../../util/git';
 import { clearDnsCache, printDnsStats } from '../../util/http/dns';
 import * as queue from '../../util/http/queue';
 import * as schemaUtil from '../../util/schema';
@@ -91,6 +92,7 @@ export async function renovateRepository(
   printDnsStats();
   clearDnsCache();
   schemaUtil.reportErrors();
-  logger.info({ durationMs: splits.total }, 'Repository finished');
+  const cloned = isCloned();
+  logger.info({ cloned, durationMs: splits.total }, 'Repository finished');
   return repoResult;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds a `cloned` boolean to `Repository finished`.

## Context

Better understanding of how much we are improving clone %.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
