### PR TITLE
feat(nuget): skip restore non-leaf projects

### DIFF
--- a/lib/modules/manager/nuget/artifacts.ts
+++ b/lib/modules/manager/nuget/artifacts.ts
@@ -132,22 +132,19 @@ export async function updateArtifacts({
     return null;
   }
 
-  const packageFiles = await getDependentPackageFiles(
+  const deps = await getDependentPackageFiles(
     packageFileName,
     isCentralManament
   );
-
-  if (!isCentralManament) {
-    packageFiles.push(packageFileName);
-  }
+  const packageFiles = deps.filter((d) => d.isLeaf).map((d) => d.name);
 
   logger.trace(
     { packageFiles },
     `Found ${packageFiles.length} dependent package files`
   );
 
-  const lockFileNames = packageFiles.map((f) =>
-    getSiblingFileName(f, 'packages.lock.json')
+  const lockFileNames = deps.map((f) =>
+    getSiblingFileName(f.name, 'packages.lock.json')
   );
 
   const existingLockFileContentMap = await getFileContentMap(lockFileNames);

--- a/lib/modules/manager/nuget/artifacts.ts
+++ b/lib/modules/manager/nuget/artifacts.ts
@@ -132,9 +132,10 @@ export async function updateArtifacts({
     return null;
   }
 
-  const packageFiles = [
-    ...(await getDependentPackageFiles(packageFileName, isCentralManament)),
-  ];
+  const packageFiles = await getDependentPackageFiles(
+    packageFileName,
+    isCentralManament
+  );
 
   if (!isCentralManament) {
     packageFiles.push(packageFileName);

--- a/lib/modules/manager/nuget/package-tree.spec.ts
+++ b/lib/modules/manager/nuget/package-tree.spec.ts
@@ -63,7 +63,7 @@ describe('modules/manager/nuget/package-tree', () => {
       ]);
     });
 
-    it('returns projects for two projects with one reference and central versions', async () => {
+    it('returns leaf project for two projects with one reference and central versions', async () => {
       git.getFileList.mockResolvedValue(['one/one.csproj', 'two/two.csproj']);
       Fixtures.mock({
         '/tmp/repo/one/one.csproj': Fixtures.get(
@@ -79,10 +79,10 @@ describe('modules/manager/nuget/package-tree', () => {
 
       expect(
         await getDependentPackageFiles('Directory.Packages.props', true)
-      ).toEqual(['one/one.csproj', 'two/two.csproj']);
+      ).toEqual(['two/two.csproj']);
     });
 
-    it('returns two projects for three projects with two linear references', async () => {
+    it('returns leaf projects for three projects with two linear references', async () => {
       git.getFileList.mockResolvedValue([
         'one/one.csproj',
         'two/two.csproj',
@@ -101,7 +101,6 @@ describe('modules/manager/nuget/package-tree', () => {
       });
 
       expect(await getDependentPackageFiles('one/one.csproj')).toEqual([
-        'two/two.csproj',
         'three/three.csproj',
       ]);
 
@@ -109,7 +108,9 @@ describe('modules/manager/nuget/package-tree', () => {
         'three/three.csproj',
       ]);
 
-      expect(await getDependentPackageFiles('three/three.csproj')).toEqual([]);
+      expect(
+        await getDependentPackageFiles('three/three.csproj')
+      ).toBeEmptyArray();
     });
 
     it('returns two projects for three projects with two tree-like references', async () => {
@@ -135,8 +136,10 @@ describe('modules/manager/nuget/package-tree', () => {
         'three/three.csproj',
       ]);
 
-      expect(await getDependentPackageFiles('two/two.csproj')).toEqual([]);
-      expect(await getDependentPackageFiles('three/three.csproj')).toEqual([]);
+      expect(await getDependentPackageFiles('two/two.csproj')).toBeEmptyArray();
+      expect(
+        await getDependentPackageFiles('three/three.csproj')
+      ).toBeEmptyArray();
     });
 
     it('throws error on circular reference', async () => {
@@ -158,7 +161,7 @@ describe('modules/manager/nuget/package-tree', () => {
     it('skips on invalid xml file', async () => {
       git.getFileList.mockResolvedValue(['foo/bar.csproj']);
       Fixtures.mock({ '/tmp/repo/foo/bar.csproj': '<invalid' });
-      expect(await getDependentPackageFiles('foo/bar.csproj')).toEqual([]);
+      expect(await getDependentPackageFiles('foo/bar.csproj')).toBeEmptyArray();
     });
   });
 });

--- a/lib/modules/manager/nuget/package-tree.ts
+++ b/lib/modules/manager/nuget/package-tree.ts
@@ -10,7 +10,7 @@ export const NUGET_CENTRAL_FILE = 'Directory.Packages.props';
 export const MSBUILD_CENTRAL_FILE = 'Packages.props';
 
 /**
- * Get all package files at any level of ancestry that depend on packageFileName
+ * Get all leaf package files of ancestry that depend on packageFileName.
  */
 export async function getDependentPackageFiles(
   packageFileName: string,
@@ -68,7 +68,8 @@ export async function getDependentPackageFiles(
 
   const dependents = recursivelyGetDependentPackageFiles(
     packageFileName,
-    graph
+    graph,
+    packageFileName
   );
 
   // deduplicate
@@ -80,17 +81,20 @@ export async function getDependentPackageFiles(
  */
 function recursivelyGetDependentPackageFiles(
   packageFileName: string,
-  graph: ReturnType<typeof Graph>
+  graph: ReturnType<typeof Graph>,
+  rootPackageFilename: string
 ): string[] {
   const dependents = graph.adjacent(packageFileName);
 
   if (dependents.length === 0) {
-    return [];
+    return packageFileName === rootPackageFilename ? [] : [packageFileName];
   }
 
-  return dependents.concat(
-    dependents.map((d) => recursivelyGetDependentPackageFiles(d, graph)).flat()
-  );
+  return dependents
+    .map((d) =>
+      recursivelyGetDependentPackageFiles(d, graph, rootPackageFilename)
+    )
+    .flat();
 }
 
 /**

--- a/lib/modules/manager/nuget/types.ts
+++ b/lib/modules/manager/nuget/types.ts
@@ -24,3 +24,8 @@ export interface MsbuildSdk {
   readonly version: string;
   readonly rollForward: string;
 }
+
+export interface ProjectFile {
+  readonly isLeaf: boolean;
+  readonly name: string;
+}


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Skip explicit restore on intermediate packages files for perf.
They are restored from dependends anyways.
<!-- Describe what behavior is changed by this PR. -->

## Context
- closes #15998
- ref #14312
- https://github.com/renovate-reproductions/dotnet-testing/pulls

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
