### PR TITLE
fix(cache): skip save repo cache on dry-run

### DIFF
--- a/lib/util/cache/repository/index.spec.ts
+++ b/lib/util/cache/repository/index.spec.ts
@@ -36,6 +36,18 @@ describe('util/cache/repository/index', () => {
     expect(isCacheModified()).toBeUndefined();
   });
 
+  it('skips saves cache on dry run', async () => {
+    GlobalConfig.set({
+      cacheDir: '/tmp/cache',
+      platform: 'github',
+      dryRun: true,
+    });
+    await initRepoCache({ ...config, repositoryCache: 'enabled' });
+    await saveCache();
+    expect(fs.outputCacheFile).not.toHaveBeenCalled();
+    expect(isCacheModified()).toBeUndefined();
+  });
+
   it('resets cache', async () => {
     await initRepoCache({ ...config, repositoryCache: 'reset' });
     expect(fs.readCacheFile).not.toHaveBeenCalled();

--- a/lib/util/cache/repository/index.ts
+++ b/lib/util/cache/repository/index.ts
@@ -1,3 +1,5 @@
+import { GlobalConfig } from '../../../config/global';
+import { logger } from '../../../logger';
 import { RepoCacheNull } from './impl/null';
 import type { RepoCache, RepoCacheData } from './types';
 
@@ -18,7 +20,11 @@ export function getCache(): RepoCacheData {
 }
 
 export async function saveCache(): Promise<void> {
-  await repoCache.save();
+  if (GlobalConfig.get('dryRun')) {
+    logger.info(`DRY-RUN: Would save repository cache.`);
+  } else {
+    await repoCache.save();
+  }
 }
 
 export function isCacheModified(): boolean | undefined {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
 Skip saving repo cache on dry run because the written state would be wrong, because we never changed branches / PR's
<!-- Describe what behavior is changed by this PR. -->

## Context

Added some more reviewers to have a consense about this propably breaking behavior change
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
