### PR TITLE
fix(package-rules): don’t warn for for matchDepX

### DIFF
--- a/lib/util/package-rules/package-names.ts
+++ b/lib/util/package-rules/package-names.ts
@@ -21,7 +21,7 @@ export class PackageNameMatcher extends Matcher {
     }
 
     if (matchPackageNames.includes(depName)) {
-      logger.once.warn(
+      logger.once.info(
         { packageRule, packageName, depName },
         'Use matchDepNames instead of matchPackageNames'
       );

--- a/lib/util/package-rules/package-patterns.ts
+++ b/lib/util/package-rules/package-patterns.ts
@@ -39,7 +39,7 @@ export class PackagePatternsMatcher extends Matcher {
       return true;
     }
     if (matchPatternsAgainstName(matchPackagePatterns, depName)) {
-      logger.once.warn(
+      logger.once.info(
         { packageRule, packageName, depName },
         'Use matchDepPatterns instead of matchPackagePatterns'
       );

--- a/lib/util/package-rules/package-prefixes.ts
+++ b/lib/util/package-rules/package-prefixes.ts
@@ -23,7 +23,7 @@ export class PackagePrefixesMatcher extends Matcher {
       return true;
     }
     if (matchPackagePrefixes.some((prefix) => depName.startsWith(prefix))) {
-      logger.once.warn(
+      logger.once.info(
         { packageName, depName },
         'Use matchDepPatterns instead of matchPackagePrefixes'
       );


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Lowers warning to info for matchDepX.

## Context

Too many false warnings, so too much noise. Lowering it until we catch the lowest hanging fruit.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
