### PR TITLE
fix(packagist): Fix url resolving

### DIFF
--- a/lib/modules/datasource/packagist/index.ts
+++ b/lib/modules/datasource/packagist/index.ts
@@ -5,7 +5,7 @@ import { cache } from '../../../util/cache/package/decorator';
 import * as hostRules from '../../../util/host-rules';
 import type { HttpOptions } from '../../../util/http/types';
 import * as p from '../../../util/promises';
-import { joinUrlParts, resolveBaseUrl } from '../../../util/url';
+import { joinUrlParts, parseUrl, resolveBaseUrl } from '../../../util/url';
 import * as composerVersioning from '../../versioning/composer';
 import { Datasource } from '../datasource';
 import type { GetReleasesConfig, ReleaseResult } from '../types';
@@ -133,7 +133,10 @@ export class PackagistDatasource extends Datasource {
     registryUrl: string,
     registryMeta: RegistryMeta
   ): string | null {
+    const registryHost = parseUrl(registryUrl)?.origin;
+
     if (
+      registryHost &&
       registryMeta.providersUrl &&
       packageName in registryMeta.providerPackages
     ) {
@@ -142,12 +145,12 @@ export class PackagistDatasource extends Datasource {
       if (hash) {
         url = url.replace('%hash%', hash);
       }
-      return resolveBaseUrl(registryUrl, url);
+      return resolveBaseUrl(registryHost, url);
     }
 
-    if (registryMeta.providersLazyUrl) {
+    if (registryHost && registryMeta.providersLazyUrl) {
       return resolveBaseUrl(
-        registryUrl,
+        registryHost,
         registryMeta.providersLazyUrl.replace('%package%', packageName)
       );
     }

--- a/lib/modules/datasource/packagist/index.ts
+++ b/lib/modules/datasource/packagist/index.ts
@@ -5,7 +5,7 @@ import { cache } from '../../../util/cache/package/decorator';
 import * as hostRules from '../../../util/host-rules';
 import type { HttpOptions } from '../../../util/http/types';
 import * as p from '../../../util/promises';
-import { joinUrlParts, parseUrl, resolveBaseUrl } from '../../../util/url';
+import { joinUrlParts, resolveBaseUrl } from '../../../util/url';
 import * as composerVersioning from '../../versioning/composer';
 import { Datasource } from '../datasource';
 import type { GetReleasesConfig, ReleaseResult } from '../types';
@@ -133,10 +133,9 @@ export class PackagistDatasource extends Datasource {
     registryUrl: string,
     registryMeta: RegistryMeta
   ): string | null {
-    const registryHost = parseUrl(registryUrl)?.origin;
+    const { origin: registryHost } = new URL(registryUrl);
 
     if (
-      registryHost &&
       registryMeta.providersUrl &&
       packageName in registryMeta.providerPackages
     ) {
@@ -148,7 +147,7 @@ export class PackagistDatasource extends Datasource {
       return resolveBaseUrl(registryHost, url);
     }
 
-    if (registryHost && registryMeta.providersLazyUrl) {
+    if (registryMeta.providersLazyUrl) {
       return resolveBaseUrl(
         registryHost,
         registryMeta.providersLazyUrl.replace('%package%', packageName)


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- `resolveBaseUrl('https://example.com/foo', '/bar') === 'https://example.com/foo/bar'`
- we need Packagist to join it as `https://example.com/bar`

## Context

- Fix: #20649
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
