### PR TITLE
docs: fix broken relative link

### DIFF
--- a/docs/usage/key-concepts/presets.md
+++ b/docs/usage/key-concepts/presets.md
@@ -51,7 +51,7 @@ Once you find a preset you like, put it in an `extends` array in your config fil
 
 If you have a Renovate config that may help others, you can put it into Renovate's built-in presets.
 
-Read [Contributing to presets](./config-presets.md#contributing-to-presets) to learn how.
+Read [Contributing to presets](../config-presets.md#contributing-to-presets) to learn how.
 
 ## Summary
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Fix a broken relative link

## Context

The typo slipped through in this PR:

- #21534

In the VS Code editor I can now click on the newly added links and it takes me to the correct file and correct location. I hope this now also works when we build the docs site. 🤞 

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
