### PR TITLE
refactor(datasource): Use `Result` utility class for lookups

### DIFF
--- a/lib/modules/datasource/index.ts
+++ b/lib/modules/datasource/index.ts
@@ -7,6 +7,7 @@ import * as memCache from '../../util/cache/memory';
 import * as packageCache from '../../util/cache/package';
 import { clone } from '../../util/clone';
 import { regEx } from '../../util/regex';
+import { Result } from '../../util/result';
 import { uniq } from '../../util/uniq';
 import { trimTrailingSlash } from '../../util/url';
 import * as allVersioning from '../versioning';
@@ -19,8 +20,6 @@ import type {
   DigestConfig,
   GetDigestInputConfig,
   GetPkgReleasesConfig,
-  GetPkgReleasesResultError,
-  GetPkgReleasesResultSuccess,
   GetReleasesConfig,
   ReleaseResult,
 } from './types';
@@ -431,15 +430,10 @@ export async function getPkgReleases(
   return res;
 }
 
-export async function getPkgReleasesWithResult(
+export function getPkgReleasesWithResult(
   config: GetPkgReleasesConfig
-): Promise<GetPkgReleasesResultSuccess | GetPkgReleasesResultError> {
-  try {
-    const result = await getPkgReleases(config);
-    return { result };
-  } catch (error) {
-    return { error };
-  }
+): Promise<Result<ReleaseResult | null>> {
+  return Result.wrap(getPkgReleases(config));
 }
 
 export function supportsDigests(datasource: string | undefined): boolean {

--- a/lib/modules/datasource/types.ts
+++ b/lib/modules/datasource/types.ts
@@ -74,16 +74,6 @@ export interface ReleaseResult {
   replacementVersion?: string;
 }
 
-export interface GetPkgReleasesResultError {
-  error: Error;
-  result?: never;
-}
-
-export interface GetPkgReleasesResultSuccess {
-  error?: never;
-  result: ReleaseResult | null;
-}
-
 export type RegistryStrategy = 'first' | 'hunt' | 'merge';
 
 export interface DatasourceApi extends ModuleApi {

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -82,11 +82,11 @@ export async function lookupUpdates(
         res.skipReason = 'is-pinned';
         return res;
       }
-      const lookupResult = await getPkgReleasesWithResult(config);
-      if (lookupResult.error) {
+      const lookupResult = (await getPkgReleasesWithResult(config)).unwrap();
+      if (!lookupResult.ok) {
         throw lookupResult.error;
       }
-      dependency = clone(lookupResult.result);
+      dependency = clone(lookupResult.value);
       if (!dependency) {
         // If dependency lookup fails then warn and return
         const warning: ValidationMessage = {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
