### PR TITLE
chore: update templates to recommend discussions

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/mend-renovate-app-support.yml
+++ b/.github/DISCUSSION_TEMPLATE/mend-renovate-app-support.yml
@@ -2,8 +2,8 @@ body:
   - type: checkboxes
     id: hosted-app-checkbox
     attributes:
-      label: I'm using the Mend Renovate hosted app.
-      description: Only use this discussion if you're using the Mend Renovate hosted app.
+      label: I'm using the Mend Renovate hosted app on github.com.
+      description: Only use this discussion if you're using the Mend Renovate hosted app and have a "it's not running" type of problem.
       options:
         - label: I'm using the Mend Renovate hosted app.
           required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,13 +1,12 @@
 name: Bug report
-description: Confirmed bugs only. If in doubt, create a Discussion instead.
+description: Confirmed bugs only. Create a discussion first.
 labels: ['type:bug', 'status:requirements', 'priority-5-triage']
 body:
   - type: markdown
     attributes:
       value: |
-        Before you begin to fill out the form, make sure you have actually found a bug.
-        If you're not sure then create a [discussion](https://github.com/renovatebot/renovate/discussions) first.
-        If you have questions or want help with Renovate, then also create a [discussion](https://github.com/renovatebot/renovate/discussions).
+        Please don't create these bug reports unless you're an experienced user or absolutely certain you found a bug.
+        It is preferred that you create a [discussion](https://github.com/renovatebot/renovate/discussions/new) first and allow maintainers to decide.
 
   - type: dropdown
     id: how-are-you-running-renovate

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Start a discussion (config, doubts, docs)
+  - name: Start a discussion
     url: https://github.com/renovatebot/renovate/discussions/new
-    about: If you have any questions about bot configuration or doubts about whether you should create a feature request or bug report, or have problems with the documentation please select the button to create a Discussion instead of an Issue.
+    about: Our preferred starting point if you have any questions or suggestions about bot configuration, features or behavior.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,5 @@
 name: Feature request
-description: Suggest an idea for this project.
+description: For maintainers only. For everyone else, please start an Ideas [discussion](https://github.com/renovatebot/renovate/discussions/new).
 labels: ['type:feature', 'status:requirements', 'priority-5-triage']
 body:
   - type: textarea


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This PR updates issues and discussion templates to more strongly recommend users start with a discussion instead of bug reports or feature requests.

## Context

It wastes our time when users - especially inexperienced ones - create multiple invalid issues per day which we need to convert to discussions and clean up. Some users get quite belligerent about it too, which leads to even more wasted time responding to their follow-ups.

Another source of time wasting is when a feature request is framed as a bug report and needs to be converted.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
