### PR TITLE
fix: delete outdated fingerprint

### DIFF
--- a/lib/workers/repository/process/write.spec.ts
+++ b/lib/workers/repository/process/write.spec.ts
@@ -228,7 +228,7 @@ describe('workers/repository/process/write', () => {
       ].sort();
 
       const branchFingerprint = fingerprint({
-        branch,
+        branchFingerprintConfig: generateBranchFingerprintConfig(branch),
         managers,
       });
       repoCache.getCache.mockReturnValueOnce({
@@ -272,7 +272,7 @@ describe('workers/repository/process/write', () => {
         ),
       ].sort();
       const branchFingerprint = fingerprint({
-        branch,
+        branchFingerprintConfig: generateBranchFingerprintConfig(branch),
         managers,
       });
       repoCache.getCache.mockReturnValueOnce({

--- a/lib/workers/repository/process/write.ts
+++ b/lib/workers/repository/process/write.ts
@@ -39,6 +39,7 @@ export function canSkipBranchUpdateCheck(
 ): boolean {
   if (!branchState.branchFingerprint) {
     logger.trace('branch.isUpToDate(): no fingerprint');
+    delete branchState.branchFingerprint;
     return false;
   }
 

--- a/lib/workers/repository/process/write.ts
+++ b/lib/workers/repository/process/write.ts
@@ -39,12 +39,12 @@ export function canSkipBranchUpdateCheck(
 ): boolean {
   if (!branchState.branchFingerprint) {
     logger.trace('branch.isUpToDate(): no fingerprint');
-    delete branchState.branchFingerprint;
     return false;
   }
 
   if (branchFingerprint !== branchState.branchFingerprint) {
     logger.debug('branch.isUpToDate(): needs recalculation');
+    delete branchState.branchFingerprint;
     return false;
   }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- delete the cached fingerprint when it doesn't match the one generated during repo processing
<!-- Describe what behavior is changed by this PR. -->

## Context
- When we change the logic for calculating fingerprint there is a chance to endup with old fingerprint in cache because we only update cached fingerprint when a new commit is made or it is undefined. So by deleting cached fingeprint when it doesn't match the newly generated one we handle this case.
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
