### PR TITLE
refactor(bitbucket): use paginated api for commit statuses

### DIFF
--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -367,9 +367,7 @@ async function getStatus(
   const sha = await getBranchCommit(branchName);
   return (
     await bitbucketHttp.getJson<PagedResult<BitbucketStatus>>(
-      // TODO: types (#7154)
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-      `/2.0/repositories/${config.repository}/commit/${sha}/statuses`,
+      `/2.0/repositories/${config.repository}/commit/${sha!}/statuses`,
       {
         paginate: true,
         memCache,

--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -365,13 +365,15 @@ async function getStatus(
   memCache = true
 ): Promise<BitbucketStatus[]> {
   const sha = await getBranchCommit(branchName);
-  return utils.accumulateValues<BitbucketStatus>(
-    // TODO: types (#7154)
-    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-    `/2.0/repositories/${config.repository}/commit/${sha}/statuses`,
-    'get',
-    { memCache }
-  );
+  return (
+    await bitbucketHttp.getJson<PagedResult<BitbucketStatus>>(
+      `/2.0/repositories/${config.repository}/commit/${sha!}/statuses`,
+      {
+        paginate: true,
+        memCache,
+      }
+    )
+  ).body.values;
 }
 // Returns the combined status for a branch.
 export async function getBranchStatus(

--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -367,7 +367,9 @@ async function getStatus(
   const sha = await getBranchCommit(branchName);
   return (
     await bitbucketHttp.getJson<PagedResult<BitbucketStatus>>(
-      `/2.0/repositories/${config.repository}/commit/${sha!}/statuses`,
+      // TODO: types (#7154)
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+      `/2.0/repositories/${config.repository}/commit/${sha}/statuses`,
       {
         paginate: true,
         memCache,


### PR DESCRIPTION
## Changes

Use paginated api for commit statuses

## Context

https://github.com/renovatebot/renovate/discussions/22272

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository