### PR TITLE
refactor(manager/gradle): ignore stdout of artifact updates via stdio convenience option

### DIFF
--- a/lib/modules/manager/gradle-wrapper/utils.ts
+++ b/lib/modules/manager/gradle-wrapper/utils.ts
@@ -21,20 +21,6 @@ export function gradleWrapperFileName(): string {
   return './gradlew';
 }
 
-export function nullRedirectionCommand(): string {
-  if (
-    os.platform() === 'win32' &&
-    GlobalConfig.get('binarySource') !== 'docker'
-  ) {
-    // TODO: Windows environment without docker needs to be implemented
-    logger.debug(
-      'Updating artifacts may fail due to excessive output from "gradle.bat :dependencies" command.'
-    );
-    return '';
-  }
-  return ' > /dev/null';
-}
-
 export async function prepareGradleCommand(
   gradlewFile: string
 ): Promise<string | null> {

--- a/lib/modules/manager/gradle/artifacts.spec.ts
+++ b/lib/modules/manager/gradle/artifacts.spec.ts
@@ -159,9 +159,10 @@ describe('modules/manager/gradle/artifacts', () => {
         },
       },
       {
-        cmd: './gradlew --console=plain -q :dependencies --update-locks org.junit.jupiter:junit-jupiter-api,org.junit.jupiter:junit-jupiter-engine > /dev/null',
+        cmd: './gradlew --console=plain -q :dependencies --update-locks org.junit.jupiter:junit-jupiter-api,org.junit.jupiter:junit-jupiter-engine',
         options: {
           cwd: '/tmp/github/some/repo',
+          stdio: ['pipe', 'ignore', 'pipe'],
         },
       },
     ]);
@@ -204,6 +205,7 @@ describe('modules/manager/gradle/artifacts', () => {
         cmd: 'gradlew.bat --console=plain -q :dependencies --update-locks org.junit.jupiter:junit-jupiter-api,org.junit.jupiter:junit-jupiter-engine',
         options: {
           cwd: '/tmp/github/some/repo',
+          stdio: ['pipe', 'ignore', 'pipe'],
         },
       },
     ]);
@@ -243,9 +245,10 @@ describe('modules/manager/gradle/artifacts', () => {
         },
       },
       {
-        cmd: './gradlew --console=plain -q :dependencies --update-locks org.springframework.boot:org.springframework.boot.gradle.plugin > /dev/null',
+        cmd: './gradlew --console=plain -q :dependencies --update-locks org.springframework.boot:org.springframework.boot.gradle.plugin',
         options: {
           cwd: '/tmp/github/some/repo',
+          stdio: ['pipe', 'ignore', 'pipe'],
         },
       },
     ]);
@@ -293,9 +296,10 @@ describe('modules/manager/gradle/artifacts', () => {
         },
       },
       {
-        cmd: './gradlew --console=plain -q :dependencies --write-locks > /dev/null',
+        cmd: './gradlew --console=plain -q :dependencies --write-locks',
         options: {
           cwd: '/tmp/github/some/repo',
+          stdio: ['pipe', 'ignore', 'pipe'],
         },
       },
     ]);
@@ -355,9 +359,12 @@ describe('modules/manager/gradle/artifacts', () => {
           ' bash -l -c "' +
           'install-tool java 16.0.1' +
           ' && ' +
-          './gradlew --console=plain -q :dependencies --write-locks > /dev/null' +
+          './gradlew --console=plain -q :dependencies --write-locks' +
           '"',
-        options: { cwd: '/tmp/github/some/repo' },
+        options: {
+          cwd: '/tmp/github/some/repo',
+          stdio: ['pipe', 'ignore', 'pipe'],
+        },
       },
     ]);
   });
@@ -390,8 +397,11 @@ describe('modules/manager/gradle/artifacts', () => {
       },
       { cmd: 'install-tool java 16.0.1' },
       {
-        cmd: './gradlew --console=plain -q :dependencies --write-locks > /dev/null',
-        options: { cwd: '/tmp/github/some/repo' },
+        cmd: './gradlew --console=plain -q :dependencies --write-locks',
+        options: {
+          cwd: '/tmp/github/some/repo',
+          stdio: ['pipe', 'ignore', 'pipe'],
+        },
       },
     ]);
   });
