### PR TITLE
chore: reword branch creation limit message on onboarding PR

### DIFF
--- a/lib/workers/repository/onboarding/pr/pr-list.spec.ts
+++ b/lib/workers/repository/onboarding/pr/pr-list.spec.ts
@@ -132,7 +132,7 @@ describe('workers/repository/onboarding/pr/pr-list', () => {
 
         <br />
 
-        🚸 Branch creation will be limited to maximum 1 per hour, so it doesn't swamp any CI resources or spam the project. See docs for \`prhourlylimit\` for details.
+        🚸 Branch creation will be limited to maximum 1 per hour, so it doesn't swamp any CI resources or overwhelm the project. See docs for \`prhourlylimit\` for details.
 
         "
       `);

--- a/lib/workers/repository/onboarding/pr/pr-list.ts
+++ b/lib/workers/repository/onboarding/pr/pr-list.ts
@@ -70,7 +70,7 @@ export function getPrList(
     prHourlyLimit < branches.length
   ) {
     prDesc += emojify(
-      `<br />\n\n:children_crossing: Branch creation will be limited to maximum ${prHourlyLimit} per hour, so it doesn't swamp any CI resources or spam the project. See docs for \`prhourlylimit\` for details.\n\n`
+      `<br />\n\n:children_crossing: Branch creation will be limited to maximum ${prHourlyLimit} per hour, so it doesn't swamp any CI resources or overwhelm the project. See docs for \`prhourlylimit\` for details.\n\n`
     );
   }
   return prDesc;


### PR DESCRIPTION
## Changes

- Replace word `spam` with `overwhelm`

## Context

I think we should use overwhelm instead of spam.

Tangentially related issue:

- #18939

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository