### PR TITLE
feat: autoclose PRs when repo disabled

### DIFF
--- a/lib/workers/repository/finalise/prune.ts
+++ b/lib/workers/repository/finalise/prune.ts
@@ -5,16 +5,18 @@ import { logger } from '../../../logger';
 import { platform } from '../../../modules/platform';
 import { ensureComment } from '../../../modules/platform/comment';
 import { scm } from '../../../modules/platform/scm';
-import { getBranchList } from '../../../util/git';
+import { getBranchList, setUserRepoConfig } from '../../../util/git';
 
 async function cleanUpBranches(
-  { pruneStaleBranches: enabled }: RenovateConfig,
+  config: RenovateConfig,
   remainingBranches: string[]
 ): Promise<void> {
-  if (enabled === false) {
+  if (!config.pruneStaleBranches) {
     logger.debug('Branch/PR pruning is disabled - skipping');
     return;
   }
+  // set git author in case repo is not initialised yet
+  setUserRepoConfig(config);
   for (const branchName of remainingBranches) {
     try {
       const pr = await platform.findPr({

--- a/lib/workers/repository/finalise/prune.ts
+++ b/lib/workers/repository/finalise/prune.ts
@@ -15,7 +15,7 @@ async function cleanUpBranches(
     logger.debug('Branch/PR pruning is disabled - skipping');
     return;
   }
-  // set git author in case repo is not initialised yet
+  // set Git author in case the repository is not initialized yet
   setUserRepoConfig(config);
   for (const branchName of remainingBranches) {
     try {


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Calls the branch cleanup function when repo is disabled by config, due to no config, or due to forking.

## Context

Closes #21242

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
