### PR TITLE
fix(changelog/gitlab): custom endpoint and repository length validation

### DIFF
--- a/lib/workers/repository/update/pr/changelog/gitlab/index.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/gitlab/index.spec.ts
@@ -4,6 +4,7 @@ import { partial } from '../../../../../../../test/util';
 import * as semverVersioning from '../../../../../../modules/versioning/semver';
 import * as hostRules from '../../../../../../util/host-rules';
 import type { BranchUpgradeConfig } from '../../../../../types';
+import { GitLabChangeLogSource } from './source';
 
 const upgrade = partial<BranchUpgradeConfig>({
   manager: 'some-manager',
@@ -28,6 +29,8 @@ const upgrade = partial<BranchUpgradeConfig>({
 });
 
 const matchHost = 'https://gitlab.com/';
+
+const changelogSource = new GitLabChangeLogSource();
 
 describe('workers/repository/update/pr/changelog/gitlab/index', () => {
   afterEach(() => {
@@ -345,6 +348,33 @@ describe('workers/repository/update/pr/changelog/gitlab/index', () => {
         },
       });
       expect(config.sourceUrl).toBe(sourceUrl); // ensure unmodified function argument
+    });
+  });
+
+  describe('hasValidRepository', () => {
+    it('handles invalid repository', () => {
+      expect(changelogSource.hasValidRepository('foo')).toBeFalse();
+    });
+
+    it('handles valid repository', () => {
+      expect(changelogSource.hasValidRepository('some/repo')).toBeTrue();
+      expect(changelogSource.hasValidRepository('some/repo/name')).toBeTrue();
+    });
+  });
+
+  describe('getAllTags', () => {
+    it('handles endpoint', async () => {
+      httpMock
+        .scope('https://git.test.com/')
+        .get('/api/v4/projects/some%2Frepo/repository/tags?per_page=100')
+        .reply(200, [
+          { name: 'v5.2.0' },
+          { name: 'v5.4.0' },
+          { name: 'v5.5.0' },
+        ]);
+      expect(
+        await changelogSource.getAllTags('https://git.test.com/', 'some/repo')
+      ).toEqual(['v5.2.0', 'v5.4.0', 'v5.5.0']);
     });
   });
 });

--- a/lib/workers/repository/update/pr/changelog/gitlab/source.ts
+++ b/lib/workers/repository/update/pr/changelog/gitlab/source.ts
@@ -18,4 +18,8 @@ export class GitLabChangeLogSource extends ChangeLogSource {
   ): string {
     return `${baseUrl}${repository}/compare/${prevHead}...${nextHead}`;
   }
+
+  override hasValidRepository(repository: string): boolean {
+    return repository.split('/').length >= 2;
+  }
 }

--- a/lib/workers/repository/update/pr/changelog/source.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/source.spec.ts
@@ -41,4 +41,15 @@ describe('workers/repository/update/pr/changelog/source', () => {
       );
     });
   });
+
+  describe('hasValidRepository', () => {
+    it('handles invalid repository', () => {
+      expect(changelogSource.hasValidRepository('foo')).toBeFalse();
+      expect(changelogSource.hasValidRepository('some/repo/name')).toBeFalse();
+    });
+
+    it('handles valid repository', () => {
+      expect(changelogSource.hasValidRepository('some/repo')).toBeTrue();
+    });
+  });
 });

--- a/lib/workers/repository/update/pr/changelog/source.ts
+++ b/lib/workers/repository/update/pr/changelog/source.ts
@@ -42,6 +42,7 @@ export abstract class ChangeLogSource {
   async getAllTags(endpoint: string, repository: string): Promise<string[]> {
     const tags = (
       await getPkgReleases({
+        registryUrls: [endpoint],
         datasource: this.datasource,
         packageName: repository,
         versioning:
@@ -91,7 +92,7 @@ export abstract class ChangeLogSource {
       return null;
     }
 
-    if (repository.split('/').length !== 2) {
+    if (is.falsy(this.hasValidRepository(repository))) {
       logger.debug(`Invalid ${this.platform} URL found: ${sourceUrl}`);
       return null;
     }
@@ -265,5 +266,9 @@ export abstract class ChangeLogSource {
 
   protected shouldSkipPackage(config: BranchUpgradeConfig): boolean {
     return false;
+  }
+
+  hasValidRepository(repository: string): boolean {
+    return repository.split('/').length === 2;
   }
 }


### PR DESCRIPTION
## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

Back port #23165 to v35

Discussion: https://github.com/renovatebot/renovate/discussions/23156

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
