### PR TITLE
ci: Always run `ubuntu-latest` job in `prefetch` matrix

### DIFF
--- a/.github/actions/calculate-prefetch-matrix/action.yml
+++ b/.github/actions/calculate-prefetch-matrix/action.yml
@@ -67,9 +67,10 @@ runs:
       env:
         MACOS_MISS: ${{ steps.modules-caches.outputs.macos }}
         WINDOWS_MISS: ${{ steps.modules-caches.outputs.windows }}
-        PREFETCH_MAC_ONLY: '["macos-latest"]'
-        PREFETCH_WINDOWS_ONLY: '["windows-latest"]'
-        PREFETCH_BOTH: '["macos-latest", "windows-latest"]'
+        # Ubuntu is always available as the subject of required status check
+        PREFETCH_MAC_ONLY: '["ubuntu-latest", "macos-latest"]'
+        PREFETCH_WINDOWS_ONLY: '["ubuntu-latest", "windows-latest"]'
+        PREFETCH_BOTH: '["ubuntu-latest", "macos-latest", "windows-latest"]'
         PREFETCH_FALLBACK: '["ubuntu-latest"]'
       shell: bash
       run: |


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Always run `ubuntu-latest` with no steps performed in the `prefetch` job

## Context

In order to make all the job chain required, we need at least one job in matrix we can point to. It's the limitation of platform, but consequences are minimal.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
