### PR TITLE
refactor(packagist): Use catch-all schema for releases fields

### DIFF
--- a/lib/modules/datasource/packagist/index.ts
+++ b/lib/modules/datasource/packagist/index.ts
@@ -118,28 +118,11 @@ export class PackagistDatasource extends Datasource {
     return packagistFile;
   }
 
-  /* istanbul ignore next */
   private static extractDepReleases(
     composerReleases: unknown
   ): ReleaseResult | null {
-    const parsedRecord =
-      schema.ComposerReleasesRecord.safeParse(composerReleases);
-    if (parsedRecord.success) {
-      return schema.extractReleaseResult(Object.values(parsedRecord.data));
-    }
-
-    const parsedArray =
-      schema.ComposerReleasesArray.safeParse(composerReleases);
-    if (parsedArray.success) {
-      logger.once.info('Packagist: extracting releases from array');
-      return schema.extractReleaseResult(parsedArray.data);
-    }
-
-    logger.once.info(
-      { composerReleases },
-      'Packagist: unknown format to extract from'
-    );
-    return null;
+    const parsedReleases = schema.ComposerReleases.parse(composerReleases);
+    return schema.extractReleaseResult(parsedReleases);
   }
 
   @cache({

--- a/lib/modules/datasource/packagist/index.ts
+++ b/lib/modules/datasource/packagist/index.ts
@@ -10,6 +10,7 @@ import * as composerVersioning from '../../versioning/composer';
 import { Datasource } from '../datasource';
 import type { GetReleasesConfig, ReleaseResult } from '../types';
 import * as schema from './schema';
+import { extractDepReleases } from './schema';
 import type {
   AllPackages,
   PackageMeta,
@@ -118,13 +119,6 @@ export class PackagistDatasource extends Datasource {
     return packagistFile;
   }
 
-  private static extractDepReleases(
-    composerReleases: unknown
-  ): ReleaseResult | null {
-    const parsedReleases = schema.ComposerReleases.parse(composerReleases);
-    return schema.extractReleaseResult(parsedReleases);
-  }
-
   @cache({
     namespace: `datasource-${PackagistDatasource.id}`,
     key: (regUrl: string) => regUrl,
@@ -162,7 +156,7 @@ export class PackagistDatasource extends Datasource {
       tasks.push(async () => {
         const res = await this.getPackagistFile(regUrl, file);
         for (const [key, val] of Object.entries(res.packages ?? {})) {
-          includesPackages[key] = PackagistDatasource.extractDepReleases(val);
+          includesPackages[key] = extractDepReleases(val);
         }
       });
     }
@@ -223,9 +217,7 @@ export class PackagistDatasource extends Datasource {
         includesPackages,
       } = allPackages;
       if (packages?.[packageName]) {
-        const dep = PackagistDatasource.extractDepReleases(
-          packages[packageName]
-        );
+        const dep = extractDepReleases(packages[packageName]);
         return dep;
       }
       if (includesPackages?.[packageName]) {
@@ -251,7 +243,7 @@ export class PackagistDatasource extends Datasource {
       // TODO: fix types (#9610)
       const versions = (await this.http.getJson<any>(pkgUrl, opts)).body
         .packages[packageName];
-      const dep = PackagistDatasource.extractDepReleases(versions);
+      const dep = extractDepReleases(versions);
       logger.trace({ dep }, 'dep');
       return dep;
     } catch (err) /* istanbul ignore next */ {

--- a/lib/modules/datasource/packagist/schema.spec.ts
+++ b/lib/modules/datasource/packagist/schema.spec.ts
@@ -1,8 +1,7 @@
 import type { ReleaseResult } from '../types';
 import {
   ComposerRelease,
-  ComposerReleasesArray,
-  ComposerReleasesRecord,
+  ComposerReleases,
   MinifiedArray,
   parsePackagesResponse,
   parsePackagesResponses,
@@ -111,54 +110,22 @@ describe('modules/datasource/packagist/schema', () => {
     });
   });
 
-  describe('ComposerReleasesArray', () => {
-    it('rejects ComposerReleasesArray', () => {
-      expect(() => ComposerReleasesArray.parse(null)).toThrow();
-      expect(() => ComposerReleasesArray.parse(undefined)).toThrow();
-      expect(() => ComposerReleasesArray.parse('')).toThrow();
-      expect(() => ComposerReleasesArray.parse({})).toThrow();
+  describe('ComposerReleases', () => {
+    it('rejects ComposerReleases', () => {
+      expect(() => ComposerReleases.parse(null)).toThrow();
+      expect(() => ComposerReleases.parse(undefined)).toThrow();
+      expect(() => ComposerReleases.parse('')).toThrow();
+      expect(() => ComposerReleases.parse({})).toThrow();
     });
 
-    it('parses ComposerReleasesArray', () => {
-      expect(ComposerReleasesArray.parse([])).toEqual([]);
-      expect(ComposerReleasesArray.parse([null])).toEqual([]);
-      expect(ComposerReleasesArray.parse([1, 2, 3])).toEqual([]);
-      expect(ComposerReleasesArray.parse(['foobar'])).toEqual([]);
+    it('parses ComposerReleases', () => {
+      expect(ComposerReleases.parse([])).toEqual([]);
+      expect(ComposerReleases.parse([null])).toEqual([]);
+      expect(ComposerReleases.parse([1, 2, 3])).toEqual([]);
+      expect(ComposerReleases.parse(['foobar'])).toEqual([]);
       expect(
-        ComposerReleasesArray.parse([
-          { version: '1.2.3' },
-          { version: 'dev-main' },
-        ])
+        ComposerReleases.parse([{ version: '1.2.3' }, { version: 'dev-main' }])
       ).toEqual([{ version: '1.2.3' }, { version: 'dev-main' }]);
-    });
-  });
-
-  describe('ComposerReleasesRecord', () => {
-    it('rejects ComposerReleasesRecord', () => {
-      expect(() => ComposerReleasesRecord.parse(null)).toThrow();
-      expect(() => ComposerReleasesRecord.parse(undefined)).toThrow();
-      expect(() => ComposerReleasesRecord.parse('')).toThrow();
-      expect(() => ComposerReleasesRecord.parse([])).toThrow();
-    });
-
-    it('parses ComposerReleasesRecord', () => {
-      expect(ComposerReleasesRecord.parse({})).toEqual({});
-      expect(ComposerReleasesRecord.parse({ foo: null })).toEqual({});
-      expect(ComposerReleasesRecord.parse({ foo: 1, bar: 2, baz: 3 })).toEqual(
-        {}
-      );
-      expect(ComposerReleasesRecord.parse({ foo: 'bar' })).toEqual({});
-      expect(
-        ComposerReleasesRecord.parse({
-          '0.0.1': { foo: 'bar' },
-          '0.0.2': { version: '0.0.1' },
-          '1.2.3': { version: '1.2.3' },
-          'dev-main': { version: 'dev-main' },
-        })
-      ).toEqual({
-        '1.2.3': { version: '1.2.3' },
-        'dev-main': { version: 'dev-main' },
-      });
     });
   });
 

--- a/lib/modules/datasource/packagist/schema.spec.ts
+++ b/lib/modules/datasource/packagist/schema.spec.ts
@@ -111,18 +111,15 @@ describe('modules/datasource/packagist/schema', () => {
   });
 
   describe('ComposerReleases', () => {
-    it('rejects ComposerReleases', () => {
-      expect(() => ComposerReleases.parse(null)).toThrow();
-      expect(() => ComposerReleases.parse(undefined)).toThrow();
-      expect(() => ComposerReleases.parse('')).toThrow();
-      expect(() => ComposerReleases.parse({})).toThrow();
-    });
-
     it('parses ComposerReleases', () => {
-      expect(ComposerReleases.parse([])).toEqual([]);
-      expect(ComposerReleases.parse([null])).toEqual([]);
-      expect(ComposerReleases.parse([1, 2, 3])).toEqual([]);
-      expect(ComposerReleases.parse(['foobar'])).toEqual([]);
+      expect(ComposerReleases.parse(null)).toBeEmptyArray();
+      expect(ComposerReleases.parse(undefined)).toBeEmptyArray();
+      expect(ComposerReleases.parse('')).toBeEmptyArray();
+      expect(ComposerReleases.parse({})).toBeEmptyArray();
+      expect(ComposerReleases.parse([])).toBeEmptyArray();
+      expect(ComposerReleases.parse([null])).toBeEmptyArray();
+      expect(ComposerReleases.parse([1, 2, 3])).toBeEmptyArray();
+      expect(ComposerReleases.parse(['foobar'])).toBeEmptyArray();
       expect(
         ComposerReleases.parse([{ version: '1.2.3' }, { version: 'dev-main' }])
       ).toEqual([{ version: '1.2.3' }, { version: 'dev-main' }]);

--- a/lib/modules/datasource/packagist/schema.ts
+++ b/lib/modules/datasource/packagist/schema.ts
@@ -149,6 +149,13 @@ export function extractReleaseResult(
   return result;
 }
 
+export function extractDepReleases(
+  composerReleases: unknown
+): ReleaseResult | null {
+  const parsedReleases = ComposerReleases.parse(composerReleases);
+  return extractReleaseResult(parsedReleases);
+}
+
 export function parsePackagesResponses(
   packageName: string,
   packagesResponses: unknown[]

--- a/lib/modules/datasource/packagist/schema.ts
+++ b/lib/modules/datasource/packagist/schema.ts
@@ -65,23 +65,16 @@ export const ComposerRelease = z
   );
 export type ComposerRelease = z.infer<typeof ComposerRelease>;
 
-export const ComposerReleasesArray = z
-  .array(ComposerRelease.nullable().catch(null))
+export const ComposerReleases = z
+  .union([
+    z.array(ComposerRelease.nullable().catch(null)),
+    z
+      .record(ComposerRelease.nullable().catch(null))
+      .transform((map) => Object.values(map)),
+  ])
+  .catch([])
   .transform((xs) => xs.filter((x): x is ComposerRelease => x !== null));
-export type ComposerReleasesArray = z.infer<typeof ComposerReleasesArray>;
-
-export const ComposerReleasesRecord = z
-  .record(ComposerRelease.nullable().catch(null))
-  .transform((map) => {
-    const res: Record<string, ComposerRelease> = {};
-    for (const [key, value] of Object.entries(map)) {
-      if (value !== null && value.version === key) {
-        res[key] = value;
-      }
-    }
-    return res;
-  });
-export type ComposerReleasesRecord = z.infer<typeof ComposerReleasesRecord>;
+export type ComposerReleases = z.infer<typeof ComposerReleases>;
 
 export const ComposerPackagesResponse = z.object({
   packages: z.record(z.unknown()),
@@ -90,11 +83,11 @@ export const ComposerPackagesResponse = z.object({
 export function parsePackagesResponse(
   packageName: string,
   packagesResponse: unknown
-): ComposerReleasesArray {
+): ComposerReleases {
   try {
     const { packages } = ComposerPackagesResponse.parse(packagesResponse);
     const array = MinifiedArray.parse(packages[packageName]);
-    const releases = ComposerReleasesArray.parse(array);
+    const releases = ComposerReleases.parse(array);
     return releases;
   } catch (err) {
     logger.debug(
@@ -106,7 +99,7 @@ export function parsePackagesResponse(
 }
 
 export function extractReleaseResult(
-  ...composerReleasesArrays: ComposerReleasesArray[]
+  ...composerReleasesArrays: ComposerReleases[]
 ): ReleaseResult | null {
   const releases: Release[] = [];
   let homepage: string | null | undefined;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Based on log messages, stick to catch-all schema for the particular response fields

## Context

- Ref: #19495
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
