### PR TITLE
docs: remove obsolete WIP message for `bazel-module` manager

### DIFF
--- a/lib/modules/manager/bazel-module/readme.md
+++ b/lib/modules/manager/bazel-module/readme.md
@@ -1,8 +1,1 @@
-<!-- prettier-ignore -->
-!!! warning
-    The `bazel-module` manager is a work-in-progress.
-    It is currently disabled.
-    The manager only supports updating `bazel_dep` declarations.
-    For more information, see [issue 13658](https://github.com/renovatebot/renovate/issues/13658).
-
 The `bazel-module` manager can update [Bazel module (bzlmod)](https://bazel.build/external/module) enabled workspaces.


### PR DESCRIPTION
## Changes

Remove obsolete work-in-progress message in `readme.md` for `bazel-module` manager.

## Context

Related #13658.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
