### PR TITLE
feat(dry-run): when dry-run write PR change details to filesystem

### DIFF
--- a/lib/util/dryrun.ts
+++ b/lib/util/dryrun.ts
@@ -1,0 +1,25 @@
+import { GlobalConfig } from '../config/global';
+import { logger } from '../logger';
+import { writeLocalFile } from './fs';
+
+export function dryRunCanDoAction(
+  name: string,
+  jsonData: object | string,
+  markdownData?: string,
+  loggerMeta?: Record<string, any>
+): boolean {
+  const dryRun = GlobalConfig.get('dryRun');
+  if (dryRun) {
+    logger.info(loggerMeta ?? {}, `DRY-RUN: Would ${name}`);
+    if (GlobalConfig.get('localDir')) {
+      void writeLocalFile(
+        `dryrun/${name}.json`,
+        JSON.stringify(jsonData, undefined, 2)
+      );
+      if (markdownData) {
+        void writeLocalFile(`dryrun/${name}.md`, markdownData);
+      }
+    }
+  }
+  return !!dryRun;
+}

--- a/lib/workers/repository/update/pr/automerge.ts
+++ b/lib/workers/repository/update/pr/automerge.ts
@@ -1,5 +1,4 @@
 // TODO #7154
-import { GlobalConfig } from '../../../../config/global';
 import { logger } from '../../../../logger';
 import { Pr, platform } from '../../../../modules/platform';
 import {
@@ -7,6 +6,7 @@ import {
   ensureCommentRemoval,
 } from '../../../../modules/platform/comment';
 import { scm } from '../../../../modules/platform/scm';
+import { dryRunCanDoAction } from '../../../../util/dryrun';
 import type { BranchConfig } from '../../../types';
 import { isScheduledNow } from '../branch/schedule';
 import { resolveBranchStatus } from '../branch/status-checks';
@@ -93,10 +93,13 @@ export async function checkAutoMerge(
     // TODO: types (#7154)
     logger.debug(`Applying automerge comment: ${automergeComment!}`);
     // istanbul ignore if
-    if (GlobalConfig.get('dryRun')) {
-      logger.info(
-        `DRY-RUN: Would add PR automerge comment to PR #${pr.number}`
-      );
+    if (
+      !dryRunCanDoAction(
+        `add PR automerge comment to PR #${pr.number}`,
+        {},
+        automergeComment
+      )
+    ) {
       return {
         automerged: false,
         prAutomergeBlockReason: 'DryRun',
@@ -118,13 +121,12 @@ export async function checkAutoMerge(
   }
   // Let's merge this
   // istanbul ignore if
-  if (GlobalConfig.get('dryRun')) {
-    // TODO: types (#7154)
-    logger.info(
-      `DRY-RUN: Would merge PR #${
-        pr.number
-      } with strategy "${automergeStrategy!}"`
-    );
+  if (
+    !dryRunCanDoAction(
+      `merge PR #${pr.number} with strategy "${automergeStrategy!}"`,
+      {}
+    )
+  ) {
     return {
       automerged: false,
       prAutomergeBlockReason: 'DryRun',

--- a/lib/workers/repository/update/pr/participants.ts
+++ b/lib/workers/repository/update/pr/participants.ts
@@ -1,8 +1,8 @@
 import is from '@sindresorhus/is';
-import { GlobalConfig } from '../../../../config/global';
 import type { RenovateConfig } from '../../../../config/types';
 import { logger } from '../../../../logger';
 import { Pr, platform } from '../../../../modules/platform';
+import { dryRunCanDoAction } from '../../../../util/dryrun';
 import { sampleSize } from '../../../../util/sample';
 import { codeOwnersForPr } from './code-owners';
 
@@ -50,9 +50,7 @@ export async function addParticipants(
         assignees = sampleSize(assignees, config.assigneesSampleSize);
       }
       if (assignees.length > 0) {
-        if (GlobalConfig.get('dryRun')) {
-          logger.info(`DRY-RUN: Would add assignees to PR #${pr.number}`);
-        } else {
+        if (dryRunCanDoAction(`add assignees to PR #${pr.number}`, assignees)) {
           await platform.addAssignees(pr.number, assignees);
           logger.debug({ assignees }, 'Added assignees');
         }
@@ -82,9 +80,7 @@ export async function addParticipants(
         reviewers = sampleSize(reviewers, config.reviewersSampleSize);
       }
       if (reviewers.length > 0) {
-        if (GlobalConfig.get('dryRun')) {
-          logger.info(`DRY-RUN: Would add reviewers to PR #${pr.number}`);
-        } else {
+        if (dryRunCanDoAction(`add reviewers to PR #${pr.number}`, reviewers)) {
           await platform.addReviewers(pr.number, reviewers);
           logger.debug({ reviewers }, 'Added reviewers');
         }


### PR DESCRIPTION
When in dry-run mode I'd like to be able to preview what pull requests it wants to create/modify/etc. So I've moved dry-run check/log logic into it's own file and added file writing to it.