### PR TITLE
feat!: allow post upgrade templating by default

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2640,6 +2640,9 @@ You can use variable templating in your commands as long as [`allowPostUpgradeCo
 A list of glob-style matchers that determine which files will be included in the final commit made by Renovate.
 Dotfiles are included.
 
+Optional field which defaults to any non-ignored file in the repo (`**/*` glob pattern).
+Specify a custom value for this if you wish to exclude certain files which are modified by your `postUpgradeTasks` and you don't want committed.
+
 ### executionMode
 
 Defaults to `update`, but can also be set to `branch`.

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -40,8 +40,7 @@ The command to install dependencies (`npm ci --ignore-scripts`) is needed becaus
         "commands": [
           "npm ci --ignore-scripts",
           "npx ng update {{{depName}}} --from={{{currentVersion}}} --to={{{newVersion}}} --migrate-only --allow-dirty --force"
-        ],
-        "fileFilters": ["**/**"]
+        ]
       }
     }
   ]

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -66,7 +66,7 @@ const options: RenovateOptions[] = [
     type: 'array',
     subType: 'string',
     parent: 'postUpgradeTasks',
-    default: [],
+    default: ['**/*'],
     cli: false,
   },
   {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Defaults `fileFilters` to everything

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
