### PR TITLE
feat(manager/gradle): extend support for property accessors

### DIFF
--- a/lib/modules/manager/gradle/parser.spec.ts
+++ b/lib/modules/manager/gradle/parser.spec.ts
@@ -436,6 +436,7 @@ describe('modules/manager/gradle/parser', () => {
         ${''}              | ${'group: "foo", name: "bar", version: baz'}                                      | ${null}
         ${''}              | ${'group: "foo", name: "bar", version: "1.2.3@@@"'}                               | ${null}
         ${'baz = "1.2.3"'} | ${'group: "foo", name: "bar", version: baz'}                                      | ${{ depName: 'foo:bar', currentValue: '1.2.3', groupName: 'baz' }}
+        ${'some = "foo"'}  | ${'group: property("some"), name: property("some"), version: "1.2.3"'}            | ${{ depName: 'foo:foo', currentValue: '1.2.3' }}
         ${'some = "foo"'}  | ${'group: some, name: some, version: "1.2.3"'}                                    | ${{ depName: 'foo:foo', currentValue: '1.2.3' }}
         ${'some = "foo"'}  | ${'group: "${some}", name: "${some}", version: "1.2.3"'}                          | ${{ depName: 'foo:foo', currentValue: '1.2.3' }}
         ${'baz = "1.2.3"'} | ${'group: "foo", name: "bar", version: "${baz}"'}                                 | ${{ depName: 'foo:bar', currentValue: '1.2.3', groupName: 'baz' }}
@@ -520,6 +521,7 @@ describe('modules/manager/gradle/parser', () => {
           ${''}                             | ${'dependencySet(group: "foo", version: "1.2.3") { entry "bar1"; entry ("bar2") }'}                 | ${validOutput}
           ${'baz = "1.2.3"'}                | ${'dependencySet(group: "foo", version: baz) { entry "bar1"; entry ("bar2") }'}                     | ${validOutput1}
           ${'baz = "1.2.3"'}                | ${'dependencySet(group: "foo", version: "${baz}") { entry "bar1"; entry ("bar2") }'}                | ${validOutput1}
+          ${'baz = "1.2.3"'}                | ${'dependencySet(group: "foo", version: property("baz")) { entry "bar1"; entry ("bar2") }'}         | ${validOutput1}
           ${'some = "foo"; other = "bar1"'} | ${'dependencySet(group: some, version: "1.2.3") { entry other; entry "bar2" }'}                     | ${validOutput}
           ${'some = "foo"; baz = "1.2.3"'}  | ${'dependencySet(group: some, version: "${baz}456") { entry "bar1"; entry "bar2" }'}                | ${{}}
           ${'some = "foo"; other = "bar1"'} | ${'dependencySet(group: some, version: "1.2.3") { entry(other); entry "bar2" }'}                    | ${validOutput}
@@ -687,10 +689,12 @@ describe('modules/manager/gradle/parser', () => {
       ${''}                                         | ${'library("foo.bar", "foo", "bar").version("1.2.3")'}          | ${{ depName: 'foo:bar', currentValue: '1.2.3' }}
       ${'baz = "1.2.3"'}                            | ${'library("foo.bar", "foo", "bar").version(baz)'}              | ${{ depName: 'foo:bar', currentValue: '1.2.3' }}
       ${'baz = "1.2.3"'}                            | ${'library("foo.bar", "foo", "bar").version("${baz}")'}         | ${{ depName: 'foo:bar', currentValue: '1.2.3' }}
+      ${'baz = "1.2.3"'}                            | ${'library("foo.bar", "foo", "bar").version(property("baz"))'}  | ${{ depName: 'foo:bar', currentValue: '1.2.3' }}
       ${'baz = "1.2.3"'}                            | ${'library("foo.bar", "foo", "bar").version("${baz}xy")'}       | ${{ depName: 'foo:bar', currentValue: '1.2.3xy', skipReason: 'unknown-version' }}
       ${'baz = "1.2.3"'}                            | ${'library("foo.bar", "foo", "bar").version(baz + ".45")'}      | ${{ depName: 'foo:bar', currentValue: '1.2.3.45', skipReason: 'unknown-version' }}
       ${'group = "foo"; artifact = "bar"'}          | ${'library("foo.bar", group, artifact).version("1.2.3")'}       | ${{ depName: 'foo:bar', currentValue: '1.2.3' }}
       ${'f = "foo"; b = "bar"'}                     | ${'library("foo.bar", "${f}", "${b}").version("1.2.3")'}        | ${{ depName: 'foo:bar', currentValue: '1.2.3' }}
+      ${'f = "foo"; b = "bar"; v = "1.2.3"'}        | ${'library("foo.bar", property("f"), "${b}").version(v)'}       | ${{ depName: 'foo:bar', currentValue: '1.2.3' }}
       ${'f = "foo"; b = "bar"'}                     | ${'library("foo.bar", "${f}" + f, "${b}").version("1.2.3")'}    | ${{ depName: 'foofoo:bar', currentValue: '1.2.3' }}
       ${'version("baz", "1.2.3")'}                  | ${'library("foo.bar", "foo", "bar").versionRef("baz")'}         | ${{ depName: 'foo:bar', currentValue: '1.2.3', groupName: 'baz' }}
       ${'library("foo-bar_baz-qux", "foo", "bar")'} | ${'"${libs.foo.bar.baz.qux}:1.2.3"'}                            | ${{ depName: 'foo:bar', currentValue: '1.2.3' }}

--- a/lib/modules/manager/gradle/parser/dependencies.ts
+++ b/lib/modules/manager/gradle/parser/dependencies.ts
@@ -20,16 +20,19 @@ import {
 
 const qGroupId = qConcatExpr(
   qTemplateString,
+  qPropertyAccessIdentifier,
   qVariableAccessIdentifier
 ).handler((ctx) => storeInTokenMap(ctx, 'groupId'));
 
 const qArtifactId = qConcatExpr(
   qTemplateString,
+  qPropertyAccessIdentifier,
   qVariableAccessIdentifier
 ).handler((ctx) => storeInTokenMap(ctx, 'artifactId'));
 
 const qVersion = qConcatExpr(
   qTemplateString,
+  qPropertyAccessIdentifier,
   qVariableAccessIdentifier
 ).handler((ctx) => storeInTokenMap(ctx, 'version'));
 
@@ -122,14 +125,7 @@ const qKotlinShortNotationDependencies = q
       .join(qArtifactId)
       .op(',')
       .opt(q.sym<Ctx>('version').op('='))
-      .join(
-        qConcatExpr(
-          qTemplateString,
-          qPropertyAccessIdentifier,
-          qVariableAccessIdentifier
-        )
-      )
-      .handler((ctx) => storeInTokenMap(ctx, 'version'))
+      .join(qVersion)
       .end(),
   })
   .handler(handleKotlinShortNotationDep)
@@ -195,15 +191,8 @@ const qImplicitGradlePlugin = q
     search: q
       .sym<Ctx>(regEx(/^(?:toolVersion|version)$/))
       .op('=')
-      .join(
-        qConcatExpr(
-          qTemplateString,
-          qPropertyAccessIdentifier,
-          qVariableAccessIdentifier
-        )
-      ),
+      .join(qVersion),
   })
-  .handler((ctx) => storeInTokenMap(ctx, 'version'))
   .handler(handleImplicitGradlePlugin)
   .handler(cleanupTempVars);
 

--- a/lib/modules/manager/gradle/parser/version-catalogs.ts
+++ b/lib/modules/manager/gradle/parser/version-catalogs.ts
@@ -3,6 +3,7 @@ import type { Ctx } from '../types';
 import {
   cleanupTempVars,
   qConcatExpr,
+  qPropertyAccessIdentifier,
   qStringValue,
   qStringValueAsSymbol,
   qTemplateString,
@@ -14,11 +15,13 @@ import { handleLibraryDep } from './handlers';
 
 const qGroupId = qConcatExpr(
   qTemplateString,
+  qPropertyAccessIdentifier,
   qVariableAccessIdentifier
 ).handler((ctx) => storeInTokenMap(ctx, 'groupId'));
 
 const qArtifactId = qConcatExpr(
   qTemplateString,
+  qPropertyAccessIdentifier,
   qVariableAccessIdentifier
 ).handler((ctx) => storeInTokenMap(ctx, 'artifactId'));
 
@@ -39,7 +42,13 @@ const qVersionCatalogVersion = q
       endsWith: ')',
       search: q
         .begin<Ctx>()
-        .join(qConcatExpr(qTemplateString, qVariableAccessIdentifier))
+        .join(
+          qConcatExpr(
+            qTemplateString,
+            qPropertyAccessIdentifier,
+            qVariableAccessIdentifier
+          )
+        )
         .end(),
     })
   )


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Supplements support for [Groovy's](https://docs.gradle.org/current/dsl/org.gradle.api.plugins.ExtraPropertiesExtension.html#N1B540) & [Kotlin's extra property](https://docs.gradle.org/current/userguide/writing_build_scripts.html#sec:extra_properties) accessor methods to remaining locations, which PR  #18990 didn't cover. In fact, there was really no reason not to do it right away.

The intention of this change is to support a uniform set of value matchers for `groupId`, `artifactId` and `version`, where applicable. This also paves the way for a follow-up refactor PR that will help abstracting away redundant matchers.

<!-- Describe what behavior is changed by this PR. -->

## Context

- PR #18990

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
