### PR TITLE
fix(rubygems): Use module-local memory cache

### DIFF
--- a/lib/modules/datasource/rubygems/index.spec.ts
+++ b/lib/modules/datasource/rubygems/index.spec.ts
@@ -1,9 +1,8 @@
 import { getPkgReleases } from '..';
 import { Fixtures } from '../../../../test/fixtures';
 import * as httpMock from '../../../../test/http-mock';
-import * as memCache from '../../../util/cache/memory';
 import * as rubyVersioning from '../../versioning/ruby';
-import { VersionsDatasource } from './versions-datasource';
+import { VersionsDatasource, memCache } from './versions-datasource';
 import { RubyGemsDatasource } from '.';
 
 const rubygemsOrgVersions = Fixtures.get('rubygems-org.txt');
@@ -25,12 +24,8 @@ describe('modules/datasource/rubygems/index', () => {
     };
 
     beforeEach(() => {
-      memCache.init();
+      memCache.clear();
       jest.resetAllMocks();
-    });
-
-    afterEach(() => {
-      memCache.reset();
     });
 
     it('returns null for missing pkg', async () => {

--- a/lib/modules/datasource/rubygems/versions-datasource.ts
+++ b/lib/modules/datasource/rubygems/versions-datasource.ts
@@ -1,7 +1,6 @@
 import { PAGE_NOT_FOUND_ERROR } from '../../../constants/error-messages';
 import { logger } from '../../../logger';
 import { ExternalHostError } from '../../../types/errors/external-host-error';
-import * as memCache from '../../../util/cache/memory';
 import { getElapsedMinutes } from '../../../util/date';
 import { HttpError } from '../../../util/http';
 import { newlineRegex } from '../../../util/regex';
@@ -16,6 +15,8 @@ interface RegistryCache {
   registryUrl: string;
 }
 
+export const memCache = new Map<string, RegistryCache>();
+
 export class VersionsDatasource extends Datasource {
   constructor(override readonly id: string) {
     super(id);
@@ -23,7 +24,7 @@ export class VersionsDatasource extends Datasource {
 
   getRegistryCache(registryUrl: string): RegistryCache {
     const cacheKey = `rubygems-versions-cache:${registryUrl}`;
-    const regCache = memCache.get<RegistryCache>(cacheKey) ?? {
+    const regCache = memCache.get(cacheKey) ?? {
       lastSync: new Date('2000-01-01'),
       packageReleases: new Map<string, string[]>(),
       contentLength: 0,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Renovate memory cache is being reset for each new repository, while we want to have the memory cache for usage during the app lifetime.

## Context

- Reverts: #21874

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
