### PR TITLE
feat(bazel): Support for `maven.artifact` positional args

### DIFF
--- a/lib/modules/manager/bazel/parser.spec.ts
+++ b/lib/modules/manager/bazel/parser.spec.ts
@@ -228,6 +228,12 @@ describe('modules/manager/bazel/parser', () => {
             group = "com.example2",
             artifact = "bar",
             version = "2.2.2",
+          ),
+          maven.artifact(
+            "com.example3",
+            "baz",
+            "3.3.3",
+            neverlink = True
           )
         ],
         repositories = [
@@ -246,9 +252,15 @@ describe('modules/manager/bazel/parser', () => {
           'com.example1:foo:1.1.1',
           {
             _function: 'maven.artifact',
-            artifact: 'bar',
             group: 'com.example2',
+            artifact: 'bar',
             version: '2.2.2',
+          },
+          {
+            _function: 'maven.artifact',
+            '0': 'com.example3',
+            '1': 'baz',
+            '2': '3.3.3',
           },
         ],
         repositories: [

--- a/lib/modules/manager/bazel/rules/index.spec.ts
+++ b/lib/modules/manager/bazel/rules/index.spec.ts
@@ -357,10 +357,16 @@ describe('modules/manager/bazel/rules/index', () => {
           artifacts: [
             'com.example1:foo:1.1.1',
             {
-              artifact: 'bar',
-              function: 'maven.artifact',
+              _function: 'maven.artifact',
               group: 'com.example2',
+              artifact: 'bar',
               version: '2.2.2',
+            },
+            {
+              _function: 'maven.artifact',
+              '0': 'com.example3',
+              '1': 'baz',
+              '2': '3.3.3',
             },
           ],
           repositories: [
@@ -384,6 +390,16 @@ describe('modules/manager/bazel/rules/index', () => {
           datasource: 'maven',
           depType: 'maven_install',
           depName: 'com.example2:bar',
+          registryUrls: [
+            'https://example1.com/maven2',
+            'https://example2.com/maven2',
+          ],
+        },
+        {
+          currentValue: '3.3.3',
+          datasource: 'maven',
+          depType: 'maven_install',
+          depName: 'com.example3:baz',
           registryUrls: [
             'https://example1.com/maven2',
             'https://example2.com/maven2',

--- a/lib/modules/manager/bazel/rules/maven.ts
+++ b/lib/modules/manager/bazel/rules/maven.ts
@@ -5,11 +5,20 @@ import type { PackageDependency } from '../../types';
 
 export const mavenRules = ['maven_install'] as const;
 
-const ArtifactSpec = z.object({
-  group: z.string(),
-  artifact: z.string(),
-  version: z.string(),
-});
+const ArtifactSpec = z.union([
+  z.object({
+    group: z.string(),
+    artifact: z.string(),
+    version: z.string(),
+  }),
+  z
+    .object({
+      '0': z.string(),
+      '1': z.string(),
+      '2': z.string(),
+    })
+    .transform((x) => ({ group: x[0], artifact: x[1], version: x[2] })),
+]);
 type ArtifactSpec = z.infer<typeof ArtifactSpec>;
 
 export const MavenTarget = z


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Support for syntax like this:

```bazel
maven_install(
    artifacts = [
        maven.artifact("com.squareup", "javapoet", "1.11.0", neverlink = True),
    ],
    # ...
)
```

- Name args like these as `"0"`, `"1"`, `"2"`, etc
- Consider these indexes as aliases for group, artifact and version

## Context

- Ref: #5151 

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
