### PR TITLE
chore: bump Node.js version for Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,7 +1,7 @@
 tasks:
   - init: >
-      nvm install 16 &&
-      nvm use 16 &&
+      nvm install 18 &&
+      nvm use 18 &&
       yarn install &&
       yarn run build
     command: yarn run start

--- a/docs/development/remote-development.md
+++ b/docs/development/remote-development.md
@@ -46,12 +46,60 @@ If you need more hours you'll need to buy a plan with more hours.
 
 ### Gitpod tips
 
-- Use `yarn jest:16` to run the tests on Gitpod
+- Use `yarn jest` to run the tests on Gitpod
 
 ### Known problems with Gitpod
 
-- `yarn jest:16` has some failing tests
-- You can't preview Markdown files in the VS Code online editor
+There are two failing tests when running `yarn jest` on Gitpod:
+
+```bash
+Summary of all failing tests
+ FAIL  lib/util/git/index.spec.ts (635.102 s, 319 MB heap size)
+  ● util/git/index › isBranchModified() › should return false when author matches
+
+    expected true to be false or Boolean(false)
+
+      283 |
+      284 |     it('should return false when author matches', async () => {
+    > 285 |       expect(await git.isBranchModified('renovate/future_branch')).toBeFalse();
+          |                                                                    ^
+      286 |       expect(await git.isBranchModified('renovate/future_branch')).toBeFalse();
+      287 |     });
+      288 |
+
+      at Object.<anonymous> (lib/util/git/index.spec.ts:285:68)
+
+  ● util/git/index › isBranchModified() › should return false when author is ignored
+
+    expected true to be false or Boolean(false)
+
+      291 |         gitIgnoredAuthors: ['custom@example.com'],
+      292 |       });
+    > 293 |       expect(await git.isBranchModified('renovate/custom_author')).toBeFalse();
+          |                                                                    ^
+      294 |     });
+      295 |
+      296 |     it('should return true when custom author is unknown', async () => {
+
+      at Object.<anonymous> (lib/util/git/index.spec.ts:293:68)
+
+ FAIL  test/static-files.spec.ts (14.506 s, 288 MB heap size)
+  ● static-files › has same static files in lib and dist
+
+    thrown: "Exceeded timeout of 10000 ms for a test.
+    Use jest.setTimeout(newTimeout) to increase the timeout value, if this is a long-running test."
+
+      36 |   jest.setTimeout(10 * 1000);
+      37 |
+    > 38 |   it('has same static files in lib and dist', async () => {
+         |   ^
+      39 |     expect(await getFiles('dist')).toEqual(await getFiles('lib'));
+      40 |   });
+      41 | });
+
+      at test/static-files.spec.ts:38:3
+      at Object.<anonymous> (test/static-files.spec.ts:34:1)
+```
 
 ## GitHub Codespaces
 


### PR DESCRIPTION
## Changes

- Use Node.js 18
- Update the Remote development docs
- You can now preview Markdown files when using Gitpod
- Remove  reference to `yarn jest:16` as we're now using Node 18

## Context

Jest is slow on Node.js 18. I see the Node.js 14 tests complete a lot quicker, see:

- https://github.com/renovatebot/renovate/actions/runs/3375278273/usage

Total time to run `yarn jest` on Node.js `18` in Gitpod:

```bash
Test Suites: 2 failed, 548 passed, 550 total
Tests:       3 failed, 10635 passed, 10638 total
Snapshots:   898 passed, 898 total
Time:        1313.857 s
```

When running the Jest tests on Gitpod "out of the box" two Git author related tests fail. I don't know if we want to document those "fails".

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
