### PR TITLE
docs: refresh links around presets

### DIFF
--- a/docs/development/creating-editing-renovate-presets.md
+++ b/docs/development/creating-editing-renovate-presets.md
@@ -1,6 +1,6 @@
 # Creating/editing Renovate presets
 
-Renovate comes with default presets that you can find in the `lib/config/presets/internal` directory.
+Renovate comes with default presets that you can find in the [`lib/config/presets/internal`](https://github.com/renovatebot/renovate/tree/main/lib/config/presets/internal) directory.
 You can suggest changes to the presets with a pull request.
 
 Follow the rules below to increase the chance that your pull request gets merged.

--- a/docs/usage/config-presets.md
+++ b/docs/usage/config-presets.md
@@ -211,7 +211,7 @@ Renovate will determine the current platform and look up the preset from there.
 ## Contributing to presets
 
 Have you configured a rule that you think others might benefit from?
-Please consider contributing it to the [Renovate](https://github.com/renovatebot/renovate) repository so that it gains higher visibility and saves others from reinventing the same thing.
+Please consider contributing it to the [Renovate repository](https://github.com/renovatebot/renovate/tree/main/lib/config/presets/internal) so that it gains higher visibility and saves others from reinventing the same thing.
 
 ## Organization level presets
 

--- a/docs/usage/noise-reduction.md
+++ b/docs/usage/noise-reduction.md
@@ -176,7 +176,8 @@ Let's automerge it if all the linting updates pass:
 ```
 
 Have you come up with a rule that you think others would benefit from?
-How about a PR back to [renovate-config](https://github.com/singapore/renovate-config) with the above rule named `":automergeEslintWeekly"` ?
+How about a PR to [our presets](https://github.com/renovatebot/renovate/tree/main/lib/config/presets/internal)?
+For example the above rule could be named `":automergeEslintWeekly"` in `schedule.ts`.
 
 ## Lock file considerations
 


### PR DESCRIPTION
## Changes

Add links to more relevant places and fix an archaic link.

## Context

I was looking around and reading docs, I found some outdates links and some others which didn't link anywhere, so navigation was tedious.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
