### PR TITLE
refactor: replace enums with union/object

### DIFF
--- a/lib/modules/platform/azure/index.spec.ts
+++ b/lib/modules/platform/azure/index.spec.ts
@@ -12,7 +12,7 @@ import {
   REPOSITORY_NOT_FOUND,
 } from '../../../constants/error-messages';
 import type { logger as _logger } from '../../../logger';
-import { BranchStatus, PrState } from '../../../types';
+import { BranchStatus } from '../../../types';
 import type * as _git from '../../../util/git';
 import type * as _hostRules from '../../../util/host-rules';
 import type { Platform, RepoParams } from '../types';
@@ -232,7 +232,7 @@ describe('modules/platform/azure/index', () => {
       const res = await azure.findPr({
         branchName: 'branch-a',
         prTitle: 'branch a pr',
-        state: PrState.Open,
+        state: 'open',
       });
       expect(res).toMatchSnapshot();
     });
@@ -259,7 +259,7 @@ describe('modules/platform/azure/index', () => {
       const res = await azure.findPr({
         branchName: 'branch-a',
         prTitle: 'branch a pr',
-        state: PrState.NotOpen,
+        state: '!open',
       });
       expect(res).toMatchSnapshot();
     });
@@ -286,7 +286,7 @@ describe('modules/platform/azure/index', () => {
       const res = await azure.findPr({
         branchName: 'branch-a',
         prTitle: 'branch a pr',
-        state: PrState.Closed,
+        state: 'closed',
       });
       expect(res).toMatchSnapshot();
     });
@@ -843,7 +843,7 @@ describe('modules/platform/azure/index', () => {
         number: 1234,
         prTitle: 'The New Title',
         prBody: 'Hello world again',
-        state: PrState.Closed,
+        state: 'closed',
       });
       expect(updatePullRequest.mock.calls).toMatchSnapshot();
     });
@@ -861,7 +861,7 @@ describe('modules/platform/azure/index', () => {
         number: 1234,
         prTitle: 'The New Title',
         prBody: 'Hello world again',
-        state: PrState.Open,
+        state: 'open',
       });
       expect(updatePullRequest.mock.calls).toMatchSnapshot();
     });

--- a/lib/modules/platform/azure/index.ts
+++ b/lib/modules/platform/azure/index.ts
@@ -16,7 +16,7 @@ import {
   REPOSITORY_NOT_FOUND,
 } from '../../../constants/error-messages';
 import { logger } from '../../../logger';
-import { BranchStatus, PrState, VulnerabilityAlert } from '../../../types';
+import { BranchStatus, VulnerabilityAlert } from '../../../types';
 import * as git from '../../../util/git';
 import * as hostRules from '../../../util/host-rules';
 import { regEx } from '../../../util/regex';
@@ -295,7 +295,7 @@ export async function getPr(pullRequestId: number): Promise<Pr | null> {
 export async function findPr({
   branchName,
   prTitle,
-  state = PrState.All,
+  state = 'all',
 }: FindPRConfig): Promise<Pr | null> {
   let prsFiltered: Pr[] = [];
   try {
@@ -310,11 +310,11 @@ export async function findPr({
     }
 
     switch (state) {
-      case PrState.All:
+      case 'all':
         // no more filter needed, we can go further...
         break;
-      case PrState.NotOpen:
-        prsFiltered = prsFiltered.filter((item) => item.state !== PrState.Open);
+      case '!open':
+        prsFiltered = prsFiltered.filter((item) => item.state !== 'open');
         break;
       default:
         prsFiltered = prsFiltered.filter((item) => item.state === state);
@@ -333,7 +333,7 @@ export async function getBranchPr(branchName: string): Promise<Pr | null> {
   logger.debug(`getBranchPr(${branchName})`);
   const existingPr = await findPr({
     branchName,
-    state: PrState.Open,
+    state: 'open',
   });
   return existingPr ? getPr(existingPr.number) : null;
 }
@@ -503,13 +503,13 @@ export async function updatePr({
     objToUpdate.description = max4000Chars(sanitize(body));
   }
 
-  if (state === PrState.Open) {
+  if (state === 'open') {
     await azureApiGit.updatePullRequest(
       { status: PullRequestStatus.Active },
       config.repoId,
       prNo
     );
-  } else if (state === PrState.Closed) {
+  } else if (state === 'closed') {
     objToUpdate.status = PullRequestStatus.Abandoned;
   }
 

--- a/lib/modules/platform/azure/types.ts
+++ b/lib/modules/platform/azure/types.ts
@@ -4,11 +4,10 @@ export interface AzurePr extends Pr {
   sourceRefName?: string;
 }
 
-// eslint-disable-next-line typescript-enum/no-enum
-export enum AzurePrVote {
-  NoVote = 0,
-  Reject = -10,
-  WaitingForAuthor = -5,
-  ApprovedWithSuggestions = 5,
-  Approved = 10,
-}
+export const AzurePrVote = {
+  NoVote: 0,
+  Reject: -10,
+  WaitingForAuthor: -5,
+  ApprovedWithSuggestions: 5,
+  Approved: 10,
+};

--- a/lib/modules/platform/azure/util.ts
+++ b/lib/modules/platform/azure/util.ts
@@ -5,7 +5,7 @@ import {
   PullRequestStatus,
 } from 'azure-devops-node-api/interfaces/GitInterfaces.js';
 import { logger } from '../../../logger';
-import { HostRule, PrState } from '../../../types';
+import type { HostRule, PrState } from '../../../types';
 import type { GitOptions } from '../../../types/git';
 import { addSecretForSanitizing } from '../../../util/sanitize';
 import { toBase64 } from '../../../util/string';
@@ -78,8 +78,8 @@ export function getBranchNameWithoutRefsPrefix(
 }
 
 const stateMap = {
-  [PullRequestStatus.Abandoned]: PrState.Closed,
-  [PullRequestStatus.Completed]: PrState.Merged,
+  [PullRequestStatus.Abandoned]: 'closed',
+  [PullRequestStatus.Completed]: 'merged',
 } as Record<PullRequestStatus, PrState | undefined>;
 
 export function getRenovatePRFormat(azurePr: GitPullRequest): AzurePr {
@@ -98,7 +98,7 @@ export function getRenovatePRFormat(azurePr: GitPullRequest): AzurePr {
   const createdAt = azurePr.creationDate?.toISOString();
 
   // TODO #7154
-  const state = stateMap[azurePr.status!] ?? PrState.Open;
+  const state = stateMap[azurePr.status!] ?? 'open';
 
   const sourceRefName = azurePr.sourceRefName;
 

--- a/lib/modules/platform/bitbucket-server/index.spec.ts
+++ b/lib/modules/platform/bitbucket-server/index.spec.ts
@@ -5,7 +5,7 @@ import {
   REPOSITORY_EMPTY,
   REPOSITORY_NOT_FOUND,
 } from '../../../constants/error-messages';
-import { BranchStatus, PrState } from '../../../types';
+import { BranchStatus } from '../../../types';
 import type * as _git from '../../../util/git';
 import type { Platform } from '../types';
 
@@ -1263,7 +1263,7 @@ describe('modules/platform/bitbucket-server/index', () => {
             await bitbucket.findPr({
               branchName: 'userName1/pullRequest5',
               prTitle: 'title',
-              state: PrState.Open,
+              state: 'open',
             })
           ).toMatchSnapshot();
         });
@@ -1283,7 +1283,7 @@ describe('modules/platform/bitbucket-server/index', () => {
             await bitbucket.findPr({
               branchName: 'userName1/pullRequest5',
               prTitle: 'title',
-              state: PrState.Closed,
+              state: 'closed',
             })
           ).toBeNull();
         });
@@ -1443,7 +1443,7 @@ describe('modules/platform/bitbucket-server/index', () => {
               number: 5,
               prTitle: 'title',
               prBody: 'body',
-              state: PrState.Closed,
+              state: 'closed',
             })
           ).toResolve();
         });
@@ -1469,7 +1469,7 @@ describe('modules/platform/bitbucket-server/index', () => {
               number: 5,
               prTitle: 'title',
               prBody: 'body',
-              state: PrState.Open,
+              state: 'open',
             })
           ).toResolve();
         });
@@ -1558,7 +1558,7 @@ describe('modules/platform/bitbucket-server/index', () => {
               number: 5,
               prTitle: 'title',
               prBody: 'body',
-              state: PrState.Open,
+              state: 'open',
             })
           ).toResolve();
         });

--- a/lib/modules/platform/bitbucket-server/index.ts
+++ b/lib/modules/platform/bitbucket-server/index.ts
@@ -8,7 +8,7 @@ import {
   REPOSITORY_NOT_FOUND,
 } from '../../../constants/error-messages';
 import { logger } from '../../../logger';
-import { BranchStatus, PrState, VulnerabilityAlert } from '../../../types';
+import { BranchStatus, VulnerabilityAlert } from '../../../types';
 import type { FileData } from '../../../types/platform/bitbucket-server';
 import * as git from '../../../util/git';
 import { deleteBranch } from '../../../util/git';
