### PR TITLE
docs(bitbucket-pipelines): authenticated registries

### DIFF
--- a/lib/modules/manager/bitbucket-pipelines/index.ts
+++ b/lib/modules/manager/bitbucket-pipelines/index.ts
@@ -1,5 +1,8 @@
+import type { ProgrammingLanguage } from '../../../constants';
 import { DockerDatasource } from '../../datasource/docker';
 import { extractPackageFile } from './extract';
+
+export const language: ProgrammingLanguage = 'docker';
 
 export { extractPackageFile };
 

--- a/lib/modules/manager/bitbucket-pipelines/index.ts
+++ b/lib/modules/manager/bitbucket-pipelines/index.ts
@@ -1,8 +1,5 @@
-import type { ProgrammingLanguage } from '../../../constants';
 import { DockerDatasource } from '../../datasource/docker';
 import { extractPackageFile } from './extract';
-
-export const language: ProgrammingLanguage = 'docker';
 
 export { extractPackageFile };
 

--- a/lib/modules/manager/bitbucket-pipelines/readme.md
+++ b/lib/modules/manager/bitbucket-pipelines/readme.md
@@ -25,24 +25,26 @@ The following `regexManager` configuration can be used for authenticated Docker 
 }
 ```
 
-### Migrating existing
+### Replacing unauthenticated with authenticated registries
 
 With the [regex manager](https://docs.renovatebot.com/modules/manager/regex/) you can configure Renovate to assist with migrating your Bitbucket Pipelines from unauthenticated registries to authenticated registries.
 
 An example configuration is shown below
 
 ```json
