### PR TITLE
fix(cargo): Allow custom env vars to be passed through to cargo update

### DIFF
--- a/lib/modules/manager/cargo/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/modules/manager/cargo/__snapshots__/artifacts.spec.ts.snap
@@ -1,5 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`modules/manager/cargo/artifacts passes customEnvVariables through while updating the cargo lock 1`] = `
+[
+  {
+    "cmd": "cargo update --manifest-path Cargo.toml --workspace",
+    "options": {
+      "cwd": undefined,
+      "encoding": "utf-8",
+      "env": {
+        "FOO_ENV": "bar",
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+]
+`;
+
 exports[`modules/manager/cargo/artifacts returns null if unchanged 1`] = `
 [
   {

--- a/lib/modules/manager/cargo/artifacts.ts
+++ b/lib/modules/manager/cargo/artifacts.ts
@@ -2,6 +2,7 @@ import { quote } from 'shlex';
 import { TEMPORARY_ERROR } from '../../../constants/error-messages';
 import { logger } from '../../../logger';
 import { exec } from '../../../util/exec';
+import { getChildProcessEnv } from '../../../util/exec/env';
 import type { ExecOptions } from '../../../util/exec/types';
 import {
   findLocalSiblingOrParent,
@@ -24,6 +25,9 @@ async function cargoUpdate(
 
   const execOptions: ExecOptions = {
     docker: {},
+    extraEnv: {
+      ...getChildProcessEnv(),
+    },
     toolConstraints: [{ toolName: 'rust', constraint }],
   };
   await exec(cmd, execOptions);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds support to pass custom env variables through to Cargo while updating lockfile.

## Context

We're trying to allow Cargo to authenticate with a private repository to update its lockfile.
In order to do so, we need to set `CARGO_NET_GIT_FETCH_WITH_CLI` to true.

It is currently unexpected that adding a `customEnvVariables` does not propagate through to the call to `cargo update`.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
