### PR TITLE
feat(github-actions): support vulnerability alerts

### DIFF
--- a/lib/workers/repository/init/__snapshots__/vulnerability.spec.ts.snap
+++ b/lib/workers/repository/init/__snapshots__/vulnerability.spec.ts.snap
@@ -45,6 +45,36 @@ go",
     ],
   },
   {
+    "allowedVersions": "1.8.3",
+    "force": {
+      "branchTopic": "{{{datasource}}}-{{{depName}}}-vulnerability",
+      "commitMessageSuffix": "[SECURITY]",
+      "dependencyDashboardApproval": false,
+      "groupName": null,
+      "prCreation": "immediate",
+      "rangeStrategy": "update-lockfile",
+      "schedule": [],
+      "stabilityDays": 0,
+    },
+    "isVulnerabilityAlert": true,
+    "matchCurrentVersion": "1.8.2",
+    "matchDatasources": [
+      "github-tags",
+    ],
+    "matchFiles": [
+      ".github/workflows/build.yaml",
+    ],
+    "matchPackageNames": [
+      "bar",
+    ],
+    "prBodyNotes": [
+      "### GitHub Vulnerability Alerts",
+      "#### [def]()
+
+actions",
+    ],
+  },
+  {
     "allowedVersions": "==2.2.1.0",
     "force": {
       "branchTopic": "{{{datasource}}}-{{{depName}}}-vulnerability",

--- a/lib/workers/repository/init/vulnerability.spec.ts
+++ b/lib/workers/repository/init/vulnerability.spec.ts
@@ -87,6 +87,23 @@ describe('workers/repository/init/vulnerability', () => {
           },
         },
         {
+          dismissReason: null,
+          vulnerableManifestFilename: '.github/workflows/build.yaml',
+          vulnerableManifestPath: '.github/workflows/build.yaml',
+          vulnerableRequirements: '= 1.8.2',
+          securityAdvisory: {
+            description: 'actions',
+            identifiers: [{ type: 'GHSA', value: 'def' }],
+            references: [{ url: '' }],
+            severity: 'HIGH',
+          },
+          securityVulnerability: {
+            package: { name: 'bar', ecosystem: 'ACTIONS' },
+            firstPatchedVersion: { identifier: '1.8.3' },
+            vulnerableVersionRange: '>= 1.8, < 1.8.3',
+          },
+        },
+        {
           // this will be ignored
           dismissReason: null,
           vulnerableManifestFilename: 'package-lock.json',
@@ -313,8 +330,9 @@ describe('workers/repository/init/vulnerability', () => {
       ]);
       const res = await detectVulnerabilityAlerts(config);
       expect(res.packageRules).toMatchSnapshot();
-      expect(res.packageRules).toHaveLength(4);
+      expect(res.packageRules).toHaveLength(5);
       expect(res.packageRules?.[1]?.matchFiles?.[0]).toBe('go.mod');
+      expect(res.packageRules?.[2]?.matchCurrentVersion).toBe('1.8.2');
       expect(res.remediations).toMatchSnapshot({
         'backend/package-lock.json': [
           {

--- a/lib/workers/repository/init/vulnerability.ts
+++ b/lib/workers/repository/init/vulnerability.ts
@@ -2,6 +2,7 @@ import type { PackageRule, RenovateConfig } from '../../../config/types';
 import { NO_VULNERABILITY_ALERTS } from '../../../constants/error-messages';
 import { logger } from '../../../logger';
 import { CrateDatasource } from '../../../modules/datasource/crate';
+import { GithubTagsDatasource } from '../../../modules/datasource/github-tags';
 import { GoDatasource } from '../../../modules/datasource/go';
 import { MavenDatasource } from '../../../modules/datasource/maven';
 import { NpmDatasource } from '../../../modules/datasource/npm';
@@ -65,6 +66,7 @@ export async function detectVulnerabilityAlerts(
   }
   const config = { ...input };
   const versionings: Record<string, string> = {
+    'github-tags': semverVersioning.id,
     go: semverVersioning.id,
     packagist: composerVersioning.id,
     maven: mavenVersioning.id,
@@ -94,6 +96,7 @@ export async function detectVulnerabilityAlerts(
         continue;
       }
       const datasourceMapping: Record<string, string> = {
+        ACTIONS: GithubTagsDatasource.id,
         COMPOSER: PackagistDatasource.id,
         GO: GoDatasource.id,
         MAVEN: MavenDatasource.id,
@@ -126,6 +129,10 @@ export async function detectVulnerabilityAlerts(
           regEx(/^= /),
           '== '
         );
+      }
+      if (datasource === GithubTagsDatasource.id) {
+        // GitHub Actions uses docker versioning, which doesn't support `= 1.2.3` matching, so we strip the equals
+        vulnerableRequirements = vulnerableRequirements.replace(/^=\s*/, '');
       }
       combinedAlerts[fileName] ||= {};
       combinedAlerts[fileName][datasource] ||= {};


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds vulnerability alert awareness to github actions

## Context

Closes #17250
Replaces #17254

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
