### PR TITLE
fix(manager/terraform): Guard against empty `module` and `provider` fields

### DIFF
--- a/lib/modules/manager/terraform/extractors/others/modules.ts
+++ b/lib/modules/manager/terraform/extractors/others/modules.ts
@@ -30,7 +30,13 @@ export class ModuleExtractor extends DependencyExtractor {
 
   extract(hclRoot: TerraformDefinitionFile): PackageDependency[] {
     const modules = hclRoot.module;
-    if (!is.nonEmptyObject(modules)) {
+    if (is.nullOrUndefined(modules)) {
+      return [];
+    }
+
+    // istanbul ignore if
+    if (!is.plainObject(modules)) {
+      logger.debug({ modules }, 'Terraform: unexpected `modules` value');
       return [];
     }
 

--- a/lib/modules/manager/terraform/extractors/others/modules.ts
+++ b/lib/modules/manager/terraform/extractors/others/modules.ts
@@ -30,7 +30,7 @@ export class ModuleExtractor extends DependencyExtractor {
 
   extract(hclRoot: TerraformDefinitionFile): PackageDependency[] {
     const modules = hclRoot.module;
-    if (is.nullOrUndefined(modules)) {
+    if (!is.nonEmptyObject(modules)) {
       return [];
     }
 

--- a/lib/modules/manager/terraform/extractors/others/providers.ts
+++ b/lib/modules/manager/terraform/extractors/others/providers.ts
@@ -14,7 +14,7 @@ export class ProvidersExtractor extends TerraformProviderExtractor {
     locks: ProviderLock[]
   ): PackageDependency[] {
     const providerTypes = hclRoot?.provider;
-    if (is.nullOrUndefined(providerTypes)) {
+    if (!is.nonEmptyObject(providerTypes)) {
       return [];
     }
 

--- a/lib/modules/manager/terraform/extractors/others/providers.ts
+++ b/lib/modules/manager/terraform/extractors/others/providers.ts
@@ -1,4 +1,5 @@
 import is from '@sindresorhus/is';
+import { logger } from '../../../../../logger';
 import type { PackageDependency } from '../../../types';
 import { TerraformProviderExtractor } from '../../base';
 import type { TerraformDefinitionFile } from '../../hcl/types';
@@ -14,7 +15,16 @@ export class ProvidersExtractor extends TerraformProviderExtractor {
     locks: ProviderLock[]
   ): PackageDependency[] {
     const providerTypes = hclRoot?.provider;
-    if (!is.nonEmptyObject(providerTypes)) {
+    if (is.nullOrUndefined(providerTypes)) {
+      return [];
+    }
+
+    // istanbul ignore if
+    if (!is.plainObject(providerTypes)) {
+      logger.debug(
+        { providerTypes },
+        'Terraform: unexpected `providerTypes` value'
+      );
       return [];
     }
 

--- a/lib/modules/manager/terraform/extractors/resources/helm-release.ts
+++ b/lib/modules/manager/terraform/extractors/resources/helm-release.ts
@@ -1,4 +1,5 @@
 import is from '@sindresorhus/is';
+import { logger } from '../../../../../logger';
 import { DockerDatasource } from '../../../../datasource/docker';
 import { HelmDatasource } from '../../../../datasource/helm';
 import { isOCIRegistry } from '../../../helmv3/utils';
@@ -16,9 +17,19 @@ export class HelmReleaseExtractor extends DependencyExtractor {
     const dependencies = [];
 
     const helmReleases = hclMap?.resource?.helm_release;
-    if (!is.nonEmptyObject(helmReleases)) {
+    if (is.nullOrUndefined(helmReleases)) {
       return [];
     }
+
+    // istanbul ignore if
+    if (!is.plainObject(helmReleases)) {
+      logger.debug(
+        { helmReleases },
+        'Terraform: unexpected `helmReleases` value'
+      );
+      return [];
+    }
+
     for (const helmRelease of Object.values(helmReleases).flat()) {
       const dep: PackageDependency = {
         currentValue: helmRelease.version,

--- a/lib/modules/manager/terraform/extractors/resources/helm-release.ts
+++ b/lib/modules/manager/terraform/extractors/resources/helm-release.ts
@@ -16,7 +16,7 @@ export class HelmReleaseExtractor extends DependencyExtractor {
     const dependencies = [];
 
     const helmReleases = hclMap?.resource?.helm_release;
-    if (is.nullOrUndefined(helmReleases)) {
+    if (!is.nonEmptyObject(helmReleases)) {
       return [];
     }
     for (const helmRelease of Object.values(helmReleases).flat()) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

- Ref: #20182 
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
