### PR TITLE
fix(setup_cfg): parsing for requirements install requires

### DIFF
--- a/lib/modules/manager/setup-cfg/__fixtures__/setup-cfg-1.txt
+++ b/lib/modules/manager/setup-cfg/__fixtures__/setup-cfg-1.txt
@@ -17,6 +17,8 @@ install_requires =
 
     requests[security] ~=2.18
     compact~=1.2.3;python>'3.10'
+install_requires= 
+    responses >=2.27.0
 
 setup_requires =
     six ~=1.4

--- a/lib/modules/manager/setup-cfg/__snapshots__/extract.spec.ts.snap
+++ b/lib/modules/manager/setup-cfg/__snapshots__/extract.spec.ts.snap
@@ -84,6 +84,12 @@ exports[`modules/manager/setup-cfg/extract extractPackageFile() extracts depende
       "depType": "install",
     },
     {
+      "currentValue": ">=2.27.0",
+      "datasource": "pypi",
+      "depName": "responses",
+      "depType": "install",
+    },
+    {
       "currentValue": "~=1.4",
       "datasource": "pypi",
       "depName": "six",

--- a/lib/modules/manager/setup-cfg/extract.spec.ts
+++ b/lib/modules/manager/setup-cfg/extract.spec.ts
@@ -24,6 +24,7 @@ describe('modules/manager/setup-cfg/extract', () => {
           { depName: 'nmspc.pkg', currentValue: '==1.0' },
           { depName: 'requests', currentValue: '~=2.18' },
           { depName: 'compact', currentValue: '~=1.2.3' },
+          { depName: 'responses', currentValue: '>=2.27.0' },
           { depName: 'six', currentValue: '~=1.4' },
           { depName: 'tqdm', currentValue: '~=4.19' },
           { depName: 'tenacity', currentValue: '~=6.0' },

--- a/lib/modules/manager/setup-cfg/extract.ts
+++ b/lib/modules/manager/setup-cfg/extract.ts
@@ -102,8 +102,6 @@ export function extractPackageFile(
       let line = rawLine;
       const newSectionName = getSectionName(line);
       const newSectionRecord = getSectionRecord(line);
-
-
       if (newSectionName) {
         sectionName = newSectionName;
       }

--- a/lib/modules/manager/setup-cfg/extract.ts
+++ b/lib/modules/manager/setup-cfg/extract.ts
@@ -41,10 +41,6 @@ function parseDep(
   section: string | null,
   record: string | null
 ): PackageDependency | null {
-  logger.debug(
-    `parseDep args: ${line} ${section ? section : ''} ${record ? record : ''}`
-  );
-
   const packagePattern = '[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9._-]*[a-zA-Z0-9]';
   const extrasPattern = '(?:\\s*\\[[^\\]]+\\])?';
 
@@ -86,9 +82,6 @@ function parseDep(
     dep.currentVersion = currentValue.replace(/^==\s*/, '');
   }
 
-  logger.debug(`parseDep result:`);
-  logger.debug(dep);
-
   return dep;
 }
 
@@ -109,23 +102,7 @@ export function extractPackageFile(
       let line = rawLine;
       const newSectionName = getSectionName(line);
       const newSectionRecord = getSectionRecord(line);
-      logger.debug(`extractPackageFile in first forEach line: ${line}`);
-      logger.debug(
-        `extractPackageFile in first forEach newSectionName: ${newSectionName}`
-      );
-      logger.debug(
-        `extractPackageFile in first forEach newSectionRecord: ${newSectionRecord}`
-      );
-      logger.debug(
-        `extractPackageFile in first forEach newSectionName: ${
-          sectionName ?? ''
-        }`
-      );
-      logger.debug(
-        `extractPackageFile in first forEach newSectionRecord: ${
-          sectionRecord ?? ''
-        }`
-      );
+
 
       if (newSectionName) {
         sectionName = newSectionName;
@@ -135,17 +112,6 @@ export function extractPackageFile(
         // Propably there are also requirements in this line.
         line = rawLine.replace(regEx(/^[^=]*=\s*/), '');
         line.split(';').forEach((part) => {
-          logger.debug(`extractPackageFile in second forEach part: ${part}`);
-          logger.debug(
-            `extractPackageFile in second sectionName sectionName: ${
-              sectionName ?? ''
-            }`
-          );
-          logger.debug(
-            `extractPackageFile in second forEach sectionRecord: ${
-              sectionRecord ?? ''
-            }`
-          );
           const dep = parseDep(part, sectionName, sectionRecord);
           if (dep) {
             deps.push(dep);
@@ -159,15 +125,6 @@ export function extractPackageFile(
         deps.push(dep);
       }
     });
-
-  const result = deps.length ? { deps } : null;
-
-  if (result) {
-    result.deps.forEach((r) => {
-      logger.debug(`extractPackageFile result:`);
-      logger.debug(r);
-    });
-  }
 
   return deps.length ? { deps } : null;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Dependencies under `install_requires` will now get picked up by renovate, for the setup.cfg file when there is no spacing between `install_requires` and `=`. This applies to `setup_requires` and `test_requires` as well.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->
Python setup-cfg manager does not detect dependencies under `install_requires` when there is no spacing between 'install_requires` and the `=` sign. i.e. https://github.com/sukelly/testrepo2/blob/main/setup.cfg

This is non-complaint with Python's [ConfigParser](https://docs.python.org/3/library/configparser.html) which doesn't require the spacing. The aim is to parse the setup.cfg file to be compliant with what is valid with Python's ConfigParser.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [X] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
