### PR TITLE
refactor: move getChildProcessEnv to break dependency loop

### DIFF
--- a/lib/util/exec/index.ts
+++ b/lib/util/exec/index.ts
@@ -10,7 +10,6 @@ import {
   removeDockerContainer,
   sideCarImage,
 } from './docker';
-import { getChildProcessEnv } from './env';
 import { getHermitEnvs, isHermit } from './hermit';
 import type {
   DockerOptions,
@@ -20,37 +19,7 @@ import type {
   Opt,
   RawExecOptions,
 } from './types';
-
-export function getChildEnv({
-  extraEnv,
-  env: forcedEnv = {},
-}: ExecOptions): Record<string, string> {
-  const globalConfigEnv = GlobalConfig.get('customEnvVariables');
-
-  const inheritedKeys: string[] = [];
-  for (const [key, val] of Object.entries(extraEnv ?? {})) {
-    if (is.string(val)) {
-      inheritedKeys.push(key);
-    }
-  }
-
-  const parentEnv = getChildProcessEnv(inheritedKeys);
-  const combinedEnv = {
-    ...extraEnv,
-    ...parentEnv,
-    ...globalConfigEnv,
-    ...forcedEnv,
-  };
-
-  const result: Record<string, string> = {};
-  for (const [key, val] of Object.entries(combinedEnv)) {
-    if (is.string(val)) {
-      result[key] = `${val}`;
-    }
-  }
-
-  return result;
-}
+import { getChildEnv } from './utils';
 
 function dockerEnvVars(extraEnv: ExtraEnv, childEnv: ExtraEnv): string[] {
   const extraEnvKeys = Object.keys(extraEnv);

--- a/lib/util/exec/utils.ts
+++ b/lib/util/exec/utils.ts
@@ -1,0 +1,35 @@
+import is from '@sindresorhus/is';
+import { GlobalConfig } from '../../config/global';
+import { getChildProcessEnv } from './env';
+import type { ExecOptions } from './types';
+
+export function getChildEnv({
+  extraEnv,
+  env: forcedEnv = {},
+}: ExecOptions): Record<string, string> {
+  const globalConfigEnv = GlobalConfig.get('customEnvVariables');
+
+  const inheritedKeys: string[] = [];
+  for (const [key, val] of Object.entries(extraEnv ?? {})) {
+    if (is.string(val)) {
+      inheritedKeys.push(key);
+    }
+  }
+
+  const parentEnv = getChildProcessEnv(inheritedKeys);
+  const combinedEnv = {
+    ...extraEnv,
+    ...parentEnv,
+    ...globalConfigEnv,
+    ...forcedEnv,
+  };
+
+  const result: Record<string, string> = {};
+  for (const [key, val] of Object.entries(combinedEnv)) {
+    if (is.string(val)) {
+      result[key] = `${val}`;
+    }
+  }
+
+  return result;
+}

--- a/lib/util/template/index.spec.ts
+++ b/lib/util/template/index.spec.ts
@@ -1,15 +1,15 @@
 import { mocked } from '../../../test/util';
 import { getOptions } from '../../config/options';
-import * as _exec from '../exec';
+import * as _execUtils from '../exec/utils';
 import * as template from '.';
 
-jest.mock('../exec');
+jest.mock('../exec/utils');
 
-const exec = mocked(_exec);
+const execUtils = mocked(_execUtils);
 
 describe('util/template/index', () => {
   beforeEach(() => {
-    exec.getChildEnv.mockReturnValue({
+    execUtils.getChildEnv.mockReturnValue({
       CUSTOM_FOO: 'foo',
       HOME: '/root',
     });

--- a/lib/util/template/index.ts
+++ b/lib/util/template/index.ts
@@ -2,7 +2,7 @@ import is from '@sindresorhus/is';
 import handlebars from 'handlebars';
 import { GlobalConfig } from '../../config/global';
 import { logger } from '../../logger';
-import { getChildEnv } from '../exec';
+import { getChildEnv } from '../exec/utils';
 
 handlebars.registerHelper('encodeURIComponent', encodeURIComponent);
 handlebars.registerHelper('decodeURIComponent', decodeURIComponent);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
This PR moves `getChildEnv` to a utils.ts, which allows the usage of `template` in datasources.
<!-- Describe what behavior is changed by this PR. -->

## Context
This prepares for the reimplementation of https://github.com/renovatebot/renovate/pull/20753
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
