### PR TITLE
ci: Fix `test-success` job condition

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -384,7 +384,7 @@ jobs:
       - name: Fail for skipped tests when PR is ready for review
         if: |
           github.event_name == 'pull_request' &&
-          github.event.pull_request.draft == false &&
+          github.event.pull_request.draft != true &&
           needs.test.result == 'skipped'
         run: exit 1
 
@@ -397,7 +397,7 @@ jobs:
       - name: Fail for skipped coverage when PR is ready for review
         if: |
           github.event_name == 'pull_request' &&
-          github.event.pull_request.draft == false &&
+          github.event.pull_request.draft != true &&
           needs.coverage.result == 'skipped'
         run: exit 1
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -375,22 +375,30 @@ jobs:
     timeout-minutes: 1
     if: always()
     steps:
-      - if: |
+      - name: Fail for failed or cancelled tests
+        if: |
           needs.test.result == 'failure' ||
-          needs.test.result == 'cancelled' ||
-          (needs.test.result == 'skipped' &&
-            !(github.event.pull_request.draft &&
-              needs.setup.outputs.test-matrix-empty == 'true')
-          )
+          needs.test.result == 'cancelled'
         run: exit 1
 
-      - if: |
+      - name: Fail for skipped tests when PR is ready for review
+        if: |
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.draft == false &&
+          needs.test.result == 'skipped'
+        run: exit 1
+
+      - name: Fail for failed or cancelled coverage
+        if: |
           needs.coverage.result == 'failure' ||
-          needs.coverage.result == 'cancelled' ||
-          (needs.coverage.result == 'skipped' &&
-            !(github.event.pull_request.draft &&
-              needs.setup.outputs.test-matrix-empty == 'true')
-          )
+          needs.coverage.result == 'cancelled'
+        run: exit 1
+
+      - name: Fail for skipped coverage when PR is ready for review
+        if: |
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.draft == false &&
+          needs.coverage.result == 'skipped'
         run: exit 1
 
   build:


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Split steps, name them and simplify conditions

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
