### PR TITLE
docs: Use a PEP440-compliant version constraint in pip-compile documentation

### DIFF
--- a/lib/modules/manager/pip-compile/readme.md
+++ b/lib/modules/manager/pip-compile/readme.md
@@ -35,7 +35,7 @@ To get Renovate to use another version of Python, add a constraints` rule to the
 ```json
 {
   "constraints": {
-    "python": "3.7"
+    "python": "==3.7"
   }
 }
 ```


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Updates the example in the documentation of the `pip-compile` manager to declare a Python version constraint using a [PEP440](https://peps.python.org/pep-0440/)-compliant format.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

Using a Python version as suggested in the docs causes the `pip-compile` invocation to fail. Note, that this is especially annoying as it is not detected as a configuration error by Renovate. (I assume that the constraint is not validated.)

Relevant log excerpt of a failed run: 
```
DEBUG: Executing command(branch="renovate/mkdocs-material-9.x")
{
  "command": "docker run --rm --name=renovate_sidecar --label=renovate_child -v \"/mnt/renovate/gh/TheMrMilchmann/sqldelight\":\"/mnt/renovate/gh/TheMrMilchmann/sqldelight\" -v \"/tmp/renovate-cache\":\"/tmp/renovate-cache\" -v \"/tmp/containerbase\":\"/tmp/containerbase\" -e PIP_CACHE_DIR -e BUILDPACK_CACHE_DIR -e CONTAINERBASE_CACHE_DIR -w \"/mnt/renovate/gh/TheMrMilchmann/sqldelight/.github/workflows\" docker.io/renovate/sidecar bash -l -c \"install-tool python 3.11 && pip install --user pip-tools && pip-compile requirements.in\""
}
DEBUG: rawExec err(branch="renovate/mkdocs-material-9.x")
{
  "err": {
    "name": "ExecError",
    "cmd": "/bin/sh -c docker run --rm --name=renovate_sidecar --label=renovate_child -v \"/mnt/renovate/gh/TheMrMilchmann/sqldelight\":\"/mnt/renovate/gh/TheMrMilchmann/sqldelight\" -v \"/tmp/renovate-cache\":\"/tmp/renovate-cache\" -v \"/tmp/containerbase\":\"/tmp/containerbase\" -e PIP_CACHE_DIR -e BUILDPACK_CACHE_DIR -e CONTAINERBASE_CACHE_DIR -w \"/mnt/renovate/gh/TheMrMilchmann/sqldelight/.github/workflows\" docker.io/renovate/sidecar bash -l -c \"install-tool python 3.11 && pip install --user pip-tools && pip-compile requirements.in\"",
    "stderr": "",
    "stdout": "Invalid version: 3.11\n",
    "options": {
      "cwd": "/mnt/renovate/gh/TheMrMilchmann/sqldelight/.github/workflows",
      "encoding": "utf-8",
      "env": {
        "PIP_CACHE_DIR": "/tmp/renovate-cache/others/pip",
        "HOME": "/home/ubuntu",
        "PATH": "/home/ubuntu/.local/bin:/home/ubuntu/bin:/opt/buildpack/tools/python/3.9.3/bin:/home/ubuntu/.npm-global/bin:/home/ubuntu/renovateapp/node_modules/.bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
        "LC_ALL": "C.UTF-8",
        "LANG": "C.UTF-8",
        "BUILDPACK_CACHE_DIR": "/tmp/containerbase",
        "CONTAINERBASE_CACHE_DIR": "/tmp/containerbase"
      },
      "maxBuffer": 10485760,
      "timeout": 900000
    },
    "exitCode": 1,
    "message": "Command failed: docker run --rm --name=renovate_sidecar --label=renovate_child -v \"/mnt/renovate/gh/TheMrMilchmann/sqldelight\":\"/mnt/renovate/gh/TheMrMilchmann/sqldelight\" -v \"/tmp/renovate-cache\":\"/tmp/renovate-cache\" -v \"/tmp/containerbase\":\"/tmp/containerbase\" -e PIP_CACHE_DIR -e BUILDPACK_CACHE_DIR -e CONTAINERBASE_CACHE_DIR -w \"/mnt/renovate/gh/TheMrMilchmann/sqldelight/.github/workflows\" docker.io/renovate/sidecar bash -l -c \"install-tool python 3.11 && pip install --user pip-tools && pip-compile requirements.in\"\n",
    "stack": "ExecError: Command failed: docker run --rm --name=renovate_sidecar --label=renovate_child -v \"/mnt/renovate/gh/TheMrMilchmann/sqldelight\":\"/mnt/renovate/gh/TheMrMilchmann/sqldelight\" -v \"/tmp/renovate-cache\":\"/tmp/renovate-cache\" -v \"/tmp/containerbase\":\"/tmp/containerbase\" -e PIP_CACHE_DIR -e BUILDPACK_CACHE_DIR -e CONTAINERBASE_CACHE_DIR -w \"/mnt/renovate/gh/TheMrMilchmann/sqldelight/.github/workflows\" docker.io/renovate/sidecar bash -l -c \"install-tool python 3.11 && pip install --user pip-tools && pip-compile requirements.in\"\n\n    at ChildProcess.<anonymous> (/home/ubuntu/renovateapp/node_modules/renovate/dist/util/exec/common.js:87:24)\n    at ChildProcess.emit (node:events:525:35)\n    at ChildProcess.emit (node:domain:489:12)\n    at Process.ChildProcess._handle.onexit (node:internal/child_process:293:12)"
  }
}
```

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
