### PR TITLE
fix(pod): massage registry URL before checking if it's a GitHub registry

### DIFF
--- a/lib/modules/datasource/pod/index.ts
+++ b/lib/modules/datasource/pod/index.ts
@@ -228,9 +228,9 @@ export class PodDatasource extends Datasource {
     }
 
     let result: ReleaseResult | null = null;
-    const match = githubRegex.exec(baseUrl);
+    const massagedUrl = massageGithubUrl(baseUrl);
+    const match = githubRegex.exec(massagedUrl);
     if (match) {
-      baseUrl = massageGithubUrl(baseUrl);
       const { hostURL, account, repo } = match?.groups ?? {};
       const opts = { hostURL, account, repo };
       result = await this.getReleasesFromGithub(podName, opts);


### PR DESCRIPTION
## Changes

Create a standardised version of the GitHub podspec URL and run the GitHub regex check against that.

## Context

This [fix](https://github.com/renovatebot/renovate/pull/15194) causes the GitHub podspec registry check to fail unless it's a vanilla HTTPS URL. This change makes it work as intended again, without side effects.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
