### PR TITLE
fix(npm): augment constraints less aggressively

### DIFF
--- a/lib/modules/manager/npm/extract/locked-versions.spec.ts
+++ b/lib/modules/manager/npm/extract/locked-versions.spec.ts
@@ -344,6 +344,39 @@ describe('modules/manager/npm/extract/locked-versions', () => {
       ]);
     });
 
+    it('skips augmenting v2 lock file constraint', async () => {
+      npm.getNpmLock.mockReturnValue({
+        lockedVersions: { a: '1.0.0', b: '2.0.0', c: '3.0.0' },
+        lockfileVersion: 2,
+      });
+      const packageFiles = [
+        {
+          npmLock: 'package-lock.json',
+          constraints: {
+            npm: '>=9.0.0',
+          },
+          deps: [
+            { depName: 'a', currentValue: '1.0.0' },
+            { depName: 'b', currentValue: '2.0.0' },
+          ],
+        },
+      ];
+      await getLockedVersions(packageFiles);
+      expect(packageFiles).toEqual([
+        {
+          constraints: {
+            npm: '>=9.0.0',
+          },
+          deps: [
+            { currentValue: '1.0.0', depName: 'a', lockedVersion: '1.0.0' },
+            { currentValue: '2.0.0', depName: 'b', lockedVersion: '2.0.0' },
+          ],
+          lockFiles: ['package-lock.json'],
+          npmLock: 'package-lock.json',
+        },
+      ]);
+    });
+
     it('appends <7 to npm constraints', async () => {
       npm.getNpmLock.mockReturnValue({
         lockedVersions: {
@@ -375,6 +408,47 @@ describe('modules/manager/npm/extract/locked-versions', () => {
       expect(packageFiles).toEqual([
         {
           constraints: { npm: '>=6.0.0 <7' },
+          deps: [
+            { currentValue: '1.0.0', depName: 'a', lockedVersion: '1.0.0' },
+            { currentValue: '2.0.0', depName: 'b', lockedVersion: '2.0.0' },
+          ],
+          lockFiles: ['package-lock.json'],
+          npmLock: 'package-lock.json',
+        },
+      ]);
+    });
+
+    it('skips appending <7 to npm constraints', async () => {
+      npm.getNpmLock.mockReturnValue({
+        lockedVersions: {
+          a: '1.0.0',
+          b: '2.0.0',
+          c: '3.0.0',
+        },
+        lockfileVersion: 1,
+      });
+      const packageFiles = [
+        {
+          npmLock: 'package-lock.json',
+          constraints: {
+            npm: '^8.0.0',
+          },
+          deps: [
+            {
+              depName: 'a',
+              currentValue: '1.0.0',
+            },
+            {
+              depName: 'b',
+              currentValue: '2.0.0',
+            },
+          ],
+        },
+      ];
+      await getLockedVersions(packageFiles);
+      expect(packageFiles).toEqual([
+        {
+          constraints: { npm: '^8.0.0' },
           deps: [
             { currentValue: '1.0.0', depName: 'a', lockedVersion: '1.0.0' },
             { currentValue: '2.0.0', depName: 'b', lockedVersion: '2.0.0' },

--- a/lib/modules/manager/npm/extract/locked-versions.ts
+++ b/lib/modules/manager/npm/extract/locked-versions.ts
@@ -60,7 +60,7 @@ export async function getLockedVersions(
       if (lockfileVersion === 1) {
         if (packageFile.constraints?.npm) {
           // Add a <7 constraint if it's not already a fixed version
-          if (!semver.valid(packageFile.constraints.npm)) {
+          if (semver.satisfies('6.14.18', packageFile.constraints.npm)) {
             packageFile.constraints.npm += ' <7';
           }
         } else {
@@ -68,8 +68,8 @@ export async function getLockedVersions(
         }
       } else if (lockfileVersion === 2) {
         if (packageFile.constraints?.npm) {
-          // Add a <9 constraint if it's not already a fixed version
-          if (!semver.valid(packageFile.constraints.npm)) {
+          // Add a <9 constraint if the latest 8.x is compatible
+          if (semver.satisfies('8.19.3', packageFile.constraints.npm)) {
             packageFile.constraints.npm += ' <9';
           }
         } else {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Augments npm constraints less aggressively by checking whether the latest 6.x or 8.x satisfies the existing constraint.

## Context

Too many `No matching or stable tool versions found - using an unstable version` warns in the hosted app.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
