### PR TITLE
fix(yarn): use yarn up -R for lock file updating

### DIFF
--- a/lib/modules/manager/npm/post-update/__snapshots__/yarn.spec.ts.snap
+++ b/lib/modules/manager/npm/post-update/__snapshots__/yarn.spec.ts.snap
@@ -884,7 +884,7 @@ exports[`modules/manager/npm/post-update/yarn performs lock file updates using y
     },
   },
   {
-    "cmd": "yarn up 'some-dep@^1.0.0'",
+    "cmd": "yarn up -R some-dep",
     "options": {
       "cwd": "some-dir",
       "encoding": "utf-8",
@@ -934,7 +934,7 @@ exports[`modules/manager/npm/post-update/yarn performs lock file updates using y
     },
   },
   {
-    "cmd": "yarn up 'some-dep@^1.0.0' --mode=update-lockfile",
+    "cmd": "yarn up -R some-dep --mode=update-lockfile",
     "options": {
       "cwd": "some-dir",
       "encoding": "utf-8",

--- a/lib/modules/manager/npm/post-update/yarn.ts
+++ b/lib/modules/manager/npm/post-update/yarn.ts
@@ -221,7 +221,7 @@ export async function generateLockFile(
             .join(' ')}${cmdOptions}`
         );
       } else {
-        // `yarn up` updates to the latest release, so the range should be specified
+        // `yarn up -R` updates to the latest release in each range
         commands.push(
           `yarn up -R ${lockUpdates
             // TODO: types (#7154)

--- a/lib/modules/manager/npm/post-update/yarn.ts
+++ b/lib/modules/manager/npm/post-update/yarn.ts
@@ -223,9 +223,9 @@ export async function generateLockFile(
       } else {
         // `yarn up` updates to the latest release, so the range should be specified
         commands.push(
-          `yarn up ${lockUpdates
+          `yarn up -R ${lockUpdates
             // TODO: types (#7154)
-            .map((update) => `${update.depName!}@${update.newValue!}`)
+            .map((update) => `${update.depName!}`)
             .filter(uniqueStrings)
             .map(quote)
             .join(' ')}${cmdOptions}`


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Uses the `-R` flag for recursive for lock file updates.

## Context

Closes #20281

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
