### PR TITLE
refactor: satisfy type checks for `array.includes`

### DIFF
--- a/lib/modules/manager/npm/extract/monorepo.ts
+++ b/lib/modules/manager/npm/extract/monorepo.ts
@@ -42,7 +42,10 @@ export async function detectMonorepos(
         .filter(Boolean);
 
       p.deps?.forEach((dep) => {
-        if (internalPackageNames.includes(dep.depName)) {
+        if (
+          is.string(dep.depName) &&
+          internalPackageNames.includes(dep.depName)
+        ) {
           dep.isInternal = true;
         }
       });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Check `PackageDependency.depName` is defined

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->
Part of #20553

`ts-reset` changes the type signature of `Array.includes` from:

```ts
includes(searchElement: T, fromIndex?: number): boolean;
```

to

```ts
includes( 
   searchElement: T | (TSReset.WidenLiteral<T> & {}),
   fromIndex?: number,
): boolean;
```

Without this type check, we get the error 

```
error TS2769: No overload matches this call.
  Overload 1 of 2, '(searchElement: string, fromIndex?: number | undefined): boolean', gave the following error.
    Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
      Type 'undefined' is not assignable to type 'string'.
  Overload 2 of 2, '(searchElement: string, fromIndex?: number | undefined): boolean', gave the following error.
    Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
      Type 'undefined' is not assignable to type 'string'.
```

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
