### PR TITLE
fix: don’t block PR if matching merged PR found

### DIFF
--- a/lib/workers/repository/update/branch/handle-existing.ts
+++ b/lib/workers/repository/update/branch/handle-existing.ts
@@ -47,8 +47,6 @@ export async function handleClosedPr(
         await scm.deleteBranch(config.branchName);
       }
     }
-  } else if (pr.state === 'merged') {
-    logger.debug(`Merged PR with PrNo: ${pr.number} is blocking this branch`);
   }
 }
 

--- a/lib/workers/repository/update/branch/index.spec.ts
+++ b/lib/workers/repository/update/branch/index.spec.ts
@@ -318,7 +318,7 @@ describe('workers/repository/update/branch/index', () => {
       expect(scm.deleteBranch).toHaveBeenCalledTimes(1);
     });
 
-    it('skips branch if merged PR found', async () => {
+    it('allows branch even if merged PR found', async () => {
       const pr = partial<Pr>({
         number: 13,
         state: 'merged',
@@ -329,7 +329,7 @@ describe('workers/repository/update/branch/index', () => {
       await branchWorker.processBranch(config);
       expect(reuse.shouldReuseExistingBranch).toHaveBeenCalledTimes(0);
       expect(logger.debug).toHaveBeenCalledWith(
-        `Merged PR with PrNo: ${pr.number} is blocking this branch`
+        `Matching PR #${pr.number} was merged previously`
       );
     });
 

--- a/lib/workers/repository/update/branch/index.ts
+++ b/lib/workers/repository/update/branch/index.ts
@@ -155,8 +155,7 @@ export async function processBranch(
         config.automerge = false;
         config.automergedPreviously = true;
       }
-    }
-    if (!branchPr && existingPr && !dependencyDashboardCheck) {
+    } else if (!branchPr && existingPr && !dependencyDashboardCheck) {
       logger.debug(
         { prTitle: config.prTitle },
         'Closed PR already exists. Skipping branch.'


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Fixes check for existing merged PR

## Context

Fixes #22730

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
