### PR TITLE
feat(npm)!: disable rollbackPrs for npm by default

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -3192,9 +3192,8 @@ There are times when a dependency version in use by a project gets removed from 
 For some registries, existing releases or even whole packages can be removed or "yanked" at any time, while for some registries only very new or unused releases can be removed.
 Renovate's "rollback" feature exists to propose a downgrade to the next-highest release if the current release is no longer found in the registry.
 
-Renovate does not create these rollback PRs by default, with one exception: npm packages get a rollback PR if needed.
-
-You can configure the `rollbackPrs` property globally, per-language, or per-package to override the default behavior.
+Renovate does not create these rollback PRs by default, so this functionality needs to be opted-into.
+We recommend you do this selectively with `packageRules` and not globally.
 
 ## ruby
 

--- a/lib/config/index.spec.ts
+++ b/lib/config/index.spec.ts
@@ -96,7 +96,6 @@ describe('config/index', () => {
       const config = configParser.getManagerConfig(parentConfig, 'npm');
       expect(config).toContainEntries([
         ['fileMatch', ['(^|/)package\\.json$']],
-        ['rollbackPrs', true],
       ]);
       expect(
         configParser.getManagerConfig(parentConfig, 'html')

--- a/lib/modules/manager/npm/index.ts
+++ b/lib/modules/manager/npm/index.ts
@@ -17,7 +17,6 @@ export const supportsLockFileMaintenance = true;
 
 export const defaultConfig = {
   fileMatch: ['(^|/)package\\.json$'],
-  rollbackPrs: true,
   versioning: npmVersioning.id,
   digest: {
     prBodyDefinitions: {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Disables rollbackPrs by default for npm

## Context

I think there's too many false positives here that outweigh the benefits. This means that users can opt-in if they see a need.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
