### PR TITLE
fix: allow null/undefined as param

### DIFF
--- a/lib/workers/repository/update/pr/changelog/release-notes.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/release-notes.spec.ts
@@ -92,10 +92,7 @@ describe('workers/repository/update/pr/changelog/release-notes', () => {
       expect(
         await addReleaseNotes(input as never, {} as BranchUpgradeConfig)
       ).toEqual(input);
-      // TODO #7154
-      expect(
-        await addReleaseNotes(null as never, {} as BranchUpgradeConfig)
-      ).toBeNull();
+      expect(await addReleaseNotes(null, {} as BranchUpgradeConfig)).toBeNull();
       expect(
         await addReleaseNotes(
           { versions: [] } as never,

--- a/lib/workers/repository/update/pr/changelog/release-notes.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/release-notes.spec.ts
@@ -87,6 +87,13 @@ describe('workers/repository/update/pr/changelog/release-notes', () => {
   });
 
   describe('addReleaseNotes()', () => {
+    it('returns null if input is null/undefined', async () => {
+      expect(await addReleaseNotes(null, {} as BranchUpgradeConfig)).toBeNull();
+      expect(
+        await addReleaseNotes(undefined, {} as BranchUpgradeConfig)
+      ).toBeNull();
+    });
+
     it('returns input if invalid', async () => {
       const input = { a: 1 };
       expect(
@@ -94,10 +101,7 @@ describe('workers/repository/update/pr/changelog/release-notes', () => {
       ).toEqual(input);
       expect(await addReleaseNotes(null, {} as BranchUpgradeConfig)).toBeNull();
       expect(
-        await addReleaseNotes(
-          { versions: [] } as never,
-          {} as BranchUpgradeConfig
-        )
+        await addReleaseNotes({ versions: [] }, {} as BranchUpgradeConfig)
       ).toStrictEqual({
         versions: [],
       });

--- a/lib/workers/repository/update/pr/changelog/release-notes.ts
+++ b/lib/workers/repository/update/pr/changelog/release-notes.ts
@@ -399,14 +399,13 @@ export function releaseNotesCacheMinutes(releaseDate?: string | Date): number {
   return 14495; // 5 minutes shy of 10 days
 }
 
-// TODO #7154 allow `null` and `undefined`
 export async function addReleaseNotes(
-  input: ChangeLogResult,
+  input: ChangeLogResult | null | undefined,
   config: BranchUpgradeConfig
-): Promise<ChangeLogResult> {
+): Promise<ChangeLogResult | null> {
   if (!input?.versions || !input.project?.type) {
     logger.debug('Missing project or versions');
-    return input;
+    return input ?? null;
   }
   const output: ChangeLogResult = { ...input, versions: [] };
   const { repository, sourceDirectory } = input.project;

--- a/lib/workers/repository/update/pr/changelog/source-github.ts
+++ b/lib/workers/repository/update/pr/changelog/source-github.ts
@@ -165,7 +165,7 @@ export async function getChangeLogJSON(
     }
   }
 
-  let res: ChangeLogResult = {
+  let res: ChangeLogResult | null = {
     project: {
       apiBaseUrl,
       baseUrl,

--- a/lib/workers/repository/update/pr/changelog/source-gitlab.ts
+++ b/lib/workers/repository/update/pr/changelog/source-gitlab.ts
@@ -137,7 +137,7 @@ export async function getChangeLogJSON(
     }
   }
 
-  let res: ChangeLogResult = {
+  let res: ChangeLogResult | null = {
     project: {
       apiBaseUrl,
       baseUrl,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- Allow `null/undefined` as parameter for `addReleaseNotes` fn
<!-- Describe what behavior is changed by this PR. -->

## Context
- Pending TODO
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
