### PR TITLE
docs: document how to configure OS cert store for Python

### DIFF
--- a/docs/usage/examples/self-hosting.md
+++ b/docs/usage/examples/self-hosting.md
@@ -437,6 +437,14 @@ RUN update-ca-certificates
 # Change back to the Ubuntu user
 USER 1000
 
-# Node comes with an own certificate authority store and thus needs to trust the self-signed certificate explicitly
+# Some tools come with their own certificate authority stores and thus need to trust the self-signed certificate or the entire OS store explicitly.
+# This list is _not_ comprehensive and other tools may require further configuration.
+#
+# Node
 ENV NODE_EXTRA_CA_CERTS=/usr/local/share/ca-certificates/self-signed-certificate.crt
+# Python
+RUN pip config set global.cert /etc/ssl/certs/ca-certificates.crt
+ENV REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+# OpenSSL
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 ```


### PR DESCRIPTION
## Changes

Additional information was added to the `Dockerfile` in section [Self-signed TLS/SSL certificates](https://docs.renovatebot.com/examples/self-hosting/#renovate-docker-image) to document how Python should be configured to accept the global CA store.

## Context

Discussion: [discussions/22297](https://github.com/renovatebot/renovate/discussions/22297) 

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
- [x] None of the about - documentation change only