### PR TITLE
fix(manager/helmfile): Use helmfile relative path

### DIFF
--- a/lib/modules/manager/helmfile/__fixtures__/uses-kustomization.yaml
+++ b/lib/modules/manager/helmfile/__fixtures__/uses-kustomization.yaml
@@ -1,0 +1,10 @@
+repositories:
+  - name: bitnami
+    url: https://charts.bitnami.com/bitnami
+
+releases:
+    - name: my-chart
+      chart: ../charts/my-chart
+    - name: memcached
+      version: 6.0.0
+      chart: bitnami/memcached

--- a/lib/modules/manager/helmfile/extract.spec.ts
+++ b/lib/modules/manager/helmfile/extract.spec.ts
@@ -390,12 +390,11 @@ describe('modules/manager/helmfile/extract', () => {
     });
 
     it('detects kustomize and respects relative paths', async () => {
-      // eslint-disable-next-line require-await, @typescript-eslint/require-await
-      fs.localPathExists.mockImplementationOnce(async (path) => {
+      fs.localPathExists.mockImplementationOnce((path) => {
         if (!path.startsWith(GlobalConfig.get('localDir') ?? '')) {
           throw new Error(FILE_ACCESS_VIOLATION_ERROR);
         }
-        return true;
+        return Promise.resolve(true);
       });
 
       const parentDir = `${localDir}/project`;

--- a/lib/modules/manager/helmfile/extract.spec.ts
+++ b/lib/modules/manager/helmfile/extract.spec.ts
@@ -6,12 +6,12 @@ import { extractPackageFile } from '.';
 
 jest.mock('../../../util/fs');
 
-const LOCAL_DIR = '/tmp/github/some/repo';
+const localDir = '/tmp/github/some/repo';
 
 describe('modules/manager/helmfile/extract', () => {
   describe('extractPackageFile()', () => {
     beforeEach(() => {
-      GlobalConfig.set({ localDir: LOCAL_DIR });
+      GlobalConfig.set({ localDir });
       jest.resetAllMocks();
     });
 
@@ -398,7 +398,7 @@ describe('modules/manager/helmfile/extract', () => {
         return true;
       });
 
-      const parentDir = `${LOCAL_DIR}/project`;
+      const parentDir = `${localDir}/project`;
       fs.getParentDir.mockReturnValue(parentDir);
       const result = await extractPackageFile(
         Fixtures.get('uses-kustomization.yaml'),

--- a/lib/modules/manager/helmfile/extract.ts
+++ b/lib/modules/manager/helmfile/extract.ts
@@ -75,7 +75,7 @@ export async function extractPackageFile(
       if (isLocalPath(dep.chart)) {
         if (
           kustomizationsKeysUsed(dep) ||
-          (await localChartHasKustomizationsYaml(dep))
+          (await localChartHasKustomizationsYaml(dep, fileName))
         ) {
           needKustomize = true;
         }

--- a/lib/modules/manager/helmfile/utils.ts
+++ b/lib/modules/manager/helmfile/utils.ts
@@ -1,6 +1,6 @@
 import upath from 'upath';
 
-import { localPathExists } from '../../../util/fs';
+import { getParentDir, localPathExists } from '../../../util/fs';
 import type { Release } from './types';
 
 /** Returns true if a helmfile release contains kustomize specific keys **/
@@ -15,7 +15,11 @@ export function kustomizationsKeysUsed(release: Release): boolean {
 /** Returns true if a helmfile release uses a local chart with a kustomization.yaml file **/
 // eslint-disable-next-line require-await
 export async function localChartHasKustomizationsYaml(
-  release: Release
+  release: Release,
+  helmFileYamlFileName: string
 ): Promise<boolean> {
-  return localPathExists(upath.join(release.chart, 'kustomization.yaml'));
+  const helmfileYamlParentDir = getParentDir(helmFileYamlFileName) || '';
+  return localPathExists(
+    upath.join(helmfileYamlParentDir, release.chart, 'kustomization.yaml')
+  );
 }


### PR DESCRIPTION
When detecting kustomization.yaml the path lookup was relative to the current working directory and not the current helmfile.yaml as expected. When using a chart path with `../` this would throw a `file-access-violation-error`.

Followup to #21111 