### PR TITLE
fix: separateMajorMinor=undefined should like true

### DIFF
--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -1218,6 +1218,7 @@ const options: RenovateOptions[] = [
     description:
       'If set to `false`, Renovate will upgrade dependencies to their latest release only. Renovate will not separate major or minor branches.',
     type: 'boolean',
+    default: true,
   },
   {
     name: 'separateMultipleMajor',

--- a/lib/workers/repository/updates/branch-name.spec.ts
+++ b/lib/workers/repository/updates/branch-name.spec.ts
@@ -50,7 +50,6 @@ describe('workers/repository/updates/branch-name', () => {
         groupName: 'some group name',
         groupSlug: 'some group slug',
         updateType: 'major',
-        separateMajorMinor: true,
         separateMultipleMajor: false,
         newMajor: 2,
         group: {

--- a/lib/workers/repository/updates/branch-name.ts
+++ b/lib/workers/repository/updates/branch-name.ts
@@ -56,7 +56,7 @@ export function generateBranchName(update: RenovateConfig): void {
     update.groupSlug = slugify(update.groupSlug ?? update.groupName, {
       lower: true,
     });
-    if (update.updateType === 'major' && update.separateMajorMinor) {
+    if (update.updateType === 'major' && update.separateMajorMinor !== false) {
       if (update.separateMultipleMajor) {
         const newMajor = String(update.newMajor);
         update.groupSlug = `major-${newMajor}-${update.groupSlug}`;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

currently we do not seperate major and minor when `separateMajorMinor=undefined`, which is default value.
The docs say set to disabled to group.
<!-- Describe what behavior is changed by this PR. -->

## Context
- https://github.com/containerbase/base/pull/599
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
