### PR TITLE
fix: error gracefully when .editorconfig parsing fails

### DIFF
--- a/lib/util/json-writer/__fixtures__/.customer_file
+++ b/lib/util/json-writer/__fixtures__/.customer_file
@@ -1,0 +1,27 @@
+#
+# .editorconfig
+#
+# http://editorconfig.org
+#
+# The EditorConfig project consists of a file format for defining coding styles
+# and a collection of text editor plugins that enable editors to read the file
+# format and adhere to defined styles.
+#
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+
+# package.json specific rules
+[package.json]
+indent_size = 2
+
+# .yml specific rules
+[*.yml]
+indent_size = 2

--- a/lib/util/json-writer/editor-config.spec.ts
+++ b/lib/util/json-writer/editor-config.spec.ts
@@ -51,6 +51,18 @@ describe('util/json-writer/editor-config', () => {
     expect(format.indentationType).toBe(IndentationType.Space);
   });
 
+  // temporary ignoring error https://github.com/renovatebot/renovate/issues/18540
+  it('should temporary give undefined until its fixed on the library', async () => {
+    expect.assertions(2);
+    Fixtures.mock({
+      '.editorconfig': Fixtures.get('.customer_file'),
+    });
+    const format = await EditorConfig.getCodeFormat(defaultConfigFile);
+
+    expect(format.indentationSize).toBeUndefined();
+    expect(format.indentationType).toBeUndefined();
+  });
+
   it('should not handle non json config from .editorconfig', async () => {
     expect.assertions(2);
     Fixtures.mock({

--- a/lib/util/json-writer/editor-config.ts
+++ b/lib/util/json-writer/editor-config.ts
@@ -16,10 +16,7 @@ export class EditorConfig {
       };
     } catch (err) {
       logger.warn({ err }, 'Failed to parse editor config');
-      return {
-        indentationSize: undefined,
-        indentationType: undefined,
-      };
+      return { };
     }
   }
 

--- a/lib/util/json-writer/editor-config.ts
+++ b/lib/util/json-writer/editor-config.ts
@@ -17,7 +17,6 @@ export class EditorConfig {
     } catch (err) {
       logger.warn({ err }, 'Failed to parse editor config');
       return {};
-      return {};
     }
   }
 

--- a/lib/util/json-writer/editor-config.ts
+++ b/lib/util/json-writer/editor-config.ts
@@ -1,18 +1,27 @@
 import { KnownProps, parse } from 'editorconfig';
 import upath from 'upath';
 import { GlobalConfig } from '../../config/global';
+import { logger } from '../../logger';
 import type { CodeFormat } from './code-format';
 import { IndentationType } from './indentation-type';
 
 export class EditorConfig {
   public static async getCodeFormat(fileName: string): Promise<CodeFormat> {
     const { localDir } = GlobalConfig.get();
-    const knownProps = await parse(upath.join(localDir, fileName));
-
-    return {
-      indentationSize: EditorConfig.getIndentationSize(knownProps),
-      indentationType: EditorConfig.getIndentationType(knownProps),
-    };
+    let knownProps = undefined;
+    try {
+      knownProps = await parse(upath.join(localDir, fileName));
+      return {
+        indentationSize: EditorConfig.getIndentationSize(knownProps),
+        indentationType: EditorConfig.getIndentationType(knownProps),
+      };
+    } catch (err) {
+      logger.warn({ err }, 'Failed to parse editor config');
+      return {
+        indentationSize: undefined,
+        indentationType: undefined,
+      };
+    }
   }
 
   private static getIndentationType(

--- a/lib/util/json-writer/editor-config.ts
+++ b/lib/util/json-writer/editor-config.ts
@@ -8,7 +8,6 @@ import { IndentationType } from './indentation-type';
 export class EditorConfig {
   public static async getCodeFormat(fileName: string): Promise<CodeFormat> {
     const { localDir } = GlobalConfig.get();
-    let knownProps = undefined;
     try {
       knownProps = await parse(upath.join(localDir, fileName));
       return {

--- a/lib/util/json-writer/editor-config.ts
+++ b/lib/util/json-writer/editor-config.ts
@@ -9,7 +9,7 @@ export class EditorConfig {
   public static async getCodeFormat(fileName: string): Promise<CodeFormat> {
     const { localDir } = GlobalConfig.get();
     try {
-      knownProps = await parse(upath.join(localDir, fileName));
+      const knownProps = await parse(upath.join(localDir, fileName));
       return {
         indentationSize: EditorConfig.getIndentationSize(knownProps),
         indentationType: EditorConfig.getIndentationType(knownProps),

--- a/lib/util/json-writer/editor-config.ts
+++ b/lib/util/json-writer/editor-config.ts
@@ -8,19 +8,15 @@ import { IndentationType } from './indentation-type';
 export class EditorConfig {
   public static async getCodeFormat(fileName: string): Promise<CodeFormat> {
     const { localDir } = GlobalConfig.get();
-    let knownProps = undefined;
     try {
-      knownProps = await parse(upath.join(localDir, fileName));
+      const knownProps = await parse(upath.join(localDir, fileName));
       return {
         indentationSize: EditorConfig.getIndentationSize(knownProps),
         indentationType: EditorConfig.getIndentationType(knownProps),
       };
     } catch (err) {
       logger.warn({ err }, 'Failed to parse editor config');
-      return {
-        indentationSize: undefined,
-        indentationType: undefined,
-      };
+      return {};
     }
   }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

added try catch and a test with customer's file

<!-- Describe what behavior is changed by this PR. -->

## Context

- Closes #18540
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
