### PR TITLE
docs: update template capture group definitions

### DIFF
--- a/lib/modules/manager/regex/readme.md
+++ b/lib/modules/manager/regex/readme.md
@@ -32,10 +32,8 @@ Configuration-wise, it works like this:
 - You can optionally have a `versioning` capture group or a `versioningTemplate` config field. If neither are present, `semver-coerced` will be used as the default
 - You can optionally have an `extractVersion` capture group or an `extractVersionTemplate` config field
 - You can optionally have a `currentDigest` capture group.
-- You can optionally have a `registryUrl` capture group or a `registryUrlTemplate` config field
-  - If it's a valid URL, it will be converted to the `registryUrls` field as a single-length array.
-- You can optionally have an `indentation` capture group.
-  - If it's not empty or whitespace, it will be reset to an empty string.
+- You can optionally have a `registryUrl` capture group or a `registryUrlTemplate` config field. If it's a valid URL, it will be converted to the `registryUrls` field as a single-length array.
+- You can optionally have an `indentation` capture group. It must be either empty or whitespace only, otherwise it will be reset to an empty string.
 
 ### Regular Expression Capture Groups
 


### PR DESCRIPTION
## Changes

Remove nested bullet markdown.

Clarify docs for `indentation` capture group

## Context

I noticed that the [docs](https://docs.renovatebot.com/modules/manager/regex/) didn't match the intentions of the markdown

Current state
![Screenshot 2023-04-03 at 5 47 09 PM](https://user-images.githubusercontent.com/386277/229635567-ffb4b4b1-ac78-460d-8f7f-f96b86f1d65d.png)

![Screenshot 2023-04-03 at 5 47 26 PM](https://user-images.githubusercontent.com/386277/229635506-ec01f520-aab5-4e10-a294-9aa1600ab4ce.png)

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
