### PR TITLE
refactor(date): Use Jest fake timers

### DIFF
--- a/lib/util/date.spec.ts
+++ b/lib/util/date.spec.ts
@@ -1,3 +1,4 @@
+import { DateTime } from 'luxon';
 import {
   getElapsedDays,
   getElapsedHours,
@@ -5,34 +6,40 @@ import {
   getElapsedMs,
 } from './date';
 
-const ONE_MINUTE_MS = 60 * 1000;
-const ONE_HOUR_MS = 60 * ONE_MINUTE_MS;
-const ONE_DAY_MS = 24 * ONE_HOUR_MS;
-
 describe('util/date', () => {
-  const Jan1 = new Date(new Date().getFullYear(), 0, 1);
+  const t0 = DateTime.fromISO('2020-10-10');
 
-  it('returns elapsed days', () => {
-    const elapsedDays = Math.floor(
-      (new Date().getTime() - new Date(Jan1).getTime()) / ONE_DAY_MS
-    );
-    expect(getElapsedDays(Jan1.toDateString())).toBe(elapsedDays);
+  beforeAll(() => {
+    jest.useFakeTimers();
   });
 
-  it('returns elapsed minutes', () => {
-    const elapsedMinutes = Math.floor(
-      (new Date().getTime() - new Date(Jan1).getTime()) / ONE_MINUTE_MS
-    );
-    expect(getElapsedMinutes(new Date(Jan1))).toBe(elapsedMinutes);
+  beforeEach(() => {
+    jest.setSystemTime(t0.toMillis());
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  describe('getElapsedDays', () => {
+    it('returns elapsed days', () => {
+      const t = t0.minus({ days: 42 });
+      expect(getElapsedDays(t.toISO()!)).toBe(42);
+    });
+  });
+
+  describe('getElapsedMinutes', () => {
+    it('returns elapsed minutes', () => {
+      const t = t0.minus({ minutes: 42 });
+      expect(getElapsedMinutes(t.toJSDate())).toBe(42);
+    });
   });
 
   describe('getElapsedHours', () => {
     it('returns elapsed hours', () => {
-      const elapsedHours = Math.floor(
-        (new Date().getTime() - new Date(Jan1).getTime()) / ONE_HOUR_MS
-      );
-      expect(getElapsedHours(Jan1.toISOString())).toBe(elapsedHours); // ISOstring
-      expect(getElapsedHours(Jan1)).toBe(elapsedHours); // JS Date
+      const t = t0.minus({ hours: 42 });
+      expect(getElapsedHours(t.toISO()!)).toBe(42); // ISOstring
+      expect(getElapsedHours(t.toJSDate())).toBe(42); // JS Date
     });
 
     it('returns zero when date passed is invalid', () => {
@@ -40,10 +47,10 @@ describe('util/date', () => {
     });
   });
 
-  describe('getElapsedMilliseconds', () => {
+  describe('getElapsedMs', () => {
     it('returns elapsed time in milliseconds', () => {
-      const elapsedMs = new Date().getTime() - new Date(Jan1).getTime();
-      expect(getElapsedMs(Jan1.toISOString())).toBe(elapsedMs);
+      const t = t0.minus({ milliseconds: 42 });
+      expect(getElapsedMs(t.toISO()!)).toBe(42);
     });
   });
 });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Sometimes CI randomly fails like this:

```
util/date › getElapsedMilliseconds › returns elapsed time in milliseconds

    expect(received).toBe(expected) // Object.is equality

    Expected: 9469618351
    Received: 9469618352

      44 |     it('returns elapsed time in milliseconds', () => {
      45 |       const elapsedMs = new Date().getTime() - new Date(Jan1).getTime();
    > 46 |       expect(getElapsedMs(Jan1.toISOString())).toBe(elapsedMs);
         |                                                ^
      47 |     });
      48 |   });
      49 | });

      at Object.<anonymous> (lib/util/date.spec.ts:46:48)
```

This PR should fix it.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
