### PR TITLE
fix(presets/workarounds): update java LTS allowed versions expression

### DIFF
--- a/lib/config/presets/internal/workarounds.ts
+++ b/lib/config/presets/internal/workarounds.ts
@@ -79,7 +79,7 @@ export const presets: Record<string, Preset> = {
     description: 'Limit Java runtime versions to LTS releases',
     packageRules: [
       {
-        allowedVersions: '/^(8|11|17)',
+        allowedVersions: '/^(?:8|11|17)',
         description:
           'Limit Java runtime versions to LTS releases. To receive all major releases add `workarounds:javaLTSVersions` to the `ignorePresets` array.',
         matchDatasources: ['docker', 'adoptium-java'],

--- a/lib/config/presets/internal/workarounds.ts
+++ b/lib/config/presets/internal/workarounds.ts
@@ -79,7 +79,7 @@ export const presets: Record<string, Preset> = {
     description: 'Limit Java runtime versions to LTS releases',
     packageRules: [
       {
-        allowedVersions: '/^(?:8|11|17|21|25|29)(?:\\.|$)/',
+        allowedVersions: '/^(?:8|11|17)',
         description:
           'Limit Java runtime versions to LTS releases. To receive all major releases add `workarounds:javaLTSVersions` to the `ignorePresets` array.',
         matchDatasources: ['docker', 'adoptium-java'],

--- a/lib/config/presets/internal/workarounds.ts
+++ b/lib/config/presets/internal/workarounds.ts
@@ -79,7 +79,7 @@ export const presets: Record<string, Preset> = {
     description: 'Limit Java runtime versions to LTS releases',
     packageRules: [
       {
-        allowedVersions: '/^(?:8|11|17)',
+        allowedVersions: '/^(?:8|11|17)(?:\\.|-|$)/',
         description:
           'Limit Java runtime versions to LTS releases. To receive all major releases add `workarounds:javaLTSVersions` to the `ignorePresets` array.',
         matchDatasources: ['docker', 'adoptium-java'],

--- a/lib/config/presets/internal/workarounds.ts
+++ b/lib/config/presets/internal/workarounds.ts
@@ -79,7 +79,7 @@ export const presets: Record<string, Preset> = {
     description: 'Limit Java runtime versions to LTS releases',
     packageRules: [
       {
-        allowedVersions: '/^(?:8|11|17)',
+        allowedVersions: '/^(8|11|17)',
         description:
           'Limit Java runtime versions to LTS releases. To receive all major releases add `workarounds:javaLTSVersions` to the `ignorePresets` array.',
         matchDatasources: ['docker', 'adoptium-java'],


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Update the allowedVersions expression used by workaround `javaLTSVersions` to that it
- doesn't pre-emptively recommend updates to future major versions which are still pre-release (eg: https://github.com/setchy/renovate-java-test/pull/16)
- only checks the prefix for LTS versions and is more relaxed about what follows (ie: 17-alpine)

Tested on https://github.com/setchy/renovate-java-test

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