@@ -275,7 +275,7 @@ export async function getPr(
 // TODO: coverage (#9624)
 // istanbul ignore next
 function matchesState(state: string, desiredState: string): boolean {
-  if (desiredState === PrState.All) {
+  if (desiredState === 'all') {
     return true;
   }
   if (desiredState.startsWith('!')) {
@@ -323,7 +323,7 @@ export async function getPrList(refreshCache?: boolean): Promise<Pr[]> {
 export async function findPr({
   branchName,
   prTitle,
-  state = PrState.All,
+  state = 'all',
   refreshCache,
 }: FindPRConfig): Promise<Pr | null> {
   logger.debug(`findPr(${branchName}, "${prTitle!}", "${state}")`);
@@ -342,7 +342,7 @@ export async function getBranchPr(branchName: string): Promise<BbsPr | null> {
   logger.debug(`getBranchPr(${branchName})`);
   const existingPr = await findPr({
     branchName,
-    state: PrState.Open,
+    state: 'open',
   });
   return existingPr ? getPr(existingPr.number) : null;
 }
@@ -893,8 +893,8 @@ export async function updatePr({
     const currentState = updatedPr.state;
     // TODO #7154
     const newState = {
-      [PrState.Open]: 'OPEN',
-      [PrState.Closed]: 'DECLINED',
+      ['open']: 'OPEN',
+      ['closed']: 'DECLINED',
     }[state!];
 
     if (
@@ -902,7 +902,7 @@ export async function updatePr({
       ['OPEN', 'DECLINED'].includes(currentState) &&
       currentState !== newState
     ) {
-      const command = state === PrState.Open ? 'reopen' : 'decline';
+      const command = state === 'open' ? 'reopen' : 'decline';
       const { body: updatedStatePr } = await bitbucketServerHttp.postJson<{
         version: number;
       }>(

--- a/lib/modules/platform/bitbucket-server/utils.ts
+++ b/lib/modules/platform/bitbucket-server/utils.ts
@@ -3,7 +3,7 @@ import url from 'url';
 import is from '@sindresorhus/is';
 import { CONFIG_GIT_URL_UNAVAILABLE } from '../../../constants/error-messages';
 import { logger } from '../../../logger';
-import { HostRule, PrState } from '../../../types';
+import type { HostRule } from '../../../types';
 import type { GitProtocol } from '../../../types/git';
 import * as git from '../../../util/git';
 import { BitbucketServerHttp } from '../../../util/http/bitbucket-server';
@@ -20,9 +20,9 @@ const bitbucketServerHttp = new BitbucketServerHttp();
 
 // https://docs.atlassian.com/bitbucket-server/rest/6.0.0/bitbucket-rest.html#idp250
 const prStateMapping: any = {
-  MERGED: PrState.Merged,
-  DECLINED: PrState.Closed,
-  OPEN: PrState.Open,
+  MERGED: 'merged',
+  DECLINED: 'closed',
+  OPEN: 'open',
 };
 
 export function prInfo(pr: BbsRestPr): BbsPr {

--- a/lib/modules/platform/bitbucket/index.spec.ts
+++ b/lib/modules/platform/bitbucket/index.spec.ts
@@ -1,6 +1,6 @@
 import * as httpMock from '../../../../test/http-mock';
 import type { logger as _logger } from '../../../logger';
-import { BranchStatus, PrState } from '../../../types';
+import { BranchStatus } from '../../../types';
 import type * as _git from '../../../util/git';
 import { setBaseUrl } from '../../../util/http/bitbucket';
 import type { Platform, PlatformResult, RepoParams } from '../types';
@@ -1210,7 +1210,7 @@ describe('modules/platform/bitbucket/index', () => {
         await bitbucket.updatePr({
           number: pr.id,
           prTitle: pr.title,
-          state: PrState.Closed,
+          state: 'closed',
         })
       ).toBeUndefined();
     });

--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -3,7 +3,7 @@ import is from '@sindresorhus/is';
 import JSON5 from 'json5';
 import { REPOSITORY_NOT_FOUND } from '../../../constants/error-messages';
 import { logger } from '../../../logger';
-import { BranchStatus, PrState, VulnerabilityAlert } from '../../../types';
+import { BranchStatus, VulnerabilityAlert } from '../../../types';
 import * as git from '../../../util/git';
 import * as hostRules from '../../../util/host-rules';
 import { BitbucketHttp, setBaseUrl } from '../../../util/http/bitbucket';
@@ -231,7 +231,7 @@ export function getRepoForceRebase(): Promise<boolean> {
 
 // istanbul ignore next
 function matchesState(state: string, desiredState: string): boolean {
-  if (desiredState === PrState.All) {
+  if (desiredState === 'all') {
     return true;
   }
   if (desiredState.startsWith('!')) {
@@ -259,7 +259,7 @@ export async function getPrList(): Promise<Pr[]> {
 export async function findPr({
   branchName,
   prTitle,
-  state = PrState.All,
+  state = 'all',
 }: FindPRConfig): Promise<Pr | null> {
   // TODO: types (#7154)
   // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
@@ -333,7 +333,7 @@ export async function getBranchPr(branchName: string): Promise<Pr | null> {
   logger.debug(`getBranchPr(${branchName})`);
   const existingPr = await findPr({
     branchName,
-    state: PrState.Open,
+    state: 'open',
   });
   return existingPr ? getPr(existingPr.number) : null;
 }
@@ -853,7 +853,7 @@ export async function updatePr({
     }
   }
 
-  if (state === PrState.Closed && pr) {
+  if (state === 'closed' && pr) {
     await bitbucketHttp.postJson(
       `/2.0/repositories/${config.repository}/pullrequests/${prNo}/decline`
     );

--- a/lib/modules/platform/bitbucket/utils.ts
+++ b/lib/modules/platform/bitbucket/utils.ts
@@ -1,6 +1,6 @@
 import url from 'url';
 import type { MergeStrategy } from '../../../config/types';
-import { BranchStatus, PrState } from '../../../types';
+import type { BranchStatus } from '../../../types';
 import { BitbucketHttp } from '../../../util/http/bitbucket';
 import type { HttpOptions, HttpResponse } from '../../../util/http/types';
 import { getPrBodyStruct } from '../pr-body';
@@ -185,7 +185,7 @@ export function prInfo(pr: PrResponse): Pr {
     targetBranch: pr.destination?.branch?.name,
     title: pr.title,
     state: prStates.closed?.includes(pr.state)
-      ? /* istanbul ignore next */ PrState.Closed
+      ? /* istanbul ignore next */ 'closed'
       : pr.state?.toLowerCase(),
     createdAt: pr.created_on,
   };

--- a/lib/modules/platform/codecommit/index.spec.ts
+++ b/lib/modules/platform/codecommit/index.spec.ts
@@ -10,7 +10,6 @@ import {
   GetRepositoryCommand,
   ListPullRequestsCommand,
   ListRepositoriesCommand,
-  // MergeBranchesBySquashCommand,
   PostCommentForPullRequestCommand,
   UpdatePullRequestDescriptionCommand,
   UpdatePullRequestStatusCommand,
@@ -24,7 +23,6 @@ import {
   REPOSITORY_EMPTY,
   REPOSITORY_NOT_FOUND,
 } from '../../../constants/error-messages';
-import { PrState } from '../../../types';
 import * as git from '../../../util/git';
 import type { Platform } from '../types';
 import { CodeCommitPr, config } from './index';
@@ -270,7 +268,7 @@ describe('modules/platform/codecommit/index', () => {
       const res = await codeCommit.findPr({
         branchName: 'sourceBranch',
         prTitle: 'someTitle',
-        state: PrState.Open,
+        state: 'open',
       });
       expect(res).toBeNull();
       expect(logger.logger.error).toHaveBeenCalledWith({ err }, 'findPr error');
@@ -296,7 +294,7 @@ describe('modules/platform/codecommit/index', () => {
       const res = await codeCommit.findPr({
         branchName: 'sourceBranch',
         prTitle: 'someTitle',
-        state: PrState.Open,
+        state: 'open',
       });
       expect(res).toMatchObject({
         sourceBranch: 'refs/heads/sourceBranch',
@@ -327,7 +325,7 @@ describe('modules/platform/codecommit/index', () => {
       const res = await codeCommit.findPr({
         branchName: 'sourceBranch',
         prTitle: 'someTitle',
-        state: PrState.All,
+        state: 'all',
       });
       expect(res).toMatchObject({
         sourceBranch: 'refs/heads/sourceBranch',
@@ -345,7 +343,7 @@ describe('modules/platform/codecommit/index', () => {
       const prRes = {
         pullRequest: {
           title: 'someTitle',
-          pullRequestStatus: PrState.NotOpen,
+          pullRequestStatus: '!open',
           pullRequestTargets: [
             {
               sourceReference: 'refs/heads/sourceBranch',
@@ -358,7 +356,7 @@ describe('modules/platform/codecommit/index', () => {
       const res = await codeCommit.findPr({
         branchName: 'sourceBranch',
         prTitle: 'someTitle',
-        state: PrState.NotOpen,
+        state: '!open',
       });
       expect(res).toMatchObject({
         sourceBranch: 'refs/heads/sourceBranch',
@@ -376,7 +374,7 @@ describe('modules/platform/codecommit/index', () => {
       const prRes = {
         pullRequest: {
           title: 'someTitle',
-          pullRequestStatus: PrState.Closed,
+          pullRequestStatus: 'closed',
           pullRequestTargets: [
             {
               sourceReference: 'refs/heads/sourceBranch',
@@ -403,7 +401,7 @@ describe('modules/platform/codecommit/index', () => {
       const res = await codeCommit.findPr({
         branchName: 'sourceBranch',
         prTitle: 'someTitle',
-        state: PrState.Open,
+        state: 'open',
       });
       expect(res).toBeNull();
     });
@@ -679,7 +677,7 @@ describe('modules/platform/codecommit/index', () => {
           number: 1,
           prTitle: 'title',
           prBody: 'body',
-          state: PrState.Open,
+          state: 'open',
         })
       ).toResolve();
     });
@@ -704,7 +702,7 @@ describe('modules/platform/codecommit/index', () => {
           number: 1,
           prTitle: 'title',
           prBody: 'new description',
-          state: PrState.Open,
+          state: 'open',
         })
       ).toResolve();
     });
@@ -728,7 +726,7 @@ describe('modules/platform/codecommit/index', () => {
           number: 1,
           prTitle: 'title',
           prBody: 'new description',
-          state: PrState.Open,
+          state: 'open',
         })
       ).toResolve();
     });
@@ -744,7 +742,7 @@ describe('modules/platform/codecommit/index', () => {
           number: 1,
           prTitle: 'title',
           prBody: 'body',
-          state: PrState.Open,
+          state: 'open',
         })
       ).toResolve();
     });
@@ -758,7 +756,7 @@ describe('modules/platform/codecommit/index', () => {
           number: 1,
           prTitle: 'title',
           prBody: 'body',
-          state: PrState.Closed,
+          state: 'closed',
         })
       ).toResolve();
     });

--- a/lib/modules/platform/codecommit/index.ts
+++ b/lib/modules/platform/codecommit/index.ts
@@ -192,8 +192,8 @@ export async function getPrList(): Promise<CodeCommitPr[]> {
       sourceBranch: prInfo.pullRequestTargets![0].sourceReference!,
       state:
         prInfo.pullRequestStatus === PullRequestStatusEnum.OPEN
-          ? PrState.Open
-          : PrState.Closed,
+          ? 'open'
+          : 'closed',
       number: Number.parseInt(prId),
       title: prInfo.title!,
       body: prInfo.description!,
@@ -210,7 +210,7 @@ export async function getPrList(): Promise<CodeCommitPr[]> {
 export async function findPr({
   branchName,
   prTitle,
-  state = PrState.All,
+  state = 'all',
 }: FindPRConfig): Promise<CodeCommitPr | null> {
   let prsFiltered: CodeCommitPr[] = [];
   try {
@@ -225,13 +225,13 @@ export async function findPr({
     }
 
     switch (state) {
-      case PrState.All:
+      case 'all':
         break;
-      case PrState.NotOpen:
-        prsFiltered = prsFiltered.filter((item) => item.state !== PrState.Open);
+      case '!open':
+        prsFiltered = prsFiltered.filter((item) => item.state !== 'open');
         break;
       default:
-        prsFiltered = prsFiltered.filter((item) => item.state === PrState.Open);
+        prsFiltered = prsFiltered.filter((item) => item.state === 'open');
         break;
     }
   } catch (err) {
@@ -249,7 +249,7 @@ export async function getBranchPr(
   logger.debug(`getBranchPr(${branchName})`);
   const existingPr = await findPr({
     branchName,
-    state: PrState.Open,
+    state: 'open',
   });
   return existingPr ? getPr(existingPr.number) : null;
 }
@@ -267,12 +267,12 @@ export async function getPr(
   const prInfo = prRes.pullRequest;
   let prState: PrState;
   if (prInfo.pullRequestTargets![0].mergeMetadata?.isMerged) {
-    prState = PrState.Merged;
+    prState = 'merged';
   } else {
     prState =
       prInfo.pullRequestStatus === PullRequestStatusEnum.OPEN
-        ? PrState.Open
-        : PrState.Closed;
+        ? 'open'
+        : 'closed';
   }
 
   return {
@@ -387,7 +387,7 @@ export async function createPr({
 
   return {
     number: Number.parseInt(prCreateRes.pullRequest.pullRequestId),
-    state: PrState.Open,
+    state: 'open',
     title: prCreateRes.pullRequest.title,
     sourceBranch,
     targetBranch,
@@ -424,7 +424,7 @@ export async function updatePr({
   }
 
   const prStatusInput =
-    state === PrState.Closed
+    state === 'closed'
       ? PullRequestStatusEnum.CLOSED
       : PullRequestStatusEnum.OPEN;
   if (cachedPr?.state !== prStatusInput) {

--- a/lib/modules/platform/gitea/gitea-helper.spec.ts
+++ b/lib/modules/platform/gitea/gitea-helper.spec.ts
@@ -1,5 +1,4 @@
 import * as httpMock from '../../../../test/http-mock';
-import { PrState } from '../../../types';
 import { setBaseUrl } from '../../../util/http/gitea';
 import { toBase64 } from '../../../util/string';
 import {
@@ -109,7 +108,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
 
   const mockPR: PR = {
     number: 13,
-    state: PrState.Open,
+    state: 'open',
     title: 'Some PR',
     body: 'Lorem ipsum dolor sit amet',
     mergeable: true,
@@ -348,7 +347,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
     it('should call /api/v1/repos/[repo]/pulls/[pull] endpoint', async () => {
       const updatedMockPR: PR = {
         ...mockPR,
-        state: PrState.Closed,
+        state: 'closed',
         title: 'new-title',
         body: 'new-body',
       };
@@ -359,7 +358,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
         .reply(200, updatedMockPR);
 
       const res = await updatePR(mockRepo.full_name, mockPR.number, {
-        state: PrState.Closed,
+        state: 'closed',
         title: 'new-title',
         body: 'new-body',
         assignees: [otherMockUser.username],
@@ -442,7 +441,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
         .reply(200, [mockPR]);
 
       const res = await searchPRs(mockRepo.full_name, {
-        state: PrState.Open,
+        state: 'open',
         labels: [mockLabel.id, otherMockLabel.id],
       });
       expect(res).toEqual([mockPR]);

--- a/lib/modules/platform/gitea/gitea-helper.ts
+++ b/lib/modules/platform/gitea/gitea-helper.ts
@@ -1,4 +1,4 @@
-import { BranchStatus, PrState } from '../../../types';
+import { BranchStatus } from '../../../types';
 import { GiteaHttp, GiteaHttpOptions } from '../../../util/http/gitea';
 import { getQueryString } from '../../../util/url';
 import type {
@@ -141,7 +141,7 @@ export async function closePR(
 ): Promise<void> {
   await updatePR(repoPath, idx, {
     ...options,
-    state: PrState.Closed,
+    state: 'closed',
   });
 }
 

--- a/lib/modules/platform/gitea/index.spec.ts
+++ b/lib/modules/platform/gitea/index.spec.ts
@@ -30,7 +30,6 @@ import type {
   Issue,
   Label,
   PR,
-  PRState,
   Repo,
   RepoContents,
   User,
@@ -83,7 +82,7 @@ describe('modules/platform/gitea/index', () => {
       number: 1,
       title: 'Some PR',
       body: 'some random pull request',
-      state: PrState.Open,
+      state: 'open',
       diff_url: 'https://gitea.renovatebot.com/some/repo/pulls/1.diff',
       created_at: '2015-03-22T20:36:16Z',
       closed_at: undefined,
@@ -99,7 +98,7 @@ describe('modules/platform/gitea/index', () => {
       number: 2,
       title: 'Other PR',
       body: 'other random pull request',
-      state: PrState.Closed,
+      state: 'closed',
       diff_url: 'https://gitea.renovatebot.com/some/repo/pulls/2.diff',
       created_at: '2011-08-18T22:30:38Z',
       closed_at: '2016-01-09T10:03:21Z',
@@ -115,7 +114,7 @@ describe('modules/platform/gitea/index', () => {
       number: 3,
       title: 'WIP: Draft PR',
       body: 'other random pull request',
-      state: PrState.Open,
+      state: 'open',
       diff_url: 'https://gitea.renovatebot.com/some/repo/pulls/3.diff',
       created_at: '2011-08-18T22:30:39Z',
       closed_at: '2016-01-09T10:03:22Z',
@@ -755,7 +754,7 @@ describe('modules/platform/gitea/index', () => {
           number: 3,
           title: 'Third-party PR',
           body: 'other random pull request',
-          state: PrState.Open,
+          state: 'open',
           diff_url: 'https://gitea.renovatebot.com/some/repo/pulls/3.diff',
           created_at: '2011-08-18T22:30:38Z',
           closed_at: '2016-01-09T10:03:21Z',
@@ -881,7 +880,7 @@ describe('modules/platform/gitea/index', () => {
       expect(
         await gitea.findPr({
           branchName: mockPR.head.label,
-          state: `!${mockPR.state}` as PRState,
+          state: `!${mockPR.state as PrState}` as never, // wrong argument being passed intentionally
         })
       ).toBeNull();
     });
@@ -927,7 +926,7 @@ describe('modules/platform/gitea/index', () => {
   describe('createPr', () => {
     const mockNewPR: MockPr = {
       number: 42,
-      state: PrState.Open,
+      state: 'open',
       head: {
         label: 'pr-branch',
         sha: mockCommitHash,
@@ -1234,13 +1233,13 @@ describe('modules/platform/gitea/index', () => {
         number: 1,
         prTitle: 'New Title',
         prBody: 'New Body',
-        state: PrState.Closed,
+        state: 'closed',
       });
 
       expect(helper.updatePR).toHaveBeenCalledWith(mockRepo.full_name, 1, {
         title: 'New Title',
         body: 'New Body',
-        state: PrState.Closed,
+        state: 'closed',
       });
     });
   });

--- a/lib/modules/platform/gitea/index.ts
+++ b/lib/modules/platform/gitea/index.ts
@@ -10,7 +10,7 @@ import {
   REPOSITORY_MIRRORED,
 } from '../../../constants/error-messages';
 import { logger } from '../../../logger';
-import { BranchStatus, PrState, VulnerabilityAlert } from '../../../types';
+import { BranchStatus, VulnerabilityAlert } from '../../../types';
 import * as git from '../../../util/git';
 import { setBaseUrl } from '../../../util/http/gitea';
 import { sanitize } from '../../../util/sanitize';
@@ -136,7 +136,7 @@ function toRenovatePR(data: PR): Pr | null {
 }
 
 function matchesState(actual: string, expected: string): boolean {
-  if (expected === PrState.All) {
+  if (expected === 'all') {
     return true;
   }
   if (expected.startsWith('!')) {
@@ -437,11 +437,7 @@ const platform: Platform = {
   getPrList(): Promise<Pr[]> {
     if (config.prList === null) {
       config.prList = helper
-        .searchPRs(
-          config.repository,
-          { state: PrState.All },
-          { useCache: false }
-        )
+        .searchPRs(config.repository, { state: 'all' }, { useCache: false })
         .then((prs) => {
           const prList = prs.map(toRenovatePR).filter(is.truthy);
           logger.debug(`Retrieved ${prList.length} Pull Requests`);
@@ -481,7 +477,7 @@ const platform: Platform = {
   async findPr({
     branchName,
     prTitle: title,
-    state = PrState.All,
+    state = 'all',
   }: FindPRConfig): Promise<Pr | null> {
     logger.debug(`findPr(${branchName}, ${title!}, ${state})`);
     const prList = await platform.getPrList();
@@ -579,7 +575,7 @@ const platform: Platform = {
         config.prList = null;
         const pr = await platform.findPr({
           branchName: sourceBranch,
-          state: PrState.Open,
+          state: 'open',
         });
 
         // If a valid PR was found, return and gracefully recover from the error. Otherwise, abort and throw error.
@@ -909,7 +905,7 @@ const platform: Platform = {
 
   async getBranchPr(branchName: string): Promise<Pr | null> {
     logger.debug(`getBranchPr(${branchName})`);
-    const pr = await platform.findPr({ branchName, state: PrState.Open });
+    const pr = await platform.findPr({ branchName, state: 'open' });
     return pr ? platform.getPr(pr.number) : null;
   },
 

--- a/lib/modules/platform/gitea/types.ts
+++ b/lib/modules/platform/gitea/types.ts
@@ -1,11 +1,9 @@
-import type { PrState } from '../../../types';
-
 export interface PrReviewersParams {
   reviewers?: string[];
   team_reviewers?: string[];
 }
 
-export type PRState = PrState.Open | PrState.Closed | PrState.All;
+export type PRState = 'open' | 'closed' | 'all';
 export type IssueState = 'open' | 'closed' | 'all';
 export type CommitStatusType =
   | 'pending'

--- a/lib/modules/platform/github/common.ts
+++ b/lib/modules/platform/github/common.ts
@@ -1,5 +1,4 @@
 import is from '@sindresorhus/is';
-import { PrState } from '../../../types';
 import * as schema from '../../../util/schema';
 import { getPrBodyStruct } from '../pr-body';
 import * as platformSchemas from '../schemas';
@@ -16,9 +15,7 @@ export function coerceRestPr(pr: GhRestPr): GhPr {
     sourceBranch: pr.head?.ref,
     title: pr.title,
     state:
-      pr.state === PrState.Closed && is.string(pr.merged_at)
-        ? PrState.Merged
-        : pr.state,
+      pr.state === 'closed' && is.string(pr.merged_at) ? 'merged' : pr.state,
     bodyStruct,
     updated_at: pr.updated_at,
     node_id: pr.node_id,

--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -7,7 +7,7 @@ import {
   REPOSITORY_NOT_FOUND,
   REPOSITORY_RENAMED,
 } from '../../../constants/error-messages';
-import { BranchStatus, PrState, VulnerabilityAlert } from '../../../types';
+import { BranchStatus, VulnerabilityAlert } from '../../../types';
 import * as repository from '../../../util/cache/repository';
 import * as _git from '../../../util/git';
 import * as _hostRules from '../../../util/host-rules';
@@ -619,7 +619,7 @@ describe('modules/platform/github/index', () => {
       number: 1,
       head: { ref: 'branch-1', sha: '111', repo: { full_name: 'some/repo' } },
       base: { repo: { pushed_at: '' } },
-      state: PrState.Open,
+      state: 'open',
       title: 'PR #1',
       created_at: t1,
       updated_at: t1,
@@ -631,7 +631,7 @@ describe('modules/platform/github/index', () => {
       ...pr1,
       number: 2,
       head: { ref: 'branch-2', sha: '222', repo: { full_name: 'some/repo' } },
-      state: PrState.Open,
+      state: 'open',
       title: 'PR #2',
       updated_at: t2,
     };
@@ -640,7 +640,7 @@ describe('modules/platform/github/index', () => {
       ...pr1,
       number: 3,
       head: { ref: 'branch-3', sha: '333', repo: { full_name: 'some/repo' } },
-      state: PrState.Open,
+      state: 'open',
       title: 'PR #3',
       updated_at: t3,
     };
@@ -784,7 +784,7 @@ describe('modules/platform/github/index', () => {
           {
             number: 90,
             head: { ref: 'somebranch', repo: { full_name: 'other/repo' } },
-            state: PrState.Open,
+            state: 'open',
             title: 'PR from another repo',
             updated_at: '01-09-2022',
           },
@@ -792,7 +792,7 @@ describe('modules/platform/github/index', () => {
             number: 91,
             base: { sha: '1234' },
             head: { ref: 'somebranch', repo: { full_name: 'some/repo' } },
-            state: PrState.Open,
+            state: 'open',
             title: 'Some title',
             updated_at: '01-09-2022',
           },
@@ -817,14 +817,14 @@ describe('modules/platform/github/index', () => {
           {
             number: 90,
             head: { ref: 'somebranch', repo: { full_name: 'other/repo' } },
-            state: PrState.Open,
+            state: 'open',
             updated_at: '01-09-2022',
           },
           {
             number: 91,
             head: { ref: 'somebranch', repo: { full_name: 'some/repo' } },
             title: 'old title - autoclosed',
-            state: PrState.Closed,
+            state: 'closed',
             closed_at: DateTime.now().minus({ days: 6 }).toISO(),
             updated_at: '01-09-2022',
           },
@@ -836,7 +836,7 @@ describe('modules/platform/github/index', () => {
           number: 91,
           base: { sha: '1234' },
           head: { ref: 'somebranch', repo: { full_name: 'some/repo' } },
-          state: PrState.Open,
+          state: 'open',
           title: 'old title',
           updated_at: '01-09-2022',
         });
@@ -862,7 +862,7 @@ describe('modules/platform/github/index', () => {
             number: 1,
             head: { ref: 'somebranch', repo: { full_name: 'some/repo' } },
             title: 'old title - autoclosed',
-            state: PrState.Closed,
+            state: 'closed',
             closed_at: DateTime.now().minus({ days: 6 }).toISO(),
           },
         ]);
@@ -886,13 +886,13 @@ describe('modules/platform/github/index', () => {
           {
             number: 90,
             head: { ref: 'somebranch', repo: { full_name: 'other/repo' } },
-            state: PrState.Open,
+            state: 'open',
           },
           {
             number: 91,
             head: { ref: 'somebranch', repo: { full_name: 'some/repo' } },
             title: 'old title - autoclosed',
-            state: PrState.Closed,
+            state: 'closed',
             closed_at: DateTime.now().minus({ days: 7 }).toISO(),
           },
         ]);
@@ -914,7 +914,7 @@ describe('modules/platform/github/index', () => {
             number: 91,
             head: { ref: 'somebranch', repo: { full_name: 'some/repo' } },
             title: 'old title - autoclosed',
-            state: PrState.Closed,
+            state: 'closed',
             closed_at: DateTime.now().minus({ minutes: 10 }).toISO(),
           },
         ])
@@ -940,7 +940,7 @@ describe('modules/platform/github/index', () => {
             number: 91,
             head: { ref: 'somebranch', repo: { full_name: 'some/repo' } },
             title: 'old title - autoclosed',
-            state: PrState.Closed,
+            state: 'closed',
             closed_at: DateTime.now().minus({ minutes: 10 }).toISO(),
           },
         ])
@@ -1970,7 +1970,7 @@ describe('modules/platform/github/index', () => {
               repo: { full_name: 'some/repo' },
             },
             title: 'branch a pr',
-            state: PrState.Open,
+            state: 'open',
             user: { login: 'not-me' },
           },
           {
@@ -1980,7 +1980,7 @@ describe('modules/platform/github/index', () => {
               repo: { full_name: 'some/repo' },
             },
             title: 'branch a pr',
-            state: PrState.Open,
+            state: 'open',
             user: { login: 'me' },
           },
         ]);
@@ -2010,14 +2010,14 @@ describe('modules/platform/github/index', () => {
             number: 1,
             head: { ref: 'branch-a', repo: { full_name: 'some/repo' } },
             title: 'branch a pr',
-            state: PrState.Closed,
+            state: 'closed',
           },
         ]);
       await github.initRepo({ repository: 'some/repo' });
 
       const res = await github.findPr({
         branchName: 'branch-a',
-        state: PrState.NotOpen,
+        state: '!open',
       });
 
       expect(res).toMatchObject({
@@ -2039,7 +2039,7 @@ describe('modules/platform/github/index', () => {
             number: 1,
             head: { ref: 'branch-a', repo: { full_name: 'some/repo' } },
             title: 'foo',
-            state: PrState.Closed,
+            state: 'closed',
           },
         ]);
       await github.initRepo({ repository: 'some/repo' } as never);
@@ -2064,7 +2064,7 @@ describe('modules/platform/github/index', () => {
             number: 1,
             head: { ref: 'branch-a', repo: { full_name: 'some/repo' } },
             title: 'branch a pr',
-            state: PrState.Open,
+            state: 'open',
           },
         ]);
       await github.initRepo({ repository: 'some/repo' });
@@ -2080,7 +2080,7 @@ describe('modules/platform/github/index', () => {
       res = await github.findPr({
         branchName: 'branch-a',
         prTitle: 'branch a pr',
-        state: PrState.Open,
+        state: 'open',
       });
       expect(res).toBeDefined();
       res = await github.findPr({ branchName: 'branch-b' });
@@ -2398,7 +2398,7 @@ describe('modules/platform/github/index', () => {
               repo: { full_name: 'some/repo' },
             },
             title: 'build(deps): update dependency delay to v4.0.1',
-            state: PrState.Closed,
+            state: 'closed',
             updated_at: '01-09-2022',
           },
           {
@@ -2407,7 +2407,7 @@ describe('modules/platform/github/index', () => {
               ref: 'renovate/jest-monorepo',
               repo: { full_name: 'some/repo' },
             },
-            state: PrState.Open,
+            state: 'open',
             title: 'chore(deps): update dependency jest to v23.6.0',
             updated_at: '01-09-2022',
           },
@@ -2442,14 +2442,14 @@ describe('modules/platform/github/index', () => {
               repo: { full_name: 'some/repo' },
             },
             title: 'chore(deps): update dependency jest to v23.6.0',
-            state: PrState.Closed,
+            state: 'closed',
           },
         ]);
       await github.initRepo({ repository: 'some/repo' });
 
       const pr = await github.getPr(2500);
 
-      expect(pr).toMatchObject({ number: 2500, state: PrState.Closed });
+      expect(pr).toMatchObject({ number: 2500, state: 'closed' });
     });
 
     it('should return merged PR', async () => {
@@ -2467,7 +2467,7 @@ describe('modules/platform/github/index', () => {
               repo: { full_name: 'some/repo' },
             },
             title: 'chore(deps): update dependency jest to v23.6.0',
-            state: PrState.Closed,
+            state: 'closed',
             merged_at: DateTime.now().toISO(),
           },
         ]);
@@ -2475,7 +2475,7 @@ describe('modules/platform/github/index', () => {
 
       const pr = await github.getPr(2500);
 
-      expect(pr).toMatchObject({ number: 2500, state: PrState.Merged });
+      expect(pr).toMatchObject({ number: 2500, state: 'merged' });
     });
 
     it('should return null if no PR is returned from GitHub', async () => {
@@ -2504,7 +2504,7 @@ describe('modules/platform/github/index', () => {
         .get('/repos/some/repo/pulls/1234')
         .reply(200, {
           number: 1234,
-          state: PrState.Closed,
+          state: 'closed',
           base: { sha: 'abc' },
           head: { sha: 'def', ref: 'some/branch' },
           merged_at: 'sometime',
@@ -2530,7 +2530,7 @@ describe('modules/platform/github/index', () => {
         .get('/repos/some/repo/pulls/1234')
         .reply(200, {
           number: 1234,
-          state: PrState.Open,
+          state: 'open',
           mergeable_state: 'dirty',
           base: { sha: '1234' },
           head: { ref: 'some/branch' },
@@ -2568,7 +2568,7 @@ describe('modules/platform/github/index', () => {
         .get('/repos/some/repo/pulls/1234')
         .reply(200, {
           number: 1234,
-          state: PrState.Open,
+          state: 'open',
           base: { sha: '5678' },
           head: { ref: 'some/branch' },
           commits: 1,
@@ -2611,7 +2611,7 @@ describe('modules/platform/github/index', () => {
         number: 1234,
         prTitle: 'The New Title',
         prBody: 'Hello world again',
-        state: PrState.Closed,
+        state: 'closed',
       };
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
@@ -2635,7 +2635,7 @@ describe('modules/platform/github/index', () => {
             number: 1234,
             base: { sha: '1234' },
             head: { ref: 'somebranch', repo: { full_name: 'some/repo' } },
-            state: PrState.Open,
+            state: 'open',
             title: 'Some PR',
           },
         ])
@@ -2651,8 +2651,8 @@ describe('modules/platform/github/index', () => {
       const prAfter = await github.getPr(1234); // obtained from cache
 
       expect(mergeResult).toBeTrue();
-      expect(prBefore?.state).toBe(PrState.Open);
-      expect(prAfter?.state).toBe(PrState.Merged);
+      expect(prBefore?.state).toBe('open');
+      expect(prAfter?.state).toBe('merged');
     });
 
     it('should handle merge error', async () => {

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -21,7 +21,7 @@ import {
   REPOSITORY_RENAMED,
 } from '../../../constants/error-messages';
 import { logger } from '../../../logger';
-import { BranchStatus, PrState, VulnerabilityAlert } from '../../../types';
+import { BranchStatus, VulnerabilityAlert } from '../../../types';
 import { ExternalHostError } from '../../../types/errors/external-host-error';
 import * as git from '../../../util/git';
 import { listCommitTree, pushCommitToRenovateRef } from '../../../util/git';
@@ -664,7 +664,7 @@ export async function getPr(prNo: number): Promise<GhPr | null> {
 }
 
 function matchesState(state: string, desiredState: string): boolean {
-  if (desiredState === PrState.All) {
+  if (desiredState === 'all') {
     return true;
   }
   if (desiredState.startsWith('!')) {
@@ -693,7 +693,7 @@ export async function getPrList(): Promise<GhPr[]> {
 export async function findPr({
   branchName,
   prTitle,
-  state = PrState.All,
+  state = 'all',
 }: FindPRConfig): Promise<GhPr | null> {
   logger.debug(`findPr(${branchName}, ${prTitle}, ${state})`);
   const prList = await getPrList();
@@ -730,7 +730,7 @@ export async function getBranchPr(branchName: string): Promise<GhPr | null> {
 
   const openPr = await findPr({
     branchName,
-    state: PrState.Open,
+    state: 'open',
   });
   if (openPr) {
     return openPr;
@@ -738,7 +738,7 @@ export async function getBranchPr(branchName: string): Promise<GhPr | null> {
 
   const autoclosedPr = await findPr({
     branchName,
-    state: PrState.Closed,
+    state: 'closed',
   });
   if (
     autoclosedPr?.title?.endsWith(' - autoclosed') &&
@@ -1637,7 +1637,7 @@ export async function mergePr({
   );
   const cachedPr = config.prList?.find(({ number }) => number === prNo);
   if (cachedPr) {
-    cachePr({ ...cachedPr, state: PrState.Merged });
+    cachePr({ ...cachedPr, state: 'merged' });
   }
   return true;
 }

--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -10,7 +10,7 @@ import {
   REPOSITORY_MIRRORED,
 } from '../../../constants/error-messages';
 import type { logger as _logger } from '../../../logger';
-import { BranchStatus, PrState } from '../../../types';
+import { BranchStatus } from '../../../types';
 import type * as _git from '../../../util/git';
 import type * as _hostRules from '../../../util/host-rules';
 import { toBase64 } from '../../../util/string';
@@ -1313,12 +1313,12 @@ describe('modules/platform/gitlab/index', () => {
             iid: 1,
             source_branch: 'branch-a',
             title: 'branch a pr',
-            state: PrState.Merged,
+            state: 'merged',
           },
         ]);
       const res = await gitlab.findPr({
         branchName: 'branch-a',
-        state: PrState.NotOpen,
+        state: '!open',
       });
       expect(res).toBeDefined();
     });
@@ -1340,7 +1340,7 @@ describe('modules/platform/gitlab/index', () => {
       const res = await gitlab.findPr({
         branchName: 'branch-a',
         prTitle: 'branch a pr',
-        state: PrState.Open,
+        state: 'open',
       });
       expect(res).toBeDefined();
     });
@@ -1788,7 +1788,7 @@ describe('modules/platform/gitlab/index', () => {
           iid: 12345,
           title: 'do something',
           description: 'a merge request',
-          state: PrState.Merged,
+          state: 'merged',
           merge_status: 'cannot_be_merged',
           diverged_commits_count: 5,
           source_branch: 'some-branch',
@@ -1811,7 +1811,7 @@ describe('modules/platform/gitlab/index', () => {
           iid: 12345,
           title: 'Draft: do something',
           description: 'a merge request',
-          state: PrState.Merged,
+          state: 'merged',
           merge_status: 'cannot_be_merged',
           diverged_commits_count: 5,
           source_branch: 'some-branch',
@@ -1834,7 +1834,7 @@ describe('modules/platform/gitlab/index', () => {
           iid: 12345,
           title: 'WIP: do something',
           description: 'a merge request',
-          state: PrState.Merged,
+          state: 'merged',
           merge_status: 'cannot_be_merged',
           diverged_commits_count: 5,
           source_branch: 'some-branch',
@@ -1857,7 +1857,7 @@ describe('modules/platform/gitlab/index', () => {
           iid: 12345,
           title: 'do something',
           description: 'a merge request',
-          state: PrState.Open,
+          state: 'open',
           diverged_commits_count: 5,
           source_branch: 'some-branch',
           target_branch: 'master',
@@ -1881,7 +1881,7 @@ describe('modules/platform/gitlab/index', () => {
           iid: 12345,
           title: 'do something',
           description: 'a merge request',
-          state: PrState.Open,
+          state: 'open',
           merge_status: 'cannot_be_merged',
           diverged_commits_count: 2,
           source_branch: 'some-branch',
@@ -1913,7 +1913,7 @@ describe('modules/platform/gitlab/index', () => {
             iid: 1,
             source_branch: 'branch-a',
             title: 'branch a pr',
-            state: PrState.Open,
+            state: 'open',
           },
         ])
         .put('/api/v4/projects/undefined/merge_requests/1')
@@ -1935,7 +1935,7 @@ describe('modules/platform/gitlab/index', () => {
             iid: 1,
             source_branch: 'branch-a',
             title: 'Draft: foo',
-            state: PrState.Open,
+            state: 'open',
           },
         ])
         .put('/api/v4/projects/undefined/merge_requests/1')
@@ -1957,7 +1957,7 @@ describe('modules/platform/gitlab/index', () => {
             iid: 1,
             source_branch: 'branch-a',
             title: 'WIP: foo',
-            state: PrState.Open,
+            state: 'open',
           },
         ])
         .put('/api/v4/projects/undefined/merge_requests/1')
@@ -1979,7 +1979,7 @@ describe('modules/platform/gitlab/index', () => {
             iid: 1,
             source_branch: 'branch-a',
             title: 'branch a pr',
-            state: PrState.Open,
+            state: 'open',
           },
         ])
         .put('/api/v4/projects/undefined/merge_requests/1')
@@ -1989,7 +1989,7 @@ describe('modules/platform/gitlab/index', () => {
           number: 1,
           prTitle: 'title',
           prBody: 'body',
-          state: PrState.Closed,
+          state: 'closed',
         })
       ).toResolve();
     });
@@ -2072,7 +2072,7 @@ These updates have all been created already. Click a checkbox below to force a r
           iid: 12345,
           title: 'some change',
           description: 'a merge request',
-          state: PrState.Merged,
+          state: 'merged',
           merge_status: 'cannot_be_merged',
           diverged_commits_count: 5,
           source_branch: 'some-branch',

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -16,7 +16,7 @@ import {
   TEMPORARY_ERROR,
 } from '../../../constants/error-messages';
 import { logger } from '../../../logger';
-import { BranchStatus, PrState, VulnerabilityAlert } from '../../../types';
+import { BranchStatus, VulnerabilityAlert } from '../../../types';
 import * as git from '../../../util/git';
 import * as hostRules from '../../../util/host-rules';
 import { setBaseUrl } from '../../../util/http/gitlab';
@@ -491,7 +491,7 @@ async function fetchPrList(): Promise<Pr[]> {
         number: pr.iid,
         sourceBranch: pr.source_branch,
         title: pr.title,
-        state: pr.state === 'opened' ? PrState.Open : pr.state,
+        state: pr.state === 'opened' ? 'open' : pr.state,
         createdAt: pr.created_at,
       })
     );
@@ -625,7 +625,7 @@ export async function getPr(iid: number): Promise<GitlabPr> {
     number: mr.iid,
     displayNumber: `Merge Request #${mr.iid}`,
     bodyStruct: getPrBodyStruct(mr.description),
-    state: mr.state === 'opened' ? PrState.Open : mr.state,
+    state: mr.state === 'opened' ? 'open' : mr.state,
     headPipelineStatus: mr.head_pipeline?.status,
     hasAssignees: !!(mr.assignee?.id ?? mr.assignees?.[0]?.id),
     hasReviewers: !!mr.reviewers?.length,
@@ -649,8 +649,8 @@ export async function updatePr({
     title = draftPrefix + title;
   }
   const newState = {
-    [PrState.Closed]: 'close',
-    [PrState.Open]: 'reopen',
+    ['closed']: 'close',
+    ['open']: 'reopen',
     // TODO: null check (#7154)
   }[state!];
   await gitlabApi.putJson(
@@ -716,7 +716,7 @@ export function massageMarkdown(input: string): string {
 // Branch
 
 function matchesState(state: string, desiredState: string): boolean {
-  if (desiredState === PrState.All) {
+  if (desiredState === 'all') {
     return true;
   }
   if (desiredState.startsWith('!')) {
@@ -728,7 +728,7 @@ function matchesState(state: string, desiredState: string): boolean {
 export async function findPr({
   branchName,
   prTitle,
-  state = PrState.All,
+  state = 'all',
 }: FindPRConfig): Promise<Pr | null> {
   logger.debug(`findPr(${branchName}, ${prTitle!}, ${state})`);
   const prList = await getPrList();
@@ -749,7 +749,7 @@ export async function getBranchPr(
   logger.debug(`getBranchPr(${branchName})`);
   const existingPr = await findPr({
     branchName,
-    state: PrState.Open,
+    state: 'open',
   });
   return existingPr ? getPr(existingPr.number) : null;
 }

--- a/lib/modules/platform/types.ts
+++ b/lib/modules/platform/types.ts
@@ -1,5 +1,5 @@
 import type { MergeStrategy } from '../../config/types';
-import type { BranchStatus, PrState, VulnerabilityAlert } from '../../types';
+import type { BranchStatus, VulnerabilityAlert } from '../../types';
 import type { CommitFilesConfig, CommitSha } from '../../util/git/types';
 
 type VulnerabilityKey = string;
@@ -109,7 +109,7 @@ export interface UpdatePrConfig {
   platformOptions?: PlatformPrOptions;
   prTitle: string;
   prBody?: string;
-  state?: PrState.Open | PrState.Closed;
+  state?: 'open' | 'closed';
 }
 export interface EnsureIssueConfig {
   title: string;
@@ -130,7 +130,7 @@ export interface BranchStatusConfig {
 export interface FindPRConfig {
   branchName: string;
   prTitle?: string | null;
-  state?: PrState.Open | PrState.Closed | PrState.NotOpen | PrState.All;
+  state?: 'open' | 'closed' | '!open' | 'all';
   refreshCache?: boolean;
 }
 export interface MergePRConfig {

--- a/lib/modules/versioning/gradle/compare.ts
+++ b/lib/modules/versioning/gradle/compare.ts
@@ -86,17 +86,16 @@ export function tokenize(versionStr: string): Token[] | null {
   return result;
 }
 
-// eslint-disable-next-line typescript-enum/no-enum
-export enum QualifierRank {
-  Dev = -1,
-  Default = 0,
-  RC,
-  Snapshot,
-  Final,
-  GA,
-  Release,
-  SP,
-}
+export const QualifierRank = {
+  Dev: -1,
+  Default: 0,
+  RC: 1,
+  Snapshot: 2,
+  Final: 3,
+  GA: 4,
+  Release: 5,
+  SP: 6,
+};
 
 export function qualifierRank(input: string): number {
   const val = input.toLowerCase();

--- a/lib/modules/versioning/maven/compare.ts
+++ b/lib/modules/versioning/maven/compare.ts
@@ -166,16 +166,15 @@ function commonOrder(token: Token): number {
   return 3;
 }
 
-// eslint-disable-next-line typescript-enum/no-enum
-export enum QualifierTypes {
-  Alpha = 1,
-  Beta,
-  Milestone,
-  RC,
-  Snapshot,
-  Release,
-  SP,
-}
+export const QualifierTypes = {
+  Alpha: 1,
+  Beta: 2,
+  Milestone: 3,
+  RC: 4,
+  Snapshot: 5,
+  Release: 6,
+  SP: 7,
+};
 
 export function qualifierType(token: Token): number | null {
   const val = token.val;

--- a/lib/types/pr-state.ts
+++ b/lib/types/pr-state.ts
@@ -1,8 +1,1 @@
-// eslint-disable-next-line typescript-enum/no-enum
-export enum PrState {
-  Merged = 'merged',
-  Open = 'open',
-  Closed = 'closed',
-  All = 'all',
-  NotOpen = '!open',
-}
+export type PrState = 'merged' | 'open' | 'closed' | 'all' | '!open';

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -27,7 +27,7 @@ import { logger } from '../../logger';
 import { api as semverCoerced } from '../../modules/versioning/semver-coerced';
 import { ExternalHostError } from '../../types/errors/external-host-error';
 import type { GitProtocol } from '../../types/git';
-import { Limit, incLimitedValue } from '../../workers/global/limits';
+import { incLimitedValue } from '../../workers/global/limits';
 import { newlineRegex, regEx } from '../regex';
 import { parseGitAuthor } from './author';
 import { getCachedBehindBaseResult } from './behind-base-branch-cache';
@@ -782,7 +782,7 @@ export async function mergeBranch(branchName: string): Promise<void> {
     status = await git.status();
     await gitRetry(() => git.merge(['--ff-only', branchName]));
     await gitRetry(() => git.push('origin', config.currentBranch));
-    incLimitedValue(Limit.Commits);
+    incLimitedValue('Commits');
   } catch (err) {
     logger.debug(
       {
@@ -1032,7 +1032,7 @@ export async function pushCommit({
     );
     delete pushRes.repo;
     logger.debug({ result: pushRes }, 'git push');
-    incLimitedValue(Limit.Commits);
+    incLimitedValue('Commits');
     result = true;
   } catch (err) /* istanbul ignore next */ {
     handleCommitError(files, branchName, err);

--- a/lib/workers/global/index.ts
+++ b/lib/workers/global/index.ts
@@ -24,7 +24,7 @@ import * as repositoryWorker from '../repository';
 import { autodiscoverRepositories } from './autodiscover';
 import { parseConfigs } from './config/parse';
 import { globalFinalize, globalInitialize } from './initialize';
-import { Limit, isLimitReached } from './limits';
+import { isLimitReached } from './limits';
 
 export async function getRepositoryConfig(
   globalConfig: RenovateConfig,
@@ -50,7 +50,7 @@ function getGlobalConfig(): Promise<RenovateConfig> {
 }
 
 function haveReachedLimits(): boolean {
-  if (isLimitReached(Limit.Commits)) {
+  if (isLimitReached('Commits')) {
     logger.info('Max commits created for this run.');
     return true;
   }

--- a/lib/workers/global/initialize.ts
+++ b/lib/workers/global/initialize.ts
@@ -9,7 +9,7 @@ import * as packageCache from '../../util/cache/package';
 import { setEmojiConfig } from '../../util/emoji';
 import { validateGitVersion } from '../../util/git';
 import * as hostRules from '../../util/host-rules';
-import { Limit, setMaxLimit } from './limits';
+import { setMaxLimit } from './limits';
 
 async function setDirectories(input: AllConfig): Promise<AllConfig> {
   const config: AllConfig = { ...input };
@@ -45,7 +45,7 @@ async function setDirectories(input: AllConfig): Promise<AllConfig> {
 function limitCommitsPerRun(config: RenovateConfig): void {
   let limit = config.prCommitsPerRunLimit;
   limit = typeof limit === 'number' && limit > 0 ? limit : null;
-  setMaxLimit(Limit.Commits, limit);
+  setMaxLimit('Commits', limit);
 }
 
 async function checkVersions(): Promise<void> {

--- a/lib/workers/global/limits.spec.ts
+++ b/lib/workers/global/limits.spec.ts
@@ -1,5 +1,4 @@
 import {
-  Limit,
   incLimitedValue,
   isLimitReached,
   resetAllLimits,
@@ -16,49 +15,49 @@ describe('workers/global/limits', () => {
   });
 
   it('increments limited value', () => {
-    setMaxLimit(Limit.Commits, 3);
+    setMaxLimit('Commits', 3);
 
-    expect(isLimitReached(Limit.Commits)).toBeFalse();
+    expect(isLimitReached('Commits')).toBeFalse();
 
-    incLimitedValue(Limit.Commits, 2);
-    expect(isLimitReached(Limit.Commits)).toBeFalse();
+    incLimitedValue('Commits', 2);
+    expect(isLimitReached('Commits')).toBeFalse();
 
-    incLimitedValue(Limit.Commits);
-    expect(isLimitReached(Limit.Commits)).toBeTrue();
+    incLimitedValue('Commits');
+    expect(isLimitReached('Commits')).toBeTrue();
 
-    incLimitedValue(Limit.Commits);
-    expect(isLimitReached(Limit.Commits)).toBeTrue();
+    incLimitedValue('Commits');
+    expect(isLimitReached('Commits')).toBeTrue();
   });
 
   it('defaults to unlimited', () => {
-    expect(isLimitReached(Limit.Commits)).toBeFalse();
+    expect(isLimitReached('Commits')).toBeFalse();
   });
 
   it('increments undefined', () => {
-    incLimitedValue(Limit.Commits);
-    expect(isLimitReached(Limit.Commits)).toBeFalse();
+    incLimitedValue('Commits');
+    expect(isLimitReached('Commits')).toBeFalse();
   });
 
   it('resets counter', () => {
-    setMaxLimit(Limit.Commits, 1);
-    incLimitedValue(Limit.Commits);
-    expect(isLimitReached(Limit.Commits)).toBeTrue();
-    setMaxLimit(Limit.Commits, 1);
-    expect(isLimitReached(Limit.Commits)).toBeFalse();
+    setMaxLimit('Commits', 1);
+    incLimitedValue('Commits');
+    expect(isLimitReached('Commits')).toBeTrue();
+    setMaxLimit('Commits', 1);
+    expect(isLimitReached('Commits')).toBeFalse();
   });
 
   it('resets limit', () => {
-    setMaxLimit(Limit.Commits, 1);
-    incLimitedValue(Limit.Commits);
-    expect(isLimitReached(Limit.Commits)).toBeTrue();
-    setMaxLimit(Limit.Commits, null);
-    expect(isLimitReached(Limit.Commits)).toBeFalse();
+    setMaxLimit('Commits', 1);
+    incLimitedValue('Commits');
+    expect(isLimitReached('Commits')).toBeTrue();
+    setMaxLimit('Commits', null);
+    expect(isLimitReached('Commits')).toBeFalse();
   });
 
   it('sets non-positive limit as reached', () => {
-    setMaxLimit(Limit.Commits, 0);
-    expect(isLimitReached(Limit.Commits)).toBeTrue();
-    setMaxLimit(Limit.Commits, -1000);
-    expect(isLimitReached(Limit.Commits)).toBeTrue();
+    setMaxLimit('Commits', 0);
+    expect(isLimitReached('Commits')).toBeTrue();
+    setMaxLimit('Commits', -1000);
+    expect(isLimitReached('Commits')).toBeTrue();
   });
 });

--- a/lib/workers/global/limits.ts
+++ b/lib/workers/global/limits.ts
@@ -1,11 +1,6 @@
 import { logger } from '../../logger';
 
-// eslint-disable-next-line typescript-enum/no-enum
-export enum Limit {
-  Commits = 'Commits',
-  PullRequests = 'PullRequests',
-  Branches = 'Branches',
-}
+export type Limit = 'Commits' | 'PullRequests' | 'Branches';
 
 interface LimitValue {
   max: number | null;

--- a/lib/workers/repository/config-migration/branch/index.spec.ts
+++ b/lib/workers/repository/config-migration/branch/index.spec.ts
@@ -11,7 +11,6 @@ import {
 import { GlobalConfig } from '../../../../config/global';
 import { logger } from '../../../../logger';
 import type { Pr } from '../../../../modules/platform';
-import { PrState } from '../../../../types';
 import { createConfigMigrationBranch } from './create';
 import type { MigratedData } from './migrated-data';
 import { rebaseMigrationBranch } from './rebase';
@@ -104,7 +103,7 @@ describe('workers/repository/config-migration/branch/index', () => {
 
     describe('handle closed PR', () => {
       const title = 'PR title';
-      const pr = partial<Pr>({ title, state: PrState.Closed, number: 1 });
+      const pr = partial<Pr>({ title, state: 'closed', number: 1 });
 
       it('skips branch when there is a closed one delete it and add an ignore PR message', async () => {
         platform.findPr.mockResolvedValueOnce(pr);

--- a/lib/workers/repository/config-migration/branch/index.ts
+++ b/lib/workers/repository/config-migration/branch/index.ts
@@ -3,7 +3,6 @@ import type { RenovateConfig } from '../../../../config/types';
 import { logger } from '../../../../logger';
 import { FindPRConfig, Pr, platform } from '../../../../modules/platform';
 import { ensureComment } from '../../../../modules/platform/comment';
-import { PrState } from '../../../../types';
 import {
   branchExists,
   checkoutBranch,
@@ -37,7 +36,7 @@ export async function checkConfigMigrationBranch(
     const closedPrConfig: FindPRConfig = {
       branchName: configMigrationBranch,
       prTitle,
-      state: PrState.Closed,
+      state: 'closed',
     };
 
     // handles closed PR
@@ -82,7 +81,7 @@ export async function migrationPrExists(branchName: string): Promise<boolean> {
 
 async function handlepr(config: RenovateConfig, pr: Pr): Promise<void> {
   if (
-    pr.state === PrState.Closed &&
+    pr.state === 'closed' &&
     !config.suppressNotifications!.includes('prIgnoreNotification')
   ) {
     if (GlobalConfig.get('dryRun')) {

--- a/lib/workers/repository/error-config.spec.ts
+++ b/lib/workers/repository/error-config.spec.ts
@@ -3,7 +3,6 @@ import { RenovateConfig, getConfig, platform } from '../../../test/util';
 import { GlobalConfig } from '../../config/global';
 import { CONFIG_VALIDATION } from '../../constants/error-messages';
 import type { Pr } from '../../modules/platform';
-import { PrState } from '../../types';
 import { raiseConfigWarningIssue } from './error-config';
 
 jest.mock('../../modules/platform');
@@ -47,7 +46,7 @@ describe('workers/repository/error-config', () => {
       platform.getBranchPr.mockResolvedValue({
         ...mock<Pr>(),
         number: 1,
-        state: PrState.Open,
+        state: 'open',
       });
       const res = await raiseConfigWarningIssue(config, error);
       expect(res).toBeUndefined();
@@ -60,7 +59,7 @@ describe('workers/repository/error-config', () => {
       platform.getBranchPr.mockResolvedValue({
         ...mock<Pr>(),
         number: 1,
-        state: PrState.Open,
+        state: 'open',
       });
       GlobalConfig.set({ dryRun: 'full' });
       const res = await raiseConfigWarningIssue(config, error);
@@ -76,7 +75,7 @@ describe('workers/repository/error-config', () => {
       platform.getBranchPr.mockResolvedValueOnce({
         ...mock<Pr>(),
         number: 1,
-        state: PrState.NotOpen,
+        state: '!open',
       });
       const res = await raiseConfigWarningIssue(config, error);
       expect(res).toBeUndefined();

--- a/lib/workers/repository/error-config.ts
+++ b/lib/workers/repository/error-config.ts
@@ -3,7 +3,6 @@ import { GlobalConfig } from '../../config/global';
 import type { RenovateConfig } from '../../config/types';
 import { logger } from '../../logger';
 import { platform } from '../../modules/platform';
-import { PrState } from '../../types';
 import { regEx } from '../../util/regex';
 
 export async function raiseConfigWarningIssue(
@@ -23,7 +22,7 @@ export async function raiseConfigWarningIssue(
     )}\`\n`;
   }
   const pr = await platform.getBranchPr(config.onboardingBranch!);
-  if (pr?.state === PrState.Open) {
+  if (pr?.state === 'open') {
     logger.debug('Updating onboarding PR with config error notice');
     body = `## Action Required: Fix Renovate Configuration\n\n${body}`;
     body += `\n\nOnce you have resolved this problem (in this onboarding branch), Renovate will return to providing you with a preview of your repository's configuration.`;

--- a/lib/workers/repository/finalise/prune.ts
+++ b/lib/workers/repository/finalise/prune.ts
@@ -4,7 +4,6 @@ import { REPOSITORY_CHANGED } from '../../../constants/error-messages';
 import { logger } from '../../../logger';
 import { platform } from '../../../modules/platform';
 import { ensureComment } from '../../../modules/platform/comment';
-import { PrState } from '../../../types';
 import {
   deleteBranch,
   getBranchList,
@@ -23,7 +22,7 @@ async function cleanUpBranches(
     try {
       const pr = await platform.findPr({
         branchName,
-        state: PrState.Open,
+        state: 'open',
       });
       const branchIsModified = await isBranchModified(branchName);
       if (pr) {
@@ -40,7 +39,7 @@ async function cleanUpBranches(
               await platform.updatePr({
                 number: pr.number,
                 prTitle: newPrTitle,
-                state: PrState.Open,
+                state: 'open',
               });
             }
 
@@ -68,7 +67,7 @@ async function cleanUpBranches(
           await platform.updatePr({
             number: pr.number,
             prTitle: newPrTitle,
-            state: PrState.Closed,
+            state: 'closed',
           });
           await deleteBranch(branchName);
         }

--- a/lib/workers/repository/finalise/repository-statistics.ts
+++ b/lib/workers/repository/finalise/repository-statistics.ts
@@ -1,7 +1,6 @@
 import type { RenovateConfig } from '../../../config/types';
 import { logger } from '../../../logger';
 import type { Pr } from '../../../modules/platform';
-import { PrState } from '../../../types';
 import { getCache, isCacheModified } from '../../../util/cache/repository';
 import type { BranchCache } from '../../../util/cache/repository/types';
 import type {
@@ -25,13 +24,13 @@ export function runRenovateRepoStats(
     }
     prStats.total += 1;
     switch (pr.state) {
-      case PrState.Merged:
+      case 'merged':
         prStats.merged += 1;
         break;
-      case PrState.Closed:
+      case 'closed':
         prStats.closed += 1;
         break;
-      case PrState.Open:
+      case 'open':
         prStats.open += 1;
         break;
       default:

--- a/lib/workers/repository/onboarding/branch/check.ts
+++ b/lib/workers/repository/onboarding/branch/check.ts
@@ -7,7 +7,6 @@ import {
 import { logger } from '../../../../logger';
 import { Pr, platform } from '../../../../modules/platform';
 import { ensureComment } from '../../../../modules/platform/comment';
-import { PrState } from '../../../../types';
 import { getCache } from '../../../../util/cache/repository';
 import { readLocalFile } from '../../../../util/fs';
 import { getFileList } from '../../../../util/git';
@@ -45,7 +44,7 @@ function closedPrExists(config: RenovateConfig): Promise<Pr | null> {
   return platform.findPr({
     branchName: config.onboardingBranch!,
     prTitle: config.onboardingPrTitle,
-    state: PrState.NotOpen,
+    state: '!open',
   });
 }
 

--- a/lib/workers/repository/onboarding/branch/index.spec.ts
+++ b/lib/workers/repository/onboarding/branch/index.spec.ts
@@ -14,7 +14,6 @@ import {
 } from '../../../../constants/error-messages';
 import { logger } from '../../../../logger';
 import type { Pr } from '../../../../modules/platform';
-import { PrState } from '../../../../types';
 import * as _cache from '../../../../util/cache/repository';
 import type { FileAddition } from '../../../../util/git/types';
 import * as _config from './config';
@@ -228,7 +227,7 @@ describe('workers/repository/onboarding/branch/index', () => {
         {
           ...mock<Pr>(),
           sourceBranch: 'renovate/something',
-          state: PrState.Open,
+          state: 'open',
         },
       ]);
       await expect(checkOnboardingBranch(config)).rejects.toThrow();

--- a/lib/workers/repository/process/limits.spec.ts
+++ b/lib/workers/repository/process/limits.spec.ts
@@ -5,7 +5,6 @@ import {
   git,
   platform,
 } from '../../../../test/util';
-import { PrState } from '../../../types';
 import type { BranchConfig } from '../../types';
 import * as limits from './limits';
 
@@ -63,7 +62,7 @@ describe('workers/repository/process/limits', () => {
         branchName
           ? Promise.resolve({
               sourceBranch: branchName,
-              state: PrState.Open,
+              state: 'open',
             } as never)
           : Promise.reject('some error')
       );

--- a/lib/workers/repository/process/limits.ts
+++ b/lib/workers/repository/process/limits.ts
@@ -1,9 +1,7 @@
-// TODO #7154
 import { DateTime } from 'luxon';
 import type { RenovateConfig } from '../../../config/types';
 import { logger } from '../../../logger';
 import { Pr, platform } from '../../../modules/platform';
-import { PrState } from '../../../types';
 import { ExternalHostError } from '../../../types/errors/external-host-error';
 import { branchExists } from '../../../util/git';
 import type { BranchConfig } from '../../types';
@@ -55,7 +53,7 @@ export async function getConcurrentPrsRemaining(
           if (
             pr &&
             pr.sourceBranch !== config.onboardingBranch &&
-            pr.state === PrState.Open
+            pr.state === 'open'
           ) {
             openPrs.push(pr);
           }
@@ -121,7 +119,6 @@ export function getConcurrentBranchesRemaining(
 
       return concurrentRemaining;
     } catch (err) {
-      // TODO: #7154 should never throw
       logger.error({ err }, 'Error checking concurrent branches');
       return limit;
     }

--- a/lib/workers/repository/process/limits.ts
+++ b/lib/workers/repository/process/limits.ts
@@ -119,6 +119,7 @@ export function getConcurrentBranchesRemaining(
 
       return concurrentRemaining;
     } catch (err) {
+      // TODO: #7154 should never throw
       logger.error({ err }, 'Error checking concurrent branches');
       return limit;
     }

--- a/lib/workers/repository/process/write.spec.ts
+++ b/lib/workers/repository/process/write.spec.ts
@@ -15,7 +15,7 @@ import type {
   RepoCacheData,
 } from '../../../util/cache/repository/types';
 import { fingerprint } from '../../../util/fingerprint';
-import { Limit, isLimitReached } from '../../global/limits';
+import { isLimitReached } from '../../global/limits';
 import { BranchConfig, BranchResult, BranchUpgradeConfig } from '../../types';
 import * as _branchWorker from '../update/branch';
 import * as _limits from './limits';
@@ -119,11 +119,11 @@ describe('workers/repository/process/write', () => {
       });
       git.branchExists.mockReturnValueOnce(false).mockReturnValueOnce(true);
       limits.getBranchesRemaining.mockResolvedValueOnce(1);
-      expect(isLimitReached(Limit.Branches)).toBeFalse();
+      expect(isLimitReached('Branches')).toBeFalse();
       GlobalConfig.set({ dryRun: 'full' });
       config.baseBranches = ['main', 'dev'];
       await writeUpdates(config, branches);
-      expect(isLimitReached(Limit.Branches)).toBeTrue();
+      expect(isLimitReached('Branches')).toBeTrue();
       expect(addMeta).toHaveBeenCalledWith({
         baseBranch: 'main',
         branch: branchName,

--- a/lib/workers/repository/process/write.ts
+++ b/lib/workers/repository/process/write.ts
@@ -7,7 +7,7 @@ import type { BranchCache } from '../../../util/cache/repository/types';
 import { fingerprint } from '../../../util/fingerprint';
 import { branchExists, getBranchCommit } from '../../../util/git';
 import { setBranchNewCommit } from '../../../util/git/set-branch-commit';
-import { Limit, incLimitedValue, setMaxLimit } from '../../global/limits';
+import { incLimitedValue, setMaxLimit } from '../../global/limits';
 import {
   BranchConfig,
   BranchResult,
@@ -124,13 +124,13 @@ export async function writeUpdates(
   );
   const prsRemaining = await getPrsRemaining(config, branches);
   logger.debug(`Calculated maximum PRs remaining this run: ${prsRemaining}`);
-  setMaxLimit(Limit.PullRequests, prsRemaining);
+  setMaxLimit('PullRequests', prsRemaining);
 
   const branchesRemaining = await getBranchesRemaining(config, branches);
   logger.debug(
     `Calculated maximum branches remaining this run: ${branchesRemaining}`
   );
-  setMaxLimit(Limit.Branches, branchesRemaining);
+  setMaxLimit('Branches', branchesRemaining);
 
   for (const branch of branches) {
     const { baseBranch, branchName } = branch;
@@ -176,7 +176,7 @@ export async function writeUpdates(
       return 'automerged';
     }
     if (!branchExisted && branchExists(branch.branchName)) {
-      incLimitedValue(Limit.Branches);
+      incLimitedValue('Branches');
     }
   }
   removeMeta(['branch', 'baseBranch']);

--- a/lib/workers/repository/update/branch/check-existing.spec.ts
+++ b/lib/workers/repository/update/branch/check-existing.spec.ts
@@ -1,7 +1,6 @@
 import { getConfig, partial, platform } from '../../../../../test/util';
 import { logger } from '../../../../logger';
 import type { Pr } from '../../../../modules/platform';
-import { PrState } from '../../../../types';
 import type { BranchConfig } from '../../../types';
 import { prAlreadyExisted } from './check-existing';
 
@@ -35,7 +34,7 @@ describe('workers/repository/update/branch/check-existing', () => {
       platform.findPr.mockResolvedValueOnce({ number: 12 } as never);
       platform.getPr.mockResolvedValueOnce({
         number: 12,
-        state: PrState.Closed,
+        state: 'closed',
       } as never);
       expect(await prAlreadyExisted(config)).toEqual({ number: 12 });
       expect(platform.findPr).toHaveBeenCalledTimes(1);
@@ -48,7 +47,7 @@ describe('workers/repository/update/branch/check-existing', () => {
       platform.getPr.mockResolvedValueOnce(
         partial<Pr>({
           number: 12,
-          state: PrState.Closed,
+          state: 'closed',
         })
       );
       expect(await prAlreadyExisted(config)).toEqual({ number: 12 });

--- a/lib/workers/repository/update/branch/check-existing.ts
+++ b/lib/workers/repository/update/branch/check-existing.ts
@@ -2,7 +2,6 @@
 import { REPOSITORY_CHANGED } from '../../../../constants/error-messages';
 import { logger } from '../../../../logger';
 import { Pr, platform } from '../../../../modules/platform';
-import { PrState } from '../../../../types';
 import type { BranchConfig } from '../../../types';
 
 export async function prAlreadyExisted(
@@ -18,7 +17,7 @@ export async function prAlreadyExisted(
   let pr = await platform.findPr({
     branchName: config.branchName,
     prTitle: config.prTitle,
-    state: PrState.NotOpen,
+    state: '!open',
   });
 
   if (!pr && config.branchPrefix !== config.branchPrefixOld) {
@@ -28,7 +27,7 @@ export async function prAlreadyExisted(
         config.branchPrefixOld!
       ),
       prTitle: config.prTitle,
-      state: PrState.NotOpen,
+      state: '!open',
     });
     if (pr) {
       logger.debug('Found closed PR with branchPrefixOld');
@@ -39,7 +38,7 @@ export async function prAlreadyExisted(
     logger.debug('Found closed PR with current title');
     const prDetails = await platform.getPr(pr.number);
     // istanbul ignore if
-    if (prDetails!.state === PrState.Open) {
+    if (prDetails!.state === 'open') {
       logger.debug('PR reopened - aborting run');
       throw new Error(REPOSITORY_CHANGED);
     }

--- a/lib/workers/repository/update/branch/handle-existing.ts
+++ b/lib/workers/repository/update/branch/handle-existing.ts
@@ -2,13 +2,12 @@ import { GlobalConfig } from '../../../../config/global';
 import { logger } from '../../../../logger';
 import type { Pr } from '../../../../modules/platform';
 import { ensureComment } from '../../../../modules/platform/comment';
-import { PrState } from '../../../../types';
 import { branchExists, deleteBranch } from '../../../../util/git';
 import * as template from '../../../../util/template';
 import type { BranchConfig } from '../../../types';
 
 export async function handlepr(config: BranchConfig, pr: Pr): Promise<void> {
-  if (pr.state === PrState.Closed) {
+  if (pr.state === 'closed') {
     let content;
     // TODO #7154
     const userStrings = config.userStrings!;
@@ -41,7 +40,7 @@ export async function handlepr(config: BranchConfig, pr: Pr): Promise<void> {
         await deleteBranch(config.branchName);
       }
     }
-  } else if (pr.state === PrState.Merged) {
+  } else if (pr.state === 'merged') {
     logger.debug(`Merged PR with PrNo: ${pr.number} is blocking this branch`);
   }
 }

--- a/lib/workers/repository/update/branch/index.spec.ts
+++ b/lib/workers/repository/update/branch/index.spec.ts
@@ -18,7 +18,6 @@ import * as _npmPostExtract from '../../../../modules/manager/npm/post-update';
 import type { WriteExistingFilesResult } from '../../../../modules/manager/npm/post-update/types';
 import type { Pr } from '../../../../modules/platform';
 import { hashBody } from '../../../../modules/platform/pr-body';
-import { PrState } from '../../../../types';
 import * as _repoCache from '../../../../util/cache/repository';
 import * as _exec from '../../../../util/exec';
 import type { FileChange, StatusResult } from '../../../../util/git/types';
@@ -240,7 +239,7 @@ describe('workers/repository/update/branch/index', () => {
       config.updateNotScheduled = true;
       git.branchExists.mockReturnValue(true);
       platform.getBranchPr.mockResolvedValueOnce({
-        state: PrState.Open,
+        state: 'open',
       } as Pr);
       git.isBranchModified.mockResolvedValueOnce(false);
       await branchWorker.processBranch(config);
@@ -253,7 +252,7 @@ describe('workers/repository/update/branch/index', () => {
       config.updateType = 'major';
       checkExisting.prAlreadyExisted.mockResolvedValueOnce({
         number: 13,
-        state: PrState.Closed,
+        state: 'closed',
       } as Pr);
       await branchWorker.processBranch(config);
       expect(reuse.shouldReuseExistingBranch).toHaveBeenCalledTimes(0);
@@ -265,7 +264,7 @@ describe('workers/repository/update/branch/index', () => {
       config.updateType = 'digest';
       checkExisting.prAlreadyExisted.mockResolvedValueOnce({
         number: 13,
-        state: PrState.Closed,
+        state: 'closed',
       } as Pr);
       await branchWorker.processBranch(config);
       expect(reuse.shouldReuseExistingBranch).toHaveBeenCalledTimes(0);
@@ -276,7 +275,7 @@ describe('workers/repository/update/branch/index', () => {
       git.branchExists.mockReturnValue(true);
       checkExisting.prAlreadyExisted.mockResolvedValueOnce({
         number: 13,
-        state: PrState.Closed,
+        state: 'closed',
       } as Pr);
       await branchWorker.processBranch(config);
       expect(reuse.shouldReuseExistingBranch).toHaveBeenCalledTimes(0);
@@ -287,7 +286,7 @@ describe('workers/repository/update/branch/index', () => {
       git.branchExists.mockReturnValue(true);
       checkExisting.prAlreadyExisted.mockResolvedValueOnce({
         number: 13,
-        state: PrState.Merged,
+        state: 'merged',
       } as Pr);
       await branchWorker.processBranch(config);
       expect(reuse.shouldReuseExistingBranch).toHaveBeenCalledTimes(0);
@@ -297,7 +296,7 @@ describe('workers/repository/update/branch/index', () => {
       schedule.isScheduledNow.mockReturnValueOnce(false);
       git.branchExists.mockReturnValue(true);
       platform.getBranchPr.mockResolvedValueOnce({
-        state: PrState.Merged,
+        state: 'merged',
       } as Pr);
       git.isBranchModified.mockResolvedValueOnce(true);
       await expect(branchWorker.processBranch(config)).rejects.toThrow(
@@ -309,7 +308,7 @@ describe('workers/repository/update/branch/index', () => {
       schedule.isScheduledNow.mockReturnValueOnce(false);
       git.branchExists.mockReturnValue(true);
       platform.getBranchPr.mockResolvedValueOnce({
-        state: PrState.Open,
+        state: 'open',
         labels: ['rebase'],
       } as Pr);
       git.isBranchModified.mockResolvedValueOnce(true);
@@ -330,7 +329,7 @@ describe('workers/repository/update/branch/index', () => {
       });
       git.branchExists.mockReturnValue(true);
       platform.getBranchPr.mockResolvedValueOnce({
-        state: PrState.Open,
+        state: 'open',
         bodyStruct: { hash: '' },
       } as Pr);
       git.isBranchModified.mockResolvedValueOnce(true);
@@ -350,7 +349,7 @@ describe('workers/repository/update/branch/index', () => {
       });
       git.branchExists.mockReturnValue(true);
       platform.getBranchPr.mockResolvedValueOnce({
-        state: PrState.Open,
+        state: 'open',
         targetBranch: 'v6',
       } as Pr);
       git.isBranchModified.mockResolvedValueOnce(false);
@@ -948,7 +947,7 @@ describe('workers/repository/update/branch/index', () => {
     it('closed pr (dry run)', async () => {
       git.branchExists.mockReturnValue(true);
       checkExisting.prAlreadyExisted.mockResolvedValueOnce({
-        state: PrState.Closed,
+        state: 'closed',
       } as Pr);
       GlobalConfig.set({ ...adminConfig, dryRun: 'full' });
       expect(await branchWorker.processBranch(config)).toEqual({
@@ -965,7 +964,7 @@ describe('workers/repository/update/branch/index', () => {
         createdInVer: '1.0.2',
       });
       platform.getBranchPr.mockResolvedValueOnce({
-        state: PrState.Open,
+        state: 'open',
       } as Pr);
       git.isBranchModified.mockResolvedValueOnce(true);
       GlobalConfig.set({ ...adminConfig, dryRun: 'full' });
@@ -992,7 +991,7 @@ describe('workers/repository/update/branch/index', () => {
       git.branchExists.mockReturnValue(true);
       platform.getBranchPr.mockResolvedValueOnce({
         title: 'rebase!',
-        state: PrState.Open,
+        state: 'open',
         bodyStruct: {
           hash: hashBody(`- [x] <!-- rebase-check -->`),
           rebaseRequested: true,
@@ -1031,7 +1030,7 @@ describe('workers/repository/update/branch/index', () => {
       git.branchExists.mockReturnValue(true);
       platform.getBranchPr.mockResolvedValueOnce({
         title: 'rebase!',
-        state: PrState.Open,
+        state: 'open',
         bodyStruct: {
           hash: hashBody(`- [x] <!-- rebase-check -->`),
           rebaseRequested: true,
@@ -1077,7 +1076,7 @@ describe('workers/repository/update/branch/index', () => {
       git.branchExists.mockReturnValue(true);
       platform.getBranchPr.mockResolvedValueOnce({
         title: 'rebase!',
-        state: PrState.Open,
+        state: 'open',
         bodyStruct: {
           hash: hashBody(`- [x] <!-- rebase-check -->`),
           rebaseRequested: true,
@@ -1116,7 +1115,7 @@ describe('workers/repository/update/branch/index', () => {
       git.branchExists.mockReturnValue(true);
       platform.getBranchPr.mockResolvedValueOnce({
         title: 'rebase!',
-        state: PrState.Open,
+        state: 'open',
         labels: ['stop-updating'],
         bodyStruct: { hash: hashBody(`- [ ] <!-- rebase-check -->`) },
       } as Pr);
@@ -1141,7 +1140,7 @@ describe('workers/repository/update/branch/index', () => {
       platform.getBranchPr.mockResolvedValueOnce(
         partial<Pr>({
           sourceBranch: 'old/some-branch',
-          state: PrState.Open,
+          state: 'open',
         })
       );
       const inconfig = {
@@ -1178,7 +1177,7 @@ describe('workers/repository/update/branch/index', () => {
       git.branchExists.mockReturnValue(true);
       platform.getBranchPr.mockResolvedValueOnce({
         title: 'Update dependency',
-        state: PrState.Open,
+        state: 'open',
         labels: ['stop-updating'],
         bodyStruct: {
           hash: hashBody(`- [x] <!-- rebase-check -->`),
@@ -1218,7 +1217,7 @@ describe('workers/repository/update/branch/index', () => {
       git.branchExists.mockReturnValue(true);
       platform.getBranchPr.mockResolvedValueOnce({
         title: 'rebase!',
-        state: PrState.Open,
+        state: 'open',
         labels: ['stop-updating'],
         bodyStruct: { hash: hashBody(`- [ ] <!-- rebase-check -->`) },
       } as Pr);
@@ -1264,7 +1263,7 @@ describe('workers/repository/update/branch/index', () => {
       git.branchExists.mockReturnValue(true);
       platform.getBranchPr.mockResolvedValueOnce({
         title: 'rebase!',
-        state: PrState.Open,
+        state: 'open',
         bodyStruct: {
           hash: hashBody(`- [x] <!-- rebase-check -->`),
           rebaseRequested: true,
@@ -1356,7 +1355,7 @@ describe('workers/repository/update/branch/index', () => {
       git.branchExists.mockReturnValue(true);
       platform.getBranchPr.mockResolvedValueOnce({
         title: 'rebase!',
-        state: PrState.Open,
+        state: 'open',
         bodyStruct: {
           hash: hashBody(`- [x] <!-- rebase-check -->`),
           rebaseRequested: true,
@@ -1439,7 +1438,7 @@ describe('workers/repository/update/branch/index', () => {
       git.branchExists.mockReturnValue(true);
       platform.getBranchPr.mockResolvedValueOnce({
         title: 'rebase!',
-        state: PrState.Open,
+        state: 'open',
         bodyStruct: {
           hash: hashBody(`- [x] <!-- rebase-check -->`),
           rebaseRequested: true,
@@ -1527,7 +1526,7 @@ describe('workers/repository/update/branch/index', () => {
       git.branchExists.mockReturnValue(true);
       platform.getBranchPr.mockResolvedValueOnce({
         title: 'rebase!',
-        state: PrState.Open,
+        state: 'open',
         bodyStruct: {
           hash: hashBody(`- [x] <!-- rebase-check -->`),
           rebaseRequested: true,
@@ -1682,7 +1681,7 @@ describe('workers/repository/update/branch/index', () => {
       git.branchExists.mockReturnValue(true);
       platform.getBranchPr.mockResolvedValueOnce({
         title: 'rebase!',
-        state: PrState.Open,
+        state: 'open',
         bodyStruct: {
           hash: hashBody(`- [x] <!-- rebase-check -->`),
           rebaseRequested: true,
@@ -1831,7 +1830,7 @@ describe('workers/repository/update/branch/index', () => {
       platform.getBranchPr.mockResolvedValueOnce(
         partial<Pr>({
           sourceBranch: 'old/some-branch',
-          state: PrState.Open,
+          state: 'open',
         })
       );
       const inconfig = {
@@ -1867,7 +1866,7 @@ describe('workers/repository/update/branch/index', () => {
       platform.getBranchPr.mockResolvedValueOnce(
         partial<Pr>({
           sourceBranch: 'old/some-branch',
-          state: PrState.Open,
+          state: 'open',
         })
       );
       config.reuseExistingBranch = true;
@@ -1903,7 +1902,7 @@ describe('workers/repository/update/branch/index', () => {
       git.branchExists.mockReturnValue(true);
       platform.getBranchPr.mockResolvedValueOnce({
         title: 'pending!',
-        state: PrState.Open,
+        state: 'open',
         bodyStruct: {
           hash: hashBody(`- [x] <!-- approve-all-pending-prs -->`),
           rebaseRequested: false,
@@ -1936,7 +1935,7 @@ describe('workers/repository/update/branch/index', () => {
       git.branchExists.mockReturnValue(true);
       platform.getBranchPr.mockResolvedValueOnce({
         title: 'unlimited!',
-        state: PrState.Open,
+        state: 'open',
         bodyStruct: {
           hash: hashBody(`- [x] <!-- create-all-rate-limited-prs -->`),
           rebaseRequested: false,

--- a/lib/workers/repository/update/branch/index.ts
+++ b/lib/workers/repository/update/branch/index.ts
@@ -22,7 +22,7 @@ import {
   ensureCommentRemoval,
 } from '../../../../modules/platform/comment';
 import { hashBody } from '../../../../modules/platform/pr-body';
-import { BranchStatus, PrState } from '../../../../types';
+import { BranchStatus } from '../../../../types';
 import { ExternalHostError } from '../../../../types/errors/external-host-error';
 import { getElapsedDays } from '../../../../util/date';
 import { emojify } from '../../../../util/emoji';
@@ -201,7 +201,7 @@ export async function processBranch(
       const branchIsModified = await isBranchModified(config.branchName);
       if (branchPr) {
         logger.debug('Found existing branch PR');
-        if (branchPr.state !== PrState.Open) {
+        if (branchPr.state !== 'open') {
           logger.debug(
             'PR has been closed or merged since this run started - aborting'
           );
@@ -249,7 +249,7 @@ export async function processBranch(
       } else if (branchIsModified) {
         const oldPr = await platform.findPr({
           branchName: config.branchName,
-          state: PrState.NotOpen,
+          state: '!open',
         });
         if (!oldPr) {
           logger.debug('Branch has been edited but found no PR - skipping');

--- a/lib/workers/repository/update/branch/index.ts
+++ b/lib/workers/repository/update/branch/index.ts
@@ -40,7 +40,7 @@ import {
   satisfiesConfidenceLevel,
 } from '../../../../util/merge-confidence';
 import * as template from '../../../../util/template';
-import { Limit, isLimitReached } from '../../../global/limits';
+import { isLimitReached } from '../../../global/limits';
 import { BranchConfig, BranchResult, PrBlockedBy } from '../../../types';
 import { embedChangelog, needsChangelogs } from '../../changelog';
 import { ensurePr, getPlatformPrOptions, updatePrDebugData } from '../pr';
@@ -142,7 +142,7 @@ export async function processBranch(
     }
     if (
       !branchExists &&
-      isLimitReached(Limit.Branches) &&
+      isLimitReached('Branches') &&
       !dependencyDashboardCheck &&
       !config.isVulnerabilityAlert
     ) {
@@ -154,7 +154,7 @@ export async function processBranch(
       };
     }
     if (
-      isLimitReached(Limit.Commits) &&
+      isLimitReached('Commits') &&
       !dependencyDashboardCheck &&
       !config.isVulnerabilityAlert
     ) {

--- a/lib/workers/repository/update/branch/reuse.spec.ts
+++ b/lib/workers/repository/update/branch/reuse.spec.ts
@@ -1,6 +1,5 @@
 import { git, platform } from '../../../../../test/util';
 import type { Pr } from '../../../../modules/platform';
-import { PrState } from '../../../../types';
 import type { BranchConfig } from '../../../types';
 import { shouldReuseExistingBranch } from './reuse';
 
@@ -11,7 +10,7 @@ describe('workers/repository/update/branch/reuse', () => {
     const pr: Pr = {
       number: 42,
       sourceBranch: 'master',
-      state: PrState.Open,
+      state: 'open',
       title: 'any',
     };
     let config: BranchConfig;

--- a/lib/workers/repository/update/pr/index.spec.ts
+++ b/lib/workers/repository/update/pr/index.spec.ts
@@ -75,9 +75,7 @@ describe('workers/repository/update/pr/index', () => {
 
         expect(res).toEqual({ type: 'with-pr', pr });
         expect(limits.incLimitedValue).toHaveBeenCalledOnce();
-        expect(limits.incLimitedValue).toHaveBeenCalledWith(
-          limits.Limit.PullRequests
-        );
+        expect(limits.incLimitedValue).toHaveBeenCalledWith('PullRequests');
         expect(logger.logger.info).toHaveBeenCalledWith(
           { pr: pr.number, prTitle },
           'PR created'

--- a/lib/workers/repository/update/pr/index.spec.ts
+++ b/lib/workers/repository/update/pr/index.spec.ts
@@ -9,7 +9,7 @@ import {
 import * as _comment from '../../../../modules/platform/comment';
 import { getPrBodyStruct } from '../../../../modules/platform/pr-body';
 import type { Pr } from '../../../../modules/platform/types';
-import { BranchStatus, PrState } from '../../../../types';
+import { BranchStatus } from '../../../../types';
 import { ExternalHostError } from '../../../../types/errors/external-host-error';
 import * as _limits from '../../../global/limits';
 import type { BranchConfig, BranchUpgradeConfig } from '../../../types';
@@ -50,7 +50,7 @@ describe('workers/repository/update/pr/index', () => {
       sourceBranch,
       title: prTitle,
       bodyStruct,
-      state: PrState.Open,
+      state: 'open',
     };
 
     const config: BranchConfig = {

--- a/lib/workers/repository/update/pr/index.ts
+++ b/lib/workers/repository/update/pr/index.ts
@@ -21,7 +21,7 @@ import { ExternalHostError } from '../../../../types/errors/external-host-error'
 import { stripEmojis } from '../../../../util/emoji';
 import { deleteBranch, getBranchLastCommitTime } from '../../../../util/git';
 import { memoize } from '../../../../util/memoize';
-import { Limit, incLimitedValue, isLimitReached } from '../../../global/limits';
+import { incLimitedValue, isLimitReached } from '../../../global/limits';
 import type {
   BranchConfig,
   BranchUpgradeConfig,
@@ -349,7 +349,7 @@ export async function ensurePr(
       try {
         if (
           !dependencyDashboardCheck &&
-          isLimitReached(Limit.PullRequests) &&
+          isLimitReached('PullRequests') &&
           !config.isVulnerabilityAlert
         ) {
           logger.debug('Skipping PR - limit reached');
@@ -365,7 +365,7 @@ export async function ensurePr(
           draftPR: config.draftPR,
         });
 
-        incLimitedValue(Limit.PullRequests);
+        incLimitedValue('PullRequests');
         logger.info({ pr: pr?.number, prTitle }, 'PR created');
       } catch (err) {
         logger.debug({ err }, 'Pull request creation error');


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- Convert the following enums to union:
1. PrState
2. Limit
3. AzurePrVote
4. QualifierRank
5. QualifierTypes

<!-- Describe what behavior is changed by this PR. -->

## Context
- Ref: #13743 
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->
