### PR TITLE
feat: refactor changelog platforms

### DIFF
--- a/lib/workers/repository/update/pr/changelog/api.ts
+++ b/lib/workers/repository/update/pr/changelog/api.ts
@@ -1,0 +1,9 @@
+import type { ChangeLogSource } from './source';
+import { GitHubChangeLogSource } from './source-github';
+import { GitLabChangeLogSource } from './source-gitlab';
+
+const api = new Map<string, ChangeLogSource>();
+export default api;
+
+api.set('github', new GitHubChangeLogSource());
+api.set('gitlab', new GitLabChangeLogSource());

--- a/lib/workers/repository/update/pr/changelog/github.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/github.spec.ts
@@ -217,6 +217,16 @@ describe('workers/repository/update/pr/changelog/github', () => {
       ).toEqual({ error: 'MissingGithubToken' });
     });
 
+    it('handles suppressed Github warnings', async () => {
+      GlobalConfig.set({ githubTokenWarn: false });
+      expect(
+        await getChangeLogJSON({
+          ...upgrade,
+          sourceUrl: 'https://github.com',
+        })
+      ).toBeNull();
+    });
+
     it('handles no releases', async () => {
       expect(
         await getChangeLogJSON({

--- a/lib/workers/repository/update/pr/changelog/github/index.ts
+++ b/lib/workers/repository/update/pr/changelog/github/index.ts
@@ -5,10 +5,7 @@ import type {
   GithubGitTree,
   GithubGitTreeNode,
 } from '../../../../../../types/platform/github';
-import {
-  queryReleases,
-  queryTags,
-} from '../../../../../../util/github/graphql';
+import { queryReleases } from '../../../../../../util/github/graphql';
 import { GithubHttp } from '../../../../../../util/http/github';
 import { fromBase64 } from '../../../../../../util/string';
 import { ensureTrailingSlash, joinUrlParts } from '../../../../../../util/url';
@@ -21,40 +18,6 @@ import type {
 
 export const id = 'github-changelog';
 const http = new GithubHttp(id);
-
-export async function getTags(
-  endpoint: string,
-  repository: string
-): Promise<string[]> {
-  logger.trace('github.getTags()');
-  try {
-    const tags = await queryTags(
-      {
-        registryUrl: endpoint,
-        packageName: repository,
-      },
-      http
-    );
-
-    // istanbul ignore if
-    if (!tags.length) {
-      logger.debug(`No Github tags found for repository:${repository}`);
-    }
-
-    return tags.map(({ version }) => version);
-  } catch (err) {
-    logger.debug(
-      { sourceRepo: repository, err },
-      'Failed to fetch Github tags'
-    );
-    // istanbul ignore if
-    if (err.message?.includes('Bad credentials')) {
-      logger.warn('Bad credentials triggering tag fail lookup in changelog');
-      throw err;
-    }
-    return [];
-  }
-}
 
 export async function getReleaseNotesMd(
   repository: string,

--- a/lib/workers/repository/update/pr/changelog/gitlab/index.ts
+++ b/lib/workers/repository/update/pr/changelog/gitlab/index.ts
@@ -1,7 +1,6 @@
 import changelogFilenameRegex from 'changelog-filename-regex';
 import { logger } from '../../../../../../logger';
 import type { GitlabRelease } from '../../../../../../modules/datasource/gitlab-releases/types';
-import type { GitlabTag } from '../../../../../../modules/datasource/gitlab-tags/types';
 import type { GitlabTreeNode } from '../../../../../../types/platform/gitlab';
 import { GitlabHttp } from '../../../../../../util/http/gitlab';
 import { ensureTrailingSlash } from '../../../../../../util/url';
@@ -14,41 +13,6 @@ import type {
 
 export const id = 'gitlab-changelog';
 const http = new GitlabHttp(id);
-
-export async function getTags(
-  endpoint: string,
-  repository: string
-): Promise<string[]> {
-  logger.trace('gitlab.getTags()');
-  const urlEncodedRepo = encodeURIComponent(repository);
-  const url = `${ensureTrailingSlash(
-    endpoint
-  )}projects/${urlEncodedRepo}/repository/tags?per_page=100`;
-  try {
-    const res = await http.getJson<GitlabTag[]>(url, {
-      paginate: true,
-    });
-
-    const tags = res.body;
-
-    if (!tags.length) {
-      logger.debug(`No Gitlab tags found for ${repository}`);
-    }
-
-    return tags.map((tag) => tag.name).filter(Boolean);
-  } catch (err) {
-    logger.debug(
-      { sourceRepo: repository, err },
-      'Failed to fetch Gitlab tags'
-    );
-    // istanbul ignore if
-    if (err.message?.includes('Bad credentials')) {
-      logger.warn('Bad credentials triggering tag fail lookup in changelog');
-      throw err;
-    }
-    return [];
-  }
-}
 
 export async function getReleaseNotesMd(
   repository: string,

--- a/lib/workers/repository/update/pr/changelog/index.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/index.spec.ts
@@ -93,7 +93,7 @@ describe('workers/repository/update/pr/changelog/index', () => {
     });
 
     it('works without Github', async () => {
-      githubTagsMock.mockRejectedValueOnce(new Error('Unknown'));
+      githubTagsMock.mockRejectedValue(new Error('Unknown'));
       // 4 versions, so 4 calls without cache
       githubReleasesMock
         .mockRejectedValueOnce(new Error('Unknown'))
@@ -165,7 +165,7 @@ describe('workers/repository/update/pr/changelog/index', () => {
     });
 
     it('filters unnecessary warns', async () => {
-      githubTagsMock.mockRejectedValueOnce(new Error('Unknown Github Repo'));
+      githubTagsMock.mockRejectedValue(new Error('Unknown Github Repo'));
       githubReleasesMock.mockRejectedValueOnce(
         new Error('Unknown Github Repo')
       );
@@ -270,8 +270,8 @@ describe('workers/repository/update/pr/changelog/index', () => {
     });
 
     it('supports github enterprise and github.com changelog', async () => {
-      githubTagsMock.mockRejectedValueOnce([]);
-      githubReleasesMock.mockRejectedValueOnce([]);
+      githubTagsMock.mockRejectedValue([]);
+      githubReleasesMock.mockRejectedValue([]);
       httpMock.scope(githubApiHost).persist().get(/.*/).reply(200, []);
       hostRules.add({
         hostType: 'github',
@@ -304,8 +304,8 @@ describe('workers/repository/update/pr/changelog/index', () => {
     });
 
     it('supports github enterprise and github enterprise changelog', async () => {
-      githubTagsMock.mockRejectedValueOnce([]);
-      githubReleasesMock.mockRejectedValueOnce([]);
+      githubTagsMock.mockRejectedValue([]);
+      githubReleasesMock.mockRejectedValue([]);
       httpMock
         .scope('https://github-enterprise.example.com')
         .persist()
@@ -344,8 +344,8 @@ describe('workers/repository/update/pr/changelog/index', () => {
     });
 
     it('supports github.com and github enterprise changelog', async () => {
-      githubTagsMock.mockRejectedValueOnce([]);
-      githubReleasesMock.mockRejectedValueOnce([]);
+      githubTagsMock.mockRejectedValue([]);
+      githubReleasesMock.mockRejectedValue([]);
       httpMock
         .scope('https://github-enterprise.example.com')
         .persist()

--- a/lib/workers/repository/update/pr/changelog/index.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/index.spec.ts
@@ -55,6 +55,15 @@ describe('workers/repository/update/pr/changelog/index', () => {
       ).toBeNull();
     });
 
+    it('handles unsupported changelog source', async () => {
+      expect(
+        await getChangeLogJSON({
+          ...upgrade,
+          sourceUrl: 'https://dev.azure.com/unknown-repo',
+        })
+      ).toBeNull();
+    });
+
     it('returns null if no currentVersion', async () => {
       expect(
         await getChangeLogJSON({

--- a/lib/workers/repository/update/pr/changelog/index.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/index.spec.ts
@@ -5,6 +5,7 @@ import * as semverVersioning from '../../../../../modules/versioning/semver';
 import * as githubGraphql from '../../../../../util/github/graphql';
 import * as hostRules from '../../../../../util/host-rules';
 import type { BranchConfig } from '../../../../types';
+import * as releases from './releases';
 import { getChangeLogJSON } from '.';
 
 jest.mock('../../../../../modules/datasource/npm');
@@ -13,6 +14,7 @@ const githubApiHost = 'https://api.github.com';
 
 const githubTagsMock = jest.spyOn(githubGraphql, 'queryTags');
 const githubReleasesMock = jest.spyOn(githubGraphql, 'queryReleases');
+const getInRangeReleasesMock = jest.spyOn(releases, 'getInRangeReleases');
 
 const upgrade = partial<BranchConfig>({
   endpoint: 'https://api.github.com/',
@@ -267,6 +269,14 @@ describe('workers/repository/update/pr/changelog/index', () => {
           releases: [{ version: '0.9.0' }],
         })
       ).toBeNull();
+    });
+
+    it('will call getInRangeReleases when releases is undefined', async () => {
+      await getChangeLogJSON({
+        ...upgrade,
+        releases: undefined,
+      });
+      expect(getInRangeReleasesMock).toHaveBeenCalledOnce();
     });
 
     it('supports github enterprise and github.com changelog', async () => {

--- a/lib/workers/repository/update/pr/changelog/source-github.ts
+++ b/lib/workers/repository/update/pr/changelog/source-github.ts
@@ -1,213 +1,80 @@
-// TODO #7154
 import URL from 'node:url';
 import { GlobalConfig } from '../../../../../config/global';
 import { logger } from '../../../../../logger';
-import type { Release } from '../../../../../modules/datasource/types';
-import * as allVersioning from '../../../../../modules/versioning';
-import * as memCache from '../../../../../util/cache/memory';
-import * as packageCache from '../../../../../util/cache/package';
 import * as hostRules from '../../../../../util/host-rules';
-import { regEx } from '../../../../../util/regex';
 import type { BranchUpgradeConfig } from '../../../../types';
-import { slugifyUrl } from './common';
-import { getTags } from './github';
-import { addReleaseNotes } from './release-notes';
-import { getInRangeReleases } from './releases';
-import type { ChangeLogRelease, ChangeLogResult } from './types';
-
-function getCachedTags(
-  endpoint: string,
-  repository: string
-): Promise<string[]> {
-  const cacheKey = `getTags-${endpoint}-${repository}`;
-  const cachedResult = memCache.get<Promise<string[]>>(cacheKey);
-  // istanbul ignore if
-  if (cachedResult !== undefined) {
-    return cachedResult;
+import { ChangeLogSource } from './source';
+import type { ChangeLogError } from './types';
+export class GitHubChangeLogSource extends ChangeLogSource {
+  constructor() {
+    super('github', 'github-tags');
   }
-  const promisedRes = getTags(endpoint, repository);
-  memCache.set(cacheKey, promisedRes);
-  return promisedRes;
-}
 
-export async function getChangeLogJSON(
-  config: BranchUpgradeConfig
-): Promise<ChangeLogResult | null> {
-  const versioning = config.versioning!;
-  const currentVersion = config.currentVersion!;
-  const newVersion = config.newVersion!;
-  const sourceUrl = config.sourceUrl!;
-  const sourceDirectory = config.sourceDirectory!;
-  const packageName = config.packageName!;
-  const manager = config.manager;
-  if (sourceUrl === 'https://github.com/DefinitelyTyped/DefinitelyTyped') {
-    logger.trace('No release notes for @types');
-    return null;
+  getAPIBaseUrl(config: BranchUpgradeConfig): string {
+    return config.sourceUrl!.startsWith('https://github.com/')
+      ? 'https://api.github.com/'
+      : this.getBaseUrl(config) + 'api/v3/';
   }
-  const version = allVersioning.get(versioning);
-  const { protocol, host, pathname } = URL.parse(sourceUrl);
-  // TODO: types (#7154)
-  const baseUrl = `${protocol!}//${host!}/`;
-  const url = sourceUrl.startsWith('https://github.com/')
-    ? 'https://api.github.com/'
-    : sourceUrl;
-  const { token } = hostRules.find({
-    hostType: 'github',
-    url,
-  });
-  // istanbul ignore if
-  if (!token) {
-    if (host!.endsWith('.github.com') || host === 'github.com') {
-      if (!GlobalConfig.get('githubTokenWarn')) {
-        logger.debug(
-          { manager, packageName, sourceUrl },
-          'GitHub token warning has been suppressed. Skipping release notes retrieval'
-        );
-        return null;
-      }
-      logger.warn(
-        { manager, packageName, sourceUrl },
-        'No github.com token has been configured. Skipping release notes retrieval'
-      );
-      return { error: 'MissingGithubToken' };
+
+  getCompareURL(
+    baseUrl: string,
+    repository: string,
+    prevHead: string,
+    nextHead: string
+  ): string {
+    return `${baseUrl}${repository}/compare/${prevHead}...${nextHead}`;
+  }
+
+  protected override shouldSkipPackage(config: BranchUpgradeConfig): boolean {
+    if (
+      config.sourceUrl === 'https://github.com/DefinitelyTyped/DefinitelyTyped'
+    ) {
+      logger.trace('No release notes for @types');
+      return true;
     }
-    logger.debug(
-      { manager, packageName, sourceUrl },
-      'Repository URL does not match any known github hosts - skipping changelog retrieval'
-    );
-    return null;
-  }
-  const apiBaseUrl = sourceUrl.startsWith('https://github.com/')
-    ? 'https://api.github.com/'
-    : baseUrl + 'api/v3/';
-  const repository = pathname!
-    .slice(1)
-    .replace(regEx(/\/$/), '')
-    .replace(regEx(/\.git$/), '');
-  if (repository.split('/').length !== 2) {
-    logger.debug(`Invalid github URL found: ${sourceUrl}`);
-    return null;
-  }
-  const releases = config.releases ?? (await getInRangeReleases(config));
-  if (!releases?.length) {
-    logger.debug('No releases');
-    return null;
-  }
-  // This extra filter/sort should not be necessary, but better safe than sorry
-  const validReleases = [...releases]
-    .filter((release) => version.isVersion(release.version))
-    .sort((a, b) => version.sortVersions(a.version, b.version));
 
-  if (validReleases.length < 2) {
-    logger.debug(`Not enough valid releases for dep ${packageName}`);
-    return null;
+    return false;
   }
 
-  let tags: string[];
+  protected override hasValidToken(config: BranchUpgradeConfig): {
+    isValid: boolean;
+    error?: ChangeLogError;
+  } {
+    const sourceUrl = config.sourceUrl!;
+    const parsedUrl = URL.parse(sourceUrl);
+    const host = parsedUrl.host!;
+    const manager = config.manager;
+    const packageName = config.packageName;
 
-  async function getRef(release: Release): Promise<string | null> {
-    if (!tags) {
-      tags = await getCachedTags(apiBaseUrl, repository);
-    }
-    const tagName = findTagOfRelease(
-      version,
-      packageName,
-      release.version,
-      tags
-    );
-    if (tagName) {
-      return tagName;
-    }
-    if (release.gitRef) {
-      return release.gitRef;
-    }
-    return null;
-  }
-
-  const cacheNamespace = 'changelog-github-release';
-
-  function getCacheKey(prev: string, next: string): string {
-    return `${slugifyUrl(sourceUrl)}:${packageName}:${prev}:${next}`;
-  }
-
-  const changelogReleases: ChangeLogRelease[] = [];
-  // compare versions
-  const include = (v: string): boolean =>
-    version.isGreaterThan(v, currentVersion) &&
-    !version.isGreaterThan(v, newVersion);
-  for (let i = 1; i < validReleases.length; i += 1) {
-    const prev = validReleases[i - 1];
-    const next = validReleases[i];
-    if (include(next.version)) {
-      let release = await packageCache.get(
-        cacheNamespace,
-        getCacheKey(prev.version, next.version)
-      );
-      // istanbul ignore else
-      if (!release) {
-        release = {
-          version: next.version,
-          gitRef: next.gitRef,
-          date: next.releaseTimestamp,
-          // put empty changes so that existing templates won't break
-          changes: [],
-          compare: {},
-        };
-        const prevHead = await getRef(prev);
-        const nextHead = await getRef(next);
-        if (prevHead && nextHead) {
-          release.compare.url = `${baseUrl}${repository}/compare/${prevHead}...${nextHead}`;
+    const url = sourceUrl.startsWith('https://github.com/')
+      ? 'https://api.github.com/'
+      : sourceUrl;
+    const { token } = hostRules.find({
+      hostType: 'github',
+      url,
+    });
+    // istanbul ignore if
+    if (!token) {
+      if (host.endsWith('.github.com') || host === 'github.com') {
+        if (!GlobalConfig.get('githubTokenWarn')) {
+          logger.debug(
+            { manager, packageName, sourceUrl },
+            'GitHub token warning has been suppressed. Skipping release notes retrieval'
+          );
+          return { isValid: false };
         }
-        const cacheMinutes = 55;
-        await packageCache.set(
-          cacheNamespace,
-          getCacheKey(prev.version, next.version),
-          release,
-          cacheMinutes
+        logger.warn(
+          { manager, packageName, sourceUrl },
+          'No github.com token has been configured. Skipping release notes retrieval'
         );
+        return { isValid: false, error: 'MissingGithubToken' };
       }
-      changelogReleases.unshift(release);
+      logger.debug(
+        { manager, packageName, sourceUrl },
+        'Repository URL does not match any known github hosts - skipping changelog retrieval'
+      );
+      return { isValid: false };
     }
+    return { isValid: true };
   }
-
-  let res: ChangeLogResult | null = {
-    project: {
-      apiBaseUrl,
-      baseUrl,
-      type: 'github',
-      repository,
-      sourceUrl,
-      sourceDirectory,
-      packageName,
-    },
-    versions: changelogReleases,
-  };
-
-  res = await addReleaseNotes(res, config);
-
-  return res;
-}
-
-function findTagOfRelease(
-  version: allVersioning.VersioningApi,
-  packageName: string,
-  depNewVersion: string,
-  tags: string[]
-): string | undefined {
-  const regex = regEx(`(?:${packageName}|release)[@-]`, undefined, false);
-  const exactReleaseRegex = regEx(`${packageName}[@\\-_]v?${depNewVersion}`);
-  const exactTagsList = tags.filter((tag) => {
-    return exactReleaseRegex.test(tag);
-  });
-  let tagName: string | undefined;
-  if (exactTagsList.length) {
-    tagName = exactTagsList
-      .filter((tag) => version.isVersion(tag.replace(regex, '')))
-      .find((tag) => version.equals(tag.replace(regex, ''), depNewVersion));
-  } else {
-    tagName = tags
-      .filter((tag) => version.isVersion(tag.replace(regex, '')))
-      .find((tag) => version.equals(tag.replace(regex, ''), depNewVersion));
-  }
-  return tagName;
 }

--- a/lib/workers/repository/update/pr/changelog/source-gitlab.ts
+++ b/lib/workers/repository/update/pr/changelog/source-gitlab.ts
@@ -1,156 +1,21 @@
-// TODO #7154
-import URL from 'node:url';
-import { logger } from '../../../../../logger';
-import type { Release } from '../../../../../modules/datasource/types';
-import * as allVersioning from '../../../../../modules/versioning';
-import * as memCache from '../../../../../util/cache/memory';
-import * as packageCache from '../../../../../util/cache/package';
-import { regEx } from '../../../../../util/regex';
 import type { BranchUpgradeConfig } from '../../../../types';
-import { slugifyUrl } from './common';
-import { getTags } from './gitlab';
-import { addReleaseNotes } from './release-notes';
-import { getInRangeReleases } from './releases';
-import type { ChangeLogRelease, ChangeLogResult } from './types';
+import { ChangeLogSource } from './source';
 
-const cacheNamespace = 'changelog-gitlab-release';
-
-function getCachedTags(
-  endpoint: string,
-  versionScheme: string,
-  repository: string
-): Promise<string[]> {
-  const cacheKey = `getTags-${endpoint}-${versionScheme}-${repository}`;
-  const cachedResult = memCache.get<Promise<string[]>>(cacheKey);
-  // istanbul ignore if
-  if (cachedResult !== undefined) {
-    return cachedResult;
-  }
-  const promisedRes = getTags(endpoint, repository);
-  memCache.set(cacheKey, promisedRes);
-  return promisedRes;
-}
-
-export async function getChangeLogJSON(
-  config: BranchUpgradeConfig
-): Promise<ChangeLogResult | null> {
-  const versioning = config.versioning!;
-  const currentVersion = config.currentVersion!;
-  const newVersion = config.newVersion!;
-  const sourceUrl = config.sourceUrl!;
-  const packageName = config.packageName!;
-  const sourceDirectory = config.sourceDirectory!;
-
-  logger.trace('getChangeLogJSON for gitlab');
-  const version = allVersioning.get(versioning);
-
-  const parsedUrl = URL.parse(sourceUrl);
-  const protocol = parsedUrl.protocol!;
-  const host = parsedUrl.host!;
-  const pathname = parsedUrl.pathname!;
-
-  logger.trace({ protocol, host, pathname }, 'Protocol, host, pathname');
-  const baseUrl = protocol.concat('//', host, '/');
-  const apiBaseUrl = baseUrl.concat('api/v4/');
-  const repository = pathname
-    .slice(1)
-    .replace(regEx(/\/$/), '')
-    .replace(regEx(/\.git$/), '');
-  if (repository.split('/').length < 2) {
-    logger.info({ sourceUrl }, 'Invalid gitlab URL found');
-    return null;
-  }
-  const releases = config.releases ?? (await getInRangeReleases(config));
-  if (!releases?.length) {
-    logger.debug('No releases');
-    return null;
-  }
-  // This extra filter/sort should not be necessary, but better safe than sorry
-  const validReleases = [...releases]
-    .filter((release) => version.isVersion(release.version))
-    .sort((a, b) => version.sortVersions(a.version, b.version));
-
-  if (validReleases.length < 2) {
-    logger.debug('Not enough valid releases');
-    return null;
+export class GitLabChangeLogSource extends ChangeLogSource {
+  constructor() {
+    super('gitlab', 'gitlab-tags');
   }
 
-  let tags: string[];
-
-  async function getRef(release: Release): Promise<string | null> {
-    if (!tags) {
-      tags = await getCachedTags(apiBaseUrl, versioning, repository);
-    }
-    const regex = regEx(`(?:${packageName}|release)[@-]`, undefined, false);
-    const tagName = tags
-      .filter((tag) => version.isVersion(tag.replace(regex, '')))
-      .find((tag) => version.equals(tag.replace(regex, ''), release.version));
-    if (tagName) {
-      return tagName;
-    }
-    if (release.gitRef) {
-      return release.gitRef;
-    }
-    return null;
+  getAPIBaseUrl(config: BranchUpgradeConfig): string {
+    return this.getBaseUrl(config) + 'api/v4/';
   }
 
-  function getCacheKey(prev: string, next: string): string {
-    return `${slugifyUrl(sourceUrl)}:${packageName}:${prev}:${next}`;
+  getCompareURL(
+    baseUrl: string,
+    repository: string,
+    prevHead: string,
+    nextHead: string
+  ): string {
+    return `${baseUrl}${repository}/compare/${prevHead}...${nextHead}`;
   }
-
-  const changelogReleases: ChangeLogRelease[] = [];
-  // compare versions
-  const include = (v: string): boolean =>
-    version.isGreaterThan(v, currentVersion) &&
-    !version.isGreaterThan(v, newVersion);
-  for (let i = 1; i < validReleases.length; i += 1) {
-    const prev = validReleases[i - 1];
-    const next = validReleases[i];
-    if (include(next.version)) {
-      let release = await packageCache.get(
-        cacheNamespace,
-        getCacheKey(prev.version, next.version)
-      );
-      if (!release) {
-        release = {
-          version: next.version,
-          date: next.releaseTimestamp,
-          gitRef: next.gitRef,
-          // put empty changes so that existing templates won't break
-          changes: [],
-          compare: {},
-        };
-        const prevHead = await getRef(prev);
-        const nextHead = await getRef(next);
-        if (prevHead && nextHead) {
-          release.compare.url = `${baseUrl}${repository}/compare/${prevHead}...${nextHead}`;
-        }
-        const cacheMinutes = 55;
-        await packageCache.set(
-          cacheNamespace,
-          getCacheKey(prev.version, next.version),
-          release,
-          cacheMinutes
-        );
-      }
-      changelogReleases.unshift(release);
-    }
-  }
-
-  let res: ChangeLogResult | null = {
-    project: {
-      apiBaseUrl,
-      baseUrl,
-      type: 'gitlab',
-      repository,
-      sourceUrl,
-      packageName,
-      sourceDirectory,
-    },
-    versions: changelogReleases,
-  };
-
-  res = await addReleaseNotes(res, config);
-
-  return res;
 }

--- a/lib/workers/repository/update/pr/changelog/source.ts
+++ b/lib/workers/repository/update/pr/changelog/source.ts
@@ -1,0 +1,264 @@
+import URL from 'node:url';
+import is from '@sindresorhus/is';
+import { logger } from '../../../../../logger';
+import { getPkgReleases } from '../../../../../modules/datasource';
+import type { Release } from '../../../../../modules/datasource/types';
+import * as allVersioning from '../../../../../modules/versioning';
+import * as packageCache from '../../../../../util/cache/package';
+import { regEx } from '../../../../../util/regex';
+import { trimSlashes } from '../../../../../util/url';
+import type { BranchUpgradeConfig } from '../../../../types';
+import { slugifyUrl } from './common';
+import { addReleaseNotes } from './release-notes';
+import { getInRangeReleases } from './releases';
+import type {
+  ChangeLogError,
+  ChangeLogRelease,
+  ChangeLogResult,
+} from './types';
+
+export abstract class ChangeLogSource {
+  private platform;
+  private datasource;
+  private cacheNamespace: string;
+
+  constructor(
+    platform: 'github' | 'gitlab',
+    datasource: 'github-tags' | 'gitlab-tags'
+  ) {
+    this.platform = platform;
+    this.datasource = datasource;
+    this.cacheNamespace = `changelog-${platform}-release`;
+  }
+
+  abstract getCompareURL(
+    baseUrl: string,
+    repository: string,
+    prevHead: string,
+    nextHead: string
+  ): string;
+
+  abstract getAPIBaseUrl(config: BranchUpgradeConfig): string;
+
+  async getAllTags(endpoint: string, repository: string): Promise<string[]> {
+    const tags = (
+      await getPkgReleases({
+        datasource: this.datasource,
+        packageName: repository,
+        versioning:
+          'regex:(?<major>\\d+)(\\.(?<minor>\\d+))?(\\.(?<patch>\\d+))?',
+      })
+    )?.releases;
+
+    if (is.nullOrUndefined(tags) || is.emptyArray(tags)) {
+      logger.debug(
+        `No ${this.datasource} tags found for repository: ${repository}`
+      );
+
+      return [];
+    }
+
+    return tags.map(({ version }) => version);
+  }
+
+  public async getChangeLogJSON(
+    config: BranchUpgradeConfig
+  ): Promise<ChangeLogResult | null> {
+    logger.trace(`getChangeLogJSON for ${this.platform}`);
+
+    const versioning = config.versioning!;
+    const currentVersion = config.currentVersion!;
+    const newVersion = config.newVersion!;
+    const sourceUrl = config.sourceUrl!;
+    const packageName = config.packageName!;
+    const sourceDirectory = config.sourceDirectory;
+    const version = allVersioning.get(versioning);
+
+    if (this.shouldSkipPackage(config)) {
+      return null;
+    }
+
+    const baseUrl = this.getBaseUrl(config);
+    const apiBaseUrl = this.getAPIBaseUrl(config);
+    const repository = this.getRepositoryFromUrl(config);
+
+    const tokenResponse = this.hasValidToken(config);
+    if (!tokenResponse.isValid) {
+      if (tokenResponse.error) {
+        return {
+          error: tokenResponse.error,
+        };
+      }
+      return null;
+    }
+
+    if (repository.split('/').length !== 2) {
+      logger.debug(`Invalid ${this.platform} URL found: ${sourceUrl}`);
+      return null;
+    }
+
+    const releases = config.releases ?? (await getInRangeReleases(config));
+    if (!releases?.length) {
+      logger.debug('No releases');
+      return null;
+    }
+    // This extra filter/sort should not be necessary, but better safe than sorry
+    const validReleases = [...releases]
+      .filter((release) => version.isVersion(release.version))
+      .sort((a, b) => version.sortVersions(a.version, b.version));
+
+    if (validReleases.length < 2) {
+      logger.debug(`Not enough valid releases for dep ${packageName}`);
+      return null;
+    }
+
+    const changelogReleases: ChangeLogRelease[] = [];
+    // compare versions
+    const include = (v: string): boolean =>
+      version.isGreaterThan(v, currentVersion) &&
+      !version.isGreaterThan(v, newVersion);
+
+    for (let i = 1; i < validReleases.length; i += 1) {
+      const prev = validReleases[i - 1];
+      const next = validReleases[i];
+      if (!include(next.version)) {
+        continue;
+      }
+      let release = await packageCache.get(
+        this.cacheNamespace,
+        this.getCacheKey(sourceUrl, packageName, prev.version, next.version)
+      );
+      if (!release) {
+        release = {
+          version: next.version,
+          date: next.releaseTimestamp,
+          gitRef: next.gitRef,
+          // put empty changes so that existing templates won't break
+          changes: [],
+          compare: {},
+        };
+        const prevHead = await this.getRef(
+          version,
+          packageName,
+          prev,
+          apiBaseUrl,
+          repository
+        );
+        const nextHead = await this.getRef(
+          version,
+          packageName,
+          next,
+          apiBaseUrl,
+          repository
+        );
+        if (is.nonEmptyString(prevHead) && is.nonEmptyString(nextHead)) {
+          release.compare.url = this.getCompareURL(
+            baseUrl,
+            repository,
+            prevHead,
+            nextHead
+          );
+        }
+        const cacheMinutes = 55;
+        await packageCache.set(
+          this.cacheNamespace,
+          this.getCacheKey(sourceUrl, packageName, prev.version, next.version),
+          release,
+          cacheMinutes
+        );
+      }
+      changelogReleases.unshift(release);
+    }
+
+    let res: ChangeLogResult | null = {
+      project: {
+        apiBaseUrl,
+        baseUrl,
+        type: this.platform,
+        repository,
+        sourceUrl,
+        sourceDirectory,
+        packageName,
+      },
+      versions: changelogReleases,
+    };
+
+    res = await addReleaseNotes(res, config);
+
+    return res;
+  }
+
+  private findTagOfRelease(
+    version: allVersioning.VersioningApi,
+    packageName: string,
+    depNewVersion: string,
+    tags: string[]
+  ): string | undefined {
+    const regex = regEx(`(?:${packageName}|release)[@-]`, undefined, false);
+    const exactReleaseRegex = regEx(`${packageName}[@\\-_]v?${depNewVersion}`);
+    const exactTagsList = tags.filter((tag) => {
+      return exactReleaseRegex.test(tag);
+    });
+    const tagList = exactTagsList.length ? exactTagsList : tags;
+    return tagList
+      .filter((tag) => version.isVersion(tag.replace(regex, '')))
+      .find((tag) => version.equals(tag.replace(regex, ''), depNewVersion));
+  }
+
+  private async getRef(
+    version: allVersioning.VersioningApi,
+    packageName: string,
+    release: Release,
+    apiBaseUrl: string,
+    repository: string
+  ): Promise<string | null> {
+    const tags = await this.getAllTags(apiBaseUrl, repository);
+
+    const tagName = this.findTagOfRelease(
+      version,
+      packageName,
+      release.version,
+      tags
+    );
+    if (is.nonEmptyString(tagName)) {
+      return tagName;
+    }
+    if (is.nonEmptyString(release.gitRef)) {
+      return release.gitRef;
+    }
+    return null;
+  }
+
+  private getCacheKey(
+    sourceUrl: string,
+    packageName: string,
+    prev: string,
+    next: string
+  ): string {
+    return `${slugifyUrl(sourceUrl)}:${packageName}:${prev}:${next}`;
+  }
+
+  protected getBaseUrl(config: BranchUpgradeConfig): string {
+    const parsedUrl = URL.parse(config.sourceUrl!);
+    const protocol = parsedUrl.protocol!;
+    const host = parsedUrl.host!;
+    return `${protocol}//${host}/`;
+  }
+
+  private getRepositoryFromUrl(config: BranchUpgradeConfig): string {
+    const parsedUrl = URL.parse(config.sourceUrl!);
+    const pathname = parsedUrl.pathname!;
+    return trimSlashes(pathname).replace(regEx(/\.git$/), '');
+  }
+
+  protected hasValidToken(config: BranchUpgradeConfig): {
+    isValid: boolean;
+    error?: ChangeLogError;
+  } {
+    return { isValid: true };
+  }
+
+  protected shouldSkipPackage(config: BranchUpgradeConfig): boolean {
+    return false;
+  }
+}


### PR DESCRIPTION
## Changes

Refactor changelog source logic in preparation for new source types being added.

## Context

Split from #22094

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
