### PR TITLE
fix: set branch fingerprint whenever updates are verified

### DIFF
--- a/lib/workers/repository/process/write.spec.ts
+++ b/lib/workers/repository/process/write.spec.ts
@@ -186,6 +186,7 @@ describe('workers/repository/process/write', () => {
       });
       branchWorker.processBranch.mockResolvedValueOnce({
         branchExists: true,
+        updatesVerified: true,
         result: BranchResult.Done,
         commitSha: 'some-value',
       });

--- a/lib/workers/repository/process/write.ts
+++ b/lib/workers/repository/process/write.ts
@@ -161,10 +161,9 @@ export async function writeUpdates(
     branch.prBlockedBy = res?.prBlockedBy;
     branch.prNo = res?.prNo;
     branch.result = res?.result;
-    branch.branchFingerprint =
-      res?.commitSha || !branchState.branchFingerprint
-        ? branchFingerprint
-        : branchState.branchFingerprint;
+    branch.branchFingerprint = res?.updatesVerified
+      ? branchFingerprint
+      : branchState.branchFingerprint;
 
     if (res?.commitSha) {
       setBranchNewCommit(branchName, baseBranch, res.commitSha);

--- a/lib/workers/repository/update/branch/index.spec.ts
+++ b/lib/workers/repository/update/branch/index.spec.ts
@@ -684,6 +684,7 @@ describe('workers/repository/update/branch/index', () => {
       git.getBranchCommit.mockReturnValue('123test');
       expect(await branchWorker.processBranch(inconfig)).toEqual({
         branchExists: true,
+        updatesVerified: true,
         prNo: undefined,
         result: 'pending',
         commitSha: '123test',
@@ -913,6 +914,7 @@ describe('workers/repository/update/branch/index', () => {
       const processBranchResult = await branchWorker.processBranch(config);
       expect(processBranchResult).toEqual({
         branchExists: true,
+        updatesVerified: true,
         prNo: undefined,
         result: 'pr-created',
         commitSha: '123test',
@@ -936,6 +938,7 @@ describe('workers/repository/update/branch/index', () => {
       const processBranchResult = await branchWorker.processBranch(config);
       expect(processBranchResult).toEqual({
         branchExists: true,
+        updatesVerified: true,
         prNo: undefined,
         result: 'done',
         commitSha: '123test',
@@ -1007,6 +1010,7 @@ describe('workers/repository/update/branch/index', () => {
       } as BranchConfig;
       expect(await branchWorker.processBranch(inconfig)).toEqual({
         branchExists: true,
+        updatesVerified: true,
         prNo: undefined,
         result: 'done',
         commitSha: null,
@@ -1048,6 +1052,7 @@ describe('workers/repository/update/branch/index', () => {
         })
       ).toEqual({
         branchExists: true,
+        updatesVerified: true,
         prNo: undefined,
         result: 'done',
         commitSha: null,
@@ -1089,6 +1094,7 @@ describe('workers/repository/update/branch/index', () => {
       } as BranchConfig;
       expect(await branchWorker.processBranch(inconfig)).toEqual({
         branchExists: true,
+        updatesVerified: true,
         prNo: undefined,
         result: 'done',
         commitSha: null,
@@ -1149,6 +1155,7 @@ describe('workers/repository/update/branch/index', () => {
       };
       expect(await branchWorker.processBranch(inconfig)).toEqual({
         branchExists: true,
+        updatesVerified: false,
         prNo: undefined,
         result: 'done',
         commitSha: null,
@@ -1188,6 +1195,7 @@ describe('workers/repository/update/branch/index', () => {
       } as BranchConfig;
       expect(await branchWorker.processBranch(inconfig)).toEqual({
         branchExists: true,
+        updatesVerified: true,
         prNo: undefined,
         result: 'done',
         commitSha: null,
@@ -1224,6 +1232,7 @@ describe('workers/repository/update/branch/index', () => {
       } as BranchConfig;
       expect(await branchWorker.processBranch(inconfig)).toEqual({
         branchExists: true,
+        updatesVerified: true,
         prNo: undefined,
         result: 'done',
         commitSha: null,
@@ -1309,6 +1318,7 @@ describe('workers/repository/update/branch/index', () => {
       const result = await branchWorker.processBranch(inconfig);
       expect(result).toEqual({
         branchExists: true,
+        updatesVerified: true,
         prNo: undefined,
         result: 'done',
         commitSha: null,
@@ -1483,6 +1493,7 @@ describe('workers/repository/update/branch/index', () => {
       const result = await branchWorker.processBranch(inconfig);
       expect(result).toEqual({
         branchExists: true,
+        updatesVerified: true,
         prNo: undefined,
         result: 'done',
         commitSha: null,
@@ -1608,6 +1619,7 @@ describe('workers/repository/update/branch/index', () => {
 
       expect(result).toEqual({
         branchExists: true,
+        updatesVerified: true,
         prNo: undefined,
         result: 'done',
         commitSha: null,
@@ -1753,6 +1765,7 @@ describe('workers/repository/update/branch/index', () => {
       const result = await branchWorker.processBranch(inconfig);
       expect(result).toEqual({
         branchExists: true,
+        updatesVerified: true,
         prNo: undefined,
         result: 'done',
         commitSha: null,
@@ -1810,6 +1823,7 @@ describe('workers/repository/update/branch/index', () => {
       git.getBranchCommit.mockReturnValue('123test');
       expect(await branchWorker.processBranch(inconfig)).toEqual({
         branchExists: true,
+        updatesVerified: true,
         prNo: undefined,
         result: 'done',
         commitSha: '123test',
@@ -1846,6 +1860,7 @@ describe('workers/repository/update/branch/index', () => {
       };
       expect(await branchWorker.processBranch(inconfig)).toEqual({
         branchExists: true,
+        updatesVerified: false,
         prNo: undefined,
         result: 'done',
         commitSha: null,
@@ -1882,6 +1897,7 @@ describe('workers/repository/update/branch/index', () => {
         })
       ).toEqual({
         branchExists: true,
+        updatesVerified: true,
         commitSha: '123test',
         prNo: undefined,
         result: 'done',
@@ -1914,6 +1930,7 @@ describe('workers/repository/update/branch/index', () => {
         })
       ).toEqual({
         branchExists: true,
+        updatesVerified: true,
         commitSha: '123test',
         prNo: undefined,
         result: 'done',

--- a/lib/workers/repository/update/branch/index.ts
+++ b/lib/workers/repository/update/branch/index.ts
@@ -75,6 +75,7 @@ async function deleteBranchSilently(branchName: string): Promise<void> {
 
 export interface ProcessBranchResult {
   branchExists: boolean;
+  updatesVerified?: boolean;
   prBlockedBy?: PrBlockedBy;
   prNo?: number;
   result: BranchResult;
@@ -88,6 +89,7 @@ export async function processBranch(
   let config: BranchConfig = { ...branchConfig };
   logger.trace({ config }, 'processBranch()');
   let branchExists = gitBranchExists(config.branchName);
+  let updatesVerified = false;
   if (!branchExists && config.branchPrefix !== config.branchPrefixOld) {
     const branchName = config.branchName.replace(
       config.branchPrefix!,
@@ -525,6 +527,7 @@ export async function processBranch(
       }
 
       commitSha = await commitFilesToBranch(config);
+      updatesVerified = true;
     }
     // istanbul ignore if
     if (branchPr && platform.refreshPr) {
@@ -557,6 +560,7 @@ export async function processBranch(
       logger.debug({ commitSha }, `Branch status pending`);
       return {
         branchExists: true,
+        updatesVerified,
         prNo: branchPr?.number,
         result: BranchResult.Pending,
         commitSha,
@@ -660,6 +664,7 @@ export async function processBranch(
       // we have already warned inside the bundler artifacts error handling, so just return
       return {
         branchExists: true,
+        updatesVerified,
         prNo: branchPr?.number,
         result: BranchResult.Error,
         commitSha,
@@ -826,6 +831,7 @@ export async function processBranch(
   if (!branchExists) {
     return {
       branchExists: true,
+      updatesVerified,
       prNo: branchPr?.number,
       result: BranchResult.PrCreated,
       commitSha,
@@ -833,6 +839,7 @@ export async function processBranch(
   }
   return {
     branchExists,
+    updatesVerified,
     prNo: branchPr?.number,
     result: BranchResult.Done,
     commitSha,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds `updatesVerified` awareness to `processBranch()` and uses that to set the fingerprint instead of `sha`.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
