### PR TITLE
feat(bundler): try matching lock file to package file first

### DIFF
--- a/lib/modules/manager/bundler/artifacts.ts
+++ b/lib/modules/manager/bundler/artifacts.ts
@@ -23,7 +23,11 @@ import type {
   UpdateArtifactsConfig,
   UpdateArtifactsResult,
 } from '../types';
-import { getBundlerConstraint, getLockFileName, getRubyConstraint } from './common';
+import {
+  getBundlerConstraint,
+  getLockFileName,
+  getRubyConstraint,
+} from './common';
 import {
   findAllAuthenticatable,
   getAuthenticationHeaderValue,

--- a/lib/modules/manager/bundler/artifacts.ts
+++ b/lib/modules/manager/bundler/artifacts.ts
@@ -23,7 +23,7 @@ import type {
   UpdateArtifactsConfig,
   UpdateArtifactsResult,
 } from '../types';
-import { getBundlerConstraint, getRubyConstraint } from './common';
+import { getBundlerConstraint, getLockFileName, getRubyConstraint } from './common';
 import {
   findAllAuthenticatable,
   getAuthenticationHeaderValue,
@@ -97,7 +97,7 @@ export async function updateArtifacts(
     logger.debug('Aborting Bundler artifacts due to previous failed attempt');
     throw new Error(existingError);
   }
-  const lockFileName = `${packageFileName}.lock`;
+  const lockFileName = await getLockFileName(packageFileName);
   const existingLockFileContent = await readLocalFile(lockFileName, 'utf8');
   if (!existingLockFileContent) {
     logger.debug('No Gemfile.lock found');

--- a/lib/modules/manager/bundler/artifacts.ts
+++ b/lib/modules/manager/bundler/artifacts.ts
@@ -25,7 +25,7 @@ import type {
 } from '../types';
 import {
   getBundlerConstraint,
-  getLockFileName,
+  getLockFilePath,
   getRubyConstraint,
 } from './common';
 import {
@@ -101,7 +101,7 @@ export async function updateArtifacts(
     logger.debug('Aborting Bundler artifacts due to previous failed attempt');
     throw new Error(existingError);
   }
-  const lockFileName = await getLockFileName(packageFileName);
+  const lockFileName = await getLockFilePath(packageFileName);
   const existingLockFileContent = await readLocalFile(lockFileName, 'utf8');
   if (!existingLockFileContent) {
     logger.debug('No Gemfile.lock found');

--- a/lib/modules/manager/bundler/common.spec.ts
+++ b/lib/modules/manager/bundler/common.spec.ts
@@ -6,7 +6,7 @@ import type { RepoGlobalConfig } from '../../../config/types';
 import type { UpdateArtifact } from '../types';
 import {
   getBundlerConstraint,
-  getLockFileName,
+  getLockFilePath,
   getRubyConstraint,
 } from './common';
 
@@ -103,13 +103,13 @@ describe('modules/manager/bundler/common', () => {
   describe('getLockFileName', () => {
     it('returns packageFileName.lock', async () => {
       fs.localPathExists.mockResolvedValueOnce(true);
-      const lockFileName = await getLockFileName('packageFileName');
+      const lockFileName = await getLockFilePath('packageFileName');
       expect(lockFileName).toBe('packageFileName.lock');
     });
 
     it('returns Gemfile.lock', async () => {
       fs.localPathExists.mockResolvedValueOnce(false);
-      const lockFileName = await getLockFileName('packageFileName');
+      const lockFileName = await getLockFilePath('packageFileName');
       expect(lockFileName).toBe('Gemfile.lock');
     });
   });

--- a/lib/modules/manager/bundler/common.spec.ts
+++ b/lib/modules/manager/bundler/common.spec.ts
@@ -4,7 +4,7 @@ import { fs, partial } from '../../../../test/util';
 import { GlobalConfig } from '../../../config/global';
 import type { RepoGlobalConfig } from '../../../config/types';
 import type { UpdateArtifact } from '../types';
-import { getBundlerConstraint, getRubyConstraint } from './common';
+import { getBundlerConstraint, getLockFileName, getRubyConstraint } from './common';
 
 jest.mock('../../../util/fs');
 
@@ -93,6 +93,20 @@ describe('modules/manager/bundler/common', () => {
       });
       const version = await getRubyConstraint(config);
       expect(version).toBeNull();
+    });
+  });
+
+  describe('getLockFileName', () => {
+    it('returns packageFileName.lock', async () => {
+      fs.localPathExists.mockResolvedValueOnce(true);
+      const lockFileName = await getLockFileName('packageFileName');
+      expect(lockFileName).toBe('packageFileName.lock');
+    });
+
+    it('returns Gemfile.lock', async () => {
+      fs.localPathExists.mockResolvedValueOnce(false);
+      const lockFileName = await getLockFileName('packageFileName');
+      expect(lockFileName).toBe('Gemfile.lock');
     });
   });
 });

--- a/lib/modules/manager/bundler/common.spec.ts
+++ b/lib/modules/manager/bundler/common.spec.ts
@@ -4,7 +4,11 @@ import { fs, partial } from '../../../../test/util';
 import { GlobalConfig } from '../../../config/global';
 import type { RepoGlobalConfig } from '../../../config/types';
 import type { UpdateArtifact } from '../types';
-import { getBundlerConstraint, getLockFileName, getRubyConstraint } from './common';
+import {
+  getBundlerConstraint,
+  getLockFileName,
+  getRubyConstraint,
+} from './common';
 
 jest.mock('../../../util/fs');
 

--- a/lib/modules/manager/bundler/common.ts
+++ b/lib/modules/manager/bundler/common.ts
@@ -1,5 +1,5 @@
 import { logger } from '../../../logger';
-import { getSiblingFileName, readLocalFile } from '../../../util/fs';
+import { getSiblingFileName, readLocalFile, localPathExists } from '../../../util/fs';
 import { regEx } from '../../../util/regex';
 import type { UpdateArtifact } from '../types';
 
@@ -67,4 +67,8 @@ export function getBundlerConstraint(
     }
   }
   return null;
