### PR TITLE
fix(versioning/composer): handle abnormal subset ranges

### DIFF
--- a/lib/modules/versioning/composer/index.spec.ts
+++ b/lib/modules/versioning/composer/index.spec.ts
@@ -69,6 +69,8 @@ describe('modules/versioning/composer/index', () => {
     ${'~1.0 | ~2.0'}  | ${true}
     ${'~1.0||~2.0'}   | ${true}
     ${'~1.0 || ~2.0'} | ${true}
+    ${'<8.0-DEV'}     | ${true}
+    ${'<8-DEV'}       | ${true}
   `('isValid("$version") === $expected', ({ version, expected }) => {
     const res = !!semver.isValid(version);
     expect(res).toBe(expected);
@@ -134,6 +136,8 @@ describe('modules/versioning/composer/index', () => {
     ${'^1.0.0'}           | ${'^0.9.0'}           | ${false}
     ${'^1.1.0 || ^2.0.0'} | ${'^1.0.0 || ^2.0.0'} | ${true}
     ${'^1.0.0 || ^2.0.0'} | ${'^1.1.0 || ^2.0.0'} | ${false}
+    ${'^7.0.0'}           | ${'<8.0-DEV'}         | ${true}
+    ${'^7.0.0'}           | ${'less than 8'}      | ${false}
   `('subset("$a", "$b") === $expected', ({ a, b, expected }) => {
     expect(semver.subset!(a, b)).toBe(expected);
   });

--- a/lib/modules/versioning/composer/index.ts
+++ b/lib/modules/versioning/composer/index.ts
@@ -91,6 +91,11 @@ function composer2npm(input: string): string {
         '>=$1 <1'
       );
 
+      // add extra digits to <8-DEV and <8.0-DEV
+      output = output
+        .replace(regEx(/^(<\d+(\.\d+)?)$/g), '$1.0')
+        .replace(regEx(/^(<\d+(\.\d+)?)$/g), '$1.0');
+
       return output + stability;
     })
     .map((part) => part.replace(/([a-z])([0-9])/gi, '$1.$2'))
@@ -171,7 +176,12 @@ function minSatisfyingVersion(
 }
 
 function subset(subRange: string, superRange: string): boolean | undefined {
-  return npm.subset!(composer2npm(subRange), composer2npm(superRange));
+  try {
+    return npm.subset!(composer2npm(subRange), composer2npm(superRange));
+  } catch (err) {
+    logger.trace({ err }, 'composer.subset error');
+    return false;
+  }
 }
 
 function getNewValue({


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Makes composer versioning more resilient to bad versions in subset()

## Context

Closes #21856

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
