### PR TITLE
fix(terraform): return null for files without deps

### DIFF
--- a/lib/modules/manager/terraform/extract.spec.ts
+++ b/lib/modules/manager/terraform/extract.spec.ts
@@ -40,6 +40,17 @@ describe('modules/manager/terraform/extract', () => {
       expect(await extractPackageFile('nothing here', '1.tf', {})).toBeNull();
     });
 
+    it('returns null for no deps', async () => {
+      // ModuleExtractor matches `module` at any position.
+      const src = codeBlock`
+        data "sops_file" "secrets" {
+          source_file = "\${path.module}/secrets.enc.json"
+        }
+        `;
+
+      expect(await extractPackageFile(src, '1.tf', {})).toBeNull();
+    });
+
     it('extracts  modules', async () => {
       const res = await extractPackageFile(modules, 'modules.tf', {});
       expect(res?.deps).toHaveLength(18);

--- a/lib/modules/manager/terraform/extract.ts
+++ b/lib/modules/manager/terraform/extract.ts
@@ -1,6 +1,11 @@
 import is from '@sindresorhus/is';
 import { logger } from '../../../logger';
-import type { ExtractConfig, PackageFileContent } from '../types';
+import type {
+  ExtractConfig,
+  PackageDependency,
+  PackageFileContent,
+} from '../types';
+import type { DependencyExtractor } from './base';
 import { resourceExtractors } from './extractors';
 import * as hcl from './hcl';
 import {
@@ -15,7 +20,7 @@ export async function extractPackageFile(
 ): Promise<PackageFileContent | null> {
   logger.trace({ content }, `terraform.extractPackageFile(${packageFile})`);
 
-  const passedExtractors = [];
+  const passedExtractors: DependencyExtractor[] = [];
   for (const extractor of resourceExtractors) {
     if (checkFileContainsDependency(content, extractor.getCheckList())) {
       passedExtractors.push(extractor);
@@ -36,7 +41,7 @@ export async function extractPackageFile(
       .toString()}]`
   );
 
-  const dependencies = [];
+  const dependencies: PackageDependency[] = [];
   const hclMap = await hcl.parseHCL(content, packageFile);
   if (is.nullOrUndefined(hclMap)) {
     logger.debug({ packageFile }, 'failed to parse HCL file');
@@ -51,5 +56,5 @@ export async function extractPackageFile(
   }
 
   dependencies.forEach((value) => delete value.managerData);
-  return { deps: dependencies };
+  return dependencies.length ? { deps: dependencies } : null;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Return null from `extractPackageFile` when no deps where extracted.
Extractor can match false positives, so we can simply skip those files.
Otherwise i see nearly all terraform files on my dashboard.
<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
