### PR TITLE
fix: When `--include-forks` is passed, assume `=true`

### DIFF
--- a/lib/workers/global/config/parse/cli.ts
+++ b/lib/workers/global/config/parse/cli.ts
@@ -24,7 +24,7 @@ export function getConfig(input: string[]): AllConfig {
         .replace('--expose-env=true', '--trust-level=high')
         .replace('--expose-env', '--trust-level=high')
         .replace('--renovate-fork', '--include-forks')
-        .replace('--renovate-fork$', '--include-forks=true')
+        .replace(/^--include-forks$/, '--include-forks=true')
         .replace('"platform":"', '"hostType":"')
         .replace('"endpoint":"', '"matchHost":"')
         .replace('"host":"', '"matchHost":"')

--- a/lib/workers/global/config/parse/cli.ts
+++ b/lib/workers/global/config/parse/cli.ts
@@ -24,6 +24,7 @@ export function getConfig(input: string[]): AllConfig {
         .replace('--expose-env=true', '--trust-level=high')
         .replace('--expose-env', '--trust-level=high')
         .replace('--renovate-fork', '--include-forks')
+        .replace('--renovate-fork$', '--include-forks=true')
         .replace('"platform":"', '"hostType":"')
         .replace('"endpoint":"', '"matchHost":"')
         .replace('"host":"', '"matchHost":"')


### PR DESCRIPTION
## Changes

Changes `--include-forks` from a parameter to a switch by assuming `=true` when no value is passed in.

## Context

Make the `--include-forks` act like other switches such as: `--autodiscover` and `--dry-run`.

## Documentation (please check one with an [x])

The documentation mentions `--include-forks=true` once, I could replace it, but the value remains valid.

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
