### PR TITLE
fix: remove rebase-all-open-prs checkbox from read only issue bodies

### DIFF
--- a/lib/modules/platform/utils/__fixtures__/issue-body.txt
+++ b/lib/modules/platform/utils/__fixtures__/issue-body.txt
@@ -1,3 +1,12 @@
+## Open
+
+These updates have all been created already. Click a checkbox below to force a retry/rebase of any.
+
+ - [ ] <!-- rebase-branch=branchName1 -->[pr1](../pull/1)
+ - [ ] <!-- rebase-branch=branchName2 -->[pr2](../pull/2) (`dep2`, `dep3`)
+ - [ ] <!-- rebase-branch=branchName3 -->[pr3](../pull/3)
+ - [ ] <!-- rebase-all-open-prs -->**Click on this checkbox to rebase all open PRs at once**
+
 ## Edited/Blocked
 
 These updates have been manually edited so Renovate will no longer make changes. To discard all commits and start over, click on a checkbox.

--- a/lib/modules/platform/utils/read-only-issue-body.spec.ts
+++ b/lib/modules/platform/utils/read-only-issue-body.spec.ts
@@ -14,7 +14,7 @@ describe('modules/platform/utils/read-only-issue-body', () => {
     it('removes all checkbox-related instructions', () => {
       expect(readOnlyIssueBody(issueBody)).toEqual(
         expect.not.stringMatching(
-          /click (?:(?:on |)a|their) checkbox|check the box below/gi
+          /click (?:(?:on |)a|their|this) checkbox|check the box below/gi
         )
       );
     });

--- a/lib/modules/platform/utils/read-only-issue-body.ts
+++ b/lib/modules/platform/utils/read-only-issue-body.ts
@@ -6,7 +6,8 @@ export function readOnlyIssueBody(body: string): string {
     .replace(' unless you click a checkbox below', '')
     .replace(' To discard all commits and start over, click on a checkbox.', '')
     .replace(regEx(/ Click (?:on |)a checkbox.*\./g), '')
-    .replace(regEx(/\[ ] <!-- \w*-branch.*-->/g), '');
+    .replace(regEx(/\[ ] <!-- \w*-branch.*-->/g), '')
+    .replace(regEx(/- \[ ] <!-- rebase-all-open-prs -->.*/g), '');
 }
 
 export default readOnlyIssueBody;


### PR DESCRIPTION
## Changes

Removes `rebase-all-open-prs` checkbox from read only issue bodies

## Context

Resolves https://github.com/renovatebot/renovate/issues/20577

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository