### PR TITLE
fix(forkMode): disallow edits by maintainers when forkOrg is set

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -419,6 +419,7 @@ It will also override any settings in `packageRules`.
 
 This configuration option lets you choose an organization you want repositories forked into when "fork mode" is enabled.
 It must be set to a GitHub Organization name and not a GitHub user account.
+When set, "allow edits by maintainers" will be false for PRs because GitHub does not allow this setting for organizations.
 
 This can be used if you're migrating from user-based forks to organization-based forks.
 

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -484,6 +484,7 @@ export async function initRepo({
 
   if (forkToken) {
     logger.debug('Bot is in fork mode');
+    config.forkOrg = forkOrg;
     config.forkToken = forkToken;
     // save parent name then delete
     config.parentRepo = config.repository;
@@ -1572,6 +1573,7 @@ export async function createPr({
   if (config.forkToken) {
     options.token = config.forkToken;
     options.body.maintainer_can_modify =
+      !config.forkOrg &&
       platformOptions?.forkModeDisallowMaintainerEdits !== true;
   }
   logger.debug({ title, head, base, draft: draftPR }, 'Creating PR');


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Disallow maintainer edits when forkOrg is set

## Context

This isn't allowed anyway.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
