### PR TITLE
refactor(dotnet-version): Fix schema for dates

### DIFF
--- a/lib/modules/datasource/dotnet-version/schema.ts
+++ b/lib/modules/datasource/dotnet-version/schema.ts
@@ -12,13 +12,13 @@ const SupportPhase = z.union([
 const ReleaseIndex = z.object({
   'channel-version': z.string(),
   'latest-release': z.string(),
-  'latest-release-date': z.date(),
+  'latest-release-date': z.string(),
   security: z.boolean(),
   'latest-runtime': z.string(),
   'latest-sdk': z.string(),
   product: Product,
   'support-phase': SupportPhase,
-  'eol-date': z.date().nullable(),
+  'eol-date': z.string().nullable(),
   'releases.json': z.string(),
 });
 export const DotnetReleasesIndexSchema = z.object({
@@ -30,7 +30,7 @@ const ReleaseDetails = z.object({
   'version-display': z.string(),
 });
 const ReleaseSchema = z.object({
-  'release-date': z.date(),
+  'release-date': z.string(),
   'release-version': z.string(),
   security: z.boolean(),
   'release-notes': z.string(),
@@ -40,7 +40,7 @@ const ReleaseSchema = z.object({
 export const DotnetReleasesSchema = z.object({
   'channel-version': z.string(),
   'latest-release': z.string(),
-  'latest-release-date': z.date(),
+  'latest-release-date': z.string(),
   'latest-runtime': z.string(),
   'latest-sdk': z.string(),
   'support-phase': SupportPhase,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Inbound JSON data can't have fields with `date` type, though they can be coerced to Date. However, seems like it isn't required anywhere. That said, we're replacing `z.date()` to `z.string()`.

## Context

- Ref: #21357
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
