### PR TITLE
fix(manager/terraform): correctly extract oci charts

### DIFF
--- a/lib/modules/manager/terraform/extract.spec.ts
+++ b/lib/modules/manager/terraform/extract.spec.ts
@@ -7,18 +7,18 @@ import type { RepoGlobalConfig } from '../../../config/types';
 import * as hashicorp from '../../versioning/hashicorp';
 import { extractPackageFile } from '.';
 
-const modules = Fixtures?.get('modules.tf');
-const bitbucketModules = Fixtures?.get('bitbucketModules.tf');
-const azureDevOpsModules = Fixtures?.get('azureDevOpsModules.tf');
-const providers = Fixtures?.get('providers.tf');
-const docker = Fixtures?.get('docker.tf');
-const kubernetes = Fixtures?.get('kubernetes.tf');
+const modules = Fixtures.get('modules.tf');
+const bitbucketModules = Fixtures.get('bitbucketModules.tf');
+const azureDevOpsModules = Fixtures.get('azureDevOpsModules.tf');
+const providers = Fixtures.get('providers.tf');
+const docker = Fixtures.get('docker.tf');
+const kubernetes = Fixtures.get('kubernetes.tf');
 
-const helm = Fixtures?.get('helm.tf');
-const lockedVersion = Fixtures?.get('lockedVersion.tf');
-const lockedVersionLockfile = Fixtures?.get('rangeStrategy.hcl');
-const terraformBlock = Fixtures?.get('terraformBlock.tf');
-const tfeWorkspaceBlock = Fixtures?.get('tfeWorkspace.tf');
+const helm = Fixtures.get('helm.tf');
+const lockedVersion = Fixtures.get('lockedVersion.tf');
+const lockedVersionLockfile = Fixtures.get('rangeStrategy.hcl');
+const terraformBlock = Fixtures.get('terraformBlock.tf');
+const tfeWorkspaceBlock = Fixtures.get('tfeWorkspace.tf');
 
 const adminConfig: RepoGlobalConfig = {
   // `join` fixes Windows CI
@@ -602,7 +602,6 @@ describe('modules/manager/terraform/extract', () => {
           datasource: 'helm',
           depName: undefined,
           depType: 'helm_release',
-          registryUrls: ['https://charts.helm.sh/stable'],
           skipReason: 'invalid-name',
         },
         {
@@ -629,7 +628,7 @@ describe('modules/manager/terraform/extract', () => {
           datasource: 'docker',
           depName: 'karpenter',
           depType: 'helm_release',
-          registryUrls: ['https://public.ecr.aws/karpenter'],
+          packageName: 'public.ecr.aws/karpenter/karpenter',
         },
       ]);
     });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Currently oci charts are wrongly extracted when the chart repo is configured via `repository`.
The docker datasource will then add the `/v2/` api path to the wrong place. 
<!-- Describe what behavior is changed by this PR. -->

## Context
- fixes #21971
- regression of #20237
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
