### PR TITLE
feat(platform/bitbucket): add support for Bitbucket development branching model

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -145,7 +145,7 @@ By default, Renovate will use a repository's "main branch" (typically called `ma
 
 Configuring this to `true` means that Renovate will detect and use the Bitbucket [development branch](https://support.atlassian.com/bitbucket-cloud/docs/branch-a-repository/#The-branching-model) as defined by the repository's branching model.
 
-If the "development branch" is configured but the branch itself does not exist (e.g. it was deleted), Renovate will fall back to using the repository's "main branch".
+If the "development branch" is configured but the branch itself does not exist (e.g. it was deleted), Renovate will fall back to using the repository's "main branch". This fall back behavior matches that of the Bitbucket Cloud web interface.
 
 ## binarySource
 

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -139,6 +139,14 @@ For example:
 }
 ```
 
+## bbUseDevelopmentBranch
+
+By default, Renovate will use a repository's "main branch" (typically called `main` or `master`) as the "default branch".
+
+Configuring this to `true` means that Renovate will detect and use the Bitbucket [development branch](https://support.atlassian.com/bitbucket-cloud/docs/branch-a-repository/#The-branching-model) as defined by the repository's branching model.
+
+If the "development branch" is configured but the branch itself does not exist (e.g. it was deleted), Renovate will fall back to using the repository's "main branch".
+
 ## binarySource
 
 Renovate often needs to use third-party binaries in its PRs, like `npm` to update `package-lock.json` or `go` to update `go.sum`.
@@ -708,10 +716,6 @@ Set this to an S3 URI to enable S3 backed repository cache.
 !!! tip
     If you're storing the repository cache on Amazon S3 then you may set a folder hierarchy as part of `repositoryCacheType`.
     For example, `repositoryCacheType: 's3://bucket-name/dir1/.../dirN/'`.
-
-<!-- prettier-ignore -->
-!!! note
-    S3 repository is used as a repository cache (e.g. extracted dependencies) and not a lookup cache (e.g. available versions of dependencies). To keep the later remotely, define [Redis URL](#redisurl).
 
 ## requireConfig
 

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -717,6 +717,10 @@ Set this to an S3 URI to enable S3 backed repository cache.
     If you're storing the repository cache on Amazon S3 then you may set a folder hierarchy as part of `repositoryCacheType`.
     For example, `repositoryCacheType: 's3://bucket-name/dir1/.../dirN/'`.
 
+<!-- prettier-ignore -->
+!!! note
+    S3 repository is used as a repository cache (e.g. extracted dependencies) and not a lookup cache (e.g. available versions of dependencies). To keep the later remotely, define [Redis URL](#redisurl).
+
 ## requireConfig
 
 By default, Renovate needs a Renovate config file in each repository where it runs before it will propose any dependency updates.

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -1623,6 +1623,14 @@ const options: RenovateOptions[] = [
     default: true,
     supportedPlatforms: ['bitbucket', 'bitbucket-server'],
   },
+  {
+    name: 'bbUseDevelopmentBranch',
+    description: `Use the repository's [development branch](https://support.atlassian.com/bitbucket-cloud/docs/branch-a-repository/#The-branching-model) as the repository's default branch.`,
+    type: 'boolean',
+    default: false,
+    supportedPlatforms: ['bitbucket'],
+    globalOnly: true,
+  },
   // Automatic merging
   {
     name: 'automerge',

--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -173,7 +173,6 @@ export async function initRepo({
     ignorePrAuthor,
   } as Config;
   let info: RepoInfo;
-  let developmentBranch: string | undefined;
   let mainBranch: string;
   try {
     info = utils.repoInfoTransformer(

--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -188,7 +188,7 @@ export async function initRepo({
 
     if (bbUseDevelopmentBranch) {
       // Fetch Bitbucket development branch
-      developmentBranch = (
+      const developmentBranch = (
         await bitbucketHttp.getJson<RepoBranchingModel>(
           `/2.0/repositories/${repository}/branching-model`
         )

--- a/lib/modules/platform/bitbucket/types.ts
+++ b/lib/modules/platform/bitbucket/types.ts
@@ -36,6 +36,15 @@ export interface RepoInfo {
   uuid: string;
 }
 
+export interface RepoBranchingModel {
+  development: {
+    name: string;
+    branch?: {
+      name: string;
+    };
+  };
+}
+
 export interface BranchResponse {
   target: {
     hash: string;

--- a/lib/modules/platform/types.ts
+++ b/lib/modules/platform/types.ts
@@ -42,6 +42,7 @@ export interface RepoParams {
   renovateUsername?: string;
   cloneSubmodules?: boolean;
   ignorePrAuthor?: boolean;
+  bbUseDevelopmentBranch?: boolean;
 }
 
 export interface PrDebugData {


### PR DESCRIPTION
## Changes

Continuation of #20803

Updates the Bitbucket Cloud repository initialization logic to fetch and set the development branch name instead of relying only on the main branch name.

## Context

Closes https://github.com/renovatebot/renovate/issues/20802

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository