### PR TITLE
refactor(bitbucket): use paginated api for tags

### DIFF
--- a/lib/modules/datasource/bitbucket-tags/index.ts
+++ b/lib/modules/datasource/bitbucket-tags/index.ts
@@ -2,7 +2,6 @@ import { cache } from '../../../util/cache/package/decorator';
 import { BitbucketHttp } from '../../../util/http/bitbucket';
 import { ensureTrailingSlash } from '../../../util/url';
 import type { PagedResult, RepoInfoBody } from '../../platform/bitbucket/types';
-import * as utils from '../../platform/bitbucket/utils';
 import { Datasource } from '../datasource';
 import type { DigestConfig, GetReleasesConfig, ReleaseResult } from '../types';
 import type { BitbucketCommit, BitbucketTag } from './types';
@@ -56,7 +55,9 @@ export class BitbucketTagsDatasource extends Datasource {
     packageName: repo,
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
     const url = `/2.0/repositories/${repo}/refs/tags`;
-    const bitbucketTags = await utils.accumulateValues(url);
+    const bitbucketTags = (await this.bitbucketHttp.getJson<PagedResult<BitbucketTag>>(url, {
+      paginate: true,
+    })).body.values;
 
     const dependency: ReleaseResult = {
       sourceUrl: BitbucketTagsDatasource.getSourceUrl(repo, registryUrl),

--- a/lib/modules/datasource/bitbucket-tags/index.ts
+++ b/lib/modules/datasource/bitbucket-tags/index.ts
@@ -55,9 +55,11 @@ export class BitbucketTagsDatasource extends Datasource {
     packageName: repo,
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
     const url = `/2.0/repositories/${repo}/refs/tags`;
-    const bitbucketTags = (await this.bitbucketHttp.getJson<PagedResult<BitbucketTag>>(url, {
-      paginate: true,
-    })).body.values;
+    const bitbucketTags = (
+      await this.bitbucketHttp.getJson<PagedResult<BitbucketTag>>(url, {
+        paginate: true,
+      })
+    ).body.values;
 
     const dependency: ReleaseResult = {
       sourceUrl: BitbucketTagsDatasource.getSourceUrl(repo, registryUrl),


### PR DESCRIPTION
## Changes

Use paginated api for tags

## Context

https://github.com/renovatebot/renovate/discussions/22272

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
