### PR TITLE
feat: matchPackagePrefixes include packageName

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2288,6 +2288,9 @@ See also `excludePackagePrefixes`.
 
 Like the earlier `matchPackagePatterns` example, the above will configure `rangeStrategy` to `replace` for any package starting with `angular`.
 
+`matchPackagePrefixes` will match against `packageName` first, and then `depName`, however `depName` matching is deprecated and will be removed in a future major release.
+If matching against `depName`, use `matchDepPatterns` instead.
+
 ### matchSourceUrlPrefixes
 
 Here's an example of where you use this to group together all packages from the `renovatebot` GitHub org:

--- a/lib/util/package-rules/package-prefixes.spec.ts
+++ b/lib/util/package-rules/package-prefixes.spec.ts
@@ -15,6 +15,32 @@ describe('util/package-rules/package-prefixes', () => {
       );
       expect(result).toBeFalse();
     });
+
+    it('should return true if packageName matched', () => {
+      const result = packagePrefixesMatcher.matches(
+        {
+          depName: 'abc1',
+          packageName: 'def1',
+        },
+        {
+          matchPackagePrefixes: ['def'],
+        }
+      );
+      expect(result).toBeTrue();
+    });
+
+    it('should return true but warn if depName matched', () => {
+      const result = packagePrefixesMatcher.matches(
+        {
+          depName: 'abc1',
+          packageName: 'def1',
+        },
+        {
+          matchPackagePrefixes: ['abc'],
+        }
+      );
+      expect(result).toBeTrue();
+    });
   });
 
   describe('exclude', () => {

--- a/lib/util/package-rules/package-prefixes.ts
+++ b/lib/util/package-rules/package-prefixes.ts
@@ -1,20 +1,36 @@
 import is from '@sindresorhus/is';
 import type { PackageRule, PackageRuleInputConfig } from '../../config/types';
+import { logger } from '../../logger';
 import { Matcher } from './base';
 
 export class PackagePrefixesMatcher extends Matcher {
   override matches(
-    { depName }: PackageRuleInputConfig,
+    { depName, packageName }: PackageRuleInputConfig,
     { matchPackagePrefixes }: PackageRule
   ): boolean | null {
     if (is.undefined(matchPackagePrefixes)) {
       return null;
     }
+
     if (is.undefined(depName)) {
       return false;
     }
 
-    return matchPackagePrefixes.some((prefix) => depName.startsWith(prefix));
+    if (
+      is.string(packageName) &&
+      matchPackagePrefixes.some((prefix) => packageName.startsWith(prefix))
+    ) {
+      return true;
+    }
+    if (matchPackagePrefixes.some((prefix) => depName.startsWith(prefix))) {
+      logger.once.warn(
+        { packageName, depName },
+        'Use matchDepPatterns instead of matchPackagePrefixes'
+      );
+      return true;
+    }
+
+    return false;
   }
 
   override excludes(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Includes `packageName` with `matchPackagePrefixes`.

## Context

Required to fix #23178

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
