### PR TITLE
feat(presets): timed presets give Renovate 4 hours to create branches

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -1695,7 +1695,7 @@ If you wish to enable this feature then you could add this to your configuration
 }
 ```
 
-To reduce "noise" in the repository, it defaults its schedule to `"before 5am on monday"`, i.e. to achieve once-per-week semantics.
+To reduce "noise" in the repository, it defaults its schedule to `"before 4am on monday"`, i.e. to achieve once-per-week semantics.
 Depending on its running schedule, Renovate may run a few times within that time window - even possibly updating the lock file more than once - but it hopefully leaves enough time for tests to run and automerge to apply, if configured.
 
 ## major

--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -154,7 +154,7 @@ Set configuration option `rangeStrategy` to `"replace"`.
 
 ### Keep lock files (including sub-dependencies) up-to-date, even when `package.json` hasn't changed
 
-By default, if you enable lock-file maintenance, Renovate will update the lockfile `["before 5am on monday"]`.
+By default, if you enable lock-file maintenance, Renovate will update the lockfile `["before 4am on monday"]`.
 If you want to update the lock file more often, set the `schedule` field inside the `lockFileMaintenance` object.
 
 ### Wait until tests have passed before creating the PR

--- a/docs/usage/key-concepts/scheduling.md
+++ b/docs/usage/key-concepts/scheduling.md
@@ -93,11 +93,11 @@ If you use the GitHub hosted app, the default is that Renovate will always be al
 Be sure to schedule enough time for Renovate to process your repository.
 Do not set schedules like "Run Renovate for an hour each Sunday" as you _will_ run into problems.
 
-Say you want Renovate bot to run each day before 2 am:
+Say you want Renovate to run each day before 4 am:
 
 ```json
 {
-  "schedule": ["before 2am"]
+  "schedule": ["before 4am"]
 }
 ```
 

--- a/docs/usage/noise-reduction.md
+++ b/docs/usage/noise-reduction.md
@@ -107,7 +107,7 @@ Or perhaps at least weekly:
     {
       "matchPackagePatterns": ["eslint"],
       "groupName": "eslint",
-      "schedule": ["before 2am on monday"]
+      "schedule": ["before 4am on monday"]
     }
   ]
 }
@@ -167,7 +167,7 @@ Let's automerge it if all the linting updates pass:
     {
       "matchPackagePatterns": ["eslint"],
       "groupName": "eslint",
-      "schedule": ["before 2am on monday"],
+      "schedule": ["before 4am on monday"],
       "automerge": true,
       "automergeType": "branch"
     }

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -1905,7 +1905,7 @@ const options: RenovateOptions[] = [
       commitMessageAction: 'Lock file maintenance',
       commitMessageTopic: null,
       commitMessageExtra: null,
-      schedule: ['before 5am on monday'],
+      schedule: ['before 4am on monday'],
       groupName: null,
       prBodyDefinitions: {
         Change: 'All locks refreshed',

--- a/lib/config/presets/internal/schedule.ts
+++ b/lib/config/presets/internal/schedule.ts
@@ -3,8 +3,8 @@ import type { Preset } from '../types';
 /* eslint sort-keys: ["error", "asc", {caseSensitive: false, natural: true}] */
 
 const daily = ['before 2am'];
-const earlyMondays = ['before 3am on Monday'];
-const monthly = ['before 3am on the first day of the month'];
+const earlyMondays = ['before 5am on Monday'];
+const monthly = ['before 5am on the first day of the month'];
 const nonOfficeHours = [
   'after 10pm every weekday',
   'before 5am every weekday',

--- a/lib/config/presets/internal/schedule.ts
+++ b/lib/config/presets/internal/schedule.ts
@@ -2,9 +2,9 @@ import type { Preset } from '../types';
 
 /* eslint sort-keys: ["error", "asc", {caseSensitive: false, natural: true}] */
 
-const daily = ['before 2am'];
-const earlyMondays = ['before 5am on Monday'];
-const monthly = ['before 5am on the first day of the month'];
+const daily = ['before 4am'];
+const earlyMondays = ['before 4am on Monday'];
+const monthly = ['before 4am on the first day of the month'];
 const nonOfficeHours = [
   'after 10pm every weekday',
   'before 5am every weekday',

--- a/lib/workers/repository/update/branch/schedule.spec.ts
+++ b/lib/workers/repository/update/branch/schedule.spec.ts
@@ -115,7 +115,7 @@ describe('workers/repository/update/branch/schedule', () => {
     it('massages schedules', () => {
       expect(
         schedule.hasValidSchedule([
-          'before 3am on the first day of the month',
+          'before 5am on the first day of the month',
         ])[0]
       ).toBeTrue();
       expect(schedule.hasValidSchedule(['every month'])[0]).toBeTrue();
@@ -268,8 +268,8 @@ describe('workers/repository/update/branch/schedule', () => {
         sched                     | tz                  | datetime                          | expected
         ${'after 4pm'}            | ${'Asia/Singapore'} | ${'2017-06-30T15:59:00.000+0800'} | ${false}
         ${'after 4pm'}            | ${'Asia/Singapore'} | ${'2017-06-30T16:01:00.000+0800'} | ${true}
-        ${'before 3am on Monday'} | ${'Asia/Tokyo'}     | ${'2017-06-26T02:59:00.000+0900'} | ${true}
-        ${'before 3am on Monday'} | ${'Asia/Tokyo'}     | ${'2017-06-26T03:01:00.000+0900'} | ${false}
+        ${'before 5am on Monday'} | ${'Asia/Tokyo'}     | ${'2017-06-26T04:59:00.000+0900'} | ${true}
+        ${'before 5am on Monday'} | ${'Asia/Tokyo'}     | ${'2017-06-26T05:01:00.000+0900'} | ${false}
       `('$sched, $tz, $datetime', ({ sched, tz, datetime, expected }) => {
         config.schedule = [sched];
         config.timezone = tz;

--- a/lib/workers/repository/update/branch/schedule.spec.ts
+++ b/lib/workers/repository/update/branch/schedule.spec.ts
@@ -268,8 +268,8 @@ describe('workers/repository/update/branch/schedule', () => {
         sched                     | tz                  | datetime                          | expected
         ${'after 4pm'}            | ${'Asia/Singapore'} | ${'2017-06-30T15:59:00.000+0800'} | ${false}
         ${'after 4pm'}            | ${'Asia/Singapore'} | ${'2017-06-30T16:01:00.000+0800'} | ${true}
-        ${'before 5am on Monday'} | ${'Asia/Tokyo'}     | ${'2017-06-26T04:59:00.000+0900'} | ${true}
-        ${'before 5am on Monday'} | ${'Asia/Tokyo'}     | ${'2017-06-26T05:01:00.000+0900'} | ${false}
+        ${'before 4am on Monday'} | ${'Asia/Tokyo'}     | ${'2017-06-26T03:59:00.000+0900'} | ${true}
+        ${'before 4am on Monday'} | ${'Asia/Tokyo'}     | ${'2017-06-26T04:01:00.000+0900'} | ${false}
       `('$sched, $tz, $datetime', ({ sched, tz, datetime, expected }) => {
         config.schedule = [sched];
         config.timezone = tz;

--- a/lib/workers/repository/update/branch/schedule.ts
+++ b/lib/workers/repository/update/branch/schedule.ts
@@ -9,8 +9,8 @@ import { logger } from '../../../../logger';
 const minutesChar = '*';
 
 const scheduleMappings: Record<string, string> = {
-  'every month': 'before 3am on the first day of the month',
-  monthly: 'before 3am on the first day of the month',
+  'every month': 'before 5am on the first day of the month',
+  monthly: 'before 5am on the first day of the month',
 };
 
 export function hasValidTimezone(timezone: string): [true] | [false, string] {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Presets that have a "time window" now have 4 hours to create branches

## Context

This change was suggested by @rarkins in this comment:

- https://github.com/renovatebot/renovate/discussions/22335#discussioncomment-5966868

We have presets that rely on (extend) the `schedule:earlyMondays` or `schedule:monthly` presets. Do you want me to label this a breaking change, and target our `v36` branch, so we merge it as a breaking change?

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
