### PR TITLE
fix(github): catch fork list failures gracefully

### DIFF
--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -260,17 +260,26 @@ export async function listForks(
   token: string,
   repository: string
 ): Promise<GhRestRepo[]> {
-  // Get list of existing repos
-  const url = `repos/${repository}/forks?per_page=100`;
-  const repos = (
-    await githubApi.getJson<GhRestRepo[]>(url, {
-      token,
-      paginate: true,
-      pageLimit: 100,
-    })
-  ).body;
-  logger.debug(`Found ${repos.length} forked repo(s)`);
-  return repos;
+  try {
+    // Get list of existing repos
+    const url = `repos/${repository}/forks?per_page=100`;
+    const repos = (
+      await githubApi.getJson<GhRestRepo[]>(url, {
+        token,
+        paginate: true,
+        pageLimit: 100,
+      })
+    ).body;
+    logger.debug(`Found ${repos.length} forked repo(s)`);
+    return repos;
+  } catch (err) {
+    if (err.statusCode === 404) {
+      logger.debug('Cannot list repo forks - it is likely private');
+    } else {
+      logger.debug({ err }, 'Unknown error listing repository forks');
+    }
+    throw new Error(REPOSITORY_CANNOT_FORK);
+  }
 }
 
 export async function findFork(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds try/catch to the fork listing function, which can throw.

## Context

Private repos fail at this step when in fork mode

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
