### PR TITLE
docs(faq): explain when new Renovate OSS releases are added to the hosted app

### DIFF
--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -29,7 +29,7 @@ The Renovate team only fixes bugs in an older version if:
 If you're using the hosted app, you don't need to do anything, as the Renovate maintainers update the hosted app regularly.
 If you're self hosting Renovate, use the latest release if possible.
 
-## Why is the Mend hosted app using a older version compared to source?
+## When are new Renovate OSS releases added to the hosted Mend Renovate App?
 
 The Renovate maintainers manually update the hosted app.
 This means the hosted app can lag a few hours to a week behind the open source version.

--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -29,6 +29,11 @@ The Renovate team only fixes bugs in an older version if:
 If you're using the hosted app, you don't need to do anything, as the Renovate maintainers update the hosted app regularly.
 If you're self hosting Renovate, use the latest release if possible.
 
+## Why is the Mend hosted app using a older version compared to source?
+
+The Renovate maintainers manually update the hosted app.
+This means the hosted app can lag a few hours to a week behind the open source version.
+
 ## Renovate core features not supported on all platforms
 
 | Feature              | Platforms which lack feature                               | See Renovate issue(s)                                        |


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Explain why the hosted mend app may lag behind compared to the latest open source version

## Context

The _Which Renovate versions are officially supported?_ section of the FAQ already mentions:

> If you're using the hosted app, you don't need to do anything, as the Renovate maintainers update the hosted app regularly.

But the whole "app lags behind open source version" should probably have its own heading. 😄 

I'm trying to stop users getting confused like this:

- #22738

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
