### PR TITLE
chore: drop broken placeholders, drop duplicate description

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/ask-a-question.yml
+++ b/.github/DISCUSSION_TEMPLATE/ask-a-question.yml
@@ -22,7 +22,6 @@ body:
     attributes:
       label: If you're self-hosting Renovate, select which platform you are using.
       options:
-        - 'Placeholder value, please select the correct response from the dropdown'
         - 'AWS CodeCommit'
         - 'Azure DevOps (dev.azure.com)'
         - 'Azure DevOps Server'

--- a/.github/DISCUSSION_TEMPLATE/report-a-problem.yml
+++ b/.github/DISCUSSION_TEMPLATE/report-a-problem.yml
@@ -22,7 +22,6 @@ body:
     attributes:
       label: If you're self-hosting Renovate, select which platform you are using.
       options:
-        - 'Placeholder value, please select the correct response from the dropdown'
         - 'AWS CodeCommit'
         - 'Azure DevOps (dev.azure.com)'
         - 'Azure DevOps Server'

--- a/.github/ISSUE_TEMPLATE/administration-only.yml
+++ b/.github/ISSUE_TEMPLATE/administration-only.yml
@@ -25,7 +25,6 @@ body:
     id: describe-why-we-need-want-these-changes
     attributes:
       label: Describe why we need/want these change(s).
-      description: 'Do not report any security concerns here. Email renovate-disclosure@mend.io instead.'
     validations:
       required: true
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Drop placeholders that don't sort first (for whatever reason)
- Drop duplicate security email redirect (the issue form is for administrators, so we probably only need one reminder)

## Context

The `Placeholder value, please select the correct response from the dropdown` only seems to be picked first in some cases.

I think GitHub automatically adds a `None` option to the dropdowns when there are more than `X` number of dropdowns? Or maybe the `validations.required: true` or `false` affects this `None` behavior?

Follow-up after PR:

- #22469 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
