### PR TITLE
fix(docker): log Docker Hub errors

### DIFF
--- a/lib/modules/datasource/docker/index.ts
+++ b/lib/modules/datasource/docker/index.ts
@@ -938,7 +938,7 @@ export class DockerDatasource extends Datasource {
         );
         throw new ExternalHostError(err);
       }
-      if ([401, 403].includes(err.statusCode) && isDockerHost(registryHost)) {
+      if (err.statusCode === 401 && isDockerHost(registryHost)) {
         logger.warn(
           { registryHost, dockerRepository, err },
           'docker registry failure: unauthorized'

--- a/lib/modules/datasource/docker/index.ts
+++ b/lib/modules/datasource/docker/index.ts
@@ -931,7 +931,6 @@ export class DockerDatasource extends Datasource {
           jfrogRepository + '/library/' + dockerImage
         );
       }
-      // prettier-ignore
       if (err.statusCode === 429 && isDockerHost(registryHost)) {
         logger.warn(
           { registryHost, dockerRepository, err },
@@ -939,8 +938,7 @@ export class DockerDatasource extends Datasource {
         );
         throw new ExternalHostError(err);
       }
-      // prettier-ignore
-      if (err.statusCode === 401 && isDockerHost(registryHost)) {
+      if ([401, 403].includes(err.statusCode) && isDockerHost(registryHost)) {
         logger.warn(
           { registryHost, dockerRepository, err },
           'docker registry failure: unauthorized'
@@ -953,6 +951,9 @@ export class DockerDatasource extends Datasource {
           'docker registry failure: internal error'
         );
         throw new ExternalHostError(err);
+      }
+      if (isDockerHost(registryHost)) {
+        logger.info({ err }, 'Docker Hub lookup failure');
       }
       throw err;
     }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds 403 to external host errors for Docker Hub and logs any non-external host error errors.

## Context

#18676

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
