### PR TITLE
fix(composer): propose new regex to match git tags

### DIFF
--- a/lib/modules/manager/composer/__snapshots__/extract.spec.ts.snap
+++ b/lib/modules/manager/composer/__snapshots__/extract.spec.ts.snap
@@ -8,7 +8,7 @@ exports[`modules/manager/composer/extract extractPackageFile() extracts dependen
       "datasource": "github-tags",
       "depName": "php",
       "depType": "require",
-      "extractVersion": "^php-(?<version>.*)$",
+      "extractVersion": "^php-(?<version>\d+(?:\.\d+)*)(?<prerelease>.*)$",
       "packageName": "php/php-src",
     },
     {
@@ -219,7 +219,7 @@ exports[`modules/manager/composer/extract extractPackageFile() extracts dependen
       "datasource": "github-tags",
       "depName": "php",
       "depType": "require",
-      "extractVersion": "^php-(?<version>.*)$",
+      "extractVersion": "^php-(?<version>\d+(?:\.\d+)*)(?<prerelease>.*)$",
       "packageName": "php/php-src",
     },
     {
@@ -427,7 +427,7 @@ exports[`modules/manager/composer/extract extractPackageFile() extracts object r
       "datasource": "github-tags",
       "depName": "php",
       "depType": "require",
-      "extractVersion": "^php-(?<version>.*)$",
+      "extractVersion": "^php-(?<version>\d+(?:\.\d+)*)(?<prerelease>.*)$",
       "packageName": "php/php-src",
     },
     {

--- a/lib/modules/manager/composer/extract.ts
+++ b/lib/modules/manager/composer/extract.ts
@@ -132,7 +132,8 @@ export async function extractPackageFile(
               currentValue,
               datasource: GithubTagsDatasource.id,
               packageName: 'php/php-src',
-              extractVersion: '^php-(?<version>.*)$',
+              extractVersion:
+                '^php-(?<version>\\d+(?:\\.\\d+)*)(?<prerelease>.*)$',
             });
           } else {
             // Default datasource and packageName


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
This PR modifies the `extractVersion` for the `php` package to better match the git tags used.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->
Closes https://github.com/renovatebot/renovate/issues/18693.

Tags:
```
php-8.2.0RC5
php-8.1.12
php-8.0.25
php-8.2.0RC4
php-8.1.12RC1
php-8.0.25RC1
php-8.1.11
php-8.0.24
```

Current regex: `^php-(?<version>.*)$`
Proposed regex: `^php-(?<version>\d+(?:\.\d+)*)(?<prerelease>.*)$`

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
