### PR TITLE
fix(post-upgrade-tasks)!: enable dot option for file filters

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2419,7 +2419,8 @@ You can use variable templating in your commands if [`allowPostUpgradeCommandTem
 
 ### fileFilters
 
-A list of glob-style matchers that determine which files will be included in the final commit made by Renovate. Dotfiles are included by default by glob-style matchers.
+A list of glob-style matchers that determine which files will be included in the final commit made by Renovate.
+Dotfiles are included.
 
 ### executionMode
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2419,7 +2419,7 @@ You can use variable templating in your commands if [`allowPostUpgradeCommandTem
 
 ### fileFilters
 
-A list of glob-style matchers that determine which files will be included in the final commit made by Renovate.
+A list of glob-style matchers that determine which files will be included in the final commit made by Renovate. Dotfiles are included by default by glob-style matchers.
 
 ### executionMode
 

--- a/lib/workers/repository/update/branch/execute-post-upgrade-commands.ts
+++ b/lib/workers/repository/update/branch/execute-post-upgrade-commands.ts
@@ -106,7 +106,7 @@ export async function postUpgradeCommandsExecutor(
 
       for (const relativePath of status.modified.concat(status.not_added)) {
         for (const pattern of fileFilters) {
-          if (minimatch(relativePath, pattern)) {
+          if (minimatch(relativePath, pattern, { dot: true })) {
             logger.debug(
               { file: relativePath, pattern },
               'Post-upgrade file saved'
@@ -134,7 +134,7 @@ export async function postUpgradeCommandsExecutor(
 
       for (const relativePath of status.deleted || []) {
         for (const pattern of fileFilters) {
-          if (minimatch(relativePath, pattern)) {
+          if (minimatch(relativePath, pattern, { dot: true })) {
             logger.debug(
               { file: relativePath, pattern },
               'Post-upgrade file removed'


### PR DESCRIPTION
Default to including dot files for fileFilters in postUpgradeTasks

Closes #21276

BREAKING CHANGE: Glob patterns used for Post upgrade task "fileFilters" now include dotfiles by default.

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Default to including dot files for fileFilters in postUpgradeTasks

## Context

Closes #21276

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
