### PR TITLE
docs: use relative URLs in more places

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -853,7 +853,7 @@ Encrypted secrets usually have a single organization.
 But you may encrypt a secret with more than one organization, for example: `org1,org2`.
 This way the secret can be used in both the `org1` and `org2` organizations.
 
-For more information on how to use secrets for private packages, read [Private package support](../usage/getting-started/private-packages.md).
+For more information on how to use secrets for private packages, read [Private package support](./getting-started/private-packages.md).
 
 ## excludeCommitPaths
 
@@ -930,7 +930,7 @@ Renovate can fetch release notes when they are hosted on one of these platforms:
 - GitHub (.com and Enterprise Server)
 - GitLab (.com and CE/EE)
 
-If you are running on any platform except github.com, you need to [configure a Personal Access Token](../usage/getting-started/running.md/#githubcom-token-for-release-notes) to allow Renovate to fetch release notes from github.com.
+If you are running on any platform except github.com, you need to [configure a Personal Access Token](./getting-started/running.md#githubcom-token-for-release-notes) to allow Renovate to fetch release notes from github.com.
 
 <!-- prettier-ignore -->
 !!! note
@@ -1712,7 +1712,7 @@ Note: Renovate will wait for the set duration to pass for each **separate** vers
 Renovate does not wait until the package has seen no releases for x time-duration(`minimumReleaseAge`).
 `minimumReleaseAge` is not intended to help with slowing down fast releasing project updates.
 If you want to slow down PRs for a specific package, setup a custom schedule for that package.
-Read [our selective-scheduling help](../usage/noise-reduction.md#selective-scheduling) to learn how to set the schedule.
+Read [our selective-scheduling help](./noise-reduction.md#selective-scheduling) to learn how to set the schedule.
 
 If the time since the release is less than the set `minimumReleaseAge` a "pending" status check is added to the branch.
 If enough days have passed then the "pending" status is removed, and a "passing" status check is added.
@@ -1770,12 +1770,12 @@ Check out our [Node.js documentation](https://docs.renovatebot.com/node) for a c
 
 ## npmToken
 
-See [Private npm module support](../usage/getting-started/private-packages.md) for details on how this is used.
+See [Private npm module support](./getting-started/private-packages.md) for details on how this is used.
 Typically you would encrypt it and put it inside the `encrypted` object.
 
 ## npmrc
 
-See [Private npm module support](../usage/getting-started/private-packages.md) for details on how this is used.
+See [Private npm module support](./getting-started/private-packages.md) for details on how this is used.
 
 ## npmrcMerge
 
@@ -2590,7 +2590,7 @@ The `postUpgradeTasks` configuration consists of three fields:
 
 A list of commands that are executed after Renovate has updated a dependency but before the commit is made.
 
-You can use variable templating in your commands if [`allowPostUpgradeCommandTemplating`](../usage/self-hosted-configuration.md#allowpostupgradecommandtemplating) is enabled.
+You can use variable templating in your commands if [`allowPostUpgradeCommandTemplating`](./self-hosted-configuration.md#allowpostupgradecommandtemplating) is enabled.
 
 <!-- prettier-ignore -->
 !!! note

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -526,7 +526,7 @@ To help you with this, Renovate will create config migration pull requests, when
 
 Example:
 
-After we changed the [`baseBranches`](https://docs.renovatebot.com/configuration-options/#basebranches) feature, the Renovate configuration migration pull request would make this change:
+After we changed the [`baseBranches`](#basebranches) feature, the Renovate configuration migration pull request would make this change:
 
 ```diff
 {
@@ -853,7 +853,7 @@ Encrypted secrets usually have a single organization.
 But you may encrypt a secret with more than one organization, for example: `org1,org2`.
 This way the secret can be used in both the `org1` and `org2` organizations.
 
-For more information on how to use secrets for private packages, read [Private package support](https://docs.renovatebot.com/getting-started/private-packages).
+For more information on how to use secrets for private packages, read [Private package support](../usage/getting-started/private-packages.md).
 
 ## excludeCommitPaths
 
@@ -930,7 +930,7 @@ Renovate can fetch release notes when they are hosted on one of these platforms:
 - GitHub (.com and Enterprise Server)
 - GitLab (.com and CE/EE)
 
-If you are running on any platform except github.com, you need to [configure a Personal Access Token](https://docs.renovatebot.com/getting-started/running/#githubcom-token-for-release-notes) to allow Renovate to fetch release notes from github.com.
+If you are running on any platform except github.com, you need to [configure a Personal Access Token](../usage/getting-started/running.md/#githubcom-token-for-release-notes) to allow Renovate to fetch release notes from github.com.
 
 <!-- prettier-ignore -->
 !!! note
@@ -1712,7 +1712,7 @@ Note: Renovate will wait for the set duration to pass for each **separate** vers
 Renovate does not wait until the package has seen no releases for x time-duration(`minimumReleaseAge`).
 `minimumReleaseAge` is not intended to help with slowing down fast releasing project updates.
 If you want to slow down PRs for a specific package, setup a custom schedule for that package.
-Read [our selective-scheduling help](https://docs.renovatebot.com/noise-reduction/#selective-scheduling) to learn how to set the schedule.
+Read [our selective-scheduling help](../usage/noise-reduction.md#selective-scheduling) to learn how to set the schedule.
 
 If the time since the release is less than the set `minimumReleaseAge` a "pending" status check is added to the branch.
 If enough days have passed then the "pending" status is removed, and a "passing" status check is added.
@@ -1770,12 +1770,12 @@ Check out our [Node.js documentation](https://docs.renovatebot.com/node) for a c
 
 ## npmToken
 
-See [Private npm module support](https://docs.renovatebot.com/getting-started/private-packages) for details on how this is used.
+See [Private npm module support](../usage/getting-started/private-packages.md) for details on how this is used.
 Typically you would encrypt it and put it inside the `encrypted` object.
 
 ## npmrc
 
-See [Private npm module support](https://docs.renovatebot.com/getting-started/private-packages) for details on how this is used.
+See [Private npm module support](../usage/getting-started/private-packages.md) for details on how this is used.
 
 ## npmrcMerge
 
@@ -2590,11 +2590,11 @@ The `postUpgradeTasks` configuration consists of three fields:
 
 A list of commands that are executed after Renovate has updated a dependency but before the commit is made.
 
-You can use variable templating in your commands if [`allowPostUpgradeCommandTemplating`](https://docs.renovatebot.com/self-hosted-configuration/#allowpostupgradecommandtemplating) is enabled.
+You can use variable templating in your commands if [`allowPostUpgradeCommandTemplating`](../usage/self-hosted-configuration.md#allowpostupgradecommandtemplating) is enabled.
 
 <!-- prettier-ignore -->
 !!! note
-    Do not use `git add` in your commands to add new files to be tracked, add them by including them in your [`fileFilters`](https://docs.renovatebot.com/self-hosted-configuration/#filefilters) instead.
+    Do not use `git add` in your commands to add new files to be tracked, add them by including them in your [`fileFilters`](#filefilters) instead.
 
 ### fileFilters
 
@@ -3333,11 +3333,11 @@ Renovate does not support scheduled minutes or "at an exact time" granularity.
 !!! tip
     If you want to _disable_ Renovate, then avoid setting `schedule` to `"never"`.
     Instead, use the `enabled` config option to disable Renovate.
-    Read the [`enabled` config option docs](https://docs.renovatebot.com/configuration-options/#enabled) to learn more.
+    Read the [`enabled` config option docs](#enabled) to learn more.
 
 <!-- prettier-ignore -->
 !!! note
-    Actions triggered via the [Dependency Dashboard](https://docs.renovatebot.com/configuration-options/#dependencydashboard) are not restricted by a configured schedule.
+    Actions triggered via the [Dependency Dashboard](#dependencydashboard) are not restricted by a configured schedule.
 
 <!-- prettier-ignore -->
 !!! tip

--- a/docs/usage/dependency-pinning.md
+++ b/docs/usage/dependency-pinning.md
@@ -130,7 +130,7 @@ So to reduce the interruptions of automated dependency updates, consider putting
 - Update only on weekends? This way you update packages at most once per week, _and_ your CI build runners are likely to be idle anyway
 - Update daily, but between hours like midnight and 5am? That way notifications don't pop up in people's feed while they're working, _and_ you also get the benefit of not tying up build machines when developers need to use them
 
-To learn all about controlling Renovate's schedule, read the [key concepts, scheduling](../usage/key-concepts/scheduling.md) docs.
+To learn all about controlling Renovate's schedule, read the [key concepts, scheduling](./key-concepts/scheduling.md) docs.
 
 ### Grouping related packages
 

--- a/docs/usage/dependency-pinning.md
+++ b/docs/usage/dependency-pinning.md
@@ -130,7 +130,7 @@ So to reduce the interruptions of automated dependency updates, consider putting
 - Update only on weekends? This way you update packages at most once per week, _and_ your CI build runners are likely to be idle anyway
 - Update daily, but between hours like midnight and 5am? That way notifications don't pop up in people's feed while they're working, _and_ you also get the benefit of not tying up build machines when developers need to use them
 
-To learn all about controlling Renovate's schedule, read the [key concepts, scheduling](https://docs.renovatebot.com/key-concepts/scheduling/) docs.
+To learn all about controlling Renovate's schedule, read the [key concepts, scheduling](../usage/key-concepts/scheduling.md) docs.
 
 ### Grouping related packages
 

--- a/docs/usage/docker.md
+++ b/docs/usage/docker.md
@@ -225,7 +225,7 @@ module.exports = {
 };
 ```
 
-You can add additional host rules, read the [`hostRules` documentation](../usage/configuration-options.md#hostrules) for more information.
+You can add additional host rules, read the [`hostRules` documentation](./configuration-options.md#hostrules) for more information.
 
 #### Self-hosted Docker registry
 
@@ -298,7 +298,7 @@ If all your dependencies are on the Google Artifact Registry, you can base64 enc
       }
       ```
 
-   1. If you want to add it to your repository Renovate configuration file, [encrypt](../usage/configuration-options.md#encrypted) it and then add it:
+   1. If you want to add it to your repository Renovate configuration file, [encrypt](./configuration-options.md#encrypted) it and then add it:
 
       ```json
       {
@@ -351,7 +351,7 @@ If you have dependencies on Google Container Registry (and Artifact Registry) yo
       }
       ```
 
-   1. If you want to add it to your repository Renovate configuration file, [encrypt](../usage/configuration-options.md#encrypted) it and then add it:
+   1. If you want to add it to your repository Renovate configuration file, [encrypt](./configuration-options.md#encrypted) it and then add it:
 
       ```json
       {

--- a/docs/usage/docker.md
+++ b/docs/usage/docker.md
@@ -225,7 +225,7 @@ module.exports = {
 };
 ```
 
-You can add additional host rules, read the [`hostRules` documentation](https://docs.renovatebot.com/configuration-options/#hostrules) for more information.
+You can add additional host rules, read the [`hostRules` documentation](../usage/configuration-options.md#hostrules) for more information.
 
 #### Self-hosted Docker registry
 
@@ -298,7 +298,7 @@ If all your dependencies are on the Google Artifact Registry, you can base64 enc
       }
       ```
 
-   1. If you want to add it to your repository Renovate configuration file, [encrypt](https://docs.renovatebot.com/configuration-options/#encrypted) it and then add it:
+   1. If you want to add it to your repository Renovate configuration file, [encrypt](../usage/configuration-options.md#encrypted) it and then add it:
 
       ```json
       {
@@ -351,7 +351,7 @@ If you have dependencies on Google Container Registry (and Artifact Registry) yo
       }
       ```
 
-   1. If you want to add it to your repository Renovate configuration file, [encrypt](https://docs.renovatebot.com/configuration-options/#encrypted) it and then add it:
+   1. If you want to add it to your repository Renovate configuration file, [encrypt](../usage/configuration-options.md#encrypted) it and then add it:
 
       ```json
       {

--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -64,7 +64,7 @@ The base branch could be called `trunk` or `mainline` or `prod`, and Git would w
 
 ### Troubleshoot Renovate
 
-If you have problems with Renovate, or want to know where Renovate keeps the logging output then read our [troubleshooting documentation](../usage/troubleshooting.md).
+If you have problems with Renovate, or want to know where Renovate keeps the logging output then read our [troubleshooting documentation](./troubleshooting.md).
 
 ### Tell Renovate to ask for approval before creating a Pull Request
 
@@ -111,7 +111,7 @@ The `dependencyDashboardApproval` config option is outside of a `packageRules` a
 }
 ```
 
-Read our documentation on the [dependencyDashboardApproval](../usage/configuration-options.md#dependencydashboardapproval) config option.
+Read our documentation on the [dependencyDashboardApproval](./configuration-options.md#dependencydashboardapproval) config option.
 
 ### Use an alternative branch as my Pull Request target
 
@@ -134,7 +134,7 @@ See the dedicated [Private npm module support](./getting-started/private-package
 
 ### Control Renovate's schedule
 
-To learn about controlling Renovate schedule, read the [key concepts, scheduling](../usage/key-concepts/scheduling.md) docs.
+To learn about controlling Renovate schedule, read the [key concepts, scheduling](./key-concepts/scheduling.md) docs.
 
 ### Disable Renovate for certain dependency types
 

--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -64,7 +64,7 @@ The base branch could be called `trunk` or `mainline` or `prod`, and Git would w
 
 ### Troubleshoot Renovate
 
-If you have problems with Renovate, or want to know where Renovate keeps the logging output then read our [troubleshooting documentation](https://docs.renovatebot.com/troubleshooting/).
+If you have problems with Renovate, or want to know where Renovate keeps the logging output then read our [troubleshooting documentation](../usage/troubleshooting.md).
 
 ### Tell Renovate to ask for approval before creating a Pull Request
 
@@ -111,7 +111,7 @@ The `dependencyDashboardApproval` config option is outside of a `packageRules` a
 }
 ```
 
-Read our documentation on the [dependencyDashboardApproval](https://docs.renovatebot.com/configuration-options/#dependencydashboardapproval) config option.
+Read our documentation on the [dependencyDashboardApproval](../usage/configuration-options.md#dependencydashboardapproval) config option.
 
 ### Use an alternative branch as my Pull Request target
 
@@ -134,7 +134,7 @@ See the dedicated [Private npm module support](./getting-started/private-package
 
 ### Control Renovate's schedule
 
-To learn about controlling Renovate schedule, read the [key concepts, scheduling](https://docs.renovatebot.com/key-concepts/scheduling/) docs.
+To learn about controlling Renovate schedule, read the [key concepts, scheduling](../usage/key-concepts/scheduling.md) docs.
 
 ### Disable Renovate for certain dependency types
 

--- a/docs/usage/getting-started/private-packages.md
+++ b/docs/usage/getting-started/private-packages.md
@@ -497,7 +497,7 @@ The preferred approach to secrets is that the bot administrator configures them 
 If you need to provide credentials to the hosted Renovate App, please do this:
 
 - Encrypt each secret string using <https://app.renovatebot.com/encrypt>. Note: this encrypts using the app's public key fully in the browser and does not send the original secret to any server. You can download this file and perform the encryption fully offline if you like.
-- Wrap each secret field in an [encrypted](https://docs.renovatebot.com/configuration-options/#encrypted) object and paste in the encrypted secret value instead. An example is shown below:
+- Wrap each secret field in an [encrypted](../configuration-options.md#encrypted) object and paste in the encrypted secret value instead. An example is shown below:
 
 ```json
 {
@@ -537,7 +537,7 @@ If per-repository config must be done within the repository, it is still recomme
 For instructions on this, see the above section on encrypting secrets for the Mend Renovate App but instead:
 
 - Save a copy of the <https://app.renovatebot.com/encrypt> HTML file locally, or host it locally
-- Generate a public/private key pair for the app using the instructions in [privateKey](https://docs.renovatebot.com/self-hosted-configuration/#privatekey)
+- Generate a public/private key pair for the app using the instructions in [privateKey](../self-hosted-configuration.md#privatekey)
 - Replace the existing public key in the HTML with the public key you generated in the step prior
 - Use the resulting HTML encrypt page to encrypt secrets for your app before adding them to user/repository config
 - Configure the app to run with `privateKey` set to the private key you generated above

--- a/docs/usage/getting-started/use-cases.md
+++ b/docs/usage/getting-started/use-cases.md
@@ -129,7 +129,7 @@ We use these Renovate features to automerge an internal dependency:
 
 - [Git submodule support](https://docs.renovatebot.com/modules/manager/git-submodules/)
 - [`automerge`](../configuration-options.md#automerge) set to `true`
-- [`automergeType`](../configuration-options/#automergetype) set to `branch`
+- [`automergeType`](../configuration-options.md#automergetype) set to `branch`
 
 ##### Background information
 

--- a/docs/usage/getting-started/use-cases.md
+++ b/docs/usage/getting-started/use-cases.md
@@ -121,15 +121,15 @@ Renovate finds and updates internal dependencies just like external or Open Sour
 
 Renovate's automerge feature is really useful for internal dependencies where you can say "if it passes tests let's merge it".
 
-To learn more about "automerge" read the [key concepts, automerge](https://docs.renovatebot.com/key-concepts/automerge/) documentation.
+To learn more about "automerge" read the [key concepts, automerge](../key-concepts/automerge.md) documentation.
 
 #### Example of automerging internal dependencies
 
 We use these Renovate features to automerge an internal dependency:
 
 - [Git submodule support](https://docs.renovatebot.com/modules/manager/git-submodules/)
-- [`automerge`](https://docs.renovatebot.com/configuration-options/#automerge) set to `true`
-- [`automergeType`](https://docs.renovatebot.com/configuration-options/#automergetype) set to `branch`
+- [`automerge`](../configuration-options.md#automerge) set to `true`
+- [`automergeType`](../configuration-options/#automergetype) set to `branch`
 
 ##### Background information
 

--- a/docs/usage/golang.md
+++ b/docs/usage/golang.md
@@ -14,8 +14,8 @@ Renovate supports upgrading dependencies in `go.mod` files and their accompanyin
 1. Renovate resolves the dependency's source repository and checks for SemVer tags if found. Otherwise commits and `v0.0.0-....` syntax will be used
 1. If Renovate finds an update, Renovate will update `go.mod` to the new value
 1. Renovate runs `go get` to update the `go.sum` files (you can configure which directory are included using the `goGetDirs` option)
-1. If the user has enabled the option `gomodUpdateImportPaths` in the [`postUpdateOptions`](https://docs.renovatebot.com/configuration-options/#postupdateoptions) array, then Renovate uses [mod](https://github.com/marwan-at-work/mod) to update import paths on major updates, which can update any Go source file
-1. If the user has any of the available `gomodTidy` options (e.g. `gomodTidy1.17`) in the [`postUpdateOptions`](https://docs.renovatebot.com/configuration-options/#postupdateoptions), then Renovate runs `go mod tidy` with the respective options (multiple options are allowed).
+1. If the user has enabled the option `gomodUpdateImportPaths` in the [`postUpdateOptions`](../usage/configuration-options.md#postupdateoptions) array, then Renovate uses [mod](https://github.com/marwan-at-work/mod) to update import paths on major updates, which can update any Go source file
+1. If the user has any of the available `gomodTidy` options (e.g. `gomodTidy1.17`) in the [`postUpdateOptions`](../usage/configuration-options.md#postupdateoptions), then Renovate runs `go mod tidy` with the respective options (multiple options are allowed).
 1. `go mod vendor` is run if vendored modules are detected
 1. A PR will be created with `go.mod`,`go.sum`, and any updated vendored files updated in the one commit
 1. If the source repository has either a "changelog" file or uses GitHub releases, then Release Notes for each version will be embedded in the generated PR
@@ -39,7 +39,7 @@ To enable this replace massaging behavior, add `gomodMassage` to your `postUpdat
 
 ### Module Tidying
 
-Go Modules tidying is not enabled by default, and is opt-in via the [`postUpdateOptions`](https://docs.renovatebot.com/configuration-options/#postupdateoptions) config option.
+Go Modules tidying is not enabled by default, and is opt-in via the [`postUpdateOptions`](../usage/configuration-options.md#postupdateoptions) config option.
 The reason for this is that a `go mod tidy` command may make changes to `go.mod` and `go.sum` that are completely unrelated to the updated module(s) in the PR, and so may be confusing to some users.
 
 ### Module Vendoring

--- a/docs/usage/golang.md
+++ b/docs/usage/golang.md
@@ -14,8 +14,8 @@ Renovate supports upgrading dependencies in `go.mod` files and their accompanyin
 1. Renovate resolves the dependency's source repository and checks for SemVer tags if found. Otherwise commits and `v0.0.0-....` syntax will be used
 1. If Renovate finds an update, Renovate will update `go.mod` to the new value
 1. Renovate runs `go get` to update the `go.sum` files (you can configure which directory are included using the `goGetDirs` option)
-1. If the user has enabled the option `gomodUpdateImportPaths` in the [`postUpdateOptions`](../usage/configuration-options.md#postupdateoptions) array, then Renovate uses [mod](https://github.com/marwan-at-work/mod) to update import paths on major updates, which can update any Go source file
-1. If the user has any of the available `gomodTidy` options (e.g. `gomodTidy1.17`) in the [`postUpdateOptions`](../usage/configuration-options.md#postupdateoptions), then Renovate runs `go mod tidy` with the respective options (multiple options are allowed).
+1. If the user has enabled the option `gomodUpdateImportPaths` in the [`postUpdateOptions`](./configuration-options.md#postupdateoptions) array, then Renovate uses [mod](https://github.com/marwan-at-work/mod) to update import paths on major updates, which can update any Go source file
+1. If the user has any of the available `gomodTidy` options (e.g. `gomodTidy1.17`) in the [`postUpdateOptions`](./configuration-options.md#postupdateoptions), then Renovate runs `go mod tidy` with the respective options (multiple options are allowed).
 1. `go mod vendor` is run if vendored modules are detected
 1. A PR will be created with `go.mod`,`go.sum`, and any updated vendored files updated in the one commit
 1. If the source repository has either a "changelog" file or uses GitHub releases, then Release Notes for each version will be embedded in the generated PR
@@ -39,7 +39,7 @@ To enable this replace massaging behavior, add `gomodMassage` to your `postUpdat
 
 ### Module Tidying
 
-Go Modules tidying is not enabled by default, and is opt-in via the [`postUpdateOptions`](../usage/configuration-options.md#postupdateoptions) config option.
+Go Modules tidying is not enabled by default, and is opt-in via the [`postUpdateOptions`](./configuration-options.md#postupdateoptions) config option.
 The reason for this is that a `go mod tidy` command may make changes to `go.mod` and `go.sum` that are completely unrelated to the updated module(s) in the PR, and so may be confusing to some users.
 
 ### Module Vendoring

--- a/docs/usage/java.md
+++ b/docs/usage/java.md
@@ -44,7 +44,7 @@ Renovate does not support:
 - Catalog versions using `reject`, and `rejectAll` constraints
 - Catalog versions using more than one of `require`, `strictly`, `prefer` in a single declaration
 - Catalogs with custom names that do not end in `.toml`
-- Catalogs outside the `gradle` folder whose names do not end in `.versions.toml` (unless overridden via [`fileMatch`](https://docs.renovatebot.com/configuration-options/#filematch) configuration)
+- Catalogs outside the `gradle` folder whose names do not end in `.versions.toml` (unless overridden via [`fileMatch`](../usage/configuration-options.md#filematch) configuration)
 
 ## Gradle Wrapper
 

--- a/docs/usage/java.md
+++ b/docs/usage/java.md
@@ -44,7 +44,7 @@ Renovate does not support:
 - Catalog versions using `reject`, and `rejectAll` constraints
 - Catalog versions using more than one of `require`, `strictly`, `prefer` in a single declaration
 - Catalogs with custom names that do not end in `.toml`
-- Catalogs outside the `gradle` folder whose names do not end in `.versions.toml` (unless overridden via [`fileMatch`](../usage/configuration-options.md#filematch) configuration)
+- Catalogs outside the `gradle` folder whose names do not end in `.versions.toml` (unless overridden via [`fileMatch`](./configuration-options.md#filematch) configuration)
 
 ## Gradle Wrapper
 

--- a/docs/usage/key-concepts/automerge.md
+++ b/docs/usage/key-concepts/automerge.md
@@ -117,7 +117,7 @@ For example:
 }
 ```
 
-For more information read [`platformAutomerge`](https://docs.renovatebot.com/configuration-options/#platformautomerge).
+For more information read [`platformAutomerge`](../configuration-options.md#platformautomerge).
 
 ### GitHub Merge Queue
 

--- a/docs/usage/key-concepts/dashboard.md
+++ b/docs/usage/key-concepts/dashboard.md
@@ -15,7 +15,7 @@ Having the Dependency Dashboard also enables the concept of an "approval" workfl
 ## Supported platforms
 
 The Dependency Dashboard requires that the host platforms supports the concept of issues with dynamic Markdown checkboxes.
-Read [our FAQ, Renovate core features not supported on all platforms](https://docs.renovatebot.com/faq/#renovate-core-features-not-supported-on-all-platforms) to see if your platform can use the Dependency Dashboard feature.
+Read [our FAQ, Renovate core features not supported on all platforms](../faq.md#renovate-core-features-not-supported-on-all-platforms) to see if your platform can use the Dependency Dashboard feature.
 
 ## How to enable the dashboard
 

--- a/docs/usage/key-concepts/scheduling.md
+++ b/docs/usage/key-concepts/scheduling.md
@@ -60,7 +60,7 @@ You can set a specific time zone in your local config file like this:
 }
 ```
 
-Read our docs on the [timezone](https://docs.renovatebot.com/configuration-options/#timezone) configuration option.
+Also read the [`timezone` config option docs](../configuration-options.md#timezone).
 
 ### Scheduling syntax
 
@@ -139,4 +139,4 @@ Say you want to restrict `aws-sdk` to weekly updates, you would create this pack
 The "schedule" property must _always_ be defined in an array, even if you only set a single schedule.
 Multiple entries in the array means "or".
 
-Read the [schedule config option](https://docs.renovatebot.com/configuration-options/#schedule) documentation to learn more.
+Read the [schedule config option](../configuration-options.md#schedule) documentation to learn more.

--- a/docs/usage/node.md
+++ b/docs/usage/node.md
@@ -39,4 +39,4 @@ For example, if you want to use at least npm `8.1.0` and also allow newer versio
 }
 ```
 
-Alternatively, the npm version can also be configured via the [`constraints` option](https://docs.renovatebot.com/configuration-options/#constraints).
+Alternatively, the npm version can also be configured via the [`constraints` option](./configuration-options.md#constraints).

--- a/docs/usage/noise-reduction.md
+++ b/docs/usage/noise-reduction.md
@@ -54,7 +54,7 @@ Grouping dependencies versus single PRs:
 
 ## Scheduling Renovate
 
-For a high level overview of scheduling when Renovate bot runs, read the [key concepts, scheduling](https://docs.renovatebot.com/key-concepts/scheduling/) docs.
+For a high level overview of scheduling when Renovate bot runs, read the [key concepts, scheduling](./key-concepts/scheduling.md) docs.
 
 On its own, the Renovate CLI tool runs once and then exits.
 Hence, it only runs as often as its administrator sets it to (e.g. via `cron`).

--- a/docs/usage/php.md
+++ b/docs/usage/php.md
@@ -21,7 +21,7 @@ Either install the [Renovate App](https://github.com/apps/renovate) on GitHub, o
 
 ## Private packages
 
-If you are using a [privately hosted Composer package](https://getcomposer.org/doc/articles/authentication-for-private-packages.md) you can pass the credentials via the [`hostRules`](https://docs.renovatebot.com/configuration-options/#hostrules) configuration.
+If you are using a [privately hosted Composer package](https://getcomposer.org/doc/articles/authentication-for-private-packages.md) you can pass the credentials via the [`hostRules`](./configuration-options.md#hostrules) configuration.
 
 ```json
 {

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -399,7 +399,7 @@ If you must expose all environment variables to package managers, you can set th
     Secrets and other confidential information stored in environment variables could be leaked by a malicious script, that enumerates all environment variables.
 
 Set `exposeAllEnv` to `true` only if you have reviewed, and trust, the repositories which Renovate bot runs against.
-Alternatively, you can use the [`customEnvVariables`](https://docs.renovatebot.com/self-hosted-configuration/#customenvvariables) config option to handpick a set of variables you need to expose.
+Alternatively, you can use the [`customEnvVariables`](./self-hosted-configuration.md#customenvvariables) config option to handpick a set of variables you need to expose.
 
 Setting this to `true` also allows for variable substitution in `.npmrc` files.
 
@@ -541,7 +541,7 @@ If `commitMessagePrefix` or `semanticCommits` values are set then they will be p
 
 ## onboardingConfigFileName
 
-If set to one of the valid [config file names](https://docs.renovatebot.com/configuration-options/), the onboarding PR will create a configuration file with the provided name instead of `renovate.json`.
+If set to one of the valid [config file names](./configuration-options.md), the onboarding PR will create a configuration file with the provided name instead of `renovate.json`.
 Falls back to `renovate.json` if the name provided is not valid.
 
 ## onboardingNoDeps

--- a/docs/usage/templates.md
+++ b/docs/usage/templates.md
@@ -109,6 +109,6 @@ This is for security reasons.
 
 `HOME is {{env.HOME}}`
 
-If you're self-hosting Renovate, you can expose additional variables with the [`customEnvVariables`](https://docs.renovatebot.com/self-hosted-configuration/#customenvvariables) config option.
+If you're self-hosting Renovate, you can expose additional variables with the [`customEnvVariables`](./self-hosted-configuration.md#customenvvariables) config option.
 
-You can also use the [`exposeAllEnv`](https://docs.renovatebot.com/self-hosted-configuration/#exposeallenv) config option to allow all environment variables in templates, but make sure to consider the security implications of giving the scripts unrestricted access to all variables.
+You can also use the [`exposeAllEnv`](./self-hosted-configuration.md#exposeallenv) config option to allow all environment variables in templates, but make sure to consider the security implications of giving the scripts unrestricted access to all variables.

--- a/docs/usage/user-stories/swissquote.md
+++ b/docs/usage/user-stories/swissquote.md
@@ -168,16 +168,16 @@ This helped a lot to reduce the noise in PRs, the second month we got 400 Pull R
 > The next section could look like an ad or a sponsored post; it’s not. We’re just big fans of the product.
 
 The ease of getting started with Renovate’s Docker image is what got us onboard easily.
-But what confirmed our choice is the insane crazy amount of features and [configuration options](https://docs.renovatebot.com/configuration-options/).
+But what confirmed our choice is the insane crazy amount of features and [configuration options](../configuration-options.md).
 
 Some features and options we enjoy:
 
-- [Shared configurations (presets)](https://docs.renovatebot.com/key-concepts/presets/), we have a Swissquote default configuration we set for all repositories, each team can extend it with their own practices
-- [Integration with GitHub’s Dependabot alerts](https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts) to raise the priority and send security remediation PRs as soon as possible
-- Each rule can be customized either globally [or specified per package](https://docs.renovatebot.com/configuration-options/#packagerules)
-- Works with your [private package registry](https://docs.renovatebot.com/getting-started/private-packages/)
+- [Shared configurations (presets)](../key-concepts/presets.md), we have a Swissquote default configuration we set for all repositories, each team can extend it with their own practices
+- [Integration with GitHub’s Dependabot alerts](../configuration-options.md#vulnerabilityalerts) to raise the priority and send security remediation PRs as soon as possible
+- Each rule can be customized either globally [or specified per package](../configuration-options/#packagerules)
+- Works with your [private package registry](../getting-started/private-packages.md)
 - Supports more than 70 [languages and package managers](https://docs.renovatebot.com/modules/manager/#supported-managers): Maven, Docker, npm, Docker Compose, Python
-- If you are using dependencies in a custom way, [there is a special regexManager](https://docs.renovatebot.com/configuration-options/#regexmanagers) that allows you to transform patterns into dependencies
+- If you are using dependencies in a custom way, [there is a special regexManager](../configuration-options.md#regexmanagers) that allows you to transform patterns into dependencies
 
 There is an [on-premise option](https://www.mend.io/free-developer-tools/renovate/on-premises/), but you can also have it as [an app on GitHub.com](https://github.com/marketplace/renovate).
 On our side, we’re not using the on-premise but rather a custom scheduler using the open source Docker image.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Use relative URLs in more places

## Context

Helps with:

- #13400

I still have more links that point to our production docs site, that should be converted to relative links as well. Those links point to `modules`, `presets` or `manager`. Some of those things are auto-generated, so VSCode doesn't help me point to the correct place for those.

Help wanted to get the issue fixed for good! 😉 

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
