### PR TITLE
test: jest isolation

### DIFF
--- a/lib/config/presets/index.spec.ts
+++ b/lib/config/presets/index.spec.ts
@@ -23,27 +23,6 @@ const gitHub = mocked(_github);
 
 const presetIkatyang = Fixtures.getJson('renovate-config-ikatyang.json');
 
-npm.getPreset.mockImplementation(({ repo, presetName }) => {
-  if (repo === 'renovate-config-ikatyang') {
-    return presetIkatyang.versions[presetIkatyang['dist-tags'].latest][
-      'renovate-config'
-    ][presetName!];
-  }
-  if (repo === 'renovate-config-notfound') {
-    throw new Error(PRESET_DEP_NOT_FOUND);
-  }
-  if (repo === 'renovate-config-noconfig') {
-    throw new Error(PRESET_RENOVATE_CONFIG_NOT_FOUND);
-  }
-  if (repo === 'renovate-config-throw') {
-    throw new Error('whoops');
-  }
-  if (repo === 'renovate-config-wrongpreset') {
-    throw new Error(PRESET_NOT_FOUND);
-  }
-  return null;
-});
-
 describe('config/presets/index', () => {
   describe('resolvePreset', () => {
     let config: RenovateConfig;
@@ -51,6 +30,26 @@ describe('config/presets/index', () => {
     beforeEach(() => {
       config = {};
       memCache.init();
+      npm.getPreset.mockImplementation(({ repo, presetName }) => {
+        if (repo === 'renovate-config-ikatyang') {
+          return presetIkatyang.versions[presetIkatyang['dist-tags'].latest][
+            'renovate-config'
+          ][presetName!];
+        }
+        if (repo === 'renovate-config-notfound') {
+          throw new Error(PRESET_DEP_NOT_FOUND);
+        }
+        if (repo === 'renovate-config-noconfig') {
+          throw new Error(PRESET_RENOVATE_CONFIG_NOT_FOUND);
+        }
+        if (repo === 'renovate-config-throw') {
+          throw new Error('whoops');
+        }
+        if (repo === 'renovate-config-wrongpreset') {
+          throw new Error(PRESET_NOT_FOUND);
+        }
+        return null;
+      });
     });
 
     it('returns same if no presets', async () => {

--- a/lib/config/presets/internal/index.spec.ts
+++ b/lib/config/presets/internal/index.spec.ts
@@ -5,7 +5,7 @@ import { validateConfig } from '../../validation';
 import * as npm from '../npm';
 import * as internal from '.';
 
-jest.mock('./npm');
+jest.mock('../npm');
 jest.mock('../../../modules/datasource/npm');
 
 jest.spyOn(npm, 'getPreset').mockResolvedValue(undefined);

--- a/lib/modules/manager/gradle/extract.spec.ts
+++ b/lib/modules/manager/gradle/extract.spec.ts
@@ -50,6 +50,10 @@ describe('modules/manager/gradle/extract', () => {
   it('logs a warning in case parseGradle throws an exception', async () => {
     const filename = 'build.gradle';
     const err = new Error('unknown');
+    const fsMock = {
+      'build.gradle': '',
+    };
+    mockFs(fsMock);
 
     jest.spyOn(parser, 'parseGradle').mockImplementationOnce(() => {
       throw err;

--- a/lib/modules/manager/gradle/parser.spec.ts
+++ b/lib/modules/manager/gradle/parser.spec.ts
@@ -833,7 +833,6 @@ describe('modules/manager/gradle/parser', () => {
     const fileContents = {
       'foo/bar.gradle': key + ' = "' + value + '"',
     };
-    mockFs(fileContents);
 
     test.each`
       def                        | input                                                     | output
@@ -871,6 +870,7 @@ describe('modules/manager/gradle/parser', () => {
       ${'base="foo"'}            | ${'apply(from = File(base, "bar.gradle"))'}               | ${validOutput}
       ${'base="foo"'}            | ${'apply(from = File("${base}", "bar.gradle"))'}          | ${validOutput}
     `('$def | $input', ({ def, input, output }) => {
+      mockFs(fileContents);
       const { vars } = parseGradle(
         [def, input].join('\n'),
         {},

--- a/lib/util/cache/package/decorator.spec.ts
+++ b/lib/util/cache/package/decorator.spec.ts
@@ -10,16 +10,17 @@ describe('util/cache/package/decorator', () => {
   const setCache = jest.spyOn(packageCache, 'set');
 
   let count = 1;
-  const getValue = jest.fn(() => {
-    const res = String(100 * count + 10 * count + count);
-    count += 1;
-    return Promise.resolve(res);
-  });
+  const getValue = jest.fn();
 
   beforeEach(async () => {
     memCache.init();
     await packageCache.init({ cacheDir: os.tmpdir() });
     count = 1;
+    getValue.mockImplementation(() => {
+      const res = String(100 * count + 10 * count + count);
+      count += 1;
+      return Promise.resolve(res);
+    });
   });
 
   it('should cache string', async () => {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Incremental work towards #18934 and related to #18768

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->
When enabling `resetMocks` in the global jest configuration, there are a lot of tests that fail due to incorrect isolation. This results in tests that are at best fragile and at worst entirely incorrect.

This PR is carved out of #18934 in an attempt to make incremental progress.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
