### PR TITLE
fix: sanitize special characters in URLs

### DIFF
--- a/lib/logger/utils.spec.ts
+++ b/lib/logger/utils.spec.ts
@@ -37,6 +37,7 @@ describe('logger/utils', () => {
     input                                                                 | output
     ${' https://somepw@domain.com/gitlab/org/repo?go-get'}                | ${' https://**redacted**@domain.com/gitlab/org/repo?go-get'}
     ${'https://someuser:somepw@domain.com'}                               | ${'https://**redacted**@domain.com'}
+    ${'https://someuser:pass%word_with-speci(a)l&chars@domain.com'}       | ${'https://**redacted**@domain.com'}
     ${'https://someuser:@domain.com'}                                     | ${'https://**redacted**@domain.com'}
     ${'redis://:somepw@172.32.11.71:6379/0'}                              | ${'redis://**redacted**@172.32.11.71:6379/0'}
     ${'some text with\r\n url: https://somepw@domain.com\nand some more'} | ${'some text with\r\n url: https://**redacted**@domain.com\nand some more'}

--- a/lib/logger/utils.ts
+++ b/lib/logger/utils.ts
@@ -244,7 +244,7 @@ export function validateLogLevel(logLevelToCheck: string | undefined): void {
 }
 
 // Can't use `util/regex` because of circular reference to logger
-const urlRe = /[a-z]{3,9}:\/\/[-;:&=+$,\w]+@[a-z0-9.-]+/gi;
+const urlRe = /[a-z]{3,9}:\/\/[^@/]+@[a-z0-9.-]+/gi;
 const urlCredRe = /\/\/[^@]+@/g;
 
 export function sanitizeUrls(text: string): string {


### PR DESCRIPTION

## Changes

The sanitizing of URLs should include special characters like %, (, ), ! (and more)
This PR will include all characters by defining only characters that don't trigger the sanitization (@ because it's the separator between credentials and URL and / because it's the URL separator).

## Context
- Closes #21571 

I've noticed the mentioned behavior only on git clone errors.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository