### PR TITLE
chore: update eslint config to allow direct reference of static class functions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -137,7 +137,7 @@ module.exports = {
       },
     ],
 
-    '@typescript-eslint/unbound-method': 2,
+    '@typescript-eslint/unbound-method': [2, { ignoreStatic: true }],
     '@typescript-eslint/ban-types': 2,
     '@renovate/jest-root-describe': 2,
 


### PR DESCRIPTION
## Changes

Update eslint configuration to allow static class functions to be referenced directly without wrapping them in an arrow function.

## Context

[Slack discussion](https://renovatebot.slack.com/archives/CAFH752JU/p1681933718434939)

If someone defines a static comparison function on a class, it would be ideal to reference this function in `Array.sort()` like so:
```typescript
bzlmodVersions.sort(BzlmodVersion.defaultCompare);
```

However, eslint's [unbound-method](https://typescript-eslint.io/rules/unbound-method/) rule will complain with the following message:
```
@typescript-eslint/unbound-method: Avoid referencing unbound methods which may cause unintentional scoping of `this`.If your function does not access `this`, you can annotate it with `this: void`, or consider using an arrow function instead.
```

Given that static class functions should be written without a reference to `this`, configuring [ignoreStatic](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/unbound-method.md#ignorestatic) for the rule would allow one to reference the static function directly.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
