### PR TITLE
fix(logs): warn when Package lookup failures occur

### DIFF
--- a/lib/workers/repository/errors-warnings.ts
+++ b/lib/workers/repository/errors-warnings.ts
@@ -55,6 +55,9 @@ function getDepWarnings(
       }
     }
   }
+  if (warnings.length) {
+    logger.warn({ warnings, files: warningFiles }, 'Package lookup failures');
+  }
   return { warnings, warningFiles };
 }
 
@@ -70,7 +73,6 @@ export function getDepWarningsOnboardingPR(
   if (!warnings.length) {
     return '';
   }
-  logger.debug({ warnings, warningFiles }, 'Found package lookup warnings');
   warningText = emojify(
     `\n---\n\n### :warning: Dependency Lookup Warnings :warning:\n\n`
   );
@@ -90,7 +92,7 @@ export function getDepWarningsPR(
   config: RenovateConfig,
   dependencyDashboard?: boolean
 ): string {
-  const { warnings, warningFiles } = getDepWarnings(packageFiles);
+  const { warnings } = getDepWarnings(packageFiles);
   if (config.suppressNotifications?.includes('dependencyLookupWarnings')) {
     return '';
   }
@@ -98,7 +100,6 @@ export function getDepWarningsPR(
   if (!warnings.length) {
     return '';
   }
-  logger.debug({ warnings, warningFiles }, 'Found package lookup warnings');
   warningText = emojify(
     `\n---\n\n### :warning: Dependency Lookup Warnings :warning:\n\n`
   );
@@ -130,7 +131,6 @@ export function getDepWarningsDashboard(
     .map((dep) => '`' + dep + '`')
     .join(', ');
 
-  logger.debug({ warnings, warningFiles }, 'Found package lookup warnings');
   let warningText = emojify(
     `\n---\n\n### :warning: Dependency Lookup Warnings :warning:\n\n`
   );


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Logs a warning when package lookups occur

## Context

More details for those who aren't logging at debug level

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
