### PR TITLE
fix(datasource/nuget): Support username only registry auth

### DIFF
--- a/lib/modules/manager/nuget/artifacts.ts
+++ b/lib/modules/manager/nuget/artifacts.ts
@@ -49,11 +49,13 @@ async function addSourceCmds(
       // Add name for registry, if known.
       addSourceCmd += ` --name ${quote(registry.name)}`;
     }
-    if (username && password) {
-      // Add registry credentials from host rules, if configured.
-      addSourceCmd += ` --username ${quote(username)} --password ${quote(
-        password
-      )} --store-password-in-clear-text`;
+    if (username) {
+      // Add registry username from host rules, if configured.
+      addSourceCmd += ` --username ${quote(username)}`;
+    }
+    if (password) {
+      // Add registry password from host rules, if configured.
+      addSourceCmd += ` --password ${quote(password)} --store-password-in-clear-text`;
     }
     result.push(addSourceCmd);
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
When we want to use private nuget feed for updating package lock file, on Azure Devops, only password (PAT token) is required. It means that username can be null as described in docs :

[https://docs.renovatebot.com/nuget/#authenticated-feeds](url)

Note:
```
Only Basic HTTP authentication (via username and password) is supported. For Azure DevOps, you can use a Personal Access Token (PAT) with read permissions on Packaging along with an empty username.
```

But, without this change, neither password or username is set for `dotnet restore` command when username is empty.

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
