### PR TITLE
fix(manager/npm): don't warn for empty `.yarnrc.yml`

### DIFF
--- a/lib/modules/manager/npm/extract/yarnrc.spec.ts
+++ b/lib/modules/manager/npm/extract/yarnrc.spec.ts
@@ -43,6 +43,16 @@ describe('modules/manager/npm/extract/yarnrc', () => {
       });
       expect(registryUrl).toBeNull();
     });
+
+    it('ignores missing scope registryServer', () => {
+      const registryUrl = resolveRegistryUrl('@scope/a-package', {
+        npmScopes: {
+          scope: {},
+        },
+        npmRegistryServer: 'https://private.example.com/npm',
+      });
+      expect(registryUrl).toBeNull();
+    });
   });
 
   describe('loadConfigFromYarnrcYml()', () => {
@@ -91,6 +101,7 @@ describe('modules/manager/npm/extract/yarnrc', () => {
         `,
         null,
       ],
+      ['', null],
     ])('produces expected config (%s)', (yarnrcYml, expectedConfig) => {
       const config = loadConfigFromYarnrcYml(yarnrcYml);
 

--- a/lib/modules/manager/npm/extract/yarnrc.ts
+++ b/lib/modules/manager/npm/extract/yarnrc.ts
@@ -17,11 +17,14 @@ export type YarnConfig = z.infer<typeof YarnrcYmlSchema>;
 
 export function loadConfigFromYarnrcYml(yarnrcYml: string): YarnConfig | null {
   try {
-    return YarnrcYmlSchema.parse(
-      load(yarnrcYml, {
-        json: true,
-      })
-    );
+    const obj = load(yarnrcYml, {
+      json: true,
+    });
+    if (!obj) {
+      // emtpy yaml file
+      return null;
+    }
+    return YarnrcYmlSchema.parse(obj);
   } catch (err) {
     logger.warn({ yarnrcYml, err }, `Failed to load yarnrc file`);
     return null;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
`js-yaml.load` can return `undefined` which causes a `zod` Error and a warning when the file is empty.
So we now explict check this and return `null`.
<!-- Describe what behavior is changed by this PR. -->

## Context
- regression of #19864 by @fgreinacher <!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
