### PR TITLE
fix(cargo): widen not bump when value includes less-than

### DIFF
--- a/lib/modules/manager/cargo/range.spec.ts
+++ b/lib/modules/manager/cargo/range.spec.ts
@@ -7,8 +7,19 @@ describe('modules/manager/cargo/range', () => {
     expect(getRangeStrategy(config)).toBe('widen');
   });
 
+  it('returns widen if current value includes <', () => {
+    const config: RangeConfig = {
+      rangeStrategy: 'auto',
+      currentValue: '<1.0.0',
+    };
+    expect(getRangeStrategy(config)).toBe('widen');
+  });
+
   it('defaults to bump', () => {
-    const config: RangeConfig = { rangeStrategy: 'auto' };
+    const config: RangeConfig = {
+      rangeStrategy: 'auto',
+      currentValue: '1.0.0',
+    };
     expect(getRangeStrategy(config)).toBe('bump');
   });
 });

--- a/lib/modules/manager/cargo/range.ts
+++ b/lib/modules/manager/cargo/range.ts
@@ -2,7 +2,14 @@ import type { RangeStrategy } from '../../../types';
 import type { RangeConfig } from '../types';
 
 export function getRangeStrategy({
+  currentValue,
   rangeStrategy,
 }: RangeConfig): RangeStrategy {
-  return rangeStrategy === 'auto' ? 'bump' : rangeStrategy;
+  if (rangeStrategy !== 'auto') {
+    return rangeStrategy;
+  }
+  if (currentValue?.includes('<')) {
+    return 'widen';
+  }
+  return 'bump';
 }

--- a/lib/modules/manager/cargo/readme.md
+++ b/lib/modules/manager/cargo/readme.md
@@ -1,1 +1,6 @@
 Extracts dependencies from `Cargo.toml` files, and also updates `Cargo.lock` files too if found.
+
+When using the default rangeStrategy=auto:
+
+- If a "less than" instruction is found (e.g. `<2`) then `rangeStrategy=widen` will be selected,
+- Otherwise, `rangeStrategy=bump` will be selected.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Change auto rangeStrategy choice from bump to widen if the currentValue includes a less-than indicator (<)

## Context

#22694

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
