### PR TITLE
fix: Revert "fix: Add support for PAT in Bitbucket Server. Closes #14900"

### DIFF
--- a/lib/modules/platform/bitbucket-server/index.ts
+++ b/lib/modules/platform/bitbucket-server/index.ts
@@ -81,14 +81,13 @@ export function initPlatform({
   endpoint,
   username,
   password,
-  token,
 }: PlatformParams): Promise<PlatformResult> {
   if (!endpoint) {
     throw new Error('Init: You must configure a Bitbucket Server endpoint');
   }
-  if (!(username && password) && !token) {
+  if (!(username && password)) {
     throw new Error(
-      'Init: You must configure either a Bitbucket Server token or username and password'
+      'Init: You must configure a Bitbucket Server username/password'
     );
   }
   // TODO: Add a connection check that endpoint/username/password combination are valid (#9595)


### PR DESCRIPTION
Reverts renovatebot/renovate#20974

Does not work as intended. 
The original PR doesn't use the token, it just allows it to bypass the validation on `initPlatform`

- #14900