### PR TITLE
fix: dynamically load prettier

### DIFF
--- a/lib/expose.cjs
+++ b/lib/expose.cjs
@@ -14,4 +14,12 @@ function re2() {
   return require('re2');
 }
 
-module.exports = { dirname: __dirname, re2, pkg };
+/**
+ * return's prettier
+ * @returns {typeof import('prettier')}
+ */
+function prettier() {
+  return require('prettier');
+}
+
+module.exports = { dirname: __dirname, re2, pkg, prettier };

--- a/lib/workers/repository/config-migration/branch/migrated-data.ts
+++ b/lib/workers/repository/config-migration/branch/migrated-data.ts
@@ -1,8 +1,9 @@
 import detectIndent from 'detect-indent';
 import JSON5 from 'json5';
-import prettier, { BuiltInParserName } from 'prettier';
+import type { BuiltInParserName } from 'prettier';
 import upath from 'upath';
 import { migrateConfig } from '../../../../config/migration';
+import { prettier } from '../../../../expose.cjs';
 import { logger } from '../../../../logger';
 import { readLocalFile } from '../../../../util/fs';
 import { getFileList } from '../../../../util/git';
@@ -68,7 +69,7 @@ export async function applyPrettierFormatting(
       useTabs: indent?.type === 'tab',
     };
 
-    return prettier.format(content, options);
+    return prettier().format(content, options);
   } finally {
     logger.trace('applyPrettierFormatting - END');
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Only load prettier if really needed
<!-- Describe what behavior is changed by this PR. -->

## Context
- fixes #19937
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
