### PR TITLE
refactor(manager/gradle): manage nesting depth separate from tokens

### DIFF
--- a/lib/modules/manager/gradle/parser.ts
+++ b/lib/modules/manager/gradle/parser.ts
@@ -56,6 +56,7 @@ export function parseGradle(
     registryUrls: [],
 
     varTokens: [],
+    tmpNestingDepth: [],
     tmpTokenStore: {},
     tokenMap: {},
   });

--- a/lib/modules/manager/gradle/parser/common.ts
+++ b/lib/modules/manager/gradle/parser/common.ts
@@ -1,4 +1,5 @@
 import { lexer, parser, query as q } from 'good-enough-parser';
+import { clone } from '../../../../util/clone';
 import { regEx } from '../../../../util/regex';
 import type { Ctx, NonEmptyArray, PackageVariables } from '../types';
 
@@ -36,6 +37,22 @@ export const ANNOYING_METHODS: ReadonlySet<string> = new Set([
 
 export function storeVarToken(ctx: Ctx, node: lexer.Token): Ctx {
   ctx.varTokens.push(node);
+  return ctx;
+}
+
+export function increaseNestingDepth(ctx: Ctx): Ctx {
+  ctx.tmpNestingDepth.push(...ctx.varTokens);
+  ctx.varTokens = [];
+  return ctx;
+}
+
+export function reduceNestingDepth(ctx: Ctx): Ctx {
+  ctx.tmpNestingDepth.pop();
+  return ctx;
+}
+
+export function prependNestingDepth(ctx: Ctx): Ctx {
+  ctx.varTokens = [...clone(ctx.tmpNestingDepth), ...ctx.varTokens];
   return ctx;
 }
 

--- a/lib/modules/manager/gradle/types.ts
+++ b/lib/modules/manager/gradle/types.ts
@@ -82,6 +82,7 @@ export interface Ctx {
   registryUrls: PackageRegistry[];
 
   varTokens: lexer.Token[];
+  tmpNestingDepth: lexer.Token[];
   tmpTokenStore: Record<string, lexer.Token[]>;
   tokenMap: Record<string, lexer.Token[]>;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Refactored the handling of nested hierarchies to be stored in a separate variable instead of prepending it to extracted tokens. This should make the code better understandable but also paves the way for nested queries that require the tree hierarchy to be preserved. This only affects Groovy and Kotlin maps, tests and functionality remain unchanged.

This also eases future support for nested Kotlin objects, such as 
```kotlin
object some {
  object other {
    val versions = mapOf("foo1" to "bar1")
  }
}
```
because here the `qKotlinMultiMapOfVarAssignment` handler would need to inherit the hierarchy of objects (just mentioning this to give an example of nested queries).

<!-- Describe what behavior is changed by this PR. -->

## Context

- https://github.com/renovatebot/renovate/pull/19127

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
