### PR TITLE
fix(ansible-galaxy): handle git source

### DIFF
--- a/lib/modules/manager/ansible-galaxy/collections.ts
+++ b/lib/modules/manager/ansible-galaxy/collections.ts
@@ -30,7 +30,11 @@ function interpretLine(
     }
     case 'source': {
       localDependency.managerData.source = value;
-      localDependency.registryUrls = value ? [value] : [];
+      if (value?.startsWith('git@')) {
+        localDependency.packageName = value;
+      } else {
+        localDependency.registryUrls = value ? [value] : [];
+      }
       break;
     }
     case 'type': {

--- a/lib/modules/manager/ansible-galaxy/extract.spec.ts
+++ b/lib/modules/manager/ansible-galaxy/extract.spec.ts
@@ -46,6 +46,7 @@ describe('modules/manager/ansible-galaxy/extract', () => {
         version: 2.7.5`;
       const res = extractPackageFile(yamlFile, 'requirements.yml');
       expect(res?.deps).toHaveLength(1);
+      expect(res?.deps[0].currentValue).toBe('2.7.5');
       expect(res?.deps[0].registryUrls).toBeUndefined();
       expect(res?.deps[0].packageName).toBe(
         'git@github.com:ansible-collections/community.docker'

--- a/lib/modules/manager/ansible-galaxy/extract.spec.ts
+++ b/lib/modules/manager/ansible-galaxy/extract.spec.ts
@@ -38,6 +38,20 @@ describe('modules/manager/ansible-galaxy/extract', () => {
       expect(res?.deps[0].currentValue).toBe('1.1.3');
     });
 
+    it('extracts git@ dependencies', () => {
+      const yamlFile = codeBlock`collections:
+      - name: community.docker
+        source: git@github.com:ansible-collections/community.docker
+        type: git
+        version: 2.7.5`;
+      const res = extractPackageFile(yamlFile, 'requirements.yml');
+      expect(res?.deps).toHaveLength(1);
+      expect(res?.deps[0].registryUrls).toBeUndefined();
+      expect(res?.deps[0].packageName).toBe(
+        'git@github.com:ansible-collections/community.docker'
+      );
+    });
+
     it('check if an empty file returns null', () => {
       const res = extractPackageFile('\n', 'requirements.yml');
       expect(res).toBeNull();


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds logic for when a git source is in the collections.value field in ansible galaxy

## Context

Fixes #21580

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
