### PR TITLE
feat(manager/helmfile): use the specific helmfile version that specified in the helmfile.lock.

### DIFF
--- a/lib/modules/manager/helmfile/artifacts.spec.ts
+++ b/lib/modules/manager/helmfile/artifacts.spec.ts
@@ -325,7 +325,7 @@ describe('modules/manager/helmfile/artifacts', () => {
             'bash -l -c "' +
             'install-tool helm v3.7.2' +
             ' && ' +
-            'install-tool helmfile v0.129.0' +
+            'install-tool helmfile v0.151.0' +
             ' && ' +
             'install-tool kustomize 5.0.0' +
             ' && ' +
@@ -338,7 +338,7 @@ describe('modules/manager/helmfile/artifacts', () => {
       binarySource: 'install',
       expectedCommands: [
         { cmd: 'install-tool helm v3.7.2' },
-        { cmd: 'install-tool helmfile v0.129.0' },
+        { cmd: 'install-tool helmfile v0.151.0' },
         { cmd: 'install-tool kustomize 5.0.0' },
         { cmd: 'helmfile deps -f helmfile.yaml' },
       ],
@@ -358,9 +358,6 @@ describe('modules/manager/helmfile/artifacts', () => {
       // helm
       datasource.getPkgReleases.mockResolvedValueOnce({
         releases: [{ version: 'v3.7.2' }],
-      });
-      datasource.getPkgReleases.mockResolvedValueOnce({
-        releases: [{ version: 'v0.129.0' }],
       });
       datasource.getPkgReleases.mockResolvedValueOnce({
         releases: [{ version: '5.0.0' }],

--- a/lib/modules/manager/helmfile/artifacts.spec.ts
+++ b/lib/modules/manager/helmfile/artifacts.spec.ts
@@ -325,7 +325,7 @@ describe('modules/manager/helmfile/artifacts', () => {
             'bash -l -c "' +
             'install-tool helm v3.7.2' +
             ' && ' +
-            'install-tool helmfile v0.151.0' +
+            'install-tool helmfile 0.151.0' +
             ' && ' +
             'install-tool kustomize 5.0.0' +
             ' && ' +
@@ -338,7 +338,7 @@ describe('modules/manager/helmfile/artifacts', () => {
       binarySource: 'install',
       expectedCommands: [
         { cmd: 'install-tool helm v3.7.2' },
-        { cmd: 'install-tool helmfile v0.151.0' },
+        { cmd: 'install-tool helmfile 0.151.0' },
         { cmd: 'install-tool kustomize 5.0.0' },
         { cmd: 'helmfile deps -f helmfile.yaml' },
       ],

--- a/lib/modules/manager/helmfile/artifacts.ts
+++ b/lib/modules/manager/helmfile/artifacts.ts
@@ -49,8 +49,7 @@ export async function updateArtifacts({
   try {
     await writeLocalFile(packageFileName, newPackageFileContent);
 
-    // we need to prefix version with v to install helmfile.
-    const helmfileVersion = `v${parseLock(existingLockFileContent).version}`;
+    const helmfileVersion = parseLock(existingLockFileContent).version;
     const toolConstraints: ToolConstraint[] = [
       {
         toolName: 'helm',

--- a/lib/modules/manager/helmfile/artifacts.ts
+++ b/lib/modules/manager/helmfile/artifacts.ts
@@ -49,7 +49,6 @@ export async function updateArtifacts({
   try {
     await writeLocalFile(packageFileName, newPackageFileContent);
 
-    const helmfileVersion = parseLock(existingLockFileContent).version;
     const toolConstraints: ToolConstraint[] = [
       {
         toolName: 'helm',
@@ -57,7 +56,9 @@ export async function updateArtifacts({
       },
       {
         toolName: 'helmfile',
-        constraint: config.constraints?.helmfile ?? helmfileVersion,
+        constraint:
+          config.constraints?.helmfile ??
+          parseLock(existingLockFileContent).version,
       },
     ];
     const needKustomize = updatedDeps.some(

--- a/lib/modules/manager/helmfile/artifacts.ts
+++ b/lib/modules/manager/helmfile/artifacts.ts
@@ -14,7 +14,12 @@ import { getFile } from '../../../util/git';
 import { regEx } from '../../../util/regex';
 import { generateHelmEnvs } from '../helmv3/common';
 import type { UpdateArtifact, UpdateArtifactsResult } from '../types';
-import { generateRegistryLoginCmd, isOCIRegistry, parseDoc } from './utils';
+import {
+  generateRegistryLoginCmd,
+  isOCIRegistry,
+  parseDoc,
+  parseLock,
+} from './utils';
 
 export async function updateArtifacts({
   packageFileName,
@@ -44,6 +49,8 @@ export async function updateArtifacts({
   try {
     await writeLocalFile(packageFileName, newPackageFileContent);
 
+    // we need to prefix version with v to install helmfile.
+    const helmfileVersion = `v${parseLock(existingLockFileContent).version}`;
     const toolConstraints: ToolConstraint[] = [
       {
         toolName: 'helm',
@@ -51,7 +58,7 @@ export async function updateArtifacts({
       },
       {
         toolName: 'helmfile',
-        constraint: config.constraints?.helmfile,
+        constraint: config.constraints?.helmfile ?? helmfileVersion,
       },
     ];
     const needKustomize = updatedDeps.some(

--- a/lib/modules/manager/helmfile/schema.ts
+++ b/lib/modules/manager/helmfile/schema.ts
@@ -19,3 +19,7 @@ export const DocSchema = z.object({
   releases: z.array(ReleaseSchema).optional(),
   repositories: z.array(RepositorySchema).optional(),
 });
+
+export const LockSchema = z.object({
+  version: z.string(),
+});

--- a/lib/modules/manager/helmfile/types.ts
+++ b/lib/modules/manager/helmfile/types.ts
@@ -1,9 +1,16 @@
 import type { z } from 'zod';
 
-import type { DocSchema, ReleaseSchema, RepositorySchema } from './schema';
+import type {
+  DocSchema,
+  LockSchema,
+  ReleaseSchema,
+  RepositorySchema,
+} from './schema';
 
 export type Release = z.infer<typeof ReleaseSchema>;
 
 export type Repository = z.infer<typeof RepositorySchema>;
 
 export type Doc = z.infer<typeof DocSchema>;
+
+export type Lock = z.infer<typeof LockSchema>;

--- a/lib/modules/manager/helmfile/utils.ts
+++ b/lib/modules/manager/helmfile/utils.ts
@@ -7,8 +7,8 @@ import { DockerDatasource } from '../../datasource/docker';
 import { generateLoginCmd } from '../helmv3/common';
 import type { RepositoryRule } from '../helmv3/types';
 
-import { DocSchema } from './schema';
-import type { Doc, Release, Repository } from './types';
+import { DocSchema, LockSchema } from './schema';
+import type { Doc, Lock, Release, Repository } from './types';
 
 /** Returns true if a helmfile release contains kustomize specific keys **/
 export function kustomizationsKeysUsed(release: Release): boolean {
@@ -34,6 +34,11 @@ export async function localChartHasKustomizationsYaml(
 export function parseDoc(packageFileContent: string): Doc {
   const doc = yaml.load(packageFileContent);
   return DocSchema.parse(doc);
+}
+
+export function parseLock(lockFileContent: string): Lock {
+  const lock = yaml.load(lockFileContent);
+  return LockSchema.parse(lock);
 }
 
 export function isOCIRegistry(repository: Repository): boolean {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This feature is discussed [here](https://github.com/renovatebot/renovate/discussions/22699).

<!-- Describe what behavior is changed by this PR. -->


I updated the helmfile manager to use specific helmfile version that specified in the helmfile.lock when updating the helmfile.lock if tool constraints is not set manually.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
