### PR TITLE
fix(pnpm): lockfile v6 is supported as low as version 7.24.2

### DIFF
--- a/lib/modules/manager/npm/post-update/pnpm.ts
+++ b/lib/modules/manager/npm/post-update/pnpm.ts
@@ -194,7 +194,7 @@ export async function getConstraintFromLockFile(
  */
 
 const lockToPnpmVersionMapping = [
-  { lockfileVersion: 6.0, lowerConstraint: '>=8' },
+  { lockfileVersion: 6.0, lowerConstraint: '>=7.24.2' },
   {
     lockfileVersion: 5.4,
     lowerConstraint: '>=7',


### PR DESCRIPTION
## Changes

Allow pnpm versions as low as 7.24.2 with pnpm lockfile version 6 (https://github.com/pnpm/pnpm/releases/tag/v7.24.2)

## Context

We haven't upgraded to pnpm 8 yet but we do have a v6 lockfile, which is hitting trouble with the renovate-assumed pnpm version constraint.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
