### PR TITLE
fix(maven): Support versions containing `+` sign

### DIFF
--- a/lib/modules/versioning/ivy/index.ts
+++ b/lib/modules/versioning/ivy/index.ts
@@ -42,13 +42,27 @@ function isValid(str: string): boolean {
   if (!str) {
     return false;
   }
-  return maven.isVersion(str) || !!parseDynamicRevision(str);
+
+  if (LATEST_REGEX.test(str)) {
+    return true;
+  }
+
+  return isVersion(str) || !!parseDynamicRevision(str);
 }
 
 function isVersion(str: string): boolean {
-  if (!str || LATEST_REGEX.test(str)) {
+  if (!str) {
     return false;
   }
+
+  if (LATEST_REGEX.test(str)) {
+    return false;
+  }
+
+  if (str.includes('+')) {
+    return false;
+  }
+
   return maven.isVersion(str);
 }
 

--- a/lib/modules/versioning/maven/compare.spec.ts
+++ b/lib/modules/versioning/maven/compare.spec.ts
@@ -187,6 +187,7 @@ describe('modules/versioning/maven/compare', () => {
         ${'1-0.alpha'}                                  | ${'1-0.beta'}
         ${'1_5ea'}                                      | ${'1_c3b'}
         ${'1_c3b'}                                      | ${'2'}
+        ${'17.0.5'}                                     | ${'17.0.5+8'}
       `('$x < $y', ({ x, y }) => {
         expect(compare(x, y)).toBe(-1);
         expect(compare(y, x)).toBe(1);

--- a/lib/modules/versioning/maven/compare.ts
+++ b/lib/modules/versioning/maven/compare.ts
@@ -44,7 +44,7 @@ function isDigit(char: string): boolean {
 }
 
 function isLetter(char: string): boolean {
-  return regEx(/^[a-z_]$/i).test(char);
+  return regEx(/^[a-z_+]$/i).test(char);
 }
 
 function isTransition(prevChar: string, nextChar: string): boolean {
@@ -281,7 +281,7 @@ function isVersion(version: unknown): version is string {
   if (!version || typeof version !== 'string') {
     return false;
   }
-  if (!regEx(/^[a-z_0-9.-]+$/i).test(version)) {
+  if (!regEx(/^[-.a-z_+0-9]+$/i).test(version)) {
     return false;
   }
   if (regEx(/^[.-]/).test(version)) {

--- a/lib/modules/versioning/maven/index.spec.ts
+++ b/lib/modules/versioning/maven/index.spec.ts
@@ -11,6 +11,7 @@ describe('modules/versioning/maven/index', () => {
   test.each`
     version              | expected
     ${'1.0.0'}           | ${true}
+    ${'17.0.5+8'}        | ${true}
     ${'[1.12.6,1.18.6]'} | ${true}
     ${undefined}         | ${false}
   `('isValid("$version") === $expected', ({ version, expected }) => {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Support for `+` sign for maven versioning
- Make sure it doesn't break Ivy versioning

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
