### PR TITLE
refactor: safely parse errors from Azure DevOps API

### DIFF
--- a/lib/modules/platform/azure/azure-helper.ts
+++ b/lib/modules/platform/azure/azure-helper.ts
@@ -7,6 +7,7 @@ import { logger } from '../../../logger';
 import { streamToString } from '../../../util/streams';
 import { getNewBranchName } from '../util';
 import * as azureApi from './azure-got-wrapper';
+import { WrappedExceptionSchema } from './schema';
 import {
   getBranchNameWithoutRefsPrefix,
   getBranchNameWithoutRefsheadsPrefix,
@@ -82,18 +83,23 @@ export async function getFile(
   if (item?.readable) {
     const fileContent = await streamToString(item);
     try {
-      const jTmp = JSON.parse(fileContent);
-      if (jTmp.typeKey === 'GitItemNotFoundException') {
-        // file not found
-        return null;
-      }
-      if (jTmp.typeKey === 'GitUnresolvableToCommitException') {
-        // branch not found
-        return null;
+      const result = await WrappedExceptionSchema.safeParseAsync(
+        JSON.parse(fileContent)
+      );
+      if (result.success) {
+        if (result.data.typeKey === 'GitItemNotFoundException') {
+          logger.warn(`Unable to find file ${filePath}`);
+          return null;
+        }
+        if (result.data.typeKey === 'GitUnresolvableToCommitException') {
+          logger.warn(`Unable to find branch ${branchName}`);
+          return null;
+        }
       }
     } catch (error) {
       // it 's not a JSON, so I send the content directly with the line under
     }
+
     return fileContent;
   }
   return null; // no file found

--- a/lib/modules/platform/azure/schema.ts
+++ b/lib/modules/platform/azure/schema.ts
@@ -1,0 +1,17 @@
+import type { WrappedException } from 'azure-devops-node-api/interfaces/common/VSSInterfaces';
+import { z } from 'zod';
+
+export const WrappedExceptionSchema: z.ZodSchema<WrappedException> = z.lazy(
+  () =>
+    z.object({
+      customProperties: z.record(z.any()).optional(),
+      errorCode: z.number().optional(),
+      eventId: z.number().optional(),
+      helpLink: z.string().optional(),
+      innerException: WrappedExceptionSchema.optional(),
+      message: z.string().optional(),
+      stackTrace: z.string().optional(),
+      typeKey: z.string().optional(),
+      typeName: z.string().optional(),
+    })
+);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Define a schema for safely parsing errors from the Azure DevOps API.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->
This is required for #20553.

One of the rules of `@total-typescript/ts-reset` changes the return type of `JSON.parse` from `any` to `unknown`[^1]. This means that we need to do runtime type checking to verify the data that we are parsing.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
[^1]: https://github.com/total-typescript/ts-reset#make-jsonparse-return-unknown