### PR TITLE
fix(git): log gitPrivateKey events

### DIFF
--- a/lib/util/git/private-key.ts
+++ b/lib/util/git/private-key.ts
@@ -1,4 +1,5 @@
 import os from 'os';
+import is from '@sindresorhus/is';
 import fs from 'fs-extra';
 import upath from 'upath';
 import { PLATFORM_GPG_FAILED } from '../../constants/error-messages';
@@ -10,7 +11,13 @@ let gitPrivateKey: string | undefined;
 let keyId: string | undefined;
 
 export function setPrivateKey(key: string | undefined): void {
-  gitPrivateKey = key?.trim();
+  if (!is.nonEmptyStringAndNotWhitespace(key)) {
+    return;
+  }
+  logger.debug(
+    'gitPrivateKey: successfully set (but not yet written/configured)'
+  );
+  gitPrivateKey = key.trim();
 }
 
 async function importKey(): Promise<void> {
@@ -34,11 +41,11 @@ export async function writePrivateKey(): Promise<void> {
   if (!gitPrivateKey) {
     return;
   }
-  logger.debug('Setting git private key');
   try {
     await importKey();
+    logger.debug('gitPrivateKey: imported');
   } catch (err) {
-    logger.warn({ err }, 'Error writing git private key');
+    logger.warn({ err }, 'gitPrivateKey: error importing');
     throw new Error(PLATFORM_GPG_FAILED);
   }
 }
@@ -47,7 +54,7 @@ export async function configSigningKey(cwd: string): Promise<void> {
   if (!gitPrivateKey) {
     return;
   }
-  logger.debug('Configuring commits signing');
+  logger.debug('gitPrivateKey: configuring commit signing');
   // TODO: types (#7154)
   await exec(`git config user.signingkey ${keyId!}`, { cwd });
   await exec(`git config commit.gpgsign true`, { cwd });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds logging to gitPrivateKey events.

## Context

Better visibility/troubleshooting.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
