### PR TITLE
chore: Revert "chore: process labels on pull requests"

### DIFF
--- a/.github/workflows/label-actions.yml
+++ b/.github/workflows/label-actions.yml
@@ -5,14 +5,11 @@ on:
     types: [labeled]
   discussion:
     types: [labeled]
-  pull_request:
-    types: [labeled]
 
 permissions:
   contents: read
   issues: write
   discussions: write
-  pull-requests: write
 
 jobs:
   reaction:
@@ -21,4 +18,4 @@ jobs:
       - uses: dessant/label-actions@93ea5ec1d65e6a21427a1571a18a5b8861206b0b # renovate: tag=v2.2.0
         with:
           github-token: ${{ github.token }}
-          process-only: 'issues, discussions, prs'
+          process-only: 'issues, discussions'


### PR DESCRIPTION
Doesn't work without a PAT on forks