### PR TITLE
test: Add SNAPSHOT as a test for isStable

### DIFF
--- a/lib/modules/versioning/docker/index.spec.ts
+++ b/lib/modules/versioning/docker/index.spec.ts
@@ -1,3 +1,4 @@
+import maven from '../maven';
 import semver from '../semver';
 import docker from '.';
 
@@ -171,7 +172,7 @@ describe('modules/versioning/docker/index', () => {
     ${'3.8.3-SNAPSHOT'}   | ${false}
     ${'3.8.3-1-SNAPSHOT'} | ${false}
   `('isStable("$version") === $expected', ({ version, expected }) => {
-    const res = docker.isStable(version);
+    const res = maven.isStable(version);
     expect(!!res).toBe(expected);
   });
 

--- a/lib/modules/versioning/docker/index.spec.ts
+++ b/lib/modules/versioning/docker/index.spec.ts
@@ -161,13 +161,15 @@ describe('modules/versioning/docker/index', () => {
   );
 
   test.each`
-    version             | expected
-    ${'3.7.0'}          | ${true}
-    ${'3.7.0b1'}        | ${false}
-    ${'3.7-alpine'}     | ${true}
-    ${'3.8.0-alpine'}   | ${true}
-    ${'3.8.0b1-alpine'} | ${false}
-    ${'3.8.2'}          | ${true}
+    version               | expected
+    ${'3.7.0'}            | ${true}
+    ${'3.7.0b1'}          | ${false}
+    ${'3.7-alpine'}       | ${true}
+    ${'3.8.0-alpine'}     | ${true}
+    ${'3.8.0b1-alpine'}   | ${false}
+    ${'3.8.2'}            | ${true}
+    ${'3.8.3-SNAPSHOT'}   | ${false}
+    ${'3.8.3-1-SNAPSHOT'} | ${false}
   `('isStable("$version") === $expected', ({ version, expected }) => {
     const res = docker.isStable(version);
     expect(!!res).toBe(expected);

--- a/lib/modules/versioning/maven/index.spec.ts
+++ b/lib/modules/versioning/maven/index.spec.ts
@@ -69,6 +69,8 @@ describe('modules/versioning/maven/index', () => {
     ${'Hoxton.RELEASE'}     | ${true}
     ${'Hoxton.SR'}          | ${true}
     ${'Hoxton.SR1'}         | ${true}
+    ${'1.2.3-SNAPSHOT'}     | ${false}
+    ${'1.2.3-1-SNAPSHOT'}   | ${false}
   `('isStable("$version") === $expected', ({ version, expected }) => {
     const res = !!isStable(version);
     expect(res).toBe(expected);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
I do not have a `-SNAPSHOT` in my version and renovate proposes `-SNAPSHOT`.
I would like to have only the 7.17.3 updated to 7.17.7.

`lib/module/versioning/docker/index.spec.ts`

```jest
    ✕ isStable("3.8.3-SNAPSHOT") === false (2 ms)
    ✕ isStable("3.8.3-1-SNAPSHOT") === false (1 ms)
```

My suggestion is to hint to the renovate engine that i want to use the versioning of `lib/module/versioning/maven`<br/>
Same test as above:

```jest
PASS  lib/modules/versioning/maven/index.spec.ts
```

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

Renovate version:<br/>
`renovate/renovate:32.165.1-slim@sha256:fbe8b824c6d123fe7f28bed65fecdd7b8bb57e6a1eb513afcf8bc862e43b8993`

```json
               {
                 "depName": "docker.elastic.co/kibana/kibana",
                 "currentValue": "7.17.3",
                 "datasource": "docker",
                 "versioning": "regex:^[^\\d]*(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(-(?<prerelease>.*-SNAPSHOT)|-(?<build>.*))?.*$",
                 "replaceString": "\n    image: docker.elastic.co/kibana/kibana:7.17.3",
                 "depIndex": 2,
                 "updates": [
                   {
                     "bucket": "non-major",
                     "newVersion": "7.17.7-SNAPSHOT",
                     "newValue": "7.17.7-SNAPSHOT",
                     "newMajor": 7,
                     "newMinor": 17,
                     "updateType": "patch",
                     "branchName": "renovate/elastic-lifecycle"
                   },
                   {
                     "bucket": "major",
                     "newVersion": "8.6.0-SNAPSHOT",
                     "newValue": "8.6.0-SNAPSHOT",
                     "newMajor": 8,
                     "newMinor": 6,
                     "updateType": "major",
                     "branchName": "renovate/major-elastic-lifecycle"
                   }
                 ],
                 "warnings": [],
                 "sourceUrl": "https://github.com/elastic/kibana",
                 "currentVersion": "7.17.3",
                 "isSingleVersion": true,
                 "fixedVersion": "7.17.3"
               }
```

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [X] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository, or
- [X] A dependency in production

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
