### PR TITLE
chore: extract and lookup duration logging

### DIFF
--- a/lib/util/cache/memory/types.ts
+++ b/lib/util/cache/memory/types.ts
@@ -1,0 +1,4 @@
+export interface LookupStats {
+  datasource: string;
+  duration: number;
+}

--- a/lib/workers/repository/extract/index.ts
+++ b/lib/workers/repository/extract/index.ts
@@ -52,11 +52,19 @@ export async function extractAllDependencies(
     extractResult.extractionFingerprints[manager] = hashMap.get(manager);
   }
 
+  const extractDurations: Record<string, number> = {};
   const extractResults = await Promise.all(
     extractList.map(async (managerConfig) => {
+      const start = Date.now();
       const packageFiles = await getManagerPackageFiles(managerConfig);
+      const durationMs = Math.round(Date.now() - start);
+      extractDurations[managerConfig.manager] = durationMs;
       return { manager: managerConfig.manager, packageFiles };
     })
+  );
+  logger.debug(
+    { managers: extractDurations },
+    'manager extract durations (ms)'
   );
   let fileCount = 0;
   for (const { manager, packageFiles } of extractResults) {

--- a/lib/workers/repository/index.ts
+++ b/lib/workers/repository/index.ts
@@ -24,7 +24,7 @@ import { ensureOnboardingPr } from './onboarding/pr';
 import { extractDependencies, updateRepo } from './process';
 import type { ExtractResult } from './process/extract-update';
 import { ProcessResult, processResult } from './result';
-import { printRequestStats } from './stats';
+import { printLookupStats, printRequestStats } from './stats';
 
 // istanbul ignore next
 export async function renovateRepository(
@@ -109,6 +109,7 @@ export async function renovateRepository(
   const splits = getSplits();
   logger.debug(splits, 'Repository timing splits (milliseconds)');
   printRequestStats();
+  printLookupStats();
   printDnsStats();
   clearDnsCache();
   schemaUtil.reportErrors();

--- a/lib/workers/repository/stats.spec.ts
+++ b/lib/workers/repository/stats.spec.ts
@@ -1,8 +1,9 @@
 import { logger, mocked } from '../../../test/util';
 import type { Logger } from '../../logger/types';
 import * as _memCache from '../../util/cache/memory';
+import type { LookupStats } from '../../util/cache/memory/types';
 import type { RequestStats } from '../../util/http/types';
-import { printRequestStats } from './stats';
+import { printLookupStats, printRequestStats } from './stats';
 
 jest.mock('../../util/cache/memory');
 
@@ -10,6 +11,44 @@ const memCache = mocked(_memCache);
 const log = logger.logger as jest.Mocked<Logger>;
 
 describe('workers/repository/stats', () => {
+  describe('printLookupStats()', () => {
+    it('runs', () => {
+      const stats: LookupStats[] = [
+        {
+          datasource: 'npm',
+          duration: 100,
+        },
+        {
+          datasource: 'npm',
+          duration: 200,
+        },
+        {
+          datasource: 'docker',
+          duration: 1000,
+        },
+      ];
+      memCache.get.mockImplementationOnce(() => stats as any);
+      expect(printLookupStats()).toBeUndefined();
+      expect(log.debug).toHaveBeenCalledTimes(1);
+      expect(log.debug.mock.calls[0][0]).toMatchInlineSnapshot(`
+        {
+          "docker": {
+            "averageMs": 1000,
+            "count": 1,
+            "maximumMs": 1000,
+            "totalMs": 1000,
+          },
+          "npm": {
+            "averageMs": 150,
+            "count": 2,
+            "maximumMs": 200,
+            "totalMs": 300,
+          },
+        }
+      `);
+    });
+  });
+
   describe('printRequestStats()', () => {
     it('runs', () => {
       const getStats: number[] = [30, 100, 10, 20];


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds debug statements for manager extract and datasource lookup times.

## Context

More observability into where the time goes.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
