### PR TITLE
fix(manager/gradle): extend allowed nesting depth for Kotlin objects from 3 to 4

### DIFF
--- a/lib/modules/manager/gradle/parser.spec.ts
+++ b/lib/modules/manager/gradle/parser.spec.ts
@@ -981,8 +981,10 @@ describe('modules/manager/gradle/parser', () => {
             const val core = "androidx.test:core:\${Deps.Test.version}"
 
             object Espresso {
-              private const val version = "3.3.0-rc01"
-              const val espressoCore = "androidx.test.espresso:espresso-core:$version"
+              object Release {
+                private const val version = "3.3.0-rc01"
+                const val espressoCore = "androidx.test.espresso:espresso-core:$version"
+              }
             }
 
             object Androidx {
@@ -1003,8 +1005,8 @@ describe('modules/manager/gradle/parser', () => {
             key: 'Deps.Test.version',
             value: '1.3.0-rc01',
           },
-          'Deps.Test.Espresso.version': {
-            key: 'Deps.Test.Espresso.version',
+          'Deps.Test.Espresso.Release.version': {
+            key: 'Deps.Test.Espresso.Release.version',
             value: '3.3.0-rc01',
           },
         },
@@ -1022,7 +1024,7 @@ describe('modules/manager/gradle/parser', () => {
           {
             depName: 'androidx.test.espresso:espresso-core',
             currentValue: '3.3.0-rc01',
-            groupName: 'Deps.Test.Espresso.version',
+            groupName: 'Deps.Test.Espresso.Release.version',
           },
           {
             depName: 'androidx.test:core-ktx',

--- a/lib/modules/manager/gradle/parser/objects.ts
+++ b/lib/modules/manager/gradle/parser/objects.ts
@@ -49,6 +49,8 @@ const qKotlinMultiObjectExpr = (
 
 export const qKotlinMultiObjectVarAssignment = qKotlinMultiObjectExpr(
   qKotlinMultiObjectExpr(
-    qKotlinMultiObjectExpr(qKotlinSingleObjectVarAssignment)
+    qKotlinMultiObjectExpr(
+      qKotlinMultiObjectExpr(qKotlinSingleObjectVarAssignment)
+    )
   )
 ).handler(cleanupTempVars);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds an additional nesting depth layer to the gradle parser for Kotlin objects.

<!-- Describe what behavior is changed by this PR. -->

## Context

- Solves https://github.com/renovatebot/renovate/discussions/22948

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

Test repo: https://github.com/renovate-demo/22948-renovate-gradle-issue/pull/2

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
