### PR TITLE
chore(utils/array): add isNotNullOrUndefined

### DIFF
--- a/lib/util/array.spec.ts
+++ b/lib/util/array.spec.ts
@@ -1,0 +1,12 @@
+import { isNotNullOrUndefined } from './array';
+
+describe('util/array', () => {
+  it.each`
+    a                  | exp
+    ${null}            | ${false}
+    ${undefined}       | ${false}
+    ${{ name: 'foo' }} | ${true}
+  `('.isNotNullOrUndefined', ({ a, exp }) => {
+    expect(isNotNullOrUndefined(a)).toEqual(exp);
+  });
+});

--- a/lib/util/array.ts
+++ b/lib/util/array.ts
@@ -10,3 +10,12 @@ export function coerceArray<T>(input: T[] | null | undefined): T[] {
 export function sortNumeric(a: number, b: number): number {
   return a - b;
 }
+
+// Useful for filtering an array so that it includes values that are not null or
+// undefined. This predicate acts as a type guard so that the resulting type for
+// `values.filter(isNotNullOrUndefined)` is `T[]`.
+export function isNotNullOrUndefined<T>(
+  value: T | undefined | null
+): value is T {
+  return !is.nullOrUndefined(value);
+}


### PR DESCRIPTION
## Changes

Add `isNotNullOrUndefined` to `lib/util/array`. This predicate is useful for filtering arrays such that values that are `null` or `undefined` are excluded.

Related to #21893.

## Context

In #21893, an array in the `bazel-module` manager is generated that can contain `null` values. These values should be ignored such that the resulting array should only contain entries with the typed value (e.g., `T[]`). The `isNotNullOrUndefined` predicate acts as a type guard such that the `null` and `undefined` values are removed and the type of the resulting array only contains the desired type.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
