### PR TITLE
refactor: Use `/versions` only on rubygems

### DIFF
--- a/lib/modules/datasource/rubygems/index.spec.ts
+++ b/lib/modules/datasource/rubygems/index.spec.ts
@@ -22,15 +22,10 @@ describe('modules/datasource/rubygems/index', () => {
     it('returns null for missing pkg', async () => {
       httpMock
         .scope('https://firstparty.com')
-        .get('/basepath/versions')
-        .reply(404);
-      httpMock
-        .scope('https://firstparty.com')
         .get('/basepath/api/v1/gems/rails.json')
         .reply(200, { name: 'rails' })
         .get('/basepath/api/v1/versions/rails.json')
         .reply(200, []);
-      httpMock.scope('https://thirdparty.com').get('/versions').reply(404);
       httpMock
         .scope('https://thirdparty.com')
         .get('/api/v1/gems/rails.json')
@@ -126,8 +121,6 @@ describe('modules/datasource/rubygems/index', () => {
     it('works with real data', async () => {
       httpMock
         .scope('https://thirdparty.com/')
-        .get('/versions')
-        .reply(404)
         .get('/api/v1/gems/rails.json')
         .reply(200, railsInfo)
         .get('/api/v1/versions/rails.json')
@@ -149,14 +142,10 @@ describe('modules/datasource/rubygems/index', () => {
     it('uses multiple source urls', async () => {
       httpMock
         .scope('https://thirdparty.com/')
-        .get('/versions')
-        .reply(404)
         .get('/api/v1/gems/rails.json')
         .reply(401);
       httpMock
         .scope('https://firstparty.com/')
-        .get('/basepath/versions')
-        .reply(404)
         .get('/basepath/api/v1/gems/rails.json')
         .reply(200, railsInfo)
         .get('/basepath/api/v1/versions/rails.json')
@@ -178,8 +167,6 @@ describe('modules/datasource/rubygems/index', () => {
     it('falls back to info when version request fails', async () => {
       httpMock
         .scope('https://thirdparty.com/')
-        .get('/versions')
-        .reply(404)
         .get('/api/v1/gems/rails.json')
         .reply(200, railsInfo)
         .get('/api/v1/versions/rails.json')
@@ -200,8 +187,6 @@ describe('modules/datasource/rubygems/index', () => {
     it('errors when version request fails with anything other than 400 or 404', async () => {
       httpMock
         .scope('https://thirdparty.com/')
-        .get('/versions')
-        .reply(404)
         .get('/api/v1/gems/rails.json')
         .reply(200, railsInfo)
         .get('/api/v1/versions/rails.json')
@@ -222,8 +207,6 @@ describe('modules/datasource/rubygems/index', () => {
     it('falls back to dependencies api', async () => {
       httpMock
         .scope('https://thirdparty.com/')
-        .get('/versions')
-        .reply(404)
         .get('/api/v1/gems/rails.json')
         .reply(404, railsInfo)
         .get('/api/v1/dependencies?gems=rails')
@@ -244,8 +227,6 @@ describe('modules/datasource/rubygems/index', () => {
     it('returns null for GitHub Packages package miss', async () => {
       httpMock
         .scope('https://rubygems.pkg.github.com/example')
-        .get('/versions')
-        .reply(404)
         .get('/api/v1/dependencies?gems=rails')
         .reply(200, emptyMarshalArray);
       expect(
@@ -261,8 +242,6 @@ describe('modules/datasource/rubygems/index', () => {
     it('returns a dep for GitHub Packages package hit', async () => {
       httpMock
         .scope('https://rubygems.pkg.github.com/example')
-        .get('/versions')
-        .reply(404)
         .get('/api/v1/dependencies?gems=rails')
         .reply(200, railsDependencies);
       const res = await getPkgReleases({


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
