### PR TITLE
fix(vulnerabilities): prevent exception due to invalid OSV event version

### DIFF
--- a/lib/workers/repository/process/vulnerabilities.spec.ts
+++ b/lib/workers/repository/process/vulnerabilities.spec.ts
@@ -136,8 +136,32 @@ describe('workers/repository/process/vulnerabilities', () => {
       );
     });
 
-    it('exception due to invalid version upon comparison', async () => {
-      const err = new TypeError('Invalid Version: ^1.1.0');
+    it('exception while fetching vulnerabilities', async () => {
+      const err = new Error('unknown');
+      const packageFiles: Record<string, PackageFileContent[]> = {
+        npm: [
+          {
+            deps: [
+              {
+                depName: 'lodash',
+                currentValue: '4.17.11',
+                datasource: 'npm',
+              },
+            ],
+          },
+        ],
+      };
+      getVulnerabilitiesMock.mockRejectedValueOnce(err);
+
+      await vulnerabilities.fetchVulnerabilities(config, packageFiles);
+      expect(logger.logger.warn).toHaveBeenCalledWith(
+        { err },
+        'Error fetching vulnerability information for lodash'
+      );
+    });
+
+    it('log event with invalid version', async () => {
+      const event = { fixed: '^6.0' };
       const packageFiles: Record<string, PackageFileContent[]> = {
         npm: [
           {
@@ -165,7 +189,7 @@ describe('workers/repository/process/vulnerabilities', () => {
               ranges: [
                 {
                   type: 'SEMVER',
-                  events: [{ introduced: '^0' }, { fixed: '^1.1.0' }],
+                  events: [{ introduced: '0' }, event],
                 },
               ],
             },
@@ -175,8 +199,8 @@ describe('workers/repository/process/vulnerabilities', () => {
 
       await vulnerabilities.fetchVulnerabilities(config, packageFiles);
       expect(logger.logger.debug).toHaveBeenCalledWith(
-        { err },
-        'Error fetching vulnerability information for lodash'
+        { event },
+        'Skipping OSV event with invalid version'
       );
     });
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Adds `versioningApi.isVersion()` before all invocations of `versioningApi.sortVersions()` that handle raw OSV data
  - Currently, `sortEvents()` does sorting on unchecked versions and throws an exception if a version is found that is not compliant with the used versioning scheme. This could happen for invalid versions (eg. semver with value _1.2_) or events with values that are not of interest for renovate (e.g. a GIT hash in the the `limit` field).
  - renovate shouldn't throw an exception in such a case but continue processing. The range / event where this happened, may not even be related to `depVersion`, i.e., just be yet another range or affected statement in an advisory.

- Don't return package rules in case an exception has occurred but log a warning. 
  - Currently, if an exception occurs e.g. in `this.isPackageVulnerable()`, the existing list of package rules would be returned. This list may not be sorted correctly, potentially recommending an update to a lower version that wouldn't remediate all listed findings.
  - The new behavior is inline with how it's already done for GH alerts: https://github.com/renovatebot/renovate/blob/59432b412973a86d99ce7319d93d557473b781db/lib/workers/repository/init/vulnerability.ts#L166

<!-- Describe what behavior is changed by this PR. -->

## Context

- https://github.com/renovatebot/renovate/issues/20427#issuecomment-1435638670
- The changes in this PR cover an edge case:
  - 0.58% or 83 of 14311 vulnerabilities overall use _semver_ versioning and specify a non-compliant version that could trigger this behavior.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

Test repo: https://github.com/renovate-demo/20427-jquery/pull/1

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
