### PR TITLE
fix(manager/gradle): ignore "publishing" repositories

### DIFF
--- a/lib/modules/manager/gradle/parser.spec.ts
+++ b/lib/modules/manager/gradle/parser.spec.ts
@@ -219,6 +219,7 @@ describe('modules/manager/gradle/parser', () => {
         ${'base="https://foo.bar"'} | ${'maven { setUrl(base) }'}                                      | ${'https://foo.bar'}
         ${''}                       | ${'maven { setUrl(["https://foo.bar/baz"]) }'}                   | ${null}
         ${''}                       | ${'maven { setUrl("foo", "bar") }'}                              | ${null}
+        ${'base="https://foo.bar"'} | ${'publishing { repositories { maven("${base}/baz") } }'}        | ${null}
       `('$def | $input', ({ def, input, url }) => {
         const expected = [url].filter(Boolean);
         const { urls } = parseGradle([def, input].join('\n'));

--- a/lib/modules/manager/gradle/parser.ts
+++ b/lib/modules/manager/gradle/parser.ts
@@ -284,6 +284,12 @@ const qCustomRegistryUrl = q
   .handler(handleCustomRegistryUrl)
   .handler(cleanupTempVars);
 
+const qRegistryUrls = q.alt<Ctx>(
+  q.sym<Ctx>('publishing').tree(),
+  qPredefinedRegistries,
+  qCustomRegistryUrl
+);
+
 const qVersionCatalogVersion = q
   .op<Ctx>('.')
   .alt(
@@ -427,8 +433,7 @@ export function parseGradle(
       qGroovyMapNotationDependencies,
       qKotlinMapNotationDependencies,
       qPlugins,
-      qPredefinedRegistries,
-      qCustomRegistryUrl,
+      qRegistryUrls,
       qVersionCatalogDependencies,
       qLongFormDep,
       qApplyFrom


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Ignores repositories defined for publishing build artifacts using the `maven-publish` plugin (ex. [here](https://docs.gradle.org/current/userguide/publishing_maven.html#publishing_maven:repositories)).

<!-- Describe what behavior is changed by this PR. -->

## Context

* Closes #17067

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

When running this PR on https://github.com/JohNan/renovatebot-bugreport, requests are only made to expected URLs. Before this change, https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/ was also called.
<details><summary>Logs</summary>

```
DEBUG: http statistics (repository=JohNan/renovatebot-bugreport)
       "urls": {
         "https://api.github.com/graphql (POST,200)": 2,
         "https://api.github.com/repos/JohNan/renovatebot-bugreport/pulls (GET,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/0.0.1-test-1/org.jetbrains.kotlin.jvm.gradle.plugin-0.0.1-test-1.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/0.0.1-test-2/org.jetbrains.kotlin.jvm.gradle.plugin-0.0.1-test-2.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/0.1.1.2-5-test-2/org.jetbrains.kotlin.jvm.gradle.plugin-0.1.1.2-5-test-2.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/0.1.1.2-5-test-4/org.jetbrains.kotlin.jvm.gradle.plugin-0.1.1.2-5-test-4.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/0.1.1.2-5-test-5/org.jetbrains.kotlin.jvm.gradle.plugin-0.1.1.2-5-test-5.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.1.1/org.jetbrains.kotlin.jvm.gradle.plugin-1.1.1.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.1.2-2/org.jetbrains.kotlin.jvm.gradle.plugin-1.1.2-2.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.1.2-5/org.jetbrains.kotlin.jvm.gradle.plugin-1.1.2-5.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.1.2/org.jetbrains.kotlin.jvm.gradle.plugin-1.1.2.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.1.3-2/org.jetbrains.kotlin.jvm.gradle.plugin-1.1.3-2.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.1.3/org.jetbrains.kotlin.jvm.gradle.plugin-1.1.3.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.1.4-2/org.jetbrains.kotlin.jvm.gradle.plugin-1.1.4-2.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.1.4-3/org.jetbrains.kotlin.jvm.gradle.plugin-1.1.4-3.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.1.4/org.jetbrains.kotlin.jvm.gradle.plugin-1.1.4.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.1.50/org.jetbrains.kotlin.jvm.gradle.plugin-1.1.50.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.1.51/org.jetbrains.kotlin.jvm.gradle.plugin-1.1.51.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.1.60/org.jetbrains.kotlin.jvm.gradle.plugin-1.1.60.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.1.61/org.jetbrains.kotlin.jvm.gradle.plugin-1.1.61.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.2.0/org.jetbrains.kotlin.jvm.gradle.plugin-1.2.0.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.2.10/org.jetbrains.kotlin.jvm.gradle.plugin-1.2.10.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.2.20/org.jetbrains.kotlin.jvm.gradle.plugin-1.2.20.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.2.21/org.jetbrains.kotlin.jvm.gradle.plugin-1.2.21.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.2.30/org.jetbrains.kotlin.jvm.gradle.plugin-1.2.30.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.2.31/org.jetbrains.kotlin.jvm.gradle.plugin-1.2.31.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.2.40/org.jetbrains.kotlin.jvm.gradle.plugin-1.2.40.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.2.41/org.jetbrains.kotlin.jvm.gradle.plugin-1.2.41.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.2.50/org.jetbrains.kotlin.jvm.gradle.plugin-1.2.50.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.2.51/org.jetbrains.kotlin.jvm.gradle.plugin-1.2.51.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.2.60/org.jetbrains.kotlin.jvm.gradle.plugin-1.2.60.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.2.61/org.jetbrains.kotlin.jvm.gradle.plugin-1.2.61.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.2.70/org.jetbrains.kotlin.jvm.gradle.plugin-1.2.70.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.2.71/org.jetbrains.kotlin.jvm.gradle.plugin-1.2.71.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.3.0-rc-190/org.jetbrains.kotlin.jvm.gradle.plugin-1.3.0-rc-190.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.3.0-rc-198/org.jetbrains.kotlin.jvm.gradle.plugin-1.3.0-rc-198.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.3.0/org.jetbrains.kotlin.jvm.gradle.plugin-1.3.0.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.3.10/org.jetbrains.kotlin.jvm.gradle.plugin-1.3.10.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.3.11/org.jetbrains.kotlin.jvm.gradle.plugin-1.3.11.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.3.20/org.jetbrains.kotlin.jvm.gradle.plugin-1.3.20.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.3.21/org.jetbrains.kotlin.jvm.gradle.plugin-1.3.21.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.3.30/org.jetbrains.kotlin.jvm.gradle.plugin-1.3.30.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.3.31/org.jetbrains.kotlin.jvm.gradle.plugin-1.3.31.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.3.40/org.jetbrains.kotlin.jvm.gradle.plugin-1.3.40.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.3.41/org.jetbrains.kotlin.jvm.gradle.plugin-1.3.41.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.3.50/org.jetbrains.kotlin.jvm.gradle.plugin-1.3.50.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.3.60/org.jetbrains.kotlin.jvm.gradle.plugin-1.3.60.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.3.61/org.jetbrains.kotlin.jvm.gradle.plugin-1.3.61.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.3.70/org.jetbrains.kotlin.jvm.gradle.plugin-1.3.70.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.3.71/org.jetbrains.kotlin.jvm.gradle.plugin-1.3.71.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.3.72/org.jetbrains.kotlin.jvm.gradle.plugin-1.3.72.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.4.0-rc/org.jetbrains.kotlin.jvm.gradle.plugin-1.4.0-rc.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.4.0/org.jetbrains.kotlin.jvm.gradle.plugin-1.4.0.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.4.10/org.jetbrains.kotlin.jvm.gradle.plugin-1.4.10.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.4.20-M1/org.jetbrains.kotlin.jvm.gradle.plugin-1.4.20-M1.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.4.20-M2/org.jetbrains.kotlin.jvm.gradle.plugin-1.4.20-M2.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.4.20-RC/org.jetbrains.kotlin.jvm.gradle.plugin-1.4.20-RC.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.4.20/org.jetbrains.kotlin.jvm.gradle.plugin-1.4.20.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.4.21-2/org.jetbrains.kotlin.jvm.gradle.plugin-1.4.21-2.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.4.21/org.jetbrains.kotlin.jvm.gradle.plugin-1.4.21.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.4.30-M1/org.jetbrains.kotlin.jvm.gradle.plugin-1.4.30-M1.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.4.30-RC/org.jetbrains.kotlin.jvm.gradle.plugin-1.4.30-RC.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.4.30/org.jetbrains.kotlin.jvm.gradle.plugin-1.4.30.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.4.31/org.jetbrains.kotlin.jvm.gradle.plugin-1.4.31.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.4.32/org.jetbrains.kotlin.jvm.gradle.plugin-1.4.32.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.5.0-M1/org.jetbrains.kotlin.jvm.gradle.plugin-1.5.0-M1.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.5.0-M2/org.jetbrains.kotlin.jvm.gradle.plugin-1.5.0-M2.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.5.0-RC/org.jetbrains.kotlin.jvm.gradle.plugin-1.5.0-RC.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.5.0/org.jetbrains.kotlin.jvm.gradle.plugin-1.5.0.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.5.10/org.jetbrains.kotlin.jvm.gradle.plugin-1.5.10.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.5.20-M1/org.jetbrains.kotlin.jvm.gradle.plugin-1.5.20-M1.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.5.20-RC/org.jetbrains.kotlin.jvm.gradle.plugin-1.5.20-RC.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.5.20/org.jetbrains.kotlin.jvm.gradle.plugin-1.5.20.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.5.21/org.jetbrains.kotlin.jvm.gradle.plugin-1.5.21.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.5.30-M1/org.jetbrains.kotlin.jvm.gradle.plugin-1.5.30-M1.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.5.30-RC/org.jetbrains.kotlin.jvm.gradle.plugin-1.5.30-RC.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.5.30/org.jetbrains.kotlin.jvm.gradle.plugin-1.5.30.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.5.31/org.jetbrains.kotlin.jvm.gradle.plugin-1.5.31.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.5.32/org.jetbrains.kotlin.jvm.gradle.plugin-1.5.32.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.6.0-M1/org.jetbrains.kotlin.jvm.gradle.plugin-1.6.0-M1.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.6.0-RC/org.jetbrains.kotlin.jvm.gradle.plugin-1.6.0-RC.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.6.0-RC2/org.jetbrains.kotlin.jvm.gradle.plugin-1.6.0-RC2.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.6.0/org.jetbrains.kotlin.jvm.gradle.plugin-1.6.0.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.6.10-RC/org.jetbrains.kotlin.jvm.gradle.plugin-1.6.10-RC.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.6.10/org.jetbrains.kotlin.jvm.gradle.plugin-1.6.10.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.6.20-M1/org.jetbrains.kotlin.jvm.gradle.plugin-1.6.20-M1.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.6.20-RC/org.jetbrains.kotlin.jvm.gradle.plugin-1.6.20-RC.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.6.20-RC2/org.jetbrains.kotlin.jvm.gradle.plugin-1.6.20-RC2.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.6.20/org.jetbrains.kotlin.jvm.gradle.plugin-1.6.20.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.6.21/org.jetbrains.kotlin.jvm.gradle.plugin-1.6.21.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.7.0-Beta/org.jetbrains.kotlin.jvm.gradle.plugin-1.7.0-Beta.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.7.0-RC/org.jetbrains.kotlin.jvm.gradle.plugin-1.7.0-RC.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.7.0-RC2/org.jetbrains.kotlin.jvm.gradle.plugin-1.7.0-RC2.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.7.0/org.jetbrains.kotlin.jvm.gradle.plugin-1.7.0.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.7.10/org.jetbrains.kotlin.jvm.gradle.plugin-1.7.10.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.7.20-Beta/org.jetbrains.kotlin.jvm.gradle.plugin-1.7.20-Beta.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.7.20-RC/org.jetbrains.kotlin.jvm.gradle.plugin-1.7.20-RC.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.7.20/org.jetbrains.kotlin.jvm.gradle.plugin-1.7.20.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.7.21/org.jetbrains.kotlin.jvm.gradle.plugin-1.7.21.pom (GET,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.7.21/org.jetbrains.kotlin.jvm.gradle.plugin-1.7.21.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.8.0-Beta/org.jetbrains.kotlin.jvm.gradle.plugin-1.8.0-Beta.pom (HEAD,200)": 1,
         "https://plugins.gradle.org/m2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/maven-metadata.xml (GET,200)": 1,
         "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.7.0-Beta/org.jetbrains.kotlin.jvm.gradle.plugin-1.7.0-Beta.pom (HEAD,200)": 1,
         "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.7.0-RC/org.jetbrains.kotlin.jvm.gradle.plugin-1.7.0-RC.pom (HEAD,200)": 1,
         "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.7.0-RC2/org.jetbrains.kotlin.jvm.gradle.plugin-1.7.0-RC2.pom (HEAD,200)": 1,
         "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.7.0/org.jetbrains.kotlin.jvm.gradle.plugin-1.7.0.pom (HEAD,200)": 1,
         "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.7.10/org.jetbrains.kotlin.jvm.gradle.plugin-1.7.10.pom (HEAD,200)": 1,
         "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.7.20-Beta/org.jetbrains.kotlin.jvm.gradle.plugin-1.7.20-Beta.pom (HEAD,200)": 1,
         "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.7.20-RC/org.jetbrains.kotlin.jvm.gradle.plugin-1.7.20-RC.pom (HEAD,200)": 1,
         "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.7.20/org.jetbrains.kotlin.jvm.gradle.plugin-1.7.20.pom (HEAD,200)": 1,
         "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.7.21/org.jetbrains.kotlin.jvm.gradle.plugin-1.7.21.pom (GET,200)": 1,
         "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.7.21/org.jetbrains.kotlin.jvm.gradle.plugin-1.7.21.pom (HEAD,200)": 1,
         "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/1.8.0-Beta/org.jetbrains.kotlin.jvm.gradle.plugin-1.8.0-Beta.pom (HEAD,200)": 1,
         "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/index.html (GET,404)": 1,
         "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/maven-metadata.xml (GET,200)": 1,
         "https://services.gradle.org/versions/all (GET,200)": 1
       },
       "hostStats": {
         "api.github.com": {"requestCount": 3, "requestAvgMs": 487, "queueAvgMs": 0},
         "plugins.gradle.org": {
           "requestCount": 100,
           "requestAvgMs": 93,
           "queueAvgMs": 0
         },
         "repo.maven.apache.org": {
           "requestCount": 13,
           "requestAvgMs": 94,
           "queueAvgMs": 0
         },
         "services.gradle.org": {
           "requestCount": 1,
           "requestAvgMs": 108,
           "queueAvgMs": 0
         }
       },
       "totalRequests": 117

```

</details>


<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
