### PR TITLE
feat: allow setting RENOVATE_FORCE environment variable

### DIFF
--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -246,7 +246,6 @@ const options: RenovateOptions[] = [
     globalOnly: true,
     type: 'object',
     cli: false,
-    env: true,
   },
   {
     name: 'forceCli',

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -246,7 +246,7 @@ const options: RenovateOptions[] = [
     globalOnly: true,
     type: 'object',
     cli: false,
-    env: false,
+    env: true,
   },
   {
     name: 'forceCli',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Allows `RENOVATE_FORCE` env variable to override config. For example `RENOVATE_FORCE={"schedule": null}`

I assume the docs are all auto generated from this config so I don't think any updates are needed here?

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

Closes #19359

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required (assumes this is auto generated?)

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
