### PR TITLE
docs(gitlab): add hostType to registry hostRules guide

### DIFF
--- a/lib/modules/platform/gitlab/index.md
+++ b/lib/modules/platform/gitlab/index.md
@@ -29,7 +29,7 @@ Remember to set `platform=gitlab` somewhere in your Renovate config file.
 
 If you're using a private [GitLab container registry](https://docs.gitlab.com/ee/user/packages/container_registry/), you must:
 
-- Set the `RENOVATE_HOST_RULES` CI variable to `[{"matchHost": "${CI_REGISTRY}","username": "${GITLAB_USER_NAME}","password": "${RENOVATE_TOKEN}"}]`.
+- Set the `RENOVATE_HOST_RULES` CI variable to `[{"matchHost": "${CI_REGISTRY}","username": "${GITLAB_USER_NAME}","password": "${RENOVATE_TOKEN}", "hostType": "docker"}]`.
 - Make sure the user that owns the `RENOVATE_TOKEN` PAT is a member of the corresponding GitLab projects/groups with the right permissions.
 - Make sure the `RENOVATE_TOKEN` PAT has the `read_registry` scope.
 


### PR DESCRIPTION
Fix docs about private GitLab Container Registry config.

## Changes

Update Docs about GitLab private registry, so that the example works. 

## Context

Wasted 4 hours trying to get Renovate to work with a private GitLab registry, and I never once considered that the example might be wrong, before I stumbled on this issue:
- #17940 

If you use [env to config host rules](https://docs.renovatebot.com/self-hosted-configuration/#detecthostrulesfromenv), then you need to config like this:

- DOCKER_GITLAB_EXAMPLE_COM_PASSWORD=renovate-bot
- DOCKER_GITLAB_EXAMPLE_COM_USERNAME=glpat-xxxxxxxx

And if you use "normal" json config host rules, they need to look like this: 

```
  "hostRules": [
    {
      "hostType": "docker",
      "matchHost": "gitlab.example.com",
      "username": "renovate-bot",
      "password": "glpat-xxxxxxxxxx"
    }
  ],
```

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
