### PR TITLE
fix(datasource/npm): cache public modules

### DIFF
--- a/lib/modules/datasource/npm/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/datasource/npm/__snapshots__/index.spec.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`modules/datasource/npm/index should fetch package info from custom registry 1`] = `
 {
+  "isPrivate": true,
   "name": "foobar",
   "registryUrl": "https://npm.mycustomregistry.com",
   "releases": [
@@ -25,6 +26,7 @@ exports[`modules/datasource/npm/index should fetch package info from custom regi
 
 exports[`modules/datasource/npm/index should fetch package info from npm 1`] = `
 {
+  "isPrivate": false,
   "name": "foobar",
   "registryUrl": "https://registry.npmjs.org",
   "releases": [
@@ -48,6 +50,7 @@ exports[`modules/datasource/npm/index should fetch package info from npm 1`] = `
 
 exports[`modules/datasource/npm/index should handle foobar 1`] = `
 {
+  "isPrivate": true,
   "name": "foobar",
   "registryUrl": "https://registry.npmjs.org",
   "releases": [
@@ -71,6 +74,7 @@ exports[`modules/datasource/npm/index should handle foobar 1`] = `
 
 exports[`modules/datasource/npm/index should handle no time 1`] = `
 {
+  "isPrivate": true,
   "name": "foobar",
   "registryUrl": "https://registry.npmjs.org",
   "releases": [
@@ -93,6 +97,7 @@ exports[`modules/datasource/npm/index should handle no time 1`] = `
 
 exports[`modules/datasource/npm/index should not send an authorization header if public package 1`] = `
 {
+  "isPrivate": true,
   "name": "foobar",
   "registryUrl": "https://registry.npmjs.org",
   "releases": [
@@ -116,6 +121,7 @@ exports[`modules/datasource/npm/index should not send an authorization header if
 
 exports[`modules/datasource/npm/index should parse repo url (string) 1`] = `
 {
+  "isPrivate": true,
   "name": "foobar",
   "registryUrl": "https://registry.npmjs.org",
   "releases": [
@@ -134,6 +140,7 @@ exports[`modules/datasource/npm/index should parse repo url (string) 1`] = `
 
 exports[`modules/datasource/npm/index should parse repo url 1`] = `
 {
+  "isPrivate": true,
   "name": "foobar",
   "registryUrl": "https://registry.npmjs.org",
   "releases": [
@@ -152,6 +159,7 @@ exports[`modules/datasource/npm/index should parse repo url 1`] = `
 
 exports[`modules/datasource/npm/index should replace any environment variable in npmrc 1`] = `
 {
+  "isPrivate": true,
   "name": "foobar",
   "registryUrl": "https://registry.from-env.com",
   "releases": [
@@ -181,6 +189,7 @@ exports[`modules/datasource/npm/index should return deprecated 1`] = `
 
 Marking the latest version of an npm package as deprecated results in the entire package being considered deprecated, so contact the package author you think this is a mistake.",
   "deprecationSource": "npm",
