### PR TITLE
Add extractVersion to regex-manager preset

### DIFF
--- a/lib/config/presets/internal/regex-managers.ts
+++ b/lib/config/presets/internal/regex-managers.ts
@@ -9,7 +9,7 @@ export const presets: Record<string, Preset> = {
       {
         fileMatch: ['(^|/|\\.)Dockerfile$', '(^|/)Dockerfile[^/]*$'],
         matchStrings: [
-          '# renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>[^\\s]+?)(?: (lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[a-z-0-9]+?))?\\s(?:ENV|ARG) .+?_VERSION[ =]"?(?<currentValue>.+?)"?\\s',
+          '# renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>[^\\s]+?)(?: (lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[a-z-0-9]+?))?(?: (extractVersion)=(?<extractVersion>[^\\s]+?))?\\s(?:ENV|ARG) .+?_VERSION[ =]\"?(?<currentValue>[^\"\\s]+?)\"?\\s',
         ],
       },
     ],


### PR DESCRIPTION
## Changes

Allow overwriting `extractVersion` in `regex-manager` preset. This allows removing prefixes like `v` for git tags by appending something like `extractVersion=^v(?<version>\d+\.\d+(?:\.\d+)?)` to the comment.

## Context

Sometimes Github release binaries don't include the prefix (e.g. https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protobuf-cpp-3.21.12.tar.gz).

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
