### PR TITLE
fix: guarantee symmetric result from sort branch predicate

### DIFF
--- a/lib/workers/repository/process/sort.spec.ts
+++ b/lib/workers/repository/process/sort.spec.ts
@@ -100,5 +100,43 @@ describe('workers/repository/process/sort', () => {
         { prPriority: -1, prTitle: 'some pin', updateType: 'pin' },
       ]);
     });
+
+    it('sorts based on isVulnerabilityAlert symmetric', () => {
+      const branches = [
+        {
+          updateType: 'minor' as UpdateType,
+          prTitle: 'a minor update',
+          prPriority: -1,
+          isVulnerabilityAlert: true,
+        },
+        {
+          updateType: 'major' as UpdateType,
+          prTitle: 'some major update',
+          prPriority: 1,
+        },
+        {
+          updateType: 'pin' as UpdateType,
+          prTitle: 'some pin',
+          prPriority: -1,
+        },
+        {
+          updateType: 'pin' as UpdateType,
+          prTitle: 'some other pin',
+          prPriority: 0,
+        },
+      ];
+      sortBranches(branches);
+      expect(branches).toEqual([
+        {
+          isVulnerabilityAlert: true,
+          prPriority: -1,
+          prTitle: 'a minor update',
+          updateType: 'minor',
+        },
+        { prPriority: 1, prTitle: 'some major update', updateType: 'major' },
+        { prPriority: 0, prTitle: 'some other pin', updateType: 'pin' },
+        { prPriority: -1, prTitle: 'some pin', updateType: 'pin' },
+      ]);
+    });
   });
 });

--- a/lib/workers/repository/process/sort.ts
+++ b/lib/workers/repository/process/sort.ts
@@ -16,6 +16,10 @@ export function sortBranches(branches: Partial<BranchConfig>[]): void {
     if (a.isVulnerabilityAlert && !b.isVulnerabilityAlert) {
       return -1;
     }
+    if (!a.isVulnerabilityAlert && b.isVulnerabilityAlert) {
+      return 1;
+    }
+
     // TODO #7154
     if (a.prPriority !== b.prPriority) {
       return b.prPriority! - a.prPriority!;


### PR DESCRIPTION
## Changes

Assures symmetrical response from the branch sort predicate when there is a difference in the isVulnerabilityAlert flag.

## Context

If left as is, in some rare cases it might leave the list of branches in-properly sorted.

- #17276

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

Note: this is trivial change with very hard real time simulation.