### PR TITLE
fix: make HermitVersioning support semver range in matchCurrentVersion

### DIFF
--- a/lib/modules/versioning/hermit/index.spec.ts
+++ b/lib/modules/versioning/hermit/index.spec.ts
@@ -81,16 +81,27 @@ describe('modules/versioning/hermit/index', () => {
   );
 
   test.each`
-    version      | other        | expected
-    ${'@1'}      | ${'@1.2'}    | ${false}
-    ${'@1.2'}    | ${'@1.2'}    | ${true}
-    ${'@1.2.3'}  | ${'@1.2'}    | ${false}
-    ${'@latest'} | ${'@1'}      | ${false}
-    ${'@stable'} | ${'@stable'} | ${true}
+    version      | range              | expected
+    ${'0.6.1'}   | ${'>0.6.0 <0.7.0'} | ${true}
+    ${'0.6.1'}   | ${'<0.7.0'}        | ${true}
+    ${'0.6.1'}   | ${'<=0.7.0'}       | ${true}
+    ${'0.6.1'}   | ${'>=0.6.0'}       | ${true}
+    ${'0.6.1'}   | ${'>0.6.0'}        | ${true}
+    ${'0.6.1'}   | ${'0.6.x'}         | ${true}
+    ${'0.6.1'}   | ${'0.6.*'}         | ${true}
+    ${'0.6.1'}   | ${'0.6.0 - 0.6.3'} | ${true}
+    ${'0.6.1'}   | ${'~0.6'}          | ${true}
+    ${'0.6.1'}   | ${'0.6.1'}         | ${true}
+    ${'0.0.6'}   | ${'^0.0.6'}        | ${true}
+    ${'@1'}      | ${'@1.2'}          | ${false}
+    ${'@1.2'}    | ${'@1.2'}          | ${true}
+    ${'@1.2.3'}  | ${'@1.2'}          | ${false}
+    ${'@latest'} | ${'@1'}            | ${false}
+    ${'@stable'} | ${'@stable'}       | ${true}
   `(
-    'matches("$version", "$other") === $expected',
-    ({ version, other, expected }) => {
-      expect(versioning.matches(version, other)).toBe(expected);
+    'matches("$version", "$range") === $expected',
+    ({ version, range, expected }) => {
+      expect(versioning.matches(version, range)).toBe(expected);
     }
   );
 

--- a/lib/modules/versioning/hermit/index.ts
+++ b/lib/modules/versioning/hermit/index.ts
@@ -1,3 +1,4 @@
+import { satisfies } from 'semver';
 import { RegExpVersion, RegExpVersioningApi } from '../regex';
 import type { VersioningApiConstructor } from '../types';
 
@@ -173,7 +174,14 @@ export class HermitVersioning extends RegExpVersioningApi {
   }
 
   override matches(version: string, range: string): boolean {
-    return this.equals(version, range);
+    if (
+      HermitVersioning._isChannel(version) &&
+      HermitVersioning._isChannel(range)
+    ) {
+      return this.equals(version, range);
+    }
+
+    return satisfies(version, range);
   }
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
This PR adds Semver range matches support for HermitVersioning on `packageRules -> matchCurrentVersion`. At the moment it only supports exact version matches. 


## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

We found that we could not use Semver range matches in `packageRules -> matchCurrentVersion` for Hermit package when we wanted to limit the version for emergent upgrade. 

e.g. we were intended to limit our emergent upgrade to `<0.65.6`. However it doesn't work.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [X] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
