### PR TITLE
fix(datasource/conan): continue on error during fetching package url

### DIFF
--- a/lib/modules/datasource/conan/index.spec.ts
+++ b/lib/modules/datasource/conan/index.spec.ts
@@ -383,5 +383,55 @@ describe('modules/datasource/conan/index', () => {
         })
       ).toBeNull();
     });
+
+    it('artifactory no package url', async () => {
+      httpMock
+        .scope('https://fake.artifactory.com/artifactory/api/conan/test-repo/')
+        .get('/v2/conans/search?q=arti')
+        .reply(
+          200,
+          { results: ['arti/1.0.0@_/_', 'arti/1.1.1@_/_'] },
+          {
+            'x-jfrog-version': 'latest',
+          }
+        );
+      httpMock
+        .scope('https://fake.artifactory.com/artifactory/api/conan/test-repo/')
+        .get('/v2/conans/arti/1.1.1/_/_/latest')
+        .reply(200, {
+          revision: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          time: '2032-06-23T00:00:00.000+0000',
+        });
+      httpMock
+        .scope(
+          'https://fake.artifactory.com/artifactory/api/storage/test-repo/'
+        )
+        .get(
+          '/_/arti/1.1.1/_/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/export/conanfile.py?properties=conan.package.url'
+        )
+        .reply(200);
+
+      config.registryUrls = [
+        'https://fake.artifactory.com/artifactory/api/conan/test-repo',
+      ];
+      config.packageName = 'arti';
+      expect(
+        await getPkgReleases({
+          ...config,
+          packageName: 'arti/1.1@_/_',
+        })
+      ).toEqual({
+        registryUrl:
+          'https://fake.artifactory.com/artifactory/api/conan/test-repo',
+        releases: [
+          {
+            version: '1.0.0',
+          },
+          {
+            version: '1.1.1',
+          },
+        ],
+      });
+    });
   });
 });

--- a/lib/modules/datasource/conan/index.spec.ts
+++ b/lib/modules/datasource/conan/index.spec.ts
@@ -433,5 +433,44 @@ describe('modules/datasource/conan/index', () => {
         ],
       });
     });
+
+    it('artifactory http error', async () => {
+      httpMock
+        .scope('https://fake.artifactory.com/artifactory/api/conan/test-repo/')
+        .get('/v2/conans/search?q=arti')
+        .reply(
+          200,
+          { results: ['arti/1.0.0@_/_', 'arti/1.1.1@_/_'] },
+          {
+            'x-jfrog-version': 'latest',
+          }
+        );
+      httpMock
+        .scope('https://fake.artifactory.com/artifactory/api/conan/test-repo/')
+        .get('/v2/conans/arti/1.1.1/_/_/latest')
+        .reply(404);
+
+      config.registryUrls = [
+        'https://fake.artifactory.com/artifactory/api/conan/test-repo',
+      ];
+      config.packageName = 'arti';
+      expect(
+        await getPkgReleases({
+          ...config,
+          packageName: 'arti/1.1@_/_',
+        })
+      ).toEqual({
+        registryUrl:
+          'https://fake.artifactory.com/artifactory/api/conan/test-repo',
+        releases: [
+          {
+            version: '1.0.0',
+          },
+          {
+            version: '1.1.1',
+          },
+        ],
+      });
+    });
   });
 });

--- a/lib/modules/datasource/conan/index.ts
+++ b/lib/modules/datasource/conan/index.ts
@@ -204,7 +204,7 @@ export class ConanDatasource extends Datasource {
               }
             }
           } catch (err) {
-            logger.debug({ err }, "Couldn't determine conan package url");
+            logger.debug({ err }, "Couldn't determine Conan package url");
           }
           return dep;
         }

--- a/lib/modules/datasource/conan/index.ts
+++ b/lib/modules/datasource/conan/index.ts
@@ -204,8 +204,7 @@ export class ConanDatasource extends Datasource {
               }
             }
           } catch (err) {
-            // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-            logger.warn(`Couldn't determine conan package url ${err}`);
+            logger.debug({ err }, "Couldn't determine conan package url");
           }
           return dep;
         }

--- a/lib/modules/datasource/conan/index.ts
+++ b/lib/modules/datasource/conan/index.ts
@@ -192,9 +192,12 @@ export class ConanDatasource extends Datasource {
             const packageUrlResp = await this.http.getJson<ConanProperties>(
               packageUrl
             );
-            const conanPackageUrl =
-              packageUrlResp.body.properties['conan.package.url'][0];
-            dep.sourceUrl = conanPackageUrl;
+
+            if (packageUrlResp.body.properties && 'conan.package.url' in packageUrlResp.body.properties) {
+              const conanPackageUrl =
+                packageUrlResp.body.properties['conan.package.url'][0];
+              dep.sourceUrl = conanPackageUrl;
+            }
           }
           return dep;
         }

