### PR TITLE
fix(versioning/hashicorp): handle empty constraint

### DIFF
--- a/lib/modules/versioning/hashicorp/convertor.spec.ts
+++ b/lib/modules/versioning/hashicorp/convertor.spec.ts
@@ -3,6 +3,7 @@ import { hashicorp2npm, npm2hashicorp } from './convertor';
 describe('modules/versioning/hashicorp/convertor', () => {
   test.each`
     hashicorp           | npm
+    ${''}               | ${''}
     ${'4.2.0'}          | ${'4.2.0'}
     ${'4.2.0-alpha'}    | ${'4.2.0-alpha'}
     ${'~> 4.0'}         | ${'^4.0'}

--- a/lib/modules/versioning/hashicorp/convertor.ts
+++ b/lib/modules/versioning/hashicorp/convertor.ts
@@ -10,6 +10,9 @@ import { regEx } from '../../../util/regex';
  * are made
  */
 export function hashicorp2npm(input: string): string {
+  if (!input) {
+    return input;
+  }
   return input
     .split(',')
     .map((single) => {
@@ -62,6 +65,9 @@ export function hashicorp2npm(input: string): string {
  * It cannot handle `*`, `1.x.x`, range with `-`, `||`
  */
 export function npm2hashicorp(input: string): string {
+  if (!input) {
+    return input;
+  }
   return input
     .split(' ')
     .map((single) => {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Ignore empty constraint

<!-- Describe what behavior is changed by this PR. -->

## Context
- Fixes #21364

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
