### PR TITLE
test: time difference with time zone

### DIFF
--- a/docs/development/local-development.md
+++ b/docs/development/local-development.md
@@ -29,6 +29,10 @@ sudo apt-get update
 sudo apt-get install -y git build-essential nodejs yarn
 ```
 
+#### Nix
+
+To enter a development shell with the necessary packages, run `nix-shell --packages gcc gitFull nodejs yarn`.
+
 #### Windows
 
 Follow these steps to set up your development environment on Windows 10.

--- a/lib/util/date.spec.ts
+++ b/lib/util/date.spec.ts
@@ -7,7 +7,7 @@ import {
 } from './date';
 
 describe('util/date', () => {
-  const t0 = DateTime.fromISO('2020-10-10');
+  const t0 = DateTime.fromISO('2020-10-10', {zone: 'utc'});
 
   beforeAll(() => {
     jest.useFakeTimers();

--- a/lib/util/date.spec.ts
+++ b/lib/util/date.spec.ts
@@ -7,7 +7,7 @@ import {
 } from './date';
 
 describe('util/date', () => {
-  const t0 = DateTime.fromISO('2020-10-10', {zone: 'utc'});
+  const t0 = DateTime.fromISO('2020-10-10', { zone: 'utc' });
 
   beforeAll(() => {
     jest.useFakeTimers();


### PR DESCRIPTION
## Changes

None.

## Context

By testing without a time zone, the original test worked differently based on the local time zone of the machine running the test. This is presumably because of a summer time/winter time difference, because changing the date from `2020-10-10` to `2020-05-10` without setting the time zone also makes the test pass on my machine (Pacific/Auckland time zone).

## Documentation

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository