### PR TITLE
test(platform): add test that hostRules are passed through initPlatform()

### DIFF
--- a/lib/modules/platform/index.spec.ts
+++ b/lib/modules/platform/index.spec.ts
@@ -76,4 +76,45 @@ describe('modules/platform/index', () => {
       platform: 'bitbucket',
     });
   });
+
+  it('merges config hostRules with platform hostRules', async () => {
+    httpMock.scope('https://ghe.renovatebot.com').head('/').reply(200);
+
+    const config = {
+      platform: 'github' as PlatformId,
+      endpoint: 'https://ghe.renovatebot.com',
+      gitAuthor: 'user@domain.com',
+      username: 'abc',
+      token: '123',
+      hostRules: [
+        {
+          hostType: 'github',
+          matchHost: 'github.com',
+          token: '123',
+          username: 'abc',
+        },
+      ],
+    };
+
+    expect(await platform.initPlatform(config)).toEqual({
+      endpoint: 'https://ghe.renovatebot.com/',
+      gitAuthor: 'user@domain.com',
+      hostRules: [
+        {
+          hostType: 'github',
+          matchHost: 'github.com',
+          token: '123',
+          username: 'abc',
+        },
+        {
+          hostType: 'github',
+          matchHost: 'ghe.renovatebot.com',
+          token: '123',
+          username: 'abc',
+        },
+      ],
+      platform: 'github',
+      renovateUsername: 'abc',
+    });
+  });
 });

--- a/lib/modules/platform/index.spec.ts
+++ b/lib/modules/platform/index.spec.ts
@@ -90,8 +90,8 @@ describe('modules/platform/index', () => {
         {
           hostType: 'github',
           matchHost: 'github.com',
-          token: '123',
-          username: 'abc',
+          token: '456',
+          username: 'def',
         },
       ],
     };
@@ -103,8 +103,8 @@ describe('modules/platform/index', () => {
         {
           hostType: 'github',
           matchHost: 'github.com',
-          token: '123',
-          username: 'abc',
+          token: '456',
+          username: 'def',
         },
         {
           hostType: 'github',


### PR DESCRIPTION


<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Add a test to check that initial hostRules (e.g. for github.com) are passed through the initPlatform() call. It validates that a platform initialization of GitHub Enterprise Server doesn't "drop" other predefined hostRules (e.g. for github.com).

## Context

This is a test to cover a regression which caused #19488 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
