### PR TITLE
fix(regex): limit regex manager iterations to 10k to avoid OoM

### DIFF
--- a/lib/modules/manager/regex/utils.spec.ts
+++ b/lib/modules/manager/regex/utils.spec.ts
@@ -1,0 +1,14 @@
+import { regEx } from '../../../util/regex';
+import * as utils from './utils';
+
+describe('modules/manager/regex/utils', () => {
+  it('does not crash for lazy regex', () => {
+    const lazyMatch = regEx('(?<currentDigest>.*?)', 'g');
+    expect(
+      utils.regexMatchAll(
+        lazyMatch,
+        '1f699d2bfc99bbbe4c1ed5bb8fc21e6911d69c6e\n'
+      )
+    ).toBeArray();
+  });
+});

--- a/lib/modules/manager/regex/utils.ts
+++ b/lib/modules/manager/regex/utils.ts
@@ -85,12 +85,15 @@ export function regexMatchAll(
 ): RegExpMatchArray[] {
   const matches: RegExpMatchArray[] = [];
   let matchResult: RegExpMatchArray | null;
+  let iterations = 0;
+  const maxIterations = 10000;
   do {
     matchResult = regex.exec(content);
     if (matchResult) {
       matches.push(matchResult);
     }
-  } while (matchResult);
+    iterations += 1;
+  } while (matchResult && iterations < maxIterations);
   return matches;
 }
 

--- a/lib/modules/manager/regex/utils.ts
+++ b/lib/modules/manager/regex/utils.ts
@@ -94,6 +94,9 @@ export function regexMatchAll(
     }
     iterations += 1;
   } while (matchResult && iterations < maxIterations);
+  if (iterations === maxIterations) {
+    logger.warn('Max iterations reached for matchStrings');
+  }
   return matches;
 }
 


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Limits matchStrings matching to 10k to reduce change of hanging/crashing. The test completes in 16ms for me locally.

## Context

Fixes #22083

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
