### PR TITLE
fix(datasource/cpan): add `module.authorized` condition for querying releases

### DIFF
--- a/lib/modules/datasource/cpan/index.ts
+++ b/lib/modules/datasource/cpan/index.ts
@@ -43,6 +43,7 @@ export class CpanDatasource extends Datasource {
             filter: {
               and: [
                 { term: { 'module.name': packageName } },
+                { term: { 'module.authorized': true } },
                 { exists: { field: 'module.associated_pod' } },
               ],
             },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

- Add `term: { 'module.authorized': true }` filter for `v1/file/_search` query

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

refs:
- https://github.com/metacpan/metacpan-api/blob/97b4791bf274bfb4e25f3a122e7115a2e9315404/docs/indexing.md?plain=1#L19-L28
- https://metacpan.org/pod/PAUSE::Permissions

Without the condition, some unrelated distributions might be hit.

<img width="917" alt="image" src="https://github.com/renovatebot/renovate/assets/909674/f992398e-eb03-4324-bc2d-7f279dc0b6b8">

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
