### PR TITLE
test(manager/regex): add replaceString to all non-snapshot based test assertions

### DIFF
--- a/lib/modules/manager/regex/index.spec.ts
+++ b/lib/modules/manager/regex/index.spec.ts
@@ -163,6 +163,8 @@ describe('modules/manager/regex/index', () => {
           datasource: 'gradle-version',
           depName: 'gradle',
           versioning: 'maven',
+          replaceString:
+            'ENV GRADLE_VERSION=6.2 # gradle-version/gradle&versioning=maven\n',
         },
       ],
     });
@@ -235,6 +237,7 @@ describe('modules/manager/regex/index', () => {
           currentValue: '17.0.0-alpine',
           datasource: 'docker',
           indentation: '     ',
+          replaceString: '     image: eclipse-temurin:17.0.0-alpine',
         },
       ],
     });
@@ -261,6 +264,7 @@ describe('modules/manager/regex/index', () => {
           currentValue: '17.0.0-alpine',
           datasource: 'docker',
           indentation: '',
+          replaceString: 'name: image: eclipse-temurin:17.0.0-alpine',
         },
       ],
     });
@@ -578,6 +582,8 @@ describe('modules/manager/regex/index', () => {
           packageName: 'dotnet-runtime',
           currentValue: '6.0.13',
           datasource: 'dotnet-version',
+          replaceString:
+            '# renovate: datasource=dotnet packageName=dotnet-runtime\nRUN install-tool dotnet 6.0.13',
         },
       ],
     });


### PR DESCRIPTION
## Changes

Update all manage/regex non-snapshot based tests to assert value for `replaceString`, given how critical this is to the managers functionality.

Note: tests using snapshots already validate `replaceString`

## Context

Follow on from #21370

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
