### PR TITLE
fix(git): git http url fix

### DIFF
--- a/lib/util/git/url.spec.ts
+++ b/lib/util/git/url.spec.ts
@@ -58,6 +58,9 @@ describe('util/git/url', () => {
       expect(
         getHttpUrl('http://gitlab.com:8443/', 'gitlab-ci-token:token')
       ).toBe('http://gitlab-ci-token:token@gitlab.com:8443/');
+      expect(
+        getHttpUrl('git@gitlab.com:some/repo', 'token')
+      ).toBe('https://gitlab-ci-token:token@gitlab.com/some/repo');
     });
 
     it('returns github url with token', () => {
@@ -70,6 +73,9 @@ describe('util/git/url', () => {
       expect(
         getHttpUrl('http://github.com:8443/', 'x-access-token:token')
       ).toBe('http://x-access-token:token@github.com:8443/');
+      expect(
+        getHttpUrl('git@github.com:some/repo', 'token')
+      ).toBe('https://x-access-token:token@gitlab.com/some/repo');
     });
   });
 

--- a/lib/util/git/url.spec.ts
+++ b/lib/util/git/url.spec.ts
@@ -58,9 +58,9 @@ describe('util/git/url', () => {
       expect(
         getHttpUrl('http://gitlab.com:8443/', 'gitlab-ci-token:token')
       ).toBe('http://gitlab-ci-token:token@gitlab.com:8443/');
-      expect(
-        getHttpUrl('git@gitlab.com:some/repo', 'token')
-      ).toBe('https://gitlab-ci-token:token@gitlab.com/some/repo');
+      expect(getHttpUrl('git@gitlab.com:some/repo', 'token')).toBe(
+        'https://gitlab-ci-token:token@gitlab.com/some/repo'
+      );
     });
 
     it('returns github url with token', () => {
@@ -73,9 +73,9 @@ describe('util/git/url', () => {
       expect(
         getHttpUrl('http://github.com:8443/', 'x-access-token:token')
       ).toBe('http://x-access-token:token@github.com:8443/');
-      expect(
-        getHttpUrl('git@github.com:some/repo', 'token')
-      ).toBe('https://x-access-token:token@gitlab.com/some/repo');
+      expect(getHttpUrl('git@github.com:some/repo', 'token')).toBe(
+        'https://x-access-token:token@github.com/some/repo'
+      );
     });
   });
 

--- a/lib/util/git/url.ts
+++ b/lib/util/git/url.ts
@@ -10,7 +10,7 @@ export function parseGitUrl(url: string): gitUrlParse.GitUrl {
 
 export function getHttpUrl(url: string, token?: string): string {
   const parsedUrl = parseGitUrl(url);
-  
+
   const protocol = regEx(/^https?$/).exec(parsedUrl.protocol)
     ? parsedUrl.protocol
     : 'https';

--- a/lib/util/git/url.ts
+++ b/lib/util/git/url.ts
@@ -10,11 +10,15 @@ export function parseGitUrl(url: string): gitUrlParse.GitUrl {
 
 export function getHttpUrl(url: string, token?: string): string {
   const parsedUrl = parseGitUrl(url);
+  
+  const protocol = regEx(/^https?$/).exec(parsedUrl.protocol)
+    ? parsedUrl.protocol
+    : 'https';
 
   parsedUrl.token = token ?? '';
 
   if (token) {
-    switch (detectPlatform(url)) {
+    switch (detectPlatform(parsedUrl.toString(protocol))) {
       case 'gitlab':
         parsedUrl.token = token.includes(':')
           ? token
@@ -28,9 +32,6 @@ export function getHttpUrl(url: string, token?: string): string {
     }
   }
 
-  const protocol = regEx(/^https?$/).exec(parsedUrl.protocol)
-    ? parsedUrl.protocol
-    : 'https';
   return parsedUrl.toString(protocol);
 }
 


### PR DESCRIPTION
## Changes

- `getHttpUrl` in `util/git/url.ts` now passes the http(s) representation of the url into `detectPlatform`

## Context

- `detectPlatform` calls `parseUrl(url)`, which fails for `ssh`-style URLs. 
- This should make `getHttpUrl` correctly able to detect the platform of `ssh`-style URLs
- This is a follow-on from #17837 - My previous PR missed this issue

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
