### PR TITLE
fix(manager/kustomize): Don't crash on non-string resources

### DIFF
--- a/lib/modules/manager/kustomize/extract.ts
+++ b/lib/modules/manager/kustomize/extract.ts
@@ -32,7 +32,9 @@ const gitUrlWithPath = regEx(
 export function extractResource(base: string): PackageDependency | null {
   let match: RegExpExecArray | null;
 
-  if (base.includes('_git')) {
+  if (typeof base !== 'string') {
+    return null
+  } else if (base.includes('_git')) {
     match = underscoreGitRegex.exec(base);
   } else if (base.includes('.git')) {
     match = dotGitRegex.exec(base);

--- a/lib/modules/manager/kustomize/extract.ts
+++ b/lib/modules/manager/kustomize/extract.ts
@@ -32,7 +32,7 @@ const gitUrlWithPath = regEx(
 export function extractResource(base: string): PackageDependency | null {
   let match: RegExpExecArray | null;
 
-  if (typeof base !== 'string') {
+  if (!is.string(base)) {
     return null
   } else if (base.includes('_git')) {
     match = underscoreGitRegex.exec(base);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This PR fixes an exception that happens when a `kustomization.yaml` contains `resources` that are not strings. These might be `null` resources or any other invalid resources.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

Even though non-string resources are forbidden in Kustomize, it might still happen when some form of pre-processing or templating is applied to `kustomization.yaml` files. In that case, renovate should error out when extracting packages.

This was not a problem before https://github.com/renovatebot/renovate/pull/20116 got merged as Renovate simply bailed out in `extractResource` due to non-strings not matching the regex.

The stack trace of the original exception was:
```
TypeError: base.includes is not a function
    at extractResource (/opt/buildpack/tools/renovate/34.128.3/node_modules/renovate/lib/modules/manager/kustomize/extract.ts:35:12)
    at Object.extractPackageFile (/opt/buildpack/tools/renovate/34.128.3/node_modules/renovate/lib/modules/manager/kustomize/extract.ts:192:17)
    at extractPackageFile (/opt/buildpack/tools/renovate/34.128.3/node_modules/renovate/lib/modules/manager/index.ts:70:9)
    at getManagerPackageFiles (/opt/buildpack/tools/renovate/34.128.3/node_modules/renovate/lib/workers/repository/extract/manager-files.ts:52:43)
    at /opt/buildpack/tools/renovate/34.128.3/node_modules/renovate/lib/workers/repository/extract/index.ts:57:28
    at async Promise.all (index 3)
    at extractAllDependencies (/opt/buildpack/tools/renovate/34.128.3/node_modules/renovate/lib/workers/repository/extract/index.ts:55:26)
    at extract (/opt/buildpack/tools/renovate/34.128.3/node_modules/renovate/lib/workers/repository/process/extract-update.ts:139:28)
    at extractDependencies (/opt/buildpack/tools/renovate/34.128.3/node_modules/renovate/lib/workers/repository/process/index.ts:120:26)
    at Object.renovateRepository (/opt/buildpack/tools/renovate/34.128.3/node_modules/renovate/lib/workers/repository/index.ts:56:9)
    at attributes.repository (/opt/buildpack/tools/renovate/34.128.3/node_modules/renovate/lib/workers/global/index.ts:181:11)
    at start (/opt/buildpack/tools/renovate/34.128.3/node_modules/renovate/lib/workers/global/index.ts:166:7)
    at /opt/buildpack/tools/renovate/34.128.3/node_modules/renovate/lib/renovate.ts:18:22
```
- ref #20055

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
