### PR TITLE
refactor(bazel): Allow for parsing multiple deps from single rule

### DIFF
--- a/lib/modules/manager/bazel/extract.ts
+++ b/lib/modules/manager/bazel/extract.ts
@@ -1,6 +1,6 @@
 import type { PackageDependency, PackageFile } from '../types';
 import { parse } from './parser';
-import { extractDepFromFragment } from './rules';
+import { extractDepsFromFragment } from './rules';
 import type { RecordFragment } from './types';
 
 export function extractPackageFile(
@@ -16,7 +16,7 @@ export function extractPackageFile(
 
   for (let idx = 0; idx < fragments.length; idx += 1) {
     const fragment = fragments[idx];
-    for (const dep of extractDepFromFragment(fragment)) {
+    for (const dep of extractDepsFromFragment(fragment)) {
       dep.replaceString = fragment.value;
       dep.managerData = { idx };
       deps.push(dep);

--- a/lib/modules/manager/bazel/extract.ts
+++ b/lib/modules/manager/bazel/extract.ts
@@ -16,15 +16,11 @@ export function extractPackageFile(
 
   for (let idx = 0; idx < fragments.length; idx += 1) {
     const fragment = fragments[idx];
-
-    const dep = extractDepFromFragment(fragment);
-    if (!dep) {
-      continue;
+    for (const dep of extractDepFromFragment(fragment)) {
+      dep.replaceString = fragment.value;
+      dep.managerData = { idx };
+      deps.push(dep);
     }
-
-    dep.replaceString = fragment.value;
-    dep.managerData = { idx };
-    deps.push(dep);
   }
 
   return deps.length ? { deps } : null;

--- a/lib/modules/manager/bazel/rules/docker.ts
+++ b/lib/modules/manager/bazel/rules/docker.ts
@@ -15,14 +15,23 @@ export const DockerTarget = z
     registry: z.string(),
   })
   .transform(
-    ({ rule, name, repository, tag, digest, registry }): PackageDependency => ({
-      datasource: DockerDatasource.id,
-      versioning: dockerVersioning,
-      depType: rule,
-      depName: name,
-      packageName: repository,
-      currentValue: tag,
-      currentDigest: digest,
-      registryUrls: [registry],
-    })
+    ({
+      rule,
+      name,
+      repository,
+      tag,
+      digest,
+      registry,
+    }): PackageDependency[] => [
+      {
+        datasource: DockerDatasource.id,
+        versioning: dockerVersioning,
+        depType: rule,
+        depName: name,
+        packageName: repository,
+        currentValue: tag,
+        currentDigest: digest,
+        registryUrls: [registry],
+      },
+    ]
   );

--- a/lib/modules/manager/bazel/rules/git.ts
+++ b/lib/modules/manager/bazel/rules/git.ts
@@ -23,7 +23,7 @@ export const GitTarget = z
     remote: z.string(),
   })
   .refine(({ tag, commit }) => !!tag || !!commit)
-  .transform(({ rule, name, tag, commit, remote }): PackageDependency => {
+  .transform(({ rule, name, tag, commit, remote }): PackageDependency[] => {
     const dep: PackageDependency = {
       depType: rule,
       depName: name,
@@ -47,5 +47,5 @@ export const GitTarget = z
       dep.skipReason = 'unsupported-datasource';
     }
 
-    return dep;
+    return [dep];
   });

--- a/lib/modules/manager/bazel/rules/go.ts
+++ b/lib/modules/manager/bazel/rules/go.ts
@@ -16,7 +16,7 @@ export const GoTarget = z
   })
   .refine(({ tag, commit }) => !!tag || !!commit)
   .transform(
-    ({ rule, name, tag, commit, importpath, remote }): PackageDependency => {
+    ({ rule, name, tag, commit, importpath, remote }): PackageDependency[] => {
       const dep: PackageDependency = {
         datasource: GoDatasource.id,
         depType: rule,
@@ -46,6 +46,6 @@ export const GoTarget = z
         }
       }
 
-      return dep;
+      return [dep];
     }
   );

--- a/lib/modules/manager/bazel/rules/http.ts
+++ b/lib/modules/manager/bazel/rules/http.ts
@@ -62,10 +62,10 @@ export const HttpTarget = z
     sha256: z.string(),
   })
   .refine(({ url, urls }) => !!url || !!urls)
-  .transform(({ rule, name, url, urls = [] }): PackageDependency | null => {
+  .transform(({ rule, name, url, urls = [] }): PackageDependency[] => {
     const parsedUrl = [url, ...urls].map(parseArchiveUrl).find(is.truthy);
     if (!parsedUrl) {
-      return null;
+      return [];
     }
 
     const dep: PackageDependency = {
@@ -81,5 +81,5 @@ export const HttpTarget = z
       dep.currentValue = parsedUrl.currentValue;
     }
 
-    return dep;
+    return [dep];
   });

--- a/lib/modules/manager/bazel/rules/index.spec.ts
+++ b/lib/modules/manager/bazel/rules/index.spec.ts
@@ -1,5 +1,5 @@
 import { parseArchiveUrl } from './http';
-import { extractDepFromFragmentData } from '.';
+import { extractDepsFromFragmentData } from '.';
 
 describe('modules/manager/bazel/rules/index', () => {
   it('parses archiveUrl', () => {
@@ -46,15 +46,15 @@ describe('modules/manager/bazel/rules/index', () => {
   describe('git', () => {
     it('extracts git dependencies', () => {
       expect(
-        extractDepFromFragmentData({ rule: 'foo_bar', name: 'foo_bar' })
+        extractDepsFromFragmentData({ rule: 'foo_bar', name: 'foo_bar' })
       ).toBeEmptyArray();
 
       expect(
-        extractDepFromFragmentData({ rule: 'git_repository', name: 'foo_bar' })
+        extractDepsFromFragmentData({ rule: 'git_repository', name: 'foo_bar' })
       ).toBeEmptyArray();
 
       expect(
-        extractDepFromFragmentData({
+        extractDepsFromFragmentData({
           rule: 'git_repository',
           name: 'foo_bar',
           tag: '1.2.3',
@@ -62,7 +62,7 @@ describe('modules/manager/bazel/rules/index', () => {
       ).toBeEmptyArray();
 
       expect(
-        extractDepFromFragmentData({
+        extractDepsFromFragmentData({
           rule: 'git_repository',
           name: 'foo_bar',
           tag: '1.2.3',
@@ -79,7 +79,7 @@ describe('modules/manager/bazel/rules/index', () => {
       ]);
 
       expect(
-        extractDepFromFragmentData({
+        extractDepsFromFragmentData({
           rule: 'git_repository',
           name: 'foo_bar',
           commit: 'abcdef0123abcdef0123abcdef0123abcdef0123',
@@ -96,7 +96,7 @@ describe('modules/manager/bazel/rules/index', () => {
       ]);
 
       expect(
-        extractDepFromFragmentData({
+        extractDepsFromFragmentData({
           rule: 'git_repository',
           name: 'foo_bar',
           tag: '1.2.3',
@@ -116,15 +116,15 @@ describe('modules/manager/bazel/rules/index', () => {
   describe('go', () => {
     it('extracts go dependencies', () => {
       expect(
-        extractDepFromFragmentData({ rule: 'foo_bar', name: 'foo_bar' })
+        extractDepsFromFragmentData({ rule: 'foo_bar', name: 'foo_bar' })
       ).toBeEmptyArray();
 
       expect(
-        extractDepFromFragmentData({ rule: 'go_repository', name: 'foo_bar' })
+        extractDepsFromFragmentData({ rule: 'go_repository', name: 'foo_bar' })
       ).toBeEmptyArray();
 
       expect(
-        extractDepFromFragmentData({
+        extractDepsFromFragmentData({
           rule: 'go_repository',
           name: 'foo_bar',
           tag: '1.2.3',
@@ -132,7 +132,7 @@ describe('modules/manager/bazel/rules/index', () => {
       ).toBeEmptyArray();
 
       expect(
-        extractDepFromFragmentData({
+        extractDepsFromFragmentData({
           rule: 'go_repository',
           name: 'foo_bar',
           tag: '1.2.3',
@@ -149,7 +149,7 @@ describe('modules/manager/bazel/rules/index', () => {
       ]);
 
       expect(
-        extractDepFromFragmentData({
+        extractDepsFromFragmentData({
           rule: 'go_repository',
           name: 'foo_bar',
           commit: 'abcdef0123abcdef0123abcdef0123abcdef0123',
@@ -167,7 +167,7 @@ describe('modules/manager/bazel/rules/index', () => {
       ]);
 
       expect(
-        extractDepFromFragmentData({
+        extractDepsFromFragmentData({
           rule: 'go_repository',
           name: 'foo_bar',
           tag: '1.2.3',
@@ -185,7 +185,7 @@ describe('modules/manager/bazel/rules/index', () => {
       ]);
 
       expect(
-        extractDepFromFragmentData({
+        extractDepsFromFragmentData({
           rule: 'go_repository',
           name: 'foo_bar',
           tag: '1.2.3',
@@ -208,15 +208,15 @@ describe('modules/manager/bazel/rules/index', () => {
   describe('http', () => {
     it('extracts http dependencies', () => {
       expect(
-        extractDepFromFragmentData({ rule: 'foo_bar', name: 'foo_bar' })
+        extractDepsFromFragmentData({ rule: 'foo_bar', name: 'foo_bar' })
       ).toBeEmptyArray();
 
       expect(
-        extractDepFromFragmentData({ rule: 'http_archive', name: 'foo_bar' })
+        extractDepsFromFragmentData({ rule: 'http_archive', name: 'foo_bar' })
       ).toBeEmptyArray();
 
       expect(
-        extractDepFromFragmentData({
+        extractDepsFromFragmentData({
           rule: 'http_archive',
           name: 'foo_bar',
           sha256: 'abcdef0123abcdef0123abcdef0123abcdef0123',
@@ -224,7 +224,7 @@ describe('modules/manager/bazel/rules/index', () => {
       ).toBeEmptyArray();
 
       expect(
-        extractDepFromFragmentData({
+        extractDepsFromFragmentData({
           rule: 'http_archive',
           name: 'foo_bar',
           sha256: 'abcdef0123abcdef0123abcdef0123abcdef0123',
@@ -241,7 +241,7 @@ describe('modules/manager/bazel/rules/index', () => {
       ]);
 
       expect(
-        extractDepFromFragmentData({
+        extractDepsFromFragmentData({
           rule: 'http_archive',
           name: 'foo_bar',
           sha256: 'abcdef0123abcdef0123abcdef0123abcdef0123',
@@ -261,7 +261,7 @@ describe('modules/manager/bazel/rules/index', () => {
       ]);
 
       expect(
-        extractDepFromFragmentData({
+        extractDepsFromFragmentData({
           rule: 'http_archive',
           name: 'foo_bar',
           sha256: 'abcdef0123abcdef0123abcdef0123abcdef0123',
@@ -278,7 +278,7 @@ describe('modules/manager/bazel/rules/index', () => {
       ]);
 
       expect(
-        extractDepFromFragmentData({
+        extractDepsFromFragmentData({
           rule: 'http_archive',
           name: 'foo_bar',
           sha256: 'abcdef0123abcdef0123abcdef0123abcdef0123',
@@ -298,7 +298,7 @@ describe('modules/manager/bazel/rules/index', () => {
       ]);
 
       expect(
-        extractDepFromFragmentData({
+        extractDepsFromFragmentData({
           rule: 'http_archive',
           name: 'aspect_rules_js',
           sha256:
@@ -322,11 +322,11 @@ describe('modules/manager/bazel/rules/index', () => {
   describe('docker', () => {
     it('extracts docker dependencies', () => {
       expect(
-        extractDepFromFragmentData({ rule: 'foo_bar', name: 'foo_bar' })
+        extractDepsFromFragmentData({ rule: 'foo_bar', name: 'foo_bar' })
       ).toBeEmptyArray();
 
       expect(
-        extractDepFromFragmentData({
+        extractDepsFromFragmentData({
           rule: 'container_pull',
           name: 'foo_bar',
           tag: '1.2.3',

--- a/lib/modules/manager/bazel/rules/index.spec.ts
+++ b/lib/modules/manager/bazel/rules/index.spec.ts
@@ -47,11 +47,11 @@ describe('modules/manager/bazel/rules/index', () => {
     it('extracts git dependencies', () => {
       expect(
         extractDepFromFragmentData({ rule: 'foo_bar', name: 'foo_bar' })
-      ).toBeNull();
+      ).toBeEmptyArray();
 
       expect(
         extractDepFromFragmentData({ rule: 'git_repository', name: 'foo_bar' })
-      ).toBeNull();
+      ).toBeEmptyArray();
 
       expect(
         extractDepFromFragmentData({
@@ -59,7 +59,7 @@ describe('modules/manager/bazel/rules/index', () => {
           name: 'foo_bar',
           tag: '1.2.3',
         })
-      ).toBeNull();
+      ).toBeEmptyArray();
 
       expect(
         extractDepFromFragmentData({
@@ -68,13 +68,15 @@ describe('modules/manager/bazel/rules/index', () => {
           tag: '1.2.3',
           remote: 'https://github.com/foo/bar',
         })
-      ).toEqual({
-        datasource: 'github-releases',
-        depType: 'git_repository',
-        depName: 'foo_bar',
-        packageName: 'foo/bar',
-        currentValue: '1.2.3',
-      });
+      ).toEqual([
+        {
+          datasource: 'github-releases',
+          depType: 'git_repository',
+          depName: 'foo_bar',
+          packageName: 'foo/bar',
+          currentValue: '1.2.3',
+        },
+      ]);
 
       expect(
         extractDepFromFragmentData({
@@ -83,13 +85,15 @@ describe('modules/manager/bazel/rules/index', () => {
           commit: 'abcdef0123abcdef0123abcdef0123abcdef0123',
           remote: 'https://github.com/foo/bar',
         })
-      ).toEqual({
-        datasource: 'github-releases',
-        depType: 'git_repository',
-        depName: 'foo_bar',
-        packageName: 'foo/bar',
-        currentDigest: 'abcdef0123abcdef0123abcdef0123abcdef0123',
-      });
+      ).toEqual([
+        {
+          datasource: 'github-releases',
+          depType: 'git_repository',
+          depName: 'foo_bar',
+          packageName: 'foo/bar',
+          currentDigest: 'abcdef0123abcdef0123abcdef0123abcdef0123',
+        },
+      ]);
 
       expect(
         extractDepFromFragmentData({
@@ -98,12 +102,14 @@ describe('modules/manager/bazel/rules/index', () => {
           tag: '1.2.3',
           remote: 'https://gitlab.com/foo/bar',
         })
-      ).toMatchObject({
-        currentValue: '1.2.3',
-        depName: 'foo_bar',
-        depType: 'git_repository',
-        skipReason: 'unsupported-datasource',
-      });
+      ).toMatchObject([
+        {
+          currentValue: '1.2.3',
+          depName: 'foo_bar',
+          depType: 'git_repository',
+          skipReason: 'unsupported-datasource',
+        },
+      ]);
     });
   });
 
@@ -111,11 +117,11 @@ describe('modules/manager/bazel/rules/index', () => {
     it('extracts go dependencies', () => {
       expect(
         extractDepFromFragmentData({ rule: 'foo_bar', name: 'foo_bar' })
-      ).toBeNull();
+      ).toBeEmptyArray();
 
       expect(
         extractDepFromFragmentData({ rule: 'go_repository', name: 'foo_bar' })
-      ).toBeNull();
+      ).toBeEmptyArray();
 
       expect(
         extractDepFromFragmentData({
@@ -123,7 +129,7 @@ describe('modules/manager/bazel/rules/index', () => {
           name: 'foo_bar',
           tag: '1.2.3',
         })
-      ).toBeNull();
+      ).toBeEmptyArray();
 
       expect(
         extractDepFromFragmentData({
@@ -132,13 +138,15 @@ describe('modules/manager/bazel/rules/index', () => {
           tag: '1.2.3',
           importpath: 'foo/bar/baz',
         })
-      ).toEqual({
-        datasource: 'go',
-        depType: 'go_repository',
-        depName: 'foo_bar',
-        packageName: 'foo/bar/baz',
-        currentValue: '1.2.3',
-      });
+      ).toEqual([
+        {
+          datasource: 'go',
+          depType: 'go_repository',
+          depName: 'foo_bar',
+          packageName: 'foo/bar/baz',
+          currentValue: '1.2.3',
+        },
+      ]);
 
       expect(
         extractDepFromFragmentData({
@@ -147,14 +155,16 @@ describe('modules/manager/bazel/rules/index', () => {
           commit: 'abcdef0123abcdef0123abcdef0123abcdef0123',
           importpath: 'foo/bar/baz',
         })
-      ).toEqual({
-        datasource: 'go',
-        depType: 'go_repository',
-        depName: 'foo_bar',
-        packageName: 'foo/bar/baz',
-        currentDigest: 'abcdef0123abcdef0123abcdef0123abcdef0123',
-        digestOneAndOnly: true,
-      });
+      ).toEqual([
+        {
+          datasource: 'go',
+          depType: 'go_repository',
+          depName: 'foo_bar',
+          packageName: 'foo/bar/baz',
+          currentDigest: 'abcdef0123abcdef0123abcdef0123abcdef0123',
+          digestOneAndOnly: true,
+        },
+      ]);
 
       expect(
         extractDepFromFragmentData({
@@ -164,13 +174,15 @@ describe('modules/manager/bazel/rules/index', () => {
           importpath: 'foo/bar/baz',
           remote: 'https://github.com/foo/bar',
         })
-      ).toEqual({
-        datasource: 'go',
-        depType: 'go_repository',
-        depName: 'foo_bar',
-        packageName: 'github.com/foo/bar',
-        currentValue: '1.2.3',
-      });
+      ).toEqual([
+        {
+          datasource: 'go',
+          depType: 'go_repository',
+          depName: 'foo_bar',
+          packageName: 'github.com/foo/bar',
+          currentValue: '1.2.3',
+        },
+      ]);
 
       expect(
         extractDepFromFragmentData({
@@ -180,14 +192,16 @@ describe('modules/manager/bazel/rules/index', () => {
           importpath: 'foo/bar/baz',
           remote: 'https://example.com/foo/bar',
         })
-      ).toEqual({
-        datasource: 'go',
-        depType: 'go_repository',
-        depName: 'foo_bar',
-        packageName: 'foo/bar/baz',
-        currentValue: '1.2.3',
-        skipReason: 'unsupported-remote',
-      });
+      ).toEqual([
+        {
+          datasource: 'go',
+          depType: 'go_repository',
+          depName: 'foo_bar',
+          packageName: 'foo/bar/baz',
+          currentValue: '1.2.3',
+          skipReason: 'unsupported-remote',
+        },
+      ]);
     });
   });
 
@@ -195,11 +209,11 @@ describe('modules/manager/bazel/rules/index', () => {
     it('extracts http dependencies', () => {
       expect(
         extractDepFromFragmentData({ rule: 'foo_bar', name: 'foo_bar' })
-      ).toBeNull();
+      ).toBeEmptyArray();
 
       expect(
         extractDepFromFragmentData({ rule: 'http_archive', name: 'foo_bar' })
-      ).toBeNull();
+      ).toBeEmptyArray();
 
       expect(
         extractDepFromFragmentData({
@@ -207,7 +221,7 @@ describe('modules/manager/bazel/rules/index', () => {
           name: 'foo_bar',
           sha256: 'abcdef0123abcdef0123abcdef0123abcdef0123',
         })
-      ).toBeNull();
+      ).toBeEmptyArray();
 
       expect(
         extractDepFromFragmentData({
@@ -216,13 +230,15 @@ describe('modules/manager/bazel/rules/index', () => {
           sha256: 'abcdef0123abcdef0123abcdef0123abcdef0123',
           url: 'https://github.com/foo/bar/archive/abcdef0123abcdef0123abcdef0123abcdef0123.tar.gz',
         })
-      ).toEqual({
-        currentDigest: 'abcdef0123abcdef0123abcdef0123abcdef0123',
-        datasource: 'github-tags',
-        depName: 'foo_bar',
-        depType: 'http_archive',
-        packageName: 'foo/bar',
-      });
+      ).toEqual([
+        {
+          currentDigest: 'abcdef0123abcdef0123abcdef0123abcdef0123',
+          datasource: 'github-tags',
+          depName: 'foo_bar',
+          depType: 'http_archive',
+          packageName: 'foo/bar',
+        },
+      ]);
 
       expect(
         extractDepFromFragmentData({
@@ -234,13 +250,15 @@ describe('modules/manager/bazel/rules/index', () => {
             'https://github.com/foo/bar/archive/abcdef0123abcdef0123abcdef0123abcdef0123.tar.gz',
           ],
         })
-      ).toEqual({
-        currentDigest: 'abcdef0123abcdef0123abcdef0123abcdef0123',
-        datasource: 'github-tags',
-        depName: 'foo_bar',
-        depType: 'http_archive',
-        packageName: 'foo/bar',
-      });
+      ).toEqual([
+        {
+          currentDigest: 'abcdef0123abcdef0123abcdef0123abcdef0123',
+          datasource: 'github-tags',
+          depName: 'foo_bar',
+          depType: 'http_archive',
+          packageName: 'foo/bar',
+        },
+      ]);
 
       expect(
         extractDepFromFragmentData({
@@ -249,13 +267,15 @@ describe('modules/manager/bazel/rules/index', () => {
           sha256: 'abcdef0123abcdef0123abcdef0123abcdef0123',
           url: 'https://github.com/foo/bar/releases/download/1.2.3/foobar-1.2.3.tar.gz',
         })
-      ).toEqual({
-        currentValue: '1.2.3',
-        datasource: 'github-releases',
-        depName: 'foo_bar',
-        depType: 'http_archive',
-        packageName: 'foo/bar',
-      });
+      ).toEqual([
+        {
+          currentValue: '1.2.3',
+          datasource: 'github-releases',
+          depName: 'foo_bar',
+          depType: 'http_archive',
+          packageName: 'foo/bar',
+        },
+      ]);
 
       expect(
         extractDepFromFragmentData({
@@ -267,13 +287,15 @@ describe('modules/manager/bazel/rules/index', () => {
             'https://github.com/foo/bar/releases/download/1.2.3/foobar-1.2.3.tar.gz',
           ],
         })
-      ).toEqual({
-        currentValue: '1.2.3',
-        datasource: 'github-releases',
-        depName: 'foo_bar',
-        depType: 'http_archive',
-        packageName: 'foo/bar',
-      });
+      ).toEqual([
+        {
+          currentValue: '1.2.3',
+          datasource: 'github-releases',
+          depName: 'foo_bar',
+          depType: 'http_archive',
+          packageName: 'foo/bar',
+        },
+      ]);
 
       expect(
         extractDepFromFragmentData({
@@ -285,13 +307,15 @@ describe('modules/manager/bazel/rules/index', () => {
             'https://github.com/aspect-build/rules_js/archive/refs/tags/v1.1.2.tar.gz',
           ],
         })
-      ).toEqual({
-        currentValue: 'v1.1.2',
-        datasource: 'github-tags',
-        depName: 'aspect_rules_js',
-        depType: 'http_archive',
-        packageName: 'aspect-build/rules_js',
-      });
+      ).toEqual([
+        {
+          currentValue: 'v1.1.2',
+          datasource: 'github-tags',
+          depName: 'aspect_rules_js',
+          depType: 'http_archive',
+          packageName: 'aspect-build/rules_js',
+        },
+      ]);
     });
   });
 
@@ -299,7 +323,7 @@ describe('modules/manager/bazel/rules/index', () => {
     it('extracts docker dependencies', () => {
       expect(
         extractDepFromFragmentData({ rule: 'foo_bar', name: 'foo_bar' })
-      ).toBeNull();
+      ).toBeEmptyArray();
 
       expect(
         extractDepFromFragmentData({
@@ -310,16 +334,18 @@ describe('modules/manager/bazel/rules/index', () => {
           repository: 'example.com/foo/bar',
           registry: 'https://example.com',
         })
-      ).toEqual({
-        currentDigest: 'abcdef0123abcdef0123abcdef0123abcdef0123',
-        currentValue: '1.2.3',
-        datasource: 'docker',
-        depName: 'foo_bar',
-        depType: 'container_pull',
-        packageName: 'example.com/foo/bar',
-        registryUrls: ['https://example.com'],
-        versioning: 'docker',
-      });
+      ).toEqual([
+        {
+          currentDigest: 'abcdef0123abcdef0123abcdef0123abcdef0123',
+          currentValue: '1.2.3',
+          datasource: 'docker',
+          depName: 'foo_bar',
+          depType: 'container_pull',
+          packageName: 'example.com/foo/bar',
+          registryUrls: ['https://example.com'],
+          versioning: 'docker',
+        },
+      ]);
     });
   });
 });

--- a/lib/modules/manager/bazel/rules/index.ts
+++ b/lib/modules/manager/bazel/rules/index.ts
@@ -18,17 +18,17 @@ export const supportedRulesRegex = regEx(`^${supportedRules.join('|')}$`);
 
 export function extractDepFromFragmentData(
   fragmentData: FragmentData
-): PackageDependency | null {
+): PackageDependency[] {
   const res = Target.safeParse(fragmentData);
   if (!res.success) {
-    return null;
+    return [];
   }
   return res.data;
 }
 
 export function extractDepFromFragment(
   fragment: Fragment
-): PackageDependency | null {
+): PackageDependency[] {
   const fragmentData = extract(fragment);
   return extractDepFromFragmentData(fragmentData);
 }

--- a/lib/modules/manager/bazel/rules/index.ts
+++ b/lib/modules/manager/bazel/rules/index.ts
@@ -16,7 +16,7 @@ const Target = z.union([DockerTarget, GitTarget, GoTarget, HttpTarget]);
 const supportedRules = [...dockerRules, ...gitRules, ...goRules, ...httpRules];
 export const supportedRulesRegex = regEx(`^${supportedRules.join('|')}$`);
 
-export function extractDepFromFragmentData(
+export function extractDepsFromFragmentData(
   fragmentData: FragmentData
 ): PackageDependency[] {
   const res = Target.safeParse(fragmentData);
@@ -26,11 +26,11 @@ export function extractDepFromFragmentData(
   return res.data;
 }
 
-export function extractDepFromFragment(
+export function extractDepsFromFragment(
   fragment: Fragment
 ): PackageDependency[] {
   const fragmentData = extract(fragment);
-  return extractDepFromFragmentData(fragmentData);
+  return extractDepsFromFragmentData(fragmentData);
 }
 
 export function extract(fragment: Fragment): FragmentData {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

For Maven, we need to be return multiple dependencies from single rule declaration.

## Context

- Ref: #5151 

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
