### PR TITLE
fix(cocoapods): allow `pod install` to run as root

### DIFF
--- a/lib/modules/manager/cocoapods/artifacts.ts
+++ b/lib/modules/manager/cocoapods/artifacts.ts
@@ -69,7 +69,7 @@ export async function updateArtifacts({
   );
   const cocoapods = match?.groups?.cocoapodsVersion ?? null;
 
-  const cmd = [...getPluginCommands(newPackageFileContent), 'pod install'];
+  const cmd = [...getPluginCommands(newPackageFileContent), 'pod install --allow-root'];
   const execOptions: ExecOptions = {
     cwdFile: packageFileName,
     extraEnv: {


### PR DESCRIPTION
## Changes

Allow `pod install` command to run as root

## Context

The `pod install` command fails with the error `You cannot run CocoaPods as root` if run as root, which I think is virtually guaranteed in renovate if I'm reading the code correctly. Given that it's running in a docker container that gets destroyed immediately afterwards I feel that it's ok to allow this. 

The `--allow-root` option is (barely) documented at https://guides.cocoapods.org/terminal/commands.html#pod_install

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
