### PR TITLE
docs: add helm to supported tools list for dynamic install 

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -163,6 +163,7 @@ Supported tools for dynamic install are:
 - `flux`
 - `golang`
 - `gradle-wrapper`
+- `helm`
 - `jb`
 - `jsonnet-bundler`
 - `lerna`


### PR DESCRIPTION
## Changes

Added `helm` to the list of supported tools for dynamic install. See PR #13719

## Context

Docs for self-hosted configuration updated to list `helm` too.


## Documentation (please check one with an [x])

- [X] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [X] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