@@ -426,9 +436,10 @@ describe('modules/manager/gradle/artifacts', () => {
         },
       },
       {
-        cmd: './gradlew --console=plain -q :dependencies :sub1:dependencies :sub2:dependencies --write-locks > /dev/null',
+        cmd: './gradlew --console=plain -q :dependencies :sub1:dependencies :sub2:dependencies --write-locks',
         options: {
           cwd: '/tmp/github/some/repo',
+          stdio: ['pipe', 'ignore', 'pipe'],
         },
       },
     ]);
@@ -527,8 +538,11 @@ describe('modules/manager/gradle/artifacts', () => {
       },
       { cmd: 'install-tool java 11.0.1' },
       {
-        cmd: './gradlew --console=plain -q :dependencies --write-locks > /dev/null',
-        options: { cwd: '/tmp/github/some/repo' },
+        cmd: './gradlew --console=plain -q :dependencies --write-locks',
+        options: {
+          cwd: '/tmp/github/some/repo',
+          stdio: ['pipe', 'ignore', 'pipe'],
+        },
       },
     ]);
   });

--- a/lib/modules/manager/gradle/artifacts.ts
+++ b/lib/modules/manager/gradle/artifacts.ts
@@ -14,7 +14,6 @@ import {
   extractGradleVersion,
   getJavaConstraint,
   gradleWrapperFileName,
-  nullRedirectionCommand,
   prepareGradleCommand,
 } from '../gradle-wrapper/utils';
 import type { UpdateArtifact, UpdateArtifactsResult } from '../types';
