### PR TITLE
fix(gitlab): gitLabIgnoreApprovals works with multiple approval rules

### DIFF
--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -1770,7 +1770,7 @@ describe('modules/platform/gitlab/index', () => {
       });
     });
 
-    it('will modify rules of type regular, if such rules exist', async () => {
+    it('will remove rules of type regular, if such rules exist', async () => {
       await initPlatform('13.3.6-ee');
       httpMock
         .scope(gitlabApiHost)
@@ -1797,11 +1797,6 @@ describe('modules/platform/gitlab/index', () => {
         .get('/api/v4/projects/undefined/merge_requests/12345/approval_rules')
         .reply(200, [
           {
-            name: 'AnyApproverRule',
-            rule_type: 'any_approver',
-            id: 50005,
-          },
-          {
             name: 'RegularApproverRule',
             rule_type: 'regular',
             id: 50006,
@@ -1812,17 +1807,15 @@ describe('modules/platform/gitlab/index', () => {
             id: 50007,
           },
         ])
-        .put(
-          '/api/v4/projects/undefined/merge_requests/12345/approval_rules/50005'
-        )
-        .reply(200)
-        .put(
+        .delete(
           '/api/v4/projects/undefined/merge_requests/12345/approval_rules/50006'
         )
         .reply(200)
-        .put(
+        .delete(
           '/api/v4/projects/undefined/merge_requests/12345/approval_rules/50007'
         )
+        .reply(200)
+        .post('/api/v4/projects/undefined/merge_requests/12345/approval_rules')
         .reply(200);
       expect(
         await gitlab.createPr({

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -547,11 +547,13 @@ async function ignoreApprovals(pr: number): Promise<void> {
       ({ rule_type, name }) => rule_type !== 'any_approver' && name !== ruleName
     );
 
-    await p.all(
-      existingRegularApproverRules.map((rule) => async (): Promise<void> => {
-        await gitlabApi.deleteJson(`${url}/${rule.id}`);
-      })
-    );
+    if (existingRegularApproverRules.length) {
+      await p.all(
+        existingRegularApproverRules.map((rule) => async (): Promise<void> => {
+          await gitlabApi.deleteJson(`${url}/${rule.id}`);
+        })
+      );
+    }
 
     if (existingAnyApproverRule) {
       await gitlabApi.putJson(`${url}/${existingAnyApproverRule.id}`, {

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -547,7 +547,7 @@ async function ignoreApprovals(pr: number): Promise<void> {
       ({ rule_type, name }) => rule_type !== 'any_approver' && name !== ruleName
     );
 
-    if (existingRegularApproverRules.length) {
+    if (existingRegularApproverRules?.length) {
       await p.all(
         existingRegularApproverRules.map((rule) => async (): Promise<void> => {
           await gitlabApi.deleteJson(`${url}/${rule.id}`);

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -547,8 +547,8 @@ async function ignoreApprovals(pr: number): Promise<void> {
       ({ rule_type, name }) => rule_type !== 'any_approver' && name !== ruleName
     );
 
-    await Promise.all(
-      existingRegularApproverRules?.map(async (rule) => {
+    await p.all(
+      existingRegularApproverRules.map((rule) => async (): Promise<void> => {
         await gitlabApi.deleteJson(`${url}/${rule.id}`);
       })
     );

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -543,9 +543,11 @@ async function ignoreApprovals(pr: number): Promise<void> {
     );
 
     if (existingAnyApproverRule) {
-      await gitlabApi.putJson(`${url}/${existingAnyApproverRule.id}`, {
-        body: { ...existingAnyApproverRule, approvals_required: 0 },
-      });
+      for (const rule of rules) {
+        await gitlabApi.putJson(`${url}/${rule.id}`, {
+          body: { ...existingAnyApproverRule, approvals_required: 0 },
+        });
+      }
       return;
     }
 


### PR DESCRIPTION


<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Currently `gitLabIgnoreApprovals` sets the `approvals_required` parameter to 0 only for the default `any_approver` rule.
If additional custom approval rules are in place in the project configuration, automerge is not working anymore since GitLab 1.16 because of this: https://gitlab.com/gitlab-org/gitlab/-/issues/388140

## Context

Simpler fix compared to https://github.com/renovatebot/renovate/pull/22306, without adding an additional config option.


<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
