### PR TITLE
fix(platform/bitbucket): update rebase instructions

### DIFF
--- a/lib/modules/platform/bitbucket/comments.ts
+++ b/lib/modules/platform/bitbucket/comments.ts
@@ -95,6 +95,10 @@ export async function ensureComment({
         }
       });
     }
+
+    // sanitize any language that isn't supported by Bitbucket Cloud
+    body = sanitizeCommentBody(body);
+
     if (!commentId) {
       await addComment(config, prNo, body);
       logger.info(
@@ -145,4 +149,11 @@ export async function ensureCommentRemoval(
   } catch (err) /* istanbul ignore next */ {
     logger.warn({ err }, 'Error ensuring comment removal');
   }
+}
+
+function sanitizeCommentBody(body: string): string {
+  return body.replace(
+    'checking the rebase/retry box above',
+    'renaming this PR to start with "rebase!"'
+  );
 }

--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -484,7 +484,7 @@ export function massageMarkdown(input: string): string {
   return smartTruncate(input, 50000)
     .replace(
       'you tick the rebase/retry checkbox',
-      'rename PR to start with "rebase!"'
+      'by renaming this PR to start with "rebase!"'
     )
     .replace(regEx(/<\/?summary>/g), '**')
     .replace(regEx(/<\/?details>/g), '')

--- a/lib/workers/repository/update/branch/handle-existing.ts
+++ b/lib/workers/repository/update/branch/handle-existing.ts
@@ -62,7 +62,7 @@ export async function handleModifiedPr(
 
   const editedPrCommentTopic = 'Edited/Blocked Notification';
   const content =
-    'Renovate will not automatically rebase this PR, because it does not recognize the last commit author and assumes somebody else may have edited the PR.\n' +
+    'Renovate will not automatically rebase this PR, because it does not recognize the last commit author and assumes somebody else may have edited the PR.\n\n' +
     'You can manually request rebase by checking the rebase/retry box above.\n\n' +
     emojify(' :warning: **Warning**: custom changes will be lost.');
 


### PR DESCRIPTION
## Changes

Update rebase instructions to remove references to checkboxes and make consistent across both PR body and comments

<!-- Describe what behavior is changed by this PR. -->

## Context

- https://github.com/renovatebot/renovate/issues/5510

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
