### PR TITLE
chore: needs-discussion issues are closed as not planned

### DIFF
--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -216,6 +216,7 @@
 
     Thanks, the Renovate team
   close: true
+  close-reason: 'not planned'
   lock: true
   lock-reason: 'resolved'
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Automatically close issues that are labeled `needs-discussion` as `not planned`

## Context

The default GitHub close reason is `completed`, but we don't intend to work on Issues that need a Discussion first. So we should use the `not planned` reason when auto-closing those issues.

Quote from the `dessant/label-actions` readme: [^1]

> - **`close-reason`**
>   - Reason for closing threads, value must be:
>     - `completed` or `not planned` for issues
>     - `duplicate`, `outdated` or `resolved` for discussions
>   - Optional, defaults to `''`

Follow-up PR after:

- #22642

[^1]: [`dessant/label-actions` readme, section about actions](https://github.com/dessant/label-actions#actions)

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
