### PR TITLE
feat(versioning/regex): add `revision` as fifth capture group

### DIFF
--- a/lib/modules/versioning/regex/index.spec.ts
+++ b/lib/modules/versioning/regex/index.spec.ts
@@ -1,14 +1,24 @@
-import { VersioningApi, get } from '..';
+import { get } from '..';
 import { CONFIG_VALIDATION } from '../../../constants/error-messages';
 
 describe('modules/versioning/regex/index', () => {
   describe('regex versioning', () => {
-    const regex: VersioningApi = get(
+    const regex = get(
       'regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(?<prerelease>[^.-]+)?(?:-(?<compatibility>.*))?$'
     );
 
     it('requires a valid configuration to be initialized', () => {
       expect(() => get('regex:not a regex')).toThrow();
+    });
+
+    it('works without config', () => {
+      const re = get('regex');
+      expect(re.isValid('alpine')).toBeFalse();
+    });
+
+    it('works with missing version', () => {
+      const re = get('regex:^(?<major>\\d+)?(?<compabillity>.+)');
+      expect(re.isValid('alpine')).toBeTrue();
     });
 
     describe('throws', () => {
@@ -43,7 +53,7 @@ describe('modules/versioning/regex/index', () => {
       ${'1.2.aardvark-foo'} | ${false}
       ${'1.2a2.3'}          | ${false}
     `('isValid("$version") === $expected', ({ version, expected }) => {
-      expect(!!regex.isValid(version)).toBe(expected);
+      expect(regex.isValid(version)).toBe(expected);
     });
 
     test.each`
@@ -342,9 +352,9 @@ describe('modules/versioning/regex/index', () => {
     );
   });
 
-  describe('Supported 4th number as build', () => {
+  describe('Supported 4th number as build and 5th as revision', () => {
     const re = get(
-      'regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(:?-(?<compatibility>.*-r)(?<build>\\d+))?$'
+      'regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(:?-(?<compatibility>.+)(?<build>\\d+)-r(?<revision>\\d+))?$'
     );
 
     test.each`

--- a/lib/modules/versioning/regex/index.ts
+++ b/lib/modules/versioning/regex/index.ts
@@ -71,7 +71,8 @@ export class RegExpVersioningApi extends GenericVersioningApi<RegExpVersion> {
       return null;
     }
 
-    const { major, minor, patch, build, prerelease, compatibility } = groups;
+    const { major, minor, patch, build, revision, prerelease, compatibility } =
+      groups;
     const release = [
       typeof major === 'undefined' ? 0 : Number.parseInt(major, 10),
       typeof minor === 'undefined' ? 0 : Number.parseInt(minor, 10),
@@ -80,6 +81,9 @@ export class RegExpVersioningApi extends GenericVersioningApi<RegExpVersion> {
 
     if (build) {
       release.push(Number.parseInt(build, 10));
+      if (revision) {
+        release.push(Number.parseInt(revision, 10));
+      }
     }
 
     return {

--- a/lib/modules/versioning/regex/readme.md
+++ b/lib/modules/versioning/regex/readme.md
@@ -5,6 +5,7 @@ The valid capture groups for `regex` versioning are:
 
 - `major`, `minor`, and `patch`: at least one of these must be provided. When determining whether a package has updates, these values will be compared in the standard semantic versioning fashion. If any of these fields are omitted, they will be treated as if they were `0` -- in this way, you can describe versioning schemes with up to three incrementing values.
 - `build`: this capture group can be used after you've already used the `major`, `minor` and `patch` capture groups and need a fourth version part. `build` updates are handled like `patch` updates.
+- `revision`: this capture group can be used after you've already used the `build` capture groups and need a fifth version part. `revision` updates are handled like `patch` updates.
 - `prerelease`: this value, if captured, will mark a given release as a prerelease (e.g. unstable). If this value is captured and you have configured `"ignoreUnstable": true`, the given release will be skipped.
 - `compatibility`: this value defines the "build compatibility" of a given dependency. A proposed Renovate update will never change the specified compatibility value. For example, if you are pinning to `1.2.3-linux` (and `linux` is captured as the compatibility value), Renovate will not update you to `1.2.4-osx`.
 
@@ -37,7 +38,7 @@ Here is another example, this time for handling `python` Docker images, which us
 }
 ```
 
-Here is another example, this time for handling Bitnami Docker images, which use build indicators as well as version suffixes for compatibility:
+Here is another example, this time for handling Bitnami Docker images, which use `build` and `revision` indicators as well as version suffixes for compatibility:
 
 ```json
 {
@@ -45,7 +46,7 @@ Here is another example, this time for handling Bitnami Docker images, which use
     {
       "matchDatasources": ["docker"],
       "matchPackagePrefixes": ["bitnami/"],
-      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(:?-(?<compatibility>.*-r)(?<build>\\d+))?$"
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(:?-(?<compatibility>.+)(?<build>\\d+)-r(?<revision>\\d+))?$"
     }
   ]
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Allows to use `revision` as fifth capture group to allow updates of bitnami docker images.
eg `bitnami/postgresql` docker image  `11.16.0-debian-10-r23 -> 11.16.0-debian-11-r33`
<!-- Describe what behavior is changed by this PR. -->

## Context
- #4860
- #9155
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
