### PR TITLE
feat: detect bitbucket host types

### DIFF
--- a/lib/util/common.spec.ts
+++ b/lib/util/common.spec.ts
@@ -34,11 +34,18 @@ describe('util/common', () => {
         hostType: 'gitea',
         matchHost: 'gt.example.com',
       });
+      hostRules.add({
+        hostType: 'bitbucket',
+        matchHost: 'bb.example.com',
+      });
       expect(detectPlatform('https://gl.example.com/chalk/chalk')).toBe(
         'gitlab'
       );
       expect(detectPlatform('https://gh.example.com/chalk/chalk')).toBe(
         'github'
+      );
+      expect(detectPlatform('https://bb.example.com/chalk/chalk')).toBe(
+        'bitbucket'
       );
       expect(detectPlatform('https://gt.example.com/chalk/chalk')).toBeNull();
     });

--- a/lib/util/common.ts
+++ b/lib/util/common.ts
@@ -1,4 +1,5 @@
 import {
+  BITBUCKET_API_USING_HOST_TYPES,
   GITHUB_API_USING_HOST_TYPES,
   GITLAB_API_USING_HOST_TYPES,
 } from '../constants';
@@ -34,6 +35,9 @@ export function detectPlatform(
     return null;
   }
 
+  if (BITBUCKET_API_USING_HOST_TYPES.includes(hostType)) {
+    return 'bitbucket';
+  }
   if (GITLAB_API_USING_HOST_TYPES.includes(hostType)) {
     return 'gitlab';
   }


### PR DESCRIPTION
## Changes

Detect bitbucket platform by host types

## Context

Split from #22094

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
