### PR TITLE
feat(manager/pep621): support pdm lock files

### DIFF
--- a/lib/modules/manager/pep621/artifacts.spec.ts
+++ b/lib/modules/manager/pep621/artifacts.spec.ts
@@ -22,7 +22,11 @@ const adminConfig: RepoGlobalConfig = {
 describe('modules/manager/pep621/artifacts', () => {
   describe('updateArtifacts()', () => {
     it('return null if all processors returns are empty', async () => {
-      const updatedDeps = [{ depName: 'dep1' }];
+      const updatedDeps = [
+        {
+          packageName: 'dep1',
+        },
+      ];
       const result = await updateArtifacts({
         packageFileName: 'pyproject.toml',
         newPackageFileContent: '',
@@ -43,7 +47,7 @@ describe('modules/manager/pep621/artifacts', () => {
         releases: [{ version: 'v2.6.1' }, { version: 'v2.5.0' }],
       });
 
-      const updatedDeps = [{ depName: 'dep1' }];
+      const updatedDeps = [{ packageName: 'dep1' }];
       const result = await updateArtifacts({
         packageFileName: 'pyproject.toml',
         newPackageFileContent: '',
@@ -73,7 +77,19 @@ describe('modules/manager/pep621/artifacts', () => {
           },
         },
         {
-          cmd: 'docker run --rm --name=renovate_sidecar --label=renovate_child -v "/tmp/github/some/repo":"/tmp/github/some/repo" -v "/tmp/cache":"/tmp/cache" -e BUILDPACK_CACHE_DIR -e CONTAINERBASE_CACHE_DIR -w "/tmp/github/some/repo" containerbase/sidecar bash -l -c "install-tool pdm v2.5.0 && pdm update dep1"',
+          cmd:
+            'docker run --rm --name=renovate_sidecar --label=renovate_child ' +
+            '-v "/tmp/github/some/repo":"/tmp/github/some/repo" ' +
+            '-v "/tmp/cache":"/tmp/cache" ' +
+            '-e BUILDPACK_CACHE_DIR ' +
+            '-e CONTAINERBASE_CACHE_DIR ' +
+            '-w "/tmp/github/some/repo" ' +
+            'containerbase/sidecar ' +
+            'bash -l -c "' +
+            'install-tool pdm v2.5.0 ' +
+            '&& ' +
+            'pdm update dep1' +
+            '"',
           options: {
             cwd: '/tmp/github/some/repo',
             encoding: 'utf-8',

--- a/lib/modules/manager/pep621/artifacts.spec.ts
+++ b/lib/modules/manager/pep621/artifacts.spec.ts
@@ -1,0 +1,21 @@
+import type { UpdateArtifactsConfig } from '../types';
+import { updateArtifacts } from './artifacts';
+
+jest.mock('../../../util/fs');
+
+const config: UpdateArtifactsConfig = {};
+
+describe('modules/manager/pep621/artifacts', () => {
+  describe('updateArtifacts()', () => {
+    it('return null if all processors returns are empty', async () => {
+      const updatedDeps = [{ depName: 'dep1' }];
+      const result = await updateArtifacts({
+        packageFileName: 'pyproject.toml',
+        newPackageFileContent: '',
+        config,
+        updatedDeps,
+      });
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/lib/modules/manager/pep621/artifacts.ts
+++ b/lib/modules/manager/pep621/artifacts.ts
@@ -1,0 +1,23 @@
+import is from '@sindresorhus/is';
+import { writeLocalFile } from '../../../util/fs';
+import type { UpdateArtifact, UpdateArtifactsResult } from '../types';
+import { processors } from './processors';
+
+export async function updateArtifacts(
+  updateArtifact: UpdateArtifact
+): Promise<UpdateArtifactsResult[] | null> {
+  const { packageFileName, newPackageFileContent } = updateArtifact;
+
+  await writeLocalFile(packageFileName, newPackageFileContent);
+
+  // process specific tool sets
+  const result: UpdateArtifactsResult[] = [];
+  for (const processor of processors) {
+    const artifactUpdates = await processor.updateArtifacts(updateArtifact);
+    if (is.array(artifactUpdates)) {
+      result.push(...artifactUpdates);
+    }
+  }
+
+  return result.length > 0 ? result : null;
+}

--- a/lib/modules/manager/pep621/index.ts
+++ b/lib/modules/manager/pep621/index.ts
@@ -1,7 +1,10 @@
 import { PypiDatasource } from '../../datasource/pypi';
 export { extractPackageFile } from './extract';
+export { updateArtifacts } from './artifacts';
 
 export const supportedDatasources = [PypiDatasource.id];
+
+export const supportsLockFileMaintenance = true;
 
 export const defaultConfig = {
   fileMatch: ['(^|/)pyproject\\.toml$'],

--- a/lib/modules/manager/pep621/processors/pdm.spec.ts
+++ b/lib/modules/manager/pep621/processors/pdm.spec.ts
@@ -67,7 +67,7 @@ describe('modules/manager/pep621/processors/pdm', () => {
       ]);
     });
 
-    it('rethrow error', async () => {
+    it('returns artifact error', async () => {
       const execSnapshots = mockExecAll();
       GlobalConfig.set({ ...adminConfig, binarySource: 'docker' });
       fs.getSiblingFileName.mockReturnValueOnce('pdm.lock');

--- a/lib/modules/manager/pep621/processors/pdm.spec.ts
+++ b/lib/modules/manager/pep621/processors/pdm.spec.ts
@@ -25,7 +25,7 @@ describe('modules/manager/pep621/processors/pdm', () => {
   describe('updateArtifacts()', () => {
     it('return null if there is no lock file', async () => {
       fs.getSiblingFileName.mockReturnValueOnce('pdm.lock');
-      const updatedDeps = [{ depName: 'dep1' }];
+      const updatedDeps = [{ packageName: 'dep1' }];
       const result = await processor.updateArtifacts({
         packageFileName: 'pyproject.toml',
         newPackageFileContent: '',
@@ -46,7 +46,7 @@ describe('modules/manager/pep621/processors/pdm', () => {
         releases: [{ version: 'v2.6.1' }, { version: 'v2.5.0' }],
       });
 
-      const updatedDeps = [{ depName: 'dep1' }];
+      const updatedDeps = [{ packageName: 'dep1' }];
       const result = await processor.updateArtifacts({
         packageFileName: 'pyproject.toml',
         newPackageFileContent: '',
@@ -62,7 +62,19 @@ describe('modules/manager/pep621/processors/pdm', () => {
           cmd: 'docker ps --filter name=renovate_sidecar -aq',
         },
         {
-          cmd: 'docker run --rm --name=renovate_sidecar --label=renovate_child -v "/tmp/github/some/repo":"/tmp/github/some/repo" -v "/tmp/cache":"/tmp/cache" -e BUILDPACK_CACHE_DIR -e CONTAINERBASE_CACHE_DIR -w "/tmp/github/some/repo" containerbase/sidecar bash -l -c "install-tool pdm v2.5.0 && pdm update dep1"',
+          cmd:
+            'docker run --rm --name=renovate_sidecar --label=renovate_child ' +
+            '-v "/tmp/github/some/repo":"/tmp/github/some/repo" ' +
+            '-v "/tmp/cache":"/tmp/cache" ' +
+            '-e BUILDPACK_CACHE_DIR ' +
+            '-e CONTAINERBASE_CACHE_DIR ' +
+            '-w "/tmp/github/some/repo" ' +
+            'containerbase/sidecar ' +
+            'bash -l -c "' +
+            'install-tool pdm v2.5.0 ' +
+            '&& ' +
+            'pdm update dep1' +
+            '"',
         },
       ]);
     });
@@ -75,7 +87,7 @@ describe('modules/manager/pep621/processors/pdm', () => {
         throw new Error('test error');
       });
 
-      const updatedDeps = [{ depName: 'dep1' }];
+      const updatedDeps = [{ packageName: 'dep1' }];
       const result = await processor.updateArtifacts({
         packageFileName: 'pyproject.toml',
         newPackageFileContent: '',
@@ -99,7 +111,7 @@ describe('modules/manager/pep621/processors/pdm', () => {
         releases: [{ version: 'v2.6.1' }, { version: 'v2.5.0' }],
       });
 
-      const updatedDeps = [{ depName: 'dep1' }, { depName: 'dep2' }];
+      const updatedDeps = [{ packageName: 'dep1' }, { packageName: 'dep2' }];
       const result = await processor.updateArtifacts({
         packageFileName: 'pyproject.toml',
         newPackageFileContent: '',
@@ -152,7 +164,7 @@ describe('modules/manager/pep621/processors/pdm', () => {
       ]);
       expect(execSnapshots).toMatchObject([
         {
-          cmd: 'pdm update ',
+          cmd: 'pdm update',
         },
       ]);
     });

--- a/lib/modules/manager/pep621/processors/pdm.spec.ts
+++ b/lib/modules/manager/pep621/processors/pdm.spec.ts
@@ -57,28 +57,12 @@ describe('modules/manager/pep621/processors/pdm', () => {
       expect(execSnapshots).toMatchObject([
         {
           cmd: 'docker pull containerbase/sidecar',
-          options: {
-            encoding: 'utf-8',
-          },
         },
         {
           cmd: 'docker ps --filter name=renovate_sidecar -aq',
-          options: {
-            encoding: 'utf-8',
-          },
         },
         {
           cmd: 'docker run --rm --name=renovate_sidecar --label=renovate_child -v "/tmp/github/some/repo":"/tmp/github/some/repo" -v "/tmp/cache":"/tmp/cache" -e BUILDPACK_CACHE_DIR -e CONTAINERBASE_CACHE_DIR -w "/tmp/github/some/repo" containerbase/sidecar bash -l -c "install-tool pdm v2.5.0 && pdm update dep1"',
-          options: {
-            cwd: '/tmp/github/some/repo',
-            encoding: 'utf-8',
-            env: {
-              BUILDPACK_CACHE_DIR: '/tmp/cache/containerbase',
-              CONTAINERBASE_CACHE_DIR: '/tmp/cache/containerbase',
-            },
-            maxBuffer: 10485760,
-            timeout: 900000,
-          },
         },
       ]);
     });
@@ -102,6 +86,75 @@ describe('modules/manager/pep621/processors/pdm', () => {
         { artifactError: { lockFile: 'pdm.lock', stderr: 'test error' } },
       ]);
       expect(execSnapshots).toEqual([]);
+    });
+
+    it('return update dep update', async () => {
+      const execSnapshots = mockExecAll();
+      GlobalConfig.set(adminConfig);
+      fs.getSiblingFileName.mockReturnValueOnce('pdm.lock');
+      fs.readLocalFile.mockResolvedValueOnce('test content');
+      fs.readLocalFile.mockResolvedValueOnce('changed test content');
+      // pdm
+      getPkgReleases.mockResolvedValueOnce({
+        releases: [{ version: 'v2.6.1' }, { version: 'v2.5.0' }],
+      });
+
+      const updatedDeps = [{ depName: 'dep1' }, { depName: 'dep2' }];
+      const result = await processor.updateArtifacts({
+        packageFileName: 'pyproject.toml',
+        newPackageFileContent: '',
+        config: {},
+        updatedDeps,
+      });
+      expect(result).toEqual([
+        {
+          file: {
+            contents: 'changed test content',
+            path: 'pdm.lock',
+            type: 'addition',
+          },
+        },
+      ]);
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'pdm update dep1 dep2',
+        },
+      ]);
+    });
+
+    it('return update on lockfileMaintenance', async () => {
+      const execSnapshots = mockExecAll();
+      GlobalConfig.set(adminConfig);
+      fs.getSiblingFileName.mockReturnValueOnce('pdm.lock');
+      fs.readLocalFile.mockResolvedValueOnce('test content');
+      fs.readLocalFile.mockResolvedValueOnce('changed test content');
+      // pdm
+      getPkgReleases.mockResolvedValueOnce({
+        releases: [{ version: 'v2.6.1' }, { version: 'v2.5.0' }],
+      });
+
+      const result = await processor.updateArtifacts({
+        packageFileName: 'pyproject.toml',
+        newPackageFileContent: '',
+        config: {
+          updateType: 'lockFileMaintenance',
+        },
+        updatedDeps: [],
+      });
+      expect(result).toEqual([
+        {
+          file: {
+            contents: 'changed test content',
+            path: 'pdm.lock',
+            type: 'addition',
+          },
+        },
+      ]);
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'pdm update ',
+        },
+      ]);
     });
   });
 });

--- a/lib/modules/manager/pep621/processors/pdm.ts
+++ b/lib/modules/manager/pep621/processors/pdm.ts
@@ -1,6 +1,15 @@
 import is from '@sindresorhus/is';
+import { TEMPORARY_ERROR } from '../../../../constants/error-messages';
+import { logger } from '../../../../logger';
+import { exec } from '../../../../util/exec';
+import type { ExecOptions, ToolConstraint } from '../../../../util/exec/types';
+import { getSiblingFileName, readLocalFile } from '../../../../util/fs';
 import { PypiDatasource } from '../../../datasource/pypi';
-import type { PackageDependency } from '../../types';
+import type {
+  PackageDependency,
+  UpdateArtifact,
+  UpdateArtifactsResult,
+} from '../../types';
 import type { PyProject } from '../schema';
 import { parseDependencyGroupRecord } from '../utils';
 import type { PyProjectProcessor } from './types';
@@ -38,5 +47,76 @@ export class PdmProcessor implements PyProjectProcessor {
     }
 
     return deps;
+  }
+
+  async updateArtifacts(
+    updateArtifact: UpdateArtifact
+  ): Promise<UpdateArtifactsResult[] | null> {
+    const { config, updatedDeps, packageFileName } = updateArtifact;
+
+    const isLockFileMaintenance = config.updateType === 'lockFileMaintenance';
+
+    // abort if no lockfile is defined
+    const lockFileName = getSiblingFileName(packageFileName, 'pdm.lock');
+    try {
+      const existingLockFileContent = await readLocalFile(lockFileName, 'utf8');
+      if (!existingLockFileContent) {
+        logger.debug('No pdm.lock found');
+        return null;
+      }
+
+      const toolConstraint: ToolConstraint = {
+        toolName: 'pdm',
+        constraint: config.constraints?.pdm,
+      };
+
+      const execOptions: ExecOptions = {
+        docker: {},
+        toolConstraints: [toolConstraint],
+      };
+
+      // on lockFileMaintenance do not specify any packages and update the complete lock file
+      // else only update specific packages
+      let packageList = '';
+      if (!isLockFileMaintenance) {
+        packageList = updatedDeps
+          .map((value) => value.packageName ?? value.depName ?? '')
+          .join(' ');
+      }
+      const cmd = `pdm update ${packageList}`;
+      await exec([cmd], execOptions);
+
+      // check for changes
+      const fileChanges: UpdateArtifactsResult[] = [];
+      const newLockContent = await readLocalFile(lockFileName, 'utf8');
+      const isLockFileChanged = existingLockFileContent !== newLockContent;
+      if (isLockFileChanged) {
+        fileChanges.push({
+          file: {
+            type: 'addition',
+            path: lockFileName,
+            contents: newLockContent,
+          },
+        });
+      } else {
+        logger.debug('pdm.lock is unchanged');
+      }
+
+      return fileChanges.length > 0 ? fileChanges : null;
+    } catch (err) {
+      // istanbul ignore if
+      if (err.message === TEMPORARY_ERROR) {
+        throw err;
+      }
+      logger.debug({ err }, 'Failed to update PDM lock file');
+      return [
+        {
+          artifactError: {
+            lockFile: lockFileName,
+            stderr: err.message,
+          },
+        },
+      ];
+    }
   }
 }

--- a/lib/modules/manager/pep621/processors/pdm.ts
+++ b/lib/modules/manager/pep621/processors/pdm.ts
@@ -79,12 +79,12 @@ export class PdmProcessor implements PyProjectProcessor {
       // else only update specific packages
       let packageList = '';
       if (!isLockFileMaintenance) {
-        packageList = updatedDeps
-          .map((value) => value.packageName ?? value.depName)
+        packageList = ' ' + updatedDeps
+          .map((value) => value.packageName)
           .join(' ');
       }
-      const cmd = `pdm update ${packageList}`;
-      await exec([cmd], execOptions);
+      const cmd = `pdm update${packageList}`;
+      await exec(cmd, execOptions);
 
       // check for changes
       const fileChanges: UpdateArtifactsResult[] = [];
@@ -102,7 +102,7 @@ export class PdmProcessor implements PyProjectProcessor {
         logger.debug('pdm.lock is unchanged');
       }
 
-      return fileChanges.length > 0 ? fileChanges : null;
+      return fileChanges.length ? fileChanges : null;
     } catch (err) {
       // istanbul ignore if
       if (err.message === TEMPORARY_ERROR) {

--- a/lib/modules/manager/pep621/processors/pdm.ts
+++ b/lib/modules/manager/pep621/processors/pdm.ts
@@ -60,7 +60,7 @@ export class PdmProcessor implements PyProjectProcessor {
     const lockFileName = getSiblingFileName(packageFileName, 'pdm.lock');
     try {
       const existingLockFileContent = await readLocalFile(lockFileName, 'utf8');
-      if (!existingLockFileContent) {
+      if (is.nullOrUndefined(existingLockFileContent)) {
         logger.debug('No pdm.lock found');
         return null;
       }
@@ -80,7 +80,7 @@ export class PdmProcessor implements PyProjectProcessor {
       let packageList = '';
       if (!isLockFileMaintenance) {
         packageList = updatedDeps
-          .map((value) => value.packageName ?? value.depName ?? '')
+          .map((value) => value.packageName ?? value.depName)
           .join(' ');
       }
       const cmd = `pdm update ${packageList}`;

--- a/lib/modules/manager/pep621/processors/pdm.ts
+++ b/lib/modules/manager/pep621/processors/pdm.ts
@@ -79,9 +79,8 @@ export class PdmProcessor implements PyProjectProcessor {
       // else only update specific packages
       let packageList = '';
       if (!isLockFileMaintenance) {
-        packageList = ' ' + updatedDeps
-          .map((value) => value.packageName)
-          .join(' ');
+        packageList = ' ';
+        packageList += updatedDeps.map((value) => value.packageName).join(' ');
       }
       const cmd = `pdm update${packageList}`;
       await exec(cmd, execOptions);

--- a/lib/modules/manager/pep621/processors/types.ts
+++ b/lib/modules/manager/pep621/processors/types.ts
@@ -1,7 +1,15 @@
-import type { PackageDependency } from '../../types';
+import type {
+  PackageDependency,
+  UpdateArtifact,
+  UpdateArtifactsResult,
+} from '../../types';
 import type { PyProject } from '../schema';
 
 export interface PyProjectProcessor {
+  updateArtifacts(
+    updateArtifact: UpdateArtifact
+  ): Promise<UpdateArtifactsResult[] | null>;
+
   /**
    * Extracts additional dependencies and/or modifies existing ones based on the tool configuration.
    * If no relevant section for the processor exists, then it should return the received dependencies unmodified.

--- a/lib/modules/manager/pep621/readme.md
+++ b/lib/modules/manager/pep621/readme.md
@@ -2,7 +2,7 @@ This manager supports updating dependencies inside `pyproject.toml` files.
 
 In addition to standard dependencies, these toolsets are also supported:
 
-- `pdm`
+- `pdm` ( including `pdm.lock` files )
 
 Available `depType`s:
 

--- a/lib/util/exec/containerbase.ts
+++ b/lib/util/exec/containerbase.ts
@@ -130,6 +130,11 @@ const allToolConfig: Record<string, ToolConfig> = {
     hash: true,
     versioning: npmVersioningId,
   },
+  pdm: {
+    datasource: 'github-releases',
+    packageName: 'pdm-project/pdm',
+    versioning: semverVersioningId,
+  },
   php: {
     datasource: 'github-releases',
     packageName: 'containerbase/php-prebuild',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
This PR is a follow up to: 
- https://github.com/renovatebot/renovate/pull/22082
- https://github.com/containerbase/base/pull/973

and add support for PDM lockfiles ( `pdm.lock` ) 
<!-- Describe what behavior is changed by this PR. -->

## Context
https://github.com/renovatebot/renovate/issues/10187
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

https://github.com/secustor/pdm-pep621-reproduction

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
