### PR TITLE
fix(onboarding): don’t check onboarding cache unless onboarding=true

### DIFF
--- a/lib/workers/repository/onboarding/branch/check.spec.ts
+++ b/lib/workers/repository/onboarding/branch/check.spec.ts
@@ -20,6 +20,7 @@ describe('workers/repository/onboarding/branch/check', () => {
   const config = partial<RenovateConfig>({
     requireConfig: 'required',
     suppressNotifications: [],
+    onboarding: true,
   });
 
   it('skips normal onboarding check if onboardingCache is valid', async () => {

--- a/lib/workers/repository/onboarding/branch/check.ts
+++ b/lib/workers/repository/onboarding/branch/check.ts
@@ -68,6 +68,7 @@ export async function isOnboarded(config: RenovateConfig): Promise<boolean> {
   // if onboarding cache is present and base branch has not been updated branch is not onboarded
   // if closed pr exists then presence of onboarding cache doesn't matter as we need to skip onboarding
   if (
+    config.onboarding &&
     !pr &&
     onboardingBranchCache &&
     onboardingBranchCache.defaultBranchSha ===


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Only check onboarding cache if onboarding=true

## Context

The new onboarding cache interfered with Renovate's ability to disable onboarding and clean up stray PRs

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
