### PR TITLE
fix(manager/dockerfile): improve RegEx to match ARG values with trailing spaces

### DIFF
--- a/lib/modules/manager/dockerfile/extract.spec.ts
+++ b/lib/modules/manager/dockerfile/extract.spec.ts
@@ -763,20 +763,20 @@ describe('modules/manager/dockerfile/extract', () => {
 
     it('handles FROM with version in ARG value', () => {
       const res = extractPackageFile(
-        'ARG\tVARIANT="1.60.0-bullseye"\nFROM\trust:${VARIANT}\n',
+        'ARG\tVARIANT="1.60.0-bullseye" \nFROM\trust:${VARIANT}\n',
         '',
         {}
       )?.deps;
       expect(res).toEqual([
         {
           autoReplaceStringTemplate:
-            'ARG	VARIANT="{{#if newValue}}{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}"',
+            'ARG\tVARIANT="{{#if newValue}}{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}" ',
           currentDigest: undefined,
           currentValue: '1.60.0-bullseye',
           datasource: 'docker',
           depName: 'rust',
           depType: 'final',
-          replaceString: 'ARG	VARIANT="1.60.0-bullseye"',
+          replaceString: 'ARG\tVARIANT="1.60.0-bullseye" ',
         },
       ]);
     });

--- a/lib/modules/manager/dockerfile/extract.ts
+++ b/lib/modules/manager/dockerfile/extract.ts
@@ -276,7 +276,7 @@ export function extractPackageFile(
     const argRegex = regEx(
       '^[ \\t]*ARG(?:' +
         escapeChar +
-        '[ \\t]*\\r?\\n| |\\t|#.*?\\r?\\n)+(?<name>\\S+)[ =](?<value>.*)',
+        '[ \\t]*\\r?\\n| |\\t|#.*?\\r?\\n)+(?<name>\\w+)[ =](?<value>\\S*)',
       'im'
     );
     const argMatch = argRegex.exec(instruction);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

The `argRegex` pattern is faulty:
  - ARG name matched via `(?<name>\S+)`:
    - With testcase `ARG abc=1.0.0 `, the `\S+` causes the entire string to be matched (see [here](https://regex101.com/r/lGcZVX/1))
  - ARG value matched via `(?<value>.*)`:
    - Extracts ARG value with trailing space `ARG abc=1.0.0 `, while moby buildkit / Docker trims it. This further leads to `currentValue` carrying this space as well
    - https://github.com/renovatebot/renovate/blob/fbaac110c9fd95f064b6ab90e49722a468661600/lib/modules/manager/dockerfile/extract.ts#L287-L292 fails if the quote is not the last character, e.g. `ARG abc="1.0.0" ` (trailing space)

### Solution
- Change ARG name to `\w+`: More exact, since `[a-zA-Z0-9_]` is what Docker expects too (no $/-,.) and it fixes the above
- Change ARG value to `\S*`: Allows `ARG abc=` (legit case) but extracts arg values only until before a whitespace and fixes the issues mentioned above

P.S.: The `\t` change is unrelated but makes it more explicit that there is a tab space.

<!-- Describe what behavior is changed by this PR. -->

## Context

https://github.com/renovatebot/renovate/pull/18061#issuecomment-1264658095

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
