### PR TITLE
feat(automerge)!: default to platformAutomerge=true

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2332,28 +2332,28 @@ If enabled Renovate will pin Docker images or GitHub Actions by means of their S
 ## platformAutomerge
 
 <!-- prettier-ignore -->
-!!! warning
-    Before you enable `platformAutomerge` you should enable your Git hosting platform's capabilities to enforce test passing before PR merge.
+!!! note
+    If you use the default `platformAutomerge=true` then you should enable your Git hosting platform's capabilities to enforce test passing before PR merge.
     If you don't do this, the platform might merge Renovate PRs even if the repository's tests haven't started, are in still in progress, or possibly even when they have failed.
     On GitHub this is called "Require status checks before merging", which you can find in the "Branch protection rules" section of the settings for your repository.
     [GitHub docs, about protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches)
     [GitHub docs, require status checks before merging](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#require-status-checks-before-merging)
     If you're using another platform, search their documentation for a similar feature.
 
-If you have enabled `automerge` and set `automergeType=pr` in the Renovate config, then you can also set `platformAutomerge` to `true` to speed up merging via the platform's native automerge functionality.
+If you have enabled `automerge` and set `automergeType=pr` in the Renovate config, then leaving `platformAutomerge` as `true` speeds up merging via the platform's native automerge functionality.
 
 Renovate tries platform-native automerge only when it initially creates the PR.
 Any PR that is being updated will be automerged with the Renovate-based automerge.
 
 `platformAutomerge` will configure PRs to be merged after all (if any) branch policies have been met.
-This option is available for Azure, GitHub and GitLab.
+This option is available for Azure, Gitea, GitHub and GitLab.
 It falls back to Renovate-based automerge if the platform-native automerge is not available.
 
 You can also fine-tune the behavior by setting `packageRules` if you want to use it selectively (e.g. per-package).
 
 Note that the outcome of `rebaseWhen=auto` can differ when `platformAutomerge=true`.
 Normally when you set `rebaseWhen=auto` Renovate rebases any branch that's behind the base branch automatically, and some people rely on that.
-This behavior is no longer guaranteed when you enable `platformAutomerge` because the platform might automerge a branch which is not up-to-date.
+This behavior is no longer guaranteed when `platformAutomerge` is true because the platform might automerge a branch which is not up-to-date.
 For example, GitHub might automerge a Renovate branch even if it's behind the base branch at the time.
 
 Please check platform specific docs for version requirements.

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2353,7 +2353,7 @@ You can also fine-tune the behavior by setting `packageRules` if you want to use
 
 Note that the outcome of `rebaseWhen=auto` can differ when `platformAutomerge=true`.
 Normally when you set `rebaseWhen=auto` Renovate rebases any branch that's behind the base branch automatically, and some people rely on that.
-This behavior is no longer guaranteed when `platformAutomerge` is true because the platform might automerge a branch which is not up-to-date.
+This behavior is no longer guaranteed when `platformAutomerge` is `true` because the platform might automerge a branch which is not up-to-date.
 For example, GitHub might automerge a Renovate branch even if it's behind the base branch at the time.
 
 Please check platform specific docs for version requirements.

--- a/docs/usage/key-concepts/automerge.md
+++ b/docs/usage/key-concepts/automerge.md
@@ -100,8 +100,8 @@ Say you want to automerge `patch` and `minor` updates for packages in the `group
 
 ### Faster merges with platform-native automerge
 
-Renovate by default uses platform-native automerge to speed up automerging.
-The config option is called `platformAutomerge` and can be disabled if it's not desired.
+By default, Renovate uses platform-native automerge to speed up automerging.
+If you don't want Renovate to use the platform-native automerge, then set `platformAutomerge` to `false`.
 
 For example:
 

--- a/docs/usage/key-concepts/automerge.md
+++ b/docs/usage/key-concepts/automerge.md
@@ -100,9 +100,8 @@ Say you want to automerge `patch` and `minor` updates for packages in the `group
 
 ### Faster merges with platform-native automerge
 
-You can speed up merges by letting Renovate use your platform's native automerge.
-The config option is called `platformAutomerge`.
-If `automerge=true` and `automergeType=pr` then you can set `platformAutomerge=true`.
+Renovate by default uses platform-native automerge to speed up automerging.
+The config option is called `platformAutomerge` and can be disabled if it's not desired.
 
 For example:
 
@@ -112,7 +111,7 @@ For example:
     "enabled": true,
     "automerge": true,
     "automergeType": "pr",
-    "platformAutomerge": true
+    "platformAutomerge": false
   }
 }
 ```
@@ -155,11 +154,10 @@ On `github.com`, go to your repository's "homepage", click on Settings, scroll d
 Then go to your repository's branch protection rules for your base branch (usually `main`) and enable the "Require merge queue" setting.
 Confirm you've set the correct "required checks" for your base branch.
 
-Finally, allow Renovate to automerge by setting `automerge=true` and `platformAutomerge=true` in your Renovate config file, for example:
+Finally, allow Renovate to automerge by setting `automerge=true` in your Renovate config file, for example:
 
 ```json
 {
-  "platformAutomerge": true,
   "packageRules": [
     {
       "description": "Automerge non-major updates",
@@ -180,7 +178,7 @@ On `github.com`, go to your repository's "homepage", click on Settings, scroll d
 Go to your repository's branch protection rules for your base branch (usually `main`) and enable the "Require merge queue" setting.
 Confirm you've set the correct "required checks" for your base branch.
 
-Finally, allow Renovate to automerge by setting `automerge=true` and `platformAutomerge=true` in your Renovate config file (see earlier example).
+Finally, allow Renovate to automerge by setting `automerge=true` in your Renovate config file (see earlier example).
 
 ## Automerging and scheduling
 

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -2563,7 +2563,7 @@ const options: RenovateOptions[] = [
     description: `Controls if platform-native auto-merge is used.`,
     type: 'boolean',
     supportedPlatforms: ['azure', 'gitea', 'github', 'gitlab'],
-    default: false,
+    default: true,
   },
   {
     name: 'userStrings',

--- a/lib/modules/platform/gitea/index.md
+++ b/lib/modules/platform/gitea/index.md
@@ -18,7 +18,7 @@ Either the account should have full name and email address set to allow Renovate
 ## Unsupported platform features/concepts
 
 - **Adding reviewers to PRs not supported**: Gitea versions older than `v1.14.0` do not have the required API.
-- **Setting `platformAutomerge` to use platform-native automerge for PRs not supported**: Gitea versions older than v1.17.0 do not have the required API.
+- **`platformAutomerge` (default=true) for platform-native automerge not supported**: Gitea versions older than v1.17.0 do not have the required API.
 - **Git upload filters**: If you're using a Gitea version older than `v1.16.0` then you must enable [clone filters](https://docs.gitea.io/en-us/clone-filters/).
 
 ## Features awaiting implementation

--- a/lib/modules/platform/gitea/index.md
+++ b/lib/modules/platform/gitea/index.md
@@ -18,7 +18,7 @@ Either the account should have full name and email address set to allow Renovate
 ## Unsupported platform features/concepts
 
 - **Adding reviewers to PRs not supported**: Gitea versions older than `v1.14.0` do not have the required API.
-- **`platformAutomerge` (default=true) for platform-native automerge not supported**: Gitea versions older than v1.17.0 do not have the required API.
+- **`platformAutomerge` (`true` by default) for platform-native automerge not supported**: Gitea versions older than v1.17.0 do not have the required API.
 - **Git upload filters**: If you're using a Gitea version older than `v1.16.0` then you must enable [clone filters](https://docs.gitea.io/en-us/clone-filters/).
 
 ## Features awaiting implementation


### PR DESCRIPTION


<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

BREAKING CHANGE: Platform automerge is now used by default when PR automerge is configured

## Context

Closes #21319

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
