### PR TITLE
feat(bitbucket): add support for pagelen

### DIFF
--- a/lib/modules/platform/bitbucket/index.spec.ts
+++ b/lib/modules/platform/bitbucket/index.spec.ts
@@ -813,7 +813,9 @@ describe('modules/platform/bitbucket/index', () => {
       };
       const scope = await initRepoMock();
       scope
-        .get('/2.0/repositories/some/repo/effective-default-reviewers')
+        .get(
+          '/2.0/repositories/some/repo/effective-default-reviewers?pagelen=100'
+        )
         .reply(200, {
           values: [projectReviewer, repoReviewer],
         })
@@ -855,7 +857,9 @@ describe('modules/platform/bitbucket/index', () => {
       };
       const scope = await initRepoMock();
       scope
-        .get('/2.0/repositories/some/repo/effective-default-reviewers')
+        .get(
+          '/2.0/repositories/some/repo/effective-default-reviewers?pagelen=100'
+        )
         .reply(200, {
           values: [
             activeReviewerWithinWorkspace,
@@ -924,7 +928,9 @@ describe('modules/platform/bitbucket/index', () => {
       };
       const scope = await initRepoMock();
       scope
-        .get('/2.0/repositories/some/repo/effective-default-reviewers')
+        .get(
+          '/2.0/repositories/some/repo/effective-default-reviewers?pagelen=100'
+        )
         .reply(200, {
           values: [memberReviewer, notMemberReviewer],
         })
@@ -973,7 +979,9 @@ describe('modules/platform/bitbucket/index', () => {
       };
       const scope = await initRepoMock();
       scope
-        .get('/2.0/repositories/some/repo/effective-default-reviewers')
+        .get(
+          '/2.0/repositories/some/repo/effective-default-reviewers?pagelen=100'
+        )
         .reply(200, {
           values: [reviewer],
         })
@@ -1017,7 +1025,9 @@ describe('modules/platform/bitbucket/index', () => {
 
       const scope = await initRepoMock();
       scope
-        .get('/2.0/repositories/some/repo/effective-default-reviewers')
+        .get(
+          '/2.0/repositories/some/repo/effective-default-reviewers?pagelen=100'
+        )
         .reply(200, {
           values: [reviewer],
         })
@@ -1054,7 +1064,9 @@ describe('modules/platform/bitbucket/index', () => {
 
       const scope = await initRepoMock();
       scope
-        .get('/2.0/repositories/some/repo/effective-default-reviewers')
+        .get(
+          '/2.0/repositories/some/repo/effective-default-reviewers?pagelen=100'
+        )
         .reply(200, {
           values: [reviewer],
         })

--- a/lib/util/http/bitbucket.spec.ts
+++ b/lib/util/http/bitbucket.spec.ts
@@ -56,27 +56,90 @@ describe('util/http/bitbucket', () => {
     });
   });
 
-  it('paginates', async () => {
+  it('paginates: adds default pagelen if non is present', async () => {
     httpMock
       .scope(baseUrl)
-      .get('/some-url')
+      .get('/some-url?foo=bar&pagelen=100')
       .reply(200, {
         values: ['a'],
         page: '1',
-        next: `${baseUrl}/some-url?page=2`,
+        next: `${baseUrl}/some-url?foo=bar&pagelen=100&page=2`,
       })
-      .get('/some-url?page=2')
+      .get('/some-url?foo=bar&pagelen=100&page=2')
       .reply(200, {
         values: ['b', 'c'],
         page: '2',
-        next: `${baseUrl}/some-url?page=3`,
+        next: `${baseUrl}/some-url?foo=bar&pagelen=100&page=3`,
       })
-      .get('/some-url?page=3')
+      .get('/some-url?foo=bar&pagelen=100&page=3')
       .reply(200, {
         values: ['d'],
         page: '3',
       });
-    const res = await api.getJson('some-url', { paginate: true });
+    const res = await api.getJson('/some-url?foo=bar', { paginate: true });
+    expect(res.body).toEqual({
+      page: '1',
+      pagelen: 4,
+      size: 4,
+      values: ['a', 'b', 'c', 'd'],
+      next: undefined,
+    });
+  });
+
+  it('paginates: respects pagelen if already set in path', async () => {
+    httpMock
+      .scope(baseUrl)
+      .get('/some-url?pagelen=10')
+      .reply(200, {
+        values: ['a'],
+        page: '1',
+        next: `${baseUrl}/some-url?pagelen=10&page=2`,
+      })
+      .get('/some-url?pagelen=10&page=2')
+      .reply(200, {
+        values: ['b', 'c'],
+        page: '2',
+        next: `${baseUrl}/some-url?pagelen=10&page=3`,
+      })
+      .get('/some-url?pagelen=10&page=3')
+      .reply(200, {
+        values: ['d'],
+        page: '3',
+      });
+    const res = await api.getJson('some-url?pagelen=10', { paginate: true });
+    expect(res.body).toEqual({
+      page: '1',
+      pagelen: 4,
+      size: 4,
+      values: ['a', 'b', 'c', 'd'],
+      next: undefined,
+    });
+  });
+
+  it('paginates: respects pagelen if set in options', async () => {
+    httpMock
+      .scope(baseUrl)
+      .get('/some-url?pagelen=20')
+      .reply(200, {
+        values: ['a'],
+        page: '1',
+        next: `${baseUrl}/some-url?pagelen=20&page=2`,
+      })
+      .get('/some-url?pagelen=20&page=2')
+      .reply(200, {
+        values: ['b', 'c'],
+        page: '2',
+        next: `${baseUrl}/some-url?pagelen=20&page=3`,
+      })
+      .get('/some-url?pagelen=20&page=3')
+      .reply(200, {
+        values: ['d'],
+        page: '3',
+      });
+    const res = await api.getJson('some-url', {
+      paginate: true,
+      pagelen: 20,
+    });
     expect(res.body).toEqual({
       page: '1',
       pagelen: 4,

--- a/lib/util/http/bitbucket.ts
+++ b/lib/util/http/bitbucket.ts
@@ -73,7 +73,7 @@ function hasPagelen(path: string): boolean {
   return !is.nullOrUndefined(resolvedURL.searchParams.get('pagelen'));
 }
 
-function addPagelenToPath(path: string, pagenlen: number): string {
+function addPagelenToPath(path: string, pagelen: number): string {
   const resolvedURL = parseUrl(resolveBaseUrl(baseUrl, path));
 
   // istanbul ignore if
@@ -81,7 +81,7 @@ function addPagelenToPath(path: string, pagenlen: number): string {
     return path;
   }
 
-  resolvedURL.searchParams.set('pagelen', pagenlen.toString());
+  resolvedURL.searchParams.set('pagelen', pagelen.toString());
 
   return resolvedURL.toString();
 }

--- a/lib/util/http/bitbucket.ts
+++ b/lib/util/http/bitbucket.ts
@@ -30,8 +30,9 @@ export class BitbucketHttp extends Http<BitbucketHttpOptions> {
 
     let pathWithPagelen = path;
 
-    if ((opts.paginate || opts.pagelen) && !hasPagelen(pathWithPagelen)) {
-      pathWithPagelen = addPagelenToPath(pathWithPagelen, opts.pagelen);
+    if (opts.paginate && !hasPagelen(pathWithPagelen)) {
+      const pagelen = opts.pagelen ?? MAX_PAGELEN;
+      pathWithPagelen = addPagelenToPath(pathWithPagelen, pagelen);
     }
 
     const result = await super.request<T>(pathWithPagelen, opts);
@@ -72,10 +73,7 @@ function hasPagelen(path: string): boolean {
   return !is.nullOrUndefined(resolvedURL.searchParams.get('pagelen'));
 }
 
-function addPagelenToPath(
-  path: string,
-  pagenlen: number = MAX_PAGELEN
-): string {
+function addPagelenToPath(path: string, pagenlen: number): string {
   const resolvedURL = parseUrl(resolveBaseUrl(baseUrl, path));
 
   // istanbul ignore if

--- a/lib/util/http/bitbucket.ts
+++ b/lib/util/http/bitbucket.ts
@@ -66,6 +66,7 @@ export class BitbucketHttp extends Http<BitbucketHttpOptions> {
 function hasPagelen(path: string): boolean {
   const resolvedURL = parseUrl(resolveBaseUrl(baseUrl, path));
 
+  // istanbul ignore if
   if (is.nullOrUndefined(resolvedURL)) {
     return false;
   }

--- a/lib/util/http/bitbucket.ts
+++ b/lib/util/http/bitbucket.ts
@@ -29,7 +29,7 @@ export class BitbucketHttp extends Http<BitbucketHttpOptions> {
   ): Promise<HttpResponse<T>> {
     const opts = { baseUrl, ...options };
 
-    let resolvedURL = parseUrl(resolveBaseUrl(baseUrl, path));
+    const resolvedURL = parseUrl(resolveBaseUrl(baseUrl, path));
 
     // istanbul ignore if: this should never happen
     if (is.nullOrUndefined(resolvedURL)) {
@@ -39,7 +39,7 @@ export class BitbucketHttp extends Http<BitbucketHttpOptions> {
 
     if (opts.paginate && !hasPagelen(resolvedURL)) {
       const pagelen = opts.pagelen ?? MAX_PAGELEN;
-      resolvedURL = addPagelenToPath(resolvedURL, pagelen);
+      resolvedURL.searchParams.set('pagelen', pagelen.toString());
     }
 
     const result = await super.request<T>(resolvedURL.toString(), opts);
@@ -72,11 +72,6 @@ export class BitbucketHttp extends Http<BitbucketHttpOptions> {
 
 function hasPagelen(url: URL): boolean {
   return !is.nullOrUndefined(url.searchParams.get('pagelen'));
-}
-
-function addPagelenToPath(url: URL, pagelen: number): URL {
-  url.searchParams.set('pagelen', pagelen.toString());
-  return url;
 }
 
 function isPagedResult(obj: any): obj is PagedResult {


### PR DESCRIPTION
## Changes

- Add support for optional paglen
- Add max pagelen if non provided and requesting paginated data
- Update pagination logic to use next url as-is previous response

## Context

Pre-req for #22272

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
