### PR TITLE
docs(self-hosting examples): update renovate version references

### DIFF
--- a/docs/usage/examples/self-hosting.md
+++ b/docs/usage/examples/self-hosting.md
@@ -25,9 +25,9 @@ For example, all the following are valid tags:
 
 ```sh
 docker run --rm renovate/renovate
-docker run --rm renovate/renovate:34
-docker run --rm renovate/renovate:34.24
-docker run --rm renovate/renovate:34.24.0
+docker run --rm renovate/renovate:35
+docker run --rm renovate/renovate:35.14
+docker run --rm renovate/renovate:35.14.4
 ```
 
 <!-- prettier-ignore -->
@@ -64,7 +64,7 @@ spec:
             - name: renovate
               # Update this to the latest available and then enable Renovate on
               # the manifest
-              image: renovate/renovate:34.24.0
+              image: renovate/renovate:35.14.4
               args:
                 - user/repo
               # Environment Variables
@@ -123,7 +123,7 @@ spec:
       template:
         spec:
           containers:
-            - image: renovate/renovate:34.24.0
+            - image: renovate/renovate:35.14.4
               name: renovate-bot
               env: # For illustration purposes, please use secrets.
                 - name: RENOVATE_PLATFORM
@@ -368,7 +368,7 @@ spec:
           containers:
             - name: renovate
               # Update this to the latest available and then enable Renovate on the manifest
-              image: renovate/renovate:34.24.0
+              image: renovate/renovate:35.14.4
               volumeMounts:
                 - name: ssh-key-volume
                   readOnly: true


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Upgrade Renovate version references from `34` to `35`

## Context

We're now on major version `35` of Renovate. We have configured Renovate to update these references with a PR, but those PRs skip some items. I'm fixing the misses manually.

Related stuff:

- https://github.com/renovatebot/renovate/pull/21040
- https://github.com/renovatebot/.github/issues/31

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
