### PR TITLE
docs: link to all supported managers

### DIFF
--- a/docs/usage/python.md
+++ b/docs/usage/python.md
@@ -5,13 +5,7 @@ description: Python/pip dependencies support in Renovate
 
 # Python package manager support
 
-Renovate supports the following Python package managers:
-
-- `pip` (e.g. `requirements.txt`, `requirements.pip`) files
-- `pipenv` (e.g. `Pipfile`)
-- `poetry` (e.g. `pyproject.toml`)
-- `setup.py` file
-- `setup.cfg` file
+Renovate supports several Python package managers, including `pip`, `pipenv`, `poetry`, etc. See [all supported Managers](https://docs.renovatebot.com/modules/manager/).
 
 ## Versioning support
 

--- a/docs/usage/python.md
+++ b/docs/usage/python.md
@@ -5,7 +5,8 @@ description: Python/pip dependencies support in Renovate
 
 # Python package manager support
 
-Renovate supports several Python package managers, including `pip`, `pipenv`, `poetry`, etc. See [all supported Managers](https://docs.renovatebot.com/modules/manager/).
+Renovate supports several Python package managers, including `pip`, `pipenv`, `poetry`, etc.
+See [all supported managers](https://docs.renovatebot.com/modules/manager/).
 
 ## Versioning support
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Making it clear that the Python page is only references _some_ of the managers, and linking to full list.

## Context

We were under the impression `pip-compile` wasn't supported, as it's not on the list of supported managers on the Python page.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
