### PR TITLE
refactor: safely parse decrypted config

### DIFF
--- a/lib/config/schema.ts
+++ b/lib/config/schema.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const DecryptedObject = z.object({
+  o: z.string().optional(),
+  r: z.string().optional(),
+  v: z.string().optional(),
+});


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Define and use a schema for type checking decrypted config

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->
This is required for #20553.

One of the rules of `@total-typescript/ts-reset` changes the return type of `JSON.parse` from `any` to `unknown`[^1]. This means that we need to do runtime type checking to verify the data that we are parsing.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
[^1]: https://github.com/total-typescript/ts-reset#make-jsonparse-return-unknown