### PR TITLE
fix(git): Ensure `baseBranch` is checked out before git-based merge

### DIFF
--- a/lib/workers/repository/update/branch/automerge.spec.ts
+++ b/lib/workers/repository/update/branch/automerge.spec.ts
@@ -66,18 +66,28 @@ describe('workers/repository/update/branch/automerge', () => {
     it('returns false if automerge fails', async () => {
       config.automerge = true;
       config.automergeType = 'branch';
+      config.baseBranch = 'test-branch';
       platform.getBranchStatus.mockResolvedValueOnce(BranchStatus.green);
       git.mergeBranch.mockImplementationOnce(() => {
         throw new Error('merge error');
       });
-      expect(await tryBranchAutomerge(config)).toBe('failed');
+
+      const res = await tryBranchAutomerge(config);
+
+      expect(res).toBe('failed');
+      expect(git.checkoutBranch).toHaveBeenCalled();
     });
 
     it('returns true if automerge succeeds', async () => {
       config.automerge = true;
       config.automergeType = 'branch';
+      config.baseBranch = 'test-branch';
       platform.getBranchStatus.mockResolvedValueOnce(BranchStatus.green);
-      expect(await tryBranchAutomerge(config)).toBe('automerged');
+
+      const res = await tryBranchAutomerge(config);
+
+      expect(res).toBe('automerged');
+      expect(git.checkoutBranch).toHaveBeenCalledWith('test-branch');
     });
 
     it('returns true if automerge succeeds (dry-run)', async () => {

--- a/lib/workers/repository/update/branch/automerge.ts
+++ b/lib/workers/repository/update/branch/automerge.ts
@@ -4,7 +4,7 @@ import type { RenovateConfig } from '../../../../config/types';
 import { logger } from '../../../../logger';
 import { platform } from '../../../../modules/platform';
 import { BranchStatus } from '../../../../types';
-import { mergeBranch } from '../../../../util/git';
+import { checkoutBranch, mergeBranch } from '../../../../util/git';
 import { isScheduledNow } from './schedule';
 import { resolveBranchStatus } from './status-checks';
 
@@ -43,6 +43,7 @@ export async function tryBranchAutomerge(
         // TODO: types (#7154)
         logger.info(`DRY-RUN: Would automerge branch ${config.branchName!}`);
       } else {
+        await checkoutBranch(config.baseBranch!);
         await mergeBranch(config.branchName!);
       }
       logger.info({ branch: config.branchName }, 'Branch automerged');


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

- Fixes: #18209

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
