### PR TITLE
feat(platform/gitlab): Allow custom delay for pipeline status via experimental variable

### DIFF
--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -124,6 +124,14 @@ If set, Renovate will rewrite GitHub Enterprise Server's pagination responses to
 !!! note
     For the GitHub Enterprise Server platform only.
 
+## `RENOVATE_X_GITLAB_BRANCH_STATUS_DELAY`
+
+Adjust default time (in milliseconds) given to GitLab to create pipelines for a commit pushed by Renovate.
+
+Can be useful for slow-running, self-hosted GitLab instances that don't react fast enough for the default delay to help.
+
+Default value: `1000` (milliseconds).
+
 ## `OTEL_EXPORTER_OTLP_ENDPOINT`
 
 If set, Renovate will export OpenTelemetry data to the supplied endpoint.

--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -1,4 +1,5 @@
 // TODO fix mocks
+import type * as _timers from 'timers/promises';
 import type { Platform, RepoParams } from '..';
 import * as httpMock from '../../../../test/http-mock';
 import {
@@ -22,6 +23,7 @@ describe('modules/platform/gitlab/index', () => {
   let hostRules: jest.Mocked<typeof _hostRules>;
   let git: jest.Mocked<typeof _git>;
   let logger: jest.Mocked<typeof _logger>;
+  let timers: jest.Mocked<typeof _timers>;
 
   beforeEach(async () => {
     // reset module
@@ -32,6 +34,7 @@ describe('modules/platform/gitlab/index', () => {
     logger = (await import('../../../logger')).logger as never;
     jest.mock('../../../util/host-rules');
     jest.mock('timers/promises');
+    timers = require('timers/promises');
     hostRules = require('../../../util/host-rules');
     jest.mock('../../../util/git');
     git = require('../../../util/git');
@@ -44,6 +47,7 @@ describe('modules/platform/gitlab/index', () => {
       token: '123test',
     });
     delete process.env.GITLAB_IGNORE_REPO_URL;
+    delete process.env.RENOVATE_X_GITLAB_BRANCH_STATUS_DELAY;
   });
 
   async function initFakePlatform(version: string) {
@@ -826,6 +830,57 @@ describe('modules/platform/gitlab/index', () => {
           url: 'some-url',
         })
       ).toResolve();
+    });
+
+    it('waits for 1000ms by default', async () => {
+      const scope = await initRepo();
+      scope
+        .post(
+          '/api/v4/projects/some%2Frepo/statuses/0d9c7726c3d628b7e28af234595cfd20febdbf8e'
+        )
+        .reply(200, {})
+        .get(
+          '/api/v4/projects/some%2Frepo/repository/commits/0d9c7726c3d628b7e28af234595cfd20febdbf8e/statuses'
+        )
+        .reply(200, []);
+
+      await gitlab.setBranchStatus({
+        branchName: 'some-branch',
+        context: 'some-context',
+        description: 'some-description',
+        state: 'green',
+        url: 'some-url',
+      });
+
+      expect(timers.setTimeout.mock.calls).toHaveLength(1);
+      expect(timers.setTimeout.mock.calls[0][0]).toBe(1000);
+    });
+
+    it('waits for RENOVATE_X_GITLAB_BRANCH_STATUS_DELAY ms when set', async () => {
+      const delay = 5000;
+      process.env.RENOVATE_X_GITLAB_BRANCH_STATUS_DELAY = String(delay);
+
+      const scope = await initRepo();
+      scope
+        .post(
+          '/api/v4/projects/some%2Frepo/statuses/0d9c7726c3d628b7e28af234595cfd20febdbf8e'
+        )
+        .reply(200, {})
+        .get(
+          '/api/v4/projects/some%2Frepo/repository/commits/0d9c7726c3d628b7e28af234595cfd20febdbf8e/statuses'
+        )
+        .reply(200, []);
+
+      await gitlab.setBranchStatus({
+        branchName: 'some-branch',
+        context: 'some-context',
+        description: 'some-description',
+        state: 'green',
+        url: 'some-url',
+      });
+
+      expect(timers.setTimeout.mock.calls).toHaveLength(1);
+      expect(timers.setTimeout.mock.calls[0][0]).toBe(delay);
     });
   });
 

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -866,7 +866,11 @@ export async function setBranchStatus({
   }
   try {
     // give gitlab some time to create pipelines for the sha
-    await setTimeout(1000);
+    await setTimeout(
+      process.env.RENOVATE_X_GITLAB_BRANCH_STATUS_DELAY
+        ? parseInt(process.env.RENOVATE_X_GITLAB_BRANCH_STATUS_DELAY, 10)
+        : 1000
+    );
 
     await gitlabApi.postJson(url, { body: options });
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: … -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Add new experimental variable, `RENOVATE_X_GITLAB_BRANCH_STATUS_DELAY`, to allow users to control the delay between Renovate pushing a commit to a branch and setting its status (when `minimumReleaseAge`/`stabilityDays` is used) to further combat race conditions when a slow GitLab instance doesn't react fast enough, causing duplicate pipelines.

Defaults to previous 1s delay if not set.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

Renovate's external commit status, `renovate/stability-days`, ends up creating a duplicate pipeline for Merge Requests when GitLab doesn't create the "actual" pipeline for a commit fast enough. This was previously worked around with a 1000ms delay but even that isn't enough in some cases -> allow customizing it via an experimental variable, `RENOVATE_X_GITLAB_BRANCH_STATUS_DELAY`.

Discussion: https://github.com/renovatebot/renovate/discussions/23132

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
