### PR TITLE
refactor: Don't restrict error type for `Result<T, E>`

### DIFF
--- a/lib/modules/datasource/index.ts
+++ b/lib/modules/datasource/index.ts
@@ -8,7 +8,6 @@ import * as packageCache from '../../util/cache/package';
 import { clone } from '../../util/clone';
 import { filterMap } from '../../util/filter-map';
 import { regEx } from '../../util/regex';
-import { Result } from '../../util/result';
 import { trimTrailingSlash } from '../../util/url';
 import { defaultVersioning } from '../versioning';
 import * as allVersioning from '../versioning';
@@ -504,12 +503,6 @@ export async function getPkgReleases(
   sortAndRemoveDuplicates(config, res);
   applyConstraintsFiltering(config, res);
   return res;
-}
-
-export function getPkgReleasesSafe(
-  config: GetPkgReleasesConfig
-): Promise<Result<ReleaseResult | null>> {
-  return Result.wrap(getPkgReleases(config));
 }
 
 export function supportsDigests(datasource: string | undefined): boolean {

--- a/lib/util/result.spec.ts
+++ b/lib/util/result.spec.ts
@@ -3,50 +3,45 @@ import { Result } from './result';
 describe('util/result', () => {
   describe('ok', () => {
     it('constructs successful result from value', () => {
-      expect(Result.ok(42).value()).toBe(42);
+      expect(Result.ok(42).value).toBe(42);
     });
   });
 
   describe('err', () => {
-    it('constructs error result', () => {
+    it('constructs `true` error by default', () => {
       const res = Result.err();
-      expect(res.error()).toEqual(new Error());
-    });
-
-    it('constructs error result from string', () => {
-      const res = Result.err('oops');
-      expect(res.error()?.message).toBe('oops');
+      expect(res.error).toBeTrue();
     });
 
     it('constructs error result from Error instance', () => {
       const err = new Error('oops');
       const res = Result.err(err);
-      expect(res.error()).toBe(err);
+      expect(res.error).toBe(err);
     });
   });
 
   describe('wrap', () => {
     it('wraps function returning successful result', () => {
       const res = Result.wrap(() => 42);
-      expect(res.value()).toBe(42);
+      expect(res.value).toBe(42);
     });
 
     it('wraps function that throws an error', () => {
       const res = Result.wrap(() => {
         throw new Error('oops');
       });
-      expect(res.error()?.message).toBe('oops');
+      expect(res.error?.message).toBe('oops');
     });
 
     it('wraps promise resolving to value', async () => {
       const res = await Result.wrap(Promise.resolve(42));
-      expect(res.value()).toBe(42);
+      expect(res.value).toBe(42);
     });
 
     it('wraps promise rejecting with error', async () => {
       const err = new Error('oops');
       const res = await Result.wrap(Promise.reject(err));
-      expect(res.error()?.message).toBe('oops');
+      expect(res.error?.message).toBe('oops');
     });
   });
 
@@ -61,59 +56,47 @@ describe('util/result', () => {
     it('no-op for error result', () => {
       const err = new Error('bar');
       const res = Result.err(err).transform(fn);
-      expect(res.value()).toBeUndefined();
-      expect(res.error()).toBe(err);
+      expect(res.value).toBeUndefined();
+      expect(res.error).toBe(err);
     });
   });
 
-  describe('unwrap', () => {
-    it('unwraps successful result', () => {
+  describe('catch', () => {
+    it('returns original value for successful result', () => {
       const res = Result.ok(42);
-      expect(res.unwrap()).toEqual({ ok: true, value: 42 });
+      expect(res.catch(0)).toBe(42);
     });
 
-    it('unwraps error result with fallback value', () => {
+    it('returns fallback value for error result', () => {
       const err = new Error('oops');
       const res = Result.err(err);
-      expect(res.unwrap(42)).toEqual({ ok: true, value: 42 });
-    });
-
-    it('unwraps error result', () => {
-      const err = new Error('oops');
-      const res = Result.err(err);
-      expect(res.unwrap()).toEqual({ ok: false, error: err });
+      expect(res.catch(42)).toBe(42);
     });
   });
 
   describe('value', () => {
     it('returns successful value', () => {
       const res = Result.ok(42);
-      expect(res.value()).toBe(42);
-    });
-
-    it('returns fallback value for error result', () => {
-      const err = new Error('oops');
-      const res = Result.err(err);
-      expect(res.value(42)).toBe(42);
+      expect(res.value).toBe(42);
     });
 
     it('returns undefined value for error result', () => {
       const err = new Error('oops');
       const res = Result.err(err);
-      expect(res.value()).toBeUndefined();
+      expect(res.value).toBeUndefined();
     });
   });
 
   describe('error', () => {
     it('returns undefined error for successful result', () => {
       const res = Result.ok(42);
-      expect(res.error()).toBeUndefined();
+      expect(res.error).toBeUndefined();
     });
 
     it('returns error for non-successful result', () => {
       const err = new Error('oops');
       const res = Result.err(err);
-      expect(res.error()).toEqual(err);
+      expect(res.error).toEqual(err);
     });
   });
 });

--- a/lib/util/result.ts
+++ b/lib/util/result.ts
@@ -1,32 +1,28 @@
 interface Ok<T> {
-  ok: true;
-  value: T;
+  readonly ok: true;
+  readonly value: T;
 }
 
-interface Err {
-  ok: false;
-  error: Error;
+interface Err<E> {
+  readonly ok: false;
+  readonly error: E;
 }
 
-type Res<T> = Ok<T> | Err;
+type Res<T, E> = Ok<T> | Err<E>;
 
-export class Result<T> {
-  static ok<T>(value: T): Result<T> {
+export class Result<T, E = Error> {
+  static ok<T>(value: T): Result<T, never> {
     return new Result({ ok: true, value });
   }
 
-  static err(): Result<never>;
-  static err(error: Error): Result<never>;
-  static err(message: string): Result<never>;
-  static err(error?: Error | string): Result<never> {
-    if (typeof error === 'undefined') {
-      return new Result({ ok: false, error: new Error() });
+  static err(): Result<never, true>;
+  static err<E>(e: E): Result<never, E>;
+  static err<E>(e?: E): Result<never, E> | Result<never, true> {
+    if (typeof e === 'undefined' && arguments.length === 0) {
+      return new Result({ ok: false, error: true });
     }
 
-    if (typeof error === 'string') {
-      return new Result({ ok: false, error: new Error(error) });
-    }
-
+    const error = e as E;
     return new Result({ ok: false, error });
   }
 
@@ -55,36 +51,23 @@ export class Result<T> {
       : Result.wrapCallback(input);
   }
 
-  private constructor(private res: Res<T>) {}
+  private constructor(public readonly res: Res<T, E>) {}
 
-  transform<U>(fn: (value: T) => U): Result<U> {
+  transform<U>(fn: (value: T) => U): Result<U, E> {
     return this.res.ok
       ? Result.ok(fn(this.res.value))
       : Result.err(this.res.error);
   }
 
-  unwrap(): Res<T>;
-  unwrap<U>(fallback: U): Res<T | U>;
-  unwrap<U>(fallback?: U): Res<T | U> {
-    if (this.res.ok) {
-      return this.res;
-    }
-
-    if (arguments.length) {
-      return { ok: true, value: fallback as U };
-    }
-
-    return this.res;
+  catch<U>(fallback: U): T | U {
+    return this.res.ok ? this.res.value : fallback;
   }
 
-  value(): T | undefined;
-  value<U>(fallback: U): T | U;
-  value<U>(fallback?: U): T | U | undefined {
-    const res = arguments.length ? this.unwrap(fallback as U) : this.unwrap();
-    return res.ok ? res.value : undefined;
+  get value(): T | undefined {
+    return this.res.ok ? this.res.value : undefined;
   }
 
-  error(): Error | undefined {
+  get error(): E | undefined {
     return this.res.ok ? undefined : this.res.error;
   }
 }

--- a/lib/util/result.ts
+++ b/lib/util/result.ts
@@ -1,10 +1,10 @@
 interface Ok<T> {
-  readonly ok: true;
+  readonly success: true;
   readonly value: T;
 }
 
 interface Err<E> {
-  readonly ok: false;
+  readonly success: false;
   readonly error: E;
 }
 
@@ -12,18 +12,18 @@ type Res<T, E> = Ok<T> | Err<E>;
 
 export class Result<T, E = Error> {
   static ok<T>(value: T): Result<T, never> {
-    return new Result({ ok: true, value });
+    return new Result({ success: true, value });
   }
 
   static err(): Result<never, true>;
   static err<E>(e: E): Result<never, E>;
   static err<E>(e?: E): Result<never, E> | Result<never, true> {
     if (typeof e === 'undefined' && arguments.length === 0) {
-      return new Result({ ok: false, error: true });
+      return new Result({ success: false, error: true });
     }
 
     const error = e as E;
-    return new Result({ ok: false, error });
+    return new Result({ success: false, error });
   }
 
   private static wrapCallback<T>(callback: () => T): Result<T> {
@@ -54,20 +54,20 @@ export class Result<T, E = Error> {
   private constructor(public readonly res: Res<T, E>) {}
 
   transform<U>(fn: (value: T) => U): Result<U, E> {
-    return this.res.ok
+    return this.res.success
       ? Result.ok(fn(this.res.value))
       : Result.err(this.res.error);
   }
 
   catch<U>(fallback: U): T | U {
-    return this.res.ok ? this.res.value : fallback;
+    return this.res.success ? this.res.value : fallback;
   }
 
   get value(): T | undefined {
-    return this.res.ok ? this.res.value : undefined;
+    return this.res.success ? this.res.value : undefined;
   }
 
   get error(): E | undefined {
-    return this.res.ok ? undefined : this.res.error;
+    return this.res.success ? undefined : this.res.error;
   }
 }

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -9,7 +9,7 @@ import {
   getDatasourceList,
   getDefaultVersioning,
   getDigest,
-  getPkgReleasesSafe,
+  getPkgReleases,
   isGetPkgReleasesConfig,
   supportsDigests,
 } from '../../../../modules/datasource';
@@ -30,6 +30,7 @@ import {
   addReplacementUpdateIfValid,
   isReplacementRulesConfigured,
 } from './utils';
+import { Result } from '../../../../util/result';
 
 export async function lookupUpdates(
   inconfig: LookupUpdateConfig
@@ -82,7 +83,7 @@ export async function lookupUpdates(
         res.skipReason = 'is-pinned';
         return res;
       }
-      const lookupResult = (await getPkgReleasesSafe(config)).unwrap();
+      const { res: lookupResult } = await Result.wrap(getPkgReleases(config));
       if (!lookupResult.ok) {
         throw lookupResult.error;
       }

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -19,6 +19,7 @@ import { ExternalHostError } from '../../../../types/errors/external-host-error'
 import { clone } from '../../../../util/clone';
 import { applyPackageRules } from '../../../../util/package-rules';
 import { regEx } from '../../../../util/regex';
+import { Result } from '../../../../util/result';
 import { getBucket } from './bucket';
 import { getCurrentVersion } from './current';
 import { filterVersions } from './filter';
@@ -30,7 +31,6 @@ import {
   addReplacementUpdateIfValid,
   isReplacementRulesConfigured,
 } from './utils';
-import { Result } from '../../../../util/result';
 
 export async function lookupUpdates(
   inconfig: LookupUpdateConfig

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -84,7 +84,7 @@ export async function lookupUpdates(
         return res;
       }
       const { res: lookupResult } = await Result.wrap(getPkgReleases(config));
-      if (!lookupResult.ok) {
+      if (!lookupResult.success) {
         throw lookupResult.error;
       }
       dependency = clone(lookupResult.value);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

`Error` can not be right decision for representing error results: for example, we not necessarily want to have stacktraces.

There is no reason why error can't be of any type, including something lightweight like just `true` literal.

This PR refactors error type and also provides some improvements for the `Result` API.

Names has been aligned to `zod` schema library, as it solves very similar problems for us.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
