### PR TITLE
fix(sbt-plugin): switch defaultRegistryUrl to `repo.scala-sbt.org/scalasbt/sbt-plugin-releases`

### DIFF
--- a/lib/modules/datasource/sbt-plugin/index.spec.ts
+++ b/lib/modules/datasource/sbt-plugin/index.spec.ts
@@ -52,12 +52,12 @@ describe('modules/datasource/sbt-plugin/index', () => {
         .reply(200, "<a href='1.2.3/'>4.5.6/</a>");
 
       httpMock
-        .scope('https://dl.bintray.com')
-        .get('/sbt/sbt-plugin-releases/com.github.gseitz/')
+        .scope('https://repo.scala-sbt.org')
+        .get('/scalasbt/sbt-plugin-releases/com.github.gseitz/')
         .reply(200, '');
       httpMock
-        .scope('https://dl.bintray.com')
-        .get('/sbt/sbt-plugin-releases/org.foundweekends/sbt-bintray/')
+        .scope('https://repo.scala-sbt.org')
+        .get('/scalasbt/sbt-plugin-releases/org.foundweekends/sbt-bintray/')
         .reply(
           200,
           '<html>\n' +
@@ -69,9 +69,9 @@ describe('modules/datasource/sbt-plugin/index', () => {
             '</html>'
         );
       httpMock
-        .scope('https://dl.bintray.com')
+        .scope('https://repo.scala-sbt.org')
         .get(
-          '/sbt/sbt-plugin-releases/org.foundweekends/sbt-bintray/scala_2.12/'
+          '/scalasbt/sbt-plugin-releases/org.foundweekends/sbt-bintray/scala_2.12/'
         )
         .reply(
           200,
@@ -85,9 +85,9 @@ describe('modules/datasource/sbt-plugin/index', () => {
             '</html>\n'
         );
       httpMock
-        .scope('https://dl.bintray.com')
+        .scope('https://repo.scala-sbt.org')
         .get(
-          '/sbt/sbt-plugin-releases/org.foundweekends/sbt-bintray/scala_2.12/sbt_1.0/'
+          '/scalasbt/sbt-plugin-releases/org.foundweekends/sbt-bintray/scala_2.12/sbt_1.0/'
         )
         .reply(
           200,
@@ -169,8 +169,8 @@ describe('modules/datasource/sbt-plugin/index', () => {
         })
       ).toEqual({
         dependencyUrl:
-          'https://dl.bintray.com/sbt/sbt-plugin-releases/org.foundweekends/sbt-bintray',
-        registryUrl: 'https://dl.bintray.com/sbt/sbt-plugin-releases',
+          'https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/org.foundweekends/sbt-bintray',
+        registryUrl: 'https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases',
         releases: [{ version: '0.5.5' }],
       });
     });
@@ -185,8 +185,8 @@ describe('modules/datasource/sbt-plugin/index', () => {
         })
       ).toEqual({
         dependencyUrl:
-          'https://dl.bintray.com/sbt/sbt-plugin-releases/org.foundweekends/sbt-bintray',
-        registryUrl: 'https://dl.bintray.com/sbt/sbt-plugin-releases',
+          'https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/org.foundweekends/sbt-bintray',
+        registryUrl: 'https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases',
         releases: [{ version: '0.5.5' }],
       });
     });

--- a/lib/modules/datasource/sbt-plugin/index.ts
+++ b/lib/modules/datasource/sbt-plugin/index.ts
@@ -10,7 +10,7 @@ import { getLatestVersion, parseIndexDir } from '../sbt-package/util';
 import type { GetReleasesConfig, ReleaseResult } from '../types';
 
 export const SBT_PLUGINS_REPO =
-  'https://dl.bintray.com/sbt/sbt-plugin-releases';
+  'https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases';
 
 export const defaultRegistryUrls = [SBT_PLUGINS_REPO];
 

--- a/lib/modules/manager/sbt/__snapshots__/extract.spec.ts.snap
+++ b/lib/modules/manager/sbt/__snapshots__/extract.spec.ts.snap
@@ -266,7 +266,7 @@ exports[`modules/manager/sbt/extract extractPackageFile() extracts deps for gene
         "https://example.com/repos/3/",
         "https://example.com/repos/4/",
         "https://example.com/repos/5/",
-        "https://dl.bintray.com/sbt/sbt-plugin-releases",
+        "https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases",
       ],
     },
     {
@@ -435,7 +435,7 @@ exports[`modules/manager/sbt/extract extractPackageFile() extracts deps when sca
         "https://example.com/repos/3/",
         "https://example.com/repos/4/",
         "https://example.com/repos/5/",
-        "https://dl.bintray.com/sbt/sbt-plugin-releases",
+        "https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases",
       ],
     },
   ],

--- a/lib/modules/manager/sbt/extract.spec.ts
+++ b/lib/modules/manager/sbt/extract.spec.ts
@@ -118,7 +118,7 @@ describe('modules/manager/sbt/extract', () => {
             packageName: 'com.github.gseitz:sbt-release',
             registryUrls: [
               'https://repo.maven.apache.org/maven2',
-              'https://dl.bintray.com/sbt/sbt-plugin-releases',
+              'https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases',
             ],
           },
         ],


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

This PR updates the defaultRegistryUrl for `sbt-plugin` to `repo.scala-sbt.org/scalasbt/sbt-plugin-releases`. This is required because `dl.bintray.com` is no longer available. The official Scala docs mention that [bintray is no longer used to host plugins](https://www.scala-sbt.org/1.x/docs/Bintray-For-Plugins.html) and [recommends to switch to this new registry](https://www.scala-sbt.org/1.x/docs/Resolvers.html#Predefined+resolvers).

## Context

Fixes #19399 

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