@@ -163,16 +162,8 @@ export async function updateArtifacts({
       cmd += ` --update-locks ${updatedDepNames.map(quote).join(',')}`;
     }
 
-    // `./gradlew :dependencies` command can output huge text due to `:dependencies`
-    // that renders dependency graphs. Given the output can exceed `ExecOptions.maxBuffer` size,
-    // drop stdout from the command.
-    //
-    // Note: Windows without docker doesn't supported this yet
-    const nullRedirection = nullRedirectionCommand();
-    cmd += nullRedirection;
-
     await writeLocalFile(packageFileName, newPackageFileContent);
-    await exec(cmd, execOptions);
+    await exec(cmd, { ...execOptions, ignoreStdout: true });
 
     const res = await getUpdatedLockfiles(oldLockFileContentMap);
     logger.debug('Returning updated Gradle dependency lockfiles');

--- a/lib/modules/manager/gradle/readme.md
+++ b/lib/modules/manager/gradle/readme.md
@@ -3,6 +3,8 @@ It does not call `gradle` directly in order to extract a list of dependencies.
 
 ### Updating lockfiles
 
-Updating lockfiles is done with `./gradlew :dependencies --wirte/update-locks` command.
-This command can output excessive text to the console.
-While running the command, the output to stdout is dropped when you run Renovate on most platforms other than Windows.
+The gradle manager supports gradle lock files in `.lockfile` artifacts, as well as lock files used by the [gradle-consistent-versions](https://github.com/palantir/gradle-consistent-versions) plugin.
+During [lock file maintenance](https://docs.renovatebot.com/configuration-options/#lockfilemaintenance), renovate calls `./gradlew :dependencies --write-locks` on the root project and subprojects.
+For regular dependency updates, renovate automatically updates lock state entries via the `--update-locks` command line flag.
+
+As the output of these commands can be very large, any text other than errors (in `stderr`) is discarded.

--- a/lib/util/exec/index.spec.ts
+++ b/lib/util/exec/index.spec.ts
@@ -711,6 +711,29 @@ describe('util/exec/index', () => {
     ],
 
     [
+      'Discarded stdout if ignoreStdout=true',
+      {
+        processEnv,
+        inCmd,
+        inOpts: {
+          ignoreStdout: true,
+          cwdFile: '/somefile',
+        },
+        outCmd,
+        outOpts: [
+          {
+            cwd,
+            encoding,
+            env: envMock.basic,
+            timeout: 900000,
+            maxBuffer: 10485760,
+            stdio: ['pipe', 'ignore', 'pipe'],
+          },
+        ],
+      },
+    ],
+
+    [
       'Hermit',
       {
         processEnv: {

--- a/lib/util/exec/index.ts
+++ b/lib/util/exec/index.ts
@@ -87,6 +87,11 @@ function getRawExecOptions(opts: ExecOptions): RawExecOptions {
 
   // Set default max buffer size to 10MB
   rawExecOptions.maxBuffer = rawExecOptions.maxBuffer ?? 10 * 1024 * 1024;
+
+  if (opts.ignoreStdout) {
+    rawExecOptions.stdio = ['pipe', 'ignore', 'pipe'];
+  }
+
   return rawExecOptions;
 }
 

--- a/lib/util/exec/types.ts
+++ b/lib/util/exec/types.ts
@@ -49,6 +49,7 @@ export interface ExecOptions {
   docker?: Opt<DockerOptions>;
   toolConstraints?: Opt<ToolConstraint[]>;
   preCommands?: Opt<string[]>;
+  ignoreStdout?: boolean;
   // Following are pass-through to child process
   maxBuffer?: number | undefined;
   timeout?: number | undefined;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

PR https://github.com/renovatebot/renovate/pull/20820 introduced a method to redirect stdout to `> /dev/null`. This approach didn't include Windows. This PR refactors the implementation to rely on [`options.stdio`](https://nodejs.org/api/child_process.html#child_process_options_stdio) instead, as this works on all platforms. 

This PR also removes the now no longer existing limitation from the README, corrects a typo in the command, and slightly rephrases it to explain renovate's behavior. 

<!-- Describe what behavior is changed by this PR. -->

## Context

- https://github.com/renovatebot/renovate/pull/20820
- https://github.com/renovatebot/renovate/discussions/20736

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

Test repo: https://github.com/renovate-demo/5534-1-gradle7-multi-rsocket-requests-lease-examples

<details>
  <summary>Output on Windows (first command with stdout, second without)</summary>

```  
DEBUG: Executing command (repository=renovate-demo/5534-1-gradle7-multi-rsocket-requests-lease-examples, branch=renovate/gradle-7.x)
       "command": "gradlew.bat --console=plain -q properties"
DEBUG: exec completed (repository=renovate-demo/5534-1-gradle7-multi-rsocket-requests-lease-examples, branch=renovate/gradle-7.x)
       "durationMs": 4560,
       "stdout": "Building module jaunt-rsocket-requests-lease:1.1.4-feature-oss-SNAPSHOT\r\nBuilding module jaunt-rsocket-requests-lease-idl:1.1.4-feature-oss-SNAPSHOT\r\n\r\n------------------------------------------------------------\r\nRoot project 'jaunt-rsocket-requests-lease-examples-parent'\r\n------------------------
------------------------------------\r\n\r\nallprojects: [root project 'jaunt-rsocket-requests-lease-examples-parent', project ':jaunt-rsocket-requests-lease', project ':jaunt-rsocket-requests-lease-idl']\r\nant: org.gradle.api.internal.project.DefaultAntBuilder@705627a8\r\nantBuilderFactory: org.gradle.api.internal.project.DefaultAntBuilderFactory@555754d3\r\nartifacts: org.gradle.api.internal.artifacts.dsl.DefaultArtifactHandler_Decorated@33c7d22\r\nasDynamicObject: DynamicObject for root project 'jaunt-rsocket-requests-lease-examples-parent'\r\nbaseClassLoaderScope: org.gradle.api.internal.initialization.DefaultClassLoaderScope@3112af37\r\nbuildDir: C:\\renovate-demo\\5534-1-gradle7-multi-rsocket-requests-lease-examples\\build\r\nbuildFile: C:\\renovate-demo\\5534-1-gradle7-multi-rsocket-requests-lease-examples\\build.gradle\r\nbuildPath: :\r\nbuildScriptSource: org.gradle.groovy.scripts.TextResourceScriptSource@7038b5da\r\nbuildscript: org.gradle.api.internal.initialization.DefaultScriptHandler@1f2696c2\r\nchildProjects: {jaunt-rsocket-requests-lease=project ':jaunt-rsocket-requests-lease', jaunt-rsocket-requests-lease-idl=project ':jaunt-rsocket-requests-lease-idl'}\r\nclass: class org.gradle.api.internal.project.DefaultProject_Decorated\r\nclassLoaderScope: org.gradle.api.internal.initialization.DefaultClassLoaderScope@61831143\r\ncomponents: SoftwareComponentInternal set\r\nconfigurationActions: org.gradle.configuration.project.DefaultProjectConfigurationActionContainer@7f132d69\r\nconfigurationTargetIdentifier: org.gradle.configuration.ConfigurationTargetIdentifier$1@5b5c4eab\r\nconfigurations: configuration container\r\nconvention: org.gradle.internal.extensibility.DefaultConvention@6effa67f\r\ncrossProjectModelAccess: org.gradle.api.internal.project.DefaultCrossProjectModelAccess@4544ade4\r\ndefaultTasks: [clean, build]\r\ndeferredProjectConfiguration: org.gradle.api.internal.project.DeferredProjectConfiguration@235aa840\r\ndependencies: org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyHandler_Decorated@1a4a8396\r\ndependencyFactory: org.gradle.api.internal.artifacts.DefaultDependencyFactory@99502fe\r\ndependencyLocking: org.gradle.internal.locking.DefaultDependencyLockingHandler_Decorated@695eb5a5\r\ndependencyManagementPluginVersion: 1.0.11.RELEASE\r\ndependencyMetaDataProvider: org.gradle.internal.service.scopes.ProjectScopeServices$ProjectBackedModuleMetaDataProvider@1f300866\r\ndepth: 0\r\ndescription: null\r\ndetachedState: false\r\ndisplayName: root project 'jaunt-rsocket-requests-lease-examples-parent'\r\next: org.gradle.internal.extensibility.DefaultExtraPropertiesExtension@51a86e25\r\nextensions: org.gradle.internal.extensibility.DefaultConvention@6effa67f\r\nfileOperations: org.gradle.api.internal.file.DefaultFileOperations@700b041c\r\nfileResolver: org.gradle.api.internal.file.BaseDirFileResolver@6c647425\r\ngitPluginVersion: 0.13.0\r\ngitVersion: com.palantir.gradle.gitversion.GitVersionPlugin$1@738832f7\r\ngoogleJavaFormatPluginVersion: 0.9\r\ngradle: build 'jaunt-rsocket-requests-lease-examples-parent'\r\ngroup: com.jauntsdn.rsocket\r\nhdrHistogramVersion: 2.1.12\r\nidentityPath: :\r\ninheritedScope: org.gradle.internal.extensibility.ExtensibleDynamicObject$InheritedDynamicObject@61c3b3e5\r\ninternalStatus: property(java.lang.Object, fixed(class java.lang.String, release))\r\nlayout: org.gradle.api.internal.file.DefaultProjectLayout@49407025\r\nlistenerBuildOperationDecorator: org.gradle.configuration.internal.DefaultListenerBuildOperationDecorator@6caf074\r\nlogbackVersion: 1.2.11\r\nlogger: org.gradle.internal.logging.slf4j.OutputEventListenerBackedLogger@346775d0\r\nlogging: org.gradle.internal.logging.services.DefaultLoggingManager@4847b422\r\nmodel: root project 'jaunt-rsocket-requests-lease-examples-parent'\r\nmodelIdentityDisplayName: null\r\nmodelRegistry: org.gradle.model.internal.registry.DefaultModelRegistry@24c2457\r\nname: jaunt-rsocket-requests-lease-examples-parent\r\nnormalization: org.gradle.normalization.internal.DefaultInputNormalizationHandler_Decorated@53d42d3a\r\nobjects: org.gradle.api.internal.model.DefaultObjectFactory@5c121b65\r\nowner: root project 'jaunt-rsocket-requests-lease-examples-parent'\r\nparent: null\r\nparentIdentifier: null\r\npath: :\r\npluginContext: false\r\npluginManager: org.gradle.api.internal.plugins.DefaultPluginManager_Decorated@29815261\r\nplugins: [org.gradle.api.plugins.HelpTasksPlugin@30bc14d4, org.gradle.buildinit.plugins.BuildInitPlugin@7f322bf, org.gradle.buildinit.plugins.WrapperPlugin@3f37a0fe, com.palantir.gradle.gitversion.GitVersionRootPlugin@2b2276df, com.palantir.gradle.gitversion.GitVersionPlugin@23ca7f05, com.github.benmanes.gradle.versions.VersionsPlugin@3861a3d4]\r\nprintVersion: task ':printVersion'\r\nprocessOperations: org.gradle.process.internal.DefaultExecActionFactory$DecoratingExecActionFactory@4a0ca59a\r\nproject: root project 'jaunt-rsocket-requests-lease-examples-parent'\r\nprojectConfigurator: org.gradle.api.internal.project.BuildOperationCrossProjectConfigurator@3843fc1c\r\nprojectDir: C:\\renovate-demo\\5534-1-gradle7-multi-rsocket-requests-lease-examples\r\nprojectEvaluationBroadcaster: ProjectEvaluationListener broadcast\r\nprojectEvaluator: org.gradle.configuration.project.LifecycleProjectEvaluator@74460142\r\nprojectPath: :\r\nproperties: {...}\r\nprotobufPluginVersion: 0.8.19\r\nproviders: org.gradle.api.internal.provider.DefaultProviderFactory_Decorated@577757f1\r\nrSocketVersion: 1.1.4\r\nrepositories: repository container\r\nresources: org.gradle.api.internal.resources.DefaultResourceHandler@78f818f0\r\nrootDir: C:\\renovate-demo\\5534-1-gradle7-multi-rsocket-requests-lease-examples\r\nrootProject: root project 'jaunt-rsocket-requests-lease-examples-parent'\r\nrootScript: false\r\nscript: false\r\nscriptHandlerFactory: org.gradle.api.internal.initialization.DefaultScriptHandlerFactory@5f7ca8ef\r\nscriptPluginFactory: org.gradle.configuration.ScriptPluginFactorySelector@1bf4fe53\r\nserviceRegistryFactory: org.gradle.internal.service.scopes.ProjectScopeServices$$Lambda$976/0x0000000801398000@7651fa03\r\nservices: ProjectScopeServices\r\nslf4jVersion: 1.7.36\r\nstandardOutputCapture: org.gradle.internal.logging.services.DefaultLoggingManager@4847b422\r\nstate: project state 'EXECUTED'\r\nstatus: release\r\nsubprojects: [project ':jaunt-rsocket-requests-lease', project ':jaunt-rsocket-requests-lease-idl']\r\ntaskThatOwnsThisObject: null\r\ntasks: task set\r\nversion: 1.1.4\r\nversionDetails: com.palantir.gradle.gitversion.GitVersionPlugin$2@4ed643a1\r\nversionsPluginVersion: 0.42.0\r\n",
       "stderr": ""
DEBUG: Setting CONTAINERBASE_CACHE_DIR to C:/renovate/cache/containerbase (repository=renovate-demo/5534-1-gradle7-multi-rsocket-requests-lease-examples, branch=renovate/gradle-7.x)
DEBUG: Falling back to binarySource=global (repository=renovate-demo/5534-1-gradle7-multi-rsocket-requests-lease-examples, branch=renovate/gradle-7.x)
DEBUG: Executing command (repository=renovate-demo/5534-1-gradle7-multi-rsocket-requests-lease-examples, branch=renovate/gradle-7.x)
       "command": "gradlew.bat --console=plain -q :dependencies :jaunt-rsocket-requests-lease:dependencies :jaunt-rsocket-requests-lease-idl:dependencies --write-locks"
DEBUG: exec completed (repository=renovate-demo/5534-1-gradle7-multi-rsocket-requests-lease-examples, branch=renovate/gradle-7.x)
       "durationMs": 4898,
       "stdout": "",
       "stderr": ""
DEBUG: Returning updated Gradle dependency lockfiles (repository=renovate-demo/5534-1-gradle7-multi-rsocket-requests-lease-examples, branch=renovate/gradle-7.x)
```
</details>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
