### PR TITLE
chore: improve devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,3 +9,5 @@ RUN install-tool python 3.11.4
 
 # renovate: datasource=npm
 RUN install-tool yarn 1.22.19
+
+USER ubuntu

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,14 +7,11 @@
   },
   "name": "Renovate",
   "dockerFile": "Dockerfile",
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {}
+  },
   "customizations": {
     "vscode": {
-      "settings": {
-        "terminal.integrated.profiles.linux": {
-          "bash": { "path": "/bin/bash" }
-        },
-        "terminal.integrated.defaultProfile.linux": "bash"
-      },
       "extensions": [
         "dbaeumer.vscode-eslint",
         "esbenp.prettier-vscode",
@@ -30,5 +27,7 @@
     "seccomp=unconfined",
     "--privileged"
   ],
-  "postCreateCommand": "yarn install"
+  "postCreateCommand": "yarn install",
+  // Otherwise jest watcher fails because deps were not installed yet
+  "waitFor": "postCreateCommand"
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

- No longer runs as root user, which is a bad practice anyway.
- Add [common-utils](https://github.com/devcontainers/features/tree/main/src/common-utils#readme) feature to the container, which brings many improvements to the shell prompt making it much more helpful.
- Ensure VS Code waits for `yarn install` to run before loading extensions, so that the Jest test watcher will not thrown errors during the first execution (which would happen in parallel with the dependencies installation and it would fail because they were not installed yet, like `cross-env`)
- Remove default shell profile selection from vscode settings so that the container's default will be chosen automatically (for existing users this changes nothing because the container's default is Bash anyway), which is good for people adding [their own dotfiles to the devcontainer](https://code.visualstudio.com/docs/devcontainers/containers#_personalizing-with-dotfile-repositories) that changes the default shell to ZSH (like I do).

For users migrating from the old devcontainer, make sure to:

```
sudo chown -R $(id -u):$(id -g) .
```

From the root of the Renovate repository (outside of the devcontainer) to reclaim the ownership of the files (previously owned by root like `node_modules`), otherwise the new container will fail during startup with some permission denied errors.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

I started with the Renovate source code today, and I realized that the devcontainer could use some love.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
