### PR TITLE
docs(docker): mention required version for Harbor proxy cache feature

### DIFF
--- a/lib/modules/datasource/docker/readme.md
+++ b/lib/modules/datasource/docker/readme.md
@@ -12,3 +12,5 @@ Here's an example from our `renovate/renovate` Dockerfile:
 ```dockerfile
 LABEL org.opencontainers.image.source="https://github.com/renovatebot/renovate"
 ```
+
+If you use [Harbor](https://goharbor.io/) as a proxy cache for Docker Hub, then you must use Harbor version `2.5.0` or higher.


### PR DESCRIPTION
## Changes

- For Renovate to work with Harbor proxy cache feature, users must use Harbor `2.5.0` or higher

## Context

As requested by @viceice in:

- https://github.com/renovatebot/renovate/discussions/20275#discussioncomment-4918299

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository