### PR TITLE
chore: use `node:` protocol imports

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,5 +1,5 @@
-import os from 'os';
-import v8 from 'v8';
+import os from 'node:os';
+import v8 from 'node:v8';
 import type { InitialOptionsTsJest } from 'ts-jest/dist/types';
 
 const ci = !!process.env.CI;

--- a/lib/config/decrypt.ts
+++ b/lib/config/decrypt.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 import is from '@sindresorhus/is';
 import * as openpgp from 'openpgp';
 import { logger } from '../logger';

--- a/lib/instrumentation/index.ts
+++ b/lib/instrumentation/index.ts
@@ -1,4 +1,4 @@
-import { ClientRequest } from 'http';
+import { ClientRequest } from 'node:http';
 import type {
   Context,
   Span,

--- a/lib/logger/pretty-stdout.ts
+++ b/lib/logger/pretty-stdout.ts
@@ -1,8 +1,8 @@
 // Code originally derived from https://github.com/hadfieldn/node-bunyan-prettystream but since heavily edited
 // Neither fork nor original repo appear to be maintained
 
-import { Stream } from 'stream';
-import * as util from 'util';
+import { Stream } from 'node:stream';
+import * as util from 'node:util';
 import chalk from 'chalk';
 import stringify from 'json-stringify-pretty-compact';
 import type { BunyanRecord } from './types';

--- a/lib/logger/types.ts
+++ b/lib/logger/types.ts
@@ -1,4 +1,4 @@
-import type { Stream } from 'stream';
+import type { Stream } from 'node:stream';
 import type { LogLevel } from 'bunyan';
 
 export interface LogError {

--- a/lib/logger/utils.ts
+++ b/lib/logger/utils.ts
@@ -1,4 +1,4 @@
-import { Stream } from 'stream';
+import { Stream } from 'node:stream';
 import is from '@sindresorhus/is';
 import bunyan from 'bunyan';
 import fs from 'fs-extra';

--- a/lib/modules/datasource/docker/index.ts
+++ b/lib/modules/datasource/docker/index.ts
@@ -1,4 +1,4 @@
-import URL from 'url';
+import URL from 'node:url';
 import { ECR } from '@aws-sdk/client-ecr';
 import type { ECRClientConfig } from '@aws-sdk/client-ecr';
 import is from '@sindresorhus/is';

--- a/lib/modules/datasource/go/base.ts
+++ b/lib/modules/datasource/go/base.ts
@@ -1,6 +1,6 @@
 // TODO: types (#7154)
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
-import URL from 'url';
+import URL from 'node:url';
 import { logger } from '../../../logger';
 import { detectPlatform } from '../../../util/common';
 import * as hostRules from '../../../util/host-rules';

--- a/lib/modules/datasource/maven/s3.spec.ts
+++ b/lib/modules/datasource/maven/s3.spec.ts
@@ -1,4 +1,4 @@
-import { Readable } from 'stream';
+import { Readable } from 'node:stream';
 import {
   GetObjectCommand,
   HeadObjectCommand,

--- a/lib/modules/datasource/maven/util.ts
+++ b/lib/modules/datasource/maven/util.ts
@@ -1,4 +1,4 @@
-import { Readable } from 'stream';
+import { Readable } from 'node:stream';
 import { GetObjectCommand, HeadObjectCommand } from '@aws-sdk/client-s3';
 import { DateTime } from 'luxon';
 import { XmlDocument } from 'xmldoc';

--- a/lib/modules/datasource/npm/get.ts
+++ b/lib/modules/datasource/npm/get.ts
@@ -1,4 +1,4 @@
-import url from 'url';
+import url from 'node:url';
 import is from '@sindresorhus/is';
 import { DateTime } from 'luxon';
 import { GlobalConfig } from '../../../config/global';

--- a/lib/modules/datasource/npm/npmrc.ts
+++ b/lib/modules/datasource/npm/npmrc.ts
@@ -1,4 +1,4 @@
-import url from 'url';
+import url from 'node:url';
 import is from '@sindresorhus/is';
 import ini from 'ini';
 import { GlobalConfig } from '../../../config/global';

--- a/lib/modules/datasource/pod/index.ts
+++ b/lib/modules/datasource/pod/index.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 import { HOST_DISABLED } from '../../../constants/error-messages';
 import { logger } from '../../../logger';
 import { ExternalHostError } from '../../../types/errors/external-host-error';

--- a/lib/modules/datasource/pypi/index.ts
+++ b/lib/modules/datasource/pypi/index.ts
@@ -1,4 +1,4 @@
-import url from 'url';
+import url from 'node:url';
 import changelogFilenameRegex from 'changelog-filename-regex';
 import { logger } from '../../../logger';
 import { parse } from '../../../util/html';

--- a/lib/modules/manager/bazel/artifacts.spec.ts
+++ b/lib/modules/manager/bazel/artifacts.spec.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 import { codeBlock } from 'common-tags';
 import * as httpMock from '../../../../test/http-mock';
 import { partial } from '../../../../test/util';

--- a/lib/modules/manager/git-submodules/extract.ts
+++ b/lib/modules/manager/git-submodules/extract.ts
@@ -1,4 +1,4 @@
-import URL from 'url';
+import URL from 'node:url';
 import Git, { SimpleGit } from 'simple-git';
 import upath from 'upath';
 import { GlobalConfig } from '../../../config/global';

--- a/lib/modules/manager/gradle-wrapper/artifacts.spec.ts
+++ b/lib/modules/manager/gradle-wrapper/artifacts.spec.ts
@@ -1,5 +1,5 @@
-import type { Stats } from 'fs';
-import os from 'os';
+import type { Stats } from 'node:fs';
+import os from 'node:os';
 import { join } from 'upath';
 import { envMock, mockExecAll } from '../../../../test/exec-util';
 import { Fixtures } from '../../../../test/fixtures';

--- a/lib/modules/manager/gradle-wrapper/util.spec.ts
+++ b/lib/modules/manager/gradle-wrapper/util.spec.ts
@@ -1,5 +1,5 @@
-import type { Stats } from 'fs';
-import os from 'os';
+import type { Stats } from 'node:fs';
+import os from 'node:os';
 import { fs, partial } from '../../../../test/util';
 import { GlobalConfig } from '../../../config/global';
 import {

--- a/lib/modules/manager/gradle-wrapper/utils.ts
+++ b/lib/modules/manager/gradle-wrapper/utils.ts
@@ -1,4 +1,4 @@
-import os from 'os';
+import os from 'node:os';
 import { GlobalConfig } from '../../../config/global';
 import { logger } from '../../../logger';
 import { chmodLocalFile, statLocalFile } from '../../../util/fs';

--- a/lib/modules/manager/gradle/artifacts.spec.ts
+++ b/lib/modules/manager/gradle/artifacts.spec.ts
@@ -1,4 +1,4 @@
-import os from 'os';
+import os from 'node:os';
 import { join } from 'upath';
 import {
   envMock,

--- a/lib/modules/manager/gradle/parser/handlers.ts
+++ b/lib/modules/manager/gradle/parser/handlers.ts
@@ -1,4 +1,4 @@
-import url from 'url';
+import URL from 'node:url';
 import upath from 'upath';
 import { logger } from '../../../../logger';
 import { getSiblingFileName } from '../../../../util/fs';
@@ -289,7 +289,7 @@ export function handleCustomRegistryUrl(ctx: Ctx): Ctx {
   if (registryUrl) {
     registryUrl = registryUrl.replace(regEx(/\\/g), '');
     try {
-      const { host, protocol } = url.parse(registryUrl);
+      const { host, protocol } = URL.parse(registryUrl);
       if (host && protocol) {
         ctx.registryUrls.push({
           registryUrl,

--- a/lib/modules/manager/homebrew/update.spec.ts
+++ b/lib/modules/manager/homebrew/update.spec.ts
@@ -1,4 +1,4 @@
-import { Readable } from 'stream';
+import { Readable } from 'node:stream';
 import { Fixtures } from '../../../../test/fixtures';
 import * as httpMock from '../../../../test/http-mock';
 import { updateDependency } from '.';

--- a/lib/modules/manager/maven-wrapper/artifacts.spec.ts
+++ b/lib/modules/manager/maven-wrapper/artifacts.spec.ts
@@ -1,5 +1,5 @@
-import type { Stats } from 'fs';
-import os from 'os';
+import type { Stats } from 'node:fs';
+import os from 'node:os';
 import type { StatusResult } from 'simple-git';
 import { join } from 'upath';
 import { envMock, mockExecAll } from '../../../../test/exec-util';

--- a/lib/modules/manager/maven-wrapper/artifacts.ts
+++ b/lib/modules/manager/maven-wrapper/artifacts.ts
@@ -1,5 +1,5 @@
-import type { Stats } from 'fs';
-import os from 'os';
+import type { Stats } from 'node:fs';
+import os from 'node:os';
 import is from '@sindresorhus/is';
 import { dirname, join } from 'upath';
 import { GlobalConfig } from '../../../config/global';

--- a/lib/modules/manager/npm/detect.ts
+++ b/lib/modules/manager/npm/detect.ts
@@ -1,4 +1,4 @@
-import os from 'os';
+import os from 'node:os';
 import is from '@sindresorhus/is';
 import upath from 'upath';
 import { logger } from '../../../logger';

--- a/lib/modules/manager/puppet/extract.spec.ts
+++ b/lib/modules/manager/puppet/extract.spec.ts
@@ -1,4 +1,4 @@
-import { EOL } from 'os';
+import { EOL } from 'node:os';
 import { Fixtures } from '../../../../test/fixtures';
 import { GitTagsDatasource } from '../../datasource/git-tags';
 import { GithubTagsDatasource } from '../../datasource/github-tags';

--- a/lib/modules/manager/puppet/puppetfile-parser.spec.ts
+++ b/lib/modules/manager/puppet/puppetfile-parser.spec.ts
@@ -1,4 +1,4 @@
-import { EOL } from 'os';
+import { EOL } from 'node:os';
 import { Fixtures } from '../../../../test/fixtures';
 import { parsePuppetfile } from './puppetfile-parser';
 

--- a/lib/modules/manager/regex/utils.ts
+++ b/lib/modules/manager/regex/utils.ts
@@ -1,4 +1,4 @@
-import { URL } from 'url';
+import { URL } from 'node:url';
 import is from '@sindresorhus/is';
 import { migrateDatasource } from '../../../config/migrations/custom/datasource-migration';
 import type { RegexManagerTemplates } from '../../../config/types';

--- a/lib/modules/manager/terraform/lockfile/hash.spec.ts
+++ b/lib/modules/manager/terraform/lockfile/hash.spec.ts
@@ -1,4 +1,4 @@
-import { createReadStream } from 'fs';
+import { createReadStream } from 'node:fs';
 import { DirectoryResult, dir } from 'tmp-promise';
 import { Fixtures } from '../../../../../test/fixtures';
 import * as httpMock from '../../../../../test/http-mock';

--- a/lib/modules/manager/terraform/lockfile/hash.ts
+++ b/lib/modules/manager/terraform/lockfile/hash.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 import extract from 'extract-zip';
 import upath from 'upath';
 import { logger } from '../../../../logger';

--- a/lib/modules/platform/azure/azure-helper.spec.ts
+++ b/lib/modules/platform/azure/azure-helper.spec.ts
@@ -1,4 +1,4 @@
-import { Readable } from 'stream';
+import { Readable } from 'node:stream';
 import { GitPullRequestMergeStrategy } from 'azure-devops-node-api/interfaces/GitInterfaces.js';
 
 describe('modules/platform/azure/azure-helper', () => {

--- a/lib/modules/platform/azure/index.spec.ts
+++ b/lib/modules/platform/azure/index.spec.ts
@@ -1,4 +1,4 @@
-import { Readable } from 'stream';
+import { Readable } from 'node:stream';
 import is from '@sindresorhus/is';
 import type { IGitApi } from 'azure-devops-node-api/GitApi';
 import {

--- a/lib/modules/platform/azure/util.spec.ts
+++ b/lib/modules/platform/azure/util.spec.ts
@@ -1,4 +1,4 @@
-import { Readable } from 'stream';
+import { Readable } from 'node:stream';
 import { streamToString } from '../../../util/streams';
 import {
   getBranchNameWithoutRefsheadsPrefix,

--- a/lib/modules/platform/bitbucket-server/utils.ts
+++ b/lib/modules/platform/bitbucket-server/utils.ts
@@ -1,5 +1,5 @@
 // SEE for the reference https://github.com/renovatebot/renovate/blob/c3e9e572b225085448d94aa121c7ec81c14d3955/lib/platform/bitbucket/utils.js
-import url from 'url';
+import url, { URL } from 'node:url';
 import is from '@sindresorhus/is';
 import { CONFIG_GIT_URL_UNAVAILABLE } from '../../../constants/error-messages';
 import { logger } from '../../../logger';

--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -1,4 +1,4 @@
-import URL from 'url';
+import URL from 'node:url';
 import is from '@sindresorhus/is';
 import JSON5 from 'json5';
 import { REPOSITORY_NOT_FOUND } from '../../../constants/error-messages';

--- a/lib/modules/platform/bitbucket/utils.ts
+++ b/lib/modules/platform/bitbucket/utils.ts
@@ -1,4 +1,4 @@
-import url from 'url';
+import URL from 'node:url';
 import type { MergeStrategy } from '../../../config/types';
 import type { BranchStatus } from '../../../types';
 import { BitbucketHttp } from '../../../util/http/bitbucket';
@@ -64,8 +64,8 @@ export const buildStates: Record<BranchStatus, BitbucketBranchState> = {
 };
 
 const addMaxLength = (inputUrl: string, pagelen = 100): string => {
-  const { search, ...parsedUrl } = url.parse(inputUrl, true);
-  const maxedUrl = url.format({
+  const { search, ...parsedUrl } = URL.parse(inputUrl, true);
+  const maxedUrl = URL.format({
     ...parsedUrl,
     query: { ...parsedUrl.query, pagelen },
   });

--- a/lib/modules/platform/codecommit/index.ts
+++ b/lib/modules/platform/codecommit/index.ts
@@ -1,4 +1,4 @@
-import { Buffer } from 'buffer';
+import { Buffer } from 'node:buffer';
 import {
   GetCommentsForPullRequestOutput,
   ListRepositoriesOutput,

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -1,6 +1,6 @@
 // TODO: types (#7154)
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
-import URL from 'url';
+import URL from 'node:url';
 import is from '@sindresorhus/is';
 import delay from 'delay';
 import JSON5 from 'json5';

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -1,4 +1,4 @@
-import URL from 'url';
+import URL from 'node:url';
 import is from '@sindresorhus/is';
 import delay from 'delay';
 import JSON5 from 'json5';

--- a/lib/modules/platform/index.ts
+++ b/lib/modules/platform/index.ts
@@ -1,4 +1,4 @@
-import URL from 'url';
+import URL from 'node:url';
 import type { AllConfig } from '../../config/types';
 import type { PlatformId } from '../../constants';
 import { PLATFORM_NOT_FOUND } from '../../constants/error-messages';

--- a/lib/util/cache/package/decorator.spec.ts
+++ b/lib/util/cache/package/decorator.spec.ts
@@ -1,4 +1,4 @@
-import os from 'os';
+import os from 'node:os';
 import { GlobalConfig } from '../../../config/global';
 import * as memCache from '../memory';
 import { cache } from './decorator';

--- a/lib/util/cache/package/file.spec.ts
+++ b/lib/util/cache/package/file.spec.ts
@@ -1,4 +1,4 @@
-import os from 'os';
+import os from 'node:os';
 import cacache from 'cacache';
 import { cleanup, get, init, set } from './file';
 

--- a/lib/util/cache/repository/impl/s3.spec.ts
+++ b/lib/util/cache/repository/impl/s3.spec.ts
@@ -1,4 +1,4 @@
-import { Readable } from 'stream';
+import { Readable } from 'node:stream';
 import {
   GetObjectCommand,
   GetObjectCommandInput,

--- a/lib/util/cache/repository/impl/s3.ts
+++ b/lib/util/cache/repository/impl/s3.ts
@@ -1,4 +1,4 @@
-import { Readable } from 'stream';
+import { Readable } from 'node:stream';
 import {
   GetObjectCommand,
   GetObjectCommandInput,

--- a/lib/util/compress.ts
+++ b/lib/util/compress.ts
@@ -1,5 +1,5 @@
-import { promisify } from 'util';
-import zlib from 'zlib';
+import { promisify } from 'node:util';
+import zlib from 'node:zlib';
 
 const brotliCompress = promisify(zlib.brotliCompress);
 const brotliDecompress = promisify(zlib.brotliDecompress);

--- a/lib/util/exec/common.spec.ts
+++ b/lib/util/exec/common.spec.ts
@@ -1,11 +1,11 @@
-import { spawn as _spawn } from 'child_process';
-import type { SendHandle, Serializable } from 'child_process';
-import { Readable } from 'stream';
+import { spawn as _spawn } from 'node:child_process';
+import type { SendHandle, Serializable } from 'node:child_process';
+import { Readable } from 'node:stream';
 import { mockedFunction, partial } from '../../../test/util';
 import { exec } from './common';
 import type { RawExecOptions } from './types';
 
-jest.mock('child_process');
+jest.mock('node:child_process');
 const spawn = mockedFunction(_spawn);
 
 type MessageListener = (message: Serializable, sendHandle: SendHandle) => void;

--- a/lib/util/exec/common.ts
+++ b/lib/util/exec/common.ts
@@ -1,4 +1,4 @@
-import { ChildProcess, spawn } from 'child_process';
+import { ChildProcess, spawn } from 'node:child_process';
 import { ExecError, ExecErrorData } from './exec-error';
 import type { ExecResult, RawExecOptions } from './types';
 

--- a/lib/util/exec/hermit.spec.ts
+++ b/lib/util/exec/hermit.spec.ts
@@ -1,4 +1,4 @@
-import os from 'os';
+import os from 'node:os';
 import _findUp from 'find-up';
 import upath from 'upath';
 import { mockExecAll } from '../../../test/exec-util';

--- a/lib/util/exec/hermit.ts
+++ b/lib/util/exec/hermit.ts
@@ -1,4 +1,4 @@
-import os from 'os';
+import os from 'node:os';
 import upath from 'upath';
 import { GlobalConfig } from '../../config/global';
 import { logger } from '../../logger';

--- a/lib/util/exec/types.ts
+++ b/lib/util/exec/types.ts
@@ -1,4 +1,4 @@
-import type { SpawnOptions as ChildProcessSpawnOptions } from 'child_process';
+import type { SpawnOptions as ChildProcessSpawnOptions } from 'node:child_process';
 
 export interface ToolConstraint {
   toolName: string;

--- a/lib/util/fs/index.ts
+++ b/lib/util/fs/index.ts
@@ -1,5 +1,5 @@
-import stream from 'stream';
-import util from 'util';
+import stream from 'node:stream';
+import util from 'node:util';
 import is from '@sindresorhus/is';
 import findUp from 'find-up';
 import fs from 'fs-extra';

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -1,4 +1,4 @@
-import URL from 'url';
+import URL from 'node:url';
 import is from '@sindresorhus/is';
 import delay from 'delay';
 import fs from 'fs-extra';

--- a/lib/util/git/private-key.ts
+++ b/lib/util/git/private-key.ts
@@ -1,4 +1,4 @@
-import os from 'os';
+import os from 'node:os';
 import is from '@sindresorhus/is';
 import fs from 'fs-extra';
 import upath from 'upath';

--- a/lib/util/http/dns.ts
+++ b/lib/util/http/dns.ts
@@ -1,4 +1,8 @@
-import { LookupAllOptions, LookupOneOptions, lookup as _dnsLookup } from 'dns';
+import {
+  LookupAllOptions,
+  LookupOneOptions,
+  lookup as _dnsLookup,
+} from 'node:dns';
 import type { EntryObject, IPFamily, LookupOptions } from 'cacheable-lookup';
 import QuickLRU from 'quick-lru';
 import { logger } from '../../logger';

--- a/lib/util/http/types.ts
+++ b/lib/util/http/types.ts
@@ -1,4 +1,4 @@
-import type { IncomingHttpHeaders } from 'http';
+import type { IncomingHttpHeaders } from 'node:http';
 import type {
   OptionsOfBufferResponseBody,
   OptionsOfJSONResponseBody,

--- a/lib/util/modules.ts
+++ b/lib/util/modules.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'node:fs';
 import upath from 'upath';
 
 function relatePath(here: string, there: string): string {

--- a/lib/util/streams.spec.ts
+++ b/lib/util/streams.spec.ts
@@ -1,4 +1,4 @@
-import { Readable } from 'stream';
+import { Readable } from 'node:stream';
 import { streamToString } from './streams';
 
 describe('util/streams', () => {

--- a/lib/util/streams.ts
+++ b/lib/util/streams.ts
@@ -1,4 +1,4 @@
-import { Readable } from 'stream';
+import { Readable } from 'node:stream';
 
 export async function streamToString(
   stream: NodeJS.ReadableStream

--- a/lib/workers/global/config/parse/codespaces.ts
+++ b/lib/workers/global/config/parse/codespaces.ts
@@ -1,4 +1,4 @@
-import readline from 'readline';
+import readline from 'node:readline';
 import type { AllConfig } from '../../../../config/types';
 
 // istanbul ignore next

--- a/lib/workers/global/config/parse/file.spec.ts
+++ b/lib/workers/global/config/parse/file.spec.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'node:fs';
 import fsExtra from 'fs-extra';
 import { DirectoryResult, dir } from 'tmp-promise';
 import upath from 'upath';

--- a/lib/workers/global/initialize.ts
+++ b/lib/workers/global/initialize.ts
@@ -1,4 +1,4 @@
-import os from 'os';
+import os from 'node:os';
 import fs from 'fs-extra';
 import upath from 'upath';
 import { applySecretsToConfig } from '../../config/secrets';

--- a/lib/workers/repository/stats.ts
+++ b/lib/workers/repository/stats.ts
@@ -1,4 +1,4 @@
-import URL from 'url';
+import URL from 'node:url';
 import { logger } from '../../logger';
 import { sortNumeric } from '../../util/array';
 import * as memCache from '../../util/cache/memory';

--- a/lib/workers/repository/update/pr/changelog/release-notes.ts
+++ b/lib/workers/repository/update/pr/changelog/release-notes.ts
@@ -1,5 +1,5 @@
 // TODO #7154
-import URL from 'url';
+import URL from 'node:url';
 import is from '@sindresorhus/is';
 import { DateTime } from 'luxon';
 import MarkdownIt from 'markdown-it';

--- a/lib/workers/repository/update/pr/changelog/source-github.ts
+++ b/lib/workers/repository/update/pr/changelog/source-github.ts
@@ -1,5 +1,5 @@
 // TODO #7154
-import URL from 'url';
+import URL from 'node:url';
 import { GlobalConfig } from '../../../../../config/global';
 import { logger } from '../../../../../logger';
 import type { Release } from '../../../../../modules/datasource/types';

--- a/lib/workers/repository/update/pr/changelog/source-gitlab.ts
+++ b/lib/workers/repository/update/pr/changelog/source-gitlab.ts
@@ -1,5 +1,5 @@
 // TODO #7154
-import URL from 'url';
+import URL from 'node:url';
 import { logger } from '../../../../../logger';
 import type { Release } from '../../../../../modules/datasource/types';
 import * as allVersioning from '../../../../../modules/versioning';

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -1,5 +1,5 @@
-import type fs from 'fs';
-import type { PathLike, Stats } from 'fs';
+import type fs from 'node:fs';
+import type { PathLike, Stats } from 'node:fs';
 import { jest } from '@jest/globals';
 import callsite from 'callsite';
 import { DirectoryJSON, fs as memfs, vol } from 'memfs';

--- a/test/http-mock.ts
+++ b/test/http-mock.ts
@@ -1,4 +1,4 @@
-import type { Url } from 'url';
+import type { Url } from 'node:url';
 import { afterAll, afterEach, beforeAll } from '@jest/globals';
 // eslint-disable-next-line no-restricted-imports
 import nock from 'nock';

--- a/test/static-files.spec.ts
+++ b/test/static-files.spec.ts
@@ -1,4 +1,4 @@
-import util from 'util';
+import util from 'node:util';
 import _glob from 'glob';
 
 const glob = util.promisify(_glob);

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 import { expect, jest } from '@jest/globals';
 import type { Plugin } from 'pretty-format';
 import upath from 'upath';

--- a/test/website-docs.spec.ts
+++ b/test/website-docs.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
-import fs from 'fs';
+import fs from 'node:fs';
 import is from '@sindresorhus/is';
 import { getOptions } from '../lib/config/options';
 

--- a/tools/check-fenced-code.mjs
+++ b/tools/check-fenced-code.mjs
@@ -1,4 +1,4 @@
-import { promisify } from 'util';
+import { promisify } from 'node:util';
 import fs from 'fs-extra';
 import g from 'glob';
 import MarkdownIt from 'markdown-it';

--- a/tools/clean-cache.mjs
+++ b/tools/clean-cache.mjs
@@ -1,4 +1,4 @@
-import { tmpdir } from 'os';
+import { tmpdir } from 'node:os';
 import { remove } from 'fs-extra';
 import upath from 'upath';
 

--- a/tools/generate-imports.mjs
+++ b/tools/generate-imports.mjs
@@ -1,4 +1,4 @@
-import util from 'util';
+import util from 'node:util';
 import fs from 'fs-extra';
 import _glob from 'glob';
 import hasha from 'hasha';

--- a/tools/static-data/generate-azure-pipelines-tasks.mjs
+++ b/tools/static-data/generate-azure-pipelines-tasks.mjs
@@ -1,5 +1,5 @@
-import os from 'os';
-import { promisify } from 'util';
+import os from 'node:os';
+import { promisify } from 'node:util';
 import fs from 'fs-extra';
 import g from 'glob';
 import JSON5 from 'json5';


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
[Use `node:` protocol][1] to import builtin modules

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->
`node:` protocol imports are now the preferred way to import builtin Node.js modules. Advantages are:
- It's immediately clear where an import is coming from
- Zero chance of something in `node_modules` overriding an import
- Going forward new Node.js modules will only be available via `node:` style imports, starting with [`node:test` in Node.js v18][2]

An `eslint-plugin-import` rule is currently under consideration to enforce this. See https://github.com/import-js/eslint-plugin-import/issues/2717

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
[1]: https://nodejs.org/api/esm.html#node-imports
[2]: https://nodejs.org/docs/latest-v18.x/api/test.html