### PR TITLE
feat(templates): add decodeURIComponent helper

### DIFF
--- a/docs/usage/templates.md
+++ b/docs/usage/templates.md
@@ -49,6 +49,16 @@ In the example above `baseDir` is the string you want to transform into a valid 
 
 Read the [MDN Web Docs, encodeURIComponent()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent) to learn more.
 
+### decodeURIComponent
+
+If you want to decode a percent-encoded string, use the built-in function `decodeURIComponent` like this:
+
+`{{{decodeURIComponent depName}}}`
+
+In the example above `depName` is the string you want to decode.
+
+Read the [MDN Web Docs, decodeURIComponent()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/decodeURIComponent) to learn more.
+
 ### replace
 
 The `replace` helper replaces _all_ found strings with the replacement string.

--- a/lib/util/template/index.spec.ts
+++ b/lib/util/template/index.spec.ts
@@ -158,4 +158,22 @@ describe('util/template/index', () => {
       expect(template.containsTemplates('{{body}}', ['logJSON'])).toBeFalse();
     });
   });
+
+  describe('percent encoding', () => {
+    it('encodes values', () => {
+      const output = template.compile(
+        '{{{encodeURIComponent "@fsouza/prettierd"}}}',
+        undefined as never
+      );
+      expect(output).toBe('%40fsouza%2Fprettierd');
+    });
+
+    it('decodes values', () => {
+      const output = template.compile(
+        '{{{decodeURIComponent "%40fsouza/prettierd"}}}',
+        undefined as never
+      );
+      expect(output).toBe('@fsouza/prettierd');
+    });
+  });
 });

--- a/lib/util/template/index.ts
+++ b/lib/util/template/index.ts
@@ -4,6 +4,7 @@ import { GlobalConfig } from '../../config/global';
 import { logger } from '../../logger';
 
 handlebars.registerHelper('encodeURIComponent', encodeURIComponent);
+handlebars.registerHelper('decodeURIComponent', decodeURIComponent);
 
 handlebars.registerHelper('stringToPrettyJSON', (input: string): string =>
   JSON.stringify(JSON.parse(input), null, 2)


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds the decodeURIComponent helper, useful for decoding percent-encoded strings.
For example, [purl](https://github.com/package-url/purl-spec) identifiers require
certain components to be percent-encoded (e.g. [`pkg:npm/%40fsouza/prettierd`](https://github.com/mason-org/mason-registry/pull/155)).

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
