### PR TITLE
refactor(datasource/orb): log res when no response

### DIFF
--- a/lib/modules/datasource/orb/index.ts
+++ b/lib/modules/datasource/orb/index.ts
@@ -2,7 +2,7 @@ import { logger } from '../../../logger';
 import { cache } from '../../../util/cache/package/decorator';
 import { Datasource } from '../datasource';
 import type { GetReleasesConfig, ReleaseResult } from '../types';
-import type { OrbRelease } from './types';
+import type { OrbResponse } from './types';
 
 const query = `
 query($packageName: String!) {
@@ -45,20 +45,22 @@ export class OrbDatasource extends Datasource {
       query,
       variables: { packageName },
     };
-    const res: OrbRelease = (
-      await this.http.postJson<{ data: { orb: OrbRelease } }>(url, {
+    const res = (
+      await this.http.postJson<OrbResponse>(url, {
         body,
       })
-    ).body.data.orb;
-    if (!res) {
-      logger.debug(`Failed to look up orb ${packageName}`);
+    ).body;
+    if (!res?.data?.orb) {
+      logger.debug({ res }, `Failed to look up orb ${packageName}`);
       return null;
     }
+
+    const { orb } = res.data;
     // Simplify response before caching and returning
-    const homepage = res.homeUrl?.length
-      ? res.homeUrl
+    const homepage = orb.homeUrl?.length
+      ? orb.homeUrl
       : `https://circleci.com/developer/orbs/orb/${packageName}`;
-    const releases = res.versions.map(({ version, createdAt }) => ({
+    const releases = orb.versions.map(({ version, createdAt }) => ({
       version,
       releaseTimestamp: createdAt ?? null,
     }));

--- a/lib/modules/datasource/orb/types.ts
+++ b/lib/modules/datasource/orb/types.ts
@@ -5,3 +5,9 @@ export interface OrbRelease {
     createdAt?: string;
   }[];
 }
+
+export interface OrbResponse {
+  data?: {
+    orb?: OrbRelease;
+  };
+}


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Log response when no orb found.

## Context

https://github.com/renovatebot/renovate/issues/20132#issuecomment-1410794557

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
