### PR TITLE
fix(datasource): verify registryUrls before constructing key for cache entry

### DIFF
--- a/lib/modules/datasource/index.ts
+++ b/lib/modules/datasource/index.ts
@@ -326,9 +326,9 @@ function getRawReleases(
   config: GetReleasesInternalConfig
 ): Promise<ReleaseResult | null> {
   const { datasource, packageName, registryUrls } = config;
-  const cacheKey = `${cacheNamespace}${datasource}${packageName}${String(
+  const cacheKey = `${cacheNamespace}${datasource}${packageName}${registryUrls ? String(
     registryUrls
-  )}`;
+  ) : ''}`;
   // By returning a Promise and reusing it, we should only fetch each package at most once
   const cachedResult = memCache.get<Promise<ReleaseResult | null>>(cacheKey);
   // istanbul ignore if


### PR DESCRIPTION
Sometimes when `registryUrls` is null, when constructing a key for a memory cache entry, `String(registryUrls)` makes the key invalid

@rarkins please have a look