### PR TITLE
docs(noise reduction): replace admonition with new heading

### DIFF
--- a/docs/usage/noise-reduction.md
+++ b/docs/usage/noise-reduction.md
@@ -40,11 +40,17 @@ In that case you might create a config like this:
 
 By setting `matchPackagePatterns` to "eslint", it means that any package with ESLint anywhere in its name will be grouped into a `renovate/eslint` branch and related PR.
 
-**Caution**: Any time you group dependencies together, you naturally increase the chance that the branch will have an error ("break" your build).
-When you have more than one package upgrade in a PR, it's going to take you longer to work out which one broke than if they were all in separate PRs.
-Also, you will be held up upgrading all those dependencies until they all pass.
-If you weren't grouping, then you could keep upgrading all dependencies except the one that fails, instead of being held up.
-You will also have less flexibility about what to do when one or more in the group have a major upgrade and may break the others.
+### Be smart about grouping dependencies
+
+Grouping dependencies _may_ help you, but can also cause problems.
+Sometimes you're better off getting a single PR per dependency!
+
+Grouping dependencies versus single PRs:
+
+- Grouping dependencies increases the chance that the branch has an error ("break" your build)
+- When you upgrade multiple dependencies in one PR, it takes longer to find out which package broke the build
+- If a group PR "breaks", you'll have to wait upgrading your other dependencies until _all_ updates in the PR pass
+- You will have less flexibility when one (or more) dependencies in the group have a major upgrade, but the other dependencies are good to go
 
 ## Scheduling Renovate
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Replace `caution` pseudo-admonition with a new heading
- Use lists to compare grouped PR with single update PR
- Rewite to use simple words and phrases

## Context

I first thought about converting the pseudo-admonition `**Caution:**` into a proper Material for MkDocs style admonition. But when I did this, I though: "This should just be it's own section in the docs". 😄 

Let me know what you like best. 😉 

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
