### PR TITLE
fix(manager/pep621): group pdm binary calls based on dependency groups

### DIFF
--- a/lib/modules/manager/pep621/extract.ts
+++ b/lib/modules/manager/pep621/extract.ts
@@ -7,6 +7,7 @@ import type {
 } from '../types';
 import { processors } from './processors';
 import {
+  depTypes,
   parseDependencyGroupRecord,
   parseDependencyList,
   parsePyProject,
@@ -32,11 +33,11 @@ export function extractPackageFile(
 
   // pyProject standard definitions
   deps.push(
-    ...parseDependencyList('project.dependencies', def.project?.dependencies)
+    ...parseDependencyList(depTypes.dependencies, def.project?.dependencies)
   );
   deps.push(
     ...parseDependencyGroupRecord(
-      'project.optional-dependencies',
+      depTypes.optionalDependencies,
       def.project?.['optional-dependencies']
     )
   );

--- a/lib/modules/manager/pep621/processors/pdm.spec.ts
+++ b/lib/modules/manager/pep621/processors/pdm.spec.ts
@@ -5,6 +5,7 @@ import { GlobalConfig } from '../../../../config/global';
 import type { RepoGlobalConfig } from '../../../../config/types';
 import { getPkgReleases as _getPkgReleases } from '../../../datasource';
 import type { UpdateArtifactsConfig } from '../../types';
+import { depTypes } from '../utils';
 import { PdmProcessor } from './pdm';
 
 jest.mock('../../../../util/fs');
@@ -130,7 +131,28 @@ describe('modules/manager/pep621/processors/pdm', () => {
         releases: [{ version: 'v2.6.1' }, { version: 'v2.5.0' }],
       });
 
-      const updatedDeps = [{ packageName: 'dep1' }, { packageName: 'dep2' }];
+      const updatedDeps = [
+        {
+          packageName: 'dep1',
+          depType: depTypes.dependencies,
+        },
+        { packageName: 'dep2', depType: depTypes.dependencies },
+        {
+          depName: 'group1/dep3',
+          depType: depTypes.optionalDependencies,
+        },
+        { depName: 'group1/dep4', depType: depTypes.optionalDependencies },
+        {
+          depName: 'group2/dep5',
+          depType: depTypes.pdmDevDependencies,
+        },
+        { depName: 'group2/dep6', depType: depTypes.pdmDevDependencies },
+        {
+          depName: 'group3/dep7',
+          depType: depTypes.pdmDevDependencies,
+        },
+        { depName: 'group3/dep8', depType: depTypes.pdmDevDependencies },
+      ];
       const result = await processor.updateArtifacts(
         {
           packageFileName: 'pyproject.toml',
@@ -152,6 +174,15 @@ describe('modules/manager/pep621/processors/pdm', () => {
       expect(execSnapshots).toMatchObject([
         {
           cmd: 'pdm update dep1 dep2',
+        },
+        {
+          cmd: 'pdm update -G group1 dep3 dep4',
+        },
+        {
+          cmd: 'pdm update -dG group2 dep5 dep6',
+        },
+        {
+          cmd: 'pdm update -dG group3 dep7 dep8',
         },
       ]);
     });

--- a/lib/modules/manager/pep621/processors/pdm.ts
+++ b/lib/modules/manager/pep621/processors/pdm.ts
@@ -9,9 +9,10 @@ import type {
   PackageDependency,
   UpdateArtifact,
   UpdateArtifactsResult,
+  Upgrade,
 } from '../../types';
 import type { PyProject } from '../schema';
-import { parseDependencyGroupRecord } from '../utils';
+import { depTypes, parseDependencyGroupRecord } from '../utils';
 import type { PyProjectProcessor } from './types';
 
 export class PdmProcessor implements PyProjectProcessor {
@@ -23,7 +24,7 @@ export class PdmProcessor implements PyProjectProcessor {
 
     deps.push(
       ...parseDependencyGroupRecord(
-        'tool.pdm.dev-dependencies',
+        depTypes.pdmDevDependencies,
         pdm['dev-dependencies']
       )
     );
@@ -84,13 +85,13 @@ export class PdmProcessor implements PyProjectProcessor {
 
       // on lockFileMaintenance do not specify any packages and update the complete lock file
       // else only update specific packages
-      let packageList = '';
-      if (!isLockFileMaintenance) {
-        packageList = ' ';
-        packageList += updatedDeps.map((value) => value.packageName).join(' ');
+      const cmds: string[] = [];
+      if (isLockFileMaintenance) {
+        cmds.push('pdm update');
+      } else {
+        cmds.push(...generateCMDs(updatedDeps));
       }
-      const cmd = `pdm update${packageList}`;
-      await exec(cmd, execOptions);
+      await exec(cmds, execOptions);
 
       // check for changes
       const fileChanges: UpdateArtifactsResult[] = [];
@@ -125,4 +126,45 @@ export class PdmProcessor implements PyProjectProcessor {
       ];
     }
   }
+}
+
+function generateCMDs(updatedDeps: Upgrade[]): string[] {
+  const cmds: string[] = [];
+  const packagesByCMD: Record<string, string[]> = {};
+  for (const dep of updatedDeps) {
+    switch (dep.depType) {
+      case depTypes.optionalDependencies: {
+        const [group, name] = dep.depName!.split('/');
+        addPackageToCMDRecord(packagesByCMD, `pdm update -G ${group}`, name);
+        break;
+      }
+      case depTypes.pdmDevDependencies: {
+        const [group, name] = dep.depName!.split('/');
+        addPackageToCMDRecord(packagesByCMD, `pdm update -dG ${group}`, name);
+        break;
+      }
+      default: {
+        addPackageToCMDRecord(packagesByCMD, `pdm update`, dep.packageName!);
+      }
+    }
+  }
+
+  for (const commandPrefix in packagesByCMD) {
+    const packageList = packagesByCMD[commandPrefix].join(' ');
+    const cmd = `${commandPrefix} ${packageList}`;
+    cmds.push(cmd);
+  }
+
+  return cmds;
+}
+
+function addPackageToCMDRecord(
+  packagesByCMD: Record<string, string[]>,
+  commandPrefix: string,
+  packageName: string
+): void {
+  if (is.nullOrUndefined(packagesByCMD[commandPrefix])) {
+    packagesByCMD[commandPrefix] = [];
+  }
+  packagesByCMD[commandPrefix].push(packageName);
 }

--- a/lib/modules/manager/pep621/utils.ts
+++ b/lib/modules/manager/pep621/utils.ts
@@ -11,6 +11,12 @@ const pep508Regex = regEx(
   /^(?<packageName>[A-Z0-9._-]+)\s*(\[(?<extras>[A-Z0-9,._-]+)\])?\s*(?<currentValue>[^;]+)?(;\s*(?<marker>.*))?/i
 );
 
+export const depTypes = {
+  dependencies: 'project.dependencies',
+  optionalDependencies: 'project.optional-dependencies',
+  pdmDevDependencies: 'tool.pdm.dev-dependencies',
+};
+
 export function parsePEP508(
   value: string | null | undefined
 ): Pep508ParseResult | null {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Adds separate PDM binary calls based on dependency section and group. 
<!-- Describe what behavior is changed by this PR. -->

## Context
https://github.com/renovatebot/renovate/discussions/22440
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository
https://github.com/secustor/renovate-reproduction-22440
<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
