### PR TITLE
refactor(rubygems): Extract `copystring` function to the utils

### DIFF
--- a/lib/modules/datasource/rubygems/versions-datasource.ts
+++ b/lib/modules/datasource/rubygems/versions-datasource.ts
@@ -6,6 +6,7 @@ import { getElapsedMinutes } from '../../../util/date';
 import { HttpError } from '../../../util/http';
 import { newlineRegex } from '../../../util/regex';
 import { LooseArray } from '../../../util/schema-utils';
+import { copystr } from '../../../util/string';
 import { Datasource } from '../datasource';
 import type { GetReleasesConfig, ReleaseResult } from '../types';
 
@@ -95,29 +96,12 @@ export class VersionsDatasource extends Datasource {
     return { releases };
   }
 
-  /**
-   * Since each `/versions` response exceeds 10MB,
-   * there is potential for a memory leak if we extract slices
-   * of the response body (i.e. versions) and store them in memory.
-   *
-   *   https://bugs.chromium.org/p/v8/issues/detail?id=2869
-   *
-   * This method meant to be called for `version` and `packageName`
-   * before storing them in the cache.
-   */
-  private copystr(x: string): string {
-    const len = Buffer.byteLength(x, 'utf8');
-    const buf = Buffer.allocUnsafeSlow(len); // allocate standalone buffer
-    buf.write(x, 'utf8');
-    return buf.toString('utf8');
-  }
-
   private updatePackageReleases(
     packageReleases: PackageReleases,
     lines: Lines
   ): void {
     for (const line of lines) {
-      const packageName = this.copystr(line.packageName);
+      const packageName = copystr(line.packageName);
       let versions = packageReleases.get(packageName) ?? [];
 
       const { deletedVersions, addedVersions } = line;
@@ -130,7 +114,7 @@ export class VersionsDatasource extends Datasource {
         const existingVersions = new Set(versions);
         for (const addedVersion of addedVersions) {
           if (!existingVersions.has(addedVersion)) {
-            const version = this.copystr(addedVersion);
+            const version = copystr(addedVersion);
             versions.push(version);
           }
         }

--- a/lib/util/string.ts
+++ b/lib/util/string.ts
@@ -67,3 +67,18 @@ export function titleCase(input: string): string {
 
   return words.join(' ');
 }
+
+/**
+ * Sometimes we extract small strings from a multi-megabyte files.
+ * If we then save them in the in-memory cache, V8 may not free
+ * the initial buffer, which can lead to memory leaks:
+ *
+ *   https://bugs.chromium.org/p/v8/issues/detail?id=2869
+ *
+ */
+export function copystr(x: string): string {
+  const len = Buffer.byteLength(x, 'utf8');
+  const buf = Buffer.allocUnsafeSlow(len);
+  buf.write(x, 'utf8');
+  return buf.toString('utf8');
+}


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Extract function to the `util/string.ts`
- Simplify code by using only slower type of string memory allocation for copy.

## Context

- Ref: #21887

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