+  "isPrivate": true,
   "name": "foobar",
   "registryUrl": "https://registry.npmjs.org",
   "releases": [
@@ -212,6 +221,7 @@ Marking the latest version of an npm package as deprecated results in the entire
 
 exports[`modules/datasource/npm/index should send an authorization header if provided 1`] = `
 {
+  "isPrivate": true,
   "name": "@foobar/core",
   "registryUrl": "https://registry.npmjs.org",
   "releases": [
@@ -235,6 +245,7 @@ exports[`modules/datasource/npm/index should send an authorization header if pro
 
 exports[`modules/datasource/npm/index should use default registry if missing from npmrc 1`] = `
 {
+  "isPrivate": true,
   "name": "foobar",
   "registryUrl": "https://registry.npmjs.org",
   "releases": [
@@ -258,6 +269,7 @@ exports[`modules/datasource/npm/index should use default registry if missing fro
 
 exports[`modules/datasource/npm/index should use host rules by baseUrl if provided 1`] = `
 {
+  "isPrivate": true,
   "name": "foobar",
   "registryUrl": "https://npm.mycustomregistry.com/_packaging/mycustomregistry/npm/registry",
   "releases": [
@@ -281,6 +293,7 @@ exports[`modules/datasource/npm/index should use host rules by baseUrl if provid
 
 exports[`modules/datasource/npm/index should use host rules by hostName if provided 1`] = `
 {
+  "isPrivate": true,
   "name": "foobar",
   "registryUrl": "https://npm.mycustomregistry.com",
   "releases": [

--- a/lib/modules/datasource/npm/get.ts
+++ b/lib/modules/datasource/npm/get.ts
@@ -172,7 +172,10 @@ export async function getDependency(
     });
     logger.trace({ dep }, 'dep');
     const cacheControl = raw.headers?.['cache-control'];
-    if (is.nonEmptyString(cacheControl) && regEx(/(^|,)\s*public\s*(,|$)/).test(cacheControl)) {
+    if (
+      is.nonEmptyString(cacheControl) &&
+      regEx(/(^|,)\s*public\s*(,|$)/).test(cacheControl)
+    ) {
       dep.isPrivate = false;
       const cacheData = { softExpireAt, etag };
       await packageCache.set(

--- a/lib/modules/datasource/npm/get.ts
+++ b/lib/modules/datasource/npm/get.ts
@@ -171,7 +171,12 @@ export async function getDependency(
       return release;
     });
     logger.trace({ dep }, 'dep');
-    if (raw.headers?.['cache-control']?.startsWith('public,')) {
+    if (
+      raw.headers?.['cache-control']
+        ?.split(',') // break into elements
+        ?.map((el) => el.trim()) // remove exterior whitespace
+        ?.includes('public') // this is what we care about
+    ) {
       dep.isPrivate = false;
       const cacheData = { softExpireAt, etag };
       await packageCache.set(

--- a/lib/modules/datasource/npm/get.ts
+++ b/lib/modules/datasource/npm/get.ts
@@ -172,10 +172,10 @@ export async function getDependency(
     });
     logger.trace({ dep }, 'dep');
     if (
-      raw.headers?.['cache-control']
-        ?.split(',') // break into elements
-        ?.map((el) => el.trim()) // remove exterior whitespace
-        ?.includes('public') // this is what we care about
+      (raw.headers?.['cache-control'] || '')
+        .split(',') // break into elements
+        .map((el) => el.trim()) // remove exterior whitespace
+        .includes('public') // this is what we care about
     ) {
       dep.isPrivate = false;
       const cacheData = { softExpireAt, etag };

--- a/lib/modules/datasource/npm/get.ts
+++ b/lib/modules/datasource/npm/get.ts
@@ -171,12 +171,7 @@ export async function getDependency(
       return release;
     });
     logger.trace({ dep }, 'dep');
-    if (
-      (raw.headers?.['cache-control'] ?? '')
-        .split(',') // break into elements
-        .map((el) => el.trim()) // remove exterior whitespace
-        .includes('public') // this is what we care about
-    ) {
+    if (/(^|,)\s*public\s*(,|$)/.test(raw.headers?.['cache-control'] ?? '')) {
       dep.isPrivate = false;
       const cacheData = { softExpireAt, etag };
       await packageCache.set(

--- a/lib/modules/datasource/npm/get.ts
+++ b/lib/modules/datasource/npm/get.ts
@@ -171,7 +171,8 @@ export async function getDependency(
       return release;
     });
     logger.trace({ dep }, 'dep');
-    if (/(^|,)\s*public\s*(,|$)/.test(raw.headers?.['cache-control'] ?? '')) {
+    const cacheControl = raw.headers?.['cache-control'];
+    if (is.nonEmptyString(cacheControl) && regEx(/(^|,)\s*public\s*(,|$)/).test(cacheControl)) {
       dep.isPrivate = false;
       const cacheData = { softExpireAt, etag };
       await packageCache.set(

--- a/lib/modules/datasource/npm/get.ts
+++ b/lib/modules/datasource/npm/get.ts
@@ -172,7 +172,7 @@ export async function getDependency(
     });
     logger.trace({ dep }, 'dep');
     if (
-      (raw.headers?.['cache-control'] || '')
+      (raw.headers?.['cache-control'] ?? '')
         .split(',') // break into elements
         .map((el) => el.trim()) // remove exterior whitespace
         .includes('public') // this is what we care about

--- a/lib/modules/datasource/npm/index.spec.ts
+++ b/lib/modules/datasource/npm/index.spec.ts
@@ -64,9 +64,10 @@ describe('modules/datasource/npm/index', () => {
     httpMock
       .scope('https://registry.npmjs.org')
       .get('/foobar')
-      .reply(200, npmResponse);
+      .reply(200, npmResponse, { 'cache-control': 'public, expires=300' });
     const res = await getPkgReleases({ datasource, depName: 'foobar' });
     expect(res).toMatchSnapshot();
+    expect(res?.isPrivate).toBeFalse();
   });
 
   it('should parse repo url', async () => {
@@ -155,6 +156,7 @@ describe('modules/datasource/npm/index', () => {
       .reply(200, npmResponse);
     const res = await getPkgReleases({ datasource, depName: 'foobar' });
     expect(res).toMatchSnapshot();
+    expect(res?.isPrivate).toBeTrue();
   });
 
   it('should handle no time', async () => {
@@ -307,6 +309,7 @@ describe('modules/datasource/npm/index', () => {
     const npmrc = `registry=https://npm.mycustomregistry.com/`;
     const res = await getPkgReleases({ datasource, depName: 'foobar', npmrc });
     expect(res).toMatchSnapshot();
+    expect(res?.isPrivate).toBeTrue();
   });
 
   it('should replace any environment variable in npmrc', async () => {

--- a/lib/modules/datasource/npm/index.spec.ts
+++ b/lib/modules/datasource/npm/index.spec.ts
@@ -64,7 +64,7 @@ describe('modules/datasource/npm/index', () => {
     httpMock
       .scope('https://registry.npmjs.org')
       .get('/foobar')
-      .reply(200, npmResponse, { 'cache-control': 'public, expires=300' });
+      .reply(200, npmResponse, { 'Cache-control': 'public, expires=300' });
     const res = await getPkgReleases({ datasource, depName: 'foobar' });
     expect(res).toMatchSnapshot();
     expect(res?.isPrivate).toBeFalse();


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Uses `cache-control` header to determine whether package is private or public and can be cached.

## Context

Closes #9587

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
