### PR TITLE
feat(manager/gradle): support separate registry URLs for plugins

### DIFF
--- a/lib/modules/manager/gradle/extract.ts
+++ b/lib/modules/manager/gradle/extract.ts
@@ -38,10 +38,6 @@ function getRegistryUrlsForDep(
     .filter((item) => item.scope === scope)
     .map((item) => item.registryUrl);
 
-  if (dep.registryUrls) {
-    registryUrls.push(...dep.registryUrls);
-  }
-
   if (!registryUrls.length && scope === 'plugin') {
     registryUrls.push(REGISTRY_URLS.gradlePluginPortal);
   }

--- a/lib/modules/manager/gradle/extract.ts
+++ b/lib/modules/manager/gradle/extract.ts
@@ -38,7 +38,9 @@ function getRegistryUrlsForDep(
     .filter((item) => item.scope === scope)
     .map((item) => item.registryUrl);
 
-  registryUrls.push(...(dep.registryUrls ?? []));
+  if (dep.registryUrls) {
+    registryUrls.push(...dep.registryUrls);
+  }
 
   if (!registryUrls.length && scope === 'plugin') {
     registryUrls.push(REGISTRY_URLS.gradlePluginPortal);

--- a/lib/modules/manager/gradle/extract.ts
+++ b/lib/modules/manager/gradle/extract.ts
@@ -10,8 +10,10 @@ import {
   usesGcv,
 } from './extract/consistent-versions-plugin';
 import { parseGradle, parseProps } from './parser';
+import { REGISTRY_URLS } from './parser/common';
 import type {
   GradleManagerData,
+  PackageRegistry,
   PackageVariables,
   VariableRegistry,
 } from './types';
@@ -26,6 +28,25 @@ import {
 
 const datasource = MavenDatasource.id;
 
+function getRegistryUrlsForDep(
+  packageRegistries: PackageRegistry[],
+  dep: PackageDependency<GradleManagerData>
+): string[] {
+  const scope = dep.depType === 'plugin' ? 'plugin' : 'dep';
+
+  const registryUrls = packageRegistries
+    .filter((item) => item.scope === scope)
+    .map((item) => item.registryUrl);
+
+  registryUrls.push(...(dep.registryUrls ?? []));
+
+  if (!registryUrls.length && scope === 'plugin') {
+    registryUrls.push(REGISTRY_URLS.gradlePluginPortal);
+  }
+
+  return [...new Set(registryUrls)];
+}
+
 export async function extractAllPackageFiles(
   config: ExtractConfig,
   packageFiles: string[]
@@ -33,7 +54,7 @@ export async function extractAllPackageFiles(
   const extractedDeps: PackageDependency<GradleManagerData>[] = [];
   const varRegistry: VariableRegistry = {};
   const packageFilesByName: Record<string, PackageFile> = {};
-  const packageRegistries: string[] = [];
+  const packageRegistries: PackageRegistry[] = [];
   const reorderedFiles = reorderFiles(packageFiles);
   const fileContents = await getFileContentMap(packageFiles, true);
 
@@ -75,7 +96,11 @@ export async function extractAllPackageFiles(
           vars: gradleVars,
         } = parseGradle(content, vars, packageFile, fileContents);
         for (const url of urls) {
-          if (!packageRegistries.includes(url)) {
+          const registryAlreadyKnown = packageRegistries.some(
+            (item) =>
+              item.registryUrl === url.registryUrl && item.scope === url.scope
+          );
+          if (!registryAlreadyKnown) {
             packageRegistries.push(url);
           }
         }
@@ -114,9 +139,7 @@ export async function extractAllPackageFiles(
         };
       }
 
-      dep.registryUrls = [
-        ...new Set([...packageRegistries, ...(dep.registryUrls ?? [])]),
-      ];
+      dep.registryUrls = getRegistryUrlsForDep(packageRegistries, dep);
 
       if (!dep.depType) {
         dep.depType = key.startsWith('buildSrc')

--- a/lib/modules/manager/gradle/extract/catalog.ts
+++ b/lib/modules/manager/gradle/extract/catalog.ts
@@ -276,7 +276,6 @@ export function parseCatalog(
       depType: 'plugin',
       depName,
       packageName: `${depName}:${depName}.gradle.plugin`,
-      registryUrls: ['https://plugins.gradle.org/m2/'],
       currentValue,
       commitMessageTopic: `plugin ${pluginName}`,
       managerData: { fileReplacePosition },

--- a/lib/modules/manager/gradle/parser.spec.ts
+++ b/lib/modules/manager/gradle/parser.spec.ts
@@ -545,7 +545,7 @@ describe('modules/manager/gradle/parser', () => {
         ${'jcenter()'}                                 | ${REGISTRY_URLS.jcenter}
       `('$input', ({ input, output }) => {
         const { urls } = parseGradle(input);
-        expect(urls).toStrictEqual([output].filter(Boolean));
+        expect(urls).toMatchObject([{ registryUrl: output }]);
       });
     });
 
@@ -587,10 +587,59 @@ describe('modules/manager/gradle/parser', () => {
         ${''}                       | ${'maven { setUrl("foo", "bar") }'}                              | ${null}
         ${'base="https://foo.bar"'} | ${'publishing { repositories { maven("${base}/baz") } }'}        | ${null}
       `('$def | $input', ({ def, input, url }) => {
-        const expected = [url].filter(Boolean);
+        const expected = url ? [{ registryUrl: url }] : [];
         const { urls } = parseGradle([def, input].join('\n'));
-        expect(urls).toStrictEqual(expected);
+        expect(urls).toMatchObject(expected);
       });
+    });
+
+    it('pluginManagement', () => {
+      const input = codeBlock`
+          pluginManagement {
+            def fooVersion = "1.2.3"
+            repositories {
+              mavenLocal()
+              maven { url = "https://foo.bar/plugins" }
+              gradlePluginPortal()
+            }
+            plugins {
+              id("foo.bar") version "$fooVersion"
+            }
+          }
+          dependencyResolutionManagement {
+            repositories {
+              maven { url = "https://foo.bar/deps" }
+              mavenCentral()
+            }
+          }
+        `;
+
+      const { deps, urls } = parseGradle(input);
+      expect(deps).toMatchObject([
+        {
+          depType: 'plugin',
+          depName: 'foo.bar',
+          currentValue: '1.2.3',
+        },
+      ]);
+      expect(urls).toMatchObject([
+        {
+          registryUrl: 'https://foo.bar/plugins',
+          scope: 'plugin',
+        },
+        {
+          registryUrl: REGISTRY_URLS.gradlePluginPortal,
+          scope: 'plugin',
+        },
+        {
+          registryUrl: 'https://foo.bar/deps',
+          scope: 'dep',
+        },
+        {
+          registryUrl: REGISTRY_URLS.mavenCentral,
+          scope: 'dep',
+        },
+      ]);
     });
   });
 

--- a/lib/modules/manager/gradle/parser.ts
+++ b/lib/modules/manager/gradle/parser.ts
@@ -10,6 +10,7 @@ import { qVersionCatalogs } from './parser/version-catalogs';
 import type {
   Ctx,
   GradleManagerData,
+  PackageRegistry,
   PackageVariables,
   ParseGradleResult,
 } from './types';
@@ -26,7 +27,7 @@ export function parseGradle(
 ): ParseGradleResult {
   let vars: PackageVariables = { ...initVars };
   const deps: PackageDependency<GradleManagerData>[] = [];
-  const urls: string[] = [];
+  const urls: PackageRegistry[] = [];
 
   const query = q.tree<Ctx>({
     type: 'root-tree',

--- a/lib/modules/manager/gradle/parser/handlers.ts
+++ b/lib/modules/manager/gradle/parser/handlers.ts
@@ -216,7 +216,6 @@ export function handlePlugin(ctx: Ctx): Ctx {
     depType: 'plugin',
     depName,
     packageName,
-    registryUrls: [REGISTRY_URLS.gradlePluginPortal],
     commitMessageTopic: `plugin ${depName}`,
     currentValue: pluginVersion[0].value,
     managerData: {
@@ -246,11 +245,22 @@ export function handlePlugin(ctx: Ctx): Ctx {
   return ctx;
 }
 
+function isPluginRegistry(ctx: Ctx): boolean {
+  if (ctx.tokenMap.registryScope) {
+    const registryScope = loadFromTokenMap(ctx, 'registryScope')[0].value;
+    return registryScope === 'pluginManagement';
+  }
+
+  return false;
+}
+
 export function handlePredefinedRegistryUrl(ctx: Ctx): Ctx {
   const registryName = loadFromTokenMap(ctx, 'registryUrl')[0].value;
-  ctx.registryUrls.push(
-    REGISTRY_URLS[registryName as keyof typeof REGISTRY_URLS]
-  );
+
+  ctx.registryUrls.push({
+    registryUrl: REGISTRY_URLS[registryName as keyof typeof REGISTRY_URLS],
+    scope: isPluginRegistry(ctx) ? 'plugin' : 'dep',
+  });
 
   return ctx;
 }
@@ -281,7 +291,10 @@ export function handleCustomRegistryUrl(ctx: Ctx): Ctx {
     try {
       const { host, protocol } = url.parse(registryUrl);
       if (host && protocol) {
-        ctx.registryUrls.push(registryUrl);
+        ctx.registryUrls.push({
+          registryUrl,
+          scope: isPluginRegistry(ctx) ? 'plugin' : 'dep',
+        });
       }
     } catch (e) {
       // no-op

--- a/lib/modules/manager/gradle/types.ts
+++ b/lib/modules/manager/gradle/types.ts
@@ -16,7 +16,7 @@ export type VariableRegistry = Record<string, PackageVariables>;
 
 export interface ParseGradleResult {
   deps: PackageDependency<GradleManagerData>[];
-  urls: string[];
+  urls: PackageRegistry[];
   vars: PackageVariables;
 }
 
@@ -67,6 +67,11 @@ export interface RichVersion {
 export type GradleVersionPointerTarget = string | RichVersion;
 export type GradleVersionCatalogVersion = string | VersionPointer | RichVersion;
 
+export interface PackageRegistry {
+  registryUrl: string;
+  scope: 'dep' | 'plugin';
+}
+
 export interface Ctx {
   readonly packageFile: string;
   readonly fileContents: Record<string, string | null>;
@@ -74,7 +79,7 @@ export interface Ctx {
 
   globalVars: PackageVariables;
   deps: PackageDependency<GradleManagerData>[];
-  registryUrls: string[];
+  registryUrls: PackageRegistry[];
 
   varTokens: lexer.Token[];
   tmpTokenStore: Record<string, lexer.Token[]>;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

* Separates handling of registry URLs for plugins and regular dependencies
* Introduces an extensible interface for package registries, e.g. to later also support `content` or `exclusiveContent` 

This change causes Gradle plugins to be looked up in a different set of repos than regular deps (analogous to how Gradle behaves). Basically, this is a follow-up after https://github.com/renovatebot/renovate/pull/16430, which can meanwhile be realized due to the new Gradle parser.

<!-- Describe what behavior is changed by this PR. -->

## Context

* Currently, `plugins.gradle.org` is hard-coded and **always** appended as a registry URL for plugins
  * Gradle actually uses `plugins.gradle.org` only as an [implicit fallback](https://github.com/gradle/gradle/blob/ff15f68e68d26538cb100d2276827b71b4e9289b/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/internal/DefaultPluginArtifactRepositories.java#L45-L47), if no other repos are specified
  * Potential security implications (leaking private package names, dependency confusion attacks)
* Until now, plugins were also looked up in repos specified for regular dependencies, e.g. `mavenCentral()`. This impeded lookup performance and resulted in 404s
* So far, if repos were defined within `pluginManagement`, regular deps may have also been looked up in these repos
  * Definitions [often](https://github.com/search?type=code&q=pluginManagement%20%7B%20repositories%20language%3AGradle) include the `gradlePluginPortal()` fallback. In case there is no local match, `plugins.gradle.org` still redirects requests further to JCenter for [some reason](https://discuss.gradle.org/t/plugins-redirecting-to-jcenter/41909). In practice this means that, e.g. if projects specify only private registries for regular deps, updates may still be retrieved indirectly via JCenter

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
