### PR TITLE
fix(github): Typo in token warning message

### DIFF
--- a/lib/workers/global/config/parse/env.ts
+++ b/lib/workers/global/config/parse/env.ts
@@ -135,7 +135,7 @@ export function getConfig(inputEnv: NodeJS.ProcessEnv): AllConfig {
   if (env.GITHUB_COM_TOKEN) {
     if (env.GITHUB_COM_TOKEN.startsWith('github_pat_')) {
       logger.warn(
-        'GITHUB_COM_TOKEN: Fine-grained Personal Access Tokens do not support do not support the GitHub GraphQL API. Use a classic PAT instead.'
+        'GITHUB_COM_TOKEN: Fine-grained Personal Access Tokens do not support the GitHub GraphQL API. Use a classic PAT instead.'
       );
     } else {
       logger.debug(`Converting GITHUB_COM_TOKEN into a global host rule`);


### PR DESCRIPTION
## Changes

Just a typo in a warning message.
