### PR TITLE
feat(schema-utils): Support `LooseRecord` key validation

### DIFF
--- a/lib/util/schema-utils.spec.ts
+++ b/lib/util/schema-utils.spec.ts
@@ -71,42 +71,18 @@ describe('util/schema-utils', () => {
 
       s.parse({ foo: 'foo', bar: 'bar' });
 
-      expect(errorData).toMatchInlineSnapshot(
-        {
-          error: {
-            issues: [
-              {
-                code: 'custom',
-                message: 'Invalid input',
-                path: ['foo'],
-              },
-            ],
-          },
-          input: { bar: 'bar', foo: 'foo' },
+      expect(errorData).toMatchObject({
+        error: {
+          issues: [
+            {
+              code: 'custom',
+              message: 'Invalid input',
+              path: ['foo'],
+            },
+          ],
         },
-        `
-        {
-          "error": {
-            "addIssue": [Function],
-            "addIssues": [Function],
-            "issues": [
-              {
-                "code": "custom",
-                "message": "Invalid input",
-                "path": [
-                  "foo",
-                ],
-              },
-            ],
-            "name": "ZodError",
-          },
-          "input": {
-            "bar": "bar",
-            "foo": "foo",
-          },
-        }
-      `
-      );
+        input: { bar: 'bar', foo: 'foo' },
+      });
     });
 
     it('runs callback for wrong elements', () => {

--- a/lib/util/schema-utils.spec.ts
+++ b/lib/util/schema-utils.spec.ts
@@ -49,6 +49,66 @@ describe('util/schema-utils', () => {
       expect(s.parse({ foo: 'foo', bar: 123 })).toEqual({ foo: 'foo' });
     });
 
+    it('supports key schema', () => {
+      const s = LooseRecord(
+        z.string().refine((x) => x === 'bar'),
+        z.string()
+      );
+      expect(s.parse({ foo: 'foo', bar: 'bar' })).toEqual({ bar: 'bar' });
+    });
+
+    it('reports key schema errors', () => {
+      let errorData: unknown = null;
+      const s = LooseRecord(
+        z.string().refine((x) => x === 'bar'),
+        z.string(),
+        {
+          onError: (x) => {
+            errorData = x;
+          },
+        }
+      );
+
+      s.parse({ foo: 'foo', bar: 'bar' });
+
+      expect(errorData).toMatchInlineSnapshot(
+        {
+          error: {
+            issues: [
+              {
+                code: 'custom',
+                message: 'Invalid input',
+                path: ['foo'],
+              },
+            ],
+          },
+          input: { bar: 'bar', foo: 'foo' },
+        },
+        `
+        {
+          "error": {
+            "addIssue": [Function],
+            "addIssues": [Function],
+            "issues": [
+              {
+                "code": "custom",
+                "message": "Invalid input",
+                "path": [
+                  "foo",
+                ],
+              },
+            ],
+            "name": "ZodError",
+          },
+          "input": {
+            "bar": "bar",
+            "foo": "foo",
+          },
+        }
+      `
+      );
+    });
+
     it('runs callback for wrong elements', () => {
       let err: z.ZodError | undefined = undefined;
       const Schema = LooseRecord(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Make `LooseRecord` support optional `Key` schema

## Context

Useful for:
- Ref: #22281
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
