### PR TITLE
fix(pnpm): use latest pnpm when upgrading pnpm

### DIFF
--- a/lib/modules/manager/npm/post-update/pnpm.spec.ts
+++ b/lib/modules/manager/npm/post-update/pnpm.spec.ts
@@ -98,6 +98,7 @@ describe('modules/manager/npm/post-update/pnpm', () => {
         depType: 'packageManager',
         depName: 'pnpm',
         newValue: '6.16.1',
+        newVersion: '6.16.1',
       },
     ]);
     expect(fs.readLocalFile).toHaveBeenCalledTimes(1);

--- a/lib/modules/manager/npm/post-update/pnpm.ts
+++ b/lib/modules/manager/npm/post-update/pnpm.ts
@@ -16,6 +16,15 @@ import type { NpmPackage } from '../extract/types';
 import { getNodeToolConstraint } from './node-version';
 import type { GenerateLockFileResult, PnpmLockFile } from './types';
 
+function getPnpmConstraintFromUpgrades(upgrades: Upgrade[]): string | null {
+  for (const upgrade of upgrades) {
+    if (upgrade.depName === 'pnpm' && upgrade.newVersion) {
+      return upgrade.newVersion;
+    }
+  }
+  return null;
+}
+
 export async function generateLockFile(
   lockFileDir: string,
   env: NodeJS.ProcessEnv,
@@ -32,7 +41,9 @@ export async function generateLockFile(
     const pnpmToolConstraint: ToolConstraint = {
       toolName: 'pnpm',
       constraint:
-        config.constraints?.pnpm ?? (await getPnpmConstraint(lockFileDir)),
+        getPnpmConstraintFromUpgrades(upgrades) ??
+        config.constraints?.pnpm ??
+        (await getPnpmConstraint(lockFileDir)),
     };
 
     const extraEnv: ExtraEnv = {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This fixes the edge case where `pnpm` itself is upgraded. I don't think it's related to the other problem in #22250 so not closing it.

## Context

Addresses #22250

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
