### PR TITLE
fix(auto-replace): handle missing depName or packageName values

### DIFF
--- a/lib/workers/repository/update/branch/auto-replace.ts
+++ b/lib/workers/repository/update/branch/auto-replace.ts
@@ -103,7 +103,13 @@ export async function confirmIfDepUpdated(
 
 function getDepsSignature(deps: PackageDependency[]): string {
   // TODO: types (#7154)
-  return deps.map((dep) => `${dep.depName!}${dep.packageName!}`).join(',');
+  return deps
+    .map(
+      (dep) =>
+        `${(dep.depName ?? dep.packageName)!}${(dep.packageName ??
+          dep.depName)!}`
+    )
+    .join(',');
 }
 
 export async function checkBranchDepsMatchBaseDeps(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

There were times when the extract function extracts `depName` only, but then was comparing to `depName.packageName` and thinking deps had changed. This change falls `packageName` back to `depName` and vice versa, for forwards compatibility.

## Context

Closes #21004
Closes #20966
Closes #20906

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
