### PR TITLE
fix(datasource/dotnet): account for nullable releases

### DIFF
--- a/lib/modules/datasource/dotnet/index.ts
+++ b/lib/modules/datasource/dotnet/index.ts
@@ -4,6 +4,7 @@ import type { HttpResponse } from '../../../util/http/types';
 import { Datasource } from '../datasource';
 import type { GetReleasesConfig, Release, ReleaseResult } from '../types';
 import {
+  DotnetRelease,
   DotnetReleases,
   DotnetReleasesIndex,
   DotnetReleasesIndexSchema,
@@ -94,14 +95,22 @@ export class DotnetDatasource extends Datasource {
       const type = DotnetDatasource.getType(packageName);
       const { releases: releases } = body;
       result = releases
+        .filter(
+          (
+            release
+          ): release is {
+            [P in keyof DotnetRelease]: NonNullable<DotnetRelease[P]>;
+          } => {
+            return is.nullOrUndefined(release[type]);
+          }
+        )
         .map((release) => {
           return {
-            version: release[type]?.version,
+            version: release[type].version,
             releaseTimestamp: release['release-date'],
             changelogUrl: release['release-notes'],
           };
-        })
-        .filter((release) => is.nonEmptyString(release.version)) as Release[];
+        });
     }
 
     return result;

--- a/lib/modules/datasource/dotnet/index.ts
+++ b/lib/modules/datasource/dotnet/index.ts
@@ -1,3 +1,4 @@
+import is from '@sindresorhus/is';
 import { cache } from '../../../util/cache/package/decorator';
 import type { HttpResponse } from '../../../util/http/types';
 import { Datasource } from '../datasource';
@@ -71,7 +72,8 @@ export class DotnetDatasource extends Datasource {
 
   @cache({
     namespace: `datasource-${DotnetDatasource.id}`,
-    key: (releaseUrl: string) => releaseUrl,
+    key: (releaseUrl: string, packageName: string) =>
+      `${releaseUrl}:${packageName}`,
     ttlMinutes: 1440,
   })
   async getChannelReleases(
@@ -91,13 +93,15 @@ export class DotnetDatasource extends Datasource {
     if (body) {
       const type = DotnetDatasource.getType(packageName);
       const { releases: releases } = body;
-      result = releases.map((release) => {
-        return {
-          version: release[type].version,
-          releaseTimestamp: release['release-date'],
-          changelogUrl: release['release-notes'],
-        };
-      });
+      result = releases
+        .map((release) => {
+          return {
+            version: release[type]?.version,
+            releaseTimestamp: release['release-date'],
+            changelogUrl: release['release-notes'],
+          };
+        })
+        .filter((release) => is.nonEmptyString(release.version)) as Release[];
     }
 
     return result;

--- a/lib/modules/datasource/dotnet/index.ts
+++ b/lib/modules/datasource/dotnet/index.ts
@@ -101,7 +101,7 @@ export class DotnetDatasource extends Datasource {
           ): release is {
             [P in keyof DotnetRelease]: NonNullable<DotnetRelease[P]>;
           } => {
-            return is.nullOrUndefined(release[type]);
+            return !is.nullOrUndefined(release[type]);
           }
         )
         .map((release) => {

--- a/lib/modules/datasource/dotnet/readme.md
+++ b/lib/modules/datasource/dotnet/readme.md
@@ -1,1 +1,2 @@
 This datasource returns releases of the .NET Runtime and SDK.
+It only accepts dependencies with the name `dotnet-sdk` or `dotnet-runtime`.

--- a/lib/modules/datasource/dotnet/schema.ts
+++ b/lib/modules/datasource/dotnet/schema.ts
@@ -34,8 +34,8 @@ const Release = z.object({
   'release-version': z.string(),
   security: z.boolean(),
   'release-notes': z.string(),
-  runtime: ReleaseDetails,
-  sdk: ReleaseDetails,
+  runtime: z.nullable(ReleaseDetails),
+  sdk: z.nullable(ReleaseDetails),
 });
 export const DotnetReleasesSchema = z.object({
   'channel-version': z.string(),

--- a/lib/modules/datasource/dotnet/schema.ts
+++ b/lib/modules/datasource/dotnet/schema.ts
@@ -29,7 +29,7 @@ const ReleaseDetails = z.object({
   version: z.string(),
   'version-display': z.string(),
 });
-const Release = z.object({
+const ReleaseSchema = z.object({
   'release-date': z.date(),
   'release-version': z.string(),
   security: z.boolean(),
@@ -44,8 +44,9 @@ export const DotnetReleasesSchema = z.object({
   'latest-runtime': z.string(),
   'latest-sdk': z.string(),
   'support-phase': SupportPhase,
-  releases: z.array(Release),
+  releases: z.array(ReleaseSchema),
 });
 
 export type DotnetReleasesIndex = z.infer<typeof DotnetReleasesIndexSchema>;
 export type DotnetReleases = z.infer<typeof DotnetReleasesSchema>;
+export type DotnetRelease = z.infer<typeof ReleaseSchema>;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
This includes multiple fixes:
- Updates to the JSON Schema to allow for nullable releases
- Filter out releases which are `null`
- Update cache key to account for runtime and sdk
- Update documentation to denote how to use the dotnet datasource

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->
- fixes #18283 

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
