### PR TITLE
fix(manager/mix): comment handling in mix dependency extraction

### DIFF
--- a/lib/modules/manager/mix/__fixtures__/mix.exs
+++ b/lib/modules/manager/mix/__fixtures__/mix.exs
@@ -15,8 +15,7 @@ defmodule MyProject.MixProject do
   end
 
   defp deps() do
-    [
-      #{:broadway_dashboard, "~> 0.2.2"},
+    [ #{:broadway_dashboard, "~> 0.2.2"},
 #{:broadway_dashboard, "~> 0.2.2"},
 #   {:broadway_dashboard, "~> 0.2.2"},
       #    {:broadway_dashboard, "~> 0.2.2"},

--- a/lib/modules/manager/mix/extract.ts
+++ b/lib/modules/manager/mix/extract.ts
@@ -8,7 +8,7 @@ const depSectionRegExp = regEx(/defp\s+deps.*do/g);
 const depMatchRegExp = regEx(
   /{:(?<depName>\w+),\s*(?<datasource>[^:"]+)?:?\s*"(?<currentValue>[^"]+)",?\s*(?:organization: "(?<organization>.*)")?.*}/gm
 );
-const commentMatchRegExp = regEx(/^\s*#/);
+const commentMatchRegExp = regEx(/#.*$/);
 
 export async function extractPackageFile(
   content: string,
@@ -18,7 +18,7 @@ export async function extractPackageFile(
   const deps: PackageDependency[] = [];
   const contentArr = content
     .split(newlineRegex)
-    .filter((line) => !commentMatchRegExp.test(line));
+    .map((line) => line.replace(commentMatchRegExp, ''));
   for (let lineNumber = 0; lineNumber < contentArr.length; lineNumber += 1) {
     if (contentArr[lineNumber].match(depSectionRegExp)) {
       let depBuffer = '';


### PR DESCRIPTION
## Changes

Fixes how comments are handled when extracting dependencies so partially commented out lines are parsed correctly, as discussed in [this thread](https://github.com/renovatebot/renovate/pull/19128/files#r1033019526).

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository