### PR TITLE
chore: Disable consistent-return eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,8 +41,16 @@ module.exports = {
     ],
     'import/prefer-default-export': 0, // no benefit
 
+    /*
+     * This rule is not needed since the project uses typescript and the rule
+     * `@typescript-eslint/explicit-function-return-type`.
+     *
+     * Any non-exhaustive definition of the function will therefore result in a
+     * typescript TS2366 error.
+     */
+    'consistent-return': 0,
+
     // other rules
-    'consistent-return': 'error',
     eqeqeq: 'error',
     'no-console': 'error',
     'no-negated-condition': 'error',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

The eslint rule `consistent-return` is disabled.

## Context

This rule is not needed since the project uses typescript and the rule `@typescript-eslint/explicit-function-return-type`.

Any non-exhaustive definition of the function will therefore result in a typescript `TS2366` error.

Follow up of https://github.com/renovatebot/renovate/pull/18925#discussion_r1022815105

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
