### PR TITLE
feat(presets): group `@types/react` and `@types/react-dom` together, along with other React packages

### DIFF
--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -341,7 +341,7 @@ const staticGroups = {
     packageRules: [
       {
         extends: 'monorepo:react',
-        groupName: 'React packages',
+        groupName: 'react monorepo',
         matchPackageNames: ['@types/react', '@types/react-dom'],
       },
     ],

--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -336,6 +336,16 @@ const staticGroups = {
       },
     ],
   },
+  react: {
+    description: 'Group React and corresponding `@types` packages together.',
+    packageRules: [
+      {
+        extends: 'monorepo:react',
+        groupName: 'React packages',
+        matchPackageNames: ['@types/react', '@types/react-dom'],
+      },
+    ],
+  },
   recommended: {
     description:
       'Use curated list of recommended non-monorepo package groupings.',
@@ -359,6 +369,7 @@ const staticGroups = {
       'group:kubernetes',
       'group:phpstan',
       'group:polymer',
+      'group:react',
       'group:resilience4j',
       'group:rubyOnRails',
       'group:rubyOmniauth',

--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -340,7 +340,6 @@ const staticGroups = {
     description: 'Group React and corresponding `@types` packages together.',
     packageRules: [
       {
-        extends: 'monorepo:react',
         groupName: 'react monorepo',
         matchPackageNames: ['@types/react', '@types/react-dom'],
       },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This new group bundles upgrades of `@types/react` and `@types/react-dom` together, as discussed [here](https://github.com/renovatebot/renovate/issues/15081). It avoids situations like these:

<img width="513" alt="Screen Shot 2023-02-16 at 2 49 19 PM" src="https://user-images.githubusercontent.com/113730/219471699-d2bf5e7a-4cf4-4c2e-afc9-139d326f6a16.png">

## Context

- Closes #15081

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
