### PR TITLE
feat: RENOVATE_X_IGNORE_RE2

### DIFF
--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -44,6 +44,10 @@ See [issue 8660](https://github.com/renovatebot/renovate/issues/8660) for backgr
 
 Suppress the default warning when a deprecated version of Node.js is used to run Renovate.
 
+## `RENOVATE_X_IGNORE_RE2`
+
+Skip initializing `RE2` for regular expressions and instead use Node-native `RegExp` instead.
+
 ## `RENOVATE_X_PLATFORM_VERSION`
 
 If set, Renovate will use this string as GitLab server version instead of checking via the GitLab API.

--- a/lib/util/regex.ts
+++ b/lib/util/regex.ts
@@ -8,16 +8,18 @@ let RegEx: RegExpConstructor;
 
 const cache = new Map<string, RegExp>();
 
-try {
-  const RE2 = re2();
-  // Test if native is working
-  new RE2('.*').exec('test');
-  logger.debug('Using RE2 as regex engine');
-  RegEx = RE2;
-} catch (err) {
-  logger.warn({ err }, 'RE2 not usable, falling back to RegExp');
-  RegEx = RegExp;
+if (!process.env.RENOVATE_X_IGNORE_RE2) {
+  try {
+    const RE2 = re2();
+    // Test if native is working
+    new RE2('.*').exec('test');
+    logger.debug('Using RE2 as regex engine');
+    RegEx = RE2;
+  } catch (err) {
+    logger.warn({ err }, 'RE2 not usable, falling back to RegExp');
+  }
 }
+RegEx ??= RegExp;
 
 export function regEx(
   pattern: string | RegExp,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds `RENOVATE_X_IGNORE_RE2` options to skip loading RE2.

## Context

In some environments it won't work and it would be nice to suppress the warning and skip the loading altogether.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
