### PR TITLE
fix(cache): catch redis set value errors

### DIFF
--- a/lib/util/cache/package/redis.ts
+++ b/lib/util/cache/package/redis.ts
@@ -76,7 +76,7 @@ export async function set(
       { EX: redisTTL }
     );
   } catch (err) {
-    logger.debug({ err, namespace, key }, 'Error setting cache value');
+    logger.once.debug({ err }, 'Error while setting cache value');
   }
 }
 

--- a/lib/util/cache/package/redis.ts
+++ b/lib/util/cache/package/redis.ts
@@ -65,15 +65,19 @@ export async function set(
   // Redis requires TTL to be integer, not float
   const redisTTL = Math.floor(ttlMinutes * 60);
 
-  await client?.set(
-    getKey(namespace, key),
-    JSON.stringify({
-      compress: true,
-      value: await compress(JSON.stringify(value)),
-      expiry: DateTime.local().plus({ minutes: ttlMinutes }),
-    }),
-    { EX: redisTTL }
-  );
+  try {
+    await client?.set(
+      getKey(namespace, key),
+      JSON.stringify({
+        compress: true,
+        value: await compress(JSON.stringify(value)),
+        expiry: DateTime.local().plus({ minutes: ttlMinutes }),
+      }),
+      { EX: redisTTL }
+    );
+  } catch (err) {
+    logger.debug({ err, namespace, key }, 'Error setting cache value');
+  }
 }
 
 export async function init(url: string): Promise<void> {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Catch thrown errors when trying to set a cache value when using redis
<!-- Describe what behavior is changed by this PR. -->

## Context
Prevent aborting run due to failure while setting value in Redis
Example
```
{
	"name": "renovate",
	"hostname": "c0cc38dbabd4",
	"pid": 9,
	"level": 30,
	"logContext": "c07cb5de9f02460c86ed63a00bcc8f85",
	"repository": "...",
	"msg": "External host error causing abort - skipping",
	"time": "2023-03-30T11:25:44.526Z",
	"v": 0
},
{
	"name": "renovate",
	"hostname": "c0cc38dbabd4",
	"pid": 9,
	"level": 20,
	"logContext": "c07cb5de9f02460c86ed63a00bcc8f85",
	"datasource": "docker",
	"packageName": "mcr.microsoft.com/mssql/server",
	"err": {
		"message": "The client is closed",
		"stack": "Error: The client is closed
    at Commander._RedisClient_sendCommand (/opt/buildpack/tools/renovate/35.23.3/node_modules/@redis/client/dist/lib/client/index.js:482:31)
    at Commander.commandsExecutor (/opt/buildpack/tools/renovate/35.23.3/node_modules/@redis/client/dist/lib/client/index.js:193:154)
    at Commander.BaseClass.<computed> [as set] (/opt/buildpack/tools/renovate/35.23.3/node_modules/@redis/client/dist/lib/commander.js:8:29)
    at Object.set (/opt/buildpack/tools/renovate/35.23.3/node_modules/renovate/lib/util/cache/package/redis.ts:68:17)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at Object.set (/opt/buildpack/tools/renovate/35.23.3/node_modules/renovate/lib/util/cache/package/index.ts:49:3)
    at /opt/buildpack/tools/renovate/35.23.3/node_modules/renovate/lib/util/cache/package/decorator.ts:123:7
    at DockerDatasource.getReleases (/opt/buildpack/tools/renovate/35.23.3/node_modules/renovate/lib/modules/datasource/docker/index.ts:1156:20)
    at getRegistryReleases (/opt/buildpack/tools/renovate/35.23.3/node_modules/renovate/lib/modules/datasource/index.ts:73:15)
    at fetchReleases (/opt/buildpack/tools/renovate/35.23.3/node_modules/renovate/lib/modules/datasource/index.ts:299:15)"
	},
	"msg": "Datasource unknown error",
	"time": "2023-03-30T11:25:51.653Z",
	"v": 0
}
```
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
