### PR TITLE
fix(go): Avoid tag fetching for `v0.0.0`

### DIFF
--- a/lib/modules/datasource/go/index.spec.ts
+++ b/lib/modules/datasource/go/index.spec.ts
@@ -17,11 +17,13 @@ jest.mock('./releases-direct', () => {
   return {
     GoDirectDatasource: jest.fn().mockImplementation(() => {
       return {
-        git: { getDigest: () => getDigestGitMock() },
-        github: { getDigest: () => getDigestGithubMock() },
-        gitlab: { getDigest: () => getDigestGitlabMock() },
-        bitbucket: { getDigest: () => getDigestBitbucketMock() },
-        getReleases: () => getReleasesDirectMock(),
+        git: { getDigest: (...args: any[]) => getDigestGitMock(...args) },
+        github: { getDigest: (...args: any[]) => getDigestGithubMock(...args) },
+        gitlab: { getDigest: (...args: any[]) => getDigestGitlabMock(...args) },
+        bitbucket: {
+          getDigest: (...args: any[]) => getDigestBitbucketMock(...args),
+        },
+        getReleases: (...args: any[]) => getReleasesDirectMock(...args),
       };
     }),
   };
@@ -158,7 +160,7 @@ describe('modules/datasource/go/index', () => {
       expect(res).toBe('abcdefabcdefabcdefabcdef');
     });
 
-    it('returns digest', async () => {
+    it('returns github digest', async () => {
       httpMock
         .scope('https://golang.org/')
         .get('/x/text?go-get=1')
@@ -166,9 +168,38 @@ describe('modules/datasource/go/index', () => {
       getDigestGithubMock.mockResolvedValueOnce('abcdefabcdefabcdefabcdef');
       const res = await datasource.getDigest(
         { packageName: 'golang.org/x/text' },
-        null
+        'v1.2.3'
       );
       expect(res).toBe('abcdefabcdefabcdefabcdef');
+      expect(getDigestGithubMock).toHaveBeenCalledWith(
+        {
+          datasource: 'github-tags',
+          packageName: 'golang/text',
+          registryUrl: 'https://github.com',
+        },
+        'v1.2.3'
+      );
+    });
+
+    it('returns github default branch digest', async () => {
+      httpMock
+        .scope('https://golang.org/')
+        .get('/x/text?go-get=1')
+        .reply(200, Fixtures.get('go-get-github.html'));
+      getDigestGithubMock.mockResolvedValueOnce('abcdefabcdefabcdefabcdef');
+      const res = await datasource.getDigest(
+        { packageName: 'golang.org/x/text' },
+        'v0.0.0'
+      );
+      expect(res).toBe('abcdefabcdefabcdefabcdef');
+      expect(getDigestGithubMock).toHaveBeenCalledWith(
+        {
+          datasource: 'github-tags',
+          packageName: 'golang/text',
+          registryUrl: 'https://github.com',
+        },
+        undefined
+      );
     });
 
     it('support bitbucket digest', async () => {

--- a/lib/modules/datasource/go/index.ts
+++ b/lib/modules/datasource/go/index.ts
@@ -65,8 +65,11 @@ export class GoDatasource extends Datasource {
     }
 
     // ignore vX.Y.Z-(0.)? pseudo versions that are used Go Modules - look up default branch instead
+    // ignore v0.0.0 versions to fetch the digest of default branch, not the commit of non-existing tag `v0.0.0`
     const tag =
-      value && !GoDatasource.pversionRegexp.test(value) ? value : undefined;
+      value && !GoDatasource.pversionRegexp.test(value) && value !== 'v0.0.0'
+        ? value
+        : undefined;
 
     switch (source.datasource) {
       case GitTagsDatasource.id: {

--- a/lib/modules/datasource/go/releases-direct.ts
+++ b/lib/modules/datasource/go/releases-direct.ts
@@ -6,7 +6,7 @@ import { Datasource } from '../datasource';
 import { GitTagsDatasource } from '../git-tags';
 import { GithubTagsDatasource } from '../github-tags';
 import { GitlabTagsDatasource } from '../gitlab-tags';
-import type { DatasourceApi, GetReleasesConfig, ReleaseResult } from '../types';
+import type { GetReleasesConfig, ReleaseResult } from '../types';
 import { BaseGoDatasource } from './base';
 import { getSourceUrl } from './common';
 
@@ -15,8 +15,8 @@ export class GoDirectDatasource extends Datasource {
 
   git: GitTagsDatasource;
   github: GithubTagsDatasource;
-  gitlab: DatasourceApi;
-  bitbucket: DatasourceApi;
+  gitlab: GitlabTagsDatasource;
+  bitbucket: BitBucketTagsDatasource;
 
   constructor() {
     super(GoDirectDatasource.id);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

When `v0.0.0` is detected as version, we don't need to fetch it from GitHub or another platform, because it doesn't exist. This PR makes it to resort to HEAD commit fetching instead.

## Context

- Blocks: #9667

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
