### PR TITLE
feat: baseBranches $default

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -300,6 +300,14 @@ With a negation, all branches except those matching the regex will be added to t
 }
 ```
 
+You can also use the special `"$default"` string to denote the repository's default branch, which is useful if you have it in an org preset, e.g.:
+
+```json
+{
+  "baseBranches": ["$default", "/^release\\/.*/"]
+}
+```
+
 <!-- prettier-ignore -->
 !!! note
     Do _not_ use the `baseBranches` config option when you've set a `forkToken`.

--- a/lib/workers/repository/process/index.spec.ts
+++ b/lib/workers/repository/process/index.spec.ts
@@ -150,5 +150,20 @@ describe('workers/repository/process/index', () => {
       expect(addMeta).toHaveBeenCalledWith({ baseBranch: 'dev' });
       expect(addMeta).toHaveBeenCalledWith({ baseBranch: 'some-other' });
     });
+
+    it('maps $default to defaultBranch', async () => {
+      extract.mockResolvedValue({} as never);
+      config.baseBranches = ['$default'];
+      config.defaultBranch = 'master';
+      git.getBranchList.mockReturnValue(['dev', 'master']);
+      scm.branchExists.mockResolvedValue(true);
+      const res = await extractDependencies(config);
+      expect(res).toStrictEqual({
+        branchList: [undefined],
+        branches: [undefined],
+        packageFiles: undefined,
+      });
+      expect(addMeta).toHaveBeenCalledWith({ baseBranch: 'master' });
+    });
   });
 });

--- a/lib/workers/repository/process/index.ts
+++ b/lib/workers/repository/process/index.ts
@@ -82,7 +82,10 @@ async function getBaseBranchConfig(
   return baseBranchConfig;
 }
 
-function unfoldBaseBranches(baseBranches: string[]): string[] {
+function unfoldBaseBranches(
+  defaultBranch: string,
+  baseBranches: string[]
+): string[] {
   const unfoldedList: string[] = [];
 
   const allBranches = getBranchList();
@@ -90,7 +93,13 @@ function unfoldBaseBranches(baseBranches: string[]): string[] {
     const isAllowedPred = configRegexPredicate(baseBranch);
     if (isAllowedPred) {
       const matchingBranches = allBranches.filter(isAllowedPred);
+      logger.debug(
+        `baseBranches regex "${baseBranch}" matches [${matchingBranches.join()}]`
+      );
       unfoldedList.push(...matchingBranches);
+    } else if (baseBranch === '$default') {
+      logger.debug(`baseBranches "$default" matches "${defaultBranch}"`);
+      unfoldedList.push(defaultBranch);
     } else {
       unfoldedList.push(baseBranch);
     }
@@ -109,7 +118,10 @@ export async function extractDependencies(
     packageFiles: null!,
   };
   if (GlobalConfig.get('platform') !== 'local' && config.baseBranches?.length) {
-    config.baseBranches = unfoldBaseBranches(config.baseBranches);
+    config.baseBranches = unfoldBaseBranches(
+      config.defaultBranch!,
+      config.baseBranches
+    );
     logger.debug({ baseBranches: config.baseBranches }, 'baseBranches');
     const extracted: Record<string, Record<string, PackageFile[]>> = {};
     for (const baseBranch of config.baseBranches) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds special option `"$default"` to `baseBranches`.

## Context

See docs change

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
