### PR TITLE
feat: Add `filterMap` utility for fast array transforms

### DIFF
--- a/lib/util/filter-map.spec.ts
+++ b/lib/util/filter-map.spec.ts
@@ -1,0 +1,17 @@
+import { filterMap } from './filter-map';
+
+describe('util/filter-map', () => {
+  it('should return an empty array when given an empty array', () => {
+    const input: unknown[] = [];
+    const output = filterMap(input, () => 42);
+    expect(output).toBe(input);
+    expect(output).toBeEmpty();
+  });
+
+  it('should return an array with only the mapped values that pass the filter', () => {
+    const input = [0, 1, 2, 3, 4];
+    const output = filterMap(input, (n) => n * n);
+    expect(output).toBe(input);
+    expect(output).toEqual([1, 4, 9, 16]);
+  });
+});

--- a/lib/util/filter-map.ts
+++ b/lib/util/filter-map.ts
@@ -1,0 +1,26 @@
+import is from '@sindresorhus/is';
+
+type Falsy = false | '' | 0 | 0n | null | undefined;
+
+/**
+ * Filter and map an array *in place* with single iteration.
+ */
+export function filterMap<T, U>(array: T[], fn: (item: T) => Falsy | U): U[] {
+  const length = array.length;
+  let newIdx = 0;
+  for (let oldIdx = 0; oldIdx < length; oldIdx += 1) {
+    const item = array[oldIdx];
+    const res = fn(item);
+    if (is.truthy(res)) {
+      array[newIdx] = res as never;
+      newIdx += 1;
+    }
+  }
+
+  const deletedCount = length - newIdx;
+  if (deletedCount) {
+    array.length = length - deletedCount;
+  }
+
+  return array as never;
+}


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Release results for some packages can be huge (e.g. Renovate itself), so it may be inefficient to apply series of filterings and mappings, allocating memory for new array over and over.

This PR introduces utility function that performs `filter-map` transform more efficiently.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
