### PR TITLE
fix(platform/bitbucket-server): do not force lowercase project keys in autodiscover mode

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -103,7 +103,7 @@ RENOVATE_AUTODISCOVER_FILTER="/myapp/(readme\.md|src/.*)/"
 }
 ```
 
-The search for repositories is not case-sensitive.
+The search for repositories is case-insensitive.
 
 **Regex**:
 

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -103,6 +103,8 @@ RENOVATE_AUTODISCOVER_FILTER="/myapp/(readme\.md|src/.*)/"
 }
 ```
 
+The search for repositories is not case-sensitive.
+
 **Regex**:
 
 All text inside the start and end `/` will be treated as a regular expression.

--- a/lib/modules/platform/bitbucket-server/index.spec.ts
+++ b/lib/modules/platform/bitbucket-server/index.spec.ts
@@ -266,7 +266,7 @@ describe('modules/platform/bitbucket-server/index', () => {
               values: [repoMock(url, 'SOME', 'repo')],
               start: 0,
             });
-          expect(await bitbucket.getRepos()).toEqual(['some/repo']);
+          expect(await bitbucket.getRepos()).toEqual(['SOME/repo']);
         });
       });
 

--- a/lib/modules/platform/bitbucket-server/index.ts
+++ b/lib/modules/platform/bitbucket-server/index.ts
@@ -110,7 +110,7 @@ export async function getRepos(): Promise<string[]> {
     );
     const result = repos.map(
       (r: { project: { key: string }; slug: string }) =>
-        `${r.project.key.toLowerCase()}/${r.slug}`
+        `${r.project.key}/${r.slug}`
     );
     logger.debug({ result }, 'result of getRepos()');
     return result;

--- a/lib/workers/global/autodiscover.spec.ts
+++ b/lib/workers/global/autodiscover.spec.ts
@@ -164,4 +164,18 @@ describe('workers/global/autodiscover', () => {
     const res = await autodiscoverRepositories(config);
     expect(res.repositories).toEqual(expectedRepositories);
   });
+
+  it('filters autodiscovered github repos case-insensitive', async () => {
+    config.autodiscover = true;
+    config.autodiscoverFilter = ['project/re*'];
+    config.platform = 'github';
+    hostRules.find = jest.fn(() => ({
+      token: 'abc',
+    }));
+    ghApi.getRepos = jest.fn(() =>
+      Promise.resolve(['project/repo', 'PROJECT/repo2'])
+    );
+    const res = await autodiscoverRepositories(config);
+    expect(res.repositories).toEqual(['project/repo', 'PROJECT/repo2']);
+  });
 });

--- a/lib/workers/global/autodiscover.ts
+++ b/lib/workers/global/autodiscover.ts
@@ -105,7 +105,7 @@ export function applyFilters(repos: string[], filters: string[]): string[] {
       }
       res = repos.filter(autodiscoveryPred);
     } else {
-      res = repos.filter(minimatch.filter(filter));
+      res = repos.filter(minimatch.filter(filter, { nocase: true }));
     }
     for (const repository of res) {
       matched.add(repository);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Removes an inconsistency on bitbucket-server where project keys in `autodiscoverFilter` need to be lower-cased to be found 
  - Return auto-discovered repositories on bitbucket-server as-is, i.e., without always lower-casing the project key
- Make `autodiscoverFilter` search using minimatch case-insensitive
  - Required for existing configs with lower-cased project keys to continue auto-discovering the same repos after this PR

<!-- Describe what behavior is changed by this PR. -->

## Context

- https://github.com/renovatebot/renovate/discussions/23158
  - Previous discussion probably facing the same issue: https://github.com/renovatebot/renovate/discussions/16111
- https://github.com/renovatebot/renovate/pull/2774 -> initially introduced `getRepos()` with `r.project.key.toLowerCase()` but included no reasoning why this was needed.

Notes:
- `/rest/api/1.0/repos` returns the project key as-is (see [here](https://docs.atlassian.com/bitbucket-server/rest/7.19.3/bitbucket-rest.html#idp450) or [here](https://developer.atlassian.com/server/bitbucket/rest/v811/api-group-repository/#api-api-latest-repos-get) for sample responses)
- Generally, BitBucket Server processes project key and repo slugs in REST API calls case-insensitive (this [never changed](https://developer.atlassian.com/server/bitbucket/reference/api-changelog/))

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

Also verified by following the instructions outlined [here](https://docs.renovatebot.com/modules/platform/bitbucket-server/#testing), creating a project key with uppercase letters, adding a repository, enabling autodiscovery, and defining `autodiscoverFilter` with a project key that was once uppercase-only, once lower-case only.

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
