### PR TITLE
fix(template): Proxy Compile Input loses values from arrays

### DIFF
--- a/lib/util/template/index.spec.ts
+++ b/lib/util/template/index.spec.ts
@@ -116,22 +116,25 @@ describe('util/template/index', () => {
 
   describe('proxyCompileInput', () => {
     const allowedField = 'body';
+    const allowedArrayField = 'prBodyNotes';
     const forbiddenField = 'foobar';
 
     type TestCompileInput = Record<
-      typeof allowedField | typeof forbiddenField,
+      typeof allowedField | typeof allowedArrayField | typeof forbiddenField,
       unknown
     >;
 
     const compileInput: TestCompileInput = {
       [allowedField]: 'allowed',
+      [allowedArrayField]: ['allowed'],
       [forbiddenField]: 'forbidden',
     };
 
-    it('accessing allowed files', () => {
+    it('accessing allowed fields', () => {
       const p = template.proxyCompileInput(compileInput);
 
       expect(p[allowedField]).toBe('allowed');
+      expect(p[allowedArrayField]).toStrictEqual(['allowed']);
       expect(p[forbiddenField]).toBeUndefined();
     });
 
@@ -153,6 +156,7 @@ describe('util/template/index', () => {
       const arr = proxy[allowedField] as TestCompileInput[];
       const obj = arr[0];
       expect(obj[allowedField]).toBe('allowed');
+      expect(obj[allowedArrayField]).toStrictEqual(['allowed']);
       expect(obj[forbiddenField]).toBeUndefined();
     });
   });

--- a/lib/util/template/index.ts
+++ b/lib/util/template/index.ts
@@ -185,9 +185,11 @@ const compileInputProxyHandler: ProxyHandler<CompileInput> = {
     const value = target[prop];
 
     if (is.array(value)) {
-      return value
-        .filter(is.plainObject)
-        .map((element) => proxyCompileInput(element as CompileInput));
+      return value.map((element) =>
+        is.primitive(element)
+          ? element
+          : proxyCompileInput(element as CompileInput)
+      );
     }
 
     if (is.plainObject(value)) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This change prevents the values in `Array<string>` inputs (e.g. `prBodyNotes`) from being stripped by the `proxyCompileInput` / allowed fields process.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->
I was trying to implement a "fallback" rule that provides general instructions if there aren't any other rules in place. Based on [the documentation](https://docs.renovatebot.com/templates/#exposed-config-options), I believe something like this should work. 

```javascript
        {
            "matchPackagePatterns": ["*"],
            "prBodyNotes": `{{#unless prBodyNotes}}Only show this if there aren't more specific configurations{{/unless}}`
        }
```

Unfortunately, it rendered the fallback message even when another rule (that includes `prBodyNotes`) matches, indicating that the `prBodyNotes` value is not being supplied in the template context.

After having a look at the implementation and tests, I believe it is because the `proxyCompileInput` is dropping the values in `prBodyNotes` when it attempts to recurse into the array. I don't *believe* this is intentional, as `prBodyNotes` (et al) is listed in the `exposedConfigOptions`.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
