### PR TITLE
chore: exclude __mocks__ in jest config due to jest-haste-map warning

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -68,7 +68,11 @@ const config: JestConfig = {
       },
     ],
   },
-  modulePathIgnorePatterns: ['<rootDir>/dist/', '/__fixtures__/'],
+  modulePathIgnorePatterns: [
+    '<rootDir>/dist/',
+    '/__fixtures__/',
+    '/__mocks__/',
+  ],
   reporters: ci ? ['default', 'github-actions'] : ['default'],
   setupFilesAfterEnv: [
     'jest-extended/all',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

The merge of PR https://github.com/renovatebot/renovate/issues/15731 has introduced a second `__mocks__/index.ts` file. Jest now complains with a warning:
```
jest-haste-map: duplicate manual mock found: index
  The following files share their name; please delete one of them:
    * <rootDir>\lib\instrumentation\__mocks__\index.ts
    * <rootDir>\lib\logger\__mocks__\index.ts
```

This is tracked as a bug here: https://github.com/facebook/jest/issues/6801

Excluding `__mocks__`  removes the warning (suggestion provided [here](https://github.com/facebook/jest/issues/6801#issuecomment-712951064)).

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
