### PR TITLE
feat(manager/gomod): capture indirect dependencies for Go Modules

### DIFF
--- a/lib/modules/manager/gomod/__snapshots__/extract.spec.ts.snap
+++ b/lib/modules/manager/gomod/__snapshots__/extract.spec.ts.snap
@@ -662,6 +662,17 @@ exports[`modules/manager/gomod/extract extractPackageFile() extracts single-line
   {
     "currentValue": "v1.0.0",
     "datasource": "go",
+    "depName": "github.com/davecgh/go-spew",
+    "depType": "indirect",
+    "enabled": false,
+    "managerData": {
+      "lineNumber": 4,
+    },
+    "skipReason": "disabled",
+  },
+  {
+    "currentValue": "v1.0.0",
+    "datasource": "go",
     "depName": "golang.org/x/foo",
     "depType": "require",
     "managerData": {

--- a/lib/modules/manager/gomod/extract.spec.ts
+++ b/lib/modules/manager/gomod/extract.spec.ts
@@ -13,8 +13,10 @@ describe('modules/manager/gomod/extract', () => {
     it('extracts single-line requires', () => {
       const res = extractPackageFile(gomod1)?.deps;
       expect(res).toMatchSnapshot();
-      expect(res).toHaveLength(8);
-      expect(res?.filter((e) => e.skipReason)).toHaveLength(1);
+      expect(res).toHaveLength(9);
+      expect(res?.filter((e) => e.depType === 'require')).toHaveLength(7);
+      expect(res?.filter((e) => e.depType === 'indirect')).toHaveLength(1);
+      expect(res?.filter((e) => e.skipReason)).toHaveLength(2);
       expect(res?.filter((e) => e.depType === 'replace')).toHaveLength(1);
     });
 

--- a/lib/modules/manager/gomod/extract.ts
+++ b/lib/modules/manager/gomod/extract.ts
@@ -70,10 +70,18 @@ export function extractPackageFile(content: string): PackageFile | null {
         deps.push(dep);
       }
       const requireMatch = regEx(/^require\s+([^\s]+)\s+([^\s]+)/).exec(line);
-      if (requireMatch && !line.endsWith('// indirect')) {
-        logger.trace({ lineNumber }, `require line: "${line}"`);
-        const dep = getDep(lineNumber, requireMatch, 'require');
-        deps.push(dep);
+      if (requireMatch) {
+        if (line.endsWith('// indirect')) {
+          logger.trace({ lineNumber }, `indirect line: "${line}"`);
+          const dep = getDep(lineNumber, requireMatch, 'indirect');
+          dep.enabled = false;
+          dep.skipReason = 'disabled'; // https://github.com/renovatebot/renovate/issues/19430
+          deps.push(dep);
+        } else {
+          logger.trace({ lineNumber }, `require line: "${line}"`);
+          const dep = getDep(lineNumber, requireMatch, 'require');
+          deps.push(dep);
+        }
       }
       if (line.trim() === 'require (') {
         logger.trace(`Matched multi-line require on line ${lineNumber}`);

--- a/lib/modules/manager/gomod/update.spec.ts
+++ b/lib/modules/manager/gomod/update.spec.ts
@@ -362,5 +362,16 @@ describe('modules/manager/gomod/update', () => {
       });
       expect(res).toBeNull();
     });
+
+    it('should not make any changes for indirect upgrades', () => {
+      const upgrade = {
+        depName: 'github.com/davecgh/go-spew',
+        managerData: { lineNumber: 4 },
+        newValue: 'v1.1.1',
+        depType: 'indirect',
+      };
+      const res = updateDependency({ fileContent: gomod1, upgrade });
+      expect(res).toEqual(gomod1);
+    });
   });
 });

--- a/lib/modules/manager/types.ts
+++ b/lib/modules/manager/types.ts
@@ -97,6 +97,7 @@ export interface Package<T> extends ManagerData<T> {
   target?: string;
   versioning?: string;
   dataType?: string;
+  enabled?: boolean;
 
   // npm manager
   bumpVersion?: ReleaseType | string;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

To allow folks to be able to discover the dependencies available through
indirect (transitive) dependencies for Go modules, we can parse them as
a separate `depType`.

This also makes sure that it's clear that `indirect` dependencies do not
get updated by Renovate.



<!-- Describe what behavior is changed by this PR. -->

## Context

- Closes #19416

As noted in #19416, this provides the ability to discover indirect dependencies.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
