### PR TITLE
fix(merge-confidence): escape forward slashes in package names

### DIFF
--- a/lib/util/merge-confidence/index.spec.ts
+++ b/lib/util/merge-confidence/index.spec.ts
@@ -155,6 +155,30 @@ describe('util/merge-confidence/index', () => {
         ).toBe('high');
       });
 
+      it('escapes a package name containing a forward slash', async () => {
+        const datasource = 'npm';
+        const packageName = '@jest/global';
+        const escapedPackageName = '@jest%2fglobal';
+        const currentVersion = '24.3.0';
+        const newVersion = '25.0.0';
+        httpMock
+          .scope(apiBaseUrl)
+          .get(
+            `/api/mc/json/${datasource}/${escapedPackageName}/${currentVersion}/${newVersion}`
+          )
+          .reply(200, { confidence: 'high' });
+
+        expect(
+          await getMergeConfidenceLevel(
+            datasource,
+            packageName,
+            currentVersion,
+            newVersion,
+            'major'
+          )
+        ).toBe('high');
+      });
+
       it('returns neutral on invalid merge confidence response from api', async () => {
         const datasource = 'npm';
         const depName = 'renovate';

--- a/lib/util/merge-confidence/index.ts
+++ b/lib/util/merge-confidence/index.ts
@@ -66,7 +66,7 @@ const updateTypeConfidenceMapping: Record<UpdateType, MergeConfidence | null> =
  * Retrieves the merge confidence of a package update if the merge confidence API is enabled. Otherwise, undefined is returned.
  *
  * @param datasource
- * @param depName
+ * @param packageName
  * @param currentVersion
  * @param newVersion
  * @param updateType
@@ -76,7 +76,7 @@ const updateTypeConfidenceMapping: Record<UpdateType, MergeConfidence | null> =
  */
 export async function getMergeConfidenceLevel(
   datasource: string,
-  depName: string,
+  packageName: string,
   currentVersion: string,
   newVersion: string,
   updateType: UpdateType
@@ -98,14 +98,14 @@ export async function getMergeConfidenceLevel(
     return mappedConfidence;
   }
 
-  return await queryApi(datasource, depName, currentVersion, newVersion);
+  return await queryApi(datasource, packageName, currentVersion, newVersion);
 }
 
 /**
  * Queries the Merge Confidence API with the given package release information.
  *
  * @param datasource
- * @param depName
+ * @param packageName
  * @param currentVersion
  * @param newVersion
  *
@@ -117,7 +117,7 @@ export async function getMergeConfidenceLevel(
  */
 async function queryApi(
   datasource: string,
-  depName: string,
+  packageName: string,
   currentVersion: string,
   newVersion: string
 ): Promise<MergeConfidence> {
@@ -126,14 +126,21 @@ async function queryApi(
     return 'neutral';
   }
 
-  const url = `${apiBaseUrl}api/mc/json/${datasource}/${depName}/${currentVersion}/${newVersion}`;
+  const escapedPackageName = packageName.replace('/', '%2f');
+  const url = `${apiBaseUrl}api/mc/json/${datasource}/${escapedPackageName}/${currentVersion}/${newVersion}`;
   const cacheKey = `${token}:${url}`;
   const cachedResult = await packageCache.get(hostType, cacheKey);
 
   // istanbul ignore if
   if (cachedResult) {
     logger.debug(
-      { datasource, depName, currentVersion, newVersion, cachedResult },
+      {
+        datasource,
+        packageName,
+        currentVersion,
+        newVersion,
+        cachedResult,
+      },
       'using merge confidence cached result'
     );
     return cachedResult;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context
if we dont escape these will get a 404 error.


<details>
  <summary>Click to expand log message</summary>
  
```json
{
	"name": "renovate",
	"hostname": "Gabriel-Dell5420",
	"pid": 23224,
	"level": 40,
	"logContext": "630I8tIeldSmLy2pRmZkR",
	"repository": "ladzaretti/TestRepo3",
	"err": {
		"name": "HTTPError",
		"code": "ERR_NON_2XX_3XX_RESPONSE",
		"timings": {
			"start": 1679832399823,
			"socket": 1679832399823,
			"lookup": 1679832399824,
			"connect": 1679832399839,
			"secureConnect": 1679832399921,
			"upload": 1679832399924,
			"response": 1679832400349,
			"end": 1679832400350,
			"phases": {
				"wait": 0,
				"dns": 1,
				"tcp": 15,
				"tls": 82,
				"request": 3,
				"firstByte": 425,
				"download": 1,
				"total": 527
			}
		},
		"message": "Response code 404 (Not Found)",
		"stack": "HTTPError: Response code 404 (Not Found)\n    at Request.<anonymous> (C:\\projects\\ladzaretti-renovate\\node_modules\\got\\dist\\source\\as-promise\\index.js:118:42)\n    at processTicksAndRejections (node:internal/process/task_queues:95:5)",
		"options": {
			"headers": {
				"user-agent": "RenovateBot/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
				"accept": "application/json",
				"authorization": "***********",
				"accept-encoding": "gzip, deflate, br"
			},
			"url": "https://badges.renovateapi.com/api/mc/json/npm/@jest/test-result/29.3.1/29.5.0",
			"hostType": "merge-confidence",
			"username": "",
			"password": "",
			"method": "GET",
			"http2": false
		},
		"response": {
			"statusCode": 404,
			"statusMessage": "Not Found",
			"body": "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\n<title>Error</title>\n</head>\n<body>\n<pre>Cannot GET /api/mc/json/npm/@jest/test-result/29.3.1/29.5.0</pre>\n</body>\n</html>\n",
			"headers": {
				"content-type": "text/html; charset=utf-8",
				"content-length": "186",
				"connection": "close",
				"x-powered-by": "Express",
				"content-security-policy": "default-src 'none'",
				"x-content-type-options": "nosniff",
				"date": "Sun, 26 Mar 2023 12:06:40 GMT",
				"x-cache": "Error from cloudfront",
				"via": "1.1 7e038b68f9f72fffb56ed14d01b11f3a.cloudfront.net (CloudFront)",
				"x-amz-cf-pop": "TLV50-C1",
				"x-amz-cf-id": "sfDERFl1_XIuQAUJvEJC89zYgsfAtB-kpyr_pUhjUGLJpAJOsdFh0Q=="
			},
			"httpVersion": "1.1",
			"retryCount": 0
		}
	},
	"msg": "error fetching merge confidence data",
	"time": "2023-03-26T12:06:40.356Z",
	"v": 0
}
```

</details>

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
