### PR TITLE
fix(changelog): always print dependency name

### DIFF
--- a/lib/workers/repository/update/pr/body/changelogs.spec.ts
+++ b/lib/workers/repository/update/pr/body/changelogs.spec.ts
@@ -78,7 +78,7 @@ describe('workers/repository/update/pr/body/changelogs', () => {
       some/repo (dep-1)
       some/repo (dep-2)
       some/repo (dep-3)
-      other/repo
+      other/repo (dep-4)
 
       "
     `);

--- a/lib/workers/repository/update/pr/body/changelogs.ts
+++ b/lib/workers/repository/update/pr/body/changelogs.ts
@@ -11,23 +11,9 @@ export function getChangelogs(config: BranchConfig): string {
     return releaseNotes;
   }
 
-  const countReleaseNodesByRepoName: Record<string, number> = {};
-
   for (const upgrade of config.upgrades) {
     if (upgrade.hasReleaseNotes && upgrade.repoName) {
-      countReleaseNodesByRepoName[upgrade.repoName] =
-        (countReleaseNodesByRepoName[upgrade.repoName] || 0) + 1;
-    }
-  }
-
-  for (const upgrade of config.upgrades) {
-    if (upgrade.hasReleaseNotes && upgrade.repoName) {
-      // TODO: types (#7154)
-      upgrade.releaseNotesSummaryTitle = `${upgrade.repoName}${
-        countReleaseNodesByRepoName[upgrade.repoName] > 1
-          ? ` (${upgrade.depName!})`
-          : ''
-      }`;
+      upgrade.releaseNotesSummaryTitle = `${upgrade.repoName} (${upgrade.depName!})`
     }
   }
 

--- a/lib/workers/repository/update/pr/body/changelogs.ts
+++ b/lib/workers/repository/update/pr/body/changelogs.ts
@@ -13,7 +13,9 @@ export function getChangelogs(config: BranchConfig): string {
 
   for (const upgrade of config.upgrades) {
     if (upgrade.hasReleaseNotes && upgrade.repoName) {
-      upgrade.releaseNotesSummaryTitle = `${upgrade.repoName} (${upgrade.depName!})`
+      upgrade.releaseNotesSummaryTitle = `${
+        upgrade.repoName
+      } (${upgrade.depName!})`;
     }
   }
 


### PR DESCRIPTION
Sometimes the repository name doesn't indidacte the component name, hence it is useful to always print the dependency name in the release notes. Discussion about fix: https://github.com/renovatebot/renovate/discussions/22830

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Old situation (Release Notes "only" contains the repository)
![image](https://github.com/renovatebot/renovate/assets/46988880/78345910-6ec5-4539-9d00-e927cc6b2511)

New situation:
![image](https://github.com/renovatebot/renovate/assets/46988880/969cbd7a-2c36-4cc5-bbb4-3c13a34a58f8)

## Context

In the organization where I work, we often have a mismatch between the repository name and the actual component name, making it hard to see which release note belongs to where.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [X] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
