### PR TITLE
docs: update python docs to indicate poetry support

### DIFF
--- a/docs/usage/python.md
+++ b/docs/usage/python.md
@@ -9,6 +9,7 @@ Renovate supports the following Python package managers:
 
 - `pip` (e.g. `requirements.txt`, `requirements.pip`) files
 - `pipenv` (e.g. `Pipfile`)
+- `poetry` (e.g. `pyproject.toml`)
 - `setup.py` file
 - `setup.cfg` file
 
@@ -58,6 +59,10 @@ some-other-package==1.0.0
 ### Sources in `Pipfile`
 
 Renovate detects any custom-configured sources in `Pipfile` and uses them.
+
+### Sources in `pyproject.toml`
+
+Renovate detects any custom-configured sources in `pyproject.toml` and uses them.
 
 ### Specify URL in configuration
 


### PR DESCRIPTION
It appears poetry has been supported since 15.4.0 (https://github.com/renovatebot/renovate/releases/tag/15.4.0). Just updating docs to reflect that.

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

_No functionality changes_. This just updates the documentation.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

Noticed documentation did not properly indicate support for poetry, but it appears that poetry is, in fact, supported.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
