### PR TITLE
refactor(jest): enable clearMocks

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -39,6 +39,7 @@ function jestGithubRunnerSpecs(): JestConfig {
 
 const config: JestConfig = {
   cacheDirectory: '.cache/jest',
+  clearMocks: true,
   coverageDirectory: './coverage',
   collectCoverage: true,
   collectCoverageFrom: [

--- a/lib/config/presets/index.spec.ts
+++ b/lib/config/presets/index.spec.ts
@@ -50,7 +50,6 @@ describe('config/presets/index', () => {
 
     beforeEach(() => {
       config = {};
-      jest.clearAllMocks();
       memCache.init();
     });
 

--- a/lib/instrumentation/decorator.spec.ts
+++ b/lib/instrumentation/decorator.spec.ts
@@ -7,10 +7,6 @@ afterAll(disableInstrumentations);
 describe('instrumentation/decorator', () => {
   const spy = jest.fn(() => Promise.resolve());
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   it('should instrument async function', async () => {
     class MyClass {
       @instrument({ name: 'getNumber' })

--- a/lib/instrumentation/index.spec.ts
+++ b/lib/instrumentation/index.spec.ts
@@ -17,7 +17,6 @@ describe('instrumentation/index', () => {
   const oldEnv = process.env;
 
   beforeEach(() => {
-    jest.clearAllMocks();
     api.trace.disable(); // clear global components
     process.env = { ...oldEnv };
   });

--- a/lib/modules/datasource/cdnjs/index.spec.ts
+++ b/lib/modules/datasource/cdnjs/index.spec.ts
@@ -13,10 +13,6 @@ const pathFor = (s: string): string =>
 
 describe('modules/datasource/cdnjs/index', () => {
   describe('getReleases', () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
-    });
-
     it('throws for empty result', async () => {
       httpMock.scope(baseUrl).get(pathFor('foo/bar')).reply(200, '}');
       await expect(

--- a/lib/modules/datasource/gradle-version/index.spec.ts
+++ b/lib/modules/datasource/gradle-version/index.spec.ts
@@ -20,7 +20,6 @@ describe('modules/datasource/gradle-version/index', () => {
         versioning,
         depName: 'abc',
       };
-      jest.clearAllMocks();
     });
 
     it('processes real data', async () => {

--- a/lib/modules/datasource/npm/get.spec.ts
+++ b/lib/modules/datasource/npm/get.spec.ts
@@ -15,7 +15,6 @@ const http = new Http('npm');
 
 describe('modules/datasource/npm/get', () => {
   beforeEach(() => {
-    jest.clearAllMocks();
     hostRules.clear();
     setNpmrc();
   });

--- a/lib/modules/datasource/orb/index.spec.ts
+++ b/lib/modules/datasource/orb/index.spec.ts
@@ -29,10 +29,6 @@ const datasource = OrbDatasource.id;
 
 describe('modules/datasource/orb/index', () => {
   describe('getReleases', () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
-    });
-
     it('returns null for empty result', async () => {
       httpMock.scope(baseUrl).post('/graphql-unstable').reply(200, {});
       expect(

--- a/lib/modules/datasource/terraform-module/index.spec.ts
+++ b/lib/modules/datasource/terraform-module/index.spec.ts
@@ -16,10 +16,6 @@ const localTerraformEnterprisebaseUrl = 'https://terraform.foo.bar';
 
 describe('modules/datasource/terraform-module/index', () => {
   describe('getReleases', () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
-    });
-
     it('returns null for empty result', async () => {
       httpMock
         .scope(baseUrl)

--- a/lib/modules/manager/npm/post-update/yarn.spec.ts
+++ b/lib/modules/manager/npm/post-update/yarn.spec.ts
@@ -40,7 +40,6 @@ env.getChildProcessEnv.mockReturnValue(envMock.basic);
 describe('modules/manager/npm/post-update/yarn', () => {
   beforeEach(() => {
     delete process.env.BUILDPACK;
-    jest.clearAllMocks();
     Fixtures.reset();
     GlobalConfig.set({ localDir: '.', cacheDir: '/tmp/cache' });
     docker.resetPrefetchedImages();

--- a/lib/modules/platform/bitbucket/comments.spec.ts
+++ b/lib/modules/platform/bitbucket/comments.spec.ts
@@ -8,8 +8,6 @@ describe('modules/platform/bitbucket/comments', () => {
   const config: comments.CommentsConfig = { repository: 'some/repo' };
 
   beforeEach(() => {
-    jest.clearAllMocks();
-
     setBaseUrl(baseUrl);
   });
 

--- a/lib/modules/platform/gitea/index.spec.ts
+++ b/lib/modules/platform/gitea/index.spec.ts
@@ -199,7 +199,6 @@ describe('modules/platform/gitea/index', () => {
 
   beforeEach(async () => {
     jest.resetModules();
-    jest.clearAllMocks();
     jest.mock('./gitea-helper');
     jest.mock('../../../util/git');
     jest.mock('../../../logger');

--- a/lib/util/cache/package/decorator.spec.ts
+++ b/lib/util/cache/package/decorator.spec.ts
@@ -15,10 +15,6 @@ describe('util/cache/package/decorator', () => {
     await packageCache.init({ cacheDir: os.tmpdir() });
   });
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   it('should cache string', async () => {
     class MyClass {
       @cache({ namespace: 'namespace', key: 'key' })

--- a/lib/util/cache/repository/impl/s3.spec.ts
+++ b/lib/util/cache/repository/impl/s3.spec.ts
@@ -58,7 +58,6 @@ describe('util/cache/repository/impl/s3', () => {
 
   beforeEach(() => {
     GlobalConfig.set({ platform: 'github' });
-    jest.clearAllMocks();
     s3Mock.reset();
     s3Cache = new RepoCacheS3(repository, '0123456789abcdef', url);
     getObjectCommandInput = createGetObjectCommandInput(repository, url);

--- a/lib/util/package-rules/current-version.spec.ts
+++ b/lib/util/package-rules/current-version.spec.ts
@@ -4,10 +4,6 @@ import { CurrentVersionMatcher } from './current-version';
 describe('util/package-rules/current-version', () => {
   const matcher = new CurrentVersionMatcher();
 
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
   describe('match', () => {
     it('return false on version exception', () => {
       const spy = jest.spyOn(pep440, 'matches').mockImplementationOnce(() => {

--- a/lib/workers/repository/config-migration/branch/commit-message.spec.ts
+++ b/lib/workers/repository/config-migration/branch/commit-message.spec.ts
@@ -5,10 +5,6 @@ describe('workers/repository/config-migration/branch/commit-message', () => {
   const config = getConfig();
   const fileName = 'renovate.json';
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   afterAll(() => {
     jest.resetAllMocks();
   });

--- a/lib/workers/repository/config-migration/branch/create.spec.ts
+++ b/lib/workers/repository/config-migration/branch/create.spec.ts
@@ -16,7 +16,6 @@ describe('workers/repository/config-migration/branch/create', () => {
   let migratedConfigData: MigratedData;
 
   beforeEach(() => {
-    jest.clearAllMocks();
     config = getConfig();
     config.baseBranch = 'dev';
     config.defaultBranch = 'master';

--- a/lib/workers/repository/dependency-dashboard.spec.ts
+++ b/lib/workers/repository/dependency-dashboard.spec.ts
@@ -31,7 +31,6 @@ const getIssueSpy = platform.getIssue;
 let config: RenovateConfig;
 
 beforeEach(() => {
-  jest.clearAllMocks();
   massageMdSpy.mockImplementation(massageMarkdown);
   config = getConfig();
   config.platform = 'github';
@@ -69,7 +68,6 @@ async function dryRun(
   ensureIssueClosingCalls = 0,
   ensureIssueCalls = 0
 ) {
-  jest.clearAllMocks();
   GlobalConfig.set({ dryRun: 'full' });
   await dependencyDashboard.ensureDependencyDashboard(config, branches);
   expect(platform.ensureIssueClosing).toHaveBeenCalledTimes(

--- a/lib/workers/repository/dependency-dashboard.spec.ts
+++ b/lib/workers/repository/dependency-dashboard.spec.ts
@@ -65,8 +65,8 @@ function genRandPackageFile(
 async function dryRun(
   branches: BranchConfig[],
   platform: jest.MockedObject<Platform>,
-  ensureIssueClosingCalls = 0,
-  ensureIssueCalls = 0
+  ensureIssueClosingCalls: number,
+  ensureIssueCalls: number
 ) {
   GlobalConfig.set({ dryRun: 'full' });
   await dependencyDashboard.ensureDependencyDashboard(config, branches);
@@ -170,7 +170,7 @@ describe('workers/repository/dependency-dashboard', () => {
       expect(platform.ensureIssue).toHaveBeenCalledTimes(0);
 
       // same with dry run
-      await dryRun(branches, platform);
+      await dryRun(branches, platform, 1, 0);
     });
 
     it('do nothing if it has no dependencyDashboardApproval branches', async () => {
@@ -190,7 +190,7 @@ describe('workers/repository/dependency-dashboard', () => {
       expect(platform.ensureIssue).toHaveBeenCalledTimes(0);
 
       // same with dry run
-      await dryRun(branches, platform);
+      await dryRun(branches, platform, 1, 0);
     });
 
     it('closes Dependency Dashboard when there is 0 PR opened and dependencyDashboardAutoclose is true', async () => {
@@ -205,7 +205,7 @@ describe('workers/repository/dependency-dashboard', () => {
       expect(platform.ensureIssue).toHaveBeenCalledTimes(0);
 
       // same with dry run
-      await dryRun(branches, platform);
+      await dryRun(branches, platform, 1, 0);
     });
 
     it('closes Dependency Dashboard when all branches are automerged and dependencyDashboardAutoclose is true', async () => {
@@ -232,7 +232,7 @@ describe('workers/repository/dependency-dashboard', () => {
       expect(platform.ensureIssue).toHaveBeenCalledTimes(0);
 
       // same with dry run
-      await dryRun(branches, platform);
+      await dryRun(branches, platform, 1, 0);
     });
 
     it('open or update Dependency Dashboard when all branches are closed and dependencyDashboardAutoclose is false', async () => {
@@ -249,7 +249,7 @@ describe('workers/repository/dependency-dashboard', () => {
       expect(platform.ensureIssue.mock.calls[0][0].body).toMatchSnapshot();
 
       // same with dry run
-      await dryRun(branches, platform);
+      await dryRun(branches, platform, 0, 1);
     });
 
     it('open or update Dependency Dashboard when rules contain approvals', async () => {
@@ -280,7 +280,7 @@ describe('workers/repository/dependency-dashboard', () => {
       expect(platform.ensureIssue.mock.calls[0][0].body).toMatchSnapshot();
 
       // same with dry run
-      await dryRun(branches, platform);
+      await dryRun(branches, platform, 0, 1);
     });
 
     it('checks an issue with 2 Pending Approvals, 2 not scheduled, 2 pr-hourly-limit-reached and 2 in error', async () => {
@@ -362,7 +362,7 @@ describe('workers/repository/dependency-dashboard', () => {
       );
 
       // same with dry run
-      await dryRun(branches, platform);
+      await dryRun(branches, platform, 0, 1);
     });
 
     it('checks an issue with 2 PR pr-edited', async () => {
@@ -399,7 +399,7 @@ describe('workers/repository/dependency-dashboard', () => {
       );
 
       // same with dry run
-      await dryRun(branches, platform, 0, 0);
+      await dryRun(branches, platform, 0, 1);
     });
 
     it('checks an issue with 3 PR in progress and rebase all option', async () => {
@@ -444,7 +444,7 @@ describe('workers/repository/dependency-dashboard', () => {
       );
 
       // same with dry run
-      await dryRun(branches, platform, 0, 0);
+      await dryRun(branches, platform, 0, 1);
     });
 
     it('checks an issue with 2 PR closed / ignored', async () => {
@@ -479,7 +479,7 @@ describe('workers/repository/dependency-dashboard', () => {
       );
 
       // same with dry run
-      await dryRun(branches, platform, 0, 0);
+      await dryRun(branches, platform, 0, 1);
     });
 
     it('checks an issue with 3 PR in approval', async () => {
@@ -529,7 +529,7 @@ describe('workers/repository/dependency-dashboard', () => {
       );
 
       // same with dry run
-      await dryRun(branches, platform);
+      await dryRun(branches, platform, 0, 1);
     });
 
     it('contains logged problems', async () => {
@@ -761,7 +761,7 @@ describe('workers/repository/dependency-dashboard', () => {
       ]);
 
       // same with dry run
-      await dryRun(branches, platform);
+      await dryRun(branches, platform, 0, 1);
     });
 
     describe('checks detected dependencies section', () => {
@@ -790,7 +790,7 @@ describe('workers/repository/dependency-dashboard', () => {
           expect(platform.ensureIssue.mock.calls[0][0].body).toMatchSnapshot();
 
           // same with dry run
-          await dryRun(branches, platform);
+          await dryRun(branches, platform, 0, 1);
         });
 
         it('show default message in issues body when packageFiles is empty', async () => {
@@ -802,7 +802,7 @@ describe('workers/repository/dependency-dashboard', () => {
           expect(platform.ensureIssue.mock.calls[0][0].body).toMatchSnapshot();
 
           // same with dry run
-          await dryRun(branches, platform);
+          await dryRun(branches, platform, 0, 1);
         });
 
         it('show default message in issues body when when packageFiles is null', async () => {
@@ -814,7 +814,7 @@ describe('workers/repository/dependency-dashboard', () => {
           expect(platform.ensureIssue.mock.calls[0][0].body).toMatchSnapshot();
 
           // same with dry run
-          await dryRun(branches, platform);
+          await dryRun(branches, platform, 0, 1);
         });
 
         it('shows different combinations of version+digest for a given dependency', async () => {
@@ -825,7 +825,7 @@ describe('workers/repository/dependency-dashboard', () => {
           expect(platform.ensureIssue.mock.calls[0][0].body).toMatchSnapshot();
 
           // same with dry run
-          await dryRun(branches, platform);
+          await dryRun(branches, platform, 0, 1);
         });
       });
 
@@ -843,7 +843,7 @@ describe('workers/repository/dependency-dashboard', () => {
           expect(platform.ensureIssue.mock.calls[0][0].body).toMatchSnapshot();
 
           // same with dry run
-          await dryRun(branches, platform);
+          await dryRun(branches, platform, 0, 1);
         });
 
         it('show default message in issues body when packageFiles is empty', async () => {
@@ -854,7 +854,7 @@ describe('workers/repository/dependency-dashboard', () => {
           expect(platform.ensureIssue.mock.calls[0][0].body).toMatchSnapshot();
 
           // same with dry run
-          await dryRun(branches, platform);
+          await dryRun(branches, platform, 0, 1);
         });
 
         it('show default message in issues body when when packageFiles is null', async () => {
@@ -865,7 +865,7 @@ describe('workers/repository/dependency-dashboard', () => {
           expect(platform.ensureIssue.mock.calls[0][0].body).toMatchSnapshot();
 
           // same with dry run
-          await dryRun(branches, platform);
+          await dryRun(branches, platform, 0, 1);
         });
 
         it('truncates the body of a really big repo', async () => {
@@ -881,7 +881,7 @@ describe('workers/repository/dependency-dashboard', () => {
           ).toBeTrue();
 
           // same with dry run
-          await dryRun(branches, platform);
+          await dryRun(branches, platform, 0, 1);
         });
       });
 
@@ -916,7 +916,7 @@ describe('workers/repository/dependency-dashboard', () => {
           expect(platform.ensureIssue).toHaveBeenCalledTimes(1);
           expect(platform.ensureIssue.mock.calls[0][0].body).toMatchSnapshot();
           // same with dry run
-          await dryRun(branches, platform);
+          await dryRun(branches, platform, 0, 1);
         });
       });
 

--- a/lib/workers/repository/onboarding/branch/config.spec.ts
+++ b/lib/workers/repository/onboarding/branch/config.spec.ts
@@ -19,7 +19,6 @@ describe('workers/repository/onboarding/branch/config', () => {
   });
 
   beforeEach(() => {
-    jest.clearAllMocks();
     config = getConfig();
     config.platform = 'github';
     config.repository = 'some/repo';

--- a/lib/workers/repository/onboarding/branch/create.spec.ts
+++ b/lib/workers/repository/onboarding/branch/create.spec.ts
@@ -14,7 +14,6 @@ describe('workers/repository/onboarding/branch/create', () => {
   let config: RenovateConfig;
 
   beforeEach(() => {
-    jest.clearAllMocks();
     config = getConfig();
   });
 

--- a/lib/workers/repository/stats.spec.ts
+++ b/lib/workers/repository/stats.spec.ts
@@ -66,7 +66,7 @@ describe('workers/repository/stats', () => {
       memCache.get.mockImplementationOnce(() => httpStats as any);
       expect(printRequestStats()).toBeUndefined();
       expect(log.trace).toHaveBeenCalledOnce();
-      expect(log.debug).toHaveBeenCalledTimes(3);
+      expect(log.debug).toHaveBeenCalledTimes(2);
       expect(log.trace.mock.calls[0][0]).toMatchInlineSnapshot(`
         {
           "allRequests": [
@@ -127,7 +127,7 @@ describe('workers/repository/stats', () => {
           },
         }
       `);
-      expect(log.debug.mock.calls[1][0]).toMatchInlineSnapshot(`
+      expect(log.debug.mock.calls[0][0]).toMatchInlineSnapshot(`
         {
           "get": {
             "avgMs": 40,
@@ -143,7 +143,7 @@ describe('workers/repository/stats', () => {
           },
         }
       `);
-      expect(log.debug.mock.calls[2][0]).toMatchInlineSnapshot(`
+      expect(log.debug.mock.calls[1][0]).toMatchInlineSnapshot(`
         {
           "hostStats": {
             "api.github.com": {

--- a/lib/workers/repository/update/branch/automerge.spec.ts
+++ b/lib/workers/repository/update/branch/automerge.spec.ts
@@ -17,10 +17,6 @@ describe('workers/repository/update/branch/automerge', () => {
       GlobalConfig.reset();
     });
 
-    afterEach(() => {
-      jest.clearAllMocks();
-    });
-
     it('returns false if not configured for automerge', async () => {
       config.automerge = false;
       expect(await tryBranchAutomerge(config)).toBe('no automerge');

--- a/lib/workers/repository/update/pr/automerge.spec.ts
+++ b/lib/workers/repository/update/pr/automerge.spec.ts
@@ -22,10 +22,6 @@ describe('workers/repository/update/pr/automerge', () => {
       pr = partial<Pr>({});
     });
 
-    afterEach(() => {
-      jest.clearAllMocks();
-    });
-
     it('should not automerge if not configured', async () => {
       await prAutomerge.checkAutoMerge(pr, config);
       expect(platform.mergePr).toHaveBeenCalledTimes(0);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
- Sets `clearMocks`[^1] in `jest.config.ts` (equivalent to calling `jest.clearAllMocks`[^2] before each test)
- Removes any explicit calls to `jest.clearAllMocks`
- Fixes tests that were relying on faulty mock counts

This automatically clears mock calls, instances, contexts and results before every test. This makes it more difficult to write tests which rely on each other.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->
#18768 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
[^1]: https://jestjs.io/docs/configuration#clearmocks-boolean
[^2]: https://jestjs.io/docs/jest-object#jestclearallmocks