### PR TITLE
fix(manager/gradle): handle dot as optional when parsing plugins in Kotlin DSL

### DIFF
--- a/lib/modules/manager/gradle/parser.spec.ts
+++ b/lib/modules/manager/gradle/parser.spec.ts
@@ -549,6 +549,7 @@ describe('modules/manager/gradle/parser', () => {
         ${''}               | ${'id(["foo.bar"]) version "1.2.3"'}       | ${null}
         ${''}               | ${'id("foo", "bar") version "1.2.3"'}      | ${null}
         ${''}               | ${'id "foo".version("1.2.3")'}             | ${null}
+        ${''}               | ${'id("foo.bar") version("1.2.3")'}        | ${{ depName: 'foo.bar', packageName: 'foo.bar:foo.bar.gradle.plugin', currentValue: '1.2.3' }}
         ${''}               | ${'id("foo.bar") version "1.2.3"'}         | ${{ depName: 'foo.bar', packageName: 'foo.bar:foo.bar.gradle.plugin', currentValue: '1.2.3' }}
         ${''}               | ${'id "foo.bar" version "$baz"'}           | ${{ depName: 'foo.bar', skipReason: 'unknown-version', currentValue: 'baz' }}
         ${'baz = "1.2.3"'}  | ${'id "foo.bar" version "$baz"'}           | ${{ depName: 'foo.bar', packageName: 'foo.bar:foo.bar.gradle.plugin', currentValue: '1.2.3', groupName: 'baz' }}

--- a/lib/modules/manager/gradle/parser/plugins.ts
+++ b/lib/modules/manager/gradle/parser/plugins.ts
@@ -14,7 +14,6 @@ const qVersion = qValueMatcher.handler((ctx) =>
   storeInTokenMap(ctx, 'version')
 );
 
-// kotlin("jvm") version "1.3.71"
 export const qPlugins = q
   .sym(regEx(/^(?:id|kotlin)$/), storeVarToken)
   .handler((ctx) => storeInTokenMap(ctx, 'methodName'))
@@ -24,6 +23,7 @@ export const qPlugins = q
       .handler((ctx: Ctx) => storeInTokenMap(ctx, 'pluginName'))
       .sym('version')
       .join(qVersion),
+    // kotlin("jvm") version "1.3.71"
     q
       .tree({
         type: 'wrapped-tree',
@@ -37,8 +37,9 @@ export const qPlugins = q
         // id("foo.bar") version "1.2.3"
         q.sym<Ctx>('version').join(qVersion),
         // id("foo.bar").version("1.2.3")
+        // id("foo.bar") version("1.2.3")
         q
-          .op<Ctx>('.')
+          .opt(q.op<Ctx>('.'))
           .sym('version')
           .tree({
             maxDepth: 1,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

The version of Gradle plugins in Kotlin DSL can be specified in brackets, e.g. `id("com.gradle.enterprise") version("3.12.1")`. Although not documented on reference pages [here](https://kotlinlang.org/docs/multiplatform-dsl-reference.html#59e30746) or [here](https://docs.gradle.org/current/userguide/plugins.html) and currently not supported by renovate, this seems to be a quite prevalent pattern in the wild (~[6k results](https://github.com/search?type=code&auto_enroll=true&q=%2Fid%5B%28+%5D%28.%2B%29%5B%29+%5D+version%5C%28%22%2F) on GH). 

This change makes the dot between `id(..)` or `kotlin(...)` and `version(...)` optional to enable parsing this pattern.

<!-- Describe what behavior is changed by this PR. -->

## Context

- https://github.com/renovatebot/renovate/discussions/21337

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

Test repo: https://github.com/renovate-demo/21337-reproduction/pull/1

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
