### PR TITLE
feat(pub): Support updating lock files

### DIFF
--- a/lib/modules/manager/pub/artifacts.spec.ts
+++ b/lib/modules/manager/pub/artifacts.spec.ts
@@ -1,0 +1,229 @@
+import { join } from 'upath';
+import { envMock, mockExecAll } from '../../../../test/exec-util';
+import { env, fs } from '../../../../test/util';
+import { GlobalConfig } from '../../../config/global';
+import type { RepoGlobalConfig } from '../../../config/types';
+import type { UpdateArtifactsConfig } from '../types';
+import * as pub from '.';
+
+jest.mock('../../../util/exec/env');
+jest.mock('../../../util/fs');
+jest.mock('../../../util/git');
+jest.mock('../../../util/http');
+
+const adminConfig: RepoGlobalConfig = {
+  localDir: join('/tmp/github/some/repo'),
+  cacheDir: join('/tmp/cache'),
+  containerbaseDir: join('/tmp/cache/containerbase'),
+};
+
+const config: UpdateArtifactsConfig = {};
+
+describe('modules/manager/pub/artifacts', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    env.getChildProcessEnv.mockReturnValue(envMock.basic);
+    GlobalConfig.set(adminConfig);
+  });
+
+  afterEach(() => {
+    GlobalConfig.set(adminConfig);
+  });
+
+  it('returns null if no pubspec.lock found', async () => {
+    const updatedDeps = [{ depName: 'dep1' }];
+    expect(
+      await pub.updateArtifacts({
+        packageFileName: 'pubspec.yaml',
+        updatedDeps,
+        newPackageFileContent: '',
+        config,
+      })
+    ).toBeNull();
+  });
+
+  it('returns null if updatedDeps is empty', async () => {
+    expect(
+      await pub.updateArtifacts({
+        packageFileName: 'pubspec.yaml',
+        updatedDeps: [],
+        newPackageFileContent: '',
+        config,
+      })
+    ).toBeNull();
+  });
+
+  it('returns null if unchanged', async () => {
+    const execSnapshots = mockExecAll();
+    fs.readLocalFile.mockResolvedValueOnce('Current pubspec.lock');
+    fs.readLocalFile.mockResolvedValueOnce('Current pubspec.lock');
+    const updatedDeps = [{ depName: 'dep1' }];
+    expect(
+      await pub.updateArtifacts({
+        packageFileName: 'pubspec.yaml',
+        updatedDeps,
+        newPackageFileContent: '',
+        config,
+      })
+    ).toBeNull();
+    expect(execSnapshots).toMatchObject([
+      {
+        cmd: 'dart pub upgrade',
+        options: {
+          cwd: '/tmp/github/some/repo',
+          encoding: 'utf-8',
+          env: {
+            HOME: '/home/user',
+            HTTPS_PROXY: 'https://example.com',
+            HTTP_PROXY: 'http://example.com',
+            LANG: 'en_US.UTF-8',
+            LC_ALL: 'en_US',
+            NO_PROXY: 'localhost',
+            PATH: '/tmp/path',
+          },
+          maxBuffer: 10485760,
+          timeout: 900000,
+        },
+      },
+    ]);
+  });
+
+  it('returns updated dart pubspec.lock', async () => {
+    const execSnapshots = mockExecAll();
+    fs.readLocalFile.mockResolvedValueOnce('Old pubspec.lock');
+    fs.readLocalFile.mockResolvedValueOnce('New pubspec.lock');
+    const updatedDeps = [{ depName: 'dep1' }];
+    expect(
+      await pub.updateArtifacts({
+        packageFileName: 'pubspec.yaml',
+        updatedDeps,
+        newPackageFileContent: '',
+        config,
+      })
+    ).not.toBeNull();
+    expect(execSnapshots).toMatchObject([
+      {
+        cmd: 'dart pub upgrade',
+        options: {
+          cwd: '/tmp/github/some/repo',
+          encoding: 'utf-8',
+          env: {
+            HOME: '/home/user',
+            HTTPS_PROXY: 'https://example.com',
+            HTTP_PROXY: 'http://example.com',
+            LANG: 'en_US.UTF-8',
+            LC_ALL: 'en_US',
+            NO_PROXY: 'localhost',
+            PATH: '/tmp/path',
+          },
+          maxBuffer: 10485760,
+          timeout: 900000,
+        },
+      },
+    ]);
+  });
+
+  it('returns updated dart pubspec.lock for lockfile maintenance', async () => {
+    const execSnapshots = mockExecAll();
+    fs.readLocalFile.mockResolvedValueOnce('Old pubspec.lock');
+    fs.readLocalFile.mockResolvedValueOnce('New pubspec.lock');
+    expect(
+      await pub.updateArtifacts({
+        packageFileName: 'pubspec.yaml',
+        updatedDeps: [],
+        newPackageFileContent: '',
+        config: { ...config, updateType: 'lockFileMaintenance' },
+      })
+    ).not.toBeNull();
+    expect(execSnapshots).toMatchObject([
+      {
+        cmd: 'dart pub upgrade',
+        options: {
+          cwd: '/tmp/github/some/repo',
+          encoding: 'utf-8',
+          env: {
+            HOME: '/home/user',
+            HTTPS_PROXY: 'https://example.com',
+            HTTP_PROXY: 'http://example.com',
+            LANG: 'en_US.UTF-8',
+            LC_ALL: 'en_US',
+            NO_PROXY: 'localhost',
+            PATH: '/tmp/path',
+          },
+          maxBuffer: 10485760,
+          timeout: 900000,
+        },
+      },
+    ]);
+  });
+
+  it('returns updated flutter pubspec.lock', async () => {
+    const execSnapshots = mockExecAll();
+    fs.readLocalFile.mockResolvedValueOnce('Old pubspec.lock');
+    fs.readLocalFile.mockResolvedValueOnce('New pubspec.lock');
+    const updatedDeps = [{ depName: 'dep1' }];
+    expect(
+      await pub.updateArtifacts({
+        packageFileName: 'pubspec.yaml',
+        updatedDeps,
+        newPackageFileContent: 'sdk: flutter',
+        config,
+      })
+    ).not.toBeNull();
+    expect(execSnapshots).toMatchObject([
+      {
+        cmd: 'flutter pub upgrade',
+        options: {
+          cwd: '/tmp/github/some/repo',
+          encoding: 'utf-8',
+          env: {
+            HOME: '/home/user',
+            HTTPS_PROXY: 'https://example.com',
+            HTTP_PROXY: 'http://example.com',
+            LANG: 'en_US.UTF-8',
+            LC_ALL: 'en_US',
+            NO_PROXY: 'localhost',
+            PATH: '/tmp/path',
+          },
+          maxBuffer: 10485760,
+          timeout: 900000,
+        },
+      },
+    ]);
+  });
+
+  it('returns updated flutter pubspec.lock for lockfile maintenance', async () => {
+    const execSnapshots = mockExecAll();
+    fs.readLocalFile.mockResolvedValueOnce('Old pubspec.lock');
+    fs.readLocalFile.mockResolvedValueOnce('New pubspec.lock');
+    expect(
+      await pub.updateArtifacts({
+        packageFileName: 'pubspec.yaml',
+        updatedDeps: [],
+        newPackageFileContent: 'sdk: flutter',
+        config: { ...config, updateType: 'lockFileMaintenance' },
+      })
+    ).not.toBeNull();
+    expect(execSnapshots).toMatchObject([
+      {
+        cmd: 'flutter pub upgrade',
+        options: {
+          cwd: '/tmp/github/some/repo',
+          encoding: 'utf-8',
+          env: {
+            HOME: '/home/user',
+            HTTPS_PROXY: 'https://example.com',
+            HTTP_PROXY: 'http://example.com',
+            LANG: 'en_US.UTF-8',
+            LC_ALL: 'en_US',
+            NO_PROXY: 'localhost',
+            PATH: '/tmp/path',
+          },
+          maxBuffer: 10485760,
+          timeout: 900000,
+        },
+      },
+    ]);
+  });
+});

