### PR TITLE
docs: improve documentation for GitLab datasources

### DIFF
--- a/lib/modules/datasource/gitlab-packages/readme.md
+++ b/lib/modules/datasource/gitlab-packages/readme.md
@@ -4,7 +4,8 @@ To specify which specific repository should be queried when looking up a package
 
 As an example, `gitlab-org/ci-cd/package-stage/feature-testing/new-packages-list:@gitlab-org/nk-js` would look for the`@gitlab-org/nk-js` packages in the generic packages repository of the `gitlab-org/ci-cd/package-stage/feature-testing/new-packages-list` project.
 
-To specify where to find a self-hosted GitLab instance, specify `registryUrl`. An example would be `https://gitlab.company.com`.
+To specify where to find a self-hosted GitLab instance, specify `registryUrl`.
+An example would be `https://gitlab.company.com`.
 
 If you are using a self-hosted GitLab instance, please note the following requirements:
 

--- a/lib/modules/datasource/gitlab-packages/readme.md
+++ b/lib/modules/datasource/gitlab-packages/readme.md
@@ -4,6 +4,8 @@ To specify which specific repository should be queried when looking up a package
 
 As an example, `gitlab-org/ci-cd/package-stage/feature-testing/new-packages-list:@gitlab-org/nk-js` would look for the`@gitlab-org/nk-js` packages in the generic packages repository of the `gitlab-org/ci-cd/package-stage/feature-testing/new-packages-list` project.
 
+To specify where to find a self-hosted GitLab instance, specify `registryUrl`. An example would be `https://gitlab.company.com`.
+
 If you are using a self-hosted GitLab instance, please note the following requirements:
 
 - If you are on the `Free` edition, this datasource requires at least GitLab 13.3

--- a/lib/modules/datasource/gitlab-releases/readme.md
+++ b/lib/modules/datasource/gitlab-releases/readme.md
@@ -1,0 +1,40 @@
+[GitLab Releases API](https://docs.gitlab.com/ee/api/releases/) supports looking up [releases supported by GitLab](https://docs.gitlab.com/ee/user/project/releases/) and can be used in combination with [regex managers](https://docs.renovatebot.com/modules/manager/regex/) to keep dependencies up-to-date which are not specifically supported by Renovate.
+
+To specify which specific repository should be queried when looking up a package, the `depName` should be set to the project path.
+
+As an example, `gitlab-org/ci-cd/package-stage/feature-testing/new-packages-list` would look for releases in the `gitlab-org/ci-cd/package-stage/feature-testing/new-packages-list` project.
+
+To specify where to find a self-hosted GitLab instance, specify `registryUrl`. An example would be `https://gitlab.company.com`.
+
+Please note the following requirements:
+
+- This datasource requires at least GitLab 11.7
+
+**Usage Example**
+
+A real-world example for this specific datasource would be maintaining package versions in a config file.
+This can be achieved by configuring a generic regex manager in `renovate.json` for files named `versions.ini`:
+
+```json
+{
+  "regexManagers": [
+    {
+      "fileMatch": ["^versions.ini$"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?( registryUrl=(?<registryUrl>.*?))?\\s.*?_VERSION=(?<currentValue>.*)\\s"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    }
+  ]
+}
+```
+
+Now you may use comments in your `versions.ini` files to automatically update dependencies, which could look like this:
+
+```ini
+# renovate: datasource=gitlab-releases depName=gitlab-org/ci-cd/package-stage/feature-testing/new-packages-list versioning=semver registryUrl=https://gitlab.com
+NKJS_VERSION=3.4.0
+
+```
+
+By default, `gitlab-releases` uses the `semver` versioning scheme.

--- a/lib/modules/datasource/gitlab-releases/readme.md
+++ b/lib/modules/datasource/gitlab-releases/readme.md
@@ -4,7 +4,8 @@ To specify which specific repository should be queried when looking up a package
 
 As an example, `gitlab-org/ci-cd/package-stage/feature-testing/new-packages-list` would look for releases in the `gitlab-org/ci-cd/package-stage/feature-testing/new-packages-list` project.
 
-To specify where to find a self-hosted GitLab instance, specify `registryUrl`. An example would be `https://gitlab.company.com`.
+To specify where to find a self-hosted GitLab instance, specify `registryUrl`.
+An example would be `https://gitlab.company.com`.
 
 Please note the following requirements:
 

--- a/lib/modules/datasource/gitlab-releases/readme.md
+++ b/lib/modules/datasource/gitlab-releases/readme.md
@@ -34,7 +34,6 @@ Now you may use comments in your `versions.ini` files to automatically update de
 ```ini
 # renovate: datasource=gitlab-releases depName=gitlab-org/ci-cd/package-stage/feature-testing/new-packages-list versioning=semver registryUrl=https://gitlab.com
 NKJS_VERSION=3.4.0
-
 ```
 
 By default, `gitlab-releases` uses the `semver` versioning scheme.

--- a/lib/modules/datasource/gitlab-tags/readme.md
+++ b/lib/modules/datasource/gitlab-tags/readme.md
@@ -30,7 +30,6 @@ Now you may use comments in your `versions.ini` files to automatically update de
 ```ini
 # renovate: datasource=gitlab-tags depName=gitlab-org/ci-cd/package-stage/feature-testing/new-packages-list versioning=semver registryUrl=https://gitlab.com
 NKJS_VERSION=3.4.0
-
 ```
 
 By default, `gitlab-tags` uses the `semver` versioning scheme.

--- a/lib/modules/datasource/gitlab-tags/readme.md
+++ b/lib/modules/datasource/gitlab-tags/readme.md
@@ -1,0 +1,36 @@
+[GitLab Tags API](https://docs.gitlab.com/ee/api/tags.html) supports looking up [Git tags](https://docs.gitlab.com/ee/topics/git/tags.html#tags) and can be used in combination with [regex managers](https://docs.renovatebot.com/modules/manager/regex/) to keep dependencies up-to-date which are not specifically supported by Renovate.
+
+To specify which specific repository should be queried when looking up a package, the `depName` should be set to the project path.
+
+As an example, `gitlab-org/ci-cd/package-stage/feature-testing/new-packages-list` would look for releases in the `gitlab-org/ci-cd/package-stage/feature-testing/new-packages-list` project.
+
+To specify where to find a self-hosted GitLab instance, specify `registryUrl`. An example would be `https://gitlab.company.com`.
+
+**Usage Example**
+
+A real-world example for this specific datasource would be maintaining package versions in a config file.
+This can be achieved by configuring a generic regex manager in `renovate.json` for files named `versions.ini`:
+
+```json
+{
+  "regexManagers": [
+    {
+      "fileMatch": ["^versions.ini$"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?( registryUrl=(?<registryUrl>.*?))?\\s.*?_VERSION=(?<currentValue>.*)\\s"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    }
+  ]
+}
+```
+
+Now you may use comments in your `versions.ini` files to automatically update dependencies, which could look like this:
+
+```ini
+# renovate: datasource=gitlab-tags depName=gitlab-org/ci-cd/package-stage/feature-testing/new-packages-list versioning=semver registryUrl=https://gitlab.com
+NKJS_VERSION=3.4.0
+
+```
+
+By default, `gitlab-tags` uses the `semver` versioning scheme.


### PR DESCRIPTION
## Changes

Improve documentation about GitLab datasources.

## Context

It was hard for me to find out how to use `regexManager` with `gitlab-tags` datasource on a self-hosted GitLab instance. This documentation would have saved me half a day of work.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
- [x] Documentation changes only

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
