### PR TITLE
chore: improve issue forms and template chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,7 +12,7 @@ body:
       value: |
         **Stop!** Only create a Bug Report if you're a maintainer of Renovate.
         If you're a user of Renovate, please create a GitHub Discussion.
-        Please go back a step and select Discussion instead of Issue.
+        Please go back a step and select _Start a discussion_ instead of Issue.
 
   - type: dropdown
     id: how-are-you-running-renovate

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,6 +5,10 @@ labels:
 body:
   - type: markdown
     attributes:
+      value: '# This form is for Renovate maintainers only.'
+
+  - type: markdown
+    attributes:
       value: |
         STOP! Only create a Bug Report if you're a maintainer of Renovate.
         If you're a user of Renovate, please create a GitHub Discussion.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,7 +10,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        STOP! Only create a Bug Report if you're a maintainer of Renovate.
+        **Stop!** Only create a Bug Report if you're a maintainer of Renovate.
         If you're a user of Renovate, please create a GitHub Discussion.
         Please go back a step and select Discussion instead of Issue.
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,6 +2,10 @@ name: Feature request
 description: For maintainers only. For everyone else, please start an Ideas [discussion](https://github.com/renovatebot/renovate/discussions/new).
 labels: ['type:feature', 'status:requirements', 'priority-5-triage']
 body:
+  - type: markdown
+    attributes:
+      value: '# This form is for Renovate maintainers only.'
+  
   - type: textarea
     id: what-would-you-like-renovate-to-be-able-to-do
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,11 +1,17 @@
 name: Feature request
 description: For maintainers only. For everyone else, please start an Ideas discussion.
-labels: ['type:feature', 'status:requirements', 'priority-5-triage', 'needs-discussion']
+labels:
+  [
+    'type:feature',
+    'status:requirements',
+    'priority-5-triage',
+    'needs-discussion',
+  ]
 body:
   - type: markdown
     attributes:
       value: '# This form is for Renovate maintainers only.'
-  
+
   - type: textarea
     id: what-would-you-like-renovate-to-be-able-to-do
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: For maintainers only. For everyone else, please start an Ideas [discussion](https://github.com/renovatebot/renovate/discussions/new).
-labels: ['type:feature', 'status:requirements', 'priority-5-triage']
+labels: ['type:feature', 'status:requirements', 'priority-5-triage', 'needs-discussion']
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,5 @@
 name: Feature request
-description: For maintainers only. For everyone else, please start an Ideas [discussion](https://github.com/renovatebot/renovate/discussions/new).
+description: For maintainers only. For everyone else, please start an Ideas discussion.
 labels: ['type:feature', 'status:requirements', 'priority-5-triage', 'needs-discussion']
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/refactor.yml
+++ b/.github/ISSUE_TEMPLATE/refactor.yml
@@ -1,5 +1,5 @@
 name: Refactor (internal)
-description: For internal use only.
+description: For maintainers only.
 labels: ['type:refactor', 'status:requirements', 'priority-5-triage', 'needs-discussion']
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/refactor.yml
+++ b/.github/ISSUE_TEMPLATE/refactor.yml
@@ -1,6 +1,6 @@
 name: Refactor (internal)
 description: For internal use only.
-labels: ['type:refactor', 'status:requirements', 'priority-5-triage']
+labels: ['type:refactor', 'status:requirements', 'priority-5-triage', 'needs-discussion']
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/refactor.yml
+++ b/.github/ISSUE_TEMPLATE/refactor.yml
@@ -1,6 +1,12 @@
 name: Refactor (internal)
 description: For maintainers only.
-labels: ['type:refactor', 'status:requirements', 'priority-5-triage', 'needs-discussion']
+labels:
+  [
+    'type:refactor',
+    'status:requirements',
+    'priority-5-triage',
+    'needs-discussion',
+  ]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Add big `h1` warning that the issues are for maintainers only (this warning is only visual, it's not copied into the issue body)
- Use **bold** text instead of all caps for the `Stop!` text
- Match GitHub's words for the _Start a discussion_ item in the template chooser
- Add `needs-discussion` label to the Feature and Refactor issues
- Update description for Refactor issue
- Remove non-functional link to the Discussions

## Context

We merged this PR:

- #21736

I think we still need some more fixes.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
