### PR TITLE
fix(cache): use UTC dates for cache strategy calculations

### DIFF
--- a/lib/util/github/graphql/cache-strategies/abstract-cache-strategy.ts
+++ b/lib/util/github/graphql/cache-strategies/abstract-cache-strategy.ts
@@ -73,7 +73,7 @@ export abstract class AbstractGithubGraphqlCacheStrategy<
     const storedData = await this.load();
     if (storedData) {
       const cacheTTLDuration = {
-        days: AbstractGithubGraphqlCacheStrategy.cacheTTLDays,
+        hours: AbstractGithubGraphqlCacheStrategy.cacheTTLDays * 24,
       };
       if (!isDateExpired(this.now, storedData.createdAt, cacheTTLDuration)) {
         result = storedData;

--- a/lib/util/github/graphql/cache-strategies/abstract-cache-strategy.ts
+++ b/lib/util/github/graphql/cache-strategies/abstract-cache-strategy.ts
@@ -23,7 +23,7 @@ export abstract class AbstractGithubGraphqlCacheStrategy<
   /**
    * The time which is used during single cache access cycle.
    */
-  protected readonly now = DateTime.now();
+  protected readonly now = DateTime.now().toUTC();
 
   /**
    * Set of all versions which were reconciled
@@ -80,7 +80,7 @@ export abstract class AbstractGithubGraphqlCacheStrategy<
       }
     }
 
-    this.createdAt = DateTime.fromISO(result.createdAt);
+    this.createdAt = DateTime.fromISO(result.createdAt).toUTC();
     this.items = result.items;
     return this.items;
   }
@@ -91,7 +91,7 @@ export abstract class AbstractGithubGraphqlCacheStrategy<
    */
   private isStabilized(item: GithubItem): boolean {
     const unstableDuration = {
-      days: AbstractGithubGraphqlCacheStrategy.cacheTTLDays,
+      hours: AbstractGithubGraphqlCacheStrategy.cacheTTLDays * 24,
     };
     return isDateExpired(this.now, item.releaseTimestamp, unstableDuration);
   }

--- a/lib/util/github/graphql/cache-strategies/memory-cache-strategy.spec.ts
+++ b/lib/util/github/graphql/cache-strategies/memory-cache-strategy.spec.ts
@@ -4,7 +4,25 @@ import { clone } from '../../../clone';
 import type { GithubDatasourceItem, GithubGraphqlCacheRecord } from '../types';
 import { GithubGraphqlMemoryCacheStrategy } from './memory-cache-strategy';
 
-const isoTs = (t: string) => DateTime.fromJSDate(new Date(t)).toISO()!;
+// const isoTs = (t: string) => DateTime.fromJSDate(new Date(t)).toISO()!;
+
+const hourMinRe = /T\d{2}:\d{2}$/;
+const hourMinSecRe = /T\d{2}:\d{2}:\d{2}$/;
+const hourMinSecMillisRe = /T\d{2}:\d{2}:\d{2}\.\d\d\d$/;
+
+const isoTs = (t: string) => {
+  let iso = t.replace(' ', 'T');
+  if (hourMinSecMillisRe.test(iso)) {
+    iso = iso + 'Z';
+  } else if (hourMinSecRe.test(iso)) {
+    iso = iso + '.000Z';
+  } else if (hourMinRe.test(iso)) {
+    iso = iso + ':00.000Z';
+  } else {
+    throw new Error('Unrecognized date-time string. ' + t);
+  }
+  return iso;
+};
 
 const mockTime = (input: string): void => {
   const now = DateTime.fromISO(isoTs(input)).valueOf();

--- a/lib/util/github/graphql/cache-strategies/package-cache-strategy.spec.ts
+++ b/lib/util/github/graphql/cache-strategies/package-cache-strategy.spec.ts
@@ -4,7 +4,7 @@ import { clone } from '../../../clone';
 import type { GithubDatasourceItem, GithubGraphqlCacheRecord } from '../types';
 import { GithubGraphqlPackageCacheStrategy } from './package-cache-strategy';
 
-const isoTs = (t: string) => DateTime.fromJSDate(new Date(t)).toISO()!;
+const isoTs = (t: string) => t.replace(' ', 'T') + ':00.000Z';
 
 const mockTime = (input: string): void => {
   const now = DateTime.fromISO(isoTs(input)).valueOf();

--- a/lib/util/github/graphql/cache-strategies/package-cache-strategy.ts
+++ b/lib/util/github/graphql/cache-strategies/package-cache-strategy.ts
@@ -16,11 +16,13 @@ export class GithubGraphqlPackageCacheStrategy<
     cacheRecord: GithubGraphqlCacheRecord<GithubItem>
   ): Promise<void> {
     if (this.hasUpdatedItems) {
-      const expiry = this.createdAt.plus({
-        // Not using 'days' as it does not handle adjustments for Daylight Saving time.
-        // The offset in the resulting DateTime object does not match that of the expiry or this.now.
-        hours: AbstractGithubGraphqlCacheStrategy.cacheTTLDays * 24,
-      });
+      const expiry = this.createdAt
+        .plus({
+          // Not using 'days' as it does not handle adjustments for Daylight Saving time.
+          // The offset in the resulting DateTime object does not match that of the expiry or this.now.
+          hours: AbstractGithubGraphqlCacheStrategy.cacheTTLDays * 24,
+        })
+        .toUTC();
       const ttlMinutes = expiry.diff(this.now, ['minutes']).as('minutes');
       if (ttlMinutes && ttlMinutes > 0) {
         await packageCache.set(

--- a/lib/util/github/graphql/util.ts
+++ b/lib/util/github/graphql/util.ts
@@ -20,6 +20,6 @@ export function isDateExpired(
   initialTimestamp: string,
   duration: DurationLikeObject
 ): boolean {
-  const expiryTime = DateTime.fromISO(initialTimestamp).plus(duration);
+  const expiryTime = DateTime.fromISO(initialTimestamp).plus(duration).toUTC();
   return currentTime >= expiryTime;
 }


### PR DESCRIPTION
## Changes

Use UTC dates and deterministic durations for cache strategy date calculations.

## Context

The fix #21389 appears to have broken unit tests for developers in [CEST](https://en.wikipedia.org/wiki/Central_European_Summer_Time) and probably other timezones with a positive offset. 

I believe that the underlying issue is that the current implementation performs date calculations in the current system timezone. This can lead to ambiguities when calculating expiration timestamps.  

In addition, I found another date calculation that was using `days` for its date calculation. I have switched it to `hours` like the fix in #21389.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
