### PR TITLE
chore: add i am a maintainer checkbox to issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -15,8 +15,8 @@ body:
         We only accept issues from Renovate maintainers. If you are not a maintainer, please create a Discussion instead.
       options:
         - label: I am a maintainer
-      validations:
-        required: true
+    validations:
+      required: true
 
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,6 +7,17 @@ body:
     attributes:
       value: '# This form is for Renovate maintainers only.'
 
+  - type: checkboxes
+    id: are-you-a-maintainer
+    attributes:
+      label: Are you a maintainer?
+      description: |
+        We only accept issues from Renovate maintainers. If you are not a maintainer, please create a Discussion instead.
+      options:
+        - label: I am a maintainer
+    validations:
+      required: true
+
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -15,8 +15,8 @@ body:
         We only accept issues from Renovate maintainers. If you are not a maintainer, please create a Discussion instead.
       options:
         - label: I am a maintainer
-    validations:
-      required: true
+      validations:
+        required: true
 
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -12,6 +12,17 @@ body:
     attributes:
       value: '# This form is for Renovate maintainers only.'
 
+  - type: checkboxes
+    id: are-you-a-maintainer
+    attributes:
+      label: Are you a maintainer?
+      description: |
+        We only accept issues from Renovate maintainers. If you are not a maintainer, please create a Discussion instead.
+      options:
+        - label: I am a maintainer
+    validations:
+      required: true
+
   - type: textarea
     id: what-would-you-like-renovate-to-be-able-to-do
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -20,8 +20,8 @@ body:
         We only accept issues from Renovate maintainers. If you are not a maintainer, please create a Discussion instead.
       options:
         - label: I am a maintainer
-      validations:
-        required: true
+    validations:
+      required: true
 
   - type: textarea
     id: what-would-you-like-renovate-to-be-able-to-do

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -20,8 +20,8 @@ body:
         We only accept issues from Renovate maintainers. If you are not a maintainer, please create a Discussion instead.
       options:
         - label: I am a maintainer
-    validations:
-      required: true
+      validations:
+        required: true
 
   - type: textarea
     id: what-would-you-like-renovate-to-be-able-to-do

--- a/.github/ISSUE_TEMPLATE/refactor.yml
+++ b/.github/ISSUE_TEMPLATE/refactor.yml
@@ -20,8 +20,8 @@ body:
         We only accept issues from Renovate maintainers. If you are not a maintainer, please create a Discussion instead.
       options:
         - label: I am a maintainer
-    validations:
-      required: true
+      validations:
+        required: true
 
   - type: textarea
     id: describe-proposed-changes

--- a/.github/ISSUE_TEMPLATE/refactor.yml
+++ b/.github/ISSUE_TEMPLATE/refactor.yml
@@ -12,6 +12,17 @@ body:
     attributes:
       value: '# This form is for Renovate maintainers only.'
 
+  - type: checkboxes
+    id: are-you-a-maintainer
+    attributes:
+      label: Are you a maintainer?
+      description: |
+        We only accept issues from Renovate maintainers. If you are not a maintainer, please create a Discussion instead.
+      options:
+        - label: I am a maintainer
+    validations:
+      required: true
+
   - type: textarea
     id: describe-proposed-changes
     attributes:

--- a/.github/ISSUE_TEMPLATE/refactor.yml
+++ b/.github/ISSUE_TEMPLATE/refactor.yml
@@ -20,8 +20,8 @@ body:
         We only accept issues from Renovate maintainers. If you are not a maintainer, please create a Discussion instead.
       options:
         - label: I am a maintainer
-      validations:
-        required: true
+    validations:
+      required: true
 
   - type: textarea
     id: describe-proposed-changes


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Add a "I am a maintainer" checkbox to our issue forms

## Context

I'm not sure if the checkbox is properly marked as mandatory, when I preview the forms on my branch I don't see the `*` that denotes it's mandatory...

I'm opening this PR because a user suggested adding a checkbox to the form here:

- https://github.com/renovatebot/renovate/discussions/22458#discussioncomment-6020368

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
