### PR TITLE
fix(docs): use correct folder name in README for helm Subchart archives

### DIFF
--- a/lib/modules/manager/helmv3/readme.md
+++ b/lib/modules/manager/helmv3/readme.md
@@ -72,7 +72,7 @@ For this you use a custom `hostRules` array.
 ### Subchart archives
 
 To get updates for subchart archives put `helmUpdateSubChartArchives` in your `postUpdateOptions` configuration.
-Renovate now updates archives in the `/chart` folder.
+Renovate now updates archives in the `/charts` folder.
 
 ```json
 {


### PR DESCRIPTION
## Changes

Fix the name of the folder/directory which gets updated by the Helm manager when enabling `helmUpdateSubChartArchives`.

## Context

Wrong folder name in docs.

## Documentation (please check one with an [x])

- [X] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [X] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