--- a/lib/modules/manager/pub/artifacts.ts
+++ b/lib/modules/manager/pub/artifacts.ts
@@ -1,0 +1,99 @@
+import { TEMPORARY_ERROR } from '../../../constants/error-messages';
+import { logger } from '../../../logger';
+import { exec } from '../../../util/exec';
+import {
+  getSiblingFileName,
+  readLocalFile,
+  writeLocalFile,
+} from '../../../util/fs';
+import { regEx } from '../../../util/regex';
+import type { UpdateArtifact, UpdateArtifactsResult } from '../types';
+
+function getFlutterConstraint(lockFileContent: string): string | undefined {
+  return regEx(/^\tflutter: ['"](?<flutterVersion>.*)['"]$/m).exec(
+    lockFileContent
+  )?.groups?.flutterVersion;
+}
+
+function getDartConstraint(lockFileContent: string): string | undefined {
+  return regEx(/^\tdart: ['"](?<dartVersion>.*)['"]$/m).exec(lockFileContent)
+    ?.groups?.dartVersion;
+}
+
+export async function updateArtifacts({
+  packageFileName,
+  updatedDeps,
+  newPackageFileContent,
+  config,
+}: UpdateArtifact): Promise<UpdateArtifactsResult[] | null> {
+  if (
+    !(
+      config.updateType === 'lockFileMaintenance' ||
+      config.updateType === 'lockfileUpdate'
+    ) &&
+    updatedDeps.length < 1
+  ) {
+    return null;
+  }
+
+  const lockFileName = getSiblingFileName(packageFileName, 'pubspec.lock');
+  const oldLockFileContent = await readLocalFile(lockFileName, 'utf8');
+  if (!oldLockFileContent) {
+    return null;
+  }
+
+  try {
+    await writeLocalFile(packageFileName, newPackageFileContent);
+
+    const isFlutter = newPackageFileContent.includes('sdk: flutter');
+    const toolName = isFlutter ? 'flutter' : 'dart';
+
+    const constraint = isFlutter
+      ? config.constraints?.flutter ?? getFlutterConstraint(oldLockFileContent)
+      : config.constraints?.dart ?? getDartConstraint(oldLockFileContent);
+    await exec(`${toolName} pub upgrade`, {
+      cwdFile: packageFileName,
+      docker: {
+        image: 'sidecar',
+      },
+      toolConstraints: [
+        {
+          toolName,
+          constraint,
+        },
+      ],
+    });
+
+    const newLockFileContent = await readLocalFile(lockFileName, 'utf8');
+    if (
+      oldLockFileContent === newLockFileContent ||
+      newLockFileContent === undefined
+    ) {
+      return null;
+    }
+
+    return [
+      {
+        file: {
+          type: 'addition',
+          path: lockFileName,
+          contents: newLockFileContent,
+        },
+      },
+    ];
+  } catch (err) {
+    // istanbul ignore if
+    if (err.message === TEMPORARY_ERROR) {
+      throw err;
+    }
+    logger.warn({ err }, `Failed to update ${lockFileName} file`);
+    return [
+      {
+        artifactError: {
+          lockFile: lockFileName,
+          stderr: err.message,
+        },
+      },
+    ];
+  }
+}

--- a/lib/modules/manager/pub/index.ts
+++ b/lib/modules/manager/pub/index.ts
@@ -1,9 +1,11 @@
 import { DartDatasource } from '../../datasource/dart';
 import * as npmVersioning from '../../versioning/npm';
 
+export { updateArtifacts } from './artifacts';
 export { extractPackageFile } from './extract';
 
 export const supportedDatasources = [DartDatasource.id];
+export const supportsLockFileMaintenance = true;
 
 export const defaultConfig = {
   fileMatch: ['(^|/)pubspec\\.ya?ml$'],


### PR DESCRIPTION
## Changes

pubspec.lock file now gets updated when a pub dependency changes.

## Context

closes https://github.com/renovatebot/renovate/issues/6049
continuation of https://github.com/renovatebot/renovate/pull/11132

@rarkins @viceice 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository