### PR TITLE
refactor(manager/gradle): split `extractAllPackageFiles` into multiple sub-methods

### DIFF
--- a/lib/modules/manager/gradle/parser.ts
+++ b/lib/modules/manager/gradle/parser.ts
@@ -18,6 +18,20 @@ import type {
 import { isDependencyString, parseDependencyString } from './utils';
 
 const groovy = lang.createLang('groovy');
+const ctx: Ctx = {
+  packageFile: '',
+  fileContents: {},
+  recursionDepth: 0,
+
+  globalVars: {},
+  deps: [],
+  registryUrls: [],
+
+  varTokens: [],
+  tmpNestingDepth: [],
+  tmpTokenStore: {},
+  tokenMap: {},
+};
 
 setParseGradleFunc(parseGradle);
 
@@ -47,18 +61,11 @@ export function parseGradle(
   });
 
   const parsedResult = groovy.query(input, query, {
+    ...ctx,
     packageFile,
     fileContents,
     recursionDepth,
-
-    globalVars: initVars,
-    deps: [],
-    registryUrls: [],
-
-    varTokens: [],
-    tmpNestingDepth: [],
-    tmpTokenStore: {},
-    tokenMap: {},
+    globalVars: vars,
   });
 
   if (parsedResult) {

--- a/lib/modules/manager/gradle/utils.spec.ts
+++ b/lib/modules/manager/gradle/utils.spec.ts
@@ -5,6 +5,7 @@ import {
   parseDependencyString,
   reorderFiles,
   toAbsolutePath,
+  updateVars,
   versionLikeSubstring,
 } from './utils';
 
@@ -174,6 +175,23 @@ describe('modules/manager/gradle/utils', () => {
       bar: { key: 'bar', value: 'bar' },
       baz: { key: 'baz', value: 'baz' },
       qux: { key: 'qux', value: 'QUX' },
+    });
+  });
+
+  it('updateVars', () => {
+    const registry: VariableRegistry = {
+      [toAbsolutePath('/foo/bar/baz')]: {
+        bar: { key: 'bar', value: 'bar' } as never,
+        baz: { key: 'baz', value: 'baz' } as never,
+      },
+    };
+
+    updateVars(registry, '/foo/bar/baz', { qux: { key: 'qux', value: 'qux' } });
+    const res = getVars(registry, '/foo/bar/baz/build.gradle');
+    expect(res).toStrictEqual({
+      bar: { key: 'bar', value: 'bar' },
+      baz: { key: 'baz', value: 'baz' },
+      qux: { key: 'qux', value: 'qux' },
     });
   });
 });

--- a/lib/modules/manager/gradle/utils.ts
+++ b/lib/modules/manager/gradle/utils.ts
@@ -172,3 +172,12 @@ export function getVars(
   const parentVars = registry[parentDir] || {};
   return getVars(registry, parentDir, { ...parentVars, ...vars });
 }
+
+export function updateVars(
+  registry: VariableRegistry,
+  dir: string,
+  newVars: PackageVariables
+): void {
+  const oldVars = registry[dir] ?? {};
+  registry[dir] = { ...oldVars, ...newVars };
+}


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d53c435</samp>

### Summary
🆕🔧📝

<!--
1.  🆕 for the new `updateVars` function and test case.
2.  🔧 for the refactoring of the Gradle manager module and the `parseGradle` function.
3.  📝 for the improved documentation and comments in the code.
-->
Refactored the Gradle manager module to improve the parsing logic and variable handling. Extracted the parsing logic into a separate file `gradle/parser.ts` and used a common context object for the `groovy.query` calls. Added a new function `updateVars` in `gradle/utils.ts` to update the variable registry from a directory, and added a test case for it in `gradle/utils.spec.ts`.

> _We're parsing Gradle files with ease, me hearties_
> _We've got a function to update the vars_
> _We've refactored the code to make it tidy_
> _So pull the ropes and raise the yardarm high_

### Walkthrough
*  Refactor `extractAllPackageFiles` function to extract parsing logic into a separate function `parsePackageFiles` and use imported `updateVars` function ([link](https://github.com/renovatebot/renovate/pull/21429/files?diff=unified&w=0#diff-c7a6f8beaa6617591689dd07a6719aff69ffdcd009f3465225adb6c385eb3cd8L17), [link](https://github.com/renovatebot/renovate/pull/21429/files?diff=unified&w=0#diff-c7a6f8beaa6617591689dd07a6719aff69ffdcd009f3465225adb6c385eb3cd8L27-R44), [link](https://github.com/renovatebot/renovate/pull/21429/files?diff=unified&w=0#diff-c7a6f8beaa6617591689dd07a6719aff69ffdcd009f3465225adb6c385eb3cd8L48-R72), [link](https://github.com/renovatebot/renovate/pull/21429/files?diff=unified&w=0#diff-c7a6f8beaa6617591689dd07a6719aff69ffdcd009f3465225adb6c385eb3cd8L71-R96), [link](https://github.com/renovatebot/renovate/pull/21429/files?diff=unified&w=0#diff-c7a6f8beaa6617591689dd07a6719aff69ffdcd009f3465225adb6c385eb3cd8L96-R105), [link](https://github.com/renovatebot/renovate/pull/21429/files?diff=unified&w=0#diff-c7a6f8beaa6617591689dd07a6719aff69ffdcd009f3465225adb6c385eb3cd8R116-R135), [link](https://github.com/renovatebot/renovate/pull/21429/files?diff=unified&w=0#diff-872fda5a9c0c9c8ce83a578c23041e96e674e351010f9e90030a239abd154ee3L21-R35), [link](https://github.com/renovatebot/renovate/pull/21429/files?diff=unified&w=0#diff-872fda5a9c0c9c8ce83a578c23041e96e674e351010f9e90030a239abd154ee3L50-R68))
* Add `updatePackageRegistries` function to simplify adding registry URLs from Gradle scripts and avoid duplicates ([link](https://github.com/renovatebot/renovate/pull/21429/files?diff=unified&w=0#diff-c7a6f8beaa6617591689dd07a6719aff69ffdcd009f3465225adb6c385eb3cd8L27-R44), [link](https://github.com/renovatebot/renovate/pull/21429/files?diff=unified&w=0#diff-c7a6f8beaa6617591689dd07a6719aff69ffdcd009f3465225adb6c385eb3cd8L96-R105))
* Add `updateVars` function to `lib/modules/manager/gradle/utils.ts` to update variable registry with new variables from a given directory ([link](https://github.com/renovatebot/renovate/pull/21429/files?diff=unified&w=0#diff-acac9732368a702a52e8c2018d9f7fdc836963239235b562be668076dbe4ebb4R175-R183))
* Add test case for `updateVars` function in `lib/modules/manager/gradle/utils.spec.ts` ([link](https://github.com/renovatebot/renovate/pull/21429/files?diff=unified&w=0#diff-491199ba91a53b78e9b4b11c4d7a0b14bd3622e958572a409dfb38d546bafcf2R8), [link](https://github.com/renovatebot/renovate/pull/21429/files?diff=unified&w=0#diff-491199ba91a53b78e9b4b11c4d7a0b14bd3622e958572a409dfb38d546bafcf2R180-R196))



<!-- Describe what behavior is changed by this PR. -->

## Context

- Pave the way for #5480

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
