### PR TITLE
fix: Prevent uninitialized cacheProxy from being accessed in cleanup

### DIFF
--- a/lib/util/cache/package/index.spec.ts
+++ b/lib/util/cache/package/index.spec.ts
@@ -7,6 +7,9 @@ describe('util/cache/package/index', () => {
   it('returns undefined if not initialized', async () => {
     expect(await get('test', 'missing-key')).toBeUndefined();
     expect(await set('test', 'some-key', 'some-value', 5)).toBeUndefined();
+    expect(async () => {
+      await cleanup({});
+    }).not.toThrow();
   });
 
   it('sets and gets file', async () => {

--- a/lib/util/cache/package/index.ts
+++ b/lib/util/cache/package/index.ts
@@ -4,7 +4,7 @@ import * as fileCache from './file';
 import * as redisCache from './redis';
 import type { PackageCache } from './types';
 
-let cacheProxy: PackageCache;
+let cacheProxy: PackageCache | undefined;
 
 function getGlobalKey(namespace: string, key: string): string {
   return `global%%${namespace}%%${key}`;
@@ -74,7 +74,7 @@ export async function cleanup(config: AllConfig): Promise<void> {
   if (config?.redisUrl) {
     await redisCache.end();
   }
-  if (cacheProxy.cleanup) {
+  if (cacheProxy?.cleanup) {
     await cacheProxy.cleanup();
   }
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Updating `cleanup` function to check if `cacheProxy.cleanup` exists by using `cacheProxy?.cleanup`.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

It's possible that `cacheProxy` might not be initialized when `cleanup` is called, which would result in the following error:
```
TypeError: Cannot read properties of undefined (reading 'cleanup')
```

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
