### PR TITLE
fix(manager/gradle): resolve values when assigning symbols to variables

### DIFF
--- a/lib/modules/manager/gradle/parser.spec.ts
+++ b/lib/modules/manager/gradle/parser.spec.ts
@@ -76,6 +76,7 @@ describe('modules/manager/gradle/parser', () => {
           libraries += [
             guava: "com.google.guava:guava:31.1-jre",
             detekt: '1.18.1',
+            core2: versions.core
           ]
         }
         `;
@@ -97,6 +98,10 @@ describe('modules/manager/gradle/parser', () => {
           'libraries.detekt': {
             key: 'libraries.detekt',
             value: '1.18.1',
+          },
+          'libraries.core2': {
+            key: 'versions.core',
+            value: '1.7.0',
           },
         });
       });
@@ -246,6 +251,7 @@ describe('modules/manager/gradle/parser', () => {
 
       it('nested map', () => {
         const input = codeBlock`
+          val junitPlatformVersion: String by extra { "1.0.1" }
           ext["deps"] = mapOf(
             "support" to mapOf(
               "appCompat" to "com.android.support:appcompat-v7:26.0.2",
@@ -259,7 +265,8 @@ describe('modules/manager/gradle/parser', () => {
             "support2" to mapOfInvalid(
               "design2" to "com.android.support:design:26.0.2"
             ),
-            "picasso" to "com.squareup.picasso:picasso:2.5.2"
+            "picasso" to "com.squareup.picasso:picasso:2.5.2",
+            "junit-platform-runner" to junitPlatformVersion
           )
         `;
 
@@ -284,6 +291,10 @@ describe('modules/manager/gradle/parser', () => {
           'deps.picasso': {
             key: 'deps.picasso',
             value: 'com.squareup.picasso:picasso:2.5.2',
+          },
+          'deps.junit-platform-runner': {
+            key: 'junitPlatformVersion',
+            value: '1.0.1',
           },
         });
       });

--- a/lib/modules/manager/gradle/parser/assignments.ts
+++ b/lib/modules/manager/gradle/parser/assignments.ts
@@ -7,7 +7,7 @@ import {
   increaseNestingDepth,
   prependNestingDepth,
   qStringValue,
-  qTemplateString,
+  qValueMatcher,
   qVariableAssignmentIdentifier,
   reduceNestingDepth,
   storeInTokenMap,
@@ -76,7 +76,7 @@ const qGroovySingleMapOfVarAssignment = q.alt(
     .handler(coalesceVariable)
     .handler((ctx) => storeInTokenMap(ctx, 'keyToken'))
     .op(':')
-    .join(qTemplateString)
+    .join(qValueMatcher)
     .handler((ctx) => storeInTokenMap(ctx, 'valToken'))
     .handler(handleAssignment)
 );
@@ -117,7 +117,7 @@ const qKotlinSingleMapOfVarAssignment = qStringValue
   .handler(prependNestingDepth)
   .handler(coalesceVariable)
   .handler((ctx) => storeInTokenMap(ctx, 'keyToken'))
-  .join(qTemplateString)
+  .join(qValueMatcher)
   .handler((ctx) => storeInTokenMap(ctx, 'valToken'))
   .handler(handleAssignment);
 

--- a/lib/modules/manager/gradle/parser/handlers.ts
+++ b/lib/modules/manager/gradle/parser/handlers.ts
@@ -30,6 +30,12 @@ export function handleAssignment(ctx: Ctx): Ctx {
     ctx.tokenMap.templateStringTokens = valTokens;
     handleDepString(ctx);
     delete ctx.tokenMap.templateStringTokens;
+  } else if (valTokens[0].type === 'symbol') {
+    // foo = bar || foo = "${bar}"
+    const varData = ctx.globalVars[valTokens[0].value];
+    if (varData) {
+      ctx.globalVars[key] = { ...varData };
+    }
   } else {
     // = string value
     const dep = parseDependencyString(valTokens[0].value);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

* Adds an additional clause to `handleAssignments` to correctly process variable alias definitions, e.g. `val some = other`. 
* Changes `qTemplateString` to `qValueMatcher`, as with this PR `handleAssignments` covers the 3 possible combinations that `qValueMatcher` matches (multiple tokens, single string token with string value, single token with symbol).
* Add tests for pure symbol assignments like `foo = bar` (the equivalent `foo = "${bar}"` pattern is already covered).

Currently, `handleAssignments` expects either multiple tokens or **one token, which it assumes to be a string value**. If a single symbol token (= a variable) is assigned to another variable, by mistake, the _else_ branch is also used, which leads to a wrong variable assignment (see example below):
https://github.com/renovatebot/renovate/blob/80c3725356d0b63800c5c7388a9893e1a05e6201/lib/modules/manager/gradle/parser/handlers.ts#L28-L34

Hence, this PR adds an extra clause that specifically targets variable aliases, i.e., assignments of single symbol tokens. 

The change only affects Groovy and Kotlin maps because in all other spots, only pure string values are assigned (conservative approach to prevent garbage assignments).

<!-- Describe what behavior is changed by this PR. -->

## Context

In practice, the missing clause leads to wrong variable assignments, e.g.:
```kotlin
val junitPlatformVersion = "1.2.3"
val deps = mapOf(
    "junit-platform-runner" to "${junitPlatformVersion}"
)
```

would result in **the variable name `junitPlatformVersion` being assigned as string value** to `deps.junit-platform-runner`:
```json
"globalVars": {
  "junitPlatformVersion": {
    "key": "junitPlatformVersion",
    "value": "1.2.3",
    "fileReplacePosition": 28,
    "packageFile": "testfile"
  },
  "deps.junit-platform-runner": {
    "key": "deps.junit-platform-runner",
    "value": "junitPlatformVersion",
    "fileReplacePosition": 89,
    "packageFile": "testfile"
  }
}
```

whereas this would be correct:
```json
"globalVars": {
  "junitPlatformVersion": {
    "key": "junitPlatformVersion",
    "value": "1.2.3",
    "fileReplacePosition": 28,
    "packageFile": "testfile"
  },
  "deps.junit-platform-runner": {
    "key": "junitPlatformVersion",
    "value": "1.2.3",
    "fileReplacePosition": 28,
    "packageFile": "testfile"
  }
}
```

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
