### PR TITLE
fix(manager/flux): remove isSystemManifest check to have a functional manager

### DIFF
--- a/lib/modules/manager/flux/artifacts.ts
+++ b/lib/modules/manager/flux/artifacts.ts
@@ -4,7 +4,6 @@ import { exec } from '../../../util/exec';
 import type { ExecOptions } from '../../../util/exec/types';
 import { readLocalFile } from '../../../util/fs';
 import type { UpdateArtifact, UpdateArtifactsResult } from '../types';
-import { isSystemManifest } from './common';
 import type { FluxManagerData } from './types';
 
 export async function updateArtifacts({
@@ -12,7 +11,7 @@ export async function updateArtifacts({
   updatedDeps,
 }: UpdateArtifact<FluxManagerData>): Promise<UpdateArtifactsResult[] | null> {
   const systemDep = updatedDeps[0];
-  if (!isSystemManifest(packageFileName) || !systemDep?.newVersion) {
+  if (!systemDep?.newVersion) {
     return null;
   }
   const existingFileContent = await readLocalFile(packageFileName);

--- a/lib/modules/manager/flux/common.ts
+++ b/lib/modules/manager/flux/common.ts
@@ -1,6 +1,0 @@
-import { regEx } from '../../../util/regex';
-
-export const systemManifestRegex = '(^|/)flux-system/gotk-components\\.yaml$';
-export function isSystemManifest(file: string): boolean {
-  return regEx(systemManifestRegex).test(file);
-}

--- a/lib/modules/manager/flux/extract.ts
+++ b/lib/modules/manager/flux/extract.ts
@@ -5,7 +5,6 @@ import { regEx } from '../../../util/regex';
 import { GithubReleasesDatasource } from '../../datasource/github-releases';
 import { HelmDatasource } from '../../datasource/helm';
 import type { ExtractConfig, PackageDependency, PackageFile } from '../types';
-import { isSystemManifest } from './common';
 import type {
   FluxManagerData,
   FluxManifest,
@@ -14,20 +13,18 @@ import type {
 } from './types';
 
 function readManifest(content: string, file: string): FluxManifest | null {
-  if (isSystemManifest(file)) {
-    const versionMatch = regEx(
-      /#\s*Flux\s+Version:\s*(\S+)(?:\s*#\s*Components:\s*([A-Za-z,-]+))?/
-    ).exec(content);
-    if (!versionMatch) {
-      return null;
-    }
-    return {
-      kind: 'system',
-      file,
-      version: versionMatch[1],
-      components: versionMatch[2],
-    };
+  const versionMatch = regEx(
+    /#\s*Flux\s+Version:\s*(\S+)(?:\s*#\s*Components:\s*([A-Za-z,-]+))?/
+  ).exec(content);
+  if (!versionMatch) {
+    return null;
   }
+  return {
+    kind: 'system',
+    file,
+    version: versionMatch[1],
+    components: versionMatch[2],
+  };
 
   const manifest: FluxManifest = {
     kind: 'resource',

--- a/lib/modules/manager/flux/index.ts
+++ b/lib/modules/manager/flux/index.ts
@@ -1,9 +1,10 @@
 import { GithubReleasesDatasource } from '../../datasource/github-releases';
 import { HelmDatasource } from '../../datasource/helm';
-import { systemManifestRegex } from './common';
 
 export { extractAllPackageFiles, extractPackageFile } from './extract';
 export { updateArtifacts } from './artifacts';
+
+export const systemManifestRegex = '(^|/)flux-system/gotk-components\\.yaml$';
 
 export const defaultConfig = {
   fileMatch: [systemManifestRegex],


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Remove `isSystemManifest` function


## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->
Fix #18517
It's not possible to use a custom `fileMatch` with `flux `manager because of the check done with `isSystemManifest` function.
This function is not useful as we already target the correct manifest(s) with the `fileMatch` filter.
With this fix, we are aligned with the documentation https://docs.renovatebot.com/modules/manager/flux/

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