--- a/lib/modules/datasource/conan/index.ts
+++ b/lib/modules/datasource/conan/index.ts
@@ -153,51 +153,59 @@ export class ConanDatasource extends Datasource {
             }
           }
 
-          if (isArtifactoryServer(rep)) {
-            const conanApiRegexp =
-              /(?<host>.*)\/artifactory\/api\/conan\/(?<repo>[^/]+)/;
-            const groups = url.match(conanApiRegexp)?.groups;
-            if (!groups) {
-              return dep;
+          try {
+            if (isArtifactoryServer(rep)) {
+              const conanApiRegexp =
+                /(?<host>.*)\/artifactory\/api\/conan\/(?<repo>[^/]+)/;
+              const groups = url.match(conanApiRegexp)?.groups;
+              if (!groups) {
+                return dep;
+              }
+              const semver = allVersioning.get('semver');
+
+              const sortedReleases = dep.releases
+                .filter((release) => semver.isVersion(release.version))
+                .sort((a, b) => semver.sortVersions(a.version, b.version));
+
+              const latestVersion = sortedReleases.at(-1)?.version;
+
+              if (!latestVersion) {
+                return dep;
+              }
+              logger.debug(
+                `Conan package ${packageName} has latest version ${latestVersion}`
+              );
+
+              const latestRevisionUrl = joinUrlParts(
+                url,
+                `v2/conans/${conanPackage.conanName}/${latestVersion}/${conanPackage.userAndChannel}/latest`
+              );
+              const revResp = await this.http.getJson<ConanRevisionJSON>(
+                latestRevisionUrl
+              );
+              const packageRev = revResp.body.revision;
+
+              const [user, channel] = conanPackage.userAndChannel.split('/');
+              const packageUrl = joinUrlParts(
+                `${groups.host}/artifactory/api/storage/${groups.repo}`,
+                `${user}/${conanPackage.conanName}/${latestVersion}/${channel}/${packageRev}/export/conanfile.py?properties=conan.package.url`
+              );
+              const packageUrlResp = await this.http.getJson<ConanProperties>(
+                packageUrl
+              );
+
+              if (
+                packageUrlResp.body.properties &&
+                'conan.package.url' in packageUrlResp.body.properties
+              ) {
+                const conanPackageUrl =
+                  packageUrlResp.body.properties['conan.package.url'][0];
+                dep.sourceUrl = conanPackageUrl;
+              }
             }
-            const semver = allVersioning.get('semver');
-
-            const sortedReleases = dep.releases
-              .filter((release) => semver.isVersion(release.version))
-              .sort((a, b) => semver.sortVersions(a.version, b.version));
-
-            const latestVersion = sortedReleases.at(-1)?.version;
-
-            if (!latestVersion) {
-              return dep;
-            }
-            logger.debug(
-              `Conan package ${packageName} has latest version ${latestVersion}`
-            );
-
-            const latestRevisionUrl = joinUrlParts(
-              url,
-              `v2/conans/${conanPackage.conanName}/${latestVersion}/${conanPackage.userAndChannel}/latest`
-            );
-            const revResp = await this.http.getJson<ConanRevisionJSON>(
-              latestRevisionUrl
-            );
-            const packageRev = revResp.body.revision;
-
-            const [user, channel] = conanPackage.userAndChannel.split('/');
-            const packageUrl = joinUrlParts(
-              `${groups.host}/artifactory/api/storage/${groups.repo}`,
-              `${user}/${conanPackage.conanName}/${latestVersion}/${channel}/${packageRev}/export/conanfile.py?properties=conan.package.url`
-            );
-            const packageUrlResp = await this.http.getJson<ConanProperties>(
-              packageUrl
-            );
-
-            if (packageUrlResp.body.properties && 'conan.package.url' in packageUrlResp.body.properties) {
-              const conanPackageUrl =
-                packageUrlResp.body.properties['conan.package.url'][0];
-              dep.sourceUrl = conanPackageUrl;
-            }
+          } catch (err) {
+            // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+            logger.warn(`Couldn't determine conan package url ${err}`);
           }
           return dep;
         }


### PR DESCRIPTION
## Changes
Ignore errors during fetching package url of a conan package when using jfrog artifactory

<!-- Describe what behavior is changed by this PR. -->

## Context
- Fixes #23373
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [X] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
