### PR TITLE
fix(versioning/cargo): Disable support for `rangeStrategy: widen`

### DIFF
--- a/lib/modules/versioning/cargo/index.ts
+++ b/lib/modules/versioning/cargo/index.ts
@@ -12,7 +12,6 @@ export const urls = [
 export const supportsRanges = true;
 export const supportedRangeStrategies: RangeStrategy[] = [
   'bump',
-  'widen',
   'pin',
   'replace',
 ];


### PR DESCRIPTION

## Changes

This PR removes `widen` from the `supportedRangeStrategies` for the `cargo` versioning scheme.

## Context

The `||` operator is not supported by cargo, so we can't possibly support `widen`, since it relies on `||` being supported.

see https://github.com/dtolnay/semver/issues/57#issuecomment-848203295

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
