### PR TITLE
fix(composer): Improve stability detection (including PHP)

### DIFF
--- a/lib/modules/manager/composer/__snapshots__/extract.spec.ts.snap
+++ b/lib/modules/manager/composer/__snapshots__/extract.spec.ts.snap
@@ -5,11 +5,11 @@ exports[`modules/manager/composer/extract extractPackageFile() extracts dependen
   "deps": [
     {
       "currentValue": ">=5.3.2",
-      "datasource": "github-tags",
+      "datasource": "docker",
       "depName": "php",
       "depType": "require",
-      "extractVersion": "^php-(?<version>.*)$",
-      "packageName": "php/php-src",
+      "extractVersion": "^(?<version>\\d+(?:\\.\\d+)*[^-]*)",
+      "versioning": "composer",
     },
     {
       "currentValue": "*",
@@ -216,11 +216,11 @@ exports[`modules/manager/composer/extract extractPackageFile() extracts dependen
   "deps": [
     {
       "currentValue": ">=5.3.2",
-      "datasource": "github-tags",
+      "datasource": "docker",
       "depName": "php",
       "depType": "require",
-      "extractVersion": "^php-(?<version>.*)$",
-      "packageName": "php/php-src",
+      "extractVersion": "^(?<version>\\d+(?:\\.\\d+)*[^-]*)",
+      "versioning": "composer",
     },
     {
       "currentValue": "*",

--- a/lib/modules/manager/composer/__snapshots__/extract.spec.ts.snap
+++ b/lib/modules/manager/composer/__snapshots__/extract.spec.ts.snap
@@ -8,7 +8,7 @@ exports[`modules/manager/composer/extract extractPackageFile() extracts dependen
       "datasource": "docker",
       "depName": "php",
       "depType": "require",
-      "extractVersion": "^(?<version>\\d+(?:\\.\\d+)*[^-]*)",
+      "extractVersion": "^(?<version>\\d+\\.\\d+\\.\\d+(?:RC\\d+|beta\\d+|alpha\\d+)*)",
       "versioning": "composer",
     },
     {
@@ -219,7 +219,7 @@ exports[`modules/manager/composer/extract extractPackageFile() extracts dependen
       "datasource": "docker",
       "depName": "php",
       "depType": "require",
-      "extractVersion": "^(?<version>\\d+(?:\\.\\d+)*[^-]*)",
+      "extractVersion": "^(?<version>\\d+\\.\\d+\\.\\d+(?:RC\\d+|beta\\d+|alpha\\d+)*)",
       "versioning": "composer",
     },
     {

--- a/lib/modules/manager/composer/extract.spec.ts
+++ b/lib/modules/manager/composer/extract.spec.ts
@@ -82,11 +82,11 @@ describe('modules/manager/composer/extract', () => {
         deps: [
           {
             currentValue: '>=5.5',
-            datasource: 'github-tags',
+            datasource: 'docker',
             depName: 'php',
             depType: 'require',
-            extractVersion: '^php-(?<version>.*)$',
-            packageName: 'php/php-src',
+            extractVersion: '^(?<version>\\d+(?:\\.\\d+)*[^-]*)',
+            versioning: 'composer',
           },
           {
             currentValue: '~1.0.12',

--- a/lib/modules/manager/composer/extract.spec.ts
+++ b/lib/modules/manager/composer/extract.spec.ts
@@ -85,7 +85,8 @@ describe('modules/manager/composer/extract', () => {
             datasource: 'docker',
             depName: 'php',
             depType: 'require',
-            extractVersion: '^(?<version>\\d+(?:\\.\\d+)*[^-]*)',
+            extractVersion:
+              '^(?<version>\\d+\\.\\d+\\.\\d+(?:RC\\d+|beta\\d+|alpha\\d+)*)',
             versioning: 'composer',
           },
           {

--- a/lib/modules/manager/composer/extract.ts
+++ b/lib/modules/manager/composer/extract.ts
@@ -2,8 +2,8 @@ import is from '@sindresorhus/is';
 import { logger } from '../../../logger';
 import { readLocalFile } from '../../../util/fs';
 import { regEx } from '../../../util/regex';
+import { DockerDatasource } from '../../datasource/docker';
 import { GitTagsDatasource } from '../../datasource/git-tags';
-import { GithubTagsDatasource } from '../../datasource/github-tags';
 import { PackagistDatasource } from '../../datasource/packagist';
 import { api as semverComposer } from '../../versioning/composer';
 import type { PackageDependency, PackageFile } from '../types';
@@ -14,6 +14,7 @@ import type {
   ComposerRepositories,
   Repo,
 } from './types';
+import { composerVersioningId } from './utils';
 
 /**
  * The regUrl is expected to be a base URL. GitLab composer repository installation guide specifies
@@ -127,9 +128,9 @@ export async function extractPackageFile(
               depType,
               depName,
               currentValue,
-              datasource: GithubTagsDatasource.id,
-              packageName: 'php/php-src',
-              extractVersion: '^php-(?<version>.*)$',
+              datasource: DockerDatasource.id,
+              extractVersion: '^(?<version>\\d+(?:\\.\\d+)*[^-]*)',
+              versioning: composerVersioningId,
             });
           } else {
             // Default datasource and packageName

--- a/lib/modules/manager/composer/extract.ts
+++ b/lib/modules/manager/composer/extract.ts
@@ -129,7 +129,8 @@ export async function extractPackageFile(
               depName,
               currentValue,
               datasource: DockerDatasource.id,
-              extractVersion: '^(?<version>\\d+(?:\\.\\d+)*[^-]*)',
+              extractVersion:
+                '^(?<version>\\d+\\.\\d+\\.\\d+(?:RC\\d+|beta\\d+|alpha\\d+)*)',
               versioning: composerVersioningId,
             });
           } else {

--- a/lib/modules/versioning/composer/index.spec.ts
+++ b/lib/modules/versioning/composer/index.spec.ts
@@ -12,8 +12,11 @@ describe('modules/versioning/composer/index', () => {
     a               | b                  | expected
     ${'1.2.0'}      | ${'v1.2'}          | ${true}
     ${'v1.0.0'}     | ${'1'}             | ${true}
+    ${'1.0alpha3'}  | ${'1.0.0-alpha.3'} | ${true}
     ${'1.0@alpha3'} | ${'1.0.0-alpha.3'} | ${true}
+    ${'1.0beta'}    | ${'1.0.0-beta'}    | ${true}
     ${'1.0@beta'}   | ${'1.0.0-beta'}    | ${true}
+    ${'1.0rc2'}     | ${'1.0.0-rc.2'}    | ${true}
     ${'1.0@rc2'}    | ${'1.0.0-rc.2'}    | ${true}
   `('equals("$a", "$b") === $expected', ({ a, b, expected }) => {
     expect(semver.equals(a, b)).toBe(expected);
@@ -55,6 +58,9 @@ describe('modules/versioning/composer/index', () => {
     ${'~1.2.3-beta1'} | ${true}
     ${'^1.2.3-alpha'} | ${true}
     ${'>1.2.3-rc2'}   | ${true}
+    ${'~1.2.3beta1'}  | ${true}
+    ${'^1.2.3alpha'}  | ${true}
+    ${'>1.2.3rc2'}    | ${true}
     ${'~1.2.3@beta'}  | ${true}
     ${'^1.2.3@alpha'} | ${true}
     ${'>1.2.3@rc'}    | ${true}

--- a/lib/modules/versioning/composer/index.spec.ts
+++ b/lib/modules/versioning/composer/index.spec.ts
@@ -173,8 +173,11 @@ describe('modules/versioning/composer/index', () => {
   );
 
   test.each`
-    versions                                     | expected
-    ${['1.2.3-beta', '2.0.1', '1.3.4', '1.2.3']} | ${['1.2.3-beta', '1.2.3', '1.3.4', '2.0.1']}
+    versions                                                                   | expected
+    ${['1.2.3-beta', '2.0.1', '1.3.4', '1.2.3']}                               | ${['1.2.3-beta', '1.2.3', '1.3.4', '2.0.1']}
+    ${['1.0.0-rc.5', '1.0.0-rc.1', '1.0.0-rc.3', '1.0.0-rc']}                  | ${['1.0.0-rc', '1.0.0-rc.1', '1.0.0-rc.3', '1.0.0-rc.5']}
+    ${['1.0.0-beta', '1.0.0-dev', '1.0.0-rc', '1.0.0-alpha']}                  | ${['1.0.0-dev', '1.0.0-alpha', '1.0.0-beta', '1.0.0-rc']}
+    ${['1.2.0-dev', '1.0.0-rc.5', '1.2.0-rc.2', '1.0.0-rc.5', '1.2.0-beta.3']} | ${['1.0.0-rc.5', '1.0.0-rc.5', '1.2.0-dev', '1.2.0-beta.3', '1.2.0-rc.2']}
   `('$versions -> sortVersions -> $expected ', ({ versions, expected }) => {
     expect(versions.sort(semver.sortVersions)).toEqual(expected);
   });

--- a/lib/modules/versioning/composer/index.ts
+++ b/lib/modules/versioning/composer/index.ts
@@ -44,7 +44,10 @@ function padZeroes(input: string): string {
 
 function convertStabilityModifier(input: string): string {
   // Handle stability modifiers.
-  const versionParts = input.split('@');
+  const versionParts = input
+    // 1.0beta2 to 1.0@beta2
+    .replace(regEx(/(\d+(?:\.\d+)*)(beta|alpha|rc)/gi), '$1@$2')
+    .split('@');
   if (versionParts.length === 1) {
     return input;
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Currently the GitHub tags for PHP are used when deciding the PHP version, however this has led to a couple of issues and this PR proposes to fix those by using the official docker PHP datasource.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->
In order to solve https://github.com/renovatebot/renovate/discussions/18695 I've been digging further through the versioning codebase in order to get a better grasp of how this is working.

Originally in https://github.com/renovatebot/renovate/pull/18474, @viceice suggested that we use the @containerbase org and the docker images stored there. This would not allow for unstable PHP versions, and the official docker PHP images were suggested (as these are available for unstable versions) https://hub.docker.com/_/php/tags.

The original decision to reject this was, I believe, based on my own lack of knowledge in this area of the codebase and being uncertain as to whether the tags would be correctly parsed. As I've gotten more familiar I'm fairly confident that they would be. 

I've made 2 assumptions with this that I haven't been able to confirm:
- That by setting the `datasource` as `docker`, the versioning for that package will also be `docker` and not `composer`.
- That the `depName` of `php` is enough for the docker datasource to discover the image.

Issues addressed by this PR:
- Supersedes https://github.com/renovatebot/renovate/pull/18694
- Fixes https://github.com/renovatebot/renovate/issues/18693
- Should help with https://github.com/renovatebot/renovate/discussions/18624

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