-"regexManagers": [
-  {
-    "description": "Bitbucket Pipelines: migrate from unauthenticated to authenticated registry",
-    "fileMatch": ["(^|\\/|\\.)bitbucket-pipelines.ya?ml$"],
-    "matchStringsStrategy": "combination",
-    "matchStrings": [
-      "\\s*image:\\s*(?<depName>[a-z-]+)(?::(?<currentValue>[a-z0-9.-]+))?(?:@(?<currentDigest>sha256:[a-f0-9]+))?",
-      "\\s*image:\\s*\\n\\s*name:\\s*(?<depName>[a-z-]+)(?::(?<currentValue>[a-z0-9.-]+))?(?:@(?<currentDigest>sha256:[a-f0-9]+))?\\n\\s*username:\\s*\\$SOME_USER\\n\\s*password:\\s*\\$SOME_PASSWORD"
-    ],
-    "datasourceTemplate": "docker",
-    "autoReplaceStringTemplate": "image:\n  name: {{{packageName}}}{{#if newValue}}:{{{newValue}}}{{/if}}{{#if newDigest}}@{{{newDigest}}}{{/if}}\n  username: $SOME_USER\n  password: $SOME_PASSWORD"
-  }
-]
+{
+  "regexManagers": [
+    {
+      "description": "Bitbucket Pipelines: migrate from unauthenticated to authenticated registry",
+      "fileMatch": ["(^|\\/|\\.)bitbucket-pipelines.ya?ml$"],
+      "matchStringsStrategy": "combination",
+      "matchStrings": [
+        "\\s*image:\\s*(?<depName>[a-z-]+)(?::(?<currentValue>[a-z0-9.-]+))?(?:@(?<currentDigest>sha256:[a-f0-9]+))?",
+        "\\s*image:\\s*\\n\\s*name:\\s*(?<depName>[a-z-]+)(?::(?<currentValue>[a-z0-9.-]+))?(?:@(?<currentDigest>sha256:[a-f0-9]+))?\\n\\s*username:\\s*\\$SOME_USER\\n\\s*password:\\s*\\$SOME_PASSWORD"
+      ],
+      "datasourceTemplate": "docker",
+      "autoReplaceStringTemplate": "image:\n  name: {{{packageName}}}{{#if newValue}}:{{{newValue}}}{{/if}}{{#if newDigest}}@{{{newDigest}}}{{/if}}\n  username: $SOME_USER\n  password: $SOME_PASSWORD"
+    }
+  ]
+}
 ```

--- a/lib/modules/manager/bitbucket-pipelines/readme.md
+++ b/lib/modules/manager/bitbucket-pipelines/readme.md
@@ -8,7 +8,8 @@ Bitbucket Pipelines supports using an authenticated Docker registry, including s
 
 More details can be found on the Atlassian [Bitbucket Pipeline documentation](https://support.atlassian.com/bitbucket-cloud/docs/use-docker-images-as-build-environments) site
 
-The following `regexManager` configuration can be used for authenticated Docker Hub or private registries. Changes will be required for Amazon ECR or Google GCR use cases.
+The following `regexManager` configuration can be used for authenticated Docker Hub or private registries.
+You'll need to change this example config if you're using Amazon ECR or Google GCR.
 
 ```json
 {

--- a/lib/modules/manager/bitbucket-pipelines/readme.md
+++ b/lib/modules/manager/bitbucket-pipelines/readme.md
@@ -30,7 +30,7 @@ You'll need to change this example config if you're using Amazon ECR or Google G
 
 With the [regex manager](https://docs.renovatebot.com/modules/manager/regex/) you can configure Renovate to assist with migrating your Bitbucket Pipelines from unauthenticated registries to authenticated registries.
 
-An example configuration is shown below
+For example:
 
 ```json
 {

--- a/lib/modules/manager/bitbucket-pipelines/readme.md
+++ b/lib/modules/manager/bitbucket-pipelines/readme.md
@@ -1,3 +1,48 @@
 Extracts dependencies from Bitbucket Pipelines config files.
 
 If you need to change the versioning format, read the [versioning](https://docs.renovatebot.com/modules/versioning/) documentation to learn more.
+
+### Using private build images
+
+Bitbucket Pipelines supports using an authenticated Docker registry, including self-hosted private registries, Docker Hub, Amazon ECR and Google GCR.
+
+More details can be found on the Atlassian [Bitbucket Pipeline documentation](https://support.atlassian.com/bitbucket-cloud/docs/use-docker-images-as-build-environments) site
+
+The following `regexManager` configuration can be used for authenticated Docker Hub or private registries. Changes will be required for Amazon ECR or Google GCR use cases.
+
+```json
+{
+  "regexManagers": [
+    {
+      "matchManagers": ["bitbucket-pipelines"],
+      "matchStrings": [
+        "\\s*-?\\s?image:\\s*\\n\\s+name:\\s+\"?(?<depName>[a-z/.-]+)(?::(?<currentValue>[a-z0-9.-]+))?(?:@(?<currentDigest>sha256:[a-f0-9]+))?"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker"
+    }
+  ]
+}
+```
+
+### Migrating existing
+
+With the [regex manager](https://docs.renovatebot.com/modules/manager/regex/) you can configure Renovate to assist with migrating your Bitbucket Pipelines from unauthenticated registries to authenticated registries.
+
+An example configuration is shown below
+
+```json
+"regexManagers": [
+  {
+    "description": "Bitbucket Pipelines: migrate from unauthenticated to authenticated registry",
+    "fileMatch": ["(^|\\/|\\.)bitbucket-pipelines.ya?ml$"],
+    "matchStringsStrategy": "combination",
+    "matchStrings": [
+      "\\s*image:\\s*(?<depName>[a-z-]+)(?::(?<currentValue>[a-z0-9.-]+))?(?:@(?<currentDigest>sha256:[a-f0-9]+))?",
+      "\\s*image:\\s*\\n\\s*name:\\s*(?<depName>[a-z-]+)(?::(?<currentValue>[a-z0-9.-]+))?(?:@(?<currentDigest>sha256:[a-f0-9]+))?\\n\\s*username:\\s*\\$SOME_USER\\n\\s*password:\\s*\\$SOME_PASSWORD"
+    ],
+    "datasourceTemplate": "docker",
+    "autoReplaceStringTemplate": "image:\n  name: {{{packageName}}}{{#if newValue}}:{{{newValue}}}{{/if}}{{#if newDigest}}@{{{newDigest}}}{{/if}}\n  username: $SOME_USER\n  password: $SOME_PASSWORD"
+  }
+]
+```


### PR DESCRIPTION
## Changes

Add documentation for
- authenticated registry support
- migrating from unauthenticated to authenticated registry formats

## Context

Publishing examples from these two sources
- https://github.com/renovatebot/renovate/issues/13555#issuecomment-1479419939
- https://github.com/renovatebot/renovate/discussions/21094#discussioncomment-5399664

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository