### PR TITLE
fix(datasource/helm): Skip helm charts with no listed versions

### DIFF
--- a/lib/modules/datasource/helm/__fixtures__/index_emptypackage.yaml
+++ b/lib/modules/datasource/helm/__fixtures__/index_emptypackage.yaml
@@ -10,18 +10,6 @@ entries:
     engine: gotpl
     home: https://www.getambassador.io/
     icon: https://www.getambassador.io/images/logo.png
-    keywords:
-    - api gateway
-    - ambassador
-    - datawire
-    - envoy
-    maintainers:
-    - email: markus@maga.se
-      name: flydiverny
-    - email: flynn@datawire.io
-      name: kflynn
-    - email: nkrause@datawire.io
-      name: nbkrause
     name: ambassador
     sources:
     - https://github.com/datawire/ambassador

--- a/lib/modules/datasource/helm/__fixtures__/index_emptypackage.yaml
+++ b/lib/modules/datasource/helm/__fixtures__/index_emptypackage.yaml
@@ -1,38 +1,5 @@
 apiVersion: v1
 entries:
-  acs-engine-autoscaler:
-  - apiVersion: v1
-    appVersion: 2.1.1
-    created: 2019-06-02T08:56:36.116031089Z
-    deprecated: true
-    description: DEPRECATED Scales worker nodes within agent pools
-    digest: 93f924d4498d588bcdda88c7401e27c6fa0f50ff0601e78885eca13eb683c1e2
-    home: https://github.com/wbuchwalter/Kubernetes-acs-engine-autoscaler
-    icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
-    name: acs-engine-autoscaler
-    sources:
-    - https://github.com/wbuchwalter/Kubernetes-acs-engine-autoscaler
-    urls:
-    - https://charts.helm.sh/stable/packages/acs-engine-autoscaler-2.2.2.tgz
-    version: 2.2.2
-  - apiVersion: v1
-    appVersion: 2.1.1
-    created: 2018-12-11T02:55:17.96986758Z
-    description: Scales worker nodes within agent pools
-    digest: 3232999ebabc42cd7c5475251b5cd2e0c6bf4363551cff13ebe3a78cee1dfba6
-    home: https://github.com/wbuchwalter/Kubernetes-acs-engine-autoscaler
-    icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
-    maintainers:
-    - email: ritazh@microsoft.com
-      name: ritazh
-    - email: wibuch@microsoft.com
-      name: wbuchwalter
-    name: acs-engine-autoscaler
-    sources:
-    - https://github.com/wbuchwalter/Kubernetes-acs-engine-autoscaler
-    urls:
-    - https://charts.helm.sh/stable/packages/acs-engine-autoscaler-2.2.1.tgz
-    version: 2.2.1
   aerospike: []
   ambassador:
   - apiVersion: v1
@@ -62,30 +29,3 @@ entries:
     urls:
     - https://charts.helm.sh/stable/packages/ambassador-2.7.0.tgz
     version: 2.7.0
-  - apiVersion: v1
-    appVersion: 0.70.1
-    created: 2019-05-31T18:57:01.540843138Z
-    description: A Helm chart for Datawire Ambassador
-    digest: ba549d35ca7827573343fe1613dcad31f258bfcc2959f6005220bfb300030a21
-    engine: gotpl
-    home: https://www.getambassador.io/
-    icon: https://www.getambassador.io/images/logo.png
-    keywords:
-    - api gateway
-    - ambassador
-    - datawire
-    - envoy
-    maintainers:
-    - email: markus@maga.se
-      name: flydiverny
-    - email: flynn@datawire.io
-      name: kflynn
-    - email: nkrause@datawire.io
-      name: nbkrause
-    name: ambassador
-    sources:
-    - https://github.com/datawire/ambassador
-    - https://github.com/prometheus/statsd_exporter
-    urls:
-    - https://charts.helm.sh/stable/packages/ambassador-2.6.2.tgz
-    version: 2.6.2

