### PR TITLE
fix(versioning/hashicorp): allow numbered unstable versions

### DIFF
--- a/lib/modules/versioning/hashicorp/convertor.spec.ts
+++ b/lib/modules/versioning/hashicorp/convertor.spec.ts
@@ -18,6 +18,7 @@ describe('modules/versioning/hashicorp/convertor', () => {
     ${'< 4.0'}          | ${'<4.0'}
     ${'> 4.0, < 5.0'}   | ${'>4.0 <5.0'}
     ${'~> 2.3.4'}       | ${'~2.3.4'}
+    ${'0.1.0-beta.0'}   | ${'0.1.0-beta.0'}
   `(
     'hashicorp2npm("$hashicorp") === $npm && npm2hashicorp("$npm") === $hashicorp',
     ({ hashicorp, npm }) => {

--- a/lib/modules/versioning/hashicorp/convertor.ts
+++ b/lib/modules/versioning/hashicorp/convertor.ts
@@ -14,7 +14,9 @@ export function hashicorp2npm(input: string): string {
     .split(',')
     .map((single) => {
       const r = single.match(
-        regEx(/^\s*(|=|!=|>|<|>=|<=|~>)\s*v?((\d+)(\.\d+){0,2}[\w-+]*)\s*$/)
+        regEx(
+          /^\s*(|=|!=|>|<|>=|<=|~>)\s*v?((\d+)(\.\d+){0,2}[\w-+]*(\.\d+)*)\s*$/
+        )
       );
       if (!r) {
         logger.warn(
@@ -64,7 +66,7 @@ export function npm2hashicorp(input: string): string {
     .split(' ')
     .map((single) => {
       const r = single.match(
-        regEx(/^(|>|<|>=|<=|~|\^)v?((\d+)(\.\d+){0,2}[\w-]*)$/)
+        regEx(/^(|>|<|>=|<=|~|\^)v?((\d+)(\.\d+){0,2}[\w-]*(\.\d+)*)$/)
       );
       if (!r) {
         throw new Error('invalid npm constraint');

--- a/lib/modules/versioning/hashicorp/index.spec.ts
+++ b/lib/modules/versioning/hashicorp/index.spec.ts
@@ -36,6 +36,7 @@ describe('modules/versioning/hashicorp/index', () => {
     ${'>=4.1'}              | ${true}
     ${'<=4.1.2'}            | ${true}
     ${''}                   | ${false}
+    ${'0.1.0-beta.0'}       | ${true}
   `('isValid("$input") === $expected', ({ input, expected }) => {
     const res = !!semver.isValid(input);
     expect(res).toBe(expected);


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Supports versions like `0.1.0-beta.0` for hashicorp versioning

## Context

Fixes #21332

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
