### PR TITLE
fix(manager/gradle): optimize performance of Gradle lock file maintenance and ensure gradlew is executable

### DIFF
--- a/lib/modules/manager/gradle/artifacts.spec.ts
+++ b/lib/modules/manager/gradle/artifacts.spec.ts
@@ -209,6 +209,21 @@ describe('modules/manager/gradle/artifacts', () => {
     ]);
   });
 
+  it('aborts lock file maintenance if packageFileName is not build.gradle(.kts) in root project', async () => {
+    expect(
+      await updateArtifacts({
+        packageFileName: 'somedir/settings.gradle',
+        updatedDeps: [],
+        newPackageFileContent: '',
+        config: { isLockFileMaintenance: true },
+      })
+    ).toBeNull();
+
+    expect(logger.logger.trace).toHaveBeenCalledWith(
+      'No build.gradle(.kts) file or not in root project - skipping lock file maintenance'
+    );
+  });
+
   it('performs lock file maintenance', async () => {
     const execSnapshots = mockExecAll();
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This PR addresses two issues:

1) If `gradlew` was committed via Windows but an update is later run on a Unix platform, it may miss the executable bit. Updating Gradle lockfiles will then fail with `Command failed: ./gradlew --console=plain -q properties\n/bin/sh: 1: ./gradlew: Permission denied\n`

The solution is to add the `prepareGradleCommand()`, analogous to what `gradle-wrapper` manager does.

2) Currently, with Gradle lock file maintenance, a separate call to `updateArtifacts()` is made for each file in scope, e.g. `build.gradle`, `settings.gradle`, `gradle.properties`. This is unnecessary if they belong to the same root project and use the same gradle wrapper. As a consequence, lock file maintenance is run redundantly on the same set of files.

To optimize performance, it is enough to run lock file maintenance only in case `build.gradle` or `build.gradle.kts` is encountered in the same directory as `gradlew`.

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
