### PR TITLE
fix: ensure git.hasDiff will not compare against files

### DIFF
--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -897,7 +897,9 @@ export async function hasDiff(
 ): Promise<boolean> {
   await syncGit();
   try {
-    return (await gitRetry(() => git.diff([sourceRef, targetRef, '--']))) !== '';
+    return (
+      (await gitRetry(() => git.diff([sourceRef, targetRef, '--']))) !== ''
+    );
   } catch (err) {
     return true;
   }

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -897,7 +897,7 @@ export async function hasDiff(
 ): Promise<boolean> {
   await syncGit();
   try {
-    return (await gitRetry(() => git.diff([sourceRef, targetRef]))) !== '';
+    return (await gitRetry(() => git.diff([sourceRef, targetRef, '--']))) !== '';
   } catch (err) {
     return true;
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

This fixes a situation in which git.hasDiff may try to compare against a remote branch but there is a file with the same name. The fix resolves such ambiguity, so that git will always treat the argument as a revision spec and not a potential file.

## Context

```
❯ git diff HEAD origin/master
[works]
❯ mkdir -p origin && touch origin/master
❯ git diff HEAD origin/master
fatal: ambiguous argument 'origin/master': both revision and filename
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
> git diff HEAD origin/master --
[works]
```

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
