### PR TITLE
feat(http): Add `getHttpSafe()` method

### DIFF
--- a/lib/util/http/index.spec.ts
+++ b/lib/util/http/index.spec.ts
@@ -404,30 +404,6 @@ describe('util/http/index', () => {
         expect(val).toBeUndefined();
         expect(err).toBeInstanceOf(HttpError);
       });
-
-      it('returns error for empty body', async () => {
-        httpMock.scope('http://example.com').get('/').reply(200, '');
-
-        const { val, err } = await http
-          .getJsonSafe<string>('http://example.com')
-          .unwrap();
-
-        expect(val).toBeUndefined();
-        expect(err).toBeInstanceOf(EmptyResultError);
-        expect(err?.message).toBe(`Empty result: ''`);
-      });
-
-      it('returns error for null', async () => {
-        httpMock.scope('http://example.com').get('/').reply(200, 'null');
-
-        const { val, err } = await http
-          .getJsonSafe<string>('http://example.com')
-          .unwrap();
-
-        expect(val).toBeUndefined();
-        expect(err).toBeInstanceOf(EmptyResultError);
-        expect(err?.message).toBe(`Empty result: 'null'`);
-      });
     });
 
     describe('postJson', () => {

--- a/lib/util/http/index.spec.ts
+++ b/lib/util/http/index.spec.ts
@@ -10,7 +10,7 @@ import * as hostRules from '../host-rules';
 import * as queue from './queue';
 import * as throttle from './throttle';
 import type { HttpResponse } from './types';
-import { EmptyResultError, Http, HttpError } from '.';
+import { Http, HttpError } from '.';
 
 const baseUrl = 'http://renovate.com';
 

--- a/lib/util/http/index.ts
+++ b/lib/util/http/index.ts
@@ -352,35 +352,29 @@ export class Http<Opts extends HttpOptions = HttpOptions> {
     return this.requestJson<ResT>('get', args);
   }
 
-  getJsonSafe<ResT>(
-    url: string,
-    options?: Opts & HttpRequestOptions<ResT>
-  ): AsyncResult<ResT, RequestError | EmptyResultError>;
-  getJsonSafe<ResT, Schema extends ZodType<ResT> = ZodType<ResT>>(
-    url: string,
-    schema: Schema
-  ): AsyncResult<Infer<Schema>, SafeJsonError>;
-  getJsonSafe<ResT, Schema extends ZodType<ResT> = ZodType<ResT>>(
+  getJsonSafe<
+    ResT extends NonNullable<unknown>,
+    Schema extends ZodType<ResT> = ZodType<ResT>
+  >(url: string, schema: Schema): AsyncResult<Infer<Schema>, SafeJsonError>;
+  getJsonSafe<
+    ResT extends NonNullable<unknown>,
+    Schema extends ZodType<ResT> = ZodType<ResT>
+  >(
     url: string,
     options: Opts & HttpRequestOptions<Infer<Schema>>,
     schema: Schema
   ): AsyncResult<Infer<Schema>, SafeJsonError>;
-  getJsonSafe<ResT = unknown, Schema extends ZodType<ResT> = ZodType<ResT>>(
+  getJsonSafe<
+    ResT extends NonNullable<unknown>,
+    Schema extends ZodType<ResT> = ZodType<ResT>
+  >(
     arg1: string,
     arg2?: (Opts & HttpRequestOptions<ResT>) | Schema,
     arg3?: Schema
   ): AsyncResult<ResT, SafeJsonError> {
     const args = this.resolveArgs<ResT>(arg1, arg2, arg3);
     return Result.wrap(this.requestJson<ResT>('get', args)).transform(
-      ({ body }) => {
-        if (!body) {
-          const message = `Empty result: '${String(body)}'`;
-          const err = new EmptyResultError(message);
-          return Result.err(err);
-        }
-
-        return Result.ok(body);
-      }
+      (response) => response.body
     );
   }
 

--- a/lib/util/http/index.ts
+++ b/lib/util/http/index.ts
@@ -31,6 +31,7 @@ import './legacy';
 export { RequestError as HttpError };
 
 export class EmptyResultError extends Error {}
+export type SafeJsonError = RequestError | ZodError | EmptyResultError;
 
 type JsonArgs<
   Opts extends HttpOptions & HttpRequestOptions<ResT>,
@@ -358,17 +359,17 @@ export class Http<Opts extends HttpOptions = HttpOptions> {
   getJsonSafe<ResT, Schema extends ZodType<ResT> = ZodType<ResT>>(
     url: string,
     schema: Schema
-  ): AsyncResult<Infer<Schema>, RequestError | ZodError | EmptyResultError>;
+  ): AsyncResult<Infer<Schema>, SafeJsonError>;
   getJsonSafe<ResT, Schema extends ZodType<ResT> = ZodType<ResT>>(
     url: string,
     options: Opts & HttpRequestOptions<Infer<Schema>>,
     schema: Schema
-  ): AsyncResult<Infer<Schema>, RequestError | ZodError | EmptyResultError>;
+  ): AsyncResult<Infer<Schema>, SafeJsonError>;
   getJsonSafe<ResT = unknown, Schema extends ZodType<ResT> = ZodType<ResT>>(
     arg1: string,
     arg2?: (Opts & HttpRequestOptions<ResT>) | Schema,
     arg3?: Schema
-  ): AsyncResult<ResT, RequestError | ZodError | EmptyResultError> {
+  ): AsyncResult<ResT, SafeJsonError> {
     const args = this.resolveArgs<ResT>(arg1, arg2, arg3);
     return Result.wrap(this.requestJson<ResT>('get', args)).transform(
       ({ body }) => {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- `getJsonSafe` returns `ResultPromise<T, HttpError | ZodError | EmptyResultError>`
- `EmptyResultError` is returned in case of response (possibly, transformed) containing `null` or an empty string.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
