### PR TITLE
fix(manager/gradle): prefix version catalog aliases with "libs."

### DIFF
--- a/lib/modules/manager/gradle/parser.spec.ts
+++ b/lib/modules/manager/gradle/parser.spec.ts
@@ -184,7 +184,7 @@ describe('modules/manager/gradle/parser', () => {
       ${''}                                         | ${'library("foo", "bar", "baz", "qux"]).version("1.2.3")'}      | ${null}
       ${''}                                         | ${'library("foo.bar", "foo", "bar").version("1.2.3", "4.5.6")'} | ${null}
       ${'group = "foo"; artifact="bar"'}            | ${'library("foo.bar", group, artifact).version("1.2.3")'}       | ${{ depName: 'foo:bar', currentValue: '1.2.3' }}
-      ${'library("foo-bar_baz-qux", "foo", "bar")'} | ${'"${foo.bar.baz.qux}:1.2.3"'}                                 | ${{ depName: 'foo:bar', currentValue: '1.2.3' }}
+      ${'library("foo-bar_baz-qux", "foo", "bar")'} | ${'"${libs.foo.bar.baz.qux}:1.2.3"'}                            | ${{ depName: 'foo:bar', currentValue: '1.2.3' }}
     `('$def | $str', async ({ def, str, output }) => {
       const input = [def, str].join('\n');
       const { deps } = await parseGradle(input);

--- a/lib/modules/manager/gradle/parser.ts
+++ b/lib/modules/manager/gradle/parser.ts
@@ -377,7 +377,7 @@ function processLibraryDep(input: SyntaxHandlerInput): SyntaxHandlerOutput {
   const { tokenMap } = input;
 
   const varNameToken = tokenMap.varName;
-  const key = varNameToken.value.replace(regEx(/[-_]/g), '.');
+  const key = `libs.${varNameToken.value.replace(regEx(/[-_]/g), '.')}`;
   const fileReplacePosition = varNameToken.offset;
   const packageFile = input.packageFile;
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Prefix version catalog aliases with `libs`, as the version catalog default name, to prevent confusion with variables that have the same name and to comply with [gradle behavior](https://docs.gradle.org/current/userguide/platforms.html#sub:mapping-aliases-to-accessors):
> For example the aliases groovyCore, groovyJson and groovyXml would be mapped to the libs.groovyCore, libs.groovyJson and libs.groovyXml accessors respectively.

This also fixes a related issue: renovate stores library aliases as variable for later use. Since gradle configs reference them with the catalog name prefixed only, these references never worked until now, since the prefix wasn't prepended.

<!-- Describe what behavior is changed by this PR. -->

## Context

Closes https://github.com/renovatebot/renovate/issues/18825

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

Test repo: https://github.com/renovate-demo/18825/pull/1

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
