### PR TITLE
fix(onboarding): improve preset description resolution

### DIFF
--- a/lib/config/presets/__snapshots__/index.spec.ts.snap
+++ b/lib/config/presets/__snapshots__/index.spec.ts.snap
@@ -31,7 +31,7 @@ exports[`config/presets/index resolvePreset migrates automerge in presets 1`] = 
   "branchPrefix": "renovate/",
   "description": [
     "Prefix \`renovate/\` to all branch names.",
-    "If Renovate detects semantic commits, it will use semantic commit type \`fix\` for dependencies and \`chore\` for all others.",
+    "Use semantic commit type \`fix\` for dependencies and \`chore\` for all others if semantic commits are in use.",
     "Require all status checks to pass before any automerging.",
     "Pin dependency versions for \`devDependencies\` and retain SemVer ranges for others.",
   ],

--- a/lib/config/presets/internal/default.ts
+++ b/lib/config/presets/internal/default.ts
@@ -525,7 +525,7 @@ export const presets: Record<string, Preset> = {
   },
   semanticPrefixFixDepsChoreOthers: {
     description:
-      'If Renovate detects semantic commits, it will use semantic commit type `fix` for dependencies and `chore` for all others.',
+      'Use semantic commit type `fix` for dependencies and `chore` for all others if semantic commits are in use.',
     packageRules: [
       {
         matchPackagePatterns: ['*'],

--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -398,7 +398,7 @@ const staticGroups = {
       'group:springWs',
       'group:symfony',
     ],
-    ignoreDeps: [],
+    ignoreDeps: [], // Hack to improve onboarding PR description
   },
   resilience4j: {
     description: 'Group Java Resilience4j packages.',
@@ -730,7 +730,7 @@ for (const monorepo of Object.keys(monorepos.presets)) {
 config.monorepos = {
   description: 'Group known monorepo packages together.',
   extends: monorepoNames,
-  ignoreDeps: [],
+  ignoreDeps: [], // Hack to improve onboarding PR description
 };
 
 export const presets: Record<string, Preset> = config;

--- a/lib/config/presets/internal/replacements.ts
+++ b/lib/config/presets/internal/replacements.ts
@@ -10,7 +10,7 @@ import {
 /* eslint sort-keys: ["error", "asc", {"caseSensitive": false, "natural": true}] */
 export const presets: Record<string, Preset> = {
   all: {
-    description: 'All replacements.',
+    description: 'Apply crowd-sourced package replacement rules.',
     extends: [
       'replacements:apollo-server-to-scoped',
       'replacements:babel-eslint-to-eslint-parser',
@@ -34,6 +34,7 @@ export const presets: Record<string, Preset> = {
       'replacements:vsts-task-lib-to-azure-pipelines-task-lib',
       'replacements:xmldom-to-scoped',
     ],
+    ignoreDeps: [], // Hack to improve onboarding PR description
   },
   'apollo-server-to-scoped': {
     description: '`apollo-server` packages became scoped.',

--- a/lib/config/presets/internal/workarounds.ts
+++ b/lib/config/presets/internal/workarounds.ts
@@ -5,7 +5,7 @@ import type { Preset } from '../types';
 export const presets: Record<string, Preset> = {
   all: {
     description: [
-      'A collection of workarounds for known problems with packages.',
+      'Apply crowd-sourced workarounds for known problems with packages.',
     ],
     extends: [
       'workarounds:mavenCommonsAncientVersion',
@@ -20,7 +20,7 @@ export const presets: Record<string, Preset> = {
       'workarounds:disableMavenParentRoot',
       'workarounds:containerbase',
     ],
-    ignoreDeps: [],
+    ignoreDeps: [], // Hack to improve onboarding PR description
   },
   containerbase: {
     description: 'Add some containerbase overrides',


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Updates some preset descriptions plus fixes the bug where too much replacement info is displayed.

Now:

<img width="781" alt="image" src="https://user-images.githubusercontent.com/6311784/227763810-e4196221-4622-414b-81b4-871b76bc5075.png">


## Context

Closes #21161

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
