### PR TITLE
fix(maven): do not strip .git suffix from sourceUrl

### DIFF
--- a/lib/modules/datasource/maven/util.ts
+++ b/lib/modules/datasource/maven/util.ts
@@ -405,8 +405,7 @@ export async function getDependencyInfo(
       .replace(regEx(/^scm:/), '')
       .replace(regEx(/^git:/), '')
       .replace(regEx(/^git@github.com:/), 'https://github.com/')
-      .replace(regEx(/^git@github.com\//), 'https://github.com/')
-      .replace(regEx(/\.git$/), '');
+      .replace(regEx(/^git@github.com\//), 'https://github.com/');
 
     if (result.sourceUrl.startsWith('//')) {
       // most likely the result of us stripping scm:, git: etc


### PR DESCRIPTION
Signed-off-by: Jan Høydahl <janhoy@users.noreply.github.com>

## Changes

Remove `.git` suffix stripping of git repo urls

## Context

Fixes #19234 

Now a link to e.g. https://gitbox.apache.org/repos/asf?p=commons-lang.git will be valid.
Also, since both GitHub and GitLab accepts both formats, a link to https://github.com/renovatebot/renovate.git or https://gitlab.com/janhoy/antora-lunr-extension.git (with the `.git` suffix) also works as before. 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
