### PR TITLE
docs(go modules): vendored major upgrades not supported

### DIFF
--- a/docs/usage/golang.md
+++ b/docs/usage/golang.md
@@ -47,6 +47,11 @@ The reason for this is that a `go mod tidy` command may make changes to `go.mod`
 Vendoring of Go Modules is done automatically if `vendor/modules.txt` is present.
 Renovate will commit all files changed within the `vendor/` folder.
 
+<!-- prettier-ignore -->
+!!! note
+    Renovate does not support vendoring major upgrades of Go modules.
+    Follow issue [#21010](https://github.com/renovatebot/renovate/issues/21010).
+
 ### Go binary version
 
 By default, Renovate will keep up with the latest version of the `go` binary.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Add `note` admonition about our support of vendored major upgrades for Go modules

## Context

I think we don't support vendored major upgrade for Go modules? Related issue:

- #21010

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
