### PR TITLE
docs(about us): bump number of outside contributors

### DIFF
--- a/docs/usage/about-us.md
+++ b/docs/usage/about-us.md
@@ -2,7 +2,7 @@
 
 Renovate was created by [Mend](https://www.mend.io/) staff and they continue to work on Renovate.
 
-More than 700 outside contributors helped improve Renovate.
+More than 750 outside contributors helped improve Renovate.
 
 ## Special thanks
 


### PR DESCRIPTION
## Changes

- Bump number of outside contributors to `750`

## Context

GitHub shows we have more than `750` outside contributors, so I'm updating the docs to show the bigger number. 😄 

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
