### PR TITLE
fix(manager/gradle): normalize version aliases in version catalogs

### DIFF
--- a/lib/modules/manager/gradle/__fixtures__/1/libs.versions.toml
+++ b/lib/modules/manager/gradle/__fixtures__/1/libs.versions.toml
@@ -17,5 +17,6 @@ kotest = [ "kotest-runner-junit5", "kotest-assertions-core-jvm" ]
 
 [plugins]
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
-publish-on-central = { id = "org.danilopianini.publish-on-central", version.ref = "publish.on.central" }
+publish-on-central = { id = "org.danilopianini.publish-on-central", version.ref = "publish_on.central" }
 grgit = { id = "org.ajoberstar.grgit", version.unknown = "this will fail" }
+grgit2 = { id = "org.ajoberstar.grgit2", version.ref = "unknown-ref" }

--- a/lib/modules/manager/gradle/__fixtures__/2/libs.versions.toml
+++ b/lib/modules/manager/gradle/__fixtures__/2/libs.versions.toml
@@ -1,12 +1,12 @@
 [versions]
 kotlin = "1.5.21"
-retrofit = "2.8.2"
+retro_fit = "2.8.2"
 
 [libraries]
 okHttp = "com.squareup.okhttp3:okhttp:4.9.0"
 okio = { module = "com.squareup.okio:okio", version = "2.8.0" }
 picasso = { group = "com.squareup.picasso", name = "picasso", version = "2.5.1" }
-retrofit2-retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
+retrofit2-retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retro_fit" }
 google-firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
 google-firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics" }
 google-firebase-messaging = "com.google.firebase:firebase-messaging"

--- a/lib/modules/manager/gradle/extract.spec.ts
+++ b/lib/modules/manager/gradle/extract.spec.ts
@@ -606,6 +606,11 @@ describe('modules/manager/gradle/extract', () => {
               registryUrls: ['https://plugins.gradle.org/m2/'],
               skipReason: 'unspecified-version',
             },
+            {
+              depName: 'org.ajoberstar.grgit2',
+              depType: 'plugin',
+              skipReason: 'unspecified-version',
+            },
           ],
         },
       ]);
@@ -631,7 +636,7 @@ describe('modules/manager/gradle/extract', () => {
               groupName: 'com.squareup.okhttp3',
               currentValue: '4.9.0',
               managerData: {
-                fileReplacePosition: 99,
+                fileReplacePosition: 100,
                 packageFile: 'gradle/libs.versions.toml',
               },
             },
@@ -640,7 +645,7 @@ describe('modules/manager/gradle/extract', () => {
               groupName: 'com.squareup.okio',
               currentValue: '2.8.0',
               managerData: {
-                fileReplacePosition: 161,
+                fileReplacePosition: 162,
                 packageFile: 'gradle/libs.versions.toml',
               },
             },
@@ -649,16 +654,16 @@ describe('modules/manager/gradle/extract', () => {
               groupName: 'com.squareup.picasso',
               currentValue: '2.5.1',
               managerData: {
-                fileReplacePosition: 243,
+                fileReplacePosition: 244,
                 packageFile: 'gradle/libs.versions.toml',
               },
             },
             {
               depName: 'com.squareup.retrofit2:retrofit',
-              groupName: 'retrofit',
+              groupName: 'retro.fit',
               currentValue: '2.8.2',
               managerData: {
-                fileReplacePosition: 41,
+                fileReplacePosition: 42,
                 packageFile: 'gradle/libs.versions.toml',
               },
             },
@@ -691,7 +696,7 @@ describe('modules/manager/gradle/extract', () => {
               packageName:
                 'org.jetbrains.kotlin.jvm:org.jetbrains.kotlin.jvm.gradle.plugin',
               managerData: {
-                fileReplacePosition: 661,
+                fileReplacePosition: 663,
                 packageFile: 'gradle/libs.versions.toml',
               },
               registryUrls: ['https://plugins.gradle.org/m2/'],
@@ -716,7 +721,7 @@ describe('modules/manager/gradle/extract', () => {
               packageName:
                 'org.danilopianini.multi-jvm-test-plugin:org.danilopianini.multi-jvm-test-plugin.gradle.plugin',
               managerData: {
-                fileReplacePosition: 822,
+                fileReplacePosition: 824,
                 packageFile: 'gradle/libs.versions.toml',
               },
               registryUrls: ['https://plugins.gradle.org/m2/'],
@@ -818,7 +823,7 @@ describe('modules/manager/gradle/extract', () => {
             },
             {
               depName: 'mocha-junit:mocha-junit',
-              groupName: 'mocha-junit-reporter',
+              groupName: 'mocha.junit.reporter',
               currentValue: '2.0.2',
               managerData: {
                 fileReplacePosition: 82,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Fixes a regression introduced with #21820 by ensuring that all lookups of version refs (aliases) are performed on their normalized alias representations.

<!-- Describe what behavior is changed by this PR. -->

The regression happened because `version.ref` expected version aliases to occur with `-`, instead of `.` or `_`. Since the corresponding version aliases themselves were not normalized, aliases with underscores could no longer be matched.

The normalization scheme is aligned to the one used by Gradle. There was nothing wrong with replacing `_` by `-` but since gradle replaces them by `.` it seems reasonable to stay consistent with gradle here. 

## Context

- Closes https://github.com/renovatebot/renovate/discussions/22365

Some extra notes for occasional future reference:
- For inline version catalogs and catalogs in TOML files, Gradle normalizes aliases in version catalogs ([here](https://github.com/gradle/gradle/blob/master/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VersionCatalog.java))
- The corresponding [AliasNormalizer](https://github.com/gradle/gradle/blob/495c11fce5e43fb0e9c9552e647ec28e0b74013d/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/AliasNormalizer.java) was introduced with https://github.com/gradle/gradle/commit/a17338d65211a9235d27765fc9d4f13dff8f0534 and is used when building *or* accessing aliases in version catalogs (e.g. [here](https://github.com/gradle/gradle/blob/495c11fce5e43fb0e9c9552e647ec28e0b74013d/subprojects/dependency-management/src/main/java/org/gradle/api/internal/catalog/DefaultVersionCatalogBuilder.java#L287)).
- The [TomlCatalogFileParser](https://github.com/gradle/gradle/blob/495c11fce5e43fb0e9c9552e647ec28e0b74013d/subprojects/core/src/main/java/org/gradle/api/internal/catalog/parser/TomlCatalogFileParser.java) itself does no normalization.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

Test repo: https://github.com/renovate-demo/22365/pull/2

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
