### PR TITLE
fix: immortal digest groups

### DIFF
--- a/lib/workers/repository/updates/generate.spec.ts
+++ b/lib/workers/repository/updates/generate.spec.ts
@@ -238,6 +238,36 @@ describe('workers/repository/updates/generate', () => {
       expect(res.recreateClosed).toBeFalsy();
     });
 
+    it('groups multiple digest updates immortally', () => {
+      const branch: BranchUpgradeConfig[] = [
+        {
+          manager: 'some-manager',
+          depName: 'some-dep',
+          groupName: 'some-group',
+          branchName: 'some-branch',
+          prTitle: 'some-title',
+          commitMessageExtra: 'to {{{newDigestShort}}}',
+          newValue: '5.1.2',
+          newDigest: 'sha256:abcdef123',
+          isDigest: true,
+        },
+        {
+          manager: 'some-manager',
+          depName: 'some-other-dep',
+          groupName: 'some-group',
+          branchName: 'some-branch',
+          prTitle: 'some-title',
+          commitMessageExtra: 'to {{{newDigestShort}}}',
+          newValue: '5.2.0',
+          newDigest: 'sha256:abcdef987654321',
+          isDigest: true,
+        },
+      ];
+      const res = generateBranchConfig(branch);
+      expect(res.groupName).toBeDefined();
+      expect(res.recreateClosed).toBeTrue();
+    });
+
     it('groups multiple upgrades different version', () => {
       const branch: BranchUpgradeConfig[] = [
         {

--- a/lib/workers/repository/updates/generate.ts
+++ b/lib/workers/repository/updates/generate.ts
@@ -83,6 +83,28 @@ export function generateBranchConfig(
   const toVersions: string[] = [];
   const toValues = new Set<string>();
   for (const upg of branchUpgrades) {
+    if (upg.currentDigest) {
+      upg.currentDigestShort =
+        upg.currentDigestShort ??
+        upg.currentDigest.replace('sha256:', '').substring(0, 7);
+    }
+    if (upg.newDigest) {
+      upg.newDigestShort =
+        upg.newDigestShort ||
+        upg.newDigest.replace('sha256:', '').substring(0, 7);
+    }
+    if (upg.isDigest || upg.isPinDigest) {
+      upg.displayFrom = upg.currentDigestShort;
+      upg.displayTo = upg.newDigestShort;
+    } else if (upg.isLockfileUpdate) {
+      upg.displayFrom = upg.currentVersion;
+      upg.displayTo = upg.newVersion;
+    } else if (!upg.isLockFileMaintenance) {
+      upg.displayFrom = upg.currentValue;
+      upg.displayTo = upg.newValue;
+    }
+    upg.displayFrom ??= '';
+    upg.displayTo ??= '';
     if (!depNames.includes(upg.depName!)) {
       depNames.push(upg.depName!);
     }
@@ -123,28 +145,6 @@ export function generateBranchConfig(
       upgrade.commitMessageExtra = `to v${toVersions[0]}`;
     }
 
-    if (upgrade.currentDigest) {
-      upgrade.currentDigestShort =
-        upgrade.currentDigestShort ??
-        upgrade.currentDigest.replace('sha256:', '').substring(0, 7);
-    }
-    if (upgrade.newDigest) {
-      upgrade.newDigestShort =
-        upgrade.newDigestShort ||
-        upgrade.newDigest.replace('sha256:', '').substring(0, 7);
-    }
-    if (upgrade.isDigest || upgrade.isPinDigest) {
-      upgrade.displayFrom = upgrade.currentDigestShort;
-      upgrade.displayTo = upgrade.newDigestShort;
-    } else if (upgrade.isLockfileUpdate) {
-      upgrade.displayFrom = upgrade.currentVersion;
-      upgrade.displayTo = upgrade.newVersion;
-    } else if (!upgrade.isLockFileMaintenance) {
-      upgrade.displayFrom = upgrade.currentValue;
-      upgrade.displayTo = upgrade.newValue;
-    }
-    upgrade.displayFrom ??= '';
-    upgrade.displayTo ??= '';
     const pendingVersionsLength = upgrade.pendingVersions?.length;
     if (pendingVersionsLength) {
       upgrade.displayPending = `\`${upgrade


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Makes digest groups immortal.

## Context

Fixes #18183

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
