### PR TITLE
refactor(manager/gradle): ensure gradle parser is only invoked for gradle script files

### DIFF
--- a/lib/modules/manager/gradle/extract.ts
+++ b/lib/modules/manager/gradle/extract.ts
@@ -12,6 +12,7 @@ import type {
 } from './types';
 import {
   getVars,
+  isGradleScriptFile,
   isPropsFile,
   isTOMLFile,
   reorderFiles,
@@ -70,7 +71,7 @@ export async function extractAllPackageFiles(
       } else if (isTOMLFile(packageFile)) {
         const updatesFromCatalog = parseCatalog(packageFile, content);
         extractedDeps.push(...updatesFromCatalog);
-      } else {
+      } else if (isGradleScriptFile(packageFile)) {
         const vars = getVars(registry, dir);
         const {
           deps,

--- a/lib/modules/manager/gradle/utils.ts
+++ b/lib/modules/manager/gradle/utils.ts
@@ -84,6 +84,11 @@ export function parseDependencyString(
 const gradleVersionsFileRegex = regEx('^versions\\.gradle(?:\\.kts)?$', 'i');
 const gradleBuildFileRegex = regEx('^build\\.gradle(?:\\.kts)?$', 'i');
 
+export function isGradleScriptFile(path: string): boolean {
+  const filename = upath.basename(path).toLowerCase();
+  return filename.endsWith('.gradle.kts') || filename.endsWith('.gradle');
+}
+
 export function isGradleVersionsFile(path: string): boolean {
   const filename = upath.basename(path);
   return gradleVersionsFileRegex.test(filename);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Add a check to gradle manager that ensures `parseGradle()` is only invoked for gradle script files. 

The current `else` condition has the effect that if additional files are matched via `fileMatch` they will also be passed to `parseGradle()`. This has no impact, in practice, since the parser simply won't yield dependency findings then. Nonetheless, it is not efficient to parse unsupported file types.

<!-- Describe what behavior is changed by this PR. -->

## Context

* #19182
  * Attempts to prevent gradle parsing of `versions.lock` with a no-op `else if` in `extract.ts`
  * This PR should make this obsolete

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
