### PR TITLE
docs(python): remove draft text

### DIFF
--- a/docs/usage/python.md
+++ b/docs/usage/python.md
@@ -90,8 +90,6 @@ Fill the array with alternate index URL(s).
     If a `requirements.txt` file has a index-url then Renovate follows that link, instead of following any link set in the `registryUrls` array.
     To override the URL found in `requirements.txt`, you must create a custom `packageRules` setting.
     This is because `packageRules` are applied _after_ package file extraction.
-    OPTION 1: Create new secion in private packages docs, and add this link: Go to the [private package support docs](https://docs.renovatebot.com/getting-started/private-packages/#pip).
-    OPTION 2: Link to [specify URL in Python docs](https://docs.renovatebot.com/python/#specify-url-in-configuration)
 
 ## Disabling Python support
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Remove draft text left over after PR #16465

## Context

We're accidentally showing draft text on the published docs. 😄 

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
