### PR TITLE
fix(gradle): set Java 17 as constraint for gradle >= 7.3

### DIFF
--- a/lib/modules/manager/gradle-wrapper/util.spec.ts
+++ b/lib/modules/manager/gradle-wrapper/util.spec.ts
@@ -39,6 +39,12 @@ describe('modules/manager/gradle-wrapper/util', () => {
       GlobalConfig.set({ binarySource: 'docker' });
       expect(getJavaConstraint('7.0.1')).toBe('^16.0.0');
     });
+
+    it('return ^17.0.0 for docker gradle >= 7.3', () => {
+      GlobalConfig.set({ binarySource: 'docker' });
+      expect(getJavaConstraint('7.3.0')).toBe('^17.0.0');
+      expect(getJavaConstraint('8.0.1')).toBe('^17.0.0');
+    });
   });
 
   describe('extractGradleVersion()', () => {

--- a/lib/modules/manager/gradle-wrapper/utils.ts
+++ b/lib/modules/manager/gradle-wrapper/utils.ts
@@ -48,6 +48,10 @@ export function getJavaConstraint(
   gradleVersion: string | null | undefined
 ): string | null {
   const major = gradleVersion ? gradleVersioning.getMajor(gradleVersion) : null;
+  const minor = gradleVersion ? gradleVersioning.getMinor(gradleVersion) : null;
+  if (major && (major > 7 || (major >= 7 && minor && minor >= 3))) {
+    return '^17.0.0';
+  }
   if (major && major >= 7) {
     return '^16.0.0';
   }

--- a/lib/modules/manager/gradle/artifacts.spec.ts
+++ b/lib/modules/manager/gradle/artifacts.spec.ts
@@ -83,7 +83,7 @@ describe('modules/manager/gradle/artifacts', () => {
         content = 'New gradle.lockfile';
       } else if (fileName === 'gradle/wrapper/gradle-wrapper.properties') {
         content =
-          'distributionUrl=https\\://services.gradle.org/distributions/gradle-7.4-bin.zip';
+          'distributionUrl=https\\://services.gradle.org/distributions/gradle-7.2-bin.zip';
       }
 
       return Promise.resolve(content);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Define Java 17 (LTS) as constraint for gradle >= 7.3, because Java 16 is EOL since 1 year, 5 months

<!-- Describe what behavior is changed by this PR. -->

## Context

- Closes https://github.com/renovatebot/renovate/issues/20564

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

Test repo: https://github.com/renovate-demo/20564-renovate-java-17-dependency-example

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
