### PR TITLE
docs(presets): fix typo

### DIFF
--- a/lib/config/presets/internal/default.ts
+++ b/lib/config/presets/internal/default.ts
@@ -509,7 +509,7 @@ export const presets: Record<string, Preset> = {
     packageRules: [
       {
         matchPackagePatterns: ['*'],
-        semanticCommitType: '{{arg0}}',
+        semanticCommitTypeAll: '{{arg0}}',
       },
     ],
   },


### PR DESCRIPTION
## Changes

Im not sure about this but looks like a typo in the doc about `semanticCommitTypeAll` that is using `semanticCommitType` in the example ?

## Context

reading docs :)

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required


