### PR TITLE
fix(changelog): correct excactReleaseRegex

### DIFF
--- a/lib/workers/repository/update/pr/changelog/github.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/github.spec.ts
@@ -366,6 +366,10 @@ describe('workers/repository/update/pr/changelog/github', () => {
           { version: '1.0.1' },
           { version: 'correctPrefix/target@1.0.1' },
           { version: 'wrongPrefix/target-1.0.1' },
+          { version: 'v1.0.2' },
+          { version: '1.0.2' },
+          { version: 'correctPrefix/target-1.0.2' },
+          { version: 'wrongPrefix/target@1.0.2' },
         ])
       );
 
@@ -376,9 +380,10 @@ describe('workers/repository/update/pr/changelog/github', () => {
         endpoint: 'https://api.github.com/',
         versioning: 'npm',
         currentVersion: '1.0.0',
-        newVersion: '1.0.1',
+        newVersion: '1.0.2',
         sourceUrl: 'https://github.com/chalk/chalk',
         releases: [
+          { version: '1.0.2', gitRef: '789012' },
           { version: '1.0.1', gitRef: '123456' },
           { version: '0.1.1', gitRef: 'npm_1.0.0' },
         ],
@@ -398,6 +403,18 @@ describe('workers/repository/update/pr/changelog/github', () => {
           packageName: 'correctPrefix/target',
         },
         versions: [
+          {
+            version: '1.0.2',
+            date: undefined,
+            changes: [],
+            compare: {
+              url: 'https://github.com/chalk/chalk/compare/correctPrefix/target@1.0.1...correctPrefix/target-1.0.2',
+            },
+            releaseNotes: {
+              url: 'https://github.com/chalk/chalk/compare/correctPrefix/target@1.0.1...correctPrefix/target-1.0.2',
+              notesSourceUrl: '',
+            },
+          },
           {
             version: '1.0.1',
             date: undefined,

--- a/lib/workers/repository/update/pr/changelog/source-github.ts
+++ b/lib/workers/repository/update/pr/changelog/source-github.ts
@@ -195,7 +195,7 @@ function findTagOfRelease(
   tags: string[]
 ): string | undefined {
   const regex = regEx(`(?:${packageName}|release)[@-]`, undefined, false);
-  const excactReleaseRegex = regEx(`${packageName}[@-_]v?${depNewVersion}`);
+  const excactReleaseRegex = regEx(`${packageName}[@\\-_]v?${depNewVersion}`);
   const exactTagsList = tags.filter((tag) => {
     return excactReleaseRegex.test(tag);
   });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

`[@-_]` means a single character in the range between @ (index 64) and _ (index 95), so `-` itself is not matched correctly. Fix it by escaping `-`.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

- #15590

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
