### PR TITLE
fix(nuget): disable msbuild node reuse

### DIFF
--- a/lib/modules/manager/nuget/artifacts.spec.ts
+++ b/lib/modules/manager/nuget/artifacts.spec.ts
@@ -91,6 +91,7 @@ describe('modules/manager/nuget/artifacts', () => {
           env: {
             NUGET_PACKAGES:
               '/tmp/renovate/cache/__renovate-private-cache/nuget/packages',
+            MSBUILDDISABLENODEREUSE: '1',
           },
         },
       },
@@ -131,6 +132,7 @@ describe('modules/manager/nuget/artifacts', () => {
           env: {
             NUGET_PACKAGES:
               '/tmp/renovate/cache/__renovate-private-cache/nuget/packages',
+            MSBUILDDISABLENODEREUSE: '1',
           },
         },
       },
@@ -216,6 +218,7 @@ describe('modules/manager/nuget/artifacts', () => {
           env: {
             NUGET_PACKAGES:
               '/tmp/renovate/cache/__renovate-private-cache/nuget/packages',
+            MSBUILDDISABLENODEREUSE: '1',
           },
         },
       },
@@ -262,6 +265,7 @@ describe('modules/manager/nuget/artifacts', () => {
           '-v "/tmp/github/some/repo":"/tmp/github/some/repo" ' +
           '-v "/tmp/renovate/cache":"/tmp/renovate/cache" ' +
           '-e NUGET_PACKAGES ' +
+          '-e MSBUILDDISABLENODEREUSE ' +
           '-e BUILDPACK_CACHE_DIR ' +
           '-e CONTAINERBASE_CACHE_DIR ' +
           '-w "/tmp/github/some/repo" ' +
@@ -277,6 +281,7 @@ describe('modules/manager/nuget/artifacts', () => {
             CONTAINERBASE_CACHE_DIR: '/tmp/renovate/cache/containerbase',
             NUGET_PACKAGES:
               '/tmp/renovate/cache/__renovate-private-cache/nuget/packages',
+            MSBUILDDISABLENODEREUSE: '1',
           },
         },
       },
@@ -320,6 +325,7 @@ describe('modules/manager/nuget/artifacts', () => {
             CONTAINERBASE_CACHE_DIR: '/tmp/renovate/cache/containerbase',
             NUGET_PACKAGES:
               '/tmp/renovate/cache/__renovate-private-cache/nuget/packages',
+            MSBUILDDISABLENODEREUSE: '1',
           },
         },
       },
@@ -332,6 +338,7 @@ describe('modules/manager/nuget/artifacts', () => {
             CONTAINERBASE_CACHE_DIR: '/tmp/renovate/cache/containerbase',
             NUGET_PACKAGES:
               '/tmp/renovate/cache/__renovate-private-cache/nuget/packages',
+            MSBUILDDISABLENODEREUSE: '1',
           },
         },
       },
@@ -373,6 +380,7 @@ describe('modules/manager/nuget/artifacts', () => {
           env: {
             NUGET_PACKAGES:
               '/tmp/renovate/cache/__renovate-private-cache/nuget/packages',
+            MSBUILDDISABLENODEREUSE: '1',
           },
         },
       },

--- a/lib/modules/manager/nuget/artifacts.ts
+++ b/lib/modules/manager/nuget/artifacts.ts
@@ -71,7 +71,10 @@ async function runDotnetRestore(
     docker: {
       image: 'sidecar',
     },
-    extraEnv: { NUGET_PACKAGES: join(nugetCacheDir, 'packages') },
+    extraEnv: {
+      NUGET_PACKAGES: join(nugetCacheDir, 'packages'),
+      MSBUILDDISABLENODEREUSE: '1',
+    },
     toolConstraints: [
       { toolName: 'dotnet', constraint: config.constraints?.dotnet },
     ],


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
set `MSBUILDDISABLENODEREUSE=1` to disable long living dotnet process on global or install mode 
<!-- Describe what behavior is changed by this PR. -->

## Context
- https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2022
- https://alistairbmackay.wordpress.com/2014/01/26/msbuild-hidden-environment-variables/
- https://github.com/dotnet/msbuild/blob/main/documentation/wiki/MSBuild-Tips-&-Tricks.md#environment-variables


![image](https://user-images.githubusercontent.com/1798109/203948005-fe3a49ed-5e55-468e-b8bb-2e0c4bc30817.png)

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
