### PR TITLE
refactor(bitbucket): use paginated api for comments

### DIFF
--- a/lib/modules/platform/bitbucket/comments.ts
+++ b/lib/modules/platform/bitbucket/comments.ts
@@ -1,8 +1,7 @@
 import { logger } from '../../../logger';
 import { BitbucketHttp } from '../../../util/http/bitbucket';
 import type { EnsureCommentConfig, EnsureCommentRemovalConfig } from '../types';
-import type { Config } from './types';
-import { accumulateValues } from './utils';
+import type { Config, PagedResult } from './types';
 
 const bitbucketHttp = new BitbucketHttp();
 
@@ -21,9 +20,11 @@ async function getComments(
   config: CommentsConfig,
   prNo: number
 ): Promise<Comment[]> {
-  const comments = await accumulateValues<Comment>(
-    `/2.0/repositories/${config.repository}/pullrequests/${prNo}/comments`
-  );
+  const comments = (await bitbucketHttp.getJson<PagedResult<Comment>>(
+    `/2.0/repositories/${config.repository}/pullrequests/${prNo}/comments`, {
+      paginate: true
+    }
+  )).body.values;
 
   logger.debug(`Found ${comments.length} comments`);
   return comments;

--- a/lib/modules/platform/bitbucket/comments.ts
+++ b/lib/modules/platform/bitbucket/comments.ts
@@ -20,11 +20,14 @@ async function getComments(
   config: CommentsConfig,
   prNo: number
 ): Promise<Comment[]> {
-  const comments = (await bitbucketHttp.getJson<PagedResult<Comment>>(
-    `/2.0/repositories/${config.repository}/pullrequests/${prNo}/comments`, {
-      paginate: true
-    }
-  )).body.values;
+  const comments = (
+    await bitbucketHttp.getJson<PagedResult<Comment>>(
+      `/2.0/repositories/${config.repository}/pullrequests/${prNo}/comments`,
+      {
+        paginate: true,
+      }
+    )
+  ).body.values;
 
   logger.debug(`Found ${comments.length} comments`);
   return comments;


### PR DESCRIPTION
## Changes

Use paginated api for comments

## Context

https://github.com/renovatebot/renovate/discussions/22272

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
