### PR TITLE
fix(packagist): De-minify fields

### DIFF
--- a/lib/modules/datasource/packagist/schema.spec.ts
+++ b/lib/modules/datasource/packagist/schema.spec.ts
@@ -2,13 +2,74 @@ import type { ReleaseResult } from '../types';
 import {
   ComposerRelease,
   ComposerReleases,
+  MinifiedArray,
   parsePackagesResponse,
   parsePackagesResponses,
 } from './schema';
 
 describe('modules/datasource/packagist/schema', () => {
+  describe('MinifiedArray', () => {
+    it('parses MinifiedArray', () => {
+      expect(MinifiedArray.parse([])).toEqual([]);
+
+      // Source: https://github.com/composer/metadata-minifier/blob/1.0.0/tests/MetadataMinifierTest.php
+      expect(
+        MinifiedArray.parse([
+          {
+            name: 'foo/bar',
+            version: '2.0.0',
+            version_normalized: '2.0.0.0',
+            type: 'library',
+            scripts: {
+              foo: 'bar',
+            },
+            license: ['MIT'],
+          },
+          {
+            version: '1.2.0',
+            version_normalized: '1.2.0.0',
+            license: ['GPL'],
+            homepage: 'https://example.org',
+            scripts: '__unset',
+          },
+          {
+            version: '1.0.0',
+            version_normalized: '1.0.0.0',
+            homepage: '__unset',
+          },
+        ])
+      ).toEqual([
+        {
+          name: 'foo/bar',
+          version: '2.0.0',
+          version_normalized: '2.0.0.0',
+          type: 'library',
+          scripts: {
+            foo: 'bar',
+          },
+          license: ['MIT'],
+        },
+        {
+          name: 'foo/bar',
+          version: '1.2.0',
+          version_normalized: '1.2.0.0',
+          type: 'library',
+          license: ['GPL'],
+          homepage: 'https://example.org',
+        },
+        {
+          name: 'foo/bar',
+          version: '1.0.0',
+          version_normalized: '1.0.0.0',
+          type: 'library',
+          license: ['GPL'],
+        },
+      ]);
+    });
+  });
+
   describe('ComposerRelease', () => {
-    it('rejects', () => {
+    it('rejects ComposerRelease', () => {
       expect(() => ComposerRelease.parse(null)).toThrow();
       expect(() => ComposerRelease.parse(undefined)).toThrow();
       expect(() => ComposerRelease.parse('')).toThrow();
@@ -17,7 +78,7 @@ describe('modules/datasource/packagist/schema', () => {
       expect(() => ComposerRelease.parse({ version: null })).toThrow();
     });
 
-    it('parses', () => {
+    it('parses ComposerRelease', () => {
       expect(ComposerRelease.parse({ version: '' })).toEqual({ version: '' });
       expect(ComposerRelease.parse({ version: 'dev-main' })).toEqual({
         version: 'dev-main',
@@ -50,14 +111,14 @@ describe('modules/datasource/packagist/schema', () => {
   });
 
   describe('ComposerReleases', () => {
-    it('rejects', () => {
+    it('rejects ComposerReleases', () => {
       expect(() => ComposerReleases.parse(null)).toThrow();
       expect(() => ComposerReleases.parse(undefined)).toThrow();
       expect(() => ComposerReleases.parse('')).toThrow();
       expect(() => ComposerReleases.parse({})).toThrow();
     });
 
-    it('parses', () => {
+    it('parses ComposerReleases', () => {
       expect(ComposerReleases.parse([])).toEqual([]);
       expect(ComposerReleases.parse([null])).toEqual([]);
       expect(ComposerReleases.parse([1, 2, 3])).toEqual([]);
@@ -69,7 +130,7 @@ describe('modules/datasource/packagist/schema', () => {
   });
 
   describe('parsePackageResponse', () => {
-    it('parses', () => {
+    it('parses package response', () => {
       expect(parsePackagesResponse('foo/bar', null)).toEqual([]);
       expect(parsePackagesResponse('foo/bar', {})).toEqual([]);
       expect(parsePackagesResponse('foo/bar', { packages: '123' })).toEqual([]);
@@ -83,10 +144,36 @@ describe('modules/datasource/packagist/schema', () => {
         })
       ).toEqual([{ version: '1.2.3' }]);
     });
+
+    it('expands minified fields', () => {
+      expect(
+        parsePackagesResponse('foo/bar', {
+          packages: {
+            'foo/bar': [
+              { version: '3.3.3', require: { php: '^8.0' } },
+              { version: '2.2.2' },
+              { version: '1.1.1' },
+              { version: '0.0.4', require: { php: '^7.0' } },
+              { version: '0.0.3' },
+              { version: '0.0.2', require: '__unset' },
+              { version: '0.0.1' },
+            ],
+          },
+        })
+      ).toEqual([
+        { version: '3.3.3', require: { php: '^8.0' } },
+        { version: '2.2.2', require: { php: '^8.0' } },
+        { version: '1.1.1', require: { php: '^8.0' } },
+        { version: '0.0.4', require: { php: '^7.0' } },
+        { version: '0.0.3', require: { php: '^7.0' } },
+        { version: '0.0.2' },
+        { version: '0.0.1' },
+      ] satisfies ComposerRelease[]);
+    });
   });
 
   describe('parsePackagesResponses', () => {
-    it('parses', () => {
+    it('parses array of responses', () => {
       expect(parsePackagesResponses('foo/bar', [null])).toBeNull();
       expect(parsePackagesResponses('foo/bar', [{}])).toBeNull();
       expect(
@@ -103,6 +190,7 @@ describe('modules/datasource/packagist/schema', () => {
                   time: '111',
                   homepage: 'https://example.com/1',
                   source: { url: 'git@example.com:foo/bar-1' },
+                  require: { php: '^8.0' },
                 },
               ],
               'baz/qux': [
@@ -123,6 +211,7 @@ describe('modules/datasource/packagist/schema', () => {
                   time: '333',
                   homepage: 'https://example.com/3',
                   source: { url: 'git@example.com:foo/bar-3' },
+                  require: { php: '^7.0' },
                 },
               ],
               'baz/qux': [
@@ -140,8 +229,18 @@ describe('modules/datasource/packagist/schema', () => {
         homepage: 'https://example.com/1',
         sourceUrl: 'git@example.com:foo/bar-1',
         releases: [
-          { version: '1.1.1', gitRef: 'v1.1.1', releaseTimestamp: '111' },
-          { version: '3.3.3', gitRef: 'v3.3.3', releaseTimestamp: '333' },
+          {
+            version: '1.1.1',
+            gitRef: 'v1.1.1',
+            releaseTimestamp: '111',
+            constraints: { php: ['^8.0'] },
+          },
+          {
+            version: '3.3.3',
+            gitRef: 'v3.3.3',
+            releaseTimestamp: '333',
+            constraints: { php: ['^7.0'] },
+          },
         ],
       } satisfies ReleaseResult);
     });

--- a/lib/modules/datasource/packagist/schema.spec.ts
+++ b/lib/modules/datasource/packagist/schema.spec.ts
@@ -144,32 +144,6 @@ describe('modules/datasource/packagist/schema', () => {
         })
       ).toEqual([{ version: '1.2.3' }]);
     });
-
-    it('expands minified fields', () => {
-      expect(
-        parsePackagesResponse('foo/bar', {
-          packages: {
-            'foo/bar': [
-              { version: '3.3.3', require: { php: '^8.0' } },
-              { version: '2.2.2' },
-              { version: '1.1.1' },
-              { version: '0.0.4', require: { php: '^7.0' } },
-              { version: '0.0.3' },
-              { version: '0.0.2', require: '__unset' },
-              { version: '0.0.1' },
-            ],
-          },
-        })
-      ).toEqual([
-        { version: '3.3.3', require: { php: '^8.0' } },
-        { version: '2.2.2', require: { php: '^8.0' } },
-        { version: '1.1.1', require: { php: '^8.0' } },
-        { version: '0.0.4', require: { php: '^7.0' } },
-        { version: '0.0.3', require: { php: '^7.0' } },
-        { version: '0.0.2' },
-        { version: '0.0.1' },
-      ] satisfies ComposerRelease[]);
-    });
   });
 
   describe('parsePackagesResponses', () => {
@@ -190,7 +164,6 @@ describe('modules/datasource/packagist/schema', () => {
                   time: '111',
                   homepage: 'https://example.com/1',
                   source: { url: 'git@example.com:foo/bar-1' },
-                  require: { php: '^8.0' },
                 },
               ],
               'baz/qux': [
@@ -211,7 +184,6 @@ describe('modules/datasource/packagist/schema', () => {
                   time: '333',
                   homepage: 'https://example.com/3',
                   source: { url: 'git@example.com:foo/bar-3' },
-                  require: { php: '^7.0' },
                 },
               ],
               'baz/qux': [

--- a/lib/modules/datasource/packagist/schema.spec.ts
+++ b/lib/modules/datasource/packagist/schema.spec.ts
@@ -229,18 +229,8 @@ describe('modules/datasource/packagist/schema', () => {
         homepage: 'https://example.com/1',
         sourceUrl: 'git@example.com:foo/bar-1',
         releases: [
-          {
-            version: '1.1.1',
-            gitRef: 'v1.1.1',
-            releaseTimestamp: '111',
-            constraints: { php: ['^8.0'] },
-          },
-          {
-            version: '3.3.3',
-            gitRef: 'v3.3.3',
-            releaseTimestamp: '333',
-            constraints: { php: ['^7.0'] },
-          },
+          { version: '1.1.1', gitRef: 'v1.1.1', releaseTimestamp: '111' },
+          { version: '3.3.3', gitRef: 'v3.3.3', releaseTimestamp: '333' },
         ],
       } satisfies ReleaseResult);
     });

--- a/lib/modules/datasource/packagist/schema.ts
+++ b/lib/modules/datasource/packagist/schema.ts
@@ -112,10 +112,6 @@ export function parsePackagesResponses(
         dep.releaseTimestamp = composerRelease.time;
       }
 
-      if (composerRelease.require?.php) {
-        dep.constraints = { php: [composerRelease.require.php] };
-      }
-
       releases.push(dep);
 
       if (!homepage && composerRelease.homepage) {

--- a/lib/modules/datasource/packagist/schema.ts
+++ b/lib/modules/datasource/packagist/schema.ts
@@ -1,6 +1,43 @@
+import is from '@sindresorhus/is';
 import { z } from 'zod';
 import { logger } from '../../../logger';
 import type { Release, ReleaseResult } from '../types';
+
+export const MinifiedArray = z.array(z.record(z.unknown())).transform((xs) => {
+  // Ported from: https://github.com/composer/metadata-minifier/blob/main/src/MetadataMinifier.php#L17
+  if (xs.length === 0) {
+    return xs;
+  }
+
+  const prevVals: Record<string, unknown> = {};
+  for (const x of xs) {
+    for (const key of Object.keys(x)) {
+      prevVals[key] ??= undefined;
+    }
+
+    for (const key of Object.keys(prevVals)) {
+      const val = x[key];
+      if (val === '__unset') {
+        delete x[key];
+        prevVals[key] = undefined;
+        continue;
+      }
+
+      if (!is.undefined(val)) {
+        prevVals[key] = val;
+        continue;
+      }
+
+      if (!is.undefined(prevVals[key])) {
+        x[key] = prevVals[key];
+        continue;
+      }
+    }
+  }
+
+  return xs;
+});
+export type MinifiedArray = z.infer<typeof MinifiedArray>;
 
 export const ComposerRelease = z
   .object({
@@ -17,6 +54,12 @@ export const ComposerRelease = z
           .nullable()
           .catch(null),
         time: z.string().nullable().catch(null),
+        require: z
+          .object({
+            php: z.string(),
+          })
+          .nullable()
+          .catch(null),
       })
       .partial()
   );
@@ -37,7 +80,8 @@ export function parsePackagesResponse(
 ): ComposerReleases {
   try {
     const { packages } = ComposerPackagesResponse.parse(packagesResponse);
-    const releases = ComposerReleases.parse(packages[packageName]);
+    const array = MinifiedArray.parse(packages[packageName]);
+    const releases = ComposerReleases.parse(array);
     return releases;
   } catch (err) {
     logger.debug(
@@ -66,6 +110,10 @@ export function parsePackagesResponses(
 
       if (composerRelease.time) {
         dep.releaseTimestamp = composerRelease.time;
+      }
+
+      if (composerRelease.require?.php) {
+        dep.constraints = { php: [composerRelease.require.php] };
       }
 
       releases.push(dep);

--- a/lib/modules/datasource/packagist/schema.ts
+++ b/lib/modules/datasource/packagist/schema.ts
@@ -54,12 +54,6 @@ export const ComposerRelease = z
           .nullable()
           .catch(null),
         time: z.string().nullable().catch(null),
-        require: z
-          .object({
-            php: z.string(),
-          })
-          .nullable()
-          .catch(null),
       })
       .partial()
   );


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- De-minify fields at the schema level
- [Code ported from Composer-related library](https://github.com/composer/metadata-minifier/blob/c549d23829536f0d0e984aaabbf02af91f443207/src/MetadataMinifier.php#L17)

## Context

- Ref: #18715

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
