### PR TITLE
fix: use correct values for replacements

### DIFF
--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -154,14 +154,14 @@ export async function lookupUpdates(
         res.updates.push(rollback);
       }
       let rangeStrategy = getRangeStrategy(config);
-      if (dependency.replacementName && dependency.replacementVersion) {
+      if (config.replacementName && config.replacementVersion) {
         res.updates.push({
           updateType: 'replacement',
-          newName: dependency.replacementName,
+          newName: config.replacementName,
           newValue: versioning.getNewValue({
             // TODO #7154
             currentValue: currentValue!,
-            newVersion: dependency.replacementVersion,
+            newVersion: config.replacementVersion,
             rangeStrategy: rangeStrategy!,
           })!,
         });

--- a/lib/workers/repository/process/lookup/types.ts
+++ b/lib/workers/repository/process/lookup/types.ts
@@ -45,6 +45,8 @@ export interface LookupUpdateConfig
   depName: string;
   minimumConfidence?: string;
   extractedConstraints?: Record<string, string>;
+  replacementName?: string;
+  replacementVersion?: string;
 }
 
 export interface UpdateResult {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Changes the replacement updates to use `replacementName` and `replacementVersion` from `config` instead of `dependency`

## Context

This was part of my [other PR](https://github.com/renovatebot/renovate/pull/17882).

Reason for this change is that I encountered a problem when replacing 2 different versions of the same dependency with different new dependencies.

I also tested this in my big [replacement demo repository](https://gitlab.com/t.kulmburg/replacement-demo) to ensure it doesn't break other replacements when combined with my [other PR](https://github.com/renovatebot/renovate/pull/17883), which contains the main replacement feature.

- closes #14962

## Example

### Dockerfile:
```
FROM openjdk:8-jre
FROM openjdk:17-slim-buster
```
### packageRules:
```
    {
    "matchManagers": ["dockerfile"],
    "matchPackageNames": ["openjdk"],
    "matchCurrentVersion": "/^17/",
    "replacementName": "eclipse-temurin",
    "replacementVersion": "17-jdk-jammy"
    },
    {
      "matchManagers": ["dockerfile"],
      "matchPackageNames": ["openjdk"],
      "matchCurrentVersion": "/^8/",
      "replacementName": "eclipse-temurin",
      "replacementVersion": "8u342-b07.1-jre"
    },
```

### Log output:
```
logger.debug(`CONFIG: ${config.replacementName} -- ${config.replacementVersion}`)
logger.debug(`DEP: ${dependency.replacementName} -- ${depName.replacementVersion}`)
```

```
DEBUG: CONFIG: eclipse-temurin -- 8u342-b07.1-jre (repository=xx/renovate-test)
DEBUG: DEP: eclipse-temurin -- 8u342-b07.1-jre (repository=xx/renovate-test)

DEBUG: CONFIG: eclipse-temurin -- 17-jdk-jammy (repository=xx/renovate-test)
DEBUG: DEP: eclipse-temurin -- 8u342-b07.1-jre (repository=xx/renovate-test)
```

This shows that when using `dependency`, both will get replaced with the same version.
When using `config` however, we get the replacement we wanted.



## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
