### PR TITLE
feat(manager/gradle): enable support for concatenated properties

### DIFF
--- a/lib/modules/manager/gradle/parser.spec.ts
+++ b/lib/modules/manager/gradle/parser.spec.ts
@@ -1,3 +1,4 @@
+import is from '@sindresorhus/is';
 import { codeBlock } from 'common-tags';
 import { Fixtures } from '../../../../test/fixtures';
 import { fs, logger } from '../../../../test/util';
@@ -324,7 +325,7 @@ describe('modules/manager/gradle/parser', () => {
         ${'foo.bar = "foo:bar:1.2.3"'} | ${{ depName: 'foo:bar', currentValue: '1.2.3' }}
       `('$input', ({ input, output }) => {
         const { deps } = parseGradle(input);
-        expect(deps).toMatchObject([output].filter(Boolean));
+        expect(deps).toMatchObject([output]);
       });
     });
 
@@ -347,7 +348,7 @@ describe('modules/manager/gradle/parser', () => {
         ${'a = "foo"; b = "bar"; c="1.2.3"'} | ${'"${a}:${b}:${property("c")}"'}      | ${{ depName: 'foo:bar', currentValue: '1.2.3', groupName: 'c' }}
       `('$def | $str', ({ def, str, output }) => {
         const { deps } = parseGradle([def, str].join('\n'));
-        expect(deps).toMatchObject([output].filter(Boolean));
+        expect(deps).toMatchObject([output].filter(is.truthy));
       });
     });
 
@@ -368,7 +369,7 @@ describe('modules/manager/gradle/parser', () => {
         ${'foo.bar = "bar"; baz = "1.2.3"'}  | ${'"foo:bar_${foo.bar}:" + baz'}  | ${{ depName: 'foo:bar_bar', currentValue: '1.2.3', managerData: { fileReplacePosition: 24 } }}
       `('$def | $str', ({ def, str, output }) => {
         const { deps } = parseGradle([def, str].join('\n'));
-        expect(deps).toMatchObject([output].filter(Boolean));
+        expect(deps).toMatchObject([output]);
       });
     });
 
@@ -424,7 +425,7 @@ describe('modules/manager/gradle/parser', () => {
         ${''}              | ${'kotlin("foo", "1.2.3@@@")'}        | ${null}
       `('$def | $str', ({ def, str, output }) => {
         const { deps } = parseGradle([def, str].join('\n'));
-        expect(deps).toMatchObject([output].filter(Boolean));
+        expect(deps).toMatchObject([output].filter(is.truthy));
       });
     });
 
@@ -453,7 +454,7 @@ describe('modules/manager/gradle/parser', () => {
         ${''}              | ${'(group = "foo", name = "bar", version = "1.2.3", changing: true)'}             | ${{ depName: 'foo:bar', currentValue: '1.2.3' }}
       `('$def | $str', ({ def, str, output }) => {
         const { deps } = parseGradle([def, str].join('\n'));
-        expect(deps).toMatchObject([output].filter(Boolean));
+        expect(deps).toMatchObject([output].filter(is.truthy));
       });
     });
 
@@ -558,7 +559,7 @@ describe('modules/manager/gradle/parser', () => {
         ${'baz = "1.3.71"'} | ${'kotlin("jvm") version baz'}             | ${{ depName: 'org.jetbrains.kotlin.jvm', packageName: 'org.jetbrains.kotlin.jvm:org.jetbrains.kotlin.jvm.gradle.plugin', currentValue: '1.3.71' }}
       `('$def | $input', ({ def, input, output }) => {
         const { deps } = parseGradle([def, input].join('\n'));
-        expect(deps).toMatchObject([output].filter(Boolean));
+        expect(deps).toMatchObject([output].filter(is.truthy));
       });
     });
   });
@@ -707,7 +708,7 @@ describe('modules/manager/gradle/parser', () => {
     `('$def | $str', ({ def, str, output }) => {
       const input = [def, str].join('\n');
       const { deps } = parseGradle(input);
-      expect(deps).toMatchObject([output].filter(Boolean));
+      expect(deps).toMatchObject([output].filter(is.truthy));
     });
   });
 
@@ -730,7 +731,7 @@ describe('modules/manager/gradle/parser', () => {
       ${'mapScalar("foo", "bar", "baz")'}                          | ${{ depName: 'foo:bar', currentValue: 'baz', skipReason: 'ignored' }}
     `('$input', ({ input, output }) => {
       const { deps } = parseGradle(input);
-      expect(deps).toMatchObject([output].filter(Boolean));
+      expect(deps).toMatchObject([output].filter(is.truthy));
     });
   });
 
