### PR TITLE
fix(packageRules): evaluate confidence matcher first

### DIFF
--- a/lib/util/package-rules/index.spec.ts
+++ b/lib/util/package-rules/index.spec.ts
@@ -716,6 +716,7 @@ describe('util/package-rules/index', () => {
       const config: TestConfig = {
         packageRules: [
           {
+            matchUpdateTypes: ['major'],
             matchConfidence: ['high'],
             x: 1,
           },

--- a/lib/util/package-rules/matchers.ts
+++ b/lib/util/package-rules/matchers.ts
@@ -20,7 +20,11 @@ import { UpdateTypesMatcher } from './update-types';
 const matchers: MatcherApi[][] = [];
 export default matchers;
 
-// each manager under the same key will use a logical OR, if multiple matchers are applied AND will be used
+// Each matcher under the same index will use a logical OR, if multiple matchers are applied AND will be used
+
+// applyPackageRules evaluates matchers in the order of insertion. It also returns early when any set matcher fails.
+// Therefore, when multiple matchers are set in a single packageRule, we might not check all set matchers, which can cause unwanted lookups and PR flip-flops.
+matchers.push([new MergeConfidenceMatcher()]);
 matchers.push([
   new DepNameMatcher(),
   new DepPatternsMatcher(),
@@ -34,7 +38,6 @@ matchers.push([new BaseBranchesMatcher()]);
 matchers.push([new ManagersMatcher()]);
 matchers.push([new DatasourcesMatcher()]);
 matchers.push([new UpdateTypesMatcher()]);
-matchers.push([new MergeConfidenceMatcher()]);
 matchers.push([new SourceUrlsMatcher(), new SourceUrlPrefixesMatcher()]);
 matchers.push([new CurrentValueMatcher()]);
 matchers.push([new CurrentVersionMatcher()]);

--- a/lib/util/package-rules/matchers.ts
+++ b/lib/util/package-rules/matchers.ts
@@ -22,8 +22,9 @@ export default matchers;
 
 // Each matcher under the same index will use a logical OR, if multiple matchers are applied AND will be used
 
-// applyPackageRules evaluates matchers in the order of insertion. It also returns early when any set matcher fails.
-// Therefore, when multiple matchers are set in a single packageRule, we might not check all set matchers, which can cause unwanted lookups and PR flip-flops.
+// applyPackageRules evaluates matchers in the order of insertion and returns early on failure.
+// Therefore, when multiple matchers are set in a single packageRule, some may not be checked.
+// Since matchConfidence matcher can abort the run due to unauthenticated use, it should be evaluated first.
 matchers.push([new MergeConfidenceMatcher()]);
 matchers.push([
   new DepNameMatcher(),


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Evaluate `matchConfidence` first when applying package rules.

`applyPackageRules` evaluates matchers in the order of insertion. It also returns early when any set matcher fails.
Therefore, when multiple matchers are set in a single `packageRule`, we might not check all set matchers, which can cause unwanted lookup and PR flip-flop.


<!-- Describe what behavior is changed by this PR. -->

## Context
When scanning the following [reproduction repository](https://github.com/ladzaretti/pr-order-eval/issues), we fail to abort run before performing lookup, although `matchConfidence` is used without credentials.
This in turn treated as `LookupError` as can be seen in the corresponding [Dashboard](https://github.com/ladzaretti/pr-order-eval/issues/1).

<details>
<summary>Click to expand Logs</summary>

```
DEBUG: Found npm package files (repository=ladzaretti/pr-order-eval)
DEBUG: Found 1 package file(s) (repository=ladzaretti/pr-order-eval)
 INFO: Dependency extraction complete (repository=ladzaretti/pr-order-eval, baseBranch=main)
       "stats": {
         "managers": {"npm": {"fileCount": 1, "depCount": 1}},
         "total": {"fileCount": 1, "depCount": 1}
       }
ERROR: lookupUpdates error (repository=ladzaretti/pr-order-eval, packageFile=package.json)
       "currentDigest": undefined,
       "currentValue": "4.0.0",
       "datasource": "npm",
       "packageName": "lodash",
       "digestOneAndOnly": undefined,
       "followTag": null,
       "lockedVersion": undefined,
       "pinDigests": false,
       "rollbackPrs": false,
       "isVulnerabilityAlert": undefined,
       "updatePinnedDependencies": true,
       "unconstrainedValue": false,
       "err": {
         "validationMessage": "Missing credentials",
         "validationError": "The `matchConfidence` matcher in `packageRules` requires authentication. Please refer to the [documentation](https://docs.renovatebot.com
/configuration-options/#matchconfidence) and add the required host rule.",
         "message": "missing-api-credentials",
         "stack": "Error: missing-api-credentials\n    at MergeConfidenceMatcher.matches (C:\\projects\\ladzaretti-renovate\\lib\\util\\package-rules\\merge-confidenc
e.ts:20:21)\n    at matcherOR (C:\\projects\\ladzaretti-renovate\\lib\\util\\package-rules\\utils.ts:19:27)\n    at matchesRule (C:\\projects\\ladzaretti-renovate\\li
b\\util\\package-rules\\index.ts:17:30)\n    at applyPackageRules (C:\\projects\\ladzaretti-renovate\\lib\\util\\package-rules\\index.ts:74:9)\n    at filterInternalC
hecks (C:\\projects\\ladzaretti-renovate\\lib\\workers\\repository\\process\\lookup\\filter-checks.ts:54:40)\n    at lookupUpdates (C:\\projects\\ladzaretti-renovate\
\lib\\workers\\repository\\process\\lookup\\index.ts:276:37)\n    at async withLookupStats (C:\\projects\\ladzaretti-renovate\\lib\\workers\\repository\\process\\fetc
h.ts:29:18)\n    at async fetchDepUpdates (C:\\projects\\ladzaretti-renovate\\lib\\workers\\repository\\process\\fetch.ts:74:30)\n    at async C:\\projects\\ladzarett
i-renovate\\node_modules\\p-map\\index.js:57:22"
       }
DEBUG: PackageFiles.add() - Package file saved for base branch (repository=ladzaretti/pr-order-eval, baseBranch=main)

```

</details>
 
 
 ____

## Expected Behavior
> Raise a [new warning issue](https://github.com/ladzaretti/grouping-mc-testing/issues/49) whenever the `matchConfidence` `PackageRules` matcher is used without credentials.

As per:
- https://github.com/renovatebot/renovate/pull/22296

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
