### PR TITLE
fix(cache): pass REPOSITORY_CHANGED error up

### DIFF
--- a/lib/workers/repository/cache.ts
+++ b/lib/workers/repository/cache.ts
@@ -1,5 +1,6 @@
 /* istanbul ignore file */
 
+import { REPOSITORY_CHANGED } from '../../constants/error-messages';
 import { logger } from '../../logger';
 import { platform } from '../../modules/platform';
 import { getCache } from '../../util/cache/repository';
@@ -93,6 +94,9 @@ async function generateBranchCache(
     if (errCodes.includes(err.response?.statusCode)) {
       logger.warn({ err, branchName }, 'HTTP error generating branch cache');
       return null;
+    }
+    if (err.message === REPOSITORY_CHANGED) {
+      throw err;
     }
     logger.error({ err, branchName }, 'Error generating branch cache');
     return null;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Catches and rethrows repository changed error when generating branch cache

## Context

Error seen in production app

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
