### PR TITLE
docs: add restriction on matchCurrentVersion

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2031,7 +2031,7 @@ The `currentVersion` field will be one of the following (in order of preference)
 
 Consider using instead `matchCurrentValue` if you wish to match against the raw string value of a dependency.
 
-`matchCurrentVersion` can be an exact SemVer version or a SemVer range:
+`matchCurrentVersion` can be an exact version or a version range:
 
 ```json
 {
@@ -2044,8 +2044,8 @@ Consider using instead `matchCurrentValue` if you wish to match against the raw 
 }
 ```
 
-The syntax of the SemVer range must follow the [versioning scheme](https://docs.renovatebot.com/modules/versioning/#supported-versioning)
-used by the [manager](https://docs.renovatebot.com/modules/manager/#supported-managers) which discovered the configured package.
+The syntax of the version range must follow the [versioning scheme](https://docs.renovatebot.com/modules/versioning/#supported-versioning)
+used by the matched packages. This is usually defined by the [manager](https://docs.renovatebot.com/modules/manager/#supported-managers) which discovered them.
 
 This field also supports Regular Expressions which must begin and end with `/`.
 For example, the following enforces that only `1.*` versions will be used:

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2044,8 +2044,8 @@ Consider using instead `matchCurrentValue` if you wish to match against the raw 
 }
 ```
 
-The syntax of the version range must follow the [versioning scheme](https://docs.renovatebot.com/modules/versioning/#supported-versioning)
-used by the matched packages. This is usually defined by the [manager](https://docs.renovatebot.com/modules/manager/#supported-managers) which discovered them.
+The syntax of the version range must follow the [versioning scheme](https://docs.renovatebot.com/modules/versioning/#supported-versioning) used by the matched package(s).
+This is usually defined by the [manager](https://docs.renovatebot.com/modules/manager/#supported-managers) which discovered them or by the default versioning for the package's [datasource](https://docs.renovatebot.com/modules/datasource/).
 
 This field also supports Regular Expressions which must begin and end with `/`.
 For example, the following enforces that only `1.*` versions will be used:

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2043,6 +2043,7 @@ Consider using instead `matchCurrentValue` if you wish to match against the raw 
   ]
 }
 ```
+The syntax of the SemVer range must follow the [versioning scheme](https://docs.renovatebot.com/modules/versioning/#supported-versioning) scheme used by the [manager](https://docs.renovatebot.com/modules/manager/#supported-managers) which discovered the configured package.
 
 This field also supports Regular Expressions which must begin and end with `/`.
 For example, the following enforces that only `1.*` versions will be used:

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2043,7 +2043,9 @@ Consider using instead `matchCurrentValue` if you wish to match against the raw 
   ]
 }
 ```
-The syntax of the SemVer range must follow the [versioning scheme](https://docs.renovatebot.com/modules/versioning/#supported-versioning) scheme used by the [manager](https://docs.renovatebot.com/modules/manager/#supported-managers) which discovered the configured package.
+
+The syntax of the SemVer range must follow the [versioning scheme](https://docs.renovatebot.com/modules/versioning/#supported-versioning)
+used by the [manager](https://docs.renovatebot.com/modules/manager/#supported-managers) which discovered the configured package.
 
 This field also supports Regular Expressions which must begin and end with `/`.
 For example, the following enforces that only `1.*` versions will be used:

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2046,6 +2046,7 @@ Consider using instead `matchCurrentValue` if you wish to match against the raw 
 
 The syntax of the version range must follow the [versioning scheme](https://docs.renovatebot.com/modules/versioning/#supported-versioning) used by the matched package(s).
 This is usually defined by the [manager](https://docs.renovatebot.com/modules/manager/#supported-managers) which discovered them or by the default versioning for the package's [datasource](https://docs.renovatebot.com/modules/datasource/).
+For example, a Gradle package would typically need Gradle constraint syntax (e.g. `[,7.0)`) and not SemVer syntax (e.g. `<7.0`).
 
 This field also supports Regular Expressions which must begin and end with `/`.
 For example, the following enforces that only `1.*` versions will be used:


### PR DESCRIPTION
## Changes

Document "known" restriction.

## Context

- https://github.com/renovatebot/renovate/discussions/21408

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
