### PR TITLE
fix(gomod): skip updating import path for incompatible versions

### DIFF
--- a/lib/modules/manager/gomod/artifacts.spec.ts
+++ b/lib/modules/manager/gomod/artifacts.spec.ts
@@ -1434,6 +1434,52 @@ describe('modules/manager/gomod/artifacts', () => {
     ]);
   });
 
+  it('skips updating import paths when incompatible version', async () => {
+    fs.readLocalFile.mockResolvedValueOnce('Current go.sum');
+    fs.readLocalFile.mockResolvedValueOnce(null); // vendor modules filename
+    const execSnapshots = mockExecAll();
+    git.getRepoStatus.mockResolvedValueOnce({
+      modified: ['go.sum'],
+    } as StatusResult);
+    fs.readLocalFile
+      .mockResolvedValueOnce('New go.sum')
+      .mockResolvedValueOnce('New go.mod');
+    expect(
+      await gomod.updateArtifacts({
+        packageFileName: 'go.mod',
+        updatedDeps: [
+          {
+            depName: 'github.com/docker/docker',
+            newVersion: 'v23.0.0+incompatible',
+          },
+        ],
+        newPackageFileContent: gomod1,
+        config: {
+          ...config,
+          updateType: 'major',
+          postUpdateOptions: ['gomodUpdateImportPaths'],
+        },
+      })
+    ).toEqual([
+      { file: { type: 'addition', path: 'go.sum', contents: 'New go.sum' } },
+      { file: { type: 'addition', path: 'go.mod', contents: 'New go.mod' } },
+    ]);
+    expect(execSnapshots).toMatchObject([
+      {
+        cmd: 'go get -d -t ./...',
+        options: { cwd: '/tmp/github/some/repo' },
+      },
+      {
+        cmd: 'go mod tidy',
+        options: { cwd: '/tmp/github/some/repo' },
+      },
+      {
+        cmd: 'go mod tidy',
+        options: { cwd: '/tmp/github/some/repo' },
+      },
+    ]);
+  });
+
   it('skips gomodTidy without gomodUpdateImportPaths on major update', async () => {
     fs.readLocalFile.mockResolvedValueOnce('Current go.sum');
     fs.readLocalFile.mockResolvedValueOnce(null); // vendor modules filename

--- a/lib/modules/manager/gomod/artifacts.spec.ts
+++ b/lib/modules/manager/gomod/artifacts.spec.ts
@@ -1439,9 +1439,11 @@ describe('modules/manager/gomod/artifacts', () => {
       .mockResolvedValueOnce('Current go.sum')
       .mockResolvedValueOnce(null); // vendor modules filename
     const execSnapshots = mockExecAll();
-    git.getRepoStatus.mockResolvedValueOnce({
-      modified: ['go.sum'],
-    } as StatusResult);
+    git.getRepoStatus.mockResolvedValueOnce(
+      partial<StatusResult>({
+        modified: ['go.sum'],
+      })
+    );
     fs.readLocalFile
       .mockResolvedValueOnce('New go.sum')
       .mockResolvedValueOnce('New go.mod');

--- a/lib/modules/manager/gomod/artifacts.spec.ts
+++ b/lib/modules/manager/gomod/artifacts.spec.ts
@@ -1435,8 +1435,9 @@ describe('modules/manager/gomod/artifacts', () => {
   });
 
   it('skips updating import paths when incompatible version', async () => {
-    fs.readLocalFile.mockResolvedValueOnce('Current go.sum');
-    fs.readLocalFile.mockResolvedValueOnce(null); // vendor modules filename
+    fs.readLocalFile
+      .mockResolvedValueOnce('Current go.sum')
+      .mockResolvedValueOnce(null); // vendor modules filename
     const execSnapshots = mockExecAll();
     git.getRepoStatus.mockResolvedValueOnce({
       modified: ['go.sum'],

--- a/lib/modules/manager/gomod/artifacts.ts
+++ b/lib/modules/manager/gomod/artifacts.ts
@@ -131,9 +131,7 @@ function getUpdateImportPathCmds(
   const updateImportCommands = updatedDeps
     .filter(
       ({ newVersion }) =>
-        valid(newVersion) &&
-        newVersion !== undefined &&
-        !newVersion.endsWith('+incompatible')
+        valid(newVersion) && !newVersion!.endsWith('+incompatible')
     )
     .map(({ depName, newVersion }) => ({
       depName: depName!,

--- a/lib/modules/manager/gomod/artifacts.ts
+++ b/lib/modules/manager/gomod/artifacts.ts
@@ -129,14 +129,19 @@ function getUpdateImportPathCmds(
   }
 
   const updateImportCommands = updatedDeps
-    .filter(({ newVersion }) => valid(newVersion))
+    .filter(
+      ({ newVersion }) =>
+        valid(newVersion) &&
+        newVersion !== undefined &&
+        !newVersion.endsWith('+incompatible')
+    )
     .map(({ depName, newVersion }) => ({
       depName: depName!,
       newMajor: major(newVersion!),
     }))
     // Skip path updates going from v0 to v1
     .filter(
-      ({ depName, newMajor }) => depName.startsWith('gopkg.in') || newMajor > 1
+      ({ depName, newMajor }) => depName.startsWith('gopkg.in/') || newMajor > 1
     )
 
     .map(

--- a/lib/modules/manager/gomod/update.spec.ts
+++ b/lib/modules/manager/gomod/update.spec.ts
@@ -96,7 +96,7 @@ describe('modules/manager/gomod/update', () => {
         depType: 'require',
       };
       const res = updateDependency({ fileContent: gomod1, upgrade });
-      expect(res).not.toEqual(gomod2);
+      expect(res).not.toEqual(gomod1);
       expect(res).toContain('github.com/pkg/errors/v2 v2.0.0');
     });
 
@@ -112,8 +112,25 @@ describe('modules/manager/gomod/update', () => {
       };
       const res = updateDependency({ fileContent: gomod1, upgrade });
       expect(res).toMatchSnapshot();
-      expect(res).not.toEqual(gomod2);
+      expect(res).not.toEqual(gomod1);
       expect(res).toContain('gopkg.in/russross/blackfriday.v2 v2.0.0');
+    });
+
+    it('skip replacing incompatible major updates', () => {
+      const upgrade = {
+        depName: 'github.com/Azure/azure-sdk-for-go',
+        managerData: { lineNumber: 8 },
+        newMajor: 26,
+        updateType: 'major' as UpdateType,
+        currentValue: 'v25.1.0+incompatible',
+        newValue: 'v26.0.0+incompatible',
+        depType: 'require',
+      };
+      const res = updateDependency({ fileContent: gomod1, upgrade });
+      expect(res).not.toEqual(gomod1);
+      expect(res).toContain(
+        'github.com/Azure/azure-sdk-for-go v26.0.0+incompatible'
+      );
     });
 
     it('returns null if mismatch', () => {

--- a/lib/modules/manager/gomod/update.ts
+++ b/lib/modules/manager/gomod/update.ts
@@ -105,7 +105,8 @@ export function updateDependency({
         );
       } else if (
         upgrade.newMajor! > 1 &&
-        !newLine.includes(`/v${upgrade.newMajor}`)
+        !newLine.includes(`/v${upgrade.newMajor}`) &&
+        !upgrade.newValue!.endsWith('+incompatible')
       ) {
         if (depName === depNameNoVersion) {
           // If package currently has no version, pin to latest one.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Skip `gomodUpdateImportPaths` post update option if `newVersion` ends with `+incompatible`

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

> `+incompatible` indicates that a version is part of the same module as versions with lower major version numbers;

https://go.dev/ref/mod#incompatible-versions

Renovate opened this PR: parca-dev/parca-agent#1427

### Got

```diff
-	github.com/docker/docker v20.10.23+incompatible
+	github.com/docker/docker/v23 v23.0.1+incompatible
```

### Expected

```diff
-	github.com/docker/docker v20.10.23+incompatible
+	github.com/docker/docker v23.0.1+incompatible
```

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
