### PR TITLE
fix(npm): use nvmrc from lock file dir

### DIFF
--- a/lib/modules/manager/npm/post-update/lerna.ts
+++ b/lib/modules/manager/npm/post-update/lerna.ts
@@ -43,7 +43,7 @@ export async function generateLockFiles(
   }
   logger.debug(`Spawning lerna with ${lernaClient} to create lock files`);
   const toolConstraints: ToolConstraint[] = [
-    await getNodeToolConstraint(config, []),
+    await getNodeToolConstraint(config, [], lockFileDir),
   ];
   const cmd: string[] = [];
   let cmdOptions = '';

--- a/lib/modules/manager/npm/post-update/node-version.spec.ts
+++ b/lib/modules/manager/npm/post-update/node-version.spec.ts
@@ -17,34 +17,34 @@ describe('modules/manager/npm/post-update/node-version', () => {
     it('returns package.json range', async () => {
       fs.readLocalFile.mockResolvedValueOnce(null as never);
       fs.readLocalFile.mockResolvedValueOnce(null as never);
-      const res = await getNodeConstraint(config);
+      const res = await getNodeConstraint(config, '');
       expect(res).toBe('^12.16.0');
     });
 
     it('returns .node-version value', async () => {
       fs.readLocalFile.mockResolvedValueOnce(null as never);
       fs.readLocalFile.mockResolvedValueOnce('12.16.1\n');
-      const res = await getNodeConstraint(config);
+      const res = await getNodeConstraint(config, '');
       expect(res).toBe('12.16.1');
     });
 
     it('returns .nvmrc value', async () => {
       fs.readLocalFile.mockResolvedValueOnce('12.16.2\n');
-      const res = await getNodeConstraint(config);
+      const res = await getNodeConstraint(config, '');
       expect(res).toBe('12.16.2');
     });
 
     it('ignores unusable ranges in dotfiles', async () => {
       fs.readLocalFile.mockResolvedValueOnce('latest');
       fs.readLocalFile.mockResolvedValueOnce('lts');
-      const res = await getNodeConstraint(config);
+      const res = await getNodeConstraint(config, '');
       expect(res).toBe('^12.16.0');
     });
 
     it('returns no constraint', async () => {
       fs.readLocalFile.mockResolvedValueOnce(null as never);
       fs.readLocalFile.mockResolvedValueOnce(null as never);
-      const res = await getNodeConstraint({ ...config, constraints: null });
+      const res = await getNodeConstraint({ ...config, constraints: null }, '');
       expect(res).toBeNull();
     });
   });
@@ -64,9 +64,11 @@ describe('modules/manager/npm/post-update/node-version', () => {
   describe('getNodeToolConstraint()', () => {
     it('returns getNodeUpdate', async () => {
       expect(
-        await getNodeToolConstraint(config, [
-          { depName: 'node', newValue: '16.15.0' },
-        ])
+        await getNodeToolConstraint(
+          config,
+          [{ depName: 'node', newValue: '16.15.0' }],
+          ''
+        )
       ).toEqual({
         toolName: 'node',
         constraint: '16.15.0',
@@ -74,7 +76,7 @@ describe('modules/manager/npm/post-update/node-version', () => {
     });
 
     it('returns getNodeConstraint', async () => {
-      expect(await getNodeToolConstraint(config, [])).toEqual({
+      expect(await getNodeToolConstraint(config, [], '')).toEqual({
         toolName: 'node',
         constraint: '^12.16.0',
       });

--- a/lib/modules/manager/npm/post-update/npm.ts
+++ b/lib/modules/manager/npm/post-update/npm.ts
@@ -63,7 +63,7 @@ export async function generateLockFile(
       cwdFile: lockFileName,
       extraEnv,
       toolConstraints: [
-        await getNodeToolConstraint(config, upgrades),
+        await getNodeToolConstraint(config, upgrades, lockFileDir),
         npmToolConstraint,
       ],
       docker: {

--- a/lib/modules/manager/npm/post-update/pnpm.ts
+++ b/lib/modules/manager/npm/post-update/pnpm.ts
@@ -46,7 +46,7 @@ export async function generateLockFile(
         image: 'sidecar',
       },
       toolConstraints: [
-        await getNodeToolConstraint(config, upgrades),
+        await getNodeToolConstraint(config, upgrades, lockFileDir),
         pnpmToolConstraint,
       ],
     };

--- a/lib/modules/manager/npm/post-update/yarn.ts
+++ b/lib/modules/manager/npm/post-update/yarn.ts
@@ -99,7 +99,7 @@ export async function generateLockFile(
   let lockFile: string | null = null;
   try {
     const toolConstraints: ToolConstraint[] = [
-      await getNodeToolConstraint(config, upgrades),
+      await getNodeToolConstraint(config, upgrades, lockFileDir),
     ];
     const yarnUpdate = upgrades.find(isYarnUpdate);
     const yarnCompatibility = yarnUpdate


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Use the lock file dir to find `.nvmrc` instead of the package file dir

## Context

Closes #18885

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
