### PR TITLE
chore: run label action on prs

### DIFF
--- a/.github/workflows/label-actions.yml
+++ b/.github/workflows/label-actions.yml
@@ -5,11 +5,14 @@ on:
     types: [labeled]
   discussion:
     types: [labeled]
+  pull_request_target:
+    types: [labeled]
 
 permissions:
   contents: read
   issues: write
   discussions: write
+  pull-requests: write
 
 jobs:
   reaction:
@@ -18,4 +21,3 @@ jobs:
       - uses: dessant/label-actions@074b96a62f35c226ecb38e840f44941bde0343a6 # v3.0.0
         with:
           github-token: ${{ github.token }}
-          process-only: 'issues, discussions'


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
 Run label action on PR's via `pull_request_target` so we use the workflow from main and the token can write to fork PR's.
<!-- Describe what behavior is changed by this PR. -->

## Context
- #18836
- #18838
- https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
