### PR TITLE
refactor(manager/bazel): Leverage schemas for dependency extraction

### DIFF
--- a/lib/modules/manager/bazel/extract.spec.ts
+++ b/lib/modules/manager/bazel/extract.spec.ts
@@ -1,7 +1,8 @@
 import { Fixtures } from '../../../../test/fixtures';
-import { extractPackageFile as extract } from '.';
+import { extractPackageFile as _extractPackageFile } from '.';
 
-const extractPackageFile = (content: string) => extract(content, 'WORKSPACE');
+const extractPackageFile = (content: string) =>
+  _extractPackageFile(content, 'WORKSPACE');
 
 describe('modules/manager/bazel/extract', () => {
   describe('extractPackageFile()', () => {

--- a/lib/modules/manager/bazel/parser.spec.ts
+++ b/lib/modules/manager/bazel/parser.spec.ts
@@ -1,4 +1,4 @@
-import { parse } from './parser';
+import { extract, parse } from './parser';
 
 describe('modules/manager/bazel/parser', () => {
   it('parses rules input', () => {
@@ -44,6 +44,10 @@ describe('modules/manager/bazel/parser', () => {
         },
       ],
     });
+    expect(extract(res)).toMatchObject([
+      { rule: 'go_repository', name: 'foo' },
+      { rule: 'go_repository', name: 'bar', deps: ['baz', 'qux'] },
+    ]);
   });
 
   it('parses multiple archives', () => {
@@ -100,6 +104,25 @@ describe('modules/manager/bazel/parser', () => {
         },
       ],
     });
+    expect(extract(res)).toMatchObject([
+      {
+        rule: 'http_archive',
+        name: 'aspect_rules_js',
+        sha256:
+          'db9f446752fe4100320cf8487e8fd476b9af0adf6b99b601bcfd70b289bb0598',
+        strip_prefix: 'rules_js-1.1.2',
+        url: 'https://github.com/aspect-build/rules_js/archive/refs/tags/v1.1.2.tar.gz',
+      },
+      {
+        rule: 'http_archive',
+        name: 'rules_nodejs',
+        sha256:
+          '5aef09ed3279aa01d5c928e3beb248f9ad32dde6aafe6373a8c994c3ce643064',
+        urls: [
+          'https://github.com/bazelbuild/rules_nodejs/releases/download/5.5.3/rules_nodejs-core-5.5.3.tar.gz',
+        ],
+      },
+    ]);
   });
 
   it('parses http_archive', () => {
@@ -129,6 +152,15 @@ describe('modules/manager/bazel/parser', () => {
         },
       ],
     });
+    expect(extract(res)).toMatchObject([
+      {
+        rule: 'http_archive',
+        name: 'rules_nodejs',
+        sha256:
+          '5aef09ed3279aa01d5c928e3beb248f9ad32dde6aafe6373a8c994c3ce643064',
+        url: 'https://github.com/bazelbuild/rules_nodejs/releases/download/5.5.3/rules_nodejs-core-5.5.3.tar.gz',
+      },
+    ]);
   });
 
   it('parses http_archive with prefixes and multiple urls', () => {
@@ -174,5 +206,23 @@ describe('modules/manager/bazel/parser', () => {
         },
       ],
     });
+    expect(extract(res)).toMatchObject([
+      {
+        name: 'bazel_toolchains',
+        rule: 'http_archive',
+        sha256:
+          '4b1468b254a572dbe134cc1fd7c6eab1618a72acd339749ea343bd8f55c3b7eb',
+        strip_prefix:
+          'bazel-toolchains-d665ccfa3e9c90fa789671bf4ef5f7c19c5715c4',
+        urls: [
+          'https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/d665ccfa3e9c90fa789671bf4ef5f7c19c5715c4.tar.gz',
+          'https://github.com/bazelbuild/bazel-toolchains/archive/d665ccfa3e9c90fa789671bf4ef5f7c19c5715c4.tar.gz',
+        ],
+      },
+    ]);
+  });
+
+  it('extracts null from null', () => {
+    expect(extract(null)).toBeNull();
   });
 });

