### PR TITLE
feat(github-tags): enable datasource for registry hunting

### DIFF
--- a/lib/modules/datasource/github-tags/index.ts
+++ b/lib/modules/datasource/github-tags/index.ts
@@ -18,6 +18,8 @@ export class GithubTagsDatasource extends Datasource {
 
   override readonly defaultRegistryUrls = ['https://github.com'];
 
+  override readonly registryStrategy = 'hunt';
+
   override http: GithubHttp;
 
   constructor() {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This PR enables the `github-tags` datasource to use multiple registries to "hunt" for a dependency. This is helpful for looking up the newest tag of a GitHub Action in GitHub Enterprise Server, where the Action could be either stored on GitHub Enterprise Server or github.com. 

This change allows users to leverage following configuration to lookup github-actions in both a GitHub Enterprise Server and github.com as fallback: 
```json
{
  "packageRules": [
    {
      "description": "Use github.enterprise.com as primary data source for GitHub Action updates and use github.com as fallback",
      "matchDatasources": [
        "github-tags"
      ],
      "matchManagers": [
        "github-actions"
      ],
      "registryUrls": [
        "https://github.enterprise.com",
        "https://github.com"
      ]
    }
  ]
}
```
<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

This PR partly supports in the implementation of #10178

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
