### PR TITLE
fix(platform/bitbucket): remove blockquote markdown from bitbucket issue description

### DIFF
--- a/lib/modules/platform/bitbucket/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/platform/bitbucket/__snapshots__/index.spec.ts.snap
@@ -140,7 +140,17 @@ exports[`modules/platform/bitbucket/index initRepo() works with username and pas
 }
 `;
 
-exports[`modules/platform/bitbucket/index massageMarkdown() returns diff files 1`] = `"**foo**bartext"`;
+exports[`modules/platform/bitbucket/index massageMarkdown() returns diff files 1`] = `
+"**foo**
+
+
+**text**
+
+
+
+
+"
+`;
 
 exports[`modules/platform/bitbucket/index updatePr() rethrows exception when PR update error due to unknown reviewers error 1`] = `"Response code 400 (Bad Request)"`;
 

--- a/lib/modules/platform/bitbucket/index.spec.ts
+++ b/lib/modules/platform/bitbucket/index.spec.ts
@@ -1059,8 +1059,10 @@ describe('modules/platform/bitbucket/index', () => {
   describe('massageMarkdown()', () => {
     it('returns diff files', () => {
       const prBody =
-        '<details><summary>foo</summary>bar</details>text<details>' +
-        '\n---\n\n - [ ] <!-- rebase-check --> rebase\n<!--renovate-config-hash:-->';
+        '<details><summary>foo</summary>\n<blockquote>\n\n<details><summary>text</summary>' +
+        '\n---\n\n - [ ] <!-- rebase-check --> rebase\n<!--renovate-config-hash:-->' +
+        '\n\n</details>\n\n</blockquote>\n</details>';
+
       expect(bitbucket.massageMarkdown(prBody)).toMatchSnapshot();
     });
   });

--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -487,7 +487,7 @@ export function massageMarkdown(input: string): string {
       'by renaming this PR to start with "rebase!"'
     )
     .replace(regEx(/<\/?summary>/g), '**')
-    .replace(regEx(/<\/?details>/g), '')
+    .replace(regEx(/<\/?(details|blockquote)>/g), '')
     .replace(regEx(`\n---\n\n.*?<!-- rebase-check -->.*?\n`), '')
     .replace(regEx(/\]\(\.\.\/pull\//g), '](../../pull-requests/')
     .replace(regEx(/<!--renovate-(?:debug|config-hash):.*?-->/g), '');
@@ -499,8 +499,6 @@ export async function ensureIssue({
   body,
 }: EnsureIssueConfig): Promise<EnsureIssueResult | null> {
   logger.debug(`ensureIssue()`);
-  const description = massageMarkdown(sanitize(body));
-
   /* istanbul ignore if */
   if (!config.has_issues) {
     logger.warn('Issues are disabled - cannot ensureIssue');
@@ -509,6 +507,8 @@ export async function ensureIssue({
   }
   try {
     let issues = await findOpenIssues(title);
+    const description = massageMarkdown(sanitize(body));
+
     if (!issues.length && reuseTitle) {
       issues = await findOpenIssues(reuseTitle);
     }
@@ -518,6 +518,7 @@ export async function ensureIssue({
         await closeIssue(issue.id);
       }
       const [issue] = issues;
+
       if (
         issue.title !== title ||
         String(issue.content?.raw).trim() !== description.trim()


### PR DESCRIPTION
## Changes

Removes open/close `blockquote` markdown tags from Bitbucket Issue descriptions



## Context

Resolves https://github.com/renovatebot/renovate/issues/20583

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository
