### PR TITLE
fix(manager/bazel-module): skip non-local .bazelrc imports

### DIFF
--- a/lib/modules/manager/bazel-module/__fixtures__/extract/multiple-bazelrcs/.bazelrc
+++ b/lib/modules/manager/bazel-module/__fixtures__/extract/multiple-bazelrcs/.bazelrc
@@ -9,3 +9,6 @@ build --jobs 600
 
 # This file does not exist.
 try-import %workspace%/local.bazelrc
+
+# This file does not exist/is outside of the basePath
+try-import /does-not-exist/.bazelrc

--- a/lib/modules/manager/bazel-module/bazelrc.spec.ts
+++ b/lib/modules/manager/bazel-module/bazelrc.spec.ts
@@ -16,6 +16,12 @@ function mockReadLocalFile(files: Record<string, string | null>) {
   });
 }
 
+function mockIsValidLocalPath(files: Record<string, boolean>) {
+  fs.isValidLocalPath.mockImplementation((file: string): boolean => {
+    return file in files;
+  });
+}
+
 describe('modules/manager/bazel-module/bazelrc', () => {
   describe('BazelOption', () => {
     it.each`
@@ -88,6 +94,11 @@ describe('modules/manager/bazel-module/bazelrc', () => {
   describe('read()', () => {
     it('when .bazelrc does not exist', async () => {
       mockReadLocalFile({ '.bazelrc': null });
+      mockIsValidLocalPath({
+        '.bazelrc': true,
+        'foo.bazelrc': true,
+        'shared.bazelrc': true,
+      });
       const result = await read('.');
       expect(result).toHaveLength(0);
     });
@@ -98,6 +109,11 @@ describe('modules/manager/bazel-module/bazelrc', () => {
           // This is not a valid comment
           build --show_timestamps --keep_going --jobs 600
           `,
+      });
+      mockIsValidLocalPath({
+        '.bazelrc': true,
+        'foo.bazelrc': true,
+        'shared.bazelrc': true,
       });
       const result = await read('.');
       expect(result).toEqual([
@@ -116,6 +132,11 @@ describe('modules/manager/bazel-module/bazelrc', () => {
           build --show_timestamps --keep_going --jobs 600
           build --color=yes
           `,
+      });
+      mockIsValidLocalPath({
+        '.bazelrc': true,
+        'foo.bazelrc': true,
+        'shared.bazelrc': true,
       });
       const result = await read('.');
       expect(result).toEqual([
@@ -141,6 +162,11 @@ describe('modules/manager/bazel-module/bazelrc', () => {
           build --color=yes
           `,
       });
+      mockIsValidLocalPath({
+        '.bazelrc': true,
+        'foo.bazelrc': true,
+        'shared.bazelrc': true,
+      });
       const result = await read('.');
       expect(result).toEqual([
         new CommandEntry('build', [new BazelOption('show_timestamps')]),
@@ -155,6 +181,11 @@ describe('modules/manager/bazel-module/bazelrc', () => {
           try-import %workspace%/local.bazelrc
           `,
         'local.bazelrc': null,
+      });
+      mockIsValidLocalPath({
+        '.bazelrc': true,
+        'foo.bazelrc': true,
+        'shared.bazelrc': true,
       });
       const result = await read('.');
       expect(result).toEqual([
@@ -175,6 +206,11 @@ describe('modules/manager/bazel-module/bazelrc', () => {
           build --show_timestamps
           `,
       });
+      mockIsValidLocalPath({
+        '.bazelrc': true,
+        'foo.bazelrc': true,
+        'shared.bazelrc': true,
+      });
       const result = await read('.');
       expect(result).toEqual([
         new CommandEntry('build', [new BazelOption('show_timestamps')]),
@@ -194,6 +230,11 @@ describe('modules/manager/bazel-module/bazelrc', () => {
         'foo.bazelrc': codeBlock`
           import %workspace%/shared.bazelrc
           `,
+      });
+      mockIsValidLocalPath({
+        '.bazelrc': true,
+        'foo.bazelrc': true,
+        'shared.bazelrc': true,
       });
       expect.assertions(1);
       await expect(read('.')).rejects.toEqual(

--- a/lib/modules/manager/bazel-module/bazelrc.spec.ts
+++ b/lib/modules/manager/bazel-module/bazelrc.spec.ts
@@ -94,11 +94,7 @@ describe('modules/manager/bazel-module/bazelrc', () => {
   describe('read()', () => {
     it('when .bazelrc does not exist', async () => {
       mockReadLocalFile({ '.bazelrc': null });
-      mockIsValidLocalPath({
-        '.bazelrc': true,
-        'foo.bazelrc': true,
-        'shared.bazelrc': true,
-      });
+      mockIsValidLocalPath({ '.bazelrc': true });
       const result = await read('.');
       expect(result).toHaveLength(0);
     });
@@ -110,11 +106,7 @@ describe('modules/manager/bazel-module/bazelrc', () => {
           build --show_timestamps --keep_going --jobs 600
           `,
       });
-      mockIsValidLocalPath({
-        '.bazelrc': true,
-        'foo.bazelrc': true,
-        'shared.bazelrc': true,
-      });
+      mockIsValidLocalPath({ '.bazelrc': true });
       const result = await read('.');
       expect(result).toEqual([
         new CommandEntry('build', [
@@ -133,11 +125,7 @@ describe('modules/manager/bazel-module/bazelrc', () => {
           build --color=yes
           `,
       });
-      mockIsValidLocalPath({
-        '.bazelrc': true,
-        'foo.bazelrc': true,
-        'shared.bazelrc': true,
-      });
+      mockIsValidLocalPath({ '.bazelrc': true });
       const result = await read('.');
       expect(result).toEqual([
         new CommandEntry('build', [
@@ -164,7 +152,7 @@ describe('modules/manager/bazel-module/bazelrc', () => {
       });
       mockIsValidLocalPath({
         '.bazelrc': true,
-        'foo.bazelrc': true,
+        'local.bazelrc': true,
         'shared.bazelrc': true,
       });
       const result = await read('.');
@@ -182,11 +170,7 @@ describe('modules/manager/bazel-module/bazelrc', () => {
           `,
         'local.bazelrc': null,
       });
-      mockIsValidLocalPath({
-        '.bazelrc': true,
-        'foo.bazelrc': true,
-        'shared.bazelrc': true,
-      });
+      mockIsValidLocalPath({ '.bazelrc': true });
       const result = await read('.');
       expect(result).toEqual([
         new CommandEntry('build', [new BazelOption('jobs', '600')]),
@@ -242,6 +226,22 @@ describe('modules/manager/bazel-module/bazelrc', () => {
           'Attempted to read a bazelrc multiple times. file: shared.bazelrc'
         )
       );
+    });
+
+    it('when .bazelrc refers to a non-local file', async () => {
+      mockReadLocalFile({
+        '.bazelrc': codeBlock`
+          import /non-local.bazelrc
+          build --jobs 600
+          `,
+      });
+      mockIsValidLocalPath({
+        '.bazelrc': true,
+      });
+      const result = await read('.');
+      expect(result).toEqual([
+        new CommandEntry('build', [new BazelOption('jobs', '600')]),
+      ]);
     });
   });
 });

--- a/lib/modules/manager/bazel-module/bazelrc.ts
+++ b/lib/modules/manager/bazel-module/bazelrc.ts
@@ -2,6 +2,7 @@ import upath from 'upath';
 import { isNotNullOrUndefined } from '../../../util/array';
 import * as fs from '../../../util/fs';
 import { regEx } from '../../../util/regex';
+import { logger } from '../../../logger';
 
 const importRegex = regEx(`^(?<type>(?:try-)?import)\\s+(?<path>\\S+)$`);
 const optionRegex = regEx(
@@ -124,8 +125,12 @@ async function readFile(
     const importFile = upath.normalize(
       entry.path.replace('%workspace%', workspaceDir)
     );
-    const importEntries = await readFile(importFile, workspaceDir, readFiles);
-    results.push(...importEntries);
+    if (fs.isValidLocalPath(importFile)) {
+      const importEntries = await readFile(importFile, workspaceDir, readFiles);
+      results.push(...importEntries);
+    } else {
+      logger.debug(`Skipping non-local .bazelrc import ${importFile}`);
+    }
   }
   return results;
 }

--- a/lib/modules/manager/bazel-module/bazelrc.ts
+++ b/lib/modules/manager/bazel-module/bazelrc.ts
@@ -1,8 +1,8 @@
 import upath from 'upath';
+import { logger } from '../../../logger';
 import { isNotNullOrUndefined } from '../../../util/array';
 import * as fs from '../../../util/fs';
 import { regEx } from '../../../util/regex';
-import { logger } from '../../../logger';
 
 const importRegex = regEx(`^(?<type>(?:try-)?import)\\s+(?<path>\\S+)$`);
 const optionRegex = regEx(


### PR DESCRIPTION
## Changes
In the bazel-module manager, (try-)imports that point to locations outside of the basePath cause the entire manager to fail.

## Context
https://github.com/renovatebot/renovate/discussions/23382

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