--- a/lib/modules/datasource/helm/__fixtures__/index_emptypackage.yaml
+++ b/lib/modules/datasource/helm/__fixtures__/index_emptypackage.yaml
@@ -1,0 +1,91 @@
+apiVersion: v1
+entries:
+  acs-engine-autoscaler:
+  - apiVersion: v1
+    appVersion: 2.1.1
+    created: 2019-06-02T08:56:36.116031089Z
+    deprecated: true
+    description: DEPRECATED Scales worker nodes within agent pools
+    digest: 93f924d4498d588bcdda88c7401e27c6fa0f50ff0601e78885eca13eb683c1e2
+    home: https://github.com/wbuchwalter/Kubernetes-acs-engine-autoscaler
+    icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
+    name: acs-engine-autoscaler
+    sources:
+    - https://github.com/wbuchwalter/Kubernetes-acs-engine-autoscaler
+    urls:
+    - https://charts.helm.sh/stable/packages/acs-engine-autoscaler-2.2.2.tgz
+    version: 2.2.2
+  - apiVersion: v1
+    appVersion: 2.1.1
+    created: 2018-12-11T02:55:17.96986758Z
+    description: Scales worker nodes within agent pools
+    digest: 3232999ebabc42cd7c5475251b5cd2e0c6bf4363551cff13ebe3a78cee1dfba6
+    home: https://github.com/wbuchwalter/Kubernetes-acs-engine-autoscaler
+    icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
+    maintainers:
+    - email: ritazh@microsoft.com
+      name: ritazh
+    - email: wibuch@microsoft.com
+      name: wbuchwalter
+    name: acs-engine-autoscaler
+    sources:
+    - https://github.com/wbuchwalter/Kubernetes-acs-engine-autoscaler
+    urls:
+    - https://charts.helm.sh/stable/packages/acs-engine-autoscaler-2.2.1.tgz
+    version: 2.2.1
+  aerospike: []
+  ambassador:
+  - apiVersion: v1
+    appVersion: 0.70.1
+    created: 2019-06-02T08:56:36.119470813Z
+    description: A Helm chart for Datawire Ambassador
+    digest: 880002d74accfc9dab1debcc78c134fb4989e73ff84b137ce7aa92bf4d726297
+    engine: gotpl
+    home: https://www.getambassador.io/
+    icon: https://www.getambassador.io/images/logo.png
+    keywords:
+    - api gateway
+    - ambassador
+    - datawire
+    - envoy
+    maintainers:
+    - email: markus@maga.se
+      name: flydiverny
+    - email: flynn@datawire.io
+      name: kflynn
+    - email: nkrause@datawire.io
+      name: nbkrause
+    name: ambassador
+    sources:
+    - https://github.com/datawire/ambassador
+    - https://github.com/prometheus/statsd_exporter
+    urls:
+    - https://charts.helm.sh/stable/packages/ambassador-2.7.0.tgz
+    version: 2.7.0
+  - apiVersion: v1
+    appVersion: 0.70.1
+    created: 2019-05-31T18:57:01.540843138Z
+    description: A Helm chart for Datawire Ambassador
+    digest: ba549d35ca7827573343fe1613dcad31f258bfcc2959f6005220bfb300030a21
+    engine: gotpl
+    home: https://www.getambassador.io/
+    icon: https://www.getambassador.io/images/logo.png
+    keywords:
+    - api gateway
+    - ambassador
+    - datawire
+    - envoy
+    maintainers:
+    - email: markus@maga.se
+      name: flydiverny
+    - email: flynn@datawire.io
+      name: kflynn
+    - email: nkrause@datawire.io
+      name: nbkrause
+    name: ambassador
+    sources:
+    - https://github.com/datawire/ambassador
+    - https://github.com/prometheus/statsd_exporter
+    urls:
+    - https://charts.helm.sh/stable/packages/ambassador-2.6.2.tgz
+    version: 2.6.2

