### PR TITLE
fix(github-actions): harden job container extraction

### DIFF
--- a/lib/modules/manager/github-actions/extract.ts
+++ b/lib/modules/manager/github-actions/extract.ts
@@ -1,3 +1,4 @@
+import is from '@sindresorhus/is';
 import { load } from 'js-yaml';
 import { logger } from '../../../logger';
 import { newlineRegex, regEx } from '../../../util/regex';
@@ -5,7 +6,7 @@ import { GithubTagsDatasource } from '../../datasource/github-tags';
 import * as dockerVersioning from '../../versioning/docker';
 import { getDep } from '../dockerfile/extract';
 import type { PackageDependency, PackageFile } from '../types';
-import type { Container, Workflow } from './types';
+import type { Workflow } from './types';
 
 const dockerActionRe = regEx(/^\s+uses: ['"]?docker:\/\/([^'"]+)\s*$/);
 const actionRe = regEx(
@@ -76,14 +77,13 @@ function extractWithRegex(content: string): PackageDependency[] {
   return deps;
 }
 
-function extractContainer(container: string | Container): PackageDependency {
-  let dep: PackageDependency;
-  if (typeof container === 'string') {
-    dep = getDep(container);
-  } else {
-    dep = getDep(container?.image);
+function extractContainer(container: unknown): PackageDependency | undefined {
+  if (is.string(container)) {
+    return getDep(container);
+  } else if (is.plainObject(container) && is.string(container.image)) {
+    return getDep(container.image);
   }
-  return dep;
+  return undefined;
 }
 
 function extractWithYAMLParser(
@@ -105,16 +105,18 @@ function extractWithYAMLParser(
   }
 
   for (const job of Object.values(pkg?.jobs ?? {})) {
-    if (job.container !== undefined) {
-      const dep = extractContainer(job.container);
+    const dep = extractContainer(job.container);
+    if (dep) {
       dep.depType = 'container';
       deps.push(dep);
     }
 
     for (const service of Object.values(job.services ?? {})) {
       const dep = extractContainer(service);
-      dep.depType = 'service';
-      deps.push(dep);
+      if (dep) {
+        dep.depType = 'service';
+        deps.push(dep);
+      }
     }
   }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Hardens container extraction for github-actions

## Context

Errors in the hosted app

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
