### PR TITLE
fix: update cache record TTL to not account for Daylight Saving time

### DIFF
--- a/lib/util/github/graphql/cache-strategies/package-cache-strategy.ts
+++ b/lib/util/github/graphql/cache-strategies/package-cache-strategy.ts
@@ -17,7 +17,9 @@ export class GithubGraphqlPackageCacheStrategy<
   ): Promise<void> {
     if (this.hasUpdatedItems) {
       const expiry = this.createdAt.plus({
-        days: AbstractGithubGraphqlCacheStrategy.cacheTTLDays,
+        // Not using 'days' as it does not handle adjustments for Daylight Saving time.
+        // The offset in the resulting DateTime object does not match that of the expiry or this.now.
+        hours: AbstractGithubGraphqlCacheStrategy.cacheTTLDays * 24,
       });
       const ttlMinutes = expiry.diff(this.now, ['minutes']).as('minutes');
       if (ttlMinutes && ttlMinutes > 0) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Fixes #21343.

Calculating the expiry time using `DateTime.plus()` with an offset of `days` accounts for Daylight Saving time adjustments. The tests for the package cache strategy do not assume that this conversion will occur (e.g. `15 * 24 * 60`).  Using `hours` instead of `days` performs a straight conversion achieving the desired outcome.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

My personal laptop is set to US Mountain time (UTC−07:00 in standard time, UTC−06:00 for Daylight Saving time). The `DateTime.plus()` function calculates a different value if one uses the `days` property on a `Duration` versus the `hours`.  From [the documentation](https://moment.github.io/luxon/api-docs/index.html#duration),

>Adding hours, minutes, seconds, or milliseconds increases the timestamp by the right number of milliseconds. Adding days, months, or years shifts the calendar, accounting for DSTs and leap years along the way. Thus, dt.plus({ hours: 24 }) may result in a different time than dt.plus({ days: 1 }) if there's a DST shift in between.

Based upon my understanding of the code, the expiry time should not consider Daylight Saving Time.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Existing unit tests, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
