### PR TITLE
refactor: safely parse `Pipfile.lock`

### DIFF
--- a/lib/modules/manager/pipenv/artifacts.ts
+++ b/lib/modules/manager/pipenv/artifacts.ts
@@ -15,11 +15,12 @@ import type {
   UpdateArtifactsConfig,
   UpdateArtifactsResult,
 } from '../types';
+import { PipfileLockSchema } from './schema';
 
 function getPythonConstraint(
   existingLockFileContent: string,
   config: UpdateArtifactsConfig
-): string | undefined | null {
+): string | undefined {
   const { constraints = {} } = config;
   const { python } = constraints;
 
@@ -28,14 +29,21 @@ function getPythonConstraint(
     return python;
   }
   try {
-    const pipfileLock = JSON.parse(existingLockFileContent);
-    if (pipfileLock?._meta?.requires?.python_version) {
-      const pythonVersion: string = pipfileLock._meta.requires.python_version;
+    const result = PipfileLockSchema.safeParse(
+      JSON.parse(existingLockFileContent)
+    );
+    // istanbul ignore if: not easily testable
+    if (!result.success) {
+      logger.warn({ error: result.error }, 'Invalid Pipfile.lock');
+      return undefined;
+    }
+    if (result.data._meta?.requires?.python_version) {
+      const pythonVersion: string = result.data._meta.requires.python_version;
       return `== ${pythonVersion}.*`;
     }
-    if (pipfileLock?._meta?.requires?.python_full_version) {
+    if (result.data._meta?.requires?.python_full_version) {
       const pythonFullVersion: string =
-        pipfileLock._meta.requires.python_full_version;
+        result.data._meta.requires.python_full_version;
       return `== ${pythonFullVersion}`;
     }
   } catch (err) {
@@ -56,14 +64,19 @@ function getPipenvConstraint(
     return pipenv;
   }
   try {
-    const pipfileLock = JSON.parse(existingLockFileContent);
-    if (pipfileLock?.default?.pipenv?.version) {
-      const pipenvVersion: string = pipfileLock.default.pipenv.version;
-      return pipenvVersion;
+    const result = PipfileLockSchema.safeParse(
+      JSON.parse(existingLockFileContent)
+    );
+    // istanbul ignore if: not easily testable
+    if (!result.success) {
+      logger.warn({ error: result.error }, 'Invalid Pipfile.lock');
+      return '';
     }
-    if (pipfileLock?.develop?.pipenv?.version) {
-      const pipenvVersion: string = pipfileLock.develop.pipenv.version;
-      return pipenvVersion;
+    if (result.data.default?.pipenv?.version) {
+      return result.data.default.pipenv.version;
+    }
+    if (result.data.develop?.pipenv?.version) {
+      return result.data.develop.pipenv.version;
     }
   } catch (err) {
     // Do nothing

--- a/lib/modules/manager/pipenv/artifacts.ts
+++ b/lib/modules/manager/pipenv/artifacts.ts
@@ -38,12 +38,11 @@ function getPythonConstraint(
       return undefined;
     }
     if (result.data._meta?.requires?.python_version) {
-      const pythonVersion: string = result.data._meta.requires.python_version;
+      const pythonVersion = result.data._meta.requires.python_version;
       return `== ${pythonVersion}.*`;
     }
     if (result.data._meta?.requires?.python_full_version) {
-      const pythonFullVersion: string =
-        result.data._meta.requires.python_full_version;
+      const pythonFullVersion = result.data._meta.requires.python_full_version;
       return `== ${pythonFullVersion}`;
     }
   } catch (err) {

--- a/lib/modules/manager/pipenv/schema.ts
+++ b/lib/modules/manager/pipenv/schema.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+// TODO Full schema
+const PipfileLockEntrySchema = z
+  .record(
+    z.string(),
+    z.object({
+      version: z.string().optional(),
+    })
+  )
+  .optional();
+export const PipfileLockSchema = z.object({
+  _meta: z
+    .object({
+      requires: z
+        .object({
+          python_version: z.string().optional(),
+          python_full_version: z.string().optional(),
+        })
+        .optional(),
+    })
+    .optional(),
+  default: PipfileLockEntrySchema,
+  develop: PipfileLockEntrySchema,
+});

--- a/lib/modules/manager/pipenv/schema.ts
+++ b/lib/modules/manager/pipenv/schema.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod';
 
-// TODO Full schema
 const PipfileLockEntrySchema = z
   .record(
     z.string(),


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Define and use a minimal schema for type checking `Pipfile.lock`

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->
This is required for #20553.

One of the rules of `@total-typescript/ts-reset` changes the return type of `JSON.parse` from `any` to `unknown`[^1]. This means that we need to do runtime type checking to verify the data that we are parsing.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
[^1]: https://github.com/total-typescript/ts-reset#make-jsonparse-return-unknown