### PR TITLE
fix(renovate-config-validator): support .renovaterc

### DIFF
--- a/lib/workers/global/config/parse/__fixtures__/.renovaterc
+++ b/lib/workers/global/config/parse/__fixtures__/.renovaterc
@@ -1,0 +1,3 @@
+{
+  "token": "abcdefg"
+}

--- a/lib/workers/global/config/parse/__fixtures__/.renovaterc
+++ b/lib/workers/global/config/parse/__fixtures__/.renovaterc
@@ -1,3 +1,5 @@
 {
-  "token": "abcdefg"
+  // Renovate parses all configuration files as JSON5.
+  // https://github.com/renovatebot/renovate/pull/22991#issuecomment-1609106254
+  token: "abcdefg",
 }

--- a/lib/workers/global/config/parse/file.spec.ts
+++ b/lib/workers/global/config/parse/file.spec.ts
@@ -35,6 +35,7 @@ describe('workers/global/config/parse/file', () => {
         'custom js config file exporting an async function',
         'config-async-function.js',
       ],
+      ['.renovaterc', '.renovaterc'],
       ['JSON5 config file', 'config.json5'],
       ['YAML config file', 'config.yaml'],
     ])('parses %s', async (fileType, filePath) => {

--- a/lib/workers/global/config/parse/file.ts
+++ b/lib/workers/global/config/parse/file.ts
@@ -10,7 +10,7 @@ import { readSystemFile } from '../../../../util/fs';
 
 export async function getParsedContent(file: string): Promise<RenovateConfig> {
   if (upath.basename(file) === '.renovaterc') {
-    return JSON.parse(await readSystemFile(file, 'utf8'));
+    return JSON5.parse(await readSystemFile(file, 'utf8'));
   }
   switch (upath.extname(file)) {
     case '.yaml':
@@ -18,9 +18,8 @@ export async function getParsedContent(file: string): Promise<RenovateConfig> {
       return load(await readSystemFile(file, 'utf8'), {
         json: true,
       }) as RenovateConfig;
-    case '.json':
-      return JSON.parse(await readSystemFile(file, 'utf8'));
     case '.json5':
+    case '.json':
       return JSON5.parse(await readSystemFile(file, 'utf8'));
     case '.js': {
       const tmpConfig = await import(file);

--- a/lib/workers/global/config/parse/file.ts
+++ b/lib/workers/global/config/parse/file.ts
@@ -16,9 +16,9 @@ export async function getParsedContent(file: string): Promise<RenovateConfig> {
         json: true,
       }) as RenovateConfig;
     case '':
-      // .renovaterc should be parsed as JSON
-      // RENOVATE_CONFIG_FILE without file extension should be parsed as JSON
-      /* falls through */
+    // .renovaterc should be parsed as JSON
+    // RENOVATE_CONFIG_FILE without file extension should be parsed as JSON
+    /* falls through */
     case '.json':
       return JSON.parse(await readSystemFile(file, 'utf8'));
     case '.json5':

--- a/lib/workers/global/config/parse/file.ts
+++ b/lib/workers/global/config/parse/file.ts
@@ -9,7 +9,7 @@ import { logger } from '../../../../logger';
 import { readSystemFile } from '../../../../util/fs';
 
 export async function getParsedContent(file: string): Promise<RenovateConfig> {
-  if (file === '.renovaterc') {
+  if (upath.basename(file) === '.renovaterc') {
     return JSON.parse(await readSystemFile(file, 'utf8'));
   }
   switch (upath.extname(file)) {

--- a/lib/workers/global/config/parse/file.ts
+++ b/lib/workers/global/config/parse/file.ts
@@ -15,8 +15,12 @@ export async function getParsedContent(file: string): Promise<RenovateConfig> {
       return load(await readSystemFile(file, 'utf8'), {
         json: true,
       }) as RenovateConfig;
-    case '.json5':
+    case '':
+      // .renovaterc should be parsed as JSON
+      // RENOVATE_CONFIG_FILE without file extension should be parsed as JSON
     case '.json':
+      return JSON.parse(await readSystemFile(file, 'utf8'));
+    case '.json5':
       return JSON5.parse(await readSystemFile(file, 'utf8'));
     case '.js': {
       const tmpConfig = await import(file);

--- a/lib/workers/global/config/parse/file.ts
+++ b/lib/workers/global/config/parse/file.ts
@@ -18,6 +18,7 @@ export async function getParsedContent(file: string): Promise<RenovateConfig> {
     case '':
       // .renovaterc should be parsed as JSON
       // RENOVATE_CONFIG_FILE without file extension should be parsed as JSON
+      /* falls through */
     case '.json':
       return JSON.parse(await readSystemFile(file, 'utf8'));
     case '.json5':

--- a/lib/workers/global/config/parse/file.ts
+++ b/lib/workers/global/config/parse/file.ts
@@ -9,16 +9,15 @@ import { logger } from '../../../../logger';
 import { readSystemFile } from '../../../../util/fs';
 
 export async function getParsedContent(file: string): Promise<RenovateConfig> {
+  if (file === '.renovaterc') {
+    return JSON.parse(await readSystemFile(file, 'utf8'));
+  }
   switch (upath.extname(file)) {
     case '.yaml':
     case '.yml':
       return load(await readSystemFile(file, 'utf8'), {
         json: true,
       }) as RenovateConfig;
-    case '':
-    // .renovaterc should be parsed as JSON
-    // RENOVATE_CONFIG_FILE without file extension should be parsed as JSON
-    /* falls through */
     case '.json':
       return JSON.parse(await readSystemFile(file, 'utf8'));
     case '.json5':


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

~~Fix two bugs.~~

Fix a bug.

- ~~A configuration file *.json parses as JSON5. So renovate-config-validator allows invalid JSON wrongly~~
- renovate-config-validator can't parse `.renovaterc`

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

- https://github.com/renovatebot/renovate/discussions/22990

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
