### PR TITLE
fix(datasource/packagist): Use serializable type for `availablePackages`

### DIFF
--- a/lib/modules/datasource/packagist/index.ts
+++ b/lib/modules/datasource/packagist/index.ts
@@ -184,7 +184,10 @@ export class PackagistDatasource extends Datasource {
     try {
       const meta = await this.getRegistryMeta(registryUrl);
 
-      if (meta.availablePackages && !meta.availablePackages.has(packageName)) {
+      if (
+        meta.availablePackages &&
+        !meta.availablePackages.includes(packageName)
+      ) {
         return null;
       }
 

--- a/lib/modules/datasource/packagist/schema.ts
+++ b/lib/modules/datasource/packagist/schema.ts
@@ -207,10 +207,7 @@ export const RegistryMeta = z
         ['providers-lazy-url']: z.string().nullable().catch(null),
         ['providers-url']: z.string().nullable().catch(null),
         ['metadata-url']: z.string().nullable().catch(null),
-        ['available-packages']: z
-          .array(z.string())
-          .nullable()
-          .catch(null),
+        ['available-packages']: z.array(z.string()).nullable().catch(null),
       })
     )
   )

--- a/lib/modules/datasource/packagist/schema.ts
+++ b/lib/modules/datasource/packagist/schema.ts
@@ -209,7 +209,6 @@ export const RegistryMeta = z
         ['metadata-url']: z.string().nullable().catch(null),
         ['available-packages']: z
           .array(z.string())
-          .transform((xs) => new Set(xs))
           .nullable()
           .catch(null),
       })


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Using `Set` was bad idea, since it doesn't play well with serialization, so at some point we'll have non-nullish value, but not the `Set` itself.
Therefore, `object doesn't have "has" method` error will be thrown.

## Context

- Ref: #23111
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
