### PR TITLE
docs: add @setchy to about-us

### DIFF
--- a/docs/usage/about-us.md
+++ b/docs/usage/about-us.md
@@ -37,6 +37,7 @@ Some features made a lot of people happy, and efficient!
 - [@astellingwerf](https://github.com/astellingwerf) reviews PRs
 - [@danports](https://github.com/danports) worked on the Flux manager, and other managers. Feel free to ping `@danports` for any Flux-related issue or PR
 - [@shegox](https://github.com/shegox) worked on the Go manager, and improved our docs
+- [@setchy](https://github.com/setchy) focused on Bitbucket Cloud and replacement features
 
 ## Renovate development
 


### PR DESCRIPTION
## Changes

Add myself to [about-us](https://docs.renovatebot.com/about-us/)

## Context

Per @HonkingGoose kind suggestion over [here](https://github.com/renovatebot/renovate/pull/20861#issuecomment-1465731627)

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository