### PR TITLE
feat(npm): use npm <9 when lockfileVersion=2

### DIFF
--- a/lib/modules/manager/npm/extract/locked-versions.spec.ts
+++ b/lib/modules/manager/npm/extract/locked-versions.spec.ts
@@ -298,7 +298,42 @@ describe('modules/manager/npm/extract/locked-versions', () => {
       await getLockedVersions(packageFiles);
       expect(packageFiles).toEqual([
         {
-          constraints: {},
+          constraints: {
+            npm: '<9',
+          },
+          deps: [
+            { currentValue: '1.0.0', depName: 'a', lockedVersion: '1.0.0' },
+            { currentValue: '2.0.0', depName: 'b', lockedVersion: '2.0.0' },
+          ],
+          lockFiles: ['package-lock.json'],
+          npmLock: 'package-lock.json',
+        },
+      ]);
+    });
+
+    it('augments v2 lock file constraint', async () => {
+      npm.getNpmLock.mockReturnValue({
+        lockedVersions: { a: '1.0.0', b: '2.0.0', c: '3.0.0' },
+        lockfileVersion: 2,
+      });
+      const packageFiles = [
+        {
+          npmLock: 'package-lock.json',
+          constraints: {
+            npm: '>=7.0.0',
+          },
+          deps: [
+            { depName: 'a', currentValue: '1.0.0' },
+            { depName: 'b', currentValue: '2.0.0' },
+          ],
+        },
+      ];
+      await getLockedVersions(packageFiles);
+      expect(packageFiles).toEqual([
+        {
+          constraints: {
+            npm: '>=7.0.0 <9',
+          },
           deps: [
             { currentValue: '1.0.0', depName: 'a', lockedVersion: '1.0.0' },
             { currentValue: '2.0.0', depName: 'b', lockedVersion: '2.0.0' },

--- a/lib/modules/manager/npm/extract/locked-versions.ts
+++ b/lib/modules/manager/npm/extract/locked-versions.ts
@@ -66,6 +66,16 @@ export async function getLockedVersions(
         } else {
           packageFile.constraints!.npm = '<7';
         }
+      } else if (lockfileVersion === 2) {
+        debugger;
+        if (packageFile.constraints?.npm) {
+          // Add a <9 constraint if it's not already a fixed version
+          if (!semver.valid(packageFile.constraints.npm)) {
+            packageFile.constraints.npm += ' <9';
+          }
+        } else {
+          packageFile.constraints!.npm = '<9';
+        }
       }
       for (const dep of packageFile.deps) {
         // TODO: types (#7154)

--- a/lib/modules/manager/npm/extract/locked-versions.ts
+++ b/lib/modules/manager/npm/extract/locked-versions.ts
@@ -67,7 +67,6 @@ export async function getLockedVersions(
           packageFile.constraints!.npm = '<7';
         }
       } else if (lockfileVersion === 2) {
-        debugger;
         if (packageFile.constraints?.npm) {
           // Add a <9 constraint if it's not already a fixed version
           if (!semver.valid(packageFile.constraints.npm)) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Automatically set npm constraint <9 if lockfileVersion=2

## Context

- Closes #19045

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