+}
+
+export async function getLockFileName(packageFileName: string): Promise<string> {
+  return await localPathExists(`${packageFileName}.lock`) ? `${packageFileName}.lock` : `Gemfile.lock`;
 }

--- a/lib/modules/manager/bundler/common.ts
+++ b/lib/modules/manager/bundler/common.ts
@@ -73,10 +73,11 @@ export function getBundlerConstraint(
   return null;
 }
 
-export async function getLockFileName(
-  packageFileName: string
+export async function getLockFilePath(
+  packageFilePath: string
 ): Promise<string> {
-  return (await localPathExists(`${packageFileName}.lock`))
-    ? `${packageFileName}.lock`
+  logger.debug(`Looking for lockfile for ${packageFilePath}`);
+  return (await localPathExists(`${packageFilePath}.lock`))
+    ? `${packageFilePath}.lock`
     : `Gemfile.lock`;
 }

--- a/lib/modules/manager/bundler/common.ts
+++ b/lib/modules/manager/bundler/common.ts
@@ -1,5 +1,9 @@
 import { logger } from '../../../logger';
-import { getSiblingFileName, readLocalFile, localPathExists } from '../../../util/fs';
+import {
+  getSiblingFileName,
+  localPathExists,
+  readLocalFile,
+} from '../../../util/fs';
 import { regEx } from '../../../util/regex';
 import type { UpdateArtifact } from '../types';
 
@@ -69,6 +73,10 @@ export function getBundlerConstraint(
   return null;
 }
 
-export async function getLockFileName(packageFileName: string): Promise<string> {
-  return await localPathExists(`${packageFileName}.lock`) ? `${packageFileName}.lock` : `Gemfile.lock`;
+export async function getLockFileName(
+  packageFileName: string
+): Promise<string> {
+  return (await localPathExists(`${packageFileName}.lock`))
+    ? `${packageFileName}.lock`
+    : `Gemfile.lock`;
 }

--- a/lib/modules/manager/bundler/extract.ts
+++ b/lib/modules/manager/bundler/extract.ts
@@ -5,7 +5,7 @@ import { newlineRegex, regEx } from '../../../util/regex';
 import { RubyVersionDatasource } from '../../datasource/ruby-version';
 import { RubyGemsDatasource } from '../../datasource/rubygems';
 import type { PackageDependency, PackageFileContent } from '../types';
-import { delimiters, extractRubyVersion, getLockFileName } from './common';
+import { delimiters, extractRubyVersion, getLockFilePath } from './common';
 import { extractLockFileEntries } from './locked-version';
 
 function formatContent(input: string): string {
@@ -210,11 +210,13 @@ export async function extractPackageFile(
   }
 
   if (packageFile) {
-    const gemfileLock = await getLockFileName(packageFile);
-    const lockContent = await readLocalFile(gemfileLock, 'utf8');
+    const gemfileLockPath = await getLockFilePath(packageFile);
+    const lockContent = await readLocalFile(gemfileLockPath, 'utf8');
     if (lockContent) {
-      logger.debug(`Found Gemfile.lock file packageFile: ${packageFile}`);
-      res.lockFiles = [gemfileLock];
+      logger.debug(
+        `Found lock file ${gemfileLockPath} for packageFile: ${packageFile}`
+      );
+      res.lockFiles = [gemfileLockPath];
       const lockedEntries = extractLockFileEntries(lockContent);
       for (const dep of res.deps) {
         // TODO: types (#7154)

--- a/lib/modules/manager/bundler/extract.ts
+++ b/lib/modules/manager/bundler/extract.ts
@@ -5,7 +5,7 @@ import { newlineRegex, regEx } from '../../../util/regex';
 import { RubyVersionDatasource } from '../../datasource/ruby-version';
 import { RubyGemsDatasource } from '../../datasource/rubygems';
 import type { PackageDependency, PackageFileContent } from '../types';
-import { delimiters, extractRubyVersion } from './common';
+import { delimiters, extractRubyVersion, getLockFileName } from './common';
 import { extractLockFileEntries } from './locked-version';
 
 function formatContent(input: string): string {
@@ -210,7 +210,7 @@ export async function extractPackageFile(
   }
 
   if (packageFile) {
-    const gemfileLock = `${packageFile}.lock`;
+    const gemfileLock = await getLockFileName(packageFile);
     const lockContent = await readLocalFile(gemfileLock, 'utf8');
     if (lockContent) {
       logger.debug(`Found Gemfile.lock file packageFile: ${packageFile}`);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- (Bundler) Fallback to use Gemfile.lock at the root of projects.

## Context

This change allows for support of multi gemfile pattern for single ruby projects in which a single Gemfile dynamically loads gems from other gemfiles resulting in a single lock file.  As per bundler convention this file is `Gemfile.lock` when the main gemfile is `Gemfile`. 

Issue Reference: #22725

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [X] Both unit tests + ran on a real repository

Changes validated in https://github.com/jorge-wonolo/renovate-test gems without ranges are now resolving lock file versions.

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
