### PR TITLE
fix(manager/gradle): only accept known format for optional classifiers

### DIFF
--- a/lib/modules/manager/gradle/utils.spec.ts
+++ b/lib/modules/manager/gradle/utils.spec.ts
@@ -39,12 +39,14 @@ describe('modules/manager/gradle/utils', () => {
     expect(isDependencyString('foo.foo:bar.bar:1.2.3')).toBeTrue();
     expect(isDependencyString('foo:bar:baz:qux')).toBeTrue();
     expect(isDependencyString('foo.bar:baz:1.2.3')).toBeTrue();
+    expect(isDependencyString('foo.bar:baz:1.2.3:linux-cpu-x86_64')).toBeTrue();
     expect(isDependencyString('foo.bar:baz:1.2.+')).toBeTrue();
     expect(isDependencyString('foo:bar:baz:qux:quux')).toBeFalse();
     expect(isDependencyString("foo:bar:1.2.3'")).toBeFalse();
     expect(isDependencyString('foo:bar:1.2.3"')).toBeFalse();
     expect(isDependencyString('-Xep:ParameterName:OFF')).toBeFalse();
     expect(isDependencyString('foo$bar:baz:1.2.+')).toBeFalse();
+    expect(isDependencyString('scm:git:https://some.git')).toBeFalse();
   });
 
   it('parseDependencyString', () => {

--- a/lib/modules/manager/gradle/utils.ts
+++ b/lib/modules/manager/gradle/utils.ts
@@ -30,7 +30,13 @@ export function isDependencyString(input: string): boolean {
     return false;
   }
   // eslint-disable-next-line prefer-const
-  let [tempGroupId, tempArtifactId, tempVersionPart] = split;
+  let [tempGroupId, tempArtifactId, tempVersionPart, optionalClassifier] =
+    split;
+
+  if (optionalClassifier && !artifactRegex.test(optionalClassifier)) {
+    return false;
+  }
+
   if (
     tempVersionPart !== versionLikeSubstring(tempVersionPart) &&
     tempVersionPart.includes('@')


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Fixes a regression introduced by allowing optional dependency classifiers with PR https://github.com/renovatebot/renovate/pull/18469. 

Unfortunately, there is no strict format on how a valid classifier should look like. [According to Maven](https://maven.apache.org/pom.html#dependencies), it's an arbitrary string. [Gradle parses any string](https://github.com/gradle/gradle/blob/master/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/ParsedModuleStringNotation.java), if only the number of separators matches.

The check added in this PR restricts possible classifiers to "reasonable" values, i.e., analogous to how `artifactId` or `groupId` look like. This filters obviously invalid classifiers like URLs. The rationale here is: better allow only classifiers with good confidence, than not to extract dependency definitions with classifiers at all.

<!-- Describe what behavior is changed by this PR. -->

## Context

Closes https://github.com/renovatebot/renovate/issues/18513

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

Test repo: https://github.com/renovate-demo/18513-renovate-gradle-properties-bug/issues/1

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
