### PR TITLE
refactor(changelog): use util/url instead of deprecated URL

### DIFF
--- a/lib/workers/repository/update/pr/changelog/source.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/source.spec.ts
@@ -1,0 +1,44 @@
+import { partial } from '../../../../../../test/util';
+import type { BranchConfig } from '../../../../types';
+import { GitHubChangeLogSource } from './github/source';
+
+const changelogSource = new GitHubChangeLogSource();
+const upgrade = partial<BranchConfig>({
+  endpoint: 'https://api.github.com/',
+  packageName: 'renovate',
+  sourceUrl: 'https://github.com/renovatebot/renovate',
+});
+
+describe('workers/repository/update/pr/changelog/source', () => {
+  describe('getBaseUrl', () => {
+    it('handles unsupported sourceUrl', () => {
+      expect(
+        changelogSource.getBaseUrl({
+          ...upgrade,
+          sourceUrl: undefined,
+        })
+      ).toBeEmptyString();
+    });
+
+    it('handles sourceUrl', () => {
+      expect(changelogSource.getBaseUrl(upgrade)).toBe('https://github.com/');
+    });
+  });
+
+  describe('getRepositoryFromUrl', () => {
+    it('handles unsupported sourceUrl', () => {
+      expect(
+        changelogSource.getRepositoryFromUrl({
+          ...upgrade,
+          sourceUrl: undefined,
+        })
+      ).toBeEmptyString();
+    });
+
+    it('handles sourceUrl', () => {
+      expect(changelogSource.getRepositoryFromUrl(upgrade)).toBe(
+        'renovatebot/renovate'
+      );
+    });
+  });
+});

--- a/lib/workers/repository/update/pr/changelog/source.ts
+++ b/lib/workers/repository/update/pr/changelog/source.ts
@@ -1,4 +1,3 @@
-import URL from 'node:url';
 import is from '@sindresorhus/is';
 import { logger } from '../../../../../logger';
 import { getPkgReleases } from '../../../../../modules/datasource';
@@ -6,7 +5,7 @@ import type { Release } from '../../../../../modules/datasource/types';
 import * as allVersioning from '../../../../../modules/versioning';
 import * as packageCache from '../../../../../util/cache/package';
 import { regEx } from '../../../../../util/regex';
-import { trimSlashes } from '../../../../../util/url';
+import { parseUrl, trimSlashes } from '../../../../../util/url';
 import type { BranchUpgradeConfig } from '../../../../types';
 import { slugifyUrl } from './common';
 import { addReleaseNotes } from './release-notes';
@@ -238,16 +237,22 @@ export abstract class ChangeLogSource {
     return `${slugifyUrl(sourceUrl)}:${packageName}:${prev}:${next}`;
   }
 
-  protected getBaseUrl(config: BranchUpgradeConfig): string {
-    const parsedUrl = URL.parse(config.sourceUrl!);
-    const protocol = parsedUrl.protocol!;
-    const host = parsedUrl.host!;
+  getBaseUrl(config: BranchUpgradeConfig): string {
+    const parsedUrl = parseUrl(config.sourceUrl);
+    if (is.nullOrUndefined(parsedUrl)) {
+      return '';
+    }
+    const protocol = parsedUrl.protocol;
+    const host = parsedUrl.host;
     return `${protocol}//${host}/`;
   }
 
-  private getRepositoryFromUrl(config: BranchUpgradeConfig): string {
-    const parsedUrl = URL.parse(config.sourceUrl!);
-    const pathname = parsedUrl.pathname!;
+  getRepositoryFromUrl(config: BranchUpgradeConfig): string {
+    const parsedUrl = parseUrl(config.sourceUrl);
+    if (is.nullOrUndefined(parsedUrl)) {
+      return '';
+    }
+    const pathname = parsedUrl.pathname;
     return trimSlashes(pathname).replace(regEx(/\.git$/), '');
   }
 


### PR DESCRIPTION
## Changes

Use util/url function

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
