### PR TITLE
fix(manager/gradle-wrapper): refresh Gradle lockfile after wrapper update

### DIFF
--- a/lib/modules/manager/gradle/artifacts.ts
+++ b/lib/modules/manager/gradle/artifacts.ts
@@ -149,7 +149,11 @@ export async function updateArtifacts({
       .map(quote)
       .join(' ')}`;
 
-    if (config.isLockFileMaintenance || isGcvPropsFile(packageFileName)) {
+    if (
+      config.isLockFileMaintenance ||
+      !updatedDeps.length ||
+      isGcvPropsFile(packageFileName)
+    ) {
       cmd += ' --write-locks';
     } else {
       const updatedDepNames = updatedDeps


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds an additional step to `gradle-wrapper` manager to update optionally existing gradle lockfiles. This is needed in case lockfiles and gradle built-in plugins with hard-coded versions like `jacoco` or `pmd` are used.

If no lock files exist, `updateArtifacts` of the `gradle` manager returns gracefully.

<!-- Describe what behavior is changed by this PR. -->

## Context

- https://github.com/renovatebot/renovate/discussions/23071

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

Test repo: https://github.com/renovate-demo/23071-renovate-gradle-lockfile-test/pull/1

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
