### PR TITLE
feat(manager/gomod): update indirect dependencies for Go Modules

### DIFF
--- a/lib/modules/manager/gomod/__snapshots__/extract.spec.ts.snap
+++ b/lib/modules/manager/gomod/__snapshots__/extract.spec.ts.snap
@@ -662,6 +662,16 @@ exports[`modules/manager/gomod/extract extractPackageFile() extracts single-line
   {
     "currentValue": "v1.0.0",
     "datasource": "go",
+    "depName": "github.com/davecgh/go-spew",
+    "depType": "indirect",
+    "enabled": false,
+    "managerData": {
+      "lineNumber": 4,
+    },
+  },
+  {
+    "currentValue": "v1.0.0",
+    "datasource": "go",
     "depName": "golang.org/x/foo",
     "depType": "require",
     "managerData": {

--- a/lib/modules/manager/gomod/extract.spec.ts
+++ b/lib/modules/manager/gomod/extract.spec.ts
@@ -13,7 +13,9 @@ describe('modules/manager/gomod/extract', () => {
     it('extracts single-line requires', () => {
       const res = extractPackageFile(gomod1)?.deps;
       expect(res).toMatchSnapshot();
-      expect(res).toHaveLength(8);
+      expect(res).toHaveLength(9);
+      expect(res?.filter((e) => e.depType === 'require')).toHaveLength(7);
+      expect(res?.filter((e) => e.depType === 'indirect')).toHaveLength(1);
       expect(res?.filter((e) => e.skipReason)).toHaveLength(1);
       expect(res?.filter((e) => e.depType === 'replace')).toHaveLength(1);
     });

--- a/lib/modules/manager/gomod/extract.ts
+++ b/lib/modules/manager/gomod/extract.ts
@@ -70,10 +70,17 @@ export function extractPackageFile(content: string): PackageFile | null {
         deps.push(dep);
       }
       const requireMatch = regEx(/^require\s+([^\s]+)\s+([^\s]+)/).exec(line);
-      if (requireMatch && !line.endsWith('// indirect')) {
-        logger.trace({ lineNumber }, `require line: "${line}"`);
-        const dep = getDep(lineNumber, requireMatch, 'require');
-        deps.push(dep);
+      if (requireMatch) {
+        if (line.endsWith('// indirect')) {
+          logger.trace({ lineNumber }, `indirect line: "${line}"`);
+          const dep = getDep(lineNumber, requireMatch, 'indirect');
+          dep.enabled = false;
+          deps.push(dep);
+        } else {
+          logger.trace({ lineNumber }, `require line: "${line}"`);
+          const dep = getDep(lineNumber, requireMatch, 'require');
+          deps.push(dep);
+        }
       }
       if (line.trim() === 'require (') {
         logger.trace(`Matched multi-line require on line ${lineNumber}`);

--- a/lib/modules/manager/gomod/readme.md
+++ b/lib/modules/manager/gomod/readme.md
@@ -8,3 +8,17 @@ You might be interested in the following `postUpdateOptions`:
 
 When Renovate is running using `binarySource=docker` (such as in the hosted Mend Renovate app) then it will pick the latest compatible version of Go to run, i.e. the latest `1.x` release.
 Even if the `go.mod` has a version like `go 1.14`, Renovate will treat it as a `^1.14` constraint and not `=1.14`.
+
+Indirect updates are disabled by default. To enable them, add a package rule such as:
+
+```json
+{
+  "packageRules": [
+    {
+      "matchDatasources": ["go"],
+      "matchDepTypes": ["indirect"],
+      "enabled": true
+    }
+  ]
+}
+```

--- a/lib/modules/manager/gomod/readme.md
+++ b/lib/modules/manager/gomod/readme.md
@@ -15,7 +15,7 @@ Indirect updates are disabled by default. To enable them, add a package rule suc
 {
   "packageRules": [
     {
-      "matchDatasources": ["go"],
+      "matchManagers": ["gomod"],
       "matchDepTypes": ["indirect"],
       "enabled": true
     }

--- a/lib/modules/manager/gomod/update.spec.ts
+++ b/lib/modules/manager/gomod/update.spec.ts
@@ -362,5 +362,29 @@ describe('modules/manager/gomod/update', () => {
       });
       expect(res).toBeNull();
     });
+
+    it('should perform indirect upgrades when top-level', () => {
+      const upgrade = {
+        depName: 'github.com/davecgh/go-spew',
+        managerData: { lineNumber: 4 },
+        newValue: 'v1.1.1',
+        depType: 'indirect',
+      };
+      const res = updateDependency({ fileContent: gomod1, upgrade });
+      expect(res).not.toEqual(gomod1);
+      expect(res).toContain(`${upgrade.newValue} // indirect`);
+    });
+
+    it('should perform indirect upgrades when in require blocks', () => {
+      const upgrade = {
+        depName: 'github.com/go-ole/go-ole',
+        managerData: { lineNumber: 23, multiLine: true },
+        newValue: 'v1.5.0',
+        depType: 'indirect',
+      };
+      const res = updateDependency({ fileContent: gomod3, upgrade });
+      expect(res).not.toEqual(gomod2);
+      expect(res).toContain(`${upgrade.newValue} // indirect`);
+    });
   });
 });

--- a/lib/modules/manager/gomod/update.ts
+++ b/lib/modules/manager/gomod/update.ts
@@ -55,7 +55,7 @@ export function updateDependency({
           /^(?<depPart>replace\s+[^\s]+[\s]+[=][>]+\s+)(?<divider>[^\s]+\s+)[^\s]+/
         );
       }
-    } else if (depType === 'require') {
+    } else if (depType === 'require' || depType === 'indirect') {
       if (upgrade.managerData.multiLine) {
         updateLineExp = regEx(/^(?<depPart>\s+[^\s]+)(?<divider>\s+)[^\s]+/);
       } else {
@@ -135,6 +135,11 @@ export function updateDependency({
       logger.debug('No changes necessary');
       return fileContent;
     }
+
+    if (depType === 'indirect') {
+      newLine += ' // indirect';
+    }
+
     lines[upgrade.managerData.lineNumber] = newLine;
     return lines.join('\n');
   } catch (err) {

--- a/lib/modules/manager/types.ts
+++ b/lib/modules/manager/types.ts
@@ -97,6 +97,7 @@ export interface Package<T> extends ManagerData<T> {
   target?: string;
   versioning?: string;
   dataType?: string;
+  enabled?: boolean;
 
   // npm manager
   bumpVersion?: ReleaseType | string;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

To allow folks to update their indirect dependencies for Go modules, we
can parse them as `depType: indirect`.

This introduces a new `Package.enabled` field to allow disabling the
packages, and re-enable packages after the fact.

Closes #19416, #19430.


<!-- Describe what behavior is changed by this PR. -->

## Context

- Closes #19416
- Closes #19430

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
