### PR TITLE
fix: log packageRule when recommending matchDepX

### DIFF
--- a/lib/util/package-rules/package-names.ts
+++ b/lib/util/package-rules/package-names.ts
@@ -6,8 +6,9 @@ import { Matcher } from './base';
 export class PackageNameMatcher extends Matcher {
   override matches(
     { depName, packageName }: PackageRuleInputConfig,
-    { matchPackageNames }: PackageRule
+    packageRule: PackageRule
   ): boolean | null {
+    const { matchPackageNames } = packageRule;
     if (is.undefined(matchPackageNames)) {
       return null;
     }
@@ -21,7 +22,7 @@ export class PackageNameMatcher extends Matcher {
 
     if (matchPackageNames.includes(depName)) {
       logger.once.warn(
-        { packageName, depName },
+        { packageRule, packageName, depName },
         'Use matchDepNames instead of matchPackageNames'
       );
       return true;

--- a/lib/util/package-rules/package-patterns.ts
+++ b/lib/util/package-rules/package-patterns.ts
@@ -21,8 +21,9 @@ function matchPatternsAgainstName(
 export class PackagePatternsMatcher extends Matcher {
   override matches(
     { depName, packageName }: PackageRuleInputConfig,
-    { matchPackagePatterns }: PackageRule
+    packageRule: PackageRule
   ): boolean | null {
+    const { matchPackagePatterns } = packageRule;
     if (is.undefined(matchPackagePatterns)) {
       return null;
     }
@@ -39,7 +40,7 @@ export class PackagePatternsMatcher extends Matcher {
     }
     if (matchPatternsAgainstName(matchPackagePatterns, depName)) {
       logger.once.warn(
-        { packageName, depName },
+        { packageRule, packageName, depName },
         'Use matchDepPatterns instead of matchPackagePatterns'
       );
       return true;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Add full package rule to log

## Context

Make it easier to determine which rule is triggering it

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
