### PR TITLE
fix: Properly detect named groups with `(?P<name>)` syntax in regexManager.matchStrings

### DIFF
--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -425,7 +425,7 @@ describe('config/validation', () => {
         regexManagers: [
           {
             fileMatch: ['Dockerfile'],
-            matchStrings: ['ENV (?<currentValue>.*?)\\s'],
+            matchStrings: ['ENV (?P<currentValue>.*?)\\s'],
             depNameTemplate: 'foo',
             datasourceTemplate: 'bar',
             registryUrlTemplate: 'foobar',

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -460,7 +460,7 @@ export async function validateConfig(
                           !regexManager[`${field}Template`] &&
                           !regexManager.matchStrings.some(
                             (matchString: string) =>
-                              matchString.includes(`(?<${field}>`)
+                              matchString.includes(`(?<${field}>`) || matchString.includes(`(?P<${field}>`)
                           )
                         ) {
                           errors.push({


### PR DESCRIPTION
Using a `(?P<name>)` style named group in regexManager.matchStrings caused config validation errors because of missing fields.

While `(?<name>)` works, RE2's supported way of matching named groups is the `(?P<name>)` syntax (see https://github.com/google/re2/wiki/Syntax). This PR properly detects both variants.

I changed the "pass" test to include one of each variants.