### PR TITLE
fix: compute `recreateClosed` for normal PRs

### DIFF
--- a/lib/workers/repository/updates/__snapshots__/generate.spec.ts.snap
+++ b/lib/workers/repository/updates/__snapshots__/generate.spec.ts.snap
@@ -23,6 +23,7 @@ exports[`workers/repository/updates/generate generateBranchConfig() handles @typ
   "prBodyColumns": [],
   "prTitle": "some-title",
   "prettyDepType": "dependency",
+  "recreateClosed": false,
   "releaseTimestamp": undefined,
   "reuseLockFiles": true,
   "upgrades": [
@@ -41,6 +42,7 @@ exports[`workers/repository/updates/generate generateBranchConfig() handles @typ
       "newValue": "0.6.0",
       "prTitle": "some-title",
       "prettyDepType": "dependency",
+      "recreateClosed": false,
     },
     {
       "branchName": "some-branch",
@@ -59,6 +61,7 @@ exports[`workers/repository/updates/generate generateBranchConfig() handles @typ
       "newValue": "1.0.0",
       "prTitle": "some-other-title",
       "prettyDepType": "dependency",
+      "recreateClosed": false,
     },
     {
       "branchName": "some-branch",
@@ -74,6 +77,7 @@ exports[`workers/repository/updates/generate generateBranchConfig() handles @typ
       "newValue": "0.5.7",
       "prTitle": "some-title",
       "prettyDepType": "dependency",
+      "recreateClosed": false,
     },
   ],
 }
@@ -136,6 +140,7 @@ exports[`workers/repository/updates/generate generateBranchConfig() handles @typ
       "newValue": "1.0.0",
       "prTitle": "some-other-title",
       "prettyDepType": "dependency",
+      "recreateClosed": false,
     },
     {
       "branchName": "some-branch",
@@ -155,6 +160,7 @@ exports[`workers/repository/updates/generate generateBranchConfig() handles @typ
       "prTitle": "some-title",
       "prettyDepType": "dependency",
       "prettyNewVersion": "v0.5.8",
+      "recreateClosed": false,
     },
   ],
 }
@@ -223,6 +229,7 @@ exports[`workers/repository/updates/generate generateBranchConfig() handles lock
   "prTitle": "some-title",
   "prettyDepType": "dependency",
   "prettyNewVersion": "v1.0.1",
+  "recreateClosed": false,
   "releaseTimestamp": undefined,
   "reuseLockFiles": true,
   "upgrades": [
@@ -243,6 +250,7 @@ exports[`workers/repository/updates/generate generateBranchConfig() handles lock
       "prTitle": "some-title",
       "prettyDepType": "dependency",
       "prettyNewVersion": "v1.0.1",
+      "recreateClosed": false,
     },
   ],
 }

--- a/lib/workers/repository/updates/generate.spec.ts
+++ b/lib/workers/repository/updates/generate.spec.ts
@@ -46,6 +46,7 @@ describe('workers/repository/updates/generate', () => {
       expect(res.foo).toBe(1);
       expect(res.groupName).toBeUndefined();
       expect(res.releaseTimestamp).toBeDefined();
+      expect(res.recreateClosed).toBe(false);
     });
 
     it('handles lockFileMaintenance', () => {
@@ -143,6 +144,7 @@ describe('workers/repository/updates/generate', () => {
       const res = generateBranchConfig(branch);
       expect(res.foo).toBe(1);
       expect(res.groupName).toBeUndefined();
+      expect(res.recreateClosed).toBe(false);
     });
 
     it('groups multiple upgrades same version', () => {
@@ -215,6 +217,7 @@ describe('workers/repository/updates/generate', () => {
         foo: '1.0.0',
         bar: '2.0.0',
       });
+      expect(res.recreateClosed).toBe(false);
     });
 
     it('groups major updates with different versions but same newValue, no recreateWhen', () => {
@@ -528,7 +531,7 @@ describe('workers/repository/updates/generate', () => {
       const res = generateBranchConfig(branch);
       expect(res.foo).toBe(2);
       expect(res.singleVersion).toBeUndefined();
-      expect(res.recreateClosed).toBeUndefined();
+      expect(res.recreateClosed).toBeFalse();
       expect(res.groupName).toBeDefined();
       expect(res.releaseTimestamp).toBe('2017-02-08T20:01:41+00:00');
     });
@@ -571,7 +574,7 @@ describe('workers/repository/updates/generate', () => {
       const res = generateBranchConfig(branch);
       expect(res.foo).toBe(2);
       expect(res.singleVersion).toBeUndefined();
-      expect(res.recreateClosed).toBeUndefined();
+      expect(res.recreateClosed).toBeFalse();
       expect(res.groupName).toBeDefined();
       expect(res.releaseTimestamp).toBe('2017-02-08T20:01:41+00:00');
     });

--- a/lib/workers/repository/updates/generate.ts
+++ b/lib/workers/repository/updates/generate.ts
@@ -83,6 +83,8 @@ export function generateBranchConfig(
   const toVersions: string[] = [];
   const toValues = new Set<string>();
   for (const upg of branchUpgrades) {
+    upg.recreateClosed = upg.recreateWhen === 'always';
+
     if (upg.currentDigest) {
       upg.currentDigestShort =
         upg.currentDigestShort ??


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context
Ref: https://github.com/renovatebot/renovate/discussions/23282
The above issue arises because we use `recreateClosed` to decide whether to check a PR already exists or not [here](https://github.com/renovatebot/renovate/blob/eeab2c362ad8e2c5f40f35e7d459c2f95a8967f7/lib/workers/repository/update/branch/check-existing.ts#L11). But the `recreateClosed` value is only calculated for immortal PRs and not normal PR.

Hence, for normal PRs that have been closed previously coouldn't be recreated.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
