### PR TITLE
feat(presets): Group for Spock Framework packages

### DIFF
--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -363,6 +363,7 @@ const staticGroups = {
       'group:rubyOnRails',
       'group:rubyOmniauth',
       'group:socketio',
+      'group:spock',
       'group:springAmqp',
       'group:springAndroid',
       'group:springBatch',
@@ -441,6 +442,15 @@ const staticGroups = {
         matchPackagePrefixes: ['socket.io'],
       },
     ],
+  },
+  spock: {
+    description: 'Group Spock Framework packages.',
+    packageRules: [
+      {
+        groupName: 'spock',
+        matchPackagePrefixes: ["org.spockframework:spock-"],
+      }
+    ]
   },
   springAmqp: {
     description: 'Group Java Spring AMQP packages.',

--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -363,7 +363,6 @@ const staticGroups = {
       'group:rubyOnRails',
       'group:rubyOmniauth',
       'group:socketio',
-      'group:spock',
       'group:springAmqp',
       'group:springAndroid',
       'group:springBatch',
@@ -442,15 +441,6 @@ const staticGroups = {
         matchPackagePrefixes: ['socket.io'],
       },
     ],
-  },
-  spock: {
-    description: 'Group Spock Framework packages.',
-    packageRules: [
-      {
-        groupName: 'spock',
-        matchPackagePrefixes: ["org.spockframework:spock-"],
-      }
-    ]
   },
   springAmqp: {
     description: 'Group Java Spring AMQP packages.',

--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -449,8 +449,8 @@ const staticGroups = {
       {
         groupName: 'spock',
         matchPackagePrefixes: ["org.spockframework:spock-"],
-      },
-    ],
+      }
+    ]
   },
   springAmqp: {
     description: 'Group Java Spring AMQP packages.',

--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -449,8 +449,8 @@ const staticGroups = {
       {
         groupName: 'spock',
         matchPackagePrefixes: ["org.spockframework:spock-"],
-      }
-    ]
+      },
+    ],
   },
   springAmqp: {
     description: 'Group Java Spring AMQP packages.',

--- a/lib/config/presets/internal/monorepo.ts
+++ b/lib/config/presets/internal/monorepo.ts
@@ -271,7 +271,7 @@ const patternGroups = {
   embroider: '^@embroider/',
   fullcalendar: '^@fullcalendar/',
   spfx: ['^@microsoft\\/sp-', '^@microsoft\\/eslint-.+-spfx$'],
-  spock: '^org.spockframework:spock-',
+  spock: '^org\\.spockframework:spock-',
   'syncfusion-dotnet': '^Syncfusion\\.',
   wordpress: '^@wordpress/',
 };

--- a/lib/config/presets/internal/monorepo.ts
+++ b/lib/config/presets/internal/monorepo.ts
@@ -271,7 +271,7 @@ const patternGroups = {
   embroider: '^@embroider/',
   fullcalendar: '^@fullcalendar/',
   spfx: ['^@microsoft\\/sp-', '^@microsoft\\/eslint-.+-spfx$'],
-  spock: '^org.spockframework:spock-",
+  spock: '^org.spockframework:spock-',
   'syncfusion-dotnet': '^Syncfusion\\.',
   wordpress: '^@wordpress/',
 };

--- a/lib/config/presets/internal/monorepo.ts
+++ b/lib/config/presets/internal/monorepo.ts
@@ -271,6 +271,7 @@ const patternGroups = {
   embroider: '^@embroider/',
   fullcalendar: '^@fullcalendar/',
   spfx: ['^@microsoft\\/sp-', '^@microsoft\\/eslint-.+-spfx$'],
+  spock: '^org.spockframework:spock-",
   'syncfusion-dotnet': '^Syncfusion\\.',
   wordpress: '^@wordpress/',
 };


### PR DESCRIPTION
## Changes

[Several](https://search.maven.org/search?q=g:org.spockframework) Spock Framework packages should be updates at the same time.

## Context

When a dedicated prperty is not used, multiple modules of Spock used in the same projects could be updated in separate MRs, which doesn't make sense.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
