### PR TITLE
feat(platform/github): autodiscover repos by topic

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -130,6 +130,14 @@ If using negations, all repositories except those who match the regex are added 
 Some platforms allow you to add tags, or topics, to repositories and retrieve repository lists by specifying those
 topics. Set this variable to a list of strings, all of which will be topics for the autodiscovered repositories.
 
+For example:
+
+```json
+{
+  "autodiscoverTopics": ["managed-by-renovate"]
+}
+```
+
 ## baseDir
 
 By default Renovate uses a temporary directory like `/tmp/renovate` to store its data.

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -800,13 +800,13 @@ const options: RenovateOptions[] = [
   },
   {
     name: 'autodiscoverTopics',
-    description: '',
+    description: 'Filter the list of autodiscovered repositories by topics.',
     stage: 'global',
     type: 'array',
     subType: 'string',
     default: null,
     globalOnly: true,
-    supportedPlatforms: ['gitlab'],
+    supportedPlatforms: ['gitlab', 'github'],
   },
   {
     name: 'prCommitsPerRunLimit',

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -806,7 +806,7 @@ const options: RenovateOptions[] = [
     subType: 'string',
     default: null,
     globalOnly: true,
-    supportedPlatforms: ['gitlab', 'github'],
+    supportedPlatforms: ['github', 'gitlab'],
   },
   {
     name: 'prCommitsPerRunLimit',

--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -212,16 +212,11 @@ describe('modules/platform/github/index', () => {
             archived: true,
             topics: ['managed-by-renovate'],
           },
-          {
-            full_name: 'g/h',
-            archived: false,
-            topics: ['managed-by-renovate'],
-          },
           null,
         ]);
 
       const repos = await github.getRepos({ topics: ['managed-by-renovate'] });
-      expect(repos).toEqual(['c/d', 'g/h']);
+      expect(repos).toEqual(['c/d']);
     });
 
     it('should return an array of repos when using Github App endpoint', async () => {

--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -192,6 +192,38 @@ describe('modules/platform/github/index', () => {
       expect(repos).toMatchSnapshot();
     });
 
+    it('should filters repositories by topics', async () => {
+      httpMock
+        .scope(githubApiHost)
+        .get('/user/repos?per_page=100')
+        .reply(200, [
+          {
+            full_name: 'a/b',
+            archived: false,
+            topics: [],
+          },
+          {
+            full_name: 'c/d',
+            archived: false,
+            topics: ['managed-by-renovate'],
+          },
+          {
+            full_name: 'e/f',
+            archived: true,
+            topics: ['managed-by-renovate'],
+          },
+          {
+            full_name: 'g/h',
+            archived: false,
+            topics: ['managed-by-renovate'],
+          },
+          null,
+        ]);
+
+      const repos = await github.getRepos({ topics: ['managed-by-renovate'] });
+      expect(repos).toEqual(['c/d', 'g/h']);
+    });
+
     it('should return an array of repos when using Github App endpoint', async () => {
       //Use Github App token
       await github.initPlatform({

--- a/lib/modules/platform/github/types.ts
+++ b/lib/modules/platform/github/types.ts
@@ -27,6 +27,7 @@ export interface GhRestRepo {
     login: string;
   };
   archived: boolean;
+  topics: string[];
 }
 
 export interface GhRestPr {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This PR adds support for the global configuration option `autodiscoverTopics` for the Github platform.

<!-- Describe what behavior is changed by this PR. -->

## Context

This follows discussion #10011 and its implementation for Gitlab platform in #22876.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
