### PR TITLE
fix(config-migration): runtime error when comparing json5 strings

### DIFF
--- a/lib/workers/repository/config-migration/branch/__fixtures__/renovate.json
+++ b/lib/workers/repository/config-migration/branch/__fixtures__/renovate.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     ":separateMajorReleases",
     ":prImmediately",

--- a/lib/workers/repository/config-migration/branch/rebase.spec.ts
+++ b/lib/workers/repository/config-migration/branch/rebase.spec.ts
@@ -1,4 +1,5 @@
 import type { Indent } from 'detect-indent';
+import JSON5 from 'json5';
 import { Fixtures } from '../../../../../test/fixtures';
 import {
   RenovateConfig,
@@ -32,22 +33,22 @@ describe('workers/repository/config-migration/branch/rebase', () => {
   });
 
   describe('rebaseMigrationBranch()', () => {
-    const raw = Fixtures.getJson('./renovate.json');
+    const repoConfig = Fixtures.getJson('./renovate.json');
     const indent = '  ';
-    const renovateConfig = JSON.stringify(raw, undefined, indent) + '\n';
-    const filename = 'renovate.json';
-
+    const renovateConfigJson =
+      JSON.stringify(repoConfig, undefined, indent) + '\n';
+    const renovateConfigJson5 =
+      JSON5.stringify(repoConfig, undefined, indent) + '\n';
     let config: RenovateConfig;
-    let migratedConfigData: MigratedData;
+    const migratedConfigData: MigratedData = {
+      content: '',
+      filename: '',
+      indent: partial<Indent>({}),
+    };
 
     beforeEach(() => {
       jest.resetAllMocks();
       GlobalConfig.reset();
-      migratedConfigData = {
-        content: renovateConfig,
-        filename,
-        indent: partial<Indent>({}),
-      };
       config = {
         ...getConfig(),
         repository: 'some/repo',
@@ -58,62 +59,108 @@ describe('workers/repository/config-migration/branch/rebase', () => {
 
     it('does not rebase modified branch', async () => {
       git.isBranchModified.mockResolvedValueOnce(true);
+
       await rebaseMigrationBranch(config, migratedConfigData);
+
       expect(checkoutBranch).toHaveBeenCalledTimes(0);
       expect(git.commitFiles).toHaveBeenCalledTimes(0);
     });
 
-    it('does nothing if branch is up to date', async () => {
-      git.getFile
-        .mockResolvedValueOnce(renovateConfig)
-        .mockResolvedValueOnce(renovateConfig);
-      await rebaseMigrationBranch(config, migratedConfigData);
-      expect(checkoutBranch).toHaveBeenCalledTimes(0);
-      expect(git.commitFiles).toHaveBeenCalledTimes(0);
-    });
+    it.each([
+      ['renovate.json', renovateConfigJson],
+      ['renovate.json5', renovateConfigJson5],
+    ])(
+      'does nothing if branch is up to date (%s)',
+      async (filename, rawConfig) => {
+        git.getFile
+          .mockResolvedValueOnce(rawConfig)
+          .mockResolvedValueOnce(rawConfig);
+        migratedConfigData.filename = filename;
+        migratedConfigData.content = rawConfig;
 
-    it('rebases migration branch', async () => {
+        await rebaseMigrationBranch(config, migratedConfigData);
+
+        expect(checkoutBranch).toHaveBeenCalledTimes(0);
+        expect(git.commitFiles).toHaveBeenCalledTimes(0);
+      }
+    );
+
+    it.each([
+      ['renovate.json', renovateConfigJson],
+      ['renovate.json5', renovateConfigJson5],
+    ])('rebases migration branch (%s)', async (filename, rawConfig) => {
       git.isBranchBehindBase.mockResolvedValueOnce(true);
+      migratedConfigData.filename = filename;
+      migratedConfigData.content = rawConfig;
+
       await rebaseMigrationBranch(config, migratedConfigData);
+
       expect(checkoutBranch).toHaveBeenCalledWith(config.defaultBranch);
       expect(git.commitFiles).toHaveBeenCalledTimes(1);
     });
 
-    it('applies prettier formatting when rebasing the migration branch ', async () => {
-      const formatted = formattedMigratedData.content;
-      prettierSpy.mockResolvedValueOnce(formattedMigratedData.content);
-      git.isBranchBehindBase.mockResolvedValueOnce(true);
-      await rebaseMigrationBranch(config, migratedConfigData);
-      expect(checkoutBranch).toHaveBeenCalledWith(config.defaultBranch);
-      expect(git.commitFiles).toHaveBeenCalledTimes(1);
-      expect(commitFiles).toHaveBeenCalledWith({
-        branchName: 'renovate/migrate-config',
-        files: [
-          {
-            type: 'addition',
-            path: 'renovate.json',
-            contents: formatted,
-          },
-        ],
-        message: 'Migrate config renovate.json',
-        platformCommit: false,
-      });
-    });
+    it.each([
+      ['renovate.json', renovateConfigJson],
+      ['renovate.json5', renovateConfigJson5],
+    ])(
+      'applies prettier formatting when rebasing the migration branch (%s)',
+      async (filename, rawConfig) => {
+        const formatted = formattedMigratedData.content;
+        prettierSpy.mockResolvedValueOnce(formattedMigratedData.content);
+        git.isBranchBehindBase.mockResolvedValueOnce(true);
+        migratedConfigData.filename = filename;
+        migratedConfigData.content = rawConfig;
 
-    it('does not rebases migration branch when in dryRun is on', async () => {
-      GlobalConfig.set({
-        dryRun: 'full',
-      });
-      git.isBranchBehindBase.mockResolvedValueOnce(true);
-      await rebaseMigrationBranch(config, migratedConfigData);
-      expect(checkoutBranch).toHaveBeenCalledTimes(0);
-      expect(git.commitFiles).toHaveBeenCalledTimes(0);
-    });
+        await rebaseMigrationBranch(config, migratedConfigData);
 
-    it('rebases via platform', async () => {
+        expect(checkoutBranch).toHaveBeenCalledWith(config.defaultBranch);
+        expect(git.commitFiles).toHaveBeenCalledTimes(1);
+        expect(commitFiles).toHaveBeenCalledWith({
+          branchName: 'renovate/migrate-config',
+          files: [
+            {
+              type: 'addition',
+              path: filename,
+              contents: formatted,
+            },
+          ],
+          message: `Migrate config ${filename}`,
+          platformCommit: false,
+        });
+      }
+    );
+
+    it.each([
+      ['renovate.json', renovateConfigJson],
+      ['renovate.json5', renovateConfigJson5],
+    ])(
+      'does not rebases migration branch when in dryRun is on (%s)',
+      async (filename, rawConfig) => {
+        GlobalConfig.set({
+          dryRun: 'full',
+        });
+        git.isBranchBehindBase.mockResolvedValueOnce(true);
+        migratedConfigData.filename = filename;
+        migratedConfigData.content = rawConfig;
+
+        await rebaseMigrationBranch(config, migratedConfigData);
+
+        expect(checkoutBranch).toHaveBeenCalledTimes(0);
+        expect(git.commitFiles).toHaveBeenCalledTimes(0);
+      }
+    );
+
+    it.each([
+      ['renovate.json', renovateConfigJson],
+      ['renovate.json5', renovateConfigJson5],
+    ])('rebases via platform (%s)', async (filename, rawConfig) => {
       config.platformCommit = true;
       git.isBranchBehindBase.mockResolvedValueOnce(true);
+      migratedConfigData.filename = filename;
+      migratedConfigData.content = rawConfig;
+
       await rebaseMigrationBranch(config, migratedConfigData);
+
       expect(checkoutBranch).toHaveBeenCalledWith(config.defaultBranch);
       expect(platform.commitFiles).toHaveBeenCalledTimes(1);
     });

--- a/lib/workers/repository/config-migration/branch/rebase.ts
+++ b/lib/workers/repository/config-migration/branch/rebase.ts
@@ -1,3 +1,4 @@
+import JSON5 from 'json5';
 import { GlobalConfig } from '../../../../config/global';
 import type { RenovateConfig } from '../../../../config/types';
 import { logger } from '../../../../logger';
@@ -78,5 +79,5 @@ export function jsonStripWhitespaces(json: string | null): string | null {
    *
    * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#parameters
    */
-  return quickStringify(JSON.parse(json)) ?? null;
+  return quickStringify(JSON5.parse(json)) ?? null;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Use JSON5 to parse JSON strings when comparing raw file contents.

And - 

Added newlines between the `arrange-act-assert` sections within each test. 
Overall, the only changes to the tests are at the `arrange` part, most of the diff here is due to the new added newlines.


Running the modified tests in this PR without the changes to the source code yields the same error:
![image](https://user-images.githubusercontent.com/97394622/212780384-836a8312-c905-4970-a176-f93d29125270.png)

<!-- Describe what behavior is changed by this PR. -->

## Context
Closes #19860
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
