### PR TITLE
fix(presets): name typo

### DIFF
--- a/lib/config/presets/common.ts
+++ b/lib/config/presets/common.ts
@@ -24,6 +24,7 @@ export const removedPresets: Record<string, string | null> = {
   'default:unpublishSafe': 'npm:unpublishSafe',
   'helpers:oddIsUnstable': null,
   'helpers:oddIsUnstablePackages': null,
+  'group:jsTestMonMajor': 'group:jsTestNonMajor',
 };
 
 const renamedMonorepos: Record<string, string> = {

--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -208,6 +208,17 @@ const staticGroups = {
     ],
   },
   jsTestMonMajor: {
+    description:
+      'Group non-major JS test package updates together. Note: This option will be removed, use `group:jsTestNonMajor` instead.',
+    packageRules: [
+      {
+        extends: 'packages:jsTest',
+        groupName: 'JS test packages',
+        matchUpdateTypes: ['minor', 'patch'],
+      },
+    ],
+  },
+  jsTestNonMajor: {
     description: 'Group non-major JS test package updates together.',
     packageRules: [
       {

--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -207,17 +207,6 @@ const staticGroups = {
       },
     ],
   },
-  jsTestMonMajor: {
-    description:
-      'Group non-major JS test package updates together. Note: This option will be removed, use `group:jsTestNonMajor` instead.',
-    packageRules: [
-      {
-        extends: 'packages:jsTest',
-        groupName: 'JS test packages',
-        matchUpdateTypes: ['minor', 'patch'],
-      },
-    ],
-  },
   jsTestNonMajor: {
     description: 'Group non-major JS test package updates together.',
     packageRules: [


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
I have added new group preset `group:jsTestNonMajor` and added a note for typoed option to use the correct one.

## Context
Found a typo in group preset, marked it as deprecated and created new preset with correct spelling.

I think `group:jsTestMonMajor` should be removed in the next major version.

Q: Is any change in documentation necessary for this change, or it will be all auto-generated?

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
