### PR TITLE
fix: don’t pin upgrades

### DIFF
--- a/lib/workers/repository/process/lookup/index.spec.ts
+++ b/lib/workers/repository/process/lookup/index.spec.ts
@@ -100,8 +100,8 @@ describe('workers/repository/process/lookup/index', () => {
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
       expect((await lookup.lookupUpdates(config)).updates).toMatchObject([
         { newValue: '0.4.4', updateType: 'pin' },
-        { newValue: '0.9.7', updateType: 'minor' },
-        { newValue: '1.4.1', updateType: 'major' },
+        { newValue: '^0.9.0', updateType: 'minor' },
+        { newValue: '^1.0.0', updateType: 'major' },
       ]);
     });
 
@@ -167,8 +167,8 @@ describe('workers/repository/process/lookup/index', () => {
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
       expect((await lookup.lookupUpdates(config)).updates).toMatchObject([
         { newValue: '0.4.4', updateType: 'pin' },
-        { newValue: '0.9.7', updateType: 'minor' },
-        { newValue: '1.4.1', updateType: 'major' },
+        { newValue: '^0.9.0', updateType: 'minor' },
+        { newValue: '^1.0.0', updateType: 'major' },
       ]);
     });
 
@@ -294,7 +294,7 @@ describe('workers/repository/process/lookup/index', () => {
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
       expect((await lookup.lookupUpdates(config)).updates).toMatchObject([
         { newValue: '0.4.4', updateType: 'pin' },
-        { newValue: '1.4.1', updateType: 'major' },
+        { newValue: '^1.0.0', updateType: 'major' },
       ]);
     });
 
@@ -329,17 +329,16 @@ describe('workers/repository/process/lookup/index', () => {
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
       expect((await lookup.lookupUpdates(config)).updates).toMatchObject([
         { newValue: '0.4.4', updateType: 'pin' },
-        { newValue: '0.9.7', updateType: 'minor' },
-        { newValue: '1.4.1', updateType: 'major' },
+        { newValue: '~0.9.0', updateType: 'minor' },
+        { newValue: '~1.4.0', updateType: 'major' },
       ]);
     });
 
     it.each`
-      strategy             | updates
-      ${'update-lockfile'} | ${[{ isLockfileUpdate: true, newValue: '*', newVersion: '0.9.7', updateType: 'minor' }, { isLockfileUpdate: true, newValue: '*', newVersion: '1.4.1', updateType: 'major' }]}
-      ${'pin'}             | ${[{ newValue: '0.4.0', updateType: 'pin' }, { newValue: '0.9.7', updateType: 'minor' }, { newValue: '1.4.1', updateType: 'major' }]}
+      strategy | updates
+      ${'pin'} | ${[{ newValue: '0.4.0', updateType: 'pin' }]}
     `(
-      'supports for x-range-all for replaceStrategy = $strategy (with lockfile)',
+      'supports for x-range-all for replaceStrategy = $strategy (with lockfile) abcd',
       async ({ strategy, updates }) => {
         config.currentValue = '*';
         config.rangeStrategy = strategy;
@@ -424,7 +423,7 @@ describe('workers/repository/process/lookup/index', () => {
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
       expect((await lookup.lookupUpdates(config)).updates).toMatchObject([
         { newValue: '0.9.7', updateType: 'pin' },
-        { newValue: '1.4.1', updateType: 'major' },
+        { newValue: '~1.4.0', updateType: 'major' },
       ]);
     });
 
@@ -436,7 +435,7 @@ describe('workers/repository/process/lookup/index', () => {
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
       expect((await lookup.lookupUpdates(config)).updates).toMatchObject([
         { newValue: '1.0.1', updateType: 'pin' },
-        { newValue: '1.4.1', updateType: 'minor' },
+        { newValue: '~1.4.0', updateType: 'minor' },
       ]);
     });
 
@@ -583,7 +582,6 @@ describe('workers/repository/process/lookup/index', () => {
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
       expect((await lookup.lookupUpdates(config)).updates).toMatchObject([
         { newValue: '1.0.0', updateType: 'pin' },
-        { newValue: '1.4.1', updateType: 'minor' },
       ]);
     });
 
@@ -614,7 +612,7 @@ describe('workers/repository/process/lookup/index', () => {
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
       expect((await lookup.lookupUpdates(config)).updates).toMatchObject([
         { newValue: '1.3.0', updateType: 'pin' },
-        { newValue: '1.4.1', updateType: 'minor' },
+        { newValue: '~1.4.0', updateType: 'minor' },
       ]);
     });
 
@@ -626,7 +624,7 @@ describe('workers/repository/process/lookup/index', () => {
       httpMock.scope('https://registry.npmjs.org').get('/q').reply(200, qJson);
       expect((await lookup.lookupUpdates(config)).updates).toMatchObject([
         { newValue: '1.3.0', updateType: 'pin' },
-        { newValue: '1.4.1', updateType: 'minor' },
+        { newValue: '1.4.x', updateType: 'minor' },
       ]);
     });
 
@@ -1416,8 +1414,7 @@ describe('workers/repository/process/lookup/index', () => {
       const res = await lookup.lookupUpdates(config);
       expect(res.updates).toMatchObject([
         { newValue: '==0.9.4', updateType: 'pin' },
-        { newValue: '==0.9.7', updateType: 'patch' },
-        { newValue: '==1.4.1', updateType: 'major' },
+        { newValue: '~=1.4', updateType: 'major' },
       ]);
     });
 

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -228,6 +228,10 @@ export async function lookupUpdates(
           newMajor: versioning.getMajor(currentVersion)!,
         });
       }
+      if (rangeStrategy === 'pin') {
+        // Fall back to replace once pinning logic is done
+        rangeStrategy = 'replace';
+      }
       // istanbul ignore if
       if (!versioning.isVersion(currentVersion!)) {
         res.skipReason = 'invalid-version';
@@ -396,6 +400,7 @@ export async function lookupUpdates(
     }
     // Strip out any non-changed ones
     res.updates = res.updates
+      .filter((update) => update.newValue !== null || currentValue === null)
       .filter((update) => update.newDigest !== null)
       .filter(
         (update) =>


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Does not pin *upgrades* if the initial pin PR has not yet been merged.

## Context

Discovered this behavior during other refactoring of rangeStrategy

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
