### PR TITLE
fix(node): allow unstable updates within same major

### DIFF
--- a/lib/modules/versioning/index.spec.ts
+++ b/lib/modules/versioning/index.spec.ts
@@ -73,6 +73,7 @@ describe('modules/versioning/index', () => {
 
   describe('should return the same interface', () => {
     const optionalFunctions = [
+      'allowUnstableMajorUpgrades',
       'isLessThanRange',
       'valueToVersion',
       'constructor',

--- a/lib/modules/versioning/node/index.ts
+++ b/lib/modules/versioning/node/index.ts
@@ -85,6 +85,7 @@ export const api: VersioningApi = {
   matches,
   getSatisfyingVersion,
   minSatisfyingVersion,
+  allowUnstableMajorUpgrades: true,
 };
 
 export default api;

--- a/lib/modules/versioning/types.ts
+++ b/lib/modules/versioning/types.ts
@@ -106,6 +106,11 @@ export interface VersioningApi {
    * @param superRange - the dom range
    */
   subset?(subRange: string, superRange: string): boolean | undefined;
+
+  /**
+   * Return whether unstable-to-unstable upgrades within the same major version are allowed.
+   */
+  allowUnstableMajorUpgrades?: boolean;
 }
 
 export interface VersioningApiConstructor {

--- a/lib/workers/repository/process/lookup/filter.ts
+++ b/lib/workers/repository/process/lookup/filter.ts
@@ -131,12 +131,21 @@ export function filterVersions(
 
   // if current is unstable then allow unstable in the current major only
   // Allow unstable only in current major
-  return filteredVersions.filter(
-    (v) =>
-      isVersionStable(v.version) ||
-      (versioning.getMajor(v.version) === versioning.getMajor(currentVersion) &&
-        versioning.getMinor(v.version) ===
-          versioning.getMinor(currentVersion) &&
-        versioning.getPatch(v.version) === versioning.getPatch(currentVersion))
-  );
+  return filteredVersions.filter((v) => {
+    if (isVersionStable(v.version)) {
+      return true;
+    }
+    if (
+      versioning.getMajor(v.version) !== versioning.getMajor(currentVersion)
+    ) {
+      return false;
+    }
+    if (versioning.allowUnstableMajorUpgrades) {
+      return true;
+    }
+    return (
+      versioning.getMinor(v.version) === versioning.getMinor(currentVersion) &&
+      versioning.getPatch(v.version) === versioning.getPatch(currentVersion)
+    );
+  });
 }

--- a/lib/workers/repository/process/lookup/index.spec.ts
+++ b/lib/workers/repository/process/lookup/index.spec.ts
@@ -13,6 +13,7 @@ import { PackagistDatasource } from '../../../../modules/datasource/packagist';
 import { PypiDatasource } from '../../../../modules/datasource/pypi';
 import { id as dockerVersioningId } from '../../../../modules/versioning/docker';
 import { id as gitVersioningId } from '../../../../modules/versioning/git';
+import { id as nodeVersioningId } from '../../../../modules/versioning/node';
 import { id as npmVersioningId } from '../../../../modules/versioning/npm';
 import { id as pep440VersioningId } from '../../../../modules/versioning/pep440';
 import { id as poetryVersioningId } from '../../../../modules/versioning/poetry';
@@ -42,6 +43,11 @@ let config: LookupUpdateConfig;
 describe('workers/repository/process/lookup/index', () => {
   const getGithubReleases = jest.spyOn(
     GithubReleasesDatasource.prototype,
+    'getReleases'
+  );
+
+  const getGithubTags = jest.spyOn(
+    GithubTagsDatasource.prototype,
     'getReleases'
   );
 
@@ -996,6 +1002,19 @@ describe('workers/repository/process/lookup/index', () => {
       });
       expect((await lookup.lookupUpdates(config)).updates).toMatchObject([
         { newValue: '2.0.0', updateType: 'major' },
+      ]);
+    });
+
+    it('should allow unstable versions in same major for node', async () => {
+      config.currentValue = '20.3.0';
+      config.packageName = 'node';
+      config.datasource = GithubTagsDatasource.id;
+      config.versioning = nodeVersioningId;
+      getGithubTags.mockResolvedValueOnce({
+        releases: [{ version: '20.3.0' }, { version: '20.3.1' }],
+      });
+      expect((await lookup.lookupUpdates(config)).updates).toMatchObject([
+        { newValue: '20.3.1', updateType: 'patch' },
       ]);
     });
 

--- a/lib/workers/repository/process/lookup/index.spec.ts
+++ b/lib/workers/repository/process/lookup/index.spec.ts
@@ -1011,7 +1011,11 @@ describe('workers/repository/process/lookup/index', () => {
       config.datasource = GithubTagsDatasource.id;
       config.versioning = nodeVersioningId;
       getGithubTags.mockResolvedValueOnce({
-        releases: [{ version: '20.3.0' }, { version: '20.3.1' }],
+        releases: [
+          { version: '20.3.0' },
+          { version: '20.3.1' },
+          { version: '21.0.0' },
+        ],
       });
       expect((await lookup.lookupUpdates(config)).updates).toMatchObject([
         { newValue: '20.3.1', updateType: 'patch' },


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Allows unstable-to-unstable updates within the same major range for Node versioning, e.g. to allow 20.3.0 -> 20.3.1 updates.

## Context

Fixes #22934

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
