### PR TITLE
docs(hostRules): document current matchHost behaviour if a port is supplied

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -1205,7 +1205,7 @@ To match specific ports you have to add a protocol to `matchHost`:
 
 <!-- prettier-ignore -->
 !!! warning
-    Using `matchHost` without a protocol will lead to a behaviour as there is no `matchHost` configuration at all.
+    Using `matchHost` without a protocol behaves the same as if you had set no `matchHost` configuration.
 
 <!-- prettier-ignore -->
 !!! note

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -1190,6 +1190,23 @@ A preset alternative to the above is:
 }
 ```
 
+To match specific ports you have to add a protocol to `matchHost`:
+
+```json
+{
+  "hostRules": [
+    {
+      "matchHost": "https://domain.com:9118",
+      "enabled": false
+    }
+  ]
+}
+```
+
+<!-- prettier-ignore -->
+!!! warning
+    Using `matchHost` without a protocol will lead to a behaviour as there is no `matchHost` configuration at all.
+
 <!-- prettier-ignore -->
 !!! note
     Disabling a host is only 100% effective if added to self-hosted config.

--- a/lib/util/host-rules.spec.ts
+++ b/lib/util/host-rules.spec.ts
@@ -235,6 +235,26 @@ describe('util/host-rules', () => {
       expect(find({ url: 'httpsdomain.com' }).token).toBeUndefined();
     });
 
+    it('matches on matchHost with port', () => {
+      add({
+        matchHost: 'https://domain.com:9118',
+        token: 'def',
+      });
+      expect(find({ url: 'https://domain.com:9118' }).token).toBe('def');
+      expect(find({ url: 'https://domain.com' }).token).toBeUndefined();
+      expect(find({ url: 'httpsdomain.com' }).token).toBeUndefined();
+    });
+
+    it('host with port is interpreted as empty', () => {
+      add({
+        matchHost: 'domain.com:9118',
+        token: 'def',
+      });
+      expect(find({ url: 'https://domain.com:9118' }).token).toBe('def');
+      expect(find({ url: 'https://domain.com' }).token).toBe('def');
+      expect(find({ url: 'httpsdomain.com' }).token).toBe('def');
+    });
+
     it('matches on hostType and endpoint', () => {
       add({
         hostType: NugetDatasource.id,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Document current behavior for `matchHost` if there is a port supplied and add test to cover this behavior. 
<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
