### PR TITLE
feat(package-rules)!: remove fuzzy matchPaths matching

### DIFF
--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -1307,7 +1307,7 @@ const options: RenovateOptions[] = [
   {
     name: 'matchPaths',
     description:
-      'List of strings or glob patterns to match against package files. Only works inside a `packageRules` object.',
+      'List of glob patterns to match against package files. Only works inside a `packageRules` object.',
     type: 'array',
     subType: 'string',
     stage: 'repository',

--- a/lib/util/package-rules/index.spec.ts
+++ b/lib/util/package-rules/index.spec.ts
@@ -989,7 +989,7 @@ describe('util/package-rules/index', () => {
       ...config,
       depName: 'test',
     });
-    expect(res3.x).toBeDefined();
+    expect(res3.x).toBeUndefined();
   });
 
   it('empty rules', () => {

--- a/lib/util/package-rules/paths.spec.ts
+++ b/lib/util/package-rules/paths.spec.ts
@@ -17,7 +17,7 @@ describe('util/package-rules/paths', () => {
       expect(result).toBeFalse();
     });
 
-    it('should return true and log warning on partial match only', () => {
+    it('should return false on partial match only', () => {
       const result = pathsMatcher.matches(
         {
           packageFile: 'opentelemetry/http/package.json',
@@ -26,14 +26,7 @@ describe('util/package-rules/paths', () => {
           matchPaths: ['opentelemetry/http'],
         }
       );
-      expect(result).toBeTrue();
-      expect(logger.warn).toHaveBeenCalledWith(
-        {
-          packageFile: 'opentelemetry/http/package.json',
-          rulePath: 'opentelemetry/http',
-        },
-        'Partial matches for `matchPaths` are deprecated. Please use a minimatch glob pattern or switch to `matchFiles` if you need exact matching.'
-      );
+      expect(result).toBeFalse();
     });
 
     it('should return true and not log warning on partial and glob match', () => {

--- a/lib/util/package-rules/paths.ts
+++ b/lib/util/package-rules/paths.ts
@@ -1,7 +1,6 @@
 import is from '@sindresorhus/is';
 import { minimatch } from 'minimatch';
 import type { PackageRule, PackageRuleInputConfig } from '../../config/types';
-import { logger } from '../../logger';
 import { Matcher } from './base';
 
 export class PathsMatcher extends Matcher {
@@ -16,21 +15,8 @@ export class PathsMatcher extends Matcher {
       return false;
     }
 
-    return matchPaths.some((rulePath) => {
-      if (minimatch(packageFile, rulePath, { dot: true })) {
-        return true;
-      }
-
-      if (packageFile.includes(rulePath)) {
-        logger.warn(
-          {
-            rulePath,
-            packageFile,
-          },
-          'Partial matches for `matchPaths` are deprecated. Please use a minimatch glob pattern or switch to `matchFiles` if you need exact matching.'
-        );
-        return true;
-      }
-    });
+    return matchPaths.some((rulePath) =>
+      minimatch(packageFile, rulePath, { dot: true })
+    );
   }
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Drops support for partial string matching in `matchPaths`

## Context

This feature has been deprecated until now.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
