### PR TITLE
docs(composer): Renovate does not support Composer version 2.5.0 or newer

### DIFF
--- a/lib/modules/manager/composer/readme.md
+++ b/lib/modules/manager/composer/readme.md
@@ -1,3 +1,10 @@
+<!-- prettier-ignore -->
+!!! warning
+    Renovate does not support Composer version `2.5.0` or newer.
+    This is because of changes in the default behavior of Composer.
+    For now, you can do ... to workaround the problem.
+    Subscribe to these issues/discussions to follow our progress: insert link to issues.
+
 Extracts dependencies from `composer.json` files, and keeps the associated `composer.lock` file updated too.
 
 If you use [VCS repositories](https://getcomposer.org/doc/05-repositories.md#vcs) then Renovate needs a hint via the `name` property, which must match the relevant package.

--- a/lib/modules/manager/composer/readme.md
+++ b/lib/modules/manager/composer/readme.md
@@ -2,7 +2,7 @@
 !!! warning
     Renovate does not support Composer version `2.5.0` or newer.
     This is because of changes in the default behavior of Composer.
-    For now, you can do ... to workaround the problem.
+    For now, you can configure `constraints.php` to be `< 2.5.0` to work around the problem.
     Subscribe to these issues/discussions to follow our progress: insert link to issues.
 
 Extracts dependencies from `composer.json` files, and keeps the associated `composer.lock` file updated too.


### PR DESCRIPTION
## Changes

- Add warning to our Composer manager docs about `2.5.0.` (and newer) not working for us
- Things to include in warning message:
  - We're working on fixing the problem
  - What the user can do to workaround the problem
  - What issues/discussions the user can follow to be notified of changes

## Context

See this discussion for background information:

- https://github.com/renovatebot/renovate/discussions/19505

We should be careful with our wording here, we don't want to blame the maintainers of Composer. 😉 

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
