### PR TITLE
feat: fetch changelogs for private Terraform Cloud modules

### DIFF
--- a/lib/modules/datasource/terraform-module/index.ts
+++ b/lib/modules/datasource/terraform-module/index.ts
@@ -19,12 +19,14 @@ export class TerraformModuleDatasource extends TerraformDatasource {
     super(TerraformModuleDatasource.id);
   }
 
-  override readonly defaultRegistryUrls = [
+  override readonly defaultRegistryUrls = ['https://registry.terraform.io'];
+
+  override readonly defaultVersioning = hashicorpVersioning.id;
+
+  readonly extendedApiRegistryUrls = [
     'https://registry.terraform.io',
     'https://app.terraform.io',
   ];
-
-  override readonly defaultVersioning = hashicorpVersioning.id;
 
   /**
    * This function will fetch a package from the specified Terraform registry and return all semver versions.
@@ -55,7 +57,7 @@ export class TerraformModuleDatasource extends TerraformDatasource {
     const serviceDiscovery = await this.getTerraformServiceDiscoveryResult(
       registryUrlNormalized
     );
-    if (this.defaultRegistryUrls.includes(registryUrlNormalized)) {
+    if (this.extendedApiRegistryUrls.includes(registryUrlNormalized)) {
       return await this.queryRegistryExtendedApi(
         serviceDiscovery,
         registryUrlNormalized,

--- a/lib/modules/datasource/terraform-module/index.ts
+++ b/lib/modules/datasource/terraform-module/index.ts
@@ -19,7 +19,10 @@ export class TerraformModuleDatasource extends TerraformDatasource {
     super(TerraformModuleDatasource.id);
   }
 
-  override readonly defaultRegistryUrls = ['https://registry.terraform.io'];
+  override readonly defaultRegistryUrls = [
+    'https://registry.terraform.io',
+    'https://app.terraform.io',
+  ];
 
   override readonly defaultVersioning = hashicorpVersioning.id;
 
@@ -52,7 +55,7 @@ export class TerraformModuleDatasource extends TerraformDatasource {
     const serviceDiscovery = await this.getTerraformServiceDiscoveryResult(
       registryUrlNormalized
     );
-    if (registryUrlNormalized === this.defaultRegistryUrls[0]) {
+    if (this.defaultRegistryUrls.includes(registryUrlNormalized)) {
       return await this.queryRegistryExtendedApi(
         serviceDiscovery,
         registryUrlNormalized,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Release notes were only fetched for Terraform module from the official registry `registry.terraform.io`.
With this little modification, Terraform modules from the private Terraform Cloud registry `app.terraform.io` are now treated equally.
This enables release notes also for private Terraform modules hosted in Terraform Cloud.

## Context

https://github.com/renovatebot/renovate/discussions/21297#discussioncomment-5532403

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
