### PR TITLE
fix(manager/bazel-module): incorrect log message when no overrides

### DIFF
--- a/lib/modules/manager/bazel-module/rules.ts
+++ b/lib/modules/manager/bazel-module/rules.ts
@@ -217,9 +217,12 @@ export function processModulePkgDeps(
     merge.bazelDepMergeFields.forEach((k) => (bazelDepOut[k] = merge[k]));
   }
   const overrides = packageDeps.filter(isOverride);
+  if (overrides.length === 0) {
+    return deps;
+  }
   // It is an error for more than one override to exist for a module. We will
   // ignore the overrides if there is more than one.
-  if (overrides.length !== 1) {
+  if (overrides.length > 1) {
     const depTypes = overrides.map((o) => o.depType);
     logger.debug(
       { depName: moduleName, depTypes },


### PR DESCRIPTION
## Changes

The `bazel-module` manager logged a debug message stating that more than one override was detected when no overrides were detected. This PR fixes the logic to only log the message when there is more than one override.

## Context

Related to #13658.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository
