### PR TITLE
refactor: Use schema for parsing `datasource` to `DatasourceApi`

### DIFF
--- a/lib/modules/datasource/schema.ts
+++ b/lib/modules/datasource/schema.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+import datasources from './api';
+import type { DatasourceApi } from './types';
+
+export const Datasource = z
+  .string()
+  .transform((datasourceName, ctx): DatasourceApi => {
+    const datasource = datasources.get(datasourceName);
+    if (!datasource) {
+      ctx.addIssue({
+        code: 'custom',
+        message: `Datasource: '${datasourceName}' not found`,
+      });
+      return z.NEVER;
+    }
+
+    return datasource;
+  });

--- a/lib/workers/repository/process/fetch.ts
+++ b/lib/workers/repository/process/fetch.ts
@@ -56,7 +56,7 @@ async function fetchDepUpdates(
   const { depName } = dep;
   // TODO: fix types
   let depConfig = mergeChildConfig(packageFileConfig, dep);
-  const datasourceDefaultConfig = await getDefaultConfig(depConfig.datasource!);
+  const datasourceDefaultConfig = getDefaultConfig(depConfig.datasource!);
   depConfig = mergeChildConfig(depConfig, datasourceDefaultConfig);
   depConfig.versioning ??= getDefaultVersioning(depConfig.datasource);
   depConfig = applyPackageRules(depConfig);
@@ -71,9 +71,9 @@ async function fetchDepUpdates(
   } else {
     if (depConfig.datasource) {
       try {
-        const updateResult = await withLookupStats(depConfig.datasource, () =>
-          lookupUpdates(depConfig as LookupUpdateConfig)
-        );
+        const updateResult = await withLookupStats(depConfig.datasource, () => {
+          return lookupUpdates(depConfig as LookupUpdateConfig);
+        });
         Object.assign(dep, updateResult);
       } catch (err) {
         if (

--- a/lib/workers/repository/updates/flatten.ts
+++ b/lib/workers/repository/updates/flatten.ts
@@ -109,9 +109,7 @@ export async function flattenUpdates(
               });
             }
             // apply config from datasource
-            const datasourceConfig = await getDefaultConfig(
-              depConfig.datasource
-            );
+            const datasourceConfig = getDefaultConfig(depConfig.datasource);
             updateConfig = mergeChildConfig(updateConfig, datasourceConfig);
             updateConfig = applyPackageRules(updateConfig);
             // apply major/minor/patch/pin/digest


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Just like `versioning` field transformed to `VersioningApi` instance, `datasource` is being used as the key for appropriate `DatasourceApi` instance.

This PR makes it possible to specify schemas for config data containing `datasource` field such that it will be transformed to `DatasourceApi` without a need for null check every time you need datasource.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
