### PR TITLE
refactor(autoreplace): set depIndex during flatten

### DIFF
--- a/lib/modules/manager/types.ts
+++ b/lib/modules/manager/types.ts
@@ -143,7 +143,6 @@ export interface PackageDependency<T = Record<string, any>>
   updates?: LookupUpdate[];
   replaceString?: string;
   autoReplaceStringTemplate?: string;
-  depIndex?: number;
   editFile?: string;
   separateMinorPatch?: boolean;
   extractVersion?: string;

--- a/lib/workers/repository/extract/manager-files.spec.ts
+++ b/lib/workers/repository/extract/manager-files.spec.ts
@@ -59,7 +59,7 @@ describe('workers/repository/extract/manager-files', () => {
       expect(res).toEqual([
         {
           packageFile: 'Dockerfile',
-          deps: [{ depIndex: 0 }, { depIndex: 1, replaceString: 'abc' }],
+          deps: [{}, { replaceString: 'abc' }],
         },
       ]);
     });

--- a/lib/workers/repository/extract/manager-files.ts
+++ b/lib/workers/repository/extract/manager-files.ts
@@ -35,13 +35,6 @@ export async function getManagerPackageFiles(
       config,
       fileList
     );
-    if (allPackageFiles) {
-      for (const packageFile of allPackageFiles) {
-        for (let index = 0; index < packageFile.deps.length; index += 1) {
-          packageFile.deps[index].depIndex = index;
-        }
-      }
-    }
     return allPackageFiles;
   }
   const packageFiles: PackageFile[] = [];
@@ -56,9 +49,6 @@ export async function getManagerPackageFiles(
         config
       );
       if (res) {
-        for (let index = 0; index < res.deps.length; index += 1) {
-          res.deps[index].depIndex = index;
-        }
         packageFiles.push({
           ...res,
           packageFile,

--- a/lib/workers/repository/updates/flatten.spec.ts
+++ b/lib/workers/repository/updates/flatten.spec.ts
@@ -1,3 +1,4 @@
+import is from '@sindresorhus/is';
 import { RenovateConfig, getConfig } from '../../../../test/util';
 import { flattenUpdates } from './flatten';
 
@@ -144,6 +145,14 @@ describe('workers/repository/updates/flatten', () => {
       };
       const res = await flattenUpdates(config, packageFiles);
       expect(res).toHaveLength(14);
+      expect(
+        res.every(
+          (upgrade) =>
+            upgrade.isLockFileMaintenance ||
+            upgrade.isRemediation ||
+            is.number(upgrade.depIndex)
+        )
+      ).toBeTrue();
       expect(
         res.filter((update) => update.sourceRepoSlug)[0].sourceRepoSlug
       ).toBe('org-repo');

--- a/lib/workers/repository/updates/flatten.ts
+++ b/lib/workers/repository/updates/flatten.ts
@@ -91,10 +91,12 @@ export async function flattenUpdates(
         packageFileConfig.parentDir = '';
         packageFileConfig.packageFileDir = '';
       }
+      let depIndex = 0;
       for (const dep of packageFile.deps) {
         if (dep.updates.length) {
           const depConfig = mergeChildConfig(packageFileConfig, dep);
           delete depConfig.deps;
+          depConfig.depIndex = depIndex; // used for autoreplace
           for (const update of dep.updates) {
             let updateConfig = mergeChildConfig(depConfig, update);
             delete updateConfig.updates;
@@ -128,6 +130,7 @@ export async function flattenUpdates(
             updates.push(updateConfig);
           }
         }
+        depIndex += 1;
       }
       if (
         get(manager, 'supportsLockFileMaintenance') &&

--- a/lib/workers/types.ts
+++ b/lib/workers/types.ts
@@ -38,6 +38,7 @@ export interface BranchUpgradeConfig
   currentDigest?: string;
   currentDigestShort?: string;
   currentValue?: string;
+  depIndex?: number;
   excludeCommitPaths?: string[];
   githubName?: string;
   group?: GroupConfig;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

Avoid needing `depIndex` typing during extract & lookup phases

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
