### PR TITLE
feat(gomod): enable gomodUpdateImportPaths for gopkg.in

### DIFF
--- a/lib/modules/manager/gomod/artifacts.spec.ts
+++ b/lib/modules/manager/gomod/artifacts.spec.ts
@@ -1625,7 +1625,7 @@ describe('modules/manager/gomod/artifacts', () => {
     ]);
   });
 
-  it('skips updating import paths for gopkg.in dependencies', async () => {
+  it('updates import paths for gopkg.in dependencies including v0 to v1', async () => {
     fs.readLocalFile.mockResolvedValueOnce('Current go.sum');
     fs.readLocalFile.mockResolvedValueOnce(null); // vendor modules filename
     const execSnapshots = mockExecAll();
@@ -1640,7 +1640,10 @@ describe('modules/manager/gomod/artifacts', () => {
     expect(
       await gomod.updateArtifacts({
         packageFileName: 'go.mod',
-        updatedDeps: [{ depName: 'gopkg.in/yaml.v2', newVersion: 'v28.0.0' }],
+        updatedDeps: [
+          { depName: 'gopkg.in/yaml.v2', newVersion: 'v28.0.0' },
+          { depName: 'gopkg.in/foo.v0', newVersion: 'v1.0.0' },
+        ],
         newPackageFileContent: gomod1,
         config: {
           ...config,
@@ -1655,6 +1658,18 @@ describe('modules/manager/gomod/artifacts', () => {
     expect(execSnapshots).toMatchObject([
       {
         cmd: 'go get -d -t ./...',
+        options: { cwd: '/tmp/github/some/repo' },
+      },
+      {
+        cmd: 'go install github.com/marwan-at-work/mod/cmd/mod@latest',
+        options: { cwd: '/tmp/github/some/repo' },
+      },
+      {
+        cmd: 'mod upgrade --mod-name=gopkg.in/yaml.v2 -t=28',
+        options: { cwd: '/tmp/github/some/repo' },
+      },
+      {
+        cmd: 'mod upgrade --mod-name=gopkg.in/foo.v0 -t=1',
         options: { cwd: '/tmp/github/some/repo' },
       },
       {

--- a/lib/modules/manager/gomod/artifacts.ts
+++ b/lib/modules/manager/gomod/artifacts.ts
@@ -134,9 +134,9 @@ function getUpdateImportPathCmds(
       depName: depName!,
       newMajor: major(newVersion!),
     }))
-    // Skip path upates going from v0 to v1
+    // Skip path updates going from v0 to v1
     .filter(
-      ({ depName, newMajor }) => !depName.startsWith('gopkg.in') && newMajor > 1
+      ({ depName, newMajor }) => depName.startsWith('gopkg.in') || newMajor > 1
     )
 
     .map(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Remove restriction on `gomodUpdateImportPaths` post update option for `gopkg.in` modules

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

marwan-at-work/mod#18 has been merged and released upstream.

Closes #19601

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
