### PR TITLE
feat(bitbucket): add paginate http option

### DIFF
--- a/lib/util/http/bitbucket.spec.ts
+++ b/lib/util/http/bitbucket.spec.ts
@@ -55,4 +55,34 @@ describe('util/http/bitbucket', () => {
       statusCode: 200,
     });
   });
+
+  it('paginates', async () => {
+    httpMock
+      .scope(baseUrl)
+      .get('/some-url')
+      .reply(200, {
+        values: ['a'],
+        page: '1',
+        next: `${baseUrl}/some-url?page=2`,
+      })
+      .get('/some-url?page=2')
+      .reply(200, {
+        values: ['b', 'c'],
+        page: '2',
+        next: `${baseUrl}/some-url?page=3`,
+      })
+      .get('/some-url?page=3')
+      .reply(200, {
+        values: ['d'],
+        page: '3',
+      });
+    const res = await api.getJson('some-url', { paginate: true });
+    expect(res.body).toEqual({
+      page: '1',
+      pagelen: 4,
+      size: 4,
+      values: ['a', 'b', 'c', 'd'],
+      next: undefined,
+    });
+  });
 });

--- a/lib/util/http/bitbucket.ts
+++ b/lib/util/http/bitbucket.ts
@@ -1,4 +1,7 @@
-import type { HttpOptions, HttpResponse, InternalHttpOptions } from './types';
+import is from '@sindresorhus/is';
+import type { PagedResult } from '../../modules/platform/bitbucket/types';
+import { parseUrl, resolveBaseUrl } from '../url';
+import type { HttpOptions, HttpResponse } from './types';
 import { Http } from '.';
 
 let baseUrl = 'https://api.bitbucket.org/';
@@ -7,16 +10,77 @@ export const setBaseUrl = (url: string): void => {
   baseUrl = url;
 };
 
-export class BitbucketHttp extends Http {
-  constructor(type = 'bitbucket', options?: HttpOptions) {
+export interface BitbucketHttpOptions extends HttpOptions {
+  paginate?: boolean;
+}
+
+export class BitbucketHttp extends Http<BitbucketHttpOptions> {
+  constructor(type = 'bitbucket', options?: BitbucketHttpOptions) {
     super(type, options);
   }
 
-  protected override request<T>(
-    url: string | URL,
-    options?: InternalHttpOptions
+  protected override async request<T>(
+    path: string,
+    options?: BitbucketHttpOptions
   ): Promise<HttpResponse<T>> {
     const opts = { baseUrl, ...options };
-    return super.request<T>(url, opts);
+
+    const result = await super.request<T>(path, opts);
+
+    if (opts.paginate && isPagedResult(result.body)) {
+      const resultBody = result.body as PagedResult<T>;
+
+      let nextPage = getPageFromURL(resultBody.next);
+
+      while (is.nonEmptyString(nextPage)) {
+        const nextPath = getNextPagePath(path, nextPage);
+
+        if (is.nullOrUndefined(nextPath)) {
+          break;
+        }
+
+        const nextResult = await super.request<PagedResult<T>>(
+          nextPath,
+          options
+        );
+
+        resultBody.values.push(...nextResult.body.values);
+
+        nextPage = getPageFromURL(nextResult.body?.next);
+      }
+
+      // Override other page-related attributes
+      resultBody.pagelen = resultBody.values.length;
+      resultBody.size = resultBody.values.length;
+      resultBody.next = undefined;
+    }
+
+    return result;
   }
+}
+
+function getPageFromURL(url: string | undefined): string | null {
+  const resolvedURL = parseUrl(url);
+
+  if (is.nullOrUndefined(resolvedURL)) {
+    return null;
+  }
+
+  return resolvedURL.searchParams.get('page');
+}
+
+function getNextPagePath(path: string, nextPage: string): string | null {
+  const resolvedURL = parseUrl(resolveBaseUrl(baseUrl, path));
+
+  if (is.nullOrUndefined(resolvedURL)) {
+    return null;
+  }
+
+  resolvedURL.searchParams.set('page', nextPage);
+
+  return resolvedURL.toString();
+}
+
+function isPagedResult(obj: any): obj is PagedResult {
+  return is.nonEmptyObject(obj) && Array.isArray(obj.values);
 }

--- a/lib/util/http/bitbucket.ts
+++ b/lib/util/http/bitbucket.ts
@@ -35,6 +35,7 @@ export class BitbucketHttp extends Http<BitbucketHttpOptions> {
       while (is.nonEmptyString(nextPage)) {
         const nextPath = getNextPagePath(path, nextPage);
 
+        // istanbul ignore if
         if (is.nullOrUndefined(nextPath)) {
           break;
         }
@@ -72,6 +73,7 @@ function getPageFromURL(url: string | undefined): string | null {
 function getNextPagePath(path: string, nextPage: string): string | null {
   const resolvedURL = parseUrl(resolveBaseUrl(baseUrl, path));
 
+  // istanbul ignore if
   if (is.nullOrUndefined(resolvedURL)) {
     return null;
   }


### PR DESCRIPTION
## Changes

Adds paginate http options support for bitbucket client


## Context

Split out from #22094 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
