### PR TITLE
fix(manager/pip_setup): support namespaced packages

### DIFF
--- a/lib/modules/manager/pip_setup/__fixtures__/setup.py
+++ b/lib/modules/manager/pip_setup/__fixtures__/setup.py
@@ -78,6 +78,7 @@ setup(
         'raven>=5.27.1,<7.0', # pyup: nothing
         'future>=0.15.2,<0.17',
         'ipaddress>=1.0.16,<2.0;python_version<"3.3"',
+        'zope.interface>=5.5.2,<6.0.0',
     ],
     keywords=[
         'talisker',

--- a/lib/modules/manager/pip_setup/__snapshots__/extract.spec.ts.snap
+++ b/lib/modules/manager/pip_setup/__snapshots__/extract.spec.ts.snap
@@ -124,6 +124,14 @@ exports[`modules/manager/pip_setup/extract extractPackageFile() returns found de
         "lineNumber": 79,
       },
     },
+    {
+      "currentValue": ">=5.5.2,<6.0.0",
+      "datasource": "pypi",
+      "depName": "zope.interface",
+      "managerData": {
+        "lineNumber": 80,
+      },
+    },
   ],
 }
 `;

--- a/lib/modules/manager/pip_setup/extract.spec.ts
+++ b/lib/modules/manager/pip_setup/extract.spec.ts
@@ -32,6 +32,7 @@ describe('modules/manager/pip_setup/extract', () => {
           { depName: 'raven', currentValue: '>=5.27.1,<7.0' },
           { depName: 'future', currentValue: '>=0.15.2,<0.17' },
           { depName: 'ipaddress', currentValue: '>=1.0.16,<2.0' },
+          { depName: 'zope.interface', currentValue: '>=5.5.2,<6.0.0' },
         ],
       });
     });

--- a/lib/modules/manager/pip_setup/extract.ts
+++ b/lib/modules/manager/pip_setup/extract.ts
@@ -19,7 +19,7 @@ function cleanupNamedGroups(regexSource: string): string {
 
 const rangePattern = cleanupNamedGroups(RANGE_PATTERN);
 const versionPattern = `(?:${rangePattern}(?:\\s*,\\s*${rangePattern})*)`;
-const depNamePattern = '(?:[a-zA-Z][-_a-zA-Z0-9]*[a-zA-Z0-9])';
+const depNamePattern = '(?:[a-zA-Z][-_a-zA-Z0-9\\.]*[a-zA-Z0-9])';
 const depPattern = [
   '^',
   `(?<depName>${depNamePattern})`,


### PR DESCRIPTION



## Changes

Namespaced python package may include a dot (like zope.interface¹). This commit ensures the pip_setup manager will detect those dependencies.

¹ https://pypi.org/project/zope.interface/

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

Renovate is not able to update some dependencies in a setup.py file.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
