### PR TITLE
test: Suppres distracting `reuse global emitter` error message

### DIFF
--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import type { Jest } from '@jest/environment';
 // Check for missing or pending http mocks
 import './http-mock';
@@ -28,6 +29,14 @@ jest.mock('../lib/modules/platform/scm', () => ({
 }));
 
 jest.mock('../lib/logger', () => jest.createMockFromModule('../lib/logger'));
+
+const consoleError = console.error.bind(console);
+console.error = (...args) => {
+  const [first] = args;
+  if (first !== 'reusing global emitter') {
+    consoleError(...args);
+  }
+};
 
 //------------------------------------------------
 // Required global jest types


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Intercept `console.error` to filter out one particular annoying message

## Context

`find-packages` transitively depends on `signal-exit` which prints error message we can't turn off.
Although it's already fixed, I'm not sure how fast this change will propagate downstream.
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
