### PR TITLE
Add AWS ECR auth example to docker docs

### DIFF
--- a/docs/usage/docker.md
+++ b/docs/usage/docker.md
@@ -246,6 +246,23 @@ module.exports = {
 };
 ```
 
+#### AWS ECR (Amazon Web Services Elastic Container Registry)
+
+Renovate can authenticate with AWS ECR using AWS access key id & secret as the username & password, for example:
+
+```json
+"hostRules": [
+    {
+      "hostType": "docker",
+      "matchHost": "12345612312.dkr.ecr.us-east-1.amazonaws.com",
+      "username": "AKIAABCDEFGHIJKLMNOPQ",
+      "encrypted": {
+        "password": "w...A"
+      }
+    }
+  ]
+```
+
 #### Google Container Registry / Google Artifact Registry
 
 ##### Using long-lived service account credentials


### PR DESCRIPTION
## Changes

Update docker docs with AWS ECR example

## Context

I was having trouble finding docs or examples on how to setup auth with AWS ECR and renovate.

