### PR TITLE
docs(contributing): rewrite do not force push section

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -40,12 +40,13 @@ This makes it harder for us to review your work because we don't know what has c
 PRs will always be squashed by us when we merge your work.
 Commit as many times as you need in your pull request branch.
 
-If you are updating your PR branch from within the GitHub PR interface, then only use the default "Update branch" button.
+If you're updating your PR branch from within the GitHub PR interface, use the default "Update branch" button.
+This is the "Update with merge commit" option in the dropdown.
 
-Force pushing a PR is OK when:
+Force pushing a PR, or using the "Update with rebase" button is OK when you:
 
-- you need to make large changes on a PR which require a full review anyway
-- you need to bring the branch up-to-date with the target branch and incorporating the changes is more work than to create a new PR
+- make large changes on a PR which require a full review anyway
+- bring the branch up-to-date with the target branch and incorporating the changes is more work than to create a new PR
 
 ## Apply maintainer provided review suggestions
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Explain that GitHub has two options to update a branch:
  - "Update with merge commit"
  - "Update with rebase"
- Using the "Update with rebase" button is okay in some cases
- Move some words to the list platform

## Context

Reduce ambiguity on what option to use when updating a PR branch with our `main` branch.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
