### PR TITLE
fix(manager/argocd): correctly handle oci registries with custom port

### DIFF
--- a/lib/modules/manager/argocd/__fixtures__/validApplication.yml
+++ b/lib/modules/manager/argocd/__fixtures__/validApplication.yml
@@ -59,3 +59,19 @@ spec:
     chart: some/image2
     repoURL: oci://somecontainer.registry.io
     targetRevision: 1.3.0
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+spec:
+  source:
+    chart: some/image2
+    repoURL: somecontainer.registry.io:443
+    targetRevision: 1.3.0
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+spec:
+  source:
+    chart: some/image3
+    repoURL: somecontainer.registry.io:443/
+    targetRevision: 1.0.0

--- a/lib/modules/manager/argocd/extract.spec.ts
+++ b/lib/modules/manager/argocd/extract.spec.ts
@@ -64,6 +64,16 @@ describe('modules/manager/argocd/extract', () => {
             datasource: 'docker',
             depName: 'somecontainer.registry.io/some/image2',
           },
+          {
+            currentValue: '1.3.0',
+            datasource: 'docker',
+            depName: 'somecontainer.registry.io:443/some/image2',
+          },
+          {
+            currentValue: '1.0.0',
+            datasource: 'docker',
+            depName: 'somecontainer.registry.io:443/some/image3',
+          },
         ],
       });
     });

--- a/lib/modules/manager/argocd/extract.ts
+++ b/lib/modules/manager/argocd/extract.ts
@@ -37,9 +37,13 @@ function createDependency(
       source.repoURL.startsWith('oci://') ||
       !source.repoURL.includes('://')
     ) {
-      const registryURL = source.repoURL.replace('oci://', '');
+      let registryURL = source.repoURL.replace('oci://', '');
+      if (registryURL.endsWith('/')) {
+        registryURL = registryURL.slice(0, -1);
+      }
+
       return {
-        depName: urlJoin(registryURL, source.chart),
+        depName: `${registryURL}/${source.chart}`,
         currentValue: source.targetRevision,
         datasource: DockerDatasource.id,
       };

--- a/lib/modules/manager/argocd/extract.ts
+++ b/lib/modules/manager/argocd/extract.ts
@@ -1,6 +1,5 @@
 import is from '@sindresorhus/is';
 import { loadAll } from 'js-yaml';
-import urlJoin from 'url-join';
 import { logger } from '../../../logger';
 import { DockerDatasource } from '../../datasource/docker';
 import { GitTagsDatasource } from '../../datasource/git-tags';

--- a/lib/modules/manager/argocd/extract.ts
+++ b/lib/modules/manager/argocd/extract.ts
@@ -1,6 +1,7 @@
 import is from '@sindresorhus/is';
 import { loadAll } from 'js-yaml';
 import { logger } from '../../../logger';
+import { trimTrailingSlash } from '../../../util/url';
 import { DockerDatasource } from '../../datasource/docker';
 import { GitTagsDatasource } from '../../datasource/git-tags';
 import { HelmDatasource } from '../../datasource/helm';
@@ -37,9 +38,7 @@ function createDependency(
       !source.repoURL.includes('://')
     ) {
       let registryURL = source.repoURL.replace('oci://', '');
-      if (registryURL.endsWith('/')) {
-        registryURL = registryURL.slice(0, -1);
-      }
+      registryURL = trimTrailingSlash(registryURL);
 
       return {
         depName: `${registryURL}/${source.chart}`,


### PR DESCRIPTION
## Changes
urlJoin doesn't handle custom ports in the registry correctly, since it interpreted the `<registry>:<port>` as `<registry>://<port>`, resulting in the wrong registry: https://github.com/renovatebot/renovate/issues/13699#issuecomment-1274437232

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

