### PR TITLE
refactor(changelog): remove unused apiBaseUrl/endpoint param

### DIFF
--- a/lib/workers/repository/update/pr/changelog/source.ts
+++ b/lib/workers/repository/update/pr/changelog/source.ts
@@ -39,7 +39,7 @@ export abstract class ChangeLogSource {
 
   abstract getAPIBaseUrl(config: BranchUpgradeConfig): string;
 
-  async getAllTags(endpoint: string, repository: string): Promise<string[]> {
+  async getAllTags(repository: string): Promise<string[]> {
     const tags = (
       await getPkgReleases({
         datasource: this.datasource,
@@ -140,14 +140,12 @@ export abstract class ChangeLogSource {
           version,
           packageName,
           prev,
-          apiBaseUrl,
           repository
         );
         const nextHead = await this.getRef(
           version,
           packageName,
           next,
-          apiBaseUrl,
           repository
         );
         if (is.nonEmptyString(prevHead) && is.nonEmptyString(nextHead)) {
@@ -208,10 +206,9 @@ export abstract class ChangeLogSource {
     version: allVersioning.VersioningApi,
     packageName: string,
     release: Release,
-    apiBaseUrl: string,
     repository: string
   ): Promise<string | null> {
-    const tags = await this.getAllTags(apiBaseUrl, repository);
+    const tags = await this.getAllTags(repository);
 
     const tagName = this.findTagOfRelease(
       version,


### PR DESCRIPTION
## Changes

Remove unused param `apiBaseUrl` / `endpoint`

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
