### PR TITLE
feat(presets): add tfvarsVersions preset

### DIFF
--- a/lib/config/presets/internal/regex-managers.ts
+++ b/lib/config/presets/internal/regex-managers.ts
@@ -42,7 +42,7 @@ export const presets: Record<string, Preset> = {
     ],
   },
   tfvarsVersions: {
-    description: 'Update `*_version` variables in `.tfvars` files',
+    description: 'Update `*_version` variables in `.tfvars` files.',
     regexManagers: [
       {
         fileMatch: ['.+\\.tfvars$'],

--- a/lib/config/presets/internal/regex-managers.ts
+++ b/lib/config/presets/internal/regex-managers.ts
@@ -41,4 +41,16 @@ export const presets: Record<string, Preset> = {
       },
     ],
   },
+  tfvarsVersions: {
+    description: "Update `*_version` variables in `.tfvars` files",
+    regexManagers: [
+      {
+        fileMatch: [".+\\.tfvars$"],
+        matchStrings: [
+          "#\\s*renovate:\\s*datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*?_version\\s*=\\s*\"(?<currentValue>.*)\""
+        ],
+        versioningTemplate: "{{#if versioning}}{{{versioning}}}{{/if}}"
+      }
+    ],
+  }
 };

--- a/lib/config/presets/internal/regex-managers.ts
+++ b/lib/config/presets/internal/regex-managers.ts
@@ -42,15 +42,15 @@ export const presets: Record<string, Preset> = {
     ],
   },
   tfvarsVersions: {
-    description: "Update `*_version` variables in `.tfvars` files",
+    description: 'Update `*_version` variables in `.tfvars` files',
     regexManagers: [
       {
-        fileMatch: [".+\\.tfvars$"],
+        fileMatch: ['.+\\.tfvars$'],
         matchStrings: [
-          "#\\s*renovate:\\s*datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*?_version\\s*=\\s*\"(?<currentValue>.*)\""
+          '#\\s*renovate:\\s*datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*?_version\\s*=\\s*"(?<currentValue>.*)"',
         ],
-        versioningTemplate: "{{#if versioning}}{{{versioning}}}{{/if}}"
-      }
+        versioningTemplate: '{{#if versioning}}{{{versioning}}}{{/if}}',
+      },
     ],
-  }
+  },
 };

--- a/lib/config/presets/internal/regex-managers.ts
+++ b/lib/config/presets/internal/regex-managers.ts
@@ -47,7 +47,7 @@ export const presets: Record<string, Preset> = {
       {
         fileMatch: ['.+\\.tfvars$'],
         matchStrings: [
-          '#\\s*renovate:\\s*datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*?_version\\s*=\\s*"(?<currentValue>.*)"',
+          '#\\s*renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*?_version\\s*=\\s*"(?<currentValue>.*)"',
         ],
         versioningTemplate: '{{#if versioning}}{{{versioning}}}{{/if}}',
       },


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This adds a `tfvarsVersions` preset as discussed in https://github.com/renovatebot/renovate/pull/21994#discussion_r1188303503.

<!-- Describe what behavior is changed by this PR. -->

## Context

This change will make it easier to update versions in `.tfvars` files.
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
