### PR TITLE
feat(bitbucket-pipelines): extract private images

### DIFF
--- a/lib/modules/manager/bitbucket-pipelines/__fixtures__/bitbucket-pipelines.yaml
+++ b/lib/modules/manager/bitbucket-pipelines/__fixtures__/bitbucket-pipelines.yaml
@@ -1,5 +1,14 @@
 image: node:10.15.1
 
+definitions:
+  services:
+    my-service:
+      image:
+        name: node:14
+        username: $USERNAME
+        password: $PASSWORD
+        email: $EMAIL
+
 pipelines:
   default:
     - step:
@@ -23,3 +32,18 @@ pipelines:
               AWS_DEFAULT_REGION: "us-east-1"
               S3_BUCKET: "my-bucket-name"
               LOCAL_PATH: "dist"
+    - step:
+        name: Private Image Step
+        image:
+          name: node:16
+          username: $USERNAME
+          password: $PASSWORD
+          email: $EMAIL
+        script:
+          - echo "Hello private image step"
+    - step:
+        name: Service Definition Step
+        services:
+          - my-service
+        script:
+          - echo "Hello service definition step"

--- a/lib/modules/manager/bitbucket-pipelines/extract.spec.ts
+++ b/lib/modules/manager/bitbucket-pipelines/extract.spec.ts
@@ -23,6 +23,15 @@ describe('modules/manager/bitbucket-pipelines/extract', () => {
           {
             "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
             "currentDigest": undefined,
+            "currentValue": "14",
+            "datasource": "docker",
+            "depName": "node",
+            "depType": "docker",
+            "replaceString": "node:14",
+          },
+          {
+            "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
+            "currentDigest": undefined,
             "currentValue": "10.15.2",
             "datasource": "docker",
             "depName": "node",
@@ -44,9 +53,18 @@ describe('modules/manager/bitbucket-pipelines/extract', () => {
             "depName": "atlassian/aws-s3-deploy",
             "depType": "bitbucket-tags",
           },
+          {
+            "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
+            "currentDigest": undefined,
+            "currentValue": "16",
+            "datasource": "docker",
+            "depName": "node",
+            "depType": "docker",
+            "replaceString": "node:16",
+          },
         ]
       `);
-      expect(res?.deps).toHaveLength(4);
+      expect(res?.deps).toHaveLength(6);
     });
   });
 });


### PR DESCRIPTION
## Changes

Add extract regex patterns to match [Docker private images](https://support.atlassian.com/bitbucket-cloud/docs/docker-image-options)

Run against: https://github.com/setchy/renovate-bitbucket-pipelines/pull/2/files

## Context

https://github.com/renovatebot/renovate/issues/13555#issuecomment-1479419939 


## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

