### PR TITLE
fix(packagist): Replace V2 URL path instead of joining it

### DIFF
--- a/lib/modules/datasource/packagist/index.ts
+++ b/lib/modules/datasource/packagist/index.ts
@@ -70,7 +70,7 @@ export class PackagistDatasource extends Datasource {
   ): string {
     const { key, hash } = regFile;
     const fileName = hash ? key.replace('%hash%', hash) : key;
-    const url = `${regUrl}/${fileName}`;
+    const url = resolveBaseUrl(regUrl, fileName);
     return url;
   }
 

--- a/lib/util/url.ts
+++ b/lib/util/url.ts
@@ -30,6 +30,12 @@ export function trimLeadingSlash(path: string): string {
   return path.replace(/^\/+/, '');
 }
 
+/**
+ * Resolves an input path against a base URL
+ *
+ * @param baseUrl - base URL to resolve against
+ * @param input - input path (if this is a full URL, it will be returned)
+ */
 export function resolveBaseUrl(baseUrl: string, input: string | URL): string {
   const inputString = input.toString();
 
@@ -42,6 +48,21 @@ export function resolveBaseUrl(baseUrl: string, input: string | URL): string {
   }
 
   return host ? inputString : urlJoin(baseUrl, pathname || '');
+}
+
+/**
+ * Replaces the path of a URL with a new path
+ *
+ * @param baseUrl - source URL
+ * @param path - replacement path (if this is a full URL, it will be returned)
+ */
+export function replaceUrlPath(baseUrl: string | URL, path: string): string {
+  if (parseUrl(path)) {
+    return path;
+  }
+
+  const { origin } = is.string(baseUrl) ? new URL(baseUrl) : baseUrl;
+  return urlJoin(origin, path);
 }
 
 export function getQueryString(params: Record<string, any>): string {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Introduce `replaceUrlPath()` helper that is similar to `resolveBaseUrl`, but replaces the path of `baseUrl` instead of joining with it
- Make sure Packagist datasource uses it when required

## Context

- Closes: #20710

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
