### PR TITLE
docs(lockFileMaintenance): add pmd.lock

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -1675,6 +1675,7 @@ Supported lock files are:
 - `jsonnetfile.lock.json`
 - `package-lock.json`
 - `packages.lock.json`
+- `pdm.lock`
 - `Pipfile.lock`
 - `pnpm-lock.yaml`
 - `poetry.lock`

--- a/docs/usage/python.md
+++ b/docs/usage/python.md
@@ -47,6 +47,7 @@ There are three ways to do this:
 
 - index-url in `requirements.txt`
 - sources in `Pipfile`
+- sources in `pyproject.toml`
 - set URL in Renovate configuration
 
 ### index-url in `requirements.txt`


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
https://github.com/renovatebot/renovate/pull/22244 introduces support for `pdm.lock` lockfiles. This MR adds the change to the documentation.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

Relates to:
- #10187

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
