### PR TITLE
fix!: revert branchNameStrict to false

### DIFF
--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -2412,7 +2412,7 @@ const options: RenovateOptions[] = [
     name: 'branchNameStrict',
     description: `Whether to be strict about the use of special characters within the branch name.`,
     type: 'boolean',
-    default: true,
+    default: false,
   },
 ];
 


### PR DESCRIPTION
BREAKING CHANGE: reverts branchNameStrict value from true to false (which reverts the change in v33)