### PR TITLE
feat(manager/gradle): enable property accessors for registry URLs

### DIFF
--- a/lib/modules/manager/gradle/parser.spec.ts
+++ b/lib/modules/manager/gradle/parser.spec.ts
@@ -366,7 +366,7 @@ describe('modules/manager/gradle/parser', () => {
       `('$accessor', ({ accessor }) => {
         const input = `
           baz = "1.2.3"
-          api("foo:bar:$\{${String(accessor)}("baz")}")
+          api("foo:bar:$\{${String(accessor)}("baz") as String}")
         `;
         const { deps } = parseGradle(input);
         expect(deps).toMatchObject([
@@ -562,6 +562,7 @@ describe('modules/manager/gradle/parser', () => {
         ${''}                       | ${'maven(url = uri("https://foo.bar/baz"))'}                     | ${'https://foo.bar/baz'}
         ${''}                       | ${'maven(uri("https://foo.bar/baz"))'}                           | ${'https://foo.bar/baz'}
         ${'base="https://foo.bar"'} | ${'maven(uri("${base}/baz"))'}                                   | ${'https://foo.bar/baz'}
+        ${'base="https://foo.bar"'} | ${'maven(uri(property("base")))'}                                | ${'https://foo.bar'}
         ${'base="https://foo.bar"'} | ${'maven(uri(base))'}                                            | ${'https://foo.bar'}
         ${''}                       | ${'maven(uri(["https://foo.bar/baz"]))'}                         | ${null}
         ${''}                       | ${'maven { ["https://foo.bar/baz"] }'}                           | ${null}
@@ -571,6 +572,7 @@ describe('modules/manager/gradle/parser', () => {
         ${'base="https://foo.bar"'} | ${'maven { url uri("${base}/baz") }'}                            | ${'https://foo.bar/baz'}
         ${''}                       | ${'maven { url = "https://foo.bar/baz" }'}                       | ${'https://foo.bar/baz'}
         ${'base="https://foo.bar"'} | ${'maven { url = "${base}/baz" }'}                               | ${'https://foo.bar/baz'}
+        ${'base="https://foo.bar"'} | ${'maven { url = property("base") }'}                            | ${'https://foo.bar'}
         ${'base="https://foo.bar"'} | ${'maven { url = base }'}                                        | ${'https://foo.bar'}
         ${''}                       | ${'maven { url = uri("https://foo.bar/baz") }'}                  | ${'https://foo.bar/baz'}
         ${'base="https://foo.bar"'} | ${'maven { url = uri("${base}/baz") }'}                          | ${'https://foo.bar/baz'}
@@ -579,9 +581,12 @@ describe('modules/manager/gradle/parser', () => {
         ${'base="https://foo.bar"'} | ${'maven { name "baz"\nurl = "${base}/${name}" }'}               | ${'https://foo.bar/baz'}
         ${'base="https://foo.bar"'} | ${'maven { name = "baz"\nurl = "${base}/${name}" }'}             | ${'https://foo.bar/baz'}
         ${'some="baz"'}             | ${'maven { name = "${some}"\nurl = "https://foo.bar/${name}" }'} | ${'https://foo.bar/baz'}
+        ${'some="foo.bar/baz"'}     | ${'maven { name = property("some")\nurl = "https://${name}" }'}  | ${'https://foo.bar/baz'}
         ${'some="baz"'}             | ${'maven { name = some\nurl = "https://foo.bar/${name}" }'}      | ${'https://foo.bar/baz'}
         ${''}                       | ${'maven { setUrl("https://foo.bar/baz") }'}                     | ${'https://foo.bar/baz'}
+        ${''}                       | ${'maven { setUrl(uri("https://foo.bar/baz")) }'}                | ${'https://foo.bar/baz'}
         ${'base="https://foo.bar"'} | ${'maven { setUrl("${base}/baz") }'}                             | ${'https://foo.bar/baz'}
+        ${'base="https://foo.bar"'} | ${'maven { setUrl(project.property("base")) }'}                  | ${'https://foo.bar'}
         ${'base="https://foo.bar"'} | ${'maven { setUrl(base) }'}                                      | ${'https://foo.bar'}
         ${''}                       | ${'maven { setUrl(["https://foo.bar/baz"]) }'}                   | ${null}
         ${''}                       | ${'maven { setUrl("foo", "bar") }'}                              | ${null}

--- a/lib/modules/manager/gradle/parser/common.ts
+++ b/lib/modules/manager/gradle/parser/common.ts
@@ -166,7 +166,8 @@ export const qPropertyAccessIdentifier = q
     startsWith: '(',
     endsWith: ')',
     search: q.begin<Ctx>().join(qStringValueAsSymbol).end(),
-  });
+  })
+  .opt(q.sym<Ctx>('as').sym('String'));
 
 // "foo${bar}baz"
 export const qTemplateString = q


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

* Extends the existing support for property accesors to registry URLs
   * `name` and `url` of maven repo declarations may be specified as properties ([example](https://github.com/mozilla-mobile/fenix/blob/8336d98c0e6d404af3bbcc188b9fdba01362e31c/build.gradle#L30))
* Ignores `as String` type casts, occasionally used with properties in Kotlin projects ([example](https://github.com/europace/artifact-version-gradle-plugin/blob/5cc54938061b4e51dd310b90a0a47038ae4ce322/build.gradle.kts#L86))
* _Refactoring_: Extracts a common URI pattern to reuse across all spots where `java.net.URI` is expected
  * Idea: For better maintainability, have a common selector for URLs specified directly ([ref](https://docs.gradle.org/current/dsl/org.gradle.api.artifacts.repositories.MavenArtifactRepository.html#org.gradle.api.artifacts.repositories.MavenArtifactRepository:url)) or via `uri` ([ref](https://docs.gradle.org/current/javadoc/org/gradle/api/Project.html#uri-java.lang.Object-)).

<!-- Describe what behavior is changed by this PR. -->

## Context

* Related to https://github.com/renovatebot/renovate/pull/18990
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
