### PR TITLE
docs(replacement): update examples

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2231,7 +2231,7 @@ For example, the following package rule can be used to replace the registry for 
   "packageRules": [
     {
       "matchDatasources": ["docker"],
-      "matchPackagePrefix": ["^docker.io/.*)"],
+      "matchPackagePatterns": ["^docker.io/.*)"],
       "replacementNameTemplate": "{{{replace 'docker.io/' 'ghcr.io/' packageName}}}"
     }
   ]
@@ -2245,7 +2245,7 @@ Or, to add a registry prefix to any `docker` images that do not contain an expli
   "packageRules": [
     {
       "matchDatasources": ["docker"],
-      "matchPackagePrefix": ["^([^.]+)(\\/\\:)?$"],
+      "matchPackagePatterns": ["^([^.]+)([\\/\\:]|$).*"],
       "replacementNameTemplate": "some.registry.org/{{{packageName}}}"
     }
   ]

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2245,7 +2245,7 @@ Or, to add a registry prefix to any `docker` images that do not contain an expli
   "packageRules": [
     {
       "matchDatasources": ["docker"],
-      "matchPackagePatterns": ["^([^.]+)([\\:]|$).*"],
+      "matchPackagePatterns": ["^([^.]+)(:|$).*"],
       "replacementNameTemplate": "some.registry.org/{{{packageName}}}"
     }
   ]

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2245,7 +2245,7 @@ Or, to add a registry prefix to any `docker` images that do not contain an expli
   "packageRules": [
     {
       "matchDatasources": ["docker"],
-      "matchPackagePatterns": ["^([^.]+)([\\/\\:]|$).*"],
+      "matchPackagePatterns": ["^([^.]+)([\\:]|$).*"],
       "replacementNameTemplate": "some.registry.org/{{{packageName}}}"
     }
   ]

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2246,13 +2246,13 @@ Or, to add a registry prefix to any `docker` images that do not contain an expli
     {
       "description": "official images",
       "matchDatasources": ["docker"],
-      "matchPackagePatterns": ["^([^.\\/]+)(:|$).*"],
+      "matchPackagePatterns": ["^[a-z-]+(:|$).*"],
       "replacementNameTemplate": "some.registry.org/library/{{{packageName}}}"
     },
     {
       "description": "non-official images",
       "matchDatasources": ["docker"],
-      "matchPackagePatterns": ["^([^.\\/]+)\\/\\S+(:|$).*"],
+      "matchPackagePatterns": ["^[a-z-]+\\/[a-z-]+(:|$).*"],
       "replacementNameTemplate": "some.registry.org/{{{packageName}}}"
     }
   ]

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2244,8 +2244,15 @@ Or, to add a registry prefix to any `docker` images that do not contain an expli
 {
   "packageRules": [
     {
+      "description": "official images",
       "matchDatasources": ["docker"],
-      "matchPackagePatterns": ["^([^.]+)(:|$).*"],
+      "matchPackagePatterns": ["^([^.\\/]+)(:|$).*"],
+      "replacementNameTemplate": "some.registry.org/library/{{{packageName}}}"
+    },
+    {
+      "description": "non-official images",
+      "matchDatasources": ["docker"],
+      "matchPackagePatterns": ["^([^.\\/]+)\\/\\S+(:|$).*"],
       "replacementNameTemplate": "some.registry.org/{{{packageName}}}"
     }
   ]


### PR DESCRIPTION
## Changes

Correct matchPackagePrefix -> matchPackagePatterns.

Update regex example to support matching semver/pinned image names

## Context

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
