### PR TITLE
fix(versioning/hashicorp): check valid before matches

### DIFF
--- a/lib/modules/versioning/hashicorp/index.ts
+++ b/lib/modules/versioning/hashicorp/index.ts
@@ -1,3 +1,4 @@
+import { logger } from '../../../logger';
 import type { RangeStrategy } from '../../../types/versioning';
 import { api as npm } from '../npm';
 import type { NewValueConfig, VersioningApi } from '../types';
@@ -25,6 +26,7 @@ export function isValid(input: string): boolean {
     try {
       return npm.isValid(hashicorp2npm(input));
     } catch (err) {
+      logger.debug({ value: input }, 'Unsupported hashicorp versioning value');
       return false;
     }
   }
@@ -32,7 +34,7 @@ export function isValid(input: string): boolean {
 }
 
 function matches(version: string, range: string): boolean {
-  return npm.matches(version, hashicorp2npm(range));
+  return isValid(range) && npm.matches(version, hashicorp2npm(range));
 }
 
 function getSatisfyingVersion(

--- a/lib/util/package-rules/current-version.ts
+++ b/lib/util/package-rules/current-version.ts
@@ -39,6 +39,7 @@ export class CurrentVersionMatcher extends Matcher {
           isUnconstrainedValue ||
           !!(
             currentValue &&
+            version.isValid(currentValue) &&
             version.matches(matchCurrentVersionStr, currentValue)
           )
         );

--- a/lib/util/package-rules/index.spec.ts
+++ b/lib/util/package-rules/index.spec.ts
@@ -727,6 +727,7 @@ describe('util/package-rules/index', () => {
           x: 1,
         },
       ],
+      versioning: 'npm',
     };
     const res1 = applyPackageRules({
       ...config,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

Closes #19739

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
