### PR TITLE
fix: support all valid variants of composer vcs

### DIFF
--- a/lib/modules/manager/composer/extract.ts
+++ b/lib/modules/manager/composer/extract.ts
@@ -44,6 +44,13 @@ function parseRepositories(
 
         switch (repo.type) {
           case 'vcs':
+          case 'bitbucket':
+          case 'github':
+          case 'gitlab':
+          case 'perforce':
+          case 'fossil':
+          case 'svn':
+          case 'hg':
           case 'git':
             repositories[name!] = repo;
             break;


### PR DESCRIPTION
## Changes & Context

composer module to support all vcs types, have a look at https://getcomposer.org/doc/05-repositories.md#vcs the vcs driver recognizes it automatically but this are all valid types

## Documentation

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
