### PR TITLE
feat(datasource/hexpm-bob): Switch to builds.hex.pm from repo.hex.pm

### DIFF
--- a/lib/modules/datasource/hexpm-bob/common.ts
+++ b/lib/modules/datasource/hexpm-bob/common.ts
@@ -1,3 +1,3 @@
-export const defaultRegistryUrl = 'https://repo.hex.pm';
+export const defaultRegistryUrl = 'https://builds.hex.pm';
 
 export const datasource = 'hexpm-bob';

--- a/lib/modules/datasource/hexpm-bob/index.spec.ts
+++ b/lib/modules/datasource/hexpm-bob/index.spec.ts
@@ -82,7 +82,7 @@ describe('modules/datasource/hexpm-bob/index', () => {
       });
       expect(res).toEqual({
         homepage: 'https://elixir-lang.org/',
-        registryUrl: 'https://repo.hex.pm',
+        registryUrl: 'https://builds.hex.pm',
         releases: [
           {
             gitRef: '185eeec5ecbc2a0c8d9b8b97cb2d23108615ffdb',
@@ -133,7 +133,7 @@ describe('modules/datasource/hexpm-bob/index', () => {
 
       expect(res).toEqual({
         homepage: 'https://www.erlang.org/',
-        registryUrl: 'https://repo.hex.pm',
+        registryUrl: 'https://builds.hex.pm',
         releases: [
           {
             gitRef: '6efb5e31df6bc512ed6c466584ef15b846dcecab',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Builds are no longer pushed to `repo.hex.pm`. They are pushed to `builds.hex.pm` instead.

This PR changes the default registry URL to reflect this.

## Context

* Mirroring the change of elixir-lang/elixir#12540 (CC @ericmj)

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
