### PR TITLE
fix(manager/gradle): allow dependency classifiers

### DIFF
--- a/lib/modules/manager/gradle/utils.spec.ts
+++ b/lib/modules/manager/gradle/utils.spec.ts
@@ -37,10 +37,10 @@ describe('modules/manager/gradle/utils', () => {
   it('isDependencyString', () => {
     expect(isDependencyString('foo:bar:1.2.3')).toBeTrue();
     expect(isDependencyString('foo.foo:bar.bar:1.2.3')).toBeTrue();
-    expect(isDependencyString('foo:bar:baz:qux')).toBeFalse();
+    expect(isDependencyString('foo:bar:baz:qux')).toBeTrue();
     expect(isDependencyString('foo.bar:baz:1.2.3')).toBeTrue();
     expect(isDependencyString('foo.bar:baz:1.2.+')).toBeTrue();
-    expect(isDependencyString('foo.bar:baz:qux:quux')).toBeFalse();
+    expect(isDependencyString('foo:bar:baz:qux:quux')).toBeFalse();
     expect(isDependencyString("foo:bar:1.2.3'")).toBeFalse();
     expect(isDependencyString('foo:bar:1.2.3"')).toBeFalse();
     expect(isDependencyString('-Xep:ParameterName:OFF')).toBeFalse();
@@ -56,7 +56,10 @@ describe('modules/manager/gradle/utils', () => {
       depName: 'foo.foo:bar.bar',
       currentValue: '1.2.3',
     });
-    expect(parseDependencyString('foo:bar:baz:qux')).toBeNull();
+    expect(parseDependencyString('foo:bar:baz:qux')).toMatchObject({
+      depName: 'foo:bar',
+      currentValue: 'baz',
+    });
     expect(parseDependencyString('foo.bar:baz:1.2.3')).toMatchObject({
       depName: 'foo.bar:baz',
       currentValue: '1.2.3',
@@ -65,7 +68,7 @@ describe('modules/manager/gradle/utils', () => {
       depName: 'foo:bar',
       currentValue: '1.2.+',
     });
-    expect(parseDependencyString('foo.bar:baz:qux:quux')).toBeNull();
+    expect(parseDependencyString('foo:bar:baz:qux:quux')).toBeNull();
     expect(parseDependencyString("foo:bar:1.2.3'")).toBeNull();
     expect(parseDependencyString('foo:bar:1.2.3"')).toBeNull();
     expect(parseDependencyString('-Xep:ParameterName:OFF')).toBeNull();

--- a/lib/modules/manager/gradle/utils.ts
+++ b/lib/modules/manager/gradle/utils.ts
@@ -26,7 +26,7 @@ export function versionLikeSubstring(
 
 export function isDependencyString(input: string): boolean {
   const split = input?.split(':');
-  if (split?.length !== 3) {
+  if (split?.length !== 3 && split?.length !== 4) {
     return false;
   }
   // eslint-disable-next-line prefer-const


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Dependency declarations of group, artifact and version can optionally be followed by a classifier, e.g. `org.immutables:value:2.9.2:annotations`. Until now, dependency extraction failed for such definitions, since `isDependencyString()` required exactly 3 segments.

This PR adds support for an optional 4th segment to occur. The classifier isn't processed at all (and there is no need for that since it isn't mentioned in the metadata of artifacts), so I don't expect side effects as a result of this change.

<!-- Describe what behavior is changed by this PR. -->

## Context

Closes https://github.com/renovatebot/renovate/issues/5619

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

Test repo: https://github.com/renovate-demo/5619-renovate-issue-reproducer/pull/3/files

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
