### PR TITLE
refactor: Clear distinction between generic and `HttpError` handlers

### DIFF
--- a/lib/modules/datasource/datasource.ts
+++ b/lib/modules/datasource/datasource.ts
@@ -1,6 +1,5 @@
 import { ExternalHostError } from '../../types/errors/external-host-error';
-import { Http } from '../../util/http';
-import type { HttpError } from '../../util/http';
+import { Http, HttpError } from '../../util/http';
 import type {
   DatasourceApi,
   DigestConfig,
@@ -35,22 +34,29 @@ export abstract class Datasource implements DatasourceApi {
   getDigest?(config: DigestConfig, newValue?: string): Promise<string | null>;
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  handleSpecificErrors(err: HttpError): void {}
+  handleHttpErrors(err: HttpError): void {}
 
-  protected handleGenericErrors(err: HttpError): never {
+  protected handleGenericErrors(err: Error): never {
     // istanbul ignore if: not easy testable with nock
     if (err instanceof ExternalHostError) {
       throw err;
     }
-    this.handleSpecificErrors(err);
-    if (err.response?.statusCode !== undefined) {
-      if (
-        err.response?.statusCode === 429 ||
-        (err.response?.statusCode >= 500 && err.response?.statusCode < 600)
-      ) {
-        throw new ExternalHostError(err);
+
+    if (err instanceof HttpError) {
+      this.handleHttpErrors(err);
+
+      const statusCode = err.response?.statusCode;
+      if (statusCode) {
+        if (statusCode === 429) {
+          throw new ExternalHostError(err);
+        }
+
+        if (statusCode >= 500 && statusCode < 600) {
+          throw new ExternalHostError(err);
+        }
       }
     }
+
     throw err;
   }
 }

--- a/lib/modules/datasource/ruby-version/index.spec.ts
+++ b/lib/modules/datasource/ruby-version/index.spec.ts
@@ -19,14 +19,16 @@ describe('modules/datasource/ruby-version/index', () => {
       expect(res).toMatchSnapshot();
     });
 
-    it('throws for empty result', async () => {
+    it('returns null for empty result', async () => {
       httpMock
         .scope('https://www.ruby-lang.org')
         .get('/en/downloads/releases/')
         .reply(200, {});
-      await expect(
-        getPkgReleases({ datasource, packageName: 'ruby' })
-      ).rejects.toThrow();
+      const res = await getPkgReleases({
+        datasource,
+        packageName: 'ruby',
+      });
+      expect(res).toBeNull();
     });
 
     it('throws for 404', async () => {

--- a/lib/modules/datasource/ruby-version/index.ts
+++ b/lib/modules/datasource/ruby-version/index.ts
@@ -1,3 +1,4 @@
+import { logger } from '../../../logger';
 import { ExternalHostError } from '../../../types/errors/external-host-error';
 import { cache } from '../../../util/cache/package/decorator';
 import { parse } from '../../../util/html';
@@ -53,7 +54,8 @@ export class RubyVersionDatasource extends Datasource {
         }
       });
       if (!res.releases.length) {
-        throw new Error('Missing ruby releases');
+        logger.warn({ registryUrl }, 'Missing ruby releases');
+        return null;
       }
     } catch (err) {
       this.handleGenericErrors(err);

--- a/lib/modules/datasource/ruby-version/index.ts
+++ b/lib/modules/datasource/ruby-version/index.ts
@@ -62,7 +62,7 @@ export class RubyVersionDatasource extends Datasource {
     return res;
   }
 
-  override handleSpecificErrors(err: HttpError): never | void {
+  override handleHttpErrors(err: HttpError): never | void {
     throw new ExternalHostError(err);
   }
 }

--- a/lib/modules/datasource/terraform-module/base.ts
+++ b/lib/modules/datasource/terraform-module/base.ts
@@ -29,7 +29,7 @@ export abstract class TerraformDatasource extends Datasource {
     return `${ensureTrailingSlash(registryUrl)}.well-known/terraform.json`;
   }
 
-  override handleSpecificErrors(err: HttpError): void {
+  override handleHttpErrors(err: HttpError): void {
     const failureCodes = ['EAI_AGAIN'];
     // istanbul ignore if
     if (failureCodes.includes(err.code)) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Fix types and make separation between generic and `HttpError` handlers more obvious

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
