### PR TITLE
Support configuration file located at ".renovate/renovate.json[5]"

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -16,6 +16,8 @@ You can store your Renovate configuration file in one of these locations:
 1. `.github/renovate.json5`
 1. `.gitlab/renovate.json`
 1. `.gitlab/renovate.json5`
+1. `.renovate/renovate.json`
+1. `.renovate/renovate.json5`
 1. `.renovaterc`
 1. `.renovaterc.json`
 1. `.renovaterc.json5`

--- a/lib/config/app-strings.ts
+++ b/lib/config/app-strings.ts
@@ -5,6 +5,8 @@ export const configFileNames = [
   '.github/renovate.json5',
   '.gitlab/renovate.json',
   '.gitlab/renovate.json5',
+  '.renovate/renovate.json',
+  '.renovate/renovate.json5',
   '.renovaterc',
   '.renovaterc.json',
   '.renovaterc.json5',

--- a/lib/workers/repository/init/merge.spec.ts
+++ b/lib/workers/repository/init/merge.spec.ts
@@ -229,6 +229,19 @@ describe('workers/repository/init/merge', () => {
       });
     });
 
+    it('finds .renovate/renovate.json', async () => {
+      scm.getFileList.mockResolvedValue([
+        'package.json',
+        '.renovate/renovate.json',
+      ]);
+      fs.readLocalFile.mockResolvedValue('{}');
+      expect(await detectRepoFileConfig()).toEqual({
+        configFileName: '.renovate/renovate.json',
+        configFileParsed: {},
+        configFileRaw: '{}',
+      });
+    });
+
     it('finds .renovaterc.json', async () => {
       scm.getFileList.mockResolvedValue(['package.json', '.renovaterc.json']);
       fs.readLocalFile.mockResolvedValue('{}');


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This MR enables support for configuration files located at `.renovate/renovate.json[5]`.

## Context

My goal to share a common Renovate Bot configuration over multiple Git projects.
I do have read the documentation at https://docs.renovatebot.com/config-presets/, but my understanding is that using such a preset requires specifiying it in `renovate.json` (or any supported variation thereof).
While it's not a lot of text, there's always the change of someone making a typo when setting up a new project in our organization.
To work around that possibility, I was thinking of using a Git submodule pointing to a repository containing the necessary configuration referencing the preset.
Unfortunality, given that Git submodules work at the directory level, the only choices at the moment are `.github/` and `.gitlab/`, according to https://docs.renovatebot.com/configuration-options/.
But I'm already using them to store files — actually, I'm using only one, but that would seem confusing to put files in a directory named after a CI environment that I don't use.
My proposal is thus to support `.renovate/` as well.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [X] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [X] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
