### PR TITLE
docs: generate platform and datasources open features and bugs markdown

### DIFF
--- a/tools/docs/datasources.ts
+++ b/tools/docs/datasources.ts
@@ -60,8 +60,7 @@ export async function generateDatasources(
         '\n```\n';
     }
 
-    md +=
-      '\n\n' + generateFeatureAndBugMarkdown(datasourceIssuesMap, datasource);
+    md += generateFeatureAndBugMarkdown(datasourceIssuesMap, datasource);
 
     await updateFile(`${dist}/modules/datasource/${datasource}/index.md`, md);
   }

--- a/tools/docs/datasources.ts
+++ b/tools/docs/datasources.ts
@@ -1,6 +1,7 @@
 import { codeBlock } from 'common-tags';
 import { getDatasources } from '../../lib/modules/datasource';
 import { readFile, updateFile } from '../utils';
+import { OpenItems, generateFeatureAndBugMarkdown } from './github-query-items';
 import {
   formatDescription,
   formatUrls,
@@ -9,7 +10,10 @@ import {
   replaceContent,
 } from './utils';
 
-export async function generateDatasources(dist: string): Promise<void> {
+export async function generateDatasources(
+  dist: string,
+  datasourceIssuesMap: Record<string, OpenItems>
+): Promise<void> {
   const dsList = getDatasources();
   let datasourceContent = '\nSupported values for `datasource` are:\n\n';
 
@@ -55,6 +59,9 @@ export async function generateDatasources(dist: string): Promise<void> {
         JSON.stringify(defaultConfig, undefined, 2) +
         '\n```\n';
     }
+
+    md +=
+      '\n\n' + generateFeatureAndBugMarkdown(datasourceIssuesMap, datasource);
 
     await updateFile(`${dist}/modules/datasource/${datasource}/index.md`, md);
   }

--- a/tools/docs/datasources.ts
+++ b/tools/docs/datasources.ts
@@ -12,7 +12,7 @@ import {
 
 export async function generateDatasources(
   dist: string,
-  datasourceIssuesMap: Record<string, OpenItems>
+  datasourceIssuesMap: OpenItems
 ): Promise<void> {
   const dsList = getDatasources();
   let datasourceContent = '\nSupported values for `datasource` are:\n\n';

--- a/tools/docs/github-query-items.ts
+++ b/tools/docs/github-query-items.ts
@@ -38,7 +38,7 @@ export interface RenovateOpenItems {
   datasources: OpenItems;
 }
 
-export type OpenItems = Record<string, Items> | undefined;
+export type OpenItems = Record<string, Items | undefined>;
 
 export interface Items {
   bugs: ItemsEntity[];

--- a/tools/docs/github-query-items.ts
+++ b/tools/docs/github-query-items.ts
@@ -113,7 +113,7 @@ export function generateFeatureAndBugMarkdown(
   issuesMap: Record<string, OpenItems>,
   key: string
 ): string {
-  let md = '';
+  let md = '\n\n';
   const [featureList] = stringifyIssues(issuesMap[key]?.features);
   const [bugList] = stringifyIssues(issuesMap[key]?.bugs);
 

--- a/tools/docs/github-query-items.ts
+++ b/tools/docs/github-query-items.ts
@@ -61,7 +61,7 @@ export async function getOpenGitHubItems(): Promise<RenovateOpenItems> {
   }
 }
 
-export function extractIssues(
+function extractIssues(
   items: ItemsEntity[],
   labelPrefix: string
 ): Record<string, OpenItems> {

--- a/tools/docs/github-query-items.ts
+++ b/tools/docs/github-query-items.ts
@@ -1,9 +1,18 @@
 import { DateTime } from 'luxon';
 import { logger } from '../../lib/logger';
+import * as hostRules from '../../lib/util/host-rules';
 import { GithubHttp } from '../../lib/util/http/github';
 import { getQueryString } from '../../lib/util/url';
 
 const gitHubApiUrl = 'https://api.github.com/search/issues?';
+
+if (process.env.GITHUB_TOKEN) {
+  logger.debug('Using GITHUB_TOKEN from env');
+  hostRules.add({
+    matchHost: 'api.github.com',
+    token: process.env.GITHUB_TOKEN,
+  });
+}
 
 type GithubApiQueryResponse = {
   total_count: number;
@@ -11,7 +20,7 @@ type GithubApiQueryResponse = {
   items: ItemsEntity[];
 };
 
-export type ItemsEntity = {
+type ItemsEntity = {
   html_url: string;
   number: number;
   title: string;

--- a/tools/docs/github-query-items.ts
+++ b/tools/docs/github-query-items.ts
@@ -61,8 +61,6 @@ export async function getOpenGitHubItems(): Promise<RenovateOpenItems> {
   }
 }
 
-// TODO - make this parse group by the prefix automatically and save passing around ItemsEntity[]
-// platform, manager, datasource
 export function extractIssues(
   items: ItemsEntity[],
   labelPrefix: string

--- a/tools/docs/github-query-items.ts
+++ b/tools/docs/github-query-items.ts
@@ -21,7 +21,7 @@ type GithubApiQueryResponse = {
   items: ItemsEntity[];
 };
 
-type ItemsEntity = {
+export type ItemsEntity = {
   html_url: string;
   number: number;
   title: string;

--- a/tools/docs/github-query-items.ts
+++ b/tools/docs/github-query-items.ts
@@ -121,9 +121,6 @@ export function generateFeatureAndBugMarkdown(
   issuesMap: OpenItems,
   key: string
 ): string {
-  if (!issuesMap) {
-    return '';
-  }
   let md = '\n\n';
 
   const featureList = stringifyIssues(issuesMap[key]?.features);

--- a/tools/docs/github-query-items.ts
+++ b/tools/docs/github-query-items.ts
@@ -106,15 +106,15 @@ function extractIssues(items: ItemsEntity[], labelPrefix: string): OpenItems {
   return issuesMap;
 }
 
-function stringifyIssues(items: ItemsEntity[] | undefined): [string, number] {
+function stringifyIssues(items: ItemsEntity[] | undefined): string {
   if (!items) {
-    return ['', 0];
+    return '';
   }
   let list = '';
   for (const item of items) {
     list += ` - ${item.title} [#${item.number}](${item.html_url})\n`;
   }
-  return [list, items.length];
+  return list;
 }
 
 export function generateFeatureAndBugMarkdown(
@@ -125,8 +125,8 @@ export function generateFeatureAndBugMarkdown(
     return '';
   }
   let md = '\n\n';
-  const [featureList] = stringifyIssues(issuesMap[key]?.features);
-  const [bugList] = stringifyIssues(issuesMap[key]?.bugs);
+  const featureList = stringifyIssues(issuesMap[key]?.features);
+  const bugList = stringifyIssues(issuesMap[key]?.bugs);
 
   if (featureList || bugList) {
     md += '## Open items\n\n';

--- a/tools/docs/github-query-items.ts
+++ b/tools/docs/github-query-items.ts
@@ -93,10 +93,10 @@ function extractIssues(items: ItemsEntity[], labelPrefix: string): OpenItems {
     }
     switch (type) {
       case 'bug':
-        issuesMap[label].bugs.push(item);
+        issuesMap[label]?.bugs.push(item);
         break;
       case 'feature':
-        issuesMap[label].features.push(item);
+        issuesMap[label]?.features.push(item);
         break;
       default:
         break;

--- a/tools/docs/github-query-items.ts
+++ b/tools/docs/github-query-items.ts
@@ -125,6 +125,7 @@ export function generateFeatureAndBugMarkdown(
     return '';
   }
   let md = '\n\n';
+
   const featureList = stringifyIssues(issuesMap[key]?.features);
   const bugList = stringifyIssues(issuesMap[key]?.bugs);
 

--- a/tools/docs/github-query-items.ts
+++ b/tools/docs/github-query-items.ts
@@ -28,7 +28,7 @@ type ItemsEntity = {
   labels: LabelsEntity[];
 };
 
-type LabelsEntity = {
+export type LabelsEntity = {
   name: string;
 };
 

--- a/tools/docs/github-query-items.ts
+++ b/tools/docs/github-query-items.ts
@@ -107,7 +107,7 @@ function extractIssues(
   return issuesMap;
 }
 
-function stringifyIssues(items: ItemsEntity[]): [string, number] {
+function stringifyIssues(items: ItemsEntity[]| undefined): [string, number] {
   if (!items) {
     return ['', 0];
   }

--- a/tools/docs/github-query-items.ts
+++ b/tools/docs/github-query-items.ts
@@ -1,3 +1,10 @@
+import { DateTime } from 'luxon';
+import { logger } from '../../lib/logger';
+import { GithubHttp } from '../../lib/util/http/github';
+import { getQueryString } from '../../lib/util/url';
+
+const gitHubApiUrl = 'https://api.github.com/search/issues?';
+
 export type GithubApiQueryResponse = {
   total_count: number;
   incomplete_results: boolean;
@@ -14,3 +21,112 @@ export type ItemsEntity = {
 export type LabelsEntity = {
   name: string;
 };
+
+export interface GitHubIssues {
+  bugs: ItemsEntity[];
+  features: ItemsEntity[];
+}
+
+export async function getOpenGitHubItems(): Promise<ItemsEntity[]> {
+  const q = `repo:renovatebot/renovate type:issue is:open -label:priority-5-triage`;
+  const per_page = 100;
+  const githubApi = new GithubHttp();
+  try {
+    const query = getQueryString({ q, per_page });
+    const res = await githubApi.getJson<GithubApiQueryResponse>(
+      gitHubApiUrl + query,
+      {
+        paginationField: 'items',
+        paginate: true,
+      }
+    );
+    return res.body?.items ?? [];
+  } catch (err) {
+    logger.error({ err }, 'Error getting query results');
+    throw err;
+  }
+  return [];
+}
+
+export function extractIssues(
+  issuesMap: Record<string, GitHubIssues>,
+  items: ItemsEntity[],
+  labelPrefix: string
+): void {
+  if (!items || !issuesMap) {
+    return;
+  }
+  for (const item of items) {
+    const type = item.labels
+      .find((l) => l.name.startsWith('type:'))
+      ?.name.split(':')[1];
+    if (!type) {
+      continue;
+    }
+    const label = item.labels
+      .find((l) => l.name.startsWith(labelPrefix))
+      ?.name.split(':')[1];
+    if (!label) {
+      continue;
+    }
+    if (!issuesMap[label]) {
+      issuesMap[label] = { bugs: [], features: [] };
+    }
+    switch (type) {
+      case 'bug':
+        issuesMap[label].bugs.push(item);
+        break;
+      case 'feature':
+        issuesMap[label].features.push(item);
+        break;
+      default:
+        break;
+    }
+  }
+}
+
+export function stringifyIssues(items: ItemsEntity[]): [string, number] {
+  if (!items) {
+    return ['', 0];
+  }
+  let list = '';
+  for (const item of items) {
+    list += ` - ${item.title} [#${item.number}](${item.html_url})\n`;
+  }
+  return [list, items.length];
+}
+
+export function generateFeatureAndBugMarkdown(
+  issuesMap: Record<string, GitHubIssues>,
+  key: string
+): string {
+  let md = '';
+  const [featureList] = stringifyIssues(issuesMap[key]?.features);
+  const [bugList] = stringifyIssues(issuesMap[key]?.bugs);
+
+  if (featureList || bugList) {
+    md += '## Open items\n\n';
+  }
+
+  if (featureList || bugList) {
+    const now = DateTime.utc().toFormat('MMMM dd, yyyy');
+    const lists = `list of ${featureList ? 'features' : ''}${
+      featureList && bugList ? ' and ' : ''
+    }${bugList ? 'bugs' : ''}`;
+    md += `The below ${lists} were current when this page was generated on ${now}.\n\n`;
+  }
+
+  if (featureList) {
+    md += '### Feature requests\n\n';
+    md += featureList;
+    md += '\n';
+  }
+
+  if (bugList) {
+    md += '### Bug reports\n\n';
+    md += bugList;
+    md += '\n';
+  }
+
+  return md;
+}

--- a/tools/docs/manager.ts
+++ b/tools/docs/manager.ts
@@ -17,7 +17,7 @@ function getManagerLink(manager: string): string {
 
 export async function generateManagers(
   dist: string,
-  managerIssuesMap: Record<string, OpenItems>
+  managerIssuesMap: OpenItems
 ): Promise<void> {
   const managers = getManagers();
 

--- a/tools/docs/manager.ts
+++ b/tools/docs/manager.ts
@@ -3,12 +3,7 @@ import { logger } from '../../lib/logger';
 import { getManagers } from '../../lib/modules/manager';
 import * as hostRules from '../../lib/util/host-rules';
 import { readFile, updateFile } from '../utils';
-import {
-  GitHubIssues,
-  ItemsEntity,
-  extractIssues,
-  generateFeatureAndBugMarkdown,
-} from './github-query-items';
+import { OpenItems, generateFeatureAndBugMarkdown } from './github-query-items';
 import { getDisplayName, getNameWithUrl, replaceContent } from './utils';
 
 if (process.env.GITHUB_TOKEN) {
@@ -30,20 +25,11 @@ function getManagerLink(manager: string): string {
   return `[\`${manager}\`](${manager}/)`;
 }
 
-export function getManagersGitHubIssues(
-  openGithubItems: ItemsEntity[]
-): Record<string, GitHubIssues> {
-  const managerIssuesMap: Record<string, GitHubIssues> = {};
-  extractIssues(managerIssuesMap, openGithubItems, 'manager:');
-  return managerIssuesMap;
-}
-
 export async function generateManagers(
   dist: string,
-  openGithubItems: ItemsEntity[]
+  managerIssuesMap: Record<string, OpenItems>
 ): Promise<void> {
   const managers = getManagers();
-  const managerIssuesMap = getManagersGitHubIssues(openGithubItems);
 
   const allLanguages: Record<string, string[]> = {};
   for (const [manager, definition] of managers) {

--- a/tools/docs/manager.ts
+++ b/tools/docs/manager.ts
@@ -1,18 +1,8 @@
 import type { RenovateConfig } from '../../lib/config/types';
-import { logger } from '../../lib/logger';
 import { getManagers } from '../../lib/modules/manager';
-import * as hostRules from '../../lib/util/host-rules';
 import { readFile, updateFile } from '../utils';
 import { OpenItems, generateFeatureAndBugMarkdown } from './github-query-items';
 import { getDisplayName, getNameWithUrl, replaceContent } from './utils';
-
-if (process.env.GITHUB_TOKEN) {
-  logger.debug('Using GITHUB_TOKEN from env');
-  hostRules.add({
-    matchHost: 'api.github.com',
-    token: process.env.GITHUB_TOKEN,
-  });
-}
 
 function getTitle(manager: string, displayName: string): string {
   if (manager === 'regex') {

--- a/tools/docs/manager.ts
+++ b/tools/docs/manager.ts
@@ -91,7 +91,7 @@ sidebar_label: ${displayName}
     if (manager !== 'regex') {
       md += '\n## Additional Information\n\n';
     }
-    md += managerReadmeContent + '\n\n';
+    md += managerReadmeContent;
 
     md += generateFeatureAndBugMarkdown(managerIssuesMap, manager);
 

--- a/tools/docs/manager.ts
+++ b/tools/docs/manager.ts
@@ -1,15 +1,15 @@
-import { DateTime } from 'luxon';
 import type { RenovateConfig } from '../../lib/config/types';
 import { logger } from '../../lib/logger';
 import { getManagers } from '../../lib/modules/manager';
 import * as hostRules from '../../lib/util/host-rules';
-import { GithubHttp } from '../../lib/util/http/github';
-import { getQueryString } from '../../lib/util/url';
 import { readFile, updateFile } from '../utils';
-import type { GithubApiQueryResponse, ItemsEntity } from './github-query-items';
+import {
+  GitHubIssues,
+  ItemsEntity,
+  extractIssues,
+  generateFeatureAndBugMarkdown,
+} from './github-query-items';
 import { getDisplayName, getNameWithUrl, replaceContent } from './utils';
-
-const gitHubApiUrl = 'https://api.github.com/search/issues?';
 
 if (process.env.GITHUB_TOKEN) {
   logger.debug('Using GITHUB_TOKEN from env');
@@ -17,11 +17,6 @@ if (process.env.GITHUB_TOKEN) {
     matchHost: 'api.github.com',
     token: process.env.GITHUB_TOKEN,
   });
-}
-
-interface ManagerIssues {
-  bugs: ItemsEntity[];
-  features: ItemsEntity[];
 }
 
 function getTitle(manager: string, displayName: string): string {
@@ -35,84 +30,21 @@ function getManagerLink(manager: string): string {
   return `[\`${manager}\`](${manager}/)`;
 }
 
-function stringifyIssues(items: ItemsEntity[]): [string, number] {
-  if (!items) {
-    return ['', 0];
-  }
-  let list = '';
-  for (const item of items) {
-    list += ` - ${item.title} [#${item.number}](${item.html_url})\n`;
-  }
-  return [list, items.length];
-}
-
-function extractIssues(
-  managerIssuesMap: Record<string, ManagerIssues>,
-  items: ItemsEntity[]
-): void {
-  if (!items || !managerIssuesMap) {
-    return;
-  }
-  for (const item of items) {
-    const type = item.labels
-      .find((l) => l.name.startsWith('type:'))
-      ?.name.split(':')[1];
-    if (!type) {
-      continue;
-    }
-    const manager = item.labels
-      .find((l) => l.name.startsWith('manager:'))
-      ?.name.split(':')[1];
-    if (!manager) {
-      continue;
-    }
-    if (!managerIssuesMap[manager]) {
-      managerIssuesMap[manager] = { bugs: [], features: [] };
-    }
-    switch (type) {
-      case 'bug':
-        managerIssuesMap[manager].bugs.push(item);
-        break;
-      case 'feature':
-        managerIssuesMap[manager].features.push(item);
-        break;
-      default:
-        break;
-    }
-  }
-}
-
-export async function getManagersGitHubIssues(): Promise<
-  Record<string, ManagerIssues>
-> {
-  const q = `repo:renovatebot/renovate type:issue is:open -label:priority-5-triage`;
-  const per_page = 100;
-  const managerIssuesMap: Record<string, ManagerIssues> = {};
-  const githubApi = new GithubHttp('manager-issues');
-  try {
-    const query = getQueryString({ q, per_page });
-    const res = await githubApi.getJson<GithubApiQueryResponse>(
-      gitHubApiUrl + query,
-      {
-        paginationField: 'items',
-        paginate: true,
-      }
-    );
-    const items = res.body?.items ?? [];
-    extractIssues(
-      managerIssuesMap,
-      items.sort((a, b) => a.number - b.number)
-    );
-  } catch (err) {
-    logger.error({ err }, 'Error getting query results');
-    throw err;
-  }
+export function getManagersGitHubIssues(
+  openGithubItems: ItemsEntity[]
+): Record<string, GitHubIssues> {
+  const managerIssuesMap: Record<string, GitHubIssues> = {};
+  extractIssues(managerIssuesMap, openGithubItems, 'manager:');
   return managerIssuesMap;
 }
 
-export async function generateManagers(dist: string): Promise<void> {
+export async function generateManagers(
+  dist: string,
+  openGithubItems: ItemsEntity[]
+): Promise<void> {
   const managers = getManagers();
-  const managerIssuesMap = await getManagersGitHubIssues();
+  const managerIssuesMap = getManagersGitHubIssues(openGithubItems);
+
   const allLanguages: Record<string, string[]> = {};
   for (const [manager, definition] of managers) {
     const language = definition.language ?? 'other';
@@ -175,28 +107,7 @@ sidebar_label: ${displayName}
     }
     md += managerReadmeContent + '\n\n';
 
-    const [featureList] = stringifyIssues(managerIssuesMap[manager]?.features);
-    if (featureList) {
-      md += '## Open feature requests\n\n';
-      md += featureList;
-      md += '\n';
-    }
-
-    const [bugList] = stringifyIssues(managerIssuesMap[manager]?.bugs);
-    if (bugList) {
-      md += '## Open bug reports\n\n';
-      md += bugList;
-      md += '\n';
-    }
-
-    if (featureList || bugList) {
-      const now = DateTime.utc().toFormat('MMMM dd, yyyy');
-      const lists = `list of ${featureList ? 'features' : ''}${
-        featureList && bugList ? ' and ' : ''
-      }${bugList ? 'bugs' : ''}`;
-      md += '\n\n';
-      md += `The above ${lists} were current when this page was generated on ${now}.\n`;
-    }
+    md += generateFeatureAndBugMarkdown(managerIssuesMap, manager);
 
     await updateFile(`${dist}/modules/manager/${manager}/index.md`, md);
   }

--- a/tools/docs/platforms.ts
+++ b/tools/docs/platforms.ts
@@ -5,7 +5,7 @@ import { getModuleLink, replaceContent } from './utils';
 
 export async function generatePlatforms(
   dist: string,
-  platformIssuesMap: Record<string, OpenItems>
+  platformIssuesMap: OpenItems
 ): Promise<void> {
   let platformContent = 'Supported values for `platform` are: ';
   const platforms = getPlatformList();

--- a/tools/docs/platforms.ts
+++ b/tools/docs/platforms.ts
@@ -1,14 +1,14 @@
-import { DateTime } from 'luxon';
 import { logger } from '../../lib/logger';
 import { getPlatformList, getPlatforms } from '../../lib/modules/platform';
 import * as hostRules from '../../lib/util/host-rules';
-import { GithubHttp } from '../../lib/util/http/github';
-import { getQueryString } from '../../lib/util/url';
 import { readFile, updateFile } from '../utils';
-import type { GithubApiQueryResponse, ItemsEntity } from './github-query-items';
+import {
+  GitHubIssues,
+  ItemsEntity,
+  extractIssues,
+  generateFeatureAndBugMarkdown,
+} from './github-query-items';
 import { getModuleLink, replaceContent } from './utils';
-
-const gitHubApiUrl = 'https://api.github.com/search/issues?';
 
 if (process.env.GITHUB_TOKEN) {
   logger.debug('Using GITHUB_TOKEN from env');
@@ -18,87 +18,10 @@ if (process.env.GITHUB_TOKEN) {
   });
 }
 
-interface PlatformIssues {
-  bugs: ItemsEntity[];
-  features: ItemsEntity[];
-}
-
-function stringifyIssues(items: ItemsEntity[]): [string, number] {
-  if (!items) {
-    return ['', 0];
-  }
-  let list = '';
-  for (const item of items) {
-    list += ` - ${item.title} [#${item.number}](${item.html_url})\n`;
-  }
-  return [list, items.length];
-}
-
-function extractIssues(
-  platformIssuesMap: Record<string, PlatformIssues>,
-  items: ItemsEntity[]
-): void {
-  if (!items || !platformIssuesMap) {
-    return;
-  }
-  for (const item of items) {
-    const type = item.labels
-      .find((l) => l.name.startsWith('type:'))
-      ?.name.split(':')[1];
-    if (!type) {
-      continue;
-    }
-    const platform = item.labels
-      .find((l) => l.name.startsWith('platform:'))
-      ?.name.split(':')[1];
-    if (!platform) {
-      continue;
-    }
-    if (!platformIssuesMap[platform]) {
-      platformIssuesMap[platform] = { bugs: [], features: [] };
-    }
-    switch (type) {
-      case 'bug':
-        platformIssuesMap[platform].bugs.push(item);
-        break;
-      case 'feature':
-        platformIssuesMap[platform].features.push(item);
-        break;
-      default:
-        break;
-    }
-  }
-}
-
-export async function getPlatformGitHubIssues(): Promise<
-  Record<string, PlatformIssues>
-> {
-  const q = `repo:renovatebot/renovate type:issue is:open -label:priority-5-triage`;
-  const per_page = 100;
-  const platformIssuesMap: Record<string, PlatformIssues> = {};
-  const githubApi = new GithubHttp();
-  try {
-    const query = getQueryString({ q, per_page });
-    const res = await githubApi.getJson<GithubApiQueryResponse>(
-      gitHubApiUrl + query,
-      {
-        paginationField: 'items',
-        paginate: true,
-      }
-    );
-    const items = res.body?.items ?? [];
-    extractIssues(
-      platformIssuesMap,
-      items.sort((a, b) => a.number - b.number)
-    );
-  } catch (err) {
-    logger.error({ err }, 'Error getting query results');
-    throw err;
-  }
-  return platformIssuesMap;
-}
-
-export async function generatePlatforms(dist: string): Promise<void> {
+export async function generatePlatforms(
+  dist: string,
+  openGithubItems: ItemsEntity[]
+): Promise<void> {
   let platformContent = 'Supported values for `platform` are: ';
   const platforms = getPlatformList();
   for (const platform of platforms) {
@@ -117,14 +40,23 @@ export async function generatePlatforms(dist: string): Promise<void> {
   indexContent = replaceContent(indexContent, platformContent);
   await updateFile(`${dist}/modules/platform/index.md`, indexContent);
 
-  await generatePlatformOpenFeaturesAndBugs(dist);
+  const platformIssuesMap = getPlatformGitHubIssues(openGithubItems);
+  await generatePlatformOpenFeaturesAndBugs(dist, platformIssuesMap);
+}
+
+function getPlatformGitHubIssues(
+  openGithubItems: ItemsEntity[]
+): Record<string, GitHubIssues> {
+  const platformIssuesMap: Record<string, GitHubIssues> = {};
+  extractIssues(platformIssuesMap, openGithubItems, 'platform:');
+  return platformIssuesMap;
 }
 
 export async function generatePlatformOpenFeaturesAndBugs(
-  dist: string
+  dist: string,
+  platformIssuesMap: Record<string, GitHubIssues>
 ): Promise<void> {
   const platforms = getPlatforms();
-  const platformIssuesMap = await getPlatformGitHubIssues();
 
   for (const [platform] of platforms) {
     const platformReadmeContent = await readFile(
@@ -133,35 +65,7 @@ export async function generatePlatformOpenFeaturesAndBugs(
 
     let md = platformReadmeContent + '\n\n';
 
-    const [featureList] = stringifyIssues(
-      platformIssuesMap[platform]?.features
-    );
-    const [bugList] = stringifyIssues(platformIssuesMap[platform]?.bugs);
-
-    if (featureList || bugList) {
-      md += '## Open issues\n\n';
-    }
-
-    if (featureList) {
-      md += '### Feature requests\n\n';
-      md += featureList;
-      md += '\n';
-    }
-
-    if (bugList) {
-      md += '### Bug reports\n\n';
-      md += bugList;
-      md += '\n';
-    }
-
-    if (featureList || bugList) {
-      const now = DateTime.utc().toFormat('MMMM dd, yyyy');
-      const lists = `list of ${featureList ? 'features' : ''}${
-        featureList && bugList ? ' and ' : ''
-      }${bugList ? 'bugs' : ''}`;
-      md += '\n';
-      md += `The above ${lists} were current when this page was generated on ${now}.\n`;
-    }
+    md += generateFeatureAndBugMarkdown(platformIssuesMap, platform);
 
     await updateFile(`${dist}/modules/platform/${platform}/index.md`, md);
   }

--- a/tools/docs/platforms.ts
+++ b/tools/docs/platforms.ts
@@ -1,17 +1,7 @@
-import { logger } from '../../lib/logger';
 import { getPlatformList } from '../../lib/modules/platform';
-import * as hostRules from '../../lib/util/host-rules';
 import { readFile, updateFile } from '../utils';
 import { OpenItems, generateFeatureAndBugMarkdown } from './github-query-items';
 import { getModuleLink, replaceContent } from './utils';
-
-if (process.env.GITHUB_TOKEN) {
-  logger.debug('Using GITHUB_TOKEN from env');
-  hostRules.add({
-    matchHost: 'api.github.com',
-    token: process.env.GITHUB_TOKEN,
-  });
-}
 
 export async function generatePlatforms(
   dist: string,

--- a/tools/docs/platforms.ts
+++ b/tools/docs/platforms.ts
@@ -1,5 +1,5 @@
 import { logger } from '../../lib/logger';
-import { getPlatformList, getPlatforms } from '../../lib/modules/platform';
+import { getPlatformList } from '../../lib/modules/platform';
 import * as hostRules from '../../lib/util/host-rules';
 import { readFile, updateFile } from '../utils';
 import { OpenItems, generateFeatureAndBugMarkdown } from './github-query-items';
@@ -20,8 +20,11 @@ export async function generatePlatforms(
   let platformContent = 'Supported values for `platform` are: ';
   const platforms = getPlatformList();
   for (const platform of platforms) {
-    const readme = await readFile(`lib/modules/platform/${platform}/index.md`);
-    await updateFile(`${dist}/modules/platform/${platform}/index.md`, readme);
+    let md = await readFile(`lib/modules/platform/${platform}/index.md`);
+
+    md += generateFeatureAndBugMarkdown(platformIssuesMap, platform);
+
+    await updateFile(`${dist}/modules/platform/${platform}/index.md`, md);
   }
 
   platformContent += platforms
@@ -30,29 +33,7 @@ export async function generatePlatforms(
 
   platformContent += '.\n';
 
-  const indexFileName = `docs/usage/modules/platform/index.md`;
-  let indexContent = await readFile(indexFileName);
+  let indexContent = await readFile(`docs/usage/modules/platform/index.md`);
   indexContent = replaceContent(indexContent, platformContent);
   await updateFile(`${dist}/modules/platform/index.md`, indexContent);
-
-  await generatePlatformOpenFeaturesAndBugs(dist, platformIssuesMap);
-}
-
-export async function generatePlatformOpenFeaturesAndBugs(
-  dist: string,
-  platformIssuesMap: Record<string, OpenItems>
-): Promise<void> {
-  const platforms = getPlatforms();
-
-  for (const [platform] of platforms) {
-    const platformReadmeContent = await readFile(
-      `lib/modules/platform/${platform}/index.md`
-    );
-
-    let md = platformReadmeContent + '\n\n';
-
-    md += generateFeatureAndBugMarkdown(platformIssuesMap, platform);
-
-    await updateFile(`${dist}/modules/platform/${platform}/index.md`, md);
-  }
 }

--- a/tools/docs/platforms.ts
+++ b/tools/docs/platforms.ts
@@ -1,6 +1,102 @@
-import { getPlatformList } from '../../lib/modules/platform';
+import { DateTime } from 'luxon';
+import { logger } from '../../lib/logger';
+import { getPlatformList, getPlatforms } from '../../lib/modules/platform';
+import * as hostRules from '../../lib/util/host-rules';
+import { GithubHttp } from '../../lib/util/http/github';
+import { getQueryString } from '../../lib/util/url';
 import { readFile, updateFile } from '../utils';
+import type { GithubApiQueryResponse, ItemsEntity } from './github-query-items';
 import { getModuleLink, replaceContent } from './utils';
+
+const gitHubApiUrl = 'https://api.github.com/search/issues?';
+
+if (process.env.GITHUB_TOKEN) {
+  logger.debug('Using GITHUB_TOKEN from env');
+  hostRules.add({
+    matchHost: 'api.github.com',
+    token: process.env.GITHUB_TOKEN,
+  });
+}
+
+interface PlatformIssues {
+  bugs: ItemsEntity[];
+  features: ItemsEntity[];
+}
+
+function stringifyIssues(items: ItemsEntity[]): [string, number] {
+  if (!items) {
+    return ['', 0];
+  }
+  let list = '';
+  for (const item of items) {
+    list += ` - ${item.title} [#${item.number}](${item.html_url})\n`;
+  }
+  return [list, items.length];
+}
+
+function extractIssues(
+  platformIssuesMap: Record<string, PlatformIssues>,
+  items: ItemsEntity[]
+): void {
+  if (!items || !platformIssuesMap) {
+    return;
+  }
+  for (const item of items) {
+    const type = item.labels
+      .find((l) => l.name.startsWith('type:'))
+      ?.name.split(':')[1];
+    if (!type) {
+      continue;
+    }
+    const platform = item.labels
+      .find((l) => l.name.startsWith('manager:'))
+      ?.name.split(':')[1];
+    if (!platform) {
+      continue;
+    }
+    if (!platformIssuesMap[platform]) {
+      platformIssuesMap[platform] = { bugs: [], features: [] };
+    }
+    switch (type) {
+      case 'bug':
+        platformIssuesMap[platform].bugs.push(item);
+        break;
+      case 'feature':
+        platformIssuesMap[platform].features.push(item);
+        break;
+      default:
+        break;
+    }
+  }
+}
+
+export async function getPlatformGitHubIssues(): Promise<
+  Record<string, PlatformIssues>
+> {
+  const q = `repo:renovatebot/renovate type:issue is:open -label:priority-5-triage`;
+  const per_page = 100;
+  const managerIssuesMap: Record<string, PlatformIssues> = {};
+  const githubApi = new GithubHttp('platform-issues');
+  try {
+    const query = getQueryString({ q, per_page });
+    const res = await githubApi.getJson<GithubApiQueryResponse>(
+      gitHubApiUrl + query,
+      {
+        paginationField: 'items',
+        paginate: true,
+      }
+    );
+    const items = res.body?.items ?? [];
+    extractIssues(
+      managerIssuesMap,
+      items.sort((a, b) => a.number - b.number)
+    );
+  } catch (err) {
+    logger.error({ err }, 'Error getting query results');
+    throw err;
+  }
+  return managerIssuesMap;
+}
 
 export async function generatePlatforms(dist: string): Promise<void> {
   let platformContent = 'Supported values for `platform` are: ';
@@ -20,4 +116,47 @@ export async function generatePlatforms(dist: string): Promise<void> {
   let indexContent = await readFile(indexFileName);
   indexContent = replaceContent(indexContent, platformContent);
   await updateFile(`${dist}/modules/platform/index.md`, indexContent);
+
+  await generatePlatformOpenFeaturesAndBugs(dist);
+}
+
+export async function generatePlatformOpenFeaturesAndBugs(
+  dist: string
+): Promise<void> {
+  const platforms = getPlatforms();
+  const platformIssuesMap = await getPlatformGitHubIssues();
+  for (const [platform] of platforms) {
+    const platformReadmeContent = await readFile(
+      `lib/modules/platform/${platform}/readme.md`
+    );
+
+    let md = platformReadmeContent + '\n\n';
+
+    const [featureList] = stringifyIssues(
+      platformIssuesMap[platform]?.features
+    );
+    if (featureList) {
+      md += '## Open feature requests\n\n';
+      md += featureList;
+      md += '\n';
+    }
+
+    const [bugList] = stringifyIssues(platformIssuesMap[platform]?.bugs);
+    if (bugList) {
+      md += '## Open bug reports\n\n';
+      md += bugList;
+      md += '\n';
+    }
+
+    if (featureList || bugList) {
+      const now = DateTime.utc().toFormat('MMMM dd, yyyy');
+      const lists = `list of ${featureList ? 'features' : ''}${
+        featureList && bugList ? ' and ' : ''
+      }${bugList ? 'bugs' : ''}`;
+      md += '\n\n';
+      md += `The above ${lists} were current when this page was generated on ${now}.\n`;
+    }
+
+    await updateFile(`${dist}/modules/platform/${platform}/index.md`, md);
+  }
 }

--- a/tools/docs/platforms.ts
+++ b/tools/docs/platforms.ts
@@ -2,12 +2,7 @@ import { logger } from '../../lib/logger';
 import { getPlatformList, getPlatforms } from '../../lib/modules/platform';
 import * as hostRules from '../../lib/util/host-rules';
 import { readFile, updateFile } from '../utils';
-import {
-  GitHubIssues,
-  ItemsEntity,
-  extractIssues,
-  generateFeatureAndBugMarkdown,
-} from './github-query-items';
+import { OpenItems, generateFeatureAndBugMarkdown } from './github-query-items';
 import { getModuleLink, replaceContent } from './utils';
 
 if (process.env.GITHUB_TOKEN) {
@@ -20,7 +15,7 @@ if (process.env.GITHUB_TOKEN) {
 
 export async function generatePlatforms(
   dist: string,
-  openGithubItems: ItemsEntity[]
+  platformIssuesMap: Record<string, OpenItems>
 ): Promise<void> {
   let platformContent = 'Supported values for `platform` are: ';
   const platforms = getPlatformList();
@@ -40,21 +35,12 @@ export async function generatePlatforms(
   indexContent = replaceContent(indexContent, platformContent);
   await updateFile(`${dist}/modules/platform/index.md`, indexContent);
 
-  const platformIssuesMap = getPlatformGitHubIssues(openGithubItems);
   await generatePlatformOpenFeaturesAndBugs(dist, platformIssuesMap);
-}
-
-function getPlatformGitHubIssues(
-  openGithubItems: ItemsEntity[]
-): Record<string, GitHubIssues> {
-  const platformIssuesMap: Record<string, GitHubIssues> = {};
-  extractIssues(platformIssuesMap, openGithubItems, 'platform:');
-  return platformIssuesMap;
 }
 
 export async function generatePlatformOpenFeaturesAndBugs(
   dist: string,
-  platformIssuesMap: Record<string, GitHubIssues>
+  platformIssuesMap: Record<string, OpenItems>
 ): Promise<void> {
   const platforms = getPlatforms();
 

--- a/tools/generate-docs.ts
+++ b/tools/generate-docs.ts
@@ -3,6 +3,7 @@ import shell from 'shelljs';
 import { getProblems, logger } from '../lib/logger';
 import { generateConfig } from './docs/config';
 import { generateDatasources } from './docs/datasources';
+import { getOpenGitHubItems } from './docs/github-query-items';
 import { generateManagers } from './docs/manager';
 import { generateManagerAsdfSupportedPlugins } from './docs/manager-asdf-supported-plugins';
 import { generatePlatforms } from './docs/platforms';
@@ -36,8 +37,11 @@ process.on('unhandledRejection', (err) => {
       return;
     }
 
+    logger.info('* fetching open github issues');
+    const openGithubItems = await getOpenGitHubItems();
+
     logger.info('* platforms');
-    await generatePlatforms(dist);
+    await generatePlatforms(dist, openGithubItems);
 
     // versionings
     logger.info('* versionings');
@@ -49,7 +53,7 @@ process.on('unhandledRejection', (err) => {
 
     // managers
     logger.info('* managers');
-    await generateManagers(dist);
+    await generateManagers(dist, openGithubItems);
 
     // managers/asdf supported plugins
     logger.info('* managers/asdf/supported-plugins');

--- a/tools/generate-docs.ts
+++ b/tools/generate-docs.ts
@@ -38,10 +38,10 @@ process.on('unhandledRejection', (err) => {
     }
 
     logger.info('* fetching open github issues');
-    const openGithubItems = await getOpenGitHubItems();
+    const openItems = await getOpenGitHubItems();
 
     logger.info('* platforms');
-    await generatePlatforms(dist, openGithubItems);
+    await generatePlatforms(dist, openItems.platforms);
 
     // versionings
     logger.info('* versionings');
@@ -49,11 +49,11 @@ process.on('unhandledRejection', (err) => {
 
     // datasources
     logger.info('* datasources');
-    await generateDatasources(dist);
+    await generateDatasources(dist, openItems.datasources);
 
     // managers
     logger.info('* managers');
-    await generateManagers(dist, openGithubItems);
+    await generateManagers(dist, openItems.managers);
 
     // managers/asdf supported plugins
     logger.info('* managers/asdf/supported-plugins');


### PR DESCRIPTION
## Changes

Reused/refactored existing logic used to auto-generated open features and open bugs markdown for `Managers`, and extended it to cover `Platforms` and `Datasources` documentation pages.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
