### PR TITLE
feat(template): add equals helper

### DIFF
--- a/docs/usage/templates.md
+++ b/docs/usage/templates.md
@@ -82,11 +82,11 @@ Returns `true` if a given string is a substring.
 
 `{{#if (containsString depName 'python')}}Python{{else}}Other{{/if}}`
 
-### ifEquals
+### equals
 
 Returns `true` if two values equals (`==`).
 
-`{{#ifEquals depName 'python'}}Python{{else}}Other{{/ifEquals}}`
+`{{#if (equals datasource 'git-refs')}}git-refs{{else}}Other{{/if}}`
 
 ### and
 

--- a/docs/usage/templates.md
+++ b/docs/usage/templates.md
@@ -84,7 +84,7 @@ Returns `true` if a given string is a substring.
 
 ### equals
 
-Returns `true` if two values equals (`==`).
+Returns `true` if two values equals (checks strict equality, i.e. `===`).
 
 `{{#if (equals datasource 'git-refs')}}git-refs{{else}}Other{{/if}}`
 

--- a/docs/usage/templates.md
+++ b/docs/usage/templates.md
@@ -82,6 +82,12 @@ Returns `true` if a given string is a substring.
 
 `{{#if (containsString depName 'python')}}Python{{else}}Other{{/if}}`
 
+### ifEquals
+
+Returns `true` if two values equals (`==`).
+
+`{{#ifEquals depName 'python'}}Python{{else}}Other{{/ifEquals}}`
+
 ### and
 
 Returns `true` only if all expressions are `true`.

