### PR TITLE
fix(manager): unify logging

### DIFF
--- a/lib/modules/manager/ansible-galaxy/extract.ts
+++ b/lib/modules/manager/ansible-galaxy/extract.ts
@@ -24,16 +24,16 @@ export function getSliceEndNumber(
 
 export function extractPackageFile(
   content: string,
-  fileName: string
+  packageFile: string
 ): PackageFileContent | null {
-  logger.trace('ansible-galaxy.extractPackageFile()');
+  logger.trace(`ansible-galaxy.extractPackageFile(${packageFile})`);
   const galaxyFileNameRegEx = regEx(/galaxy\.ya?ml$/);
   const deps: PackageDependency[] = [];
   const lines = content.split(newlineRegex);
 
   try {
     // if this is a galaxy.yml file we have to interpret the dependencies differently
-    if (galaxyFileNameRegEx.exec(fileName)) {
+    if (galaxyFileNameRegEx.exec(packageFile)) {
       const galaxyDeps = extractCollectionsMetaDataFile(lines);
       deps.push(...galaxyDeps);
     } else {
@@ -87,7 +87,7 @@ export function extractPackageFile(
     }
     return { deps };
   } catch (err) /* istanbul ignore next */ {
-    logger.debug({ err }, 'Error extracting ansible-galaxy deps');
+    logger.debug({ err, packageFile }, 'Error extracting ansible-galaxy deps');
     return null;
   }
 }

--- a/lib/modules/manager/ansible/extract.ts
+++ b/lib/modules/manager/ansible/extract.ts
@@ -10,10 +10,10 @@ import type {
 
 export function extractPackageFile(
   content: string,
-  _filename: string,
+  packageFile: string,
   config: ExtractConfig
 ): PackageFileContent | null {
-  logger.trace('ansible.extractPackageFile()');
+  logger.trace(`ansible.extractPackageFile(${packageFile})`);
   let deps: PackageDependency[] = [];
   const re = regEx(/^\s*image:\s*'?"?([^\s'"]+)'?"?\s*$/);
   for (const line of content.split(newlineRegex)) {

--- a/lib/modules/manager/argocd/extract.ts
+++ b/lib/modules/manager/argocd/extract.ts
@@ -20,7 +20,7 @@ import { fileTestRegex } from './util';
 
 export function extractPackageFile(
   content: string,
-  fileName: string,
+  packageFile: string,
   _config?: ExtractConfig
 ): PackageFileContent | null {
   // check for argo reference. API version for the kind attribute is used
@@ -32,7 +32,7 @@ export function extractPackageFile(
   try {
     definitions = loadAll(content) as ApplicationDefinition[];
   } catch (err) {
-    logger.debug({ err, fileName }, 'Failed to parse ArgoCD definition.');
+    logger.debug({ err, packageFile }, 'Failed to parse ArgoCD definition.');
     return null;
   }
 

--- a/lib/modules/manager/asdf/extract.ts
+++ b/lib/modules/manager/asdf/extract.ts
@@ -5,9 +5,7 @@ import { regEx } from '../../../util/regex';
 import type { PackageDependency, PackageFileContent } from '../types';
 import { upgradeableTooling } from './upgradeable-tooling';
 
-export function extractPackageFile(
-  content: string,
-): PackageFileContent | null {
+export function extractPackageFile(content: string): PackageFileContent | null {
   logger.trace(`asdf.extractPackageFile()`);
 
   const regex = regEx(

--- a/lib/modules/manager/asdf/extract.ts
+++ b/lib/modules/manager/asdf/extract.ts
@@ -5,8 +5,10 @@ import { regEx } from '../../../util/regex';
 import type { PackageDependency, PackageFileContent } from '../types';
 import { upgradeableTooling } from './upgradeable-tooling';
 
-export function extractPackageFile(content: string): PackageFileContent | null {
-  logger.trace('asdf.extractPackageFile()');
+export function extractPackageFile(
+  content: string,
+): PackageFileContent | null {
+  logger.trace(`asdf.extractPackageFile()`);
 
   const regex = regEx(
     /^(?<toolName>([\w_-]+)) (?<version>[^\s#]+)(?: [^\s#]+)* *(?: #(?<comment>.*))?$/gm

--- a/lib/modules/manager/azure-pipelines/extract.ts
+++ b/lib/modules/manager/azure-pipelines/extract.ts
@@ -101,13 +101,13 @@ export function extractAzurePipelinesTasks(
 
 export function parseAzurePipelines(
   content: string,
-  filename: string
+  packageFile: string
 ): AzurePipelines | null {
   let pkg: AzurePipelines | null = null;
   try {
     pkg = load(content, { json: true }) as AzurePipelines;
   } catch (err) /* istanbul ignore next */ {
-    logger.info({ filename, err }, 'Error parsing azure-pipelines content');
+    logger.debug({ packageFile, err }, 'Error parsing azure-pipelines content');
     return null;
   }
 
@@ -116,12 +116,12 @@ export function parseAzurePipelines(
 
 export function extractPackageFile(
   content: string,
-  filename: string
+  packageFile: string
 ): PackageFileContent | null {
-  logger.trace(`azurePipelines.extractPackageFile(${filename})`);
+  logger.trace(`azurePipelines.extractPackageFile(${packageFile})`);
   const deps: PackageDependency[] = [];
 
-  const pkg = parseAzurePipelines(content, filename);
+  const pkg = parseAzurePipelines(content, packageFile);
   if (!pkg) {
     return null;
   }

--- a/lib/modules/manager/batect/extract.ts
+++ b/lib/modules/manager/batect/extract.ts
@@ -119,9 +119,9 @@ function extractReferencedConfigFiles(
 
 export function extractPackageFile(
   content: string,
-  fileName: string
+  packageFile: string
 ): ExtractionResult | null {
-  logger.trace(`batect.extractPackageFile() fileName: ${fileName}`);
+  logger.trace(`batect.extractPackageFile(${packageFile})`);
 
   try {
     const config = loadConfig(content);
@@ -132,13 +132,13 @@ export function extractPackageFile(
 
     const referencedConfigFiles = extractReferencedConfigFiles(
       config,
-      fileName
+      packageFile
     );
 
     return { deps, referencedConfigFiles };
   } catch (err) {
-    logger.warn(
-      { err, fileName },
+    logger.debug(
+      { err, packageFile },
       'Extracting dependencies from Batect configuration file failed'
     );
 

--- a/lib/modules/manager/bazel-module/extract.ts
+++ b/lib/modules/manager/bazel-module/extract.ts
@@ -6,7 +6,7 @@ import { parse } from './parser';
 
 export function extractPackageFile(
   content: string,
-  filename: string
+  packageFile: string
 ): PackageFileContent | null {
   try {
     const records = parse(content);
@@ -14,7 +14,7 @@ export function extractPackageFile(
       .transform((deps) => (deps.length ? { deps } : null))
       .parse(records);
   } catch (err) {
-    logger.debug({ err, filename }, 'Failed to parse bazel module file.');
+    logger.debug({ err, packageFile }, 'Failed to parse bazel module file.');
     return null;
   }
 }

--- a/lib/modules/manager/bicep/extract.ts
+++ b/lib/modules/manager/bicep/extract.ts
@@ -12,8 +12,8 @@ const RESOURCE_REGEX = regEx(
 
 export function extractPackageFile(
   content: string,
-  packageFile: string,
-  config: ExtractConfig
+  _packageFile: string,
+  _config: ExtractConfig
 ): Promise<PackageFileContent | null> {
   const deps: PackageDependency[] = [];
 

--- a/lib/modules/manager/bitbucket-pipelines/extract.ts
+++ b/lib/modules/manager/bitbucket-pipelines/extract.ts
@@ -12,7 +12,7 @@ import {
 
 export function extractPackageFile(
   content: string,
-  filename: string
+  packageFile: string
 ): PackageFileContent | null {
   const deps: PackageDependency[] = [];
 
@@ -60,7 +60,7 @@ export function extractPackageFile(
     }
   } catch (err) /* istanbul ignore next */ {
     logger.debug(
-      { err, filename },
+      { err, packageFile },
       'Error extracting Bitbucket Pipes dependencies'
     );
   }

--- a/lib/modules/manager/buildkite/extract.ts
+++ b/lib/modules/manager/buildkite/extract.ts
@@ -5,7 +5,10 @@ import { GithubTagsDatasource } from '../../datasource/github-tags';
 import { isVersion } from '../../versioning/semver';
 import type { PackageDependency, PackageFileContent } from '../types';
 
-export function extractPackageFile(content: string): PackageFileContent | null {
+export function extractPackageFile(
+  content: string,
+  packageFile?: string
+): PackageFileContent | null {
   const deps: PackageDependency[] = [];
   try {
     const lines = content.split(newlineRegex);
@@ -70,7 +73,7 @@ export function extractPackageFile(content: string): PackageFileContent | null {
       }
     }
   } catch (err) /* istanbul ignore next */ {
-    logger.warn({ err }, 'Error extracting BuildKite plugins');
+    logger.debug({ err, packageFile }, 'Error extracting BuildKite plugins');
   }
 
   if (!deps.length) {

--- a/lib/modules/manager/bundler/extract.ts
+++ b/lib/modules/manager/bundler/extract.ts
@@ -210,7 +210,7 @@ export async function extractPackageFile(
   }
 
   if (packageFile) {
-    const gemfileLock = packageFile + '.lock';
+    const gemfileLock = `${packageFile}.lock`;
     const lockContent = await readLocalFile(gemfileLock, 'utf8');
     if (lockContent) {
       logger.debug(`Found Gemfile.lock file packageFile: ${packageFile}`);

--- a/lib/modules/manager/bundler/extract.ts
+++ b/lib/modules/manager/bundler/extract.ts
@@ -14,7 +14,7 @@ function formatContent(input: string): string {
 
 export async function extractPackageFile(
   content: string,
-  fileName?: string
+  packageFile?: string
 ): Promise<PackageFileContent | null> {
   const res: PackageFileContent = {
     registryUrls: [],
@@ -75,8 +75,8 @@ export async function extractPackageFile(
         groupLine = lines[lineNumber];
         // istanbul ignore if
         if (!is.string(groupLine)) {
-          logger.warn(
-            { content, fileName, type: 'groupLine' },
+          logger.debug(
+            { content, packageFile, type: 'groupLine' },
             'Bundler parsing error'
           );
           groupLine = 'end';
@@ -113,8 +113,8 @@ export async function extractPackageFile(
           sourceLine = lines[lineNumber];
           // istanbul ignore if
           if (!is.string(sourceLine)) {
-            logger.warn(
-              { content, fileName, type: 'sourceLine' },
+            logger.debug(
+              { content, packageFile, type: 'sourceLine' },
               'Bundler parsing error'
             );
             sourceLine = 'end';
@@ -148,8 +148,8 @@ export async function extractPackageFile(
         platformsLine = lines[lineNumber];
         // istanbul ignore if
         if (!is.string(platformsLine)) {
-          logger.warn(
-            { content, fileName, type: 'platformsLine' },
+          logger.debug(
+            { content, packageFile, type: 'platformsLine' },
             'Bundler parsing error'
           );
           platformsLine = 'end';
@@ -181,8 +181,8 @@ export async function extractPackageFile(
         ifLine = lines[lineNumber];
         // istanbul ignore if
         if (!is.string(ifLine)) {
-          logger.warn(
-            { content, fileName, type: 'ifLine' },
+          logger.debug(
+            { content, packageFile, type: 'ifLine' },
             'Bundler parsing error'
           );
           ifLine = 'end';
@@ -209,11 +209,11 @@ export async function extractPackageFile(
     return null;
   }
 
-  if (fileName) {
-    const gemfileLock = fileName + '.lock';
+  if (packageFile) {
+    const gemfileLock = packageFile + '.lock';
     const lockContent = await readLocalFile(gemfileLock, 'utf8');
     if (lockContent) {
-      logger.debug(`Found Gemfile.lock file packageFile: ${fileName}`);
+      logger.debug(`Found Gemfile.lock file packageFile: ${packageFile}`);
       res.lockFiles = [gemfileLock];
       const lockedEntries = extractLockFileEntries(lockContent);
       for (const dep of res.deps) {

--- a/lib/modules/manager/cargo/extract.ts
+++ b/lib/modules/manager/cargo/extract.ts
@@ -150,10 +150,10 @@ function extractCargoRegistries(config: CargoConfig | null): CargoRegistries {
 
 export async function extractPackageFile(
   content: string,
-  fileName: string,
+  packageFile: string,
   _config?: ExtractConfig
 ): Promise<PackageFileContent | null> {
-  logger.trace(`cargo.extractPackageFile(${fileName})`);
+  logger.trace(`cargo.extractPackageFile(${packageFile})`);
 
   const cargoConfig = await readCargoConfig();
   const cargoRegistries = extractCargoRegistries(cargoConfig);
@@ -162,7 +162,7 @@ export async function extractPackageFile(
   try {
     cargoManifest = parse(content);
   } catch (err) {
-    logger.debug({ err }, 'Error parsing Cargo.toml file');
+    logger.debug({ err, packageFile }, 'Error parsing Cargo.toml file');
     return null;
   }
   /*
@@ -227,7 +227,7 @@ export async function extractPackageFile(
   if (!deps.length) {
     return null;
   }
-  const lockFileName = await findLocalSiblingOrParent(fileName, 'Cargo.lock');
+  const lockFileName = await findLocalSiblingOrParent(packageFile, 'Cargo.lock');
   const res: PackageFileContent = { deps };
   // istanbul ignore if
   if (lockFileName) {

--- a/lib/modules/manager/cargo/extract.ts
+++ b/lib/modules/manager/cargo/extract.ts
@@ -227,7 +227,10 @@ export async function extractPackageFile(
   if (!deps.length) {
     return null;
   }
-  const lockFileName = await findLocalSiblingOrParent(packageFile, 'Cargo.lock');
+  const lockFileName = await findLocalSiblingOrParent(
+    packageFile,
+    'Cargo.lock'
+  );
   const res: PackageFileContent = { deps };
   // istanbul ignore if
   if (lockFileName) {

--- a/lib/modules/manager/circleci/extract.ts
+++ b/lib/modules/manager/circleci/extract.ts
@@ -5,7 +5,10 @@ import * as npmVersioning from '../../versioning/npm';
 import { getDep } from '../dockerfile/extract';
 import type { PackageDependency, PackageFileContent } from '../types';
 
-export function extractPackageFile(content: string): PackageFileContent | null {
+export function extractPackageFile(
+  content: string,
+  packageFile?: string
+): PackageFileContent | null {
   const deps: PackageDependency[] = [];
   try {
     const lines = content.split(newlineRegex);
@@ -71,7 +74,7 @@ export function extractPackageFile(content: string): PackageFileContent | null {
       }
     }
   } catch (err) /* istanbul ignore next */ {
-    logger.warn({ err }, 'Error extracting circleci images');
+    logger.debug({ err, packageFile }, 'Error extracting circleci images');
   }
   if (!deps.length) {
     return null;

--- a/lib/modules/manager/cloudbuild/extract.ts
+++ b/lib/modules/manager/cloudbuild/extract.ts
@@ -4,7 +4,7 @@ import { logger } from '../../../logger';
 import { getDep } from '../dockerfile/extract';
 import type { PackageDependency, PackageFileContent } from '../types';
 
-export function extractPackageFile(content: string): PackageFileContent | null {
+export function extractPackageFile(content: string, packageFile?: string): PackageFileContent | null {
   const deps: PackageDependency[] = [];
   try {
     // TODO: fix types
@@ -29,12 +29,12 @@ export function extractPackageFile(content: string): PackageFileContent | null {
   } catch (err) /* istanbul ignore next */ {
     if (err.stack?.startsWith('YAMLException:')) {
       logger.debug(
-        { err },
+        { err, packageFile },
         'YAML exception extracting Docker images from a Cloud Build configuration file.'
       );
     } else {
-      logger.warn(
-        { err },
+      logger.debug(
+        { err, packageFile },
         'Error extracting Docker images from a Cloud Build configuration file.'
       );
     }

--- a/lib/modules/manager/cloudbuild/extract.ts
+++ b/lib/modules/manager/cloudbuild/extract.ts
@@ -4,7 +4,10 @@ import { logger } from '../../../logger';
 import { getDep } from '../dockerfile/extract';
 import type { PackageDependency, PackageFileContent } from '../types';
 
-export function extractPackageFile(content: string, packageFile?: string): PackageFileContent | null {
+export function extractPackageFile(
+  content: string,
+  packageFile?: string
+): PackageFileContent | null {
   const deps: PackageDependency[] = [];
   try {
     // TODO: fix types

--- a/lib/modules/manager/cocoapods/extract.ts
+++ b/lib/modules/manager/cocoapods/extract.ts
@@ -82,9 +82,9 @@ export function gitDep(parsedLine: ParsedLine): PackageDependency | null {
 
 export async function extractPackageFile(
   content: string,
-  fileName: string
+  packageFile: string
 ): Promise<PackageFileContent | null> {
-  logger.trace('cocoapods.extractPackageFile()');
+  logger.trace(`cocoapods.extractPackageFile(${packageFile})`);
   const deps: PackageDependency[] = [];
   const lines: string[] = content.split(newlineRegex);
 
@@ -146,7 +146,7 @@ export async function extractPackageFile(
     }
   }
   const res: PackageFileContent = { deps };
-  const lockFile = getSiblingFileName(fileName, 'Podfile.lock');
+  const lockFile = getSiblingFileName(packageFile, 'Podfile.lock');
   // istanbul ignore if
   if (await localPathExists(lockFile)) {
     res.lockFiles = [lockFile];

--- a/lib/modules/manager/composer/extract.ts
+++ b/lib/modules/manager/composer/extract.ts
@@ -4,11 +4,11 @@ import { ComposerExtract } from './schema';
 
 export async function extractPackageFile(
   content: string,
-  fileName: string
+  packageFile: string
 ): Promise<PackageFileContent | null> {
-  const res = await ComposerExtract.safeParseAsync({ content, fileName });
+  const res = await ComposerExtract.safeParseAsync({ content, fileName: packageFile });
   if (!res.success) {
-    logger.debug({ fileName, err: res.error }, 'Composer: extract failed');
+    logger.debug({ packageFile, err: res.error }, 'Composer: extract failed');
     return null;
   }
   return res.data;

--- a/lib/modules/manager/composer/extract.ts
+++ b/lib/modules/manager/composer/extract.ts
@@ -6,7 +6,10 @@ export async function extractPackageFile(
   content: string,
   packageFile: string
 ): Promise<PackageFileContent | null> {
-  const res = await ComposerExtract.safeParseAsync({ content, fileName: packageFile });
+  const res = await ComposerExtract.safeParseAsync({
+    content,
+    fileName: packageFile,
+  });
   if (!res.success) {
     logger.debug({ packageFile, err: res.error }, 'Composer: extract failed');
     return null;

--- a/lib/modules/manager/cpanfile/extract.ts
+++ b/lib/modules/manager/cpanfile/extract.ts
@@ -3,7 +3,7 @@ import { parse } from './parser';
 
 export function extractPackageFile(
   content: string,
-  packageFile?: string
+  _packageFile?: string
 ): PackageFileContent | null {
   const result = parse(content);
   if (!result?.deps.length) {

--- a/lib/modules/manager/docker-compose/extract.ts
+++ b/lib/modules/manager/docker-compose/extract.ts
@@ -30,31 +30,33 @@ class LineMapper {
 
 export function extractPackageFile(
   content: string,
-  fileName: string,
+  packageFile: string,
   extractConfig: ExtractConfig
 ): PackageFileContent | null {
-  logger.debug('docker-compose.extractPackageFile()');
+  logger.debug(`docker-compose.extractPackageFile(${packageFile})`);
   let config: DockerComposeConfig;
   try {
     // TODO: fix me (#9610)
     config = load(content, { json: true }) as DockerComposeConfig;
     if (!config) {
       logger.debug(
-        { fileName },
+        { packageFile },
         'Null config when parsing Docker Compose content'
       );
       return null;
     }
     if (typeof config !== 'object') {
       logger.debug(
-        { fileName, type: typeof config },
+        { packageFile, type: typeof config },
         'Unexpected type for Docker Compose content'
       );
       return null;
     }
   } catch (err) {
-    logger.debug({ err }, 'err');
-    logger.debug(`Parsing Docker Compose config YAML in ${fileName}`);
+    logger.debug(
+      { err, packageFile },
+      `Parsing Docker Compose config YAML failed`
+    );
     return null;
   }
   try {
@@ -85,10 +87,7 @@ export function extractPackageFile(
     logger.trace({ deps }, 'Docker Compose image');
     return { deps };
   } catch (err) /* istanbul ignore next */ {
-    logger.warn(
-      { fileName, content, err },
-      'Error extracting Docker Compose file'
-    );
+    logger.debug({ packageFile, err }, 'Error extracting Docker Compose file');
     return null;
   }
 }

--- a/lib/modules/manager/dockerfile/extract.ts
+++ b/lib/modules/manager/dockerfile/extract.ts
@@ -239,7 +239,7 @@ export function getDep(
 
 export function extractPackageFile(
   content: string,
-  _filename: string,
+  _packageFile: string,
   config: ExtractConfig
 ): PackageFileContent | null {
   const deps: PackageDependency[] = [];

--- a/lib/modules/manager/droneci/extract.ts
+++ b/lib/modules/manager/droneci/extract.ts
@@ -9,7 +9,7 @@ import type {
 
 export function extractPackageFile(
   content: string,
-  _filename: string,
+  packageFile: string,
   config: ExtractConfig
 ): PackageFileContent | null {
   const deps: PackageDependency[] = [];
@@ -73,7 +73,7 @@ export function extractPackageFile(
       }
     }
   } catch (err) /* istanbul ignore next */ {
-    logger.warn({ err }, 'Error extracting DroneCI images');
+    logger.debug({ err, packageFile }, 'Error extracting DroneCI images');
   }
   if (!deps.length) {
     return null;

--- a/lib/modules/manager/fleet/extract.ts
+++ b/lib/modules/manager/fleet/extract.ts
@@ -135,7 +135,7 @@ export function extractPackageFile(
       deps.push(...gitRepoDeps);
     }
   } catch (err) {
-    logger.warn({ error: err, packageFile }, 'Failed to parse fleet YAML');
+    logger.debug({ error: err, packageFile }, 'Failed to parse fleet YAML');
   }
 
   return deps.length ? { deps } : null;

--- a/lib/modules/manager/flux/extract.ts
+++ b/lib/modules/manager/flux/extract.ts
@@ -26,7 +26,10 @@ import type {
   SystemFluxManifest,
 } from './types';
 
-function readManifest(content: string, packageFile: string): FluxManifest | null {
+function readManifest(
+  content: string,
+  packageFile: string
+): FluxManifest | null {
   if (isSystemManifest(packageFile)) {
     const versionMatch = regEx(
       /#\s*Flux\s+Version:\s*(\S+)(?:\s*#\s*Components:\s*([A-Za-z,-]+))?/

--- a/lib/modules/manager/flux/extract.ts
+++ b/lib/modules/manager/flux/extract.ts
@@ -26,8 +26,8 @@ import type {
   SystemFluxManifest,
 } from './types';
 
-function readManifest(content: string, file: string): FluxManifest | null {
-  if (isSystemManifest(file)) {
+function readManifest(content: string, packageFile: string): FluxManifest | null {
+  if (isSystemManifest(packageFile)) {
     const versionMatch = regEx(
       /#\s*Flux\s+Version:\s*(\S+)(?:\s*#\s*Components:\s*([A-Za-z,-]+))?/
     ).exec(content);
@@ -36,7 +36,7 @@ function readManifest(content: string, file: string): FluxManifest | null {
     }
     return {
       kind: 'system',
-      file,
+      file: packageFile,
       version: versionMatch[1],
       components: versionMatch[2],
     };
@@ -44,14 +44,14 @@ function readManifest(content: string, file: string): FluxManifest | null {
 
   const manifest: FluxManifest = {
     kind: 'resource',
-    file,
+    file: packageFile,
     resources: [],
   };
   let resources: FluxResource[];
   try {
     resources = loadAll(content, null, { json: true }) as FluxResource[];
   } catch (err) {
-    logger.debug({ err }, 'Failed to parse Flux manifest');
+    logger.debug({ err, packageFile }, 'Failed to parse Flux manifest');
     return null;
   }
 

--- a/lib/modules/manager/git-submodules/extract.ts
+++ b/lib/modules/manager/git-submodules/extract.ts
@@ -130,7 +130,10 @@ export default async function extractPackageFile(
         currentDigest,
       });
     } catch (err) /* istanbul ignore next */ {
-      logger.warn({ err, packageFile }, 'Error mapping git submodules during extraction');
+      logger.warn(
+        { err, packageFile },
+        'Error mapping git submodules during extraction'
+      );
     }
   }
 

--- a/lib/modules/manager/git-submodules/extract.ts
+++ b/lib/modules/manager/git-submodules/extract.ts
@@ -92,12 +92,12 @@ async function getModules(
 
 export default async function extractPackageFile(
   _content: string,
-  fileName: string,
-  config: ExtractConfig
+  packageFile: string,
+  _config: ExtractConfig
 ): Promise<PackageFileContent | null> {
   const { localDir } = GlobalConfig.get();
   const git = Git(localDir, simpleGitConfig());
-  const gitModulesPath = upath.join(localDir, fileName);
+  const gitModulesPath = upath.join(localDir, packageFile);
 
   const depNames = await getModules(git, gitModulesPath);
 
@@ -130,7 +130,7 @@ export default async function extractPackageFile(
         currentDigest,
       });
     } catch (err) /* istanbul ignore next */ {
-      logger.warn({ err }, 'Error mapping git submodules during extraction');
+      logger.warn({ err, packageFile }, 'Error mapping git submodules during extraction');
     }
   }
 

--- a/lib/modules/manager/github-actions/extract.ts
+++ b/lib/modules/manager/github-actions/extract.ts
@@ -88,7 +88,7 @@ function extractContainer(container: unknown): PackageDependency | undefined {
 
 function extractWithYAMLParser(
   content: string,
-  filename: string
+  packageFile: string
 ): PackageDependency[] {
   logger.trace('github-actions.extractWithYAMLParser()');
   const deps: PackageDependency[] = [];
@@ -98,7 +98,7 @@ function extractWithYAMLParser(
     pkg = load(content, { json: true }) as Workflow;
   } catch (err) {
     logger.debug(
-      { filename, err },
+      { packageFile, err },
       'Failed to parse GitHub Actions Workflow YAML'
     );
     return [];
@@ -125,12 +125,12 @@ function extractWithYAMLParser(
 
 export function extractPackageFile(
   content: string,
-  filename: string
+  packageFile: string
 ): PackageFileContent | null {
-  logger.trace('github-actions.extractPackageFile()');
+  logger.trace(`github-actions.extractPackageFile(${packageFile})`);
   const deps = [
     ...extractWithRegex(content),
-    ...extractWithYAMLParser(content, filename),
+    ...extractWithYAMLParser(content, packageFile),
   ];
   if (!deps.length) {
     return null;

--- a/lib/modules/manager/gitlabci-include/extract.ts
+++ b/lib/modules/manager/gitlabci-include/extract.ts
@@ -63,7 +63,10 @@ function getAllIncludeProjects(data: GitlabPipeline): GitlabIncludeProject[] {
   return childrenData;
 }
 
-export function extractPackageFile(content: string): PackageFileContent | null {
+export function extractPackageFile(
+  content: string,
+  packageFile?: string
+): PackageFileContent | null {
   const deps: PackageDependency[] = [];
   const { platform, endpoint } = GlobalConfig.get();
   try {
@@ -80,9 +83,12 @@ export function extractPackageFile(content: string): PackageFileContent | null {
     }
   } catch (err) /* istanbul ignore next */ {
     if (err.stack?.startsWith('YAMLException:')) {
-      logger.debug({ err }, 'YAML exception extracting GitLab CI includes');
+      logger.debug(
+        { err, packageFile },
+        'YAML exception extracting GitLab CI includes'
+      );
     } else {
-      logger.warn({ err }, 'Error extracting GitLab CI includes');
+      logger.debug({ err, packageFile }, 'Error extracting GitLab CI includes');
     }
   }
   if (!deps.length) {

--- a/lib/modules/manager/gitlabci/extract.spec.ts
+++ b/lib/modules/manager/gitlabci/extract.spec.ts
@@ -111,7 +111,7 @@ describe('modules/manager/gitlabci/extract', () => {
         'lib/modules/manager/gitlabci/__fixtures__/gitlab-ci.4.yaml',
       ]);
       expect(res).toBeNull();
-      expect(logger.logger.warn).toHaveBeenCalled();
+      expect(logger.logger.debug).toHaveBeenCalled();
     });
 
     it('skips images with variables', async () => {

--- a/lib/modules/manager/gitlabci/extract.ts
+++ b/lib/modules/manager/gitlabci/extract.ts
@@ -78,7 +78,7 @@ export function extractFromJob(
 
 export function extractPackageFile(
   content: string,
-  _fileName: string,
+  packageFile: string,
   config: ExtractConfig
 ): PackageFileContent | null {
   let deps: PackageDependency[] = [];
@@ -115,7 +115,10 @@ export function extractPackageFile(
       deps = deps.filter(is.truthy);
     }
   } catch (err) /* istanbul ignore next */ {
-    logger.warn({ err }, 'Error extracting GitLab CI dependencies');
+    logger.debug(
+      { err, packageFile },
+      'Error extracting GitLab CI dependencies'
+    );
   }
 
   return deps.length ? { deps } : null;
@@ -135,7 +138,10 @@ export async function extractAllPackageFiles(
 
     const content = await readLocalFile(file, 'utf8');
     if (!content) {
-      logger.debug(`Empty or non existent gitlabci file ${file}`);
+      logger.debug(
+        { packageFile: file },
+        `Empty or non existent gitlabci file`
+      );
       continue;
     }
     let doc: GitlabPipeline;
@@ -144,7 +150,10 @@ export async function extractAllPackageFiles(
         json: true,
       }) as GitlabPipeline;
     } catch (err) {
-      logger.warn({ err, file }, 'Error extracting GitLab CI dependencies');
+      logger.debug(
+        { err, packageFile: file },
+        'Error extracting GitLab CI dependencies'
+      );
       continue;
     }
 

--- a/lib/modules/manager/gomod/extract.ts
+++ b/lib/modules/manager/gomod/extract.ts
@@ -49,7 +49,10 @@ function getGoDep(lineNumber: number, goVer: string): PackageDependency {
   };
 }
 
-export function extractPackageFile(content: string): PackageFileContent | null {
+export function extractPackageFile(
+  content: string,
+  packageFile?: string
+): PackageFileContent | null {
   logger.trace({ content }, 'gomod.extractPackageFile()');
   const deps: PackageDependency[] = [];
   try {
@@ -106,7 +109,7 @@ export function extractPackageFile(content: string): PackageFileContent | null {
       }
     }
   } catch (err) /* istanbul ignore next */ {
-    logger.warn({ err }, 'Error extracting go modules');
+    logger.warn({ err, packageFile }, 'Error extracting go modules');
   }
   if (!deps.length) {
     return null;

--- a/lib/modules/manager/gradle/extract.spec.ts
+++ b/lib/modules/manager/gradle/extract.spec.ts
@@ -60,7 +60,7 @@ describe('modules/manager/gradle/extract', () => {
     });
     await extractAllPackageFiles(partial<ExtractConfig>(), [filename]);
 
-    expect(logger.logger.warn).toHaveBeenCalledWith(
+    expect(logger.logger.debug).toHaveBeenCalledWith(
       { err, config: {}, packageFile: filename },
       `Failed to process Gradle file`
     );

--- a/lib/modules/manager/gradle/extract.ts
+++ b/lib/modules/manager/gradle/extract.ts
@@ -116,7 +116,7 @@ async function parsePackageFiles(
         extractedDeps.push(...deps);
       }
     } catch (err) {
-      logger.warn(
+      logger.debug(
         { err, config, packageFile },
         `Failed to process Gradle file`
       );
@@ -193,7 +193,7 @@ export async function extractAllPackageFiles(
 
       packageFilesByName[key] = pkgFile;
     } else {
-      logger.warn({ dep }, `Failed to process Gradle dependency`);
+      logger.debug({ dep }, `Failed to process Gradle dependency`);
     }
   }
 

--- a/lib/modules/manager/helm-requirements/extract.ts
+++ b/lib/modules/manager/helm-requirements/extract.ts
@@ -10,7 +10,7 @@ import type {
 
 export function extractPackageFile(
   content: string,
-  fileName: string,
+  packageFile: string,
   config: ExtractConfig
 ): PackageFileContent | null {
   let deps = [];
@@ -19,11 +19,11 @@ export function extractPackageFile(
   try {
     doc = load(content, { json: true }); // TODO #9610
   } catch (err) {
-    logger.debug(`Failed to parse helm requirements.yaml in ${fileName}`);
+    logger.debug({ packageFile }, `Failed to parse helm requirements.yaml`);
     return null;
   }
   if (!(doc && is.array(doc.dependencies))) {
-    logger.debug(`requirements.yaml in ${fileName} has no dependencies`);
+    logger.debug({ packageFile }, `requirements.yaml has no dependencies`);
     return null;
   }
   deps = doc.dependencies.map((dep: Record<string, any>) => {
@@ -75,7 +75,10 @@ export function extractPackageFile(
           res.skipReason = 'local-dependency';
         }
       } catch (err) {
-        logger.debug({ err }, 'Error parsing url');
+        logger.debug(
+          { err, packageFile, url: dep.repository },
+          'Error parsing url'
+        );
         res.skipReason = 'invalid-url';
       }
     }

--- a/lib/modules/manager/helm-values/extract.ts
+++ b/lib/modules/manager/helm-values/extract.ts
@@ -57,7 +57,10 @@ function findDependencies(
   return packageDependencies;
 }
 
-export function extractPackageFile(content: string): PackageFileContent | null {
+export function extractPackageFile(
+  content: string,
+  packageFile?: string
+): PackageFileContent | null {
   let parsedContent: Record<string, unknown> | HelmDockerImageDependency;
   try {
     // a parser that allows extracting line numbers would be preferable, with
@@ -65,7 +68,7 @@ export function extractPackageFile(content: string): PackageFileContent | null {
     // TODO: fix me (#9610)
     parsedContent = load(content, { json: true }) as any;
   } catch (err) {
-    logger.debug({ err }, 'Failed to parse helm-values YAML');
+    logger.debug({ err, packageFile }, 'Failed to parse helm-values YAML');
     return null;
   }
   try {
@@ -74,7 +77,10 @@ export function extractPackageFile(content: string): PackageFileContent | null {
       return { deps };
     }
   } catch (err) /* istanbul ignore next */ {
-    logger.warn({ err }, 'Error parsing helm-values parsed content');
+    logger.debug(
+      { err, packageFile },
+      'Error parsing helm-values parsed content'
+    );
   }
   return null;
 }

--- a/lib/modules/manager/helmfile/extract.ts
+++ b/lib/modules/manager/helmfile/extract.ts
@@ -33,7 +33,7 @@ function isLocalPath(possiblePath: string): boolean {
 
 export async function extractPackageFile(
   content: string,
-  fileName: string,
+  packageFile: string,
   config: ExtractConfig
 ): Promise<PackageFileContent | null> {
   const deps: PackageDependency[] = [];
@@ -44,7 +44,10 @@ export async function extractPackageFile(
   try {
     docs = loadAll(extractYaml(content), null, { json: true }) as Doc[];
   } catch (err) {
-    logger.debug({ err, fileName }, 'Failed to parse helmfile helmfile.yaml');
+    logger.debug(
+      { err, packageFile },
+      'Failed to parse helmfile helmfile.yaml'
+    );
     return null;
   }
   for (const doc of docs) {
@@ -75,7 +78,7 @@ export async function extractPackageFile(
       if (isLocalPath(dep.chart)) {
         if (
           kustomizationsKeysUsed(dep) ||
-          (await localChartHasKustomizationsYaml(dep, fileName))
+          (await localChartHasKustomizationsYaml(dep, packageFile))
         ) {
           needKustomize = true;
         }

--- a/lib/modules/manager/helmsman/extract.ts
+++ b/lib/modules/manager/helmsman/extract.ts
@@ -55,8 +55,8 @@ function createDep(
 
 export function extractPackageFile(
   content: string,
-  fileName: string,
-  config: ExtractConfig
+  packageFile: string,
+  _config: ExtractConfig
 ): PackageFileContent | null {
   try {
     // TODO: fix me (#9610)
@@ -64,7 +64,7 @@ export function extractPackageFile(
       json: true,
     }) as HelmsmanDocument;
     if (!(doc?.helmRepos && doc.apps)) {
-      logger.debug(`Missing helmRepos and/or apps keys in ${fileName}`);
+      logger.debug({ packageFile }, `Missing helmRepos and/or apps keys`);
       return null;
     }
 
@@ -79,9 +79,9 @@ export function extractPackageFile(
     return { deps };
   } catch (err) /* istanbul ignore next */ {
     if (err.stack?.startsWith('YAMLException:')) {
-      logger.debug({ err }, 'YAML exception extracting');
+      logger.debug({ err, packageFile }, 'YAML exception extracting');
     } else {
-      logger.warn({ err }, 'Error extracting');
+      logger.debug({ err, packageFile }, 'Error extracting');
     }
     return null;
   }

--- a/lib/modules/manager/helmv3/extract.ts
+++ b/lib/modules/manager/helmv3/extract.ts
@@ -12,7 +12,7 @@ import { parseRepository, resolveAlias } from './utils';
 
 export async function extractPackageFile(
   content: string,
-  fileName: string,
+  packageFile: string,
   config: ExtractConfig
 ): Promise<PackageFileContent | null> {
   let chart: {
@@ -26,26 +26,26 @@ export async function extractPackageFile(
     chart = load(content, { json: true }) as any;
     if (!(chart?.apiVersion && chart.name && chart.version)) {
       logger.debug(
-        { fileName },
+        { packageFile },
         'Failed to find required fields in Chart.yaml'
       );
       return null;
     }
     if (chart.apiVersion !== 'v2') {
       logger.debug(
-        { fileName },
+        { packageFile },
         'Unsupported Chart apiVersion. Only v2 is supported.'
       );
       return null;
     }
   } catch (err) {
-    logger.debug(`Failed to parse helm Chart.yaml from ${fileName}`);
+    logger.debug({ packageFile }, `Failed to parse helm Chart.yaml`);
     return null;
   }
   const packageFileVersion = chart.version;
   let deps: PackageDependency[] = [];
   if (!is.nonEmptyArray(chart?.dependencies)) {
-    logger.debug(`Chart has no dependencies in ${fileName}`);
+    logger.debug(`Chart has no dependencies in ${packageFile}`);
     return null;
   }
   const validDependencies = chart.dependencies.filter(
@@ -82,7 +82,7 @@ export async function extractPackageFile(
     datasource: HelmDatasource.id,
     packageFileVersion,
   };
-  const lockFileName = getSiblingFileName(fileName, 'Chart.lock');
+  const lockFileName = getSiblingFileName(packageFile, 'Chart.lock');
   // istanbul ignore if
   if (await localPathExists(lockFileName)) {
     res.lockFiles = [lockFileName];

--- a/lib/modules/manager/hermit/extract.ts
+++ b/lib/modules/manager/hermit/extract.ts
@@ -14,12 +14,12 @@ const pkgReferenceRegex = regEx(`(?<packageName>.*?)-(?<version>[0-9]{1}.*)`);
  * and looking for .{packageName}-{version}.pkg
  */
 export async function extractPackageFile(
-  content: string,
-  filename: string
+  _content: string,
+  packageFile: string
 ): Promise<PackageFileContent | null> {
-  logger.trace('hermit.extractPackageFile()');
+  logger.trace(`hermit.extractPackageFile(${packageFile})`);
   const dependencies = [] as PackageDependency[];
-  const packages = await listHermitPackages(filename);
+  const packages = await listHermitPackages(packageFile);
 
   if (!packages?.length) {
     return null;
@@ -46,18 +46,18 @@ export async function extractPackageFile(
  * listHermitPackages will fetch all installed packages from the bin folder
  */
 async function listHermitPackages(
-  hermitFile: string
+  packageFile: string
 ): Promise<HermitListItem[] | null> {
   logger.trace('hermit.listHermitPackages()');
-  const hermitFolder = upath.dirname(hermitFile);
+  const hermitFolder = upath.dirname(packageFile);
 
   let files: string[] = [];
 
   try {
     files = await readLocalDirectory(hermitFolder);
-  } catch (e) {
+  } catch (err) {
     logger.debug(
-      { hermitFolder, err: e },
+      { hermitFolder, err, packageFile },
       'error listing hermit package references'
     );
     return null;

--- a/lib/modules/manager/jenkins/extract.ts
+++ b/lib/modules/manager/jenkins/extract.ts
@@ -50,7 +50,10 @@ function getDependency(plugin: JenkinsPlugin): PackageDependency {
   return dep;
 }
 
-function extractYaml(content: string): PackageDependency[] {
+function extractYaml(
+  content: string,
+  packageFile: string
+): PackageDependency[] {
   const deps: PackageDependency[] = [];
 
   try {
@@ -64,7 +67,7 @@ function extractYaml(content: string): PackageDependency[] {
       }
     }
   } catch (err) /* istanbul ignore next */ {
-    logger.warn({ err }, 'Error parsing Jenkins plugins');
+    logger.debug({ err, packageFile }, 'Error parsing Jenkins plugins');
   }
   return deps;
 }
@@ -97,13 +100,13 @@ function extractText(content: string): PackageDependency[] {
 
 export function extractPackageFile(
   content: string,
-  fileName: string
+  packageFile: string
 ): PackageFileContent | null {
-  logger.trace('jenkins.extractPackageFile()');
+  logger.trace(`jenkins.extractPackageFile(${packageFile})`);
   const deps: PackageDependency[] = [];
 
-  if (YamlExtension.test(fileName)) {
-    deps.push(...extractYaml(content));
+  if (YamlExtension.test(packageFile)) {
+    deps.push(...extractYaml(content, packageFile));
   } else {
     deps.push(...extractText(content));
   }

--- a/lib/modules/manager/jsonnet-bundler/extract.ts
+++ b/lib/modules/manager/jsonnet-bundler/extract.ts
@@ -20,7 +20,7 @@ export function extractPackageFile(
   try {
     jsonnetFile = JSON.parse(content) as JsonnetFile;
   } catch (err) {
-    logger.debug(`Invalid JSON ${packageFile}`);
+    logger.debug({ packageFile }, `Invalid JSON`);
     return null;
   }
 

--- a/lib/modules/manager/kubernetes/extract.ts
+++ b/lib/modules/manager/kubernetes/extract.ts
@@ -17,7 +17,7 @@ import type { KubernetesConfiguration } from './types';
 
 export function extractPackageFile(
   content: string,
-  fileName: string,
+  packageFile: string,
   config: ExtractConfig
 ): PackageFileContent | null {
   logger.trace('kubernetes.extractPackageFile()');
@@ -31,7 +31,7 @@ export function extractPackageFile(
 
   const deps: PackageDependency[] = [
     ...extractImages(content, config),
-    ...extractApis(content, fileName),
+    ...extractApis(content, packageFile),
   ];
 
   return deps.length ? { deps } : null;
@@ -63,13 +63,16 @@ function extractImages(
   return deps.filter((dep) => !dep.currentValue?.includes('${'));
 }
 
-function extractApis(content: string, fileName: string): PackageDependency[] {
+function extractApis(
+  content: string,
+  packageFile: string
+): PackageDependency[] {
   let doc: KubernetesConfiguration[];
 
   try {
     doc = loadAll(content) as KubernetesConfiguration[];
   } catch (err) {
-    logger.debug({ err, fileName }, 'Failed to parse Kubernetes manifest.');
+    logger.debug({ err, packageFile }, 'Failed to parse Kubernetes manifest.');
     return [];
   }
 

--- a/lib/modules/manager/kustomize/extract.ts
+++ b/lib/modules/manager/kustomize/extract.ts
@@ -71,7 +71,7 @@ export function extractImage(image: Image): PackageDependency | null {
   const { depName } = nameDep;
   const { digest, newTag } = image;
   if (digest && newTag) {
-    logger.warn(
+    logger.debug(
       { newTag, digest },
       'Kustomize ignores newTag when digest is provided. Pick one, or use `newTag: tag@digest`'
     );
@@ -146,11 +146,15 @@ export function extractHelmChart(
   };
 }
 
-export function parseKustomize(content: string): Kustomize | null {
+export function parseKustomize(
+  content: string,
+  packageFile?:  string
+): Kustomize | null {
   let pkg: Kustomize | null = null;
   try {
     pkg = load(content, { json: true }) as Kustomize;
   } catch (e) /* istanbul ignore next */ {
+    logger.debug({ packageFile }, 'Error parsing kustomize file');
     return null;
   }
 
@@ -167,11 +171,14 @@ export function parseKustomize(content: string): Kustomize | null {
   return pkg;
 }
 
-export function extractPackageFile(content: string): PackageFileContent | null {
-  logger.trace('kustomize.extractPackageFile()');
+export function extractPackageFile(
+  content: string,
+  packageFile?: string // TODO: fix tests
+): PackageFileContent | null {
+  logger.trace(`kustomize.extractPackageFile(${packageFile!})`);
   const deps: PackageDependency[] = [];
 
-  const pkg = parseKustomize(content);
+  const pkg = parseKustomize(content, packageFile);
   if (!pkg) {
     return null;
   }

--- a/lib/modules/manager/kustomize/extract.ts
+++ b/lib/modules/manager/kustomize/extract.ts
@@ -148,7 +148,7 @@ export function extractHelmChart(
 
 export function parseKustomize(
   content: string,
-  packageFile?:  string
+  packageFile?: string
 ): Kustomize | null {
   let pkg: Kustomize | null = null;
   try {

--- a/lib/modules/manager/maven/extract.ts
+++ b/lib/modules/manager/maven/extract.ts
@@ -9,11 +9,12 @@ import { MAVEN_REPO } from '../../datasource/maven/common';
 import type { ExtractConfig, PackageDependency, PackageFile } from '../types';
 import type { MavenProp } from './types';
 
-export function parsePom(raw: string): XmlDocument | null {
+function parsePom(raw: string, packageFile: string): XmlDocument | null {
   let project: XmlDocument;
   try {
     project = new XmlDocument(raw);
-  } catch (e) {
+  } catch (err) {
+    logger.debug({ packageFile }, `Failed to parse as XML`);
     return null;
   }
   const { name, attr, children } = project;
@@ -258,7 +259,7 @@ export function extractPackage(
     return null;
   }
 
-  const project = parsePom(rawContent);
+  const project = parsePom(rawContent, packageFile);
   if (!project) {
     return null;
   }
@@ -475,7 +476,7 @@ export async function extractAllPackageFiles(
   for (const packageFile of packageFiles) {
     const content = await readLocalFile(packageFile, 'utf8');
     if (!content) {
-      logger.trace({ packageFile }, 'packageFile has no content');
+      logger.debug({ packageFile }, 'packageFile has no content');
       continue;
     }
     if (packageFile.endsWith('settings.xml')) {

--- a/lib/modules/manager/meteor/extract.ts
+++ b/lib/modules/manager/meteor/extract.ts
@@ -3,7 +3,10 @@ import { regEx } from '../../../util/regex';
 import { NpmDatasource } from '../../datasource/npm';
 import type { PackageDependency, PackageFileContent } from '../types';
 
-export function extractPackageFile(content: string): PackageFileContent | null {
+export function extractPackageFile(
+  content: string,
+  packageFile?: string
+): PackageFileContent | null {
   let deps: PackageDependency[] = [];
   const npmDepends = regEx(/\nNpm\.depends\({([\s\S]*?)}\);/).exec(content);
   if (!npmDepends) {
@@ -30,7 +33,7 @@ export function extractPackageFile(content: string): PackageFileContent | null {
       })
       .filter((dep) => dep.depName && dep.currentValue);
   } catch (err) /* istanbul ignore next */ {
-    logger.warn({ content }, 'Failed to parse meteor package.js');
+    logger.warn({ err, packageFile }, 'Failed to parse meteor package.js');
   }
   // istanbul ignore if
   if (!deps.length) {

--- a/lib/modules/manager/mix/extract.ts
+++ b/lib/modules/manager/mix/extract.ts
@@ -19,9 +19,9 @@ const commentMatchRegExp = regEx(/#.*$/);
 
 export async function extractPackageFile(
   content: string,
-  fileName: string
+  packageFile: string
 ): Promise<PackageFileContent | null> {
-  logger.trace('mix.extractPackageFile()');
+  logger.trace(`mix.extractPackageFile(${packageFile})`);
   const deps: PackageDependency[] = [];
   const contentArr = content
     .split(newlineRegex)
@@ -71,7 +71,7 @@ export async function extractPackageFile(
   }
   const res: PackageFileContent = { deps };
   const lockFileName =
-    (await findLocalSiblingOrParent(fileName, 'mix.lock')) ?? 'mix.lock';
+    (await findLocalSiblingOrParent(packageFile, 'mix.lock')) ?? 'mix.lock';
   // istanbul ignore if
   if (await localPathExists(lockFileName)) {
     res.lockFiles = [lockFileName];

--- a/lib/modules/manager/npm/extract/index.ts
+++ b/lib/modules/manager/npm/extract/index.ts
@@ -42,34 +42,34 @@ const RE_REPOSITORY_GITHUB_SSH_FORMAT = regEx(
 
 export async function extractPackageFile(
   content: string,
-  fileName: string,
+  packageFile: string,
   config: ExtractConfig
 ): Promise<PackageFileContent<NpmManagerData> | null> {
-  logger.trace(`npm.extractPackageFile(${fileName})`);
+  logger.trace(`npm.extractPackageFile(${packageFile})`);
   logger.trace({ content });
   const deps: PackageDependency[] = [];
   let packageJson: NpmPackage;
   try {
     packageJson = JSON.parse(content);
   } catch (err) {
-    logger.debug(`Invalid JSON in ${fileName}`);
+    logger.debug({ packageFile }, `Invalid JSON`);
     return null;
   }
 
   if (packageJson._id && packageJson._args && packageJson._from) {
-    logger.debug('Ignoring vendorised package.json');
+    logger.debug({ packageFile }, 'Ignoring vendorised package.json');
     return null;
   }
-  if (fileName !== 'package.json' && packageJson.renovate) {
+  if (packageFile !== 'package.json' && packageJson.renovate) {
     const error = new Error(CONFIG_VALIDATION);
-    error.validationSource = fileName;
+    error.validationSource = packageFile;
     error.validationError =
       'Nested package.json must not contain renovate configuration. Please use `packageRules` with `matchPaths` in your main config instead.';
     throw error;
   }
   const packageJsonName = packageJson.name;
   logger.debug(
-    `npm file ${fileName} has name ${JSON.stringify(packageJsonName)}`
+    `npm file ${packageFile} has name ${JSON.stringify(packageJsonName)}`
   );
   const packageFileVersion = packageJson.version;
   let workspacesPackages: string[] | undefined;
@@ -90,7 +90,7 @@ export async function extractPackageFile(
     'yarnLock' | 'packageLock' | 'shrinkwrapJson' | 'pnpmShrinkwrap',
     string
   ][]) {
-    const filePath = getSiblingFileName(fileName, val);
+    const filePath = getSiblingFileName(packageFile, val);
     if (await readLocalFile(filePath, 'utf8')) {
       lockFiles[key] = filePath;
     } else {
@@ -102,7 +102,7 @@ export async function extractPackageFile(
   delete lockFiles.shrinkwrapJson;
 
   let npmrc: string | undefined;
-  const npmrcFileName = getSiblingFileName(fileName, '.npmrc');
+  const npmrcFileName = getSiblingFileName(packageFile, '.npmrc');
   let repoNpmrc = await readLocalFile(npmrcFileName, 'utf8');
   if (is.string(repoNpmrc)) {
     if (is.string(config.npmrc) && !config.npmrcMerge) {
@@ -141,7 +141,7 @@ export async function extractPackageFile(
     npmrc = config.npmrc;
   }
 
-  const yarnrcYmlFileName = getSiblingFileName(fileName, '.yarnrc.yml');
+  const yarnrcYmlFileName = getSiblingFileName(packageFile, '.yarnrc.yml');
   const yarnZeroInstall = await isZeroInstall(yarnrcYmlFileName);
 
   let yarnConfig: YarnConfig | null = null;
@@ -150,7 +150,7 @@ export async function extractPackageFile(
     yarnConfig = loadConfigFromYarnrcYml(repoYarnrcYml);
   }
 
-  const legacyYarnrcFileName = getSiblingFileName(fileName, '.yarnrc');
+  const legacyYarnrcFileName = getSiblingFileName(packageFile, '.yarnrc');
   const repoLegacyYarnrc = await readLocalFile(legacyYarnrcFileName, 'utf8');
   if (is.string(repoLegacyYarnrc)) {
     yarnConfig = loadConfigFromLegacyYarnrc(repoLegacyYarnrc);
@@ -168,11 +168,11 @@ export async function extractPackageFile(
       }
     | undefined;
   try {
-    lernaJsonFile = getSiblingFileName(fileName, 'lerna.json');
+    lernaJsonFile = getSiblingFileName(packageFile, 'lerna.json');
     // TODO #7154
     lernaJson = JSON.parse((await readLocalFile(lernaJsonFile, 'utf8'))!);
   } catch (err) /* istanbul ignore next */ {
-    logger.warn({ err }, 'Could not parse lerna.json');
+    logger.debug({ err, lernaJsonFile }, 'Could not parse lerna.json');
   }
   if (lernaJson && !lernaJson.useWorkspaces) {
     lernaPackages = lernaJson.packages;
@@ -283,7 +283,10 @@ export async function extractPackageFile(
         dep.packageName = valSplit[0] + '@' + valSplit[1];
         dep.currentValue = valSplit[2];
       } else {
-        logger.debug('Invalid npm package alias: ' + dep.currentValue);
+        logger.debug(
+          { packageFile },
+          'Invalid npm package alias: ' + dep.currentValue
+        );
       }
     }
     if (dep.currentValue.startsWith('file:')) {
@@ -447,7 +450,10 @@ export async function extractPackageFile(
           }
         }
       } catch (err) /* istanbul ignore next */ {
-        logger.debug({ fileName, depType, err }, 'Error parsing package.json');
+        logger.debug(
+          { fileName: packageFile, depType, err },
+          'Error parsing package.json'
+        );
         return null;
       }
     }
@@ -527,7 +533,7 @@ export async function extractAllPackageFiles(
         });
       }
     } else {
-      logger.debug(`No content found in ${packageFile}`);
+      logger.debug({ packageFile }, `No content found`);
     }
   }
 

--- a/lib/modules/manager/nuget/extract.ts
+++ b/lib/modules/manager/nuget/extract.ts
@@ -76,7 +76,7 @@ export async function extractPackageFile(
   packageFile: string,
   _config: ExtractConfig
 ): Promise<PackageFileContent | null> {
-  logger.trace({ packageFile }, 'nuget.extractPackageFile()');
+  logger.trace(`nuget.extractPackageFile(${packageFile})`);
 
   const registries = await getConfiguredRegistries(packageFile);
   const registryUrls = registries
@@ -90,12 +90,12 @@ export async function extractPackageFile(
     try {
       manifest = JSON.parse(content);
     } catch (err) {
-      logger.debug(`Invalid JSON in ${packageFile}`);
+      logger.debug({ packageFile }, `Invalid JSON`);
       return null;
     }
 
     if (manifest.version !== 1) {
-      logger.debug({ contents: manifest }, 'Unsupported dotnet tools version');
+      logger.debug({ packageFile }, 'Unsupported dotnet tools version');
       return null;
     }
 
@@ -132,7 +132,7 @@ export async function extractPackageFile(
     }));
     packageFileVersion = parsedXml.valueWithPath('PropertyGroup.Version');
   } catch (err) {
-    logger.debug({ err }, `Failed to parse ${packageFile}`);
+    logger.debug({ err, packageFile }, `Failed to parse XML`);
   }
 
   if (!deps.length) {

--- a/lib/modules/manager/nuget/extract/global-manifest.ts
+++ b/lib/modules/manager/nuget/extract/global-manifest.ts
@@ -14,15 +14,12 @@ export function extractMsbuildGlobalManifest(
   try {
     manifest = JSON.parse(content);
   } catch (err) {
-    logger.debug(`Invalid JSON in ${packageFile}`);
+    logger.debug({ packageFile }, `Invalid JSON`);
     return null;
   }
 
   if (!manifest['msbuild-sdks'] && !manifest.sdk?.version) {
-    logger.debug(
-      { fileName: packageFile },
-      'This global.json is not a Nuget file'
-    );
+    logger.debug({ packageFile }, 'This global.json is not a Nuget file');
     return null;
   }
 

--- a/lib/modules/manager/osgi/extract.ts
+++ b/lib/modules/manager/osgi/extract.ts
@@ -12,13 +12,13 @@ import type { Bundle, FeatureModel } from './types';
 
 export function extractPackageFile(
   content: string,
-  fileName: string,
-  config?: ExtractConfig
+  packageFile: string,
+  _config?: ExtractConfig
 ): PackageFileContent | null {
   // References:
   // - OSGi compendium release 8 ( https://docs.osgi.org/specification/osgi.cmpn/8.0.0/service.feature.html )
   // - The Sling implementation of the feature model ( https://sling.apache.org/documentation/development/feature-model.html )
-  logger.trace({ fileName }, 'osgi.extractPackageFile');
+  logger.trace(`osgi.extractPackageFile($packageFile)`);
 
   const deps: PackageDependency[] = [];
   let featureModel: FeatureModel;
@@ -26,7 +26,7 @@ export function extractPackageFile(
     // Compendium R8 159.3: JS comments are supported
     featureModel = json5.parse<FeatureModel>(content);
   } catch (err) {
-    logger.warn({ fileName, err }, 'Failed to parse osgi file');
+    logger.warn({ packageFile, err }, 'Failed to parse osgi file');
     return null;
   }
 
@@ -34,7 +34,7 @@ export function extractPackageFile(
     // for empty an empty result
     is.nullOrUndefined(featureModel) ||
     // Compendium R8 159.9: resource versioning
-    !isSupportedFeatureResourceVersion(featureModel, fileName)
+    !isSupportedFeatureResourceVersion(featureModel, packageFile)
   ) {
     return null;
   }
@@ -55,7 +55,7 @@ export function extractPackageFile(
   // section 159.7.3 yet. As of 05-12-2022, there is no implementation that
   // supports this
   for (const [section, value] of Object.entries(featureModel)) {
-    logger.trace({ fileName, section }, 'Parsing section');
+    logger.trace({ fileName: packageFile, section }, 'Parsing section');
     const customSectionEntries = extractArtifactList(section, value);
     allBundles.push(...customSectionEntries);
   }

--- a/lib/modules/manager/pep621/extract.ts
+++ b/lib/modules/manager/pep621/extract.ts
@@ -11,10 +11,10 @@ import { parseDependencyGroupRecord, parseDependencyList } from './utils';
 
 export function extractPackageFile(
   content: string,
-  fileName: string,
-  config?: ExtractConfig
+  packageFile: string,
+  _config?: ExtractConfig
 ): PackageFileContent | null {
-  logger.trace({ fileName }, 'pep621.extractPackageFile');
+  logger.trace(`pep621.extractPackageFile(${packageFile})`);
 
   const deps: PackageDependency[] = [];
 
@@ -23,8 +23,8 @@ export function extractPackageFile(
     const jsonMap = toml.parse(content);
     def = PyProjectSchema.parse(jsonMap);
   } catch (err) {
-    logger.warn(
-      { fileName, err },
+    logger.debug(
+      {  packageFile, err },
       `Failed to parse and validate pyproject file`
     );
     return null;

--- a/lib/modules/manager/pep621/extract.ts
+++ b/lib/modules/manager/pep621/extract.ts
@@ -24,7 +24,7 @@ export function extractPackageFile(
     def = PyProjectSchema.parse(jsonMap);
   } catch (err) {
     logger.debug(
-      {  packageFile, err },
+      { packageFile, err },
       `Failed to parse and validate pyproject file`
     );
     return null;

--- a/lib/modules/manager/pipenv/extract.ts
+++ b/lib/modules/manager/pipenv/extract.ts
@@ -103,16 +103,16 @@ function extractFromSection(
 
 export async function extractPackageFile(
   content: string,
-  fileName: string
+  packageFile: string
 ): Promise<PackageFileContent | null> {
-  logger.debug('pipenv.extractPackageFile()');
+  logger.trace(`pipenv.extractPackageFile(${packageFile})`);
 
   let pipfile: PipFile;
   try {
     // TODO: fix type (#9610)
     pipfile = toml.parse(content) as any;
   } catch (err) {
-    logger.debug({ err }, 'Error parsing Pipfile');
+    logger.debug({ err, packageFile }, 'Error parsing Pipfile');
     return null;
   }
   const res: PackageFileContent = { deps: [] };
@@ -142,7 +142,7 @@ export async function extractPackageFile(
     constraints.pipenv = pipfile['dev-packages']!.pipenv;
   }
 
-  const lockFileName = fileName + '.lock';
+  const lockFileName = packageFile + '.lock';
   if (await localPathExists(lockFileName)) {
     res.lockFiles = [lockFileName];
   }

--- a/lib/modules/manager/pipenv/extract.ts
+++ b/lib/modules/manager/pipenv/extract.ts
@@ -142,7 +142,7 @@ export async function extractPackageFile(
     constraints.pipenv = pipfile['dev-packages']!.pipenv;
   }
 
-  const lockFileName = packageFile + '.lock';
+  const lockFileName = `${packageFile}.lock`;
   if (await localPathExists(lockFileName)) {
     res.lockFiles = [lockFileName];
   }

--- a/lib/modules/manager/poetry/extract.ts
+++ b/lib/modules/manager/poetry/extract.ts
@@ -146,23 +146,23 @@ function extractRegistries(pyprojectfile: PoetryFile): string[] | undefined {
 
 export async function extractPackageFile(
   content: string,
-  fileName: string
+  packageFile: string
 ): Promise<PackageFileContent | null> {
-  logger.trace(`poetry.extractPackageFile(${fileName})`);
+  logger.trace(`poetry.extractPackageFile(${packageFile})`);
   let pyprojectfile: PoetryFile;
   try {
     pyprojectfile = parse(content);
   } catch (err) {
-    logger.debug({ err }, 'Error parsing pyproject.toml file');
+    logger.debug({ err, packageFile }, 'Error parsing pyproject.toml file');
     return null;
   }
   if (!pyprojectfile.tool?.poetry) {
-    logger.debug(`${fileName} contains no poetry section`);
+    logger.debug({ packageFile }, `contains no poetry section`);
     return null;
   }
 
   // handle the lockfile
-  const lockfileName = getSiblingFileName(fileName, 'poetry.lock');
+  const lockfileName = getSiblingFileName(packageFile, 'poetry.lock');
   // TODO #7154
   const lockContents = (await readLocalFile(lockfileName, 'utf8'))!;
 
@@ -202,13 +202,13 @@ export async function extractPackageFile(
     extractedConstraints,
   };
   // Try poetry.lock first
-  let lockFile = getSiblingFileName(fileName, 'poetry.lock');
+  let lockFile = getSiblingFileName(packageFile, 'poetry.lock');
   // istanbul ignore next
   if (await localPathExists(lockFile)) {
     res.lockFiles = [lockFile];
   } else {
     // Try pyproject.lock next
-    lockFile = getSiblingFileName(fileName, 'pyproject.lock');
+    lockFile = getSiblingFileName(packageFile, 'pyproject.lock');
     if (await localPathExists(lockFile)) {
       res.lockFiles = [lockFile];
     }

--- a/lib/modules/manager/pre-commit/extract.ts
+++ b/lib/modules/manager/pre-commit/extract.ts
@@ -146,26 +146,29 @@ function findDependencies(precommitFile: PreCommitConfig): PackageDependency[] {
 
 export function extractPackageFile(
   content: string,
-  filename: string
+  packageFile: string
 ): PackageFileContent | null {
   type ParsedContent = Record<string, unknown> | PreCommitConfig;
   let parsedContent: ParsedContent;
   try {
     parsedContent = load(content, { json: true }) as ParsedContent;
   } catch (err) {
-    logger.debug({ filename, err }, 'Failed to parse pre-commit config YAML');
+    logger.debug(
+      { filename: packageFile, err },
+      'Failed to parse pre-commit config YAML'
+    );
     return null;
   }
   if (!is.plainObject<Record<string, unknown>>(parsedContent)) {
-    logger.warn(
-      { filename },
+    logger.debug(
+      { packageFile },
       `Parsing of pre-commit config YAML returned invalid result`
     );
     return null;
   }
   if (!matchesPrecommitConfigHeuristic(parsedContent)) {
     logger.debug(
-      { filename },
+      { packageFile },
       `File does not look like a pre-commit config file`
     );
     return null;
@@ -177,7 +180,10 @@ export function extractPackageFile(
       return { deps };
     }
   } catch (err) /* istanbul ignore next */ {
-    logger.warn({ filename, err }, 'Error scanning parsed pre-commit config');
+    logger.debug(
+      { packageFile, err },
+      'Error scanning parsed pre-commit config'
+    );
   }
   return null;
 }

--- a/lib/modules/manager/pub/extract.ts
+++ b/lib/modules/manager/pub/extract.ts
@@ -57,8 +57,8 @@ export function extractPackageFile(
         deps,
       };
     }
-  } catch (e) {
-    logger.debug(`Could not parse dependency from ${packageFile}`);
+  } catch (err) {
+    logger.debug({ packageFile, err }, `Could not parse YAML`);
   }
   return null;
 }

--- a/lib/modules/manager/puppet/extract.ts
+++ b/lib/modules/manager/puppet/extract.ts
@@ -44,7 +44,7 @@ function parseGitDependency(module: PuppetfileModule): PackageDependency {
   const githubUrl = isGithubUrl(git, parsedUrl);
 
   if (githubUrl && parsedUrl && parsedUrl.protocol !== 'https:') {
-    logger.warn(
+    logger.debug(
       `Access to github is only allowed for https, your url was: ${git}`
     );
     return {

--- a/lib/modules/manager/sbt/extract.ts
+++ b/lib/modules/manager/sbt/extract.ts
@@ -328,7 +328,7 @@ export function extractPackageFile(
       registryUrls: [REGISTRY_URLS.mavenCentral],
     });
   } catch (err) /* istanbul ignore next */ {
-    logger.warn({ err, packageFile }, 'Sbt parsing error');
+    logger.debug({ err, packageFile }, 'Sbt parsing error');
   }
 
   if (!parsedResult) {

--- a/lib/modules/manager/tekton/extract.ts
+++ b/lib/modules/manager/tekton/extract.ts
@@ -13,16 +13,16 @@ import type {
 
 export function extractPackageFile(
   content: string,
-  fileName: string
+  packageFile: string
 ): PackageFileContent | null {
-  logger.trace('tekton.extractPackageFile()');
+  logger.trace(`tekton.extractPackageFile(${packageFile})`);
   const deps: PackageDependency[] = [];
   let docs: TektonResource[];
   try {
     docs = loadAll(content) as TektonResource[];
   } catch (err) {
     logger.debug(
-      { err, fileName },
+      { err, packageFile },
       'Failed to parse YAML resource as a Tekton resource'
     );
     return null;

--- a/lib/modules/manager/terraform/extract.ts
+++ b/lib/modules/manager/terraform/extract.ts
@@ -10,10 +10,10 @@ import {
 
 export async function extractPackageFile(
   content: string,
-  fileName: string,
+  packageFile: string,
   config: ExtractConfig
 ): Promise<PackageFileContent | null> {
-  logger.trace({ content }, 'terraform.extractPackageFile()');
+  logger.trace({ content }, `terraform.extractPackageFile(${packageFile})`);
 
   const passedExtractors = [];
   for (const extractor of resourceExtractors) {
@@ -23,27 +23,27 @@ export async function extractPackageFile(
   }
 
   if (!passedExtractors.length) {
-    logger.trace(
-      { fileName },
+    logger.debug(
+      { packageFile },
       'preflight content check has not found any relevant content'
     );
     return null;
   }
   logger.trace(
-    { fileName },
+    { packageFile },
     `preflight content check passed for extractors: [${passedExtractors
       .map((value) => value.constructor.name)
       .toString()}]`
   );
 
   const dependencies = [];
-  const hclMap = await hcl.parseHCL(content, fileName);
+  const hclMap = await hcl.parseHCL(content, packageFile);
   if (is.nullOrUndefined(hclMap)) {
-    logger.trace({ fileName }, 'failed to parse HCL file');
+    logger.debug({ packageFile }, 'failed to parse HCL file');
     return null;
   }
 
-  const locks = await extractLocksForPackageFile(fileName);
+  const locks = await extractLocksForPackageFile(packageFile);
 
   for (const extractor of passedExtractors) {
     const deps = extractor.extract(hclMap, locks, config);

--- a/lib/modules/manager/terragrunt/extract.ts
+++ b/lib/modules/manager/terragrunt/extract.ts
@@ -11,8 +11,11 @@ import {
 const dependencyBlockExtractionRegex = regEx(/^\s*(?<type>[a-z_]+)\s+{\s*$/);
 const contentCheckList = ['terraform {'];
 
-export function extractPackageFile(content: string): PackageFileContent | null {
-  logger.trace({ content }, 'terragrunt.extractPackageFile()');
+export function extractPackageFile(
+  content: string,
+  packageFile?: string
+): PackageFileContent | null {
+  logger.trace({ content }, `terragrunt.extractPackageFile(${packageFile!})`);
   if (!checkFileContainsDependency(content, contentCheckList)) {
     return null;
   }
@@ -50,7 +53,7 @@ export function extractPackageFile(content: string): PackageFileContent | null {
       }
     }
   } catch (err) /* istanbul ignore next */ {
-    logger.warn({ err }, 'Error extracting terragrunt plugins');
+    logger.debug({ err, packageFile }, 'Error extracting terragrunt plugins');
   }
   deps.forEach((dep) => {
     // TODO #7154

--- a/lib/modules/manager/tflint-plugin/extract.ts
+++ b/lib/modules/manager/tflint-plugin/extract.ts
@@ -15,13 +15,13 @@ const dependencyBlockExtractionRegex = regEx(
 
 export function extractPackageFile(
   content: string,
-  fileName: string,
-  config: ExtractConfig
+  packageFile: string,
+  _config: ExtractConfig
 ): PackageFileContent | null {
-  logger.trace({ content }, 'tflint.extractPackageFile()');
+  logger.trace({ content }, `tflint.extractPackageFile(${packageFile})`);
   if (!checkFileContainsPlugins(content)) {
-    logger.trace(
-      { fileName },
+    logger.debug(
+      { packageFile },
       'preflight content check has not found any relevant content'
     );
     return null;
@@ -51,7 +51,7 @@ export function extractPackageFile(
       }
     }
   } catch (err) /* istanbul ignore next */ {
-    logger.warn({ err }, 'Error extracting TFLint plugins');
+    logger.debug({ err, packageFile }, 'Error extracting TFLint plugins');
   }
 
   return deps.length ? { deps } : null;

--- a/lib/modules/manager/travis/extract.ts
+++ b/lib/modules/manager/travis/extract.ts
@@ -5,14 +5,17 @@ import { GithubTagsDatasource } from '../../datasource/github-tags';
 import type { PackageDependency, PackageFileContent } from '../types';
 import type { TravisMatrixItem, TravisYaml } from './types';
 
-export function extractPackageFile(content: string): PackageFileContent | null {
+export function extractPackageFile(
+  content: string,
+  packageFile?: string
+): PackageFileContent | null {
   let doc: TravisYaml;
   try {
     doc = load(content, {
       json: true,
     }) as TravisYaml;
   } catch (err) {
-    logger.warn({ err, content }, 'Failed to parse .travis.yml file.');
+    logger.debug({ err, packageFile }, 'Failed to parse .travis.yml file.');
     return null;
   }
   let deps: PackageDependency[] = [];

--- a/lib/modules/manager/velaci/extract.ts
+++ b/lib/modules/manager/velaci/extract.ts
@@ -5,13 +5,16 @@ import { getDep } from '../dockerfile/extract';
 import type { PackageDependency, PackageFileContent } from '../types';
 import type { VelaPipelineConfiguration } from './types';
 
-export function extractPackageFile(file: string): PackageFileContent | null {
+export function extractPackageFile(
+  file: string,
+  packageFile?: string
+): PackageFileContent | null {
   let doc: VelaPipelineConfiguration | undefined;
 
   try {
     doc = load(file, { json: true }) as VelaPipelineConfiguration;
   } catch (err) {
-    logger.debug({ err, file }, 'Failed to parse Vela file.');
+    logger.debug({ err, packageFile }, 'Failed to parse Vela file.');
     return null;
   }
 

--- a/lib/modules/manager/woodpecker/extract.ts
+++ b/lib/modules/manager/woodpecker/extract.ts
@@ -7,7 +7,7 @@ import type { WoodpeckerConfig } from './types';
 
 export function extractPackageFile(
   content: string,
-  fileName: string,
+  packageFile: string,
   extractConfig: ExtractConfig
 ): PackageFileContent | null {
   logger.debug('woodpecker.extractPackageFile()');
@@ -17,21 +17,21 @@ export function extractPackageFile(
     config = load(content, { json: true }) as WoodpeckerConfig;
     if (!config) {
       logger.debug(
-        { fileName },
+        { packageFile },
         'Null config when parsing Woodpecker Configuration content'
       );
       return null;
     }
     if (typeof config !== 'object') {
       logger.debug(
-        { fileName, type: typeof config },
+        { packageFile, type: typeof config },
         'Unexpected type for Woodpecker Configuration content'
       );
       return null;
     }
   } catch (err) {
     logger.debug(
-      { fileName, err },
+      { packageFile, err },
       'Error parsing Woodpecker Configuration config YAML'
     );
     return null;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Unify parser error logging for allmost all managers.
- log `packageFile` on errors
- rename `fileName` to `packageFile`
- reduce warning to debug (was inconsistent before), maybe we should change all to warn, so users are more aware of parsing issues?
<!-- Describe what behavior is changed by this PR. -->

## Context
- closes #19696
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
