### PR TITLE
docs: update outdated info about gradle file support

### DIFF
--- a/docs/usage/java.md
+++ b/docs/usage/java.md
@@ -30,24 +30,21 @@ Renovate detects versions that are specified in a string `'group:artifact:versio
 
 Renovate can update:
 
-- `build.gradle`/`build.gradle.kts` files in the root of the repository
-- `*.gradle`/`*.gradle.kts` files in a subdirectory as multi-project configurations
-- dependencies whose version is defined in a `*.properties` file
+- `*.gradle`/`*.gradle.kts` files
+- Dependencies with version definitions in `gradle.properties` files
+- Gradle lockfiles stored in `*.lockfile` files
 - `*.versions.toml` files in any directory or `*.toml` files inside the `gradle`
   directory ([Gradle Version Catalogs docs](https://docs.gradle.org/current/userguide/platforms.html))
-- `versions.props` from [gradle-consistent-versions](https://github.com/palantir/gradle-consistent-versions) plugin
+- `versions.props` and `versions.lock` from the [gradle-consistent-versions](https://github.com/palantir/gradle-consistent-versions) plugin
 
 Renovate does not support:
 
-- Projects which do not have either a `build.gradle` or `build.gradle.kts` in the repository root
 - Android projects that require extra configuration to run (e.g. setting the Android SDK)
-- Gradle versions older than version 5.0
-- Catalogs defined inside a `build.gradle` or `build.gradle.kts` file rather than in TOML
 - Catalogs with version ranges
-- Catalogs versions using `reject`, and `rejectAll` constraints
-- Catalogs versions using more than one of `require`, `strictly`, `prefer` in a single declaration
+- Catalog versions using `reject`, and `rejectAll` constraints
+- Catalog versions using more than one of `require`, `strictly`, `prefer` in a single declaration
 - Catalogs with custom names that do not end in `.toml`
-- Catalogs outside the `gradle` folder whose names do not end in `.versions.toml`
+- Catalogs outside the `gradle` folder whose names do not end in `.versions.toml` (unless overridden via [`fileMatch`](https://docs.renovatebot.com/configuration-options/#filematch) configuration)
 
 ## Gradle Wrapper
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Update infos on renovate's gradle manager according to current capabilities and `fileMatch` definitions
  - `build.gradle` / `build.gradle.kts` is still required by gradle itself but renovate can update any build file (see discussion in context)
  - `gradle.properties` is the only supported properties file
  - Added lockfiles for gradle and gcv plugin
  - Corrected some typos

<!-- Describe what behavior is changed by this PR. -->

## Context

- https://github.com/renovatebot/renovate/discussions/20508#discussioncomment-5027774

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