--- a/lib/util/template/index.spec.ts
+++ b/lib/util/template/index.spec.ts
@@ -207,7 +207,7 @@ describe('util/template/index', () => {
   });
 
   describe('equals', () => {
-    it('should render block if equals', () => {
+    it('equals', () => {
       const output = template.compile(
         '{{#if (equals datasource "git-refs")}}https://github.com/{{packageName}}{{else}}{{packageName}}{{/if}}',
         {
@@ -218,7 +218,7 @@ describe('util/template/index', () => {
       expect(output).toBe('https://github.com/renovatebot/renovate');
     });
 
-    it('should render else block if not equals', () => {
+    it('not equals', () => {
       const output = template.compile(
         '{{#if (equals datasource "git-refs")}}https://github.com/{{packageName}}{{else}}{{packageName}}{{/if}}',
         {
@@ -227,6 +227,16 @@ describe('util/template/index', () => {
         }
       );
       expect(output).toBe('renovatebot/renovate');
+    });
+
+    it('not strict equals', () => {
+      const output = template.compile(
+        '{{#if (equals newMajor "3")}}equals{{else}}not equals{{/if}}',
+        {
+          newMajor: 3,
+        }
+      );
+      expect(output).toBe('not equals');
     });
   });
 });

--- a/lib/util/template/index.spec.ts
+++ b/lib/util/template/index.spec.ts
@@ -206,10 +206,10 @@ describe('util/template/index', () => {
     });
   });
 
-  describe('ifEquals', () => {
+  describe('equals', () => {
     it('should render block if equals', () => {
       const output = template.compile(
-        '{{#ifEquals datasource "git-refs"}}https://github.com/{{packageName}}{{else}}{{packageName}}{{/ifEquals}}',
+        '{{#if (equals datasource "git-refs")}}https://github.com/{{packageName}}{{else}}{{packageName}}{{/if}}',
         {
           datasource: 'git-refs',
           packageName: 'renovatebot/renovate',
@@ -220,7 +220,7 @@ describe('util/template/index', () => {
 
     it('should render else block if not equals', () => {
       const output = template.compile(
-        '{{#ifEquals datasource "git-refs"}}https://github.com/{{packageName}}{{else}}{{packageName}}{{/ifEquals}}',
+        '{{#if (equals datasource "git-refs")}}https://github.com/{{packageName}}{{else}}{{packageName}}{{/if}}',
         {
           datasource: 'github-releases',
           packageName: 'renovatebot/renovate',

--- a/lib/util/template/index.spec.ts
+++ b/lib/util/template/index.spec.ts
@@ -205,4 +205,28 @@ describe('util/template/index', () => {
       expect(output).toBe('@fsouza/prettierd');
     });
   });
+
+  describe('ifEquals', () => {
+    it('should render block if equals', () => {
+      const output = template.compile(
+        '{{#ifEquals datasource "git-refs"}}https://github.com/{{packageName}}{{else}}{{packageName}}{{/ifEquals}}',
+        {
+          datasource: 'git-refs',
+          packageName: 'renovatebot/renovate',
+        }
+      );
+      expect(output).toBe('https://github.com/renovatebot/renovate');
+    });
+
+    it('should render else block if not equals', () => {
+      const output = template.compile(
+        '{{#ifEquals datasource "git-refs"}}https://github.com/{{packageName}}{{else}}{{packageName}}{{/ifEquals}}',
+        {
+          datasource: 'github-releases',
+          packageName: 'renovatebot/renovate',
+        }
+      );
+      expect(output).toBe('renovatebot/renovate');
+    });
+  });
 });

--- a/lib/util/template/index.ts
+++ b/lib/util/template/index.ts
@@ -24,8 +24,7 @@ handlebars.registerHelper('containsString', (str, subStr) =>
   str?.includes(subStr)
 );
 
-// eslint-disable-next-line eqeqeq
-handlebars.registerHelper('equals', (arg1, arg2) => arg1 == arg2);
+handlebars.registerHelper('equals', (arg1, arg2) => arg1 === arg2);
 
 handlebars.registerHelper({
   and(...args) {

--- a/lib/util/template/index.ts
+++ b/lib/util/template/index.ts
@@ -24,11 +24,8 @@ handlebars.registerHelper('containsString', (str, subStr) =>
   str?.includes(subStr)
 );
 
-handlebars.registerHelper('ifEquals', function (arg1, arg2, options) {
-  // @ts-expect-error `this` refers to a Handlebars context object.
-  // eslint-disable-next-line eqeqeq
-  return arg1 == arg2 ? options.fn(this) : options.inverse(this);
-});
+// eslint-disable-next-line eqeqeq
+handlebars.registerHelper('equals', (arg1, arg2) => arg1 == arg2);
 
 handlebars.registerHelper({
   and(...args) {
@@ -207,7 +204,7 @@ export function proxyCompileInput(input: CompileInput): CompileInput {
 }
 
 const templateRegex =
-  /{{(?:#(?:if|unless|with|each|ifEquals) )?([a-zA-Z.]+)(?: as \| [a-zA-Z.]+ \|)?}}/g; // TODO #12873
+  /{{(?:#(?:if|unless|with|each) )?([a-zA-Z.]+)(?: as \| [a-zA-Z.]+ \|)?}}/g; // TODO #12873
 
 export function compile(
   template: string,

--- a/lib/util/template/index.ts
+++ b/lib/util/template/index.ts
@@ -24,6 +24,12 @@ handlebars.registerHelper('containsString', (str, subStr) =>
   str?.includes(subStr)
 );
 
+handlebars.registerHelper('ifEquals', function (arg1, arg2, options) {
+  // @ts-expect-error `this` refers to a Handlebars context object.
+  // eslint-disable-next-line eqeqeq
+  return arg1 == arg2 ? options.fn(this) : options.inverse(this);
+});
+
 handlebars.registerHelper({
   and(...args) {
     // Need to remove the 'options', as last parameter
@@ -201,7 +207,7 @@ export function proxyCompileInput(input: CompileInput): CompileInput {
 }
 
 const templateRegex =
-  /{{(?:#(?:if|unless|with|each) )?([a-zA-Z.]+)(?: as \| [a-zA-Z.]+ \|)?}}/g; // TODO #12873
+  /{{(?:#(?:if|unless|with|each|ifEquals) )?([a-zA-Z.]+)(?: as \| [a-zA-Z.]+ \|)?}}/g; // TODO #12873
 
 export function compile(
   template: string,


### PR DESCRIPTION
## Changes

Adds an `equals` template helper. This is a more strict comparison helper than the
`containsString` helper, and uses the `==` operator to check equality rather than a 
substring check.

## Context

As an example of a use case for this is that I define package sources using [purls](https://github.com/package-url/purl-spec) where the `pkg:github` type defaults to use `datasource=github-releases`. To override the default applied datasource, I also allow adding a comment like `# renovate=datasource:git-refs`, like so:

```yaml
# renovate=datasource:git-refs
id: pkg:github/renovatebot/renovate@116735f13
```

This will end up producing a renovate dependency with roughly the following structure:

```json
{
  "datasource": "git-refs",
  "packageName": "renovatebot/renovate"
}
```

To make the `packageName` compatible with `git-refs`, I'd also like to modify `packageName` in my `regexManager`:

```json
"packageNameTemplate": "{{#if (equals datasource 'git-refs')}}https://github.com/{{packageName}}{{else}}{{packageName}}{{/if}}",
```

For this, I'd need the ability to check if a value is equal to something, hence this PR.

I realized I could use the `containsString` helper, but having a stricter equality helper feels safer.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
