### PR TITLE
fix(yarn): detect already-updated for yarn 2/3

### DIFF
--- a/lib/modules/manager/npm/update/locked-dependency/yarn-lock/index.spec.ts
+++ b/lib/modules/manager/npm/update/locked-dependency/yarn-lock/index.spec.ts
@@ -21,6 +21,9 @@ describe('modules/manager/npm/update/locked-dependency/yarn-lock/index', () => {
 
     it('returns if yarn lock 2', () => {
       config.lockFileContent = yarn2Lock;
+      config.depName = 'chalk';
+      config.currentVersion = '2.4.2';
+      config.newVersion = '2.4.3';
       expect(updateLockedDependency(config).status).toBe('unsupported');
     });
 

--- a/lib/modules/manager/npm/update/locked-dependency/yarn-lock/index.ts
+++ b/lib/modules/manager/npm/update/locked-dependency/yarn-lock/index.ts
@@ -22,10 +22,6 @@ export function updateLockedDependency(
     logger.warn({ err }, 'Failed to parse yarn files');
     return { status: 'update-failed' };
   }
-  if ('__metadata' in yarnLock) {
-    logger.debug('Yarn 2+ unsupported');
-    return { status: 'unsupported' };
-  }
   try {
     const lockedDeps = getLockedDependencies(yarnLock, depName, currentVersion);
     if (!lockedDeps.length) {
@@ -44,6 +40,12 @@ export function updateLockedDependency(
         `${depName}@${currentVersion} not found in ${lockFile} - cannot update`
       );
       return { status: 'update-failed' };
+    }
+    if ('__metadata' in yarnLock) {
+      logger.debug(
+        'Cannot patch Yarn 2+ lock file directly - falling back to using yarn'
+      );
+      return { status: 'unsupported' };
     }
     logger.debug(
       `Found matching dependencies with length ${lockedDeps.length}`


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Rearranges some logic in yarn.updateLockedDependency() so that we can more efficiently detect already-updated content in Yarn 2/3

## Context

This will reduce amount of times we call `yarn`, probably work around some errors too.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
