### PR TITLE
docs(config options): nudge users away from commitMessage*

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -390,25 +390,45 @@ This is used to alter `commitMessage` and `prTitle` without needing to copy/past
 Actions may be like `Update`, `Pin`, `Roll back`, `Refresh`, etc.
 Check out the default value for `commitMessage` to understand how this field is used.
 
+<!-- prettier-ignore -->
+!!! warning
+    Warning, for advanced use only! Use at your own risk!
+
 ## commitMessageExtra
 
 This is used to alter `commitMessage` and `prTitle` without needing to copy/paste the whole string.
 The "extra" is usually an identifier of the new version, e.g. "to v1.3.2" or "to tag 9.2".
+
+<!-- prettier-ignore -->
+!!! warning
+    Warning, for advanced use only! Use at your own risk!
 
 ## commitMessagePrefix
 
 This is used to alter `commitMessage` and `prTitle` without needing to copy/paste the whole string.
 The "prefix" is usually an automatically applied semantic commit prefix, but it can also be statically configured.
 
+<!-- prettier-ignore -->
+!!! warning
+    Warning, for advanced use only! Use at your own risk!
+
 ## commitMessageSuffix
 
 This is used to add a suffix to commit messages.
 Usually left empty except for internal use (multiple base branches, and vulnerability alerts).
 
+<!-- prettier-ignore -->
+!!! warning
+    Warning, for advanced use only! Use at your own risk!
+
 ## commitMessageTopic
 
 This is used to alter `commitMessage` and `prTitle` without needing to copy/paste the whole string.
 The "topic" is usually refers to the dependency being updated, e.g. `"dependency react"`.
+
+<!-- prettier-ignore -->
+!!! warning
+    Warning, for advanced use only! Use at your own risk!
 
 ## composerIgnorePlatformReqs
 


### PR DESCRIPTION
## Changes

- Add manual admonition to docs, to nudge users away from using `commitMessage*` config options

## Context

We're going to remove direct `commitMessage` editing, see:

- #18404

But we keep the `commitMessage*` options. We only want _advanced_ users to use those options. So I'm adding a warning message to nudge beginners away.

We're planning to automate adding these "for advanced users" warnings in this issue:

- #18408

Once that issue lands, we must remove the manual warning message, or we'll have double warnings.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
