### PR TITLE
feat(manager/mix): set currentVersion field for exact dependency versions

### DIFF
--- a/lib/modules/manager/mix/__fixtures__/mix.exs
+++ b/lib/modules/manager/mix/__fixtures__/mix.exs
@@ -30,6 +30,7 @@ defmodule MyProject.MixProject do
       {:jason, ">= 1.0.0"},
       {:jason, "~> 1.0",
         optional: true},
+      {:phoenix, "== 1.6.14"},
     ]
   end
 end

--- a/lib/modules/manager/mix/extract.spec.ts
+++ b/lib/modules/manager/mix/extract.spec.ts
@@ -79,6 +79,13 @@ describe('modules/manager/mix/extract', () => {
           depName: 'jason',
           packageName: 'jason',
         },
+        {
+          currentValue: '== 1.6.14',
+          currentVersion: '1.6.14',
+          datasource: 'hex',
+          depName: 'phoenix',
+          packageName: 'phoenix',
+        },
       ]);
     });
   });

--- a/lib/modules/manager/mix/extract.ts
+++ b/lib/modules/manager/mix/extract.ts
@@ -59,6 +59,9 @@ export async function extractPackageFile(
             datasource: HexDatasource.id,
             packageName: organization ? `${app}:${organization}` : app,
           };
+          if (requirement?.startsWith('==')) {
+            dep.currentVersion = requirement.replace(regEx(/^==\s*/), '');
+          }
         }
 
         deps.push(dep);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds `currentVersion` values to extracted mix dependencies that are specified with an exact version requirement. In case `mix.lock` is not available, this enables the identification of an exact dep version (use-case: https://github.com/renovatebot/renovate/pull/20226).

An analogous snippet exists in managers for [pip_requirements](https://github.com/renovatebot/renovate/blob/11b08f486ff84298ac2db995c632c6c865baaba9/lib/modules/manager/pip_requirements/extract.ts#L120-L122) and [setup-cfg](https://github.com/renovatebot/renovate/blob/11b08f486ff84298ac2db995c632c6c865baaba9/lib/modules/manager/setup-cfg/extract.ts#L81-L83).

<!-- Describe what behavior is changed by this PR. -->

## Context

- Found while working on https://github.com/renovatebot/renovate/pull/20226

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

Test repo: https://github.com/renovate-demo/6562-vulndemo2/pull/5

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
