### PR TITLE
feat(platform): update PR target branch if baseBranch changed

### DIFF
--- a/lib/modules/platform/bitbucket/index.spec.ts
+++ b/lib/modules/platform/bitbucket/index.spec.ts
@@ -1080,7 +1080,12 @@ describe('modules/platform/bitbucket/index', () => {
         .put('/2.0/repositories/some/repo/pullrequests/5')
         .reply(200);
       await expect(
-        bitbucket.updatePr({ number: 5, prTitle: 'title', prBody: 'body' })
+        bitbucket.updatePr({
+          number: 5,
+          prTitle: 'title',
+          prBody: 'body',
+          targetBranch: 'main',
+        })
       ).toResolve();
     });
 
@@ -1143,7 +1148,12 @@ describe('modules/platform/bitbucket/index', () => {
         .put('/2.0/repositories/some/repo/pullrequests/5')
         .reply(200);
       await expect(
-        bitbucket.updatePr({ number: 5, prTitle: 'title', prBody: 'body' })
+        bitbucket.updatePr({
+          number: 5,
+          prTitle: 'title',
+          prBody: 'body',
+          targetBranch: 'main',
+        })
       ).toResolve();
     });
 
@@ -1187,7 +1197,12 @@ describe('modules/platform/bitbucket/index', () => {
         .reply(200);
 
       await expect(
-        bitbucket.updatePr({ number: 5, prTitle: 'title', prBody: 'body' })
+        bitbucket.updatePr({
+          number: 5,
+          prTitle: 'title',
+          prBody: 'body',
+          targetBranch: 'main',
+        })
       ).toResolve();
     });
 
@@ -1219,7 +1234,12 @@ describe('modules/platform/bitbucket/index', () => {
         )
         .reply(401);
       await expect(() =>
-        bitbucket.updatePr({ number: 5, prTitle: 'title', prBody: 'body' })
+        bitbucket.updatePr({
+          number: 5,
+          prTitle: 'title',
+          prBody: 'body',
+          targetBranch: 'main',
+        })
       ).rejects.toThrow(new Error('Response code 401 (Unauthorized)'));
     });
 
@@ -1244,7 +1264,12 @@ describe('modules/platform/bitbucket/index', () => {
           },
         });
       await expect(() =>
-        bitbucket.updatePr({ number: 5, prTitle: 'title', prBody: 'body' })
+        bitbucket.updatePr({
+          number: 5,
+          prTitle: 'title',
+          prBody: 'body',
+          targetBranch: 'main',
+        })
       ).rejects.toThrowErrorMatchingSnapshot();
     });
 
@@ -1269,7 +1294,12 @@ describe('modules/platform/bitbucket/index', () => {
           },
         });
       await expect(() =>
-        bitbucket.updatePr({ number: 5, prTitle: 'title', prBody: 'body' })
+        bitbucket.updatePr({
+          number: 5,
+          prTitle: 'title',
+          prBody: 'body',
+          targetBranch: 'main',
+        })
       ).rejects.toThrow(new Error('Response code 400 (Bad Request)'));
     });
 
@@ -1279,7 +1309,12 @@ describe('modules/platform/bitbucket/index', () => {
         .get('/2.0/repositories/some/repo/pullrequests/5')
         .reply(500, undefined);
       await expect(() =>
-        bitbucket.updatePr({ number: 5, prTitle: 'title', prBody: 'body' })
+        bitbucket.updatePr({
+          number: 5,
+          prTitle: 'title',
+          prBody: 'body',
+          targetBranch: 'main',
+        })
       ).rejects.toThrowErrorMatchingSnapshot();
     });
 
@@ -1298,6 +1333,7 @@ describe('modules/platform/bitbucket/index', () => {
           number: pr.id,
           prTitle: pr.title,
           state: 'closed',
+          targetBranch: 'main',
         })
       ).toBeUndefined();
     });

--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -838,6 +838,7 @@ export async function updatePr({
   number: prNo,
   prTitle: title,
   prBody: description,
+  targetBranch,
   state,
 }: UpdatePrConfig): Promise<void> {
   logger.debug(`updatePr(${prNo}, ${title}, body)`);
@@ -856,6 +857,11 @@ export async function updatePr({
           title,
           description: sanitize(description),
           reviewers: pr.reviewers,
+          destination: {
+            branch: {
+              name: targetBranch,
+            },
+          },
         },
       }
     );
@@ -873,6 +879,11 @@ export async function updatePr({
             title,
             description: sanitize(description),
             reviewers: sanitizedReviewers,
+            destination: {
+              branch: {
+                name: targetBranch,
+              },
+            },
           },
         }
       );

--- a/lib/modules/platform/types.ts
+++ b/lib/modules/platform/types.ts
@@ -108,6 +108,7 @@ export interface UpdatePrConfig {
   platformOptions?: PlatformPrOptions;
   prTitle: string;
   prBody?: string;
+  targetBranch?: string;
   state?: 'open' | 'closed';
 }
 export interface EnsureIssueConfig {

--- a/lib/workers/repository/update/pr/index.ts
+++ b/lib/workers/repository/update/pr/index.ts
@@ -353,6 +353,7 @@ export async function ensurePr(
           number: existingPr.number,
           prTitle,
           prBody,
+          targetBranch: config.baseBranch ?? '',
           platformOptions: getPlatformPrOptions(config),
         });
         logger.info({ pr: existingPr.number, prTitle }, `PR updated`);


### PR DESCRIPTION
## Changes

Sets destination branch when updating existing pull requests.


## Context

- #20799 (only partially closes)

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