@@ -904,7 +905,7 @@ describe('modules/manager/gradle/parser', () => {
       ${''}              | ${'unknown { toolVersion = "1.2.3" }'}          | ${null}
     `('$def | $input', ({ def, input, output }) => {
       const { deps } = parseGradle([def, input].join('\n'));
-      expect(deps).toMatchObject([output].filter(Boolean));
+      expect(deps).toMatchObject([output].filter(is.truthy));
     });
   });
 });

--- a/lib/modules/manager/gradle/parser/apply-from.ts
+++ b/lib/modules/manager/gradle/parser/apply-from.ts
@@ -35,8 +35,8 @@ const qApplyFromFile = q
         search: q
           .begin<Ctx>()
           .opt(
-            qFilePath
-              .op(',')
+            q
+              .join(qFilePath, q.op(','))
               .handler((ctx) => storeInTokenMap(ctx, 'parentPath'))
           )
           .join(qFilePath)

--- a/lib/modules/manager/gradle/parser/apply-from.ts
+++ b/lib/modules/manager/gradle/parser/apply-from.ts
@@ -3,6 +3,7 @@ import { regEx } from '../../../../util/regex';
 import type { Ctx } from '../types';
 import {
   cleanupTempVars,
+  qConcatExpr,
   qPropertyAccessIdentifier,
   qTemplateString,
   qVariableAccessIdentifier,
@@ -10,16 +11,16 @@ import {
 } from './common';
 import { handleApplyFrom } from './handlers';
 
-const qFilePath = q.alt(
+const qFilePath = qConcatExpr(
   qTemplateString,
   qPropertyAccessIdentifier,
   qVariableAccessIdentifier
 );
 
+// apply from: 'foo.gradle'
+// apply(from = property("foo"))
 const qApplyFromFile = q
   .alt(
-    qTemplateString, // apply from: 'foo.gradle'
-    qPropertyAccessIdentifier, // apply(from = property("foo"))
     q
       .alt(
         q
@@ -40,7 +41,8 @@ const qApplyFromFile = q
           )
           .join(qFilePath)
           .end(),
-      })
+      }),
+    qFilePath
   )
   .handler((ctx) => storeInTokenMap(ctx, 'scriptFile'));
 

--- a/lib/modules/manager/gradle/parser/common.ts
+++ b/lib/modules/manager/gradle/parser/common.ts
@@ -1,5 +1,4 @@
 import { lexer, parser, query as q } from 'good-enough-parser';
-import type { SeqBuilder } from 'good-enough-parser/dist/cjs/query/builder';
 import { regEx } from '../../../../util/regex';
 import type { Ctx, NonEmptyArray, PackageVariables } from '../types';
 
@@ -220,5 +219,5 @@ export const qTemplateString = q
 // foo + foo + "${foo}" + "foo" => "barbarbarfoo"
 export const qConcatExpr = (
   ...matchers: q.QueryBuilder<Ctx, parser.Node>[]
-): SeqBuilder<Ctx, parser.Node> =>
+): q.QueryBuilder<Ctx, parser.Node> =>
   q.alt(...matchers).many(q.op<Ctx>('+').alt(...matchers), 0, 32);

--- a/lib/modules/manager/gradle/parser/common.ts
+++ b/lib/modules/manager/gradle/parser/common.ts
@@ -1,4 +1,4 @@
-import { lexer, query as q } from 'good-enough-parser';
+import { lexer, parser, query as q } from 'good-enough-parser';
 import type { SeqBuilder } from 'good-enough-parser/dist/cjs/query/builder';
 import { regEx } from '../../../../util/regex';
 import type { Ctx, NonEmptyArray, PackageVariables } from '../types';
@@ -219,6 +219,6 @@ export const qTemplateString = q
 // foo = "bar"
 // foo + foo + "${foo}" + "foo" => "barbarbarfoo"
 export const qConcatExpr = (
-  ...matchers: q.QueryBuilder<Ctx>[]
-): SeqBuilder<Ctx> =>
+  ...matchers: q.QueryBuilder<Ctx, parser.Node>[]
+): SeqBuilder<Ctx, parser.Node> =>
   q.alt(...matchers).many(q.op<Ctx>('+').alt(...matchers), 0, 32);

--- a/lib/modules/manager/gradle/parser/dependencies.ts
+++ b/lib/modules/manager/gradle/parser/dependencies.ts
@@ -28,9 +28,10 @@ const qArtifactId = qConcatExpr(
   qVariableAccessIdentifier
 ).handler((ctx) => storeInTokenMap(ctx, 'artifactId'));
 
-const qVersion = q
-  .alt(qTemplateString, qVariableAccessIdentifier)
-  .handler((ctx) => storeInTokenMap(ctx, 'version'));
+const qVersion = qConcatExpr(
+  qTemplateString,
+  qVariableAccessIdentifier
+).handler((ctx) => storeInTokenMap(ctx, 'version'));
 
 // "foo:bar:1.2.3"
 // "foo:bar:$baz"
@@ -121,10 +122,12 @@ const qKotlinShortNotationDependencies = q
       .join(qArtifactId)
       .op(',')
       .opt(q.sym<Ctx>('version').op('='))
-      .alt(
-        qTemplateString,
-        qPropertyAccessIdentifier,
-        qVariableAccessIdentifier
+      .join(
+        qConcatExpr(
+          qTemplateString,
+          qPropertyAccessIdentifier,
+          qVariableAccessIdentifier
+        )
       )
       .handler((ctx) => storeInTokenMap(ctx, 'version'))
       .end(),
@@ -192,10 +195,12 @@ const qImplicitGradlePlugin = q
     search: q
       .sym<Ctx>(regEx(/^(?:toolVersion|version)$/))
       .op('=')
-      .alt(
-        qTemplateString,
-        qPropertyAccessIdentifier,
-        qVariableAccessIdentifier
+      .join(
+        qConcatExpr(
+          qTemplateString,
+          qPropertyAccessIdentifier,
+          qVariableAccessIdentifier
+        )
       ),
   })
   .handler((ctx) => storeInTokenMap(ctx, 'version'))

--- a/lib/modules/manager/gradle/parser/plugins.ts
+++ b/lib/modules/manager/gradle/parser/plugins.ts
@@ -3,6 +3,7 @@ import { regEx } from '../../../../util/regex';
 import type { Ctx } from '../types';
 import {
   cleanupTempVars,
+  qConcatExpr,
   qPropertyAccessIdentifier,
   qStringValue,
   qTemplateString,
@@ -12,9 +13,11 @@ import {
 } from './common';
 import { handlePlugin } from './handlers';
 
-const qVersion = q
-  .alt(qTemplateString, qPropertyAccessIdentifier, qVariableAccessIdentifier)
-  .handler((ctx) => storeInTokenMap(ctx, 'version'));
+const qVersion = qConcatExpr(
+  qTemplateString,
+  qPropertyAccessIdentifier,
+  qVariableAccessIdentifier
+).handler((ctx) => storeInTokenMap(ctx, 'version'));
 
 // kotlin("jvm") version "1.3.71"
 export const qPlugins = q

--- a/lib/modules/manager/gradle/parser/version-catalogs.ts
+++ b/lib/modules/manager/gradle/parser/version-catalogs.ts
@@ -39,7 +39,7 @@ const qVersionCatalogVersion = q
       endsWith: ')',
       search: q
         .begin<Ctx>()
-        .alt(qTemplateString, qVariableAccessIdentifier)
+        .join(qConcatExpr(qTemplateString, qVariableAccessIdentifier))
         .end(),
     })
   )

--- a/lib/modules/manager/gradle/parser/version-catalogs.ts
+++ b/lib/modules/manager/gradle/parser/version-catalogs.ts
@@ -2,6 +2,7 @@ import { query as q } from 'good-enough-parser';
 import type { Ctx } from '../types';
 import {
   cleanupTempVars,
+  qConcatExpr,
   qStringValue,
   qStringValueAsSymbol,
   qTemplateString,
@@ -11,13 +12,15 @@ import {
 } from './common';
 import { handleLibraryDep } from './handlers';
 
-const qGroupId = q
-  .alt(qTemplateString, qVariableAccessIdentifier)
-  .handler((ctx) => storeInTokenMap(ctx, 'groupId'));
+const qGroupId = qConcatExpr(
+  qTemplateString,
+  qVariableAccessIdentifier
+).handler((ctx) => storeInTokenMap(ctx, 'groupId'));
 
-const qArtifactId = q
-  .alt(qTemplateString, qVariableAccessIdentifier)
-  .handler((ctx) => storeInTokenMap(ctx, 'artifactId'));
+const qArtifactId = qConcatExpr(
+  qTemplateString,
+  qVariableAccessIdentifier
+).handler((ctx) => storeInTokenMap(ctx, 'artifactId'));
 
 const qVersionCatalogVersion = q
   .op<Ctx>('.')


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds parsing support for up to 32 properties chained via `+` operator. This enables advanced string combinations like:
```groovy
maven {
  url = repobase + "/${name}"
}

dependencies {
    classpath("io.jsonwebtoken:" + project.property("somepart") + "-api:" + project.ext["jjwt_version"])
}
```

- Parsing of regular dependency strings isn't changed with this PR. In case further properties are found _after_ `+`, they are memorized as additional tokens. This is already done the same way for template strings like `"foobar${baz}"`. String combinations, such as `"foo" + "bar" + "${baz}"` can be processed with the same handler methods.
- New tests partly include `fileReplacePosition` to validate the handling that was added to `qVariableAccessIdentifier`. It is responsible to ensure that `"some" + foo.bar` isn't mistakenly folded into `some.foo.bar`

// Update: I've now enabled `+` for `version` too. At first, the intention was not to do this, since any concatenated version string could not be updated properly anyway. Upon thinking it further, I believe it makes sense to have it enabled for more correct version extractions. E.g. a dep specified with `version: kafkaVersion + "-ce"` should rather be extracted with `unknown-version` than looked up with the value of `kafkaVersion` only, which will eventually produce no or wrong lookup results.

<!-- Describe what behavior is changed by this PR. -->

## Context

* Closes https://github.com/renovatebot/renovate/issues/8728

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

Test repo: https://github.com/renovate-demo/8728-concat

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
