### PR TITLE
fix(github-release-attachments): set token correctly

### DIFF
--- a/lib/constants/platforms.ts
+++ b/lib/constants/platforms.ts
@@ -10,6 +10,7 @@ export type PlatformId =
 export const GITHUB_API_USING_HOST_TYPES = [
   'github',
   'github-releases',
+  'github-release-attachments',
   'github-tags',
   'pod',
   'hermit',

--- a/lib/util/check-token.ts
+++ b/lib/util/check-token.ts
@@ -1,5 +1,6 @@
 import { GlobalConfig } from '../config/global';
 import { logger } from '../logger';
+import { GithubReleaseAttachmentsDatasource } from '../modules/datasource/github-release-attachments';
 import { GithubReleasesDatasource } from '../modules/datasource/github-releases';
 import { GithubTagsDatasource } from '../modules/datasource/github-tags';
 import type { PackageFileContent } from '../modules/manager/types';
@@ -31,7 +32,8 @@ export function checkGithubToken(
         if (
           !dep.skipReason &&
           (dep.datasource === GithubTagsDatasource.id ||
-            dep.datasource === GithubReleasesDatasource.id)
+            dep.datasource === GithubReleasesDatasource.id ||
+            dep.datasource === GithubReleaseAttachmentsDatasource.id)
         ) {
           dep.skipReason = 'github-token-required';
           if (dep.depName) {


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Fixes problem where `github-release-attachments` wasn't automatically getting github token credentials.

## Context

Fixes #21230

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
