### PR TITLE
fix(manager/terraform): do not return registryUrls containing undefined

### DIFF
--- a/lib/modules/manager/terraform/extract.spec.ts
+++ b/lib/modules/manager/terraform/extract.spec.ts
@@ -594,7 +594,6 @@ describe('modules/manager/terraform/extract', () => {
           datasource: 'helm',
           depName: './charts/example',
           depType: 'helm_release',
-          registryUrls: [undefined],
           skipReason: 'local-chart',
         },
         {
@@ -617,7 +616,6 @@ describe('modules/manager/terraform/extract', () => {
           datasource: 'helm',
           depName: 'redis',
           depType: 'helm_release',
-          registryUrls: [undefined],
         },
       ]);
     });

--- a/lib/modules/manager/terraform/extractors/resources/helm-release.ts
+++ b/lib/modules/manager/terraform/extractors/resources/helm-release.ts
@@ -21,10 +21,12 @@ export class HelmReleaseExtractor extends DependencyExtractor {
         const dep: PackageDependency = {
           currentValue: helmRelease.version,
           depType: 'helm_release',
-          registryUrls: [helmRelease.repository],
           depName: helmRelease.chart,
           datasource: HelmDatasource.id,
         };
+        if (!is.nullOrUndefined(helmRelease.repository)) {
+          dep.registryUrls = [helmRelease.repository];
+        }
         if (!helmRelease.chart) {
           dep.skipReason = 'invalid-name';
         } else if (checkIfStringIsPath(helmRelease.chart)) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Prevent that `undefined` is set as element of `registryUrls` for the Helm extractor. 

<!-- Describe what behavior is changed by this PR. -->

## Context
https://github.com/renovatebot/renovate/pull/19869#discussion_r1073565528
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
