### PR TITLE
fix(manager/gradle): ignore mapScalar() method from Apollo Kotlin plugin

### DIFF
--- a/lib/modules/manager/gradle/parser.spec.ts
+++ b/lib/modules/manager/gradle/parser.spec.ts
@@ -208,6 +208,7 @@ describe('modules/manager/gradle/parser', () => {
       ${'setOf("foo", "bar", "baz")'}                              | ${{ depName: 'foo:bar', currentValue: 'baz', skipReason: 'ignored' }}
       ${'mutableSetOf("foo", "bar", "baz")'}                       | ${{ depName: 'foo:bar', currentValue: 'baz', skipReason: 'ignored' }}
       ${'stages("foo", "bar", "baz")'}                             | ${{ depName: 'foo:bar', currentValue: 'baz', skipReason: 'ignored' }}
+      ${'mapScalar("foo", "bar", "baz")'}                          | ${{ depName: 'foo:bar', currentValue: 'baz', skipReason: 'ignored' }}
     `('$input', async ({ input, output }) => {
       const { deps } = await parseGradle(input);
       expect(deps).toMatchObject([output].filter(Boolean));

--- a/lib/modules/manager/gradle/parser.ts
+++ b/lib/modules/manager/gradle/parser.ts
@@ -336,6 +336,7 @@ const annoyingMethods = new Set([
   'setOf',
   'mutableSetOf',
   'stages', // https://github.com/ajoberstar/reckon
+  'mapScalar', // https://github.com/apollographql/apollo-kotlin
 ]);
 
 function processLongFormDep({


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Added `mapScalar(...)` to ignore list

Output with this patch when applied on https://github.com/nachtien/renovate-bug:
```json
"gradle": [
  {
    "packageFile": "app/build.gradle.kts",
    "datasource": "maven",
    "deps": [
      {
       "depName": "DateTime:kotlinx.datetime.Instant",
       "currentValue": "com.apollographql.apollo3.adapter.KotlinxInstantAdapter",
       "managerData": {
         "fileReplacePosition": 2223,
         "packageFile": "app/build.gradle.kts"
       },
       "skipReason": "ignored",
       "fileReplacePosition": 2223,
       "registryUrls": [
         "https://plugins.gradle.org/m2/",
         "https://dl.google.com/android/maven2/",
         "https://repo.maven.apache.org/maven2",
         "https://oss.sonatype.org/service/local/staging/deploy/maven2/",
         "https://oss.sonatype.org/content/repositories/snapshots"
       ],
       "depType": "dependencies",
       "depIndex": 0,
       "updates": []
      }
    ]
  }
]
```

<!-- Describe what behavior is changed by this PR. -->

## Context

Closes https://github.com/renovatebot/renovate/issues/18621

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
