### PR TITLE
perf(manager/pep621): do sync packages on pdm lockfile updates

### DIFF
--- a/lib/modules/manager/pep621/artifacts.spec.ts
+++ b/lib/modules/manager/pep621/artifacts.spec.ts
@@ -123,7 +123,7 @@ requires-python = "<3.9"
             '&& ' +
             'install-tool pdm v2.5.0 ' +
             '&& ' +
-            'pdm update dep1' +
+            'pdm update --no-sync dep1' +
             '"',
           options: {
             cwd: '/tmp/github/some/repo',

--- a/lib/modules/manager/pep621/processors/pdm.spec.ts
+++ b/lib/modules/manager/pep621/processors/pdm.spec.ts
@@ -86,7 +86,7 @@ describe('modules/manager/pep621/processors/pdm', () => {
             '&& ' +
             'install-tool pdm v2.5.0 ' +
             '&& ' +
-            'pdm update dep1' +
+            'pdm update --no-sync dep1' +
             '"',
         },
       ]);
@@ -173,16 +173,16 @@ describe('modules/manager/pep621/processors/pdm', () => {
       ]);
       expect(execSnapshots).toMatchObject([
         {
-          cmd: 'pdm update dep1 dep2',
+          cmd: 'pdm update --no-sync dep1 dep2',
         },
         {
-          cmd: 'pdm update -G group1 dep3 dep4',
+          cmd: 'pdm update --no-sync -G group1 dep3 dep4',
         },
         {
-          cmd: 'pdm update -dG group2 dep5 dep6',
+          cmd: 'pdm update --no-sync -dG group2 dep5 dep6',
         },
         {
-          cmd: 'pdm update -dG group3 dep7 dep8',
+          cmd: 'pdm update --no-sync -dG group3 dep7 dep8',
         },
       ]);
     });
@@ -224,7 +224,7 @@ describe('modules/manager/pep621/processors/pdm', () => {
       ]);
       expect(execSnapshots).toMatchObject([
         {
-          cmd: 'pdm update',
+          cmd: 'pdm update --no-sync',
           options: {
             cwd: '/tmp/github/some/repo/folder',
           },

--- a/lib/modules/manager/pep621/processors/pdm.ts
+++ b/lib/modules/manager/pep621/processors/pdm.ts
@@ -15,6 +15,8 @@ import type { PyProject } from '../schema';
 import { depTypes, parseDependencyGroupRecord } from '../utils';
 import type { PyProjectProcessor } from './types';
 
+const pdmUpdateCMD = 'pdm update --no-sync';
+
 export class PdmProcessor implements PyProjectProcessor {
   process(project: PyProject, deps: PackageDependency[]): PackageDependency[] {
     const pdm = project.tool?.pdm;
@@ -87,7 +89,7 @@ export class PdmProcessor implements PyProjectProcessor {
       // else only update specific packages
       const cmds: string[] = [];
       if (isLockFileMaintenance) {
-        cmds.push('pdm update');
+        cmds.push(pdmUpdateCMD);
       } else {
         cmds.push(...generateCMDs(updatedDeps));
       }
@@ -135,16 +137,24 @@ function generateCMDs(updatedDeps: Upgrade[]): string[] {
     switch (dep.depType) {
       case depTypes.optionalDependencies: {
         const [group, name] = dep.depName!.split('/');
-        addPackageToCMDRecord(packagesByCMD, `pdm update -G ${group}`, name);
+        addPackageToCMDRecord(
+          packagesByCMD,
+          `${pdmUpdateCMD} -G ${group}`,
+          name
+        );
         break;
       }
       case depTypes.pdmDevDependencies: {
         const [group, name] = dep.depName!.split('/');
-        addPackageToCMDRecord(packagesByCMD, `pdm update -dG ${group}`, name);
+        addPackageToCMDRecord(
+          packagesByCMD,
+          `${pdmUpdateCMD} -dG ${group}`,
+          name
+        );
         break;
       }
       default: {
-        addPackageToCMDRecord(packagesByCMD, `pdm update`, dep.packageName!);
+        addPackageToCMDRecord(packagesByCMD, pdmUpdateCMD, dep.packageName!);
       }
     }
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Adds `--no-sync` flag to calls of `pdm update`.

<!-- Describe what behavior is changed by this PR. -->

## Context
This prevents any loading of packages and only updates the lock files. 
https://pdm.fming.dev/latest/reference/cli/#update_2
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository
https://github.com/secustor/renovate-reproduction-22440
<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
