### PR TITLE
fix: apply recreateClosed to grouped pinDigests

### DIFF
--- a/lib/workers/repository/updates/generate.spec.ts
+++ b/lib/workers/repository/updates/generate.spec.ts
@@ -269,6 +269,76 @@ describe('workers/repository/updates/generate', () => {
       expect(res.recreateClosed).toBeTrue();
     });
 
+    it('Grouped pin & pinDigest can be recreated', () => {
+      // TODO #7154 incompatible types
+      const branch: BranchUpgradeConfig[] = [
+        {
+          ...defaultConfig,
+          isPinDigest: true,
+          updateType: 'pinDigest',
+          newValue: 'v2',
+          newDigest: 'dc323e67f16fb5f7663d20ff7941f27f5809e9b6',
+        } as BranchUpgradeConfig,
+        {
+          ...defaultConfig,
+          updateType: 'pin',
+          isPin: true,
+          newValue: "'2.2.0'",
+          newVersion: '2.2.0',
+          newMajor: 2,
+        } as BranchUpgradeConfig,
+      ];
+      const res = generateBranchConfig(branch);
+      expect(res.recreateClosed).toBeTrue();
+    });
+
+    it('Grouped pin can be recreated', () => {
+      // TODO #7154 incompatible types
+      const branch: BranchUpgradeConfig[] = [
+        {
+          ...defaultConfig,
+          updateType: 'pin',
+          isPin: true,
+          newValue: "'2.2.0'",
+          newVersion: '2.2.0',
+          newMajor: 2,
+        } as BranchUpgradeConfig,
+        {
+          ...defaultConfig,
+          updateType: 'pin',
+          isPin: true,
+          newValue: "'3.2.0'",
+          newVersion: '3.2.0',
+          newMajor: 3,
+        } as BranchUpgradeConfig,
+      ];
+      const res = generateBranchConfig(branch);
+      expect(res.recreateClosed).toBeTrue();
+    });
+
+    it('grouped pinDigest can be recreated', () => {
+      // TODO #7154 incompatible types
+      const branch: BranchUpgradeConfig[] = [
+        {
+          ...defaultConfig,
+          isPinDigest: true,
+          newDigest: 'abcd',
+          newValue: 'v3',
+          updateType: 'pinDigest',
+        } as BranchUpgradeConfig,
+        {
+          ...defaultConfig,
+          isPinDigest: true,
+          newDigest: 'dcba',
+          newMajor: 2,
+          newValue: 'v2',
+          updateType: 'pinDigest',
+        } as BranchUpgradeConfig,
+      ];
+      const res = generateBranchConfig(branch);
+      expect(res.recreateClosed).toBeTrue();
+    });
+
     it('groups multiple upgrades different version', () => {
       const branch: BranchUpgradeConfig[] = [
         {

--- a/lib/workers/repository/updates/generate.ts
+++ b/lib/workers/repository/updates/generate.ts
@@ -179,7 +179,10 @@ export function generateBranchConfig(
       logger.trace({ toValues });
       delete upgrade.commitMessageExtra;
       upgrade.recreateClosed = true;
-    } else if (newValue.length > 1 && upgrade.isDigest) {
+    } else if (
+      newValue.length > 1 &&
+      (upgrade.isDigest || upgrade.isPinDigest)
+    ) {
       logger.trace({ newValue });
       delete upgrade.commitMessageExtra;
       upgrade.recreateClosed = true;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
A grouped pinDigest PR would become ignorable, permanently blocking pinDigest until they grouped with a normal pin type as shown on the picture in context before the update.

This change now equalizes the behaviour for grouped pinDigest pull requests

## Context
https://github.com/renovatebot/renovate/discussions/20371
![image](https://user-images.githubusercontent.com/10881109/219030186-7b461844-84ee-45a4-862f-9ffbcdaffb92.png)
Specifically fixes this behaviour

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
