### PR TITLE
docs(enabledManagers): add mergeable value

### DIFF
--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -788,6 +788,7 @@ const options: RenovateOptions[] = [
     description:
       'A list of package managers to enable. If defined, then all managers not on the list are disabled.',
     type: 'array',
+    mergeable: false,
     stage: 'repository',
   },
   {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Be explicit about the fact that `enabledManagers` configuration key is not mergeable.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

[This discussion](https://github.com/renovatebot/renovate/discussions/15488#discussioncomment-2701367) is clear about this fact, but the current documentation table misses the `mergeable` value for this field: 
![Capture d’écran 2022-10-27 à 14 56 19](https://user-images.githubusercontent.com/2571084/198292483-289a6d55-4723-42f7-ae9f-b53e3f9c551f.png)


## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
