### PR TITLE
chore: debug github-tags digest problems

### DIFF
--- a/lib/modules/datasource/github-tags/index.spec.ts
+++ b/lib/modules/datasource/github-tags/index.spec.ts
@@ -1,6 +1,7 @@
 import { getPkgReleases } from '..';
 import * as httpMock from '../../../../test/http-mock';
 import * as githubGraphql from '../../../util/github/graphql';
+import type { GithubTagItem } from '../../../util/github/graphql/types';
 import * as hostRules from '../../../util/host-rules';
 import { GithubTagsDatasource } from '.';
 
@@ -66,6 +67,24 @@ describe('modules/datasource/github-tags/index', () => {
       ]);
       const res = await github.getDigest({ packageName }, 'v2.0.0');
       expect(res).toBe('abc');
+    });
+
+    it('returns null for missing hash', async () => {
+      jest.spyOn(githubGraphql, 'queryTags').mockResolvedValueOnce([
+        {
+          version: 'v1.0.0',
+          gitRef: 'v1.0.0',
+          releaseTimestamp: '2021-01-01',
+          hash: '123',
+        },
+        {
+          version: 'v2.0.0',
+          gitRef: 'v2.0.0',
+          releaseTimestamp: '2022-01-01',
+        } as GithubTagItem,
+      ]);
+      const res = await github.getDigest({ packageName }, 'v2.0.0');
+      expect(res).toBeNull();
     });
 
     it('returns null for missing tagged commit digest', async () => {

--- a/lib/modules/datasource/github-tags/index.ts
+++ b/lib/modules/datasource/github-tags/index.ts
@@ -29,11 +29,27 @@ export class GithubTagsDatasource extends Datasource {
     packageName: string,
     tag: string
   ): Promise<string | null> {
+    logger.trace(`github-tags.getTagCommit(${packageName}, ${tag})`);
     try {
       const tags = await queryTags({ packageName, registryUrl }, this.http);
+      // istanbul ignore if
+      if (!tags.length) {
+        logger.debug(
+          `github-tags.getTagCommit(): No tags found for ${packageName}`
+        );
+      }
       const tagItem = tags.find(({ version }) => version === tag);
       if (tagItem) {
-        return tagItem.hash;
+        if (tagItem.hash) {
+          return tagItem.hash;
+        }
+        logger.debug(
+          `github-tags.getTagCommit(): Tag ${tag} has no hash for ${packageName}`
+        );
+      } else {
+        logger.debug(
+          `github-tags.getTagCommit(): Tag ${tag} not found for ${packageName}`
+        );
       }
     } catch (err) {
       logger.debug(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds debugging to github-tags digest unhappy paths

## Context

#20475

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
