### PR TITLE
feat(manager/asdf): Support gohugo plugin including `extended_` version

### DIFF
--- a/lib/modules/manager/asdf/extract.spec.ts
+++ b/lib/modules/manager/asdf/extract.spec.ts
@@ -58,6 +58,7 @@ elixir 1.14.1
 elm 0.19.1
 erlang 25.1.2
 gauche 0.9.12
+gohugo extended_0.104.3
 golang 1.19.2
 haskell 9.4.2
 helm 3.10.1
@@ -179,6 +180,14 @@ dummy 1.2.3
             packageName: 'practicalscheme/gauche',
             versioning: 'semver',
             depName: 'gauche',
+          },
+          {
+            currentValue: '0.104.3',
+            datasource: 'github-releases',
+            packageName: 'gohugoio/hugo',
+            versioning: 'semver',
+            depName: 'gohugo',
+            extractVersion: '^v(?<version>\\S+)',
           },
           {
             currentValue: '1.19.2',

--- a/lib/modules/manager/asdf/upgradeable-tooling.ts
+++ b/lib/modules/manager/asdf/upgradeable-tooling.ts
@@ -16,10 +16,27 @@ export type StaticTooling = Partial<PackageDependency> &
 
 export type DynamicTooling = (version: string) => StaticTooling | undefined;
 
-export const upgradeableTooling: Record<
-  string,
-  { config: StaticTooling | DynamicTooling; asdfPluginUrl: string }
-> = {
+export type ToolingConfig = StaticTooling | DynamicTooling;
+export interface ToolingDefinition {
+  config: ToolingConfig;
+  asdfPluginUrl: string;
+}
+
+const hugoDefinition: ToolingDefinition = {
+  // This plugin supports the names `hugo` & `gohugo`
+  asdfPluginUrl: 'https://github.com/NeoHsu/asdf-hugo',
+  config: (version) => ({
+    datasource: GithubReleasesDatasource.id,
+    packageName: 'gohugoio/hugo',
+    versioning: semverVersioning.id,
+    extractVersion: '^v(?<version>\\S+)',
+    // The asdf hugo plugin supports prefixing the version with
+    // `extended_`. Extended versions feature Sass support.
+    currentValue: version.replace(/^extended_/, ''),
+  }),
+};
+
+export const upgradeableTooling: Record<string, ToolingDefinition> = {
   awscli: {
     asdfPluginUrl: 'https://github.com/MetricMike/asdf-awscli',
     config: {
@@ -121,6 +138,7 @@ export const upgradeableTooling: Record<
       versioning: semverVersioning.id,
     },
   },
+  gohugo: hugoDefinition,
   golang: {
     asdfPluginUrl: 'https://github.com/kennyp/asdf-golang',
     config: {
@@ -157,15 +175,7 @@ export const upgradeableTooling: Record<
       extractVersion: '^v(?<version>\\S+)',
     },
   },
-  hugo: {
-    asdfPluginUrl: 'https://github.com/NeoHsu/asdf-hugo',
-    config: {
-      datasource: GithubReleasesDatasource.id,
-      packageName: 'gohugoio/hugo',
-      versioning: semverVersioning.id,
-      extractVersion: '^v(?<version>\\S+)',
-    },
-  },
+  hugo: hugoDefinition,
   idris: {
     asdfPluginUrl: 'https://github.com/asdf-community/asdf-idris',
     config: {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

The asdf plugin for hugo[^1] supports the name hugo & gohugo. 
Additionally the version can be prefixed with `extended_` to install a version with Sass support.
This change mirrors that functionality in the asdf manager.

[^1]: https://github.com/nklmilojevic/asdf-hugo

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

https://github.com/kachick/renovate-config-asdf/issues/294

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
