### PR TITLE
feat(template): indentation capture group

### DIFF
--- a/lib/modules/manager/regex/readme.md
+++ b/lib/modules/manager/regex/readme.md
@@ -34,6 +34,8 @@ Configuration-wise, it works like this:
 - You can optionally have a `currentDigest` capture group.
 - You can optionally have a `registryUrl` capture group or a `registryUrlTemplate` config field
   - If it's a valid URL, it will be converted to the `registryUrls` field as a single-length array.
+- You can optionally have an `indentation` capture group.
+  - If it's not empty or whitespace, it will be reset to an empty string.
 
 ### Regular Expression Capture Groups
 

--- a/lib/modules/manager/regex/utils.ts
+++ b/lib/modules/manager/regex/utils.ts
@@ -17,6 +17,7 @@ export const validMatchFields = [
   'extractVersion',
   'registryUrl',
   'depType',
+  'indentation',
 ] as const;
 
 type ValidMatchFields = (typeof validMatchFields)[number];
@@ -38,6 +39,9 @@ function updateDependency(
       break;
     case 'datasource':
       dependency.datasource = migrateDatasource(value);
+      break;
+    case 'indentation':
+      dependency.indentation = is.emptyStringOrWhitespace(value) ? value : '';
       break;
     default:
       dependency[field] = value;

--- a/lib/modules/manager/types.ts
+++ b/lib/modules/manager/types.ts
@@ -150,6 +150,7 @@ export interface PackageDependency<T = Record<string, any>>
   extractVersion?: string;
   isInternal?: boolean;
   variableName?: string;
+  indentation?: string;
 }
 
 export interface Upgrade<T = Record<string, any>> extends PackageDependency<T> {

--- a/lib/util/template/index.ts
+++ b/lib/util/template/index.ts
@@ -87,6 +87,7 @@ export const allowedFields = {
   displayPending: 'Latest pending update, if internalChecksFilter is in use',
   displayTo: 'The to value, formatted for display',
   hasReleaseNotes: 'true if the upgrade has release notes',
+  indentation: 'The indentation of the dependency being updated',
   isLockfileUpdate: 'true if the branch is a lock file update',
   isMajor: 'true if the upgrade is major',
   isPatch: 'true if the upgrade is a patch upgrade',


### PR DESCRIPTION
## Changes

Feature enhancement to help with RegexManager `autoReplaceStringTemplate` where preserving indentation is important (ie: `yml`)

Feedback very much welcomed 🙏 

## Context

As per discussion in https://github.com/renovatebot/renovate/discussions/21169

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