--- a/lib/modules/datasource/helm/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/datasource/helm/__snapshots__/index.spec.ts.snap
@@ -116,3 +116,21 @@ exports[`modules/datasource/helm/index getReleases returns list of versions for 
   "sourceUrl": "https://github.com/datawire/ambassador",
 }
 `;
+
+exports[`modules/datasource/helm/index getReleases returns list of versions for other packages if one packages has no versions 1`] = `
+{
+  "homepage": "https://www.getambassador.io/",
+  "registryUrl": "https://example-repository.com",
+  "releases": [
+    {
+      "releaseTimestamp": "2019-05-31T18:57:01.540Z",
+      "version": "2.6.2",
+    },
+    {
+      "releaseTimestamp": "2019-06-02T08:56:36.119Z",
+      "version": "2.7.0",
+    },
+  ],
+  "sourceUrl": "https://github.com/datawire/ambassador",
+}
+`;

--- a/lib/modules/datasource/helm/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/datasource/helm/__snapshots__/index.spec.ts.snap
@@ -116,21 +116,3 @@ exports[`modules/datasource/helm/index getReleases returns list of versions for 
   "sourceUrl": "https://github.com/datawire/ambassador",
 }
 `;
-
-exports[`modules/datasource/helm/index getReleases returns list of versions for other packages if one packages has no versions 1`] = `
-{
-  "homepage": "https://www.getambassador.io/",
-  "registryUrl": "https://example-repository.com",
-  "releases": [
-    {
-      "releaseTimestamp": "2019-05-31T18:57:01.540Z",
-      "version": "2.6.2",
-    },
-    {
-      "releaseTimestamp": "2019-06-02T08:56:36.119Z",
-      "version": "2.7.0",
-    },
-  ],
-  "sourceUrl": "https://github.com/datawire/ambassador",
-}
-`;

--- a/lib/modules/datasource/helm/index.spec.ts
+++ b/lib/modules/datasource/helm/index.spec.ts
@@ -6,6 +6,7 @@ import { HelmDatasource } from '.';
 
 // Truncated index.yaml file
 const indexYaml = Fixtures.get('index.yaml');
+const emptyPackageIndexYaml = Fixtures.get('index_emptypackage.yaml');
 
 describe('modules/datasource/helm/index', () => {
   describe('getReleases', () => {
@@ -158,6 +159,20 @@ describe('modules/datasource/helm/index', () => {
         .scope('https://example-repository.com')
         .get('/index.yaml')
         .reply(200, indexYaml);
+      const releases = await getPkgReleases({
+        datasource: HelmDatasource.id,
+        packageName: 'ambassador',
+        registryUrls: ['https://example-repository.com'],
+      });
+      expect(releases).not.toBeNull();
+      expect(releases).toMatchSnapshot();
+    });
+
+    it('returns list of versions for other packages if one packages has no versions', async () => {
+      httpMock
+        .scope('https://example-repository.com')
+        .get('/index.yaml')
+        .reply(200, emptyPackageIndexYaml);
       const releases = await getPkgReleases({
         datasource: HelmDatasource.id,
         packageName: 'ambassador',

--- a/lib/modules/datasource/helm/index.spec.ts
+++ b/lib/modules/datasource/helm/index.spec.ts
@@ -6,7 +6,6 @@ import { HelmDatasource } from '.';
 
 // Truncated index.yaml file
 const indexYaml = Fixtures.get('index.yaml');
-const emptyPackageIndexYaml = Fixtures.get('index_emptypackage.yaml');
 
 describe('modules/datasource/helm/index', () => {
   describe('getReleases', () => {
@@ -172,14 +171,18 @@ describe('modules/datasource/helm/index', () => {
       httpMock
         .scope('https://example-repository.com')
         .get('/index.yaml')
-        .reply(200, emptyPackageIndexYaml);
+        .reply(200, Fixtures.get('index_emptypackage.yaml'));
       const releases = await getPkgReleases({
         datasource: HelmDatasource.id,
         packageName: 'ambassador',
         registryUrls: ['https://example-repository.com'],
       });
-      expect(releases).not.toBeNull();
-      expect(releases).toMatchSnapshot();
+      expect(releases).toMatchObject({
+        homepage: 'https://www.getambassador.io/',
+        registryUrl: 'https://example-repository.com',
+        sourceUrl: 'https://github.com/datawire/ambassador',
+        releases: expect.toBeArrayOfSize(1),
+      });
     });
 
     it('adds trailing slash to subdirectories', async () => {

--- a/lib/modules/datasource/helm/index.ts
+++ b/lib/modules/datasource/helm/index.ts
@@ -60,6 +60,9 @@ export class HelmDatasource extends Datasource {
       }
       const result: HelmRepositoryData = {};
       for (const [name, releases] of Object.entries(doc.entries)) {
+        if (releases.length === 0) {
+          continue;
+        }
         const latestRelease = releases[0];
         const sourceUrl = findSourceUrl(latestRelease);
         result[name] = {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
When parsing the helm chart index, ignore any charts with no listed releases.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

This has been seen with the helm chart index at
https://download.onlyoffice.com/charts/stable/index.yaml , which causes processing for charts with releases to be skipped as well.  The normal helm chart to deploy is `docs`, but there is another chart `documentserver` that has no releases and causes renovate to be unable to monitor the `docs` chart.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
