### PR TITLE
feat(schema): Add `looseArray` and `looseRecord` helpers

### DIFF
--- a/lib/util/schema.spec.ts
+++ b/lib/util/schema.spec.ts
@@ -81,4 +81,74 @@ describe('util/schema', () => {
       );
     });
   });
+
+  describe('looseArray', () => {
+    it('parses array', () => {
+      const s = schema.looseArray(z.string());
+      expect(s.parse(['foo', 'bar'])).toEqual(['foo', 'bar']);
+    });
+
+    it('handles non-array', () => {
+      const s = schema.looseArray(z.string());
+      expect(s.parse({ foo: 'bar' })).toEqual([]);
+    });
+
+    it('drops wrong items', () => {
+      const s = schema.looseArray(z.string());
+      expect(s.parse(['foo', 123, null, undefined, []])).toEqual(['foo']);
+    });
+
+    it('runs callback for wrong elements', () => {
+      let called = false;
+      const s = schema.looseArray(z.string(), () => {
+        called = true;
+      });
+      expect(s.parse(['foo', 123, 'bar'])).toEqual(['foo', 'bar']);
+      expect(called).toBeTrue();
+    });
+
+    it('runs callback for non-array', () => {
+      let called = false;
+      const s = schema.looseArray(z.string(), () => {
+        called = true;
+      });
+      expect(s.parse('foobar')).toEqual([]);
+      expect(called).toBeTrue();
+    });
+  });
+
+  describe('looseRecord', () => {
+    it('parses record', () => {
+      const s = schema.looseRecord(z.string());
+      expect(s.parse({ foo: 'bar' })).toEqual({ foo: 'bar' });
+    });
+
+    it('handles non-record', () => {
+      const s = schema.looseRecord(z.string());
+      expect(s.parse(['foo', 'bar'])).toEqual({});
+    });
+
+    it('drops wrong items', () => {
+      const s = schema.looseRecord(z.string());
+      expect(s.parse({ foo: 'foo', bar: 123 })).toEqual({ foo: 'foo' });
+    });
+
+    it('runs callback for wrong elements', () => {
+      let called = false;
+      const s = schema.looseRecord(z.string(), () => {
+        called = true;
+      });
+      expect(s.parse({ foo: 'foo', bar: 123 })).toEqual({ foo: 'foo' });
+      expect(called).toBeTrue();
+    });
+
+    it('runs callback for non-record', () => {
+      let called = false;
+      const s = schema.looseRecord(z.string(), () => {
+        called = true;
+      });
+      expect(s.parse('foobar')).toEqual({});
+      expect(called).toBeTrue();
+    });
+  });
 });

--- a/lib/util/schema.ts
+++ b/lib/util/schema.ts
@@ -1,5 +1,6 @@
+import is from '@sindresorhus/is';
 import hasha from 'hasha';
-import type { z } from 'zod';
+import { z } from 'zod';
 import { logger } from '../logger';
 import * as memCache from './cache/memory';
 import { safeStringify } from './stringify';
@@ -64,4 +65,81 @@ export function match<T extends z.ZodSchema>(
   }
 
   return true;
+}
+
+export function looseArray<T extends z.ZodTypeAny>(
+  schema: T,
+  catchCallback?: () => void
+): z.ZodEffects<
+  z.ZodCatch<z.ZodArray<z.ZodCatch<z.ZodNullable<T>>, 'many'>>,
+  z.TypeOf<T>[],
+  unknown
+> {
+  type Elem = z.infer<T>;
+
+  const nullableSchema = schema.nullable().catch(
+    catchCallback
+      ? () => {
+          catchCallback();
+          return null;
+        }
+      : null
+  );
+
+  const arrayOfNullables = z.array(nullableSchema);
+
+  const arrayWithFallback = catchCallback
+    ? arrayOfNullables.catch(() => {
+        catchCallback();
+        return [];
+      })
+    : arrayOfNullables.catch([]);
+
+  const filteredArray = arrayWithFallback.transform((xs) =>
+    xs.filter((x): x is Elem => !is.null_(x))
+  );
+
+  return filteredArray;
+}
+
+export function looseRecord<T extends z.ZodTypeAny>(
+  schema: T,
+  catchCallback?: () => void
+): z.ZodEffects<
+  z.ZodCatch<z.ZodRecord<z.ZodString, z.ZodCatch<z.ZodNullable<T>>>>,
+  Record<string, z.TypeOf<T>>,
+  unknown
+> {
+  type Elem = z.infer<T>;
+
+  const nullableSchema = schema.nullable().catch(
+    catchCallback
+      ? () => {
+          catchCallback();
+          return null;
+        }
+      : null
+  );
+
+  const recordOfNullables = z.record(nullableSchema);
+
+  const recordWithFallback = catchCallback
+    ? recordOfNullables.catch(() => {
+        catchCallback();
+        return {};
+      })
+    : recordOfNullables.catch({});
+
+  const filteredRecord = recordWithFallback.transform(
+    (rec): Record<string, Elem> => {
+      for (const key of Object.keys(rec)) {
+        if (is.null_(rec[key])) {
+          delete rec[key];
+        }
+      }
+      return rec;
+    }
+  );
+
+  return filteredRecord;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

It appears to be a common situation when we don't want to drop the entire data structure because of just single element that doesn't match schema.

This PR introduces `looseArray` and `looseRecord` helpers that make elements to fallback to `null` and filter them out.

Optional callback can be provided, which is good for logging purposes.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
