### PR TITLE
refactor: don't throw errors from datasource package releases lookup

### DIFF
--- a/lib/modules/datasource/index.ts
+++ b/lib/modules/datasource/index.ts
@@ -19,6 +19,8 @@ import type {
   DigestConfig,
   GetDigestInputConfig,
   GetPkgReleasesConfig,
+  GetPkgReleasesResultError,
+  GetPkgReleasesResultSuccess,
   GetReleasesConfig,
   ReleaseResult,
 } from './types';
@@ -427,6 +429,17 @@ export async function getPkgReleases(
     delete release.constraints;
   });
   return res;
+}
+
+export async function getPkgReleasesWithResult(
+  config: GetPkgReleasesConfig
+): Promise<GetPkgReleasesResultSuccess | GetPkgReleasesResultError> {
+  try {
+    const result = await getPkgReleases(config);
+    return { result };
+  } catch (error) {
+    return { error };
+  }
 }
 
 export function supportsDigests(datasource: string | undefined): boolean {

--- a/lib/modules/datasource/types.ts
+++ b/lib/modules/datasource/types.ts
@@ -76,11 +76,11 @@ export interface ReleaseResult {
 
 export interface GetPkgReleasesResultError {
   error: Error;
-  result?: undefined;
+  result?: never;
 }
 
 export interface GetPkgReleasesResultSuccess {
-  error?: undefined;
+  error?: never;
   result: ReleaseResult | null;
 }
 

--- a/lib/modules/datasource/types.ts
+++ b/lib/modules/datasource/types.ts
@@ -74,6 +74,16 @@ export interface ReleaseResult {
   replacementVersion?: string;
 }
 
+export interface GetPkgReleasesResultError {
+  error: Error;
+  result?: undefined;
+}
+
+export interface GetPkgReleasesResultSuccess {
+  error?: undefined;
+  result: ReleaseResult | null;
+}
+
 export type RegistryStrategy = 'first' | 'hunt' | 'merge';
 
 export interface DatasourceApi extends ModuleApi {

--- a/lib/workers/repository/process/lookup/index.spec.ts
+++ b/lib/workers/repository/process/lookup/index.spec.ts
@@ -89,6 +89,15 @@ describe('workers/repository/process/lookup/index', () => {
       expect((await lookup.lookupUpdates(config)).updates).toEqual([]);
     });
 
+    it('handles error result from getPkgReleasesWithResult', async () => {
+      config.currentValue = '1.0.0';
+      config.packageName = 'some-dep';
+      config.datasource = NpmDatasource.id;
+      config.rollbackPrs = true;
+      httpMock.scope('https://registry.npmjs.org').get('/some-dep').reply(500);
+      await expect(lookup.lookupUpdates(config)).rejects.toThrow();
+    });
+
     it('returns rollback for pinned version', async () => {
       config.currentValue = '0.9.99';
       config.packageName = 'q';

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -9,7 +9,7 @@ import {
   getDatasourceList,
   getDefaultVersioning,
   getDigest,
-  getPkgReleases,
+  getPkgReleasesWithResult,
   isGetPkgReleasesConfig,
   supportsDigests,
 } from '../../../../modules/datasource';
@@ -82,8 +82,11 @@ export async function lookupUpdates(
         res.skipReason = 'is-pinned';
         return res;
       }
-
-      dependency = clone(await getPkgReleases(config));
+      const lookupResult = await getPkgReleasesWithResult(config);
+      if (lookupResult.error) {
+        throw lookupResult.error;
+      }
+      dependency = clone(lookupResult.result);
       if (!dependency) {
         // If dependency lookup fails then warn and return
         const warning: ValidationMessage = {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Wraps getPkgReleases so that lookupUpdates should not receive Errors thrown.

## Context

First step towards separating out lookup from processing

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
