### PR TITLE
refactor(http): Rename `useCache` option to `memCache`

### DIFF
--- a/lib/modules/platform/bitbucket-server/index.ts
+++ b/lib/modules/platform/bitbucket-server/index.ts
@@ -258,7 +258,7 @@ export async function getPr(
 
   const res = await bitbucketServerHttp.getJson<BbsRestPr>(
     `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests/${prNo}`,
-    { useCache: !refreshCache }
+    { memCache: !refreshCache }
   );
 
   const pr: BbsPr = {
@@ -356,7 +356,7 @@ export async function refreshPr(number: number): Promise<void> {
 
 async function getStatus(
   branchName: string,
-  useCache = true
+  memCache = true
 ): Promise<utils.BitbucketCommitStatus> {
   const branchCommit = git.getBranchCommit(branchName);
 
@@ -364,9 +364,7 @@ async function getStatus(
     await bitbucketServerHttp.getJson<utils.BitbucketCommitStatus>(
       // TODO: types (#7154)
       `./rest/build-status/1.0/commits/stats/${branchCommit!}`,
-      {
-        useCache,
-      }
+      { memCache }
     )
   ).body;
 }
@@ -404,7 +402,7 @@ export async function getBranchStatus(
 
 function getStatusCheck(
   branchName: string,
-  useCache = true
+  memCache = true
 ): Promise<utils.BitbucketStatus[]> {
   const branchCommit = git.getBranchCommit(branchName);
 
@@ -412,7 +410,7 @@ function getStatusCheck(
     // TODO: types (#7154)
     `./rest/build-status/1.0/commits/${branchCommit!}`,
     'get',
-    { useCache }
+    { memCache }
   );
 }
 

--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -80,7 +80,7 @@ export async function initPlatform({
   setBaseUrl(defaults.endpoint);
   renovateUserUuid = null;
   const options: HttpOptions = {
-    useCache: false,
+    memCache: false,
   };
   if (token) {
     options.token = token;
@@ -362,7 +362,7 @@ export async function getBranchPr(branchName: string): Promise<Pr | null> {
 
 async function getStatus(
   branchName: string,
-  useCache = true
+  memCache = true
 ): Promise<BitbucketStatus[]> {
   const sha = await getBranchCommit(branchName);
   return utils.accumulateValues<BitbucketStatus>(
@@ -370,7 +370,7 @@ async function getStatus(
     // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     `/2.0/repositories/${config.repository}/commit/${sha}/statuses`,
     'get',
-    { useCache }
+    { memCache }
   );
 }
 // Returns the combined status for a branch.

--- a/lib/modules/platform/gitea/index.ts
+++ b/lib/modules/platform/gitea/index.ts
@@ -165,7 +165,7 @@ function getLabelList(): Promise<Label[]> {
   if (config.labelList === null) {
     const repoLabels = helper
       .getRepoLabels(config.repository, {
-        useCache: false,
+        memCache: false,
       })
       .then((labels) => {
         logger.debug(`Retrieved ${labels.length} repo labels`);
@@ -174,7 +174,7 @@ function getLabelList(): Promise<Label[]> {
 
     const orgLabels = helper
       .getOrgLabels(config.repository.split('/')[0], {
-        useCache: false,
+        memCache: false,
       })
       .then((labels) => {
         logger.debug(`Retrieved ${labels.length} org labels`);
@@ -382,7 +382,7 @@ const platform: Platform = {
 
       // Refresh caches by re-fetching commit status for branch
       await helper.getCombinedCommitStatus(config.repository, branchName, {
-        useCache: false,
+        memCache: false,
       });
     } catch (err) {
       logger.warn({ err }, 'Failed to set branch status');
@@ -449,7 +449,7 @@ const platform: Platform = {
   getPrList(): Promise<Pr[]> {
     if (config.prList === null) {
       config.prList = helper
-        .searchPRs(config.repository, { state: 'all' }, { useCache: false })
+        .searchPRs(config.repository, { state: 'all' }, { memCache: false })
         .then((prs) => {
           const prList = prs.map(toRenovatePR).filter(is.truthy);
           logger.debug(`Retrieved ${prList.length} Pull Requests`);
@@ -650,7 +650,7 @@ const platform: Platform = {
   getIssueList(): Promise<Issue[]> {
     if (config.issueList === null) {
       config.issueList = helper
-        .searchIssues(config.repository, { state: 'all' }, { useCache: false })
+        .searchIssues(config.repository, { state: 'all' }, { memCache: false })
         .then((issues) => {
           const issueList = issues.map(toRenovateIssue);
           logger.debug(`Retrieved ${issueList.length} Issues`);
@@ -661,12 +661,10 @@ const platform: Platform = {
     return config.issueList;
   },
 
-  async getIssue(number: number, useCache = true): Promise<Issue | null> {
+  async getIssue(number: number, memCache = true): Promise<Issue | null> {
     try {
       const body = (
-        await helper.getIssue(config.repository, number, {
-          useCache,
-        })
+        await helper.getIssue(config.repository, number, { memCache })
       ).body;
       return {
         number,

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -743,7 +743,7 @@ async function ensureBranchSha(branchName: string, sha: string): Promise<void> {
 
   let branchExists = false;
   try {
-    await githubApi.head(refUrl, { useCache: false });
+    await githubApi.head(refUrl, { memCache: false });
     branchExists = true;
   } catch (err) {
     if (err.statusCode !== 404) {
@@ -836,7 +836,9 @@ async function getStatus(
   )}/status`;
 
   return (
-    await githubApi.getJson<CombinedBranchStatus>(commitStatusUrl, { useCache })
+    await githubApi.getJson<CombinedBranchStatus>(commitStatusUrl, {
+      memCache: useCache,
+    })
   ).body;
 }
 
@@ -951,7 +953,9 @@ async function getStatusCheck(
 
   const url = `repos/${config.repository}/commits/${branchCommit}/statuses`;
 
-  return (await githubApi.getJson<GhBranchStatus[]>(url, { useCache })).body;
+  return (
+    await githubApi.getJson<GhBranchStatus[]>(url, { memCache: useCache })
+  ).body;
 }
 
 interface GithubToRenovateStatusMapping {
@@ -1077,7 +1081,7 @@ export async function getIssue(
     const issueBody = (
       await githubApi.getJson<{ body: string }>(
         `repos/${config.parentRepo ?? config.repository}/issues/${number}`,
-        { useCache }
+        { memCache: useCache }
       )
     ).body.body;
     return {

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -371,7 +371,7 @@ async function getStatus(
     return (
       await gitlabApi.getJson<GitlabBranchStatus[]>(url, {
         paginate: true,
-        useCache,
+        memCache: useCache,
       })
     ).body;
   } catch (err) /* istanbul ignore next */ {
@@ -864,7 +864,7 @@ export async function getIssueList(): Promise<GitlabIssue[]> {
     const res = await gitlabApi.getJson<
       { iid: number; title: string; labels: string[] }[]
     >(`projects/${config.repository}/issues?${query}`, {
-      useCache: false,
+      memCache: false,
       paginate: true,
     });
     // istanbul ignore if
@@ -889,7 +889,7 @@ export async function getIssue(
     const issueBody = (
       await gitlabApi.getJson<{ description: string }>(
         `projects/${config.repository}/issues/${number}`,
-        { useCache }
+        { memCache: useCache }
       )
     ).body.description;
     return {

--- a/lib/modules/platform/types.ts
+++ b/lib/modules/platform/types.ts
@@ -165,7 +165,7 @@ export type EnsureIssueResult = 'updated' | 'created';
 export interface Platform {
   findIssue(title: string): Promise<Issue | null>;
   getIssueList(): Promise<Issue[]>;
-  getIssue?(number: number, useCache?: boolean): Promise<Issue | null>;
+  getIssue?(number: number, memCache?: boolean): Promise<Issue | null>;
   getVulnerabilityAlerts?(): Promise<VulnerabilityAlert[]>;
   getRawFile(
     fileName: string,

--- a/lib/util/http/index.ts
+++ b/lib/util/http/index.ts
@@ -163,11 +163,12 @@ export class Http<Opts extends HttpOptions = HttpOptions> {
     ]);
     let resPromise: Promise<HttpResponse<T>> | null = null;
 
-    // Cache GET requests unless useCache=false
-    if (
-      (options.method === 'get' || options.method === 'head') &&
-      options.useCache !== false
-    ) {
+    // Cache GET requests unless memCache=false
+    const useMemCache =
+      options.memCache !== false &&
+      (options.method === 'get' || options.method === 'head');
+
+    if (useMemCache) {
       resPromise = memCache.get(cacheKey);
     }
 
@@ -195,8 +196,8 @@ export class Http<Opts extends HttpOptions = HttpOptions> {
 
       resPromise = queuedTask();
 
-      if (options.method === 'get' || options.method === 'head') {
-        memCache.set(cacheKey, resPromise); // always set if it's a get or a head
+      if (useMemCache) {
+        memCache.set(cacheKey, resPromise);
       }
     }
 

--- a/lib/util/http/index.ts
+++ b/lib/util/http/index.ts
@@ -155,7 +155,6 @@ export class Http<Opts extends HttpOptions = HttpOptions> {
     // use sha512: https://www.npmjs.com/package/hasha#algorithm
     const memCacheKey =
       options.memCache !== false &&
-      !etagCache &&
       (options.method === 'get' || options.method === 'head')
         ? hasha([
             'got-',

--- a/lib/util/http/types.ts
+++ b/lib/util/http/types.ts
@@ -19,7 +19,7 @@ export type GotExtraOptions = {
   token?: string;
   hostType?: string;
   enabled?: boolean;
-  useCache?: boolean;
+  memCache?: boolean;
   noAuth?: boolean;
   context?: GotContextOptions;
 };
@@ -62,7 +62,7 @@ export interface HttpOptions {
   throwHttpErrors?: boolean;
 
   token?: string;
-  useCache?: boolean;
+  memCache?: boolean;
 }
 
 export interface InternalHttpOptions extends HttpOptions {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

I want to implement `etagCache` option, but for now I want to make it clear that another cache-related option is responsible for client-side memory-located cache

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
