### PR TITLE
docs: capitalize abbreviation URL

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -1957,7 +1957,7 @@ For example to apply a special label for Major updates:
 Use this field to set the source URL for a package, including overriding an existing one.
 Source URLs are necessary in order to look up release notes.
 
-Using this field we can specify the exact url to fetch release notes from.
+Using this field we can specify the exact URL to fetch release notes from.
 
 Example setting source URL for package "dummy":
 

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -632,7 +632,7 @@ Override this object if you want to change the URLs that Renovate links to, e.g.
 
 If this value is set then Renovate will use Redis for its global cache instead of the local file system.
 The global cache is used to store lookup results (e.g. dependency versions and release notes) between repositories and runs.
-Example url: `redis://localhost`.
+Example URL: `redis://localhost`.
 
 ## repositories
 

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -1200,7 +1200,7 @@ const options: RenovateOptions[] = [
   {
     name: 'customChangelogUrl',
     description:
-      'If set, Renovate will use this url to fetch changelogs for a matched dependency. Valid only within a `packageRules` object.',
+      'If set, Renovate will use this URL to fetch changelogs for a matched dependency. Valid only within a `packageRules` object.',
     type: 'string',
     stage: 'pr',
     parent: 'packageRules',

--- a/lib/modules/manager/cdnurl/readme.md
+++ b/lib/modules/manager/cdnurl/readme.md
@@ -1,4 +1,4 @@
-**Important**: This manager isn't aware of subresource integrity (SRI) hashes. It will search/replace any matching url it finds, without consideration for things such as script integrity hashes. Use the `html` manager instead if you need SRI updating.
+**Important**: This manager isn't aware of subresource integrity (SRI) hashes. It will search/replace any matching URL it finds, without consideration for things such as script integrity hashes. Use the `html` manager instead if you need SRI updating.
 
 To enable this manager, add the matching files to `cdnurl.fileMatch`. For example:
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Abbreviations must be capitalized

## Context

There are still more places where we use `url`, which should be replaced by `URL`:

- Jest test descriptions
- Comments in code
- Debug messages
- Logging messages
- Validation messages

For example:

https://github.com/renovatebot/renovate/blob/893f7caab858ae0e90d29920f17e4dcc3f03bdca/lib/config/validation.ts#L554

By the way, the same problem applies to the abbreviation for JSON:

https://github.com/renovatebot/renovate/blob/893f7caab858ae0e90d29920f17e4dcc3f03bdca/lib/config/validation.ts#L581-L585

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
