### PR TITLE
feat: update bazel documentation and enable `bazel-module` manager

### DIFF
--- a/docs/usage/bazel.md
+++ b/docs/usage/bazel.md
@@ -24,12 +24,12 @@ Renovate checks the workspace's `.bazelrc` files for custom registry entries.
 If no registries are found, Renovate defaults to the [Bazel Central Registry](https://github.com/bazelbuild/bazel-central-registry).
 
 Here are some important points about Renovate's Bazel registry searches.
-Renovate will:
+Renovate:
 
-- use _all_ `--registry` flag values found in a workspace's `.bazelrc` file
-- use any files that are transitively imported by a `.bazelrc` file
-- only use `--registry` flag values that are not associated with [a configuration](https://bazel.build/run/bazelrc#config)
-- query the registries in the order that they are found in the `.bazelrc` file
+- uses _all_ `--registry` flag values found in a workspace's `.bazelrc` file
+- uses any files that are transitively imported by a `.bazelrc` file
+- only uses `--registry` flag values that are not associated with [a configuration](https://bazel.build/run/bazelrc#config)
+- queries the registries in the order that they are found in the `.bazelrc` file
 
 #### Example: multiple `.bazelrc` files
 

--- a/docs/usage/bazel.md
+++ b/docs/usage/bazel.md
@@ -21,7 +21,7 @@ Renovate can upgrade dependencies in Bazel `WORKSPACE` files and `MODULE.bazel` 
 Renovate searches [Bazel registries](https://bazel.build/external/registry) to find new Bazel module versions.
 You can customize the registries your Bazel workspace uses by including [`--registry`](https://bazel.build/reference/command-line-reference#flag--registry) entries in your [`.bazelrc` files](https://bazel.build/run/bazelrc).
 Renovate checks the workspace's `.bazelrc` files for custom registry entries.
-If no registries are specified, Renovate will default to the[Bazel Central Registry](https://github.com/bazelbuild/bazel-central-registry).
+If no registries are found, Renovate defaults to the[Bazel Central Registry](https://github.com/bazelbuild/bazel-central-registry).
 
 Here are some important points about Renovate's Bazel registry searches.
 Renovate will:

--- a/docs/usage/bazel.md
+++ b/docs/usage/bazel.md
@@ -22,6 +22,7 @@ Renovate searches [Bazel registries](https://bazel.build/external/registry) to f
 You can customize the registries your Bazel workspace uses by including [`--registry` CLI flag](https://bazel.build/reference/command-line-reference#flag--registry) entries in your [`bazelrc` files](https://bazel.build/run/bazelrc).
 Renovate checks the workspace's `bazelrc` files for custom registry entries.
 If no registries are specified, it will default to the [Bazel Central Registry](https://github.com/bazelbuild/bazel-central-registry).
+If you do not set any custom registries, Renovate defaults to the [Bazel Central Registry](https://github.com/bazelbuild/bazel-central-registry).
 
 The following are some important points about Renovate's Bazel registry discovery:
 

--- a/docs/usage/bazel.md
+++ b/docs/usage/bazel.md
@@ -19,7 +19,7 @@ Renovate supports upgrading dependencies in Bazel `WORKSPACE` files and `MODULE.
 ### Bazel registry discovery
 
 Renovate searches [Bazel registries](https://bazel.build/external/registry) to find new Bazel module versions.
-You can customize the registries your Bazel workspace uses by including [`--registry` CLI flag](https://bazel.build/reference/command-line-reference#flag--registry) entries in your [`.bazelrc` files](https://bazel.build/run/bazelrc).
+You can customize the registries your Bazel workspace uses by including [`--registry`](https://bazel.build/reference/command-line-reference#flag--registry) entries in your [`.bazelrc` files](https://bazel.build/run/bazelrc).
 Renovate checks the workspace's `.bazelrc` files for custom registry entries.
 If no registries are specified, it will default to the [Bazel Central Registry](https://github.com/bazelbuild/bazel-central-registry).
 If you do not set any custom registries, Renovate defaults to the [Bazel Central Registry](https://github.com/bazelbuild/bazel-central-registry).

--- a/docs/usage/bazel.md
+++ b/docs/usage/bazel.md
@@ -82,7 +82,7 @@ bazel_dep(name = "cgrindel_bazel_starlib", version = "0.15.0")
 ```
 
 In the example above, Renovate evaluates the `0.15.0` version against the repository's registries.
-If Renovate finds a newer version, it will update `0.15.0` to match that version.
+If Renovate finds a newer version, it updates `0.15.0` to match that version.
 
 #### `git_override`
 
@@ -106,8 +106,8 @@ The [`single_version_override`](https://bazel.build/rules/lib/globals/module#sin
 Renovate only evaluates _two_ attributes from this declaration: `version` and `registry`.
 
 If a `version` is specified, it overrides the version specified in the `bazel_dep` pinning it to the specified value.
-In the following example, Renovate will note that the version has been pinned to `1.2.3`.
-This will result in `rules_foo` being ignored for update evaluation.
+In the following example, Renovate notices that the version is pinned to `1.2.3`.
+This results in `rules_foo` being ignored for update evaluation.
 
 ```python
 bazel_dep(name = "rules_foo", version = "1.2.4")
@@ -118,9 +118,9 @@ single_version_override(
 )
 ```
 
-If a `registry` is specified, Renovate will use the specified registry URL to check for a new version.
-In the following example, Renovate will only use the `https://example.com/custom_registry` registry to discover `rules_foo` versions.
-Any registry values specified in the repository's `.bazelrc` files will be ignored for the `rules_foo` module.
+If a `registry` is specified, Renovate uses the specified registry URL to check for a new version.
+In the following example, Renovate only uses the `https://example.com/custom_registry` registry to discover `rules_foo` versions.
+Any registry values specified in the repository's `.bazelrc` files are ignored for the `rules_foo` module.
 
 ```python
 bazel_dep(name = "rules_foo", version = "1.2.3")
@@ -133,8 +133,8 @@ single_version_override(
 
 #### `archive_override` and `local_path_override`
 
-If Renovate finds an [`archive_override`](https://bazel.build/rules/lib/globals/module#archive_override) or a [`local_path_override`](https://bazel.build/rules/lib/globals/module#local_path_override), it will ignore the related `bazel_dep`.
-Because these declarations lack versionable attributes, Renovate will not update them.
+If Renovate finds an [`archive_override`](https://bazel.build/rules/lib/globals/module#archive_override) or a [`local_path_override`](https://bazel.build/rules/lib/globals/module#local_path_override), it ignores the related `bazel_dep`.
+Because these declarations lack versionable attributes, Renovate does not update them.
 
 ```python
 bazel_dep(name = "rules_foo", version = "1.2.3")
@@ -165,7 +165,7 @@ Renovate will extract dependencies from:
 
 ### `git_repository`
 
-Renovate will update any `git_repository` declaration that has the following:
+Renovate updates any `git_repository` declaration that has the following:
 
 1. name
 1. remote matching `https://github.com/<owner>/<repo>.git`
@@ -185,7 +185,7 @@ Renovate uses the list of **tags** on the remote repository (GitHub) to detect a
 
 ### `http_archive` and `http_file`
 
-Renovate will update any `http_archive` or `http_file` declaration that has the following:
+Renovate updates any `http_archive` or `http_file` declaration that has the following:
 
 1. name
 1. url matching `https://github.com/<owner>/<repo>/releases/download/<semver>/<repo>.tar.gz`

--- a/docs/usage/bazel.md
+++ b/docs/usage/bazel.md
@@ -5,14 +5,14 @@ description: Bazel dependencies support in Renovate
 
 # Bazel
 
-Renovate supports upgrading dependencies in Bazel `WORKSPACE` files and `MODULE.bazel` files.
+Renovate can upgrade dependencies in Bazel `WORKSPACE` files and `MODULE.bazel` files.
 
 ## How it works
 
 1. Bazel support is enabled automatically
-1. Renovate will search for any `WORKSPACE` and `MODULE.bazel` files in the repository
-1. Existing dependencies will be extracted from the files (see below for the supported dependency declarations)
-1. Renovate will replace any old versions with the latest version available
+1. Renovate searches the repository for any `WORKSPACE` and `MODULE.bazel` files
+1. Renovate extracts the dependencies it finds from the files (see below for the supported dependency declarations)
+1. Renovate updates old dependencies to the latest version
 
 ## Bazel module (`MODULE.bazel`) support
 
@@ -50,7 +50,7 @@ build --registry=https://raw.githubusercontent.com/bazelbuild/bazel-central-regi
 build --registry=https://example.com/custom_registry
 ```
 
-The resulting registry list is:
+The final registry list is:
 
 1. `<https://example.com/custom_registry>`
 1. `<https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main>`
@@ -82,12 +82,12 @@ Renovate will update the `version` value for a [`bazel_dep`](https://bazel.build
 bazel_dep(name = "cgrindel_bazel_starlib", version = "0.15.0")
 ```
 
-In the example above, the `0.15.0` will be evaluated against a repository's registries.
-If a new version is found, the value will be replaced with the new version.
+In the example above, Renovate evaluates the `0.15.0` version against the repository's registries.
+If Renovate finds a newer version, it will update `0.15.0` to match that version.
 
 #### `git_override`
 
-If Renovate finds a [`git_override`](https://bazel.build/rules/lib/globals/module#git_override), it will ignore the related `bazel_dep` and evaluate the `commit` value at the specified `remote`.
+If Renovate finds a [`git_override`](https://bazel.build/rules/lib/globals/module#git_override), it ignores the related `bazel_dep` entry and instead evaluates the `commit` value at the specified `remote`.
 
 ```python
 bazel_dep(name = "cgrindel_bazel_starlib", version = "0.15.0")
@@ -99,12 +99,12 @@ git_override(
 )
 ```
 
-If the primary branch has a newer commit than in the list, Renovate will update the `commit` value.
+If the primary branch has a newer commit than in the list, Renovate updates the `commit` value.
 
 #### `single_version_override`
 
 The [`single_version_override`](https://bazel.build/rules/lib/globals/module#single_version_override) is a declaration with many purposes.
-Renovate evaluates two attributes from this declaration: `version` and `registry`.
+Renovate only evaluates _two_ attributes from this declaration: `version` and `registry`.
 
 If a `version` is specified, it overrides the version specified in the `bazel_dep` pinning it to the specified value.
 In the following example, Renovate will note that the version has been pinned to `1.2.3`.

--- a/docs/usage/bazel.md
+++ b/docs/usage/bazel.md
@@ -118,7 +118,7 @@ single_version_override(
 ```
 
 If a `registry` is specified, Renovate will use the specified registry URL to check for a new version. 
-In the following example, Renovate will only use the `https://example.com/custom_registry` registry to look for versions for `rules_foo`.
+In the following example, Renovate will only use the `https://example.com/custom_registry` registry to discover `rules_foo` versions.
 Any registry values specified in the repository's bazlerc files will be ignored for the `rules_foo` module.
 
 ```python

--- a/docs/usage/bazel.md
+++ b/docs/usage/bazel.md
@@ -55,7 +55,7 @@ The resulting registry list is:
 1. `<https://example.com/custom_registry>`
 1. `<https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main>`
 
-#### Example: Registry entries using Bazel configuration
+#### Example: registry entries using Bazel configuration
 
 In this example, a `.bazelrc` file has registry values with and without a configuration:
 

--- a/docs/usage/bazel.md
+++ b/docs/usage/bazel.md
@@ -21,7 +21,7 @@ Renovate upgrades dependencies in Bazel `WORKSPACE` files and `MODULE.bazel` fil
 Renovate searches [Bazel registries](https://bazel.build/external/registry) to find new Bazel module versions.
 You customize the registries your Bazel workspace uses by including [`--registry`](https://bazel.build/reference/command-line-reference#flag--registry) entries in your [`.bazelrc` files](https://bazel.build/run/bazelrc).
 Renovate checks the workspace's `.bazelrc` files for custom registry entries.
-If no registries are found, Renovate defaults to the [Bazel Central Registry](https://github.com/bazelbuild/bazel-central-registry).
+If no registries are found, Renovate defaults to the [Bazel Central Registry](https://bcr.bazel.build/).
 
 Here are some important points about Renovate's Bazel registry searches.
 Renovate:

--- a/docs/usage/bazel.md
+++ b/docs/usage/bazel.md
@@ -105,7 +105,7 @@ If the primary branch has a newer commit than in the list, Renovate updates the 
 The [`single_version_override`](https://bazel.build/rules/lib/globals/module#single_version_override) is a declaration with many purposes.
 Renovate only evaluates _two_ attributes from this declaration: `version` and `registry`.
 
-If a `version` is specified, it overrides the version specified in the `bazel_dep` pinning it to the specified value.
+If a `version` is specified, it overrides the version in the `bazel_dep`.
 In the following example, Renovate notices that the version is pinned to `1.2.3`.
 This results in `rules_foo` being ignored for update evaluation.
 

--- a/docs/usage/bazel.md
+++ b/docs/usage/bazel.md
@@ -26,9 +26,9 @@ If no registries are found, Renovate defaults to the [Bazel Central Registry](ht
 Here are some important points about Renovate's Bazel registry searches.
 Renovate:
 
-- uses _all_ `--registry` flag values found in a workspace's `.bazelrc` file
+- uses _all_ `--registry` values found in a workspace's `.bazelrc` file
 - uses any files that are transitively imported by a `.bazelrc` file
-- only uses `--registry` flag values that are not associated with [a configuration](https://bazel.build/run/bazelrc#config)
+- only uses `--registry` values that are not associated with [a configuration](https://bazel.build/run/bazelrc#config)
 - queries the registries in the order that they are found in the `.bazelrc` file
 
 #### Example: multiple `.bazelrc` files

--- a/docs/usage/bazel.md
+++ b/docs/usage/bazel.md
@@ -34,7 +34,7 @@ Renovate will:
 #### Example: multiple `.bazelrc` files
 
 In this example, there is a `.bazelrc` file which imports another file called `.registry.bazelrc`.
-Both those files have `--registry` values:
+Both files have `--registry` values:
 
 ```
 # -------------

--- a/docs/usage/bazel.md
+++ b/docs/usage/bazel.md
@@ -18,16 +18,16 @@ Renovate supports upgrading dependencies in Bazel `WORKSPACE` files and `MODULE.
 
 ### Bazel Registry Discovery
 
-Bazel module version discovery centers around interrogation of one or more [Bazel registries](https://bazel.build/external/registry). 
+Bazel module version discovery centers around interrogation of one or more [Bazel registries](https://bazel.build/external/registry).
 A Bazel workspace can specify the registries that it uses by including [--registry](https://bazel.build/reference/command-line-reference#flag--registry) entries in [bazelrc files](https://bazel.build/run/bazelrc).
 Renovate will inspect a workspace's bazelrc files looking for registries to use during Bazel module version discovery.
 If no registries are specified, it will default to the [Bazel Central Registry](https://github.com/bazelbuild/bazel-central-registry).
 
 The following are some important points about Renovate's Bazel registry discovery:
+
 - Renovate will use all `--registry` flag values found in a workspace's `.bazelrc` file or any files transitively imported by the `.bazelrc` file.
 - Renovate will only use `--registry` flag values that are not associated with [a configuration](https://bazel.build/run/bazelrc#config).
 - Renovate will query the registries in the order that they are found in the bazlerc files.
-
 
 #### Example: Multiple bazelrc Files
 
@@ -49,9 +49,8 @@ build --registry=https://example.com/custom_registry
 
 The resulting registry list is:
 
-1. https://example.com/custom_registry
-2. https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main
-
+1. <https://example.com/custom_registry>
+2. <https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main>
 
 #### Example: Registry Entries Using Bazel Configuration
 
@@ -65,22 +64,22 @@ build:ci --registry=https://internal.server/custom_registry
 build --registry=https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main
 ```
 
-In this case the `https://internal.server/custom_registry` will be ignored. 
+In this case the `https://internal.server/custom_registry` will be ignored.
 The resulting registry list is:
 
-1. https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main
+1. <https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main>
 
 ### Supported Bazel Module Declarations
 
 #### `bazel_dep`
 
-Renovate will update the `version` value for a [bazel_dep](https://bazel.build/rules/lib/globals/module#bazel_dep) declaration. 
+Renovate will update the `version` value for a [bazel_dep](https://bazel.build/rules/lib/globals/module#bazel_dep) declaration.
 
 ```python
 bazel_dep(name = "cgrindel_bazel_starlib", version = "0.15.0")
 ```
 
-In the example above, the `0.15.0` will be evaluated against a repository's registries. 
+In the example above, the `0.15.0` will be evaluated against a repository's registries.
 If a new version is found, the value will be replaced with the new version.
 
 #### `git_override`
@@ -117,7 +116,7 @@ single_version_override(
 )
 ```
 
-If a `registry` is specified, Renovate will use the specified registry URL to check for a new version. 
+If a `registry` is specified, Renovate will use the specified registry URL to check for a new version.
 In the following example, Renovate will only use the `https://example.com/custom_registry` registry to discover `rules_foo` versions.
 Any registry values specified in the repository's bazlerc files will be ignored for the `rules_foo` module.
 

--- a/docs/usage/bazel.md
+++ b/docs/usage/bazel.md
@@ -14,9 +14,9 @@ Renovate supports upgrading dependencies in Bazel `WORKSPACE` files and `MODULE.
 3. Existing dependencies will be extracted from the files (see below for the supported dependency declarations)
 4. Renovate will replace any old versions with the latest version available
 
-## Bazel Module (`MODULE.bazel`) Support
+## Bazel module (`MODULE.bazel`) support
 
-### Bazel Registry Discovery
+### Bazel registry discovery
 
 Bazel module version discovery centers around interrogation of one or more [Bazel registries](https://bazel.build/external/registry).
 A Bazel workspace can specify the registries that it uses by including [--registry](https://bazel.build/reference/command-line-reference#flag--registry) entries in [bazelrc files](https://bazel.build/run/bazelrc).
@@ -52,7 +52,7 @@ The resulting registry list is:
 1. <https://example.com/custom_registry>
 2. <https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main>
 
-#### Example: Registry Entries Using Bazel Configuration
+#### Example: Registry entries using Bazel configuration
 
 In this example, a `.bazelrc` file contains registry values with and without a configuration.
 
@@ -69,7 +69,7 @@ The resulting registry list is:
 
 1. <https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main>
 
-### Supported Bazel Module Declarations
+### Supported Bazel module declarations
 
 #### `bazel_dep`
 

--- a/docs/usage/bazel.md
+++ b/docs/usage/bazel.md
@@ -5,7 +5,7 @@ description: Bazel dependencies support in Renovate
 
 # Bazel
 
-Renovate can upgrade dependencies in Bazel `WORKSPACE` files and `MODULE.bazel` files.
+Renovate upgrades dependencies in Bazel `WORKSPACE` files and `MODULE.bazel` files.
 
 ## How it works
 
@@ -19,9 +19,9 @@ Renovate can upgrade dependencies in Bazel `WORKSPACE` files and `MODULE.bazel` 
 ### Bazel registry discovery
 
 Renovate searches [Bazel registries](https://bazel.build/external/registry) to find new Bazel module versions.
-You can customize the registries your Bazel workspace uses by including [`--registry`](https://bazel.build/reference/command-line-reference#flag--registry) entries in your [`.bazelrc` files](https://bazel.build/run/bazelrc).
+You customize the registries your Bazel workspace uses by including [`--registry`](https://bazel.build/reference/command-line-reference#flag--registry) entries in your [`.bazelrc` files](https://bazel.build/run/bazelrc).
 Renovate checks the workspace's `.bazelrc` files for custom registry entries.
-If no registries are found, Renovate defaults to the[Bazel Central Registry](https://github.com/bazelbuild/bazel-central-registry).
+If no registries are found, Renovate defaults to the [Bazel Central Registry](https://github.com/bazelbuild/bazel-central-registry).
 
 Here are some important points about Renovate's Bazel registry searches.
 Renovate will:
@@ -66,7 +66,7 @@ build:ci --registry=https://internal.server/custom_registry
 build --registry=https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main
 ```
 
-In this case the `https://internal.server/custom_registry` will be ignored.
+In this case the `https://internal.server/custom_registry` is ignored.
 The final registry list is:
 
 1. `<https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main>`
@@ -75,7 +75,7 @@ The final registry list is:
 
 #### `bazel_dep`
 
-Renovate will update the `version` value for a [`bazel_dep`](https://bazel.build/rules/lib/globals/module#bazel_dep) declaration.
+Renovate updates the `version` value for a [`bazel_dep`](https://bazel.build/rules/lib/globals/module#bazel_dep) declaration.
 
 ```python
 bazel_dep(name = "cgrindel_bazel_starlib", version = "0.15.0")
@@ -154,7 +154,7 @@ Renovate ignores [`multiple_version_override`](https://bazel.build/rules/lib/glo
 
 ## Legacy `WORKSPACE` files
 
-Renovate will extract dependencies from:
+Renovate extracts dependencies from:
 
 - `container_pull`
 - `oci_pull`
@@ -167,9 +167,9 @@ Renovate will extract dependencies from:
 
 Renovate updates any `git_repository` declaration that has the following:
 
-1. name
-1. remote matching `https://github.com/<owner>/<repo>.git`
-1. tag using a valid SemVer
+1. `name`
+1. `remote` matching `https://github.com/<owner>/<repo>.git`
+1. `tag` using a valid SemVer
 
 e.g.:
 
@@ -187,9 +187,9 @@ Renovate uses the list of **tags** on the remote repository (GitHub) to detect a
 
 Renovate updates any `http_archive` or `http_file` declaration that has the following:
 
-1. name
-1. url matching `https://github.com/<owner>/<repo>/releases/download/<semver>/<repo>.tar.gz`
-1. sha256
+1. `name`
+1. `url` matching `https://github.com/<owner>/<repo>/releases/download/<semver>/<repo>.tar.gz`
+1. `sha256`
 
 e.g.:
 

--- a/docs/usage/bazel.md
+++ b/docs/usage/bazel.md
@@ -24,16 +24,18 @@ Renovate checks the workspace's `bazelrc` files for custom registry entries.
 If no registries are specified, it will default to the [Bazel Central Registry](https://github.com/bazelbuild/bazel-central-registry).
 If you do not set any custom registries, Renovate defaults to the [Bazel Central Registry](https://github.com/bazelbuild/bazel-central-registry).
 
-The following are some important points about Renovate's Bazel registry discovery:
+Here are some important points about Renovate's Bazel registry searches.
+Renovate will:
 
-- Renovate will use all `--registry` flag values found in a workspace's `.bazelrc` file or any files transitively imported by the `.bazelrc` file.
-- Renovate will only use `--registry` flag values that are not associated with [a configuration](https://bazel.build/run/bazelrc#config).
-- Renovate will query the registries in the order that they are found in the bazlerc files.
+- use _all_ `--registry` flag values found in a workspace's `.bazelrc` file
+- use any files that are transitively imported by a `.bazelrc` file
+- only use `--registry` flag values that are not associated with [a configuration](https://bazel.build/run/bazelrc#config)
+- query the registries in the order that they are found in the `.bazelrc` file
 
-#### Example: Multiple bazelrc Files
+#### Example: multiple `.bazelrc` files
 
-In the following example, there is a `.bazelrc` file that imports a file called `.registry.bazelrc`.
-Each of these files contains `--registry` values.
+In this example, there is a `.bazelrc` file which imports another file called `.registry.bazelrc`.
+Both those files have `--registry` values:
 
 ```
 # -------------
@@ -55,7 +57,7 @@ The resulting registry list is:
 
 #### Example: Registry entries using Bazel configuration
 
-In this example, a `.bazelrc` file contains registry values with and without a configuration.
+In this example, a `.bazelrc` file has registry values with and without a configuration:
 
 ```
 # -------------
@@ -66,9 +68,9 @@ build --registry=https://raw.githubusercontent.com/bazelbuild/bazel-central-regi
 ```
 
 In this case the `https://internal.server/custom_registry` will be ignored.
-The resulting registry list is:
+The final registry list is:
 
-1. <https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main>
+1. `<https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main>`
 
 ### Supported Bazel module declarations
 
@@ -101,7 +103,7 @@ If there is a more recent commit on the primary branch than the one listed, the 
 
 #### `single_version_override`
 
-The [single_version_override](https://bazel.build/rules/lib/globals/module#single_version_override) is a declaration with many purposes.
+The [`single_version_override`](https://bazel.build/rules/lib/globals/module#single_version_override) is a declaration with many purposes.
 Renovate evaluates two attributes from this declaration: `version` and `registry`.
 
 If a `version` is specified, it overrides the version specified in the `bazel_dep` pinning it to the specified value.
@@ -119,7 +121,7 @@ single_version_override(
 
 If a `registry` is specified, Renovate will use the specified registry URL to check for a new version.
 In the following example, Renovate will only use the `https://example.com/custom_registry` registry to discover `rules_foo` versions.
-Any registry values specified in the repository's bazlerc files will be ignored for the `rules_foo` module.
+Any registry values specified in the repository's `.bazelrc` files will be ignored for the `rules_foo` module.
 
 ```python
 bazel_dep(name = "rules_foo", version = "1.2.3")
@@ -132,8 +134,8 @@ single_version_override(
 
 #### `archive_override` and `local_path_override`
 
-If Renovate finds an [archive_override](https://bazel.build/rules/lib/globals/module#archive_override) or a [local_path_override](https://bazel.build/rules/lib/globals/module#local_path_override), it will ignore the related `bazel_dep`.
-Since there are no versionable attributes on these declarations, no updates will occur.
+If Renovate finds an [`archive_override`](https://bazel.build/rules/lib/globals/module#archive_override) or a [`local_path_override`](https://bazel.build/rules/lib/globals/module#local_path_override), it will ignore the related `bazel_dep`.
+Because these declarations lack versionable attributes, Renovate will not update them.
 
 ```python
 bazel_dep(name = "rules_foo", version = "1.2.3")
@@ -148,12 +150,19 @@ archive_override(
 
 #### `multiple_version_override`
 
-Renovate ignores [multiple_version_override](https://bazel.build/rules/lib/globals/module#multiple_version_override).
-It does not affect the processing of version updates for a module.
+Renovate ignores [`multiple_version_override`](https://bazel.build/rules/lib/globals/module#multiple_version_override).
+`multiple_version_override` does not affect the processing of version updates for a module.
 
-## Legacy `WORKSPACE` File Support
+## Legacy `WORKSPACE` files
 
-Existing dependencies will be extracted from `container_pull`, `oci_pull`, `git_repository`, `go_repository`, `maven_install`, and `http_archive`/`http_file` declarations
+Renovate will extract dependencies from:
+
+- `container_pull`
+- `oci_pull`
+- `git_repository`
+- `go_repository`
+- `maven_install`
+- `http_archive` or `http_file` declarations
 
 ### `git_repository`
 

--- a/docs/usage/bazel.md
+++ b/docs/usage/bazel.md
@@ -21,8 +21,7 @@ Renovate can upgrade dependencies in Bazel `WORKSPACE` files and `MODULE.bazel` 
 Renovate searches [Bazel registries](https://bazel.build/external/registry) to find new Bazel module versions.
 You can customize the registries your Bazel workspace uses by including [`--registry`](https://bazel.build/reference/command-line-reference#flag--registry) entries in your [`.bazelrc` files](https://bazel.build/run/bazelrc).
 Renovate checks the workspace's `.bazelrc` files for custom registry entries.
-If no registries are specified, it will default to the [Bazel Central Registry](https://github.com/bazelbuild/bazel-central-registry).
-If you do not set any custom registries, Renovate defaults to the [Bazel Central Registry](https://github.com/bazelbuild/bazel-central-registry).
+If no registries are specified, Renovate will default to the[Bazel Central Registry](https://github.com/bazelbuild/bazel-central-registry).
 
 Here are some important points about Renovate's Bazel registry searches.
 Renovate will:

--- a/docs/usage/bazel.md
+++ b/docs/usage/bazel.md
@@ -10,9 +10,9 @@ Renovate supports upgrading dependencies in Bazel `WORKSPACE` files and `MODULE.
 ## How it works
 
 1. Bazel support is enabled automatically
-2. Renovate will search for any `WORKSPACE` and `MODULE.bazel` files in the repository
-3. Existing dependencies will be extracted from the files (see below for the supported dependency declarations)
-4. Renovate will replace any old versions with the latest version available
+1. Renovate will search for any `WORKSPACE` and `MODULE.bazel` files in the repository
+1. Existing dependencies will be extracted from the files (see below for the supported dependency declarations)
+1. Renovate will replace any old versions with the latest version available
 
 ## Bazel module (`MODULE.bazel`) support
 
@@ -51,7 +51,7 @@ build --registry=https://example.com/custom_registry
 The resulting registry list is:
 
 1. <https://example.com/custom_registry>
-2. <https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main>
+1. <https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main>
 
 #### Example: Registry entries using Bazel configuration
 
@@ -160,8 +160,8 @@ Existing dependencies will be extracted from `container_pull`, `oci_pull`, `git_
 Renovate will update any `git_repository` declaration that has the following:
 
 1. name
-2. remote matching `https://github.com/<owner>/<repo>.git`
-3. tag using a valid SemVer
+1. remote matching `https://github.com/<owner>/<repo>.git`
+1. tag using a valid SemVer
 
 e.g.:
 
@@ -180,8 +180,8 @@ Renovate uses the list of **tags** on the remote repository (GitHub) to detect a
 Renovate will update any `http_archive` or `http_file` declaration that has the following:
 
 1. name
-2. url matching `https://github.com/<owner>/<repo>/releases/download/<semver>/<repo>.tar.gz`
-3. sha256
+1. url matching `https://github.com/<owner>/<repo>/releases/download/<semver>/<repo>.tar.gz`
+1. sha256
 
 e.g.:
 

--- a/docs/usage/bazel.md
+++ b/docs/usage/bazel.md
@@ -18,7 +18,7 @@ Renovate supports upgrading dependencies in Bazel `WORKSPACE` files and `MODULE.
 
 ### Bazel registry discovery
 
-Bazel module version discovery centers around interrogation of one or more [Bazel registries](https://bazel.build/external/registry).
+Renovate searches [Bazel registries](https://bazel.build/external/registry) to find new Bazel module versions.
 A Bazel workspace can specify the registries that it uses by including [--registry](https://bazel.build/reference/command-line-reference#flag--registry) entries in [bazelrc files](https://bazel.build/run/bazelrc).
 Renovate will inspect a workspace's bazelrc files looking for registries to use during Bazel module version discovery.
 If no registries are specified, it will default to the [Bazel Central Registry](https://github.com/bazelbuild/bazel-central-registry).

--- a/docs/usage/bazel.md
+++ b/docs/usage/bazel.md
@@ -55,7 +55,7 @@ The resulting registry list is:
 
 #### Example: Registry Entries Using Bazel Configuration
 
-In this example, a `.bazelrc` file contains registry value with and without a configuration.
+In this example, a `.bazelrc` file contains registry values with and without a configuration.
 
 ```
 # -------------

--- a/docs/usage/bazel.md
+++ b/docs/usage/bazel.md
@@ -5,16 +5,85 @@ description: Bazel dependencies support in Renovate
 
 # Bazel
 
-Renovate supports upgrading dependencies in Bazel `WORKSPACE` files.
+Renovate supports upgrading dependencies in Bazel `WORKSPACE` files and `MODULE.bazel` files.
 
 ## How it works
 
 1. Bazel support is enabled automatically
-2. Renovate will search repositories for any `WORKSPACE` files in the repository
-3. Existing dependencies will be extracted from `container_pull`, `oci_pull`, `git_repository`, `go_repository`, `maven_install`, and `http_archive`/`http_file` declarations
+2. Renovate will search for any `WORKSPACE` and `MODULE.bazel` files in the repository
+3. Existing dependencies will be extracted from the files (see below for the supported dependency declarations)
 4. Renovate will replace any old versions with the latest version available
 
-## git_repository
+## Bazel Module (`MODULE.bazel`) Support
+
+### Bazel Registry Discovery
+
+Bazel module version discovery centers around interrogation of one or more [Bazel registries](https://bazel.build/external/registry). 
+A Bazel workspace can specify the registries that it uses by including [--registry](https://bazel.build/reference/command-line-reference#flag--registry) entries in [bazelrc files](https://bazel.build/run/bazelrc).
+Renovate will inspect a workspace's bazelrc files looking for registries to use during Bazel module version discovery.
+If no registries are specified, it will default to the [Bazel Central Registry](https://github.com/bazelbuild/bazel-central-registry).
+
+The following are some important points about Renovate's Bazel registry discovery:
+- Renovate will use all `--registry` flag values found in a workspace's `.bazelrc` file or any files transitively imported by the `.bazelrc` file.
+- Renovate will only use `--registry` flag values that are not associated with [a configuration](https://bazel.build/run/bazelrc#config).
+- Renovate will query the registries in the order that they are found in the bazlerc files.
+
+
+#### Example: Multiple bazelrc Files
+
+In the following example, there is a `.bazelrc` file that imports a file called `.registry.bazelrc`.
+Each of these files contains `--registry` values.
+
+```
+# -------------
+# .bazelrc File
+# -------------
+import .registry.bazelrc
+build --registry=https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main
+
+# ----------------------
+# .registry.bazelrc File
+# ----------------------
+build --registry=https://example.com/custom_registry
+```
+
+The resulting registry list is:
+
+1. https://example.com/custom_registry
+2. https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main
+
+
+#### Example: Registry Entries Using Bazel Configuration
+
+In this example, a `.bazelrc` file contains registry value with and without a configuration.
+
+```
+# -------------
+# .bazelrc File
+# -------------
+build:ci --registry=https://internal.server/custom_registry
+build --registry=https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main
+```
+
+In this case the `https://internal.server/custom_registry` will be ignored. The resulting registry list is:
+
+1. https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main
+
+### Supported Bazel Module Declarations
+
+#### `bazel_dep`
+
+The `version` value for a `bazel_dep` declaration will be updated for a 
+
+```python
+bazel_dep(name = "cgrindel_bazel_starlib", version = "0.15.0")
+```
+
+## Legacy `WORKSPACE` File Support
+
+Existing dependencies will be extracted from `container_pull`, `oci_pull`, `git_repository`, `go_repository`, `maven_install`, and `http_archive`/`http_file` declarations
+
+### `git_repository`
 
 Renovate will update any `git_repository` declaration that has the following:
 
@@ -34,7 +103,7 @@ git_repository(
 
 Renovate uses the list of **tags** on the remote repository (GitHub) to detect a new version.
 
-## http_archive and http_file
+### `http_archive` and `http_file`
 
 Renovate will update any `http_archive` or `http_file` declaration that has the following:
 
@@ -54,7 +123,7 @@ http_archive(
 
 Renovate uses the list of **releases** that it finds at the `url` to detect a new version.
 
-## maven_install
+### `maven_install`
 
 By default, Maven dependencies are extracted in the context of Gradle versioning scheme.
 To change it, configure `packageRules` like this:

--- a/docs/usage/bazel.md
+++ b/docs/usage/bazel.md
@@ -19,8 +19,8 @@ Renovate supports upgrading dependencies in Bazel `WORKSPACE` files and `MODULE.
 ### Bazel registry discovery
 
 Renovate searches [Bazel registries](https://bazel.build/external/registry) to find new Bazel module versions.
-You can customize the registries your Bazel workspace uses by including [`--registry` CLI flag](https://bazel.build/reference/command-line-reference#flag--registry) entries in your [`bazelrc` files](https://bazel.build/run/bazelrc).
-Renovate checks the workspace's `bazelrc` files for custom registry entries.
+You can customize the registries your Bazel workspace uses by including [`--registry` CLI flag](https://bazel.build/reference/command-line-reference#flag--registry) entries in your [`.bazelrc` files](https://bazel.build/run/bazelrc).
+Renovate checks the workspace's `.bazelrc` files for custom registry entries.
 If no registries are specified, it will default to the [Bazel Central Registry](https://github.com/bazelbuild/bazel-central-registry).
 If you do not set any custom registries, Renovate defaults to the [Bazel Central Registry](https://github.com/bazelbuild/bazel-central-registry).
 
@@ -52,8 +52,8 @@ build --registry=https://example.com/custom_registry
 
 The resulting registry list is:
 
-1. <https://example.com/custom_registry>
-1. <https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main>
+1. `<https://example.com/custom_registry>`
+1. `<https://raw.githubusercontent.com/bazelbuild/bazel-central-registry/main>`
 
 #### Example: Registry entries using Bazel configuration
 
@@ -76,7 +76,7 @@ The final registry list is:
 
 #### `bazel_dep`
 
-Renovate will update the `version` value for a [bazel_dep](https://bazel.build/rules/lib/globals/module#bazel_dep) declaration.
+Renovate will update the `version` value for a [`bazel_dep`](https://bazel.build/rules/lib/globals/module#bazel_dep) declaration.
 
 ```python
 bazel_dep(name = "cgrindel_bazel_starlib", version = "0.15.0")
@@ -87,7 +87,7 @@ If a new version is found, the value will be replaced with the new version.
 
 #### `git_override`
 
-If Renovate finds a [git_override](https://bazel.build/rules/lib/globals/module#git_override), it will ignore the related `bazel_dep` and evaluate the `commit` value at the specified `remote`.
+If Renovate finds a [`git_override`](https://bazel.build/rules/lib/globals/module#git_override), it will ignore the related `bazel_dep` and evaluate the `commit` value at the specified `remote`.
 
 ```python
 bazel_dep(name = "cgrindel_bazel_starlib", version = "0.15.0")
@@ -99,7 +99,7 @@ git_override(
 )
 ```
 
-If there is a more recent commit on the primary branch than the one listed, the `commit` value will be updated.
+If the primary branch has a newer commit than in the list, Renovate will update the `commit` value.
 
 #### `single_version_override`
 

--- a/docs/usage/bazel.md
+++ b/docs/usage/bazel.md
@@ -19,8 +19,8 @@ Renovate supports upgrading dependencies in Bazel `WORKSPACE` files and `MODULE.
 ### Bazel registry discovery
 
 Renovate searches [Bazel registries](https://bazel.build/external/registry) to find new Bazel module versions.
-A Bazel workspace can specify the registries that it uses by including [--registry](https://bazel.build/reference/command-line-reference#flag--registry) entries in [bazelrc files](https://bazel.build/run/bazelrc).
-Renovate will inspect a workspace's bazelrc files looking for registries to use during Bazel module version discovery.
+You can customize the registries your Bazel workspace uses by including [`--registry` CLI flag](https://bazel.build/reference/command-line-reference#flag--registry) entries in your [`bazelrc` files](https://bazel.build/run/bazelrc).
+Renovate checks the workspace's `bazelrc` files for custom registry entries.
 If no registries are specified, it will default to the [Bazel Central Registry](https://github.com/bazelbuild/bazel-central-registry).
 
 The following are some important points about Renovate's Bazel registry discovery:

--- a/lib/modules/manager/bazel-module/index.ts
+++ b/lib/modules/manager/bazel-module/index.ts
@@ -6,10 +6,6 @@ export { extractPackageFile };
 
 export const defaultConfig = {
   fileMatch: ['(^|/)MODULE\\.bazel$'],
-  // The bazel-module manager is still under development. The milestone
-  // tracking the release of this manager is at
-  // https://github.com/renovatebot/renovate/issues/13658.
-  enabled: false,
 };
 
 export const supportedDatasources = [


### PR DESCRIPTION
## Changes

- Update the Bazel documentation to include information on Bazel module support.
- Enable the `bazel-module` manager.

## Context

Closes #13658.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
