### PR TITLE
fix(vulnerabilities): skip withdrawn security advisories

### DIFF
--- a/lib/workers/repository/process/vulnerabilities.spec.ts
+++ b/lib/workers/repository/process/vulnerabilities.spec.ts
@@ -125,6 +125,31 @@ describe('workers/repository/process/vulnerabilities', () => {
       expect(config.packageRules).toHaveLength(0);
     });
 
+    it('withdrawn vulnerability', async () => {
+      const packageFiles: Record<string, PackageFile[]> = {
+        npm: [
+          {
+            deps: [
+              { depName: 'lodash', currentValue: '4.17.10', datasource: 'npm' },
+            ],
+            packageFile: 'some-file',
+          },
+        ],
+      };
+      getVulnerabilitiesMock.mockResolvedValueOnce([
+        {
+          ...lodashVulnerability,
+          withdrawn: '2021-11-29T18:17:00Z',
+        },
+      ]);
+
+      await vulnerabilities.fetchVulnerabilities(config, packageFiles);
+      expect(logger.logger.trace).toHaveBeenCalledWith(
+        'Skipping withdrawn vulnerability GHSA-x5rq-j2xg-h7qm'
+      );
+      expect(config.packageRules).toHaveLength(0);
+    });
+
     it('invalid dep version', async () => {
       const packageFiles: Record<string, PackageFile[]> = {
         npm: [

--- a/lib/workers/repository/process/vulnerabilities.ts
+++ b/lib/workers/repository/process/vulnerabilities.ts
@@ -153,6 +153,11 @@ export class Vulnerabilities {
       }
 
       for (const vulnerability of vulnerabilities) {
+        if (vulnerability.withdrawn) {
+          logger.trace(`Skipping withdrawn vulnerability ${vulnerability.id}`);
+          continue;
+        }
+
         for (const affected of vulnerability.affected ?? []) {
           const isVulnerable = this.isPackageVulnerable(
             ecosystem,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Excludes OSV vulnerabilities from being processed / added as package rules in case they have been withdrawn. This affects ~300 vulnerability advisories across all renovate-supported ecosystems.

In practice, this change also causes PRs to be closed in case an advisory is found to be invalid after publishing.

<!-- Describe what behavior is changed by this PR. -->

## Context

- https://github.com/renovatebot/renovate/pull/20226

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

Test repo:
- Before this change: https://github.com/renovate-demo/renovate-vuln-jquery/pull/1
- After this change: https://github.com/renovate-demo/renovate-vuln-jquery2/pull/1

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
