### PR TITLE
feat(platform/bitbucket): consolidate types

### DIFF
--- a/lib/modules/datasource/bitbucket-tags/index.ts
+++ b/lib/modules/datasource/bitbucket-tags/index.ts
@@ -1,6 +1,7 @@
 import { cache } from '../../../util/cache/package/decorator';
 import { BitbucketHttp } from '../../../util/http/bitbucket';
 import { ensureTrailingSlash } from '../../../util/url';
+import type { PagedResult, RepoInfoBody } from '../../platform/bitbucket/types';
 import * as utils from '../../platform/bitbucket/utils';
 import { Datasource } from '../datasource';
 import type { DigestConfig, GetReleasesConfig, ReleaseResult } from '../types';
@@ -97,7 +98,7 @@ export class BitBucketTagsDatasource extends Datasource {
   })
   async getMainBranch(repo: string): Promise<string> {
     return (
-      await this.bitbucketHttp.getJson<utils.RepoInfoBody>(
+      await this.bitbucketHttp.getJson<RepoInfoBody>(
         `/2.0/repositories/${repo}`
       )
     ).body.mainbranch.name;
@@ -122,7 +123,7 @@ export class BitBucketTagsDatasource extends Datasource {
 
     const url = `/2.0/repositories/${repo}/commits/${mainBranch}`;
     const bitbucketCommits = (
-      await this.bitbucketHttp.getJson<utils.PagedResult<BitbucketCommit>>(url)
+      await this.bitbucketHttp.getJson<PagedResult<BitbucketCommit>>(url)
     ).body;
 
     if (bitbucketCommits.values.length === 0) {

--- a/lib/modules/platform/bitbucket/comments.ts
+++ b/lib/modules/platform/bitbucket/comments.ts
@@ -1,7 +1,8 @@
 import { logger } from '../../../logger';
 import { BitbucketHttp } from '../../../util/http/bitbucket';
 import type { EnsureCommentConfig, EnsureCommentRemovalConfig } from '../types';
-import { Config, accumulateValues } from './utils';
+import type { Config } from './types';
+import { accumulateValues } from './utils';
 
 const bitbucketHttp = new BitbucketHttp();
 

--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -31,7 +31,7 @@ import { repoFingerprint } from '../util';
 import { smartTruncate } from '../utils/pr-body';
 import { readOnlyIssueBody } from '../utils/read-only-issue-body';
 import * as comments from './comments';
-import {
+import type {
   Account,
   BitbucketStatus,
   BranchResponse,
@@ -41,8 +41,6 @@ import {
   PrResponse,
   RepoInfo,
   RepoInfoBody,
-  buildStates,
-  prStates,
 } from './types';
 import * as utils from './utils';
 import { mergeBodyTransformer } from './utils';
@@ -252,7 +250,7 @@ export async function getPrList(): Promise<Pr[]> {
   if (!config.prList) {
     logger.debug('Retrieving PR list');
     let url = `/2.0/repositories/${config.repository}/pullrequests?`;
-    url += prStates.all.map((state) => 'state=' + state).join('&');
+    url += utils.prStates.all.map((state) => 'state=' + state).join('&');
     if (renovateUserUuid && !config.ignorePrAuthor) {
       url += `&q=author.uuid="${renovateUserUuid}"`;
     }
@@ -412,7 +410,7 @@ export async function setBranchStatus({
 
   const body = {
     name: context,
-    state: buildStates[state],
+    state: utils.buildStates[state],
     key: context,
     description,
     url,

--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -134,7 +134,7 @@ export async function getRawFile(
 
   let finalBranchOrTag = branchOrTag;
   if (branchOrTag?.includes(pathSeparator)) {
-    // Branch name contans slash, so we have to replace branch name with SHA1 of the head commit; otherwise the API will not work.
+    // Branch name contains slash, so we have to replace branch name with SHA1 of the head commit; otherwise the API will not work.
     finalBranchOrTag = await getBranchCommit(branchOrTag);
   }
 

--- a/lib/modules/platform/bitbucket/types.ts
+++ b/lib/modules/platform/bitbucket/types.ts
@@ -1,31 +1,7 @@
-import type { MergeStrategy } from '../../../config/types';
-import type { BranchStatus } from '../../../types';
 import type { Pr } from '../types';
 
 export type BitbucketMergeStrategy = 'fast_forward' | 'merge_commit' | 'squash';
 
-export const prStates = {
-  open: ['OPEN'],
-  notOpen: ['MERGED', 'DECLINED', 'SUPERSEDED'],
-  merged: ['MERGED'],
-  closed: ['DECLINED', 'SUPERSEDED'],
-  all: ['OPEN', 'MERGED', 'DECLINED', 'SUPERSEDED'],
-};
-
-export const buildStates: Record<BranchStatus, BitbucketBranchState> = {
-  green: 'SUCCESSFUL',
-  red: 'FAILED',
-  yellow: 'INPROGRESS',
-};
-
-export const bitbucketMergeStrategies: Map<
-  MergeStrategy,
-  BitbucketMergeStrategy
-> = new Map([
-  ['squash', 'squash'],
-  ['merge-commit', 'merge_commit'],
-  ['fast-forward', 'fast_forward'],
-]);
 export interface MergeRequestBody {
   close_source_branch?: boolean;
   message?: string;

--- a/lib/modules/platform/bitbucket/types.ts
+++ b/lib/modules/platform/bitbucket/types.ts
@@ -1,7 +1,118 @@
+import type { MergeStrategy } from '../../../config/types';
+import type { BranchStatus } from '../../../types';
+import type { Pr } from '../types';
+
 export type BitbucketMergeStrategy = 'fast_forward' | 'merge_commit' | 'squash';
 
+export const prStates = {
+  open: ['OPEN'],
+  notOpen: ['MERGED', 'DECLINED', 'SUPERSEDED'],
+  merged: ['MERGED'],
+  closed: ['DECLINED', 'SUPERSEDED'],
+  all: ['OPEN', 'MERGED', 'DECLINED', 'SUPERSEDED'],
+};
+
+export const buildStates: Record<BranchStatus, BitbucketBranchState> = {
+  green: 'SUCCESSFUL',
+  red: 'FAILED',
+  yellow: 'INPROGRESS',
+};
+
+export const bitbucketMergeStrategies: Map<
+  MergeStrategy,
+  BitbucketMergeStrategy
+> = new Map([
+  ['squash', 'squash'],
+  ['merge-commit', 'merge_commit'],
+  ['fast-forward', 'fast_forward'],
+]);
 export interface MergeRequestBody {
   close_source_branch?: boolean;
   message?: string;
   merge_strategy?: BitbucketMergeStrategy;
+}
+
+export interface Config {
+  defaultBranch: string;
+  has_issues: boolean;
+  mergeMethod: string;
+  owner: string;
+  prList: Pr[];
+  repository: string;
+  username: string;
+  userUuid: string;
+  ignorePrAuthor: boolean;
+}
+
+export interface PagedResult<T = any> {
+  pagelen: number;
+  size?: number;
+  next?: string;
+  values: T[];
+}
+
+export interface RepoInfo {
+  isFork: boolean;
+  owner: string;
+  mainbranch: string;
+  mergeMethod: string;
+  has_issues: boolean;
+  uuid: string;
+}
+
+export interface BranchResponse {
+  target: {
+    hash: string;
+  };
+}
+
+export type BitbucketBranchState = 'SUCCESSFUL' | 'FAILED' | 'INPROGRESS';
+export interface BitbucketStatus {
+  key: string;
+  state: BitbucketBranchState;
+}
+
+export interface RepoInfoBody {
+  parent?: any;
+  owner: { username: string };
+  mainbranch: { name: string };
+  has_issues: boolean;
+  uuid: string;
+}
+
+export interface PrResponse {
+  id: number;
+  title: string;
+  state: string;
+  links: {
+    commits: {
+      href: string;
+    };
+  };
+  summary?: { raw: string };
+  source: {
+    branch: {
+      name: string;
+    };
+  };
+  destination: {
+    branch: {
+      name: string;
+    };
+  };
+  reviewers: Array<Account>;
+  created_on: string;
+}
+
+export interface Account {
+  display_name?: string;
+  uuid: string;
+  nickname?: string;
+  account_status?: string;
+}
+
+export interface EffectiveReviewer {
+  type: string;
+  reviewer_type: string;
+  user: Account;
 }

--- a/lib/modules/platform/bitbucket/types.ts
+++ b/lib/modules/platform/bitbucket/types.ts
@@ -43,6 +43,7 @@ export interface BranchResponse {
 }
 
 export type BitbucketBranchState = 'SUCCESSFUL' | 'FAILED' | 'INPROGRESS';
+
 export interface BitbucketStatus {
   key: string;
   state: BitbucketBranchState;

--- a/lib/modules/platform/bitbucket/utils.ts
+++ b/lib/modules/platform/bitbucket/utils.ts
@@ -1,16 +1,17 @@
 import url from 'url';
 import type { MergeStrategy } from '../../../config/types';
+import type { BranchStatus } from '../../../types';
 import { BitbucketHttp } from '../../../util/http/bitbucket';
 import type { HttpOptions, HttpResponse } from '../../../util/http/types';
 import { getPrBodyStruct } from '../pr-body';
 import type { Pr } from '../types';
-import {
+import type {
+  BitbucketBranchState,
+  BitbucketMergeStrategy,
   MergeRequestBody,
   PrResponse,
   RepoInfo,
   RepoInfoBody,
-  bitbucketMergeStrategies,
-  prStates,
 } from './types';
 
 const bitbucketHttp = new BitbucketHttp();
@@ -26,6 +27,15 @@ export function repoInfoTransformer(repoInfoBody: RepoInfoBody): RepoInfo {
   };
 }
 
+export const bitbucketMergeStrategies: Map<
+  MergeStrategy,
+  BitbucketMergeStrategy
+> = new Map([
+  ['squash', 'squash'],
+  ['merge-commit', 'merge_commit'],
+  ['fast-forward', 'fast_forward'],
+]);
+
 export function mergeBodyTransformer(
   mergeStrategy: MergeStrategy | undefined
 ): MergeRequestBody {
@@ -40,6 +50,20 @@ export function mergeBodyTransformer(
 
   return body;
 }
+
+export const prStates = {
+  open: ['OPEN'],
+  notOpen: ['MERGED', 'DECLINED', 'SUPERSEDED'],
+  merged: ['MERGED'],
+  closed: ['DECLINED', 'SUPERSEDED'],
+  all: ['OPEN', 'MERGED', 'DECLINED', 'SUPERSEDED'],
+};
+
+export const buildStates: Record<BranchStatus, BitbucketBranchState> = {
+  green: 'SUCCESSFUL',
+  red: 'FAILED',
+  yellow: 'INPROGRESS',
+};
 
 const addMaxLength = (inputUrl: string, pagelen = 100): string => {
   const { search, ...parsedUrl } = url.parse(inputUrl, true);

--- a/lib/modules/platform/bitbucket/utils.ts
+++ b/lib/modules/platform/bitbucket/utils.ts
@@ -27,14 +27,12 @@ export function repoInfoTransformer(repoInfoBody: RepoInfoBody): RepoInfo {
   };
 }
 
-export const bitbucketMergeStrategies: Map<
-  MergeStrategy,
-  BitbucketMergeStrategy
-> = new Map([
-  ['squash', 'squash'],
-  ['merge-commit', 'merge_commit'],
-  ['fast-forward', 'fast_forward'],
-]);
+const bitbucketMergeStrategies: Map<MergeStrategy, BitbucketMergeStrategy> =
+  new Map([
+    ['squash', 'squash'],
+    ['merge-commit', 'merge_commit'],
+    ['fast-forward', 'fast_forward'],
+  ]);
 
 export function mergeBodyTransformer(
   mergeStrategy: MergeStrategy | undefined


### PR DESCRIPTION
## Changes

Consolidates types and interfaces that were scattered around into `/platform/bitbucket/types.ts`

## Context

As suggested by @viceice on draft PR https://github.com/renovatebot/renovate/pull/20559#discussion_r1113935406 in preparation https://github.com/renovatebot/renovate/issues/20568

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository