### PR TITLE
test: cover more cases by unit tests

### DIFF
--- a/lib/workers/repository/model/semantic-commit-message.spec.ts
+++ b/lib/workers/repository/model/semantic-commit-message.spec.ts
@@ -25,6 +25,15 @@ describe('workers/repository/model/semantic-commit-message', () => {
     expect(message.toString()).toBe('fix(scope): test');
   });
 
+  it('should transform to lowercase only first letter', () => {
+    const message = new SemanticCommitMessage();
+    message.subject = 'Update My Org dependencies';
+    message.type = 'fix';
+    message.scope = 'deps ';
+
+    expect(message.toString()).toBe('fix(deps): update My Org dependencies');
+  });
+
   it('should create instance from string without scope', () => {
     const instance = SemanticCommitMessage.fromString('feat: ticket 123');
 

--- a/lib/workers/repository/updates/generate.spec.ts
+++ b/lib/workers/repository/updates/generate.spec.ts
@@ -1163,5 +1163,22 @@ describe('workers/repository/updates/generate', () => {
         'PATCH: Update dependency some-dep to 1.2.0'
       );
     });
+
+    it('using commitMessagePrefix without separator', () => {
+      const branch: BranchUpgradeConfig[] = [
+        {
+          ...defaultConfig,
+          branchName: 'some-branch',
+          commitMessagePrefix: '🆙',
+          depName: 'some-dep',
+          manager: 'some-manager',
+          newValue: '1.2.0',
+          commitMessageAction: 'Update',
+        } as BranchUpgradeConfig,
+      ];
+      const res = generateBranchConfig(branch);
+      expect(res.prTitle).toBe('🆙 Update dependency some-dep to 1.2.0');
+      expect(res.commitMessage).toBe('🆙 Update dependency some-dep to 1.2.0');
+    });
   });
 });


### PR DESCRIPTION
## Changes

Added more unit tests

## Context

https://github.com/renovatebot/renovate/pull/19013

## Documentation

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository