### PR TITLE
chore: process labels on pull requests

### DIFF
--- a/.github/workflows/label-actions.yml
+++ b/.github/workflows/label-actions.yml
@@ -5,11 +5,14 @@ on:
     types: [labeled]
   discussion:
     types: [labeled]
+  pull_request:
+    types: [labeled]
 
 permissions:
   contents: read
   issues: write
   discussions: write
+  pull-requests: write
 
 jobs:
   reaction:
@@ -18,4 +21,4 @@ jobs:
       - uses: dessant/label-actions@93ea5ec1d65e6a21427a1571a18a5b8861206b0b # renovate: tag=v2.2.0
         with:
           github-token: ${{ github.token }}
-          process-only: 'issues, discussions'
+          process-only: 'issues, discussions, prs'


### PR DESCRIPTION
## Changes

- ⚠️ Add **write** rights to pull requests for `dessant/label-actions` ⚠️ 
- Add configuration to process labels on pull requests

## Context

We created a new label:

https://github.com/renovatebot/renovate/blob/fb56b1fe85e0d17c93a35eb60ec1de3cbe349f09/.github/label-actions.yml#L154-L167

But we forgot the extra permissions and setup in the `.github/workflows/label-actions.yml` file. 😄

The [`README.md` for `dessant/label-actions`](https://github.com/dessant/label-actions/blob/master/README.md) has the explanation for the configuration options.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
