### PR TITLE
fix(manager/gradle): Convert multiple globs into regex for consistent-versions plugin

### DIFF
--- a/lib/modules/manager/gradle/extract.spec.ts
+++ b/lib/modules/manager/gradle/extract.spec.ts
@@ -960,6 +960,7 @@ describe('modules/manager/gradle/extract', () => {
           org.apache.lucene:* = 3
           org.apache.lucene:a.* = 2
           org.apache.lucene:a.b = 1
+          org.apache.foo*:* = 5
         `,
         'versions.lock': stripIndent`
           # Run ./gradlew --write-locks to regenerate this file
@@ -969,6 +970,7 @@ describe('modules/manager/gradle/extract', () => {
           org.apache.lucene:a.d:1 (10 constraints: 95be0c15)
           org.apache.lucene:d:1 (10 constraints: 95be0c15)
           org.apache.lucene:e.f:1 (10 constraints: 95be0c15)
+          org.apache.foo-bar:a:1 (10 constraints: 95be0c15)
         `,
       };
       mockFs(fsMock);
@@ -1044,6 +1046,18 @@ describe('modules/manager/gradle/extract', () => {
               lockedVersion: '1',
               groupName: 'org.apache.lucene:*',
               fileReplacePosition: 39,
+              depType: 'dependencies',
+            },
+            {
+              managerData: {
+                fileReplacePosition: 113,
+                packageFile: 'versions.props',
+              },
+              depName: 'org.apache.foo-bar:a',
+              currentValue: '5',
+              lockedVersion: '1',
+              groupName: 'org.apache.foo*:*',
+              fileReplacePosition: 113,
               depType: 'dependencies',
             },
           ],

--- a/lib/modules/manager/gradle/extract/consistent-versions-plugin.ts
+++ b/lib/modules/manager/gradle/extract/consistent-versions-plugin.ts
@@ -119,7 +119,7 @@ function globToRegex(depName: string): RegExp {
     depName
       .replace(/\*/g, '_WC_CHAR_')
       .replace(/[/\-\\^$*+?.()|[\]{}]/g, '\\$&')
-      .replace('_WC_CHAR_', '.*?')
+      .replace(/_WC_CHAR_/g, '.*?')
   );
 }
 


### PR DESCRIPTION
## Changes

Fix for #21908 which fails to upgrade lines in `versions.props` with two glob `*` chars.

## Context

Closes #21908

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