--- a/lib/modules/manager/bazel/parser.spec.ts
+++ b/lib/modules/manager/bazel/parser.spec.ts
@@ -44,7 +44,7 @@ describe('modules/manager/bazel/parser', () => {
         },
       ],
     });
-    expect(extract(res)).toMatchObject([
+    expect(extract(res!)).toMatchObject([
       { rule: 'go_repository', name: 'foo' },
       { rule: 'go_repository', name: 'bar', deps: ['baz', 'qux'] },
     ]);
@@ -104,7 +104,7 @@ describe('modules/manager/bazel/parser', () => {
         },
       ],
     });
-    expect(extract(res)).toMatchObject([
+    expect(extract(res!)).toMatchObject([
       {
         rule: 'http_archive',
         name: 'aspect_rules_js',
@@ -152,7 +152,7 @@ describe('modules/manager/bazel/parser', () => {
         },
       ],
     });
-    expect(extract(res)).toMatchObject([
+    expect(extract(res!)).toMatchObject([
       {
         rule: 'http_archive',
         name: 'rules_nodejs',
@@ -206,7 +206,7 @@ describe('modules/manager/bazel/parser', () => {
         },
       ],
     });
-    expect(extract(res)).toMatchObject([
+    expect(extract(res!)).toMatchObject([
       {
         name: 'bazel_toolchains',
         rule: 'http_archive',
@@ -220,9 +220,5 @@ describe('modules/manager/bazel/parser', () => {
         ],
       },
     ]);
-  });
-
-  it('extracts null from null', () => {
-    expect(extract(null)).toBeNull();
   });
 });

--- a/lib/modules/manager/bazel/parser.ts
+++ b/lib/modules/manager/bazel/parser.ts
@@ -239,11 +239,7 @@ export function parse(input: string): ArrayFragment | null {
   return result;
 }
 
-export function extract(fragment: Fragment | null): FragmentData | null {
-  if (!fragment) {
-    return null;
-  }
-
+export function extract(fragment: Fragment): FragmentData {
   if (fragment.type === 'string') {
     return fragment.value;
   }

--- a/lib/modules/manager/bazel/parser.ts
+++ b/lib/modules/manager/bazel/parser.ts
@@ -239,8 +239,6 @@ export function parse(input: string): ArrayFragment | null {
   return result;
 }
 
-export function extract(fragment: null): null;
-export function extract(fragment: Fragment): FragmentData;
 export function extract(fragment: Fragment | null): FragmentData | null {
   if (!fragment) {
     return null;

--- a/lib/modules/manager/bazel/rules/docker.ts
+++ b/lib/modules/manager/bazel/rules/docker.ts
@@ -3,9 +3,11 @@ import { DockerDatasource } from '../../../datasource/docker';
 import { id as dockerVersioning } from '../../../versioning/docker';
 import type { PackageDependency } from '../../types';
 
+export const dockerRules = ['container_pull'] as const;
+
 export const DockerTarget = z
   .object({
-    rule: z.enum(['container_pull']),
+    rule: z.enum(dockerRules),
     name: z.string(),
     tag: z.string(),
     digest: z.string(),

--- a/lib/modules/manager/bazel/rules/docker.ts
+++ b/lib/modules/manager/bazel/rules/docker.ts
@@ -1,38 +1,26 @@
-import is from '@sindresorhus/is';
+import { z } from 'zod';
 import { DockerDatasource } from '../../../datasource/docker';
 import { id as dockerVersioning } from '../../../versioning/docker';
 import type { PackageDependency } from '../../types';
-import type { Target } from '../types';
 
-export function dockerDependency({
-  rule: depType,
-  name: depName,
-  tag: currentValue,
-  digest: currentDigest,
-  repository: packageName,
-  registry,
-}: Target): PackageDependency | null {
-  let dep: PackageDependency | null = null;
-
-  if (
-    depType === 'container_pull' &&
-    is.string(depName) &&
-    is.string(currentValue) &&
-    is.string(currentDigest) &&
-    is.string(packageName) &&
-    is.string(registry)
-  ) {
-    dep = {
+export const DockerTarget = z
+  .object({
+    rule: z.enum(['container_pull']),
+    name: z.string(),
+    tag: z.string(),
+    digest: z.string(),
+    repository: z.string(),
+    registry: z.string(),
+  })
+  .transform(
+    ({ rule, name, repository, tag, digest, registry }): PackageDependency => ({
       datasource: DockerDatasource.id,
       versioning: dockerVersioning,
-      depType,
-      depName,
-      packageName,
-      currentValue,
-      currentDigest,
+      depType: rule,
+      depName: name,
+      packageName: repository,
+      currentValue: tag,
+      currentDigest: digest,
       registryUrls: [registry],
-    };
-  }
-
-  return dep;
-}
+    })
+  );

--- a/lib/modules/manager/bazel/rules/git.ts
+++ b/lib/modules/manager/bazel/rules/git.ts
@@ -12,9 +12,11 @@ function githubPackageName(input: string): string | undefined {
   return parseGithubUrl(input)?.match(githubUrlRegex)?.groups?.packageName;
 }
 
+export const gitRules = ['git_repository'] as const;
+
 export const GitTarget = z
   .object({
-    rule: z.enum(['git_repository']),
+    rule: z.enum(gitRules),
     name: z.string(),
     tag: z.string().optional(),
     commit: z.string().optional(),

--- a/lib/modules/manager/bazel/rules/git.ts
+++ b/lib/modules/manager/bazel/rules/git.ts
@@ -1,50 +1,49 @@
-import is from '@sindresorhus/is';
 import parseGithubUrl from 'github-url-from-git';
+import { z } from 'zod';
+import { regEx } from '../../../../util/regex';
 import { GithubReleasesDatasource } from '../../../datasource/github-releases';
 import type { PackageDependency } from '../../types';
-import type { Target } from '../types';
 
-export function gitDependency({
-  rule: depType,
-  name: depName,
-  tag: currentValue,
-  commit: currentDigest,
-  remote,
-}: Target): PackageDependency | null {
-  let dep: PackageDependency | null = null;
+const githubUrlRegex = regEx(
+  /^https:\/\/github\.com\/(?<packageName>[^/]+\/[^/]+)/
+);
 
-  if (
-    depType === 'git_repository' &&
-    is.string(depName) &&
-    (is.string(currentValue) || is.string(currentDigest)) &&
-    is.string(remote)
-  ) {
-    dep = {
-      datasource: GithubReleasesDatasource.id,
-      depType,
-      depName,
+function githubPackageName(input: string): string | undefined {
+  return parseGithubUrl(input)?.match(githubUrlRegex)?.groups?.packageName;
+}
+
+export const GitTarget = z
+  .object({
+    rule: z.enum(['git_repository']),
+    name: z.string(),
+    tag: z.string().optional(),
+    commit: z.string().optional(),
+    remote: z.string(),
+  })
+  .refine(({ tag, commit }) => !!tag || !!commit)
+  .transform(({ rule, name, tag, commit, remote }): PackageDependency => {
+    const dep: PackageDependency = {
+      depType: rule,
+      depName: name,
     };
 
-    if (is.string(currentValue)) {
-      dep.currentValue = currentValue;
+    if (tag) {
+      dep.currentValue = tag;
     }
 
-    if (is.string(currentDigest)) {
-      dep.currentDigest = currentDigest;
+    if (commit) {
+      dep.currentDigest = commit;
     }
 
-    // TODO: Check if we really need to use parse here or if it should always be a plain https url (#9605)
-    const packageName = parseGithubUrl(remote)?.substring(
-      'https://github.com/'.length
-    );
-
-    // istanbul ignore else
-    if (packageName) {
-      dep.packageName = packageName;
-    } else {
-      dep.skipReason = 'unsupported-remote';
+    const githubPackage = githubPackageName(remote);
+    if (githubPackage) {
+      dep.datasource = GithubReleasesDatasource.id;
+      dep.packageName = githubPackage;
     }
-  }
 
-  return dep;
-}
+    if (!dep.datasource) {
+      dep.skipReason = 'unsupported-datasource';
+    }
+
+    return dep;
+  });

--- a/lib/modules/manager/bazel/rules/go.ts
+++ b/lib/modules/manager/bazel/rules/go.ts
@@ -1,54 +1,49 @@
-import is from '@sindresorhus/is';
+import { z } from 'zod';
 import { regEx } from '../../../../util/regex';
 import { GoDatasource } from '../../../datasource/go';
 import type { PackageDependency } from '../../types';
-import type { Target } from '../types';
 
-export function goDependency({
-  rule: depType,
-  name: depName,
-  tag: currentValue,
-  commit: currentDigest,
-  importpath: packageName,
-  remote,
-}: Target): PackageDependency | null {
-  let dep: PackageDependency | null = null;
+export const GoTarget = z
+  .object({
+    rule: z.enum(['go_repository']),
+    name: z.string(),
+    tag: z.string().optional(),
+    commit: z.string().optional(),
+    importpath: z.string(),
+    remote: z.string().optional(),
+  })
+  .refine(({ tag, commit }) => !!tag || !!commit)
+  .transform(
+    ({ rule, name, tag, commit, importpath, remote }): PackageDependency => {
+      const dep: PackageDependency = {
+        datasource: GoDatasource.id,
+        depType: rule,
+        depName: name,
+        packageName: importpath,
+      };
 
-  if (
-    depType === 'go_repository' &&
-    is.string(depName) &&
-    (is.string(currentValue) || is.string(currentDigest)) &&
-    is.string(packageName)
-  ) {
-    dep = {
-      datasource: GoDatasource.id,
-      depType,
-      depName,
-      packageName,
-    };
-
-    if (is.string(currentValue)) {
-      dep.currentValue = currentValue;
-    }
-
-    if (is.string(currentDigest)) {
-      dep.currentValue = 'v0.0.0';
-      dep.currentDigest = currentDigest;
-      dep.currentDigestShort = currentDigest.substring(0, 7);
-      dep.digestOneAndOnly = true;
-    }
-
-    if (is.string(remote)) {
-      const remoteMatch = regEx(
-        /https:\/\/github\.com(?:.*\/)(([a-zA-Z]+)([-])?([a-zA-Z]+))/
-      ).exec(remote);
-      if (remoteMatch && remoteMatch[0].length === remote.length) {
-        dep.packageName = remote.replace('https://', '');
-      } else {
-        dep.skipReason = 'unsupported-remote';
+      if (tag) {
+        dep.currentValue = tag;
       }
-    }
-  }
 
-  return dep;
-}
+      if (commit) {
+        dep.currentValue = 'v0.0.0';
+        dep.currentDigest = commit;
+        dep.currentDigestShort = commit.substring(0, 7);
+        dep.digestOneAndOnly = true;
+      }
+
+      if (remote) {
+        const remoteMatch = regEx(
+          /https:\/\/github\.com(?:.*\/)(([a-zA-Z]+)([-])?([a-zA-Z]+))/
+        ).exec(remote);
+        if (remoteMatch && remoteMatch[0].length === remote.length) {
+          dep.packageName = remote.replace('https://', '');
+        } else {
+          dep.skipReason = 'unsupported-remote';
+        }
+      }
+
+      return dep;
+    }
+  );

--- a/lib/modules/manager/bazel/rules/go.ts
+++ b/lib/modules/manager/bazel/rules/go.ts
@@ -3,9 +3,11 @@ import { regEx } from '../../../../util/regex';
 import { GoDatasource } from '../../../datasource/go';
 import type { PackageDependency } from '../../types';
 
+export const goRules = ['go_repository'] as const;
+
 export const GoTarget = z
   .object({
-    rule: z.enum(['go_repository']),
+    rule: z.enum(goRules),
     name: z.string(),
     tag: z.string().optional(),
     commit: z.string().optional(),

--- a/lib/modules/manager/bazel/rules/http.ts
+++ b/lib/modules/manager/bazel/rules/http.ts
@@ -1,3 +1,4 @@
+import is from '@sindresorhus/is';
 import { z } from 'zod';
 import { regEx } from '../../../../util/regex';
 import { parseUrl } from '../../../../util/url';
@@ -60,7 +61,7 @@ export const HttpTarget = z
   })
   .refine(({ url, urls }) => !!url || !!urls)
   .transform(({ rule, name, url, urls = [] }): PackageDependency | null => {
-    const parsedUrl = [url, ...urls].map(parseArchiveUrl).find(Boolean);
+    const parsedUrl = [url, ...urls].map(parseArchiveUrl).find(is.truthy);
     if (!parsedUrl) {
       return null;
     }

--- a/lib/modules/manager/bazel/rules/http.ts
+++ b/lib/modules/manager/bazel/rules/http.ts
@@ -1,10 +1,10 @@
-import is from '@sindresorhus/is';
+import { z } from 'zod';
 import { regEx } from '../../../../util/regex';
 import { parseUrl } from '../../../../util/url';
 import { GithubReleasesDatasource } from '../../../datasource/github-releases';
 import { GithubTagsDatasource } from '../../../datasource/github-tags';
 import type { PackageDependency } from '../../types';
-import type { Target, UrlParsedResult } from '../types';
+import type { UrlParsedResult } from '../types';
 
 export function parseArchiveUrl(
   urlString: string | undefined | null
@@ -50,47 +50,33 @@ export function parseArchiveUrl(
   return null;
 }
 
-export function httpDependency({
-  rule: depType,
-  name: depName,
-  url,
-  urls,
-  sha256,
-}: Target): PackageDependency | null {
-  let dep: PackageDependency | null = null;
-
-  if (
-    (depType === 'http_archive' || depType === 'http_file') &&
-    is.string(depName) &&
-    is.string(sha256)
-  ) {
-    let parsedUrl: UrlParsedResult | null = null;
-    if (is.string(url)) {
-      parsedUrl = parseArchiveUrl(url);
-    } else if (is.array(urls, is.string)) {
-      for (const u of urls) {
-        parsedUrl = parseArchiveUrl(u);
-        if (parsedUrl) {
-          break;
-        }
-      }
+export const HttpTarget = z
+  .object({
+    rule: z.enum(['http_archive', 'http_file']),
+    name: z.string(),
+    url: z.string().optional(),
+    urls: z.array(z.string()).optional(),
+    sha256: z.string(),
+  })
+  .refine(({ url, urls }) => !!url || !!urls)
+  .transform(({ rule, name, url, urls = [] }): PackageDependency | null => {
+    const parsedUrl = [url, ...urls].map(parseArchiveUrl).find(Boolean);
+    if (!parsedUrl) {
+      return null;
     }
 
-    if (parsedUrl) {
-      dep = {
-        datasource: parsedUrl.datasource,
-        depType,
-        depName,
-        packageName: parsedUrl.repo,
-      };
+    const dep: PackageDependency = {
+      datasource: parsedUrl.datasource,
+      depType: rule,
+      depName: name,
+      packageName: parsedUrl.repo,
+    };
 
-      if (regEx(/^[a-f0-9]{40}$/i).test(parsedUrl.currentValue)) {
-        dep.currentDigest = parsedUrl.currentValue;
-      } else {
-        dep.currentValue = parsedUrl.currentValue;
-      }
+    if (regEx(/^[a-f0-9]{40}$/i).test(parsedUrl.currentValue)) {
+      dep.currentDigest = parsedUrl.currentValue;
+    } else {
+      dep.currentValue = parsedUrl.currentValue;
     }
-  }
 
-  return dep;
-}
+    return dep;
+  });

--- a/lib/modules/manager/bazel/rules/http.ts
+++ b/lib/modules/manager/bazel/rules/http.ts
@@ -51,9 +51,11 @@ export function parseArchiveUrl(
   return null;
 }
 
+export const httpRules = ['http_archive', 'http_file'] as const;
+
 export const HttpTarget = z
   .object({
-    rule: z.enum(['http_archive', 'http_file']),
+    rule: z.enum(httpRules),
     name: z.string(),
     url: z.string().optional(),
     urls: z.array(z.string()).optional(),

--- a/lib/modules/manager/bazel/rules/index.spec.ts
+++ b/lib/modules/manager/bazel/rules/index.spec.ts
@@ -90,6 +90,20 @@ describe('modules/manager/bazel/rules/index', () => {
         packageName: 'foo/bar',
         currentDigest: 'abcdef0123abcdef0123abcdef0123abcdef0123',
       });
+
+      expect(
+        extractDepFromFragmentData({
+          rule: 'git_repository',
+          name: 'foo_bar',
+          tag: '1.2.3',
+          remote: 'https://gitlab.com/foo/bar',
+        })
+      ).toMatchObject({
+        currentValue: '1.2.3',
+        depName: 'foo_bar',
+        depType: 'git_repository',
+        skipReason: 'unsupported-datasource',
+      });
     });
   });
 

--- a/lib/modules/manager/bazel/rules/index.ts
+++ b/lib/modules/manager/bazel/rules/index.ts
@@ -1,29 +1,20 @@
-import { ZodObject, z } from 'zod';
+import { z } from 'zod';
 import { regEx } from '../../../../util/regex';
 import type { PackageDependency } from '../../types';
 import { extract } from '../parser';
 import type { Fragment, FragmentData, Target } from '../types';
-import { DockerTarget } from './docker';
-import { GitTarget } from './git';
-import { GoTarget } from './go';
-import { HttpTarget } from './http';
+import { DockerTarget, dockerRules } from './docker';
+import { GitTarget, gitRules } from './git';
+import { GoTarget, goRules } from './go';
+import { HttpTarget, httpRules } from './http';
 
 const Target = z.union([DockerTarget, GitTarget, GoTarget, HttpTarget]);
 
 /**
- * Infer all rule names supported by Renovate in order to speed up parsing
+ * Gather all rule names supported by Renovate in order to speed up parsing
  * by filtering out other syntactically correct rules we don't support yet.
  */
-const supportedRules = Target.options.reduce<string[]>((res, targetSchema) => {
-  const schema = targetSchema._def.schema;
-  return schema instanceof ZodObject
-    ? [...res, ...schema.shape.rule.options]
-    : [...res, ...schema._def.schema.shape.rule.options];
-}, []);
-
-/**
- * Used by parser
- */
+const supportedRules = [...dockerRules, ...gitRules, ...goRules, ...httpRules];
 export const supportedRulesRegex = regEx(`^${supportedRules.join('|')}$`);
 
 export function extractDepFromFragmentData(

--- a/lib/modules/manager/bazel/rules/index.ts
+++ b/lib/modules/manager/bazel/rules/index.ts
@@ -1,4 +1,4 @@
-import { ZodEffects, ZodObject, z } from 'zod';
+import { ZodObject, z } from 'zod';
 import { regEx } from '../../../../util/regex';
 import type { PackageDependency } from '../../types';
 import { extract } from '../parser';

--- a/lib/modules/manager/bazel/rules/index.ts
+++ b/lib/modules/manager/bazel/rules/index.ts
@@ -1,74 +1,48 @@
-import is from '@sindresorhus/is';
-import { logger } from '../../../../logger';
+import { ZodEffects, ZodObject, z } from 'zod';
 import { regEx } from '../../../../util/regex';
 import type { PackageDependency } from '../../types';
-import type {
-  Fragment,
-  StringFragment,
-  Target,
-  TargetAttribute,
-} from '../types';
-import { dockerDependency } from './docker';
-import { gitDependency } from './git';
-import { goDependency } from './go';
-import { httpDependency } from './http';
+import { extract } from '../parser';
+import type { Fragment, FragmentData, Target } from '../types';
+import { DockerTarget } from './docker';
+import { GitTarget } from './git';
+import { GoTarget } from './go';
+import { HttpTarget } from './http';
 
-type DependencyExtractor = (_: Target) => PackageDependency | null;
-type DependencyExtractorRegistry = Record<string, DependencyExtractor>;
+const Target = z.union([DockerTarget, GitTarget, GoTarget, HttpTarget]);
 
-const dependencyExtractorRegistry: DependencyExtractorRegistry = {
-  git_repository: gitDependency,
-  go_repository: goDependency,
-  http_archive: httpDependency,
-  http_file: httpDependency,
-  container_pull: dockerDependency,
-};
+/**
+ * Infer all rule names supported by Renovate in order to speed up parsing
+ * by filtering out other syntactically correct rules we don't support yet.
+ */
+const supportedRules = Target.options.reduce<string[]>((res, targetSchema) => {
+  const schema = targetSchema._def.schema;
+  if (schema instanceof ZodObject) {
+    return [...res, ...schema.shape.rule.options];
+  }
+  if (schema instanceof ZodEffects) {
+    return [...res, ...schema._def.schema.shape.rule.options];
+  }
+  return res;
+}, []);
 
-const supportedRules = Object.keys(dependencyExtractorRegistry);
+/**
+ * Used by parser
+ */
 export const supportedRulesRegex = regEx(`^${supportedRules.join('|')}$`);
 
-function isTarget(x: Record<string, TargetAttribute>): x is Target {
-  return is.string(x.name) && is.string(x.rule);
-}
-
-export function coerceFragmentToTarget(fragment: Fragment): Target | null {
-  if (fragment.type === 'record') {
-    const { children } = fragment;
-    const target: Record<string, TargetAttribute> = {};
-    for (const [key, value] of Object.entries(children)) {
-      if (value.type === 'array') {
-        const values = value.children
-          .filter((x): x is StringFragment => x.type === 'string')
-          .map((x) => x.value);
-        target[key] = values;
-      } else if (value.type === 'string') {
-        target[key] = value.value;
-      }
-    }
-
-    if (isTarget(target)) {
-      return target;
-    }
+export function extractDepFromFragmentData(
+  fragmentData: FragmentData
+): PackageDependency | null {
+  const res = Target.safeParse(fragmentData);
+  if (!res.success) {
+    return null;
   }
-
-  return null;
+  return res.data;
 }
 
 export function extractDepFromFragment(
   fragment: Fragment
 ): PackageDependency | null {
-  const target = coerceFragmentToTarget(fragment);
-  if (!target) {
-    return null;
-  }
-
-  const dependencyExtractor = dependencyExtractorRegistry[target.rule];
-  if (!dependencyExtractor) {
-    logger.debug(
-      `Bazel dependency extractor function not found for ${target.rule}`
-    );
-    return null;
-  }
-
-  return dependencyExtractor(target);
+  const fragmentData = extract(fragment);
+  return extractDepFromFragmentData(fragmentData);
 }

--- a/lib/modules/manager/bazel/rules/index.ts
+++ b/lib/modules/manager/bazel/rules/index.ts
@@ -16,13 +16,9 @@ const Target = z.union([DockerTarget, GitTarget, GoTarget, HttpTarget]);
  */
 const supportedRules = Target.options.reduce<string[]>((res, targetSchema) => {
   const schema = targetSchema._def.schema;
-  if (schema instanceof ZodObject) {
-    return [...res, ...schema.shape.rule.options];
-  }
-  if (schema instanceof ZodEffects) {
-    return [...res, ...schema._def.schema.shape.rule.options];
-  }
-  return res;
+  return schema instanceof ZodObject
+    ? [...res, ...schema.shape.rule.options]
+    : [...res, ...schema._def.schema.shape.rule.options];
 }, []);
 
 /**

--- a/lib/modules/manager/bazel/types.ts
+++ b/lib/modules/manager/bazel/types.ts
@@ -38,7 +38,6 @@ export type NestedFragment = ArrayFragment | RecordFragment;
 export type Fragment = NestedFragment | StringFragment;
 
 export type FragmentData =
-  | null
   | string
   | FragmentData[]
   | { [k: string]: FragmentData };

--- a/lib/modules/manager/bazel/types.ts
+++ b/lib/modules/manager/bazel/types.ts
@@ -36,3 +36,9 @@ export interface StringFragment extends FragmentBase {
 
 export type NestedFragment = ArrayFragment | RecordFragment;
 export type Fragment = NestedFragment | StringFragment;
+
+export type FragmentData =
+  | null
+  | string
+  | FragmentData[]
+  | { [k: string]: FragmentData };


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Instead of manual type checks, this PR introduces schema usage for final phase of dependency extraction from the parsed fragment data.

## Context

- Ref: #9667
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
