### PR TITLE
fix(changelogs): better release name trimming

### DIFF
--- a/lib/workers/repository/update/pr/changelog/release-notes.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/release-notes.spec.ts
@@ -385,7 +385,7 @@ describe('workers/repository/update/pr/changelog/release-notes', () => {
         .scope('https://api.github.com/')
         .get('/repos/some/other-repository/releases?per_page=100')
         .reply(200, [
-          { tag_name: `${prefix}1.0.0` },
+          { tag_name: `${prefix}1.0.0`, name: 'Release v1.0.0' },
           {
             tag_name: `${prefix}1.0.1`,
             name: '1.0.1',
@@ -424,7 +424,7 @@ describe('workers/repository/update/pr/changelog/release-notes', () => {
           { tag_name: `${prefix}1.0.0` },
           {
             tag_name: `${prefix}1.0.1`,
-            name: '1.0.1 some release',
+            name: 'v1.0.1 some release',
             body: 'some body',
           },
         ]);

--- a/lib/workers/repository/update/pr/changelog/release-notes.ts
+++ b/lib/workers/repository/update/pr/changelog/release-notes.ts
@@ -107,10 +107,10 @@ export function massageName(
 ): string | undefined {
   let name = input ?? '';
 
-  // Remove the current tag from the name if it's used as a prefix
-  if (version && name.startsWith(version)) {
-    name = name.slice(version.length);
+  if (version) {
+    name = name.replace(RegExp(`^(Release )?v?${version}`, 'i'), '').trim();
   }
+
   name = name.trim();
   if (!name.length) {
     return undefined;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

More aggressive release note name trimming

## Context

Avoid things like this:

<img width="441" alt="image" src="https://user-images.githubusercontent.com/6311784/200106271-e354a9a7-09ec-4343-87a1-6d102d3220ba.png">


## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
