### PR TITLE
fix(package-rules): return early

### DIFF
--- a/lib/util/package-rules/index.ts
+++ b/lib/util/package-rules/index.ts
@@ -29,18 +29,13 @@ function matchesRule(
     matchApplied = true;
 
     if (!is.truthy(isMatch)) {
-      positiveMatch = false;
+      return false;
     }
   }
 
   // not a single match rule is defined --> assume to match everything
   if (!matchApplied) {
     positiveMatch = true;
-  }
-
-  // nothing has been matched
-  if (!positiveMatch) {
-    return false;
   }
 
   // excludes

--- a/lib/util/package-rules/utils.ts
+++ b/lib/util/package-rules/utils.ts
@@ -8,7 +8,6 @@ export function matcherOR(
   inputConfig: PackageRuleInputConfig,
   packageRule: PackageRule
 ): boolean | null {
-  let positiveMatch = false;
   let matchApplied = false;
   for (const matcher of groupMatchers) {
     let isMatch;
@@ -29,10 +28,10 @@ export function matcherOR(
     matchApplied = true;
 
     if (is.truthy(isMatch)) {
-      positiveMatch = true;
+      return true;
     }
   }
-  return matchApplied ? positiveMatch : null;
+  return matchApplied ? false : null;
 }
 
 export function massagePattern(pattern: string): string {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Alters package rules loop logic to return results early whenever possible.

## Context

Discovered as part of https://github.com/renovatebot/renovate/issues/19759

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
