### PR TITLE
fix(config): coerce newlines in env and CLI

### DIFF
--- a/lib/workers/global/config/parse/coersions.ts
+++ b/lib/workers/global/config/parse/coersions.ts
@@ -36,6 +36,6 @@ export const coersions: Record<string, (arg: string) => unknown> = {
       throw new Error("Invalid JSON value: '" + val + "'");
     }
   },
-  string: (val: string): string => val,
+  string: (val: string): string => val.replace(/\\n/g, '\n'),
   integer: parseInt,
 };

--- a/lib/workers/global/config/parse/env.spec.ts
+++ b/lib/workers/global/config/parse/env.spec.ts
@@ -53,6 +53,13 @@ describe('workers/global/config/parse/env', () => {
       expect(env.getConfig(envParam).token).toBe('a');
     });
 
+    it('coerces string newlines', () => {
+      const envParam: NodeJS.ProcessEnv = {
+        RENOVATE_GIT_PRIVATE_KEY: 'abc\\ndef',
+      };
+      expect(env.getConfig(envParam).gitPrivateKey).toBe('abc\ndef');
+    });
+
     it('supports custom prefixes', () => {
       const envParam: NodeJS.ProcessEnv = {
         ENV_PREFIX: 'FOOBAR_',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Restores back newline conversions for strings which was accidentally removed as part of #13171. Prior to v32 it used to apply to env only, now it applies to CLI and env.

## Context

Fixes #18502

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
