### PR TITLE
fix(manager/gradle): correct execution order for buildscript dependencies in lockfiles

### DIFF
--- a/lib/modules/manager/gradle/artifacts.ts
+++ b/lib/modules/manager/gradle/artifacts.ts
@@ -124,8 +124,6 @@ export async function updateArtifacts({
 
   try {
     const oldLockFileContentMap = await getFiles(lockFiles);
-
-    await writeLocalFile(packageFileName, newPackageFileContent);
     await prepareGradleCommand(gradlewFile);
 
     let cmd = `${gradlewName} --console=plain -q`;
@@ -159,6 +157,7 @@ export async function updateArtifacts({
       cmd += ` --update-locks ${updatedDepNames.map(quote).join(',')}`;
     }
 
+    await writeLocalFile(packageFileName, newPackageFileContent);
     await exec(cmd, execOptions);
 
     const res = await getUpdatedLockfiles(oldLockFileContentMap);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Changes the order when the updated build file is written to ensure the list of subprojects is read still before any update happens. This is needed to support `buildscript` dependencies, which are processed earlier than regular deps. Without this change, gradle detects a discrepany between build and lock files and fails.

<!-- Describe what behavior is changed by this PR. -->

## Context

- Closes #20289

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

Test repo: https://github.com/renovate-demo/20289-renovate-gradle-lock-file-example/pull/1/files 

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
